### PR TITLE
gh-120129: Slices length equals to the difference of the indices

### DIFF
--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -315,9 +315,9 @@ the second row gives the corresponding negative indices. The slice from *i* to
 *j* consists of all characters between the edges labeled *i* and *j*,
 respectively.
 
-For non-negative indices, the length of a slice is the difference of the
-indices, if both are within bounds.  For example, the length of ``word[1:3]`` is
-2.
+The length of a slice is the difference of the
+indices, if both are within bounds and their signs coincide.  For example, the length of ``word[1:3]`` is
+2 and the length of ``word[-4:-1]`` is -1-(-4) = 3.
 
 Attempting to use an index that is too large will result in an error::
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
```the length of a slice is the difference of the indices``` works with negative indices also.
Look in issue

<!-- gh-issue-number: gh-120129 -->
* Issue: gh-120129
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120130.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->