### PR TITLE
[3.12] gh-119897: Revert buggy optimization which was removed in 3.13

### DIFF
--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -213,9 +213,6 @@ _PyFrame_GetFrameObject(_PyInterpreterFrame *frame)
     return _PyFrame_MakeAndSetFrameObject(frame);
 }
 
-void
-_PyFrame_ClearLocals(_PyInterpreterFrame *frame);
-
 /* Clears all references in the frame.
  * If take is non-zero, then the _PyInterpreterFrame frame
  * may be transferred to the frame object it references

--- a/Lib/test/test_cprofile.py
+++ b/Lib/test/test_cprofile.py
@@ -83,8 +83,8 @@ class CProfileTest(ProfileTest):
 
         for func, (cc, nc, _, _, _) in pr.stats.items():
             if func[2] == "<genexpr>":
-                self.assertEqual(cc, 1)
-                self.assertEqual(nc, 1)
+                self.assertEqual(cc, 2)
+                self.assertEqual(nc, 2)
 
 
 class TestCommandLine(unittest.TestCase):

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -6,6 +6,7 @@ import doctest
 import unittest
 import weakref
 import inspect
+import types
 
 from test import support
 
@@ -89,9 +90,12 @@ class FinalizationTest(unittest.TestCase):
         self.assertEqual(gc.garbage, old_garbage)
 
     def test_lambda_generator(self):
-        # Issue #23192: Test that a lambda returning a generator behaves
+        # bpo-23192, gh-119897: Test that a lambda returning a generator behaves
         # like the equivalent function
         f = lambda: (yield 1)
+        self.assertIsInstance(f(), types.GeneratorType)
+        self.assertEqual(next(f()), 1)
+
         def g(): return (yield 1)
 
         # test 'yield from'

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -450,26 +450,6 @@ class ExceptionTest(unittest.TestCase):
         self.assertIsInstance(cm.exception.value, StopIteration)
         self.assertEqual(cm.exception.value.value, 2)
 
-    def test_close_releases_frame_locals(self):
-        # See gh-118272
-
-        class Foo:
-            pass
-
-        f = Foo()
-        f_wr = weakref.ref(f)
-
-        def genfn():
-            a = f
-            yield
-
-        g = genfn()
-        next(g)
-        del f
-        g.close()
-        support.gc_collect()
-        self.assertIsNone(f_wr())
-
 
 class GeneratorThrowTest(unittest.TestCase):
 

--- a/Lib/test/test_sys_setprofile.py
+++ b/Lib/test/test_sys_setprofile.py
@@ -267,6 +267,10 @@ class ProfileHookTestCase(TestCaseBase):
         self.check_events(g, [(1, 'call', g_ident),
                               (2, 'call', f_ident),
                               (2, 'return', f_ident),
+                              # once more; the generator is being garbage collected
+                              # and it will do a PY_THROW
+                              (2, 'call', f_ident),
+                              (2, 'return', f_ident),
                               (1, 'return', g_ident),
                               ])
 

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -374,6 +374,7 @@ static PyObject *
 gen_close(PyGenObject *gen, PyObject *args)
 {
     PyObject *retval;
+    PyObject *yf = _PyGen_yf(gen);
     int err = 0;
 
     if (gen->gi_frame_state == FRAME_CREATED) {
@@ -383,7 +384,6 @@ gen_close(PyGenObject *gen, PyObject *args)
     if (gen->gi_frame_state >= FRAME_COMPLETED) {
         Py_RETURN_NONE;
     }
-    PyObject *yf = _PyGen_yf(gen);
     if (yf) {
         PyFrameState state = gen->gi_frame_state;
         gen->gi_frame_state = FRAME_EXECUTING;
@@ -396,13 +396,12 @@ gen_close(PyGenObject *gen, PyObject *args)
      * YIELD_VALUE if the debugger has changed the lineno. */
     if (err == 0 && is_yield(frame->prev_instr)) {
         assert(is_resume(frame->prev_instr + 1));
-        int exception_handler_depth = frame->prev_instr[0].op.arg;
+        int exception_handler_depth = frame->prev_instr[0].op.code;
         assert(exception_handler_depth > 0);
         /* We can safely ignore the outermost try block
          * as it automatically generated to handle
          * StopIteration. */
         if (exception_handler_depth == 1) {
-            gen->gi_frame_state = FRAME_COMPLETED;
             Py_RETURN_NONE;
         }
     }

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -403,7 +403,6 @@ gen_close(PyGenObject *gen, PyObject *args)
          * StopIteration. */
         if (exception_handler_depth == 1) {
             gen->gi_frame_state = FRAME_COMPLETED;
-            _PyFrame_ClearLocals((_PyInterpreterFrame *)gen->gi_iframe);
             Py_RETURN_NONE;
         }
     }

--- a/Python/frame.c
+++ b/Python/frame.c
@@ -116,18 +116,6 @@ take_ownership(PyFrameObject *f, _PyInterpreterFrame *frame)
 }
 
 void
-_PyFrame_ClearLocals(_PyInterpreterFrame *frame)
-{
-    assert(frame->stacktop >= 0);
-    int stacktop = frame->stacktop;
-    frame->stacktop = 0;
-    for (int i = 0; i < stacktop; i++) {
-        Py_XDECREF(frame->localsplus[i]);
-    }
-    Py_CLEAR(frame->f_locals);
-}
-
-void
 _PyFrame_ClearExceptCode(_PyInterpreterFrame *frame)
 {
     /* It is the responsibility of the owning generator/coroutine
@@ -147,8 +135,12 @@ _PyFrame_ClearExceptCode(_PyInterpreterFrame *frame)
         }
         Py_DECREF(f);
     }
-    _PyFrame_ClearLocals(frame);
+    assert(frame->stacktop >= 0);
+    for (int i = 0; i < frame->stacktop; i++) {
+        Py_XDECREF(frame->localsplus[i]);
+    }
     Py_XDECREF(frame->frame_obj);
+    Py_XDECREF(frame->f_locals);
     Py_DECREF(frame->f_funcobj);
 }
 


### PR DESCRIPTION
Fixes #120467.

Reverts https://github.com/python/cpython/pull/111069 and the followup https://github.com/python/cpython/pull/111459.

<!-- gh-issue-number: gh-119897 -->
* Issue: gh-119897
<!-- /gh-issue-number -->
