### PR TITLE
gh-120417: Fix "imported but unused" linter warnings

### DIFF
--- a/Lib/collections/abc.py
+++ b/Lib/collections/abc.py
@@ -1,5 +1,3 @@
 from _collections_abc import *
-from _collections_abc import __all__
-from _collections_abc import _CallableGenericAlias
-
-__all__ = [*__all__, '_CallableGenericAlias']
+from _collections_abc import __all__  # noqa: F401
+from _collections_abc import _CallableGenericAlias  # noqa: F401

--- a/Lib/collections/abc.py
+++ b/Lib/collections/abc.py
@@ -1,3 +1,5 @@
 from _collections_abc import *
 from _collections_abc import __all__
 from _collections_abc import _CallableGenericAlias
+
+__all__ = [*__all__, '_CallableGenericAlias']

--- a/Lib/importlib/machinery.py
+++ b/Lib/importlib/machinery.py
@@ -21,10 +21,9 @@ def all_suffixes():
     return SOURCE_SUFFIXES + BYTECODE_SUFFIXES + EXTENSION_SUFFIXES
 
 
-__all__ = ['ModuleSpec', 'BuiltinImporter', 'FrozenImporter',
-           'SOURCE_SUFFIXES', 'DEBUG_BYTECODE_SUFFIXES',
-           'OPTIMIZED_BYTECODE_SUFFIXES', 'BYTECODE_SUFFIXES',
-           'EXTENSION_SUFFIXES', 'WindowsRegistryFinder', 'PathFinder',
-           'FileFinder', 'SourceFileLoader', 'SourcelessFileLoader',
-           'ExtensionFileLoader', 'AppleFrameworkLoader', 'NamespaceLoader',
-           'all_suffixes']
+__all__ = ['AppleFrameworkLoader', 'BYTECODE_SUFFIXES', 'BuiltinImporter',
+           'DEBUG_BYTECODE_SUFFIXES', 'EXTENSION_SUFFIXES',
+           'ExtensionFileLoader', 'FileFinder', 'FrozenImporter', 'ModuleSpec',
+           'NamespaceLoader', 'OPTIMIZED_BYTECODE_SUFFIXES', 'PathFinder',
+           'SOURCE_SUFFIXES', 'SourceFileLoader', 'SourcelessFileLoader',
+           'WindowsRegistryFinder', 'all_suffixes']

--- a/Lib/importlib/machinery.py
+++ b/Lib/importlib/machinery.py
@@ -19,3 +19,12 @@ from ._bootstrap_external import NamespaceLoader
 def all_suffixes():
     """Returns a list of all recognized module suffixes for this process"""
     return SOURCE_SUFFIXES + BYTECODE_SUFFIXES + EXTENSION_SUFFIXES
+
+
+__all__ = ['ModuleSpec', 'BuiltinImporter', 'FrozenImporter',
+           'SOURCE_SUFFIXES', 'DEBUG_BYTECODE_SUFFIXES',
+           'OPTIMIZED_BYTECODE_SUFFIXES', 'BYTECODE_SUFFIXES',
+           'EXTENSION_SUFFIXES', 'WindowsRegistryFinder', 'PathFinder',
+           'FileFinder', 'SourceFileLoader', 'SourcelessFileLoader',
+           'ExtensionFileLoader', 'AppleFrameworkLoader', 'NamespaceLoader',
+           'all_suffixes']

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -272,8 +272,7 @@ class LazyLoader(Loader):
         module.__class__ = _LazyModule
 
 
-__all__ = ['Loader', 'module_from_spec', '_resolve_name', 'spec_from_loader',
-           '_find_spec', 'MAGIC_NUMBER', '_RAW_MAGIC_NUMBER',
-           'cache_from_source', 'decode_source', 'source_from_cache',
-           'spec_from_file_location', 'source_hash', 'resolve_name',
-           'find_spec', 'LazyLoader']
+__all__ = ['LazyLoader', 'Loader', 'MAGIC_NUMBER',
+           'cache_from_source', 'decode_source', 'find_spec',
+           'module_from_spec', 'resolve_name', 'source_from_cache',
+           'source_hash', 'spec_from_file_location', 'spec_from_loader']

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -270,3 +270,10 @@ class LazyLoader(Loader):
         loader_state['is_loading'] = False
         module.__spec__.loader_state = loader_state
         module.__class__ = _LazyModule
