### PR TITLE
gh-119538: Add missing expat build dependencies

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -631,7 +631,9 @@ LIBEXPAT_HEADERS= \
 		Modules/expat/utf8tab.h \
 		Modules/expat/xmlrole.h \
 		Modules/expat/xmltok.h \
-		Modules/expat/xmltok_impl.h
+		Modules/expat/xmltok_impl.h \
+		Modules/expat/xmltok_impl.c \
+		Modules/expat/xmltok_ns.c
 
 ##########################################################################
 # hashlib's HACL* library


### PR DESCRIPTION
xmltok_impl.c and xmltok_ns.c are _included_ in xmltok.c by the C
pre-processor.


<!-- gh-issue-number: gh-119538 -->
* Issue: gh-119538
<!-- /gh-issue-number -->
