### PR TITLE
gh-120065: Increase `collect_in_thread` period to 5 ms.

### DIFF
--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -82,7 +82,7 @@ class TestBase(unittest.TestCase):
 
 
 @contextlib.contextmanager
-def collect_in_thread(period=0.0001):
+def collect_in_thread(period=0.005):
     """
     Ensure GC collections happen in a different thread, at a high frequency.
     """


### PR DESCRIPTION
This matches the default GIL switch interval. It greatly speeds up the free-threaded build: previously, it spent nearly all its time in `gc.collect()`.


<!-- gh-issue-number: gh-120065 -->
* Issue: gh-120065
<!-- /gh-issue-number -->
