### PR TITLE
gh-120388: Improve deprecation warning message, when test returns non-None

### DIFF
--- a/Lib/test/test_unittest/test_async_case.py
+++ b/Lib/test/test_unittest/test_async_case.py
@@ -312,21 +312,21 @@ class TestAsyncCase(unittest.TestCase):
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test1', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn("(<class 'int'>)", str(w.warning))
+        self.assertIn("('int')", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Test('test2').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test2', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn("(<class 'async_generator'>)", str(w.warning))
+        self.assertIn("('async_generator')", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Test('test3').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test3', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn(f'({Nothing})', str(w.warning))
+        self.assertIn(f'({Nothing.__name__!r})', str(w.warning))
 
     def test_cleanups_interleave_order(self):
         events = []

--- a/Lib/test/test_unittest/test_async_case.py
+++ b/Lib/test/test_unittest/test_async_case.py
@@ -312,21 +312,21 @@ class TestAsyncCase(unittest.TestCase):
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test1', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn("('int')", str(w.warning))
+        self.assertIn("returned 'int'", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Test('test2').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test2', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn("('async_generator')", str(w.warning))
+        self.assertIn("returned 'async_generator'", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Test('test3').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test3', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn(f'({Nothing.__name__!r})', str(w.warning))
+        self.assertIn(f'returned {Nothing.__name__!r}', str(w.warning))
 
     def test_cleanups_interleave_order(self):
         events = []

--- a/Lib/test/test_unittest/test_async_case.py
+++ b/Lib/test/test_unittest/test_async_case.py
@@ -312,18 +312,21 @@ class TestAsyncCase(unittest.TestCase):
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test1', str(w.warning))
         self.assertEqual(w.filename, __file__)
+        self.assertIn("(<class 'int'>)", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Test('test2').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test2', str(w.warning))
         self.assertEqual(w.filename, __file__)
+        self.assertIn("(<class 'async_generator'>)", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Test('test3').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test3', str(w.warning))
         self.assertEqual(w.filename, __file__)
+        self.assertIn(f'({Nothing})', str(w.warning))
 
     def test_cleanups_interleave_order(self):
         events = []

--- a/Lib/test/test_unittest/test_case.py
+++ b/Lib/test/test_unittest/test_case.py
@@ -353,7 +353,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         self.assertEqual(w.filename, __file__)
         self.assertIn("returned 'coroutine'", str(w.warning))
         self.assertIn(
-            'maybe you forgot to use IsolatedAsyncioTestCase base class?',
+            'Maybe you forgot to use IsolatedAsyncioTestCase as the base class?',
             str(w.warning),
         )
 

--- a/Lib/test/test_unittest/test_case.py
+++ b/Lib/test/test_unittest/test_case.py
@@ -325,21 +325,21 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test1', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn("(<class 'int'>)", str(w.warning))
+        self.assertIn("('int')", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Foo('test2').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test2', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn("(<class 'generator'>)", str(w.warning))
+        self.assertIn("('generator')", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Foo('test3').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test3', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn(f'({Nothing})', str(w.warning))
+        self.assertIn(f'({Nothing.__name__!r})', str(w.warning))
 
     def test_deprecation_of_return_val_from_test_async_method(self):
         class Foo(unittest.TestCase):
@@ -351,7 +351,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test1', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn("(<class 'coroutine'>)", str(w.warning))
+        self.assertIn("('coroutine')", str(w.warning))
         self.assertIn(
             (
                 "a coroutine is returned, "

--- a/Lib/test/test_unittest/test_case.py
+++ b/Lib/test/test_unittest/test_case.py
@@ -325,18 +325,40 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test1', str(w.warning))
         self.assertEqual(w.filename, __file__)
+        self.assertIn("(<class 'int'>)", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Foo('test2').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test2', str(w.warning))
         self.assertEqual(w.filename, __file__)
+        self.assertIn("(<class 'generator'>)", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Foo('test3').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test3', str(w.warning))
         self.assertEqual(w.filename, __file__)
+        self.assertIn(f'({Nothing})', str(w.warning))
+
+    def test_deprecation_of_return_val_from_test_async_method(self):
+        class Foo(unittest.TestCase):
+            async def test1(self):
+                return 1
+
+        with self.assertWarns(DeprecationWarning) as w:
+            Foo('test1').run()
+        self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
+        self.assertIn('test1', str(w.warning))
+        self.assertEqual(w.filename, __file__)
+        self.assertIn("(<class 'coroutine'>)", str(w.warning))
+        self.assertIn(
+            (
+                "a coroutine is returned, "
+                "maybe you forgot to use IsolatedAsyncioTestCase base class?"
+            ),
+            str(w.warning),
+        )
 
     def _check_call_order__subtests(self, result, events, expected_events):
         class Foo(Test.LoggingTestCase):

--- a/Lib/test/test_unittest/test_case.py
+++ b/Lib/test/test_unittest/test_case.py
@@ -325,21 +325,21 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test1', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn("('int')", str(w.warning))
+        self.assertIn("returned 'int'", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Foo('test2').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test2', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn("('generator')", str(w.warning))
+        self.assertIn("returned 'generator'", str(w.warning))
 
         with self.assertWarns(DeprecationWarning) as w:
             Foo('test3').run()
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test3', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn(f'({Nothing.__name__!r})', str(w.warning))
+        self.assertIn(f'returned {Nothing.__name__!r}', str(w.warning))
 
     def test_deprecation_of_return_val_from_test_async_method(self):
         class Foo(unittest.TestCase):
@@ -351,12 +351,9 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         self.assertIn('It is deprecated to return a value that is not None', str(w.warning))
         self.assertIn('test1', str(w.warning))
         self.assertEqual(w.filename, __file__)
-        self.assertIn("('coroutine')", str(w.warning))
+        self.assertIn("returned 'coroutine'", str(w.warning))
         self.assertIn(
-            (
-                "a coroutine is returned, "
-                "maybe you forgot to use IsolatedAsyncioTestCase base class?"
-            ),
+            'maybe you forgot to use IsolatedAsyncioTestCase base class?',
             str(w.warning),
         )
 

--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -93,7 +93,7 @@ class IsolatedAsyncioTestCase(TestCase):
         result = self._callMaybeAsync(method)
         if result is not None:
             msg = (
-                'It is deprecated to return a value that is not None '
+                f'It is deprecated to return a value that is not None '
                 f'from a test case ({method} returned {type(result).__name__!r})',
             )
             warnings.warn(msg, DeprecationWarning, stacklevel=4)

--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -93,8 +93,7 @@ class IsolatedAsyncioTestCase(TestCase):
         if (result := self._callMaybeAsync(method)) is not None:
             msg = (
                 'It is deprecated to return a value that is not None, '
-                f'got: ({type(result).__name__!r}) from a '
-                f'test case ({method})',
+                f'from a test case ({method}) returned {type(result).__name__!r}',
             )
             warnings.warn(msg, DeprecationWarning, stacklevel=4)
 

--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -93,7 +93,7 @@ class IsolatedAsyncioTestCase(TestCase):
         if (result := self._callMaybeAsync(method)) is not None:
             msg = (
                 'It is deprecated to return a value that is not None, '
-                f'got: ({type(result)}) from a '
+                f'got: ({type(result).__name__!r}) from a '
                 f'test case ({method})',
             )
             warnings.warn(msg, DeprecationWarning, stacklevel=4)

--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -92,8 +92,8 @@ class IsolatedAsyncioTestCase(TestCase):
     def _callTestMethod(self, method):
         if (result := self._callMaybeAsync(method)) is not None:
             msg = (
-                'It is deprecated to return a value that is not None, '
-                f'from a test case ({method}) returned {type(result).__name__!r}',
+                'It is deprecated to return a value that is not None '
+                f'from a test case ({method} returned {type(result).__name__!r})',
             )
             warnings.warn(msg, DeprecationWarning, stacklevel=4)
 

--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -90,7 +90,8 @@ class IsolatedAsyncioTestCase(TestCase):
         self._callAsync(self.asyncSetUp)
 
     def _callTestMethod(self, method):
-        if (result := self._callMaybeAsync(method)) is not None:
+        result = self._callMaybeAsync(method)
+        if result is not None:
             msg = (
                 'It is deprecated to return a value that is not None '
                 f'from a test case ({method} returned {type(result).__name__!r})',

--- a/Lib/unittest/async_case.py
+++ b/Lib/unittest/async_case.py
@@ -90,9 +90,13 @@ class IsolatedAsyncioTestCase(TestCase):
         self._callAsync(self.asyncSetUp)
 
     def _callTestMethod(self, method):
-        if self._callMaybeAsync(method) is not None:
-            warnings.warn(f'It is deprecated to return a value that is not None from a '
-                          f'test case ({method})', DeprecationWarning, stacklevel=4)
+        if (result := self._callMaybeAsync(method)) is not None:
+            msg = (
+                'It is deprecated to return a value that is not None, '
+                f'got: ({type(result)}) from a '
+                f'test case ({method})',
+            )
+            warnings.warn(msg, DeprecationWarning, stacklevel=4)
 
     def _callTearDown(self):
         self._callAsync(self.asyncTearDown)

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -603,9 +603,23 @@ class TestCase(object):
         self.setUp()
 
     def _callTestMethod(self, method):
-        if method() is not None:
-            warnings.warn(f'It is deprecated to return a value that is not None from a '
-                          f'test case ({method})', DeprecationWarning, stacklevel=3)
+        if (result := method()) is not None:
+            import inspect
+            from unittest.async_case import IsolatedAsyncioTestCase
+            msg = (
+                'It is deprecated to return a value that is not None, '
+                f'got: ({type(result)}) from a '
+                f'test case ({method})'
+            )
+            if (
+                inspect.iscoroutine(result)
+                and not isinstance(self, IsolatedAsyncioTestCase)
+            ):
+                msg += (
+                    '; a coroutine is returned, maybe you forgot to use '
+                    'IsolatedAsyncioTestCase base class?'
+                )
+            warnings.warn(msg, DeprecationWarning, stacklevel=3)
 
     def _callTearDown(self):
         self.tearDown()

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -608,7 +608,7 @@ class TestCase(object):
             from unittest.async_case import IsolatedAsyncioTestCase
             msg = (
                 'It is deprecated to return a value that is not None, '
-                f'got: ({type(result)}) from a '
+                f'got: ({type(result).__name__!r}) from a '
                 f'test case ({method})'
             )
             if (

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -608,17 +608,13 @@ class TestCase(object):
             from unittest.async_case import IsolatedAsyncioTestCase
             msg = (
                 'It is deprecated to return a value that is not None, '
-                f'got: ({type(result).__name__!r}) from a '
-                f'test case ({method})'
+                f'from a test case ({method}) returned {type(result).__name__!r}'
             )
             if (
                 inspect.iscoroutine(result)
                 and not isinstance(self, IsolatedAsyncioTestCase)
             ):
-                msg += (
-                    '; a coroutine is returned, maybe you forgot to use '
-                    'IsolatedAsyncioTestCase base class?'
-                )
+                msg += '; maybe you forgot to use IsolatedAsyncioTestCase base class?'
             warnings.warn(msg, DeprecationWarning, stacklevel=3)
 
     def _callTearDown(self):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -607,14 +607,16 @@ class TestCase(object):
             import inspect
             from unittest.async_case import IsolatedAsyncioTestCase
             msg = (
-                'It is deprecated to return a value that is not None, '
+                'It is deprecated to return a value that is not None '
                 f'from a test case ({method} returned {type(result).__name__!r})'
             )
             if (
                 inspect.iscoroutine(result)
                 and not isinstance(self, IsolatedAsyncioTestCase)
             ):
-                msg += '; maybe you forgot to use IsolatedAsyncioTestCase base class?'
+                msg += (
+                    '. Maybe you forgot to use IsolatedAsyncioTestCase as the base class?'
+                )
             warnings.warn(msg, DeprecationWarning, stacklevel=3)
 
     def _callTearDown(self):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -607,7 +607,7 @@ class TestCase(object):
         if result is not None:
             import inspect
             msg = (
-                'It is deprecated to return a value that is not None '
+                f'It is deprecated to return a value that is not None '
                 f'from a test case ({method} returned {type(result).__name__!r})'
             )
             if inspect.iscoroutine(result):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -603,17 +603,14 @@ class TestCase(object):
         self.setUp()
 
     def _callTestMethod(self, method):
-        if (result := method()) is not None:
+        result = method()
+        if result is not None:
             import inspect
-            from unittest.async_case import IsolatedAsyncioTestCase
             msg = (
                 'It is deprecated to return a value that is not None '
                 f'from a test case ({method} returned {type(result).__name__!r})'
             )
-            if (
-                inspect.iscoroutine(result)
-                and not isinstance(self, IsolatedAsyncioTestCase)
-            ):
+            if inspect.iscoroutine(result):
                 msg += (
                     '. Maybe you forgot to use IsolatedAsyncioTestCase as the base class?'
                 )

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -608,7 +608,7 @@ class TestCase(object):
             from unittest.async_case import IsolatedAsyncioTestCase
             msg = (
                 'It is deprecated to return a value that is not None, '
-                f'from a test case ({method}) returned {type(result).__name__!r}'
+                f'from a test case ({method} returned {type(result).__name__!r})'
             )
             if (
                 inspect.iscoroutine(result)

--- a/Misc/NEWS.d/next/Library/2024-06-12-15-07-58.gh-issue-120388.VuTQMT.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-12-15-07-58.gh-issue-120388.VuTQMT.rst
@@ -1,0 +1,3 @@
+Improve a warning message when a test method in :mod:`unittest` returns
+something other than ``None``. Now we show the returned object type and
+optional asyncio-related tip.


### PR DESCRIPTION
New message:

```
DeprecationWarning: It is deprecated to return a value that is not None, got: (<class 'coroutine'>) from a test case (<bound method TestSpecial.test_some of <test.test_enum.TestSpecial testMethod=test_some>>); a coroutine is returned, maybe you forgot to use IsolatedAsyncioTestCase base class?
  return self.run(*args, **kwds)
```

<!-- gh-issue-number: gh-120388 -->
* Issue: gh-120388
<!-- /gh-issue-number -->
