### PR TITLE
gh-120452: improve documentation about private name mangling

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1741,6 +1741,25 @@ but effective way to define class private variables.  Any identifier of the form
 is textually replaced with ``_classname__spam``, where ``classname`` is the
 current class name with any leading underscores stripped.
 
+More generally, the corresponding private member is accessed by its defining
+class using its non-transformed name. On the other hand, the transformed name
+must be used to access the private member *externally* (e.g., in a function or
+in a subclass):
+
+.. code-block:: python
+
+   class A:
+       def __one(self):
+           return 1
+       def two(self):
+           return 2 * self.__one()
+
+   class B(A):
+       def three(self):
+           return 3 * self._A__one()
+
+   four = 4 * A()._A__one()
+
 This doesn't guarantee privacy: an outside user can still deliberately access
 the "_classname__spam" attribute, and private values are visible in the object's
 ``__dict__``.  Many Python programmers never bother to use private variable

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1739,14 +1739,17 @@ Variable names with double leading underscores are "mangled" to provide a simple
 but effective way to define class private variables.  Any identifier of the form
 ``__spam`` (at least two leading underscores, at most one trailing underscore)
 is textually replaced with ``_classname__spam``, where ``classname`` is the
-current class name with any leading underscores stripped
-(see :ref:`here <private-name-mangling>` for details and special cases).
+current class name with any leading underscores stripped.
 
 This doesn't guarantee privacy: an outside user can still deliberately access
 the "_classname__spam" attribute, and private values are visible in the object's
 ``__dict__``.  Many Python programmers never bother to use private variable
 names at all.
 
+.. seealso::
+
+   The :ref:`private name mangling specifications <private-name-mangling>`
+   for details and special cases.
 
 My class defines __del__ but it is not called when I delete the object.
 -----------------------------------------------------------------------

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1741,10 +1741,8 @@ but effective way to define class private variables.  Any identifier of the form
 is textually replaced with ``_classname__spam``, where ``classname`` is the
 current class name with any leading underscores stripped.
 
-More generally, the corresponding private member is accessed by its defining
-class using its non-transformed name. On the other hand, the transformed name
-must be used to access the private member *externally* (e.g., in a function or
-in a subclass):
+The identifier can be used unchanged within the class, but to access it outside
+the class, the mangled name must be used:
 
 .. code-block:: python
 

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1758,10 +1758,9 @@ the class, the mangled name must be used:
 
    four = 4 * A()._A__one()
 
-This doesn't guarantee privacy: an outside user can still deliberately access
-the "_classname__spam" attribute, and private values are visible in the object's
-``__dict__``.  Many Python programmers never bother to use private variable
-names at all.
+In particular, this does not guarantee privacy since an outside user can still
+deliberately access the private attribute; many Python programmers never bother
+to use private variable names at all.
 
 .. seealso::
 

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1739,7 +1739,8 @@ Variable names with double leading underscores are "mangled" to provide a simple
 but effective way to define class private variables.  Any identifier of the form
 ``__spam`` (at least two leading underscores, at most one trailing underscore)
 is textually replaced with ``_classname__spam``, where ``classname`` is the
-current class name with any leading underscores stripped.
+current class name with any leading underscores stripped
+(see :ref:`here <private-name-mangling>` for details and special cases).
 
 This doesn't guarantee privacy: an outside user can still deliberately access
 the "_classname__spam" attribute, and private values are visible in the object's

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -92,7 +92,8 @@ is considered a :dfn:`private name` of that class.
 
 .. seealso::
 
-   The :ref:`tutorial on classes <_tut-classdefinition>` for more details.
+   The :ref:`tutorial on classes <tut-classdefinition>` for more details
+   on classes and their declaration.
 
 More precisely, private names are transformed to a longer form before code is
 generated for them.  If the transformed name is longer than 255 characters,

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -120,7 +120,7 @@ The transformation rule is defined as follows:
   underscore inserted, is inserted in front of the identifier, e.g., the
   identifier ``__spam`` occurring in a class named ``Foo``, ``_Foo`` or
   ``__Foo`` is transformed to ``_Foo__spam``.
-  
+
 - If the class name consists only of underscores, the transformation is the
   identity, e.g., the identifier ``__spam`` occurring in a class named ``_``
   or ``__`` is left as is.

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -144,9 +144,8 @@ a subclass):
 .. rubric:: Mangled names in imports
 
 For identifiers declared using :keyword:`import` statements, the mangling
-rule is slightly different. Throughout this paragraph, assume that we have
-the following filesystem layout and, unless stated otherwise, the code snippets
-are in the ``__main__.py`` file.
+rule is slightly different. Throughout this paragraph, we consider the
+following filesystem layout with code snippets in the ``__main__.py`` file.
 
 .. code-block:: text
 
@@ -179,11 +178,6 @@ be performed via the :func:`__import__` function, in which case the usual
 transformation rule is applied:
 
 .. code-block:: python
