### PR TITLE
gh-118626: Use less red-ish colour for non-error traceback

### DIFF
--- a/Lib/_colorize.py
+++ b/Lib/_colorize.py
@@ -6,6 +6,7 @@ COLORIZE = True
 
 
 class ANSIColors:
+    BOLD_BLUE = "\x1b[1;34m"
     BOLD_GREEN = "\x1b[1;32m"
     BOLD_MAGENTA = "\x1b[1;35m"
     BOLD_RED = "\x1b[1;31m"

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4503,15 +4503,15 @@ class TestColorizedTraceback(unittest.TestCase):
                 e, capture_locals=True
             )
         lines = "".join(exc.format(colorize=True))
-        red = _colorize.ANSIColors.RED
+        boldb = _colorize.ANSIColors.BOLD_BLUE
         boldr = _colorize.ANSIColors.BOLD_RED
         reset = _colorize.ANSIColors.RESET
-        self.assertIn("y = " + red + "x['a']['b']" + reset + boldr + "['c']" + reset, lines)
-        self.assertIn("return " + red + "(lambda *args: foo(*args))" + reset + boldr + "(1,2,3,4)" + reset, lines)
-        self.assertIn("return (lambda *args: " + red + "foo" + reset + boldr + "(*args)" + reset + ")(1,2,3,4)", lines)
+        self.assertIn("y = " + boldb + "x['a']['b']" + reset + boldr + "['c']" + reset, lines)
+        self.assertIn("return " + boldb + "(lambda *args: foo(*args))" + reset + boldr + "(1,2,3,4)" + reset, lines)
+        self.assertIn("return (lambda *args: " + boldb + "foo" + reset + boldr + "(*args)" + reset + ")(1,2,3,4)", lines)
         self.assertIn("return baz2(1,2,3,4)", lines)
         self.assertIn("return baz1(1,\n            2,3\n            ,4)", lines)
-        self.assertIn(red + "bar" + reset + boldr + "()" + reset, lines)
+        self.assertIn(boldb + "bar" + reset + boldr + "()" + reset, lines)
 
     def test_colorized_syntax_error(self):
         try:
@@ -4521,16 +4521,15 @@ class TestColorizedTraceback(unittest.TestCase):
                 e, capture_locals=True
             )
         actual = "".join(exc.format(colorize=True))
-        red = _colorize.ANSIColors.RED
-        magenta = _colorize.ANSIColors.MAGENTA
+        boldb = _colorize.ANSIColors.BOLD_BLUE
         boldm = _colorize.ANSIColors.BOLD_MAGENTA
         boldr = _colorize.ANSIColors.BOLD_RED
         reset = _colorize.ANSIColors.RESET
         expected = "".join([
-        f'  File {magenta}"<string>"{reset}, line {magenta}1{reset}\n',
-        f'    a {boldr}${reset} b\n',
-        f'      {boldr}^{reset}\n',
-        f'{boldm}SyntaxError{reset}: {magenta}invalid syntax{reset}\n']
+            f'  File {boldb}"<string>"{reset}, line {boldb}1{reset}\n',
+            f'    a {boldr}${reset} b\n',
+            f'      {boldr}^{reset}\n',
+            f'{boldm}SyntaxError{reset}: {boldb}invalid syntax{reset}\n']
         )
         self.assertIn(expected, actual)
 
@@ -4548,22 +4547,22 @@ class TestColorizedTraceback(unittest.TestCase):
                     exception_print(e)
             actual = tbstderr.getvalue().splitlines()
 