+
+
+__all__ = ['Loader', 'module_from_spec', '_resolve_name', 'spec_from_loader',
+           '_find_spec', 'MAGIC_NUMBER', '_RAW_MAGIC_NUMBER',
+           'cache_from_source', 'decode_source', 'source_from_cache',
+           'spec_from_file_location', 'source_hash', 'resolve_name',
+           'find_spec', 'LazyLoader']

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -79,7 +79,7 @@ _can_fork_exec = sys.platform not in {"emscripten", "wasi", "ios", "tvos", "watc
 
 if _mswindows:
     import _winapi
-    from _winapi import (CREATE_NEW_CONSOLE, CREATE_NEW_PROCESS_GROUP,
+    from _winapi import (CREATE_NEW_CONSOLE, CREATE_NEW_PROCESS_GROUP,  # noqa: F401
                          STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
                          STD_ERROR_HANDLE, SW_HIDE,
                          STARTF_USESTDHANDLES, STARTF_USESHOWWINDOW,

--- a/Lib/test/test_importlib/test_api.py
+++ b/Lib/test/test_importlib/test_api.py
@@ -6,6 +6,7 @@ machinery = test_util.import_importlib('importlib.machinery')
 
 import os.path
 import sys
+from test import support
 from test.support import import_helper
 from test.support import os_helper
 import types
@@ -435,6 +436,45 @@ class StartupTests:
 (Frozen_StartupTests,
  Source_StartupTests
  ) = test_util.test_both(StartupTests, machinery=machinery)
+
+
+class TestModuleAll(unittest.TestCase):
+    def test_machinery(self):
+        extra = (
+            # from importlib._bootstrap and importlib._bootstrap_external
+            'AppleFrameworkLoader',
+            'BYTECODE_SUFFIXES',
+            'BuiltinImporter',
+            'DEBUG_BYTECODE_SUFFIXES',
+            'EXTENSION_SUFFIXES',
+            'ExtensionFileLoader',
+            'FileFinder',
+            'FrozenImporter',
+            'ModuleSpec',
+            'NamespaceLoader',
+            'OPTIMIZED_BYTECODE_SUFFIXES',
+            'PathFinder',
+            'SOURCE_SUFFIXES',
+            'SourceFileLoader',
+            'SourcelessFileLoader',
+            'WindowsRegistryFinder',
+        )
+        support.check__all__(self, machinery['Source'], extra=extra)
+
+    def test_util(self):
+        extra = (
+            # from importlib.abc, importlib._bootstrap
+            # and importlib._bootstrap_external
+            'Loader',
+            'MAGIC_NUMBER',
+            'cache_from_source',
+            'decode_source',
+            'module_from_spec',
+            'source_from_cache',
+            'spec_from_file_location',
+            'spec_from_loader',
+        )
+        support.check__all__(self, util['Source'], extra=extra)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -16,6 +16,7 @@ from xml.sax.expatreader import create_parser
 from xml.sax.handler import (feature_namespaces, feature_external_ges,
                              LexicalHandler)
 from xml.sax.xmlreader import InputSource, AttributesImpl, AttributesNSImpl
+from xml import sax
 from io import BytesIO, StringIO
 import codecs
 import os.path
@@ -25,7 +26,7 @@ import sys
 from urllib.error import URLError
 import urllib.request
 from test.support import os_helper
-from test.support import findfile
+from test.support import findfile, check__all__
 from test.support.os_helper import FakePath, TESTFN
 
 
@@ -1555,6 +1556,21 @@ class CDATAHandlerTest(unittest.TestCase):
 
         self.assertFalse(self.in_cdata)
         self.assertEqual(self.char_index, 2)
+
+
+class TestModuleAll(unittest.TestCase):
+    def test_all(self):
+        extra = (
+            'ContentHandler',
+            'ErrorHandler',
+            'InputSource',
+            'SAXException',
+            'SAXNotRecognizedException',
+            'SAXNotSupportedException',
+            'SAXParseException',
+            'SAXReaderNotAvailable',
+        )
+        check__all__(self, sax, extra=extra)
 
 
 if __name__ == "__main__":

--- a/Lib/xml/sax/__init__.py
+++ b/Lib/xml/sax/__init__.py
@@ -21,9 +21,9 @@ expatreader -- Driver that allows use of the Expat parser with SAX.
 
 from .xmlreader import InputSource
 from .handler import ContentHandler, ErrorHandler
-from ._exceptions import SAXException, SAXNotRecognizedException, \
-                        SAXParseException, SAXNotSupportedException, \
-                        SAXReaderNotAvailable
+from ._exceptions import (SAXException, SAXNotRecognizedException,
+                          SAXParseException, SAXNotSupportedException,
+                          SAXReaderNotAvailable)
 
 
 def parse(source, handler, errorHandler=ErrorHandler()):
@@ -55,7 +55,7 @@ default_parser_list = ["xml.sax.expatreader"]
 # tell modulefinder that importing sax potentially imports expatreader
 _false = 0
 if _false:
-    import xml.sax.expatreader
+    import xml.sax.expatreader    # noqa: F401
 
 import os, sys
 if not sys.flags.ignore_environment and "PY_SAX_PARSER" in os.environ:
@@ -92,3 +92,9 @@ def make_parser(parser_list=()):
 def _create_parser(parser_name):
     drv_module = __import__(parser_name,{},{},['create_parser'])
     return drv_module.create_parser()
+
+
+__all__ = ['InputSource', 'ContentHandler', 'ErrorHandler', 'SAXException',
+           'SAXNotRecognizedException', 'SAXParseException',
+           'SAXNotSupportedException', 'SAXReaderNotAvailable', 'parse',
+           'parseString', 'make_parser', 'default_parser_list']

--- a/Lib/xml/sax/__init__.py
+++ b/Lib/xml/sax/__init__.py
@@ -94,7 +94,7 @@ def _create_parser(parser_name):
     return drv_module.create_parser()
 
 
-__all__ = ['InputSource', 'ContentHandler', 'ErrorHandler', 'SAXException',
-           'SAXNotRecognizedException', 'SAXParseException',
-           'SAXNotSupportedException', 'SAXReaderNotAvailable', 'parse',
-           'parseString', 'make_parser', 'default_parser_list']
+__all__ = ['ContentHandler', 'ErrorHandler', 'InputSource', 'SAXException',
+           'SAXNotRecognizedException', 'SAXNotSupportedException',
+           'SAXParseException', 'SAXReaderNotAvailable',
+           'default_parser_list', 'make_parser', 'parse', 'parseString']


### PR DESCRIPTION
Add `__all__` to the following modules: collections.abc, importlib.machinery, importlib.util and xml.sax.

Add also "# noqa: F401" in subprocess and xml.sax on two lines.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120417 -->
* Issue: gh-120417
<!-- /gh-issue-number -->
