### PR TITLE
[3.13] gh-119258: Backport optimizer frame fixes in GH-119365

### DIFF
--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -107,9 +107,9 @@ extern void _Py_uop_abstractcontext_fini(_Py_UOpsContext *ctx);
 extern _Py_UOpsAbstractFrame *_Py_uop_frame_new(
     _Py_UOpsContext *ctx,
     PyCodeObject *co,
-    _Py_UopsSymbol **localsplus_start,
-    int n_locals_already_filled,
-    int curr_stackentries);
+    int curr_stackentries,
+    _Py_UopsSymbol **args,
+    int arg_len);
 extern int _Py_uop_frame_pop(_Py_UOpsContext *ctx);
 
 PyAPI_FUNC(PyObject *) _Py_uop_symbols_test(PyObject *self, PyObject *ignored);

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -411,7 +411,7 @@ optimize_uops(
     if (_Py_uop_abstractcontext_init(ctx) < 0) {
         goto out_of_space;
     }
-    _Py_UOpsAbstractFrame *frame = _Py_uop_frame_new(ctx, co, ctx->n_consumed, 0, curr_stacklen);
+    _Py_UOpsAbstractFrame *frame = _Py_uop_frame_new(ctx, co, curr_stacklen, NULL, 0);
     if (frame == NULL) {
         return -1;
     }

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -616,17 +616,12 @@ dummy_func(void) {
             argcount++;
         }
 
-        _Py_UopsSymbol **localsplus_start = ctx->n_consumed;
-        int n_locals_already_filled = 0;
-        // Can determine statically, so we interleave the new locals
-        // and make the current stack the new locals.
-        // This also sets up for true call inlining.
+
         if (sym_is_null(self_or_null) || sym_is_not_null(self_or_null)) {
-            localsplus_start = args;
-            n_locals_already_filled = argcount;
+            OUT_OF_SPACE_IF_NULL(new_frame = frame_new(ctx, co, 0, args, argcount));
+        } else {
+            OUT_OF_SPACE_IF_NULL(new_frame = frame_new(ctx, co, 0, NULL, 0));
         }
-        OUT_OF_SPACE_IF_NULL(new_frame =
-                             frame_new(ctx, co, localsplus_start, n_locals_already_filled, 0));
     }
 
     op(_PY_FRAME_GENERAL, (callable, self_or_null, args[oparg] -- new_frame: _Py_UOpsAbstractFrame *)) {

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1697,17 +1697,11 @@
                 args--;
                 argcount++;
             }
-            _Py_UopsSymbol **localsplus_start = ctx->n_consumed;
-            int n_locals_already_filled = 0;
-            // Can determine statically, so we interleave the new locals
-            // and make the current stack the new locals.
-            // This also sets up for true call inlining.
             if (sym_is_null(self_or_null) || sym_is_not_null(self_or_null)) {
-                localsplus_start = args;
-                n_locals_already_filled = argcount;
+                OUT_OF_SPACE_IF_NULL(new_frame = frame_new(ctx, co, 0, args, argcount));
+            } else {
+                OUT_OF_SPACE_IF_NULL(new_frame = frame_new(ctx, co, 0, NULL, 0));
             }
-            OUT_OF_SPACE_IF_NULL(new_frame =
-                             frame_new(ctx, co, localsplus_start, n_locals_already_filled, 0));
             stack_pointer[-2 - oparg] = (_Py_UopsSymbol *)new_frame;
             stack_pointer += -1 - oparg;
             break;


### PR DESCRIPTION
Removes frame overlapping, instead copy over their arguments directly.

<!-- gh-issue-number: gh-119258 -->
* Issue: gh-119258
<!-- /gh-issue-number -->
