### PR TITLE
gh-120579: Guard `_testcapi` import in `test_free_threading`

### DIFF
--- a/Lib/test/test_free_threading/test_dict.py
+++ b/Lib/test/test_free_threading/test_dict.py
@@ -8,7 +8,10 @@ from functools import partial
 from threading import Thread
 from unittest import TestCase
 
-from _testcapi import dict_version
+try:
+    import _testcapi
+except ImportError:
+    _testcapi = None
 
 from test.support import threading_helper
 
@@ -139,7 +142,9 @@ class TestDict(TestCase):
             for ref in thread_list:
                 self.assertIsNone(ref())
 
+    @unittest.skipIf(_testcapi is None, 'need _testcapi module')
     def test_dict_version(self):
+        dict_version = _testcapi.dict_version
         THREAD_COUNT = 10
         DICT_COUNT = 10000
         lists = []


### PR DESCRIPTION
After:

```
» ./python.exe -m test test_free_threading -m test_dict_version -v
== CPython 3.14.0a0 (heads/main-dirty:cf49ef78f89, Jun 16 2024, 10:08:08) [Clang 15.0.0 (clang-1500.3.9.4)]
== macOS-14.4.1-arm64-arm-64bit-Mach-O little-endian
== Python build: debug
== cwd: /Users/sobolev/Desktop/cpython2/build/test_python_worker_59390æ
== CPU count: 12
== encodings: locale=UTF-8 FS=utf-8
== resources: all test resources are disabled, use -u option to unskip tests

Using random seed: 2920195885
0:00:00 load avg: 1.14 Run 1 test sequentially in a single process
0:00:00 load avg: 1.14 [1/1] test_free_threading
test_dict_version (test.test_free_threading.test_dict.TestDict.test_dict_version) ... skipped 'need _testcapi module'

----------------------------------------------------------------------
Ran 1 test in 0.000s

OK (skipped=1)

== Tests result: SUCCESS ==

1 test OK.

Total duration: 45 ms
Total tests: run=1 (filtered) skipped=1
Total test files: run=1/1 (filtered)
Result: SUCCESS
```

<!-- gh-issue-number: gh-120579 -->
* Issue: gh-120579
<!-- /gh-issue-number -->
