### PR TITLE
gh-120225: fix crash in compiler on empty block at end of exception handler

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1409,6 +1409,16 @@ class TestSpecifics(unittest.TestCase):
         for kw in ("except", "except*"):
             exec(code % kw, g, l);
 
+    def test_regression_gh_120225(self):
+        async def name_4():
+            match b'':
+                case True:
+                    pass
+                case name_5 if f'e':
+                    {name_3: name_4 async for name_2 in name_5}
+                case []:
+                    pass
+            [[]]
 
 @requires_debug_ranges()
 class TestSourcePositions(unittest.TestCase):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -578,14 +578,10 @@ dis_asyncwith = """\
                 RETURN_CONST             0 (None)
 
 %4d   L12:     CLEANUP_THROW
-
-  --   L13:     JUMP_BACKWARD_NO_INTERRUPT 25 (to L5)
-
-%4d   L14:     CLEANUP_THROW
-
-  --   L15:     JUMP_BACKWARD_NO_INTERRUPT 9 (to L11)
-
-%4d   L16:     PUSH_EXC_INFO
+       L13:     JUMP_BACKWARD_NO_INTERRUPT 25 (to L5)
+       L14:     CLEANUP_THROW
+       L15:     JUMP_BACKWARD_NO_INTERRUPT 9 (to L11)
+       L16:     PUSH_EXC_INFO
                 WITH_EXCEPT_START
                 GET_AWAITABLE            2
                 LOAD_CONST               0 (None)
@@ -630,8 +626,6 @@ ExceptionTable:
        _asyncwith.__code__.co_firstlineno + 2,
        _asyncwith.__code__.co_firstlineno + 1,
        _asyncwith.__code__.co_firstlineno + 3,
-       _asyncwith.__code__.co_firstlineno + 1,
-       _asyncwith.__code__.co_firstlineno + 1,
        _asyncwith.__code__.co_firstlineno + 1,
        _asyncwith.__code__.co_firstlineno + 3,
        )

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -578,10 +578,14 @@ dis_asyncwith = """\
                 RETURN_CONST             0 (None)
 
 %4d   L12:     CLEANUP_THROW
-       L13:     JUMP_BACKWARD_NO_INTERRUPT 25 (to L5)
-       L14:     CLEANUP_THROW
-       L15:     JUMP_BACKWARD_NO_INTERRUPT 9 (to L11)
-       L16:     PUSH_EXC_INFO
+
+  --   L13:     JUMP_BACKWARD_NO_INTERRUPT 25 (to L5)
+
+%4d   L14:     CLEANUP_THROW
+
+  --   L15:     JUMP_BACKWARD_NO_INTERRUPT 9 (to L11)
+
+%4d   L16:     PUSH_EXC_INFO
                 WITH_EXCEPT_START
                 GET_AWAITABLE            2
                 LOAD_CONST               0 (None)
@@ -626,6 +630,8 @@ ExceptionTable:
        _asyncwith.__code__.co_firstlineno + 2,
        _asyncwith.__code__.co_firstlineno + 1,
        _asyncwith.__code__.co_firstlineno + 3,
+       _asyncwith.__code__.co_firstlineno + 1,
+       _asyncwith.__code__.co_firstlineno + 1,
        _asyncwith.__code__.co_firstlineno + 1,
        _asyncwith.__code__.co_firstlineno + 3,
        )

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-07-16-09-04.gh-issue-120225.kuYf9t.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-07-16-09-04.gh-issue-120225.kuYf9t.rst
@@ -1,0 +1,1 @@
+Fix crash in compiler on empty block at end of exception handler.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2308,6 +2308,7 @@ push_cold_blocks_to_end(cfg_builder *g) {
                              NO_LOCATION);
             explicit_jump->b_cold = 1;
             explicit_jump->b_next = b->b_next;
+            explicit_jump->b_predecessors = 1;
             b->b_next = explicit_jump;
 
             /* set target */

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2304,13 +2304,8 @@ push_cold_blocks_to_end(cfg_builder *g) {
             if (!IS_LABEL(b->b_next->b_label)) {
                 b->b_next->b_label.id = next_lbl++;
             }
-            cfg_instr *prev_instr = basicblock_last_instr(b);
-            // b cannot be empty because at the end of an exception handler
-            // there is always a POP_EXCEPT + RERAISE/RETURN
-            assert(prev_instr);
-
             basicblock_addop(explicit_jump, JUMP_NO_INTERRUPT, b->b_next->b_label.id,
-                             prev_instr->i_loc);
+                             NO_LOCATION);
             explicit_jump->b_cold = 1;
             explicit_jump->b_next = b->b_next;
             b->b_next = explicit_jump;


### PR DESCRIPTION

Fixes #120225.

It's not necessary to set a line number here. It can be propagated later (and if it's not that's also ok, JUMP_NO_INTERRUPT doesn't require a line number).

<!-- gh-issue-number: gh-120225 -->
* Issue: gh-120225
<!-- /gh-issue-number -->
