### PR TITLE
gh-120417: Add #noqa to load_tests() in tests

### DIFF
--- a/Lib/test/test_asyncio/__main__.py
+++ b/Lib/test/test_asyncio/__main__.py
@@ -1,4 +1,4 @@
-from . import load_tests
+from . import load_tests  # noqa: F401
 import unittest
 
 unittest.main()

--- a/Lib/test/test_ctypes/__main__.py
+++ b/Lib/test/test_ctypes/__main__.py
@@ -1,4 +1,4 @@
-from test.test_ctypes import load_tests
+from test.test_ctypes import load_tests  # noqa: F401
 import unittest
 
 unittest.main()

--- a/Lib/test/test_email/__main__.py
+++ b/Lib/test/test_email/__main__.py
@@ -1,4 +1,4 @@
-from test.test_email import load_tests
+from test.test_email import load_tests  # noqa: F401
 import unittest
 
 unittest.main()

--- a/Lib/test/test_idle.py
+++ b/Lib/test/test_idle.py
@@ -16,7 +16,7 @@ idlelib.testing = True
 
 # Unittest.main and test.libregrtest.runtest.runtest_inner
 # call load_tests, when present here, to discover tests to run.
-from idlelib.idle_test import load_tests
+from idlelib.idle_test import load_tests  # noqa: F401
 
 if __name__ == '__main__':
     tk.NoDefaultRoot()

--- a/Lib/test/test_interpreters/__main__.py
+++ b/Lib/test/test_interpreters/__main__.py
@@ -1,4 +1,4 @@
-from . import load_tests
+from . import load_tests  # noqa: F401
 import unittest
 
 unittest.main()

--- a/Lib/test/test_json/__main__.py
+++ b/Lib/test/test_json/__main__.py
@@ -1,4 +1,4 @@
 import unittest
-from test.test_json import load_tests
+from test.test_json import load_tests  # noqa: F401
 
 unittest.main()

--- a/Lib/test/test_peg_generator/__main__.py
+++ b/Lib/test/test_peg_generator/__main__.py
@@ -1,4 +1,4 @@
 import unittest
-from . import load_tests
+from . import load_tests  # noqa: F401
 
 unittest.main()

--- a/Lib/test/test_pyrepl/__main__.py
+++ b/Lib/test/test_pyrepl/__main__.py
@@ -1,4 +1,4 @@
 import unittest
-from test.test_pyrepl import load_tests
+from test.test_pyrepl import load_tests  # noqa: F401
 
 unittest.main()

--- a/Lib/test/test_sqlite3/__main__.py
+++ b/Lib/test/test_sqlite3/__main__.py
@@ -1,4 +1,4 @@
-from test.test_sqlite3 import load_tests  # Needed for the "load tests" protocol.
+from test.test_sqlite3 import load_tests  # noqa: F401
 import unittest
 
 unittest.main()

--- a/Lib/test/test_tkinter/__main__.py
+++ b/Lib/test/test_tkinter/__main__.py
@@ -1,4 +1,4 @@
-from . import load_tests
+from . import load_tests  # noqa: F401
 import unittest
 
 unittest.main()

--- a/Lib/test/test_tomllib/__main__.py
+++ b/Lib/test/test_tomllib/__main__.py
@@ -1,6 +1,4 @@
 import unittest
-
-from . import load_tests
-
+from . import load_tests  # noqa: F401
 
 unittest.main()

--- a/Lib/test/test_tools/__main__.py
+++ b/Lib/test/test_tools/__main__.py
@@ -1,4 +1,4 @@
-from test.test_tools import load_tests
+from test.test_tools import load_tests  # noqa: F401
 import unittest
 
 unittest.main()

--- a/Lib/test/test_ttk/__main__.py
+++ b/Lib/test/test_ttk/__main__.py
@@ -1,4 +1,4 @@
-from . import load_tests
+from . import load_tests  # noqa: F401
 import unittest
 
 unittest.main()

--- a/Lib/test/test_unittest/__main__.py
+++ b/Lib/test/test_unittest/__main__.py
@@ -1,4 +1,4 @@
-from . import load_tests
+from . import load_tests  # noqa: F401
 import unittest
 
 unittest.main()


### PR DESCRIPTION
Ignore linter "imported but unused" warnings in tests when the linter doesn't understand why the import is important.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120417 -->
* Issue: gh-120417
<!-- /gh-issue-number -->
