### PR TITLE
gh-117657: Make PyType_HasFeature (exported version) atomic

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -756,7 +756,11 @@ PyType_HasFeature(PyTypeObject *type, unsigned long feature)
     // PyTypeObject is opaque in the limited C API
     flags = PyType_GetFlags(type);
 #else
-    flags = type->tp_flags;
+#   ifdef Py_GIL_DISABLED
+        flags = _Py_atomic_load_ulong_relaxed(&type->tp_flags);
+#   else
+        flags = type->tp_flags;
+#   endif
 #endif
     return ((flags & feature) != 0);
 }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3555,7 +3555,7 @@ type_init(PyObject *cls, PyObject *args, PyObject *kwds)
 unsigned long
 PyType_GetFlags(PyTypeObject *type)
 {
-    return type->tp_flags;
+    return FT_ATOMIC_LOAD_ULONG_RELAXED(type->tp_flags);
 }
 
 


### PR DESCRIPTION
Sorry I forgot that there was also an external version (non-inline) of `_PyType_HasFeature`.

Even though `type_ready` holds the type lock, it's possible for it to be modifying a the tp_flags and for another thread's `PyType_HasFeature` to read it.

```
WARNING: ThreadSanitizer: data race (pid=34702)
  Write of size 8 at 0x555555e7fc48 by thread T1:
    #0 type_ready /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:8377:20 (python+0x39108a) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #1 init_static_type /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:8446:11 (python+0x391acb) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #2 _PyStaticType_InitBuiltin /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:8464:12 (python+0x391da7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #3 _PyTypes_InitTypes /home/ken/Documents/GitHub/cpython/Objects/object.c:2329:13 (python+0x32869b) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #4 pycore_init_types /home/ken/Documents/GitHub/cpython/Python/pylifecycle.c:722:14 (python+0x57ba0a) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #5 pycore_interp_init /home/ken/Documents/GitHub/cpython/Python/pylifecycle.c:873:14 (python+0x57b796) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #6 new_interpreter /home/ken/Documents/GitHub/cpython/Python/pylifecycle.c:2247:14 (python+0x579dda) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #7 Py_NewInterpreterFromConfig /home/ken/Documents/GitHub/cpython/Python/pylifecycle.c:2280:12 (python+0x57990e) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #8 _PyXI_NewInterpreter /home/ken/Documents/GitHub/cpython/Python/crossinterp.c:1832:23 (python+0x5058d8) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #9 interp_create /home/ken/Documents/GitHub/cpython/./Modules/_interpretersmodule.c:625:13 (_interpreters.cpython-314td-x86_64-linux-gnu.so+0x3ddf) (BuildId: d3c8959e12d1bbc7f6d653e463a94965d61705f9)
    #10 cfunction_call /home/ken/Documents/GitHub/cpython/Objects/methodobject.c:540:18 (python+0x31a189) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #11 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x259183) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #12 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2589e9) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #13 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x25a590) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #14 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4a1252) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #15 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #16 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #17 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #18 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x260c31) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #19 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:70:20 (python+0x25ef55) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #20 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x25a45f) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #21 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x25a6f7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #22 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x25a8e7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #23 thread_run /home/ken/Documents/GitHub/cpython/./Modules/_threadmodule.c:337:21 (python+0x6a2168) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #24 pythread_wrapper /home/ken/Documents/GitHub/cpython/Python/thread_pthread.h:243:5 (python+0x5dd89b) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)

  Previous read of size 8 at 0x555555e7fc48 by main thread:
    #0 PyType_HasFeature /home/ken/Documents/GitHub/cpython/./Include/object.h:759:19 (python+0x383a8a) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #1 find_name_in_mro /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:5258:9 (python+0x383a8a)
    #2 _PyType_LookupRef /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:5411:11 (python+0x3806fe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #3 _PyObject_GetMethod /home/ken/Documents/GitHub/cpython/Objects/object.c:1472:23 (python+0x326f88) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #4 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:3741:25 (python+0x4b3802) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #5 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #6 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #7 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #8 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x260c31) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #9 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x25efc2) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #10 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x25a45f) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #11 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x25a6f7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #12 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x25a8e7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #13 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x4a4781) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #14 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #15 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #16 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #17 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x258c83) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #18 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x25af46) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #19 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9675:15 (python+0x3979ac) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #20 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x259183) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #21 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2589e9) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #22 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x25a590) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #23 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4a1252) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #24 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #25 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #26 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #27 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x260c31) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #28 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x25efc2) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #29 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x25a45f) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #30 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x25a6f7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #31 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x25a8e7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #32 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x4a4781) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #33 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #34 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #35 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #36 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x258c83) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #37 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x25af46) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #38 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9675:15 (python+0x3979ac) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #39 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x259183) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #40 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2589e9) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #41 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x25a590) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #42 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4a1252) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #43 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #44 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #45 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #46 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x260c31) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #47 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x25efc2) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #48 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x25a45f) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #49 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x25a6f7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #50 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x25a8e7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #51 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x4a4781) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #52 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #53 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #54 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #55 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x258c83) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #56 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x25af46) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #57 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9675:15 (python+0x3979ac) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #58 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x259183) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #59 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2589e9) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #60 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x25a590) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #61 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4a1252) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #62 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #63 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #64 PyEval_EvalCode /home/ken/Documents/GitHub/cpython/Python/ceval.c:599:21 (python+0x49afaa) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #65 builtin_exec_impl /home/ken/Documents/GitHub/cpython/Python/bltinmodule.c:1145:17 (python+0x493393) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #66 builtin_exec /home/ken/Documents/GitHub/cpython/Python/clinic/bltinmodule.c.h:556:20 (python+0x493393)
    #67 cfunction_vectorcall_FASTCALL_KEYWORDS /home/ken/Documents/GitHub/cpython/Objects/methodobject.c:441:24 (python+0x318c4c) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #68 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x2589c1) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #69 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x25a590) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #70 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4a1252) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #71 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #72 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #73 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #74 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x25a45f) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #75 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x25a6f7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #76 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x25a8e7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #77 pymain_run_module /home/ken/Documents/GitHub/cpython/Modules/main.c:297:14 (python+0x5f95d3) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #78 pymain_run_python /home/ken/Documents/GitHub/cpython/Modules/main.c (python+0x5f8ceb) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #79 Py_RunMain /home/ken/Documents/GitHub/cpython/Modules/main.c:719:5 (python+0x5f8ceb)
    #80 pymain_main /home/ken/Documents/GitHub/cpython/Modules/main.c:749:12 (python+0x5f9379) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #81 Py_BytesMain /home/ken/Documents/GitHub/cpython/Modules/main.c:773:12 (python+0x5f93f9) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #82 main /home/ken/Documents/GitHub/cpython/./Programs/python.c:15:12 (python+0x15a840) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)

  Location is global 'PyDict_Type' of size 432 at 0x555555e7fb90 (python+0x92bc48)

  Thread T1 (tid=35289, running) created by main thread at:
    #0 pthread_create <null> (python+0xdd37b) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #1 do_start_joinable_thread /home/ken/Documents/GitHub/cpython/Python/thread_pthread.h:290:14 (python+0x5dc50b) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #2 PyThread_start_joinable_thread /home/ken/Documents/GitHub/cpython/Python/thread_pthread.h:314:9 (python+0x5dc32a) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #3 ThreadHandle_start /home/ken/Documents/GitHub/cpython/./Modules/_threadmodule.c:422:9 (python+0x6a1c6f) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #4 do_start_new_thread /home/ken/Documents/GitHub/cpython/./Modules/_threadmodule.c:1798:9 (python+0x6a1c6f)
    #5 thread_PyThread_start_joinable_thread /home/ken/Documents/GitHub/cpython/./Modules/_threadmodule.c:1921:14 (python+0x6a06c5) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #6 cfunction_call /home/ken/Documents/GitHub/cpython/Objects/methodobject.c:540:18 (python+0x31a189) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #7 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x259183) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #8 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2589e9) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #9 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x25a590) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #10 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1505:19 (python+0x4a5973) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #11 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #12 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #13 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #14 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x260c31) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #15 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x25efc2) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #16 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x25a45f) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #17 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x25a6f7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #18 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x25a8e7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #19 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x4a4781) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #20 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #21 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #22 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #23 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x258c83) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #24 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x25af46) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #25 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9675:15 (python+0x3979ac) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #26 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x259183) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #27 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2589e9) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #28 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x25a590) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #29 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4a1252) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #30 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #31 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #32 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #33 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x260c31) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #34 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x25efc2) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #35 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x25a45f) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #36 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x25a6f7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #37 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x25a8e7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #38 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x4a4781) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #39 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #40 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #41 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #42 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x258c83) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #43 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x25af46) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #44 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9675:15 (python+0x3979ac) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #45 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x259183) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #46 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2589e9) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #47 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x25a590) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #48 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4a1252) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #49 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #50 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #51 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #52 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x260c31) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #53 method_vectorcall /home/ken/Documents/GitHub/cpython/Objects/classobject.c:92:18 (python+0x25efc2) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #54 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x25a45f) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #55 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x25a6f7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #56 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x25a8e7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #57 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:1358:26 (python+0x4a4781) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #58 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #59 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #60 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #61 _PyObject_VectorcallDictTstate /home/ken/Documents/GitHub/cpython/Objects/call.c:135:15 (python+0x258c83) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #62 _PyObject_Call_Prepend /home/ken/Documents/GitHub/cpython/Objects/call.c:504:24 (python+0x25af46) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #63 slot_tp_call /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:9675:15 (python+0x3979ac) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #64 _PyObject_MakeTpCall /home/ken/Documents/GitHub/cpython/Objects/call.c:242:18 (python+0x259183) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #65 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:166:16 (python+0x2589e9) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #66 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x25a590) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #67 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4a1252) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #68 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #69 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #70 PyEval_EvalCode /home/ken/Documents/GitHub/cpython/Python/ceval.c:599:21 (python+0x49afaa) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #71 builtin_exec_impl /home/ken/Documents/GitHub/cpython/Python/bltinmodule.c:1145:17 (python+0x493393) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #72 builtin_exec /home/ken/Documents/GitHub/cpython/Python/clinic/bltinmodule.c.h:556:20 (python+0x493393)
    #73 cfunction_vectorcall_FASTCALL_KEYWORDS /home/ken/Documents/GitHub/cpython/Objects/methodobject.c:441:24 (python+0x318c4c) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #74 _PyObject_VectorcallTstate /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_call.h:168:11 (python+0x2589c1) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #75 PyObject_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c:327:12 (python+0x25a590) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #76 _PyEval_EvalFrameDefault /home/ken/Documents/GitHub/cpython/Python/generated_cases.c.h:813:23 (python+0x4a1252) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #77 _PyEval_EvalFrame /home/ken/Documents/GitHub/cpython/./Include/internal/pycore_ceval.h:119:16 (python+0x49b343) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #78 _PyEval_Vector /home/ken/Documents/GitHub/cpython/Python/ceval.c:1819:12 (python+0x49b343)
    #79 _PyFunction_Vectorcall /home/ken/Documents/GitHub/cpython/Objects/call.c (python+0x25aabe) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #80 _PyVectorcall_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:273:16 (python+0x25a45f) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #81 _PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:348:16 (python+0x25a6f7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #82 PyObject_Call /home/ken/Documents/GitHub/cpython/Objects/call.c:373:12 (python+0x25a8e7) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #83 pymain_run_module /home/ken/Documents/GitHub/cpython/Modules/main.c:297:14 (python+0x5f95d3) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #84 pymain_run_python /home/ken/Documents/GitHub/cpython/Modules/main.c (python+0x5f8ceb) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #85 Py_RunMain /home/ken/Documents/GitHub/cpython/Modules/main.c:719:5 (python+0x5f8ceb)
    #86 pymain_main /home/ken/Documents/GitHub/cpython/Modules/main.c:749:12 (python+0x5f9379) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #87 Py_BytesMain /home/ken/Documents/GitHub/cpython/Modules/main.c:773:12 (python+0x5f93f9) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)
    #88 main /home/ken/Documents/GitHub/cpython/./Programs/python.c:15:12 (python+0x15a840) (BuildId: 694e56b40bf3a000e16c7d252050b947e0570c2c)

SUMMARY: ThreadSanitizer: data race /home/ken/Documents/GitHub/cpython/Objects/typeobject.c:8377:20 in type_ready
```

<!-- gh-issue-number: gh-120321 -->
* Issue: gh-120321
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
