### PR TITLE
gh-119577: Adjust DeprecationWarning when testing element truth values in ElementTree

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1058,9 +1058,10 @@ Element Objects
    :meth:`~object.__getitem__`, :meth:`~object.__setitem__`,
    :meth:`~object.__len__`.
 
-   Caution: Elements with no subelements will test as ``False``.  Testing the
-   truth value of an Element is deprecated and will raise an exception in
-   Python 3.14.  Use specific ``len(elem)`` or ``elem is None`` test instead.::
+   Caution: Elements with no subelements will test as ``False``.  In a future
+   release of Python, all elements will test as ``True`` regardless of whether
+   subelements exist.  Instead, prefer explicit ``len(elem)`` or
+   ``elem is not None`` tests.::
 
      element = root.find('foo')
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1440,8 +1440,6 @@ and will be removed in Python 3.14.
 
 * :mod:`typing`: :class:`!typing.ByteString`
 
-* :mod:`xml.etree.ElementTree`: Testing the truth value of an :class:`xml.etree.ElementTree.Element`.
-
 * The ``__package__`` and ``__cached__`` attributes on module objects.
 
 * The :attr:`~codeobject.co_lnotab` attribute of code objects.
@@ -1466,6 +1464,11 @@ although there is currently no date scheduled for their removal.
 * :mod:`array`'s ``'u'`` format code (:gh:`57281`)
 
 * :class:`typing.Text` (:gh:`92332`)
+
+* :mod:`xml.etree.ElementTree`: Testing the truth value of an
+  :class:`xml.etree.ElementTree.Element` is deprecated. In a future release it
+  will always return True. Prefer explicit ``len(elem)`` or
+  ``elem is not None`` tests instead.
 
 * Currently Python accepts numeric literals immediately followed by keywords,
   for example ``0in x``, ``1or x``, ``0if 1else 2``.  It allows confusing

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1705,11 +1705,6 @@ Pending Removal in Python 3.14
   public API.
   (Contributed by Gregory P. Smith in :gh:`88168`.)
 
-* :mod:`xml.etree.ElementTree`: Testing the truth value of an
-  :class:`~xml.etree.ElementTree.Element` is deprecated and will raise an
-  exception in Python 3.14.
-
-
 Pending Removal in Python 3.15
 ------------------------------
 
@@ -1910,6 +1905,11 @@ although there is currently no date scheduled for their removal.
 
 * :mod:`wsgiref`: ``SimpleHandler.stdout.write()`` should not do partial
   writes.
+
+* :mod:`xml.etree.ElementTree`: Testing the truth value of an
+  :class:`~xml.etree.ElementTree.Element` is deprecated. In a future release it
+  it will always return ``True``. Prefer explicit ``len(elem)`` or
+  ``elem is not None`` tests instead.
 
 * :meth:`zipimport.zipimporter.load_module` is deprecated:
   use :meth:`~zipimport.zipimporter.exec_module` instead.

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -4088,7 +4088,7 @@ class BoolTest(unittest.TestCase):
     def test_warning(self):
         e = ET.fromstring('<a style="new"></a>')
         msg = (
-            r"Testing an element's truth value will raise an exception in "
+            r"Testing an element's truth value will always return True in "
             r"future versions.  "
             r"Use specific 'len\(elem\)' or 'elem is not None' test instead.")
         with self.assertWarnsRegex(DeprecationWarning, msg):

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -201,7 +201,7 @@ class Element:
 
     def __bool__(self):
         warnings.warn(
-            "Testing an element's truth value will raise an exception in "
+            "Testing an element's truth value will always return True in "
             "future versions.  "
             "Use specific 'len(elem)' or 'elem is not None' test instead.",
             DeprecationWarning, stacklevel=2

--- a/Misc/NEWS.d/next/Library/2024-05-29-21-50-05.gh-issue-119577.S3BlKJ.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-29-21-50-05.gh-issue-119577.S3BlKJ.rst
@@ -1,0 +1,4 @@
+The :exc:`DeprecationWarning` emitted when testing the truth value of an
+:class:`xml.etree.ElementTree.Element` now describes unconditionally
+returning `True` in a future version rather than raising an exception in
+Python 3.14.

--- a/Misc/NEWS.d/next/Library/2024-05-29-21-50-05.gh-issue-119577.S3BlKJ.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-29-21-50-05.gh-issue-119577.S3BlKJ.rst
@@ -1,4 +1,4 @@
 The :exc:`DeprecationWarning` emitted when testing the truth value of an
 :class:`xml.etree.ElementTree.Element` now describes unconditionally
-returning `True` in a future version rather than raising an exception in
+returning ``True`` in a future version rather than raising an exception in
 Python 3.14.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1502,7 +1502,7 @@ element_bool(PyObject* self_)
 {
     ElementObject* self = (ElementObject*) self_;
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                     "Testing an element's truth value will raise an exception "
+                     "Testing an element's truth value will always return True "
                      "in future versions.  Use specific 'len(elem)' or "
                      "'elem is not None' test instead.",
                      1) < 0) {


### PR DESCRIPTION
Adjust this deprecation warning to refer to returning True regardless of the existence of subelements (rather than raising an exception in 3.14).

I'm not sure whether this should be described as pending for 3.16 or just "future versions".

<!-- gh-issue-number: gh-119577 -->
* Issue: gh-119577
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119762.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->