### PR TITLE
Note argparse exit code in documentation

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -722,7 +722,8 @@ exit_on_error
 ^^^^^^^^^^^^^
 
 Normally, when you pass an invalid argument list to the :meth:`~ArgumentParser.parse_args`
-method of an :class:`ArgumentParser`, it will exit with error info.
+method of an :class:`ArgumentParser`, it will print error info and exit with a status
+code of 2.
 
 If the user would like to catch errors manually, the feature can be enabled by setting
 ``exit_on_error`` to ``False``::

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -722,7 +722,7 @@ exit_on_error
 ^^^^^^^^^^^^^
 
 Normally, when you pass an invalid argument list to the :meth:`~ArgumentParser.parse_args`
-method of an :class:`ArgumentParser`, it will print error info and exit with a status
+method of an :class:`ArgumentParser`, it will print a *message* to :data:`sys.stderr` and exit with a status
 code of 2.
 
 If the user would like to catch errors manually, the feature can be enabled by setting


### PR DESCRIPTION
It is currently stated that calling `ArgumentParser.error()` exits with a code of 2.  However, it is not explicitly stated that this method is used in `ArgumentParser.parse_args()` when the arguments are invalid.  Adding a note about the exit code to the `exit_on_error` argument of the `ArgumentParser` constructor makes this relationship explicit, and also makes this piece of information easier to notice.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119568.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->