### PR TITLE
gh-119580: Improve version added section for convenience variable

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -288,7 +288,7 @@ There are three preset *convenience variables*:
 * ``$_retval``: the return value if the frame is returning
 * ``$_exception``: the exception if the frame is raising an exception
 
-.. versionadded:: 3.12
+.. versionadded:: 3.12  *convenience variable*
 
 .. index::
    pair: .pdbrc; file

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -288,7 +288,8 @@ There are three preset *convenience variables*:
 * ``$_retval``: the return value if the frame is returning
 * ``$_exception``: the exception if the frame is raising an exception
 
-.. versionadded:: 3.12  *convenience variable*
+.. versionadded:: 3.12
+   *convenience variable*
 
 .. index::
    pair: .pdbrc; file

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -289,7 +289,8 @@ There are three preset *convenience variables*:
 * ``$_exception``: the exception if the frame is raising an exception
 
 .. versionadded:: 3.12
-   *convenience variable*
+
+   Added the *convenience variable* feature.
 
 .. index::
    pair: .pdbrc; file


### PR DESCRIPTION
The version added section is not clear about what is "added" because there are a lot of content above. Clarify it by explicitly write the feature.

<!-- gh-issue-number: gh-119580 -->
* Issue: gh-119580
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119583.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->