### PR TITLE
gh-119577: Raise RuntimeError when testing element truth values in ElementTree

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1062,6 +1062,7 @@ Element Objects
    Use specific ``len(elem)`` or ``elem is None`` test instead.::
 
    .. versionchanged:: 3.14
+
       Testing the truth value of an Element raises :exc:`RuntimeError`
       after emitting :exc:`DeprecationWarning` since Python 3.12.
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1058,20 +1058,12 @@ Element Objects
    :meth:`~object.__getitem__`, :meth:`~object.__setitem__`,
    :meth:`~object.__len__`.
 
-   Caution: Elements with no subelements will test as ``False``.  Testing the
-   truth value of an Element is deprecated and will raise an exception in
-   Python 3.14.  Use specific ``len(elem)`` or ``elem is None`` test instead.::
+   Caution: Testing the truth value of an Element raises :exc:`RuntimeError`.
+   Use specific ``len(elem)`` or ``elem is None`` test instead.::
 
-     element = root.find('foo')
-
-     if not element:  # careful!
-         print("element not found, or element has no subelements")
-
-     if element is None:
-         print("element not found")
-
-   .. versionchanged:: 3.12
-      Testing the truth value of an Element emits :exc:`DeprecationWarning`.
+   .. versionchanged:: 3.14
+      Testing the truth value of an Element raises :exc:`RuntimeError`
+      after emitting :exc:`DeprecationWarning` since Python 3.12.
 
    Prior to Python 3.8, the serialisation order of the XML attributes of
    elements was artificially made predictable by sorting the attributes by

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -192,6 +192,13 @@ typing
 * Remove :class:`!typing.ByteString`. It had previously raised a
   :exc:`DeprecationWarning` since Python 3.12.
 
+xml.etree.ElementTree
+---------------------
+
+* Testing the truth value of an :class:`xml.etree.ElementTree.Element`
+  now raises :exc:`RuntimeError`. It had previously raised a
+  :exc:`DeprecationWarning` since Python 3.12.
+
 Others
 ------
 

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -4085,22 +4085,13 @@ class NoAcceleratorTest(unittest.TestCase):
 # --------------------------------------------------------------------
 
 class BoolTest(unittest.TestCase):
-    def test_warning(self):
+    def test_error(self):
         e = ET.fromstring('<a style="new"></a>')
         msg = (
-            r"Testing an element's truth value will raise an exception in "
-            r"future versions.  "
+            r"Testing an element's truth value is not supported. "
             r"Use specific 'len\(elem\)' or 'elem is not None' test instead.")
-        with self.assertWarnsRegex(DeprecationWarning, msg):
-            result = bool(e)
-        # Emulate prior behavior for now
-        self.assertIs(result, False)
-
-        # Element with children
-        ET.SubElement(e, 'b')
-        with self.assertWarnsRegex(DeprecationWarning, msg):
-            new_result = bool(e)
-        self.assertIs(new_result, True)
+        with self.assertRaisesRegex(RuntimeError, msg):
+            bool(e)
 
 # --------------------------------------------------------------------
 

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -200,13 +200,10 @@ class Element:
         return len(self._children)
 
     def __bool__(self):
-        warnings.warn(
-            "Testing an element's truth value will raise an exception in "
-            "future versions.  "
-            "Use specific 'len(elem)' or 'elem is not None' test instead.",
-            DeprecationWarning, stacklevel=2
-            )
-        return len(self._children) != 0 # emulate old behaviour, for now
+        raise RuntimeError(
+            "Testing an element's truth value is not supported. "
+            "Use specific 'len(elem)' or 'elem is not None' test instead."
+        )
 
     def __getitem__(self, index):
         return self._children[index]

--- a/Misc/NEWS.d/next/Library/2024-05-26-09-48-42.gh-issue-119577.nLcGU7.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-26-09-48-42.gh-issue-119577.nLcGU7.rst
@@ -1,0 +1,3 @@
+The :mod:`xml.etree.ElementTree` module now raises :exc:`RuntimeError` when
+testing the truth value of an :class:`xml.etree.ElementTree.Element`, after
+emitting :exc:`DeprecationWarning` since Python 3.12.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1500,18 +1500,10 @@ element_getitem(PyObject* self_, Py_ssize_t index)
 static int
 element_bool(PyObject* self_)
 {
-    ElementObject* self = (ElementObject*) self_;
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                     "Testing an element's truth value will raise an exception "
-                     "in future versions.  Use specific 'len(elem)' or "
-                     "'elem is not None' test instead.",
-                     1) < 0) {
-        return -1;
-    };
-    if (self->extra ? self->extra->length : 0) {
-        return 1;
-    }
-    return 0;
+    PyErr_SetString(PyExc_RuntimeError,
+                    "Testing an element's truth value is not supported. Use "
+                    "specific 'len(elem)' or 'elem is not None' test instead.");
+    return -1;
 }
 
 /*[clinic input]


### PR DESCRIPTION
Raise `RuntimeError` for this ambiguous behavior, as announced in Python 3.12 by a deprecation warning.

<!-- gh-issue-number: gh-119577 -->
* Issue: gh-119577
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119578.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->