### PR TITLE
gh-120496: Make enum_iter thread safe

### DIFF
--- a/Include/internal/pycore_critical_section.h
+++ b/Include/internal/pycore_critical_section.h
@@ -98,6 +98,8 @@ extern "C" {
 # define Py_END_CRITICAL_SECTION()                                      \
         _PyCriticalSection_End(&_cs);                                   \
     }
+# define Py_EXIT_CRITICAL_SECTION()                                     \
+        _PyCriticalSection_End(&_cs);
 
 # define Py_BEGIN_CRITICAL_SECTION2(a, b)                               \
     {                                                                   \
@@ -155,6 +157,7 @@ extern "C" {
 # define Py_BEGIN_CRITICAL_SECTION_MUT(mut)
 # define Py_BEGIN_CRITICAL_SECTION(op)
 # define Py_END_CRITICAL_SECTION()
+# define Py_EXIT_CRITICAL_SECTION()
 # define Py_BEGIN_CRITICAL_SECTION2(a, b)
 # define Py_END_CRITICAL_SECTION2()
 # define Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original)

--- a/Lib/test/test_enumerate.py
+++ b/Lib/test/test_enumerate.py
@@ -3,6 +3,7 @@ import operator
 import sys
 import pickle
 import gc
+import threading
 
 from test import support
 
@@ -290,6 +291,28 @@ class TestLongStart(EnumerateStartTestCase):
 
     seq, res = 'abc', [(sys.maxsize+1,'a'), (sys.maxsize+2,'b'),
                        (sys.maxsize+3,'c')]
+
+
+class EnumerateThreading(unittest.TestCase):
+    @staticmethod
+    def work(index, enum, start):
+        while True:
+            try:
+                value = next(enum)
+            except StopIteration:
+                break
+            else:
+                if value[0] + start != value[1]:
+                    raise ValueError(f'enumerate returned pair {value}')
+
+    def test_threading(self):
+        number_of_threads = 4
+        n = 100
+        start = sys.maxsize-10
+        enum = enumerate(range(start, start+n))
+        worker_threads = [threading.Thread(target=self.work, args=[ii, enum, start]) for ii in range(number_of_threads)]
+        _ = [t.start() for t in worker_threads]
+        _ = [t.join() for t in worker_threads]
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_enumerate.py
+++ b/Lib/test/test_enumerate.py
@@ -3,7 +3,7 @@ import operator
 import sys
 import pickle
 import gc
-import threading
+from threading import Thread
 
 from test import support
 
@@ -295,7 +295,7 @@ class TestLongStart(EnumerateStartTestCase):
 
 class EnumerateThreading(unittest.TestCase):
     @staticmethod
-    def work(index, enum, start):
+    def work(enum, start):
         while True:
             try:
                 value = next(enum)
@@ -309,8 +309,10 @@ class EnumerateThreading(unittest.TestCase):
         number_of_threads = 4
         n = 100
         start = sys.maxsize-10
-        enum = enumerate(range(start, start+n))
-        worker_threads = [threading.Thread(target=self.work, args=[ii, enum, start]) for ii in range(number_of_threads)]
+        enum = enumerate(range(start, start + n))
+        worker_threads = []
+        for ii in range(number_of_threads):
+            worker_threads.append(Thread(target=self.work, args=[enum, start]))
         _ = [t.start() for t in worker_threads]
         _ = [t.join() for t in worker_threads]
 

--- a/Lib/test/test_enumerate.py
+++ b/Lib/test/test_enumerate.py
@@ -6,6 +6,7 @@ import gc
 from threading import Thread
 
 from test import support
+from test.support import threading_helper
 
 class G:
     'Sequence using __getitem__'
@@ -305,6 +306,8 @@ class EnumerateThreading(unittest.TestCase):
                 if value[0] + start != value[1]:
                     raise ValueError(f'enumerate returned pair {value}')
 
+    @threading_helper.reap_threads
+    @threading_helper.requires_working_threading()
     def test_threading(self):
         number_of_threads = 4
         n = 100

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-16-19-21-07.gh-issue-120496.oP4xPi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-16-19-21-07.gh-issue-120496.oP4xPi.rst
@@ -1,0 +1,1 @@
+Make :class:`enumerate` thread-safe.


### PR DESCRIPTION
We make `enum_iter` thread-safe using a critical section. We use the same approach as in https://github.com/python/cpython/pull/119438 to allow for exits in the middle of the critical section. The method `enum_iter_long` is guarded by the critical section from `enum_long`. 

Without making `enum_iter` thread safe problems can occur:

* For `enumerate(range(10))` pairs `(n, m)` with `n` unqual to `m` can be generated
* When iterating over `sys.maxsize`, e.g. `enumerate(range(sys.maxsize - 10, sys.maxsize + 10))` an overflow can occur.
* As an optimization `enum_iter` keeps track of the returned tuple. In the free-threaded build multiple threads can operate on the same tuple.

To determine the overhead of making enumerate thread-safe here are some benchmarking results for a single-threaded application. Performance when actually using multiple-threads to readout the enumerate is considered less important.

Benchmark script:
```
import pyperf
runner = pyperf.Runner()

setup = """

def weighted_sum(k):
    value = 0
    for n, m in enumerate(k):
        value += n * m 
    return value

range10 = range(10)
range1000 = range(1000)
x = list(range(10))
"""

runner.timeit(name="enumerate(range10)", stmt="enumerate(range10)", setup=setup)
runner.timeit(name="list(enumerate(range10))", stmt="list(enumerate(range10))", setup=setup)
runner.timeit(name="list(enumerate(range1000))", stmt="list(enumerate(range1000))", setup=setup)
runner.timeit(name="weighted_sum", stmt="weighted_sum(x)", setup=setup)

```
Results of main versus free-threading:
```
enumerate(range10): Mean +- std dev: [enumerate_main] 73.2 ns +- 3.5 ns -> [enumerate_ft] 94.1 ns +- 3.5 ns: 1.29x slower
list(enumerate(range10)): Mean +- std dev: [enumerate_main] 292 ns +- 10 ns -> [enumerate_ft] 351 ns +- 19 ns: 1.20x slower
list(enumerate(range1000)): Mean +- std dev: [enumerate_main] 31.1 us +- 1.6 us -> [enumerate_ft] 32.5 us +- 1.4 us: 1.04x slower
weighted_sum: Mean +- std dev: [enumerate_main] 433 ns +- 17 ns -> [enumerate_ft] 938 ns +- 49 ns: 2.16x slower

Geometric mean: 1.37x slower
```
Results of free-threading vs. free-threading with this PR:
```
list(enumerate(range10)): Mean +- std dev: [enumerate_ft] 351 ns +- 19 ns -> [enumerate_ft_pr] 410 ns +- 18 ns: 1.17x slower
list(enumerate(range1000)): Mean +- std dev: [enumerate_ft] 32.5 us +- 1.4 us -> [enumerate_ft_pr] 40.9 us +- 1.7 us: 1.26x slower

Benchmark hidden because not significant (2): enumerate(range10), weighted_sum

Geometric mean: 1.10x slower
```

The case `enumerate(range10)` is not affected by the PR (used to check the benchmarking is stable). The cases `list(enumerate(range(x)))` slow down a bit. More representative is perhaps the `weighted_sum` benchmark where the enumerate is used a for loop with a minimal amount of work. There the overhead of the locking not significant.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120496 -->
* Issue: gh-120496
<!-- /gh-issue-number -->
