### PR TITLE
gh-117142: Support Importing ctypes in Isolated Interpreters

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-06-03-11-18-16.gh-issue-117142.kWTXQo.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-03-11-18-16.gh-issue-117142.kWTXQo.rst
@@ -1,0 +1,2 @@
+The ``ctypes`` module may now be imported in all subinterpreters, including
+those that have their own GIL.

--- a/Misc/NEWS.d/next/Library/2024-06-03-11-18-16.gh-issue-117142.kWTXQo.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-03-11-18-16.gh-issue-117142.kWTXQo.rst
@@ -1,2 +1,2 @@
-The ``ctypes`` module may now be imported in all subinterpreters, including
+The :mod:`ctypes` module may now be imported in all subinterpreters, including
 those that have their own GIL.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5939,7 +5939,7 @@ module_free(void *module)
 
 static PyModuleDef_Slot module_slots[] = {
     {Py_mod_exec, _ctypes_mod_exec},
-    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL}
 };


### PR DESCRIPTION
This makes the support official.

There is still a question of the thread-safety of mmap and of libffi, but that *should* already be solved for free-threading builds.

<!-- gh-issue-number: gh-117142 -->
* Issue: gh-117142
<!-- /gh-issue-number -->
