### PR TITLE
JIT: ignore some failing test_logging tests

### DIFF
--- a/Tools/jit/ignore-tests-emulated-linux.txt
+++ b/Tools/jit/ignore-tests-emulated-linux.txt
@@ -11,6 +11,9 @@ test.test_external_inspection.TestGetStackTrace.test_self_trace
 test.test_faulthandler.FaultHandlerTests.test_enable_fd
 test.test_faulthandler.FaultHandlerTests.test_enable_file
 test.test_init.ProcessPoolForkFailingInitializerTest.test_initializer
+test.test_logging.ConfigDictTest.test_111615
+test.test_logging.ConfigDictTest.test_config_queue_handler
+test.test_logging.ConfigDictTest.test_multiprocessing_queues
 test.test_os.ForkTests.test_fork_warns_when_non_python_thread_exists
 test.test_os.TimerfdTests.test_timerfd_initval
 test.test_os.TimerfdTests.test_timerfd_interval


### PR DESCRIPTION
Some of the test_logging tests are failing in the emulated linux environment on GitHub independently from the changes of the PR. Add them to the ignore list.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
