### PR TITLE
[3.12] gh-119070: Fix py.exe handling of /usr/bin/env commands missing extension (GH-119426)

### DIFF
--- a/Lib/test/test_launcher.py
+++ b/Lib/test/test_launcher.py
@@ -718,31 +718,6 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
             data["stdout"].strip(),
         )
 
-    def test_shebang_command_in_venv(self):
-        stem = "python-that-is-not-on-path"
-
-        # First ensure that our test name doesn't exist, and the launcher does
-        # not match any installed env
-        with self.script(f'#! /usr/bin/env {stem} arg1') as script:
-            data = self.run_py([script], expect_returncode=103)
-
-        with self.fake_venv() as (venv_exe, env):
-            # Put a "normal" Python on PATH as a distraction.
-            # The active VIRTUAL_ENV should be preferred when the name isn't an
-            # exact match.
-            exe = Path(Path(venv_exe).name).absolute()
-            exe.touch()
-            self.addCleanup(exe.unlink)
-            env["PATH"] = f"{exe.parent};{os.environ['PATH']}"
-
-            with self.script(f'#! /usr/bin/env {stem} arg1') as script:
-                data = self.run_py([script], env=env)
-            self.assertEqual(data["stdout"].strip(), f"{quote(venv_exe)} arg1 {quote(script)}")
-
-            with self.script(f'#! /usr/bin/env {exe.stem} arg1') as script:
-                data = self.run_py([script], env=env)
-            self.assertEqual(data["stdout"].strip(), f"{quote(exe)} arg1 {quote(script)}")
-
     def test_shebang_executable_extension(self):
         with self.script('#! /usr/bin/env python3.12') as script:
             data = self.run_py([script])

--- a/Lib/test/test_launcher.py
+++ b/Lib/test/test_launcher.py
@@ -717,3 +717,36 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
             f"{expect} arg1 {script}",
             data["stdout"].strip(),
         )
+
+    def test_shebang_command_in_venv(self):
+        stem = "python-that-is-not-on-path"
+
+        # First ensure that our test name doesn't exist, and the launcher does
+        # not match any installed env
+        with self.script(f'#! /usr/bin/env {stem} arg1') as script:
+            data = self.run_py([script], expect_returncode=103)
+
+        with self.fake_venv() as (venv_exe, env):
+            # Put a "normal" Python on PATH as a distraction.
+            # The active VIRTUAL_ENV should be preferred when the name isn't an
+            # exact match.
+            exe = Path(Path(venv_exe).name).absolute()
+            exe.touch()
+            self.addCleanup(exe.unlink)
+            env["PATH"] = f"{exe.parent};{os.environ['PATH']}"
+
+            with self.script(f'#! /usr/bin/env {stem} arg1') as script:
+                data = self.run_py([script], env=env)
+            self.assertEqual(data["stdout"].strip(), f"{quote(venv_exe)} arg1 {quote(script)}")
+
+            with self.script(f'#! /usr/bin/env {exe.stem} arg1') as script:
+                data = self.run_py([script], env=env)
+            self.assertEqual(data["stdout"].strip(), f"{quote(exe)} arg1 {quote(script)}")
+
+    def test_shebang_executable_extension(self):
+        with self.script('#! /usr/bin/env python3.12') as script:
+            data = self.run_py([script])
+        expect = "# Search PATH for python3.12.exe"
+        actual = [line.strip() for line in data["stderr"].splitlines()
+                  if line.startswith("# Search PATH")]
+        self.assertEqual([expect], actual)

--- a/Misc/NEWS.d/next/Windows/2024-05-22-19-43-29.gh-issue-119070._enton.rst
+++ b/Misc/NEWS.d/next/Windows/2024-05-22-19-43-29.gh-issue-119070._enton.rst
@@ -1,0 +1,3 @@
+Fixes ``py.exe`` handling of shebangs like ``/usr/bin/env python3.12``,
+which were previously interpreted as ``python3.exe`` instead of
+``python3.12.exe``.

--- a/PC/launcher2.c
+++ b/PC/launcher2.c
@@ -846,7 +846,7 @@ searchPath(SearchInfo *search, const wchar_t *shebang, int shebangLength)
     }
 
     wchar_t filename[MAXLEN];
-    if (wcsncpy_s(filename, MAXLEN, command, lastDot)) {
+    if (wcsncpy_s(filename, MAXLEN, command, commandLength)) {
         return RC_BAD_VIRTUAL_PATH;
     }
 

--- a/PC/launcher2.c
+++ b/PC/launcher2.c
@@ -858,6 +858,8 @@ searchPath(SearchInfo *search, const wchar_t *shebang, int shebangLength)
         }
     }
 
+    debug(L"# Search PATH for %s\n", filename);
+
     wchar_t pathVariable[MAXLEN];
     int n = GetEnvironmentVariableW(L"PATH", pathVariable, MAXLEN);
     if (!n) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-119070 -->
* Issue: gh-119070
<!-- /gh-issue-number -->
