### PR TITLE
gh-120162: Fix flaky test test_preauth_data_to_tls_server in test_ssl.

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4969,7 +4969,7 @@ class TestPreHandshakeClose(unittest.TestCase):
             return  # Expect the full test setup to always work on Linux.
         if (isinstance(err, ConnectionResetError) or
             (isinstance(err, OSError) and err.errno == errno.EINVAL) or
-            re.search('wrong.version.number', getattr(err, "reason", ""), re.I)):
+            re.search('wrong.version.number', getattr(err, "reason", "") or "", re.I)):
             # On Windows the TCP RST leads to a ConnectionResetError
             # (ECONNRESET) which Linux doesn't appear to surface to userspace.
             # If wrap_socket() winds up on the "if connected:" path and doing


### PR DESCRIPTION


<!-- gh-issue-number: gh-120162 -->
* Issue: gh-120162
<!-- /gh-issue-number -->
