### PR TITLE
annotations: expand documentation on "simple" assignment targets

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -893,11 +893,11 @@ Statements
    ``annotation`` is the annotation, such as a :class:`Constant` or :class:`Name`
    node. ``value`` is a single optional node.
 
-   ``simple`` is always either 0 or 1 and represents whether the assignment
-   target is a pure name, and hence simple, or an expression. A target is
-   considered simple if it is a :class:`Name` node that does not appear
-   between parentheses. Only simple targets appear in the :attr:`__annotations__`
-   dictionary of modules and classes.
+   ``simple`` is always either 0 (indicating a "complex" target) or 1
+   (indicating a "simple" target). A "simple" target consists solely of a
+   :class:`Name` node that does not appear between parentheses; all other
+   targets are considered complex. Only simple targets appear in
+   the :attr:`__annotations__` dictionary of modules and classes.
 
    .. doctest::
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -891,9 +891,13 @@ Statements
    An assignment with a type annotation. ``target`` is a single node and can
    be a :class:`Name`, a :class:`Attribute` or a :class:`Subscript`.
    ``annotation`` is the annotation, such as a :class:`Constant` or :class:`Name`
-   node. ``value`` is a single optional node. ``simple`` is a boolean integer
-   set to True for a :class:`Name` node in ``target`` that do not appear in
-   between parenthesis and are hence pure names and not expressions.
+   node. ``value`` is a single optional node.
+
+   ``simple`` is always either 0 or 1 and represents whether the assignment
+   target is a pure name, and hence simple, or an expression. A target is
+   considered simple if it is a :class:`Name` node that does not appear
+   between parentheses. Only simple targets appear in the :attr:`__annotations__`
+   dictionary of modules and classes.
 
    .. doctest::
 

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -333,7 +333,9 @@ statement, of a variable or attribute annotation and an optional assignment stat
 
 The difference from normal :ref:`assignment` is that only a single target is allowed.
 
-For simple names as assignment targets, if in class or module scope,
+The assignment target is considered simple if it consists of a single
+name that is not enclosed in parentheses.
+For simple assignment targets, if in class or module scope,
 the annotations are evaluated and stored in a special class or module
 attribute :attr:`__annotations__`
 that is a dictionary mapping from variable names (mangled if private) to
@@ -341,7 +343,8 @@ evaluated annotations. This attribute is writable and is automatically
 created at the start of class or module body execution, if annotations
 are found statically.
 
-For expressions as assignment targets, the annotations are evaluated if
+If the assignment target is not simple (an attribute, subscript node, or
+parenthesized name), the annotation is evaluated if
 in class or module scope, but not stored.
 
 If a name is annotated in a function scope, then this name is local for

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -333,7 +333,7 @@ statement, of a variable or attribute annotation and an optional assignment stat
 
 The difference from normal :ref:`assignment` is that only a single target is allowed.
 
-The assignment target is considered simple if it consists of a single
+The assignment target is considered "simple" if it consists of a single
 name that is not enclosed in parentheses.
 For simple assignment targets, if in class or module scope,
 the annotations are evaluated and stored in a special class or module


### PR DESCRIPTION
This behavior is rather surprising and it was not clearly specified.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120535.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->