### PR TITLE
gh-117657: Fix TSAN reported race in `_PyEval_IsGILEnabled`.

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -145,7 +145,8 @@ extern void _PyEval_ReleaseLock(PyInterpreterState *, PyThreadState *,
 static inline int
 _PyEval_IsGILEnabled(PyThreadState *tstate)
 {
-    return tstate->interp->ceval.gil->enabled != 0;
+    struct _gil_runtime_state *gil = tstate->interp->ceval.gil;
+    return _Py_atomic_load_int_relaxed(&gil->enabled) != 0;
 }
 
 // Enable or disable the GIL used by the interpreter that owns tstate, which

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -65,7 +65,6 @@ race_top:list_get_item_ref
 race_top:make_pending_calls
 race_top:set_add_entry
 race_top:should_intern_string
-race_top:_PyEval_IsGILEnabled
 race_top:llist_insert_tail
 race_top:_Py_slot_tp_getattr_hook
 race_top:add_threadstate


### PR DESCRIPTION
The GIL may be disabled concurrently with this call so we need to use a relaxed atomic load.


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
