### PR TITLE
gh-120161: Clean Up the Managed Static Types State

### DIFF
--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -18,11 +18,9 @@ extern "C" {
 #define _Py_MAX_GLOBAL_TYPE_VERSION_TAG (_Py_TYPE_BASE_VERSION_TAG - 1)
 
 /* For now we hard-code this to a value for which we are confident
-   all the static builtin types will fit (for all builds). */
-#define _Py_MAX_MANAGED_STATIC_BUILTIN_TYPES 200
-#define _Py_MAX_MANAGED_STATIC_EXT_TYPES 10
-#define _Py_MAX_MANAGED_STATIC_TYPES \
-    (_Py_MAX_MANAGED_STATIC_BUILTIN_TYPES + _Py_MAX_MANAGED_STATIC_EXT_TYPES)
+   all the managed static types will fit (for all builds).
+   That includes all static builtin types and managed extension types. */
+#define _Py_MAX_MANAGED_STATIC_TYPES 210
 
 struct _types_runtime_state {
     /* Used to set PyTypeObject.tp_version_tag for core static types. */
@@ -30,6 +28,12 @@ struct _types_runtime_state {
     // because of static types.
     unsigned int next_version_tag;
 
+    /* We track every managed static type.  Each one is assigned an
+     * index when it is first initialized using _PyStaticType_InitBuiltin()
+     * or _PyStaticType_InitForExtension().  It keeps that index for the
+     * duration of the process.  The same index is used when accessing
+     * the global array of type state, as well as the per-interpreter
+     * array. */
     struct {
         PyMutex mutex;
         size_t num_builtins;
@@ -116,7 +120,6 @@ struct types_state {
         size_t num_builtins;
         size_t num_types;
         struct managed_static_type_state {
-            //int initialized;
             PyTypeObject *type;
             int readying;
             int ready;

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -31,8 +31,13 @@ struct _types_runtime_state {
     unsigned int next_version_tag;
 
     struct {
+        PyMutex mutex;
+        size_t num_builtins;
+        size_t num_types;
+        size_t next_index;
         struct {
             PyTypeObject *type;
+            int isbuiltin;
             int64_t interp_count;
         } types[_Py_MAX_MANAGED_STATIC_TYPES];
     } managed_static;
@@ -58,7 +63,6 @@ struct type_cache {
 
 typedef struct {
     PyTypeObject *type;
-    int isbuiltin;
     int readying;
     int ready;
     // XXX tp_dict can probably be statically allocated,
@@ -125,7 +129,6 @@ struct types_state {
     /* We apply a similar strategy for managed extension modules. */
     struct {
         size_t num_initialized;
-        size_t next_index;
         managed_static_type_state initialized[_Py_MAX_MANAGED_STATIC_EXT_TYPES];
     } for_extensions;
     PyMutex mutex;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5943,6 +5943,8 @@ fini_static_type(PyInterpreterState *interp, PyTypeObject *type,
 void
 _PyTypes_FiniExtTypes(PyInterpreterState *interp)
 {
+    /* Static extension types must be finalized before the builtins. */
+    assert(interp->types.managed_static.num_builtins > 0);
     for (size_t i = _Py_MAX_MANAGED_STATIC_TYPES;
             i > _Py_MAX_MANAGED_STATIC_BUILTIN_TYPES; i--)
     {
@@ -5954,6 +5956,8 @@ _PyTypes_FiniExtTypes(PyInterpreterState *interp)
         }
         int64_t count = 0;
         PyTypeObject *type = static_ext_type_lookup(interp, i-1, &count);
+        /* Currently there is no other way to finalize one of these types. */
+        assert(type != NULL);
         if (type == NULL) {
             continue;
         }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -129,13 +129,11 @@ type_from_ref(PyObject *ref)
 
 /* helpers for for managed static types */
 
-#ifndef NDEBUG
 static inline int
 managed_static_type_index_is_set(PyTypeObject *self)
 {
     return self->tp_subclasses != NULL;
 }
-#endif
 
 static inline size_t
 managed_static_type_index_get(PyTypeObject *self)

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5956,7 +5956,9 @@ _PyTypes_FiniExtTypes(PyInterpreterState *interp)
 {
     /* Static extension types must be finalized before the builtins. */
     assert(interp->types.managed_static.num_builtins > 0);
+#ifndef NDEBUG
     int started = 0;
+#endif
     for (size_t i = _Py_MAX_MANAGED_STATIC_TYPES; i > 0; i--)
     {
         /* There may be gaps. */
@@ -5970,7 +5972,9 @@ _PyTypes_FiniExtTypes(PyInterpreterState *interp)
         assert(!started || type != NULL);
         /* Currently there is no other way to finalize one of these types. */
         if (type != NULL) {
+#ifndef NDEBUG
             started = 1;
+#endif
             int final = (count == 1);
             fini_static_type(interp, type, 0, final);
         }


### PR DESCRIPTION
In gh-120182, the approach I took aimed to fix the problem with minimal churn, for the sake of backporting.  This change builds on that with what I consider the cleaner approach I would have taken.

The key changes are:

* move more data into the global runtime state
* at the interpreter level, consolidate the builtins and extensions state
* add many more asserts to ensure consistency

<!-- gh-issue-number: gh-120161 -->
* Issue: gh-120161
<!-- /gh-issue-number -->
