### PR TITLE
gh-63020: json.dump now attempts to serialize dict keys with default

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -378,8 +378,10 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
                     if retry:
                         try:
                             key = _default(key)
-                        except Exception:
+                        except TypeError:
                             pass
+                        except Exception:
+                            raise
                         else:
                             continue
                     raise TypeError(f'keys must be str, int, float, bool or None, '

--- a/Lib/test/test_json/test_dump.py
+++ b/Lib/test/test_json/test_dump.py
@@ -61,7 +61,7 @@ class TestDump:
         def default(obj):
             if isinstance(obj, bytes):
                 return obj.decode()
-        self.assertEqual(self.dumps({b'a': 1}, default=default), '{"a": 1}')
+        self.assertEqual(self.dumps({b'a': b'b'}, default=default), '{"a": "b"}')
 
 class TestPyDump(TestDump, PyTest): pass
 

--- a/Lib/test/test_json/test_dump.py
+++ b/Lib/test/test_json/test_dump.py
@@ -57,6 +57,11 @@ class TestDump:
         d[1337] = "true.dat"
         self.assertEqual(self.dumps(d, sort_keys=True), '{"1337": "true.dat"}')
 
+    def test_encode_bytes_with_default(self):
+        def default(obj):
+            if isinstance(obj, bytes):
+                return obj.decode()
+        self.assertEqual(self.dumps({b'a': 1}, default=default), '{"a": 1}')
 
 class TestPyDump(TestDump, PyTest): pass
 

--- a/Lib/test/test_json/test_fail.py
+++ b/Lib/test/test_json/test_fail.py
@@ -97,6 +97,19 @@ class TestFail:
                 'keys must be str, int, float, bool or None, not tuple'):
             self.dumps(data)
 
+    def test_non_string_keys_dict_with_default(self):
+        import sys
+        data = {'a' : 1, (1, 2) : 2}
+        def default(obj):
+            if isinstance(obj, tuple):
+                raise TypeError
+            raise ValueError
+        with self.assertRaises(ValueError):
+            self.dumps(sys, default=default)
+        with self.assertRaisesRegex(TypeError,
+            'keys must be str, int, float, bool or None, not tuple'):
+            self.dumps(data, default=default)
+
     def test_not_serializable(self):
         import sys
         with self.assertRaisesRegex(TypeError,

--- a/Misc/NEWS.d/next/Library/2024-06-03-15-16-00.gh-issue-63020.INQLls.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-03-15-16-00.gh-issue-63020.INQLls.rst
@@ -1,0 +1,1 @@
+:func:`json.dump` now uses the `default` function as a fallback to serialize dict keys.

--- a/Misc/NEWS.d/next/Library/2024-06-03-15-16-00.gh-issue-63020.INQLls.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-03-15-16-00.gh-issue-63020.INQLls.rst
@@ -1,1 +1,1 @@
-:func:`json.dump` now uses the `default` function as a fallback to serialize dict keys.
+:func:`json.dump` now uses the ``default`` function as a fallback to serialize dict keys.

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1483,6 +1483,7 @@ encoder_encode_key_value(PyEncoderObject *s, _PyUnicodeWriter *writer, bool *fir
 {
     PyObject *keystr = NULL;
     PyObject *encoded;
+    PyObject *newobj;
 
     if (PyUnicode_Check(key)) {
         keystr = Py_NewRef(key);
@@ -1502,10 +1503,15 @@ encoder_encode_key_value(PyEncoderObject *s, _PyUnicodeWriter *writer, bool *fir
         return 0;
     }
     else {
-        PyErr_Format(PyExc_TypeError,
-                     "keys must be str, int, float, bool or None, "
-                     "not %.100s", Py_TYPE(key)->tp_name);
-        return -1;
+        newobj = PyObject_CallOneArg(s->defaultfn, key);
+        if (newobj == NULL) {
+            PyErr_Format(PyExc_TypeError,
+                         "keys must be str, int, float, bool or None, "
+                         "not %.100s", Py_TYPE(key)->tp_name);
+            return -1;
+        }
+        return encoder_encode_key_value(s, writer, first, newobj, value,
+                                        newline_indent, item_separator);
     }
 
     if (keystr == NULL) {


### PR DESCRIPTION
# `json.dump` now attempts to serialize dict keys with `default`

Previously a dict key must be `str`, `int`, `float`, `bool` or `None` for it to be serialized by `json.dump` as a string.

With this fix the `default` function would be called as a fallback to transform the key into one of the supported types for serialization. Since the `default` function produces a `TypeError` by default, the fallback behavior is applicable only when the `default` function is explicitly given to tranform the key into a supported one.

<!-- gh-issue-number: gh-63020 -->
* Issue: gh-63020
<!-- /gh-issue-number -->
