### PR TITLE
gh-120418: Don't assume wheeldata is deleted if `WHEEL_PKG_DIR` is set

### DIFF
--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -41,7 +41,7 @@ class TestMakefile(unittest.TestCase):
         idle_test = 'idlelib/idle_test'
         self.assertIn(idle_test, test_dirs)
 
-        used = [idle_test]
+        used = set([idle_test])
         for dirpath, dirs, files in os.walk(support.TEST_HOME_DIR):
             dirname = os.path.basename(dirpath)
             # Skip temporary dirs:
@@ -65,13 +65,14 @@ class TestMakefile(unittest.TestCase):
                         "of test directories to install"
                     )
                 )
-                used.append(relpath)
+                used.add(relpath)
 
         # Don't check the wheel dir when Python is built --with-wheel-pkg-dir
         if sysconfig.get_config_var('WHEEL_PKG_DIR'):
             test_dirs.remove('test/wheeldata')
+            used.discard('test/wheeldata')
 
         # Check that there are no extra entries:
         unique_test_dirs = set(test_dirs)
-        self.assertSetEqual(unique_test_dirs, set(used))
+        self.assertSetEqual(unique_test_dirs, used)
         self.assertEqual(len(test_dirs), len(unique_test_dirs))


### PR DESCRIPTION
Remove wheeldata from both sides of the `assertEqual`, so that we're *actually* ignoring it from the test set.

This test is only making assertions about the source tree, no code is being executed that would do anything different based on the value of `WHEEL_PKG_DIR`.

<!-- gh-issue-number: gh-120418 -->
* Issue: gh-120418
<!-- /gh-issue-number -->
