### PR TITLE
gh-120246: Enhancement for OrderedDict: Add `reorder_by_values` method

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -298,6 +298,13 @@ class OrderedDict(dict):
     def copy(self):
         'od.copy() -> a shallow copy of od'
         return self.__class__(self)
+    
+    def reorder_by_values(self):
+        '''Reorder the OrderedDict based on its values.'''
+        sorted_items = sorted(self.items(), key=lambda item: item[1])
+        self.clear()
+        for key, value in sorted_items:
+            self[key] = value
 
     @classmethod
     def fromkeys(cls, iterable, value=None):

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -298,7 +298,7 @@ class OrderedDict(dict):
     def copy(self):
         'od.copy() -> a shallow copy of od'
         return self.__class__(self)
-    
+
     def reorder_by_values(self):
         '''Reorder the OrderedDict based on its values.'''
         sorted_items = sorted(self.items(), key=lambda item: item[1])


### PR DESCRIPTION
This pull request addresses #120246 and enhances the `OrderedDict` class in the `collections` module by adding a new method `reorder_by_values`. This method sorts the items in the `OrderedDict` based on their values and reorders the dictionary accordingly. 

**Changes:**
- Added `reorder_by_values` method to `OrderedDict` class.
- Included a docstring for the new method explaining its functionality.

**Example Usage:**
```python
od = OrderedDict()
od['a'] = 3
od['b'] = 1
od['c'] = 2

od.reorder_by_values()
print(od)  # Output: OrderedDict([('b', 1), ('c', 2), ('a', 3)])
```

<!-- gh-issue-number: gh-120246 -->
* Issue: gh-120246
<!-- /gh-issue-number -->
