### PR TITLE
gh-119182: Use strict error handler in PyUnicode_FromFormat()

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -487,7 +487,8 @@ APIs:
 
       * - ``s``
         - :c:expr:`const char*` or :c:expr:`const wchar_t*`
-        - A null-terminated C character array.
+        - A null-terminated C character array. The argument is decoded from
+          UTF-8 with the "strict" error handler.
 
       * - ``p``
         - :c:expr:`const void*`
@@ -575,6 +576,10 @@ APIs:
 
    .. versionchanged:: 3.13
       Support for ``%T``, ``%#T``, ``%N`` and ``%#N`` formats added.
+
+   .. versionchanged:: 3.14
+      The ``"%s"`` format now decodes its argument from UTF-8 with the "strict"
+      error handler, instead of the "replace" error handler.
 
 
 .. c:function:: PyObject* PyUnicode_FromFormatV(const char *format, va_list vargs)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -261,6 +261,11 @@ New Features
 Porting to Python 3.14
 ----------------------
 
+* :c:func:`PyUnicode_FromFormat` now decodes the ``"%s"`` format argument from
+  UTF-8 with the "strict" error handler, instead of the "replace" error
+  handler.
+  (Contributed by Victor Stinner in :gh:`119182`.)
+
 Deprecated
 ----------
 

--- a/Lib/test/test_capi/test_getargs.py
+++ b/Lib/test/test_capi/test_getargs.py
@@ -1298,8 +1298,7 @@ class ParseTupleAndKeywords_Test(unittest.TestCase):
                 self.assertEqual(parse((), {}, '|O', [invalid]), (NULL,))
                 self.assertEqual(parse((1,), {'b': 2}, 'O|O', [invalid, 'b']),
                                     (1, 2))
-                with self.assertRaisesRegex(TypeError,
-                        f"function missing required argument '{name}\ufffd'"):
+                with self.assertRaises(UnicodeDecodeError):
                     parse((), {}, 'O', [invalid])
                 with self.assertRaisesRegex(UnicodeDecodeError,
                         f"'utf-8' codec can't decode bytes? "):

--- a/Misc/NEWS.d/next/C API/2024-06-07-22-38-08.gh-issue-119182.P3nXBm.rst
+++ b/Misc/NEWS.d/next/C API/2024-06-07-22-38-08.gh-issue-119182.P3nXBm.rst
@@ -1,0 +1,3 @@
+:c:func:`PyUnicode_FromFormat` now decodes the ``"%s"`` format argument from
+UTF-8 with the "strict" error handler, instead of the "replace" error handler.
+Patch by Victor Stinner.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -205,8 +205,7 @@ unicode_decode_utf8(const char *s, Py_ssize_t size,
 static int
 unicode_decode_utf8_writer(_PyUnicodeWriter *writer,
                            const char *s, Py_ssize_t size,
-                           _Py_error_handler error_handler, const char *errors,
-                           Py_ssize_t *consumed);
+                           _Py_error_handler error_handler, const char *errors);
 #ifdef Py_DEBUG
 static inline int unicode_is_finalizing(void);
 static int unicode_is_singleton(PyObject *unicode);
@@ -2402,11 +2401,11 @@ unicode_fromformat_write_utf8(_PyUnicodeWriter *writer, const char *str,
 
     if (width < 0) {
         return unicode_decode_utf8_writer(writer, str, length,
-                                          _Py_ERROR_REPLACE, "replace", NULL);
+                                          _Py_ERROR_STRICT, "strict");
     }
 
-    PyObject *unicode = PyUnicode_DecodeUTF8Stateful(str, length,
-                                                     "replace", NULL);
+    PyObject *unicode = unicode_decode_utf8(str, length,
+                                            _Py_ERROR_STRICT, "strict", NULL);
     if (unicode == NULL)
         return -1;
 
@@ -4930,13 +4929,9 @@ unicode_decode_utf8(const char *s, Py_ssize_t size,
 static int
 unicode_decode_utf8_writer(_PyUnicodeWriter *writer,
                            const char *s, Py_ssize_t size,
-                           _Py_error_handler error_handler, const char *errors,
-                           Py_ssize_t *consumed)
+                           _Py_error_handler error_handler, const char *errors)
 {
     if (size == 0) {
-        if (consumed) {
-            *consumed = 0;
-        }
         return 0;
     }
 
@@ -4954,9 +4949,6 @@ unicode_decode_utf8_writer(_PyUnicodeWriter *writer,
         writer->pos += decoded;
 
         if (decoded == size) {
-            if (consumed) {
-                *consumed = size;
-            }
             return 0;
         }
         s += decoded;
@@ -4964,7 +4956,7 @@ unicode_decode_utf8_writer(_PyUnicodeWriter *writer,
     }
 
     return unicode_decode_utf8_impl(writer, starts, s, end,
-                                    error_handler, errors, consumed);
+                                    error_handler, errors, NULL);
 }
 
 


### PR DESCRIPTION
PyUnicode_FromFormat() now decodes the "%s" format argument from UTF-8 with the "strict" error handler, instead of the "replace" error handler.

Remove the unused 'consumed' parameter of
unicode_decode_utf8_writer().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119182 -->
* Issue: gh-119182
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120307.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->