### PR TITLE
gh-115528: Update language reference for PEP 646

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1341,7 +1341,7 @@ a different order than they appear in the source code.
 
 .. versionchanged:: 3.11
    Parameters of the form "``*identifier``" may have an annotation
-   "``: *expression``". See :pep:`646` for details.
+   "``: *expression``". See :pep:`646`.
 
 .. index:: pair: lambda; expression
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1217,9 +1217,10 @@ A function definition defines a user-defined function object (see section
                  :   | `parameter_list_no_posonly`
    parameter_list_no_posonly: `defparameter` ("," `defparameter`)* ["," [`parameter_list_starargs`]]
                             : | `parameter_list_starargs`
-   parameter_list_starargs: "*" [`parameter`] ("," `defparameter`)* ["," ["**" `parameter` [","]]]
+   parameter_list_starargs: "*" [`star_parameter`] ("," `defparameter`)* ["," ["**" `parameter` [","]]]
                           : | "**" `parameter` [","]
    parameter: `identifier` [":" `expression`]
+   star_parameter: `identifier` [":" ["*"] `expression`]
    defparameter: `parameter` ["=" `expression`]
    funcname: `identifier`
 
@@ -1326,7 +1327,8 @@ and may only be passed by positional arguments.
 
 Parameters may have an :term:`annotation <function annotation>` of the form "``: expression``"
 following the parameter name.  Any parameter may have an annotation, even those of the form
-``*identifier`` or ``**identifier``.  Functions may have "return" annotation of
+``*identifier`` or ``**identifier``. (As a special case, parameters of the form
+``*identifier`` may have an annotation "``: *expression``".) Functions may have "return" annotation of
 the form "``-> expression``" after the parameter list.  These annotations can be
 any valid Python expression.  The presence of annotations does not change the
 semantics of a function.  The annotation values are available as values of
@@ -1336,6 +1338,10 @@ attribute of the function object.  If the ``annotations`` import from
 enables postponed evaluation.  Otherwise, they are evaluated when the function
 definition is executed.  In this case annotations may be evaluated in
 a different order than they appear in the source code.
+
+.. versionchanged:: 3.11
+   Parameters of the form "``*identifier``" may have an annotation
+   "``: *expression``". See :pep:`646` for details.
 
 .. index:: pair: lambda; expression
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -873,9 +873,13 @@ primary is subscripted, the evaluated result of the expression list will be
 passed to one of these methods. For more details on when ``__class_getitem__``
 is called instead of ``__getitem__``, see :ref:`classgetitem-versus-getitem`.
 
-If the expression list contains at least one comma, it will evaluate to a
-:class:`tuple` containing the items of the expression list. Otherwise, the
-expression list will evaluate to the value of the list's sole member.
+If the expression list contains at least one comma, or if any of the expressions
+is starred, the expression list will evaluate to a :class:`tuple` containing the
+items of the expression list. Otherwise, the expression list will evaluate to
+the value of the list's sole member.
+
+.. versionchanged:: 3.11
+   Expressions in an expression list may be starred. See :pep:`646` for details.
 
 For built-in objects, there are two types of objects that support subscription
 via :meth:`~object.__getitem__`:
@@ -1874,7 +1878,7 @@ Expression lists
    single: , (comma); expression list
 
 .. productionlist:: python-grammar
-   expression_list: `expression` ("," `expression`)* [","]
+   expression_list: `starred_expression` ("," `starred_expression`)* [","]
    starred_list: `starred_item` ("," `starred_item`)* [","]
    starred_expression: `expression` | (`starred_item` ",")* [`starred_item`]
    starred_item: `assignment_expression` | "*" `or_expr`
@@ -1897,6 +1901,9 @@ the unpacking.
 
 .. versionadded:: 3.5
    Iterable unpacking in expression lists, originally proposed by :pep:`448`.
+
+.. versionadded:: 3.11
+   Any item in an expression list may be starred. See :pep:`646`.
 
 .. index:: pair: trailing; comma
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -423,7 +423,7 @@ Yield expressions
 .. productionlist:: python-grammar
    yield_atom: "(" `yield_expression` ")"
    yield_from: "yield" "from" `expression`
-   yield_expression: "yield" `expression_list` | `yield_from`
+   yield_expression: "yield" `yield_list` | `yield_from`
 
 The yield expression is used when defining a :term:`generator` function
 or an :term:`asynchronous generator` function and
@@ -454,9 +454,9 @@ When a generator function is called, it returns an iterator known as a
 generator.  That generator then controls the execution of the generator
 function.  The execution starts when one of the generator's methods is called.
 At that time, the execution proceeds to the first yield expression, where it is
-suspended again, returning the value of :token:`~python-grammar:expression_list`
-to the generator's caller,
-or ``None`` if :token:`~python-grammar:expression_list` is omitted.
+suspended again, returning the value of
+:token:`~python-grammar:flexible_expression_list` to the generator's caller,
+or ``None`` if :token:`~python-grammar:flexible_expression_list` is omitted.
 By suspended, we mean that all local state is
 retained, including the current bindings of local variables, the instruction
 pointer, the internal evaluation stack, and the state of any exception handling.
@@ -545,9 +545,9 @@ is already executing raises a :exc:`ValueError` exception.
    :meth:`~generator.__next__` method, the current yield expression always
    evaluates to :const:`None`.  The execution then continues to the next yield
    expression, where the generator is suspended again, and the value of the
-   :token:`~python-grammar:expression_list` is returned to :meth:`__next__`'s
-   caller.  If the generator exits without yielding another value, a
-   :exc:`StopIteration` exception is raised.
+   :token:`~python-grammar:flexible_expression_list` is returned to
+   :meth:`__next__`'s caller.  If the generator exits without yielding another
+   value, a :exc:`StopIteration` exception is raised.
 
    This method is normally called implicitly, e.g. by a :keyword:`for` loop, or
    by the built-in :func:`next` function.
@@ -664,17 +664,17 @@ how a generator object would be used in a :keyword:`for` statement.
 Calling one of the asynchronous generator's methods returns an :term:`awaitable`
 object, and the execution starts when this object is awaited on. At that time,
 the execution proceeds to the first yield expression, where it is suspended
-again, returning the value of :token:`~python-grammar:expression_list` to the
-awaiting coroutine. As with a generator, suspension means that all local state
-is retained, including the current bindings of local variables, the instruction
-pointer, the internal evaluation stack, and the state of any exception handling.
-When the execution is resumed by awaiting on the next object returned by the
-asynchronous generator's methods, the function can proceed exactly as if the
-yield expression were just another external call. The value of the yield
-expression after resuming depends on the method which resumed the execution.  If
-:meth:`~agen.__anext__` is used then the result is :const:`None`. Otherwise, if
-:meth:`~agen.asend` is used, then the result will be the value passed in to that
-method.
+again, returning the value of :token:`~python-grammar:flexible_expression_list`
+to the awaiting coroutine. As with a generator, suspension means that all local
+state is retained, including the current bindings of local variables, the
+instruction pointer, the internal evaluation stack, and the state of any
+exception handling. When the execution is resumed by awaiting on the next object
+returned by the asynchronous generator's methods, the function can proceed
+exactly as if the yield expression were just another external call. The value of
+the yield expression after resuming depends on the method which resumed the
+execution. If :meth:`~agen.__anext__` is used then the result is :const:`None`.
+Otherwise, if :meth:`~agen.asend` is used, then the result will be the value
+passed in to that method.
 
 If an asynchronous generator happens to exit early by :keyword:`break`, the caller
 task being cancelled, or other exceptions, the generator's async cleanup code
@@ -728,10 +728,10 @@ which are used to control the execution of a generator function.
    asynchronous generator function is resumed with an :meth:`~agen.__anext__`
    method, the current yield expression always evaluates to :const:`None` in the
    returned awaitable, which when run will continue to the next yield
-   expression. The value of the :token:`~python-grammar:expression_list` of the
-   yield expression is the value of the :exc:`StopIteration` exception raised by
-   the completing coroutine.  If the asynchronous generator exits without
-   yielding another value, the awaitable instead raises a
+   expression. The value of the :token:`~python-grammar:flexible_expression_list`
+   of the yield expression is the value of the :exc:`StopIteration` exception
+   raised by the completing coroutine.  If the asynchronous generator exits
+   without yielding another value, the awaitable instead raises a
    :exc:`StopAsyncIteration` exception, signalling that the asynchronous
    iteration has completed.
 
@@ -861,7 +861,7 @@ will generally select an element from the container. The subscription of a
 :ref:`GenericAlias <types-genericalias>` object.
 
 .. productionlist:: python-grammar
-   subscription: `primary` "[" `expression_list` "]"
+   subscription: `primary` "[" `flexible_expression_list` "]"
 
 When an object is subscripted, the interpreter will evaluate the primary and
 the expression list.
@@ -1878,10 +1878,12 @@ Expression lists
    single: , (comma); expression list
 
 .. productionlist:: python-grammar
-   expression_list: `starred_expression` ("," `starred_expression`)* [","]
-   starred_list: `starred_item` ("," `starred_item`)* [","]
-   starred_expression: `expression` | (`starred_item` ",")* [`starred_item`]
-   starred_item: `assignment_expression` | "*" `or_expr`
+
+   starred_item: "*" `or_expr`
+   flexible_expression: `expression` | `assignment_expression` | `starred_item`
+   flexible_expression_list: `flexible_expression` ("," `flexible_expression`)* [","]
+   yield_list: `expression` ["," `flexible_expression_list`]
+               | `starred_item` "," [`flexible_expression_list`]
 
 .. index:: pair: object; tuple
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -874,12 +874,12 @@ passed to one of these methods. For more details on when ``__class_getitem__``
 is called instead of ``__getitem__``, see :ref:`classgetitem-versus-getitem`.
 
 If the expression list contains at least one comma, or if any of the expressions
-is starred, the expression list will evaluate to a :class:`tuple` containing the
-items of the expression list. Otherwise, the expression list will evaluate to
-the value of the list's sole member.
+are starred, the expression list will evaluate to a :class:`tuple` containing
+the items of the expression list. Otherwise, the expression list will evaluate
+to the value of the list's sole member.
 
 .. versionchanged:: 3.11
-   Expressions in an expression list may be starred. See :pep:`646` for details.
+   Expressions in an expression list may be starred. See :pep:`646`.
 
 For built-in objects, there are two types of objects that support subscription
 via :meth:`~object.__getitem__`:

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -253,7 +253,7 @@ A list display is a possibly empty series of expressions enclosed in square
 brackets:
 
 .. productionlist:: python-grammar
-   list_display: "[" [`starred_list` | `comprehension`] "]"
+   list_display: "[" [`expression_list` | `comprehension`] "]"
 
 A list display yields a new list object, the contents being specified by either
 a list of expressions or a comprehension.  When a comma-separated list of
@@ -278,7 +278,7 @@ A set display is denoted by curly braces and distinguishable from dictionary
 displays by the lack of colons separating keys and values:
 
 .. productionlist:: python-grammar
-   set_display: "{" (`starred_list` | `comprehension`) "}"
+   set_display: "{" (`expression_list` | `comprehension`) "}"
 
 A set display yields a new mutable set object, the contents being specified by
 either a sequence of expressions or a comprehension.  When a comma-separated
@@ -455,8 +455,8 @@ generator.  That generator then controls the execution of the generator
 function.  The execution starts when one of the generator's methods is called.
 At that time, the execution proceeds to the first yield expression, where it is
 suspended again, returning the value of
-:token:`~python-grammar:flexible_expression_list` to the generator's caller,
-or ``None`` if :token:`~python-grammar:flexible_expression_list` is omitted.
+:token:`~python-grammar:expression_list` to the generator's caller,
+or ``None`` if :token:`~python-grammar:expression_list` is omitted.
 By suspended, we mean that all local state is
 retained, including the current bindings of local variables, the instruction
 pointer, the internal evaluation stack, and the state of any exception handling.
@@ -545,7 +545,7 @@ is already executing raises a :exc:`ValueError` exception.
    :meth:`~generator.__next__` method, the current yield expression always
    evaluates to :const:`None`.  The execution then continues to the next yield
    expression, where the generator is suspended again, and the value of the
-   :token:`~python-grammar:flexible_expression_list` is returned to
+   :token:`~python-grammar:expression_list` is returned to
    :meth:`__next__`'s caller.  If the generator exits without yielding another
    value, a :exc:`StopIteration` exception is raised.
 
@@ -664,7 +664,7 @@ how a generator object would be used in a :keyword:`for` statement.
 Calling one of the asynchronous generator's methods returns an :term:`awaitable`
 object, and the execution starts when this object is awaited on. At that time,
 the execution proceeds to the first yield expression, where it is suspended
-again, returning the value of :token:`~python-grammar:flexible_expression_list`
+again, returning the value of :token:`~python-grammar:expression_list`
 to the awaiting coroutine. As with a generator, suspension means that all local
 state is retained, including the current bindings of local variables, the
 instruction pointer, the internal evaluation stack, and the state of any
@@ -728,7 +728,7 @@ which are used to control the execution of a generator function.
    asynchronous generator function is resumed with an :meth:`~agen.__anext__`
    method, the current yield expression always evaluates to :const:`None` in the
    returned awaitable, which when run will continue to the next yield
-   expression. The value of the :token:`~python-grammar:flexible_expression_list`
+   expression. The value of the :token:`~python-grammar:expression_list`
    of the yield expression is the value of the :exc:`StopIteration` exception
    raised by the completing coroutine.  If the asynchronous generator exits
    without yielding another value, the awaitable instead raises a
@@ -861,7 +861,7 @@ will generally select an element from the container. The subscription of a
 :ref:`GenericAlias <types-genericalias>` object.
 
 .. productionlist:: python-grammar
-   subscription: `primary` "[" `flexible_expression_list` "]"
+   subscription: `primary` "[" `expression_list` "]"
 
 When an object is subscripted, the interpreter will evaluate the primary and
 the expression list.
@@ -1879,11 +1879,11 @@ Expression lists
 
 .. productionlist:: python-grammar
 
-   starred_item: "*" `or_expr`
-   flexible_expression: `expression` | `assignment_expression` | `starred_item`
-   flexible_expression_list: `flexible_expression` ("," `flexible_expression`)* [","]
-   yield_list: `expression` ["," `flexible_expression_list`]
-               | `starred_item` "," [`flexible_expression_list`]
+   expression_list: `flexible_expression` ("," `flexible_expression`)* [","]
+   yield_list: `expression` ["," `expression_list`]
+               | `starred_expression` "," [`expression_list`]
+   flexible_expression: `assignment_expression` | `starred_expression`
+   starred_expression: "*" `or_expr`
 
 .. index:: pair: object; tuple
 


### PR DESCRIPTION

<!-- gh-issue-number: gh-115528 -->
* Issue: gh-115528
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120294.org.readthedocs.build/

Changed sections:
* https://cpython-previews--120294.org.readthedocs.build/en/120294/reference/compound_stmts.html#function-definitions
* https://cpython-previews--120294.org.readthedocs.build/en/120294/reference/expressions.html#subscriptions
* https://cpython-previews--120294.org.readthedocs.build/en/120294/reference/expressions.html#expression-lists

<!-- readthedocs-preview cpython-previews end -->