### PR TITLE
gh-120521: clarify except* documentation to allow tuples

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -247,8 +247,7 @@ An expression-less :keyword:`!except` clause, if present, must be last;
 it matches any exception.
 
 For an :keyword:`!except` clause with an expression, the
-expression must evaluate to a type or a tuple containing types. Each type must
-be :exc:`BaseException` or a subclass of :exc:`BaseException`.
+expression must evaluate to an exception type or a tuple of exception types.
 
 The clause matches an exception if the resulting object from evaluating the
 clause is "compatible" with the exception. An object is compatible with an

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -251,7 +251,7 @@ expression must evaluate to a type or a tuple containing types. Each type must
 be a subclass of :exc:`BaseException`; otherwise, the runtime will raise a
 :exc:`TypeError` when the handler is evaluated.
 
-The clause matches the exception if the resulting object is "compatible" with
+The clause matches an exception if the resulting object is "compatible" with
 the exception.  An object is compatible with an exception if the object is the
 class or a :term:`non-virtual base class <abstract base class>` of the exception
 object, or a tuple containing an item that is the class or a non-virtual base

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -248,12 +248,13 @@ it matches any exception.
 
 For an :keyword:`!except` clause with an expression, the
 expression must evaluate to a type or a tuple containing types. Each type must
-be a subclass of :exc:`BaseException`; otherwise, the runtime will raise a
+be :exc:`BaseException` or a subclass of :exc:`BaseException`; otherwise, the runtime will raise a
 :exc:`TypeError` when the handler is evaluated.
 
-The clause matches an exception if the resulting object is "compatible" with
-the exception.  An object is compatible with an exception if the object is the
-class or a :term:`non-virtual base class <abstract base class>` of the exception
+The clause matches an exception if the resulting object from evaluating the
+clause is "compatible" with the exception. An object is compatible with an
+exception if the object is the class or a
+:term:`non-virtual base class <abstract base class>` of the exception
 object, or a tuple containing an item that is the class or a non-virtual base
 class of the exception object.
 
@@ -382,12 +383,13 @@ exception group with an empty message string. ::
    ...
    ExceptionGroup('', (BlockingIOError()))
 
-Unlike :keyword:`except` clauses, :keyword:`!except*` clauses must have a matching
-expression; ``except*:`` is not valid syntax. When the handler is evaluated, the
-expression must evaluate to a type or a tuple containing types. Each type must
-be a subclass of :exc:`BaseException` and must not be a subclass of
-:exc:`BaseExceptionGroup`; otherwise, the runtime will raise a :exc:`TypeError`
-when the handler is evaluated.
+Unlike :keyword:`except` clauses, :keyword:`!except*` clauses must have a
+matching expression; ``except*:`` is not valid syntax. In addition to the
+requirements for matching expressions in :keyword:`except` clauses, the
+types in the matching expression of an :keyword:`!except*` clause cannot
+be :exc:`BaseExceptionGroup` or a subclass of :exc:`BaseExceptionGroup`;
+otherwise, the runtime will raise a :exc:`TypeError` when the handler is
+evaluated.
 
 It is not possible to mix :keyword:`except` and :keyword:`!except*`
 in the same :keyword:`try`.

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -383,7 +383,7 @@ exception group with an empty message string. ::
    ExceptionGroup('', (BlockingIOError()))
 
 Unlike :keyword:`except` clauses, :keyword:`!except*` clauses must have a matching
-expression; `except*:` is not valid syntax. When the handler is evaluated, the
+expression; ``except*:`` is not valid syntax. When the handler is evaluated, the
 expression must evaluate to a type or a tuple containing types. Each type must
 be a subclass of :exc:`BaseException` and must not be a subclass of
 :exc:`BaseExceptionGroup`, otherwise the runtime will raise a :exc:`TypeError`

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -386,7 +386,7 @@ Unlike :keyword:`except` clauses, :keyword:`!except*` clauses must have a matchi
 expression; ``except*:`` is not valid syntax. When the handler is evaluated, the
 expression must evaluate to a type or a tuple containing types. Each type must
 be a subclass of :exc:`BaseException` and must not be a subclass of
-:exc:`BaseExceptionGroup`, otherwise the runtime will raise a :exc:`TypeError`
+:exc:`BaseExceptionGroup`; otherwise, the runtime will raise a :exc:`TypeError`
 when the handler is evaluated.
 
 It is not possible to mix :keyword:`except` and :keyword:`!except*`

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -250,7 +250,7 @@ For an :keyword:`!except` clause with an expression, the
 expression must evaluate to an exception type or a tuple of exception types.
 The raised exception matches an :keyword:`!except` clause whose expression evaluates
 to the class or a :term:`non-virtual base class <abstract base class>` of the exception object,
-or it evaluates to a tuple that contains such a class.
+or to a tuple that contains such a class.
 
 If no :keyword:`!except` clause matches the exception,
 the search for an exception handler

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -245,13 +245,17 @@ handler is started. This search inspects the :keyword:`!except` clauses in turn
 until one is found that matches the exception.
 An expression-less :keyword:`!except` clause, if present, must be last;
 it matches any exception.
