### PR TITLE
gh-120244: Fix `re.sub()` reference leak

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-06-08-09-45-31.gh-issue-120244.8o9Dzr.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-08-09-45-31.gh-issue-120244.8o9Dzr.rst
@@ -1,0 +1,1 @@
+Fix memory leak in :meth:`re.sub()` when ``\number`` is specified to refer to a group.

--- a/Misc/NEWS.d/next/Library/2024-06-08-09-45-31.gh-issue-120244.8o9Dzr.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-08-09-45-31.gh-issue-120244.8o9Dzr.rst
@@ -1,1 +1,1 @@
-Fix memory leak in :meth:`re.sub()` when ``\number`` is specified to refer to a group.
+Fix memory leak in :func:`re.sub()` when the replacement string contains backreferences.

--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -1622,6 +1622,7 @@ _sre_template_impl(PyObject *module, PyObject *pattern, PyObject *template)
         }
         self->items[i].literal = Py_XNewRef(literal);
     }
+    PyObject_GC_Track(self);
     return (PyObject*) self;
 
 bad_template:


### PR DESCRIPTION
```
>python_d -X showrefcount -c "import re; re.sub(r'()', r'\1', '')"
[7140 refs, 4669 blocks]  # Before
[0 refs, 0 blocks]        # After
```

This patch is based on the commit: 75a6fadf369315b27e12f670e6295cf2c2cf7d7e.

cc @serhiy-storchaka


<!-- gh-issue-number: gh-120244 -->
* Issue: gh-120244
<!-- /gh-issue-number -->
