### PR TITLE
gh-119562: Remove unused private string constants from `ast.py`

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -567,15 +567,6 @@ class NodeTransformer(NodeVisitor):
                     setattr(node, field, new_node)
         return node
 
-
-_DEPRECATED_VALUE_ALIAS_MESSAGE = (
-    "{name} is deprecated and will be removed in Python {remove}; use value instead"
-)
-_DEPRECATED_CLASS_MESSAGE = (
-    "{name} is deprecated and will be removed in Python {remove}; "
-    "use ast.Constant instead"
-)
-
 class slice(AST):
     """Deprecated AST node class."""
 


### PR DESCRIPTION
Leftover cruft that should have been deleted in https://github.com/python/cpython/commit/008bc04dcb3b1fa6d7c11ed8050467dfad3090a9, but which I missed

<!-- gh-issue-number: gh-119562 -->
* Issue: gh-119562
<!-- /gh-issue-number -->
