### PR TITLE
gh-119287: clarify doc on BaseExceptionGroup.derive and link to it from contextlib.suppress

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -314,8 +314,8 @@ Functions and classes provided:
 
    If the code within the :keyword:`!with` block raises a
    :exc:`BaseExceptionGroup`, suppressed exceptions are removed from the
-   group.  If any exceptions in the group are not suppressed, a group containing them
-   is re-raised (see also :meth:`~BaseExceptionGroup.derive`).
+   group.  If any exceptions in the group are not suppressed, a group containing
+   them is re-raised (see also :meth:`~BaseExceptionGroup.derive`).
 
    .. versionadded:: 3.4
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -314,9 +314,9 @@ Functions and classes provided:
 
    If the code within the :keyword:`!with` block raises a
    :exc:`BaseExceptionGroup`, suppressed exceptions are removed from the
-   group.  If any exceptions in the group are not suppressed, a group containing
-   them is created using the old group's :meth:`~BaseExceptionGroup.derive`
-   method, and the new group is then re-raised.
+   group.  Any exceptions of the group which are not suppressed are re-raised in
+   a new group which is created using the original group's :meth:`~BaseExceptionGroup.derive`
+   method.
 
    .. versionadded:: 3.4
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -315,7 +315,8 @@ Functions and classes provided:
    If the code within the :keyword:`!with` block raises a
    :exc:`BaseExceptionGroup`, suppressed exceptions are removed from the
    group.  If any exceptions in the group are not suppressed, a group containing
-   them is re-raised (see also :meth:`~BaseExceptionGroup.derive`).
+   them is created using the old group's :meth:`~BaseExceptionGroup.derive`
+   method, and the new group is then re-raised.
 
    .. versionadded:: 3.4
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -314,7 +314,8 @@ Functions and classes provided:
 
    If the code within the :keyword:`!with` block raises a
    :exc:`BaseExceptionGroup`, suppressed exceptions are removed from the
-   group.  If any exceptions in the group are not suppressed, a group containing them is re-raised.
+   group.  If any exceptions in the group are not suppressed, a group containing them
+   is re-raised (see also :meth:`~BaseExceptionGroup.derive`).
 
    .. versionadded:: 3.4
 

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -989,7 +989,8 @@ their subgroups based on the types of the contained exceptions.
       Returns an exception group with the same :attr:`message`, but which
       wraps the exceptions in ``excs``.
 
-      This method is used by :meth:`subgroup` and :meth:`split`. A
+      This method is used by :meth:`subgroup` and :meth:`split`, which
+      are used in various contexts to break up an exception group. A
       subclass needs to override it in order to make :meth:`subgroup`
       and :meth:`split` return instances of the subclass rather
       than :exc:`ExceptionGroup`.


### PR DESCRIPTION
Fixes #119287.

<!-- gh-issue-number: gh-119287 -->
* Issue: gh-119287
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119657.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->