### PR TITLE
gh-119664: use conditional removal notice for ``codeobject.co_lnotab``

### DIFF
--- a/Doc/whatsnew/3.10.rst
+++ b/Doc/whatsnew/3.10.rst
@@ -404,7 +404,7 @@ expected line number.
 
 The :attr:`~codeobject.co_lnotab` attribute of
 :ref:`code objects <code-objects>` is deprecated and
-will be removed in 3.12.
+may be removed in a future version.
 Code that needs to convert from offset to line number should use the new
 :meth:`~codeobject.co_lines` method instead.
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1324,10 +1324,10 @@ Deprecated
   ``int``, convert to int explicitly: ``~int(x)``. (Contributed by Tim Hoffmann
   in :gh:`103487`.)
 
-* Accessing :attr:`~codeobject.co_lnotab` on code objects was deprecated in
-  Python 3.10 via :pep:`626`,
-  but it only got a proper :exc:`DeprecationWarning` in 3.12,
-  therefore it will be removed in 3.14.
+* :class:`types.CodeType`: Accessing :attr:`~codeobject.co_lnotab` was
+  deprecated in :pep:`626` since 3.10 and was planned to be removed in 3.12,
+  but it only got a proper :exc:`DeprecationWarning` in 3.12. May be removed
+  in a future version. Use the :meth:`codeobject.co_lines` method instead.
   (Contributed by Nikita Sobolev in :gh:`101866`.)
 
 Pending Removal in Python 3.13
@@ -1442,8 +1442,6 @@ and will be removed in Python 3.14.
 
 * The ``__package__`` and ``__cached__`` attributes on module objects.
 
-* The :attr:`~codeobject.co_lnotab` attribute of code objects.
-
 Pending Removal in Python 3.15
 ------------------------------
 
@@ -1462,6 +1460,8 @@ The following APIs were deprecated in earlier Python versions and will be remove
 although there is currently no date scheduled for their removal.
 
 * :mod:`array`'s ``'u'`` format code (:gh:`57281`)
+
+* The :attr:`~codeobject.co_lnotab` attribute of code objects.
 
 * :class:`typing.Text` (:gh:`92332`)
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1713,13 +1713,6 @@ Pending Removal in Python 3.14
   * date and datetime adapter, date and timestamp converter:
     see the :mod:`sqlite3` documentation for suggested replacement recipes.
 
-* :class:`types.CodeType`: Accessing :attr:`~codeobject.co_lnotab` was
-  deprecated in :pep:`626`
-  since 3.10 and was planned to be removed in 3.12,
-  but it only got a proper :exc:`DeprecationWarning` in 3.12.
-  May be removed in 3.14.
-  (Contributed by Nikita Sobolev in :gh:`101866`.)
-
 * :mod:`typing`: :class:`!typing.ByteString`, deprecated since Python 3.9,
   now causes a :exc:`DeprecationWarning` to be emitted when it is used.
 
@@ -1834,6 +1827,11 @@ although there is currently no date scheduled for their removal.
 
 * :attr:`codeobject.co_lnotab`: use the :meth:`codeobject.co_lines` method
   instead.
+
+  Accessing :attr:`~codeobject.co_lnotab` was deprecated in :pep:`626`
+  since 3.10 and was planned to be removed in 3.12, but it only got a
+  proper :exc:`DeprecationWarning` in 3.12.
+  (Contributed by Nikita Sobolev in :gh:`101866`.)
 
 * :mod:`datetime`:
 

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -348,7 +348,7 @@ class CodeTest(unittest.TestCase):
         new_code = code = func.__code__.replace(co_linetable=b'')
         self.assertEqual(list(new_code.co_lines()), [])
 
-    def test_co_lnotab_is_deprecated(self):  # TODO: remove in 3.14
+    def test_co_lnotab_is_deprecated(self):  # TODO: remove in 3.14 or later
         def func():
             pass
 

--- a/Misc/NEWS.d/3.12.0a7.rst
+++ b/Misc/NEWS.d/3.12.0a7.rst
@@ -200,7 +200,7 @@ Bachmann.
 .. section: Core and Builtins
 
 Deprecate ``co_lnotab`` in code objects, schedule it for removal in Python
-3.14
+3.14 or later.
 
 ..
 


### PR DESCRIPTION
This is an alternative to #119665 where the removal notice is written in a conditional form.

- For 3.10: replaced the explicit 3.12 by "future version"
- For 3.11: nothing was mentioned.
- For 3.12: used the original 3.13 formulation for the "Deprecated" section. Moved the item under the "Pending removal in 3.14" into the "Pending removal" section. Used the same formulation as in 3.13 as well. Replace the explicit mention of 3.14 by "future version". 
- For 3.13: merged the verbose deprecation notice in the "Deprecated" section with the deprecation notice in the "Pending removal" section. That way, we know that 3.13 is only reminding us that something will be removed in the future, but this is not something that was deprecated in 3.13. There is no need for a "future version" or a "3.14" mention since it is under the "Pending removal in a future version" section.

cc @iritkatriel 

<!-- gh-issue-number: gh-119664 -->
* Issue: gh-119664
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120263.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->