### PR TITLE
GH-89727: Fix `shutil.rmtree()` recursion error on deep trees

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -656,6 +656,7 @@ def _rmtree_safe_fd(stack, onexc):
             func = os.path.islink  # For error reporting.
             try:
                 if not os.path.samestat(orig_st, os.fstat(fd)):
+                    # Symlinks to directories are forbidden, see GH-46010.
                     raise OSError("Cannot call rmtree on a symbolic link")
                 stack.append((os.rmdir, dir_fd, path, orig_entry))
             finally:

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -751,8 +751,12 @@ def rmtree(path, ignore_errors=False, onerror=None, *, onexc=None, dir_fd=None):
             # Close any file descriptors still on the stack.
             while stack:
                 func, fd, path, entry = stack.pop()
-                if func is os.close:
+                if func is not os.close:
+                    continue
+                try:
                     os.close(fd)
+                except OSError as err:
+                    onexc(os.close, path, err)
     else:
         if dir_fd is not None:
             raise NotImplementedError("dir_fd unavailable on this platform")

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -688,6 +688,8 @@ def _rmtree_safe_fd(stack, onexc):
                     # Traverse into sub-directory.
                     stack.append((os.lstat, topfd, fullname, entry))
                     continue
+            except FileNotFoundError:
+                continue
             except OSError:
                 pass
             try:

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -741,7 +741,6 @@ class TestRmTree(BaseTest, unittest.TestCase):
             shutil.rmtree(TESTFN)
             raise
 
-    @unittest.skipIf(shutil._use_fd_functions, "fd-based functions remain unfixed (GH-89727)")
     def test_rmtree_above_recursion_limit(self):
         recursion_limit = 40
         # directory_depth > recursion_limit

--- a/Misc/NEWS.d/next/Library/2024-05-30-21-37-05.gh-issue-89727.D6S9ig.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-30-21-37-05.gh-issue-89727.D6S9ig.rst
@@ -1,0 +1,2 @@
+Fix issue with :func:`shutil.rmtree` where a :exc:`RecursionError` is raised
+on deep directory trees.


### PR DESCRIPTION
Implement `shutil._rmtree_safe_fd()` using a list as a stack to avoid emitting recursion errors on deeply nested trees.

`shutil._rmtree_unsafe()` was fixed in #119634.

<!-- gh-issue-number: gh-89727 -->
* Issue: gh-89727
<!-- /gh-issue-number -->
