### PR TITLE
gh-120155: Fix copy/paste error in HAVE_SUBOFFSETS_IN_LAST_DIM()

### DIFF
--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -268,7 +268,7 @@ PyTypeObject _PyManagedBuffer_Type = {
 /* Assumptions: ndim >= 1. The macro tests for a corner case that should
    perhaps be explicitly forbidden in the PEP. */
 #define HAVE_SUBOFFSETS_IN_LAST_DIM(view) \
-    (view->suboffsets && view->suboffsets[dest->ndim-1] >= 0)
+    (view->suboffsets && view->suboffsets[view->ndim-1] >= 0)
 
 static inline int
 last_dim_is_contiguous(const Py_buffer *dest, const Py_buffer *src)


### PR DESCRIPTION
Don't hardcode 'dest' in HAVE_SUBOFFSETS_IN_LAST_DIM() macro of memoryobject.c, but use its 'view' parameter instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120155 -->
* Issue: gh-120155
<!-- /gh-issue-number -->
