### PR TITLE
gh-118184: Support tuples for `find`, `index`, `rfind` & `rindex`

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1729,6 +1729,9 @@ expression support in the :mod:`re` module).
    first match.  Optional arguments *start* and *end* are interpreted as in
    slice notation.  Return ``-1`` if *sub* is not found.
 
+   .. seealso::
+      The :mod:`re` module, which provides advanced pattern matching.
+
    .. note::
 
       The :meth:`~str.find` method should be used only if you need to know the
@@ -2042,6 +2045,9 @@ expression support in the :mod:`re` module).
    of substrings to look for.  In this case the returned index, if found, will
    be the index of the last match.  Optional arguments *start* and *end* are
    interpreted as in slice notation.  Return ``-1`` on failure.
+
+   .. seealso::
+      The third-party :pypi:`regex` module, which provides advanced pattern matching.
 
    .. versionchanged:: 3.14
       *sub* can now be a tuple of substrings.
@@ -2884,6 +2890,9 @@ arbitrary binary data.
    The subsequence to search for may be any :term:`bytes-like object` or an
    integer in the range 0 to 255.
 
+   .. seealso::
+      The :mod:`re` module, which provides advanced pattern matching.
+
    .. note::
 
       The :meth:`~bytes.find` method should be used only if you need to know the
@@ -2979,6 +2988,9 @@ arbitrary binary data.
 
    The subsequence to search for may be any :term:`bytes-like object` or an
    integer in the range 0 to 255.
+
+   .. seealso::
+      The third-party :pypi:`regex` module, which provides advanced pattern matching.
 
    .. versionchanged:: 3.3
       Also accept an integer in the range 0 to 255 as the subsequence.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1725,8 +1725,9 @@ expression support in the :mod:`re` module).
 
    Return the lowest index in the string where substring *sub* is found within
    the slice ``s[start:end]``.  *sub* can also be a tuple of substrings to look
-   for.  Optional arguments *start* and *end* are interpreted as in slice
-   notation.  Return ``-1`` if *sub* is not found.
+   for.  In this case the returned index, if found, will be the index of the
+   first match.  Optional arguments *start* and *end* are interpreted as in
+   slice notation.  Return ``-1`` if *sub* is not found.
 
    .. note::
 
@@ -2035,7 +2036,8 @@ expression support in the :mod:`re` module).
 
    Return the highest index in the string where substring *sub* is found, such
    that *sub* is contained within ``s[start:end]``.  *sub* can also be a tuple
-   of substrings to look for.  Optional arguments *start* and *end* are
+   of substrings to look for.  In this case the returned index, if found, will
+   be the index of the last match.  Optional arguments *start* and *end* are
    interpreted as in slice notation.  Return ``-1`` on failure.
 
    .. versionchanged:: 3.14
@@ -2868,9 +2870,10 @@ arbitrary binary data.
 
    Return the lowest index in the data where the subsequence *sub* is found,
    such that *sub* is contained in the slice ``s[start:end]``.  *sub* can
-   also be a tuple of subsequences to look for.  Optional arguments *start*
-   and *end* are interpreted as in slice notation.  Return ``-1`` if *sub*
-   is not found.
+   also be a tuple of subsequences to look for.  In this case the returned
+   index, if found, will be the index of the first match.  Optional arguments
+   *start* and *end* are interpreted as in slice notation.  Return ``-1`` if
+   *sub* is not found.
 
    The subsequence to search for may be any :term:`bytes-like object` or an
    integer in the range 0 to 255.
@@ -2960,8 +2963,10 @@ arbitrary binary data.
 
    Return the highest index in the sequence where the subsequence *sub* is
    found, such that *sub* is contained within ``s[start:end]``.  *sub* can
-   also be a tuple of subsequences to look for.  Optional arguments *start*
-   and *end* are interpreted as in slice notation.  Return ``-1`` on failure.
+   also be a tuple of subsequences to look for.  In this case the returned
+   index, if found, will be the index of the last match.  Optional arguments
+   *start* and *end* are interpreted as in slice notation.  Return ``-1`` on
+   failure.
 
    The subsequence to search for may be any :term:`bytes-like object` or an
    integer in the range 0 to 255.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1794,6 +1794,9 @@ expression support in the :mod:`re` module).
    Like :meth:`~str.find`, but raise :exc:`ValueError` when the substring is
    not found.
 
+   .. versionchanged:: 3.14
+      *sub* can now be a tuple of substrings.
+
 
 .. method:: str.isalnum()
 
@@ -2048,6 +2051,9 @@ expression support in the :mod:`re` module).
 
    Like :meth:`rfind` but raises :exc:`ValueError` when the substring *sub* is not
    found.
+
+   .. versionchanged:: 3.14
+      *sub* can now be a tuple of substrings.
 
 
 .. method:: str.rjust(width[, fillchar])
@@ -2906,6 +2912,9 @@ arbitrary binary data.
    .. versionchanged:: 3.3
       Also accept an integer in the range 0 to 255 as the subsequence.
 
+   .. versionchanged:: 3.14
+       *sub* can now be a tuple of subsequences.
+
 
 .. method:: bytes.join(iterable)
             bytearray.join(iterable)
@@ -2989,6 +2998,9 @@ arbitrary binary data.
 
    .. versionchanged:: 3.3
       Also accept an integer in the range 0 to 255 as the subsequence.
+
+   .. versionchanged:: 3.14
+       *sub* can now be a tuple of subsequences.
 
 
 .. method:: bytes.rpartition(sep)

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2913,7 +2913,7 @@ arbitrary binary data.
       Also accept an integer in the range 0 to 255 as the subsequence.
 
    .. versionchanged:: 3.14
-       *sub* can now be a tuple of subsequences.
+      *sub* can now be a tuple of subsequences.
 
 
 .. method:: bytes.join(iterable)
@@ -3000,7 +3000,7 @@ arbitrary binary data.
       Also accept an integer in the range 0 to 255 as the subsequence.
 
    .. versionchanged:: 3.14
-       *sub* can now be a tuple of subsequences.
+      *sub* can now be a tuple of subsequences.
 
 
 .. method:: bytes.rpartition(sep)

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1724,8 +1724,9 @@ expression support in the :mod:`re` module).
 .. method:: str.find(sub[, start[, end]])
 
    Return the lowest index in the string where substring *sub* is found within
-   the slice ``s[start:end]``.  Optional arguments *start* and *end* are
-   interpreted as in slice notation.  Return ``-1`` if *sub* is not found.
+   the slice ``s[start:end]``.  *sub* can also be a tuple of substrings to look
+   for.  Optional arguments *start* and *end* are interpreted as in slice
+   notation.  Return ``-1`` if *sub* is not found.
 
    .. note::
 
@@ -1735,6 +1736,9 @@ expression support in the :mod:`re` module).
 
          >>> 'Py' in 'Python'
          True
+
+   .. versionchanged:: 3.14
+      *sub* can now be a tuple of substrings.
 
 
 .. method:: str.format(*args, **kwargs)
@@ -2030,8 +2034,12 @@ expression support in the :mod:`re` module).
 .. method:: str.rfind(sub[, start[, end]])
 
    Return the highest index in the string where substring *sub* is found, such
-   that *sub* is contained within ``s[start:end]``.  Optional arguments *start*
-   and *end* are interpreted as in slice notation.  Return ``-1`` on failure.
+   that *sub* is contained within ``s[start:end]``.  *sub* can also be a tuple
+   of substrings to look for.  Optional arguments *start* and *end* are
+   interpreted as in slice notation.  Return ``-1`` on failure.
+
+   .. versionchanged:: 3.14
+      *sub* can now be a tuple of substrings.
 
 
 .. method:: str.rindex(sub[, start[, end]])
@@ -2859,9 +2867,10 @@ arbitrary binary data.
             bytearray.find(sub[, start[, end]])
 
    Return the lowest index in the data where the subsequence *sub* is found,
-   such that *sub* is contained in the slice ``s[start:end]``.  Optional
-   arguments *start* and *end* are interpreted as in slice notation.  Return
-   ``-1`` if *sub* is not found.
+   such that *sub* is contained in the slice ``s[start:end]``.  *sub* can
+   also be a tuple of subsequences to look for.  Optional arguments *start*
+   and *end* are interpreted as in slice notation.  Return ``-1`` if *sub*
+   is not found.
 
    The subsequence to search for may be any :term:`bytes-like object` or an
    integer in the range 0 to 255.
@@ -2877,6 +2886,9 @@ arbitrary binary data.
 
    .. versionchanged:: 3.3
       Also accept an integer in the range 0 to 255 as the subsequence.
+
+   .. versionchanged:: 3.14
+      *sub* can now be a tuple of subsequences.
 
 
 .. method:: bytes.index(sub[, start[, end]])
@@ -2947,15 +2959,18 @@ arbitrary binary data.
             bytearray.rfind(sub[, start[, end]])
 
    Return the highest index in the sequence where the subsequence *sub* is
-   found, such that *sub* is contained within ``s[start:end]``.  Optional
-   arguments *start* and *end* are interpreted as in slice notation. Return
-   ``-1`` on failure.
+   found, such that *sub* is contained within ``s[start:end]``.  *sub* can
+   also be a tuple of subsequences to look for.  Optional arguments *start*
+   and *end* are interpreted as in slice notation.  Return ``-1`` on failure.
 
    The subsequence to search for may be any :term:`bytes-like object` or an
    integer in the range 0 to 255.
 
    .. versionchanged:: 3.3
       Also accept an integer in the range 0 to 255 as the subsequence.
+
+   .. versionchanged:: 3.14
+      *sub* can now be a tuple of subsequences.
 
 
 .. method:: bytes.rindex(sub[, start[, end]])

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -218,6 +218,8 @@ class BaseTest:
                     self.assertEqual(i[loc:loc+len(j)], j)
 
         # test tuple arguments
+        self.checkequal(0, 'foo', 'find', ('foo',))
+        self.checkequal(-1, 'foo', 'find', ('bar',))
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'))
         self.checkequal(2, '__aa__bb__', 'find', ('bb', 'aa'))
         self.checkequal(-1, '__aa__bb__', 'find', ('cc', 'dd'))
@@ -227,18 +229,18 @@ class BaseTest:
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'find', ('aa', 'bb'), 0, 3)
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 4)
-        self.checkraises(TypeError, 'hello', 'find', (None,))
+        self.checkraises(TypeError, 'hello', 'find', (1.0, 2.0))
         s = '_' * 9998 + 'aaaa' + '_' * 9998
         self.checkequal(9998, s, 'find', ('aaaa', 'bb'))
         self.checkequal(2, 'foobar', 'find', ('ob', 'oba'))
         self.checkequal(1, 'foobar', 'find', ('ob', 'oob'))
-        self.checkequal(0, '', 'find', ('',))
+        self.checkequal(0, '', 'find', ('', '_'))
         self.checkequal(2, '__abcd__', 'find', ('cd', 'ab'))
         self.checkequal(2, '__abc__', 'find', ('bc', 'ab'))
-        self.checkequal(1, 'a' + 'b' * 10000, 'find', ('b' * 10000,))
+        self.checkequal(1, 'a' + 'b' * 10000, 'find', ('b' * 10000, 'c'))
         s = 'ab' + 'c' * 100000
         self.checkequal(1, s, 'find', ('c' * 100000, 'b' + 'c' * 100000))
-        self.checkequal(0, 'foobar', 'find', ('foo',))
+        self.checkequal(0, 'foobar', 'find', ('foo', 'bar'))
 
     def test_rfind(self):
         self.checkequal(9,  'abcdefghiabc', 'rfind', 'abc')
@@ -294,6 +296,8 @@ class BaseTest:
         self.checkequal(0, '<......\u043c...', "rfind", "<")
 
         # test tuple arguments
+        self.checkequal(0, 'foo', 'rfind', ('foo',))
+        self.checkequal(-1, 'foo', 'rfind', ('bar',))
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'))
         self.checkequal(6, '__aa__bb__', 'rfind', ('bb', 'aa'))
         self.checkequal(-1, '__aa__bb__', 'rfind', ('cc', 'dd'))
@@ -302,18 +306,18 @@ class BaseTest:
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'rfind', ('aa', 'bb'), 7, 10)
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 6, 10)
-        self.checkraises(TypeError, 'hello', 'rfind', (None,))
+        self.checkraises(TypeError, 'hello', 'rfind', (1.0, 2.0))
         s = '_' * 9998 + 'aaaa' + '_' * 9998
         self.checkequal(9998, s, 'rfind', ('aaaa', 'bb'))
         self.checkequal(2, 'foobar', 'rfind', ('oba', 'ob'))
         self.checkequal(2, 'foobar', 'rfind', ('oob', 'ob'))
-        self.checkequal(0, '', 'rfind', ('',))
+        self.checkequal(0, '', 'rfind', ('', '_'))
         self.checkequal(4, '__abcd__', 'rfind', ('ab', 'cd'))
         self.checkequal(3, '__abc__', 'rfind', ('ab', 'bc'))
-        self.checkequal(0, 'b' * 10000 + 'a', 'rfind', ('b' * 10000,))
+        self.checkequal(0, 'b' * 10000 + 'a', 'rfind', ('b' * 10000, 'c'))
         s = 'ab' + 'c' * 100000
         self.checkequal(2, s, 'rfind', ('c' * 100000, 'b' + 'c' * 100000))
-        self.checkequal(3, 'foo', 'rfind', ('',))
+        self.checkequal(3, 'foo', 'rfind', ('', 'foo'))
 
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -227,9 +227,6 @@ class BaseTest:
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'find', ('aa', 'bb'), 0, 3)
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 4)
-
-        self.checkraises(TypeError, 'hello', 'find', (42,))
-
     def test_rfind(self):
         self.checkequal(9,  'abcdefghiabc', 'rfind', 'abc')
         self.checkequal(12, 'abcdefghiabc', 'rfind', '')
@@ -292,9 +289,6 @@ class BaseTest:
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'rfind', ('aa', 'bb'), 7, 10)
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 6, 10)
-
-        self.checkraises(TypeError, 'hello', 'rfind', (42,))
-
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')
         self.checkequal(3, 'abcdefghiabc', 'index', 'def')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -217,6 +217,19 @@ class BaseTest:
                 if loc != -1:
                     self.assertEqual(i[loc:loc+len(j)], j)
 
+        # test tuple arguments
+        self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'))
+        self.checkequal(2, '__aa__bb__', 'find', ('bb', 'aa'))
+        self.checkequal(-1, '__aa__bb__', 'find', ('cc', 'dd'))
+        self.checkequal(-1, '__aa__bb__', 'find', ())
+        self.checkequal(6, '__aa__bb__', 'find', ('aa', 'bb'), 3)
+        self.checkequal(-1, '__aa__bb__', 'find', ('aa', 'cc'), 3)
+        self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 10)
+        self.checkequal(-1, '__aa__bb__', 'find', ('aa', 'bb'), 0, 3)
+        self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 4)
+
+        self.checkraises(TypeError, 'hello', 'find', (42,))
+
     def test_rfind(self):
         self.checkequal(9,  'abcdefghiabc', 'rfind', 'abc')
         self.checkequal(12, 'abcdefghiabc', 'rfind', '')
@@ -269,6 +282,18 @@ class BaseTest:
 
         # issue #15534
         self.checkequal(0, '<......\u043c...', "rfind", "<")
+
+        # test tuple arguments
+        self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'))
+        self.checkequal(6, '__aa__bb__', 'rfind', ('bb', 'aa'))
+        self.checkequal(-1, '__aa__bb__', 'rfind', ('cc', 'dd'))
+        self.checkequal(-1, '__aa__bb__', 'rfind', ())
+        self.checkequal(-1, '__aa__bb__', 'rfind', ('aa', 'cc'), 3)
+        self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 0, 10)
+        self.checkequal(-1, '__aa__bb__', 'rfind', ('aa', 'bb'), 7, 10)
+        self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 6, 10)
+
+        self.checkraises(TypeError, 'hello', 'rfind', (42,))
 
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -307,7 +307,6 @@ class BaseTest:
         self.checkequal(3, '__abc__', 'rfind', ('ab', 'bc'))
         self.checkequal(0, 'b' * 10000 + 'a', 'rfind', ('b' * 10000,))
 
-
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')
         self.checkequal(3, 'abcdefghiabc', 'index', 'def')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -235,7 +235,7 @@ class BaseTest:
         self.checkequal(2, '__abcd__', 'find', ('cd', 'ab'))
         self.checkequal(2, '__abc__', 'find', ('bc', 'ab'))
         self.checkequal(1, 'a' + 'b' * 10000, 'find', ('b' * 10000,))
-
+self.checkequal(1, 'ab' + 'c' * 100000, 'find', ('c' * 100000, 'b' + 'c' * 100000))
     def test_rfind(self):
         self.checkequal(9,  'abcdefghiabc', 'rfind', 'abc')
         self.checkequal(12, 'abcdefghiabc', 'rfind', '')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -340,6 +340,11 @@ class BaseTest:
         else:
             self.checkraises(TypeError, 'hello', 'index', 42)
 
+        # test tuple arguments (should be wrapper around find)
+        self.checkequal(2, '__aa__bb__', 'index', ('aa', 'bb'))
+        self.checkequal(2, '__aa__bb__', 'index', ('aa', 'bb'))
+        self.checkraises(ValueError, '__aa__bb__', 'index', ('cc', 'dd'))
+
     def test_rindex(self):
         self.checkequal(12, 'abcdefghiabc', 'rindex', '')
         self.checkequal(3,  'abcdefghiabc', 'rindex', 'def')
