### PR TITLE
gh-120155: Fix Coverity issue in zoneinfo load_data()

### DIFF
--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -944,6 +944,7 @@ end:
 static int
 load_data(zoneinfo_state *state, PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
 {
+    int rv = 0;
     PyObject *data_tuple = NULL;
 
     long *utcoff = NULL;
@@ -1220,7 +1221,6 @@ load_data(zoneinfo_state *state, PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
         }
     }
 
-    int rv = 0;
     goto cleanup;
 error:
     // These resources only need to be freed if we have failed, if we succeed


### PR DESCRIPTION
Declare the 'rv' variable at the top of the load_data() function to make sure that it's initialized before the first 'goto error' which uses 'rv' (return rv).

Fix the Coverity issue:

```
Error: UNINIT (CWE-457):
Python-3.12.2/Modules/_zoneinfo.c:1233:5: skipped_decl: Jumping over declaration of ""rv"".
Python-3.12.2/Modules/_zoneinfo.c:1284:5: uninit_use: Using uninitialized value ""rv"".
  1282|       }
  1283|
  1284|->     return rv;
  1285|   }
  1286|
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120155 -->
* Issue: gh-120155
<!-- /gh-issue-number -->
