### PR TITLE
gh-120242: Fix handling of `[setUp,tearDown]Class` in `test_datetime`

### DIFF
--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -1,5 +1,6 @@
 import unittest
 import sys
+import functools
 
 from test.support.import_helper import import_fresh_module
 
@@ -37,29 +38,28 @@ def load_tests(loader, tests, pattern):
                 test_classes.extend(type(test) for test in suit)
         test_classes = sorted(set(test_classes), key=lambda cls: cls.__qualname__)
         for cls in test_classes:
-            orig_setUpClass = getattr(cls, 'setUpClass', None)
-            orig_tearDownClass = getattr(cls, 'tearDownClass', None)
             cls.__name__ += suffix
             cls.__qualname__ += suffix
-            @classmethod
-            def setUpClass(cls_, module=module, orig_setUpClass=orig_setUpClass):
-                cls_._save_sys_modules = sys.modules.copy()
-                sys.modules[TESTS] = module
-                sys.modules['datetime'] = module.datetime_module
-                if hasattr(module, '_pydatetime'):
-                    sys.modules['_pydatetime'] = module._pydatetime
-                sys.modules['_strptime'] = module._strptime
-                if orig_setUpClass is not None:
-                    orig_setUpClass()
-            @classmethod
-            def tearDownClass(cls_, orig_tearDownClass=orig_tearDownClass):
-                if orig_tearDownClass is not None:
-                    orig_tearDownClass()
-                sys.modules.clear()
-                sys.modules.update(cls_._save_sys_modules)
-            cls.setUpClass = setUpClass
-            cls.tearDownClass = tearDownClass
-            tests.addTests(loader.loadTestsFromTestCase(cls))
+
+            @functools.wraps(cls, updated=())
+            class Wrapper(cls):
+                @classmethod
+                def setUpClass(cls_, module=module):
+                    cls_._save_sys_modules = sys.modules.copy()
+                    sys.modules[TESTS] = module
+                    sys.modules['datetime'] = module.datetime_module
+                    if hasattr(module, '_pydatetime'):
+                        sys.modules['_pydatetime'] = module._pydatetime
+                    sys.modules['_strptime'] = module._strptime
+                    super().setUpClass()
+
+                @classmethod
+                def tearDownClass(cls_):
+                    super().tearDownClass()
+                    sys.modules.clear()
+                    sys.modules.update(cls_._save_sys_modules)
+
+            tests.addTests(loader.loadTestsFromTestCase(Wrapper))
     return tests
 
 


### PR DESCRIPTION
Now the example test from the original issue passes:

```python
» ./python.exe -m test test_datetime -v -m test_example_bug
== CPython 3.14.0a0 (heads/main-dirty:6646a9da26d, Jun 7 2024, 13:34:08) [Clang 15.0.0 (clang-1500.3.9.4)]
== macOS-14.4.1-arm64-arm-64bit-Mach-O little-endian
== Python build: debug
== cwd: /Users/sobolev/Desktop/cpython2/build/test_python_worker_65090æ
== CPU count: 12
== encodings: locale=UTF-8 FS=utf-8
== resources: all test resources are disabled, use -u option to unskip tests

Using random seed: 485307049
0:00:00 load avg: 1.16 Run 1 test sequentially in a single process
0:00:00 load avg: 1.16 [1/1] test_datetime
test_example_bug (test.datetimetester.TestExample_Pure.test_example_bug) ... ok
test_example_bug (test.datetimetester.TestExample_Fast.test_example_bug) ... ok

----------------------------------------------------------------------
Ran 2 tests in 0.000s

OK

== Tests result: SUCCESS ==

1 test OK.

Total duration: 128 ms
Total tests: run=2 (filtered)
Total test files: run=1/1 (filtered)
Result: SUCCESS
```

<!-- gh-issue-number: gh-120242 -->
* Issue: gh-120242
<!-- /gh-issue-number -->
