### PR TITLE
gh-119851: Add Py_nullptr macro

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -209,6 +209,14 @@ complete listing.
 
    .. versionadded:: 3.11
 
+.. c:macro:: Py_nullptr
+
+   Null pointer. The macro can be used in public static inline functions to
+   avoid C++ compiler warnings. The macro uses ``nullptr`` on C++11 and newer
+   and on C23 and newer. Otherwise the macro uses the legacy ``NULL`` macro.
+
+   .. versionadded:: 3.14
+
 .. c:macro:: Py_STRINGIFY(x)
 
    Convert ``x`` to a C string.  E.g. ``Py_STRINGIFY(123)`` returns

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -243,6 +243,12 @@ C API Changes
 New Features
 ------------
 
+* Add :c:macro:`Py_nullptr` macro: a null pointer. It can be used in public
+  static inline functions to avoid C++ compiler warnings. The macro uses
+  ``nullptr`` on C++11 and newer and on C23 and newer. Otherwise the macro uses
+  the legacy ``NULL`` macro.
+  (Contributed by Victor Stinner in :gh:`119851`.)
+
 Porting to Python 3.14
 ----------------------
 

--- a/Include/cpython/abstract.h
+++ b/Include/cpython/abstract.h
@@ -62,7 +62,7 @@ static inline PyObject *
 PyObject_CallMethodNoArgs(PyObject *self, PyObject *name)
 {
     size_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
-    return PyObject_VectorcallMethod(name, &self, nargsf, _Py_NULL);
+    return PyObject_VectorcallMethod(name, &self, nargsf, Py_nullptr);
 }
 
 static inline PyObject *
@@ -71,7 +71,7 @@ PyObject_CallMethodOneArg(PyObject *self, PyObject *name, PyObject *arg)
     PyObject *args[2] = {self, arg};
     size_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
     assert(arg != NULL);
-    return PyObject_VectorcallMethod(name, args, nargsf, _Py_NULL);
+    return PyObject_VectorcallMethod(name, args, nargsf, Py_nullptr);
 }
 
 /* Guess the size of object 'o' using len(o) or o.__length_hint__().

--- a/Include/cpython/methodobject.h
+++ b/Include/cpython/methodobject.h
@@ -45,7 +45,7 @@ static inline PyCFunction PyCFunction_GET_FUNCTION(PyObject *func) {
 static inline PyObject* PyCFunction_GET_SELF(PyObject *func_obj) {
     PyCFunctionObject *func = _PyCFunctionObject_CAST(func_obj);
     if (func->m_ml->ml_flags & METH_STATIC) {
-        return _Py_NULL;
+        return Py_nullptr;
     }
     return func->m_self;
 }
@@ -61,6 +61,6 @@ static inline PyTypeObject* PyCFunction_GET_CLASS(PyObject *func_obj) {
     if (func->m_ml->ml_flags & METH_METHOD) {
         return _PyCMethodObject_CAST(func)->mm_class;
     }
-    return _Py_NULL;
+    return Py_nullptr;
 }
 #define PyCFunction_GET_CLASS(func) PyCFunction_GET_CLASS(_PyObject_CAST(func))

--- a/Include/internal/pycore_call.h
+++ b/Include/internal/pycore_call.h
@@ -75,7 +75,7 @@ _PyObject_VectorcallMethodId(
 {
     PyObject *oname = _PyUnicode_FromId(name); /* borrowed */
     if (!oname) {
-        return _Py_NULL;
+        return Py_nullptr;
     }
     return PyObject_VectorcallMethod(oname, args, nargsf, kwnames);
 }
@@ -84,7 +84,7 @@ static inline PyObject *
 _PyObject_CallMethodIdNoArgs(PyObject *self, _Py_Identifier *name)
 {
     size_t nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
-    return _PyObject_VectorcallMethodId(name, &self, nargsf, _Py_NULL);
+    return _PyObject_VectorcallMethodId(name, &self, nargsf, Py_nullptr);
 }
 
 static inline PyObject *
