### PR TITLE
gh-117657: Fix TSAN race in free-threaded GC

### DIFF
--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -37,7 +37,6 @@ race_top:_PyImport_ReleaseLock
 race_top:_PyParkingLot_Park
 race_top:_PyType_HasFeature
 race_top:assign_version_tag
-race_top:gc_restore_tid
 race_top:insertdict
 race_top:lookup_tp_dict
 race_top:mi_heap_visit_pages
@@ -64,7 +63,6 @@ race_top:list_get_item_ref
 race_top:make_pending_calls
 race_top:set_add_entry
 race_top:should_intern_string
-race_top:worklist_pop
 race_top:_PyEval_IsGILEnabled
 race_top:llist_insert_tail
 race_top:_Py_slot_tp_getattr_hook
@@ -86,7 +84,6 @@ race_top:sock_close
 race_top:tstate_delete_common
 race_top:tstate_is_freed
 race_top:type_modified_unlocked
-race_top:update_refs
 race_top:write_thread_id
 race_top:PyThreadState_Clear
 


### PR DESCRIPTION
Only call `gc_restore_tid()` from stop-the-world contexts. `worklist_pop()` can be called while other threads are running, so use a relaxed atomic to modify `ob_tid`.


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
