### PR TITLE
[3.11] gh-119690: Fixes buffer type confusion in _winapi.CreateNamedPipe audit event

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-05-29-17-00-27.gh-issue-119690.tv6Zgs.rst
+++ b/Misc/NEWS.d/next/Windows/2024-05-29-17-00-27.gh-issue-119690.tv6Zgs.rst
@@ -1,0 +1,2 @@
+Fixes data type confusion in audit event raised by
+``_winapi.CreateNamedPipe``.

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -708,7 +708,7 @@ _winapi_CreateNamedPipe_impl(PyObject *module, LPCTSTR name, DWORD open_mode,
 {
     HANDLE handle;
 
-    if (PySys_Audit("_winapi.CreateNamedPipe", "uII",
+    if (PySys_Audit("_winapi.CreateNamedPipe", "sII",
                     name, open_mode, pipe_mode) < 0) {
         return INVALID_HANDLE_VALUE;
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-119690 -->
* Issue: gh-119690
<!-- /gh-issue-number -->
