### PR TITLE
gh-117657: Fix TSAN race in QSBR assertion

### DIFF
--- a/Python/qsbr.c
+++ b/Python/qsbr.c
@@ -160,7 +160,8 @@ qsbr_poll_scan(struct _qsbr_shared *shared)
 bool
 _Py_qsbr_poll(struct _qsbr_thread_state *qsbr, uint64_t goal)
 {
-    assert(_PyThreadState_GET()->state == _Py_THREAD_ATTACHED);
+    assert(_Py_atomic_load_int_relaxed(&_PyThreadState_GET()->state) == _Py_THREAD_ATTACHED);
+
     if (_Py_qbsr_goal_reached(qsbr, goal)) {
         return true;
     }

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -15,14 +15,10 @@ race:set_allocator_unlocked
 # These entries are for warnings that trigger in a library function, as called
 # by a CPython function.
 
-# https://gist.github.com/swtaarrs/9d41251e603fa6dedd604191a6da820d
-race:park_detached_threads
 # https://gist.github.com/swtaarrs/8e0e365e1d9cecece3269a2fb2f2b8b8
 race:sock_recv_impl
 # https://gist.github.com/swtaarrs/08dfe7883b4c975c31ecb39388987a67
 race:free_threadstate
-# https://gist.github.com/swtaarrs/cd6aec2006e0c1b561b68d65e9f1a872
-race:_PyParkingLot_Park
 
 
 # These warnings trigger directly in a CPython function.
@@ -33,8 +29,6 @@ race_top:_mi_heap_delayed_free_partial
 race_top:_PyEval_EvalFrameDefault
 race_top:_PyImport_AcquireLock
 race_top:_PyImport_ReleaseLock
-# https://gist.github.com/mpage/0a24eb2dd458441ededb498e9b0e5de8
-race_top:_PyParkingLot_Park
 race_top:_PyType_HasFeature
 race_top:assign_version_tag
 race_top:gc_restore_tid
@@ -66,7 +60,6 @@ race_top:set_add_entry
 race_top:should_intern_string
 race_top:worklist_pop
 race_top:_PyEval_IsGILEnabled
-race_top:llist_insert_tail
 race_top:_Py_slot_tp_getattr_hook
 race_top:add_threadstate
 race_top:dump_traceback
@@ -77,8 +70,6 @@ race_top:_PyFrame_GetCode
 race_top:_PyFrame_Initialize
 race_top:PyInterpreterState_ThreadHead
 race_top:_PyObject_TryGetInstanceAttribute
-race_top:_Py_qsbr_unregister
-race_top:_Py_qsbr_poll
 race_top:PyThreadState_Next
 race_top:Py_TYPE
 race_top:PyUnstable_InterpreterFrame_GetLine

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -15,10 +15,14 @@ race:set_allocator_unlocked
 # These entries are for warnings that trigger in a library function, as called
 # by a CPython function.
 
+# https://gist.github.com/swtaarrs/9d41251e603fa6dedd604191a6da820d
+race:park_detached_threads
 # https://gist.github.com/swtaarrs/8e0e365e1d9cecece3269a2fb2f2b8b8
 race:sock_recv_impl
 # https://gist.github.com/swtaarrs/08dfe7883b4c975c31ecb39388987a67
 race:free_threadstate
+# https://gist.github.com/swtaarrs/cd6aec2006e0c1b561b68d65e9f1a872
+race:_PyParkingLot_Park
 
 
 # These warnings trigger directly in a CPython function.
@@ -29,6 +33,8 @@ race_top:_mi_heap_delayed_free_partial
 race_top:_PyEval_EvalFrameDefault
 race_top:_PyImport_AcquireLock
 race_top:_PyImport_ReleaseLock
+# https://gist.github.com/mpage/0a24eb2dd458441ededb498e9b0e5de8
+race_top:_PyParkingLot_Park
 race_top:_PyType_HasFeature
 race_top:assign_version_tag
 race_top:gc_restore_tid
@@ -60,6 +66,7 @@ race_top:set_add_entry
 race_top:should_intern_string
 race_top:worklist_pop
 race_top:_PyEval_IsGILEnabled
+race_top:llist_insert_tail
 race_top:_Py_slot_tp_getattr_hook
 race_top:add_threadstate
 race_top:dump_traceback


### PR DESCRIPTION
Due to a limitation of TSAN, all reads from PyThreadState.state must be atomic to avoid reported races.


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
