### PR TITLE
gh-119534: Add a check in the Queue class initialization to ensure maxsize does not exceed SEM_VALUE_MAX

### DIFF
--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -40,7 +40,7 @@ class Queue(object):
             from .synchronize import SEM_VALUE_MAX as maxsize
         elif maxsize > SEM_VALUE_MAX:
             maxsize = SEM_VALUE_MAX
-        warnings.warn(f"maxsize exceeds SEM_VALUE_MAX; setting maxsize to {SEM_VALUE_MAX}", UserWarning)
+            warnings.warn(f"maxsize exceeds SEM_VALUE_MAX; setting maxsize to {SEM_VALUE_MAX}", UserWarning)
         self._maxsize = maxsize
         self._reader, self._writer = connection.Pipe(duplex=False)
         self._rlock = ctx.Lock()

--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -17,9 +17,11 @@ import time
 import types
 import weakref
 import errno
+import warnings
 
 from queue import Empty, Full
 
+from .synchronize import SEM_VALUE_MAX
 from . import connection
 from . import context
 _ForkingPickler = context.reduction.ForkingPickler
@@ -36,6 +38,9 @@ class Queue(object):
         if maxsize <= 0:
             # Can raise ImportError (see issues #3770 and #23400)
             from .synchronize import SEM_VALUE_MAX as maxsize
+        elif maxsize > SEM_VALUE_MAX:
+            maxsize = SEM_VALUE_MAX
+        warnings.warn(f"maxsize exceeds SEM_VALUE_MAX; setting maxsize to {SEM_VALUE_MAX}", UserWarning)
         self._maxsize = maxsize
         self._reader, self._writer = connection.Pipe(duplex=False)
         self._rlock = ctx.Lock()

--- a/Misc/NEWS.d/next/Library/2024-05-25-17-34-56.gh-issue-119534.He3c9q.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-25-17-34-56.gh-issue-119534.He3c9q.rst
@@ -1,0 +1,4 @@
+Fix  maxsize exceeds ``SEM_VALUE_MAX`` issue in Queue() class init
+:func:`__init__(self, maxsize=0, *, ctx)` and automatically assign it 
+``SEM_VALUE_MAX`` if ``SEM_VALUE_MAX`` is violated and a warning is 
+issued to inform the user. Patch by Marwan Seliem.

--- a/Misc/NEWS.d/next/Library/2024-05-25-17-34-56.gh-issue-119534.He3c9q.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-25-17-34-56.gh-issue-119534.He3c9q.rst
@@ -1,4 +1,4 @@
 Fix  maxsize exceeds ``SEM_VALUE_MAX`` issue in Queue() class init
-:func:`__init__(self, maxsize=0, *, ctx)` and automatically assign it 
-``SEM_VALUE_MAX`` if ``SEM_VALUE_MAX`` is violated and a warning is 
+:func:`__init__(self, maxsize=0, *, ctx)` and automatically assign it
+``SEM_VALUE_MAX`` if ``SEM_VALUE_MAX`` is violated and a warning is
 issued to inform the user. Patch by Marwan Seliem.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119534 -->
* Issue: gh-119534
<!-- /gh-issue-number -->
