### PR TITLE
gh-120211: Fix tkinter.ttk with Tcl/Tk 9.0

### DIFF
--- a/Lib/tkinter/ttk.py
+++ b/Lib/tkinter/ttk.py
@@ -690,7 +690,10 @@ class Combobox(Entry):
         returns the index of the current value in the list of values
         or -1 if the current value does not appear in the list."""
         if newindex is None:
-            return self.tk.getint(self.tk.call(self._w, "current"))
+            res = self.tk.call(self._w, "current")
+            if res == '':
+                return -1
+            return self.tk.getint(res)
         return self.tk.call(self._w, "current", newindex)
 
 
@@ -1522,7 +1525,7 @@ class LabeledScale(Frame):
         self.label.place(anchor='n' if label_side == 'top' else 's')
 
         # update the label as scale or variable changes
-        self.__tracecb = self._variable.trace_variable('w', self._adjust)
+        self.__tracecb = self._variable.trace_add('write', self._adjust)
         self.bind('<Configure>', self._adjust)
         self.bind('<Map>', self._adjust)
 
@@ -1530,7 +1533,7 @@ class LabeledScale(Frame):
     def destroy(self):
         """Destroy this widget and possibly its associated variable."""
         try:
-            self._variable.trace_vdelete('w', self.__tracecb)
+            self._variable.trace_remove('write', self.__tracecb)
         except AttributeError:
             pass
         else:

--- a/Misc/NEWS.d/next/Library/2024-06-07-13-21-11.gh-issue-120211.Rws_gf.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-07-13-21-11.gh-issue-120211.Rws_gf.rst
@@ -1,0 +1,1 @@
+Fix :mod:`tkinter.ttk` with Tcl/Tk 9.0.


### PR DESCRIPTION
* Use new methods for tracing Tcl variable.
* Fix Combobox.current() for an empty combobox.


<!-- gh-issue-number: gh-120211 -->
* Issue: gh-120211
<!-- /gh-issue-number -->
