### PR TITLE
gh-119613: Soft deprecate the Py_MEMCPY() macro

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -180,6 +180,7 @@ typedef Py_ssize_t Py_ssize_clean_t;
 #  define Py_LOCAL_INLINE(type) static inline type
 #endif
 
+// Soft deprecated since Python 3.14, use memcpy() instead.
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 < 0x030b0000
 #  define Py_MEMCPY memcpy
 #endif

--- a/Misc/NEWS.d/next/C API/2024-06-04-10-58-20.gh-issue-119613.qOr9GF.rst
+++ b/Misc/NEWS.d/next/C API/2024-06-04-10-58-20.gh-issue-119613.qOr9GF.rst
@@ -1,0 +1,2 @@
+Soft deprecate the :c:macro:`!Py_MEMCPY` macro: use directly ``memcpy()``
+instead.  Patch by Victor Stinner.


### PR DESCRIPTION
Use directly memcpy() instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119613 -->
* Issue: gh-119613
<!-- /gh-issue-number -->
