### PR TITLE
gh-117865: Defer several imports in inspect.py

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -142,7 +142,6 @@ __all__ = [
 
 
 import abc
-import ast
 import dis
 import collections.abc
 import enum
@@ -150,9 +149,7 @@ import importlib.machinery
 import itertools
 import linecache
 import os
-import re
 import sys
-import tokenize
 import token
 import types
 import functools
@@ -160,7 +157,7 @@ import builtins
 from keyword import iskeyword
 from operator import attrgetter
 from collections import namedtuple, OrderedDict
-from weakref import ref as make_weakref
+from _weakref import ref as make_weakref
 
 # Create constants for the compiler flags in Include/code.h
 # We try to get them from dis to avoid duplication
@@ -1149,6 +1146,8 @@ class BlockFinder:
         self.body_col0 = None
 
     def tokeneater(self, type, token, srowcol, erowcol, line):
+        import tokenize
+
         if not self.started and not self.indecorator:
             # skip any decorators
             if token == "@":
@@ -1194,6 +1193,8 @@ class BlockFinder:
 def getblock(lines):
     """Extract the block of code at the top of the given list of lines."""
     blockfinder = BlockFinder()
+    import tokenize
+
     try:
         tokens = tokenize.generate_tokens(iter(lines).__next__)
         for _token in tokens:
@@ -1420,6 +1421,7 @@ def formatannotation(annotation, base_module=None):
         def repl(match):
             text = match.group()
             return text.removeprefix('typing.')
+        import re
         return re.sub(r'[\w\.]+', repl, repr(annotation))
     if isinstance(annotation, types.GenericAlias):
         return str(annotation)
@@ -2155,6 +2157,8 @@ def _signature_strip_non_python_syntax(signature):
 
     lines = [l.encode('ascii') for l in signature.split('\n') if l]
     generator = iter(lines).__next__
+
+    import tokenize
     token_stream = tokenize.tokenize(generator)
 
     text = []
@@ -2191,10 +2195,10 @@ def _signature_fromstr(cls, obj, s, skip_bound_arg=True):
     """Private helper to parse content of '__text_signature__'
     and return a Signature based on it.
     """
+    import ast
+
     Parameter = cls._parameter_cls
-
     clean_signature, self_parameter = _signature_strip_non_python_syntax(s)
-
     program = "def foo" + clean_signature + ": pass"
 
     try:


### PR DESCRIPTION
Following https://github.com/python/cpython/commit/153b3f75306b5d26e29ea157105d0fdc247ef853, it is suddenly much more trivial to make the import of ast lazy in inspect.py. Once that's done, it also becomes worthwhile to make other imports lazy as well

<!-- gh-issue-number: gh-117865 -->
* Issue: gh-117865
<!-- /gh-issue-number -->
