### PR TITLE
gh-118908: Protect the REPL subprocess with a timeout in tests

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -889,7 +889,6 @@ class TestMain(TestCase):
         try:
             exit_code = process.wait(timeout=SHORT_TIMEOUT)
         except subprocess.TimeoutExpired:
-            process.terminate()
             process.kill()
             exit_code = process.returncode
         return "\n".join(output), exit_code

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -8,6 +8,7 @@ import sys
 from unittest import TestCase, skipUnless
 from unittest.mock import patch
 from test.support import force_not_colorized
+from test.support import SHORT_TIMEOUT
 
 from .support import (
     FakeConsole,
@@ -885,5 +886,10 @@ class TestMain(TestCase):
 
         os.close(master_fd)
         os.close(slave_fd)
-        exit_code = process.wait()
+        try:
+            exit_code = process.wait(timeout=SHORT_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            process.kill()
+            exit_code = process.returncode
         return "\n".join(output), exit_code


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118908 -->
* Issue: gh-118908
<!-- /gh-issue-number -->
