### PR TITLE
[3.9] gh-112769: test_zlib: test_zlib: Fix comparison of ZLIB_RUNTIME_VERSION with non-int suffix (GH-112771)

### DIFF
--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -16,6 +16,19 @@ requires_Decompress_copy = unittest.skipUnless(
         hasattr(zlib.decompressobj(), "copy"),
         'requires Decompress.copy()')
 
+def _zlib_runtime_version_tuple(zlib_version=zlib.ZLIB_RUNTIME_VERSION):
+    # Register "1.2.3" as "1.2.3.0"
+    # or "1.2.0-linux","1.2.0.f","1.2.0.f-linux"
+    v = zlib_version.split('-', 1)[0].split('.')
+    if len(v) < 4:
+        v.append('0')
+    elif not v[-1].isnumeric():
+        v[-1] = '0'
+    return tuple(map(int, v))
+
+
+ZLIB_RUNTIME_VERSION_TUPLE = _zlib_runtime_version_tuple()
+
 
 class VersionTestCase(unittest.TestCase):
 
@@ -437,9 +450,8 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         sync_opt = ['Z_NO_FLUSH', 'Z_SYNC_FLUSH', 'Z_FULL_FLUSH',
                     'Z_PARTIAL_FLUSH']
 
-        ver = tuple(int(v) for v in zlib.ZLIB_RUNTIME_VERSION.split('.'))
         # Z_BLOCK has a known failure prior to 1.2.5.3
-        if ver >= (1, 2, 5, 3):
+        if ZLIB_RUNTIME_VERSION_TUPLE >= (1, 2, 5, 3):
             sync_opt.append('Z_BLOCK')
 
         sync_opt = [getattr(zlib, opt) for opt in sync_opt
@@ -768,16 +780,7 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
 
     def test_wbits(self):
         # wbits=0 only supported since zlib v1.2.3.5
-        # Register "1.2.3" as "1.2.3.0"
-        # or "1.2.0-linux","1.2.0.f","1.2.0.f-linux"
-        v = zlib.ZLIB_RUNTIME_VERSION.split('-', 1)[0].split('.')
-        if len(v) < 4:
-            v.append('0')
-        elif not v[-1].isnumeric():
-            v[-1] = '0'
-
-        v = tuple(map(int, v))
-        supports_wbits_0 = v >= (1, 2, 3, 5)
+        supports_wbits_0 = ZLIB_RUNTIME_VERSION_TUPLE >= (1, 2, 3, 5)
 
         co = zlib.compressobj(level=1, wbits=15)
         zlib15 = co.compress(HAMLET_SCENE) + co.flush()

--- a/Misc/NEWS.d/next/Tests/2024-05-25-17-06-01.gh-issue-112769.kdLJmS.rst
+++ b/Misc/NEWS.d/next/Tests/2024-05-25-17-06-01.gh-issue-112769.kdLJmS.rst
@@ -1,0 +1,3 @@
+The tests now correctly compare zlib version when
+:const:`zlib.ZLIB_RUNTIME_VERSION` contains non-integer suffixes. For
+example zlib-ng defines the version as ``1.3.0.zlib-ng``.


### PR DESCRIPTION
zlib-ng defines the version as "1.3.0.zlib-ng".
(cherry picked from commit d384813)

Co-authored-by: Miro Hrončok miro@hroncok.cz


<!-- gh-issue-number: gh-112769 -->
* Issue: gh-112769
<!-- /gh-issue-number -->
