### PR TITLE
gh-111201: [pyrepl] Ensure optional platform-specific imports are optional

### DIFF
--- a/Lib/test/test_pyrepl/test_windows_console.py
+++ b/Lib/test/test_pyrepl/test_windows_console.py
@@ -1,24 +1,24 @@
 import itertools
 import sys
 import unittest
-from _pyrepl.console import Event, Console
-from _pyrepl.windows_console import (
-    MOVE_LEFT,
-    MOVE_RIGHT,
-    MOVE_UP,
-    MOVE_DOWN,
-    ERASE_IN_LINE,
-)
+
 from functools import partial
 from typing import Iterable
-from unittest import TestCase, main
-from unittest.mock import MagicMock, call, patch, ANY
+from unittest import TestCase
+from unittest.mock import MagicMock, call
 
 from .support import handle_all_events, code_to_events
 
 try:
-    from _pyrepl.console import Event
-    from _pyrepl.windows_console import WindowsConsole
+    from _pyrepl.console import Event, Console
+    from _pyrepl.windows_console import (
+        WindowsConsole,
+        MOVE_LEFT,
+        MOVE_RIGHT,
+        MOVE_UP,
+        MOVE_DOWN,
+        ERASE_IN_LINE,
+    )
 except ImportError:
     pass
 


### PR DESCRIPTION
This is a followup from gh-119559.

<!-- gh-issue-number: gh-111201 -->
* Issue: gh-111201
<!-- /gh-issue-number -->
