### PR TITLE
contextlib docs: Clean up redundant 'up' after 'cleanup'

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -796,7 +796,7 @@ executing that callback::
        if result:
            stack.pop_all()
 
-This allows the intended cleanup up behaviour to be made explicit up front,
+This allows the intended cleanup behaviour to be made explicit up front,
 rather than requiring a separate flag variable.
 
 If a particular application uses this pattern a lot, it can be simplified


### PR DESCRIPTION
Reported by Michael Kass on docs@


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119867.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->