### PR TITLE
gh-119724: Revert "bpo-45759: Better error messages for non-matching 'elif'/'else' statements (#29513)"

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -127,7 +127,6 @@ simple_stmt[stmt_ty] (memo):
     | &'nonlocal' nonlocal_stmt
 
 compound_stmt[stmt_ty]:
-    | invalid_compound_stmt
     | &('def' | '@' | 'async') function_def
     | &'if' if_stmt
     | &('class' | '@') class_def
@@ -1322,10 +1321,6 @@ invalid_import_from_targets:
         RAISE_SYNTAX_ERROR("trailing comma not allowed without surrounding parentheses") }
     | token=NEWLINE { 
         RAISE_SYNTAX_ERROR_STARTING_FROM(token, "Expected one or more names after 'import'") }
-
-invalid_compound_stmt:
-    | a='elif' named_expression ':' { RAISE_SYNTAX_ERROR_STARTING_FROM(a, "'elif' must match an if-statement here") }
-    | a='else' ':' { RAISE_SYNTAX_ERROR_STARTING_FROM(a, "'else' must match a valid statement here") }
 
 invalid_with_stmt:
     | ['async'] 'with' ','.(expression ['as' star_target])+ NEWLINE { RAISE_SYNTAX_ERROR("expected ':'") }

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1853,28 +1853,6 @@ Corner-cases that used to crash:
     Traceback (most recent call last):
     SyntaxError: positional patterns follow keyword patterns
 
-Non-matching 'elif'/'else' statements:
-
-    >>> if a == b:
-    ...     ...
-    ...     elif a == c:
-    Traceback (most recent call last):
-    SyntaxError: 'elif' must match an if-statement here
-
-    >>> if x == y:
-    ...     ...
-    ...     else:
-    Traceback (most recent call last):
-    SyntaxError: 'else' must match a valid statement here
-
-    >>> elif m == n:
-    Traceback (most recent call last):
-    SyntaxError: 'elif' must match an if-statement here
-
-    >>> else:
-    Traceback (most recent call last):
-    SyntaxError: 'else' must match a valid statement here
-
 Uses of the star operator which should fail:
 
 A[:*b]
@@ -2167,8 +2145,8 @@ class SyntaxTestCase(unittest.TestCase):
                      lineno=None, offset=None, end_lineno=None, end_offset=None):
         """Check that compiling code raises SyntaxError with errtext.
 
-        errtext is a regular expression that must be present in the
-        test of the exception raised. If subclass is specified, it
+        errtest is a regular expression that must be present in the
+        test of the exception raised.  If subclass is specified it
         is the expected subclass of SyntaxError (e.g. IndentationError).
         """
         try:
@@ -2191,22 +2169,6 @@ class SyntaxTestCase(unittest.TestCase):
 
         else:
             self.fail("compile() did not raise SyntaxError")
