### PR TITLE
gh-120361: Add `nonmember` test with enum flags inside to `test_enum`

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -527,7 +527,7 @@ Data Types
 
    ``Flag`` is the same as :class:`Enum`, but its members support the bitwise
    operators ``&`` (*AND*), ``|`` (*OR*), ``^`` (*XOR*), and ``~`` (*INVERT*);
-   the results of those operators are members of the enumeration.
+   the results of those operations are (aliases of) members of the enumeration.
 
    .. method:: __contains__(self, value)
 

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1506,6 +1506,16 @@ class TestSpecial(unittest.TestCase):
         self.assertEqual(Example.ALL, 3)
         self.assertIs(type(Example.ALL), int)
 
+        class Example(Flag):
+            A = auto()
+            B = auto()
+            ALL = nonmember(A | B)
+
+        self.assertEqual(Example.A.value, 1)
+        self.assertEqual(Example.B.value, 2)
+        self.assertEqual(Example.ALL, 3)
+        self.assertIs(type(Example.ALL), int)
+
     def test_nested_classes_in_enum_with_member(self):
         """Support locally-defined nested classes."""
         class Outer(Enum):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1504,6 +1504,7 @@ class TestSpecial(unittest.TestCase):
         self.assertEqual(Example.A.value, 1)
         self.assertEqual(Example.B.value, 2)
         self.assertEqual(Example.ALL, 3)
+        self.assertIs(type(Example.ALL), int)
 
     def test_nested_classes_in_enum_with_member(self):
         """Support locally-defined nested classes."""

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1495,6 +1495,16 @@ class TestSpecial(unittest.TestCase):
             spam = nonmember(SpamEnumIsInner)
         self.assertTrue(SpamEnum.spam is SpamEnumIsInner)
 
+    def test_using_members_as_nonmember(self):
+        class Example(Flag):
+            A = 1
+            B = 2
+            ALL = nonmember(A | B)
+
+        self.assertEqual(Example.A.value, 1)
+        self.assertEqual(Example.B.value, 2)
+        self.assertEqual(Example.ALL, 3)
+
     def test_nested_classes_in_enum_with_member(self):
         """Support locally-defined nested classes."""
         class Outer(Enum):


### PR DESCRIPTION
I think that this corner case is important enough to be tested.

<!-- gh-issue-number: gh-120361 -->
* Issue: gh-120361
<!-- /gh-issue-number -->
