### PR TITLE
gh-117657: Make PyType_HasFeature atomic

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -262,7 +262,7 @@ extern int _PyTraceMalloc_TraceRef(PyObject *op, PyRefTracerEvent event, void*);
 // Fast inlined version of PyType_HasFeature()
 static inline int
 _PyType_HasFeature(PyTypeObject *type, unsigned long feature) {
-    return ((type->tp_flags & feature) != 0);
+    return ((FT_ATOMIC_LOAD_ULONG_RELAXED(type->tp_flags) & feature) != 0);
 }
 
 extern void _PyType_InitCache(PyInterpreterState *interp);

--- a/Include/internal/pycore_pyatomic_ft_wrappers.h
+++ b/Include/internal/pycore_pyatomic_ft_wrappers.h
@@ -45,6 +45,8 @@ extern "C" {
     _Py_atomic_load_uint16_relaxed(&value)
 #define FT_ATOMIC_LOAD_UINT32_RELAXED(value) \
     _Py_atomic_load_uint32_relaxed(&value)
+#define FT_ATOMIC_LOAD_ULONG_RELAXED(value) \
+    _Py_atomic_load_ulong_relaxed(&value)
 #define FT_ATOMIC_STORE_PTR_RELAXED(value, new_value) \
     _Py_atomic_store_ptr_relaxed(&value, new_value)
 #define FT_ATOMIC_STORE_PTR_RELEASE(value, new_value) \
@@ -75,6 +77,7 @@ extern "C" {
 #define FT_ATOMIC_LOAD_UINT8_RELAXED(value) value
 #define FT_ATOMIC_LOAD_UINT16_RELAXED(value) value
 #define FT_ATOMIC_LOAD_UINT32_RELAXED(value) value
+#define FT_ATOMIC_LOAD_ULONG_RELAXED(value) value
 #define FT_ATOMIC_STORE_PTR_RELAXED(value, new_value) value = new_value
 #define FT_ATOMIC_STORE_PTR_RELEASE(value, new_value) value = new_value
 #define FT_ATOMIC_STORE_UINTPTR_RELEASE(value, new_value) value = new_value

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -26,7 +26,6 @@ race:free_threadstate
 race_top:_add_to_weak_set
 race_top:_in_weak_set
 race_top:_PyEval_EvalFrameDefault
-race_top:_PyType_HasFeature
 race_top:assign_version_tag
 race_top:insertdict
 race_top:lookup_tp_dict


### PR DESCRIPTION
It's possible that when a type is readying in one thread (which modify the type flags), the same type is then queried for its flags.

Here's an example from the test suite:
```
WARNING: ThreadSanitizer: data race (pid=71885)
  Write of size 8 at 0x555555e520f8 by thread T1:
    #0 type_ready /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:8314:20 (python+0x37f4e9) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #1 init_static_type /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:8383:11 (python+0x37ff36) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #2 _PyStaticType_InitBuiltin /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:8401:12 (python+0x380217) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #3 _PyTypes_InitTypes /home/ken/Documents/GitHub/cpython/Objects/object.c:2329:13 (python+0x318d3b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #4 pycore_init_types /home/ken/Documents/GitHub/cpython/Python/pylifecycle.c:722:14 (python+0x55a7ba) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #5 pycore_interp_init /home/ken/Documents/GitHub/cpython/Python/pylifecycle.c:873:14 (python+0x55a546) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #6 new_interpreter /home/ken/Documents/GitHub/cpython/Python/pylifecycle.c:2247:14 (python+0x558b9a) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #7 Py_NewInterpreterFromConfig /home/ken/Documents/GitHub/cpython/Python/pylifecycle.c:2280:12 (python+0x5586ce) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #8 _PyXI_NewInterpreter /home/ken/Documents/GitHub/cpython/Python/crossinterp.c:1832:23 (python+0x4e63f8) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #9 interp_create /home/ken/Documents/GitHub/cpython/./Modules/_interpretersmodule.c:625:13 (_interpreters.cpython-314td-x86_64-linux-gnu.so+0x3dda) (BuildId: bd1a6be1ee054a8b82c3e3e03c537ef85ee6373b)
    #10 cfunction_call /home/ken/Documents/GitHub/cpython/Objects/methodobject.c:540:18 (python+0x30b0ac) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #11 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x253d00) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #12 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2535ed) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #13 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x254fa0) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #14 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4854f2) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #15 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #16 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #17 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #18 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x25b06b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #19 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:70:20 (python+0x2596d5) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #20 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x254ea5) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #21 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x2550bb) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #22 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x2552e7) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #23 thread_run /home/ken/Documents/GitHub/cpython/./Modules/_threadmodule.c:337:21 (python+0x679ff8) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #24 pythread_wrapper /home/ken/Documents/GitHub/cpython/Python/thread_pthread.h:243:5 (python+0x5bb3bb) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)

  Previous read of size 8 at 0x555555e520f8 by main thread:
    #0 PyType_HasFeature /home/ken/Documents/GitHub/cpython/./Include/object.h:751:19 (python+0x503961) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #1 vgetargs1 /home/ken/Documents/GitHub/cpython/Python/getargs.c:379:14 (python+0x503961)
    #2 PyArg_ParseTuple /home/ken/Documents/GitHub/cpython/Python/getargs.c:101:14 (python+0x503b97) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #3 PyThreadHandleObject_join /home/ken/Documents/GitHub/cpython/./Modules/_threadmodule.c:630:10 (python+0x67b448) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #4 method_vectorcall_VARARGS /home/ken/Documents/GitHub/cpython/Objects/descrobject.c:324:24 (python+0x26cea6) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #5 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x25358b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #6 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x254fa0) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #7 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4854f2) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #8 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #9 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #10 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #11 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x25b06b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #12 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x259742) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #13 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x254ea5) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #14 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x2550bb) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #15 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x2552e7) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #16 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x488521) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #17 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #18 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #19 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #20 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x2538bd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #21 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x2558dd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #22 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9612:15 (python+0x385a2c) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #23 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x253d00) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #24 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2535ed) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #25 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x254fa0) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #26 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4854f2) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #27 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #28 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #29 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #30 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x25b06b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #31 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x259742) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #32 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x254ea5) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #33 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x2550bb) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #34 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x2552e7) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #35 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x488521) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #36 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #37 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #38 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #39 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x2538bd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #40 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x2558dd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #41 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9612:15 (python+0x385a2c) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #42 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x253d00) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #43 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2535ed) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #44 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x254fa0) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #45 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4854f2) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #46 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #47 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #48 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #49 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x25b06b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #50 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x259742) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #51 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x254ea5) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #52 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x2550bb) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #53 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x2552e7) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #54 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x488521) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #55 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #56 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #57 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #58 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x2538bd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #59 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x2558dd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #60 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9612:15 (python+0x385a2c) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #61 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x253d00) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #62 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2535ed) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #63 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x254fa0) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #64 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4854f2) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #65 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #66 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #67 PyEval_EvalCode /home/ken/Documents/GitHub/cpython/Python/ceval.c:599:21 (python+0x47f40a) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #68 builtin_exec_impl /home/ken/Documents/GitHub/cpython/Python/bltinmodule.c:1145:17 (python+0x477fb4) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #69 builtin_exec /home/ken/Documents/GitHub/cpython/Python/clinic/bltinmodule.c.h:556:20 (python+0x477fb4)
    #70 cfunction_vectorcall_FASTCALL_KEYWORDS /home/ken/Documents/GitHub/cpython/Objects/methodobject.c:441:24 (python+0x309d31) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #71 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x25358b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #72 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x254fa0) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #73 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4854f2) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #74 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #75 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #76 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #77 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x254ea5) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #78 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x2550bb) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #79 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x2552e7) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #80 pymain_run_module /home/ken/Documents/GitHub/cpython/Modules/main.c:297:14 (python+0x5d6753) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #81 pymain_run_python /home/ken/Documents/GitHub/cpython/Modules/main.c (python+0x5d5e71) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #82 Py_RunMain /home/ken/Documents/GitHub/cpython/Modules/main.c:718:5 (python+0x5d5e71)
    #83 pymain_main /home/ken/Documents/GitHub/cpython/Modules/main.c:748:12 (python+0x5d64f9) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #84 Py_BytesMain /home/ken/Documents/GitHub/cpython/Modules/main.c:772:12 (python+0x5d6579) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #85 main /home/ken/Documents/GitHub/cpython/./Programs/python.c:15:12 (python+0x15a840) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)

  Location is global 'PyTuple_Type' of size 432 at 0x555555e52040 (python+0x8fe0f8)

  Thread T1 (tid=72166, running) created by main thread at:
    #0 pthread_create <null> (python+0xdd37b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #1 do_start_joinable_thread /home/ken/Documents/GitHub/cpython/Python/thread_pthread.h:290:14 (python+0x5ba02b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #2 PyThread_start_joinable_thread /home/ken/Documents/GitHub/cpython/Python/thread_pthread.h:314:9 (python+0x5b9e4a) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #3 ThreadHandle_start /home/ken/Documents/GitHub/cpython/./Modules/_threadmodule.c:422:9 (python+0x679aff) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #4 do_start_new_thread /home/ken/Documents/GitHub/cpython/./Modules/_threadmodule.c:1798:9 (python+0x679aff)
    #5 thread_PyThread_start_joinable_thread /home/ken/Documents/GitHub/cpython/./Modules/_threadmodule.c:1921:14 (python+0x67858a) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #6 cfunction_call /home/ken/Documents/GitHub/cpython/Objects/methodobject.c:540:18 (python+0x30b0ac) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #7 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x253d00) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #8 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2535ed) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #9 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x254fa0) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #10 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1505:19 (python+0x489513) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #11 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #12 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #13 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #14 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x25b06b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #15 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x259742) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #16 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x254ea5) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #17 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x2550bb) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #18 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x2552e7) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #19 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x488521) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #20 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #21 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #22 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #23 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x2538bd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #24 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x2558dd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #25 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9612:15 (python+0x385a2c) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #26 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x253d00) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #27 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2535ed) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #28 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x254fa0) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #29 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4854f2) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #30 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #31 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #32 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #33 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x25b06b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #34 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x259742) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #35 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x254ea5) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #36 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x2550bb) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #37 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x2552e7) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #38 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x488521) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #39 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #40 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #41 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #42 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x2538bd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #43 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x2558dd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #44 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9612:15 (python+0x385a2c) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #45 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x253d00) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #46 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2535ed) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #47 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x254fa0) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #48 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4854f2) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #49 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #50 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #51 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #52 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x25b06b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #53 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x259742) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #54 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x254ea5) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #55 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x2550bb) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #56 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x2552e7) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #57 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x488521) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #58 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #59 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #60 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #61 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x2538bd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #62 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x2558dd) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #63 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9612:15 (python+0x385a2c) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #64 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x253d00) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #65 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2535ed) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #66 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x254fa0) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #67 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4854f2) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #68 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #69 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #70 PyEval_EvalCode /home/ken/Documents/GitHub/cpython/Python/ceval.c:599:21 (python+0x47f40a) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #71 builtin_exec_impl /home/ken/Documents/GitHub/cpython/Python/bltinmodule.c:1145:17 (python+0x477fb4) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #72 builtin_exec /home/ken/Documents/GitHub/cpython/Python/clinic/bltinmodule.c.h:556:20 (python+0x477fb4)
    #73 cfunction_vectorcall_FASTCALL_KEYWORDS /home/ken/Documents/GitHub/cpython/Objects/methodobject.c:441:24 (python+0x309d31) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #74 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x25358b) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #75 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x254fa0) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #76 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4854f2) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #77 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x47f793) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #78 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x47f793)
    #79 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x2554bc) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #80 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x254ea5) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #81 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x2550bb) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #82 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x2552e7) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #83 pymain_run_module /home/ken/Documents/GitHub/cpython/Modules/main.c:297:14 (python+0x5d6753) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #84 pymain_run_python /home/ken/Documents/GitHub/cpython/Modules/main.c (python+0x5d5e71) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #85 Py_RunMain /home/ken/Documents/GitHub/cpython/Modules/main.c:718:5 (python+0x5d5e71)
    #86 pymain_main /home/ken/Documents/GitHub/cpython/Modules/main.c:748:12 (python+0x5d64f9) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #87 Py_BytesMain /home/ken/Documents/GitHub/cpython/Modules/main.c:772:12 (python+0x5d6579) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)
    #88 main /home/ken/Documents/GitHub/cpython/./Programs/python.c:15:12 (python+0x15a840) (BuildId: d711891dd81ea42c5939066e7340f80d9e212f69)

SUMMARY: ThreadSanitizer: data race /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:8314:20 in type_ready
```

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
