### PR TITLE
gh-120568: fix file leak in PyUnstable_CopyPerfMapFile

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2515,12 +2515,12 @@ PyAPI_FUNC(int) PyUnstable_CopyPerfMapFile(const char* parent_filename) {
             return ret;
         }
     }
-    char buf[4096];
-    PyThread_acquire_lock(perf_map_state.map_lock, 1);
     FILE* from = fopen(parent_filename, "r");
     if (!from) {
         return -1;
     }
+    char buf[4096];
+    PyThread_acquire_lock(perf_map_state.map_lock, 1);
     int fflush_result = 0, result = 0;
     while (1) {
         size_t bytes_read = fread(buf, 1, sizeof(buf), from);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2509,10 +2509,6 @@ PyAPI_FUNC(void) PyUnstable_PerfMapState_Fini(void) {
 
 PyAPI_FUNC(int) PyUnstable_CopyPerfMapFile(const char* parent_filename) {
 #ifndef MS_WINDOWS
-    FILE* from = fopen(parent_filename, "r");
-    if (!from) {
-        return -1;
-    }
     if (perf_map_state.perf_map == NULL) {
         int ret = PyUnstable_PerfMapState_Init();
         if (ret != 0) {
@@ -2521,6 +2517,10 @@ PyAPI_FUNC(int) PyUnstable_CopyPerfMapFile(const char* parent_filename) {
     }
     char buf[4096];
     PyThread_acquire_lock(perf_map_state.map_lock, 1);
+    FILE* from = fopen(parent_filename, "r");
+    if (!from) {
+        return -1;
+    }
     int fflush_result = 0, result = 0;
     while (1) {
         size_t bytes_read = fread(buf, 1, sizeof(buf), from);


### PR DESCRIPTION
Fixes a file leak in PyUnstable_CopyPerfMapFile found by the Clang Static Analyzer.

<!-- gh-issue-number: gh-120568 -->
* Issue: gh-120568
<!-- /gh-issue-number -->
