### PR TITLE
GH-119812: ipaddress: Consider 100.64.0.0/10 private

### DIFF
--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -180,17 +180,15 @@ write code that handles both IP versions correctly.  Address objects are
 
       ``True`` if the address is defined as not globally reachable by
       iana-ipv4-special-registry_ (for IPv4) or iana-ipv6-special-registry_
-      (for IPv6) with the following exceptions:
+      (for IPv6) with the following exception:
 
-      * ``is_private`` is ``False`` for the shared address space (``100.64.0.0/10``)
-      * For IPv4-mapped IPv6-addresses the ``is_private`` value is determined by the
-        semantics of the underlying IPv4 addresses and the following condition holds
-        (see :attr:`IPv6Address.ipv4_mapped`)::
+      For IPv4-mapped IPv6-addresses the ``is_private`` value is determined by the
+      semantics of the underlying IPv4 addresses and the following condition holds
+      (see :attr:`IPv6Address.ipv4_mapped`)::
 
-            address.is_private == address.ipv4_mapped.is_private
+         address.is_private == address.ipv4_mapped.is_private
 
-      ``is_private`` has value opposite to :attr:`is_global`, except for the shared address space
-      (``100.64.0.0/10`` range) where they are both ``False``.
+      ``is_private`` has value opposite to :attr:`is_global`.
 
       .. versionchanged:: 3.13
 
@@ -204,6 +202,10 @@ write code that handles both IP versions correctly.  Address objects are
            ``2001:1::2/128``, ``2001:3::/32``, ``2001:4:112::/48``, ``2001:20::/28``, ``2001:30::/28``.
            The exceptions are not considered private.
 
+         Additionally ``100.64.0.0/10`` is no longer exceptional – both ``is_private`` and
+         ``is_global`` used to return ``False`` for addresses in that range, now ``is_private``
+         returns ``True``.
+
    .. attribute:: is_global
 
       ``True`` if the address is defined as globally reachable by
@@ -216,8 +218,7 @@ write code that handles both IP versions correctly.  Address objects are
 
          address.is_global == address.ipv4_mapped.is_global
 
