### PR TITLE
gh-119819: Conditional skip of logging tests that require multiprocessing subprocess support

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3898,6 +3898,7 @@ class ConfigDictTest(BaseTest):
                 self.addCleanup(os.remove, fn)
 
     @threading_helper.requires_working_threading()
+    @support.requires_subprocess()
     def test_config_queue_handler(self):
         q = CustomQueue()
         dq = {
@@ -3926,11 +3927,9 @@ class ConfigDictTest(BaseTest):
             msg = str(ctx.exception)
             self.assertEqual(msg, "Unable to configure handler 'ah'")
 
+    @support.requires_subprocess()
     def test_multiprocessing_queues(self):
         # See gh-119819
-
-        # will skip test if it's not available
-        import_helper.import_module('_multiprocessing')
 
         cd = copy.deepcopy(self.config_queue_handler)
         from multiprocessing import Queue as MQ, Manager as MM


### PR DESCRIPTION
multiprocessing.Manager.Queue requires the use of subprocesses; as a result, it can't run on iOS (and presumably will fail on WASI/Android as well). 

#120067 was a previous attempt to address this issue; that fix worked for some platforms, but not iOS.


<!-- gh-issue-number: gh-119819 -->
* Issue: gh-119819
<!-- /gh-issue-number -->
