### PR TITLE
Code style change: updated tp_flags initialization

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8429,7 +8429,7 @@ type_ready(PyTypeObject *type, int initial)
     }
 
     /* All done -- set the ready flag */
-    type->tp_flags = type->tp_flags | Py_TPFLAGS_READY;
+    type->tp_flags |= Py_TPFLAGS_READY;
     stop_readying(type);
 
     assert(_PyType_CheckConsistency(type));


### PR DESCRIPTION
In the file, all type flag operations use the |= operator. 
However, the replaced code was using | followed by = for initialization. 
This change was made to ensure code style consistency by using the |= operator.