-      ``is_global`` has value opposite to :attr:`is_private`, except for the shared address space
-      (``100.64.0.0/10`` range) where they are both ``False``.
+      ``is_global`` has value opposite to :attr:`is_private`.
 
       .. versionadded:: 3.4
 

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1339,17 +1339,15 @@ class IPv4Address(_BaseV4, _BaseAddress):
     def is_private(self):
         """``True`` if the address is defined as not globally reachable by
         iana-ipv4-special-registry_ (for IPv4) or iana-ipv6-special-registry_
-        (for IPv6) with the following exceptions:
+        (for IPv6) with the following exception:
 
-        * ``is_private`` is ``False`` for ``100.64.0.0/10``
-        * For IPv4-mapped IPv6-addresses the ``is_private`` value is determined by the
-            semantics of the underlying IPv4 addresses and the following condition holds
-            (see :attr:`IPv6Address.ipv4_mapped`)::
+        For IPv4-mapped IPv6-addresses the ``is_private`` value is determined by the
+        semantics of the underlying IPv4 addresses and the following condition holds
+        (see :attr:`IPv6Address.ipv4_mapped`)::
 
-                address.is_private == address.ipv4_mapped.is_private
+            address.is_private == address.ipv4_mapped.is_private
 
-        ``is_private`` has value opposite to :attr:`is_global`, except for the ``100.64.0.0/10``
-        IPv4 range where they are both ``False``.
+        ``is_private`` has value opposite to :attr:`is_global`.
         """
         return (
             any(self in net for net in self._constants._private_networks)
@@ -1369,10 +1367,9 @@ class IPv4Address(_BaseV4, _BaseAddress):
 
             address.is_global == address.ipv4_mapped.is_global
 
-        ``is_global`` has value opposite to :attr:`is_private`, except for the ``100.64.0.0/10``
-        IPv4 range where they are both ``False``.
+        ``is_global`` has value opposite to :attr:`is_private`.
         """
-        return self not in self._constants._public_network and not self.is_private
+        return not self.is_private
 
     @property
     def is_multicast(self):
@@ -1571,9 +1568,7 @@ class IPv4Network(_BaseV4, _BaseNetwork):
             iana-ipv4-special-registry.
 
         """
-        return (not (self.network_address in IPv4Network('100.64.0.0/10') and
-                    self.broadcast_address in IPv4Network('100.64.0.0/10')) and
-                not self.is_private)
+        return not self.is_private
 
 
 class _IPv4Constants:
@@ -1583,13 +1578,12 @@ class _IPv4Constants:
 
     _multicast_network = IPv4Network('224.0.0.0/4')
 
-    _public_network = IPv4Network('100.64.0.0/10')
-
     # Not globally reachable address blocks listed on
     # https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
     _private_networks = [
         IPv4Network('0.0.0.0/8'),
         IPv4Network('10.0.0.0/8'),
+        IPv4Network('100.64.0.0/10'),
         IPv4Network('127.0.0.0/8'),
         IPv4Network('169.254.0.0/16'),
         IPv4Network('172.16.0.0/12'),
@@ -2085,17 +2079,15 @@ class IPv6Address(_BaseV6, _BaseAddress):
     def is_private(self):
         """``True`` if the address is defined as not globally reachable by
         iana-ipv4-special-registry_ (for IPv4) or iana-ipv6-special-registry_
-        (for IPv6) with the following exceptions:
+        (for IPv6) with the following exception:
 
-        * ``is_private`` is ``False`` for ``100.64.0.0/10``
-        * For IPv4-mapped IPv6-addresses the ``is_private`` value is determined by the
-            semantics of the underlying IPv4 addresses and the following condition holds
-            (see :attr:`IPv6Address.ipv4_mapped`)::
+        For IPv4-mapped IPv6-addresses the ``is_private`` value is determined by the
+        semantics of the underlying IPv4 addresses and the following condition holds
+        (see :attr:`IPv6Address.ipv4_mapped`)::
 
-                address.is_private == address.ipv4_mapped.is_private
+            address.is_private == address.ipv4_mapped.is_private
 
-        ``is_private`` has value opposite to :attr:`is_global`, except for the ``100.64.0.0/10``
-        IPv4 range where they are both ``False``.
+        ``is_private`` has value opposite to :attr:`is_global`.
         """
         ipv4_mapped = self.ipv4_mapped
         if ipv4_mapped is not None:
@@ -2117,8 +2109,7 @@ class IPv6Address(_BaseV6, _BaseAddress):
 
             address.is_global == address.ipv4_mapped.is_global
 
-        ``is_global`` has value opposite to :attr:`is_private`, except for the ``100.64.0.0/10``
-        IPv4 range where they are both ``False``.
+        ``is_global`` has value opposite to :attr:`is_private`.
         """
         return not self.is_private
 

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -2263,7 +2263,7 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(True, ipaddress.ip_network(
                 '127.42.0.0/16').is_loopback)
         self.assertEqual(False, ipaddress.ip_network('128.0.0.0').is_loopback)
-        self.assertEqual(False,
+        self.assertEqual(True,
                          ipaddress.ip_network('100.64.0.0/10').is_private)
         self.assertEqual(False, ipaddress.ip_network('100.64.0.0/10').is_global)
 
@@ -2285,6 +2285,9 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(True, ipaddress.ip_address(
                 '10.255.255.255').is_private)
         self.assertEqual(False, ipaddress.ip_address('11.0.0.0').is_private)
+        self.assertEqual(True,
+                         ipaddress.ip_address('100.64.0.0').is_private)
+        self.assertEqual(False, ipaddress.ip_address('100.64.0.0').is_global)
         self.assertEqual(True, ipaddress.ip_address(
                 '172.31.255.255').is_private)
         self.assertEqual(False, ipaddress.ip_address('172.32.0.0').is_private)

--- a/Misc/NEWS.d/next/Library/2024-05-31-00-34-38.gh-issue-119812.eNvvk0.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-31-00-34-38.gh-issue-119812.eNvvk0.rst
@@ -1,0 +1,9 @@
+:attr:`ipaddress.IPv4Address.is_private` and
+:attr:`ipaddress.IPv4Network.is_private` no longer treat the
+``100.64.0.0/10`` address block in a special way.
+
+Previously the range was considered not private but not global either.
+
+Now ``is_private`` returns ``True`` for these addresses, matching the wider
+``is_private`` semantics and the IANA IPv4 Special-Purpose Address Registry
+registry saying the range is not globally reachable.


### PR DESCRIPTION
As explained in the linked ticket I believe making an exception for this range is likely to create problems and result in surprises considering:

1. The is_global/is_private relationship in that one is the opposite of the other, except for 100.64.0.0/10 until now
2. is_private returns True for ranges that IANA declares as not globally reachable and 100.64.0.0/10 is defined as being not globally reachable

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119812 -->
* Issue: gh-119812
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119813.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->