### PR TITLE
[3.12] Use Cirrus M1 macOS runners for CI (GH-119979)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,6 +228,8 @@ jobs:
     uses: ./.github/workflows/reusable-macos.yml
     with:
       config_hash: ${{ needs.check_source.outputs.config_hash }}
+      # Cirrus is M1, macos-13 is default GHA Intel
+      os-matrix: '["ghcr.io/cirruslabs/macos-runner:sonoma", "macos-13"]'
 
   build_ubuntu:
     name: 'Ubuntu'

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -8,6 +8,9 @@ on:
         required: false
         type: boolean
         default: false
+      os-matrix:
+        required: false
+        type: string
 
 jobs:
   build_macos:

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -22,10 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [
-          "macos-14",  # M1
-          "macos-13",  # Intel
-        ]
+        os: ${{fromJson(inputs.os-matrix)}}
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -16,7 +16,6 @@ class AsyncIOInteractiveConsole(code.InteractiveConsole):
     def __init__(self, locals, loop):
         super().__init__(locals)
         self.compile.compiler.flags |= ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
-
         self.loop = loop
 
     def runcode(self, code):


### PR DESCRIPTION
(cherry picked from commit 6acb32fac3511c1d5500cac66f1d6397dcdab835)

As pyrepl doesn't exist, I used a different file to trigger source test CI.