-        red = _colorize.ANSIColors.RED
+        boldb = _colorize.ANSIColors.BOLD_BLUE
         boldr = _colorize.ANSIColors.BOLD_RED
         magenta = _colorize.ANSIColors.MAGENTA
         boldm = _colorize.ANSIColors.BOLD_MAGENTA
         reset = _colorize.ANSIColors.RESET
         lno_foo = foo.__code__.co_firstlineno
         expected = ['Traceback (most recent call last):',
-            f'  File {magenta}"{__file__}"{reset}, '
-            f'line {magenta}{lno_foo+5}{reset}, in {magenta}test_colorized_traceback_is_the_default{reset}',
-            f'    {red}foo{reset+boldr}(){reset}',
-            f'    {red}~~~{reset+boldr}^^{reset}',
-            f'  File {magenta}"{__file__}"{reset}, '
-            f'line {magenta}{lno_foo+1}{reset}, in {magenta}foo{reset}',
-            f'    {red}1{reset+boldr}/{reset+red}0{reset}',
-            f'    {red}~{reset+boldr}^{reset+red}~{reset}',
-            f'{boldm}ZeroDivisionError{reset}: {magenta}division by zero{reset}']
+            f'  File {boldb}"{__file__}"{reset}, '
+            f'line {boldb}{lno_foo+5}{reset}, in {magenta}test_colorized_traceback_is_the_default{reset}',
+            f'    {boldb}foo{reset+boldr}(){reset}',
+            f'    {boldr}~~~{reset+boldr}^^{reset}',
+            f'  File {boldb}"{__file__}"{reset}, '
+            f'line {boldb}{lno_foo+1}{reset}, in {magenta}foo{reset}',
+            f'    {boldb}1{reset+boldr}/{reset+boldb}0{reset}',
+            f'    {boldr}~{reset+boldr}^{reset+boldr}~{reset}',
+            f'{boldm}ZeroDivisionError{reset}: {boldb}division by zero{reset}']
         self.assertEqual(actual, expected)
 
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -186,7 +186,7 @@ def _format_final_exc_line(etype, value, *, insert_final_newline=True, colorize=
         if value is None or not valuestr:
             line = f"{ANSIColors.BOLD_MAGENTA}{etype}{ANSIColors.RESET}{end_char}"
         else:
-            line = f"{ANSIColors.BOLD_MAGENTA}{etype}{ANSIColors.RESET}: {ANSIColors.MAGENTA}{valuestr}{ANSIColors.RESET}{end_char}"
+            line = f"{ANSIColors.BOLD_MAGENTA}{etype}{ANSIColors.RESET}: {ANSIColors.BOLD_BLUE}{valuestr}{ANSIColors.RESET}{end_char}"
     else:
         if value is None or not valuestr:
             line = f"{etype}{end_char}"
@@ -524,10 +524,10 @@ class StackSummary(list):
             filename = "<stdin>"
         if colorize:
             row.append('  File {}"{}"{}, line {}{}{}, in {}{}{}\n'.format(
-                    ANSIColors.MAGENTA,
+                    ANSIColors.BOLD_BLUE,
                     filename,
                     ANSIColors.RESET,
-                    ANSIColors.MAGENTA,
+                    ANSIColors.BOLD_BLUE,
                     frame_summary.lineno,
                     ANSIColors.RESET,
                     ANSIColors.MAGENTA,
@@ -659,8 +659,8 @@ class StackSummary(list):
                                 colorized_line_parts.append(ANSIColors.BOLD_RED + "".join(char for char, _ in caret_group) + ANSIColors.RESET)
                                 colorized_carets_parts.append(ANSIColors.BOLD_RED + "".join(caret for _, caret in caret_group) + ANSIColors.RESET)
                             elif color == "~":
-                                colorized_line_parts.append(ANSIColors.RED + "".join(char for char, _ in caret_group) + ANSIColors.RESET)
-                                colorized_carets_parts.append(ANSIColors.RED + "".join(caret for _, caret in caret_group) + ANSIColors.RESET)
+                                colorized_line_parts.append(ANSIColors.BOLD_BLUE + "".join(char for char, _ in caret_group) + ANSIColors.RESET)
+                                colorized_carets_parts.append(ANSIColors.BOLD_RED + "".join(caret for _, caret in caret_group) + ANSIColors.RESET)
                             else:
                                 colorized_line_parts.append("".join(char for char, _ in caret_group))
                                 colorized_carets_parts.append("".join(caret for _, caret in caret_group))
@@ -1267,10 +1267,10 @@ class TracebackException:
         if self.lineno is not None:
             if colorize:
                 yield '  File {}"{}"{}, line {}{}{}\n'.format(
-                    ANSIColors.MAGENTA,
+                    ANSIColors.BOLD_BLUE,
                     self.filename or "<string>",
                     ANSIColors.RESET,
-                    ANSIColors.MAGENTA,
+                    ANSIColors.BOLD_BLUE,
                     self.lineno,
                     ANSIColors.RESET,
                     )
@@ -1332,7 +1332,7 @@ class TracebackException:
                 ANSIColors.BOLD_MAGENTA,
                 stype,
                 ANSIColors.RESET,
-                ANSIColors.MAGENTA,
+                ANSIColors.BOLD_BLUE,
                 msg,
                 ANSIColors.RESET,
                 filename_suffix)

--- a/Misc/NEWS.d/next/Library/2024-06-03-13-35-37.gh-issue-118626.fYRtt1.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-03-13-35-37.gh-issue-118626.fYRtt1.rst
@@ -1,0 +1,1 @@
+Use less red-ish colour for non-error traceback. Patch by Hugo van Kemenade.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes #118626.

The magenta color used by the new REPL and within the non-error text in the new colorized tracebacks in 3.13 looks quite a bit like an error-related color in some popular color schemes.

In this PR, I'm trying to mirror something like GitHub's `pytb` colour groups to avoid having too many colours:

```pytb
>>> 4 / 0
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    4 / 0
    ~~^~~
ZeroDivisionError: division by zero
>>>
>>> 3.to_bytes(1, 'little')"
  File "<string>", line 1
    3.to_bytes(1, 'little')
     ^
SyntaxError: invalid decimal literal
```

In the before and after below, I'm using macOS and have iTerm with a dark theme, and Terminal with light theme (Novel),  to make it easy to compare without having to dig in the settings each time.

<table>
<tr>
<td>Before
<td>
<img width="330" alt="image" src="https://github.com/python/cpython/assets/1324225/e5d19c1e-ccd4-470d-bf18-9fc6df3126e7">
<td>
<img width="342" alt="image" src="https://github.com/python/cpython/assets/1324225/649f67ed-b4a1-4526-a90f-958e775e0c40">
<tr>
<td>After
<td>
<img width="355" alt="image" src="https://github.com/python/cpython/assets/1324225/8d6c2844-eacd-4d4b-a9bc-cab5e2090ae6">
<td>
<img width="339" alt="image" src="https://github.com/python/cpython/assets/1324225/8cf3bc6c-d126-4362-8080-aa7e4f0d9f1d">
<tr>
<td>
GitHub pytb
<td>
<img width="348" alt="image" src="https://github.com/python/cpython/assets/1324225/eeefb000-027e-455d-981c-b1b0f346142d">
<td>
<img width="349" alt="image" src="https://github.com/python/cpython/assets/1324225/38739571-8662-4f8a-bf94-34cc225367b2">
</table>

And a longer traceback using this script based on a test:

<details>
<summary>2.py</summary>

```python
def foo(*args):
    x = {'a': {'b': None}}
    y = x['a']['b']['c']


def baz2(*args):
    return (lambda *args: foo(*args))(1, 2, 3, 4)


def baz1(*args):
    return baz2(1, 2, 3, 4)


def bar():
    return baz1(1,
                2, 3
                , 4)


bar()
```

</details>

<details>
<summary>pytb</summary>

```pytb
❯ ./python.exe 2.py
Traceback (most recent call last):
  File "/Users/hugo/github/python/cpython/main/2.py", line 20, in <module>
    bar()
    ~~~^^
  File "/Users/hugo/github/python/cpython/main/2.py", line 15, in bar
    return baz1(1,
                2, 3
                , 4)
  File "/Users/hugo/github/python/cpython/main/2.py", line 11, in baz1
    return baz2(1, 2, 3, 4)
  File "/Users/hugo/github/python/cpython/main/2.py", line 7, in baz2
    return (lambda *args: foo(*args))(1, 2, 3, 4)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/Users/hugo/github/python/cpython/main/2.py", line 7, in <lambda>
    return (lambda *args: foo(*args))(1, 2, 3, 4)
                          ~~~^^^^^^^
  File "/Users/hugo/github/python/cpython/main/2.py", line 3, in foo
    y = x['a']['b']['c']
        ~~~~~~~~~~~^^^^^
TypeError: 'NoneType' object is not subscriptable
```


</details>

<table>
<tr>
<td>Before
<td>
<img width="661" alt="image" src="https://github.com/python/cpython/assets/1324225/e548f65a-09e1-420e-bc23-0a64e8923b5b">
<td>
<img width="682" alt="image" src="https://github.com/python/cpython/assets/1324225/a5df5d99-1b2b-432b-9825-73957cda482e">
<tr>
<td>After
<td>
<img width="661" alt="image" src="https://github.com/python/cpython/assets/1324225/088c8b7d-f1f1-46db-8250-72bb26a7a448">
<td>
<img width="682" alt="image" src="https://github.com/python/cpython/assets/1324225/8512d8b6-772d-4e54-ab89-f6fe09777a14">
<tr>
<td>
GitHub pytb
<td>
<img width="550" alt="image" src="https://github.com/python/cpython/assets/1324225/0fda1552-9c7e-443c-9da6-3fa322c3d02d">
<td>
<img width="552" alt="image" src="https://github.com/python/cpython/assets/1324225/9d08adea-fc80-4976-a883-46c7d802a36d">
</table>



<!-- gh-issue-number: gh-118626 -->
* Issue: gh-118626
<!-- /gh-issue-number -->
