### PR TITLE
gh-109305: Return an iterator in `IPv[46]Network.hosts()` when there is a single host

### DIFF
--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -594,7 +594,7 @@ dictionaries.
       network address itself and the network broadcast address.  For networks
       with a mask length of 31, the network address and network broadcast
       address are also included in the result. Networks with a mask of 32
-      will return a list containing the single host address.
+      will contain a single host address.
 
          >>> list(ip_network('192.0.2.0/29').hosts())  #doctest: +NORMALIZE_WHITESPACE
          [IPv4Address('192.0.2.1'), IPv4Address('192.0.2.2'),
@@ -765,8 +765,7 @@ dictionaries.
       hosts are all the IP addresses that belong to the network, except the
       Subnet-Router anycast address.  For networks with a mask length of 127,
       the Subnet-Router anycast address is also included in the result.
-      Networks with a mask of 128 will return a list containing the
-      single host address.
+      Networks with a mask of 128 will only contain the single host address.
 
    .. method:: overlaps(other)
    .. method:: address_exclude(network)

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1556,10 +1556,8 @@ class IPv4Network(_BaseV4, _BaseNetwork):
                 self.network_address = IPv4Address(packed &
                                                    int(self.netmask))
 
-        if self._prefixlen == (self._max_prefixlen - 1):
+        if self._prefixlen >= self._max_prefixlen - 1:
             self.hosts = self.__iter__
-        elif self._prefixlen == (self._max_prefixlen):
-            self.hosts = lambda: [IPv4Address(addr)]
 
     @property
     @functools.lru_cache()
@@ -2323,10 +2321,8 @@ class IPv6Network(_BaseV6, _BaseNetwork):
                 self.network_address = IPv6Address(packed &
                                                    int(self.netmask))
 
-        if self._prefixlen == (self._max_prefixlen - 1):
+        if self._prefixlen >= self._max_prefixlen - 1:
             self.hosts = self.__iter__
-        elif self._prefixlen == self._max_prefixlen:
-            self.hosts = lambda: [IPv6Address(addr)]
 
     def hosts(self):
         """Generate Iterator over usable hosts in a network.

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -1462,12 +1462,21 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(254, len(hosts))
         self.assertEqual(ipaddress.IPv4Address('1.2.3.1'), hosts[0])
         self.assertEqual(ipaddress.IPv4Address('1.2.3.254'), hosts[-1])
+        self.assertEqual(ipaddress.IPv4Address('1.2.3.254'), hosts[-1])
+        host_iter = self.ipv4_network.hosts()
+        self.assertEqual(next(host_iter), hosts[0])
+        self.assertEqual(next(self.ipv4_network.hosts()), hosts[0])
+        self.assertEqual(next(host_iter), hosts[1])
 
         ipv6_network = ipaddress.IPv6Network('2001:658:22a:cafe::/120')
         hosts = list(ipv6_network.hosts())
         self.assertEqual(255, len(hosts))
         self.assertEqual(ipaddress.IPv6Address('2001:658:22a:cafe::1'), hosts[0])
         self.assertEqual(ipaddress.IPv6Address('2001:658:22a:cafe::ff'), hosts[-1])
+        host_iter = self.ipv6_network.hosts()
+        self.assertEqual(next(host_iter), hosts[0])
+        self.assertEqual(next(self.ipv6_network.hosts()), hosts[0])
+        self.assertEqual(next(host_iter), hosts[1])
 
         ipv6_scoped_network = ipaddress.IPv6Network('2001:658:22a:cafe::%scope/120')
         hosts = list(ipv6_scoped_network.hosts())
@@ -1493,6 +1502,11 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(addrs, list(ipaddress.ip_network(tpl_args).hosts()))
         self.assertEqual(list(ipaddress.ip_network(str_args).hosts()),
                          list(ipaddress.ip_network(tpl_args).hosts()))
+        network = ipaddress.ip_network(str_args)
+        host_iter = network.hosts()
+        self.assertEqual(next(host_iter), addrs[0])
+        self.assertEqual(next(network.hosts()), addrs[0])
+        self.assertRaises(StopIteration, next, host_iter)
 
         addrs = [ipaddress.IPv6Address('2001:658:22a:cafe::'),
                  ipaddress.IPv6Address('2001:658:22a:cafe::1')]

--- a/Misc/NEWS.d/next/Library/2024-06-12-21-21-14.gh-issue-109305.J5UFeX.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-12-21-21-14.gh-issue-109305.J5UFeX.rst
@@ -1,0 +1,1 @@
+:meth:`ipaddress.IPv4Network.hosts` and :meth:`ipaddress.IPv6Network.hosts` will now return an iterator when there is a single IP in the network, containing this IP address.


### PR DESCRIPTION
In 8e9c47a947954c997d4b725f4551d50a1d896722, support was added for the `.hosts()` method to return the single IP in the network, instead of an empty iterator, if the mask was maximal.

However, the returned type is a list, while an iterator is returned when there is more than one IP in the network. This also contradicts with the documentation, and can surprise users (e.g. [it is not what typeshed expects][1])

The current `__iter__` already has the expected behaviour, let's reuse it.

[1]: https://github.com/python/typeshed/blob/587ad6bad806a7c2fbc2bb5451007a9782bd665b/stdlib/ipaddress.pyi#L96


<!-- gh-issue-number: gh-109305 -->
* Issue: gh-109305
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120436.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->