### PR TITLE
gh-70715: collect garbage before builtins are restored during shutdown

### DIFF
--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -787,6 +787,23 @@ class GCTests(unittest.TestCase):
         rc, out, err = assert_python_ok(TESTFN)
         self.assertEqual(out.strip(), b'__del__ called')
 
+    def test_builtin_module_access_at_exit(self):
+        code = """if 1:
+            import logging
+            class C:
+                def __enter__(self):
+                    return 'a'
+                def __exit__(self, t, v, tb):
+                    assert open
+                    assert logging.debug
+            def G():
+                with C() as i:
+                    yield from i
+            g = G()
+            next(g)"""
+        rc, out, err = assert_python_ok('-c', code)
+        self.assertEqual(err, b'')
+
     def test_get_stats(self):
         stats = gc.get_stats()
         self.assertEqual(len(stats), 3)

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-05-05-38-09.gh-issue-70715.sARd6y.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-05-05-38-09.gh-issue-70715.sARd6y.rst
@@ -1,1 +1,1 @@
-Fixed and issue where destructors and exit handlers had no access to builtins.
+Fixed an issue where destructors and exit handlers had no access to builtins.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-05-05-38-09.gh-issue-70715.sARd6y.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-05-05-38-09.gh-issue-70715.sARd6y.rst
@@ -1,0 +1,1 @@
+Fixed and issue where destructors and exit handlers had no access to builtins.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1707,16 +1707,16 @@ finalize_modules(PyThreadState *tstate)
     // Clear the modules dict
     finalize_clear_modules_dict(modules);
 
-    // Restore the original builtins dict, to ensure that any
-    // user data gets cleared.
-    finalize_restore_builtins(tstate);
-
-    // Collect garbage
+    // Collect garbage before builtins are restored
     _PyGC_CollectNoFail(tstate);
 
     // Dump GC stats before it's too late, since it uses the warnings
     // machinery.
     _PyGC_DumpShutdownStats(interp);
+
+    // Restore the original builtins dict, to ensure that any
+    // user data gets cleared.
+    finalize_restore_builtins(tstate);
 
     if (weaklist != NULL) {
         // Now, if there are any modules left alive, clear their globals to


### PR DESCRIPTION
# Collect garbage before builtins are restored during shutdown

Previously destructors and exit handlers had no access to builtins during shutdown because garbage collection is performed after builtins are restored.

This is now fixed by performing garbage collection before restoring builtins during shutdown.

<!-- gh-issue-number: gh-70715 -->
* Issue: gh-70715
<!-- /gh-issue-number -->
