### PR TITLE
gh-120117: Fix bug in etree module

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1192,7 +1192,7 @@ class ElementTreeTest(unittest.TestCase):
         self.assertEqual(serialize(e, method="xml"),
                 '<html><link /><script>1 &lt; 2</script></html>\n')
         self.assertEqual(serialize(e, method="html"),
-                '<html><link><script>1 < 2</script></html>\n')
+                '<html><link/><script>1 < 2</script></html>\n')
         self.assertEqual(serialize(e, method="text"), '1 < 2\n')
 
     def test_issue18347(self):
@@ -1426,7 +1426,7 @@ class ElementTreeTest(unittest.TestCase):
                         'HR', 'IMG', 'INPUT', 'ISINDEX', 'LINK', 'META', 'PARAM',
                         'SOURCE', 'TRACK', 'WBR']:
             for elem in [element, element.lower()]:
-                expected = '<%s>' % elem
+                expected = '<%s/>' % elem
                 serialized = serialize(ET.XML('<%s />' % elem), method='html')
                 self.assertEqual(serialized, expected)
                 serialized = serialize(ET.XML('<%s></%s>' % (elem,elem)),

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -937,8 +937,8 @@ def _serialize_html(write, elem, qnames, namespaces, **kwargs):
                         v = _escape_attrib_html(v)
                     # FIXME: handle boolean attributes
                     write(" %s=\"%s\"" % (qnames[k], v))
-            write(">")
             ltag = tag.lower()
+            write(">") if ltag not in HTML_EMPTY else write("/>")
             if text:
                 if ltag == "script" or ltag == "style":
                     write(text)


### PR DESCRIPTION
Before this commit:
while serialzing with method ``_serialize_html `` self closing tag are converting  ``<br/>``->`` <br>`` 

after this commit :

it will convert like this ``<br/>`` -> ``<br/>``

from fix it increasing the usability of tostring() record again to fromstring so it won't create any error 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120117 -->
* Issue: gh-120117
<!-- /gh-issue-number -->
