### PR TITLE
gh-120635: Avoid leaking processes in test_pyrepl

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -890,5 +890,5 @@ class TestMain(TestCase):
             exit_code = process.wait(timeout=SHORT_TIMEOUT)
         except subprocess.TimeoutExpired:
             process.kill()
-            exit_code = process.returncode
+            exit_code = process.wait()
         return "\n".join(output), exit_code


### PR DESCRIPTION
If the child process takes longer than SHORT_TIMEOUT seconds to complete, kill the process but then wait until it completes with no timeout to not leak child processes.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120635 -->
* Issue: gh-120635
<!-- /gh-issue-number -->
