### PR TITLE
gh-119506: fix `_io.TextIOWrapper.write()` write during flush

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4020,17 +4020,23 @@ class CTextIOWrapperTest(TextIOWrapperTest):
         chunk_size = 8192
 
         class MockIO(self.MockRawIO):
+            written = False
             def write(self, data):
-                t.write("efg")
+                if not self.written:
+                    self.written = True
+                    t.write("middle")
                 return super().write(data)
 
         buf = MockIO()
         t = self.TextIOWrapper(buf)
-        t.write("a" * (chunk_size - 1))
-        t.write("bcd")
+        t.write("abc")
+        t.write("def")
+        # writing data which size >= chunk_size cause flushing buffer before write.
+        t.write("g" * chunk_size)
         t.flush()
 
-        self.assertEqual([b"a" * (chunk_size - 1), b"efgbcd"], buf._write_stack)
+        self.assertEqual([b"abcdef", b"middle", b"g"*chunk_size],
+                         buf._write_stack)
 
 
 class PyTextIOWrapperTest(TextIOWrapperTest):

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4016,6 +4016,22 @@ class CTextIOWrapperTest(TextIOWrapperTest):
         t.write("x"*chunk_size)
         self.assertEqual([b"abcdef", b"ghi", b"x"*chunk_size], buf._write_stack)
 
+    def test_issue119506(self):
+        chunk_size = 8192
+
+        class MockIO(self.MockRawIO):
+            def write(self, data):
+                t.write("efg")
+                return super().write(data)
+
+        buf = MockIO()
+        t = self.TextIOWrapper(buf)
+        t.write("a" * (chunk_size - 1))
+        t.write("bcd")
+        t.flush()
+
+        self.assertEqual([b"a" * (chunk_size - 1), b"bcdefg"], buf._write_stack)
+
 
 class PyTextIOWrapperTest(TextIOWrapperTest):
     io = pyio

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4030,7 +4030,7 @@ class CTextIOWrapperTest(TextIOWrapperTest):
         t.write("bcd")
         t.flush()
 
-        self.assertEqual([b"a" * (chunk_size - 1), b"bcdefg"], buf._write_stack)
+        self.assertEqual([b"a" * (chunk_size - 1), b"efgbcd"], buf._write_stack)
 
 
 class PyTextIOWrapperTest(TextIOWrapperTest):

--- a/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
@@ -1,1 +1,1 @@
-Fix bug in :meth:`!io.TextIOWrapper.write` method of :class:`io.TextIOWrapper`, which causes its internal buffer to be rewritten during flushing of large data.
+Fix bug in :meth:`!io.TextIOWrapper.write` method, which causes wrapper's internal buffer to be rewritten during flushing of large data.

--- a/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
@@ -1,1 +1,1 @@
-Fix bug in :meth:`io.TextIOWrapper.write`, which caused :class:`io.TextIOWrapper` internal buffer to be rewritten during flushing of large data.
+Fix bug in :meth:`~io.TextIOWrapper.write` method of :class:`io.TextIOWrapper`, which causes its internal buffer to be rewritten during flushing of large data.

--- a/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
@@ -1,1 +1,1 @@
-Fix bug in :meth:`io.TextIOWrapper.write`, which caused its internal buffer to be rewritten during flushing of large data.
+Fix bug in :meth:`io.TextIOWrapper.write`, which caused :class:`io.TextIOWrapper` internal buffer to be rewritten during flushing of large data.

--- a/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
@@ -1,1 +1,1 @@
-Fix bug in :meth:`~io.TextIOWrapper.write` method of :class:`io.TextIOWrapper`, which causes its internal buffer to be rewritten during flushing of large data.
+Fix bug in :meth:`!io.TextIOWrapper.write` method of :class:`io.TextIOWrapper`, which causes its internal buffer to be rewritten during flushing of large data.

--- a/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
@@ -1,0 +1,1 @@
+Fix bug in :meth:`io.TextIOWrapper.write`, which caused its internal buffer to be rewritten during flushing of large data.

--- a/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
@@ -1,1 +1,1 @@
-Fix bug in :meth:`!io.TextIOWrapper.write` method, which causes wrapper's internal buffer to be rewritten during flushing of large data.
+Fix :meth:`!io.TextIOWrapper.write` method breaks internal buffer when the method is called again during flushing internal buffer.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1719,6 +1719,8 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
         bytes_len = PyBytes_GET_SIZE(b);
     }
 
+    PyObject *pending = self->pending_bytes;
+
     if (self->pending_bytes_count + bytes_len > self->chunk_size) {
         // Prevent to concatenate more than chunk_size data.
         if (_textiowrapper_writeflush(self) < 0) {
@@ -1728,9 +1730,9 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
         if (self->pending_bytes) {
             // gh-119506: call to _textiowrapper_writeflush()
             // can write new data to pending_bytes
-            PyObject *tmp = self->pending_bytes;
+            pending = self->pending_bytes;
             self->pending_bytes = b;
-            b = tmp;
+            b = pending;
         }
     }
 
@@ -1741,6 +1743,7 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
     else if (!PyList_CheckExact(self->pending_bytes)) {
         PyObject *list = PyList_New(2);
         if (list == NULL) {
+            self->pending_bytes = pending;
             Py_DECREF(b);
             return NULL;
         }
@@ -1750,6 +1753,7 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
     }
     else {
         if (PyList_Append(self->pending_bytes, b) < 0) {
+            self->pending_bytes = pending;
             Py_DECREF(b);
             return NULL;
         }

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1740,6 +1740,9 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
             Py_DECREF(b);
             return NULL;
         }
+        // Since Python 3.12, allocating GC object won't trigger GC and release
+        // GIL. See https://github.com/python/cpython/issues/97922
+        assert(!PyList_CheckExact(self->pending_bytes));
         PyList_SET_ITEM(list, 0, self->pending_bytes);
         PyList_SET_ITEM(list, 1, b);
         self->pending_bytes = list;


### PR DESCRIPTION
Fixes #119506

* check if call to `_textiowrapper_writeflush()` has left any data in `self->pending_bytes`. If so, store them in `self->pending_bytes` after `b`
* add test


<!-- gh-issue-number: gh-119506 -->
* Issue: gh-119506
<!-- /gh-issue-number -->
