### PR TITLE
gh-119799: Add missing `_Py_IncRefTotal` to `_Py_NewRefWithLock`

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -497,6 +497,9 @@ _Py_NewRefWithLock(PyObject *op)
     if (_Py_TryIncrefFast(op)) {
         return op;
     }
+#ifdef Py_REF_DEBUG
+    _Py_IncRefTotal(_PyThreadState_GET());
+#endif
     _Py_INCREF_STAT_INC();
     for (;;) {
         Py_ssize_t shared = _Py_atomic_load_ssize_relaxed(&op->ob_ref_shared);


### PR DESCRIPTION
The free-threaded refleak builds were reporting negative refcount deltas in some tests because of a missing `_Py_NewRefWithLock`.

<!-- gh-issue-number: gh-119799 -->
* Issue: gh-119799
<!-- /gh-issue-number -->
