### PR TITLE
[3.13] gh-117657: Fix itertools.count thread safety (GH-119268)

### DIFF
--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -48,7 +48,6 @@ race_top:_Py_dict_lookup_threadsafe
 race_top:_imp_release_lock
 race_top:_multiprocessing_SemLock_acquire_impl
 race_top:builtin_compile_impl
-race_top:count_next
 race_top:dictiter_new
 race_top:dictresize
 race_top:insert_to_emptydict


### PR DESCRIPTION
Fix itertools.count in free-threading mode
(cherry picked from commit 87939bd5790accea77c5a81093f16f28d3f0b429)


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
