### PR TITLE
gh-86425: PrettyPrinter._format and ._safe_repr now protected against cyclic recursion with thread-wide context

### DIFF
--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -97,19 +97,15 @@ Functions
 
 .. function:: isrecursive(object)
 
-   Determine if *object* requires a recursive representation.  This function is
-   subject to the same limitations as noted in :func:`saferepr` below and may raise an
-   :exc:`RecursionError` if it fails to detect a recursive object.
+   Determine if *object* requires a recursive representation.
 
 
 .. function:: saferepr(object)
 
-   Return a string representation of *object*, protected against recursion in
-   some common data structures, namely instances of :class:`dict`, :class:`list`
-   and :class:`tuple` or subclasses whose ``__repr__`` has not been overridden.  If the
-   representation of object exposes a recursive entry, the recursive reference
-   will be represented as ``<Recursion on typename with id=number>``.  The
-   representation is not otherwise formatted.
+   Return a string representation of *object*, protected against recursive data
+   structures.  If the representation of *object* exposes a recursive entry, the
+   recursive reference will be represented as ``<Recursion on typename with
+   id=number>``.  The representation is not otherwise formatted.
 
    >>> pprint.saferepr(stuff)
    "[<Recursion on list with id=...>, 'spam', 'eggs', 'lumberjack', 'knights', 'ni']"

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -381,8 +381,7 @@ class PrettyPrinter:
 
     _dispatch[bytearray.__repr__] = _pprint_bytearray
 
-    def _pprint_mappingproxy(self, object, stream, indent, allowance,
-                             context, level):
+    def _pprint_mappingproxy(self, object, stream, indent, allowance, context, level):
         stream.write('mappingproxy(')
         self._format(object.copy(), stream, indent + 13, allowance + 1,
                      context, level)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1495,7 +1495,7 @@ def test_pdb_return_to_different_file():
     (Pdb) return
     --Return--
     > ...pprint.py..._safe_repr()->('A'...)
-    -> del self._safe_repr_context...
+    -> del context...
     (Pdb) return
     --Return--
     > ...pprint.py...format()->('A'...)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1495,7 +1495,7 @@ def test_pdb_return_to_different_file():
     (Pdb) return
     --Return--
     > ...pprint.py..._safe_repr()->('A'...)
-    -> return rep,...
+    -> del self._safe_repr_context...
     (Pdb) return
     --Return--
     > ...pprint.py...format()->('A'...)

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -1134,7 +1134,7 @@ deque([('brown', 2),
         a = A()
         a.self = a
         self.assertEqual(pprint.pformat(a),
-                         f"{'self': <Recursion on A with id={id(a)}>}")
+                         f"{{'self': <Recursion on A with id={id(a)}>}}")
 
 
 class DottedPrettyPrinter(pprint.PrettyPrinter):

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -1124,6 +1124,18 @@ deque([('brown', 2),
     'jumped over a '
     'lazy dog'}""")
 
+    def test_saferepr_custom_repr_recursion_detection(self):
+        class A:
+            def __str__(self):
+                return pprint.saferepr(self.__dict__)
+            def __repr__(self):
+                return str(self)
+
+        a = A()
+        a.self = a
+        self.assertEqual(pprint.pformat(a),
+                         f"{'self': <Recursion on A with id={id(a)}>}")
+
 
 class DottedPrettyPrinter(pprint.PrettyPrinter):
 

--- a/Misc/NEWS.d/next/Library/2024-05-31-08-21-29.gh-issue-86425.L5tk-X.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-31-08-21-29.gh-issue-86425.L5tk-X.rst
@@ -1,1 +1,1 @@
-`pprint.isrecursive` and `pprint.saferepr` can now handle instances of classes with overriding `__repr__` methods defined.
+``pprint.isrecursive`` and ``pprint.saferepr`` can now handle instances of classes with a custom ``__repr__`` method without causing a ``RecursionError``.

--- a/Misc/NEWS.d/next/Library/2024-05-31-08-21-29.gh-issue-86425.L5tk-X.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-31-08-21-29.gh-issue-86425.L5tk-X.rst
@@ -1,0 +1,1 @@
+`pprint.isrecursive` and `pprint.saferepr` can now handle instances of classes with overriding `__repr__` methods defined.


### PR DESCRIPTION
# PrettyPrinter._format and ._safe_repr now protected against cyclic recursion with thread-wide context

Previously `PrettyPrinter._format` and `PrettyPrinter._safe_repr` would produce an infinite recursion error when given an object with custom `__repr__` defined because the custom `__repr__` is unable to carry on the context of seen object IDs onto the next levels of recursions.

This is now fixed by maintaining a thread-wide context for each of `_format` and `_safe_repr` so the context would not be lost with non-cooperative recursive calls.

<!-- gh-issue-number: gh-86425 -->
* Issue: gh-86425
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119829.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->