### PR TITLE
gh-119070: Update test_shebang_executable_extension to always use non-installed version

### DIFF
--- a/Lib/test/test_launcher.py
+++ b/Lib/test/test_launcher.py
@@ -766,9 +766,9 @@ class TestLauncher(unittest.TestCase, RunPyMixin):
             self.assertEqual(data["stdout"].strip(), f"{quote(exe)} arg1 {quote(script)}")
 
     def test_shebang_executable_extension(self):
-        with self.script('#! /usr/bin/env python3.12') as script:
-            data = self.run_py([script])
-        expect = "# Search PATH for python3.12.exe"
+        with self.script('#! /usr/bin/env python3.99') as script:
+            data = self.run_py([script], expect_returncode=103)
+        expect = "# Search PATH for python3.99.exe"
         actual = [line.strip() for line in data["stderr"].splitlines()
                   if line.startswith("# Search PATH")]
         self.assertEqual([expect], actual)


### PR DESCRIPTION


<!-- gh-issue-number: gh-119070 -->
* Issue: gh-119070
<!-- /gh-issue-number -->
