### PR TITLE
gh-119824: Print stack entry when user input is needed

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -329,6 +329,9 @@ can be overridden by the local file.
    *count* frames.  An arrow (``>``)
    indicates the current frame, which determines the context of most commands.
 
+   .. versionchanged:: 3.14
+      *count* argument is added.
+
 .. pdbcommand:: d(own) [count]
 
    Move the current frame *count* (default one) levels down in the stack trace

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -321,9 +321,12 @@ can be overridden by the local file.
    argument must be an identifier, ``help exec`` must be entered to get help on
    the ``!`` command.
 
-.. pdbcommand:: w(here)
+.. pdbcommand:: w(here) [count]
 
-   Print a stack trace, with the most recent frame at the bottom.  An arrow (``>``)
+   Print a stack trace, with the most recent frame at the bottom.  if *count*
+   is 0, print the current frame entry. If *count* is negative, print the least
+   recent - *count* frames. If *count* is positive, print the most recent
+   *count* frames.  An arrow (``>``)
    indicates the current frame, which determines the context of most commands.
 
 .. pdbcommand:: d(own) [count]

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -612,7 +612,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             else:
                 self.print_stack_entry(self.stack[self.curindex])
             self._cmdloop()
-            # If "w 1" is not used, pop it out
+            # If "w 0" is not used, pop it out
             if self.cmdqueue and self.cmdqueue[-1] == 'w 0':
                 self.cmdqueue.pop()
             self.forget()

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -588,36 +588,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             self._chained_exceptions = tuple()
             self._chained_exception_index = 0
 
-    def process_cmdqueue(self):
-        """Process commands in the command queue.
-
-        The function returns in two cases:
-            1. the command queue is empty
-            2. a command to continue execution is encountered
-
-        The return value is
-            True - if the user input is expected after processing,
-            False - otherwise.
-        """
-        if not self.cmdqueue:
-            return True
-
-        # It's possible that cmdqueue does not contain any command that resumes
-        # execution, and _cmdloop will stuck in the loop waiting for user input
-        # in that case. To prevent that, we append a sentinel command (step) at
-        # the end of the queue. This makes sure we can break out of the loop.
-        # If the sentinel command is consumed, we know extra user input is
-        # needed. Otherwise we can pop the sentinel command and return.
-        # The side effect of the sentinel command is that we would execute a
-        # set_step(), but that side effect will be overwritten by the actual
-        # resuming command by the user later.
-        self.cmdqueue.append('step')
-        self._cmdloop()
-        if self.cmdqueue:
-            self.cmdqueue.pop(-1)
-            return False
-        return True
-
     def interaction(self, frame, tb_or_exc):
         # Restore the previous signal handler at the Pdb prompt.
         if Pdb._previous_sigint_handler:
@@ -633,10 +603,18 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             assert tb is not None, "main exception must have a traceback"
         with self._hold_exceptions(_chained_exceptions):
             self.setup(frame, tb)
-            # Process the cmdqueue, if cmdqueue is drained, ask for user input
-            if self.process_cmdqueue():
+            # We should print the stack entry if and only if the user input
+            # is expected, and we should print it right before the user input.
+            # If self.cmdqueue is not empty, we append a "w 0" command to the
+            # queue, which is equivalent to print_stack_entry
+            if self.cmdqueue:
+                self.cmdqueue.append('w 0')
+            else:
                 self.print_stack_entry(self.stack[self.curindex])
-                self._cmdloop()
+            self._cmdloop()
+            # If "w 1" is not used, pop it out
+            if self.cmdqueue and self.cmdqueue[-1] == 'w 0':
+                self.cmdqueue.pop()
             self.forget()
 
     def displayhook(self, obj):
@@ -1431,16 +1409,24 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     complete_cl = _complete_location
 
     def do_where(self, arg):
-        """w(here)
+        """w(here) [count]
 
