### PR TITLE
[3.11] gh-119506: fix _io.TextIOWrapper.write() write during flush (#119507)

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3960,6 +3960,28 @@ class CTextIOWrapperTest(TextIOWrapperTest):
         t.write("x"*chunk_size)
         self.assertEqual([b"abcdef", b"ghi", b"x"*chunk_size], buf._write_stack)
 
+    def test_issue119506(self):
+        chunk_size = 8192
+
+        class MockIO(self.MockRawIO):
+            written = False
+            def write(self, data):
+                if not self.written:
+                    self.written = True
+                    t.write("middle")
+                return super().write(data)
+
+        buf = MockIO()
+        t = self.TextIOWrapper(buf)
+        t.write("abc")
+        t.write("def")
+        # writing data which size >= chunk_size cause flushing buffer before write.
+        t.write("g" * chunk_size)
+        t.flush()
+
+        self.assertEqual([b"abcdef", b"middle", b"g"*chunk_size],
+                         buf._write_stack)
+
 
 class PyTextIOWrapperTest(TextIOWrapperTest):
     io = pyio

--- a/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
+++ b/Misc/NEWS.d/next/Library/2024-05-24-14-32-24.gh-issue-119506.-nMNqq.rst
@@ -1,0 +1,1 @@
+Fix :meth:`!io.TextIOWrapper.write` method breaks internal buffer when the method is called again during flushing internal buffer.


### PR DESCRIPTION
This PR is backport of https://github.com/python/cpython/pull/119507

This PR fixes TextIOWrapper's inner buffer breakage.
The bug caused assertion error when Python debug build.
I am not sure it can cause crash on release build. The bug will cause:

* Lost buffered data, and,
* NUL bytes can be written instead of the lost data.

Since this bug is not verified to cause crash (and DoS) in release build, I am not sure this PR is merged into security fix branches.
But this bug can cause serious bug (data lost/breakage). So I created this PR before details went away from my head.

<!-- gh-issue-number: gh-119506 -->
* Issue: gh-119506
<!-- /gh-issue-number -->