-For an :keyword:`!except` clause with an expression,
-that expression is evaluated, and the clause matches the exception
-if the resulting object is "compatible" with the exception.  An object is
-compatible with an exception if the object is the class or a
-:term:`non-virtual base class <abstract base class>` of the exception object,
-or a tuple containing an item that is the class or a non-virtual base class
-of the exception object.
+
+For an :keyword:`!except` clause with an expression, the
+expression must evaluate to a type or a tuple containing types. Each type must
+be a subclass of :exc:`BaseException`, otherwise the runtime will raise a
+:exc:`TypeError` when the handler is evaluated.
+
+The clause matches the exception if the resulting object is "compatible" with
+the exception.  An object is compatible with an exception if the object is the
+class or a :term:`non-virtual base class <abstract base class>` of the exception
+object, or a tuple containing an item that is the class or a non-virtual base
+class of the exception object.
 
 If no :keyword:`!except` clause matches the exception,
 the search for an exception handler
@@ -378,8 +382,13 @@ exception group with an empty message string. ::
    ...
    ExceptionGroup('', (BlockingIOError()))
 
-An :keyword:`!except*` clause must have a matching type,
-and this type cannot be a subclass of :exc:`BaseExceptionGroup`.
+Unlike :keyword:`except` clauses, :keyword:`!except*` clauses must have a matching
+expression; `except*:` is not valid syntax. When the handler is evaluated, the
+expression must evaluate to a type or a tuple containing types. Each type must
+be a subclass of :exc:`BaseException` and must not be a subclass of
+:exc:`BaseExceptionGroup`, otherwise the runtime will raise a :exc:`TypeError`
+when the handler is evaluated.
+
 It is not possible to mix :keyword:`except` and :keyword:`!except*`
 in the same :keyword:`try`.
 :keyword:`break`, :keyword:`continue` and :keyword:`return`

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -248,8 +248,7 @@ it matches any exception.
 
 For an :keyword:`!except` clause with an expression, the
 expression must evaluate to a type or a tuple containing types. Each type must
-be :exc:`BaseException` or a subclass of :exc:`BaseException`; otherwise, the runtime will raise a
-:exc:`TypeError` when the handler is evaluated.
+be :exc:`BaseException` or a subclass of :exc:`BaseException`.
 
 The clause matches an exception if the resulting object from evaluating the
 clause is "compatible" with the exception. An object is compatible with an
@@ -387,9 +386,7 @@ Unlike :keyword:`except` clauses, :keyword:`!except*` clauses must have a
 matching expression; ``except*:`` is not valid syntax. In addition to the
 requirements for matching expressions in :keyword:`except` clauses, the
 types in the matching expression of an :keyword:`!except*` clause cannot
-be :exc:`BaseExceptionGroup` or a subclass of :exc:`BaseExceptionGroup`;
-otherwise, the runtime will raise a :exc:`TypeError` when the handler is
-evaluated.
+be :exc:`BaseExceptionGroup` or a subclass of :exc:`BaseExceptionGroup`.
 
 It is not possible to mix :keyword:`except` and :keyword:`!except*`
 in the same :keyword:`try`.

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -248,7 +248,7 @@ it matches any exception.
 
 For an :keyword:`!except` clause with an expression, the
 expression must evaluate to a type or a tuple containing types. Each type must
-be a subclass of :exc:`BaseException`, otherwise the runtime will raise a
+be a subclass of :exc:`BaseException`; otherwise, the runtime will raise a
 :exc:`TypeError` when the handler is evaluated.
 
 The clause matches the exception if the resulting object is "compatible" with

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -381,11 +381,9 @@ exception group with an empty message string. ::
    ...
    ExceptionGroup('', (BlockingIOError()))
 
-Unlike :keyword:`except` clauses, :keyword:`!except*` clauses must have a
-matching expression; ``except*:`` is not valid syntax. In addition to the
-requirements for matching expressions in :keyword:`except` clauses, the
-types in the matching expression of an :keyword:`!except*` clause cannot
-be :exc:`BaseExceptionGroup` or a subclass of :exc:`BaseExceptionGroup`.
+An :keyword:`!except*` clause must have a matching expression; it cannot be ``except*:``.
+Furthermore, this expression cannot contain exception group types, because that would
+have ambiguous semantics.
 
 It is not possible to mix :keyword:`except` and :keyword:`!except*`
 in the same :keyword:`try`.

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -248,13 +248,9 @@ it matches any exception.
 
 For an :keyword:`!except` clause with an expression, the
 expression must evaluate to an exception type or a tuple of exception types.
-
-The clause matches an exception if the resulting object from evaluating the
-clause is "compatible" with the exception. An object is compatible with an
-exception if the object is the class or a
-:term:`non-virtual base class <abstract base class>` of the exception
-object, or a tuple containing an item that is the class or a non-virtual base
-class of the exception object.
+The raised exception matches an :keyword:`!except` clause whose expression evaluates
+to the class or a :term:`non-virtual base class <abstract base class>` of the exception object,
+or it evaluates to a tuple that contains such a class.
 
 If no :keyword:`!except` clause matches the exception,
 the search for an exception handler


### PR DESCRIPTION
fixes #120521

Discussion link: https://discuss.python.org/t/clarifying-typing-behavior-for-exception-handlers-except-except/55060/2


<!-- gh-issue-number: gh-120521 -->
* Issue: gh-120521
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120523.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->