### PR TITLE
[3.10] gh-119690: Fixes buffer type confusion in _winapi.CreateFile and _winapi.CreateNamedPipe audit events

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-05-29-17-05-28.gh-issue-119690.U6RMtm.rst
+++ b/Misc/NEWS.d/next/Windows/2024-05-29-17-05-28.gh-issue-119690.U6RMtm.rst
@@ -1,0 +1,2 @@
+Fixes data type confusion in audit events raised by ``_winapi.CreateFile``
+and ``_winapi.CreateNamedPipe``.

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -470,7 +470,7 @@ _winapi_CreateFile_impl(PyObject *module, LPCTSTR file_name,
 {
     HANDLE handle;
 
-    if (PySys_Audit("_winapi.CreateFile", "uIIII",
+    if (PySys_Audit("_winapi.CreateFile", "sIIII",
                     file_name, desired_access, share_mode,
                     creation_disposition, flags_and_attributes) < 0) {
         return INVALID_HANDLE_VALUE;
@@ -690,7 +690,7 @@ _winapi_CreateNamedPipe_impl(PyObject *module, LPCTSTR name, DWORD open_mode,
 {
     HANDLE handle;
 
-    if (PySys_Audit("_winapi.CreateNamedPipe", "uII",
+    if (PySys_Audit("_winapi.CreateNamedPipe", "sII",
                     name, open_mode, pipe_mode) < 0) {
         return INVALID_HANDLE_VALUE;
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-119690 -->
* Issue: gh-119690
<!-- /gh-issue-number -->
