### PR TITLE
gh-120345: Fix incorrect use of the :class: role with the "()" suffix

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -787,7 +787,7 @@ Invocation from super
 ---------------------
 
 The logic for super's dotted lookup is in the :meth:`__getattribute__` method for
-object returned by :class:`super()`.
+object returned by :func:`super`.
 
 A dotted lookup such as ``super(A, obj).m`` searches ``obj.__class__.__mro__``
 for the base class ``B`` immediately following ``A`` and then returns

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -99,7 +99,7 @@ The class can be used to simulate nested scopes and is useful in templating.
         :func:`super` function.  A reference to ``d.parents`` is equivalent to:
         ``ChainMap(*d.maps[1:])``.
 
-    Note, the iteration order of a :class:`ChainMap()` is determined by
+    Note, the iteration order of a :class:`ChainMap` is determined by
     scanning the mappings last to first::
 
         >>> baseline = {'music': 'bach', 'art': 'rembrandt'}

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2153,7 +2153,7 @@ There is one more :class:`tzinfo` method that a subclass may wish to override:
 
 .. method:: tzinfo.fromutc(dt)
 
-   This is called from the default :class:`datetime.astimezone()`
+   This is called from the default :meth:`datetime.astimezone`
    implementation. When called from that, ``dt.tzinfo`` is *self*, and *dt*'s
    date and time data are to be viewed as expressing a UTC time. The purpose
    of :meth:`fromutc` is to adjust the date and time data, returning an

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -47,7 +47,7 @@ Lines are returned with any newlines intact, which means that the last line in
 a file may not have one.
 
 You can control how files are opened by providing an opening hook via the
-*openhook* parameter to :func:`fileinput.input` or :class:`FileInput()`. The
+*openhook* parameter to :func:`fileinput.input` or :func:`FileInput`. The
 hook must be a function that takes two arguments, *filename* and *mode*, and
 returns an accordingly opened file-like object. If *encoding* and/or *errors*
 are specified, they will be passed to the hook as additional keyword arguments.

--- a/Doc/tutorial/stdlib2.rst
+++ b/Doc/tutorial/stdlib2.rst
@@ -293,7 +293,7 @@ Many data structure needs can be met with the built-in list type. However,
 sometimes there is a need for alternative implementations with different
 performance trade-offs.
 
-The :mod:`array` module provides an :class:`~array.array()` object that is like
+The :mod:`array` module provides an :class:`~array.array` object that is like
 a list that stores only homogeneous data and stores it more compactly.  The
 following example shows an array of numbers stored as two byte unsigned binary
 numbers (typecode ``"H"``) rather than the usual 16 bytes per entry for regular
@@ -306,7 +306,7 @@ lists of Python int objects::
    >>> a[1:3]
    array('H', [10, 700])
 
-The :mod:`collections` module provides a :class:`~collections.deque()` object
+The :mod:`collections` module provides a :class:`~collections.deque` object
 that is like a list with faster appends and pops from the left side but slower
 lookups in the middle. These objects are well suited for implementing queues
 and breadth first tree searches::

--- a/Doc/whatsnew/2.5.rst
+++ b/Doc/whatsnew/2.5.rst
@@ -1724,7 +1724,7 @@ attribute of the function object to  change this::
 :mod:`ctypes` also provides a wrapper for Python's C API  as the
 ``ctypes.pythonapi`` object.  This object does *not*  release the global
 interpreter lock before calling a function, because the lock must be held when
-calling into the interpreter's code.   There's a :class:`py_object()` type
+calling into the interpreter's code.   There's a :class:`~ctypes.py_object` type
 constructor that will create a  :c:expr:`PyObject *` pointer.  A simple usage::
 
    import ctypes
@@ -1734,7 +1734,7 @@ constructor that will create a  :c:expr:`PyObject *` pointer.  A simple usage::
              ctypes.py_object("abc"),  ctypes.py_object(1))
    # d is now {'abc', 1}.
 
-Don't forget to use :class:`py_object()`; if it's omitted you end  up with a
+Don't forget to use :func:`~ctypes.py_object`; if it's omitted you end  up with a
 segmentation fault.
 
 :mod:`ctypes` has been around for a while, but people still write  and

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -739,7 +739,7 @@ inspect
 itertools
 ---------
 
-* Add :class:`itertools.batched()` for collecting into even-sized
+* Add :func:`itertools.batched` for collecting into even-sized
   tuples where the last batch may be shorter than the rest.
   (Contributed by Raymond Hettinger in :gh:`98363`.)
 


### PR DESCRIPTION
* Remove "()" when refer to a class as a type.
* Use :func: when refer to a callable.
* Fix reference to the datetime.astimezone() method.


<!-- gh-issue-number: gh-120345 -->
* Issue: gh-120345
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120347.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->