### PR TITLE
gh-119182: Decode PyUnicode_FromFormat() format string from UTF-8

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -387,7 +387,8 @@ APIs:
    arguments, calculate the size of the resulting Python Unicode string and return
    a string with the values formatted into it.  The variable arguments must be C
    types and must correspond exactly to the format characters in the *format*
-   ASCII-encoded string.
+   string. The *format* string is decoded from UTF-8 with the "replace" error
+   handler.
 
    A conversion specifier contains two or more characters and has the following
    components, which must occur in this order:
@@ -487,7 +488,8 @@ APIs:
 
       * - ``s``
         - :c:expr:`const char*` or :c:expr:`const wchar_t*`
-        - A null-terminated C character array.
+        - A null-terminated C character array. :c:expr:`const char*` is decoded
+          from UTF-8 with the "replace" error handler.
 
       * - ``p``
         - :c:expr:`const void*`
@@ -575,6 +577,9 @@ APIs:
 
    .. versionchanged:: 3.13
       Support for ``%T``, ``%#T``, ``%N`` and ``%#N`` formats added.
+
+   .. versionchanged:: 3.14
+      The format string is now decoded from UTF-8 instead of ASCII.
 
 
 .. c:function:: PyObject* PyUnicode_FromFormatV(const char *format, va_list vargs)

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -387,7 +387,7 @@ APIs:
    arguments, calculate the size of the resulting Python Unicode string and return
    a string with the values formatted into it.  The variable arguments must be C
    types and must correspond exactly to the format characters in the *format*
-   string. The *format* string is decoded from UTF-8 with the "replace" error
+   string. The *format* string is decoded from UTF-8 with the "strict" error
    handler.
 
    A conversion specifier contains two or more characters and has the following

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -387,8 +387,7 @@ APIs:
    arguments, calculate the size of the resulting Python Unicode string and return
    a string with the values formatted into it.  The variable arguments must be C
    types and must correspond exactly to the format characters in the *format*
-   string. The *format* string is decoded from UTF-8 with the "strict" error
-   handler.
+   string. The *format* string is decoded from UTF-8.
 
    A conversion specifier contains two or more characters and has the following
    components, which must occur in this order:

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -261,8 +261,8 @@ New Features
 Porting to Python 3.14
 ----------------------
 
-* :c:func:`PyUnicode_FromFormat` now decodes the format string from UTF-8 with
-  the "strict" error handler, instead of decoding it from ASCII.
+* :c:func:`PyUnicode_FromFormat` now decodes the format string from UTF-8,
+  instead of ASCII.
   (Contributed by Victor Stinner in :gh:`119182`.)
 
 Deprecated

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -261,6 +261,10 @@ New Features
 Porting to Python 3.14
 ----------------------
 
+* :c:func:`PyUnicode_FromFormat` now decodes the format string from UTF-8 with
+  the "replace" error handler, instead of decoding it from ASCII.
+  (Contributed by Victor Stinner in :gh:`119182`.)
+
 Deprecated
 ----------
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -262,7 +262,7 @@ Porting to Python 3.14
 ----------------------
 
 * :c:func:`PyUnicode_FromFormat` now decodes the format string from UTF-8 with
-  the "replace" error handler, instead of decoding it from ASCII.
+  the "strict" error handler, instead of decoding it from ASCII.
   (Contributed by Victor Stinner in :gh:`119182`.)
 
 Deprecated

--- a/Lib/test/test_capi/test_unicode.py
+++ b/Lib/test/test_capi/test_unicode.py
@@ -380,7 +380,7 @@ class CAPITest(unittest.TestCase):
             text = PyUnicode_FromFormat(format, *args)
             self.assertEqual(expected, text)
 
-        # ascii format, non-ascii argument
+        # ASCII format, non-ASCII %U argument
         check_format('ascii\x7f=unicode\xe9',
                      b'ascii\x7f=%U', 'unicode\xe9')
 
@@ -391,6 +391,12 @@ class CAPITest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'format string') as cm:
             PyUnicode_FromFormat(b'invalid format string\xff: %s', b'abc')
         self.assertIsInstance(cm.exception.__context__, UnicodeDecodeError)
