### PR TITLE
gh-120176: Reduce number of compares in index range checks

### DIFF
--- a/Include/internal/pycore_abstract.h
+++ b/Include/internal/pycore_abstract.h
@@ -21,6 +21,19 @@ PyObject *_PyNumber_InPlacePowerNoMod(PyObject *lhs, PyObject *rhs);
 
 extern int _PyObject_HasLen(PyObject *o);
 
+static inline int
+_Py_ValidIndex(Py_ssize_t i, Py_ssize_t limit)
+{
+    /* The cast to size_t lets us use just a single comparison
+       to check whether i is in the range: 0 <= i < limit.
+
+       See:  Section 14.2 "Bounds Checking" in the Agner Fog
+       optimization manual found at:
+       https://www.agner.org/optimize/optimizing_cpp.pdf
+    */
+    return (size_t) i < (size_t) limit;
+}
+
 /* === Sequence protocol ================================================ */
 
 #define PY_ITERSEARCH_COUNT    1

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -106,6 +106,7 @@ bytes(cdata)
 #  include <windows.h>
 #endif
 
+#include "pycore_abstract.h"      // _Py_ValidIndex()
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_ceval.h"         // _Py_EnterRecursiveCall()
 #ifdef MS_WIN32
@@ -4645,7 +4646,7 @@ Array_item(PyObject *myself, Py_ssize_t index)
     CDataObject *self = (CDataObject *)myself;
     Py_ssize_t offset, size;
 
