### PR TITLE
GH-119496: accept UTF-8 BOM in .pth files

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -185,7 +185,9 @@ def addpackage(sitedir, name, known_paths):
         return
 
     try:
-        pth_content = pth_content.decode()
+        # Accept BOM markers in .pth files as we do in source files
+        # (Windows PowerShell 5.1 makes it hard to emit UTF-8 files without a BOM)
+        pth_content = pth_content.decode(encoding="utf8-sig")
     except UnicodeDecodeError:
         # Fallback to locale encoding for backward compatibility.
         # We will deprecate this fallback in the future.

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -187,7 +187,7 @@ def addpackage(sitedir, name, known_paths):
     try:
         # Accept BOM markers in .pth files as we do in source files
         # (Windows PowerShell 5.1 makes it hard to emit UTF-8 files without a BOM)
-        pth_content = pth_content.decode(encoding="utf-8-sig")
+        pth_content = pth_content.decode("utf-8-sig")
     except UnicodeDecodeError:
         # Fallback to locale encoding for backward compatibility.
         # We will deprecate this fallback in the future.

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -187,7 +187,7 @@ def addpackage(sitedir, name, known_paths):
     try:
         # Accept BOM markers in .pth files as we do in source files
         # (Windows PowerShell 5.1 makes it hard to emit UTF-8 files without a BOM)
-        pth_content = pth_content.decode(encoding="utf8-sig")
+        pth_content = pth_content.decode(encoding="utf-8-sig")
     except UnicodeDecodeError:
         # Fallback to locale encoding for backward compatibility.
         # We will deprecate this fallback in the future.


### PR DESCRIPTION
`Out-File -Encoding utf8` in Windows Powershell 5.1 emits
UTF-8 with a BOM marker, which the regular `utf-8` codec
decodes incorrectly. `utf-8-sig` accepts a BOM, but also
works correctly without one.

<!-- gh-issue-number: gh-119496 -->
* Issue: gh-119496
<!-- /gh-issue-number -->