-
-    def _check_noerror(self, code,
-                       errtext="compile() raised unexpected SyntaxError",
-                       filename="<testcase>", mode="exec", subclass=None):
-        """Check that compiling code does not raise a SyntaxError.
-
-        errtext is the message passed to self.fail if there is
-        a SyntaxError. If the subclass parameter is specified,
-        it is the subclass of SyntaxError (e.g. IndentationError)
-        that the raised error is checked against.
-        """
-        try:
-            compile(code, filename, mode)
-        except SyntaxError as err:
-            if (not subclass) or isinstance(err, subclass):
-                self.fail(errtext)
 
     def test_expression_with_assignment(self):
         self._check_error(
@@ -2608,25 +2570,6 @@ while 1:
                       break
 """
         self._check_error(source, "too many statically nested blocks")
-
-    def test_syntax_error_non_matching_elif_else_statements(self):
-        # Check bpo-45759: 'elif' statements that doesn't match an
-        # if-statement or 'else' statements that doesn't match any
-        # valid else-able statement (e.g. 'while')
-        self._check_error(
-            "elif m == n:\n    ...",
-            "'elif' must match an if-statement here")
-        self._check_error(
-            "else:\n    ...",
-            "'else' must match a valid statement here")
-        self._check_noerror("if a == b:\n    ...\nelif a == c:\n    ...")
-        self._check_noerror("if x == y:\n    ...\nelse:\n    ...")
-        self._check_error(
-            "else = 123",
-            "invalid syntax")
-        self._check_error(
-            "elif 55 = 123",
-            "cannot assign to literal here")
 
     @support.cpython_only
     def test_error_on_parser_stack_overflow(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-03-13-25-04.gh-issue-119724.EH1dkA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-03-13-25-04.gh-issue-119724.EH1dkA.rst
@@ -1,0 +1,3 @@
+Reverted improvements to error messages for ``elif``/``else`` statements not
+matching any valid statements, which made in hard to locate the syntax
+errors inside those ``elif``/``else`` blocks.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -21,28 +21,28 @@ static KeywordToken *reserved_keywords[] = {
     (KeywordToken[]) {{NULL, -1}},
     (KeywordToken[]) {{NULL, -1}},
     (KeywordToken[]) {
-        {"if", 662},
-        {"as", 660},
-        {"in", 673},
+        {"if", 660},
+        {"as", 658},
+        {"in", 671},
         {"or", 581},
         {"is", 589},
         {NULL, -1},
     },
     (KeywordToken[]) {
         {"del", 613},
-        {"def", 677},
-        {"for", 672},
-        {"try", 644},
+        {"def", 675},
+        {"for", 670},
+        {"try", 642},
         {"and", 582},
-        {"not", 681},
+        {"not", 679},
         {NULL, -1},
     },
     (KeywordToken[]) {
         {"from", 621},
         {"pass", 504},
-        {"with", 635},
-        {"elif", 664},
-        {"else", 665},
+        {"with", 633},
+        {"elif", 662},
+        {"else", 663},
         {"None", 611},
         {"True", 610},
         {NULL, -1},
@@ -51,9 +51,9 @@ static KeywordToken *reserved_keywords[] = {
         {"raise", 525},
         {"yield", 580},
         {"break", 508},
-        {"async", 676},
-        {"class", 679},
-        {"while", 667},
+        {"async", 674},
+        {"class", 677},
+        {"while", 665},
         {"False", 612},
         {"await", 590},
         {NULL, -1},
@@ -63,12 +63,12 @@ static KeywordToken *reserved_keywords[] = {
         {"import", 622},
         {"assert", 529},
         {"global", 526},
-        {"except", 657},
+        {"except", 655},
         {"lambda", 609},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"finally", 653},
+        {"finally", 651},
         {NULL, -1},
     },
     (KeywordToken[]) {
@@ -308,316 +308,315 @@ static char *soft_keywords[] = {
 #define invalid_group_type 1221
 #define invalid_import_type 1222
 #define invalid_import_from_targets_type 1223
-#define invalid_compound_stmt_type 1224
-#define invalid_with_stmt_type 1225
-#define invalid_with_stmt_indent_type 1226
-#define invalid_try_stmt_type 1227
-#define invalid_except_stmt_type 1228
-#define invalid_finally_stmt_type 1229
-#define invalid_except_stmt_indent_type 1230
-#define invalid_except_star_stmt_indent_type 1231
-#define invalid_match_stmt_type 1232
-#define invalid_case_block_type 1233
-#define invalid_as_pattern_type 1234
-#define invalid_class_pattern_type 1235
-#define invalid_class_argument_pattern_type 1236
-#define invalid_if_stmt_type 1237
-#define invalid_elif_stmt_type 1238
-#define invalid_else_stmt_type 1239
-#define invalid_while_stmt_type 1240
-#define invalid_for_stmt_type 1241
-#define invalid_def_raw_type 1242
-#define invalid_class_def_raw_type 1243
-#define invalid_double_starred_kvpairs_type 1244
-#define invalid_kvpair_type 1245
-#define invalid_starred_expression_unpacking_type 1246
-#define invalid_starred_expression_type 1247
-#define invalid_replacement_field_type 1248
-#define invalid_conversion_character_type 1249
-#define invalid_arithmetic_type 1250
-#define invalid_factor_type 1251
-#define invalid_type_params_type 1252
-#define _loop0_1_type 1253
-#define _loop0_2_type 1254
-#define _loop1_3_type 1255
-#define _loop0_5_type 1256
-#define _gather_4_type 1257
-#define _tmp_6_type 1258
-#define _tmp_7_type 1259
-#define _tmp_8_type 1260
-#define _tmp_9_type 1261
-#define _tmp_10_type 1262
-#define _tmp_11_type 1263
-#define _tmp_12_type 1264
-#define _tmp_13_type 1265
-#define _loop1_14_type 1266
-#define _tmp_15_type 1267
-#define _tmp_16_type 1268
-#define _tmp_17_type 1269
-#define _loop0_19_type 1270
-#define _gather_18_type 1271
-#define _loop0_21_type 1272
-#define _gather_20_type 1273
-#define _tmp_22_type 1274
-#define _tmp_23_type 1275
-#define _loop0_24_type 1276
-#define _loop1_25_type 1277
-#define _loop0_27_type 1278
-#define _gather_26_type 1279
-#define _tmp_28_type 1280
-#define _loop0_30_type 1281
-#define _gather_29_type 1282
-#define _tmp_31_type 1283
-#define _loop1_32_type 1284
-#define _tmp_33_type 1285
-#define _tmp_34_type 1286
-#define _tmp_35_type 1287
-#define _loop0_36_type 1288
-#define _loop0_37_type 1289
-#define _loop0_38_type 1290
-#define _loop1_39_type 1291
-#define _loop0_40_type 1292
-#define _loop1_41_type 1293
-#define _loop1_42_type 1294
-#define _loop1_43_type 1295
-#define _loop0_44_type 1296
-#define _loop1_45_type 1297
-#define _loop0_46_type 1298
-#define _loop1_47_type 1299
-#define _loop0_48_type 1300
-#define _loop0_49_type 1301
-#define _loop1_50_type 1302
-#define _loop0_52_type 1303
-#define _gather_51_type 1304
-#define _loop0_54_type 1305
-#define _gather_53_type 1306
-#define _loop0_56_type 1307
-#define _gather_55_type 1308
-#define _loop0_58_type 1309
-#define _gather_57_type 1310
-#define _tmp_59_type 1311
-#define _loop1_60_type 1312
-#define _loop1_61_type 1313
-#define _tmp_62_type 1314
-#define _tmp_63_type 1315
-#define _loop1_64_type 1316
-#define _loop0_66_type 1317
-#define _gather_65_type 1318
-#define _tmp_67_type 1319
-#define _tmp_68_type 1320
-#define _tmp_69_type 1321
-#define _tmp_70_type 1322
-#define _loop0_72_type 1323
-#define _gather_71_type 1324
-#define _loop0_74_type 1325
-#define _gather_73_type 1326
-#define _tmp_75_type 1327
-#define _loop0_77_type 1328
-#define _gather_76_type 1329
-#define _loop0_79_type 1330
-#define _gather_78_type 1331
-#define _loop0_81_type 1332
-#define _gather_80_type 1333
-#define _loop1_82_type 1334
-#define _loop1_83_type 1335
-#define _loop0_85_type 1336
-#define _gather_84_type 1337
-#define _loop1_86_type 1338
-#define _loop1_87_type 1339
-#define _loop1_88_type 1340
-#define _tmp_89_type 1341
-#define _loop0_91_type 1342
-#define _gather_90_type 1343
-#define _tmp_92_type 1344
-#define _tmp_93_type 1345
-#define _tmp_94_type 1346
-#define _tmp_95_type 1347
-#define _tmp_96_type 1348
-#define _tmp_97_type 1349
-#define _loop0_98_type 1350
-#define _loop0_99_type 1351
-#define _loop0_100_type 1352
-#define _loop1_101_type 1353
-#define _loop0_102_type 1354
-#define _loop1_103_type 1355
-#define _loop1_104_type 1356
-#define _loop1_105_type 1357
-#define _loop0_106_type 1358
-#define _loop1_107_type 1359
-#define _loop0_108_type 1360
-#define _loop1_109_type 1361
-#define _loop0_110_type 1362
-#define _loop1_111_type 1363
-#define _loop0_112_type 1364
-#define _loop0_113_type 1365
-#define _loop1_114_type 1366
-#define _tmp_115_type 1367
-#define _loop0_117_type 1368
-#define _gather_116_type 1369
-#define _loop1_118_type 1370
-#define _loop0_119_type 1371
-#define _loop0_120_type 1372
-#define _tmp_121_type 1373
-#define _loop0_123_type 1374
-#define _gather_122_type 1375
-#define _tmp_124_type 1376
-#define _loop0_126_type 1377
-#define _gather_125_type 1378
-#define _loop0_128_type 1379
-#define _gather_127_type 1380
-#define _loop0_130_type 1381
-#define _gather_129_type 1382
-#define _loop0_132_type 1383
-#define _gather_131_type 1384
-#define _loop0_133_type 1385
-#define _loop0_135_type 1386
-#define _gather_134_type 1387
-#define _loop1_136_type 1388
-#define _tmp_137_type 1389
-#define _loop0_139_type 1390
-#define _gather_138_type 1391
-#define _loop0_141_type 1392
-#define _gather_140_type 1393
-#define _loop0_143_type 1394
-#define _gather_142_type 1395
-#define _loop0_145_type 1396
-#define _gather_144_type 1397
-#define _loop0_147_type 1398
-#define _gather_146_type 1399
-#define _tmp_148_type 1400
-#define _tmp_149_type 1401
-#define _loop0_151_type 1402
-#define _gather_150_type 1403
-#define _tmp_152_type 1404
-#define _tmp_153_type 1405
-#define _tmp_154_type 1406
-#define _tmp_155_type 1407
-#define _tmp_156_type 1408
-#define _tmp_157_type 1409
-#define _tmp_158_type 1410
-#define _tmp_159_type 1411
-#define _tmp_160_type 1412
-#define _tmp_161_type 1413
-#define _loop0_162_type 1414
-#define _loop0_163_type 1415
-#define _loop0_164_type 1416
-#define _tmp_165_type 1417
-#define _tmp_166_type 1418
-#define _tmp_167_type 1419
-#define _tmp_168_type 1420
-#define _loop0_169_type 1421
-#define _loop0_170_type 1422
-#define _loop0_171_type 1423
-#define _loop1_172_type 1424
-#define _tmp_173_type 1425
-#define _loop0_174_type 1426
-#define _tmp_175_type 1427
-#define _loop0_176_type 1428
-#define _loop1_177_type 1429
-#define _tmp_178_type 1430
-#define _tmp_179_type 1431
-#define _tmp_180_type 1432
-#define _loop0_181_type 1433
-#define _tmp_182_type 1434
-#define _tmp_183_type 1435
-#define _loop1_184_type 1436
-#define _tmp_185_type 1437
-#define _loop0_186_type 1438
-#define _loop0_187_type 1439
-#define _loop0_188_type 1440
-#define _loop0_190_type 1441
-#define _gather_189_type 1442
-#define _tmp_191_type 1443
-#define _loop0_192_type 1444
-#define _tmp_193_type 1445
-#define _loop0_194_type 1446
-#define _loop1_195_type 1447
-#define _loop1_196_type 1448
-#define _tmp_197_type 1449
-#define _tmp_198_type 1450
-#define _loop0_199_type 1451
-#define _tmp_200_type 1452
-#define _tmp_201_type 1453
-#define _tmp_202_type 1454
-#define _tmp_203_type 1455
-#define _loop0_205_type 1456
-#define _gather_204_type 1457
-#define _loop0_207_type 1458
-#define _gather_206_type 1459
-#define _loop0_209_type 1460
-#define _gather_208_type 1461
-#define _loop0_211_type 1462
-#define _gather_210_type 1463
-#define _loop0_213_type 1464
-#define _gather_212_type 1465
-#define _tmp_214_type 1466
-#define _loop0_215_type 1467
-#define _loop1_216_type 1468
-#define _tmp_217_type 1469
-#define _loop0_218_type 1470
-#define _loop1_219_type 1471
-#define _tmp_220_type 1472
-#define _tmp_221_type 1473
-#define _tmp_222_type 1474
-#define _tmp_223_type 1475
-#define _tmp_224_type 1476
-#define _tmp_225_type 1477
-#define _tmp_226_type 1478
-#define _tmp_227_type 1479
-#define _tmp_228_type 1480
-#define _tmp_229_type 1481
-#define _tmp_230_type 1482
-#define _loop0_232_type 1483
-#define _gather_231_type 1484
-#define _tmp_233_type 1485
-#define _tmp_234_type 1486
-#define _tmp_235_type 1487
-#define _tmp_236_type 1488
-#define _tmp_237_type 1489
-#define _tmp_238_type 1490
-#define _tmp_239_type 1491
-#define _loop0_240_type 1492
-#define _tmp_241_type 1493
-#define _tmp_242_type 1494
-#define _tmp_243_type 1495
-#define _tmp_244_type 1496
-#define _tmp_245_type 1497
-#define _tmp_246_type 1498
-#define _tmp_247_type 1499
-#define _tmp_248_type 1500
-#define _tmp_249_type 1501
-#define _tmp_250_type 1502
-#define _tmp_251_type 1503
-#define _tmp_252_type 1504
-#define _tmp_253_type 1505
-#define _tmp_254_type 1506
-#define _tmp_255_type 1507
-#define _tmp_256_type 1508
-#define _tmp_257_type 1509
-#define _tmp_258_type 1510
-#define _tmp_259_type 1511
-#define _tmp_260_type 1512
-#define _tmp_261_type 1513
-#define _tmp_262_type 1514
-#define _tmp_263_type 1515
-#define _tmp_264_type 1516
-#define _tmp_265_type 1517
-#define _loop0_266_type 1518
-#define _tmp_267_type 1519
-#define _tmp_268_type 1520
-#define _tmp_269_type 1521
-#define _tmp_270_type 1522
-#define _tmp_271_type 1523
-#define _tmp_272_type 1524
-#define _loop0_274_type 1525
-#define _gather_273_type 1526
-#define _tmp_275_type 1527
-#define _tmp_276_type 1528
-#define _tmp_277_type 1529
-#define _tmp_278_type 1530
-#define _tmp_279_type 1531
-#define _tmp_280_type 1532
-#define _tmp_281_type 1533
+#define invalid_with_stmt_type 1224
+#define invalid_with_stmt_indent_type 1225
+#define invalid_try_stmt_type 1226
+#define invalid_except_stmt_type 1227
+#define invalid_finally_stmt_type 1228
+#define invalid_except_stmt_indent_type 1229
+#define invalid_except_star_stmt_indent_type 1230
+#define invalid_match_stmt_type 1231
+#define invalid_case_block_type 1232
+#define invalid_as_pattern_type 1233
+#define invalid_class_pattern_type 1234
+#define invalid_class_argument_pattern_type 1235
+#define invalid_if_stmt_type 1236
+#define invalid_elif_stmt_type 1237
+#define invalid_else_stmt_type 1238
+#define invalid_while_stmt_type 1239
+#define invalid_for_stmt_type 1240
+#define invalid_def_raw_type 1241
+#define invalid_class_def_raw_type 1242
+#define invalid_double_starred_kvpairs_type 1243
+#define invalid_kvpair_type 1244
+#define invalid_starred_expression_unpacking_type 1245
+#define invalid_starred_expression_type 1246
+#define invalid_replacement_field_type 1247
+#define invalid_conversion_character_type 1248
+#define invalid_arithmetic_type 1249
+#define invalid_factor_type 1250
+#define invalid_type_params_type 1251
+#define _loop0_1_type 1252
+#define _loop0_2_type 1253
+#define _loop1_3_type 1254
+#define _loop0_5_type 1255
+#define _gather_4_type 1256
+#define _tmp_6_type 1257
+#define _tmp_7_type 1258
+#define _tmp_8_type 1259
+#define _tmp_9_type 1260
+#define _tmp_10_type 1261
+#define _tmp_11_type 1262
+#define _tmp_12_type 1263
+#define _tmp_13_type 1264
+#define _loop1_14_type 1265
+#define _tmp_15_type 1266
+#define _tmp_16_type 1267
+#define _tmp_17_type 1268
+#define _loop0_19_type 1269
+#define _gather_18_type 1270
+#define _loop0_21_type 1271
+#define _gather_20_type 1272
+#define _tmp_22_type 1273
+#define _tmp_23_type 1274
+#define _loop0_24_type 1275
+#define _loop1_25_type 1276
+#define _loop0_27_type 1277
+#define _gather_26_type 1278
+#define _tmp_28_type 1279
+#define _loop0_30_type 1280
+#define _gather_29_type 1281
+#define _tmp_31_type 1282
+#define _loop1_32_type 1283
+#define _tmp_33_type 1284
+#define _tmp_34_type 1285
+#define _tmp_35_type 1286
+#define _loop0_36_type 1287
+#define _loop0_37_type 1288
+#define _loop0_38_type 1289
+#define _loop1_39_type 1290
+#define _loop0_40_type 1291
+#define _loop1_41_type 1292
+#define _loop1_42_type 1293
+#define _loop1_43_type 1294
+#define _loop0_44_type 1295
+#define _loop1_45_type 1296
+#define _loop0_46_type 1297
+#define _loop1_47_type 1298
+#define _loop0_48_type 1299
+#define _loop0_49_type 1300
+#define _loop1_50_type 1301
+#define _loop0_52_type 1302
+#define _gather_51_type 1303
+#define _loop0_54_type 1304
+#define _gather_53_type 1305
+#define _loop0_56_type 1306
+#define _gather_55_type 1307
+#define _loop0_58_type 1308
+#define _gather_57_type 1309
+#define _tmp_59_type 1310
+#define _loop1_60_type 1311
+#define _loop1_61_type 1312
+#define _tmp_62_type 1313
+#define _tmp_63_type 1314
+#define _loop1_64_type 1315
+#define _loop0_66_type 1316
+#define _gather_65_type 1317
+#define _tmp_67_type 1318
+#define _tmp_68_type 1319
+#define _tmp_69_type 1320
+#define _tmp_70_type 1321
+#define _loop0_72_type 1322
+#define _gather_71_type 1323
+#define _loop0_74_type 1324
+#define _gather_73_type 1325
+#define _tmp_75_type 1326
+#define _loop0_77_type 1327
+#define _gather_76_type 1328
+#define _loop0_79_type 1329
+#define _gather_78_type 1330
+#define _loop0_81_type 1331
+#define _gather_80_type 1332
+#define _loop1_82_type 1333
+#define _loop1_83_type 1334
+#define _loop0_85_type 1335
+#define _gather_84_type 1336
+#define _loop1_86_type 1337
+#define _loop1_87_type 1338
+#define _loop1_88_type 1339
+#define _tmp_89_type 1340
+#define _loop0_91_type 1341
+#define _gather_90_type 1342
+#define _tmp_92_type 1343
+#define _tmp_93_type 1344
+#define _tmp_94_type 1345
+#define _tmp_95_type 1346
+#define _tmp_96_type 1347
+#define _tmp_97_type 1348
+#define _loop0_98_type 1349
+#define _loop0_99_type 1350
+#define _loop0_100_type 1351
+#define _loop1_101_type 1352
+#define _loop0_102_type 1353
+#define _loop1_103_type 1354
+#define _loop1_104_type 1355
+#define _loop1_105_type 1356
+#define _loop0_106_type 1357
+#define _loop1_107_type 1358
+#define _loop0_108_type 1359
+#define _loop1_109_type 1360
+#define _loop0_110_type 1361
+#define _loop1_111_type 1362
+#define _loop0_112_type 1363
+#define _loop0_113_type 1364
+#define _loop1_114_type 1365
+#define _tmp_115_type 1366
+#define _loop0_117_type 1367
+#define _gather_116_type 1368
+#define _loop1_118_type 1369
+#define _loop0_119_type 1370
+#define _loop0_120_type 1371
+#define _tmp_121_type 1372
+#define _loop0_123_type 1373
+#define _gather_122_type 1374
+#define _tmp_124_type 1375
+#define _loop0_126_type 1376
+#define _gather_125_type 1377
+#define _loop0_128_type 1378
+#define _gather_127_type 1379
+#define _loop0_130_type 1380
+#define _gather_129_type 1381
+#define _loop0_132_type 1382
+#define _gather_131_type 1383
+#define _loop0_133_type 1384
+#define _loop0_135_type 1385
+#define _gather_134_type 1386
+#define _loop1_136_type 1387
+#define _tmp_137_type 1388
+#define _loop0_139_type 1389
+#define _gather_138_type 1390
+#define _loop0_141_type 1391
+#define _gather_140_type 1392
+#define _loop0_143_type 1393
+#define _gather_142_type 1394
+#define _loop0_145_type 1395
+#define _gather_144_type 1396
+#define _loop0_147_type 1397
+#define _gather_146_type 1398
+#define _tmp_148_type 1399
+#define _tmp_149_type 1400
+#define _loop0_151_type 1401
+#define _gather_150_type 1402
+#define _tmp_152_type 1403
+#define _tmp_153_type 1404
+#define _tmp_154_type 1405
+#define _tmp_155_type 1406
+#define _tmp_156_type 1407
+#define _tmp_157_type 1408
+#define _tmp_158_type 1409
+#define _tmp_159_type 1410
+#define _tmp_160_type 1411
+#define _tmp_161_type 1412
+#define _loop0_162_type 1413
+#define _loop0_163_type 1414
+#define _loop0_164_type 1415
+#define _tmp_165_type 1416
+#define _tmp_166_type 1417
+#define _tmp_167_type 1418
+#define _tmp_168_type 1419
+#define _loop0_169_type 1420
+#define _loop0_170_type 1421
+#define _loop0_171_type 1422
+#define _loop1_172_type 1423
+#define _tmp_173_type 1424
+#define _loop0_174_type 1425
+#define _tmp_175_type 1426
+#define _loop0_176_type 1427
+#define _loop1_177_type 1428
+#define _tmp_178_type 1429
+#define _tmp_179_type 1430
+#define _tmp_180_type 1431
+#define _loop0_181_type 1432
+#define _tmp_182_type 1433
+#define _tmp_183_type 1434
+#define _loop1_184_type 1435
+#define _tmp_185_type 1436
+#define _loop0_186_type 1437
+#define _loop0_187_type 1438
+#define _loop0_188_type 1439
+#define _loop0_190_type 1440
+#define _gather_189_type 1441
+#define _tmp_191_type 1442
+#define _loop0_192_type 1443
+#define _tmp_193_type 1444
+#define _loop0_194_type 1445
+#define _loop1_195_type 1446
+#define _loop1_196_type 1447
+#define _tmp_197_type 1448
+#define _tmp_198_type 1449
+#define _loop0_199_type 1450
+#define _tmp_200_type 1451
+#define _tmp_201_type 1452
+#define _tmp_202_type 1453
+#define _tmp_203_type 1454
+#define _loop0_205_type 1455
+#define _gather_204_type 1456
+#define _loop0_207_type 1457
+#define _gather_206_type 1458
+#define _loop0_209_type 1459
+#define _gather_208_type 1460
+#define _loop0_211_type 1461
+#define _gather_210_type 1462
+#define _loop0_213_type 1463
+#define _gather_212_type 1464
+#define _tmp_214_type 1465
+#define _loop0_215_type 1466
+#define _loop1_216_type 1467
+#define _tmp_217_type 1468
+#define _loop0_218_type 1469
+#define _loop1_219_type 1470
+#define _tmp_220_type 1471
+#define _tmp_221_type 1472
+#define _tmp_222_type 1473
+#define _tmp_223_type 1474
+#define _tmp_224_type 1475
+#define _tmp_225_type 1476
+#define _tmp_226_type 1477
+#define _tmp_227_type 1478
+#define _tmp_228_type 1479
+#define _tmp_229_type 1480
+#define _tmp_230_type 1481
+#define _loop0_232_type 1482
+#define _gather_231_type 1483
+#define _tmp_233_type 1484
+#define _tmp_234_type 1485
+#define _tmp_235_type 1486
+#define _tmp_236_type 1487
+#define _tmp_237_type 1488
+#define _tmp_238_type 1489
+#define _tmp_239_type 1490
+#define _loop0_240_type 1491
+#define _tmp_241_type 1492
+#define _tmp_242_type 1493
+#define _tmp_243_type 1494
+#define _tmp_244_type 1495
+#define _tmp_245_type 1496
+#define _tmp_246_type 1497
+#define _tmp_247_type 1498
+#define _tmp_248_type 1499
+#define _tmp_249_type 1500
+#define _tmp_250_type 1501
+#define _tmp_251_type 1502
+#define _tmp_252_type 1503
+#define _tmp_253_type 1504
+#define _tmp_254_type 1505
+#define _tmp_255_type 1506
+#define _tmp_256_type 1507
+#define _tmp_257_type 1508
+#define _tmp_258_type 1509
+#define _tmp_259_type 1510
+#define _tmp_260_type 1511
+#define _tmp_261_type 1512
+#define _tmp_262_type 1513
+#define _tmp_263_type 1514
+#define _tmp_264_type 1515
+#define _tmp_265_type 1516
+#define _loop0_266_type 1517
+#define _tmp_267_type 1518
+#define _tmp_268_type 1519
+#define _tmp_269_type 1520
+#define _tmp_270_type 1521
+#define _tmp_271_type 1522
+#define _tmp_272_type 1523
+#define _loop0_274_type 1524
+#define _gather_273_type 1525
+#define _tmp_275_type 1526
+#define _tmp_276_type 1527
+#define _tmp_277_type 1528
+#define _tmp_278_type 1529
+#define _tmp_279_type 1530
+#define _tmp_280_type 1531
+#define _tmp_281_type 1532
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -843,7 +842,6 @@ static void *invalid_for_target_rule(Parser *p);
 static void *invalid_group_rule(Parser *p);
 static void *invalid_import_rule(Parser *p);
 static void *invalid_import_from_targets_rule(Parser *p);
-static void *invalid_compound_stmt_rule(Parser *p);
 static void *invalid_with_stmt_rule(Parser *p);
 static void *invalid_with_stmt_indent_rule(Parser *p);
 static void *invalid_try_stmt_rule(Parser *p);
@@ -2062,7 +2060,6 @@ simple_stmt_rule(Parser *p)
 }
 
 // compound_stmt:
-//     | invalid_compound_stmt
 //     | &('def' | '@' | 'async') function_def
 //     | &'if' if_stmt
 //     | &('class' | '@') class_def
@@ -2083,25 +2080,6 @@ compound_stmt_rule(Parser *p)
     }
     stmt_ty _res = NULL;
     int _mark = p->mark;
-    if (p->call_invalid_rules) { // invalid_compound_stmt
-        if (p->error_indicator) {
-            p->level--;
-            return NULL;
-        }
-        D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_compound_stmt"));
-        void *invalid_compound_stmt_var;
-        if (
-            (invalid_compound_stmt_var = invalid_compound_stmt_rule(p))  // invalid_compound_stmt
-        )
-        {
-            D(fprintf(stderr, "%*c+ compound_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "invalid_compound_stmt"));
-            _res = invalid_compound_stmt_var;
-            goto done;
-        }
-        p->mark = _mark;
-        D(fprintf(stderr, "%*c%s compound_stmt[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_compound_stmt"));
-    }
     { // &('def' | '@' | 'async') function_def
         if (p->error_indicator) {
             p->level--;
@@ -2131,7 +2109,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'if' if_stmt"));
         stmt_ty if_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 662)  // token='if'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 660)  // token='if'
             &&
             (if_stmt_var = if_stmt_rule(p))  // if_stmt
         )
@@ -2215,7 +2193,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'try' try_stmt"));
         stmt_ty try_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 644)  // token='try'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 642)  // token='try'
             &&
             (try_stmt_var = try_stmt_rule(p))  // try_stmt
         )
@@ -2236,7 +2214,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'while' while_stmt"));
         stmt_ty while_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 667)  // token='while'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 665)  // token='while'
             &&
             (while_stmt_var = while_stmt_rule(p))  // while_stmt
         )
@@ -4376,7 +4354,7 @@ class_def_raw_rule(Parser *p)
         asdl_stmt_seq* c;
         void *t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 679))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='class'
             &&
             (a = _PyPegen_name_token(p))  // NAME
             &&
@@ -4543,7 +4521,7 @@ function_def_raw_rule(Parser *p)
         void *t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 675))  // token='def'
             &&
             (n = _PyPegen_name_token(p))  // NAME
             &&
@@ -4604,9 +4582,9 @@ function_def_raw_rule(Parser *p)
         void *t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 676))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 674))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 677))  // token='def'
+            (_keyword_1 = _PyPegen_expect_token(p, 675))  // token='def'
             &&
             (n = _PyPegen_name_token(p))  // NAME
             &&
@@ -5944,7 +5922,7 @@ if_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         stmt_ty c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 662))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='if'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -5989,7 +5967,7 @@ if_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 662))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='if'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6084,7 +6062,7 @@ elif_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         stmt_ty c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 664))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 662))  // token='elif'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6129,7 +6107,7 @@ elif_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 664))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 662))  // token='elif'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6210,7 +6188,7 @@ else_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 665))  // token='else'
+            (_keyword = _PyPegen_expect_token(p, 663))  // token='else'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -6289,7 +6267,7 @@ while_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 667))  // token='while'
+            (_keyword = _PyPegen_expect_token(p, 665))  // token='while'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6389,11 +6367,11 @@ for_stmt_rule(Parser *p)
         expr_ty t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 672))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 670))  // token='for'
             &&
             (t = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 673))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 671))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -6451,13 +6429,13 @@ for_stmt_rule(Parser *p)
         expr_ty t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 676))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 674))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 672))  // token='for'
+            (_keyword_1 = _PyPegen_expect_token(p, 670))  // token='for'
             &&
             (t = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_2 = _PyPegen_expect_token(p, 673))  // token='in'
+            (_keyword_2 = _PyPegen_expect_token(p, 671))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -6586,7 +6564,7 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 635))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 633))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -6637,7 +6615,7 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 635))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 633))  // token='with'
             &&
             (a = (asdl_withitem_seq*)_gather_53_rule(p))  // ','.with_item+
             &&
@@ -6686,9 +6664,9 @@ with_stmt_rule(Parser *p)
         asdl_withitem_seq* a;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 676))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 674))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 635))  // token='with'
+            (_keyword_1 = _PyPegen_expect_token(p, 633))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -6738,9 +6716,9 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 676))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 674))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 635))  // token='with'
+            (_keyword_1 = _PyPegen_expect_token(p, 633))  // token='with'
             &&
             (a = (asdl_withitem_seq*)_gather_57_rule(p))  // ','.with_item+
             &&
@@ -6826,7 +6804,7 @@ with_item_rule(Parser *p)
         if (
             (e = expression_rule(p))  // expression
             &&
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (t = star_target_rule(p))  // star_target
             &&
@@ -6951,7 +6929,7 @@ try_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         asdl_stmt_seq* f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 644))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 642))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -6995,7 +6973,7 @@ try_stmt_rule(Parser *p)
         asdl_excepthandler_seq* ex;
         void *f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 644))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 642))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7043,7 +7021,7 @@ try_stmt_rule(Parser *p)
         asdl_excepthandler_seq* ex;
         void *f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 644))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 642))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7141,7 +7119,7 @@ except_block_rule(Parser *p)
         expr_ty e;
         void *t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 657))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (e = expression_rule(p))  // expression
             &&
@@ -7184,7 +7162,7 @@ except_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 657))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -7295,7 +7273,7 @@ except_star_block_rule(Parser *p)
         expr_ty e;
         void *t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 657))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -7397,7 +7375,7 @@ finally_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 653))  // token='finally'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='finally'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7705,7 +7683,7 @@ guard_rule(Parser *p)
         Token * _keyword;
         expr_ty guard;
         if (
-            (_keyword = _PyPegen_expect_token(p, 662))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='if'
             &&
             (guard = named_expression_rule(p))  // named_expression
         )
@@ -7900,7 +7878,7 @@ as_pattern_rule(Parser *p)
         if (
             (pattern = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (target = pattern_capture_target_rule(p))  // pattern_capture_target
         )
@@ -11195,11 +11173,11 @@ expression_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 662))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 665))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 663))  // token='else'
             &&
             (c = expression_rule(p))  // expression
         )
@@ -12081,7 +12059,7 @@ inversion_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 681))  // token='not'
+            (_keyword = _PyPegen_expect_token(p, 679))  // token='not'
             &&
             (a = inversion_rule(p))  // inversion
         )
@@ -12735,9 +12713,9 @@ notin_bitwise_or_rule(Parser *p)
         Token * _keyword_1;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 681))  // token='not'
+            (_keyword = _PyPegen_expect_token(p, 679))  // token='not'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 673))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 671))  // token='in'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -12783,7 +12761,7 @@ in_bitwise_or_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 673))  // token='in'
+            (_keyword = _PyPegen_expect_token(p, 671))  // token='in'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -12832,7 +12810,7 @@ isnot_bitwise_or_rule(Parser *p)
         if (
             (_keyword = _PyPegen_expect_token(p, 589))  // token='is'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 681))  // token='not'
+            (_keyword_1 = _PyPegen_expect_token(p, 679))  // token='not'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -17003,13 +16981,13 @@ for_if_clause_rule(Parser *p)
         expr_ty b;
         asdl_expr_seq* c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 676))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 674))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 672))  // token='for'
+            (_keyword_1 = _PyPegen_expect_token(p, 670))  // token='for'
             &&
             (a = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_2 = _PyPegen_expect_token(p, 673))  // token='in'
+            (_keyword_2 = _PyPegen_expect_token(p, 671))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -17048,11 +17026,11 @@ for_if_clause_rule(Parser *p)
         expr_ty b;
         asdl_expr_seq* c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 672))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 670))  // token='for'
             &&
             (a = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 673))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 671))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -20353,11 +20331,11 @@ expression_without_invalid_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 662))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 665))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 663))  // token='else'
             &&
             (c = expression_rule(p))  // expression
         )
@@ -20623,7 +20601,7 @@ invalid_expression_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 662))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
@@ -22561,7 +22539,7 @@ invalid_with_item_rule(Parser *p)
         if (
             (expression_var = expression_rule(p))  // expression
             &&
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -22611,13 +22589,13 @@ invalid_for_if_clause_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         void *_tmp_203_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 676), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 674), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 672))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 670))  // token='for'
             &&
             (_tmp_203_var = _tmp_203_rule(p))  // bitwise_or ((',' bitwise_or))* ','?
             &&
-            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 673)  // token='in'
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 671)  // token='in'
         )
         {
             D(fprintf(stderr, "%*c+ invalid_for_if_clause[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'? 'for' (bitwise_or ((',' bitwise_or))* ','?) !'in'"));
@@ -22663,9 +22641,9 @@ invalid_for_target_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty a;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 676), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 674), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 672))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 670))  // token='for'
             &&
             (a = star_expressions_rule(p))  // star_expressions
         )
@@ -22923,82 +22901,6 @@ invalid_import_from_targets_rule(Parser *p)
     return _res;
 }
 
-// invalid_compound_stmt: 'elif' named_expression ':' | 'else' ':'
-static void *
-invalid_compound_stmt_rule(Parser *p)
-{
-    if (p->level++ == MAXSTACK) {
-        _Pypegen_stack_overflow(p);
-    }
-    if (p->error_indicator) {
-        p->level--;
-        return NULL;
-    }
-    void * _res = NULL;
-    int _mark = p->mark;
-    { // 'elif' named_expression ':'
-        if (p->error_indicator) {
-            p->level--;
-            return NULL;
-        }
-        D(fprintf(stderr, "%*c> invalid_compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'elif' named_expression ':'"));
-        Token * _literal;
-        Token * a;
-        expr_ty named_expression_var;
-        if (
-            (a = _PyPegen_expect_token(p, 664))  // token='elif'
-            &&
-            (named_expression_var = named_expression_rule(p))  // named_expression
-            &&
-            (_literal = _PyPegen_expect_token(p, 11))  // token=':'
-        )
-        {
-            D(fprintf(stderr, "%*c+ invalid_compound_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'elif' named_expression ':'"));
-            _res = RAISE_SYNTAX_ERROR_STARTING_FROM ( a , "'elif' must match an if-statement here" );
-            if (_res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                p->level--;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = _mark;
-        D(fprintf(stderr, "%*c%s invalid_compound_stmt[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'elif' named_expression ':'"));
-    }
-    { // 'else' ':'
-        if (p->error_indicator) {
-            p->level--;
-            return NULL;
-        }
-        D(fprintf(stderr, "%*c> invalid_compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'else' ':'"));
-        Token * _literal;
-        Token * a;
-        if (
-            (a = _PyPegen_expect_token(p, 665))  // token='else'
-            &&
-            (_literal = _PyPegen_expect_token(p, 11))  // token=':'
-        )
-        {
-            D(fprintf(stderr, "%*c+ invalid_compound_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'else' ':'"));
-            _res = RAISE_SYNTAX_ERROR_STARTING_FROM ( a , "'else' must match a valid statement here" );
-            if (_res == NULL && PyErr_Occurred()) {
-                p->error_indicator = 1;
-                p->level--;
-                return NULL;
-            }
-            goto done;
-        }
-        p->mark = _mark;
-        D(fprintf(stderr, "%*c%s invalid_compound_stmt[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'else' ':'"));
-    }
-    _res = NULL;
-  done:
-    p->level--;
-    return _res;
-}
-
 // invalid_with_stmt:
 //     | 'async'? 'with' ','.(expression ['as' star_target])+ NEWLINE
 //     | 'async'? 'with' '(' ','.(expressions ['as' star_target])+ ','? ')' NEWLINE
@@ -23026,9 +22928,9 @@ invalid_with_stmt_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 676), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 674), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 635))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 633))  // token='with'
             &&
             (_gather_206_var = _gather_206_rule(p))  // ','.(expression ['as' star_target])+
             &&
@@ -23064,9 +22966,9 @@ invalid_with_stmt_rule(Parser *p)
         UNUSED(_opt_var_1); // Silence compiler warnings
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 676), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 674), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 635))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 633))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -23126,9 +23028,9 @@ invalid_with_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 676), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 674), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 635))  // token='with'
+            (a = _PyPegen_expect_token(p, 633))  // token='with'
             &&
             (_gather_210_var = _gather_210_rule(p))  // ','.(expression ['as' star_target])+
             &&
@@ -23169,9 +23071,9 @@ invalid_with_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 676), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 674), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 635))  // token='with'
+            (a = _PyPegen_expect_token(p, 633))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -23234,7 +23136,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 644))  // token='try'
+            (a = _PyPegen_expect_token(p, 642))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -23266,7 +23168,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* block_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 644))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 642))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -23305,7 +23207,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * b;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 644))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 642))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -23313,7 +23215,7 @@ invalid_try_stmt_rule(Parser *p)
             &&
             (_loop1_216_var = _loop1_216_rule(p))  // except_block+
             &&
-            (a = _PyPegen_expect_token(p, 657))  // token='except'
+            (a = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (b = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -23352,7 +23254,7 @@ invalid_try_stmt_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         Token * a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 644))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 642))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -23360,7 +23262,7 @@ invalid_try_stmt_rule(Parser *p)
             &&
             (_loop1_219_var = _loop1_219_rule(p))  // except_star_block+
             &&
-            (a = _PyPegen_expect_token(p, 657))  // token='except'
+            (a = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (_opt_var = _tmp_220_rule(p), !p->error_indicator)  // [expression ['as' NAME]]
             &&
@@ -23419,7 +23321,7 @@ invalid_except_stmt_rule(Parser *p)
         expr_ty a;
         expr_ty expressions_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 657))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (_opt_var = _PyPegen_expect_token(p, 16), !p->error_indicator)  // '*'?
             &&
@@ -23461,7 +23363,7 @@ invalid_except_stmt_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 657))  // token='except'
+            (a = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (_opt_var = _PyPegen_expect_token(p, 16), !p->error_indicator)  // '*'?
             &&
@@ -23494,7 +23396,7 @@ invalid_except_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 657))  // token='except'
+            (a = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
@@ -23522,7 +23424,7 @@ invalid_except_stmt_rule(Parser *p)
         void *_tmp_223_var;
         Token * a;
         if (
-            (a = _PyPegen_expect_token(p, 657))  // token='except'
+            (a = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -23571,7 +23473,7 @@ invalid_finally_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 653))  // token='finally'
+            (a = _PyPegen_expect_token(p, 651))  // token='finally'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -23627,7 +23529,7 @@ invalid_except_stmt_indent_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 657))  // token='except'
+            (a = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
@@ -23663,7 +23565,7 @@ invalid_except_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 657))  // token='except'
+            (a = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -23719,7 +23621,7 @@ invalid_except_star_stmt_indent_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 657))  // token='except'
+            (a = _PyPegen_expect_token(p, 655))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -23958,7 +23860,7 @@ invalid_as_pattern_rule(Parser *p)
         if (
             (or_pattern_var = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (a = _PyPegen_expect_soft_keyword(p, "_"))  // soft_keyword='"_"'
         )
@@ -23988,7 +23890,7 @@ invalid_as_pattern_rule(Parser *p)
         if (
             (or_pattern_var = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             _PyPegen_lookahead_with_name(0, _PyPegen_name_token, p)
             &&
@@ -24142,7 +24044,7 @@ invalid_if_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 662))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='if'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -24173,7 +24075,7 @@ invalid_if_stmt_rule(Parser *p)
         expr_ty a_1;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 662))  // token='if'
+            (a = _PyPegen_expect_token(p, 660))  // token='if'
             &&
             (a_1 = named_expression_rule(p))  // named_expression
             &&
@@ -24228,7 +24130,7 @@ invalid_elif_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 664))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 662))  // token='elif'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -24259,7 +24161,7 @@ invalid_elif_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 664))  // token='elif'
+            (a = _PyPegen_expect_token(p, 662))  // token='elif'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -24312,7 +24214,7 @@ invalid_else_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 665))  // token='else'
+            (a = _PyPegen_expect_token(p, 663))  // token='else'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24365,7 +24267,7 @@ invalid_while_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 667))  // token='while'
+            (_keyword = _PyPegen_expect_token(p, 665))  // token='while'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -24396,7 +24298,7 @@ invalid_while_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 667))  // token='while'
+            (a = _PyPegen_expect_token(p, 665))  // token='while'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -24455,13 +24357,13 @@ invalid_for_stmt_rule(Parser *p)
         expr_ty star_expressions_var;
         expr_ty star_targets_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 676), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 674), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 672))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 670))  // token='for'
             &&
             (star_targets_var = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 673))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 671))  // token='in'
             &&
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
             &&
@@ -24496,13 +24398,13 @@ invalid_for_stmt_rule(Parser *p)
         expr_ty star_expressions_var;
         expr_ty star_targets_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 676), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 674), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 672))  // token='for'
+            (a = _PyPegen_expect_token(p, 670))  // token='for'
             &&
             (star_targets_var = star_targets_rule(p))  // star_targets
             &&
-            (_keyword = _PyPegen_expect_token(p, 673))  // token='in'
+            (_keyword = _PyPegen_expect_token(p, 671))  // token='in'
             &&
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
             &&
@@ -24568,9 +24470,9 @@ invalid_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 676), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 674), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 677))  // token='def'
+            (a = _PyPegen_expect_token(p, 675))  // token='def'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -24627,9 +24529,9 @@ invalid_def_raw_rule(Parser *p)
         asdl_stmt_seq* block_var;
         expr_ty name_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 676), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 674), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 675))  // token='def'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -24693,7 +24595,7 @@ invalid_class_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 679))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='class'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -24732,7 +24634,7 @@ invalid_class_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 679))  // token='class'
+            (a = _PyPegen_expect_token(p, 677))  // token='class'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -25550,7 +25452,7 @@ invalid_arithmetic_rule(Parser *p)
             &&
             (_tmp_243_var = _tmp_243_rule(p))  // '+' | '-' | '*' | '/' | '%' | '//' | '@'
             &&
-            (a = _PyPegen_expect_token(p, 681))  // token='not'
+            (a = _PyPegen_expect_token(p, 679))  // token='not'
             &&
             (b = inversion_rule(p))  // inversion
         )
@@ -25599,7 +25501,7 @@ invalid_factor_rule(Parser *p)
         if (
             (_tmp_244_var = _tmp_244_rule(p))  // '+' | '-' | '~'
             &&
-            (a = _PyPegen_expect_token(p, 681))  // token='not'
+            (a = _PyPegen_expect_token(p, 679))  // token='not'
             &&
             (b = factor_rule(p))  // factor
         )
@@ -26070,7 +25972,7 @@ _tmp_7_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_7[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'def'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 675))  // token='def'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_7[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'def'"));
@@ -26108,7 +26010,7 @@ _tmp_7_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_7[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 676))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 674))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_7[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -26146,7 +26048,7 @@ _tmp_8_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_8[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'class'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 679))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='class'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_8[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'class'"));
@@ -26203,7 +26105,7 @@ _tmp_9_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_9[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'with'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 635))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 633))  // token='with'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_9[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'with'"));
@@ -26222,7 +26124,7 @@ _tmp_9_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_9[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 676))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 674))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_9[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -26260,7 +26162,7 @@ _tmp_10_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_10[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'for'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 672))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 670))  // token='for'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_10[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'for'"));
@@ -26279,7 +26181,7 @@ _tmp_10_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_10[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 676))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 674))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_10[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -27303,7 +27205,7 @@ _tmp_28_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (z = _PyPegen_name_token(p))  // NAME
         )
@@ -27466,7 +27368,7 @@ _tmp_31_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (z = _PyPegen_name_token(p))  // NAME
         )
@@ -29453,7 +29355,7 @@ _tmp_62_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (z = _PyPegen_name_token(p))  // NAME
         )
@@ -29499,7 +29401,7 @@ _tmp_63_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (z = _PyPegen_name_token(p))  // NAME
         )
@@ -35341,7 +35243,7 @@ _tmp_158_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_158[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'else'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 665))  // token='else'
+            (_keyword = _PyPegen_expect_token(p, 663))  // token='else'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_158[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'else'"));
@@ -38922,7 +38824,7 @@ _tmp_214_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_214[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 657))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 655))  // token='except'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_214[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except'"));
@@ -38941,7 +38843,7 @@ _tmp_214_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_214[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'finally'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 653))  // token='finally'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='finally'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_214[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'finally'"));
@@ -39119,7 +39021,7 @@ _tmp_217_rule(Parser *p)
         Token * _keyword;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
         )
@@ -39341,7 +39243,7 @@ _tmp_221_rule(Parser *p)
         Token * _keyword;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
         )
@@ -39382,7 +39284,7 @@ _tmp_222_rule(Parser *p)
         Token * _keyword;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
         )
@@ -39480,7 +39382,7 @@ _tmp_224_rule(Parser *p)
         Token * _keyword;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
         )
@@ -39521,7 +39423,7 @@ _tmp_225_rule(Parser *p)
         Token * _keyword;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
         )
@@ -41216,7 +41118,7 @@ _tmp_255_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 662))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='if'
             &&
             (z = disjunction_rule(p))  // disjunction
         )
@@ -41262,7 +41164,7 @@ _tmp_256_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 662))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='if'
             &&
             (z = disjunction_rule(p))  // disjunction
         )
@@ -41975,7 +41877,7 @@ _tmp_271_rule(Parser *p)
         Token * _keyword;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
         )
@@ -42234,7 +42136,7 @@ _tmp_276_rule(Parser *p)
         Token * _keyword;
         expr_ty star_target_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (star_target_var = star_target_rule(p))  // star_target
         )
@@ -42275,7 +42177,7 @@ _tmp_277_rule(Parser *p)
         Token * _keyword;
         expr_ty star_target_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (star_target_var = star_target_rule(p))  // star_target
         )
@@ -42316,7 +42218,7 @@ _tmp_278_rule(Parser *p)
         Token * _keyword;
         expr_ty star_target_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (star_target_var = star_target_rule(p))  // star_target
         )
@@ -42357,7 +42259,7 @@ _tmp_279_rule(Parser *p)
         Token * _keyword;
         expr_ty star_target_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 660))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 658))  // token='as'
             &&
             (star_target_var = star_target_rule(p))  // star_target
         )


### PR DESCRIPTION
This reverts commit 1c8f912ebdfdb146cd7dd2d7a3a67d2c5045ddb0.

3.13 Beta 2 is getting closer; IMO it'll be in a better shape with the error message change reverted.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119724 -->
* Issue: gh-119724
<!-- /gh-issue-number -->
