### PR TITLE
gh-120397: improve the speed of str.count, bytes.count et al. for single characters by about 2x.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-12-13-47-25.gh-issue-120397.n-I_cc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-12-13-47-25.gh-issue-120397.n-I_cc.rst
@@ -1,0 +1,3 @@
+Significantly improve the speed of the str.count, bytes.count and
+bytearray.count method when the argument is a single character and the
+target architecture and compiler support vectorization.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-12-13-47-25.gh-issue-120397.n-I_cc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-12-13-47-25.gh-issue-120397.n-I_cc.rst
@@ -1,2 +1,2 @@
-Improve the :meth:`str.count`, :meth:`bytes.count` and :meth:`bytearray.count`
+Improve the througput by up to two times for the :meth:`str.count`, :meth:`bytes.count` and :meth:`bytearray.count`
 methods for counting single characters.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-12-13-47-25.gh-issue-120397.n-I_cc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-12-13-47-25.gh-issue-120397.n-I_cc.rst
@@ -1,3 +1,2 @@
-Significantly improve the speed of the str.count, bytes.count and
-bytearray.count method when the argument is a single character and the
-target architecture and compiler support vectorization.
+Improve the :meth:`str.count`, :meth:`bytes.count` and :meth:`bytearray.count`
+methods for counting single characters.

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -767,7 +767,6 @@ STRINGLIB(count_char)(const STRINGLIB_CHAR *s, Py_ssize_t n,
 }
 
 
