### PR TITLE
Improve documentation for typing.get_type_hints

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3083,23 +3083,23 @@ Introspection helpers
    This is often the same as ``obj.__annotations__``, but this function makes
    the following changes to the annotations dictionary:
 
-   * Forward references encoded as string literals or :class:`ForwardRef` objects
-     are handled by evaluating them in *globalns*, *localns*, and (where applicable)
-     *obj*'s :ref:`type parameter <type-params>` namespace. If *globalns* or
-     *localns* is not given, appropriate namespace dictionaries are inferred
-     from *obj*.
+   * Forward references encoded as string literals or :class:`ForwardRef`
+     objects are handled by evaluating them in *globalns*, *localns*, and
+     (where applicable) *obj*'s :ref:`type parameter <type-params>` namespace.
+     If *globalns* or *localns* is not given, appropriate namespace
+     dictionaries are inferred from *obj*.
    * ``None`` is replaced with :class:`types.NoneType`.
-   * If :func:`@no_type_check <no_type_check>` has been applied to *obj*, an empty dictionary is
-     returned.
+   * If :func:`@no_type_check <no_type_check>` has been applied to *obj*, an
+     empty dictionary is returned.
    * If *obj* is a class ``C``, the function returns a dictionary that merges
      annotations from ``C``'s base classes with those on ``C`` directly. This
      is done by traversing ``C.__mro__`` and iteratively combining
      ``__annotations__`` dictionaries. Annotations on classes appearing
      earlier in the :term:`method resolution order` always take precedence over
      annotations on classes appearing later in the method resolution order.
-   * The function recursively replaces all occurrences of ``Annotated[T, ...]`` with ``T``,
-     unless *include_extras* is set to ``True`` (see :class:`Annotated` for
-     more information).
+   * The function recursively replaces all occurrences of ``Annotated[T, ...]``
+     with ``T``, unless *include_extras* is set to ``True`` (see
+     :class:`Annotated` for more information).
 
    See also :func:`inspect.get_annotations`, a lower-level function that
    returns annotations more directly.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3080,35 +3080,31 @@ Introspection helpers
    Return a dictionary containing type hints for a function, method, module
    or class object.
 
-   This is often the same as ``obj.__annotations__``. In addition,
-   forward references encoded as string literals are handled by evaluating
-   them in ``globals``, ``locals`` and (where applicable)
-   :ref:`type parameter <type-params>` namespaces.
-   For a class ``C``, return
-   a dictionary constructed by merging all the ``__annotations__`` along
-   ``C.__mro__`` in reverse order.
+   This is often the same as ``obj.__annotations__``, but this function makes
+   the following changes to the annotations dictionary:
 
-   The function recursively replaces all ``Annotated[T, ...]`` with ``T``,
-   unless ``include_extras`` is set to ``True`` (see :class:`Annotated` for
-   more information). For example:
+   * Forward references encoded as string literals or :class:`ForwardRef` objects
+     are handled by evaluating them in *globalns*, *localns*, and (where applicable)
+     *obj*'s :ref:`type parameter <type-params>` namespace. If *globalns* or
+     *localns* is not given, appropriate namespace dictionaries are inferred
+     from *obj*.
+   * :const:`None` is replaced with :class:`types.NoneType`.
+   * If :func:`@no_type_check <no_type_check>` has been applied to *obj*, an empty dictionary is
+     returned.
+   * If *obj* is a class ``C``, the function returns only the class's own annotations,
+     but also those of all base classes. This is done by merging all the ``__annotations__`` along
+     ``C.__mro__`` in reverse order.
 
-   .. testcode::
-
-       class Student(NamedTuple):
-           name: Annotated[str, 'some marker']
-
-       assert get_type_hints(Student) == {'name': str}
-       assert get_type_hints(Student, include_extras=False) == {'name': str}
-       assert get_type_hints(Student, include_extras=True) == {
-           'name': Annotated[str, 'some marker']
-       }
+   See also :func:`inspect.get_annotations`, a lower-level function that
+   returns annotations more directly.
 
    .. note::
 
-      :func:`get_type_hints` does not work with imported
-      :ref:`type aliases <type-aliases>` that include forward references.
-      Enabling postponed evaluation of annotations (:pep:`563`) may remove
-      the need for most forward references.
+      If any forward references in the annotations of *obj* are not resolvable
+      or are not valid Python code, this function will raise an exception
+      such as :exc:`NameError`. For example, this can happen with imported
+      :ref:`type aliases <type-aliases>` that include forward references,
+      or with names imported under :data:`if TYPE_CHECKING <TYPE_CHECKING>`.
 
    .. versionchanged:: 3.9
       Added ``include_extras`` parameter as part of :pep:`593`.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3088,12 +3088,15 @@ Introspection helpers
      *obj*'s :ref:`type parameter <type-params>` namespace. If *globalns* or
      *localns* is not given, appropriate namespace dictionaries are inferred
      from *obj*.
-   * :const:`None` is replaced with :class:`types.NoneType`.
+   * ``None`` is replaced with :class:`types.NoneType`.
    * If :func:`@no_type_check <no_type_check>` has been applied to *obj*, an empty dictionary is
      returned.
-   * If *obj* is a class ``C``, the function returns only the class's own annotations,
-     but also those of all base classes. This is done by merging all the ``__annotations__`` along
-     ``C.__mro__`` in reverse order.
+   * If *obj* is a class ``C``, the function returns a dictionary that merges
+     annotations from ``C``'s base classes with those on ``C`` directly. This
+     is done by traversing ``C.__mro__`` and iteratively combining
+     ``__annotations__`` dictionaries. Annotations on classes appearing
+     earlier in the :term:`method resolution order` always take precedence over
+     annotations on classes appearing later in the method resolution order.
 
    See also :func:`inspect.get_annotations`, a lower-level function that
    returns annotations more directly.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3097,6 +3097,9 @@ Introspection helpers
      ``__annotations__`` dictionaries. Annotations on classes appearing
      earlier in the :term:`method resolution order` always take precedence over
      annotations on classes appearing later in the method resolution order.
+   * The function recursively replaces all occurrences of ``Annotated[T, ...]`` with ``T``,
+     unless *include_extras* is set to ``True`` (see :class:`Annotated` for
+     more information).
 
    See also :func:`inspect.get_annotations`, a lower-level function that
    returns annotations more directly.


### PR DESCRIPTION
- Explicit list of what it does that is different from
  "just return `__annotations__`"
- Remove reference to PEP 563; adding the future import doesn't
  do anything to type aliases, and in general it will never make
  get_type_hints() less likely to fail.
- Remove example, as the Annotated docs already have a similar
  example, and it's unbalanced to have one example about this
  one edge case but not about other behaviors of the function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119928.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->