### PR TITLE
gh-85794: function-like objects now autospec'd with co_flags of their code objects copied

### DIFF
--- a/Lib/test/test_unittest/testmock/testcallable.py
+++ b/Lib/test/test_unittest/testmock/testcallable.py
@@ -3,6 +3,7 @@
 # http://www.voidspace.org.uk/python/mock/
 
 import unittest
+import inspect
 from test.test_unittest.testmock.support import is_instance, X, SomeClass
 
 from unittest.mock import (
@@ -144,6 +145,19 @@ class TestCallable(unittest.TestCase):
         mock.wibble.assert_called_once_with()
 
         self.assertRaises(TypeError, mock.wibble, 'some',  'args')
+
+
+    def test_autospec_inspect_iscoroutinefunction(self):
+        class A:
+            def method(self):
+                pass
+
+            async def async_method(self):
+                pass
+
+        mock = create_autospec(A)
+        self.assertFalse(inspect.iscoroutinefunction(mock.method))
+        self.assertTrue(inspect.iscoroutinefunction(mock.async_method))
 
 
 if __name__ == "__main__":

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -537,6 +537,23 @@ class NonCallableMock(Base):
         _spec_class = None
         _spec_signature = None
         _spec_asyncs = []
+        __dict__ = self.__dict__
+
+        # special-casing code carriers because co_flags is part of the specs
+        maybe_func = spec
+        code_attr = None
+        if inspect.ismethod(maybe_func):
+            maybe_func = maybe_func.__func__
+        if inspect.isfunction(maybe_func):
+            code_attr = '__code__'
+        elif inspect.iscoroutine(maybe_func):
+            code_attr = 'cr_code'
+        elif inspect.isgenerator(maybe_func):
+            code_attr = 'gi_code'
+        if code_attr:
+            __dict__[code_attr] = MagicMock(parent=self, name=code_attr,
+                _new_name=code_attr, _new_parent=self,
+                co_flags=getattr(maybe_func, code_attr).co_flags)
 
         if spec is not None and not _is_list(spec):
             if isinstance(spec, type):
@@ -561,7 +578,6 @@ class NonCallableMock(Base):
 
             spec = spec_list
 
-        __dict__ = self.__dict__
         __dict__['_spec_class'] = _spec_class
         __dict__['_spec_set'] = spec_set
         __dict__['_spec_signature'] = _spec_signature

--- a/Misc/NEWS.d/next/Library/2024-05-30-10-11-59.gh-issue-85794.j2rskf.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-30-10-11-59.gh-issue-85794.j2rskf.rst
@@ -1,0 +1,1 @@
+Fixed mock objects autospec'd to function-like objects so they can be correctly tested by ``inspect.iscoroutinefunction`` and ``asyncio.iscoroutinefunction``.


### PR DESCRIPTION
# Function-like objects now autospec'd with co_flags of their code objects copied

`inspect.iscoroutinefunction` and `asyncio.iscoroutinefunction` rely on the value of `co_flags` of the code object of a function-like object to determine whether if it is a coroutine function.

Previously accessing `func.__code__.co_flags` of a mock object spec'd to a function would simply create a child mock for `__code__` and another child mock for `co_flags`, resulting in incorrect assessments from `inspect.iscoroutinefunction`.

This is now fixed by special-casing a function-like object to create a child mock for its code attribute with `co_flags` set to that of the original object.

<!-- gh-issue-number: gh-85794 -->
* Issue: gh-85794
<!-- /gh-issue-number -->
