### PR TITLE
gh-120526: Correct signature of map builtin

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1475,7 +1475,7 @@ static PyMethodDef map_methods[] = {
 
 
 PyDoc_STRVAR(map_doc,
-"map(function, /, *iterables)\n\
+"map(function, iterable, /, *iterables)\n\
 --\n\
 \n\
 Make an iterator that computes the function using arguments from\n\


### PR DESCRIPTION
map requires at least one iterable arg. If you just do `map(map)` you get an error "map() must have at least two arguments." This corrects the signature to reflect this, in line with how it's shown in https://docs.python.org/3/library/functions.html#map .

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120526 -->
* Issue: gh-120526
<!-- /gh-issue-number -->
