### PR TITLE
gh-120155: Add assertion to sre.c match_getindex()

### DIFF
--- a/Modules/_sre/sre.c
+++ b/Modules/_sre/sre.c
@@ -2217,6 +2217,8 @@ match_getindex(MatchObject* self, PyObject* index)
         return -1;
     }
 
+    // Check that i*2 cannot overflow to make static analyzers happy
+    assert(i <= SRE_MAXGROUPS);
     return i;
 }
 


### PR DESCRIPTION
Add an assertion to help static analyzers to detect that i*2 cannot overflow.

Example of Coverity issue on Python 3.12.2:

```
Error: INTEGER_OVERFLOW (CWE-125):
Modules/_sre/sre.c:2361:5: tainted_data_return: Called function "match_getindex(self, group)", and a possible return value may be less than zero.
Modules/_sre/sre.c:2361:5: assign: Assigning: "index" = "match_getindex(self, group)".
Modules/_sre/sre.c:2368:5: overflow: The expression "index * 2L" is considered to have possibly overflowed.
Modules/_sre/sre.c:2368:5: overflow: The expression "index * 2L + 1L" is deemed overflowed because at least one of its arguments has overflowed.
Modules/_sre/sre.c:2368:5: deref_overflow: "index * 2L + 1L", which might have underflowed, is passed to "self->mark[index * 2L + 1L]".
  2366|
  2367|       /* mark is -1 if group is undefined */
  2368|->     return self->mark[index*2+1];
  2369|   }
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120155 -->
* Issue: gh-120155
<!-- /gh-issue-number -->
