### PR TITLE
[3.12] typing docs: fix indentation of TypedDict deprecation notice

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2203,9 +2203,9 @@ types.
 
       Point2D = TypedDict('Point2D', x=int, y=int, label=str)
 
-   .. deprecated-removed:: 3.11 3.13
-      The keyword-argument syntax is deprecated in 3.11 and will be removed
-      in 3.13. It may also be unsupported by static type checkers.
+     .. deprecated-removed:: 3.11 3.13
+        The keyword-argument syntax is deprecated in 3.11 and will be removed
+        in 3.13. It may also be unsupported by static type checkers.
 
    The functional syntax should also be used when any of the keys are not valid
    :ref:`identifiers <identifiers>`, for example because they are keywords or contain hyphens.


### PR DESCRIPTION
Only one of the two alternative syntaxes is deprecated, so let's make the deprecation notice part of that bullet. This PR is made to the 3.12 branch as the deprecated thing has already been removed in Python 3.13.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120124.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->