@@ -365,6 +370,11 @@ class BaseTest:
             self.checkraises(ValueError, 'hello', 'rindex', 42)
         else:
             self.checkraises(TypeError, 'hello', 'rindex', 42)
+
+        # test tuple arguments (should be wrapper around rfind)
+        self.checkequal(6, '__aa__bb__', 'rindex', ('aa', 'bb'))
+        self.checkequal(6, '__aa__bb__', 'rindex', ('bb', 'aa'))
+        self.checkraises(ValueError, '__aa__bb__', 'rindex', ('cc', 'dd'))
 
     def test_find_periodic_pattern(self):
         """Cover the special path for periodic patterns."""

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -180,8 +180,10 @@ class BaseTest:
 
         if self.contains_bytes:
             self.checkequal(-1, 'hello', 'find', 42)
+            self.checkequal(-1, 'hello', 'find', (42,))
         else:
             self.checkraises(TypeError, 'hello', 'find', 42)
+            self.checkraises(TypeError, 'hello', 'find', (42,))
 
         self.checkequal(0, '', 'find', '')
         self.checkequal(-1, '', 'find', '', 1, 1)
@@ -230,7 +232,7 @@ class BaseTest:
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'find', ('aa', 'bb'), 0, 3)
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 4)
-        self.checkraises(TypeError, 'hello', 'find', (1.0, 2.0))
+        self.checkraises(TypeError, 'hello', 'find', (None,))
         s = '_' * (N - 2) + 'aaaa' + '_' * (N - 2)
         self.checkequal((N - 2), s, 'find', ('aaaa', 'bb'))
         self.checkequal(2, 'foobar', 'find', ('ob', 'oba'))
@@ -242,6 +244,7 @@ class BaseTest:
         s = 'ab' + 'c' * (10 * N)
         self.checkequal(1, s, 'find', ('c' * (10 * N), 'b' + 'c' * (10 * N)))
         self.checkequal(0, 'foobar', 'find', ('foo', 'bar'))
+        self.checkequal(-1, 'foo', 'find', ('foobar',))
 
     def test_rfind(self):
         self.checkequal(9,  'abcdefghiabc', 'rfind', 'abc')
@@ -264,8 +267,10 @@ class BaseTest:
 
         if self.contains_bytes:
             self.checkequal(-1, 'hello', 'rfind', 42)
+            self.checkequal(-1, 'hello', 'rfind', (42,))
         else:
             self.checkraises(TypeError, 'hello', 'rfind', 42)
+            self.checkraises(TypeError, 'hello', 'rfind', (42,))
 
         # For a variety of combinations,
         #    verify that str.rfind() matches __contains__
@@ -308,18 +313,19 @@ class BaseTest:
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'rfind', ('aa', 'bb'), 7, 10)
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 6, 10)
-        self.checkraises(TypeError, 'hello', 'rfind', (1.0, 2.0))
+        self.checkraises(TypeError, 'hello', 'rfind', (None,))
         s = '_' * (N - 2) + 'aaaa' + '_' * (N - 2)
         self.checkequal((N - 2), s, 'rfind', ('aaaa', 'bb'))
         self.checkequal(2, 'foobar', 'rfind', ('oba', 'ob'))
         self.checkequal(2, 'foobar', 'rfind', ('oob', 'ob'))
-        self.checkequal(0, '', 'rfind', ('', '_'))
+        self.checkequal(1, '_', 'rfind', ('', 'a'))
         self.checkequal(4, '__abcd__', 'rfind', ('ab', 'cd'))
         self.checkequal(3, '__abc__', 'rfind', ('ab', 'bc'))
         self.checkequal(0, 'b' * N + 'a', 'rfind', ('b' * N, 'c'))
         s = 'ab' + 'c' * (10 * N)
         self.checkequal(2, s, 'rfind', ('c' * (10 * N), 'b' + 'c' * (10 * N)))
         self.checkequal(3, 'foo', 'rfind', ('', 'foo'))
+        self.checkequal(-1, 'foo', 'rfind', ('foobar',))
 
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -218,6 +218,7 @@ class BaseTest:
                     self.assertEqual(i[loc:loc+len(j)], j)
 
         # test tuple arguments
+        N = 1000  # FIND_CHUNK_SIZE
         self.checkequal(0, 'foo', 'find', ('foo',))
         self.checkequal(-1, 'foo', 'find', ('bar',))
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'))
@@ -230,16 +231,16 @@ class BaseTest:
         self.checkequal(-1, '__aa__bb__', 'find', ('aa', 'bb'), 0, 3)
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 4)
         self.checkraises(TypeError, 'hello', 'find', (1.0, 2.0))
-        s = '_' * 9998 + 'aaaa' + '_' * 9998
-        self.checkequal(9998, s, 'find', ('aaaa', 'bb'))
+        s = '_' * (N - 2) + 'aaaa' + '_' * (N - 2)
+        self.checkequal((N - 2), s, 'find', ('aaaa', 'bb'))
         self.checkequal(2, 'foobar', 'find', ('ob', 'oba'))
         self.checkequal(1, 'foobar', 'find', ('ob', 'oob'))
         self.checkequal(0, '', 'find', ('', '_'))
         self.checkequal(2, '__abcd__', 'find', ('cd', 'ab'))
         self.checkequal(2, '__abc__', 'find', ('bc', 'ab'))
-        self.checkequal(1, 'a' + 'b' * 10000, 'find', ('b' * 10000, 'c'))
-        s = 'ab' + 'c' * 100000
-        self.checkequal(1, s, 'find', ('c' * 100000, 'b' + 'c' * 100000))
+        self.checkequal(1, 'a' + 'b' * N, 'find', ('b' * N, 'c'))
+        s = 'ab' + 'c' * (10 * N)
+        self.checkequal(1, s, 'find', ('c' * (10 * N), 'b' + 'c' * (10 * N)))
         self.checkequal(0, 'foobar', 'find', ('foo', 'bar'))
 
     def test_rfind(self):
@@ -296,6 +297,7 @@ class BaseTest:
         self.checkequal(0, '<......\u043c...', "rfind", "<")
 
         # test tuple arguments
+        N = 1000  # RFIND_CHUNK_SIZE
         self.checkequal(0, 'foo', 'rfind', ('foo',))
         self.checkequal(-1, 'foo', 'rfind', ('bar',))
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'))
@@ -307,16 +309,16 @@ class BaseTest:
         self.checkequal(-1, '__aa__bb__', 'rfind', ('aa', 'bb'), 7, 10)
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 6, 10)
         self.checkraises(TypeError, 'hello', 'rfind', (1.0, 2.0))
-        s = '_' * 9998 + 'aaaa' + '_' * 9998
-        self.checkequal(9998, s, 'rfind', ('aaaa', 'bb'))
+        s = '_' * (N - 2) + 'aaaa' + '_' * (N - 2)
+        self.checkequal((N - 2), s, 'rfind', ('aaaa', 'bb'))
         self.checkequal(2, 'foobar', 'rfind', ('oba', 'ob'))
         self.checkequal(2, 'foobar', 'rfind', ('oob', 'ob'))
         self.checkequal(0, '', 'rfind', ('', '_'))
         self.checkequal(4, '__abcd__', 'rfind', ('ab', 'cd'))
         self.checkequal(3, '__abc__', 'rfind', ('ab', 'bc'))
-        self.checkequal(0, 'b' * 10000 + 'a', 'rfind', ('b' * 10000, 'c'))
-        s = 'ab' + 'c' * 100000
-        self.checkequal(2, s, 'rfind', ('c' * 100000, 'b' + 'c' * 100000))
+        self.checkequal(0, 'b' * N + 'a', 'rfind', ('b' * N, 'c'))
+        s = 'ab' + 'c' * (10 * N)
+        self.checkequal(2, s, 'rfind', ('c' * (10 * N), 'b' + 'c' * (10 * N)))
         self.checkequal(3, 'foo', 'rfind', ('', 'foo'))
 
     def test_index(self):

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -229,6 +229,12 @@ class BaseTest:
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 4)
         s = '_' * 9998 + 'aaaa' + '_' * 9998
         self.checkequal(9998, s, 'find', ('aaaa', 'bb'))
+        self.checkequal(2, 'foobar', 'find', ('ob', 'oba'))
+        self.checkequal(1, 'foobar', 'find', ('ob', 'oob'))
+        self.checkequal(0, '', 'find', ('',))
+        self.checkequal(2, '__abcd__', 'find', ('cd', 'ab'))
+        self.checkequal(2, '__abc__', 'find', ('bc', 'ab'))
+        self.checkequal(1, 'a' + 'b' * 10000, 'find', ('b' * 10000,))
 
     def test_rfind(self):
         self.checkequal(9,  'abcdefghiabc', 'rfind', 'abc')
@@ -294,6 +300,13 @@ class BaseTest:
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 6, 10)
         s = '_' * 9998 + 'aaaa' + '_' * 9998
         self.checkequal(9998, s, 'rfind', ('aaaa', 'bb'))
+        self.checkequal(2, 'foobar', 'rfind', ('oba', 'ob'))
+        self.checkequal(2, 'foobar', 'rfind', ('oob', 'ob'))
+        self.checkequal(0, '', 'rfind', ('',))
+        self.checkequal(4, '__abcd__', 'rfind', ('ab', 'cd'))
+        self.checkequal(3, '__abc__', 'rfind', ('ab', 'bc'))
+        self.checkequal(0, 'b' * 10000 + 'a', 'rfind', ('b' * 10000,))
+
 
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -307,7 +307,7 @@ class BaseTest:
         self.checkequal(4, '__abcd__', 'rfind', ('ab', 'cd'))
         self.checkequal(3, '__abc__', 'rfind', ('ab', 'bc'))
         self.checkequal(0, 'b' * 10000 + 'a', 'rfind', ('b' * 10000,))
-
+        self.checkequal(2, 'ab' + 'c' * 100000, 'rfind', ('c' * 100000, 'b' + 'c' * 100000))
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')
         self.checkequal(3, 'abcdefghiabc', 'index', 'def')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -227,6 +227,7 @@ class BaseTest:
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'find', ('aa', 'bb'), 0, 3)
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 4)
+        self.checkraises(TypeError, 'hello', 'find', (None,))
         s = '_' * 9998 + 'aaaa' + '_' * 9998
         self.checkequal(9998, s, 'find', ('aaaa', 'bb'))
         self.checkequal(2, 'foobar', 'find', ('ob', 'oba'))
@@ -235,7 +236,8 @@ class BaseTest:
         self.checkequal(2, '__abcd__', 'find', ('cd', 'ab'))
         self.checkequal(2, '__abc__', 'find', ('bc', 'ab'))
         self.checkequal(1, 'a' + 'b' * 10000, 'find', ('b' * 10000,))
-        self.checkequal(1, 'ab' + 'c' * 100000, 'find', ('c' * 100000, 'b' + 'c' * 100000))
+        s = 'ab' + 'c' * 100000
+        self.checkequal(1, s, 'find', ('c' * 100000, 'b' + 'c' * 100000))
 
     def test_rfind(self):
         self.checkequal(9,  'abcdefghiabc', 'rfind', 'abc')
@@ -299,6 +301,7 @@ class BaseTest:
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'rfind', ('aa', 'bb'), 7, 10)
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 6, 10)
+        self.checkraises(TypeError, 'hello', 'rfind', (None,))
         s = '_' * 9998 + 'aaaa' + '_' * 9998
         self.checkequal(9998, s, 'rfind', ('aaaa', 'bb'))
         self.checkequal(2, 'foobar', 'rfind', ('oba', 'ob'))
@@ -307,7 +310,8 @@ class BaseTest:
         self.checkequal(4, '__abcd__', 'rfind', ('ab', 'cd'))
         self.checkequal(3, '__abc__', 'rfind', ('ab', 'bc'))
         self.checkequal(0, 'b' * 10000 + 'a', 'rfind', ('b' * 10000,))
-        self.checkequal(2, 'ab' + 'c' * 100000, 'rfind', ('c' * 100000, 'b' + 'c' * 100000))
+        s = 'ab' + 'c' * 100000
+        self.checkequal(2, s, 'rfind', ('c' * 100000, 'b' + 'c' * 100000))
 
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -235,7 +235,8 @@ class BaseTest:
         self.checkequal(2, '__abcd__', 'find', ('cd', 'ab'))
         self.checkequal(2, '__abc__', 'find', ('bc', 'ab'))
         self.checkequal(1, 'a' + 'b' * 10000, 'find', ('b' * 10000,))
-self.checkequal(1, 'ab' + 'c' * 100000, 'find', ('c' * 100000, 'b' + 'c' * 100000))
+        self.checkequal(1, 'ab' + 'c' * 100000, 'find', ('c' * 100000, 'b' + 'c' * 100000))
+
     def test_rfind(self):
         self.checkequal(9,  'abcdefghiabc', 'rfind', 'abc')
         self.checkequal(12, 'abcdefghiabc', 'rfind', '')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -238,6 +238,7 @@ class BaseTest:
         self.checkequal(1, 'a' + 'b' * 10000, 'find', ('b' * 10000,))
         s = 'ab' + 'c' * 100000
         self.checkequal(1, s, 'find', ('c' * 100000, 'b' + 'c' * 100000))
+        self.checkequal(0, 'foobar', 'find', ('foo',))
 
     def test_rfind(self):
         self.checkequal(9,  'abcdefghiabc', 'rfind', 'abc')
@@ -312,6 +313,7 @@ class BaseTest:
         self.checkequal(0, 'b' * 10000 + 'a', 'rfind', ('b' * 10000,))
         s = 'ab' + 'c' * 100000
         self.checkequal(2, s, 'rfind', ('c' * 100000, 'b' + 'c' * 100000))
+        self.checkequal(3, 'foo', 'rfind', ('',))
 
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -227,6 +227,7 @@ class BaseTest:
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'find', ('aa', 'bb'), 0, 3)
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 4)
+
     def test_rfind(self):
         self.checkequal(9,  'abcdefghiabc', 'rfind', 'abc')
         self.checkequal(12, 'abcdefghiabc', 'rfind', '')
@@ -289,6 +290,7 @@ class BaseTest:
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'rfind', ('aa', 'bb'), 7, 10)
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 6, 10)
+
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')
         self.checkequal(3, 'abcdefghiabc', 'index', 'def')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -308,6 +308,7 @@ class BaseTest:
         self.checkequal(3, '__abc__', 'rfind', ('ab', 'bc'))
         self.checkequal(0, 'b' * 10000 + 'a', 'rfind', ('b' * 10000,))
         self.checkequal(2, 'ab' + 'c' * 100000, 'rfind', ('c' * 100000, 'b' + 'c' * 100000))
+
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')
         self.checkequal(3, 'abcdefghiabc', 'index', 'def')

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -227,6 +227,8 @@ class BaseTest:
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'find', ('aa', 'bb'), 0, 3)
         self.checkequal(2, '__aa__bb__', 'find', ('aa', 'bb'), 0, 4)
+        s = '_' * 9998 + 'aaaa' + '_' * 9998
+        self.checkequal(9998, s, 'find', ('aaaa', 'bb'))
 
     def test_rfind(self):
         self.checkequal(9,  'abcdefghiabc', 'rfind', 'abc')
@@ -290,6 +292,8 @@ class BaseTest:
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 0, 10)
         self.checkequal(-1, '__aa__bb__', 'rfind', ('aa', 'bb'), 7, 10)
         self.checkequal(6, '__aa__bb__', 'rfind', ('aa', 'bb'), 6, 10)
+        s = '_' * 9998 + 'aaaa' + '_' * 9998
+        self.checkequal(9998, s, 'rfind', ('aaaa', 'bb'))
 
     def test_index(self):
         self.checkequal(0, 'abcdefghiabc', 'index', '')

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -644,6 +644,12 @@ class BaseBytesTest:
                 ValueError, r'byte must be in range\(0, 256\)',
                 b.find, index)
 
+        # test tuple arguments
+        self.assertEqual(b.find((i,)), 1)
+        self.assertEqual(b.find((w,)), -1)
+        self.assertEqual(b.find((i, w)), 1)
+        self.assertEqual(b.find((w, i)), 1)
+
     def test_rfind(self):
         b = self.type2test(b'mississippi')
         i = 105
@@ -662,6 +668,12 @@ class BaseBytesTest:
         self.assertEqual(b.rfind(i, 1, 3), 1)
         self.assertEqual(b.rfind(i, 3, 9), 7)
         self.assertEqual(b.rfind(w, 1, 3), -1)
+
+        # test tuple arguments
+        self.assertEqual(b.rfind((i,)), 10)
+        self.assertEqual(b.rfind((w,)), -1)
+        self.assertEqual(b.rfind((i, w)), 10)
+        self.assertEqual(b.rfind((w, i)), 10)
 
     def test_index(self):
         b = self.type2test(b'mississippi')

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -644,12 +644,6 @@ class BaseBytesTest:
                 ValueError, r'byte must be in range\(0, 256\)',
                 b.find, index)
 
