### PR TITLE
[3.12] gh-120155: Fix optimize_and_assemble_code_unit() error handling

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7682,7 +7682,7 @@ optimize_and_assemble_code_unit(struct compiler_unit *u, PyObject *const_cache,
     PyCodeObject *co = NULL;
     PyObject *consts = consts_dict_keys_inorder(u->u_metadata.u_consts);
     if (consts == NULL) {
-        goto error;
+        return NULL;
     }
     cfg_builder g;
     if (instr_sequence_to_cfg(&u->u_instr_sequence, &g) < 0) {


### PR DESCRIPTION
Don't use 'g' before it's being initialized: don't use the 'error' label if consts_dict_keys_inorder() failed.

Fix the Coverity issue:

```
Error: UNINIT (CWE-457):
Python-3.12.2/Python/compile.c:7670:5: skipped_decl: Jumping over declaration of ""g"". Python-3.12.2/Python/compile.c:7714:5: uninit_use_in_call: Using uninitialized value ""g.g_block_list"" when calling ""_PyCfgBuilder_Fini"". Python-3.12.2/Python/compile.c:7714:5: uninit_use_in_call: Using uninitialized value ""g.g_entryblock"" when calling ""_PyCfgBuilder_Fini"".
  7712|       Py_XDECREF(consts);
  7713|       instr_sequence_fini(&optimized_instrs);
  7714|->     _PyCfgBuilder_Fini(&g);
  7715|       return co;
  7716|   }
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120155 -->
* Issue: gh-120155
<!-- /gh-issue-number -->
