### PR TITLE
gh-117398: Add datetime Module State

### DIFF
--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -830,6 +830,7 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(c_call));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(c_exception));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(c_return));
+    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(cached_datetime_module));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(cached_statements));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(cadata));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(cafile));

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -319,6 +319,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(c_call)
         STRUCT_FOR_ID(c_exception)
         STRUCT_FOR_ID(c_return)
+        STRUCT_FOR_ID(cached_datetime_module)
         STRUCT_FOR_ID(cached_statements)
         STRUCT_FOR_ID(cadata)
         STRUCT_FOR_ID(cafile)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -828,6 +828,7 @@ extern "C" {
     INIT_ID(c_call), \
     INIT_ID(c_exception), \
     INIT_ID(c_return), \
+    INIT_ID(cached_datetime_module), \
     INIT_ID(cached_statements), \
     INIT_ID(cadata), \
     INIT_ID(cafile), \

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -798,6 +798,9 @@ _PyUnicode_InitStaticStrings(PyInterpreterState *interp) {
     string = &_Py_ID(c_return);
     assert(_PyUnicode_CheckConsistency(string, 1));
     _PyUnicode_InternInPlace(interp, &string);
+    string = &_Py_ID(cached_datetime_module);
+    assert(_PyUnicode_CheckConsistency(string, 1));
+    _PyUnicode_InternInPlace(interp, &string);
     string = &_Py_ID(cached_statements);
     assert(_PyUnicode_CheckConsistency(string, 1));
     _PyUnicode_InternInPlace(interp, &string);

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -166,13 +166,15 @@ clear_current_module(PyInterpreterState *interp, PyObject *expected)
         if (PyDict_GetItemStringRef(dict, INTERP_KEY, &ref) < 0) {
             goto error;
         }
-        int rc = PyWeakref_GetRef(ref, &current);
-        Py_DECREF(ref);
-        if (rc < 0) {
-            goto error;
-        }
-        if (current != expected) {
-            goto finally;
+        if (ref != NULL) {
+            int rc = PyWeakref_GetRef(ref, &current);
+            Py_DECREF(ref);
+            if (rc < 0) {
+                goto error;
+            }
+            if (current != expected) {
+                goto finally;
+            }
         }
     }
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -52,6 +52,16 @@ typedef struct {
     PyObject *epoch;
 } datetime_state;
 
+/* The module has a fixed number of static objects, due to being exposed
+ * through the datetime C-API.  There are five types exposed directly,
+ * one type exposed indirectly, and one singleton constant (UTC).
+ *
+ * Each of these objects is hidden behind a macro in the same way as
+ * the per-module objects stored in module state.  The macros for the
+ * static objects don't need to be passed a state, but the consistency
+ * of doing so is more clear.  We use a dedicated noop macro, NO_STATE,
+ * to make the special case obvious. */
+
 #define NO_STATE NULL
 
 #define DATE_TYPE(st) &PyDateTime_DateType

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -135,20 +135,10 @@ _get_current_state(PyObject **p_mod)
         if (PyErr_Occurred()) {
             return NULL;
         }
-        /* The static types can outlive the module, so we must
-         * temporarily load the module if one of the static types'
-         * methods needs module state.  We can cut some corners
-         * since the module was necessarily already imported successfully
-         * and the module will only be around temporarily.  We don't even
-         * need a spec.  Normally the module would have been found
-         * and the temporary module would never happen. */
-        mod = PyModule_New("_datetime");
+        /* The static types can outlive the module,
+         * so we must re-import the module. */
+        mod = PyImport_ImportModule("_datetime");
         if (mod == NULL) {
-            return NULL;
-        }
-        ((PyModuleObject*)mod)->md_def = &datetimemodule;
-        if (PyModule_ExecDef(mod, &datetimemodule) < 0) {
-            Py_DECREF(mod);
             return NULL;
         }
     }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -55,7 +55,7 @@ typedef struct {
     int initialized;
 } datetime_state;
 
-#define GLOBAL_STATE NULL; (void)st
+#define NO_STATE NULL
 
 #define DATE_TYPE(st) &PyDateTime_DateType
 #define DATETIME_TYPE(st) &PyDateTime_DateTimeType
@@ -65,22 +65,22 @@ typedef struct {
 #define TIMEZONE_TYPE(st) &PyDateTime_TimeZoneType
 #define ISOCALENDAR_DATE_TYPE(st) st->isocalendar_date_type
 
-#define PyDate_Check(st, op) PyObject_TypeCheck(op, DATE_TYPE(st))
-#define PyDate_CheckExact(st, op) Py_IS_TYPE(op, DATE_TYPE(st))
+#define PyDate_Check(op) PyObject_TypeCheck(op, DATE_TYPE(NO_STATE))
+#define PyDate_CheckExact(op) Py_IS_TYPE(op, DATE_TYPE(NO_STATE))
 
-#define PyDateTime_Check(st, op) PyObject_TypeCheck(op, DATETIME_TYPE(st))
-#define PyDateTime_CheckExact(st, op) Py_IS_TYPE(op, DATETIME_TYPE(st))
+#define PyDateTime_Check(op) PyObject_TypeCheck(op, DATETIME_TYPE(NO_STATE))
+#define PyDateTime_CheckExact(op) Py_IS_TYPE(op, DATETIME_TYPE(NO_STATE))
 
-#define PyTime_Check(st, op) PyObject_TypeCheck(op, TIME_TYPE(st))
-#define PyTime_CheckExact(st, op) Py_IS_TYPE(op, TIME_TYPE(st))
+#define PyTime_Check(op) PyObject_TypeCheck(op, TIME_TYPE(NO_STATE))
+#define PyTime_CheckExact(op) Py_IS_TYPE(op, TIME_TYPE(NO_STATE))
 
-#define PyDelta_Check(st, op) PyObject_TypeCheck(op, DELTA_TYPE(st))
-#define PyDelta_CheckExact(st, op) Py_IS_TYPE(op, DELTA_TYPE(st))
+#define PyDelta_Check(op) PyObject_TypeCheck(op, DELTA_TYPE(NO_STATE))
+#define PyDelta_CheckExact(op) Py_IS_TYPE(op, DELTA_TYPE(NO_STATE))
 
-#define PyTZInfo_Check(st, op) PyObject_TypeCheck(op, TZINFO_TYPE(st))
-#define PyTZInfo_CheckExact(st, op) Py_IS_TYPE(op, TZINFO_TYPE(st))
+#define PyTZInfo_Check(op) PyObject_TypeCheck(op, TZINFO_TYPE(NO_STATE))
+#define PyTZInfo_CheckExact(op) Py_IS_TYPE(op, TZINFO_TYPE(NO_STATE))
 
-#define PyTimezone_Check(st, op) PyObject_TypeCheck(op, TIMEZONE_TYPE(st))
+#define PyTimezone_Check(op) PyObject_TypeCheck(op, TIMEZONE_TYPE(NO_STATE))
 
 #define CONST_US_PER_MS(st) st->us_per_ms
 #define CONST_US_PER_SECOND(st) st->us_per_second
@@ -1041,8 +1041,8 @@ new_date_ex(int year, int month, int day, PyTypeObject *type)
     return (PyObject *)self;
 }
 
-#define new_date(st, year, month, day) \
-    new_date_ex(year, month, day, DATE_TYPE(st))
+#define new_date(year, month, day) \
+    new_date_ex(year, month, day, DATE_TYPE(NO_STATE))
 
 // Forward declaration
 static PyObject *
@@ -1053,12 +1053,11 @@ static PyObject *
 new_date_subclass_ex(int year, int month, int day, PyObject *cls)
 {
     PyObject *result;
-    datetime_state *st = GLOBAL_STATE;
     // We have "fast path" constructors for two subclasses: date and datetime
-    if ((PyTypeObject *)cls == DATE_TYPE(st)) {
+    if ((PyTypeObject *)cls == DATE_TYPE(NO_STATE)) {
         result = new_date_ex(year, month, day, (PyTypeObject *)cls);
     }
-    else if ((PyTypeObject *)cls == DATETIME_TYPE(st)) {
+    else if ((PyTypeObject *)cls == DATETIME_TYPE(NO_STATE)) {
         result = new_datetime_ex(year, month, day, 0, 0, 0, 0, Py_None,
                                  (PyTypeObject *)cls);
     }
@@ -1111,8 +1110,8 @@ new_datetime_ex(int year, int month, int day, int hour, int minute,
                             tzinfo, 0, type);
 }
 
-#define new_datetime(st, y, m, d, hh, mm, ss, us, tzinfo, fold) \
-    new_datetime_ex2(y, m, d, hh, mm, ss, us, tzinfo, fold, DATETIME_TYPE(st))
+#define new_datetime(y, m, d, hh, mm, ss, us, tzinfo, fold) \
+    new_datetime_ex2(y, m, d, hh, mm, ss, us, tzinfo, fold, DATETIME_TYPE(NO_STATE))
 
 static PyObject *
 call_subclass_fold(PyObject *cls, int fold, const char *format, ...)
@@ -1154,10 +1153,9 @@ new_datetime_subclass_fold_ex(int year, int month, int day, int hour, int minute
                               int fold, PyObject *cls)
 {
     PyObject* dt;
-    datetime_state *st = GLOBAL_STATE;
-    if ((PyTypeObject*)cls == DATETIME_TYPE(st)) {
+    if ((PyTypeObject*)cls == DATETIME_TYPE(NO_STATE)) {
         // Use the fast path constructor
-        dt = new_datetime(st, year, month, day, hour, minute, second, usecond,
+        dt = new_datetime(year, month, day, hour, minute, second, usecond,
                           tzinfo, fold);
     }
     else {
@@ -1216,18 +1214,17 @@ new_time_ex(int hour, int minute, int second, int usecond,
     return new_time_ex2(hour, minute, second, usecond, tzinfo, 0, type);
 }
 
-#define new_time(st, hh, mm, ss, us, tzinfo, fold)  \
-    new_time_ex2(hh, mm, ss, us, tzinfo, fold, TIME_TYPE(st))
+#define new_time(hh, mm, ss, us, tzinfo, fold)  \
+    new_time_ex2(hh, mm, ss, us, tzinfo, fold, TIME_TYPE(NO_STATE))
 
 static PyObject *
 new_time_subclass_fold_ex(int hour, int minute, int second, int usecond,
                           PyObject *tzinfo, int fold, PyObject *cls)
 {
     PyObject *t;
-    datetime_state *st = GLOBAL_STATE;
-    if ((PyTypeObject*)cls == TIME_TYPE(st)) {
+    if ((PyTypeObject*)cls == TIME_TYPE(NO_STATE)) {
         // Use the fast path constructor
-        t = new_time(st, hour, minute, second, usecond, tzinfo, fold);
+        t = new_time(hour, minute, second, usecond, tzinfo, fold);
     }
     else {
         // Subclass
@@ -1276,8 +1273,8 @@ new_delta_ex(int days, int seconds, int microseconds, int normalize,
     return (PyObject *) self;
 }
 
-#define new_delta(st, d, s, us, normalize)  \
-    new_delta_ex(d, s, us, normalize, DELTA_TYPE(st))
+#define new_delta(d, s, us, normalize)  \
+    new_delta_ex(d, s, us, normalize, DELTA_TYPE(NO_STATE))
 
 
 typedef struct
@@ -1297,11 +1294,10 @@ static PyObject *
 create_timezone(PyObject *offset, PyObject *name)
 {
     PyDateTime_TimeZone *self;
-    datetime_state *st = GLOBAL_STATE;
-    PyTypeObject *type = TIMEZONE_TYPE(st);
+    PyTypeObject *type = TIMEZONE_TYPE(NO_STATE);
 
     assert(offset != NULL);
-    assert(PyDelta_Check(st, offset));
+    assert(PyDelta_Check(offset));
     assert(name == NULL || PyUnicode_Check(name));
 
     self = look_up_timezone(offset, name);
@@ -1326,12 +1322,11 @@ static PyObject *
 new_timezone(PyObject *offset, PyObject *name)
 {
     assert(offset != NULL);
-    datetime_state *st = GLOBAL_STATE;
-    assert(PyDelta_Check(st, offset));
+    assert(PyDelta_Check(offset));
     assert(name == NULL || PyUnicode_Check(name));
 
     if (name == NULL && delta_bool((PyDateTime_Delta *)offset) == 0) {
-        return Py_NewRef(CONST_UTC(st));
+        return Py_NewRef(CONST_UTC(NO_STATE));
     }
     if ((GET_TD_DAYS(offset) == -1 &&
             GET_TD_SECONDS(offset) == 0 &&
@@ -1357,8 +1352,7 @@ new_timezone(PyObject *offset, PyObject *name)
 static int
 check_tzinfo_subclass(PyObject *p)
 {
-    datetime_state *st = GLOBAL_STATE;
-    if (p == Py_None || PyTZInfo_Check(st, p))
+    if (p == Py_None || PyTZInfo_Check(p))
         return 0;
     PyErr_Format(PyExc_TypeError,
                  "tzinfo argument must be None or of a tzinfo subclass, "
@@ -1376,9 +1370,9 @@ get_tzinfo_member(PyObject *self)
 {
     PyObject *tzinfo = NULL;
 
-    if (PyDateTime_Check(st, self) && HASTZINFO(self))
+    if (PyDateTime_Check(self) && HASTZINFO(self))
         tzinfo = ((PyDateTime_DateTime *)self)->tzinfo;
-    else if (PyTime_Check(st, self) && HASTZINFO(self))
+    else if (PyTime_Check(self) && HASTZINFO(self))
         tzinfo = ((PyDateTime_Time *)self)->tzinfo;
 
     return tzinfo;
@@ -1397,7 +1391,7 @@ call_tzinfo_method(PyObject *tzinfo, const char *name, PyObject *tzinfoarg)
     PyObject *offset;
 
     assert(tzinfo != NULL);
-    assert(PyTZInfo_Check(st, tzinfo) || tzinfo == Py_None);
+    assert(PyTZInfo_Check(tzinfo) || tzinfo == Py_None);
     assert(tzinfoarg != NULL);
 
     if (tzinfo == Py_None)
@@ -1405,8 +1399,7 @@ call_tzinfo_method(PyObject *tzinfo, const char *name, PyObject *tzinfoarg)
     offset = PyObject_CallMethod(tzinfo, name, "O", tzinfoarg);
     if (offset == Py_None || offset == NULL)
         return offset;
-    datetime_state *st = GLOBAL_STATE;
-    if (PyDelta_Check(st, offset)) {
+    if (PyDelta_Check(offset)) {
         if ((GET_TD_DAYS(offset) == -1 &&
                 GET_TD_SECONDS(offset) == 0 &&
                 GET_TD_MICROSECONDS(offset) < 1) ||
@@ -1546,11 +1539,10 @@ tzinfo_from_isoformat_results(int rv, int tzoffset, int tz_useconds)
     if (rv == 1) {
         // Create a timezone from offset in seconds (0 returns UTC)
         if (tzoffset == 0) {
-            datetime_state *st = GLOBAL_STATE;
-            return Py_NewRef(CONST_UTC(st));
+            return Py_NewRef(CONST_UTC(NO_STATE));
         }
 
-        PyObject *delta = new_delta(st, 0, tzoffset, tz_useconds, 1);
+        PyObject *delta = new_delta(0, tzoffset, tz_useconds, 1);
         if (delta == NULL) {
             return NULL;
         }
@@ -1715,9 +1707,9 @@ static PyObject *
 make_freplacement(PyObject *object)
 {
     char freplacement[64];
-    if (PyTime_Check(st, object))
+    if (PyTime_Check(object))
         sprintf(freplacement, "%06d", TIME_GET_MICROSECOND(object));
-    else if (PyDateTime_Check(st, object))
+    else if (PyDateTime_Check(object))
         sprintf(freplacement, "%06d", DATE_GET_MICROSECOND(object));
     else
         sprintf(freplacement, "%06d", 0);
@@ -2104,8 +2096,8 @@ BadDivmod:
     goto Done;
 }
 
-#define microseconds_to_delta(st, pymicros) \
-    microseconds_to_delta_ex(pymicros, DELTA_TYPE(st))
+#define microseconds_to_delta(pymicros) \
+    microseconds_to_delta_ex(pymicros, DELTA_TYPE(NO_STATE))
 
 static PyObject *
 multiply_int_timedelta(PyObject *intobj, PyDateTime_Delta *delta)
@@ -2123,8 +2115,7 @@ multiply_int_timedelta(PyObject *intobj, PyDateTime_Delta *delta)
     if (pyus_out == NULL)
         return NULL;
 
-    datetime_state *st = GLOBAL_STATE;
-    result = microseconds_to_delta(st, pyus_out);
+    result = microseconds_to_delta(pyus_out);
     Py_DECREF(pyus_out);
     return result;
 }
@@ -2179,8 +2170,7 @@ multiply_truedivide_timedelta_float(PyDateTime_Delta *delta, PyObject *floatobj,
     Py_DECREF(temp);
     if (pyus_out == NULL)
         goto error;
-    datetime_state *st = GLOBAL_STATE;
-    result = microseconds_to_delta(st, pyus_out);
+    result = microseconds_to_delta(pyus_out);
     Py_DECREF(pyus_out);
  error:
     Py_XDECREF(pyus_in);
@@ -2205,8 +2195,7 @@ divide_timedelta_int(PyDateTime_Delta *delta, PyObject *intobj)
     if (pyus_out == NULL)
         return NULL;
 
-    datetime_state *st = GLOBAL_STATE;
-    result = microseconds_to_delta(st, pyus_out);
+    result = microseconds_to_delta(pyus_out);
     Py_DECREF(pyus_out);
     return result;
 }
@@ -2269,8 +2258,7 @@ truedivide_timedelta_int(PyDateTime_Delta *delta, PyObject *i)
     Py_DECREF(pyus_in);
     if (pyus_out == NULL)
         return NULL;
-    datetime_state *st = GLOBAL_STATE;
-    result = microseconds_to_delta(st, pyus_out);
+    result = microseconds_to_delta(pyus_out);
     Py_DECREF(pyus_out);
 
     return result;
@@ -2281,8 +2269,7 @@ delta_add(PyObject *left, PyObject *right)
 {
     PyObject *result = Py_NotImplemented;
 
-    datetime_state *st = GLOBAL_STATE;
-    if (PyDelta_Check(st, left) && PyDelta_Check(st, right)) {
+    if (PyDelta_Check(left) && PyDelta_Check(right)) {
         /* delta + delta */
         /* The C-level additions can't overflow because of the
          * invariant bounds.
@@ -2291,7 +2278,7 @@ delta_add(PyObject *left, PyObject *right)
         int seconds = GET_TD_SECONDS(left) + GET_TD_SECONDS(right);
         int microseconds = GET_TD_MICROSECONDS(left) +
                            GET_TD_MICROSECONDS(right);
-        result = new_delta(st, days, seconds, microseconds, 1);
+        result = new_delta(days, seconds, microseconds, 1);
     }
 
     if (result == Py_NotImplemented)
@@ -2302,9 +2289,7 @@ delta_add(PyObject *left, PyObject *right)
 static PyObject *
 delta_negative(PyDateTime_Delta *self)
 {
-    datetime_state *st = GLOBAL_STATE;
-    return new_delta(st,
-                     -GET_TD_DAYS(self),
+    return new_delta(-GET_TD_DAYS(self),
                      -GET_TD_SECONDS(self),
                      -GET_TD_MICROSECONDS(self),
                      1);
@@ -2316,9 +2301,7 @@ delta_positive(PyDateTime_Delta *self)
     /* Could optimize this (by returning self) if this isn't a
      * subclass -- but who uses unary + ?  Approximately nobody.
      */
-    datetime_state *st = GLOBAL_STATE;
-    return new_delta(st,
-                     GET_TD_DAYS(self),
+    return new_delta(GET_TD_DAYS(self),
                      GET_TD_SECONDS(self),
                      GET_TD_MICROSECONDS(self),
                      0);
@@ -2345,8 +2328,7 @@ delta_subtract(PyObject *left, PyObject *right)
 {
     PyObject *result = Py_NotImplemented;
 
-    datetime_state *st = GLOBAL_STATE;
-    if (PyDelta_Check(st, left) && PyDelta_Check(st, right)) {
+    if (PyDelta_Check(left) && PyDelta_Check(right)) {
         /* delta - delta */
         /* The C-level additions can't overflow because of the
          * invariant bounds.
@@ -2355,7 +2337,7 @@ delta_subtract(PyObject *left, PyObject *right)
         int seconds = GET_TD_SECONDS(left) - GET_TD_SECONDS(right);
         int microseconds = GET_TD_MICROSECONDS(left) -
                            GET_TD_MICROSECONDS(right);
-        result = new_delta(st, days, seconds, microseconds, 1);
+        result = new_delta(days, seconds, microseconds, 1);
     }
 
     if (result == Py_NotImplemented)
@@ -2379,8 +2361,7 @@ delta_cmp(PyObject *self, PyObject *other)
 static PyObject *
 delta_richcompare(PyObject *self, PyObject *other, int op)
 {
-    datetime_state *st = GLOBAL_STATE;
-    if (PyDelta_Check(st, other)) {
+    if (PyDelta_Check(other)) {
         int diff = delta_cmp(self, other);
         return diff_to_bool(diff, op);
     }
@@ -2409,8 +2390,7 @@ delta_multiply(PyObject *left, PyObject *right)
 {
     PyObject *result = Py_NotImplemented;
 
-    datetime_state *st = GLOBAL_STATE;
-    if (PyDelta_Check(st, left)) {
+    if (PyDelta_Check(left)) {
         /* delta * ??? */
         if (PyLong_Check(right))
             result = multiply_int_timedelta(right,
@@ -2436,14 +2416,13 @@ delta_divide(PyObject *left, PyObject *right)
 {
     PyObject *result = Py_NotImplemented;
 
-    datetime_state *st = GLOBAL_STATE;
-    if (PyDelta_Check(st, left)) {
+    if (PyDelta_Check(left)) {
         /* delta * ??? */
         if (PyLong_Check(right))
             result = divide_timedelta_int(
                             (PyDateTime_Delta *)left,
                             right);
-        else if (PyDelta_Check(st, right))
+        else if (PyDelta_Check(right))
             result = divide_timedelta_timedelta(
                             (PyDateTime_Delta *)left,
                             (PyDateTime_Delta *)right);
@@ -2459,9 +2438,8 @@ delta_truedivide(PyObject *left, PyObject *right)
 {
     PyObject *result = Py_NotImplemented;
 
-    datetime_state *st = GLOBAL_STATE;
-    if (PyDelta_Check(st, left)) {
-        if (PyDelta_Check(st, right))
+    if (PyDelta_Check(left)) {
+        if (PyDelta_Check(right))
             result = truedivide_timedelta_timedelta(
                             (PyDateTime_Delta *)left,
                             (PyDateTime_Delta *)right);
@@ -2486,8 +2464,7 @@ delta_remainder(PyObject *left, PyObject *right)
     PyObject *pyus_remainder;
     PyObject *remainder;
 
-    datetime_state *st = GLOBAL_STATE;
-    if (!PyDelta_Check(st, left) || !PyDelta_Check(st, right))
+    if (!PyDelta_Check(left) || !PyDelta_Check(right))
         Py_RETURN_NOTIMPLEMENTED;
 
     pyus_left = delta_to_microseconds((PyDateTime_Delta *)left);
@@ -2506,7 +2483,7 @@ delta_remainder(PyObject *left, PyObject *right)
     if (pyus_remainder == NULL)
         return NULL;
 
-    remainder = microseconds_to_delta(st, pyus_remainder);
+    remainder = microseconds_to_delta(pyus_remainder);
     Py_DECREF(pyus_remainder);
     if (remainder == NULL)
         return NULL;
@@ -2523,8 +2500,7 @@ delta_divmod(PyObject *left, PyObject *right)
     PyObject *delta;
     PyObject *result;
 
-    datetime_state *st = GLOBAL_STATE;
-    if (!PyDelta_Check(st, left) || !PyDelta_Check(st, right))
+    if (!PyDelta_Check(left) || !PyDelta_Check(right))
         Py_RETURN_NOTIMPLEMENTED;
 
     pyus_left = delta_to_microseconds((PyDateTime_Delta *)left);
@@ -2543,7 +2519,7 @@ delta_divmod(PyObject *left, PyObject *right)
     if (divmod == NULL)
         return NULL;
 
-    delta = microseconds_to_delta(st, PyTuple_GET_ITEM(divmod, 1));
+    delta = microseconds_to_delta(PyTuple_GET_ITEM(divmod, 1));
     if (delta == NULL) {
         Py_DECREF(divmod);
         return NULL;
@@ -3316,14 +3292,12 @@ add_date_timedelta(PyDateTime_Date *date, PyDateTime_Delta *delta, int negate)
 static PyObject *
 date_add(PyObject *left, PyObject *right)
 {
-    datetime_state *st = GLOBAL_STATE;
-
-    if (PyDateTime_Check(st, left) || PyDateTime_Check(st, right))
+    if (PyDateTime_Check(left) || PyDateTime_Check(right))
         Py_RETURN_NOTIMPLEMENTED;
 
-    if (PyDate_Check(st, left)) {
+    if (PyDate_Check(left)) {
         /* date + ??? */
-        if (PyDelta_Check(st, right))
+        if (PyDelta_Check(right))
             /* date + delta */
             return add_date_timedelta((PyDateTime_Date *) left,
                                       (PyDateTime_Delta *) right,
@@ -3333,7 +3307,7 @@ date_add(PyObject *left, PyObject *right)
         /* ??? + date
          * 'right' must be one of us, or we wouldn't have been called
          */
-        if (PyDelta_Check(st, left))
+        if (PyDelta_Check(left))
             /* delta + date */
             return add_date_timedelta((PyDateTime_Date *) right,
                                       (PyDateTime_Delta *) left,
@@ -3345,13 +3319,11 @@ date_add(PyObject *left, PyObject *right)
 static PyObject *
 date_subtract(PyObject *left, PyObject *right)
 {
-    datetime_state *st = GLOBAL_STATE;
-
-    if (PyDateTime_Check(st, left) || PyDateTime_Check(st, right))
+    if (PyDateTime_Check(left) || PyDateTime_Check(right))
         Py_RETURN_NOTIMPLEMENTED;
 
-    if (PyDate_Check(st, left)) {
-        if (PyDate_Check(st, right)) {
+    if (PyDate_Check(left)) {
+        if (PyDate_Check(right)) {
             /* date - date */
             int left_ord = ymd_to_ord(GET_YEAR(left),
                                       GET_MONTH(left),
@@ -3359,9 +3331,9 @@ date_subtract(PyObject *left, PyObject *right)
             int right_ord = ymd_to_ord(GET_YEAR(right),
                                        GET_MONTH(right),
                                        GET_DAY(right));
-            return new_delta(st, left_ord - right_ord, 0, 0, 0);
+            return new_delta(left_ord - right_ord, 0, 0, 0);
         }
-        if (PyDelta_Check(st, right)) {
+        if (PyDelta_Check(right)) {
             /* date - delta */
             return add_date_timedelta((PyDateTime_Date *) left,
                                       (PyDateTime_Delta *) right,
@@ -3645,7 +3617,7 @@ date_richcompare(PyObject *self, PyObject *other, int op)
      * The behavior is the same as if Date and DateTime were independent
      * classes.
      */
-    if (PyDate_Check(st, other) && !PyDateTime_Check(st, other)) {
+    if (PyDate_Check(other) && !PyDateTime_Check(other)) {
         int diff = memcmp(((PyDateTime_Date *)self)->data,
                           ((PyDateTime_Date *)other)->data,
                           _PyDateTime_DATE_DATASIZE);
@@ -3921,7 +3893,7 @@ tzinfo_fromutc(PyDateTime_TZInfo *self, PyObject *dt)
     PyObject *off = NULL, *dst = NULL;
     PyDateTime_Delta *delta = NULL;
 
-    if (!PyDateTime_Check(st, dt)) {
+    if (!PyDateTime_Check(dt)) {
         PyErr_SetString(PyExc_TypeError,
                         "fromutc: argument must be a datetime");
         return NULL;
@@ -4094,9 +4066,8 @@ timezone_new(PyTypeObject *type, PyObject *args, PyObject *kw)
 {
     PyObject *offset;
     PyObject *name = NULL;
-    datetime_state *st = GLOBAL_STATE;
     if (PyArg_ParseTupleAndKeywords(args, kw, "O!|U:timezone", timezone_kws,
-                                    DELTA_TYPE(st), &offset, &name))
+                                    DELTA_TYPE(NO_STATE), &offset, &name))
         return new_timezone(offset, name);
 
     return NULL;
@@ -4116,7 +4087,7 @@ timezone_richcompare(PyDateTime_TimeZone *self,
 {
     if (op != Py_EQ && op != Py_NE)
         Py_RETURN_NOTIMPLEMENTED;
-    if (!PyTimezone_Check(st, other)) {
+    if (!PyTimezone_Check(other)) {
         Py_RETURN_NOTIMPLEMENTED;
     }
     return delta_richcompare(self->offset, other->offset, op);
@@ -4135,7 +4106,7 @@ timezone_hash(PyDateTime_TimeZone *self)
 static int
 _timezone_check_argument(PyObject *dt, const char *meth)
 {
-    if (dt == Py_None || PyDateTime_Check(st, dt))
+    if (dt == Py_None || PyDateTime_Check(dt))
         return 0;
     PyErr_Format(PyExc_TypeError, "%s(dt) argument must be a datetime instance"
                  " or None, not %.200s", meth, Py_TYPE(dt)->tp_name);
@@ -4149,8 +4120,7 @@ timezone_repr(PyDateTime_TimeZone *self)
        to use Py_TYPE(self)->tp_name here. */
     const char *type_name = Py_TYPE(self)->tp_name;
 
-    datetime_state *st = GLOBAL_STATE;
-    if ((PyObject *)self == CONST_UTC(st)) {
+    if ((PyObject *)self == CONST_UTC(NO_STATE)) {
         return PyUnicode_FromFormat("%s.utc", type_name);
     }
 
@@ -4172,8 +4142,7 @@ timezone_str(PyDateTime_TimeZone *self)
     if (self->name != NULL) {
         return Py_NewRef(self->name);
     }
-    datetime_state *st = GLOBAL_STATE;
-    if ((PyObject *)self == CONST_UTC(st) ||
+    if ((PyObject *)self == CONST_UTC(NO_STATE) ||
            (GET_TD_DAYS(self->offset) == 0 &&
             GET_TD_SECONDS(self->offset) == 0 &&
             GET_TD_MICROSECONDS(self->offset) == 0))
@@ -4239,7 +4208,7 @@ timezone_dst(PyObject *self, PyObject *dt)
 static PyObject *
 timezone_fromutc(PyDateTime_TimeZone *self, PyDateTime_DateTime *dt)
 {
-    if (!PyDateTime_Check(st, dt)) {
+    if (!PyDateTime_Check(dt)) {
         PyErr_SetString(PyExc_TypeError,
                         "fromutc: argument must be a datetime");
         return NULL;
@@ -4336,8 +4305,7 @@ static PyDateTime_TimeZone *
 look_up_timezone(PyObject *offset, PyObject *name)
 {
     if (offset == utc_timezone.offset && name == NULL) {
-        datetime_state *st = GLOBAL_STATE;
-        return (PyDateTime_TimeZone *)CONST_UTC(st);
+        return (PyDateTime_TimeZone *)CONST_UTC(NO_STATE);
     }
     return NULL;
 }
@@ -4669,7 +4637,7 @@ time_richcompare(PyObject *self, PyObject *other, int op)
     PyObject *offset1, *offset2;
     int diff;
 
-    if (! PyTime_Check(st, other))
+    if (! PyTime_Check(other))
         Py_RETURN_NOTIMPLEMENTED;
 
     if (GET_TIME_TZINFO(self) == GET_TIME_TZINFO(other)) {
@@ -4688,9 +4656,8 @@ time_richcompare(PyObject *self, PyObject *other, int op)
      * we get off cheap.  Note that if they're both naive, offset1 ==
      * offset2 == Py_None at this point.
      */
-    datetime_state *st = GLOBAL_STATE;
     if ((offset1 == offset2) ||
-        (PyDelta_Check(st, offset1) && PyDelta_Check(st, offset2) &&
+        (PyDelta_Check(offset1) && PyDelta_Check(offset2) &&
          delta_cmp(offset1, offset2) == 0)) {
         diff = memcmp(((PyDateTime_Time *)self)->data,
                       ((PyDateTime_Time *)other)->data,
@@ -4770,7 +4737,7 @@ time_hash(PyDateTime_Time *self)
                       TIME_GET_MINUTE(self) * 60 +
                       TIME_GET_SECOND(self);
             microseconds = TIME_GET_MICROSECOND(self);
-            temp1 = new_delta(st, 0, seconds, microseconds, 1);
+            temp1 = new_delta(0, seconds, microseconds, 1);
             if (temp1 == NULL) {
                 Py_DECREF(offset);
                 return -1;
@@ -4855,9 +4822,8 @@ time_fromisoformat(PyObject *cls, PyObject *tstr) {
     }
 
     PyObject *t;
-    datetime_state *st = GLOBAL_STATE;
-    if ( (PyTypeObject *)cls == TIME_TYPE(st)) {
-        t = new_time(st, hour, minute, second, microsecond, tzinfo, 0);
+    if ( (PyTypeObject *)cls == TIME_TYPE(NO_STATE)) {
+        t = new_time(hour, minute, second, microsecond, tzinfo, 0);
     } else {
         t = PyObject_CallFunction(cls, "iiiiO",
                                   hour, minute, second, microsecond, tzinfo);
@@ -5454,10 +5420,9 @@ datetime_combine(PyObject *cls, PyObject *args, PyObject *kw)
     PyObject *tzinfo = NULL;
     PyObject *result = NULL;
 
-    datetime_state *st = GLOBAL_STATE;
     if (PyArg_ParseTupleAndKeywords(args, kw, "O!O!|O:combine", keywords,
-                                    DATE_TYPE(st), &date,
-                                    TIME_TYPE(st), &time, &tzinfo)) {
+                                    DATE_TYPE(NO_STATE), &date,
+                                    TIME_TYPE(NO_STATE), &time, &tzinfo)) {
         if (tzinfo == NULL) {
             if (HASTZINFO(time))
                 tzinfo = ((PyDateTime_Time *)time)->tzinfo;
@@ -5800,17 +5765,16 @@ add_datetime_timedelta(PyDateTime_DateTime *date, PyDateTime_Delta *delta,
 static PyObject *
 datetime_add(PyObject *left, PyObject *right)
 {
-    datetime_state *st = GLOBAL_STATE;
-    if (PyDateTime_Check(st, left)) {
+    if (PyDateTime_Check(left)) {
         /* datetime + ??? */
-        if (PyDelta_Check(st, right))
+        if (PyDelta_Check(right))
             /* datetime + delta */
             return add_datetime_timedelta(
                             (PyDateTime_DateTime *)left,
                             (PyDateTime_Delta *)right,
                             1);
     }
-    else if (PyDelta_Check(st, left)) {
+    else if (PyDelta_Check(left)) {
         /* delta + datetime */
         return add_datetime_timedelta((PyDateTime_DateTime *) right,
                                       (PyDateTime_Delta *) left,
@@ -5824,10 +5788,9 @@ datetime_subtract(PyObject *left, PyObject *right)
 {
     PyObject *result = Py_NotImplemented;
 
-    datetime_state *st = GLOBAL_STATE;
-    if (PyDateTime_Check(st, left)) {
+    if (PyDateTime_Check(left)) {
         /* datetime - ??? */
-        if (PyDateTime_Check(st, right)) {
+        if (PyDateTime_Check(right)) {
             /* datetime - datetime */
             PyObject *offset1, *offset2, *offdiff = NULL;
             int delta_d, delta_s, delta_us;
@@ -5883,7 +5846,7 @@ datetime_subtract(PyObject *left, PyObject *right)
                        DATE_GET_SECOND(right));
             delta_us = DATE_GET_MICROSECOND(left) -
                        DATE_GET_MICROSECOND(right);
-            result = new_delta(st, delta_d, delta_s, delta_us, 1);
+            result = new_delta(delta_d, delta_s, delta_us, 1);
             if (result == NULL)
                 return NULL;
 
@@ -5892,7 +5855,7 @@ datetime_subtract(PyObject *left, PyObject *right)
                 Py_DECREF(offdiff);
             }
         }
-        else if (PyDelta_Check(st, right)) {
+        else if (PyDelta_Check(right)) {
             /* datetime - delta */
             result = add_datetime_timedelta(
                             (PyDateTime_DateTime *)left,
@@ -6107,7 +6070,7 @@ datetime_richcompare(PyObject *self, PyObject *other, int op)
     PyObject *offset1, *offset2;
     int diff;
 
-    if (!PyDateTime_Check(st, other)) {
+    if (!PyDateTime_Check(other)) {
         Py_RETURN_NOTIMPLEMENTED;
     }
 
@@ -6127,9 +6090,8 @@ datetime_richcompare(PyObject *self, PyObject *other, int op)
      * we get off cheap.  Note that if they're both naive, offset1 ==
      * offset2 == Py_None at this point.
      */
-    datetime_state *st = GLOBAL_STATE;
     if ((offset1 == offset2) ||
-        (PyDelta_Check(st, offset1) && PyDelta_Check(st, offset2) &&
+        (PyDelta_Check(offset1) && PyDelta_Check(offset2) &&
          delta_cmp(offset1, offset2) == 0)) {
         diff = memcmp(((PyDateTime_DateTime *)self)->data,
                       ((PyDateTime_DateTime *)other)->data,
@@ -6224,8 +6186,7 @@ datetime_hash(PyDateTime_DateTime *self)
             seconds = DATE_GET_HOUR(self) * 3600 +
                       DATE_GET_MINUTE(self) * 60 +
                       DATE_GET_SECOND(self);
-            datetime_state *st = GLOBAL_STATE;
-            temp1 = new_delta(st, days, seconds,
+            temp1 = new_delta(days, seconds,
                               DATE_GET_MICROSECOND(self),
                               1);
             if (temp1 == NULL) {
@@ -6288,18 +6249,15 @@ local_timezone_from_timestamp(time_t timestamp)
         return NULL;
 #ifdef HAVE_STRUCT_TM_TM_ZONE
     zone = local_time_tm.tm_zone;
-    datetime_state *st = GLOBAL_STATE;
-    delta = new_delta(st, 0, local_time_tm.tm_gmtoff, 0, 1);
+    delta = new_delta(0, local_time_tm.tm_gmtoff, 0, 1);
 #else /* HAVE_STRUCT_TM_TM_ZONE */
     {
-        datetime_state *st = get_datetime_state();
         PyObject *local_time, *utc_time;
         struct tm utc_time_tm;
         char buf[100];
         strftime(buf, sizeof(buf), "%Z", &local_time_tm);
         zone = buf;
-        local_time = new_datetime(st,
-                                  local_time_tm.tm_year + 1900,
+        local_time = new_datetime(local_time_tm.tm_year + 1900,
                                   local_time_tm.tm_mon + 1,
                                   local_time_tm.tm_mday,
                                   local_time_tm.tm_hour,
@@ -6310,8 +6268,7 @@ local_timezone_from_timestamp(time_t timestamp)
         }
         if (_PyTime_gmtime(timestamp, &utc_time_tm) != 0)
             return NULL;
-        utc_time = new_datetime(st,
-                                utc_time_tm.tm_year + 1900,
+        utc_time = new_datetime(utc_time_tm.tm_year + 1900,
                                 utc_time_tm.tm_mon + 1,
                                 utc_time_tm.tm_mday,
                                 utc_time_tm.tm_hour,
@@ -6354,7 +6311,7 @@ local_timezone(PyDateTime_DateTime *utc_time)
     if (delta == NULL)
         return NULL;
 
-    one_second = new_delta(st, 0, 1, 0, 0);
+    one_second = new_delta(0, 1, 0, 0);
     if (one_second == NULL) {
         Py_DECREF(delta);
         return NULL;
@@ -6444,14 +6401,13 @@ datetime_astimezone(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
     /* Convert self to UTC. */
     offset = call_utcoffset(self_tzinfo, (PyObject *)self);
     Py_DECREF(self_tzinfo);
-    datetime_state *st = GLOBAL_STATE;
     if (offset == NULL)
         return NULL;
     else if(offset == Py_None) {
         Py_DECREF(offset);
         goto naive;
     }
-    else if (!PyDelta_Check(st, offset)) {
+    else if (!PyDelta_Check(offset)) {
         Py_DECREF(offset);
         PyErr_Format(PyExc_TypeError, "utcoffset() returned %.200s,"
                      " expected timedelta or None", Py_TYPE(offset)->tp_name);
@@ -6475,7 +6431,7 @@ datetime_astimezone(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
                                     DATE_GET_MINUTE(result),
                                     DATE_GET_SECOND(result),
                                     DATE_GET_MICROSECOND(result),
-                                    CONST_UTC(st),
+                                    CONST_UTC(NO_STATE),
                                     DATE_GET_FOLD(result),
                                     Py_TYPE(result));
         Py_DECREF(temp);
@@ -6484,7 +6440,7 @@ datetime_astimezone(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
     }
     else {
         /* Result is already aware - just replace tzinfo. */
-        Py_SETREF(result->tzinfo, Py_NewRef(CONST_UTC(st)));
+        Py_SETREF(result->tzinfo, Py_NewRef(CONST_UTC(NO_STATE)));
     }
 
     /* Attach new tzinfo and let fromutc() do the rest. */
@@ -6616,9 +6572,7 @@ datetime_timestamp(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 static PyObject *
 datetime_getdate(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 {
-    datetime_state *st = GLOBAL_STATE;
-    return new_date(st,
-                    GET_YEAR(self),
+    return new_date(GET_YEAR(self),
                     GET_MONTH(self),
                     GET_DAY(self));
 }
@@ -6626,9 +6580,7 @@ datetime_getdate(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 static PyObject *
 datetime_gettime(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 {
-    datetime_state *st = GLOBAL_STATE;
-    return new_time(st,
-                    DATE_GET_HOUR(self),
+    return new_time(DATE_GET_HOUR(self),
                     DATE_GET_MINUTE(self),
                     DATE_GET_SECOND(self),
                     DATE_GET_MICROSECOND(self),
@@ -6639,9 +6591,7 @@ datetime_gettime(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 static PyObject *
 datetime_gettimetz(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 {
-    datetime_state *st = GLOBAL_STATE;
-    return new_time(st,
-                    DATE_GET_HOUR(self),
+    return new_time(DATE_GET_HOUR(self),
                     DATE_GET_MINUTE(self),
                     DATE_GET_SECOND(self),
                     DATE_GET_MICROSECOND(self),
@@ -6933,8 +6883,7 @@ get_datetime_capi(void)
 static PyObject *
 create_timezone_from_delta(int days, int sec, int ms, int normalize)
 {
-    datetime_state *st = GLOBAL_STATE;
-    PyObject *delta = new_delta(st, days, sec, ms, normalize);
+    PyObject *delta = new_delta(days, sec, ms, normalize);
     if (delta == NULL) {
         return NULL;
     }
@@ -7021,7 +6970,7 @@ init_state(datetime_state *st, PyObject *module)
 
     /* Init Unix epoch */
     st->epoch = new_datetime(
-            st, 1970, 1, 1, 0, 0, 0, 0, (PyObject *)&utc_timezone, 0);
+            1970, 1, 1, 0, 0, 0, 0, (PyObject *)&utc_timezone, 0);
     if (st->epoch == NULL) {
         return -1;
     }
@@ -7138,31 +7087,30 @@ _datetime_exec(PyObject *module)
 
     /* timedelta values */
     PyObject *d = PyDateTime_DeltaType.tp_dict;
-    DATETIME_ADD_MACRO(d, "resolution", new_delta(st_global, 0, 0, 1, 0));
-    DATETIME_ADD_MACRO(d, "min", new_delta(st_global, -MAX_DELTA_DAYS, 0, 0, 0));
-    DATETIME_ADD_MACRO(
-            d, "max", new_delta(st_global, MAX_DELTA_DAYS, 24*3600-1, 1000000-1, 0));
+    DATETIME_ADD_MACRO(d, "resolution", new_delta(0, 0, 1, 0));
+    DATETIME_ADD_MACRO(d, "min", new_delta(-MAX_DELTA_DAYS, 0, 0, 0));
+    DATETIME_ADD_MACRO(d, "max",
+                       new_delta(MAX_DELTA_DAYS, 24*3600-1, 1000000-1, 0));
 
     /* date values */
     d = PyDateTime_DateType.tp_dict;
-    DATETIME_ADD_MACRO(d, "min", new_date(st_global, 1, 1, 1));
-    DATETIME_ADD_MACRO(d, "max", new_date(st_global, MAXYEAR, 12, 31));
-    DATETIME_ADD_MACRO(d, "resolution", new_delta(st_global, 1, 0, 0, 0));
+    DATETIME_ADD_MACRO(d, "min", new_date(1, 1, 1));
+    DATETIME_ADD_MACRO(d, "max", new_date(MAXYEAR, 12, 31));
+    DATETIME_ADD_MACRO(d, "resolution", new_delta(1, 0, 0, 0));
 
     /* time values */
     d = PyDateTime_TimeType.tp_dict;
-    DATETIME_ADD_MACRO(d, "min", new_time(st_global, 0, 0, 0, 0, Py_None, 0));
-    DATETIME_ADD_MACRO(d, "max", new_time(st_global, 23, 59, 59, 999999, Py_None, 0));
-    DATETIME_ADD_MACRO(d, "resolution", new_delta(st_global, 0, 0, 1, 0));
+    DATETIME_ADD_MACRO(d, "min", new_time(0, 0, 0, 0, Py_None, 0));
+    DATETIME_ADD_MACRO(d, "max", new_time(23, 59, 59, 999999, Py_None, 0));
+    DATETIME_ADD_MACRO(d, "resolution", new_delta(0, 0, 1, 0));
 
     /* datetime values */
     d = PyDateTime_DateTimeType.tp_dict;
-    DATETIME_ADD_MACRO(
-            d, "min", new_datetime(st_global, 1, 1, 1, 0, 0, 0, 0, Py_None, 0));
-    DATETIME_ADD_MACRO(
-            d, "max", new_datetime(
-                st_global, MAXYEAR, 12, 31, 23, 59, 59, 999999, Py_None, 0));
-    DATETIME_ADD_MACRO(d, "resolution", new_delta(st_global, 0, 0, 1, 0));
+    DATETIME_ADD_MACRO(d, "min",
+                       new_datetime(1, 1, 1, 0, 0, 0, 0, Py_None, 0));
+    DATETIME_ADD_MACRO(d, "max", new_datetime(MAXYEAR, 12, 31, 23, 59, 59,
+                                              999999, Py_None, 0));
+    DATETIME_ADD_MACRO(d, "resolution", new_delta(0, 0, 1, 0));
 
     /* timezone values */
     d = PyDateTime_TimeZoneType.tp_dict;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -7167,12 +7167,11 @@ _datetime_exec(PyObject *module)
      * values. This may change in the future.*/
 
     /* -23:59 */
-    PyObject *min = create_timezone_from_delta(-1, 60, 0, 1);
-    DATETIME_ADD_MACRO(d, "min", min);
+    DATETIME_ADD_MACRO(d, "min", create_timezone_from_delta(-1, 60, 0, 1));
 
     /* +23:59 */
-    PyObject *max = create_timezone_from_delta(0, (23 * 60 + 59) * 60, 0, 0);
-    DATETIME_ADD_MACRO(d, "max", max);
+    DATETIME_ADD_MACRO(
+            d, "max", create_timezone_from_delta(0, (23 * 60 + 59) * 60, 0, 0));
 
 #undef DATETIME_ADD_MACRO
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -98,7 +98,7 @@ get_module_state(PyObject *module)
 }
 
 
-#define INTERP_KEY "cached-datetime-module"
+#define INTERP_KEY ((PyObject *)&_Py_ID(cached_datetime_module))
 
 static PyObject *
 get_current_module(PyInterpreterState *interp)
@@ -108,7 +108,7 @@ get_current_module(PyInterpreterState *interp)
         return NULL;
     }
     PyObject *ref = NULL;
-    if (PyDict_GetItemStringRef(dict, INTERP_KEY, &ref) < 0) {
+    if (PyDict_GetItemRef(dict, INTERP_KEY, &ref) < 0) {
         return NULL;
     }
     if (ref == NULL) {
@@ -144,7 +144,7 @@ set_current_module(PyInterpreterState *interp, PyObject *mod)
     if (ref == NULL) {
         return -1;
     }
-    int rc = PyDict_SetItemString(dict, INTERP_KEY, ref);
+    int rc = PyDict_SetItem(dict, INTERP_KEY, ref);
     Py_DECREF(ref);
     return rc;
 }
@@ -163,7 +163,7 @@ clear_current_module(PyInterpreterState *interp, PyObject *expected)
 
     if (expected != NULL) {
         PyObject *ref = NULL;
-        if (PyDict_GetItemStringRef(dict, INTERP_KEY, &ref) < 0) {
+        if (PyDict_GetItemRef(dict, INTERP_KEY, &ref) < 0) {
             goto error;
         }
         if (ref != NULL) {
@@ -178,7 +178,7 @@ clear_current_module(PyInterpreterState *interp, PyObject *expected)
         }
     }
 
-    if (PyDict_DelItemString(dict, INTERP_KEY) < 0) {
+    if (PyDict_DelItem(dict, INTERP_KEY) < 0) {
         if (!PyErr_ExceptionMatches(PyExc_KeyError)) {
             goto error;
         }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -116,6 +116,9 @@ get_current_module(PyInterpreterState *interp)
     }
     PyObject *mod = NULL;
     (void)PyWeakref_GetRef(ref, &mod);
+    if (mod == Py_None) {
+        Py_CLEAR(mod);
+    }
     Py_DECREF(ref);
     return mod;
 }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -157,12 +157,10 @@ _get_current_state(PyObject **p_mod)
     return st;
 }
 
-#define GET_CURRENT_STATE(ST_VAR)   \
-    NULL;                           \
-    PyObject *current_mod = NULL;   \
-    ST_VAR = _get_current_state(&current_mod);
-#define RELEASE_CURRENT_STATE(ST_VAR)   \
-    Py_DECREF(current_mod)
+#define GET_CURRENT_STATE(MOD_VAR)  \
+    _get_current_state(&MOD_VAR)
+#define RELEASE_CURRENT_STATE(ST_VAR, MOD_VAR)  \
+    Py_DECREF(MOD_VAR)
 
 static int
 set_current_module(PyInterpreterState *interp, PyObject *mod)
@@ -2060,7 +2058,8 @@ delta_to_microseconds(PyDateTime_Delta *self)
     PyObject *x3 = NULL;
     PyObject *result = NULL;
 
-    datetime_state *st = GET_CURRENT_STATE(st);
+    PyObject *current_mod = NULL;
+    datetime_state *st = GET_CURRENT_STATE(current_mod);
 
     x1 = PyLong_FromLong(GET_TD_DAYS(self));
     if (x1 == NULL)
@@ -2098,7 +2097,7 @@ Done:
     Py_XDECREF(x1);
     Py_XDECREF(x2);
     Py_XDECREF(x3);
-    RELEASE_CURRENT_STATE(st);
+    RELEASE_CURRENT_STATE(st, current_mod);
     return result;
 }
 
@@ -2138,7 +2137,8 @@ microseconds_to_delta_ex(PyObject *pyus, PyTypeObject *type)
     PyObject *num = NULL;
     PyObject *result = NULL;
 
-    datetime_state *st = GET_CURRENT_STATE(st);
+    PyObject *current_mod = NULL;
+    datetime_state *st = GET_CURRENT_STATE(current_mod);
 
     tuple = checked_divmod(pyus, CONST_US_PER_SECOND(st));
     if (tuple == NULL) {
@@ -2183,7 +2183,7 @@ microseconds_to_delta_ex(PyObject *pyus, PyTypeObject *type)
 Done:
     Py_XDECREF(tuple);
     Py_XDECREF(num);
-    RELEASE_CURRENT_STATE(st);
+    RELEASE_CURRENT_STATE(st, current_mod);
     return result;
 
 BadDivmod:
@@ -2721,7 +2721,8 @@ delta_new(PyTypeObject *type, PyObject *args, PyObject *kw)
 {
     PyObject *self = NULL;
 
-    datetime_state *st = GET_CURRENT_STATE(st);
+    PyObject *current_mod = NULL;
+    datetime_state *st = GET_CURRENT_STATE(current_mod);
 
     /* Argument objects. */
     PyObject *day = NULL;
@@ -2826,7 +2827,7 @@ delta_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     Py_DECREF(x);
 
 Done:
-    RELEASE_CURRENT_STATE(st);
+    RELEASE_CURRENT_STATE(st, current_mod);
     return self;
 
 #undef CLEANUP
@@ -2939,11 +2940,12 @@ delta_total_seconds(PyObject *self, PyObject *Py_UNUSED(ignored))
     if (total_microseconds == NULL)
         return NULL;
 
-    datetime_state *st = GET_CURRENT_STATE(st);
+    PyObject *current_mod = NULL;
+    datetime_state *st = GET_CURRENT_STATE(current_mod);
 
     total_seconds = PyNumber_TrueDivide(total_microseconds, CONST_US_PER_SECOND(st));
 
-    RELEASE_CURRENT_STATE(st);
+    RELEASE_CURRENT_STATE(st, current_mod);
     Py_DECREF(total_microseconds);
     return total_seconds;
 }
@@ -3696,11 +3698,12 @@ date_isocalendar(PyDateTime_Date *self, PyObject *Py_UNUSED(ignored))
         week = 0;
     }
 
-    datetime_state *st = GET_CURRENT_STATE(st);
+    PyObject *current_mod = NULL;
+    datetime_state *st = GET_CURRENT_STATE(current_mod);
 
     PyObject *v = iso_calendar_date_new_impl(ISOCALENDAR_DATE_TYPE(st),
                                              year, week + 1, day + 1);
-    RELEASE_CURRENT_STATE(st);
+    RELEASE_CURRENT_STATE(st, current_mod);
     if (v == NULL) {
         return NULL;
     }
@@ -6409,10 +6412,11 @@ local_timezone(PyDateTime_DateTime *utc_time)
     PyObject *one_second;
     PyObject *seconds;
 
-    datetime_state *st = GET_CURRENT_STATE(st);
+    PyObject *current_mod = NULL;
+    datetime_state *st = GET_CURRENT_STATE(current_mod);
 
     delta = datetime_subtract((PyObject *)utc_time, CONST_EPOCH(st));
-    RELEASE_CURRENT_STATE(st);
+    RELEASE_CURRENT_STATE(st, current_mod);
     if (delta == NULL)
         return NULL;
 
@@ -6649,11 +6653,12 @@ datetime_timestamp(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
     PyObject *result;
 
     if (HASTZINFO(self) && self->tzinfo != Py_None) {
-        datetime_state *st = GET_CURRENT_STATE(st);
+        PyObject *current_mod = NULL;
+        datetime_state *st = GET_CURRENT_STATE(current_mod);
 
         PyObject *delta;
         delta = datetime_subtract((PyObject *)self, CONST_EPOCH(st));
-        RELEASE_CURRENT_STATE(st);
+        RELEASE_CURRENT_STATE(st, current_mod);
         if (delta == NULL)
             return NULL;
         result = delta_total_seconds(delta, NULL);


### PR DESCRIPTION
I was able to make use of the existing `datetime_state` struct, but there was one tricky thing I had to sort out.  We mostly aren't converting to heap types, so we can't use things like `PyType_GetModuleByDef()` to look up the module state.  The solution I came up with is somewhat novel, but I consider it straightforward.  Also, it shouldn't have much impact on performance.

In summary, this main changes of this PR are:

* I've added some macros to help hide how various objects relate to module state
* as a solution to the module state lookup problem, I've stored the last loaded module on the current interpreter's internal dict (actually a weakref)
* if the static type method is used after the module has been deleted, it is reloaded
* to avoid extra work when loading the module, we directly copy the objects (new refs only) from the old module state into the new state if the old module hasn't been deleted yet
* during module init we set various objects on the static types' `__dict__`s; to simplify things, we only do that the first time; once those static types have a separate `__dict__` per interpreter, we'll do it every time
* we now clear the module state when the module is destroyed (before, we were leaking everything in `_datetime_global_state`)

<!-- gh-issue-number: gh-117398 -->
* Issue: gh-117398
<!-- /gh-issue-number -->