@@ -93,7 +93,7 @@ _PyObject_CallMethodIdOneArg(PyObject *self, _Py_Identifier *name, PyObject *arg
     PyObject *args[2] = {self, arg};
     size_t nargsf = 2 | PY_VECTORCALL_ARGUMENTS_OFFSET;
     assert(arg != NULL);
-    return _PyObject_VectorcallMethodId(name, args, nargsf, _Py_NULL);
+    return _PyObject_VectorcallMethodId(name, args, nargsf, Py_nullptr);
 }
 
 

--- a/Include/moduleobject.h
+++ b/Include/moduleobject.h
@@ -58,10 +58,10 @@ typedef struct PyModuleDef_Base {
 } PyModuleDef_Base;
 
 #define PyModuleDef_HEAD_INIT {  \
-    PyObject_HEAD_INIT(_Py_NULL) \
-    _Py_NULL, /* m_init */       \
+    PyObject_HEAD_INIT(Py_nullptr) \
+    Py_nullptr, /* m_init */       \
     0,        /* m_index */      \
-    _Py_NULL, /* m_copy */       \
+    Py_nullptr, /* m_copy */       \
   }
 
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03050000

--- a/Include/object.h
+++ b/Include/object.h
@@ -1005,7 +1005,7 @@ static inline Py_ALWAYS_INLINE void Py_DECREF(PyObject *op)
         _Py_TYPEOF(op)* _tmp_op_ptr = &(op); \
         _Py_TYPEOF(op) _tmp_old_op = (*_tmp_op_ptr); \
         if (_tmp_old_op != NULL) { \
-            *_tmp_op_ptr = _Py_NULL; \
+            *_tmp_op_ptr = Py_nullptr; \
             Py_DECREF(_tmp_old_op); \
         } \
     } while (0)
@@ -1015,7 +1015,7 @@ static inline Py_ALWAYS_INLINE void Py_DECREF(PyObject *op)
         PyObject **_tmp_op_ptr = _Py_CAST(PyObject**, &(op)); \
         PyObject *_tmp_old_op = (*_tmp_op_ptr); \
         if (_tmp_old_op != NULL) { \
-            PyObject *_null_ptr = _Py_NULL; \
+            PyObject *_null_ptr = Py_nullptr; \
             memcpy(_tmp_op_ptr, &_null_ptr, sizeof(PyObject*)); \
             Py_DECREF(_tmp_old_op); \
         } \
