### PR TITLE
gh-120078: Fixed a typo in the documentation for the time module. Specifically t…

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -617,7 +617,7 @@ Functions
         - range [1, 12]
 
       * - 2
-        - .. attribute:: tm_day
+        - .. attribute:: tm_mday
         - range [1, 31]
 
       * - 3


### PR DESCRIPTION
Changed 'tm_day' to the correct 'tm_mday' under the time.struct_time table in the documentation for the time module. 

<!-- gh-issue-number: gh-120078 -->
* Issue: gh-120078
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120081.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->