### PR TITLE
fix enum doc typo

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -629,7 +629,7 @@ Data Types
       of two, starting with ``1``.
 
    .. versionchanged:: 3.11 The *repr()* of zero-valued flags has changed.  It
-      is now::
+      is now:
 
          >>> Color(0) # doctest: +SKIP
          <Color: 0>


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120091.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->