### PR TITLE
gh-120608: Make reversed thread-safe

### DIFF
--- a/Include/internal/pycore_critical_section.h
+++ b/Include/internal/pycore_critical_section.h
@@ -98,6 +98,8 @@ extern "C" {
 # define Py_END_CRITICAL_SECTION()                                      \
         _PyCriticalSection_End(&_cs);                                   \
     }
+# define Py_EXIT_CRITICAL_SECTION()                                     \
+        _PyCriticalSection_End(&_cs);
 
 # define Py_BEGIN_CRITICAL_SECTION2(a, b)                               \
     {                                                                   \
@@ -156,6 +158,7 @@ extern "C" {
 # define Py_BEGIN_CRITICAL_SECTION(op)
 # define Py_END_CRITICAL_SECTION()
 # define Py_BEGIN_CRITICAL_SECTION2(a, b)
+# define Py_EXIT_CRITICAL_SECTION()
 # define Py_END_CRITICAL_SECTION2()
 # define Py_BEGIN_CRITICAL_SECTION_SEQUENCE_FAST(original)
 # define Py_END_CRITICAL_SECTION_SEQUENCE_FAST()

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-16-22-42-47.gh-issue-120608._-YtWX.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-16-22-42-47.gh-issue-120608._-YtWX.rst
@@ -1,0 +1,1 @@
+Make reversed thread-safe.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-16-22-42-47.gh-issue-120608._-YtWX.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-16-22-42-47.gh-issue-120608._-YtWX.rst
@@ -1,1 +1,1 @@
-Make reversed thread-safe.
+Make :func:`reversed` thread-safe.


### PR DESCRIPTION
The `reversed` builtin is not thread-safe. In `reversed_next` the object `index` can be read and decremented by multiple threads leading to incorrect results. The part that needs to happen atomically is the check `(index >= 0)` and the decrement `ro->index--;`.

A reproducing example will be included in the tests later.

* Issue https://github.com/python/cpython/issues/120608
* We could perhaps make the code more efficient (no locks required), by using a `_Py_atomic_compare_exchange` on the `ro->index` (exchanging with `ro->index--`). This would make the code more complex and I am not sure lock contention is a performance issue here.
* The macro `Py_EXIT_CRITICAL_SECTION` is the same as proposed in https://github.com/python/cpython/pull/120591
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120608 -->
* Issue: gh-120608
<!-- /gh-issue-number -->
