### PR TITLE
gh-120178: Typo corrections

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -594,7 +594,7 @@ Glossary
       therefore it is never deallocated.
 
       Built-in strings and singletons are immortal objects. For example,
-      :const:`True` and :const:`None` singletons are immmortal.
+      :const:`True` and :const:`None` singletons are immortal.
 
       See `PEP 683 – Immortal Objects, Using a Fixed Refcount
       <https://peps.python.org/pep-0683/>`_ for more information.

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1667,7 +1667,7 @@ iterations of the loop.
 
    A no-op. Performs internal tracing, debugging and optimization checks.
 
-   The ``context`` oparand consists of two parts. The lowest two bits
+   The ``context`` operand consists of two parts. The lowest two bits
    indicate where the ``RESUME`` occurs:
 
    * ``0`` The start of a function, which is neither a generator, coroutine

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -341,7 +341,7 @@ can be overridden by the local file.
    With a *lineno* argument, set a break at line *lineno* in the current file.
    The line number may be prefixed with a *filename* and a colon,
    to specify a breakpoint in another file (possibly one that hasn't been loaded
-   yet).  The file is searched on :data:`sys.path`.  Accepatable forms of *filename*
+   yet).  The file is searched on :data:`sys.path`.  Acceptable forms of *filename*
    are ``/abspath/to/file.py``, ``relpath/file.py``, ``module`` and
    ``package.module``.
 


### PR DESCRIPTION
This corrects the typos from #120178.

oparand     -> operand
accepatable -> acceptable
immmortal   -> immortal

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120178 -->
* Issue: gh-120178
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120179.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->