### PR TITLE
gh-119659: Fix `support.no_rerun` decorator

### DIFF
--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -173,6 +173,8 @@ def runtest_refleak(test_name, test_func,
         interned_before = interned_after
 
         restore_support_xml(xml_filename)
+        refleak_helper._refleak_iteration += 1
+    refleak_helper._refleak_iteration = 0
 
     if not quiet:
         print(file=sys.stderr)

--- a/Lib/test/support/refleak_helper.py
+++ b/Lib/test/support/refleak_helper.py
@@ -6,3 +6,5 @@ for refleaks
 _hunting_for_refleaks = False
 def hunting_for_refleaks():
     return _hunting_for_refleaks
+
+_refleak_iteration = 0

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -39,16 +39,22 @@ def load_tests(loader, tests, pattern):
         for cls in test_classes:
             cls.__name__ += suffix
             cls.__qualname__ += suffix
+            orig_setUpClass = getattr(cls, 'setUpClass', None)
+            orig_tearDownClass = getattr(cls, 'tearDownClass', None)
             @classmethod
-            def setUpClass(cls_, module=module):
+            def setUpClass(cls_, module=module, orig_setUpClass=orig_setUpClass):
                 cls_._save_sys_modules = sys.modules.copy()
                 sys.modules[TESTS] = module
                 sys.modules['datetime'] = module.datetime_module
                 if hasattr(module, '_pydatetime'):
                     sys.modules['_pydatetime'] = module._pydatetime
                 sys.modules['_strptime'] = module._strptime
+                if orig_setUpClass is not None:
+                    orig_setUpClass()
             @classmethod
-            def tearDownClass(cls_):
+            def tearDownClass(cls_, orig_tearDownClass=orig_tearDownClass):
+                if orig_tearDownClass is not None:
+                    orig_tearDownClass()
                 sys.modules.clear()
                 sys.modules.update(cls_._save_sys_modules)
             cls.setUpClass = setUpClass


### PR DESCRIPTION
I've cropped some unrelated parts of the output out.

## Before

On class:

```
» ./python.exe -m test test_datetime -m test_utc_capi -v -R 3:3

----------------------------------------------------------------------
Ran 0 tests in 0.000s

NO TESTS RAN
test_datetime ran no tests

== Tests result: NO TESTS RAN ==

1 test run no tests:
    test_datetime
```

On method:

```
» ./python.exe -m test test_import -m test_basic_multiple_interpreters_deleted_no_reset -R 3:3 -v

test_basic_multiple_interpreters_deleted_no_reset (test.test_import.SinglephaseInitTests.test_basic_multiple_interpreters_deleted_no_reset) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.059s

OK
X

test_basic_multiple_interpreters_deleted_no_reset (test.test_import.SinglephaseInitTests.test_basic_multiple_interpreters_deleted_no_reset) ... skipped 'rerun not possible; module state is never cleared (see gh-102251)'

----------------------------------------------------------------------
Ran 1 test in 0.000s

OK (skipped=1)
.
```

## After

On class:

```
» ./python.exe -m test test_datetime -m test_utc_capi -v -R 3:3

test_utc_capi (test.datetimetester.CapiTest_Pure.test_utc_capi) ... skipped 'Not relevant in pure Python'
test_utc_capi (test.datetimetester.CapiTest_Fast.test_utc_capi) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.000s

OK (skipped=1)
X

setUpClass (test.datetimetester.CapiTest_Pure) ... skipped 'the encapsulated datetime C API does not support reloading'
setUpClass (test.datetimetester.CapiTest_Fast) ... skipped 'the encapsulated datetime C API does not support reloading'

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK (skipped=2)
X
```

On method:

```
» ./python.exe -m test test_import -m test_basic_multiple_interpreters_deleted_no_reset -R 3:3 -v

test_basic_multiple_interpreters_deleted_no_reset (test.test_import.SinglephaseInitTests.test_basic_multiple_interpreters_deleted_no_reset) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.056s

OK
X
.test_basic_multiple_interpreters_deleted_no_reset (test.test_import.SinglephaseInitTests.test_basic_multiple_interpreters_deleted_no_reset) ... skipped 'rerun not possible; module state is never cleared (see gh-102251)'

----------------------------------------------------------------------
Ran 1 test in 0.000s

OK (skipped=1)
.
```

<!-- gh-issue-number: gh-119659 -->
* Issue: gh-119659
<!-- /gh-issue-number -->