-        # test tuple arguments
-        self.assertEqual(b.find((i,)), 1)
-        self.assertEqual(b.find((w,)), -1)
-        self.assertEqual(b.find((i, w)), 1)
-        self.assertEqual(b.find((w, i)), 1)
-
     def test_rfind(self):
         b = self.type2test(b'mississippi')
         i = 105
@@ -668,12 +662,6 @@ class BaseBytesTest:
         self.assertEqual(b.rfind(i, 1, 3), 1)
         self.assertEqual(b.rfind(i, 3, 9), 7)
         self.assertEqual(b.rfind(w, 1, 3), -1)
-
-        # test tuple arguments
-        self.assertEqual(b.rfind((i,)), 10)
-        self.assertEqual(b.rfind((w,)), -1)
-        self.assertEqual(b.rfind((i, w)), 10)
-        self.assertEqual(b.rfind((w, i)), 10)
 
     def test_index(self):
         b = self.type2test(b'mississippi')

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -644,6 +644,10 @@ class BaseBytesTest:
                 ValueError, r'byte must be in range\(0, 256\)',
                 b.find, index)
 
+        # test tuple arguments
+        self.assertEqual(b.find((i,)), 1)
+        self.assertEqual(b.find((w,)), -1)
+
     def test_rfind(self):
         b = self.type2test(b'mississippi')
         i = 105
@@ -662,6 +666,10 @@ class BaseBytesTest:
         self.assertEqual(b.rfind(i, 1, 3), 1)
         self.assertEqual(b.rfind(i, 3, 9), 7)
         self.assertEqual(b.rfind(w, 1, 3), -1)
+
+        # test tuple arguments
+        self.assertEqual(b.rfind((i,)), 10)
+        self.assertEqual(b.rfind((w,)), -1)
 
     def test_index(self):
         b = self.type2test(b'mississippi')

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -647,6 +647,8 @@ class BaseBytesTest:
         # test tuple arguments
         self.assertEqual(b.find((i,)), 1)
         self.assertEqual(b.find((w,)), -1)
+        self.assertEqual(b.find((i, w)), 1)
+        self.assertEqual(b.find((w, i)), 1)
 
     def test_rfind(self):
         b = self.type2test(b'mississippi')
@@ -670,6 +672,8 @@ class BaseBytesTest:
         # test tuple arguments
         self.assertEqual(b.rfind((i,)), 10)
         self.assertEqual(b.rfind((w,)), -1)
+        self.assertEqual(b.rfind((i, w)), 10)
+        self.assertEqual(b.rfind((w, i)), 10)
 
     def test_index(self):
         b = self.type2test(b'mississippi')

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -5414,7 +5414,7 @@ class TestSignatureDefinitions(unittest.TestCase):
             'dict': {'pop'},
             'int': {'__round__'},
             'memoryview': {'cast', 'hex'},
-            'str': {'count', 'endswith', 'find', 'index', 'maketrans', 'rfind', 'rindex', 'startswith'},
+            'str': {'count', 'endswith', 'index', 'maketrans', 'rindex', 'startswith'},
         }
         self._test_module_has_signatures(builtins,
                 no_signature, unsupported_signature,
@@ -5589,7 +5589,7 @@ class TestSignatureDefinitions(unittest.TestCase):
             'Generic': {'__class_getitem__', '__init_subclass__'},
         }
         methods_unsupported_signature = {
-            'Text': {'count', 'find', 'index', 'rfind', 'rindex', 'startswith', 'endswith', 'maketrans'},
+            'Text': {'count', 'index', 'rindex', 'startswith', 'endswith', 'maketrans'},
         }
         self._test_module_has_signatures(typing, no_signature,
                 methods_no_signature=methods_no_signature,

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -5414,7 +5414,7 @@ class TestSignatureDefinitions(unittest.TestCase):
             'dict': {'pop'},
             'int': {'__round__'},
             'memoryview': {'cast', 'hex'},
-            'str': {'count', 'endswith', 'index', 'maketrans', 'rindex', 'startswith'},
+            'str': {'count', 'endswith', 'maketrans', 'startswith'},
         }
         self._test_module_has_signatures(builtins,
                 no_signature, unsupported_signature,
@@ -5589,7 +5589,7 @@ class TestSignatureDefinitions(unittest.TestCase):
             'Generic': {'__class_getitem__', '__init_subclass__'},
         }
         methods_unsupported_signature = {
-            'Text': {'count', 'index', 'rindex', 'startswith', 'endswith', 'maketrans'},
+            'Text': {'count', 'startswith', 'endswith', 'maketrans'},
         }
         self._test_module_has_signatures(typing, no_signature,
                 methods_no_signature=methods_no_signature,

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-24-11-07-16.gh-issue-118184.EK4di_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-24-11-07-16.gh-issue-118184.EK4di_.rst
@@ -1,1 +1,4 @@
-Support tuples for :meth:`str.find`, :meth:`bytearray.find`, :meth:`bytes.find`, :meth:`str.rfind`, :meth:`bytearray.rfind` and :meth:`bytes.rfind`.
+Support tuples for :meth:`str.find`,   :meth:`bytearray.find`,      :meth:`bytes.find`,
+                   :meth:`str.index`,  :meth:`bytearray.index`,     :meth:`bytes.index`,
+                   :meth:`str.rfind`,  :meth:`bytearray.rfind`,     :meth:`bytes.rfind`,
+                   :meth:`str.rindex`, :meth:`bytearray.rindex` and :meth:`bytes.rindex`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-24-11-07-16.gh-issue-118184.EK4di_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-24-11-07-16.gh-issue-118184.EK4di_.rst
@@ -1,4 +1,1 @@
-Support tuples for :meth:`str.find`,   :meth:`bytearray.find`,      :meth:`bytes.find`,
-                   :meth:`str.index`,  :meth:`bytearray.index`,     :meth:`bytes.index`,
-                   :meth:`str.rfind`,  :meth:`bytearray.rfind`,     :meth:`bytes.rfind`,
-                   :meth:`str.rindex`, :meth:`bytearray.rindex` and :meth:`bytes.rindex`.
+Support tuples for for :class:`str`, :class:`bytes` and :class:`bytearray` methods ``find()``, ``index()``, ``rfind()`` and ``rindex()``.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-24-11-07-16.gh-issue-118184.EK4di_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-24-11-07-16.gh-issue-118184.EK4di_.rst
@@ -1,0 +1,1 @@
+Support tuples for :meth:`str.find`, :meth:`bytearray.find`, :meth:`bytes.find`, :meth:`str.rfind`, :meth:`bytearray.rfind` and :meth:`bytes.rfind`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-24-11-07-16.gh-issue-118184.EK4di_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-24-11-07-16.gh-issue-118184.EK4di_.rst
@@ -1,1 +1,1 @@
-Support tuples for for :class:`str`, :class:`bytes` and :class:`bytearray` methods ``find()``, ``index()``, ``rfind()`` and ``rindex()``.
+Support tuples for :class:`str`, :class:`bytes` and :class:`bytearray` methods ``find()``, ``index()``, ``rfind()`` and ``rindex()``.

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -497,10 +497,10 @@ parse_args_finds_byte(const char *function_name, PyObject **subobj, char *byte)
     }
 
 Py_ssize_t
-fast_find_internal(const char *str, Py_ssize_t len,
-                   const char *sub, Py_ssize_t sub_len,
-                   Py_ssize_t start, Py_ssize_t end,
-                   int direction)
+_Py_fast_find(const char *str, Py_ssize_t len,
+              const char *sub, Py_ssize_t sub_len,
+              Py_ssize_t start, Py_ssize_t end,
+              int direction)
 {
     if (end - start < sub_len)
         return -1;
@@ -551,7 +551,7 @@ find_internal(const char *str, Py_ssize_t len,
     }
 
     ADJUST_INDICES(start, end, len);
-    return fast_find_internal(str, len, sub, sub_len, start, end, dir);
+    return _Py_fast_find(str, len, sub, sub_len, start, end, dir);
 }
 
 #define FIND_CHUNK_SIZE 1000