-
 Py_LOCAL_INLINE(Py_ssize_t)
 FASTSEARCH(const STRINGLIB_CHAR* s, Py_ssize_t n,
            const STRINGLIB_CHAR* p, Py_ssize_t m,

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -759,6 +759,7 @@ STRINGLIB(count_char_no_maxcount)(const STRINGLIB_CHAR *s, Py_ssize_t n,
 /* A specialized function of count_char that does not cut off at a maximum.
    As a result, the compiler is able to vectorize the loop. */
 {
+    Py_ssize_t count = 0;
     for (Py_ssize_t i = 0; i < n; i++) {
         if (s[i] == p0) {
             count++;
@@ -789,7 +790,7 @@ FASTSEARCH(const STRINGLIB_CHAR* s, Py_ssize_t n,
             return STRINGLIB(rfind_char)(s, n, p[0]);
         else {
             if (maxcount == PY_SSIZE_T_MAX) {
-                return STRINGLIB(count_char_no_maximum)(s, n, p[0]);
+                return STRINGLIB(count_char_no_maxcount)(s, n, p[0]);
             }
             return STRINGLIB(count_char)(s, n, p[0], maxcount);
         }

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -757,11 +757,11 @@ STRINGLIB(count_char)(const STRINGLIB_CHAR *s, Py_ssize_t n,
     }
     for (; i < n; i++) {
         if (s[i] == p0) {
-            count += 1;
+            count++;
+            if (count == maxcount) {
+                return maxcount;
+            }
         }
-    }
-    if (count >= maxcount) {
-        return maxcount;
     }
     return count;
 }

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -756,11 +756,10 @@ STRINGLIB(count_char)(const STRINGLIB_CHAR *s, Py_ssize_t n,
 static inline Py_ssize_t
 STRINGLIB(count_char_no_maximum)(const STRINGLIB_CHAR *s, Py_ssize_t n,
                                  const STRINGLIB_CHAR p0)
-/* By removing the maximum out of the loop, the compiler can optimize using
-   vectors */
+/* A specialized function of count_char that does not cut off at a maximum. 
+   As a result, the compiler is able to vectorize the loop. */
 {
-    Py_ssize_t i, count = 0;
-    for (i = 0; i < n; i++) {
+    for (Py_ssize_t i = 0; i < n; i++) {
         if (s[i] == p0) {
             count++;
         }

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -753,6 +753,22 @@ STRINGLIB(count_char)(const STRINGLIB_CHAR *s, Py_ssize_t n,
 }
 
 
+static inline Py_ssize_t
+STRINGLIB(count_char_no_maximum)(const STRINGLIB_CHAR *s, Py_ssize_t n,
+                      const STRINGLIB_CHAR p0)
+/* By removing the maximum out of the loop, the compiler can optimize using
+   vectors */
+{
+    Py_ssize_t i, count = 0;
+    for (i = 0; i < n; i++) {
+        if (s[i] == p0) {
+            count++;
+        }
+    }
+    return count;
+}
+
+
 Py_LOCAL_INLINE(Py_ssize_t)
 FASTSEARCH(const STRINGLIB_CHAR* s, Py_ssize_t n,
            const STRINGLIB_CHAR* p, Py_ssize_t m,
@@ -773,6 +789,9 @@ FASTSEARCH(const STRINGLIB_CHAR* s, Py_ssize_t n,
         else if (mode == FAST_RSEARCH)
             return STRINGLIB(rfind_char)(s, n, p[0]);
         else {
+            if (maxcount == PY_SSIZE_T_MAX) {
+                return STRINGLIB(count_char_no_maximum)(s, n, p[0]);
+            }
             return STRINGLIB(count_char)(s, n, p[0], maxcount);
         }
     }

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -740,34 +740,32 @@ static inline Py_ssize_t
 STRINGLIB(count_char)(const STRINGLIB_CHAR *s, Py_ssize_t n,
                       const STRINGLIB_CHAR p0, Py_ssize_t maxcount)
 {
-    Py_ssize_t count = 0;
-    const STRINGLIB_CHAR *restrict cursor = s;
-    const STRINGLIB_CHAR *end_ptr = s + n;
-    const STRINGLIB_CHAR *unroll_end_ptr = end_ptr - 31;
+    Py_ssize_t i, count = 0;
+    Py_ssize_t unroll_length = n - 31;
     /* By unrolling in chunks of 32, the compiler can auto vectorize, resulting
        in much better performance. */
-    while (cursor < unroll_end_ptr) {
-        for(size_t i=0; i<32; i++) {
-            if (cursor[i] == p0) {
+    for (i = 0; i < unroll_length; i+=32) {
+        const STRINGLIB_CHAR *restrict cursor = s + i;
+        for(size_t j = 0; j < 32; j++) {
+            if (cursor[j] == p0) {
                 count += 1;
             }
         }
         if (count >= maxcount) {
             return maxcount;
         }
-        cursor += 32;
     }
-    while (cursor < end_ptr) {
-        if (*cursor == p0) {
+    for (; i < n; i++) {
+        if (s[i] == p0) {
             count += 1;
         }
-        cursor += 1;
     }
     if (count >= maxcount) {
         return maxcount;
     }
     return count;
 }
+
 
 
 Py_LOCAL_INLINE(Py_ssize_t)

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -744,13 +744,17 @@ STRINGLIB(count_char)(const STRINGLIB_CHAR *s, Py_ssize_t n,
     Py_ssize_t unroll_length = n - 31;
     /* By unrolling in chunks of 32, the compiler can auto vectorize, resulting
        in much better performance. */
-    for (i = 0; i < unroll_length; i+=32) {
+    for (i = 0; i < unroll_length; i += 32) {
         const STRINGLIB_CHAR *restrict cursor = s + i;
         for(size_t j = 0; j < 32; j++) {
             if (cursor[j] == p0) {
                 count += 1;
             }
         }
+        /* By performing the check outside of the read/compare loop the
+           compiler is guaranteed that 32 bytes can be read and counted.
+           As a result it can vectorize.
+        */
         if (count >= maxcount) {
             return maxcount;
         }

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -755,7 +755,7 @@ STRINGLIB(count_char)(const STRINGLIB_CHAR *s, Py_ssize_t n,
 
 static inline Py_ssize_t
 STRINGLIB(count_char_no_maximum)(const STRINGLIB_CHAR *s, Py_ssize_t n,
-                      const STRINGLIB_CHAR p0)
+                                 const STRINGLIB_CHAR p0)
 /* By removing the maximum out of the loop, the compiler can optimize using
    vectors */
 {

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -741,25 +741,7 @@ STRINGLIB(count_char)(const STRINGLIB_CHAR *s, Py_ssize_t n,
                       const STRINGLIB_CHAR p0, Py_ssize_t maxcount)
 {
     Py_ssize_t i, count = 0;
-    Py_ssize_t unroll_length = n - 31;
-    /* By unrolling in chunks of 32, the compiler can auto vectorize, resulting
-       in much better performance. */
-    for (i = 0; i < unroll_length; i += 32) {
-        const STRINGLIB_CHAR *restrict cursor = s + i;
-        for(size_t j = 0; j < 32; j++) {
-            if (cursor[j] == p0) {
-                count += 1;
-            }
-        }
-        /* By performing the check outside of the read/compare loop the
-           compiler is guaranteed that 32 bytes can be read and counted.
-           As a result it can vectorize.
-        */
-        if (count >= maxcount) {
-            return maxcount;
-        }
-    }
-    for (; i < n; i++) {
+    for (i = 0; i < n; i++) {
         if (s[i] == p0) {
             count++;
             if (count == maxcount) {

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -754,9 +754,9 @@ STRINGLIB(count_char)(const STRINGLIB_CHAR *s, Py_ssize_t n,
 
 
 static inline Py_ssize_t
-STRINGLIB(count_char_no_maximum)(const STRINGLIB_CHAR *s, Py_ssize_t n,
-                                 const STRINGLIB_CHAR p0)
-/* A specialized function of count_char that does not cut off at a maximum. 
+STRINGLIB(count_char_no_maxcount)(const STRINGLIB_CHAR *s, Py_ssize_t n,
+                                  const STRINGLIB_CHAR p0)
+/* A specialized function of count_char that does not cut off at a maximum.
    As a result, the compiler is able to vectorize the loop. */
 {
     for (Py_ssize_t i = 0; i < n; i++) {

--- a/Objects/stringlib/fastsearch.h
+++ b/Objects/stringlib/fastsearch.h
@@ -759,6 +759,7 @@ STRINGLIB(count_char_no_maxcount)(const STRINGLIB_CHAR *s, Py_ssize_t n,
 /* A specialized function of count_char that does not cut off at a maximum.
    As a result, the compiler is able to vectorize the loop. */
 {
+    Py_ssize_t count = 0;
     for (Py_ssize_t i = 0; i < n; i++) {
         if (s[i] == p0) {
             count++;


### PR DESCRIPTION
* Issue: gh-120397

Benchmarks using: 
```
./python -m timeit -s "seq='TTTATGGTTATTTATATTTATTTATTTTTGAGATGGAGTTTTGCTCTTGCTGCCTAGGCTGGAGTGCAATGGCACGATCTCGGCTCACTGCAACCTCCGCCTCCCAGGTTCAAGCGATTCTCCTGCCTCAGCCTCCTGAGTAGCTGGGATT'" "seq.count('A'); seq.count('C'); seq.count('G');  seq.count('T')"
```
This is testing a real use case where the GC content of a DNA sequence is calculated. Other possible usages  are counting newlines.

Before:
```
500000 loops, best of 5: 461 nsec per loop
```
After:
```
1000000 loops, best of 5: 216 nsec per loop
```

