### PR TITLE
gh-120296: Fix outdated format string in `fnctlmodule.fcntl_ioctl_impl`

### DIFF
--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -170,7 +170,7 @@ fcntl_ioctl_impl(PyObject *module, int fd, unsigned long code,
     Py_ssize_t len;
     char buf[IOCTL_BUFSZ+1];  /* argument plus NUL byte */
 
-    if (PySys_Audit("fcntl.ioctl", "iIO", fd, code,
+    if (PySys_Audit("fcntl.ioctl", "ikO", fd, code,
                     ob_arg ? ob_arg : Py_None) < 0) {
         return NULL;
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-120296 -->
* Issue: gh-120296
<!-- /gh-issue-number -->
