### PR TITLE
gh-117398: Use the correct module loader for iOS in datetime CAPI test.

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -6786,6 +6786,13 @@ class CapiTest(unittest.TestCase):
                     self.assertEqual(dt_orig, dt_rt)
 
     def test_type_check_in_subinterp(self):
+        # iOS requires the use of the custom framework loader,
+        # not the ExtensionFileLoader.
+        if sys.platform == "ios":
+            extension_loader = "AppleFrameworkLoader"
+        else:
+            extension_loader = "ExtensionFileLoader"
+
         script = textwrap.dedent(f"""
             if {_interpreters is None}:
                 import _testcapi as module
@@ -6795,7 +6802,7 @@ class CapiTest(unittest.TestCase):
                 import importlib.util
                 fullname = '_testcapi_datetime'
                 origin = importlib.util.find_spec('_testcapi').origin
-                loader = importlib.machinery.ExtensionFileLoader(fullname, origin)
+                loader = importlib.machinery.{extension_loader}(fullname, origin)
                 spec = importlib.util.spec_from_loader(fullname, loader)
                 module = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(module)


### PR DESCRIPTION
#119604 added a CAPI test for subinterpreters in the datetime tests; however, the test uses the ExtensionFileLoader to load `_testcapi`. iOS requires the use of the AppleFrameworkLoader.

The buildbot validation will fail because of #120476; however, with this PR, `test_datetime` no longer fails.

<!-- gh-issue-number: gh-117398 -->
* Issue: gh-117398
<!-- /gh-issue-number -->
