### PR TITLE
gh-102864: Add switching frame test for pdb

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2566,6 +2566,7 @@ def test_pdb_issue_gh_101673():
     ...     'll',
     ...     'p a',
     ...     'u',
+    ...     'p a',
     ...     'd',
     ...     'p a',
     ...     'continue'
@@ -2581,8 +2582,10 @@ def test_pdb_issue_gh_101673():
     (Pdb) p a
     2
     (Pdb) u
-    > <doctest test.test_pdb.test_pdb_issue_gh_101673[1]>(10)<module>()
+    > <doctest test.test_pdb.test_pdb_issue_gh_101673[1]>(11)<module>()
     -> test_function()
+    (Pdb) p a
+    *** NameError: name 'a' is not defined
     (Pdb) d
     > <doctest test.test_pdb.test_pdb_issue_gh_101673[0]>(3)test_function()
     -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2555,7 +2555,7 @@ def test_pdb_issue_gh_94215():
 def test_pdb_issue_gh_101673():
     """See GH-101673
 
-    Make sure ll won't revert local variable assignment
+    Make sure ll and switching frames won't revert local variable assignment
 
     >>> def test_function():
     ...    a = 1
@@ -2564,6 +2564,9 @@ def test_pdb_issue_gh_101673():
     >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
     ...     '!a = 2',
     ...     'll',
+    ...     'p a',
+    ...     'u',
+    ...     'd',
     ...     'p a',
     ...     'continue'
     ... ]):
@@ -2575,6 +2578,14 @@ def test_pdb_issue_gh_101673():
       1         def test_function():
       2            a = 1
       3  ->        import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) p a
+    2
+    (Pdb) u
+    > <doctest test.test_pdb.test_pdb_issue_gh_101673[1]>(10)<module>()
+    -> test_function()
+    (Pdb) d
+    > <doctest test.test_pdb.test_pdb_issue_gh_101673[0]>(3)test_function()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) p a
     2
     (Pdb) continue


### PR DESCRIPTION
We once had an issue where switching frames will clear the local variable changes in pdb. PEP 667 fixed it so I closed the original PR to fix the issue. However, we should keep the regression test. Skip news as there's no user observable behavior change.

<!-- gh-issue-number: gh-102864 -->
* Issue: gh-102864
<!-- /gh-issue-number -->
