### PR TITLE
GH-119700: Catch SyntaxErrors raised by the compiler in the new REPL

### DIFF
--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -101,7 +101,7 @@ class InteractiveColoredConsole(code.InteractiveConsole):
             item = wrapper([stmt])
             try:
                 code = compile(item, filename, the_symbol, dont_inherit=True)
-            except (OverflowError, ValueError):
+            except (OverflowError, ValueError, SyntaxError):
                     self.showsyntaxerror(filename)
                     return False
 


### PR DESCRIPTION
Still needs tests and such, just running CI for now.

<!-- gh-issue-number: gh-119700 -->
* Issue: gh-119700
<!-- /gh-issue-number -->
