### PR TITLE
GH-118943: Fix another race condition when generating jit_stencils.h

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-06-18-15-28-25.gh-issue-118943.aie7nn.rst
+++ b/Misc/NEWS.d/next/Build/2024-06-18-15-28-25.gh-issue-118943.aie7nn.rst
@@ -1,0 +1,3 @@
+Fix a possible race condition affecting parallel builds configured with
+``--enable-experimental-jit``, in which FileNotFoundError could be caused by
+another process already moving ``jit_stencils.h.new`` to ``jit_stencils.h``.

--- a/Misc/NEWS.d/next/Build/2024-06-18-15-28-25.gh-issue-118943.aie7nn.rst
+++ b/Misc/NEWS.d/next/Build/2024-06-18-15-28-25.gh-issue-118943.aie7nn.rst
@@ -1,3 +1,3 @@
 Fix a possible race condition affecting parallel builds configured with
-``--enable-experimental-jit``, in which FileNotFoundError could be caused by
+``--enable-experimental-jit``, in which :exc:`FileNotFoundError` could be caused by
 another process already moving ``jit_stencils.h.new`` to ``jit_stencils.h``.

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -221,7 +221,12 @@ class _Target(typing.Generic[_S, _R]):
                 file.write("\n")
                 for line in _writer.dump(stencil_groups):
                     file.write(f"{line}\n")
-            jit_stencils_new.replace(jit_stencils)
+            try:
+                jit_stencils_new.replace(jit_stencils)
+            except FileNotFoundError:
+                # another process probably already moved the file
+                if not jit_stencils.is_file():
+                    raise
         finally:
             jit_stencils_new.unlink(missing_ok=True)
 


### PR DESCRIPTION
Another process might have already moved jit_stencils.h.new

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118943 -->
* Issue: gh-118943
<!-- /gh-issue-number -->
