### PR TITLE
[3.13] gh-111201: Skip pyrepl Windows tests earlier (#119848)

### DIFF
--- a/Lib/test/test_pyrepl/test_windows_console.py
+++ b/Lib/test/test_pyrepl/test_windows_console.py
@@ -1,6 +1,11 @@
-import itertools
 import sys
 import unittest
+
+if sys.platform != 'win32':
+    raise unittest.SkipTest("test only relevant on win32")
+
+
+import itertools
 from functools import partial
 from typing import Iterable
 from unittest import TestCase
@@ -22,7 +27,6 @@ except ImportError:
     pass
 
 
-@unittest.skipIf(sys.platform != "win32", "Test class specifically for Windows")
 class WindowsConsoleTests(TestCase):
     def console(self, events, **kwargs) -> Console:
         console = WindowsConsole()


### PR DESCRIPTION
Don't attempt to load pyrepl Windows console if platforms others than Windows. For example, the import can fail if ctypes is missing.

(cherry picked from commit 91601a55964fdb3c02b21fa3c8dc629daff2390f)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111201 -->
* Issue: gh-111201
<!-- /gh-issue-number -->