-    if (index < 0 || index >= self->b_length) {
+    if (!_Py_ValidIndex(index, self->b_length)) {
         PyErr_SetString(PyExc_IndexError,
                         "invalid index");
         return NULL;
@@ -4800,7 +4801,7 @@ Array_ass_item(PyObject *myself, Py_ssize_t index, PyObject *value)
     }
     assert(stginfo); /* Cannot be NULL for array object instances */
 
-    if (index < 0 || index >= stginfo->length) {
+    if (!_Py_ValidIndex(index, stginfo->length)) {
         PyErr_SetString(PyExc_IndexError,
                         "invalid index");
         return -1;

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -16,6 +16,7 @@
 #endif
 
 #include "Python.h"
+#include "pycore_abstract.h"      // _Py_ValidIndex()
 #include "pycore_import.h"        // _PyImport_GetModuleAttrString()
 #include "pycore_pyhash.h"        // _Py_HashSecret
 
@@ -1486,7 +1487,7 @@ element_getitem(PyObject* self_, Py_ssize_t index)
 {
     ElementObject* self = (ElementObject*) self_;
 
-    if (!self->extra || index < 0 || index >= self->extra->length) {
+    if (!self->extra || !_Py_ValidIndex(index, self->extra->length)) {
         PyErr_SetString(
             PyExc_IndexError,
             "child index out of range"
@@ -1738,7 +1739,7 @@ element_setitem(PyObject* self_, Py_ssize_t index, PyObject* item)
     Py_ssize_t i;
     PyObject* old;
 
-    if (!self->extra || index < 0 || index >= self->extra->length) {
+    if (!self->extra || !_Py_ValidIndex(index, self->extra->length)) {
         PyErr_SetString(
             PyExc_IndexError,
             "child assignment index out of range");

--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -39,6 +39,7 @@ static const char copyright[] =
     " SRE 2.2.2 Copyright (c) 1997-2002 by Secret Labs AB ";
 
 #include "Python.h"
+#include "pycore_abstract.h"         // _Py_ValidIndex()
 #include "pycore_critical_section.h" // Py_BEGIN_CRITICAL_SECTION
 #include "pycore_dict.h"             // _PyDict_Next()
 #include "pycore_long.h"             // _PyLong_GetZero()
@@ -2208,7 +2209,7 @@ match_getindex(MatchObject* self, PyObject* index)
             }
         }
     }
-    if (i < 0 || i >= self->groups) {
+    if (!_Py_ValidIndex(i, self->groups)) {
         /* raise IndexError if we were given a bad group number */
         if (!PyErr_Occurred()) {
             PyErr_SetString(PyExc_IndexError, "no such group");

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -8,6 +8,7 @@
 #endif
 
 #include "Python.h"
+#include "pycore_abstract.h"      // _Py_ValidIndex()
 #include "pycore_bytesobject.h"   // _PyBytes_Repeat
 #include "pycore_call.h"          // _PyObject_CallMethod()
 #include "pycore_ceval.h"         // _PyEval_GetBuiltin()
@@ -851,7 +852,7 @@ array_length(arrayobject *a)
 static PyObject *
 array_item(arrayobject *a, Py_ssize_t i)
 {
-    if (i < 0 || i >= Py_SIZE(a)) {
+    if (!_Py_ValidIndex(i, Py_SIZE(a))) {
         PyErr_SetString(PyExc_IndexError, "array index out of range");
         return NULL;
     }
@@ -1028,7 +1029,7 @@ array_del_slice(arrayobject *a, Py_ssize_t ilow, Py_ssize_t ihigh)
 static int
 array_ass_item(arrayobject *a, Py_ssize_t i, PyObject *v)
 {
-    if (i < 0 || i >= Py_SIZE(a)) {
+    if (!_Py_ValidIndex(i, Py_SIZE(a))) {
         PyErr_SetString(PyExc_IndexError,
                          "array assignment index out of range");
         return -1;
@@ -1311,7 +1312,7 @@ array_array_pop_impl(arrayobject *self, Py_ssize_t i)
     }
     if (i < 0)
         i += Py_SIZE(self);
-    if (i < 0 || i >= Py_SIZE(self)) {
+    if (!_Py_ValidIndex(i, Py_SIZE(self))) {
         PyErr_SetString(PyExc_IndexError, "pop index out of range");
         return NULL;
     }
@@ -2502,7 +2503,7 @@ array_ass_subscr(arrayobject* self, PyObject* item, PyObject* value)
             return -1;
         if (i < 0)
             i += Py_SIZE(self);
-        if (i < 0 || i >= Py_SIZE(self)) {
+        if (!_Py_ValidIndex(i, Py_SIZE(self))) {
             PyErr_SetString(PyExc_IndexError,
                 "array assignment index out of range");
             return -1;

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -23,7 +23,7 @@
 #endif
 
 #include <Python.h>
-#include "pycore_abstract.h"      // _Py_convert_optional_to_ssize_t()
+#include "pycore_abstract.h"      // _Py_convert_optional_to_ssize_t(), _Py_ValidIndex()
 #include "pycore_bytesobject.h"   // _PyBytes_Find()
 #include "pycore_fileutils.h"     // _Py_stat_struct
 
@@ -1131,7 +1131,7 @@ mmap_madvise_method(mmap_object *self, PyObject *args)
         return NULL;
     }
 
-    if (start < 0 || start >= self->size) {
+    if (!_Py_ValidIndex(start, self->size)) {
         PyErr_SetString(PyExc_ValueError, "madvise start out of bounds");
         return NULL;
     }
@@ -1229,7 +1229,7 @@ static PyObject *
 mmap_item(mmap_object *self, Py_ssize_t i)
 {
     CHECK_VALID(NULL);
-    if (i < 0 || i >= self->size) {
+    if (!_Py_ValidIndex(i, self->size)) {
         PyErr_SetString(PyExc_IndexError, "mmap index out of range");
         return NULL;
     }
@@ -1251,7 +1251,7 @@ mmap_subscript(mmap_object *self, PyObject *item)
             return NULL;
         if (i < 0)
             i += self->size;
-        if (i < 0 || i >= self->size) {
+        if (!_Py_ValidIndex(i, self->size)) {
             PyErr_SetString(PyExc_IndexError,
                 "mmap index out of range");
             return NULL;
@@ -1309,7 +1309,7 @@ mmap_ass_item(mmap_object *self, Py_ssize_t i, PyObject *v)
     const char *buf;
 
     CHECK_VALID(-1);
-    if (i < 0 || i >= self->size) {
+    if (!_Py_ValidIndex(i, self->size)) {
         PyErr_SetString(PyExc_IndexError, "mmap index out of range");
         return -1;
     }
@@ -1349,7 +1349,7 @@ mmap_ass_subscript(mmap_object *self, PyObject *item, PyObject *value)
             return -1;
         if (i < 0)
             i += self->size;
-        if (i < 0 || i >= self->size) {
+        if (!_Py_ValidIndex(i, self->size)) {
             PyErr_SetString(PyExc_IndexError,
                             "mmap index out of range");
             return -1;

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -1,7 +1,7 @@
 /* PyByteArray (bytearray) implementation */
 
 #include "Python.h"
-#include "pycore_abstract.h"      // _PyIndex_Check()
+#include "pycore_abstract.h"      // _PyIndex_Check(), _Py_ValidIndex()
 #include "pycore_bytes_methods.h"
 #include "pycore_bytesobject.h"
 #include "pycore_ceval.h"         // _PyEval_GetBuiltin()
@@ -359,7 +359,7 @@ bytearray_irepeat(PyByteArrayObject *self, Py_ssize_t count)
 static PyObject *
 bytearray_getitem(PyByteArrayObject *self, Py_ssize_t i)
 {
-    if (i < 0 || i >= Py_SIZE(self)) {
+    if (!_Py_ValidIndex(i, Py_SIZE(self))) {
         PyErr_SetString(PyExc_IndexError, "bytearray index out of range");
         return NULL;
     }
@@ -378,7 +378,7 @@ bytearray_subscript(PyByteArrayObject *self, PyObject *index)
         if (i < 0)
             i += PyByteArray_GET_SIZE(self);
 
-        if (i < 0 || i >= Py_SIZE(self)) {
+        if (!_Py_ValidIndex(i, Py_SIZE(self))) {
             PyErr_SetString(PyExc_IndexError, "bytearray index out of range");
             return NULL;
         }
@@ -573,7 +573,7 @@ bytearray_setitem(PyByteArrayObject *self, Py_ssize_t i, PyObject *value)
         i += Py_SIZE(self);
     }
 
-    if (i < 0 || i >= Py_SIZE(self)) {
+    if (!_Py_ValidIndex(i, Py_SIZE(self))) {
         PyErr_SetString(PyExc_IndexError, "bytearray index out of range");
         return -1;
     }
@@ -613,7 +613,7 @@ bytearray_ass_subscript(PyByteArrayObject *self, PyObject *index, PyObject *valu
             i += PyByteArray_GET_SIZE(self);
         }
 
-        if (i < 0 || i >= Py_SIZE(self)) {
+        if (!_Py_ValidIndex(i, Py_SIZE(self))) {
             PyErr_SetString(PyExc_IndexError, "bytearray index out of range");
             return -1;
         }
@@ -1911,7 +1911,7 @@ bytearray_pop_impl(PyByteArrayObject *self, Py_ssize_t index)
     }
     if (index < 0)
         index += Py_SIZE(self);
-    if (index < 0 || index >= Py_SIZE(self)) {
+    if (!_Py_ValidIndex(index, Py_SIZE(self))) {
         PyErr_SetString(PyExc_IndexError, "pop index out of range");
         return NULL;
     }

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -1,5 +1,5 @@
 #include "Python.h"
-#include "pycore_abstract.h"   // _PyIndex_Check()
+#include "pycore_abstract.h"   // _PyIndex_Check(), _Py_ValidIndex()
 #include "pycore_bytes_methods.h"
 
 PyDoc_STRVAR_shared(_Py_isspace__doc__,
@@ -660,7 +660,7 @@ _Py_bytes_contains(const char *str, Py_ssize_t len, PyObject *arg)
         PyBuffer_Release(&varg);
         return pos >= 0;
     }
-    if (ival < 0 || ival >= 256) {
+    if (!_Py_ValidIndex(ival, 256)) {
         PyErr_SetString(PyExc_ValueError, "byte must be in range(0, 256)");
         return -1;
     }

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1,7 +1,7 @@
 /* bytes object implementation */
 
 #include "Python.h"
-#include "pycore_abstract.h"      // _PyIndex_Check()
+#include "pycore_abstract.h"      // _PyIndex_Check(), _Py_ValidIndex()
 #include "pycore_bytes_methods.h" // _Py_bytes_startswith()
 #include "pycore_bytesobject.h"   // _PyBytes_Find(), _PyBytes_Repeat()
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
@@ -1506,7 +1506,7 @@ bytes_contains(PyObject *self, PyObject *arg)
 static PyObject *
 bytes_item(PyBytesObject *a, Py_ssize_t i)
 {
-    if (i < 0 || i >= Py_SIZE(a)) {
+    if (!_Py_ValidIndex(i, Py_SIZE(a))) {
         PyErr_SetString(PyExc_IndexError, "index out of range");
         return NULL;
     }
@@ -1613,7 +1613,7 @@ bytes_subscript(PyBytesObject* self, PyObject* item)
             return NULL;
         if (i < 0)
             i += PyBytes_GET_SIZE(self);
-        if (i < 0 || i >= PyBytes_GET_SIZE(self)) {
+        if (!_Py_ValidIndex(i, PyBytes_GET_SIZE(self))) {
             PyErr_SetString(PyExc_IndexError,
                             "index out of range");
             return NULL;
@@ -2810,7 +2810,7 @@ _PyBytes_FromList(PyObject *x)
         if (value == -1 && PyErr_Occurred())
             goto error;
 
-        if (value < 0 || value >= 256) {
+        if (!_Py_ValidIndex(value, 256)) {
             PyErr_SetString(PyExc_ValueError,
                             "bytes must be in range(0, 256)");
             goto error;
@@ -2851,7 +2851,7 @@ _PyBytes_FromTuple(PyObject *x)
         if (value == -1 && PyErr_Occurred())
             goto error;
 
-        if (value < 0 || value >= 256) {
+        if (!_Py_ValidIndex(value, 256)) {
             PyErr_SetString(PyExc_ValueError,
                             "bytes must be in range(0, 256)");
             goto error;
@@ -2904,7 +2904,7 @@ _PyBytes_FromIterator(PyObject *it, PyObject *x)
             goto error;
 
         /* Range check */
-        if (value < 0 || value >= 256) {
+        if (!_Py_ValidIndex(value, 256)) {
             PyErr_SetString(PyExc_ValueError,
                             "bytes must be in range(0, 256)");
             goto error;
@@ -3662,4 +3662,3 @@ _PyBytes_Repeat(char* dest, Py_ssize_t len_dest,
         }
     }
 }
-

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -116,6 +116,7 @@ As a consequence of this, split keys have a maximum size of 16.
 #define PyDict_MINSIZE 8
 
 #include "Python.h"
+#include "pycore_abstract.h"             // _Py_ValidIndex()
 #include "pycore_bitutils.h"             // _Py_bit_length
 #include "pycore_call.h"                 // _PyObject_CallNoArgs()
 #include "pycore_ceval.h"                // _PyEval_GetBuiltin()
@@ -2814,7 +2815,7 @@ _PyDict_Next(PyObject *op, Py_ssize_t *ppos, PyObject **pkey,
     i = *ppos;
     if (_PyDict_HasSplitTable(mp)) {
         assert(mp->ma_used <= SHARED_KEYS_MAX_SIZE);
-        if (i < 0 || i >= mp->ma_used)
+        if (!_Py_ValidIndex(i, mp->ma_used))
             return 0;
         int index = get_index_from_order(mp, i);
         value = mp->ma_values->values[index];
@@ -2824,7 +2825,7 @@ _PyDict_Next(PyObject *op, Py_ssize_t *ppos, PyObject **pkey,
     }
     else {
         Py_ssize_t n = mp->ma_keys->dk_nentries;
-        if (i < 0 || i >= n)
+        if (!_Py_ValidIndex(i, n))
             return 0;
         if (DK_IS_UNICODE(mp->ma_keys)) {
             PyDictUnicodeEntry *entry_ptr = &DK_UNICODE_ENTRIES(mp->ma_keys)[i];

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -11,7 +11,7 @@
  */
 
 #include "Python.h"
-#include "pycore_abstract.h"      // _PyIndex_Check()
+#include "pycore_abstract.h"      // _PyIndex_Check(), _Py_ValidIndex()
 #include "pycore_memoryobject.h"  // _PyManagedBuffer_Type
 #include "pycore_object.h"        // _PyObject_GC_UNTRACK()
 #include "pycore_strhex.h"        // _Py_strhex_with_sep()
@@ -2378,7 +2378,7 @@ lookup_dimension(const Py_buffer *view, char *ptr, int dim, Py_ssize_t index)
     if (index < 0) {
         index += nitems;
     }
-    if (index < 0 || index >= nitems) {
+    if (!_Py_ValidIndex(index, nitems)) {
         PyErr_Format(PyExc_IndexError,
                      "index out of bounds on dimension %d", dim + 1);
         return NULL;

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -2,7 +2,7 @@
 /* Tuple object implementation */
 
 #include "Python.h"
-#include "pycore_abstract.h"      // _PyIndex_Check()
+#include "pycore_abstract.h"      // _PyIndex_Check(), _Py_ValidIndex()
 #include "pycore_ceval.h"         // _PyEval_GetBuiltin()
 #include "pycore_gc.h"            // _PyObject_GC_IS_TRACKED()
 #include "pycore_initconfig.h"    // _PyStatus_OK()
@@ -102,7 +102,7 @@ PyTuple_GetItem(PyObject *op, Py_ssize_t i)
         PyErr_BadInternalCall();
         return NULL;
     }
-    if (i < 0 || i >= Py_SIZE(op)) {
+    if (!_Py_ValidIndex(i, Py_SIZE(op))) {
         PyErr_SetString(PyExc_IndexError, "tuple index out of range");
         return NULL;
     }
@@ -118,7 +118,7 @@ PyTuple_SetItem(PyObject *op, Py_ssize_t i, PyObject *newitem)
         PyErr_BadInternalCall();
         return -1;
     }
-    if (i < 0 || i >= Py_SIZE(op)) {
+    if (!_Py_ValidIndex(i, Py_SIZE(op))) {
         Py_XDECREF(newitem);
         PyErr_SetString(PyExc_IndexError,
                         "tuple assignment index out of range");
@@ -363,7 +363,7 @@ tuplecontains(PyTupleObject *a, PyObject *el)
 static PyObject *
 tupleitem(PyTupleObject *a, Py_ssize_t i)
 {
-    if (i < 0 || i >= Py_SIZE(a)) {
+    if (!_Py_ValidIndex(i, Py_SIZE(a))) {
         PyErr_SetString(PyExc_IndexError, "tuple index out of range");
         return NULL;
     }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -39,7 +39,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
 #include "Python.h"
-#include "pycore_abstract.h"      // _PyIndex_Check()
+#include "pycore_abstract.h"      // _PyIndex_Check(), _Py_ValidIndex()
 #include "pycore_bytes_methods.h" // _Py_bytes_lower()
 #include "pycore_bytesobject.h"   // _PyBytes_Repeat()
 #include "pycore_ceval.h"         // _PyEval_GetBuiltin()
@@ -3970,7 +3970,7 @@ PyUnicode_ReadChar(PyObject *unicode, Py_ssize_t index)
         PyErr_BadArgument();
         return (Py_UCS4)-1;
     }
-    if (index < 0 || index >= PyUnicode_GET_LENGTH(unicode)) {
+    if (!_Py_ValidIndex(index, PyUnicode_GET_LENGTH(unicode))) {
         PyErr_SetString(PyExc_IndexError, "string index out of range");
         return (Py_UCS4)-1;
     }
@@ -3986,7 +3986,7 @@ PyUnicode_WriteChar(PyObject *unicode, Py_ssize_t index, Py_UCS4 ch)
         PyErr_BadArgument();
         return -1;
     }
-    if (index < 0 || index >= PyUnicode_GET_LENGTH(unicode)) {
+    if (!_Py_ValidIndex(index, PyUnicode_GET_LENGTH(unicode))) {
         PyErr_SetString(PyExc_IndexError, "string index out of range");
         return -1;
     }
@@ -11368,7 +11368,7 @@ unicode_getitem(PyObject *self, Py_ssize_t index)
         PyErr_BadArgument();
         return NULL;
     }
-    if (index < 0 || index >= PyUnicode_GET_LENGTH(self)) {
+    if (!_Py_ValidIndex(index, PyUnicode_GET_LENGTH(self))) {
         PyErr_SetString(PyExc_IndexError, "string index out of range");
         return NULL;
     }

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -3,6 +3,7 @@
 #include "Python.h"
 #include "opcode.h"
 #include "pycore_interp.h"
+#include "pycore_abstract.h"        // _Py_ValidIndex()
 #include "pycore_backoff.h"
 #include "pycore_bitutils.h"        // _Py_popcount32()
 #include "pycore_object.h"          // _PyObject_GC_UNTRACK()
@@ -357,7 +358,7 @@ static PyObject *
 uop_item(_PyExecutorObject *self, Py_ssize_t index)
 {
     Py_ssize_t len = uop_len(self);
-    if (index < 0 || index >= len) {
+    if (!_Py_ValidIndex(index, len)) {
         PyErr_SetNone(PyExc_IndexError);
         return NULL;
     }


### PR DESCRIPTION
This PR is a followup to #9784 (discussed in #72583 and #67741) and extracts the helper function into `internal/pycore_abstract.h` and uses it where applicable to reduce the number of comparisons in index range checks.

See https://godbolt.org/z/jM8oexT1d for an assembly comparison.

I feel like this change doesn't reduce readability but let me know if such micro optimisation does not justify the code churn.

<!-- gh-issue-number: gh-120176 -->
* Issue: gh-120176
<!-- /gh-issue-number -->
