### PR TITLE
gh-120291: Fix a bashism in python-config.sh.in

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-06-09-15-54-22.gh-issue-120291.IpfHzE.rst
+++ b/Misc/NEWS.d/next/Build/2024-06-09-15-54-22.gh-issue-120291.IpfHzE.rst
@@ -1,0 +1,1 @@
+Make the ``python-config`` shell script compatible with non-bash shells.

--- a/Misc/python-config.sh.in
+++ b/Misc/python-config.sh.in
@@ -4,11 +4,12 @@
 
 exit_with_usage ()
 {
-    local USAGE="Usage: $0 --prefix|--exec-prefix|--includes|--libs|--cflags|--ldflags|--extension-suffix|--help|--abiflags|--configdir|--embed"
-    if [[ "$1" -eq 0 ]]; then
-        echo "$USAGE"
+    local usage
+    usage="Usage: $0 --prefix|--exec-prefix|--includes|--libs|--cflags|--ldflags|--extension-suffix|--help|--abiflags|--configdir|--embed"
+    if [ "$1" -eq 0 ]; then
+        echo "$usage"
     else
-        echo "$USAGE" >&2
+        echo "$usage" >&2
     fi
     exit $1
 }


### PR DESCRIPTION
Replace the use of bash-specific `[[ ... ]]` with POSIX-compliant `[ ... ]` to make the `python-config` shell script work with non-bash shells again.

Fixes #120291

<!-- gh-issue-number: gh-120291 -->
* Issue: gh-120291
<!-- /gh-issue-number -->
