### PR TITLE
gh-119584: Fix test_import Failed Assertion

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -2887,12 +2887,15 @@ class SinglephaseInitTests(unittest.TestCase):
 
                 self.assertIs(reloaded.snapshot.cached, reloaded.module)
 
+    @unittest.skipIf(_testinternalcapi is None, "requires _testinternalcapi")
     def test_check_state_first(self):
         for variant in ['', '_with_reinit', '_with_state']:
             name = f'{self.NAME}{variant}_check_cache_first'
             with self.subTest(name):
                 mod = self._load_dynamic(name, self.ORIGIN)
                 self.assertEqual(mod.__name__, name)
+                sys.modules.pop(name, None)
+                _testinternalcapi.clear_extension(name, self.ORIGIN)
 
     # Currently, for every single-phrase init module loaded
     # in multiple interpreters, those interpreters share a

--- a/Modules/_testsinglephase.c
+++ b/Modules/_testsinglephase.c
@@ -682,6 +682,9 @@ finally:
 /* the _testsinglephase_*_check_cache_first modules */
 /****************************************************/
 
+/* Each of these modules should only be freshly loaded.  That means
+   clearing the caches and each module def's m_base after each load. */
+
 static struct PyModuleDef _testsinglephase_check_cache_first = {
     PyModuleDef_HEAD_INIT,
     .m_name = "_testsinglephase_check_cache_first",

--- a/Python/import.c
+++ b/Python/import.c
@@ -2192,6 +2192,7 @@ clear_singlephase_extension(PyInterpreterState *interp,
             return -1;
         }
     }
+    def->m_base.m_index = 0;
 
     /* Clear the cached module def. */
     _extensions_cache_delete(path, name);

--- a/Python/import.c
+++ b/Python/import.c
@@ -2183,7 +2183,7 @@ clear_singlephase_extension(PyInterpreterState *interp,
     /* Clear data set when the module was initially loaded. */
     def->m_base.m_init = NULL;
     Py_CLEAR(def->m_base.m_copy);
-    // We leave m_index alone since there's no reason to reset it.
+    def->m_base.m_index = 0;
 
     /* Clear the PyState_*Module() cache entry. */
     Py_ssize_t index = _get_cached_module_index(cached);
@@ -2192,7 +2192,6 @@ clear_singlephase_extension(PyInterpreterState *interp,
             return -1;
         }
     }
-    def->m_base.m_index = 0;
 
     /* Clear the cached module def. */
     _extensions_cache_delete(path, name);

--- a/Python/import.c
+++ b/Python/import.c
@@ -494,7 +494,7 @@ _modules_by_index_check(PyInterpreterState *interp, Py_ssize_t index)
     if (MODULES_BY_INDEX(interp) == NULL) {
         return "Interpreters module-list not accessible.";
     }
-    if (index > PyList_GET_SIZE(MODULES_BY_INDEX(interp))) {
+    if (index >= PyList_GET_SIZE(MODULES_BY_INDEX(interp))) {
         return "Module index out of bounds.";
     }
     return NULL;


### PR DESCRIPTION
The fix in gh-119561 introduced an assertion that doesn't hold true if any of the three new test extension modules are loaded more than once.  This is fine normally but breaks if the new `test_check_state_first()` is run more than once, which happens for refleak checking and with the regrtest `--forever` flag.  We fix that here by clearing each of the three modules after loading them.

<!-- gh-issue-number: gh-119584 -->
* Issue: gh-119584
<!-- /gh-issue-number -->
