### PR TITLE
gh-120012: clarify the behaviour of `multiprocessing.Queue.empty` on closed queues.

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -837,9 +837,7 @@ For an example of the usage of queues for interprocess communication see
       Return ``True`` if the queue is empty, ``False`` otherwise.  Because of
       multithreading/multiprocessing semantics, this is not reliable.
 
-      If :meth:`put` or :meth:`put_nowait` has been called previously (i.e.,
-      if the feeder thread has been started) and if the queue is closed, this
-      method raises an :exc:`OSError` instead.
+      May raise an :exc:`OSError` on closed queues.
 
    .. method:: full()
 
@@ -945,8 +943,7 @@ For an example of the usage of queues for interprocess communication see
       Return ``True`` if the queue is empty, ``False`` otherwise.
 
       Unlike :meth:`Queue.empty`, if the queue is closed and this
-      method is called, this raises an :exc:`OSError` even if the
-      queue was never used.
+      method is called, this raises an :exc:`OSError`.
 
    .. method:: get()
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -837,7 +837,7 @@ For an example of the usage of queues for interprocess communication see
       Return ``True`` if the queue is empty, ``False`` otherwise.  Because of
       multithreading/multiprocessing semantics, this is not reliable.
 
-      May raise an :exc:`OSError` on closed queues.
+      May raise an :exc:`OSError` on closed queues. (not guaranteed)
 
    .. method:: full()
 
@@ -942,8 +942,7 @@ For an example of the usage of queues for interprocess communication see
 
       Return ``True`` if the queue is empty, ``False`` otherwise.
 
-      Unlike :meth:`Queue.empty`, if the queue is closed and this
-      method is called, this raises an :exc:`OSError`.
+      Always raises an :exc:`OSError` if the SimpleQueue is closed.
 
    .. method:: get()
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -837,6 +837,10 @@ For an example of the usage of queues for interprocess communication see
       Return ``True`` if the queue is empty, ``False`` otherwise.  Because of
       multithreading/multiprocessing semantics, this is not reliable.
 
+      If :meth:`put` or :meth:`put_nowait` has been called previously (i.e.,
+      if the feeder thread has been started) and if the queue is closed, this
+      method raises an :exc:`OSError` instead.
+
    .. method:: full()
 
       Return ``True`` if the queue is full, ``False`` otherwise.  Because of
@@ -939,6 +943,10 @@ For an example of the usage of queues for interprocess communication see
    .. method:: empty()
 
       Return ``True`` if the queue is empty, ``False`` otherwise.
+
+      Unlike :meth:`Queue.empty`, if the queue is closed and this
+      method is called, this raises an :exc:`OSError` even if the
+      queue was never used.
 
    .. method:: get()
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1202,6 +1202,17 @@ class _TestQueue(BaseTestCase):
         self.assertEqual(q.qsize(), 0)
         close_queue(q)
 
+    def test_empty_exceptions(self):
+        q = self.Queue()
+        q.close()  # this is a no-op because the feeder thread is not created
+        self.assertTrue(q.empty())
+        close_queue(q)
+
+        q = self.JoinableQueue()
+        q.close()  # this is a no-op because the feeder thread is not created
+        self.assertTrue(q.empty())
+        close_queue(q)
+
     @classmethod
     def _test_task_done(cls, q):
         for obj in iter(q.get, None):
@@ -5814,6 +5825,12 @@ class TestSimpleQueue(unittest.TestCase):
             queue.put(queue.empty())
         finally:
             parent_can_continue.set()
+
+    def test_empty_exceptions(self):
+        q = multiprocessing.SimpleQueue()
+        q.close()  # close the pipe
+        with self.assertRaisesRegex(OSError, 'is closed'):
+            q.empty()
 
     def test_empty(self):
         queue = multiprocessing.SimpleQueue()

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1334,15 +1334,16 @@ class _TestQueue(BaseTestCase):
 
     def test_closed_queue_empty_exceptions(self):
         for q in multiprocessing.Queue(), multiprocessing.JoinableQueue():
-            q.close()  # this is a no-op because the feeder thread is not created
+            q.close()  # this is a no-op since the feeder thread is None
+            q.join_thread()  # this is also a no-op
             self.assertTrue(q.empty())
 
         for q in multiprocessing.Queue(), multiprocessing.JoinableQueue():
             q.put('foo')
-            q.close()  # close the internal pipe
+            q.close()  # close the feeder thread
+            q.join_thread()  # make sure to join the feeder thread
             with self.assertRaisesRegex(OSError, 'is closed'):
                 q.empty()
-
 
     def test_closed_queue_put_get_exceptions(self):
         for q in multiprocessing.Queue(), multiprocessing.JoinableQueue():

--- a/Misc/NEWS.d/next/Documentation/2024-06-05-12-36-18.gh-issue-120012.f14DbQ.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-06-05-12-36-18.gh-issue-120012.f14DbQ.rst
@@ -1,2 +1,3 @@
-Clarify the behaviour of :meth:`multiprocessing.Queue.empty` on closed
-queues. Patch by Bénédikt Tran.
+Clarify the behaviours of :meth:`multiprocessing.Queue.empty` and
+:meth:`multiprocessing.SimpleQueue.empty` on closed queues.
+Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Documentation/2024-06-05-12-36-18.gh-issue-120012.f14DbQ.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-06-05-12-36-18.gh-issue-120012.f14DbQ.rst
@@ -1,0 +1,2 @@
+Clarify the behaviour of :meth:`multiprocessing.Queue.empty` on closed
+queues. Patch by Bénédikt Tran.


### PR DESCRIPTION
I took the liberty of clarifying the behaviour of `SimpleQueue` and `JoinableQueue` as well since `SimpleQueue` is a bit different.

I tested the behaviour on main, so I'm not entirely sure that it's the same on the previous versions, and that's why I added some tests for that.

<!-- gh-issue-number: gh-120012 -->
* Issue: gh-120012
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120102.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->