### PR TITLE
gh-117953: Skip `test_interpreters` properly without GIL

### DIFF
--- a/Lib/test/test_interpreters/__init__.py
+++ b/Lib/test/test_interpreters/__init__.py
@@ -1,6 +1,9 @@
 import os
 from test.support import load_package_tests, Py_GIL_DISABLED
+import unittest
 
-if not Py_GIL_DISABLED:
-    def load_tests(*args):
-        return load_package_tests(os.path.dirname(__file__), *args)
+if Py_GIL_DISABLED:
+    raise unittest.SkipTest("GIL disabled")
+
+def load_tests(*args):
+    return load_package_tests(os.path.dirname(__file__), *args)


### PR DESCRIPTION
```none
0:00:33 load avg: 2.57 [ 61/478] test_interpreters ran no tests -- running (1): test_subprocess (31.8 sec)
----------------------------------------------------------------------
Ran 0 tests in 0.000s

NO TESTS RAN
```

<!-- gh-issue-number: gh-117953 -->
* Issue: gh-117953
<!-- /gh-issue-number -->
