### PR TITLE
gh-117657: Fix data races for set_inheritable in fileutils.c with free-threaded builds

### DIFF
--- a/Include/internal/pycore_pyatomic_ft_wrappers.h
+++ b/Include/internal/pycore_pyatomic_ft_wrappers.h
@@ -35,6 +35,9 @@ extern "C" {
     _Py_atomic_load_uintptr_acquire(&value)
 #define FT_ATOMIC_LOAD_PTR_RELAXED(value) \
     _Py_atomic_load_ptr_relaxed(&value)
+#define FT_ATOMIC_LOAD_INT(value) _Py_atomic_load_int(&value)
+#define FT_ATOMIC_STORE_INT(value, new_value) \
+    _Py_atomic_store_int(&value, new_value)
 #define FT_ATOMIC_LOAD_UINT8(value) \
     _Py_atomic_load_uint8(&value)
 #define FT_ATOMIC_STORE_UINT8(value, new_value) \
@@ -70,6 +73,8 @@ extern "C" {
 #define FT_ATOMIC_LOAD_PTR_ACQUIRE(value) value
 #define FT_ATOMIC_LOAD_UINTPTR_ACQUIRE(value) value
 #define FT_ATOMIC_LOAD_PTR_RELAXED(value) value
+#define FT_ATOMIC_LOAD_INT(value) value
+#define FT_ATOMIC_STORE_INT(value, new_value) value = new_value
 #define FT_ATOMIC_LOAD_UINT8(value) value
 #define FT_ATOMIC_STORE_UINT8(value, new_value) value = new_value
 #define FT_ATOMIC_LOAD_UINT8_RELAXED(value) value

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1,6 +1,7 @@
 #include "Python.h"
 #include "pycore_fileutils.h"     // fileutils definitions
 #include "pycore_runtime.h"       // _PyRuntime
+#include "pycore_pyatomic_ft_wrappers.h" // FT_ATOMIC_*
 #include "osdefs.h"               // SEP
 
 #include <stdlib.h>               // mbstowcs()
@@ -1502,7 +1503,7 @@ set_inheritable(int fd, int inheritable, int raise, int *atomic_flag_works)
 #else
 
 #if defined(HAVE_SYS_IOCTL_H) && defined(FIOCLEX) && defined(FIONCLEX)
-    if (ioctl_works != 0 && raise != 0) {
+    if (raise != 0 && FT_ATOMIC_LOAD_INT(ioctl_works) != 0) {
         /* fast-path: ioctl() only requires one syscall */
         /* caveat: raise=0 is an indicator that we must be async-signal-safe
          * thus avoid using ioctl() so we skip the fast-path. */
@@ -1512,7 +1513,7 @@ set_inheritable(int fd, int inheritable, int raise, int *atomic_flag_works)
             request = FIOCLEX;
         err = ioctl(fd, request, NULL);
         if (!err) {
-            ioctl_works = 1;
+            FT_ATOMIC_STORE_INT(ioctl_works, 1);
             return 0;
         }
 
@@ -1539,7 +1540,7 @@ set_inheritable(int fd, int inheritable, int raise, int *atomic_flag_works)
                with EACCES. While FIOCLEX is safe operation it may be
                unavailable because ioctl was denied altogether.
                This can be the case on Android. */
-            ioctl_works = 0;
+            FT_ATOMIC_STORE_INT(ioctl_works, 0);
         }
         /* fallback to fcntl() if ioctl() does not work */
     }


### PR DESCRIPTION
`ioctl_works` in `set_inheritable` function is a static variable which has three possible values:

| Value | Meaning |
|-------|---------|
| -1    | Initial value when the process starts. |
| 0     | `ioctl` cannot be used for this functionality; `fcntl` is used as a fallback. |
| 1     | `ioctl` works in the current environment, and we should continue to use it.

When it is `0`, using `ioctl` as a fast path will always be skipped.

When it is `-1` or `1`, `ioctl` will be used as a fast path to perform the functionality, and it will be set to `0` or `1` based on the result of whether `ioctl` raises an error or not. And if `ioctl` failed, use `fnctl` as a slow path fallback.

Following this logic, it is safe to call `set_inheritable` with multiple threads in a free-threaded build. The fast path can be safely used even if it leads to failure. Therefore, we can simply use atomic operations to read or write `ioctl_works`'s value to resolve data races.

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
