### PR TITLE
[3.12] gh-120198: Fix race condition when editing __class__ with an audit hook active (GH-120195)

### DIFF
--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -1,9 +1,10 @@
 """Unit tests for zero-argument super() & related machinery."""
 
 import textwrap
+import threading
 import unittest
 from unittest.mock import patch
-from test.support import import_helper
+from test.support import import_helper, threading_helper
 
 
 ADAPTIVE_WARMUP_DELAY = 2
@@ -477,6 +478,38 @@ class TestSuper(unittest.TestCase):
 
         for _ in range(ADAPTIVE_WARMUP_DELAY):
             C.some(C)
+
+    @threading_helper.requires_working_threading()
+    def test___class___modification_multithreaded(self):
+        """ Note: this test isn't actually testing anything on its own.
+        It requires a sys audithook to be set to crash on older Python.
+        This should be the case anyways as our test suite sets
+        an audit hook.
+        """
+        class Foo:
+            pass
+
+        class Bar:
+            pass
+
+        thing = Foo()
+        def work():
+            foo = thing
+            for _ in range(5000):
+                foo.__class__ = Bar
+                type(foo)
+                foo.__class__ = Foo
+                type(foo)
+
+
+        threads = []
+        for _ in range(6):
+            thread = threading.Thread(target=work)
+            thread.start()
+            threads.append(thread)
+
+        for thread in threads:
+            thread.join()
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-10-15-07-16.gh-issue-120198.WW_pjO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-10-15-07-16.gh-issue-120198.WW_pjO.rst
@@ -1,0 +1,1 @@
+Fix a crash when multiple threads read and write to the same ``__class__`` of an object concurrently.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5709,7 +5709,6 @@ differs:
 static int
 object_set_class(PyObject *self, PyObject *value, void *closure)
 {
-    PyTypeObject *oldto = Py_TYPE(self);
 
     if (value == NULL) {
         PyErr_SetString(PyExc_TypeError,
@@ -5728,6 +5727,8 @@ object_set_class(PyObject *self, PyObject *value, void *closure)
                     self, "__class__", value) < 0) {
         return -1;
     }
+
+    PyTypeObject *oldto = Py_TYPE(self);
 
     /* In versions of CPython prior to 3.5, the code in
        compatible_for_assignment was not set up to correctly check for memory

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5728,7 +5728,7 @@ object_set_class(PyObject *self, PyObject *value, void *closure)
         return -1;
     }
 
-    PyTypeObject *oldto = Py_TYPE(self);  
+    PyTypeObject *oldto = Py_TYPE(self);
 
     /* In versions of CPython prior to 3.5, the code in
        compatible_for_assignment was not set up to correctly check for memory

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5728,7 +5728,7 @@ object_set_class(PyObject *self, PyObject *value, void *closure)
         return -1;
     }
 
-    PyTypeObject *oldto = Py_TYPE(self);
+    PyTypeObject *oldto = Py_TYPE(self);  
 
     /* In versions of CPython prior to 3.5, the code in
        compatible_for_assignment was not set up to correctly check for memory


### PR DESCRIPTION
Backport of #120195

<!-- gh-issue-number: gh-120198 -->
* Issue: gh-120198
<!-- /gh-issue-number -->
