### PR TITLE
ipaddress: Speed up IPv4Address.ipv6_mapped

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1424,7 +1424,7 @@ class IPv4Address(_BaseV4, _BaseAddress):
             The IPv4-mapped IPv6 address per RFC 4291.
 
         """
-        return IPv6Address(f'::ffff:{self}')
+        return IPv6Address((0xFFFF << 32) + self._ip)
 
 
 class IPv4Interface(IPv4Address):


### PR DESCRIPTION
A random find from my side, I was going through this code when I noticed some unnecessary conversions happening.

Nice performance improvement basically for free (numbers from my M1 Pro laptop):

    In [1]: from ipaddress import IPv4Address, IPv6Address

    In [2]: v4 = IPv4Address('10.0.0.1')

    In [3]: IPv6Address(f'::ffff:{v4}') == IPv6Address((0xffff << 32) + v4._ip)
    Out[3]: True

    In [4]: %timeit IPv6Address(f'::ffff:{v4}')
    3.63 µs ± 12 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

    In [5]: %timeit IPv6Address((0xffff << 32) + v4._ip)
    184 ns ± 0.413 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
