### PR TITLE
gh-120437: Fix `_CHECK_STACK_SPACE` optimization problems introduced in gh-118322

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-19-01-58-54.gh-issue-120437.nCkIoI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-19-01-58-54.gh-issue-120437.nCkIoI.rst
@@ -1,0 +1,1 @@
+Fix ``_CHECK_STACK_SPACE`` optimization problems after introduced in :gh:`118322`.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-19-01-58-54.gh-issue-120437.nCkIoI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-19-01-58-54.gh-issue-120437.nCkIoI.rst
@@ -1,1 +1,1 @@
-Fix ``_CHECK_STACK_SPACE`` optimization problems after introduced in :gh:`118322`.
+Fix ``_CHECK_STACK_SPACE`` optimization problems introduced in :gh:`118322`.

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -601,7 +601,6 @@ dummy_func(void) {
         (void)callable;
         (void)self_or_null;
         (void)args;
-        first_valid_check_stack = NULL;
         new_frame = NULL;
         ctx->done = true;
     }

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1492,7 +1492,6 @@
             (void)callable;
             (void)self_or_null;
             (void)args;
-            first_valid_check_stack = NULL;
             new_frame = NULL;
             ctx->done = true;
             stack_pointer[-2 - oparg] = (_Py_UopsSymbol *)new_frame;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important. >

Fix #120437 

<!-- gh-issue-number: gh-120437 -->
* Issue: gh-120437
<!-- /gh-issue-number -->
