### PR TITLE
gh-120200: Fix `inspect.iscoroutinefunction(inspect) is True` corner case

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -403,13 +403,13 @@ def isgeneratorfunction(obj):
     return _has_code_flag(obj, CO_GENERATOR)
 
 # A marker for markcoroutinefunction and iscoroutinefunction.
-_is_coroutine_marker = object()
+_is_coroutine_mark = object()
 
 def _has_coroutine_mark(f):
     while ismethod(f):
         f = f.__func__
     f = functools._unwrap_partial(f)
-    return getattr(f, "_is_coroutine_marker", None) is _is_coroutine_marker
+    return getattr(f, "_is_coroutine_marker", None) is _is_coroutine_mark
 
 def markcoroutinefunction(func):
     """
@@ -417,7 +417,7 @@ def markcoroutinefunction(func):
     """
     if hasattr(func, '__func__'):
         func = func.__func__
-    func._is_coroutine_marker = _is_coroutine_marker
+    func._is_coroutine_marker = _is_coroutine_mark
     return func
 
 def iscoroutinefunction(obj):

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -235,6 +235,7 @@ class TestPredicates(IsTestBase):
                     gen_coroutine_function_example))))
         self.assertFalse(inspect.iscoroutinefunction(gen_coro_pmi))
         self.assertFalse(inspect.iscoroutinefunction(gen_coro_pmc))
+        self.assertFalse(inspect.iscoroutinefunction(inspect))
         self.assertFalse(inspect.iscoroutine(gen_coro))
 
         self.assertTrue(


### PR DESCRIPTION
CC @carltongibson as the original author
CC @gvanrossum and @kumaraditya303 as original reviewers

I think that the name change is the somplest fix here. Since this name is protected and undocumented, this should not be a breaking change.

However, what do we care about more? Supporting this corner-case or keeping the old name?
If the former, then I can close this PR.

<!-- gh-issue-number: gh-120200 -->
* Issue: gh-120200
<!-- /gh-issue-number -->
