### PR TITLE
gh-120495: Fix incorrect exception handling in Tab Nanny

### DIFF
--- a/Lib/tabnanny.py
+++ b/Lib/tabnanny.py
@@ -105,12 +105,12 @@ def check(file):
         errprint("%r: Token Error: %s" % (file, msg))
         return
 
-    except SyntaxError as msg:
-        errprint("%r: Token Error: %s" % (file, msg))
-        return
-
     except IndentationError as msg:
         errprint("%r: Indentation Error: %s" % (file, msg))
+        return
+
+    except SyntaxError as msg:
+        errprint("%r: Token Error: %s" % (file, msg))
         return
 
     except NannyNag as nag:

--- a/Lib/tabnanny.py
+++ b/Lib/tabnanny.py
@@ -110,7 +110,7 @@ def check(file):
         return
 
     except SyntaxError as msg:
-        errprint("%r: Token Error: %s" % (file, msg))
+        errprint("%r: Syntax Error: %s" % (file, msg))
         return
 
     except NannyNag as nag:

--- a/Lib/test/test_tabnanny.py
+++ b/Lib/test/test_tabnanny.py
@@ -315,7 +315,7 @@ class TestCommandLine(TestCase):
     def test_with_errored_file(self):
         """Should displays error when errored python file is given."""
         with TemporaryPyFile(SOURCE_CODES["wrong_indented"]) as file_path:
-            stderr  = f"{file_path!r}: Token Error: "
+            stderr  = f"{file_path!r}: Indentation Error: "
             stderr += ('unindent does not match any outer indentation level'
                        ' (<string>, line 3)')
             self.validate_cmd(file_path, stderr=stderr, expect_failure=True)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1099,6 +1099,7 @@ Ivan Levkivskyi
 Ben Lewis
 William Lewis
 Akira Li
+Jiahao Li
 Robert Li
 Xuanji Li
 Zekun Li

--- a/Misc/NEWS.d/next/Library/2024-06-14-20-05-25.gh-issue-120495.OxgZKB.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-14-20-05-25.gh-issue-120495.OxgZKB.rst
@@ -1,0 +1,1 @@
+Fix incorrect Exception Handling in tabnanny. Patch by Wulian233

--- a/Misc/NEWS.d/next/Library/2024-06-14-20-05-25.gh-issue-120495.OxgZKB.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-14-20-05-25.gh-issue-120495.OxgZKB.rst
@@ -1,1 +1,1 @@
-Fix incorrect Exception Handling in tabnanny. Patch by Wulian233
+Fix incorrect exception handling in Tab Nanny. Patch by Wulian233.


### PR DESCRIPTION
See issue, need backport to 3.13?

![2024-06-14 195123](https://github.com/python/cpython/assets/71213467/d7851520-f2e4-464c-a8ed-e5d38960866d)

<!-- gh-issue-number: gh-120495 -->
* Issue: gh-120495
<!-- /gh-issue-number -->
