### PR TITLE
gh-120380: fix Python implementation of `pickle.Pickler` for `bytes` and `bytearray` objects in protocol version 5.

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -853,7 +853,7 @@ class _Pickler:
                         if in_memo:
                             self.__save_bytearray_aux(buf)
                         else:
-                            self.save_bytearray(m.tobytes())
+                            self.save_bytearray(buf)
                 else:
                     # Write data out-of-band
                     self.write(NEXT_BUFFER)

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -783,7 +783,7 @@ class _Pickler:
     dispatch[float] = save_float
 
     def __save_bytes_aux(self, obj):
-        # helper for writing bytearray objects for protocol >= 3
+        # helper for writing bytes objects for protocol >= 3
         assert self.proto >= 3
         n = len(obj)
         if n <= 0xff:

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -782,14 +782,9 @@ class _Pickler:
             self.write(FLOAT + repr(obj).encode("ascii") + b'\n')
     dispatch[float] = save_float
 
-    def save_bytes(self, obj):
-        if self.proto < 3:
-            if not obj: # bytes object is empty
-                self.save_reduce(bytes, (), obj=obj)
-            else:
-                self.save_reduce(codecs.encode,
-                                 (str(obj, 'latin1'), 'latin1'), obj=obj)
-            return
+    def __save_bytes_aux(self, obj):
+        # helper for writing bytearray objects for protocol >= 3
+        assert self.proto >= 3
         n = len(obj)
         if n <= 0xff:
             self.write(SHORT_BINBYTES + pack("<B", n) + obj)
@@ -799,8 +794,27 @@ class _Pickler:
             self._write_large_bytes(BINBYTES + pack("<I", n), obj)
         else:
             self.write(BINBYTES + pack("<I", n) + obj)
+
+    def save_bytes(self, obj):
+        if self.proto < 3:
+            if not obj: # bytes object is empty
+                self.save_reduce(bytes, (), obj=obj)
+            else:
+                self.save_reduce(codecs.encode,
+                                 (str(obj, 'latin1'), 'latin1'), obj=obj)
+            return
+        self.__save_bytes_aux(obj)
         self.memoize(obj)
     dispatch[bytes] = save_bytes
+
+    def __save_bytearray_aux(self, obj):
+        # helper for writing bytearray objects for protocol >= 5
+        assert self.proto >= 5
+        n = len(obj)
+        if n >= self.framer._FRAME_SIZE_TARGET:
+            self._write_large_bytes(BYTEARRAY8 + pack("<Q", n), obj)
+        else:
+            self.write(BYTEARRAY8 + pack("<Q", n) + obj)
 
     def save_bytearray(self, obj):
         if self.proto < 5:
@@ -809,11 +823,7 @@ class _Pickler:
             else:
                 self.save_reduce(bytearray, (bytes(obj),), obj=obj)
             return
-        n = len(obj)
-        if n >= self.framer._FRAME_SIZE_TARGET:
-            self._write_large_bytes(BYTEARRAY8 + pack("<Q", n), obj)
-        else:
-            self.write(BYTEARRAY8 + pack("<Q", n) + obj)
+        self.__save_bytearray_aux(obj)
         self.memoize(obj)
     dispatch[bytearray] = save_bytearray
 
@@ -832,10 +842,18 @@ class _Pickler:
                 if in_band:
                     # Write data in-band
                     # XXX The C implementation avoids a copy here
+                    buf = m.tobytes()
+                    in_memo = id(buf) in self.memo
                     if m.readonly:
-                        self.save_bytes(m.tobytes())
+                        if in_memo:
+                            self.__save_bytes_aux(buf)
+                        else:
+                            self.save_bytes(buf)
                     else:
-                        self.save_bytearray(m.tobytes())
+                        if in_memo:
+                            self.__save_bytearray_aux(buf)
+                        else:
+                            self.save_bytearray(m.tobytes())
                 else:
                     # Write data out-of-band
                     self.write(NEXT_BUFFER)

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1866,11 +1866,22 @@ class AbstractPickleTests:
 
     def test_bytearray_memoization_bug(self):
         for proto in protocols:
-            for s in b'', b'xyz', b'xyz'*100:
-                b = bytearray(s)
-                p = self.dumps((b, b), proto)
-                b1, b2 = self.loads(p)
-                self.assertIs(b1, b2)
+            for array_type in [bytearray, ZeroCopyBytes, ZeroCopyBytearray]:
+                for s in b'', b'xyz', b'xyz'*100:
+                    b = array_type(s)
+                    p = self.dumps((b, b), proto)
+                    b1, b2 = self.loads(p)
+                    self.assertIs(b1, b2)
+
+                    b1a, b2a = array_type(s), array_type(s)
+                    p = self.dumps((b1a, b2a), proto)
+                    b1b, b2b = self.loads(p)
+
+                    self.assertIsNot(b1a, b1b)
+                    self.assert_is_copy(b1a, b1b)
+
+                    self.assertIsNot(b2a, b2b)
+                    self.assert_is_copy(b2a, b2b)
 
     def test_ints(self):
         for proto in protocols:

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1849,18 +1849,20 @@ class AbstractPickleTests:
         for proto in protocols:
             for array_type in [bytes, ZeroCopyBytes]:
                 for s in b'', b'xyz', b'xyz'*100:
-                    b = array_type(s)
-                    p = self.dumps((b, b), proto)
-                    x, y = self.loads(p)
-                    self.assertIs(x, y)
-                    self.assert_is_copy((b, b), (x, y))
+                    with self.subTest(proto=proto, array_type=array_type, s=s, independent=False):
+                        b = array_type(s)
+                        p = self.dumps((b, b), proto)
+                        x, y = self.loads(p)
+                        self.assertIs(x, y)
+                        self.assert_is_copy((b, b), (x, y))
 
-                    b1, b2 = array_type(s), array_type(s)
-                    p = self.dumps((b1, b2), proto)
-                    # Note that (b1, b2) = self.loads(p) might have identical
-                    # components, i.e., b1 is b2, but this is not always the
-                    # case if the content is large (equality still holds).
-                    self.assert_is_copy((b1, b2), self.loads(p))
+                    with self.subTest(proto=proto, array_type=array_type, s=s, independent=True):
+                        b1, b2 = array_type(s), array_type(s)
+                        p = self.dumps((b1, b2), proto)
+                        # Note that (b1, b2) = self.loads(p) might have identical
+                        # components, i.e., b1 is b2, but this is not always the
+                        # case if the content is large (equality still holds).
+                        self.assert_is_copy((b1, b2), self.loads(p))
 
     def test_bytearray(self):
         for proto in protocols:
@@ -1885,25 +1887,27 @@ class AbstractPickleTests:
         for proto in protocols:
             for array_type in [bytearray, ZeroCopyBytearray]:
                 for s in b'', b'xyz', b'xyz'*100:
-                    b = array_type(s)
-                    p = self.dumps((b, b), proto)
-                    b1, b2 = self.loads(p)
-                    self.assertIs(b1, b2)
+                    with self.subTest(proto=proto, array_type=array_type, s=s, independent=False):
+                        b = array_type(s)
+                        p = self.dumps((b, b), proto)
+                        b1, b2 = self.loads(p)
+                        self.assertIs(b1, b2)
 
-                    b1a, b2a = array_type(s), array_type(s)
-                    # Unlike bytes, equal but independent bytearray objects are
-                    # never identical.
-                    self.assertIsNot(b1a, b2a)
+                    with self.subTest(proto=proto, array_type=array_type, s=s, independent=True):
+                        b1a, b2a = array_type(s), array_type(s)
+                        # Unlike bytes, equal but independent bytearray objects are
+                        # never identical.
+                        self.assertIsNot(b1a, b2a)
 
-                    p = self.dumps((b1a, b2a), proto)
-                    b1b, b2b = self.loads(p)
-                    self.assertIsNot(b1b, b2b)
+                        p = self.dumps((b1a, b2a), proto)
+                        b1b, b2b = self.loads(p)
+                        self.assertIsNot(b1b, b2b)
 
-                    self.assertIsNot(b1a, b1b)
-                    self.assert_is_copy(b1a, b1b)
+                        self.assertIsNot(b1a, b1b)
+                        self.assert_is_copy(b1a, b1b)
 
-                    self.assertIsNot(b2a, b2b)
-                    self.assert_is_copy(b2a, b2b)
+                        self.assertIsNot(b2a, b2b)
+                        self.assert_is_copy(b2a, b2b)
 
     def test_ints(self):
         for proto in protocols:

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1891,11 +1891,14 @@ class AbstractPickleTests:
                     self.assertIs(b1, b2)
 
                     b1a, b2a = array_type(s), array_type(s)
+                    # Unlike bytes, equal but independent bytearray objects are
+                    # never identical.
+                    self.assertIsNot(b1a, b2a)
+
                     p = self.dumps((b1a, b2a), proto)
                     b1b, b2b = self.loads(p)
+                    self.assertIsNot(b1b, b2b)
 
-                    # Unlike bytes, bytearray objects are never identical,
-                    # even if they have an empty data or a short data.
                     self.assertIsNot(b1a, b1b)
                     self.assert_is_copy(b1a, b1b)
 

--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -78,7 +78,7 @@ class PyclbrTest(TestCase):
 
             objname = obj.__name__
             if objname.startswith("__") and not objname.endswith("__"):
-                objname = "_%s%s" % (oclass.__name__, objname)
+                objname = "_%s%s" % (oclass.__name__.lstrip('_'), objname)
             return objname == name
 
         # Make sure the toplevel functions and classes are the same.
