### PR TITLE
gh-119727: Run tests in parallel by default

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -157,7 +157,7 @@ class Namespace(argparse.Namespace):
         self.verbose3 = False
         self.print_slow = False
         self.random_seed = None
-        self.use_mp = None
+        self.use_mp = 0
         self.forever = False
         self.header = False
         self.failfast = False

--- a/Misc/NEWS.d/next/Tests/2024-06-13-17-11-54.gh-issue-119727.Fz2b2I.rst
+++ b/Misc/NEWS.d/next/Tests/2024-06-13-17-11-54.gh-issue-119727.Fz2b2I.rst
@@ -1,0 +1,3 @@
+The Python test runner (regrtest) now runs tests in parallel by default. Use
+the ``--single-process`` option to run tests sequentially in a single process.
+Patch by Victor Stinner.


### PR DESCRIPTION
The Python test runner (regrtest) now runs tests in parallel by default.  Use the --single-process option to run tests sequentially in a single process.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119727 -->
* Issue: gh-119727
<!-- /gh-issue-number -->