-        Print a stack trace, with the most recent frame at the bottom.
+        Print a stack trace. If count is not specified, print the full stack.
+        If count is 0, print the current frame entry. If count is positive,
+        print count entries from the most recent frame. If count is negative,
+        print -count entries from the least recent frame.
         An arrow indicates the "current frame", which determines the
         context of most commands.  'bt' is an alias for this command.
         """
-        if arg:
-            self._print_invalid_arg(arg)
-            return
-        self.print_stack_trace()
+        if not arg:
+            count = None
+        else:
+            try:
+                count = int(arg or None)
+            except ValueError:
+                self.error('Invalid count (%s)' % arg)
+                return
+        self.print_stack_trace(count)
     do_w = do_where
     do_bt = do_where
 
@@ -2095,10 +2081,22 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     # It is also consistent with the up/down commands (which are
     # compatible with dbx and gdb: up moves towards 'main()'
     # and down moves towards the most recent stack frame).
+    #     * if count is None, prints the full stack
+    #     * if count = 0, prints the current frame entry
+    #     * if count < 0, prints -count least recent frame entries
+    #     * if count > 0, prints count most recent frame entries
 
-    def print_stack_trace(self):
+    def print_stack_trace(self, count=None):
+        if count is None:
+            stack_to_print = self.stack
+        elif count == 0:
+            stack_to_print = [self.stack[self.curindex]]
+        elif count < 0:
+            stack_to_print = self.stack[:-count]
+        else:
+            stack_to_print = self.stack[-count:]
         try:
-            for frame_lineno in self.stack:
+            for frame_lineno in stack_to_print:
                 self.print_stack_entry(frame_lineno)
         except KeyboardInterrupt:
             pass

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1422,7 +1422,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             count = None
         else:
             try:
-                count = int(arg or None)
+                count = int(arg)
             except ValueError:
                 self.error('Invalid count (%s)' % arg)
                 return

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -595,8 +595,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             1. the command queue is empty
             2. a command to continue execution is encountered
 
-        The return value is whether a following cmdloop should be executed, or
-        True for the first case and False for the second.
+        The return value is True if a following cmdloop should be executed, and False otherwise.
         """
         if not self.cmdqueue:
             return True

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -601,9 +601,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         if not self.cmdqueue:
             return True
 
-        # The continue command is just a sentinel to break out of the loop
+        # The step command is just a sentinel to break out of the loop
         # The side effect will be overwritten by the next resuming command
-        self.cmdqueue.append('continue')
+        self.cmdqueue.append('step')
         self._cmdloop()
         if self.cmdqueue:
             self.cmdqueue.pop(-1)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -781,7 +781,7 @@ def test_pdb_where_command():
     ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
 
     >>> def f():
-    ...     g();
+    ...     g()
 
     >>> def test_function():
     ...     f()
@@ -789,8 +789,11 @@ def test_pdb_where_command():
     >>> with PdbTestInput([  # doctest: +ELLIPSIS
     ...     'w',
     ...     'where',
+    ...     'w 1',
+    ...     'w invalid',
     ...     'u',
     ...     'w',
+    ...     'w 0',
     ...     'continue',
     ... ]):
     ...    test_function()
@@ -798,37 +801,45 @@ def test_pdb_where_command():
     -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) w
     ...
-      <doctest test.test_pdb.test_pdb_where_command[3]>(8)<module>()
+      <doctest test.test_pdb.test_pdb_where_command[3]>(11)<module>()
     -> test_function()
       <doctest test.test_pdb.test_pdb_where_command[2]>(2)test_function()
     -> f()
       <doctest test.test_pdb.test_pdb_where_command[1]>(2)f()
-    -> g();
+    -> g()
     > <doctest test.test_pdb.test_pdb_where_command[0]>(2)g()
     -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) where
     ...
-      <doctest test.test_pdb.test_pdb_where_command[3]>(8)<module>()
+      <doctest test.test_pdb.test_pdb_where_command[3]>(11)<module>()
     -> test_function()
       <doctest test.test_pdb.test_pdb_where_command[2]>(2)test_function()
     -> f()
       <doctest test.test_pdb.test_pdb_where_command[1]>(2)f()
-    -> g();
+    -> g()
     > <doctest test.test_pdb.test_pdb_where_command[0]>(2)g()
     -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) w 1
+    > <doctest test.test_pdb.test_pdb_where_command[0]>(2)g()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) w invalid
+    *** Invalid count (invalid)
     (Pdb) u
     > <doctest test.test_pdb.test_pdb_where_command[1]>(2)f()
-    -> g();
+    -> g()
     (Pdb) w
     ...
-      <doctest test.test_pdb.test_pdb_where_command[3]>(8)<module>()
+      <doctest test.test_pdb.test_pdb_where_command[3]>(11)<module>()
     -> test_function()
       <doctest test.test_pdb.test_pdb_where_command[2]>(2)test_function()
     -> f()
     > <doctest test.test_pdb.test_pdb_where_command[1]>(2)f()
-    -> g();
+    -> g()
       <doctest test.test_pdb.test_pdb_where_command[0]>(2)g()
     -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) w 0
