### PR TITLE
gh-120485: Add an override of `allow_reuse_port` on classes inheriting `socketserver.TCPServer`

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -130,6 +130,7 @@ DEFAULT_ERROR_CONTENT_TYPE = "text/html;charset=utf-8"
 class HTTPServer(socketserver.TCPServer):
 
     allow_reuse_address = 1    # Seems to make sense in testing environment
+    allow_reuse_port = 1
 
     def server_bind(self):
         """Override server_bind to store the server name."""

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -129,8 +129,8 @@ DEFAULT_ERROR_CONTENT_TYPE = "text/html;charset=utf-8"
 
 class HTTPServer(socketserver.TCPServer):
 
-    allow_reuse_address = 1    # Seems to make sense in testing environment
-    allow_reuse_port = 1
+    allow_reuse_address = True    # Seems to make sense in testing environment
+    allow_reuse_port = True
 
     def server_bind(self):
         """Override server_bind to store the server name."""

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -985,6 +985,7 @@ def listen(port=DEFAULT_LOGGING_CONFIG_PORT, verify=None):
         """
 
         allow_reuse_address = 1
+        allow_reuse_port = 1
 
         def __init__(self, host='localhost', port=DEFAULT_LOGGING_CONFIG_PORT,
                      handler=None, ready=None, verify=None):

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -984,8 +984,8 @@ def listen(port=DEFAULT_LOGGING_CONFIG_PORT, verify=None):
         A simple TCP socket-based logging config receiver.
         """
 
-        allow_reuse_address = 1
-        allow_reuse_port = 1
+        allow_reuse_address = True
+        allow_reuse_port = True
 
         def __init__(self, host='localhost', port=DEFAULT_LOGGING_CONFIG_PORT,
                      handler=None, ready=None, verify=None):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1038,6 +1038,7 @@ class TestTCPServer(ControlMixin, ThreadingTCPServer):
     """
 
     allow_reuse_address = True
+    allow_reuse_port = True
 
     def __init__(self, addr, handler, poll_interval=0.5,
                  bind_and_activate=True):

--- a/Lib/xmlrpc/server.py
+++ b/Lib/xmlrpc/server.py
@@ -578,6 +578,7 @@ class SimpleXMLRPCServer(socketserver.TCPServer,
     """
 
     allow_reuse_address = True
+    allow_reuse_port = True
 
     # Warning: this is for debugging purposes only! Never set this to True in
     # production code, as will be sending out sensitive information (exception

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-14-07-52-00.gh-issue-120485.yy4K4b.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-14-07-52-00.gh-issue-120485.yy4K4b.rst
@@ -1,1 +1,1 @@
-Add an override of `allow_reuse_port` on classes inheriting socketserver.TCPServer where `allow_reuse_address` is also overriden
+Add an override of ``allow_reuse_port`` on classes inheriting socketserver.TCPServer where ``allow_reuse_address`` is also overriden

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-14-07-52-00.gh-issue-120485.yy4K4b.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-14-07-52-00.gh-issue-120485.yy4K4b.rst
@@ -1,1 +1,1 @@
-Add an override of ``allow_reuse_port`` on classes inheriting socketserver.TCPServer where ``allow_reuse_address`` is also overridden
+Add an override of ``allow_reuse_port`` on classes subclassing ``socketserver.TCPServer`` where ``allow_reuse_address`` is also overridden.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-14-07-52-00.gh-issue-120485.yy4K4b.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-14-07-52-00.gh-issue-120485.yy4K4b.rst
@@ -1,0 +1,1 @@
+Add an override of `allow_reuse_port` on classes inheriting socketserver.TCPServer where `allow_reuse_address` is also overriden

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-14-07-52-00.gh-issue-120485.yy4K4b.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-14-07-52-00.gh-issue-120485.yy4K4b.rst
@@ -1,1 +1,1 @@
-Add an override of ``allow_reuse_port`` on classes inheriting socketserver.TCPServer where ``allow_reuse_address`` is also overriden
+Add an override of ``allow_reuse_port`` on classes inheriting socketserver.TCPServer where ``allow_reuse_address`` is also overridden


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120485 -->
* Issue: gh-120485
<!-- /gh-issue-number -->
