### PR TITLE
gh-117657: Add TSAN suppression for `set_discard_entry`

### DIFF
--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -45,6 +45,8 @@ race_top:PyMember_GetOne
 race_top:PyMember_SetOne
 race_top:new_reference
 race_top:set_contains_key
+# https://gist.github.com/colesbury/d13d033f413b4ad07929d044bed86c35
+race_top:set_discard_entry
 race_top:set_inheritable
 race_top:start_the_world
 race_top:tstate_set_detached


### PR DESCRIPTION
Seen in CI occasionally when running `test_weakref`.

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
