### PR TITLE
gh-120276: Fix incorrect `email.header.Header` `maxlinelen` default.

### DIFF
--- a/Doc/library/email.header.rst
+++ b/Doc/library/email.header.rst
@@ -77,7 +77,7 @@ Here is the :class:`Header` class description:
    The maximum line length can be specified explicitly via *maxlinelen*.  For
    splitting the first line to a shorter value (to account for the field header
    which isn't included in *s*, e.g. :mailheader:`Subject`) pass in the name of the
-   field in *header_name*.  The default *maxlinelen* is 76, and the default value
+   field in *header_name*.  The default *maxlinelen* is 78, and the default value
    for *header_name* is ``None``, meaning it is not taken into account for the
    first line of a long, split header.
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-120276 -->
* Issue: gh-120276
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120277.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->