### PR TITLE
Docs: remove temporary hardcoded links

### DIFF
--- a/Doc/tools/static/rtd_switcher.js
+++ b/Doc/tools/static/rtd_switcher.js
@@ -6,42 +6,9 @@
 
  document.addEventListener("readthedocs-addons-data-ready", function(event) {
    const config = event.detail.data()
-
-   // Add some mocked hardcoded versions pointing to the official
-   // documentation while migrating to Read the Docs.
-   // These are only for testing purposes.
-   // TODO: remove them when managing all the versions on Read the Docs,
-   // since all the "active, built and not hidden" versions will be shown automatically.
-   let versions = config.versions.active.concat([
-       {
-           slug: "dev (3.14)",
-           urls: {
-               documentation: "https://docs.python.org/3.14/",
-           }
-       },
-       {
-           slug: "dev (3.13)",
-           urls: {
-               documentation: "https://docs.python.org/3.13/",
-           }
-       },
-       {
-           slug: "3.12",
-           urls: {
-               documentation: "https://docs.python.org/3.12/",
-           }
-       },
-       {
-           slug: "3.11",
-           urls: {
-               documentation: "https://docs.python.org/3.11/",
-           }
-       },
-   ]);
-
    const versionSelect = `
    <select id="version_select">
-   ${ versions.map(
+   ${ config.versions.active.map(
        (version) => `
        <option
            value="${ version.slug }"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

For https://github.com/python/docs-community/issues/5.

Follow on from https://github.com/python/cpython/pull/116966.

Read the Docs is ready and we can remove the temporary hardcoded links added in https://github.com/python/cpython/pull/116966#issuecomment-2045379520.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120348.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->