### PR TITLE
gh-65454: avoid triggering call to a PropertyMock in NonCallableMock.__setattr__

### DIFF
--- a/Lib/test/test_unittest/testmock/testhelpers.py
+++ b/Lib/test/test_unittest/testmock/testhelpers.py
@@ -1127,6 +1127,14 @@ class TestCallList(unittest.TestCase):
         p.assert_called_once_with()
 
 
+    def test_propertymock_attach(self):
+        m = Mock()
+        p = PropertyMock()
+        type(m).foo = p
+        m.attach_mock(p, 'foo')
+        self.assertEqual(m.mock_calls, [])
+
+
 class TestCallablePredicate(unittest.TestCase):
 
     def test_type(self):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -831,7 +831,6 @@ class NonCallableMock(Base):
             raise AttributeError(f'Cannot set {mock_name}')
 
         if isinstance(value, PropertyMock):
-            print(name)
             self.__dict__[name] = value
             return
         return object.__setattr__(self, name, value)

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -830,6 +830,10 @@ class NonCallableMock(Base):
             mock_name = f'{self._extract_mock_name()}.{name}'
             raise AttributeError(f'Cannot set {mock_name}')
 
+        if isinstance(value, PropertyMock):
+            print(name)
+            self.__dict__[name] = value
+            return
         return object.__setattr__(self, name, value)
 
 

--- a/Misc/NEWS.d/next/Library/2024-06-04-08-57-02.gh-issue-65454.o9j4wF.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-04-08-57-02.gh-issue-65454.o9j4wF.rst
@@ -1,0 +1,1 @@
+:func:`unittest.mock.Mock.attach_mock` no longer triggers a call to a ``PropertyMock`` being attached.


### PR DESCRIPTION
# Avoid triggering call to a `PropertyMock` in `NonCallableMock.__setattr__`

Previously attaching a `PropertyMock` to a mock object would trigger a call to the property mock due to a recursive `__setattr__` call.

This is now fixed by setting the given property mock as an attribute of the hosting mock directly in its `__dict__` instead.

<!-- gh-issue-number: gh-65454 -->
* Issue: gh-65454
<!-- /gh-issue-number -->
