### PR TITLE
Add Tian Gao to CODEOWNERS and ACKS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,6 +174,10 @@ Lib/ast.py                    @isidentical @JelleZijlstra
 /Lib/test/test_subprocess.py  @gpshead
 /Modules/*subprocess*         @gpshead
 
+# debugger
+**/*pdb*                      @gaogaotiantian
+**/*bdb*                      @gaogaotiantian
+
 # Limited C API & stable ABI
 Tools/build/stable_abi.py     @encukou
 Misc/stable_abi.toml          @encukou

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -610,6 +610,7 @@ Nitin Ganatra
 Soumendra Ganguly (गङ्गोपाध्याय)
 Fred Gansevles
 Paul Ganssle
+Tian Gao
 Lars Marius Garshol
 Jake Garver
 Dan Gass


### PR DESCRIPTION
Add @gaogaotiantian to pdb/bdb owners. Also a long overdue for ACKS.

I'd like this to be my first merge as a core dev. So if it's not too much trouble, maybe leave the merge to myself after the review :)