### PR TITLE
[3.12] gh-103194: Fix Tkinter’s Tcl value type handling for Tcl 8.7/9.0 (GH-103846)

### DIFF
--- a/Misc/NEWS.d/next/Library/2023-04-24-05-34-23.gh-issue-103194.GwBwWL.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-24-05-34-23.gh-issue-103194.GwBwWL.rst
@@ -1,0 +1,4 @@
+Prepare Tkinter for C API changes in Tcl 8.7/9.0 to avoid
+:class:`_tkinter.Tcl_Obj` being unexpectedly returned
+instead of :class:`bool`, :class:`str`,
+:class:`bytearray`, or :class:`int`.


### PR DESCRIPTION
Some of standard Tcl types were renamed, removed, or no longer registered in Tcl 8.7/9.0. This change fixes automatic conversion of Tcl values to Python values to avoid returning a Tcl_Obj where the primary Python types (int, bool, str, bytes) were returned in older Tcl.

(cherry picked from commit 94e9585e99abc2d060cedc77b3c03e06b4a0a9c4)


<!-- gh-issue-number: gh-103194 -->
* Issue: gh-103194
<!-- /gh-issue-number -->