-
-   class Bar:
-       # explicitly import '__bar' instead of '_Bar__bar'
-       __bar = __import__("__bar")
-   print(Bar._Bar__bar)  # <module '__bar' from '/__bar.py'>
 
    class Foo:
        # explicitly import '__foo' instead of '_Foo__foo'

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -83,17 +83,27 @@ exception.
    pair: name; mangling
    pair: private; names
 
-**Private name mangling:** When an identifier that textually occurs in a class
-definition begins with two or more underscore characters and does not end in two
-or more underscores, it is considered a :dfn:`private name` of that class.
-Private names are transformed to a longer form before code is generated for
-them.  The transformation inserts the class name, with leading underscores
-removed and a single underscore inserted, in front of the name.  For example,
-the identifier ``__spam`` occurring in a class named ``Ham`` will be transformed
-to ``_Ham__spam``.  This transformation is independent of the syntactical
-context in which the identifier is used.  If the transformed name is extremely
-long (longer than 255 characters), implementation defined truncation may happen.
-If the class name consists only of underscores, no transformation is done.
+.. rubric:: Private name mangling
+
+When an identifier that textually occurs in a class definition begins with two
+or more underscore characters and does not end in two or more underscores, it
+is considered a :dfn:`private name` of that class.
+
+More precisely, private names are transformed to a longer form before code is
+generated for them.  The transformation rule is defined as follows:
+
+- If the class name consists only of underscores, no transformation is done,
+  e.g., the identifier ``__spam`` occurring in a class named ``_`` or ``__``
+  is left as is.
+
+- Otherwise, the transformation inserts the class name, with leading
+  underscores removed and a single underscore inserted, in front of
+  the identifier, e.g., the identifier ``__spam`` occurring in a class
+  named ``Ham``, ``_Ham`` or ``__Ham`` is transformed to ``_Ham__spam``.
+
+The transformation is independent of the syntactical context in which the
+identifier is used.  Nonetheless, if the transformed name is extremely long
+(longer than 255 characters), implementation-defined truncation may happen.
 
 
 .. _atom-literals:

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -142,7 +142,7 @@ rule is slightly different.  Throughout this paragraph, assume that we have
 the following filesystem layout and, unless stated otherwise, the code snippets
 are in the ``__main__.py`` file.
 
-.. code-block::
+.. code-block:: text
 
    .
    ├── __main__.py

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -107,8 +107,8 @@ identifier is used and the transformation rule is defined as follows:
   or ``__`` is left as is.
 
 - Otherwise, the transformation inserts the class name, with leading
-  underscores removed and a single underscore inserted, in front of
-  the identifier, e.g., the identifier ``__spam`` occurring in a class
+  underscores removed and a single leading underscore inserted, in front
+  of the identifier, e.g., the identifier ``__spam`` occurring in a class
   named ``Foo``, ``_Foo`` or ``__Foo`` is transformed to ``_Foo__spam``.
 
 .. _private-name-mangling-access:
@@ -194,20 +194,6 @@ with private names, e.g.:
 
    print(Foo._Foo__pkg)      # <module '__pkg' from '/__pkg/__init__.py'>
    print(Foo._Foo__pkg.mod)  # <module '__pkg.mod' from '/__pkg/mod.py'>
-
-Note that a class whose name only consists of underscores does not
-suffer from those restrictions on :keyword:`import` statements:
-
-.. code-block:: python
-
-   class _:
-       import __bar  # imports '__bar'
-       import __foo  # imports '__foo'
-       import __pkg  # imports '__pkg'
-
-   print(_.__bar)  # <module '__bar' from '/__bar.py'>
-   print(_.__foo)  # <module '__foo' from '/__foo.py'>
-   print(_.__pkg)  # <module '__pkg' from '/__pkg/__init__.py'>
 
 .. _atom-literals:
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -134,6 +134,11 @@ a subclass):
 
    four = 4 * A()._A__one()
 
+.. seealso::
+
+   The tutorial on :ref:`private variables <tut-private>` in classes for
+   a more complete example.
+
 .. _private-name-mangling-imports:
 
 .. rubric:: Mangled names in imports

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -116,14 +116,14 @@ identifier is used but only the following private identifiers are mangled:
 
 The transformation rule is defined as follows:
 
+- The class name, with leading underscores removed and a single leading
+  underscore inserted, is inserted in front of the identifier, e.g., the
+  identifier ``__spam`` occurring in a class named ``Foo``, ``_Foo`` or
+  ``__Foo`` is transformed to ``_Foo__spam``.
+  
 - If the class name consists only of underscores, the transformation is the
   identity, e.g., the identifier ``__spam`` occurring in a class named ``_``
   or ``__`` is left as is.
-
-- Otherwise, the transformation inserts the class name, with leading
-  underscores removed and a single leading underscore inserted, in front
-  of the identifier, e.g., the identifier ``__spam`` occurring in a class
-  named ``Foo``, ``_Foo`` or ``__Foo`` is transformed to ``_Foo__spam``.
 
 .. _atom-literals:
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -138,7 +138,7 @@ a subclass):
 .. rubric:: Mangled names in imports
 
 For identifiers declared using :keyword:`import` statements, the mangling
