### PR TITLE
gh-117657: Fix some simple races in instrumentation.c

### DIFF
--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1977,7 +1977,7 @@ _PyMonitoring_SetLocalEvents(PyCodeObject *code, int tool_id, _PyMonitoringEvent
     }
 
     int res;
-    LOCK_CODE(code);
+    _PyEval_StopTheWorld(interp);
     if (allocate_instrumentation_data(code)) {
         res = -1;
         goto done;
@@ -1994,7 +1994,7 @@ _PyMonitoring_SetLocalEvents(PyCodeObject *code, int tool_id, _PyMonitoringEvent
     res = force_instrument_lock_held(code, interp);
 
 done:
-    UNLOCK_CODE();
+    _PyEval_StartTheWorld(interp);
     return res;
 }
 

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -666,7 +666,7 @@ de_instrument_per_instruction(PyCodeObject *code, int i)
     int original_opcode = code->_co_monitoring->per_instruction_opcodes[i];
     CHECK(original_opcode != 0);
     CHECK(original_opcode == _PyOpcode_Deopt[original_opcode]);
-    FT_ATOMIC_STORE_UINT8_RELAXED(*opcode_ptr, original_opcode);
+    *opcode_ptr = original_opcode;
     if (_PyOpcode_Caches[original_opcode]) {
         instr[1].counter = adaptive_counter_warmup();
     }
@@ -717,7 +717,7 @@ instrument_line(PyCodeObject *code, int i)
     _PyCoLineInstrumentationData *lines = &code->_co_monitoring->lines[i];
     lines->original_opcode = _PyOpcode_Deopt[opcode];
     CHECK(lines->original_opcode > 0);
-    FT_ATOMIC_STORE_UINT8_RELAXED(*opcode_ptr, INSTRUMENTED_LINE);
+    *opcode_ptr = INSTRUMENTED_LINE;
 }
 
 static void
@@ -746,7 +746,7 @@ instrument_per_instruction(PyCodeObject *code, int i)
         code->_co_monitoring->per_instruction_opcodes[i] = _PyOpcode_Deopt[opcode];
     }
     assert(code->_co_monitoring->per_instruction_opcodes[i] > 0);
-    FT_ATOMIC_STORE_UINT8_RELAXED(*opcode_ptr, INSTRUMENTED_INSTRUCTION);
+    *opcode_ptr = INSTRUMENTED_INSTRUCTION;
 }
 
 static void

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -666,7 +666,7 @@ de_instrument_per_instruction(PyCodeObject *code, int i)
     int original_opcode = code->_co_monitoring->per_instruction_opcodes[i];
     CHECK(original_opcode != 0);
     CHECK(original_opcode == _PyOpcode_Deopt[original_opcode]);
-    *opcode_ptr = original_opcode;
+    FT_ATOMIC_STORE_UINT8_RELAXED(*opcode_ptr, original_opcode);
     if (_PyOpcode_Caches[original_opcode]) {
         instr[1].counter = adaptive_counter_warmup();
     }
@@ -717,7 +717,7 @@ instrument_line(PyCodeObject *code, int i)
     _PyCoLineInstrumentationData *lines = &code->_co_monitoring->lines[i];
     lines->original_opcode = _PyOpcode_Deopt[opcode];
     CHECK(lines->original_opcode > 0);
-    *opcode_ptr = INSTRUMENTED_LINE;
+    FT_ATOMIC_STORE_UINT8_RELAXED(*opcode_ptr, INSTRUMENTED_LINE);
 }
 
 static void
@@ -746,7 +746,7 @@ instrument_per_instruction(PyCodeObject *code, int i)
         code->_co_monitoring->per_instruction_opcodes[i] = _PyOpcode_Deopt[opcode];
     }
     assert(code->_co_monitoring->per_instruction_opcodes[i] > 0);
-    *opcode_ptr = INSTRUMENTED_INSTRUCTION;
+    FT_ATOMIC_STORE_UINT8_RELAXED(*opcode_ptr, INSTRUMENTED_INSTRUCTION);
 }
 
 static void


### PR DESCRIPTION
The other more egregious races are a little trickier.

~Also not sure why this only turns up in gcc's tsan but seemingly not in clang's tsan.~ This turns up in clang-18 TSAN (see below).

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