+    > <doctest test.test_pdb.test_pdb_where_command[1]>(2)f()
+    -> g()
     (Pdb) continue
     """
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -794,6 +794,8 @@ def test_pdb_where_command():
     ...     'u',
     ...     'w',
     ...     'w 0',
+    ...     'w 100',
+    ...     'w -100',
     ...     'continue',
     ... ]):
     ...    test_function()
@@ -801,7 +803,7 @@ def test_pdb_where_command():
     -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) w
     ...
-      <doctest test.test_pdb.test_pdb_where_command[3]>(11)<module>()
+      <doctest test.test_pdb.test_pdb_where_command[3]>(13)<module>()
     -> test_function()
       <doctest test.test_pdb.test_pdb_where_command[2]>(2)test_function()
     -> f()
@@ -811,7 +813,7 @@ def test_pdb_where_command():
     -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) where
     ...
-      <doctest test.test_pdb.test_pdb_where_command[3]>(11)<module>()
+      <doctest test.test_pdb.test_pdb_where_command[3]>(13)<module>()
     -> test_function()
       <doctest test.test_pdb.test_pdb_where_command[2]>(2)test_function()
     -> f()
@@ -829,7 +831,7 @@ def test_pdb_where_command():
     -> g()
     (Pdb) w
     ...
-      <doctest test.test_pdb.test_pdb_where_command[3]>(11)<module>()
+      <doctest test.test_pdb.test_pdb_where_command[3]>(13)<module>()
     -> test_function()
       <doctest test.test_pdb.test_pdb_where_command[2]>(2)test_function()
     -> f()
@@ -840,6 +842,26 @@ def test_pdb_where_command():
     (Pdb) w 0
     > <doctest test.test_pdb.test_pdb_where_command[1]>(2)f()
     -> g()
+    (Pdb) w 100
+    ...
+      <doctest test.test_pdb.test_pdb_where_command[3]>(13)<module>()
+    -> test_function()
+      <doctest test.test_pdb.test_pdb_where_command[2]>(2)test_function()
+    -> f()
+    > <doctest test.test_pdb.test_pdb_where_command[1]>(2)f()
+    -> g()
+      <doctest test.test_pdb.test_pdb_where_command[0]>(2)g()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) w -100
+    ...
+      <doctest test.test_pdb.test_pdb_where_command[3]>(13)<module>()
+    -> test_function()
+      <doctest test.test_pdb.test_pdb_where_command[2]>(2)test_function()
+    -> f()
+    > <doctest test.test_pdb.test_pdb_where_command[1]>(2)f()
+    -> g()
+      <doctest test.test_pdb.test_pdb_where_command[0]>(2)g()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) continue
     """
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3179,6 +3179,7 @@ def bœr():
         stdout, stderr = self.run_pdb_script(script, 'q\n', pdbrc=pdbrc, remove_home=True)
         self.assertNotIn("SyntaxError", stdout)
         self.assertIn("a+8=9", stdout)
+        self.assertIn("-> b = 2", stdout)
 
     def test_pdbrc_empty_line(self):
         """Test that empty lines in .pdbrc are ignored."""

--- a/Misc/NEWS.d/next/Library/2024-05-31-21-17-43.gh-issue-119824.CQlxWV.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-31-21-17-43.gh-issue-119824.CQlxWV.rst
@@ -1,0 +1,1 @@
+Print stack entry in :mod:`pdb` when and only when user input is needed.


### PR DESCRIPTION
We currently determine whether to print the stack entry by checking if `self.cmdqueue` is empty. However, that's not the best user experience. The expected behavior is - if pdb expects user input, the stack entry should be printed, otherwise it should not.

This patch does a small trick to achieve that without changing `cmd.Cmd` - it appends a `step` command after `self.cmdqueue` if it's not empty and let it finish the `cmdloop`. If the `step` command is executed (`self.cmdqueue` is exhausted), then that means the original `self.cmdqueue` does not have a resuming command and extra user inputs are expected. Otherwise we can simply pop the artificial `step` out and skip the user input part.

There will be a side effect for `step` command, but it will be overwritten by the resuming command from user input.

(issuing a `step` command only sets some config, it will not relinquish control immediately)

I considered this a bug fix because the current behavior is different than it was before (stack entry is not printed when `.pdbrc` exists), and this patch will revert that behavior. Thus the backport.

<!-- gh-issue-number: gh-119824 -->
* Issue: gh-119824
<!-- /gh-issue-number -->