-rule is slightly different.  Throughout this paragraph, assume that we have
+rule is slightly different. Throughout this paragraph, assume that we have
 the following filesystem layout and, unless stated otherwise, the code snippets
 are in the ``__main__.py`` file.
 
@@ -170,8 +170,7 @@ a :exc:`ModuleNotFoundError`, as illustrated by the following example:
 
 If the ``__foo`` module is needed inside the ``Foo`` class, the import can
 be performed via the :func:`__import__` function, in which case the usual
-transformation rule is applied (a similar logic applies to :func:`getattr`,
-:func:`setattr` and :func:`delattr`, see ):
+transformation rule is applied:
 
 .. code-block:: python
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -101,18 +101,18 @@ implementation-defined truncation may happen.
 The transformation is independent of the syntactical context in which the
 identifier is used but only the following private identifiers are mangled:
 
+- Any name used as the name of a variable that is assigned or read or any
+  name of an attribute being accessed.
+
+  The ``__name__`` attribute of nested functions, classes, and type aliases
+  is however not mangled.
+
 - The name of imported modules, e.g., ``__spam`` in ``import __spam``.
   If the module is part of a package (i.e., its name contains a dot),
   the name is *not* mangled, e.g., the ``__foo`` in ``import __foo.bar``
   is not mangled.
 
 - The name of an imported member, e.g., ``__f`` in ``from spam import __f``.
-
-- Any name used as the name of a variable that is assigned or read or any
-  name of an attribute being accessed.
-
-  The ``__name__`` attribute of nested functions, classes, and type aliases
-  is however not mangled.
 
 The transformation rule is defined as follows:
 

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -684,7 +684,7 @@ clashes of names with names defined by subclasses), there is limited support for
 such a mechanism, called :dfn:`name mangling`.  Any identifier of the form
 ``__spam`` (at least two leading underscores, at most one trailing underscore)
 is textually replaced with ``_classname__spam``, where ``classname`` is the
-current class name with leading underscore(s) stripped.  This mangling is done
+current class name with leading underscore(s) stripped. [#]_ This mangling is done
 without regard to the syntactic position of the identifier, as long as it
 occurs within the definition of a class.
 
@@ -924,6 +924,8 @@ Examples::
 
 
 .. rubric:: Footnotes
+
+.. [#] See :ref:`here <private-name-mangling>` for details and special cases.
 
 .. [#] Except for one thing.  Module objects have a secret read-only attribute called
    :attr:`~object.__dict__` which returns the dictionary used to implement the module's

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -684,9 +684,14 @@ clashes of names with names defined by subclasses), there is limited support for
 such a mechanism, called :dfn:`name mangling`.  Any identifier of the form
 ``__spam`` (at least two leading underscores, at most one trailing underscore)
 is textually replaced with ``_classname__spam``, where ``classname`` is the
-current class name with leading underscore(s) stripped. [#]_ This mangling is done
+current class name with leading underscore(s) stripped.  This mangling is done
 without regard to the syntactic position of the identifier, as long as it
 occurs within the definition of a class.
+
+.. seealso::
+
+   The :ref:`private name mangling specifications <private-name-mangling>`
+   for details and special cases.
 
 Name mangling is helpful for letting subclasses override methods without
 breaking intraclass method calls.  For example::
@@ -930,5 +935,3 @@ Examples::
    namespace; the name :attr:`~object.__dict__` is an attribute but not a global name.
    Obviously, using this violates the abstraction of namespace implementation, and
    should be restricted to things like post-mortem debuggers.
-
-.. [#] See :ref:`here <private-name-mangling>` for details and special cases.

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -925,10 +925,10 @@ Examples::
 
 .. rubric:: Footnotes
 
-.. [#] See :ref:`here <private-name-mangling>` for details and special cases.
-
 .. [#] Except for one thing.  Module objects have a secret read-only attribute called
    :attr:`~object.__dict__` which returns the dictionary used to implement the module's
    namespace; the name :attr:`~object.__dict__` is an attribute but not a global name.
    Obviously, using this violates the abstraction of namespace implementation, and
    should be restricted to things like post-mortem debuggers.
+
+.. [#] See :ref:`here <private-name-mangling>` for details and special cases.


### PR DESCRIPTION
I do not have a NEWS entry but tell me if I need one.

(I'm shamefully pinging @erlend-aasland since you were quite reactive a few minutes ago!)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: 

- https://cpython-previews--120451.org.readthedocs.build/en/120451/reference/expressions.html#atom-identifiers
- https://cpython-previews--120451.org.readthedocs.build/en/120451/tutorial/classes.html#private-variables
- https://cpython-previews--120451.org.readthedocs.build/en/120451/faq/programming.html#i-try-to-use-spam-and-i-get-an-error-about-someclassname-spam

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-120452 -->
* Issue: gh-120452
<!-- /gh-issue-number -->
