### PR TITLE
gh-70787: ensure thread safety when creating child mock for a magic method with calculated return value

### DIFF
--- a/Lib/test/test_unittest/testmock/testmagicmethods.py
+++ b/Lib/test/test_unittest/testmock/testmagicmethods.py
@@ -1,7 +1,6 @@
 import math
 import unittest
 import os
-from threading import Thread
 from asyncio import iscoroutinefunction
 from unittest.mock import AsyncMock, Mock, MagicMock, _magics
 

--- a/Lib/test/test_unittest/testmock/testmagicmethods.py
+++ b/Lib/test/test_unittest/testmock/testmagicmethods.py
@@ -70,24 +70,6 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(str(mock), 'foo')
 
 
-    def test_str_race_condition(self):
-        def in_thread():
-            for m in mocks:
-                try:
-                    str(m)
-                except TypeError:
-                    nonlocal fail
-                    fail = True
-        fail = False
-        mocks = [MagicMock() for _ in range(1000)]
-        threads = [Thread(target=in_thread) for _ in range(10)]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-        self.assertFalse(fail)
-
-
     def test_dict_methods(self):
         mock = Mock()
 

--- a/Lib/test/test_unittest/testmock/testthreadingmock.py
+++ b/Lib/test/test_unittest/testmock/testthreadingmock.py
@@ -2,6 +2,7 @@ import time
 import unittest
 import concurrent.futures
 
+from threading import Thread
 from test.support import threading_helper
 from unittest.mock import patch, ThreadingMock, MagicMock
 

--- a/Lib/test/test_unittest/testmock/testthreadingmock.py
+++ b/Lib/test/test_unittest/testmock/testthreadingmock.py
@@ -3,7 +3,7 @@ import unittest
 import concurrent.futures
 
 from test.support import threading_helper
-from unittest.mock import patch, ThreadingMock
+from unittest.mock import patch, ThreadingMock, MagicMock
 
 
 threading_helper.requires_working_threading(module=True)

--- a/Lib/test/test_unittest/testmock/testthreadingmock.py
+++ b/Lib/test/test_unittest/testmock/testthreadingmock.py
@@ -197,5 +197,24 @@ class TestThreadingMock(unittest.TestCase):
         m.assert_called_once()
 
 
+class TestRaceConditions(unittest.TestCase):
+    def test_str(self):
+        def f():
+            for m in mocks:
+                try:
+                    str(m)
+                except TypeError:
+                    nonlocal fail
+                    fail = True
+        fail = False
+        mocks = [MagicMock() for _ in range(1000)]
+        threads = [Thread(target=f) for _ in range(10)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        self.assertFalse(fail)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1159,9 +1159,10 @@ class CallableMixin(Base):
     def __call__(self, /, *args, **kwargs):
         # can't use self in-case a function / method we are mocking uses self
         # in the signature
-        self._mock_check_sig(*args, **kwargs)
-        self._increment_mock_call(*args, **kwargs)
-        return self._mock_call(*args, **kwargs)
+        with NonCallableMock._lock:
+            self._mock_check_sig(*args, **kwargs)
+            self._increment_mock_call(*args, **kwargs)
+            return self._mock_call(*args, **kwargs)
 
 
     def _mock_call(self, /, *args, **kwargs):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2222,10 +2222,11 @@ class MagicProxy(Base):
     def create_mock(self):
         entry = self.name
         parent = self.parent
-        m = parent._get_child_mock(name=entry, _new_name=entry,
-                                   _new_parent=parent)
-        setattr(parent, entry, m)
-        _set_return_value(parent, m, entry)
+        with NonCallableMock._lock:
+            m = parent._get_child_mock(name=entry, _new_name=entry,
+                                       _new_parent=parent)
+            setattr(parent, entry, m)
+            _set_return_value(parent, m, entry)
         return m
 
     def __get__(self, obj, _type=None):

--- a/Misc/NEWS.d/next/Library/2024-06-05-07-05-06.gh-issue-70787.H7X73B.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-05-07-05-06.gh-issue-70787.H7X73B.rst
@@ -1,0 +1,1 @@
+Fixed a possible race condition between threads that could occur between the time of creation of a child mock for a magic method and the time the calculated return value of the child mock is set.


### PR DESCRIPTION
# Ensure thread safety when creating child mock for a magic method with calculated return value

Currently while creating a child mock for a magic method such as `__str__` when it's called, a race condition between threads can occur between the time of creation of the child mock and the time the calculated return value of the child mock is set, resulting in the call to `__str__` returning a mock object rather than a string representation.

This PR fixes the issue by acquiring a lock for these operations to be made atomic.

<!-- gh-issue-number: gh-70787 -->
* Issue: gh-70787
<!-- /gh-issue-number -->
