### PR TITLE
gh-119459: Fix HiDPI blurring of every program window that using tkinter

### DIFF
--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -11,10 +11,6 @@ except ImportError:
           "Your Python may not be configured for Tk. **", file=sys.__stderr__)
     raise SystemExit(1)
 
-if sys.platform == 'win32':
-    from idlelib.util import fix_win_hidpi
-    fix_win_hidpi()
-
 from tkinter import messagebox
 
 from code import InteractiveInterpreter

--- a/Lib/idlelib/util.py
+++ b/Lib/idlelib/util.py
@@ -12,24 +12,9 @@ TODO:
     * std streams (pyshell, run),
     * warning stuff (pyshell, run).
 """
-import sys
-
 # .pyw is for Windows; .pyi is for typing stub files.
 # The extension order is needed for iomenu open/save dialogs.
 py_extensions = ('.py', '.pyw', '.pyi')
-
-
-# Fix for HiDPI screens on Windows.  CALL BEFORE ANY TK OPERATIONS!
-# URL for arguments for the ...Awareness call below.
-# https://msdn.microsoft.com/en-us/library/windows/desktop/dn280512(v=vs.85).aspx
-if sys.platform == 'win32':  # pragma: no cover
-    def fix_win_hidpi():  # Called in pyshell and turtledemo.
-        try:
-            import ctypes
-            PROCESS_SYSTEM_DPI_AWARE = 1  # Int required.
-            ctypes.OleDLL('shcore').SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE)
-        except (ImportError, AttributeError, OSError):
-            pass
 
 
 if __name__ == '__main__':

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -934,7 +934,7 @@ class Misc:
         tk_busy_hold().  Options may have any of the values accepted by
         tk_busy_hold().
 
-        Please note that the option database is referenced by the widget
+        Please note that the option database is11 referenced by the widget
         name or class.  For example, if a Frame widget with name "frame"
         is to be made busy, the busy cursor can be specified for it by
         either call:
@@ -2478,7 +2478,7 @@ class Tk(Misc, Wm):
                 try:
                     # win 8.0 or less
                     ctypes.windll.user32.SetProcessDPIAware()
-                except Exception:
+                except (ImportError, AttributeError, OSError):
                     pass
 
     def loadtk(self):

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -934,7 +934,7 @@ class Misc:
         tk_busy_hold().  Options may have any of the values accepted by
         tk_busy_hold().
 
-        Please note that the option database is11 referenced by the widget
+        Please note that the option database is referenced by the widget
         name or class.  For example, if a Frame widget with name "frame"
         is to be made busy, the busy cursor can be specified for it by
         either call:

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -2474,10 +2474,6 @@ class Tk(Misc, Wm):
                 # >= win 8.1
                 PROCESS_SYSTEM_DPI_AWARE: int = 1  # Int required
                 ctypes.windll.shcore.SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE)
-                # Ensures that the window size is not reduced due to DPI adjustments,
-                # maintaining the original size
-                ScaleFactor = ctypes.windll.shcore.GetScaleFactorForDevice(0)
-                self.tk.call('tk', 'scaling', ScaleFactor/75)
             except (ImportError, AttributeError, OSError):
                 try:
                     # win 8.0 or less

--- a/Lib/turtledemo/__main__.py
+++ b/Lib/turtledemo/__main__.py
@@ -93,10 +93,6 @@ from idlelib.textview import view_text
 import turtle
 from turtledemo import __doc__ as about_turtledemo
 
-if sys.platform == 'win32':
-    from idlelib.util import fix_win_hidpi
-    fix_win_hidpi()
-
 demo_dir = os.path.dirname(os.path.abspath(__file__))
 darwin = sys.platform == 'darwin'
 STARTUP = 1

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1097,7 +1097,6 @@ Ivan Levkivskyi
 Ben Lewis
 William Lewis
 Akira Li
-Jiahao Li
 Robert Li
 Xuanji Li
 Zekun Li

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1097,6 +1097,7 @@ Ivan Levkivskyi
 Ben Lewis
 William Lewis
 Akira Li
+Jiahao Li
 Robert Li
 Xuanji Li
 Zekun Li

--- a/Misc/NEWS.d/next/Library/2024-06-01-19-07-55.gh-issue-119459.WRP-4n.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-01-19-07-55.gh-issue-119459.WRP-4n.rst
@@ -1,0 +1,2 @@
+Fix HiDPI blurring of every program window that using tkinter. Patch by
+Wulian233


### PR DESCRIPTION
Refer https://github.com/python/cpython/issues/119459 , we believe this is a tk/tkinter bug that should be fixed in tkinter. In this PR, I added the fix code to `tkinter/__init__.py`, which fixes the window blurring problem that every program that uses tkinter has. Since I had already committed fix for turtledemo and terryjreedy fix IDLE earlier, I removed them here. Also https://github.com/python/cpython/pull/119175 was backported to 3.12 3.13 and I think this PR should be as well.


↓Fix
<img width="233" alt="fix" src="https://github.com/python/cpython/assets/71213467/ef1d0cbc-8b48-4074-ad7a-d1b3a5868847">


<!-- gh-issue-number: gh-119459 -->
* Issue: gh-119459
<!-- /gh-issue-number -->