@@ -1026,7 +1026,7 @@ static inline Py_ALWAYS_INLINE void Py_DECREF(PyObject *op)
 /* Function to use in case the object pointer can be NULL: */
 static inline void Py_XINCREF(PyObject *op)
 {
-    if (op != _Py_NULL) {
+    if (op != Py_nullptr) {
         Py_INCREF(op);
     }
 }
@@ -1036,7 +1036,7 @@ static inline void Py_XINCREF(PyObject *op)
 
 static inline void Py_XDECREF(PyObject *op)
 {
-    if (op != _Py_NULL) {
+    if (op != Py_nullptr) {
         Py_DECREF(op);
     }
 }

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -18,15 +18,18 @@
 // Macro to use the more powerful/dangerous C-style cast even in C++.
 #define _Py_CAST(type, expr) ((type)(expr))
 
-// Static inline functions should use _Py_NULL rather than using directly NULL
+// Static inline functions should use Py_nullptr rather than using directly NULL
 // to prevent C++ compiler warnings. On C23 and newer and on C++11 and newer,
-// _Py_NULL is defined as nullptr.
+// Py_nullptr is defined as nullptr.
 #if (defined (__STDC_VERSION__) && __STDC_VERSION__ > 201710L) \
         || (defined(__cplusplus) && __cplusplus >= 201103)
-#  define _Py_NULL nullptr
+#  define Py_nullptr nullptr
 #else
-#  define _Py_NULL NULL
+#  define Py_nullptr NULL
 #endif
+
+// Alias kept for backward compatibility
+#define _Py_NULL Py_nullptr
 
 
 /* Defines to build Python and its standard library:

--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -25,7 +25,7 @@ _testcppext_add(PyObject *Py_UNUSED(module), PyObject *args)
 {
     long i, j;
     if (!PyArg_ParseTuple(args, "ll:foo", &i, &j)) {
-        return _Py_NULL;
+        return Py_nullptr;
     }
     long res = i + j;
     return PyLong_FromLong(res);
@@ -56,8 +56,8 @@ static PyObject *
 test_api_casts(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 {
     PyObject *obj = Py_BuildValue("(ii)", 1, 2);
-    if (obj == _Py_NULL) {
-        return _Py_NULL;
+    if (obj == Py_nullptr) {
+        return Py_nullptr;
     }
     Py_ssize_t refcnt = Py_REFCNT(obj);
     assert(refcnt >= 1);
@@ -101,8 +101,8 @@ static PyObject *
 test_unicode(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 {
     PyObject *str = PyUnicode_FromString("abc");
-    if (str == _Py_NULL) {
-        return _Py_NULL;
+    if (str == Py_nullptr) {
+        return Py_nullptr;
     }
 
     assert(PyUnicode_Check(str));
@@ -110,7 +110,7 @@ test_unicode(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 
     // gh-92800: test PyUnicode_READ()
     const void* data = PyUnicode_DATA(str);
-    assert(data != _Py_NULL);
+    assert(data != Py_nullptr);
     int kind = PyUnicode_KIND(str);
     assert(kind == PyUnicode_1BYTE_KIND);
     assert(PyUnicode_READ(kind, data, 0) == 'a');
@@ -154,7 +154,7 @@ int VirtualPyObject::instance_count = 0;
 
 PyType_Slot VirtualPyObject_Slots[] = {
     {Py_tp_free, (void*)VirtualPyObject::dealloc},
-    {0, _Py_NULL},
+    {0, Py_nullptr},
 };
 
 PyType_Spec VirtualPyObject_Spec = {
@@ -194,13 +194,13 @@ test_virtual_object(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 
 static PyMethodDef _testcppext_methods[] = {
     {"add", _testcppext_add, METH_VARARGS, _testcppext_add_doc},
-    {"test_api_casts", test_api_casts, METH_NOARGS, _Py_NULL},
-    {"test_unicode", test_unicode, METH_NOARGS, _Py_NULL},
-    {"test_virtual_object", test_virtual_object, METH_NOARGS, _Py_NULL},
+    {"test_api_casts", test_api_casts, METH_NOARGS, Py_nullptr},
+    {"test_unicode", test_unicode, METH_NOARGS, Py_nullptr},
+    {"test_virtual_object", test_virtual_object, METH_NOARGS, Py_nullptr},
     // Note: _testcppext_exec currently runs all test functions directly.
     // When adding a new one, add a call there.
 
-    {_Py_NULL, _Py_NULL, 0, _Py_NULL}  /* sentinel */
+    {Py_nullptr, Py_nullptr, 0, Py_nullptr}  /* sentinel */
 };
 
 
@@ -234,7 +234,7 @@ _testcppext_exec(PyObject *module)
 
 static PyModuleDef_Slot _testcppext_slots[] = {
     {Py_mod_exec, reinterpret_cast<void*>(_testcppext_exec)},
-    {0, _Py_NULL}
+    {0, Py_nullptr}
 };
 
 
@@ -247,9 +247,9 @@ static struct PyModuleDef _testcppext_module = {
     0,  // m_size
     _testcppext_methods,  // m_methods
     _testcppext_slots,  // m_slots
-    _Py_NULL,  // m_traverse
-    _Py_NULL,  // m_clear
-    _Py_NULL,  // m_free
+    Py_nullptr,  // m_traverse
+    Py_nullptr,  // m_clear
+    Py_nullptr,  // m_free
 };
 
 #define _FUNC_NAME(NAME) PyInit_ ## NAME

--- a/Misc/NEWS.d/next/C API/2024-05-31-14-56-25.gh-issue-119851.RFAPlc.rst
+++ b/Misc/NEWS.d/next/C API/2024-05-31-14-56-25.gh-issue-119851.RFAPlc.rst
@@ -1,0 +1,4 @@
+Add :c:macro:`Py_nullptr` macro: a null pointer. It can be used in public
+static inline functions to avoid C++ compiler warnings. The macro uses
+``nullptr`` on C++11 and newer and on C23 and newer. Otherwise the macro
+uses the legacy ``NULL`` macro. Patch by Victor Stinner.


### PR DESCRIPTION
Rename the private _Py_NULL macro to Py_nullptr.

Keep the _Py_NULL macro as an alias to the public Py_nullptr.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119851 -->
* Issue: gh-119851
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119852.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->