### PR TITLE
gh-99180: Make `StackSummary.should_show_carets` private

### DIFF
--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -580,7 +580,7 @@ class StackSummary(list):
                 show_carets = False
                 with suppress(Exception):
                     anchors = _extract_caret_anchors_from_line_segment(segment)
-                show_carets = self.should_show_carets(start_offset, end_offset, all_lines, anchors)
+                show_carets = self._should_show_carets(start_offset, end_offset, all_lines, anchors)
 
                 result = []
 
@@ -694,7 +694,7 @@ class StackSummary(list):
 
         return ''.join(row)
 
-    def should_show_carets(self, start_offset, end_offset, all_lines, anchors):
+    def _should_show_carets(self, start_offset, end_offset, all_lines, anchors):
         with suppress(SyntaxError, ImportError):
             import ast
             tree = ast.parse('\n'.join(all_lines))


### PR DESCRIPTION
See https://github.com/python/cpython/pull/112670/files#r1613952301. This wasn't meant to be a public API; prefixing the name with an underscore means it won't show up in `help()` or autocompletion suggestions.

<!-- gh-issue-number: gh-99180 -->
* Issue: gh-99180
<!-- /gh-issue-number -->
