### PR TITLE
gh-120384: Fix array-out-of-bounds crash in `list_ass_subscript`

### DIFF
--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -193,10 +193,10 @@ class CommonTest(seq_tests.CommonTest):
 
     def test_slice_assign_iterator(self):
         x = self.type2test(range(5))
-        x[0:3] = iter(self.type2test(reversed(range(3))))
+        x[0:3] = reversed(range(3))
         self.assertEqual(x, self.type2test([2, 1, 0, 3, 4]))
 
-        x[:] = iter(self.type2test(reversed(range(3))))
+        x[:] = reversed(range(3))
         self.assertEqual(x, self.type2test([2, 1, 0]))
 
     def test_delslice(self):

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -194,7 +194,7 @@ class CommonTest(seq_tests.CommonTest):
     def test_slice_assign_iterator(self):
         x = self.type2test(range(5))
         x[0:3] = iter(self.type2test(reversed(range(3))))
-        self.assertEqual(x, [2, 1, 0, 3, 4])
+        self.assertEqual(x, self.type2test([2, 1, 0, 3, 4]))
 
         x[:] = iter(self.type2test(reversed(range(3))))
         self.assertEqual(x, self.type2test([2, 1, 0]))

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -191,6 +191,14 @@ class CommonTest(seq_tests.CommonTest):
 
         self.assertRaises(TypeError, a.__setitem__)
 
+    def test_slice_assign_iterator(self):
+        x = self.type2test(range(5))
+        x[0:3] = iter(self.type2test(reversed(range(3))))
+        self.assertEqual(x, [2, 1, 0, 3, 4])
+
+        x[:] = iter(self.type2test(reversed(range(3))))
+        self.assertEqual(x, self.type2test([2, 1, 0]))
+
     def test_delslice(self):
         a = self.type2test([0, 1])
         del a[1:2]

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -245,6 +245,20 @@ class ListTest(list_tests.CommonTest):
         with self.assertRaises(TypeError):
             a[0] < a
 
+    def test_list_index_modifing_operand(self):
+        # See gh-120384
+        class evil:
+            def __init__(self, lst):
+                self.lst = lst
+            def __iter__(self):
+                yield from self.lst
+                self.lst.clear()
+
+        lst = list(range(5))
+        operand = evil(lst)
+        with self.assertRaises(ValueError):
+            lst[::-1] = operand
+
     @cpython_only
     def test_preallocation(self):
         iterable = [0] * 10

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -101,6 +101,28 @@ class ListTest(list_tests.CommonTest):
         x[:] = x
         self.assertEqual(x, [])
 
+    def test_slice_assign_iterator(self):
+        class MyIterator:
+            def __init__(self, lst):
+                self.lst = lst
+                self.index = 0
+            def __iter__(self):
+                return self
+            def __next__(self):
+                try:
+                    res = self.lst[self.index]
+                except IndexError:
+                    raise StopIteration(self.index)
+                self.index += 1
+                return res
+
+        x = list(range(5))
+        x[0:3] = MyIterator(list(reversed(range(3))))
+        self.assertEqual(x, [2, 1, 0, 3, 4])
+
+        x[:] = MyIterator(list(reversed(range(3))))
+        self.assertEqual(x, [2, 1, 0])
+
     def test_list_resize_overflow(self):
         # gh-97616: test new_allocated * sizeof(PyObject*) overflow
         # check in list_resize()

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -101,28 +101,6 @@ class ListTest(list_tests.CommonTest):
         x[:] = x
         self.assertEqual(x, [])
 
-    def test_slice_assign_iterator(self):
-        class MyIterator:
-            def __init__(self, lst):
-                self.lst = lst
-                self.index = 0
-            def __iter__(self):
-                return self
-            def __next__(self):
-                try:
-                    res = self.lst[self.index]
-                except IndexError:
-                    raise StopIteration(self.index)
-                self.index += 1
-                return res
-
-        x = list(range(5))
-        x[0:3] = MyIterator(list(reversed(range(3))))
-        self.assertEqual(x, [2, 1, 0, 3, 4])
-
-        x[:] = MyIterator(list(reversed(range(3))))
-        self.assertEqual(x, [2, 1, 0])
-
     def test_list_resize_overflow(self):
         # gh-97616: test new_allocated * sizeof(PyObject*) overflow
         # check in list_resize()

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-13-12-17-52.gh-issue-120384.w1UBGl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-13-12-17-52.gh-issue-120384.w1UBGl.rst
@@ -1,2 +1,3 @@
 Fix an array out of bounds crash in ``list_ass_subscript``, which could be