+
+        # Truncated UTF-8 format strings
+        with self.assertRaisesRegex(ValueError, 'format string'):
+            PyUnicode_FromFormat(b'truncated utf8: \xc3')
+        with self.assertRaisesRegex(ValueError, 'format string'):
+            PyUnicode_FromFormat(b'truncated utf8: \xe2\x82')
 
         # test "%c"
         check_format('\uabcd',

--- a/Lib/test/test_capi/test_unicode.py
+++ b/Lib/test/test_capi/test_unicode.py
@@ -384,12 +384,12 @@ class CAPITest(unittest.TestCase):
         check_format('ascii\x7f=unicode\xe9',
                      b'ascii\x7f=%U', 'unicode\xe9')
 
-        # non-ascii format, ascii argument: ensure that PyUnicode_FromFormatV()
-        # raises an error
-        self.assertRaisesRegex(ValueError,
-            r'^PyUnicode_FromFormatV\(\) expects an ASCII-encoded format '
-            'string, got a non-ASCII byte: 0xe9$',
-            PyUnicode_FromFormat, b'unicode\xe9=%s', 'ascii')
+        # Non-ASCII format and non-ASCII arguments are both decoded
+        # from UTF-8/replace
+        check_format('unicode\xe9=\u20ac',
+                     'unicode\xe9=%s'.encode(), '\u20ac'.encode())
+        check_format('invalid\ufffd=abc\ufffd',
+                     b'invalid\xe9=%s', b'abc\xe9')
 
         # test "%c"
         check_format('\uabcd',

--- a/Lib/test/test_capi/test_unicode.py
+++ b/Lib/test/test_capi/test_unicode.py
@@ -384,12 +384,13 @@ class CAPITest(unittest.TestCase):
         check_format('ascii\x7f=unicode\xe9',
                      b'ascii\x7f=%U', 'unicode\xe9')
 
-        # Non-ASCII format and non-ASCII arguments are both decoded
-        # from UTF-8/replace
-        check_format('unicode\xe9=\u20ac',
-                     'unicode\xe9=%s'.encode(), '\u20ac'.encode())
-        check_format('invalid\ufffd=abc\ufffd',
-                     b'invalid\xe9=%s', b'abc\xe9')
+        # The %s arguments are decoded from UTF-8/replace.
+        # The format string is decoded from UTF-8/strict.
+        check_format('value=utf8 \u20ac',
+                     'value=%s'.encode(), 'utf8 \u20ac'.encode())
+        with self.assertRaisesRegex(ValueError, 'format string') as cm:
+            PyUnicode_FromFormat(b'invalid format string\xff: %s', b'abc')
+        self.assertIsInstance(cm.exception.__context__, UnicodeDecodeError)
 
         # test "%c"
         check_format('\uabcd',

--- a/Misc/NEWS.d/next/C API/2024-06-07-22-38-08.gh-issue-119182.P3nXBm.rst
+++ b/Misc/NEWS.d/next/C API/2024-06-07-22-38-08.gh-issue-119182.P3nXBm.rst
@@ -1,3 +1,2 @@
-:c:func:`PyUnicode_FromFormat` now decodes the format string from UTF-8 with
-the "strict" error handler, instead of decoding it from ASCII. Patch by
-Victor Stinner.
+:c:func:`PyUnicode_FromFormat` now decodes the format string from UTF-8,
+instead of ASCII. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2024-06-07-22-38-08.gh-issue-119182.P3nXBm.rst
+++ b/Misc/NEWS.d/next/C API/2024-06-07-22-38-08.gh-issue-119182.P3nXBm.rst
@@ -1,0 +1,3 @@
+:c:func:`PyUnicode_FromFormat` now decodes the format string from UTF-8 with
+the "replace" error handler, instead of decoding it from ASCII. Patch by
+Victor Stinner.

--- a/Misc/NEWS.d/next/C API/2024-06-07-22-38-08.gh-issue-119182.P3nXBm.rst
+++ b/Misc/NEWS.d/next/C API/2024-06-07-22-38-08.gh-issue-119182.P3nXBm.rst
@@ -1,3 +1,3 @@
 :c:func:`PyUnicode_FromFormat` now decodes the format string from UTF-8 with
-the "replace" error handler, instead of decoding it from ASCII. Patch by
+the "strict" error handler, instead of decoding it from ASCII. Patch by
 Victor Stinner.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -2905,7 +2905,12 @@ PyUnicode_FromFormatV(const char *format, va_list vargs)
             }
 
             if (unicode_decode_utf8_writer(&writer, f, len,
-                                           _Py_ERROR_REPLACE, "replace") < 0) {
+                                           _Py_ERROR_STRICT, "strict") < 0) {
+                PyObject *exc = PyErr_GetRaisedException();
+                PyErr_Format(PyExc_ValueError,
+                    "PyUnicode_FromFormatV() expects a valid UTF-8-encoded "
+                    "format string, got an invalid UTF-8 string");
+                _PyErr_ChainExceptions1(exc);
                 goto fail;
             }
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -2907,7 +2907,7 @@ PyUnicode_FromFormatV(const char *format, va_list vargs)
             if (unicode_decode_utf8_writer(&writer, f, len,
                                            _Py_ERROR_STRICT, "strict") < 0) {
                 PyObject *exc = PyErr_GetRaisedException();
-                PyErr_Format(PyExc_ValueError,
+                PyErr_SetString(PyExc_ValueError,
                     "PyUnicode_FromFormatV() expects a valid UTF-8-encoded "
                     "format string, got an invalid UTF-8 string");
                 _PyErr_ChainExceptions1(exc);


### PR DESCRIPTION
PyUnicode_FromFormat() now decodes the format string from UTF-8 with the "replace" error handler, instead of decoding it from ASCII.

Remove unused 'consumed' parameter of unicode_decode_utf8_writer().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119182 -->
* Issue: gh-119182
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120248.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->