### PR TITLE
gh-120400 ：Support Linux perf profile to see Python calls on RISC-V architecture

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-05-06-26-04.gh-issue-
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-05-06-26-04.gh-issue-
@@ -1,1 +1,1 @@
-Support Linux perf profile to see Python calls on RISC-V architecture
+Support Linux perf profiler to see Python calls on RISC-V architecture

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-05-06-26-04.gh-issue-
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-05-06-26-04.gh-issue-
@@ -1,0 +1,1 @@
+Support Linux perf profile to see Python calls on RISC-V architecture

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-12-12-29-45.gh-issue-120400.lZYHVS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-12-12-29-45.gh-issue-120400.lZYHVS.rst
@@ -1,0 +1,1 @@
+Support Linux perf profiler to see Python calls on RISC-V architecture.

--- a/Python/asm_trampoline.S
+++ b/Python/asm_trampoline.S
@@ -23,6 +23,14 @@ _Py_trampoline_func_start:
     ldp     x29, x30, [sp], 16
     ret
 #endif
+#ifdef __riscv
+    addi    sp,sp,-16
+    sd      ra,8(sp)
+    jalr    a3
+    ld      ra,8(sp)
+    addi    sp,sp,16
+    jr      ra
+#endif
     .globl	_Py_trampoline_func_end
 _Py_trampoline_func_end:
     .section        .note.GNU-stack,"",@progbits

--- a/configure
+++ b/configure
@@ -13133,6 +13133,8 @@ case $PLATFORM_TRIPLET in #(
     perf_trampoline=yes ;; #(
   aarch64-linux-gnu) :
     perf_trampoline=yes ;; #(
+  riscv64-linux-gnu) :
+    perf_trampoline=yes ;; #(
   *) :
     perf_trampoline=no
  ;;

--- a/configure.ac
+++ b/configure.ac
@@ -3641,6 +3641,7 @@ AC_MSG_CHECKING([perf trampoline])
 AS_CASE([$PLATFORM_TRIPLET],
   [x86_64-linux-gnu], [perf_trampoline=yes],
   [aarch64-linux-gnu], [perf_trampoline=yes],
+  [riscv64-linux-gnu], [perf_trampoline=yes],
   [perf_trampoline=no]
 )
 AC_MSG_RESULT([$perf_trampoline])


### PR DESCRIPTION
# Pull Request title

Refer to gh-96143:Allow Linux perf profiler to see Python calls 
Refer to gh-96143:Move the perf trampoline files to the Python directory


<!-- gh-issue-number: gh-120400 -->
* Issue: gh-120400
<!-- /gh-issue-number -->
