### PR TITLE
gh-109975: What's New in Python 3.13: `telnetlib` projects not found

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1334,7 +1334,7 @@ PEP 594: dead batteries (and other module removals)
   * :mod:`!sunau`.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
-  * :mod:`!telnetlib`, use the projects :pypi:`telnetlib3 ` or
+  * :mod:`!telnetlib`, use the projects :pypi:`telnetlib3` or
     :pypi:`Exscript` instead.
     (Contributed by Victor Stinner in :gh:`104773`.)
 


### PR DESCRIPTION
🔗 https://docs.python.org/3.13/whatsnew/3.13.html#pep-594-dead-batteries-and-other-module-removals

<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--119958.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->