@@ -115,8 +115,8 @@ class PyclbrTest(TestCase):
                         actualMethods.append(m)
                 foundMethods = []
                 for m in value.methods.keys():
-                    if m[:2] == '__' and m[-2:] != '__':
-                        foundMethods.append('_'+name+m)
+                    if m.startswith('__') and not m.endswith('__'):
+                        foundMethods.append(f"_{name.lstrip('_')}{m}")
                     else:
                         foundMethods.append(m)
 

--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -78,8 +78,7 @@ class PyclbrTest(TestCase):
 
             objname = obj.__name__
             if objname.startswith("__") and not objname.endswith("__"):
-                if stripped_typename := oclass.__name__.lstrip('_'):
-                    objname = f"_{stripped_typename}{objname}"
+                objname = "_%s%s" % (oclass.__name__.lstrip('_'), objname)
             return objname == name
 
         # Make sure the toplevel functions and classes are the same.
@@ -114,16 +113,12 @@ class PyclbrTest(TestCase):
                         continue
                     if ismethod(py_item, getattr(py_item, m), m):
                         actualMethods.append(m)
-
-                if stripped_typename := name.lstrip('_'):
-                    foundMethods = []
-                    for m in value.methods.keys():
-                        if m.startswith('__') and not m.endswith('__'):
-                            foundMethods.append(f"_{stripped_typename}{m}")
-                        else:
-                            foundMethods.append(m)
-                else:
-                    foundMethods = list(value.methods.keys())
+                foundMethods = []
+                for m in value.methods.keys():
+                    if m.startswith('__') and not m.endswith('__'):
+                        foundMethods.append(f"_{name.lstrip('_')}{m}")
+                    else:
+                        foundMethods.append(m)
 
                 try:
                     self.assertListEq(foundMethods, actualMethods, ignore)

--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -78,7 +78,8 @@ class PyclbrTest(TestCase):
 
             objname = obj.__name__
             if objname.startswith("__") and not objname.endswith("__"):
-                objname = "_%s%s" % (oclass.__name__.lstrip('_'), objname)
+                if stripped_typename := oclass.__name__.lstrip('_'):
+                    objname = f"_{stripped_typename}{objname}"
             return objname == name
 
         # Make sure the toplevel functions and classes are the same.
@@ -113,12 +114,16 @@ class PyclbrTest(TestCase):
                         continue
                     if ismethod(py_item, getattr(py_item, m), m):
                         actualMethods.append(m)
-                foundMethods = []
-                for m in value.methods.keys():
-                    if m.startswith('__') and not m.endswith('__'):
-                        foundMethods.append(f"_{name.lstrip('_')}{m}")
-                    else:
-                        foundMethods.append(m)
+
+                if stripped_typename := name.lstrip('_'):
+                    foundMethods = []
+                    for m in value.methods.keys():
+                        if m.startswith('__') and not m.endswith('__'):
+                            foundMethods.append(f"_{stripped_typename}{m}")
+                        else:
+                            foundMethods.append(m)
+                else:
+                    foundMethods = list(value.methods.keys())
 
                 try:
                     self.assertListEq(foundMethods, actualMethods, ignore)

--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -78,7 +78,7 @@ class PyclbrTest(TestCase):
 
             objname = obj.__name__
             if objname.startswith("__") and not objname.endswith("__"):
-                objname = "_%s%s" % (oclass.__name__.lstrip('_'), objname)
+                objname = "_%s%s" % (oclass.__name__, objname)
             return objname == name
 
         # Make sure the toplevel functions and classes are the same.
@@ -115,8 +115,8 @@ class PyclbrTest(TestCase):
                         actualMethods.append(m)
                 foundMethods = []
                 for m in value.methods.keys():
-                    if m.startswith('__') and not m.endswith('__'):
-                        foundMethods.append(f"_{name.lstrip('_')}{m}")
+                    if m[:2] == '__' and m[-2:] != '__':
+                        foundMethods.append('_'+name+m)
                     else:
                         foundMethods.append(m)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-12-18-23-15.gh-issue-120380.edtqjq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-12-18-23-15.gh-issue-120380.edtqjq.rst
@@ -1,0 +1,3 @@
+Fix Python implementation of :class:`pickle.Pickler` for :class:`bytes` and
+:class:`bytearray` objects when using protocol version 5. Patch by Bénédikt
+Tran.


### PR DESCRIPTION
The issue is not only for the one in #120380 but also affected 0-copy bytes objects. Actually, the issue is only for the empty case.

I'm not entirely sure it's the simplest way to do it and whether I could perhaps just special-case the empty case.

<!-- gh-issue-number: gh-120380 -->
* Issue: gh-120380
<!-- /gh-issue-number -->
