### PR TITLE
gh-119517: Fix several issues when pasting lot of text in the REPL

### DIFF
--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -482,3 +482,4 @@ class disable_bracketed_paste(Command):
         self.reader.in_bracketed_paste = False
         self.reader.dirty = True
         self.reader.calc_screen = self.reader.calc_complete_screen
+        self.reader.scroll_on_next_refresh = False

--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -69,7 +69,8 @@ class Console(ABC):
             self.output_fd = f_out.fileno()
 
     @abstractmethod
-    def refresh(self, screen: list[str], xy: tuple[int, int]) -> None: ...
+    def refresh(self, screen: list[str], xy: tuple[int, int],
+                scroll: bool = False) -> None: ...
 
     @abstractmethod
     def prepare(self) -> None: ...

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -256,7 +256,7 @@ class Reader:
         self.lxy = (self.pos, 0)
         self.calc_screen = self.calc_complete_screen
         self.can_colorize = can_colorize()
-    
+
     def collect_keymap(self) -> tuple[tuple[KeySpec, CommandName], ...]:
         return default_keymap
 

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -369,9 +369,10 @@ class UnixConsole(Console):
         Returns:
         - Event: Event object from the event queue.
         """
+        BUFFER_SIZE = 1024*100
         if self.wait(timeout=0):
             try:
-                chars = os.read(self.input_fd, 1024)
+                chars = os.read(self.input_fd, BUFFER_SIZE)
                 for char in chars:
                     self.push_char(char)
             except OSError as err:
@@ -381,7 +382,7 @@ class UnixConsole(Console):
         while self.event_queue.empty():
             while True:
                 try:
-                    chars = os.read(self.input_fd, 1024)
+                    chars = os.read(self.input_fd, BUFFER_SIZE)
                     for char in chars:
                         self.push_char(char)
                 except OSError as err:

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -136,7 +136,7 @@ class WindowsConsole(Console):
             # Console I/O is redirected, fallback...
             self.out = None
 
-    def refresh(self, screen: list[str], c_xy: tuple[int, int]) -> None:
+    def refresh(self, screen: list[str], c_xy: tuple[int, int], scroll: bool = True) -> None:
         """
         Refresh the console screen.
 
@@ -165,12 +165,13 @@ class WindowsConsole(Console):
             offset = cy - height + 1
             scroll_lines = offset - old_offset
 
-            # Scrolling the buffer as the current input is greater than the visible
-            # portion of the window.  We need to scroll the visible portion and the
-            # entire history
-            self._scroll(scroll_lines, self._getscrollbacksize())
-            self.__posxy = self.__posxy[0], self.__posxy[1] + scroll_lines
-            self.__offset += scroll_lines
+            if scroll:
+                # Scrolling the buffer as the current input is greater than the visible
+                # portion of the window.  We need to scroll the visible portion and the
+                # entire history
+                self._scroll(scroll_lines, self._getscrollbacksize())
+                self.__posxy = self.__posxy[0], self.__posxy[1] + scroll_lines
+                self.__offset += scroll_lines
 
             for i in range(scroll_lines):
                 self.screen.append("")

--- a/Lib/test/test_pyrepl/support.py
+++ b/Lib/test/test_pyrepl/support.py
@@ -103,7 +103,7 @@ class FakeConsole(Console):
     def getheightwidth(self) -> tuple[int, int]:
         return self.height, self.width
 
-    def refresh(self, screen: list[str], xy: tuple[int, int], scroll:bool = True) -> None:
+    def refresh(self, screen: list[str], xy: tuple[int, int], scroll: bool = True) -> None:
         pass
 
     def prepare(self) -> None:

--- a/Lib/test/test_pyrepl/support.py
+++ b/Lib/test/test_pyrepl/support.py
@@ -103,7 +103,7 @@ class FakeConsole(Console):
     def getheightwidth(self) -> tuple[int, int]:
         return self.height, self.width
 
-    def refresh(self, screen: list[str], xy: tuple[int, int]) -> None:
+    def refresh(self, screen: list[str], xy: tuple[int, int], scroll:bool = True) -> None:
         pass
 
     def prepare(self) -> None:

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-07-16-42-17.gh-issue-119517.GXgQNl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-07-16-42-17.gh-issue-119517.GXgQNl.rst
@@ -1,0 +1,2 @@
+Fix extraneous new lines in the scroll buffer when pasting in the REPL and
+make signals work again to interrupt slow operations. Patch by Pablo Galindo


### PR DESCRIPTION
* Restore signal handlers for SIGINT and SIGSTOP (Ctrl-C and Ctrl-Z)
* Ensure that signals are processed as soon as possible by making
  reads more efficient.
* Protect against invalid state in internal REPL functions when
  interrumpted.
* Do not show extraneous newlines above the scroll buffer when pasting
  text in the REPL

Signed-off-by: Pablo Galindo <pablogsal@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119517 -->
* Issue: gh-119517
<!-- /gh-issue-number -->
