### PR TITLE
gh-119823: support bytes/bytearray in complex() constructor

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -641,8 +641,8 @@ class ComplexTest(unittest.TestCase):
                      CustomBytes, CustomByteArray]
 
         for f in factories:
-            x = f(b"(1+1j)")
-            with self.subTest(type(x)):
+            with self.subTest(f=f):
+                x = f(b"(1+1j)")
                 self.assertEqual(complex(x), 1+1j)
                 with self.assertRaisesRegex(ValueError,
                                             "arg is a malformed string"):

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -632,6 +632,22 @@ class ComplexTest(unittest.TestCase):
         self.assertEqual(copysign(1., complex("-nan-nanj").real), -1.)
         self.assertEqual(copysign(1., complex("-nan-nanj").imag), -1.)
 
+    def test_other_non_numeric_input_types(self):
+        class CustomStr(str): ...
+        class CustomBytes(bytes): ...
+        class CustomByteArray(bytearray): ...
+
+        factories = [bytes, bytearray, lambda b: CustomStr(b.decode()),
+                     CustomBytes, CustomByteArray]
+
+        for f in factories:
+            x = f(b"(1+1j)")
+            with self.subTest(type(x)):
+                self.assertEqual(complex(x), 1+1j)
+                with self.assertRaisesRegex(ValueError,
+                                            "arg is a malformed string"):
+                    complex(f(b'A'))
+
     def test_underscores(self):
         # check underscores
         for lit in VALID_UNDERSCORE_LITERALS:

--- a/Misc/NEWS.d/next/Core and Builtins/2024-05-31-09-45-34.gh-issue-119823.TKAlxZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-05-31-09-45-34.gh-issue-119823.TKAlxZ.rst
@@ -1,0 +1,2 @@
+Support :class:`bytes`/:class:`bytearray` in the :class:`complex`
+constructor. Patch by Sergey B Kirpichev.

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -941,6 +941,17 @@ actual_complex_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     if (PyUnicode_Check(arg)) {
         return complex_subtype_from_string(type, arg);
     }
+    else if (PyByteArray_Check(arg) || PyBytes_Check(arg)) {
+        if (PyByteArray_Check(arg)) {
+            const char *string = PyByteArray_AS_STRING(arg);
+        }
+        else {
+            const char *string = PyBytes_AS_STRING(arg);
+        }
+        return _Py_string_to_number_with_underscores(string, Py_SIZE(arg),
+                                                     "complex", arg, type,
+                                                     complex_from_string_inner);
+    }
     PyObject *tmp = try_complex_special_method(arg);
     if (tmp) {
         Py_complex c = ((PyComplexObject*)tmp)->cval;

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -943,14 +943,17 @@ actual_complex_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     }
     else if (PyByteArray_Check(arg) || PyBytes_Check(arg)) {
         const char *string;
+        Py_ssize_t len;
 
         if (PyByteArray_Check(arg)) {
             string = PyByteArray_AS_STRING(arg);
+            len = PyByteArray_GET_SIZE(arg);
         }
         else {
             string = PyBytes_AS_STRING(arg);
+            len = PyBytes_GET_SIZE(arg);
         }
-        return _Py_string_to_number_with_underscores(string, Py_SIZE(arg),
+        return _Py_string_to_number_with_underscores(string, len,
                                                      "complex", arg, type,
                                                      complex_from_string_inner);
     }

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -942,11 +942,13 @@ actual_complex_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         return complex_subtype_from_string(type, arg);
     }
     else if (PyByteArray_Check(arg) || PyBytes_Check(arg)) {
+        const char *string;
+
         if (PyByteArray_Check(arg)) {
-            const char *string = PyByteArray_AS_STRING(arg);
+            string = PyByteArray_AS_STRING(arg);
         }
         else {
-            const char *string = PyBytes_AS_STRING(arg);
+            string = PyBytes_AS_STRING(arg);
         }
         return _Py_string_to_number_with_underscores(string, Py_SIZE(arg),
                                                      "complex", arg, type,


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119823 -->
* Issue: gh-119823
<!-- /gh-issue-number -->
