### PR TITLE
gh-119996: Special case of string search, where len(needle) == len(haystack)

### DIFF
--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -769,6 +769,15 @@ FASTSEARCH(const STRINGLIB_CHAR* s, Py_ssize_t n,
             return STRINGLIB(count_char)(s, n, p[0], maxcount);
         }
     }
+    else if (n == m) {
+        /* use special case when both strings are of equal length */
+        int res = memcmp(s, p, m * sizeof(STRINGLIB_CHAR));
+        if (mode == FAST_COUNT){
+            return res == 0 ? 1 : 0;
+        } else {
+            return res == 0 ? 0 : -1;
+        }
+    }
 
     if (mode != FAST_RSEARCH) {
         if (n < 2500 || (m < 100 && n < 30000) || m < 6) {


### PR DESCRIPTION
Before:
```bash
python -m timeit -s "hs='_' * 100000; nd='_' * 100000" "nd in hs"
# 94 usec
python -m timeit -s "hs='_' * 100000; nd='_' * 100000" "nd in hs"
#  4 usec
```
After:
```bash
python -m timeit -s "hs='_' * 100000; nd='1' * 100000" "nd in hs"
# 54 usec
python -m timeit -s "hs='_' * 100000; nd='1' * 100000" "nd in hs"
# 35 ns
```

<!-- gh-issue-number: gh-119996 -->
* Issue: gh-119996
<!-- /gh-issue-number -->
