### PR TITLE
[3.13] gh-117398: Revert gh-119636, Add multiphase support to _datetime

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -47,26 +47,6 @@ except ImportError:
     pass
 #
 
-# This is copied from test_import/__init__.py.
-# XXX Move it to support/__init__.py.
-def no_rerun(reason):
-    """Skip rerunning for a particular test.
-
-    WARNING: Use this decorator with care; skipping rerunning makes it
-    impossible to find reference leaks. Provide a clear reason for skipping the
-    test using the 'reason' parameter.
-    """
-    def deco(func):
-        _has_run = False
-        def wrapper(self):
-            nonlocal _has_run
-            if _has_run:
-                self.skipTest(reason)
-            func(self)
-            _has_run = True
-        return wrapper
-    return deco
-
 pickle_loads = {pickle.loads, pickle._loads}
 
 pickle_choices = [(pickle, pickle, proto)
@@ -6403,7 +6383,6 @@ class IranTest(ZoneInfoTest):
 
 
 @unittest.skipIf(_testcapi is None, 'need _testcapi module')
-@no_rerun("the encapsulated datetime C API does not support reloading")
 class CapiTest(unittest.TestCase):
     def setUp(self):
         # Since the C API is not present in the _Pure tests, skip all tests

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6970,26 +6970,30 @@ error:
 }
 #undef DATETIME_ADD_MACRO
 
-static PyModuleDef_Slot module_slots[] = {
-    {Py_mod_exec, _datetime_exec},
-    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-    {0, NULL},
-};
-
-static PyModuleDef datetimemodule = {
+static struct PyModuleDef datetimemodule = {
     .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "_datetime",
     .m_doc = "Fast implementation of the datetime type.",
-    .m_size = 0,
+    .m_size = -1,
     .m_methods = module_methods,
-    .m_slots = module_slots,
 };
 
 PyMODINIT_FUNC
 PyInit__datetime(void)
 {
-    return PyModuleDef_Init(&datetimemodule);
+    PyObject *mod = PyModule_Create(&datetimemodule);
+    if (mod == NULL)
+        return NULL;
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+#endif
+
+    if (_datetime_exec(mod) < 0) {
+        Py_DECREF(mod);
+        return NULL;
+    }
+
+    return mod;
 }
 
 /* ---------------------------------------------------------------------------


### PR DESCRIPTION
This reverts commit d58ebf073c755c2f0f6e4ef2296b48a4c75e5f1c.

That commit broke many buildbots, so we'll need to regroup.

<!-- gh-issue-number: gh-117398 -->
* Issue: gh-117398
<!-- /gh-issue-number -->