-invoked via some specificly tailored evil input.
+invoked via some specificly tailored input: including concurrent modification
+of a list object, where one thread assigns a slice and another clears it.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-13-12-17-52.gh-issue-120384.w1UBGl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-13-12-17-52.gh-issue-120384.w1UBGl.rst
@@ -1,0 +1,2 @@
+Fix an array out of bounds crash in ``list_ass_subscript``, which could be
+invoked via some specificly tailored evil input.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3581,6 +3581,23 @@ list_subscript(PyObject* _self, PyObject* item)
     }
 }
 
+static Py_ssize_t
+adjust_slice_indexes(PyListObject *lst,
+                     Py_ssize_t *start, Py_ssize_t *stop,
+                     Py_ssize_t step)
+{
+    Py_ssize_t slicelength = PySlice_AdjustIndices(Py_SIZE(lst), start, stop,
+                                                   step);
+
+    /* Make sure s[5:2] = [..] inserts at the right place:
+        before 5, not before 2. */
+    if ((step < 0 && *start < *stop) ||
+        (step > 0 && *start > *stop))
+        *stop = *start;
+
+    return slicelength;
+}
+
 static int
 list_ass_subscript(PyObject* _self, PyObject* item, PyObject* value)
 {
@@ -3594,22 +3611,11 @@ list_ass_subscript(PyObject* _self, PyObject* item, PyObject* value)
         return list_ass_item((PyObject *)self, i, value);
     }
     else if (PySlice_Check(item)) {
-        Py_ssize_t start, stop, step, slicelength;
+        Py_ssize_t start, stop, step;
 
         if (PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return -1;
         }
-        slicelength = PySlice_AdjustIndices(Py_SIZE(self), &start, &stop,
-                                            step);
-
-        if (step == 1)
-            return list_ass_slice(self, start, stop, value);
-
-        /* Make sure s[5:2] = [..] inserts at the right place:
-           before 5, not before 2. */
-        if ((step < 0 && start < stop) ||
-            (step > 0 && start > stop))
-            stop = start;
 
         if (value == NULL) {
             /* delete slice */
@@ -3617,6 +3623,12 @@ list_ass_subscript(PyObject* _self, PyObject* item, PyObject* value)
             size_t cur;
             Py_ssize_t i;
             int res;
+
+            Py_ssize_t slicelength = adjust_slice_indexes(self, &start, &stop,
+                                                          step);
+
+            if (step == 1)
+                return list_ass_slice(self, start, stop, value);
 
             if (slicelength <= 0)
                 return 0;
@@ -3694,6 +3706,14 @@ list_ass_subscript(PyObject* _self, PyObject* item, PyObject* value)
             }
             if (!seq)
                 return -1;
+
+            Py_ssize_t slicelength = adjust_slice_indexes(self, &start, &stop,
+                                                          step);
+
+            if (step == 1) {
+                Py_DECREF(seq);
+                return list_ass_slice(self, start, stop, value);
+            }
 
             if (PySequence_Fast_GET_SIZE(seq) != slicelength) {
                 PyErr_Format(PyExc_ValueError,

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3711,7 +3711,9 @@ list_ass_subscript(PyObject* _self, PyObject* item, PyObject* value)
                                                           step);
 
             if (step == 1) {
-                return list_ass_slice(self, start, stop, seq);
+                int res = list_ass_slice(self, start, stop, seq);
+                Py_DECREF(seq);
+                return res;
             }
 
             if (PySequence_Fast_GET_SIZE(seq) != slicelength) {

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3711,8 +3711,7 @@ list_ass_subscript(PyObject* _self, PyObject* item, PyObject* value)
                                                           step);
 
             if (step == 1) {
-                Py_DECREF(seq);
-                return list_ass_slice(self, start, stop, value);
+                return list_ass_slice(self, start, stop, seq);
             }
 
             if (PySequence_Fast_GET_SIZE(seq) != slicelength) {


### PR DESCRIPTION
Thank a lot to @MechanicPig for the reproducer and detailed bug description.

<!-- gh-issue-number: gh-120384 -->
* Issue: gh-120384
<!-- /gh-issue-number -->
