### PR TITLE
gh-118908: Fix completions after namespace change in REPL

### DIFF
--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -55,6 +55,11 @@ Command = commands.Command
 from collections.abc import Callable, Collection
 from .types import Callback, Completer, KeySpec, CommandName
 
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from typing import Any
+
 
 MoreLinesCallable = Callable[[str], bool]
 
@@ -92,7 +97,7 @@ __all__ = [
 
 @dataclass
 class ReadlineConfig:
-    readline_completer: Completer | None = RLCompleter().complete
+    readline_completer: Completer | None = None
     completer_delims: frozenset[str] = frozenset(" \t\n`~!@#$%^&*()-=+[{]}\\|;:'\",<>/?")
 
 
@@ -554,7 +559,7 @@ for _name, _ret in [
 # ____________________________________________________________
 
 
-def _setup() -> None:
+def _setup(namespace: dict[str, Any]) -> None:
     global raw_input
     if raw_input is not None:
         return  # don't run _setup twice
@@ -570,9 +575,11 @@ def _setup() -> None:
     _wrapper.f_in = f_in
     _wrapper.f_out = f_out
 
+    # set up namespace in rlcompleter
+    _wrapper.config.readline_completer = RLCompleter(namespace).complete
+
     # this is not really what readline.c does.  Better than nothing I guess
     import builtins
-
     raw_input = builtins.input
     builtins.input = _wrapper.input
 

--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -96,9 +96,9 @@ def run_multiline_interactive_console(
     console: code.InteractiveConsole | None = None,
 ) -> None:
     from .readline import _setup
-    _setup()
-
     namespace = mainmodule.__dict__ if mainmodule else DEFAULT_NAMESPACE
+    _setup(namespace)
+
     if console is None:
         console = InteractiveColoredConsole(
             namespace, filename="<stdin>"


### PR DESCRIPTION
Completions are broken after https://github.com/python/cpython/pull/119547.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118908 -->
* Issue: gh-118908
<!-- /gh-issue-number -->
