### PR TITLE
[3.12] gh-120154: On WASI, don't build test modules

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-06-10-11-42-13.gh-issue-120154.QL4kai.rst
+++ b/Misc/NEWS.d/next/Build/2024-06-10-11-42-13.gh-issue-120154.QL4kai.rst
@@ -1,0 +1,2 @@
+On WASI, test modules, such as ``_testimportmultiple`` or ``xxlimited``, are no
+longer built. Patch by Victor Stinner.

--- a/configure
+++ b/configure
@@ -28646,9 +28646,15 @@ case $ac_sys_system in #(
 
 
     py_cv_module__ctypes_test=n/a
+    py_cv_module__testexternalinspection=n/a
+    py_cv_module__testimportmultiple=n/a
+    py_cv_module__testmultiphase=n/a
+    py_cv_module__testsinglephase=n/a
     py_cv_module_fcntl=n/a
     py_cv_module_mmap=n/a
     py_cv_module_termios=n/a
+    py_cv_module_xxlimited=n/a
+    py_cv_module_xxlimited_35=n/a
     py_cv_module_=n/a
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -7302,9 +7302,15 @@ AS_CASE([$ac_sys_system],
         dnl WASI SDK 15.0 does not support file locking, mmap, and more.
         PY_STDLIB_MOD_SET_NA(
           [_ctypes_test],
+          [_testexternalinspection],
+          [_testimportmultiple],
+          [_testmultiphase],
+          [_testsinglephase],
           [fcntl],
           [mmap],
           [termios],
+          [xxlimited],
+          [xxlimited_35],
         )
       ]
     )


### PR DESCRIPTION
On WASI, test modules, such as _testimportmultiple or xxlimited, are no longer built.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120154 -->
* Issue: gh-120154
<!-- /gh-issue-number -->
