### PR TITLE
gh-119698: deprecate `symtable.Class.get_methods`

### DIFF
--- a/Doc/library/symtable.rst
+++ b/Doc/library/symtable.rst
@@ -129,6 +129,11 @@ Examining Symbol Tables
 
       Return a tuple containing the names of methods declared in the class.
 
+      .. deprecated:: 3.14
+
+         This method is deprecated since it may return non-methods (e.g.,
+         inner classes). In particular, this method should not be relied
+         on. Currently, there is no plan for a replacement.
 
 .. class:: Symbol
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -108,6 +108,11 @@ Deprecated
   as a single positional argument.
   (Contributed by Serhiy Storchaka in :gh:`109218`.)
 
+* :mod:`symtable`: The :meth:`symtable.Class.get_methods` method is deprecated.
+  It incorrectly considers non-methods objects (e.g., inner classes, type
+  aliases declared via :keyword:`type`, generator expressions or lambda
+  functions) declared in the class body as methods.
+  (Contributed by Bénédikt Tran in :gh:`119698`.)
 
 Removed
 =======

--- a/Lib/symtable.py
+++ b/Lib/symtable.py
@@ -219,6 +219,10 @@ class Class(SymbolTable):
     def get_methods(self):
         """Return a tuple of methods declared in the class.
         """
+        import warnings
+        warnings.warn('The symtable.Class.get_methods() method is deprecated.',
+                      category=DeprecationWarning, stacklevel=2)
+
         if self.__methods is None:
             d = {}
             for st in self._table.children:

--- a/Misc/NEWS.d/next/Library/2024-06-06-10-44-15.gh-issue-119698.CdHe0t.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-06-10-44-15.gh-issue-119698.CdHe0t.rst
@@ -1,0 +1,3 @@
+Deprecate :meth:`symtable.Class.get_methods`. This method may return symbols
+that are not methods and thus should not be relied on. Patch by Bénédikt
+Tran.


### PR DESCRIPTION
This is a proposal for deprecating `symtable.Class.get_methods`. I will work on an alternative that fixes the function (deprecation was easier to implement).

<!-- gh-issue-number: gh-119698 -->
* Issue: gh-119698
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120148.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->