### PR TITLE
Add a link to free-threading HOWTO to the index (follow-up to GH-119366)

### DIFF
--- a/Doc/howto/index.rst
+++ b/Doc/howto/index.rst
@@ -52,6 +52,7 @@ General:
 Advanced development:
 
 * :ref:`curses-howto`
+* :ref:`freethreading-extensions-howto`
 * :ref:`isolating-extensions-howto`
 * :ref:`python_2.3_mro`
 * :ref:`socket-howto`


### PR DESCRIPTION
Between reviewing and merging GH-119366, a new HOWTO appeared.
It needs to go on the list.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120703.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->