### PR TITLE
gh-120037: User site packages are being added when site module is enabled in _pth file

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-05-10-05-05.gh-issue-120037.QyZNce.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-05-10-05-05.gh-issue-120037.QyZNce.rst
@@ -1,0 +1,1 @@
+Fix user site packages directory being added to `sys.path` when site module is enabled in `._pth` file. Patch by Tanzim Husain.

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -762,6 +762,7 @@ if pth:
     config['use_environment'] = 0
     config['site_import'] = 0
     config['safe_path'] = 1
+    config['user_site_directory'] = 0
     pythonpath = []
     for line in pth:
         line = line.partition('#')[0].strip()


### PR DESCRIPTION
Don't add user site package directory to `sys.path` when a distribution specific `_.pth` exists with site import enabled.

I'd prefer that we add some tests for this, however none of the embedding tests looks like they test with `_pth` files enabled?

Thanks to @eryksun for the fix suggestion.

<!-- gh-issue-number: gh-120037 -->
* Issue: gh-120037
<!-- /gh-issue-number -->
