### PR TITLE
gh-120154: Fix Emscripten/WASI pattern in case statement for LDSHARED

### DIFF
--- a/configure
+++ b/configure
@@ -12892,7 +12892,7 @@ then
 		LDCXXSHARED='$(CXX) -dynamiclib -F . -framework $(PYTHONFRAMEWORK)'
 		BLDSHARED="$LDSHARED"
 		;;
-	Emscripten|WASI)
+	Emscripten*|WASI*)
 		LDSHARED='$(CC) -shared'
 		LDCXXSHARED='$(CXX) -shared';;
 	Linux*|GNU*|QNX*|VxWorks*|Haiku*)

--- a/configure.ac
+++ b/configure.ac
@@ -3417,7 +3417,7 @@ then
 		LDCXXSHARED='$(CXX) -dynamiclib -F . -framework $(PYTHONFRAMEWORK)'
 		BLDSHARED="$LDSHARED"
 		;;
-	Emscripten|WASI)
+	Emscripten*|WASI*)
 		LDSHARED='$(CC) -shared'
 		LDCXXSHARED='$(CXX) -shared';;
 	Linux*|GNU*|QNX*|VxWorks*|Haiku*)


### PR DESCRIPTION
This fixes a small typo in the configure script for CPython with respect to WASI and Emscripten builds. The issue has only surfaced now since usually such builds are done via `emconfigure` which sets the `LDSHARED` environment variable, bypassing the logic in the autoconf script.

This should not impact Pyodide builds unless the `configure` is executed directly without the `emconfigure` wrapper. Resolves #120154.

<!-- gh-issue-number: gh-120154 -->
* Issue: gh-120154
<!-- /gh-issue-number -->
