### PR TITLE
Fix incorrect pull GitHub link in What's New

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1006,7 +1006,7 @@ random
 ------
 
 * Add a :ref:`command-line interface <random-cli>`.
-  (Contributed by Hugo van Kemenade in :gh:`54321`.)
+  (Contributed by Hugo van Kemenade in :gh:`118132`.)
 
 re
 --

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1006,7 +1006,7 @@ random
 ------
 
 * Add a :ref:`command-line interface <random-cli>`.
-  (Contributed by Hugo van Kemenade in :gh:`118132`.)
+  (Contributed by Hugo van Kemenade in :gh:`118131`.)
 
 re
 --


### PR DESCRIPTION
This fixes a "What's New in Python 3.13" link which mistakenly referenced gh-54321 instead of @hugovk's gh-118132.

Change should be backported to 3.13.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120045.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->