### PR TITLE
gh-120417: Add #noqa: F401 to tests

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1221,8 +1221,8 @@ def refcount_test(test):
 
 def requires_limited_api(test):
     try:
-        import _testcapi
-        import _testlimitedcapi
+        import _testcapi  # noqa: F401
+        import _testlimitedcapi  # noqa: F401
     except ImportError:
         return unittest.skip('needs _testcapi and _testlimitedcapi modules')(test)
     return test
@@ -2299,7 +2299,7 @@ def clear_ignored_deprecations(*tokens: object) -> None:
 def requires_venv_with_pip():
     # ensurepip requires zlib to open ZIP archives (.whl binary wheel packages)
     try:
-        import zlib
+        import zlib  # noqa: F401
     except ImportError:
         return unittest.skipIf(True, "venv: ensurepip requires zlib")
 

--- a/Lib/test/test___all__.py
+++ b/Lib/test/test___all__.py
@@ -103,7 +103,7 @@ class AllTest(unittest.TestCase):
         # In case _socket fails to build, make this test fail more gracefully
         # than an AttributeError somewhere deep in concurrent.futures, email
         # or unittest.
-        import _socket
+        import _socket  # noqa: F401
 
         ignored = []
         failed_imports = []

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3103,14 +3103,14 @@ class GenericTaskTests(test_utils.TestCase):
         # fail on systems where C modules were successfully compiled
         # (hence the test for _functools etc), but _asyncio somehow didn't.
         try:
-            import _functools
-            import _json
-            import _pickle
+            import _functools  # noqa: F401
+            import _json       # noqa: F401
+            import _pickle     # noqa: F401
         except ImportError:
             self.skipTest('C modules are not available')
         else:
             try:
-                import _asyncio
+                import _asyncio  # noqa: F401
             except ImportError:
                 self.fail('_asyncio module is missing')
 

--- a/Lib/test/test_capi/check_config.py
+++ b/Lib/test/test_capi/check_config.py
@@ -10,7 +10,7 @@ import sys
 def import_singlephase():
     assert '_testsinglephase' not in sys.modules
     try:
-        import _testsinglephase
+        import _testsinglephase  # noqa: F401
     except ImportError:
         sys.modules.pop('_testsinglephase', None)
         return False

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -737,7 +737,7 @@ class CmdLineTest(unittest.TestCase):
 
         # Memory allocator debug hooks
         try:
-            import _testinternalcapi
+            import _testinternalcapi  # noqa: F401
         except ImportError:
             pass
         else:
@@ -754,7 +754,7 @@ class CmdLineTest(unittest.TestCase):
 
         # Faulthandler
         try:
-            import faulthandler
+            import faulthandler  # noqa: F401
         except ImportError:
             pass
         else:

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -2958,7 +2958,7 @@ else:
     bytes_transform_encodings.append("zlib_codec")
     transform_aliases["zlib_codec"] = ["zip", "zlib"]
 try:
-    import bz2
+    import bz2  # noqa: F401
 except ImportError:
     pass
 else:

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -441,8 +441,8 @@ class TestSpecifics(unittest.TestCase):
             def f():
                 __mangled = 1
                 __not_mangled__ = 2
-                import __mangled_mod
-                import __package__.module
+                import __mangled_mod       # noqa: F401
+                import __package__.module  # noqa: F401
 
         self.assertIn("_A__mangled", A.f.__code__.co_varnames)
         self.assertIn("__not_mangled__", A.f.__code__.co_varnames)

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -18,7 +18,7 @@ try:
     # compileall relies on ProcessPoolExecutor if ProcessPoolExecutor exists
     # and it can function.
     from multiprocessing.util import _cleanup_tests as multiprocessing_cleanup_tests
-    from concurrent.futures import ProcessPoolExecutor
+    from concurrent.futures import ProcessPoolExecutor  # noqa: F401
     from concurrent.futures.process import _check_system_limits
     _check_system_limits()
     _have_multiprocessing = True

--- a/Lib/test/test_descrtut.py
+++ b/Lib/test/test_descrtut.py
@@ -8,7 +8,7 @@
 # of much interest anymore), and a few were fiddled to make the output
 # deterministic.
 
-from test.support import sortdict
+from test.support import sortdict  # noqa: F401
 import doctest
 import unittest
 

