### PR TITLE
subprocess docs: Fix semantically important typo

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -52,7 +52,7 @@ underlying :class:`Popen` interface can be used directly.
 
    If *capture_output* is true, stdout and stderr will be captured.
    When used, the internal :class:`Popen` object is automatically created with
-   *stdout* and *stdin* both set to :data:`~subprocess.PIPE`.
+   *stdout* and *stderr* both set to :data:`~subprocess.PIPE`.
    The *stdout* and *stderr* arguments may not be supplied at the same time as *capture_output*.
    If you wish to capture and combine both streams into one,
    set *stdout* to :data:`~subprocess.PIPE`


### PR DESCRIPTION
GH-25416 accidentally replaced a reference to the *stderr* argument of
`subprocess.run` with a reference to the *stdin* argument.  *stdin* is
not affected by the `check_output` option.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119752.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->