### PR TITLE
gh-71587: Drop local reference cache to `_strptime` module in `_datetime`

### DIFF
--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -777,6 +777,7 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(_showwarnmsg));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(_shutdown));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(_slotnames));
+    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(_strptime));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(_strptime_datetime));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(_swappedbytes_));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(_type_));

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -266,6 +266,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(_showwarnmsg)
         STRUCT_FOR_ID(_shutdown)
         STRUCT_FOR_ID(_slotnames)
+        STRUCT_FOR_ID(_strptime)
         STRUCT_FOR_ID(_strptime_datetime)
         STRUCT_FOR_ID(_swappedbytes_)
         STRUCT_FOR_ID(_type_)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -775,6 +775,7 @@ extern "C" {
     INIT_ID(_showwarnmsg), \
     INIT_ID(_shutdown), \
     INIT_ID(_slotnames), \
+    INIT_ID(_strptime), \
     INIT_ID(_strptime_datetime), \
     INIT_ID(_swappedbytes_), \
     INIT_ID(_type_), \

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -639,6 +639,9 @@ _PyUnicode_InitStaticStrings(PyInterpreterState *interp) {
     string = &_Py_ID(_slotnames);
     assert(_PyUnicode_CheckConsistency(string, 1));
     _PyUnicode_InternInPlace(interp, &string);
+    string = &_Py_ID(_strptime);
+    assert(_PyUnicode_CheckConsistency(string, 1));
+    _PyUnicode_InternInPlace(interp, &string);
     string = &_Py_ID(_strptime_datetime);
     assert(_PyUnicode_CheckConsistency(string, 1));
     _PyUnicode_InternInPlace(interp, &string);

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -404,6 +404,15 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
         out, err = self.run_embedded_interpreter("test_repeated_init_exec", code)
         self.assertEqual(out, '9\n' * INIT_LOOPS)
 
+    def test_datetime_reset_strptime(self):
+        code = (
+            "import datetime;"
+            "d = datetime.datetime.strptime('2000-01-01', '%Y-%m-%d');"
+            "print(d.strftime('%Y%m%d'))"
+        )
+        out, err = self.run_embedded_interpreter("test_repeated_init_exec", code)
+        self.assertEqual(out, '20000101\n' * INIT_LOOPS)
+
 
 @unittest.skipIf(_testinternalcapi is None, "requires _testinternalcapi")
 class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2024-06-07-11-23-31.gh-issue-71587.IjFajE.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-07-11-23-31.gh-issue-71587.IjFajE.rst
@@ -1,0 +1,1 @@
+Fix crash in :meth:`_datetime.datetime.strptime` when called again on the restarted interpreter.

--- a/Misc/NEWS.d/next/Library/2024-06-07-11-23-31.gh-issue-71587.IjFajE.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-07-11-23-31.gh-issue-71587.IjFajE.rst
@@ -1,1 +1,2 @@
-Fix crash in :meth:`_datetime.datetime.strptime` when called again on the restarted interpreter.
+Fix crash in C version of :meth:`datetime.datetime.strptime` when called again
+on the restarted interpreter.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -7121,8 +7121,8 @@ traverse_state(datetime_state *st, visitproc visit, void *arg)
 {
     /* heap types */
     Py_VISIT(st->isocalendar_date_type);
+    /* containers */
     Py_VISIT(st->strptime);
-
     return 0;
 }
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -7068,7 +7068,7 @@ init_state(datetime_state *st, PyObject *module, PyObject *old_module)
             .us_per_week = Py_NewRef(st_old->us_per_week),
             .seconds_per_day = Py_NewRef(st_old->seconds_per_day),
             .epoch = Py_NewRef(st_old->epoch),
-            .strptime = Py_NewRef(st_old->strptime),
+            .strptime = st->strptime,
         };
         return 0;
     }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5529,13 +5529,13 @@ datetime_strptime(PyObject *cls, PyObject *args)
     if (module == NULL) {
         module = PyImport_ImportModule("_strptime");
         if (module == NULL) {
-            goto Done;
+            goto exit;
         }
         st->strptime = module;
     }
     result = PyObject_CallMethodObjArgs(module, &_Py_ID(_strptime_datetime),
-                                         cls, string, format, NULL);
-Done:
+                                        cls, string, format, NULL);
+exit:
     RELEASE_CURRENT_STATE(st, current_mod);
     return result;
 }

--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -393,7 +393,6 @@ Modules/xxmodule.c	-	ErrorObject	-
 
 ## initialized once
 Modules/_cursesmodule.c	-	ModDict	-
-Modules/_datetimemodule.c	datetime_strptime	module	-
 
 ## state
 Modules/_datetimemodule.c	-	_datetime_global_state	-


### PR DESCRIPTION
For **3.13 and newer**, this PR fixes the following errors ~by making each loaded `_datetime` module use its own reference cache to `_strptime` module.  The cache will be the same as the reference in `sys.modules` of the corresponding interpreter~ by importing `_strptime` module on each `strptime()` function call.

Main interpreter:
```
>_testembed_d test_repeated_init_exec "import datetime; datetime.datetime.strptime('200001', '%Y%m')"
--- Loop #1 ---
--- Loop #2 ---
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: 'NoneType' object is not callable
```
Sub interpreter:
```
>>> import _interpreters
>>> for i in range(1,3):
...     print('Sub Loop', i)
...     interp = _interpreters.create()
...     s = "import datetime; datetime.datetime.strptime('200001', '%Y%m')"
...     _interpreters.run_string(interp, s)
...     _interpreters.destroy(interp)
...
Sub Loop 1
Sub Loop 2
Assertion failed: PyUnicode_CheckExact(ep_key), file C:\cp\Objects\dictobject.c, line 1126
```
cc @ericsnowcurrently @erlend-aasland

<br>

<!-- gh-issue-number: gh-71587 -->
* Issue: gh-71587
* Issue: gh-117914
* Issue: gh-117398
<!-- /gh-issue-number -->