--- a/Lib/test/test_file_eintr.py
+++ b/Lib/test/test_file_eintr.py
@@ -21,8 +21,8 @@ if not support.has_subprocess_support:
     raise unittest.SkipTest("test module requires subprocess")
 
 # Test import all of the things we're about to try testing up front.
-import _io
-import _pyio
+import _io    # noqa: F401
+import _pyio  # noqa: F401
 
 @unittest.skipUnless(os.name == 'posix', 'tests requires a posix system.')
 class TestFileIOSignalInterrupt:

--- a/Lib/test/test_future_stmt/nested_scope.py
+++ b/Lib/test/test_future_stmt/nested_scope.py
@@ -1,6 +1,6 @@
 """This is a test"""
 
-from __future__ import nested_scopes; import site
+from __future__ import nested_scopes; import site  # noqa: F401
 
 def f(x):
     def g(y):

--- a/Lib/test/test_future_stmt/test_future.py
+++ b/Lib/test/test_future_stmt/test_future.py
@@ -67,19 +67,19 @@ class FutureTest(unittest.TestCase):
         with import_helper.CleanImport(
             'test.test_future_stmt.test_future_single_import',
         ):
-            from test.test_future_stmt import test_future_single_import
+            from test.test_future_stmt import test_future_single_import  # noqa: F401
 
     def test_future_multiple_imports(self):
         with import_helper.CleanImport(
             'test.test_future_stmt.test_future_multiple_imports',
         ):
-            from test.test_future_stmt import test_future_multiple_imports
+            from test.test_future_stmt import test_future_multiple_imports  # noqa: F401
 
     def test_future_multiple_features(self):
         with import_helper.CleanImport(
             "test.test_future_stmt.test_future_multiple_features",
         ):
