### PR TITLE
Docs makefile/RTD: Use uv if installed

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,6 +26,9 @@ build:
         exit 183;
       fi
 
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
     - make -C Doc venv html
     - mkdir _readthedocs
     - mv Doc/build/html _readthedocs/html

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -152,11 +152,7 @@ htmlview: html
 
 .PHONY: ensure-sphinx-autobuild
 ensure-sphinx-autobuild: venv
-	if uv --version > /dev/null; then \
-		$(VENVDIR)/bin/sphinx-autobuild --version > /dev/null || VIRTUAL_ENV=$(VENVDIR) uv pip install sphinx-autobuild; \
-	else \
-		$(VENVDIR)/bin/sphinx-autobuild --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install sphinx-autobuild; \
-	fi
+	$(call ensure_package,sphinx-autobuild)
 
 .PHONY: htmllive
 htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
@@ -244,16 +240,17 @@ dist:
 	rm -r dist/python-$(DISTVERSION)-docs-texinfo
 	rm dist/python-$(DISTVERSION)-docs-texinfo.tar
 
-.PHONY: ensure-pre-commit
-ensure-pre-commit: venv
+define ensure_package
 	if uv --version > /dev/null; then \
-		$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || VIRTUAL_ENV=$(VENVDIR) uv pip install pre-commit; \
+		$(VENVDIR)/bin/python3 -m $(1) --version > /dev/null || VIRTUAL_ENV=$(VENVDIR) uv pip install $(1); \
 	else \
-		$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit; \
+		$(VENVDIR)/bin/python3 -m $(1) --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install $(1); \
 	fi
+endef
 
 .PHONY: check
-check: ensure-pre-commit
+check: venv
+	$(call ensure_package,pre-commit)
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files
 
 .PHONY: serve

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -152,7 +152,11 @@ htmlview: html
 
 .PHONY: ensure-sphinx-autobuild
 ensure-sphinx-autobuild: venv
-	$(VENVDIR)/bin/sphinx-autobuild --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install sphinx-autobuild
+	if uv --version > /dev/null; then \
+		$(VENVDIR)/bin/sphinx-autobuild --version > /dev/null || VIRTUAL_ENV=$(VENVDIR) uv pip install sphinx-autobuild; \
+	else \
+		$(VENVDIR)/bin/sphinx-autobuild --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install sphinx-autobuild; \
+	fi
 
 .PHONY: htmllive
 htmllive: SPHINXBUILD = $(VENVDIR)/bin/sphinx-autobuild
@@ -174,10 +178,15 @@ venv:
 		echo "To recreate it, remove it first with \`make clean-venv'."; \
 	else \
 		echo "Creating venv in $(VENVDIR)"; \
-		$(PYTHON) -m venv $(VENVDIR); \
-		$(VENVDIR)/bin/python3 -m pip install --upgrade pip; \
-		$(VENVDIR)/bin/python3 -m pip install -r $(REQUIREMENTS); \
-		echo "The venv has been created in the $(VENVDIR) directory"; \
+		if uv --version > /dev/null; then \
+			uv venv $(VENVDIR); \
+			VIRTUAL_ENV=$(VENVDIR) uv pip install -r $(REQUIREMENTS); \
+		else \
+			$(PYTHON) -m venv $(VENVDIR); \
+			$(VENVDIR)/bin/python3 -m pip install --upgrade pip; \
+			$(VENVDIR)/bin/python3 -m pip install -r $(REQUIREMENTS); \
+			echo "The venv has been created in the $(VENVDIR) directory"; \
+		fi; \
 	fi
 
 .PHONY: dist
@@ -237,7 +246,11 @@ dist:
 
 .PHONY: check
 check: venv
-	$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit
+	if uv --version > /dev/null; then \
+		$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || VIRTUAL_ENV=$(VENVDIR) uv pip install pre-commit; \
+	else \
+		$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit; \
+	fi;
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files
 
 .PHONY: serve

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -250,7 +250,7 @@ endef
 
 .PHONY: check
 check: venv
-	$(call ensure_package,pre-commit)
+	$(call ensure_package,pre_commit)
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files
 
 .PHONY: serve

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -244,13 +244,16 @@ dist:
 	rm -r dist/python-$(DISTVERSION)-docs-texinfo
 	rm dist/python-$(DISTVERSION)-docs-texinfo.tar
 
-.PHONY: check
-check: venv
+.PHONY: ensure-pre-commit
+ensure-pre-commit: venv
 	if uv --version > /dev/null; then \
 		$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || VIRTUAL_ENV=$(VENVDIR) uv pip install pre-commit; \
 	else \
 		$(VENVDIR)/bin/python3 -m pre_commit --version > /dev/null || $(VENVDIR)/bin/python3 -m pip install pre-commit; \
-	fi;
+	fi
+
+.PHONY: check
+check: ensure-pre-commit
 	$(VENVDIR)/bin/python3 -m pre_commit run --all-files
 
 .PHONY: serve


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Like https://github.com/python/devguide/pull/1320 and https://github.com/python/peps/pull/3791.

Using uv to install dependencies is quicker than pip.

Locally, running `make -C Doc clean-venv; time make -C Doc venv` with no cache goes from 8.9s -> 2.4s:

* pip: `make -C Doc venv  4.81s user 1.52s system 71% cpu 8.896 total`
* uv: `make -C Doc venv  0.91s user 1.00s system 81% cpu 2.345 total`

And with a warm cache goes from 5.03s -> 0.08s:

* pip: `make -C Doc venv  3.47s user 0.82s system 85% cpu 5.033 total`
* uv: `make -C Doc venv  0.02s user 0.07s system 109% cpu 0.080 total`

On Read the Docs, it adds 2 seconds to install uv, and then cuts the docs build time from 199s -> 190s, about 7s reduction in all.

* pip: https://app.readthedocs.org/projects/hugovk-cpython/builds/24732336/
* uv: https://app.readthedocs.org/projects/hugovk-cpython/builds/24736480/

RTD+uv docs: https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120711.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->