@@ -636,8 +636,8 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
         goto exit;
     }
     if (subs_len == 1) {
-        result = fast_find_internal(str, len, subs[0], sub_lengths[0], start,
-                                    end, direction);
+        result = _Py_fast_find(str, len, subs[0], sub_lengths[0], start, end,
+                               direction);
         goto exit;
     }
     if (direction > 0) {
@@ -655,13 +655,12 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
                 const char *sub = subs[i];
                 Py_ssize_t sub_len = sub_lengths[i];
                 if (cur_end >= end - sub_len) { // Guard overflow
-                    new_result = fast_find_internal(str, len, sub, sub_len,
-                                                    start, end, +1);
+                    new_result = _Py_fast_find(str, len, sub, sub_len, start,
+                                               end, +1);
                 }
                 else {
-                    new_result = fast_find_internal(str, len, sub, sub_len,
-                                                    start, cur_end + sub_len,
-                                                    +1);
+                    new_result = _Py_fast_find(str, len, sub, sub_len, start,
+                                               cur_end + sub_len, +1);
                 }
                 if (new_result != -1) {
                     if (new_result == start) {
@@ -690,13 +689,13 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
                 const char *sub = subs[i];
                 Py_ssize_t sub_len = sub_lengths[i];
                 if (cur_end >= end - sub_len) { // Guard overflow
-                    new_result = fast_find_internal(str, len, sub, sub_len,
-                                                    cur_start, end, -1);
+                    new_result = _Py_fast_find(str, len, sub, sub_len,
+                                               cur_start, end, -1);
                 }
                 else {
-                    new_result = fast_find_internal(str, len, sub, sub_len,
-                                                    cur_start,
-                                                    cur_end + sub_len, -1);
+                    new_result = _Py_fast_find(str, len, sub, sub_len,
+                                               cur_start, cur_end + sub_len,
+                                               -1);
                 }
                 if (new_result != -1) {
                     if (new_result == cur_end) {

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -556,7 +556,7 @@ find_internal(const char *str, Py_ssize_t len,
     return res;
 }
 
-#define FIND_CHUNK_SIZE 10000
+#define FIND_CHUNK_SIZE 1000
 #define RFIND_CHUNK_SIZE FIND_CHUNK_SIZE
 
 static Py_ssize_t

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -591,9 +591,6 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
                     sub_len = subbuf.len;
                 }
                 Py_ssize_t sub_end = cur_end + sub_len;
-                if (sub_end > end) {
-                    sub_end = end;
-                }
                 Py_ssize_t new_result = find_internal(str, len, function_name,
                                                       subseq, start, sub_end,
                                                       +1);
@@ -634,9 +631,6 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
                     sub_len = subbuf.len;
                 }
                 Py_ssize_t sub_end = cur_end + sub_len;
-                if (sub_end > end) {
-                    sub_end = end;
-                }
                 Py_ssize_t new_result = find_internal(str, len, function_name,
                                                       subseq, cur_start,
                                                       sub_end, -1);

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -572,6 +572,7 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
     ADJUST_INDICES(start, end, len);
     // Work in chunks
     if (direction > 0) {
+        assert(FIND_CHUNK_SIZE > 0);
         for (; result == -1 && start <= end; start += FIND_CHUNK_SIZE) {
             Py_ssize_t cur_end = start + FIND_CHUNK_SIZE - 1;
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
@@ -611,6 +612,7 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
     }
     else {
         Py_ssize_t cur_end = end;
+        assert(RFIND_CHUNK_SIZE > 0);
         for (; result == -1 && cur_end >= start; cur_end -= RFIND_CHUNK_SIZE) {
             Py_ssize_t cur_start = cur_end - RFIND_CHUNK_SIZE + 1;
             if (cur_start < start) {

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -651,6 +651,7 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
                 }
                 else {
                     sub_len = subbuf.len;
+                    PyBuffer_Release(&subbuf);
                 }
                 if (cur_end >= end - sub_len) { // Guard overflow
                     new_result = find_internal(str, len, function_name, subseq,

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -564,8 +564,9 @@ find_internal(const char *str, Py_ssize_t len,
 #define RFIND_CHUNK_SIZE FIND_CHUNK_SIZE
 
 static Py_ssize_t
-find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
-                    PyObject *subobj, Py_ssize_t start, Py_ssize_t end,
+find_first_internal(const char *str, Py_ssize_t len,
+                    const char *function_name, PyObject *subobj,
+                    Py_ssize_t start, Py_ssize_t end,
                     int direction)
 {
     if (!PyTuple_Check(subobj)) {

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -603,6 +603,7 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
                 }
                 else {
                     sub_len = subbuf.len;
+                    PyBuffer_Release(&subbuf);
                 }
                 if (cur_end >= end - sub_len) { // Guard overflow
                     new_result = find_internal(str, len, function_name, subseq,

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -683,7 +683,6 @@ bytes_rfind_internal(const char *str, Py_ssize_t len,
     return find_internal(str, len, function_name, subobj, start, end, -1);
 }
 
-
 PyObject *
 _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
                 Py_ssize_t start, Py_ssize_t end)

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -557,6 +557,7 @@ find_internal(const char *str, Py_ssize_t len,
 }
 
 #define FIND_CHUNK_SIZE 10000
+#define RFIND_CHUNK_SIZE FIND_CHUNK_SIZE
 
 PyObject *
 _Py_bytes_find(const char *str, Py_ssize_t len, PyObject *subobj,
@@ -635,8 +636,8 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
         ADJUST_INDICES(start, end, len);
         // Work in chunks
         Py_ssize_t cur_end = end;
-        for (; result == -1 && cur_end >= start; cur_end -= FIND_CHUNK_SIZE) {
-            Py_ssize_t cur_start = cur_end - FIND_CHUNK_SIZE;
+        for (; result == -1 && cur_end >= start; cur_end -= RFIND_CHUNK_SIZE) {
+            Py_ssize_t cur_start = cur_end - RFIND_CHUNK_SIZE;
             if (cur_start < start) {
                 cur_start = start;
             }

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -591,6 +591,9 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
                     sub_len = subbuf.len;
                 }
                 Py_ssize_t sub_end = cur_end + sub_len;
+                if (sub_end > end) {
+                    sub_end = end;
+                }
                 Py_ssize_t new_result = find_internal(str, len, function_name,
                                                       subseq, start, sub_end,
                                                       +1);
@@ -631,6 +634,9 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
                     sub_len = subbuf.len;
                 }
                 Py_ssize_t sub_end = cur_end + sub_len;
+                if (sub_end > end) {
+                    sub_end = end;
+                }
                 Py_ssize_t new_result = find_internal(str, len, function_name,
                                                       subseq, cur_start,
                                                       sub_end, -1);

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -577,8 +577,12 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
         return find_internal(str, len, function_name, subseq, start, end,
                              direction);
     }
-    Py_ssize_t* sub_lengths = PyMem_RawMalloc(((size_t)tuple_len + 1) *
-                                              sizeof(wchar_t));
+    if ((size_t)tuple_len > (size_t)PY_SSIZE_T_MAX / sizeof(Py_ssize_t)) {
+        PyErr_SetString(PyExc_OverflowError, "tuple is too long");
+        return -2;
+    }
+    Py_ssize_t *sub_lengths = PyMem_RawMalloc(((size_t)tuple_len) *
+                                              sizeof(Py_ssize_t));
     if (!sub_lengths) {
         PyErr_NoMemory();
         return -2;

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -502,7 +502,7 @@ _Py_fast_find(const char *str, Py_ssize_t len,
               Py_ssize_t start, Py_ssize_t end,
               int direction)
 {
-    if (end - start < sub_len)
+    if (sub_len > end - start)
         return -1;
     else if (sub_len == 1) {
         Py_ssize_t result;

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -496,7 +496,7 @@ parse_args_finds_byte(const char *function_name, PyObject **subobj, char *byte)
         start = 0;                      \
     }
 
-Py_ssize_t
+static Py_ssize_t
 _Py_fast_find(const char *str, Py_ssize_t len,
               const char *sub, Py_ssize_t sub_len,
               Py_ssize_t start, Py_ssize_t end,

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -591,10 +591,12 @@ _Py_bytes_find(const char *str, Py_ssize_t len, PyObject *subobj,
                 if (new_result == -2) {
                     return NULL;
                 }
-                if (new_result != -1 &&
-                    (new_result < result || result == -1))
-                {
-                    result = cur_end = new_result;
+                if (new_result != -1) {
+                    if (new_result == start) {
+                        return start;
+                    }
+                    cur_end = new_result - 1;
+                    result = new_result;
                 }
             }
         }
@@ -661,8 +663,12 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
                 if (new_result == -2) {
                     return NULL;
                 }
-                if (new_result > result) {
-                    result = cur_start = new_result;
+                if (new_result != 1) {
+                    if (new_result == cur_end) {
+                        return cur_end;
+                    }
+                    cur_start = new_result + 1;
+                    result = new_result;
                 }
             }
         }

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -598,7 +598,6 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
 
     /* STORE SUBSTRINGS */
     ADJUST_INDICES(start, end, len);
-    Py_ssize_t slice_len = end - start;
     Py_ssize_t subs_len = 0;
     for (Py_ssize_t i = 0; i < tuple_len; i++) {
         Py_buffer subbuf;
@@ -622,7 +621,7 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
             sub = byte;
             sub_len = 1;
         }
-        if (sub_len > slice_len) {
+        if (sub_len > end - start) {
             continue;
         }
         subs[subs_len] = sub;

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -569,7 +569,7 @@ _Py_bytes_find(const char *str, Py_ssize_t len, PyObject *subobj,
         ADJUST_INDICES(start, end, len);
         // Work in chunks
         for (; result == -1 && start <= end; start += FIND_CHUNK_SIZE) {
-            Py_ssize_t cur_end = start + FIND_CHUNK_SIZE;
+            Py_ssize_t cur_end = start + FIND_CHUNK_SIZE - 1;
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *subseq = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_len;
@@ -637,7 +637,7 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
         // Work in chunks
         Py_ssize_t cur_end = end;
         for (; result == -1 && cur_end >= start; cur_end -= RFIND_CHUNK_SIZE) {
-            Py_ssize_t cur_start = cur_end - RFIND_CHUNK_SIZE;
+            Py_ssize_t cur_start = cur_end - RFIND_CHUNK_SIZE + 1;
             if (cur_start < start) {
                 cur_start = start;
             }

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -743,7 +743,9 @@ _Py_bytes_find(const char *str, Py_ssize_t len, PyObject *sub,
 {
     Py_ssize_t result = find_first_internal(str, len, "find", sub, start, end,
                                             +1);
-    return result == -2 ? NULL : PyLong_FromSsize_t(result);
+    if (result == -2)
+        return NULL;
+    return PyLong_FromSsize_t(result);
 }
 
 PyObject *
@@ -752,10 +754,14 @@ _Py_bytes_index(const char *str, Py_ssize_t len, PyObject *sub,
 {
     Py_ssize_t result = find_first_internal(str, len, "index", sub, start, end,
                                             +1);
+    if (result == -2)
+        return NULL;
     if (result == -1) {
-        PyErr_SetString(PyExc_ValueError, "subsection not found");
+        PyErr_SetString(PyExc_ValueError,
+                        "subsection not found");
+        return NULL;
     }
-    return result < 0 ? NULL : PyLong_FromSsize_t(result);
+    return PyLong_FromSsize_t(result);
 }
 
 PyObject *
@@ -764,7 +770,9 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *sub,
 {
     Py_ssize_t result = find_first_internal(str, len, "rfind", sub, start, end,
                                             -1);
-    return result == -2 ? NULL : PyLong_FromSsize_t(result);
+    if (result == -2)
+        return NULL;
+    return PyLong_FromSsize_t(result);
 }
 
 PyObject *
@@ -773,10 +781,14 @@ _Py_bytes_rindex(const char *str, Py_ssize_t len, PyObject *sub,
 {
     Py_ssize_t result = find_first_internal(str, len, "rindex", sub, start,
                                             end, -1);
+    if (result == -2)
+        return NULL;
     if (result == -1) {
-        PyErr_SetString(PyExc_ValueError, "subsection not found");
+        PyErr_SetString(PyExc_ValueError,
+                        "subsection not found");
+        return NULL;
     }
-    return result < 0 ? NULL : PyLong_FromSsize_t(result);
+    return PyLong_FromSsize_t(result);
 }
 
 PyObject *

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -593,7 +593,7 @@ find_first_internal(const char *str, Py_ssize_t len,
     result = -2; // Error
     tuple_len = PyTuple_GET_SIZE(subobj);
     if ((size_t)tuple_len > (size_t)PY_SSIZE_T_MAX / sizeof(char) ||
-        (size_t)tuple_len > (size_t)PY_SSIZE_T_MAX / sizeof(char*) ||
+        (size_t)tuple_len > (size_t)PY_SSIZE_T_MAX / sizeof(char *) ||
         (size_t)tuple_len > (size_t)PY_SSIZE_T_MAX / sizeof(Py_ssize_t))
     {
         PyErr_SetString(PyExc_OverflowError, "tuple is too long");
@@ -604,7 +604,7 @@ find_first_internal(const char *str, Py_ssize_t len,
         PyErr_NoMemory();
         goto exit;
     }
-    subs = PyMem_RawMalloc(((size_t)tuple_len) * sizeof(char*));
+    subs = PyMem_RawMalloc(((size_t)tuple_len) * sizeof(char *));
     if (!subs) {
         PyErr_NoMemory();
         goto exit;

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -663,7 +663,7 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
                 if (new_result == -2) {
                     return NULL;
                 }
-                if (new_result != 1) {
+                if (new_result != -1) {
                     if (new_result == cur_end) {
                         return PyLong_FromSsize_t(cur_end);
                     }

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -502,23 +502,29 @@ _Py_fast_find(const char *str, Py_ssize_t len,
               Py_ssize_t start, Py_ssize_t end,
               int direction)
 {
-    if (sub_len > end - start)
+    if (sub_len > end - start) {
         return -1;
+    }
     else if (sub_len == 1) {
         Py_ssize_t result;
-        if (direction > 0)
+        if (direction > 0) {
             result = stringlib_find_char(str + start, end - start, *sub);
-        else
+        }
+        else {
             result = stringlib_rfind_char(str + start, end - start, *sub);
-        if (result >= 0)
+        }
+        if (result >= 0) {
             result += start;
+        }
         return result;
     }
     else {
-        if (direction > 0)
+        if (direction > 0) {
             return stringlib_find_slice(str, len, sub, sub_len, start, end);
-        else
+        }
+        else {
             return stringlib_rfind_slice(str, len, sub, sub_len, start, end);
+        }
     }
 }
 

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -556,6 +556,8 @@ find_internal(const char *str, Py_ssize_t len,
     return res;
 }
 
+#define FIND_CHUNK_SIZE 10000
+
 PyObject *
 _Py_bytes_find(const char *str, Py_ssize_t len, PyObject *subobj,
                Py_ssize_t start, Py_ssize_t end)
@@ -564,9 +566,9 @@ _Py_bytes_find(const char *str, Py_ssize_t len, PyObject *subobj,
     if (PyTuple_Check(subobj)) {
         result = -1;
         ADJUST_INDICES(start, end, len);
-        // Work in batches of 10000
-        for (; result == -1 && start <= end; start += 10000) {
-            Py_ssize_t cur_end = start + 10000;
+        // Work in chunks
+        for (; result == -1 && start <= end; start += FIND_CHUNK_SIZE) {
+            Py_ssize_t cur_end = start + FIND_CHUNK_SIZE;
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *subseq = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_len;
@@ -631,10 +633,10 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
     if (PyTuple_Check(subobj)) {
         result = -1;
         ADJUST_INDICES(start, end, len);
-        // Work in batches of 10000
+        // Work in chunks
         Py_ssize_t cur_end = end;
-        for (; result == -1 && cur_end >= start; cur_end -= 10000) {
-            Py_ssize_t cur_start = cur_end - 10000;
+        for (; result == -1 && cur_end >= start; cur_end -= FIND_CHUNK_SIZE) {
+            Py_ssize_t cur_start = cur_end - FIND_CHUNK_SIZE;
             if (cur_start < start) {
                 cur_start = start;
             }

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -729,20 +729,20 @@ exit:
 }
 
 PyObject *
-_Py_bytes_find(const char *str, Py_ssize_t len, PyObject *subobj,
+_Py_bytes_find(const char *str, Py_ssize_t len, PyObject *sub,
                Py_ssize_t start, Py_ssize_t end)
 {
-    Py_ssize_t result = find_first_internal(str, len, "find", subobj, start,
-                                            end, +1);
+    Py_ssize_t result = find_first_internal(str, len, "find", sub, start, end,
+                                            +1);
     return result == -2 ? NULL : PyLong_FromSsize_t(result);
 }
 
 PyObject *
-_Py_bytes_index(const char *str, Py_ssize_t len, PyObject *subobj,
+_Py_bytes_index(const char *str, Py_ssize_t len, PyObject *sub,
                 Py_ssize_t start, Py_ssize_t end)
 {
-    Py_ssize_t result = find_first_internal(str, len, "index", subobj, start,
-                                            end, +1);
+    Py_ssize_t result = find_first_internal(str, len, "index", sub, start, end,
+                                            +1);
     if (result == -1) {
         PyErr_SetString(PyExc_ValueError, "subsection not found");
     }
@@ -750,19 +750,19 @@ _Py_bytes_index(const char *str, Py_ssize_t len, PyObject *subobj,
 }
 
 PyObject *
-_Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
+_Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *sub,
                 Py_ssize_t start, Py_ssize_t end)
 {
-    Py_ssize_t result = find_first_internal(str, len, "rfind", subobj, start,
-                                            end, -1);
+    Py_ssize_t result = find_first_internal(str, len, "rfind", sub, start, end,
+                                            -1);
     return result == -2 ? NULL : PyLong_FromSsize_t(result);
 }
 
 PyObject *
-_Py_bytes_rindex(const char *str, Py_ssize_t len, PyObject *subobj,
+_Py_bytes_rindex(const char *str, Py_ssize_t len, PyObject *sub,
                  Py_ssize_t start, Py_ssize_t end)
 {
-    Py_ssize_t result = find_first_internal(str, len, "rindex", subobj, start,
+    Py_ssize_t result = find_first_internal(str, len, "rindex", sub, start,
                                             end, -1);
     if (result == -1) {
         PyErr_SetString(PyExc_ValueError, "subsection not found");

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -568,6 +568,15 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
         return find_internal(str, len, function_name, subobj, start, end,
                              direction);
     }
+    Py_ssize_t tuple_len = PyTuple_GET_SIZE(subobj);
+    if (tuple_len == 0) {
+        return -1;
+    }
+    if (tuple_len == 1) {
+        PyObject *subseq = PyTuple_GET_ITEM(subobj, 0);
+        return find_internal(str, len, function_name, subseq, start, end,
+                             direction);
+    }
     Py_ssize_t result = -1;
     ADJUST_INDICES(start, end, len);
     // Work in chunks
@@ -575,7 +584,7 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
         assert(FIND_CHUNK_SIZE > 0);
         for (; result == -1 && start <= end; start += FIND_CHUNK_SIZE) {
             Py_ssize_t cur_end = start + FIND_CHUNK_SIZE - 1;
-            for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
+            for (Py_ssize_t i = 0; i < tuple_len; i++) {
                 PyObject *subseq = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_len;
                 Py_buffer subbuf;
@@ -618,7 +627,7 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
             if (cur_start < start) {
                 cur_start = start;
             }
-            for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
+            for (Py_ssize_t i = 0; i < tuple_len; i++) {
                 PyObject *subseq = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_len;
                 Py_buffer subbuf;

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -630,6 +630,10 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
         ADJUST_INDICES(start, end, len);
         // Work in batches of 10000
         for (; result == -1 && end >= start; end -= 10000) {
+            Py_ssize_t cur_start = end - 10000;
+            if (cur_start < start) {
+                cur_start = start;
+            }
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *subseq = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sublen;
@@ -645,13 +649,13 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
                 else {
                     sublen = subbuf.len;
                 }
-                Py_ssize_t cur_start = end - 10000 - sublen;
-                if (cur_start < start) {
-                    cur_start = start;
+                Py_ssize_t cur_end = end + sublen;
+                if (cur_end > end) {
+                    cur_end = end;
                 }
                 Py_ssize_t new_result = find_internal(str, len, "rfind",
-                                                      subseq, cur_start, end,
-                                                      -1);
+                                                      subseq, cur_start,
+                                                      cur_end, -1);
                 if (new_result == -2) {
                     return NULL;
                 }

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -627,12 +627,11 @@ find_first_internal(const char *str, Py_ssize_t len, const char *function_name,
             sub = byte;
             sub_len = 1;
         }
-        if (sub_len > end - start) {
-            continue;
+        if (sub_len <= end - start) {
+            subs[subs_len] = sub;
+            sub_lengths[subs_len] = sub_len;
+            subs_len++;
         }
-        subs[subs_len] = sub;
-        sub_lengths[subs_len] = sub_len;
-        subs_len++;
     }
 
     /* FIND SUBSTRINGS */

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -584,7 +584,7 @@ find_first_internal(const char *str, Py_ssize_t len,
         return find_internal(str, len, function_name, subobj, start, end,
                              direction);
     }
-    Py_ssize_t result, tuple_len, subs_len;
+    Py_ssize_t result, buffers_len, tuple_len, subs_len;
     char *bytes = NULL;
     Py_buffer *buffers = NULL;
     const char **subs = NULL;
@@ -592,6 +592,7 @@ find_first_internal(const char *str, Py_ssize_t len,
 
     /* ALLOCATE MEMORY */
     result = -2; // Error
+    buffers_len = 0;
     tuple_len = PyTuple_GET_SIZE(subobj);
     if ((size_t)tuple_len > (size_t)PY_SSIZE_T_MAX / sizeof(char) ||
         (size_t)tuple_len > (size_t)PY_SSIZE_T_MAX / sizeof(Py_buffer) ||
@@ -633,7 +634,7 @@ find_first_internal(const char *str, Py_ssize_t len,
 
         subseq = PyTuple_GET_ITEM(subobj, i);
         byte = &bytes[subs_len];
-        buffer = &buffers[i];
+        buffer = &buffers[buffers_len];
         if (!parse_args_finds_byte(function_name, &subseq, byte)) {
             goto exit;
         }
@@ -643,6 +644,7 @@ find_first_internal(const char *str, Py_ssize_t len,
             }
             sub = buffer->buf;
             sub_len = buffer->len;
+            buffers_len++;
         }
         else {
             sub = byte;
@@ -740,7 +742,7 @@ find_first_internal(const char *str, Py_ssize_t len,
 exit:
     PyMem_RawFree(bytes);
     if (buffers) {
-        for (Py_ssize_t i = 0; i < tuple_len; i++) {
+        for (Py_ssize_t i = 0; i < buffers_len; i++) {
             PyBuffer_Release(&buffers[i]);
         }
     }

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -564,8 +564,8 @@ _Py_bytes_find(const char *str, Py_ssize_t len, PyObject *subobj,
     if (PyTuple_Check(subobj)) {
         result = -1;
         for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
-            PyObject *subbytes = PyTuple_GET_ITEM(subobj, i);
-            Py_ssize_t new_result = find_internal(str, len, "find", subbytes,
+            PyObject *subseq = PyTuple_GET_ITEM(subobj, i);
+            Py_ssize_t new_result = find_internal(str, len, "find", subseq,
                                                   start, end, +1);
             if (new_result == -2) {
                 return NULL;
@@ -605,8 +605,8 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
     if (PyTuple_Check(subobj)) {
         result = -1;
         for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
-            PyObject *subbytes = PyTuple_GET_ITEM(subobj, i);
-            Py_ssize_t new_result = find_internal(str, len, "rfind", subbytes,
+            PyObject *subseq = PyTuple_GET_ITEM(subobj, i);
+            Py_ssize_t new_result = find_internal(str, len, "rfind", subseq,
                                                   start, end, -1);
             if (new_result == -2) {
                 return NULL;

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -581,12 +581,12 @@ _Py_bytes_find(const char *str, Py_ssize_t len, PyObject *subobj,
                 else {
                     sublen = subbuf.len;
                 }
-                Py_ssize_t cur_end = start + 10000 + sublen;
-                if (cur_end > end) {
-                    cur_end = end;
+                Py_ssize_t sub_end = start + 10000 + sublen;
+                if (sub_end > end) {
+                    sub_end = end;
                 }
                 Py_ssize_t new_result = find_internal(str, len, "find", subseq,
-                                                      start, cur_end, +1);
+                                                      start, sub_end, +1);
                 if (new_result == -2) {
                     return NULL;
                 }
@@ -629,10 +629,11 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
         result = -1;
         ADJUST_INDICES(start, end, len);
         // Work in batches of 10000
-        for (; result == -1 && end >= start; end -= 10000) {
-            Py_ssize_t cur_start = end - 10000;
-            if (cur_start < start) {
-                cur_start = start;
+        Py_ssize_t cur_end = end;
+        for (; result == -1 && cur_end >= start; cur_end -= 10000) {
+            Py_ssize_t sub_start = end - 10000;
+            if (sub_start < start) {
+                sub_start = start;
             }
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *subseq = PyTuple_GET_ITEM(subobj, i);
@@ -649,13 +650,13 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
                 else {
                     sublen = subbuf.len;
                 }
-                Py_ssize_t cur_end = end + sublen;
-                if (cur_end > end) {
-                    cur_end = end;
+                Py_ssize_t sub_end = cur_end + sublen;
+                if (sub_end > end) {
+                    sub_end = end;
                 }
                 Py_ssize_t new_result = find_internal(str, len, "rfind",
-                                                      subseq, cur_start,
-                                                      cur_end, -1);
+                                                      subseq, sub_start,
+                                                      sub_end, -1);
                 if (new_result == -2) {
                     return NULL;
                 }

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -593,7 +593,7 @@ _Py_bytes_find(const char *str, Py_ssize_t len, PyObject *subobj,
                 }
                 if (new_result != -1) {
                     if (new_result == start) {
-                        return start;
+                        return PyLong_FromSsize_t(start);
                     }
                     cur_end = new_result - 1;
                     result = new_result;
@@ -665,7 +665,7 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *subobj,
                 }
                 if (new_result != 1) {
                     if (new_result == cur_end) {
-                        return cur_end;
+                        return PyLong_FromSsize_t(cur_end);
                     }
                     cur_start = new_result + 1;
                     result = new_result;

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -357,7 +357,7 @@ exit:
 }
 
 PyDoc_STRVAR(unicode_find__doc__,
-"find($self, sub[, start[, end]], /)\n"
+"find($self, sub, start=None, end=None, /)\n"
 "--\n"
 "\n"
 "Return the lowest index in S where substring sub is found, such that sub is contained within S[start:end].\n"
@@ -369,14 +369,14 @@ PyDoc_STRVAR(unicode_find__doc__,
     {"find", _PyCFunction_CAST(unicode_find), METH_FASTCALL, unicode_find__doc__},
 
 static Py_ssize_t
-unicode_find_impl(PyObject *str, PyObject *substr, Py_ssize_t start,
+unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                   Py_ssize_t end);
 
 static PyObject *
 unicode_find(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *substr;
+    PyObject *subobj;
     Py_ssize_t start = 0;
     Py_ssize_t end = PY_SSIZE_T_MAX;
     Py_ssize_t _return_value;
@@ -384,11 +384,7 @@ unicode_find(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("find", nargs, 1, 3)) {
         goto exit;
     }
-    if (!PyUnicode_Check(args[0])) {
-        _PyArg_BadArgument("find", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    substr = args[0];
+    subobj = args[0];
     if (nargs < 2) {
         goto skip_optional;
     }
@@ -402,7 +398,7 @@ unicode_find(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
 skip_optional:
-    _return_value = unicode_find_impl(str, substr, start, end);
+    _return_value = unicode_find_impl(str, subobj, start, end);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -1060,7 +1056,7 @@ exit:
 }
 
 PyDoc_STRVAR(unicode_rfind__doc__,
-"rfind($self, sub[, start[, end]], /)\n"
+"rfind($self, sub, start=None, end=None, /)\n"
 "--\n"
 "\n"
 "Return the highest index in S where substring sub is found, such that sub is contained within S[start:end].\n"
@@ -1072,14 +1068,14 @@ PyDoc_STRVAR(unicode_rfind__doc__,
     {"rfind", _PyCFunction_CAST(unicode_rfind), METH_FASTCALL, unicode_rfind__doc__},
 
 static Py_ssize_t
-unicode_rfind_impl(PyObject *str, PyObject *substr, Py_ssize_t start,
+unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                    Py_ssize_t end);
 
 static PyObject *
 unicode_rfind(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *substr;
+    PyObject *subobj;
     Py_ssize_t start = 0;
     Py_ssize_t end = PY_SSIZE_T_MAX;
     Py_ssize_t _return_value;
@@ -1087,11 +1083,7 @@ unicode_rfind(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("rfind", nargs, 1, 3)) {
         goto exit;
     }
-    if (!PyUnicode_Check(args[0])) {
-        _PyArg_BadArgument("rfind", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    substr = args[0];
+    subobj = args[0];
     if (nargs < 2) {
         goto skip_optional;
     }
@@ -1105,7 +1097,7 @@ unicode_rfind(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
 skip_optional:
-    _return_value = unicode_rfind_impl(str, substr, start, end);
+    _return_value = unicode_rfind_impl(str, subobj, start, end);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -1888,4 +1880,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=9fee62bd337f809b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1db638aa49eefba8 input=a9049054013a1b77]*/

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -409,7 +409,7 @@ exit:
 }
 
 PyDoc_STRVAR(unicode_index__doc__,
-"index($self, sub[, start[, end]], /)\n"
+"index($self, sub, start=None, end=None, /)\n"
 "--\n"
 "\n"
 "Return the lowest index in S where substring sub is found, such that sub is contained within S[start:end].\n"
@@ -421,14 +421,14 @@ PyDoc_STRVAR(unicode_index__doc__,
     {"index", _PyCFunction_CAST(unicode_index), METH_FASTCALL, unicode_index__doc__},
 
 static Py_ssize_t
-unicode_index_impl(PyObject *str, PyObject *substr, Py_ssize_t start,
+unicode_index_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                    Py_ssize_t end);
 
 static PyObject *
 unicode_index(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *substr;
+    PyObject *subobj;
     Py_ssize_t start = 0;
     Py_ssize_t end = PY_SSIZE_T_MAX;
     Py_ssize_t _return_value;
@@ -436,11 +436,7 @@ unicode_index(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("index", nargs, 1, 3)) {
         goto exit;
     }
-    if (!PyUnicode_Check(args[0])) {
-        _PyArg_BadArgument("index", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    substr = args[0];
+    subobj = args[0];
     if (nargs < 2) {
         goto skip_optional;
     }
@@ -454,7 +450,7 @@ unicode_index(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
 skip_optional:
-    _return_value = unicode_index_impl(str, substr, start, end);
+    _return_value = unicode_index_impl(str, subobj, start, end);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -1108,7 +1104,7 @@ exit:
 }
 
 PyDoc_STRVAR(unicode_rindex__doc__,
-"rindex($self, sub[, start[, end]], /)\n"
+"rindex($self, sub, start=None, end=None, /)\n"
 "--\n"
 "\n"
 "Return the highest index in S where substring sub is found, such that sub is contained within S[start:end].\n"
@@ -1120,14 +1116,14 @@ PyDoc_STRVAR(unicode_rindex__doc__,
     {"rindex", _PyCFunction_CAST(unicode_rindex), METH_FASTCALL, unicode_rindex__doc__},
 
 static Py_ssize_t
-unicode_rindex_impl(PyObject *str, PyObject *substr, Py_ssize_t start,
+unicode_rindex_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                     Py_ssize_t end);
 
 static PyObject *
 unicode_rindex(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *substr;
+    PyObject *subobj;
     Py_ssize_t start = 0;
     Py_ssize_t end = PY_SSIZE_T_MAX;
     Py_ssize_t _return_value;
@@ -1135,11 +1131,7 @@ unicode_rindex(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("rindex", nargs, 1, 3)) {
         goto exit;
     }
-    if (!PyUnicode_Check(args[0])) {
-        _PyArg_BadArgument("rindex", "argument 1", "str", args[0]);
-        goto exit;
-    }
-    substr = args[0];
+    subobj = args[0];
     if (nargs < 2) {
         goto skip_optional;
     }
@@ -1153,7 +1145,7 @@ unicode_rindex(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
 skip_optional:
-    _return_value = unicode_rindex_impl(str, substr, start, end);
+    _return_value = unicode_rindex_impl(str, subobj, start, end);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -1880,4 +1872,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=1db638aa49eefba8 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5fb071b9e4dc87fa input=a9049054013a1b77]*/

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -369,14 +369,14 @@ PyDoc_STRVAR(unicode_find__doc__,
     {"find", _PyCFunction_CAST(unicode_find), METH_FASTCALL, unicode_find__doc__},
 
 static Py_ssize_t
-unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
+unicode_find_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
                   Py_ssize_t end);
 
 static PyObject *
 unicode_find(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *subobj;
+    PyObject *sub;
     Py_ssize_t start = 0;
     Py_ssize_t end = PY_SSIZE_T_MAX;
     Py_ssize_t _return_value;
@@ -384,7 +384,7 @@ unicode_find(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("find", nargs, 1, 3)) {
         goto exit;
     }
-    subobj = args[0];
+    sub = args[0];
     if (nargs < 2) {
         goto skip_optional;
     }
@@ -398,7 +398,7 @@ unicode_find(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
 skip_optional:
-    _return_value = unicode_find_impl(str, subobj, start, end);
+    _return_value = unicode_find_impl(str, sub, start, end);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -421,14 +421,14 @@ PyDoc_STRVAR(unicode_index__doc__,
     {"index", _PyCFunction_CAST(unicode_index), METH_FASTCALL, unicode_index__doc__},
 
 static Py_ssize_t
-unicode_index_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
+unicode_index_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
                    Py_ssize_t end);
 
 static PyObject *
 unicode_index(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *subobj;
+    PyObject *sub;
     Py_ssize_t start = 0;
     Py_ssize_t end = PY_SSIZE_T_MAX;
     Py_ssize_t _return_value;
@@ -436,7 +436,7 @@ unicode_index(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("index", nargs, 1, 3)) {
         goto exit;
     }
-    subobj = args[0];
+    sub = args[0];
     if (nargs < 2) {
         goto skip_optional;
     }
@@ -450,7 +450,7 @@ unicode_index(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
 skip_optional:
-    _return_value = unicode_index_impl(str, subobj, start, end);
+    _return_value = unicode_index_impl(str, sub, start, end);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -1064,14 +1064,14 @@ PyDoc_STRVAR(unicode_rfind__doc__,
     {"rfind", _PyCFunction_CAST(unicode_rfind), METH_FASTCALL, unicode_rfind__doc__},
 
 static Py_ssize_t
-unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
+unicode_rfind_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
                    Py_ssize_t end);
 
 static PyObject *
 unicode_rfind(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *subobj;
+    PyObject *sub;
     Py_ssize_t start = 0;
     Py_ssize_t end = PY_SSIZE_T_MAX;
     Py_ssize_t _return_value;
@@ -1079,7 +1079,7 @@ unicode_rfind(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("rfind", nargs, 1, 3)) {
         goto exit;
     }
-    subobj = args[0];
+    sub = args[0];
     if (nargs < 2) {
         goto skip_optional;
     }
@@ -1093,7 +1093,7 @@ unicode_rfind(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
 skip_optional:
-    _return_value = unicode_rfind_impl(str, subobj, start, end);
+    _return_value = unicode_rfind_impl(str, sub, start, end);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -1116,14 +1116,14 @@ PyDoc_STRVAR(unicode_rindex__doc__,
     {"rindex", _PyCFunction_CAST(unicode_rindex), METH_FASTCALL, unicode_rindex__doc__},
 
 static Py_ssize_t
-unicode_rindex_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
+unicode_rindex_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
                     Py_ssize_t end);
 
 static PyObject *
 unicode_rindex(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
-    PyObject *subobj;
+    PyObject *sub;
     Py_ssize_t start = 0;
     Py_ssize_t end = PY_SSIZE_T_MAX;
     Py_ssize_t _return_value;
@@ -1131,7 +1131,7 @@ unicode_rindex(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
     if (!_PyArg_CheckPositional("rindex", nargs, 1, 3)) {
         goto exit;
     }
-    subobj = args[0];
+    sub = args[0];
     if (nargs < 2) {
         goto skip_optional;
     }
@@ -1145,7 +1145,7 @@ unicode_rindex(PyObject *str, PyObject *const *args, Py_ssize_t nargs)
         goto exit;
     }
 skip_optional:
-    _return_value = unicode_rindex_impl(str, subobj, start, end);
+    _return_value = unicode_rindex_impl(str, sub, start, end);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -1872,4 +1872,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5fb071b9e4dc87fa input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fb38686a525c786a input=a9049054013a1b77]*/

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9155,7 +9155,11 @@ any_find_first_slice(PyObject *str, const char *function_name,
         }
         return any_find_slice(str, subobj, start, end, direction);
     }
-    for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
+    Py_ssize_t tuple_len = PyTuple_GET_SIZE(subobj);
+    if (tuple_len == 0) {
+        return -1;
+    }
+    for (Py_ssize_t i = 0; i < tuple_len; i++) {
         PyObject *substr = PyTuple_GET_ITEM(subobj, i);
         if (!PyUnicode_Check(substr)) {
             PyErr_Format(PyExc_TypeError,
@@ -9165,6 +9169,10 @@ any_find_first_slice(PyObject *str, const char *function_name,
             return -2;
         }
     }
+    if (tuple_len == 1) {
+        PyObject *substr = PyTuple_GET_ITEM(subobj, 0);
+        return any_find_slice(str, substr, start, end, direction);
+    }
     Py_ssize_t result = -1;
     Py_ssize_t len = PyUnicode_GET_LENGTH(str);
     ADJUST_INDICES(start, end, len);
@@ -9173,7 +9181,7 @@ any_find_first_slice(PyObject *str, const char *function_name,
         assert(FIND_CHUNK_SIZE > 0);
         for (; result == -1 && start <= end; start += FIND_CHUNK_SIZE) {
             Py_ssize_t cur_end = start + FIND_CHUNK_SIZE - 1;
-            for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
+            for (Py_ssize_t i = 0; i < tuple_len; i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
                 if (sub_end > end) {
@@ -9199,7 +9207,7 @@ any_find_first_slice(PyObject *str, const char *function_name,
             if (cur_start < start) {
                 cur_start = start;
             }
-            for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
+            for (Py_ssize_t i = 0; i < tuple_len; i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
                 if (sub_end > end) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9231,8 +9231,8 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
         sub_kind = PyUnicode_KIND(substr);
         sub_isascii = PyUnicode_IS_ASCII(substr);
         sub_len = PyUnicode_GET_LENGTH(substr);
-        if (!(sub_kind > kind || !sub_isascii && isascii ||
-              sub_len > end - start))
+        if (sub_kind <= kind && (sub_isascii || !isascii) &&
+            sub_len <= end - start)
         {
             subs[subs_len] = PyUnicode_DATA(substr);
             sub_kinds[subs_len] = sub_kind;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -11555,7 +11555,7 @@ unicode_expandtabs_impl(PyObject *self, int tabsize)
 str.find as unicode_find -> Py_ssize_t
 
     self as str: self
-    sub as subobj: object
+    sub: object
     start: slice_index(accept={int, NoneType}, c_default='0') = None
     end: slice_index(accept={int, NoneType}, c_default='PY_SSIZE_T_MAX') = None
     /
@@ -11567,12 +11567,11 @@ Return -1 on failure.
 [clinic start generated code]*/
 
 static Py_ssize_t
-unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
+unicode_find_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
                   Py_ssize_t end)
-/*[clinic end generated code: output=80175735a6d549d0 input=51e7b530950ab304]*/
+/*[clinic end generated code: output=da52b0913b08a960 input=a236fecd6e36a36a]*/
 {
-    Py_ssize_t result = any_find_first_slice(str, "find", subobj, start, end,
-                                             +1);
+    Py_ssize_t result = any_find_first_slice(str, "find", sub, start, end, +1);
     return result < 0 ? -1 : result;
 }
 
@@ -11626,11 +11625,11 @@ Raises ValueError when the substring is not found.
 [clinic start generated code]*/
 
 static Py_ssize_t
-unicode_index_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
+unicode_index_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
                    Py_ssize_t end)
-/*[clinic end generated code: output=c9af24adf2f1f99e input=f0033cf1698b6108]*/
+/*[clinic end generated code: output=4f3129c11e833e01 input=f0033cf1698b6108]*/
 {
-    Py_ssize_t result = any_find_first_slice(str, "index", subobj, start, end,
+    Py_ssize_t result = any_find_first_slice(str, "index", sub, start, end,
                                              +1);
     if (result == -1) {
         PyErr_SetString(PyExc_ValueError, "substring not found");
@@ -12725,11 +12724,11 @@ Return -1 on failure.
 [clinic start generated code]*/
 
 static Py_ssize_t
-unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
+unicode_rfind_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
                    Py_ssize_t end)
-/*[clinic end generated code: output=9d316eee7b9f9bf0 input=23ae7964e8f70b35]*/
+/*[clinic end generated code: output=0576fddc53b8616e input=23ae7964e8f70b35]*/
 {
-    Py_ssize_t result = any_find_first_slice(str, "rfind", subobj, start, end,
+    Py_ssize_t result = any_find_first_slice(str, "rfind", sub, start, end,
                                              -1);
     return result < 0 ? -1 : result;
 }
@@ -12744,11 +12743,11 @@ Raises ValueError when the substring is not found.
 [clinic start generated code]*/
 
 static Py_ssize_t
-unicode_rindex_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
+unicode_rindex_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
                     Py_ssize_t end)
-/*[clinic end generated code: output=847d553d0dc10a86 input=990f3925b149c1bc]*/
+/*[clinic end generated code: output=137ad2933d200f38 input=990f3925b149c1bc]*/
 {
-    Py_ssize_t result = any_find_first_slice(str, "rindex", subobj, start, end,
+    Py_ssize_t result = any_find_first_slice(str, "rindex", sub, start, end,
                                              -1);
     if (result == -1) {
         PyErr_SetString(PyExc_ValueError, "substring not found");

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12588,7 +12588,7 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                 }
                 Py_ssize_t new_result = any_find_slice(str, substr, cur_start,
                                                        sub_end, -1);
-                if (new_result != 1) {
+                if (new_result != -1) {
                     if (new_result == cur_end) {
                         return cur_end;
                     }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9177,7 +9177,7 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
         }
         return any_find_slice(strobj, subobj, start, end, direction);
     }
-    Py_ssize_t result, tuple_len, len, subs_len;
+    Py_ssize_t result, subs_len, tuple_len, len;
     const void **heap_subs = NULL, **subs = NULL;
     int *sub_kinds = NULL;
     Py_ssize_t *sub_lens = NULL;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9248,6 +9248,9 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
                 }
                 heap_subs[subs_len] = sub;
             }
+            else {
+                heap_subs[subs_len] = NULL;
+            }
             subs[subs_len] = sub;
             sub_kinds[subs_len] = sub_kind;
             sub_lens[subs_len] = sub_len;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9137,7 +9137,7 @@ any_find_slice(PyObject* s1, PyObject* s2,
     return result;
 }
 
-#define FIND_CHUNK_SIZE 10000
+#define FIND_CHUNK_SIZE 1000
 #define RFIND_CHUNK_SIZE FIND_CHUNK_SIZE
 
 static Py_ssize_t

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9219,7 +9219,6 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
     for (Py_ssize_t i = 0; i < tuple_len; i++) {
         PyObject *substr;
         int sub_kind, sub_isascii;
-        const void *sub;
         Py_ssize_t sub_len;
 
         substr = PyTuple_GET_ITEM(subobj, i);
@@ -9230,17 +9229,12 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
             goto exit;
         }
         sub_kind = PyUnicode_KIND(substr);
-        if (sub_kind > kind) {
-            continue;
-        }
         sub_isascii = PyUnicode_IS_ASCII(substr);
-        if (!sub_isascii && isascii) {
-            continue;
-        }
-        sub = PyUnicode_DATA(substr);
         sub_len = PyUnicode_GET_LENGTH(substr);
-        if (sub_len <= end - start) {
-            subs[subs_len] = sub;
+        if (!(sub_kind > kind || !sub_isascii && isascii ||
+              sub_len > end - start))
+        {
+            subs[subs_len] = PyUnicode_DATA(substr);
             sub_kinds[subs_len] = sub_kind;
             sub_lens[subs_len] = sub_len;
             subs_len++;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -11373,12 +11373,12 @@ unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sublen = PyUnicode_GET_LENGTH(substr);
-                Py_ssize_t cur_end = start + 10000 + sublen;
-                if (cur_end > end) {
-                    cur_end = end;
+                Py_ssize_t sub_end = start + 10000 + sublen;
+                if (sub_end > end) {
+                    sub_end = end;
                 }
                 Py_ssize_t new_result = any_find_slice(str, substr, start,
-                                                       cur_end, 1);
+                                                       sub_end, 1);
                 if (new_result != -1 &&
                     (new_result < result || result == -1))
                 {
@@ -12572,19 +12572,20 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
         Py_ssize_t len = PyUnicode_GET_LENGTH(str);
         ADJUST_INDICES(start, end, len);
         // Work in batches of 10000
-        for (; result == -1 && end >= start; end -= 10000) {
-            Py_ssize_t cur_start = end - 10000;
-            if (cur_start < start) {
-                cur_start = start;
+        Py_ssize_t cur_end = end;
+        for (; result == -1 && cur_end >= start; cur_end -= 10000) {
+            Py_ssize_t sub_start = end - 10000;
+            if (sub_start < start) {
+                sub_start = start;
             }
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
-                Py_ssize_t cur_end = end + PyUnicode_GET_LENGTH(substr);
-                if (cur_end > end) {
-                    cur_end = end;
+                Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
+                if (sub_end > end) {
+                    sub_end = end;
                 }
-                Py_ssize_t new_result = any_find_slice(str, substr, cur_start,
-                                                       cur_end, -1);
+                Py_ssize_t new_result = any_find_slice(str, substr, sub_start,
+                                                       sub_end, -1);
                 if (new_result > result) {
                     result = new_result;
                 }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -11334,6 +11334,7 @@ unicode_expandtabs_impl(PyObject *self, int tabsize)
 }
 
 #define FIND_CHUNK_SIZE 10000
+#define RFIND_CHUNK_SIZE FIND_CHUNK_SIZE
 
 /*[clinic input]
 str.find as unicode_find -> Py_ssize_t
@@ -12577,8 +12578,8 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
         ADJUST_INDICES(start, end, len);
         // Work in chunks
         Py_ssize_t cur_end = end;
-        for (; result == -1 && cur_end >= start; cur_end -= FIND_CHUNK_SIZE) {
-            Py_ssize_t cur_start = cur_end - FIND_CHUNK_SIZE;
+        for (; result == -1 && cur_end >= start; cur_end -= RFIND_CHUNK_SIZE) {
+            Py_ssize_t cur_start = cur_end - RFIND_CHUNK_SIZE;
             if (cur_start < start) {
                 cur_start = start;
             }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9176,9 +9176,6 @@ any_find_first_slice(PyObject *str, const char *function_name,
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
-                if (sub_end > end) {
-                    sub_end = end;
-                }
                 Py_ssize_t new_result = any_find_slice(str, substr, start,
                                                        sub_end, +1);
                 if (new_result != -1) {
@@ -9202,9 +9199,6 @@ any_find_first_slice(PyObject *str, const char *function_name,
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
-                if (sub_end > end) {
-                    sub_end = end;
-                }
                 Py_ssize_t new_result = any_find_slice(str, substr, cur_start,
                                                        sub_end, -1);
                 if (new_result != -1) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9134,27 +9134,28 @@ any_find_slice(PyObject* s1, PyObject* s2,
 {
     int kind1, kind2, isascii1, isascii2;
     const void *buf1, *buf2;
-    Py_ssize_t len1, len2;
+    Py_ssize_t len1, len2, result;
 
     kind1 = PyUnicode_KIND(s1);
     kind2 = PyUnicode_KIND(s2);
-    if (kind2 > kind1) {
+    if (kind2 > kind1)
         return -1;
-    }
 
     isascii1 = PyUnicode_IS_ASCII(s1);
     isascii2 = PyUnicode_IS_ASCII(s2);
-    if (!isascii2 && isascii1) {
+    if (!isascii2 && isascii1)
         return -1;
-    }
 
-    buf1 = PyUnicode_DATA(s1);
-    buf2 = PyUnicode_DATA(s2);
     len1 = PyUnicode_GET_LENGTH(s1);
     len2 = PyUnicode_GET_LENGTH(s2);
     ADJUST_INDICES(start, end, len1);
-    return fast_find(buf1, kind1, len1, buf2, kind2, len2, start, end,
-                     isascii1, direction);
+
+    buf1 = PyUnicode_DATA(s1);
+    buf2 = PyUnicode_DATA(s2);
+    result = fast_find(buf1, kind1, len1, buf2, kind2, len2, start, end,
+                       isascii1, direction);
+
+    return result;
 }
 
 #define FIND_CHUNK_SIZE 1000

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9346,10 +9346,7 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
 exit:
     if (heap_subs) {
         for (Py_ssize_t i = 0; i < subs_len; i++) {
-            void *heap_sub = heap_subs[i];
-            if (heap_sub) {
-                PyMem_Free(heap_sub);
-            }
+            PyMem_Free((void *)heap_subs[i]);
         }
     }
     PyMem_RawFree(heap_subs);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9170,6 +9170,7 @@ any_find_first_slice(PyObject *str, const char *function_name,
     ADJUST_INDICES(start, end, len);
     // Work in chunks
     if (direction > 0) {
+        assert(FIND_CHUNK_SIZE > 0);
         for (; result == -1 && start <= end; start += FIND_CHUNK_SIZE) {
             Py_ssize_t cur_end = start + FIND_CHUNK_SIZE - 1;
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
@@ -9192,6 +9193,7 @@ any_find_first_slice(PyObject *str, const char *function_name,
     }
     else {
         Py_ssize_t cur_end = end;
+        assert(RFIND_CHUNK_SIZE > 0);
         for (; result == -1 && cur_end >= start; cur_end -= RFIND_CHUNK_SIZE) {
             Py_ssize_t cur_start = cur_end - RFIND_CHUNK_SIZE + 1;
             if (cur_start < start) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9137,6 +9137,87 @@ any_find_slice(PyObject* s1, PyObject* s2,
     return result;
 }
 
+#define FIND_CHUNK_SIZE 10000
+#define RFIND_CHUNK_SIZE FIND_CHUNK_SIZE
+
+static Py_ssize_t
+any_find_first_slice(PyObject *str, const char *function_name,
+                     PyObject *subobj, Py_ssize_t start, Py_ssize_t end,
+                     int direction)
+{
+    if (!PyTuple_Check(subobj)) {
+        if (!PyUnicode_Check(subobj)) {
+            PyErr_Format(PyExc_TypeError,
+                        "find %.200s arg must be str or "
+                        "a tuple of str, not %.100s", function_name,
+                        Py_TYPE(subobj)->tp_name);
+            return -2;
+        }
+        return any_find_slice(str, subobj, start, end, direction);
+    }
+    for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
+        PyObject *substr = PyTuple_GET_ITEM(subobj, i);
+        if (!PyUnicode_Check(substr)) {
+            PyErr_Format(PyExc_TypeError,
+                        "tuple for %.200s must only contain str, "
+                        "not %.100s", function_name,
+                        Py_TYPE(substr)->tp_name);
+            return -2;
+        }
+    }
+    Py_ssize_t result = -1;
+    Py_ssize_t len = PyUnicode_GET_LENGTH(str);
+    ADJUST_INDICES(start, end, len);
+    // Work in chunks
+    if (direction > 0) {
+        for (; result == -1 && start <= end; start += FIND_CHUNK_SIZE) {
+            Py_ssize_t cur_end = start + FIND_CHUNK_SIZE - 1;
+            for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
+                PyObject *substr = PyTuple_GET_ITEM(subobj, i);
+                Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
+                if (sub_end > end) {
+                    sub_end = end;
+                }
+                Py_ssize_t new_result = any_find_slice(str, substr, start,
+                                                       sub_end, +1);
+                if (new_result != -1) {
+                    if (new_result == start) {
+                        return start;
+                    }
+                    cur_end = new_result - 1;
+                    result = new_result;
+                }
+            }
+        }
+    }
+    else {
+        Py_ssize_t cur_end = end;
+        for (; result == -1 && cur_end >= start; cur_end -= RFIND_CHUNK_SIZE) {
+            Py_ssize_t cur_start = cur_end - RFIND_CHUNK_SIZE + 1;
+            if (cur_start < start) {
+                cur_start = start;
+            }
+            for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
+                PyObject *substr = PyTuple_GET_ITEM(subobj, i);
+                Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
+                if (sub_end > end) {
+                    sub_end = end;
+                }
+                Py_ssize_t new_result = any_find_slice(str, substr, cur_start,
+                                                       sub_end, -1);
+                if (new_result != -1) {
+                    if (new_result == cur_end) {
+                        return cur_end;
+                    }
+                    cur_start = new_result + 1;
+                    result = new_result;
+                }
+            }
+        }
+    }
+    return result;
+}
+
 /* _PyUnicode_InsertThousandsGrouping() helper functions */
 #include "stringlib/localeutil.h"
 
@@ -11333,59 +11414,6 @@ unicode_expandtabs_impl(PyObject *self, int tabsize)
     return NULL;
 }
 
-#define FIND_CHUNK_SIZE 10000
-#define RFIND_CHUNK_SIZE FIND_CHUNK_SIZE
-
-static Py_ssize_t
-unicode_find_internal(PyObject *str, const char *function_name,
-                      PyObject *subobj, Py_ssize_t start, Py_ssize_t end)
-{
-    if (PyTuple_Check(subobj)) {
-        for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
-            PyObject *substr = PyTuple_GET_ITEM(subobj, i);
-            if (!PyUnicode_Check(substr)) {
-                PyErr_Format(PyExc_TypeError,
-                            "tuple for %.200s must only contain str, "
-                            "not %.100s", function_name,
-                            Py_TYPE(substr)->tp_name);
-                return -2;
-            }
-        }
-        Py_ssize_t result = -1;
-        Py_ssize_t len = PyUnicode_GET_LENGTH(str);
-        ADJUST_INDICES(start, end, len);
-        // Work in chunks
-        for (; result == -1 && start <= end; start += FIND_CHUNK_SIZE) {
-            Py_ssize_t cur_end = start + FIND_CHUNK_SIZE - 1;
-            for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
-                PyObject *substr = PyTuple_GET_ITEM(subobj, i);
-                Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
-                if (sub_end > end) {
-                    sub_end = end;
-                }
-                Py_ssize_t new_result = any_find_slice(str, substr, start,
-                                                       sub_end, 1);
-                if (new_result != -1) {
-                    if (new_result == start) {
-                        return start;
-                    }
-                    cur_end = new_result - 1;
-                    result = new_result;
-                }
-            }
-        }
-        return result;
-    }
-    if (!PyUnicode_Check(subobj)) {
-        PyErr_Format(PyExc_TypeError,
-                     "find %.200s arg must be str or "
-                     "a tuple of str, not %.100s", function_name,
-                     Py_TYPE(subobj)->tp_name);
-        return -2;
-    }
-    return any_find_slice(str, subobj, start, end, 1);
-}
-
 /*[clinic input]
 str.find as unicode_find -> Py_ssize_t
 
@@ -11406,7 +11434,8 @@ unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                   Py_ssize_t end)
 /*[clinic end generated code: output=80175735a6d549d0 input=51e7b530950ab304]*/
 {
-    Py_ssize_t result = unicode_find_internal(str, "find", subobj, start, end);
+    Py_ssize_t result = any_find_first_slice(str, "find", subobj, start, end,
+                                             +1);
     return result < 0 ? -1 : result;
 }
 
@@ -11464,8 +11493,8 @@ unicode_index_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                    Py_ssize_t end)
 /*[clinic end generated code: output=c9af24adf2f1f99e input=f0033cf1698b6108]*/
 {
-    Py_ssize_t result = unicode_find_internal(str, "index", subobj, start,
-                                              end);
+    Py_ssize_t result = any_find_first_slice(str, "index", subobj, start, end,
+                                             +1);
     if (result == -1) {
         PyErr_SetString(PyExc_ValueError, "substring not found");
     }
@@ -12549,60 +12578,6 @@ unicode_repr(PyObject *unicode)
     return repr;
 }
 
-static Py_ssize_t
-unicode_rfind_internal(PyObject *str, const char *function_name,
-                       PyObject *subobj, Py_ssize_t start, Py_ssize_t end)
-{
-    if (PyTuple_Check(subobj)) {
-        for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
-            PyObject *substr = PyTuple_GET_ITEM(subobj, i);
-            if (!PyUnicode_Check(substr)) {
-                PyErr_Format(PyExc_TypeError,
-                            "tuple for %.200s must only contain str, "
-                            "not %.100s", function_name,
-                            Py_TYPE(substr)->tp_name);
-                return -2;
-            }
-        }
-        Py_ssize_t result = -1;
-        Py_ssize_t len = PyUnicode_GET_LENGTH(str);
-        ADJUST_INDICES(start, end, len);
-        // Work in chunks
-        Py_ssize_t cur_end = end;
-        for (; result == -1 && cur_end >= start; cur_end -= RFIND_CHUNK_SIZE) {
-            Py_ssize_t cur_start = cur_end - RFIND_CHUNK_SIZE + 1;
-            if (cur_start < start) {
-                cur_start = start;
-            }
-            for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
-                PyObject *substr = PyTuple_GET_ITEM(subobj, i);
-                Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
-                if (sub_end > end) {
-                    sub_end = end;
-                }
-                Py_ssize_t new_result = any_find_slice(str, substr, cur_start,
-                                                       sub_end, -1);
-                if (new_result != -1) {
-                    if (new_result == cur_end) {
-                        return cur_end;
-                    }
-                    cur_start = new_result + 1;
-                    result = new_result;
-                }
-            }
-        }
-        return result;
-    }
-    if (!PyUnicode_Check(subobj)) {
-        PyErr_Format(PyExc_TypeError,
-                     "%.200s first arg must be str or "
-                     "a tuple of str, not %.100s", function_name,
-                     Py_TYPE(subobj)->tp_name);
-        return -2;
-    }
-    return any_find_slice(str, subobj, start, end, -1);
-}
-
 /*[clinic input]
 str.rfind as unicode_rfind = str.find
 
@@ -12617,8 +12592,8 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                    Py_ssize_t end)
 /*[clinic end generated code: output=9d316eee7b9f9bf0 input=23ae7964e8f70b35]*/
 {
-    Py_ssize_t result = unicode_rfind_internal(str, "rfind", subobj, start,
-                                               end);
+    Py_ssize_t result = any_find_first_slice(str, "rfind", subobj, start, end,
+                                             -1);
     return result < 0 ? -1 : result;
 }
 
@@ -12636,8 +12611,8 @@ unicode_rindex_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                     Py_ssize_t end)
 /*[clinic end generated code: output=847d553d0dc10a86 input=990f3925b149c1bc]*/
 {
-    Py_ssize_t result = unicode_rfind_internal(str, "rindex", subobj, start,
-                                               end);
+    Py_ssize_t result = any_find_first_slice(str, "rindex", subobj, start, end,
+                                             -1);
     if (result == -1) {
         PyErr_SetString(PyExc_ValueError, "substring not found");
     }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -11373,7 +11373,7 @@ unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
         ADJUST_INDICES(start, end, len);
         // Work in chunks
         for (; result == -1 && start <= end; start += FIND_CHUNK_SIZE) {
-            Py_ssize_t cur_end = start + FIND_CHUNK_SIZE;
+            Py_ssize_t cur_end = start + FIND_CHUNK_SIZE - 1;
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
@@ -12579,7 +12579,7 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
         // Work in chunks
         Py_ssize_t cur_end = end;
         for (; result == -1 && cur_end >= start; cur_end -= RFIND_CHUNK_SIZE) {
-            Py_ssize_t cur_start = cur_end - RFIND_CHUNK_SIZE;
+            Py_ssize_t cur_start = cur_end - RFIND_CHUNK_SIZE + 1;
             if (cur_start < start) {
                 cur_start = start;
             }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9346,9 +9346,9 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
 exit:
     if (heap_subs) {
         for (Py_ssize_t i = 0; i < subs_len; i++) {
-            const void *heap_sub = heap_subs[i];
+            void *heap_sub = heap_subs[i];
             if (heap_sub) {
-                PyMem_Free((void *)heap_sub);
+                PyMem_Free(heap_sub);
             }
         }
     }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -11333,6 +11333,8 @@ unicode_expandtabs_impl(PyObject *self, int tabsize)
     return NULL;
 }
 
+#define FIND_CHUNK_SIZE 10000
+
 /*[clinic input]
 str.find as unicode_find -> Py_ssize_t
 
@@ -11368,9 +11370,9 @@ unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
         result = -1;
         Py_ssize_t len = PyUnicode_GET_LENGTH(str);
         ADJUST_INDICES(start, end, len);
-        // Work in batches of 10000
-        for (; result == -1 && start <= end; start += 10000) {
-            Py_ssize_t cur_end = start + 10000;
+        // Work in chunks
+        for (; result == -1 && start <= end; start += FIND_CHUNK_SIZE) {
+            Py_ssize_t cur_end = start + FIND_CHUNK_SIZE;
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
@@ -12573,10 +12575,10 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
         result = -1;
         Py_ssize_t len = PyUnicode_GET_LENGTH(str);
         ADJUST_INDICES(start, end, len);
-        // Work in batches of 10000
+        // Work in chunks
         Py_ssize_t cur_end = end;
-        for (; result == -1 && cur_end >= start; cur_end -= 10000) {
-            Py_ssize_t cur_start = cur_end - 10000;
+        for (; result == -1 && cur_end >= start; cur_end -= FIND_CHUNK_SIZE) {
+            Py_ssize_t cur_start = cur_end - FIND_CHUNK_SIZE;
             if (cur_start < start) {
                 cur_start = start;
             }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9241,15 +9241,15 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
             sub_len <= end - start)
         {
             const void *sub = PyUnicode_DATA(substr);
-            if (sub_len != 1 && sub_kind != kind) {
+            if (sub_len == 1 || sub_kind == kind) {
+                heap_subs[subs_len] = NULL;
+            }
+            else {
                 sub = unicode_askind(sub_kind, sub, sub_len, kind);
                 if (!sub) {
                     goto exit;
                 }
                 heap_subs[subs_len] = sub;
-            }
-            else {
-                heap_subs[subs_len] = NULL;
             }
             subs[subs_len] = sub;
             sub_kinds[subs_len] = sub_kind;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9188,7 +9188,8 @@ any_find_first_slice(PyObject *str, const char *function_name,
             }
             for (Py_ssize_t i = 0; i < tuple_len; i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
-                Py_ssize_t new_result, sub_len = PyUnicode_GET_LENGTH(substr);
+                Py_ssize_t sub_len = PyUnicode_GET_LENGTH(substr);
+                Py_ssize_t new_result;
                 if (cur_end >= end - sub_len) { // Guard overflow
                     new_result = any_find_slice(str, substr, start, end, +1);
                 }
@@ -9222,7 +9223,8 @@ any_find_first_slice(PyObject *str, const char *function_name,
             }
             for (Py_ssize_t i = 0; i < tuple_len; i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
-                Py_ssize_t new_result, sub_len = PyUnicode_GET_LENGTH(substr);
+                Py_ssize_t sub_len = PyUnicode_GET_LENGTH(substr);
+                Py_ssize_t new_result;
                 if (cur_end >= end - sub_len) { // Guard overflow
                     new_result = any_find_slice(str, substr, cur_start, end,
                                                 -1);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -11379,10 +11379,12 @@ unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                 }
                 Py_ssize_t new_result = any_find_slice(str, substr, start,
                                                        sub_end, 1);
-                if (new_result != -1 &&
-                    (new_result < result || result == -1))
-                {
-                    result = cur_end = new_result;
+                if (new_result != -1) {
+                    if (new_result == start) {
+                        return start;
+                    }
+                    cur_end = new_result - 1;
+                    result = new_result;
                 }
             }
         }
@@ -12586,8 +12588,12 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                 }
                 Py_ssize_t new_result = any_find_slice(str, substr, cur_start,
                                                        sub_end, -1);
-                if (new_result > result) {
-                    result = cur_start = new_result;
+                if (new_result != 1) {
+                    if (new_result == cur_end) {
+                        return cur_end;
+                    }
+                    cur_start = new_result + 1;
+                    result = new_result;
                 }
             }
         }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9244,7 +9244,7 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
             if (sub_len != 1 && sub_kind != kind) {
                 sub = unicode_askind(sub_kind, sub, sub_len, kind);
                 if (!sub) {
-                    return -2;
+                    goto exit;
                 }
                 heap_subs[subs_len] = sub;
             }
@@ -9292,10 +9292,6 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
                                            sub_len, start, cur_end + sub_len,
                                            isascii, +1);
                 }
-                if (new_result == -2) {
-                    result = -2;
-                    goto exit;
-                }
                 if (new_result != -1) {
                     if (new_result == start) {
                         result = start;
@@ -9335,10 +9331,6 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
                     new_result = fast_find(str, kind, len, sub, sub_kind,
                                            sub_len, cur_start,
                                            cur_end + sub_len, isascii, -1);
-                }
-                if (new_result == -2) {
-                    result = -2;
-                    goto exit;
                 }
                 if (new_result != -1) {
                     if (new_result == cur_end) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9179,6 +9179,7 @@ any_find_first_slice(PyObject *str, const char *function_name,
     }
 
     /* STORE SUBSTRINGS */
+    int kind = PyUnicode_KIND(str);
     Py_ssize_t len = PyUnicode_GET_LENGTH(str);
     ADJUST_INDICES(start, end, len);
     Py_ssize_t subs_len = 0;
@@ -9190,6 +9191,10 @@ any_find_first_slice(PyObject *str, const char *function_name,
                         "not %.100s", function_name,
                         Py_TYPE(substr)->tp_name);
             goto exit;
+        }
+        int sub_kind = PyUnicode_KIND(substr);
+        if (sub_kind > kind) {
+            continue;
         }
         Py_ssize_t sub_len = PyUnicode_GET_LENGTH(substr);
         if (sub_len <= end - start) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9058,7 +9058,7 @@ static Py_ssize_t
 fast_find(const void *buf1, int kind1, Py_ssize_t len1,
           const void *buf2, int kind2, Py_ssize_t len2,
           Py_ssize_t start, Py_ssize_t end,
-          int isascii1, int direction)
+          int isascii, int direction)
 {
     Py_ssize_t result;
 
@@ -9081,7 +9081,7 @@ fast_find(const void *buf1, int kind1, Py_ssize_t len1,
     if (direction > 0) {
         switch (kind1) {
         case PyUnicode_1BYTE_KIND:
-            if (isascii1)
+            if (isascii)
                 result = asciilib_find_slice(buf1, len1, buf2, len2, start, end);
             else
                 result = ucs1lib_find_slice(buf1, len1, buf2, len2, start, end);
@@ -9099,7 +9099,7 @@ fast_find(const void *buf1, int kind1, Py_ssize_t len1,
     else {
         switch (kind1) {
         case PyUnicode_1BYTE_KIND:
-            if (isascii1)
+            if (isascii)
                 result = asciilib_rfind_slice(buf1, len1, buf2, len2, start, end);
             else
                 result = ucs1lib_rfind_slice(buf1, len1, buf2, len2, start, end);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9346,7 +9346,10 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
 exit:
     if (heap_subs) {
         for (Py_ssize_t i = 0; i < subs_len; i++) {
-            PyMem_Free((void *)heap_subs[i]);
+            void *heap_sub = heap_subs[i];
+            if (heap_sub) {
+                PyMem_Free(heap_sub);
+            }
         }
     }
     PyMem_RawFree(heap_subs);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -11370,10 +11370,10 @@ unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
         ADJUST_INDICES(start, end, len);
         // Work in batches of 10000
         for (; result == -1 && start <= end; start += 10000) {
+            Py_ssize_t cur_end = start + 10000;
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
-                Py_ssize_t sublen = PyUnicode_GET_LENGTH(substr);
-                Py_ssize_t sub_end = start + 10000 + sublen;
+                Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
                 if (sub_end > end) {
                     sub_end = end;
                 }
@@ -11382,7 +11382,7 @@ unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                 if (new_result != -1 &&
                     (new_result < result || result == -1))
                 {
-                    result = new_result;
+                    result = cur_end = new_result;
                 }
             }
         }
@@ -12574,9 +12574,9 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
         // Work in batches of 10000
         Py_ssize_t cur_end = end;
         for (; result == -1 && cur_end >= start; cur_end -= 10000) {
-            Py_ssize_t sub_start = end - 10000;
-            if (sub_start < start) {
-                sub_start = start;
+            Py_ssize_t cur_start = cur_end - 10000;
+            if (cur_start < start) {
+                cur_start = start;
             }
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
@@ -12584,10 +12584,10 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                 if (sub_end > end) {
                     sub_end = end;
                 }
-                Py_ssize_t new_result = any_find_slice(str, substr, sub_start,
+                Py_ssize_t new_result = any_find_slice(str, substr, cur_start,
                                                        sub_end, -1);
                 if (new_result > result) {
-                    result = new_result;
+                    result = cur_start = new_result;
                 }
             }
         }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12560,6 +12560,10 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
         ADJUST_INDICES(start, end, len);
         // Work in batches of 10000
         for (; result == -1 && end >= start; end -= 10000) {
+            Py_ssize_t cur_start = end - 10000;
+            if (cur_start < start) {
+                cur_start = start;
+            }
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
                 if (!PyUnicode_Check(substr)) {
@@ -12569,13 +12573,12 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
                                 Py_TYPE(substr)->tp_name);
                     return -1;
                 }
-                Py_ssize_t sublen = PyUnicode_GET_LENGTH(substr);
-                Py_ssize_t cur_start = end - 10000 - sublen;
-                if (cur_start < start) {
-                    cur_start = start;
+                Py_ssize_t cur_end = end + PyUnicode_GET_LENGTH(substr);
+                if (cur_end > end) {
+                    cur_end = end;
                 }
                 Py_ssize_t new_result = any_find_slice(str, substr, cur_start,
-                                                       end, -1);
+                                                       cur_end, -1);
                 if (new_result > result) {
                     result = new_result;
                 }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9189,6 +9189,9 @@ any_find_first_slice(PyObject *str, const char *function_name,
                 }
                 Py_ssize_t new_result = any_find_slice(str, substr, start,
                                                        sub_end, +1);
+                if (new_result == -2) {
+                    return -2;
+                }
                 if (new_result != -1) {
                     if (new_result == start) {
                         return start;
@@ -9215,6 +9218,9 @@ any_find_first_slice(PyObject *str, const char *function_name,
                 }
                 Py_ssize_t new_result = any_find_slice(str, substr, cur_start,
                                                        sub_end, -1);
+                if (new_result == -2) {
+                    return -2;
+                }
                 if (new_result != -1) {
                     if (new_result == cur_end) {
                         return cur_end;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9346,9 +9346,9 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
 exit:
     if (heap_subs) {
         for (Py_ssize_t i = 0; i < subs_len; i++) {
-            void *heap_sub = heap_subs[i];
+            const void *heap_sub = heap_subs[i];
             if (heap_sub) {
-                PyMem_Free(heap_sub);
+                PyMem_Free((void *)heap_sub);
             }
         }
     }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9176,6 +9176,9 @@ any_find_first_slice(PyObject *str, const char *function_name,
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
+                if (sub_end > end) {
+                    sub_end = end;
+                }
                 Py_ssize_t new_result = any_find_slice(str, substr, start,
                                                        sub_end, +1);
                 if (new_result != -1) {
@@ -9199,6 +9202,9 @@ any_find_first_slice(PyObject *str, const char *function_name,
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
                 Py_ssize_t sub_end = cur_end + PyUnicode_GET_LENGTH(substr);
+                if (sub_end > end) {
+                    sub_end = end;
+                }
                 Py_ssize_t new_result = any_find_slice(str, substr, cur_start,
                                                        sub_end, -1);
                 if (new_result != -1) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -11355,6 +11355,16 @@ unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
 {
     Py_ssize_t result;
     if (PyTuple_Check(subobj)) {
+        for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
+            PyObject *substr = PyTuple_GET_ITEM(subobj, i);
+            if (!PyUnicode_Check(substr)) {
+                PyErr_Format(PyExc_TypeError,
+                            "tuple for find must only contain str, "
+                            "not %.100s",
+                            Py_TYPE(substr)->tp_name);
+                return -1;
+            }
+        }
         result = -1;
         Py_ssize_t len = PyUnicode_GET_LENGTH(str);
         ADJUST_INDICES(start, end, len);
@@ -11362,13 +11372,6 @@ unicode_find_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
         for (; result == -1 && start <= end; start += 10000) {
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
-                if (!PyUnicode_Check(substr)) {
-                    PyErr_Format(PyExc_TypeError,
-                                "tuple for find must only contain str, "
-                                "not %.100s",
-                                Py_TYPE(substr)->tp_name);
-                    return -1;
-                }
                 Py_ssize_t sublen = PyUnicode_GET_LENGTH(substr);
                 Py_ssize_t cur_end = start + 10000 + sublen;
                 if (cur_end > end) {
@@ -12555,6 +12558,16 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
 {
     Py_ssize_t result;
     if (PyTuple_Check(subobj)) {
+        for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
+            PyObject *substr = PyTuple_GET_ITEM(subobj, i);
+            if (!PyUnicode_Check(substr)) {
+                PyErr_Format(PyExc_TypeError,
+                            "tuple for rfind must only contain str, "
+                            "not %.100s",
+                            Py_TYPE(substr)->tp_name);
+                return -1;
+            }
+        }
         result = -1;
         Py_ssize_t len = PyUnicode_GET_LENGTH(str);
         ADJUST_INDICES(start, end, len);
@@ -12566,13 +12579,6 @@ unicode_rfind_impl(PyObject *str, PyObject *subobj, Py_ssize_t start,
             }
             for (Py_ssize_t i = 0; i < PyTuple_GET_SIZE(subobj); i++) {
                 PyObject *substr = PyTuple_GET_ITEM(subobj, i);
-                if (!PyUnicode_Check(substr)) {
-                    PyErr_Format(PyExc_TypeError,
-                                "tuple for rfind must only contain str, "
-                                "not %.100s",
-                                Py_TYPE(substr)->tp_name);
-                    return -1;
-                }
                 Py_ssize_t cur_end = end + PyUnicode_GET_LENGTH(substr);
                 if (cur_end > end) {
                     cur_end = end;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9055,8 +9055,8 @@ _PyUnicode_TransformDecimalAndSpaceToASCII(PyObject *unicode)
     }
 
 static Py_ssize_t
-fast_find(const void *str, int kind, int len,
-          const void *sub, int sub_kind, int sub_len,
+fast_find(const void *str, int kind, Py_ssize_t len,
+          const void *sub, int sub_kind, Py_ssize_t sub_len,
           Py_ssize_t start, Py_ssize_t end,
           int isascii, int direction)
 {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9138,7 +9138,7 @@ any_find_slice(PyObject* s1, PyObject* s2,
 
     kind1 = PyUnicode_KIND(s1);
     kind2 = PyUnicode_KIND(s2);
-    if (kind2 > kind1)
+    if (kind1 < kind2)
         return -1;
 
     isascii1 = PyUnicode_IS_ASCII(s1);
@@ -11567,7 +11567,10 @@ unicode_find_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
 /*[clinic end generated code: output=da52b0913b08a960 input=a236fecd6e36a36a]*/
 {
     Py_ssize_t result = any_find_first_slice(str, "find", sub, start, end, +1);
-    return result < 0 ? -1 : result;
+    if (result < 0) {
+        return -1;
+    }
+    return result;
 }
 
 static PyObject *
@@ -11629,7 +11632,10 @@ unicode_index_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
     if (result == -1) {
         PyErr_SetString(PyExc_ValueError, "substring not found");
     }
-    return result < 0 ? -1 : result;
+    else if (result < 0) {
+        return -1;
+    }
+    return result;
 }
 
 /*[clinic input]
@@ -12725,7 +12731,10 @@ unicode_rfind_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
 {
     Py_ssize_t result = any_find_first_slice(str, "rfind", sub, start, end,
                                              -1);
-    return result < 0 ? -1 : result;
+    if (result < 0) {
+        return -1;
+    }
+    return result;
 }
 
 /*[clinic input]
@@ -12747,7 +12756,10 @@ unicode_rindex_impl(PyObject *str, PyObject *sub, Py_ssize_t start,
     if (result == -1) {
         PyErr_SetString(PyExc_ValueError, "substring not found");
     }
-    return result < 0 ? -1 : result;
+    else if (result < 0) {
+        return -1;
+    }
+    return result;
 }
 
 /*[clinic input]

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9186,6 +9186,7 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
 
     /* ALLOCATE MEMORY */
     result = -2; // Error
+    subs_len = 0;
     tuple_len = PyTuple_GET_SIZE(subobj);
     if ((size_t)tuple_len > (size_t)PY_SSIZE_T_MAX / sizeof(void *) ||
         (size_t)tuple_len > (size_t)PY_SSIZE_T_MAX / sizeof(int) ||
@@ -9221,7 +9222,6 @@ any_find_first_slice(PyObject *strobj, const char *function_name,
     isascii = PyUnicode_IS_ASCII(strobj);
     len = PyUnicode_GET_LENGTH(strobj);
     ADJUST_INDICES(start, end, len);
-    subs_len = 0;
     for (Py_ssize_t i = 0; i < tuple_len; i++) {
         PyObject *substr;
         int sub_kind, sub_isascii;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9148,7 +9148,7 @@ any_find_first_slice(PyObject *str, const char *function_name,
     if (!PyTuple_Check(subobj)) {
         if (!PyUnicode_Check(subobj)) {
             PyErr_Format(PyExc_TypeError,
-                        "find %.200s arg must be str or "
+                        "%.200s first arg must be str or "
                         "a tuple of str, not %.100s", function_name,
                         Py_TYPE(subobj)->tp_name);
             return -2;


### PR DESCRIPTION
From [@pfmoore on Discourse](https://discuss.python.org/t/add-tuple-support-to-more-str-functions/50628/24):

> One other option is for someone just to submit one or more PRs implementing the proposed feature(s). The PRs will either get accepted or rejected, and then you have your answer. The lack of response might just be because there’s not a lot that’s interesting to say.
> 
> I don’t personally think this is worth the effort to implement, and I’m not convinced I’d find it very useful in practice. But I also don’t think it’s such a big deal that it needs a big debate, or communty consensus, or a PEP. So if you want to put in the effort, just go for it.

### Benchmark for 1,000,000 characters

<details><summary>script</summary>

```python
# find_tuple.py
def find0(p, chars):
    for i, c in enumerate(p):
        if c in chars:
            break
    else:
        i = -1
    return i

def find1(p, subs):
    for i in range(len(p)):
        if p.startswith(subs, i):
            break
    else:
        i = -1
    return i

def find2(p, pattern):
    match = pattern.search(p)
    i = match.start() if match else -1
    return i

def find3(p, subs):
    i = -1
    for sub in subs:
        new_i = p.find(sub, 0, None if i == -1 else i)
        if new_i != -1:
            i = new_i
    return i

def find4(p, subs):
    i = p.find(subs)
    return i

def rfind0(p, chars):
    i = len(p) - 1
    while i >= 0 and p[i] not in chars:
        i -= 1
    return i

def rfind1(p, subs):
    for i in range(len(p), -1, -1):
        if p.startswith(subs, i):
            break
    else:
        i = -1
    return i

rfind2 = find2

def rfind3(p, subs):
    i = -1
    for sub in subs:
        new_i = p.rfind(sub, 0 if i == -1 else i)
        if new_i != -1:
            i = new_i
    return i

def rfind4(p, subs):
    i = p.rfind(subs)
    return i
```

```sh
# find_tuple.sh
echo find chars best case
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'ab' + '_' * 999_998; chars   = 'ab'"               "find_tuple.find0(string, chars)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'ab' + '_' * 999_998; subs    = tuple('ab')"        "find_tuple.find1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, re; string = 'ab' + '_' * 999_998; pattern = re.compile('[ab]')" "find_tuple.find2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'ab' + '_' * 999_998; subs    = 'ab'"               "find_tuple.find3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'ab' + '_' * 999_998; subs    = tuple('ab')"        "find_tuple.find4(string, subs)"
echo find chars mixed case
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'b' + '_' * 999_999; chars   = 'ab'"               "find_tuple.find0(string, chars)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'b' + '_' * 999_999; subs    = tuple('ab')"        "find_tuple.find1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, re; string = 'b' + '_' * 999_999; pattern = re.compile('[ab]')" "find_tuple.find2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'b' + '_' * 999_999; subs    = 'ab'"               "find_tuple.find3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'b' + '_' * 999_999; subs    = tuple('ab')"        "find_tuple.find4(string, subs)"
echo find chars worst case
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; chars   = 'ab'"               "find_tuple.find0(string, chars)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = tuple('ab')"        "find_tuple.find1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, re; string = '_' * 1_000_000; pattern = re.compile('[ab]')" "find_tuple.find2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = 'ab'"               "find_tuple.find3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = tuple('ab')"        "find_tuple.find4(string, subs)"
echo find subs best case
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'abcd' + '_' * 999_996; subs    = 'ab', 'cd'"          "find_tuple.find1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, re; string = 'abcd' + '_' * 999_996; pattern = re.compile('ab|cd')" "find_tuple.find2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'abcd' + '_' * 999_996; subs    = 'ab', 'cd'"          "find_tuple.find3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'abcd' + '_' * 999_996; subs    = 'ab', 'cd'"          "find_tuple.find4(string, subs)"
echo find subs mixed case
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'cd' + '_' * 999_998; subs    = 'ab', 'cd'"          "find_tuple.find1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, re; string = 'cd' + '_' * 999_998; pattern = re.compile('ab|cd')" "find_tuple.find2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'cd' + '_' * 999_998; subs    = 'ab', 'cd'"          "find_tuple.find3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = 'cd' + '_' * 999_998; subs    = 'ab', 'cd'"          "find_tuple.find4(string, subs)"
echo find subs worst case
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = 'ab', 'cd'"          "find_tuple.find1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, re; string = '_' * 1_000_000; pattern = re.compile('ab|cd')" "find_tuple.find2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = 'ab', 'cd'"          "find_tuple.find3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = 'ab', 'cd'"          "find_tuple.find4(string, subs)"
echo find many prefixes
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = tuple(f'prefix{i}' for i in range(100))"                "find_tuple.find1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, re; string = '_' * 1_000_000; pattern = re.compile('|'.join(f'prefix{i}' for i in range(100)))" "find_tuple.find2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = tuple(f'prefix{i}' for i in range(100))"                "find_tuple.find3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = tuple(f'prefix{i}' for i in range(100))"                "find_tuple.find4(string, subs)"
echo find many infixes
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = tuple(f'{i}infix{i}' for i in range(100))"                "find_tuple.find1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, re; string = '_' * 1_000_000; pattern = re.compile('|'.join(f'{i}infix{i}' for i in range(100)))" "find_tuple.find2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = tuple(f'{i}infix{i}' for i in range(100))"                "find_tuple.find3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;     string = '_' * 1_000_000; subs    = tuple(f'{i}infix{i}' for i in range(100))"                "find_tuple.find4(string, subs)"

echo ---

echo rfind chars best case
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_998 + 'ba'; chars   = 'ab'"                      "find_tuple.rfind0(string, chars)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_998 + 'ba'; subs    = tuple('ab')"               "find_tuple.rfind1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, regex; string = '_' * 999_998 + 'ba'; pattern = regex.compile('(?r)[ab]')" "find_tuple.rfind2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_998 + 'ba'; subs    = 'ab'"                      "find_tuple.rfind3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_998 + 'ba'; subs    = tuple('ab')"               "find_tuple.rfind4(string, subs)"
echo rfind chars mixed case
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_999 + 'b'; chars   = 'ab'"                      "find_tuple.rfind0(string, chars)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_999 + 'b'; subs    = tuple('ab')"               "find_tuple.rfind1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, regex; string = '_' * 999_999 + 'b'; pattern = regex.compile('(?r)[ab]')" "find_tuple.rfind2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_999 + 'b'; subs    = 'ab'"                      "find_tuple.rfind3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_999 + 'b'; subs    = tuple('ab')"               "find_tuple.rfind4(string, subs)"
echo rfind chars worst case
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; chars   = 'ab'"                      "find_tuple.rfind0(string, chars)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = tuple('ab')"               "find_tuple.rfind1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, regex; string = '_' * 1_000_000; pattern = regex.compile('(?r)[ab]')" "find_tuple.rfind2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = 'ab'"                      "find_tuple.rfind3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = tuple('ab')"               "find_tuple.rfind4(string, subs)"
echo rfind subs best case
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_996 + 'cdab'; subs    = 'ab', 'cd'"                 "find_tuple.rfind1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, regex; string = '_' * 999_996 + 'cdab'; pattern = regex.compile('(?r)ab|cd')" "find_tuple.rfind2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_996 + 'cdab'; subs    = 'ab', 'cd'"                 "find_tuple.rfind3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_996 + 'cdab'; subs    = 'ab', 'cd'"                 "find_tuple.rfind4(string, subs)"
echo rfind subs mixed case
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_998 + 'cd'; subs    = 'ab', 'cd'"                 "find_tuple.rfind1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, regex; string = '_' * 999_998 + 'cd'; pattern = regex.compile('(?r)ab|cd')" "find_tuple.rfind2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_998 + 'cd'; subs    = 'ab', 'cd'"                 "find_tuple.rfind3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 999_998 + 'cd'; subs    = 'ab', 'cd'"                 "find_tuple.rfind4(string, subs)"
echo rfind subs worst case
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = 'ab', 'cd'"                 "find_tuple.rfind1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, regex; string = '_' * 1_000_000; pattern = regex.compile('(?r)ab|cd')" "find_tuple.rfind2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = 'ab', 'cd'"                 "find_tuple.rfind3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = 'ab', 'cd'"                 "find_tuple.rfind4(string, subs)"
echo rfind many suffixes
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = tuple(f'{i}suffix' for i in range(100))"                            "find_tuple.rfind1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, regex; string = '_' * 1_000_000; pattern = regex.compile(f'(?r){'|'.join(f'{i}suffix' for i in range(100))}')" "find_tuple.rfind2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = tuple(f'{i}suffix' for i in range(100))"                            "find_tuple.rfind3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = tuple(f'{i}suffix' for i in range(100))"                            "find_tuple.rfind4(string, subs)"
echo rfind many infixes
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = tuple(f'{i}infix{i}' for i in range(100))"                            "find_tuple.rfind1(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple, regex; string = '_' * 1_000_000; pattern = regex.compile(f'(?r){'|'.join(f'{i}infix{i}' for i in range(100))}')" "find_tuple.rfind2(string, pattern)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = tuple(f'{i}infix{i}' for i in range(100))"                            "find_tuple.rfind3(string, subs)"
find-tuple/python.exe -m timeit -s "import find_tuple;        string = '_' * 1_000_000; subs    = tuple(f'{i}infix{i}' for i in range(100))"                            "find_tuple.rfind4(string, subs)"
```

</details>

<details><summary>find chars best case - 2.33x faster</summary>

```none
2000000 loops, best of 5: 177 nsec per loop
1000000 loops, best of 5: 213 nsec per loop
1000000 loops, best of 5: 277 nsec per loop
1000000 loops, best of 5: 227 nsec per loop
5000000 loops, best of 5: 76 nsec per loop
```

</details>

<details><summary>find chars mixed case - 1.80x faster</summary>

```none
2000000 loops, best of 5: 177 nsec per loop
1000000 loops, best of 5: 219 nsec per loop
1000000 loops, best of 5: 276 nsec per loop
20000 loops, best of 5: 16.2 usec per loop
5000000 loops, best of 5: 98.4 nsec per loop
```

</details>

<details><summary>find chars worst case - 1.69x slower</summary>

```none
5 loops, best of 5: 41.7 msec per loop
5 loops, best of 5: 53.8 msec per loop
50 loops, best of 5: 4.32 msec per loop
10000 loops, best of 5: 32 usec per loop
5000 loops, best of 5: 54.1 usec per loop
```

</details>

<details><summary>find subs best case - 2.93x faster</summary>

```none
1000000 loops, best of 5: 213 nsec per loop
1000000 loops, best of 5: 306 nsec per loop
1000000 loops, best of 5: 217 nsec per loop
5000000 loops, best of 5: 72.7 nsec per loop
```

</details>

<details><summary>find subs mixed case - 3.75x slower</summary>

```none
1000000 loops, best of 5: 220 nsec per loop
1000000 loops, best of 5: 285 nsec per loop
500 loops, best of 5: 733 usec per loop
500000 loops, best of 5: 824 nsec per loop
```

</details>

<details><summary>find subs worst case - 1.04x slower</summary>

```none
5 loops, best of 5: 53.2 msec per loop
50 loops, best of 5: 4.79 msec per loop
200 loops, best of 5: 1.46 msec per loop
200 loops, best of 5: 1.52 msec per loop
```

</details>

<details><summary>find many prefixes - 56.3x slower</summary>

```none
1 loop, best of 5: 602 msec per loop
500 loops, best of 5: 480 usec per loop
10 loops, best of 5: 36.8 msec per loop
10 loops, best of 5: 27 msec per loop
```

</details>

<details><summary>find many infixes - 5.69x slower</summary>

```none
1 loop, best of 5: 603 msec per loop
50 loops, best of 5: 4.32 msec per loop
10 loops, best of 5: 33.2 msec per loop
10 loops, best of 5: 24.6 msec per loop
```

</details>

---

<details><summary>rfind chars best case - 1.24x faster</summary>

```none
2000000 loops, best of 5: 114 nsec per loop
1000000 loops, best of 5: 294 nsec per loop
500000 loops, best of 5: 517 nsec per loop
1000000 loops, best of 5: 221 nsec per loop
5000000 loops, best of 5: 91.9 nsec per loop
```

</details>

<details><summary>rfind chars mixed case - 6.16x slower</summary>

```none
2000000 loops, best of 5: 115 nsec per loop
1000000 loops, best of 5: 301 nsec per loop
500000 loops, best of 5: 518 nsec per loop
500 loops, best of 5: 598 usec per loop
500000 loops, best of 5: 708 nsec per loop
```

</details>

<details><summary>rfind chars worst case - 1.06x slower</summary>

```none
5 loops, best of 5: 51.3 msec per loop
5 loops, best of 5: 53.3 msec per loop
50 loops, best of 5: 7 msec per loop
200 loops, best of 5: 1.19 msec per loop
200 loops, best of 5: 1.26 msec per loop
```

</details>

<details><summary>rfind subs best case - 2.41x faster</summary>

```none
1000000 loops, best of 5: 359 nsec per loop
500000 loops, best of 5: 574 nsec per loop
1000000 loops, best of 5: 229 nsec per loop
2000000 loops, best of 5: 94.9 nsec per loop
```

</details>

<details><summary>rfind subs mixed case - 2.26x slower</summary>

```none
1000000 loops, best of 5: 368 nsec per loop
500000 loops, best of 5: 542 nsec per loop
500 loops, best of 5: 724 usec per loop
500000 loops, best of 5: 832 nsec per loop
```

</details>

<details><summary>rfind subs worst case - 1.04x slower</summary>

```none
5 loops, best of 5: 53.9 msec per loop
50 loops, best of 5: 7 msec per loop
200 loops, best of 5: 1.44 msec per loop
200 loops, best of 5: 1.5 msec per loop
```

</details>

<details><summary>rfind many suffixes - 54.8x slower</summary>

```none
1 loop, best of 5: 605 msec per loop
500 loops, best of 5: 484 usec per loop
10 loops, best of 5: 24.6 msec per loop
10 loops, best of 5: 26.5 msec per loop
```

</details>

<details><summary>rfind many infixes - 2.60x slower</summary>

```none
1 loop, best of 5: 603 msec per loop
50 loops, best of 5: 9.37 msec per loop
10 loops, best of 5: 22.5 msec per loop
10 loops, best of 5: 24.4 msec per loop
```

</details>

### Old benchmark on Ubuntu

<details><summary>expand</summary>

> <details><summary>find best case - 2.02x faster - regex - 2.77x slower</summary>
> 
> ```none
> 1000000 loops, best of 5: 303 nsec per loop
> 1000000 loops, best of 5: 357 nsec per loop
> 1000000 loops, best of 5: 260 nsec per loop
> 2000000 loops, best of 5: 129 nsec per loop
> ```
> 
> </details>
> 
> <details><summary>find mixed case - 1.25x faster - regex - 1.54x slower</summary>
> 
> ```none
> 1000000 loops, best of 5: 301 nsec per loop
> 1000000 loops, best of 5: 370 nsec per loop
> 10000 loops, best of 5: 23.9 usec per loop
> 1000000 loops, best of 5: 240 nsec per loop
> ```
> 
> </details>
> 
> <details><summary>find worst case - 1.33x faster - regex - 500x slower</summary>
> 
> ```none
> 5 loops, best of 5: 47.2 msec per loop
> 20 loops, best of 5: 17.1 msec per loop
> 5000 loops, best of 5: 45.5 usec per loop
> 10000 loops, best of 5: 34.2 usec per loop
> ```
> 
> </details>
> 
> ---
> 
> <details><summary>rfind best case - 1.28x faster - regex - 84,049x slower</summary>
> 
> ```none
> 1000000 loops, best of 5: 209 nsec per loop
> 20 loops, best of 5: 13.7 msec per loop
> 1000000 loops, best of 5: 265 nsec per loop
> 2000000 loops, best of 5: 163 nsec per loop
> ```
> 
> </details>
> 
> <details><summary>rfind mixed case - 1.27x slower - regex - 62,673x slower</summary>
> 
> ```none
> 1000000 loops, best of 5: 217 nsec per loop
> 20 loops, best of 5: 13.6 msec per loop
> 10000 loops, best of 5: 23.8 usec per loop
> 1000000 loops, best of 5: 275 nsec per loop
> ```
> 
> </details>
> 
> <details><summary>rfind worst case - 1.30x faster - regex - 1,068x slower</summary>
> 
> ```none
> 5 loops, best of 5: 85.9 msec per loop
> 10 loops, best of 5: 37.8 msec per loop
> 5000 loops, best of 5: 44.6 usec per loop
> 10000 loops, best of 5: 35.4 usec per loop
> ```
> 
> </details>

</details>

<!-- gh-issue-number: gh-118184 -->
* Issue: gh-118184
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119501.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->