-            from test.test_future_stmt import test_future_multiple_features
+            from test.test_future_stmt import test_future_multiple_features  # noqa: F401
 
     def test_unknown_future_flag(self):
         code = """
@@ -153,7 +153,7 @@ class FutureTest(unittest.TestCase):
 
     def test_module_with_future_import_not_on_top(self):
         with self.assertRaises(SyntaxError) as cm:
-            from test.test_future_stmt import badsyntax_future
+            from test.test_future_stmt import badsyntax_future  # noqa: F401
         self.check_syntax_error(cm.exception, "badsyntax_future", lineno=3)
 
     def test_ensure_flags_dont_clash(self):

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -1287,7 +1287,7 @@ class TestClassesAndFunctions(unittest.TestCase):
             (dict.__class_getitem__, meth_type_o),
         ]
         try:
-            import _stat
+            import _stat  # noqa: F401
         except ImportError:
             # if the _stat extension is not available, stat.S_IMODE() is
             # implemented in Python, not in C
@@ -3303,7 +3303,7 @@ class TestSignatureObject(unittest.TestCase):
             (dict.__class_getitem__, meth_o),
         ]
         try:
-            import _stat
+            import _stat  # noqa: F401
         except ImportError:
             # if the _stat extension is not available, stat.S_IMODE() is
             # implemented in Python, not in C

--- a/Lib/test/test_pkg.py
+++ b/Lib/test/test_pkg.py
@@ -94,7 +94,7 @@ class TestPkg(unittest.TestCase):
     def test_1(self):
         hier = [("t1", None), ("t1 __init__.py", "")]
         self.mkhier(hier)
-        import t1
+        import t1  # noqa: F401
 
     def test_2(self):
         hier = [
@@ -124,7 +124,7 @@ class TestPkg(unittest.TestCase):
 
         from t2 import sub
         from t2.sub import subsub
-        from t2.sub.subsub import spam
+        from t2.sub.subsub import spam  # noqa: F401
         self.assertEqual(sub.__name__, "t2.sub")
         self.assertEqual(subsub.__name__, "t2.sub.subsub")
         self.assertEqual(sub.subsub.__name__, "t2.sub.subsub")

--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -1239,7 +1239,8 @@ class PydocImportTest(PydocBaseTest):
             sys.path.insert(0, TESTFN)
             try:
                 with self.assertRaisesRegex(ValueError, "ouch"):
-                    import test_error_package  # Sanity check
+                    # Sanity check
+                    import test_error_package  # noqa: F401
 
                 text = self.call_url_handler("search?key=test_error_package",
                     "Pydoc: Search Results")

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -13,7 +13,7 @@ from weakref import proxy
 
 # some platforms lack working multiprocessing
 try:
-    import _multiprocessing
+    import _multiprocessing  # noqa: F401
 except ImportError:
     multiprocessing = None
 else:
@@ -1228,7 +1228,7 @@ class ReTests(unittest.TestCase):
             newpat = pickle.loads(pickled)
             self.assertEqual(newpat, oldpat)
         # current pickle expects the _compile() reconstructor in re module
-        from re import _compile
+        from re import _compile  # noqa: F401
 
     def test_copying(self):
         import copy

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -513,7 +513,7 @@ class ImportSideEffectTests(unittest.TestCase):
         # If sitecustomize is available, it should have been imported.
         if "sitecustomize" not in sys.modules:
             try:
-                import sitecustomize
+                import sitecustomize  # noqa: F401
             except ImportError:
                 pass
             else:

--- a/Lib/test/test_sundry.py
+++ b/Lib/test/test_sundry.py
@@ -18,10 +18,11 @@ class TestUntestedModules(unittest.TestCase):
                     self.fail('{} has tests even though test_sundry claims '
                               'otherwise'.format(name))
 
-            import html.entities
+            import html.entities  # noqa: F401
 
             try:
-                import tty  # Not available on Windows
+                # Not available on Windows
+                import tty  # noqa: F401
             except ImportError:
                 if support.verbose:
                     print("skipping tty")

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -70,7 +70,7 @@ class TestSupport(unittest.TestCase):
         self.assertEqual(support.get_original_stdout(), sys.stdout)
 
     def test_unload(self):
-        import sched
+        import sched  # noqa: F401
         self.assertIn("sched", sys.modules)
         import_helper.unload("sched")
         self.assertNotIn("sched", sys.modules)

--- a/Lib/test/test_unicode_identifiers.py
+++ b/Lib/test/test_unicode_identifiers.py
@@ -19,7 +19,7 @@ class PEP3131Test(unittest.TestCase):
 
     def test_invalid(self):
         try:
-            from test.tokenizedata import badsyntax_3131
+            from test.tokenizedata import badsyntax_3131  # noqa: F401
         except SyntaxError as err:
             self.assertEqual(str(err),
               "invalid character '€' (U+20AC) (badsyntax_3131.py, line 2)")

--- a/Lib/test/test_utf8source.py
+++ b/Lib/test/test_utf8source.py
@@ -14,7 +14,7 @@ class PEP3120Test(unittest.TestCase):
 
     def test_badsyntax(self):
         try:
-            import test.tokenizedata.badsyntax_pep3120
+            import test.tokenizedata.badsyntax_pep3120  # noqa: F401
         except SyntaxError as msg:
             msg = str(msg).lower()
             self.assertTrue('utf-8' in msg)

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -499,7 +499,7 @@ class WarnTests(BaseTest):
             with original_warnings.catch_warnings(record=True,
                     module=self.module) as w:
                 self.module.simplefilter('always')
-                import test.test_warnings.data.import_warning
+                import test.test_warnings.data.import_warning  # noqa: F401
                 self.assertEqual(len(w), 1)
                 self.assertEqual(w[0].filename, __file__)
 

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -138,9 +138,9 @@ class ModuleTest(unittest.TestCase):
     def test_sanity(self):
         # Import sanity.
 
-        from xml.etree import ElementTree
-        from xml.etree import ElementInclude
-        from xml.etree import ElementPath
+        from xml.etree import ElementTree     # noqa: F401
+        from xml.etree import ElementInclude  # noqa: F401
+        from xml.etree import ElementPath     # noqa: F401
 
     def test_all(self):
         names = ("xml.etree.ElementTree", "_elementtree")

--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -308,7 +308,7 @@ class XMLRPCTestCase(unittest.TestCase):
 
     def test_ssl_presence(self):
         try:
-            import ssl
+            import ssl  # noqa: F401
         except ImportError:
             has_ssl = False
         else:


### PR DESCRIPTION
Ignore linter "imported but unused" warnings in tests when the linter doesn't understand why the import is important.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120417 -->
* Issue: gh-120417
<!-- /gh-issue-number -->
