### PR TITLE
gh-119972: typing: Fix specialization of generic with broken __eq__

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5191,6 +5191,18 @@ class GenericTests(BaseTestCase):
         self.assertEqual(A[T], A[T])
         self.assertNotEqual(A[T], B[T])
 
+    def test_buggy_eq(self):
+        class BrokenEq(abc.ABCMeta):
+            def __eq__(self, other):
+                raise TypeError("I'm broken")
+
+        class G(Generic[T], metaclass=BrokenEq):
+            pass
+
+        alias = G[int]
+        self.assertIs(get_origin(alias), G)
+        self.assertEqual(get_args(alias), (int,))
+
     def test_multiple_inheritance(self):
 
         class A(Generic[T, VT]):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1209,7 +1209,7 @@ def _generic_class_getitem(cls, args):
         args = (args,)
 
     args = tuple(_type_convert(p) for p in args)
-    is_generic_or_protocol = cls in (Generic, Protocol)
+    is_generic_or_protocol = cls is Generic or cls is Protocol
 
     if is_generic_or_protocol:
         # Generic and Protocol can only be subscripted with unique type variables.
@@ -1416,7 +1416,7 @@ class _GenericAlias(_BaseGenericAlias, _root=True):
             args = (args,)
         self.__args__ = tuple(... if a is _TypingEllipsis else
                               a for a in args)
-        enforce_default_ordering = origin in (Generic, Protocol)
+        enforce_default_ordering = origin is Generic or origin is Protocol
         self.__parameters__ = _collect_type_parameters(
             args,
             enforce_default_ordering=enforce_default_ordering,

--- a/Misc/NEWS.d/next/Library/2024-06-03-04-14-14.gh-issue-119972.nwtxx6.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-03-04-14-14.gh-issue-119972.nwtxx6.rst
@@ -1,0 +1,2 @@
+Fix specialization of :class:`typing.Generic` class with a broken ``__eq__``
+method. Patch by Jelle Zijlstra.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119972 -->
* Issue: gh-119972
<!-- /gh-issue-number -->
