### PR TITLE
gh-119599: Mark `test_free_threading.test_dict` as cpu-heavy test

### DIFF
--- a/Lib/test/test_free_threading/test_dict.py
+++ b/Lib/test/test_free_threading/test_dict.py
@@ -10,9 +10,10 @@ from unittest import TestCase
 
 from _testcapi import dict_version
 
-from test.support import threading_helper
+from test.support import requires_resource, threading_helper
 
 
+@requires_resource('cpu')
 @threading_helper.requires_working_threading()
 class TestDict(TestCase):
     def test_racing_creation_shared_keys(self):


### PR DESCRIPTION


<!-- gh-issue-number: gh-119599 -->
* Issue: gh-119599
<!-- /gh-issue-number -->
