### PR TITLE
gh-120286: Add versionless symlinks with ABI flags

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2255,7 +2255,7 @@ bininstall: commoninstall altbininstall
 		echo "Creating directory $(LIBPC)"; \
 		$(INSTALL) -d -m $(DIRMODE) $(DESTDIR)$(LIBPC); \
 	fi
- 	-if test "$(ABIFLAGS)"; then \
+	-if test "$(ABIFLAGS)"; then \
 		if test -f $(DESTDIR)$(BINDIR)/python3$(ABIFLAGS)$(EXE) -o -h $(DESTDIR)$(BINDIR)/python3$(ABIFLAGS)$(EXE); then \
 			rm -f $(DESTDIR)$(BINDIR)/python3$(ABIFLAGS)$(EXE); \
 		fi; \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2255,6 +2255,18 @@ bininstall: commoninstall altbininstall
 		echo "Creating directory $(LIBPC)"; \
 		$(INSTALL) -d -m $(DIRMODE) $(DESTDIR)$(LIBPC); \
 	fi
+ 	-if test "$(ABIFLAGS)"; then \
+		if test -f $(DESTDIR)$(BINDIR)/python3$(ABIFLAGS)$(EXE) -o -h $(DESTDIR)$(BINDIR)/python3$(ABIFLAGS)$(EXE); then \
+			rm -f $(DESTDIR)$(BINDIR)/python3$(ABIFLAGS)$(EXE); \
+		fi; \
+		(cd $(DESTDIR)$(BINDIR); $(LN) -s python$(LDVERSION)$(EXE) python3$(ABIFLAGS)$(EXE)); \
+		rm -f $(DESTDIR)$(BINDIR)/python3$(ABIFLAGS)-config; \
+		(cd $(DESTDIR)$(BINDIR); $(LN) -s python$(LDVERSION)-config python3$(ABIFLAGS)-config); \
+		rm -f $(DESTDIR)$(LIBPC)/python3$(ABIFLAGS).pc; \
+		(cd $(DESTDIR)$(LIBPC); $(LN) -s python-$(LDVERSION).pc python3$(ABIFLAGS).pc); \
+		rm -f $(DESTDIR)$(LIBPC)/python3$(ABIFLAGS)-embed.pc; \
+		(cd $(DESTDIR)$(LIBPC); $(LN) -s python-$(LDVERSION)-embed.pc python3$(ABIFLAGS)-embed.pc); \
+	fi
 	-if test -f $(DESTDIR)$(BINDIR)/python3$(EXE) -o -h $(DESTDIR)$(BINDIR)/python3$(EXE); \
 	then rm -f $(DESTDIR)$(BINDIR)/python3$(EXE); \
 	else true; \

--- a/Misc/NEWS.d/next/Build/2024-06-13-15-48-04.gh-issue-120286.iKGAVi.rst
+++ b/Misc/NEWS.d/next/Build/2024-06-13-15-48-04.gh-issue-120286.iKGAVi.rst
@@ -1,0 +1,4 @@
+On POSIX systems, there are now versionless symlinks with the ABI flags, which may include debug ("d") and free-threaded ("t").  For example:
+* ``python3`` (default, non-debug build)
+* ``python3d`` (default, debug build)
+* ``python3t`` (free-threaded build)


### PR DESCRIPTION
```mermaid
---
title: Symlinks
---
graph TD;
    python3-->python3.14;
    python3d-->python3.14d;
    python3t-->python3.14t;
    python3td-->python3.14td;
```

```zsh
wannes@Stefans-iMac python3t-shortcuts % find ~/Library/Frameworks/Python.framework/Versions/3.14/bin 
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/python3.14-config
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/pydoc3.14
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/python3
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/pip3.14
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/pip3
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/python3t
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/python3.14t
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/idle3
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/python3-config
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/python3.14t-config
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/idle3.14
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/python3t-config
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/pydoc3
/Users/wannes/Library/Frameworks/Python.framework/Versions/3.14/bin/python3.14
```

<!-- gh-issue-number: gh-120286 -->
* Issue: gh-120286
<!-- /gh-issue-number -->
