### PR TITLE
Docs: Only install sphinx-autobuild for `make htmllive`

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -150,10 +150,14 @@ gettext: build
 htmlview: html
 	$(PYTHON) -c "import os, webbrowser; webbrowser.open('file://' + os.path.realpath('build/html/index.html'))"
 
+.PHONY: ensure-sphinx-autobuild
+ensure-sphinx-autobuild:
+	$(VENVDIR)/bin/sphinx-autobuild --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install sphinx-autobuild
+
 .PHONY: htmllive
 htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
 htmllive: SPHINXOPTS = --re-ignore="/venv/" --open-browser --delay 0
-htmllive: html
+htmllive: ensure-sphinx-autobuild html
 
 .PHONY: clean
 clean: clean-venv

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -151,7 +151,7 @@ htmlview: html
 	$(PYTHON) -c "import os, webbrowser; webbrowser.open('file://' + os.path.realpath('build/html/index.html'))"
 
 .PHONY: ensure-sphinx-autobuild
-ensure-sphinx-autobuild:
+ensure-sphinx-autobuild: venv
 	$(VENVDIR)/bin/sphinx-autobuild --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install sphinx-autobuild
 
 .PHONY: htmllive

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -10,7 +10,6 @@ sphinx~=7.3.0
 
 blurb
 
-sphinx-autobuild
 sphinxext-opengraph==0.7.5
 sphinx-notfound-page==1.0.0
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


Doctest is failing on the CI because sphinx-autobuild depends on watchfiles, which is Rust and had a [new release 2h ago](https://github.com/samuelcolvin/watchfiles/releases/tag/v0.22.0), and fails with a Python 3.14 build:
```
error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.12)
= help: please check if an updated version of PyO3 is available. Current version: 0.21.2
= help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI
```
https://github.com/python/cpython/actions/runs/9256019877/job/25462093382?pr=119541#step:7:161

we don't need sphinx-autobuild on the CI, let's only install it when doing `make htmllive`.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119607.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->