### PR TITLE
gh-119659: Get the datetime CAPI Tests Running Again

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -22,7 +22,7 @@ from operator import lt, le, gt, ge, eq, ne, truediv, floordiv, mod
 
 from test import support
 from test.support import is_resource_enabled, ALWAYS_EQ, LARGEST, SMALLEST
-from test.support import warnings_helper, no_rerun
+from test.support import warnings_helper
 
 import datetime as datetime_module
 from datetime import MINYEAR, MAXYEAR
@@ -6385,7 +6385,6 @@ class IranTest(ZoneInfoTest):
 
 
 @unittest.skipIf(_testcapi is None, 'need _testcapi module')
-@no_rerun("the encapsulated datetime C API does not support reloading")
 class CapiTest(unittest.TestCase):
     def setUp(self):
         # Since the C API is not present in the _Pure tests, skip all tests

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1197,6 +1197,7 @@ def no_rerun(reason):
     test using the 'reason' parameter.
     """
     def deco(func):
+        assert not isinstance(func, type), func
         _has_run = False
         def wrapper(self):
             nonlocal _has_run


### PR DESCRIPTION
The tests were accidentally disabled by 2da0dc094fa855ed4df251aab58b6f8a2b6969a1, which didn't handle classes correctly.

I considered updating `no_rerun()` to support classes, but the way test_datetime.py works would have made things fairly messy.  Plus, it looks like the refleaks we had encountered before have been resolved.

<!-- gh-issue-number: gh-119659 -->
* Issue: gh-119659
<!-- /gh-issue-number -->
