### PR TITLE
gh-120367: fix bug where compiler detects redundant jump after pseudo op replacement

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -519,7 +519,32 @@ class TestSpecifics(unittest.TestCase):
 
         tree = ast.parse(code)
 
-        # make all instructions locations the same to create redundancies
+        # make all instruction locations the same to create redundancies
+        for node in ast.walk(tree):
+            if hasattr(node,"lineno"):
+                 del node.lineno
+                 del node.end_lineno
+                 del node.col_offset
+                 del node.end_col_offset
+
+        compile(ast.fix_missing_locations(tree), "<file>", "exec")
+
+    def test_compile_redundant_jump_after_convert_pseudo_ops(self):
+        # See gh-120367
+        code=textwrap.dedent("""
+            if name_2:
+                pass
+            else:
+                try:
+                    pass
+                except:
+                    pass
+            ~name_5
+            """)
+
+        tree = ast.parse(code)
+
+        # make all instruction locations the same to create redundancies
         for node in ast.walk(tree):
             if hasattr(node,"lineno"):
                  del node.lineno

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-18-21-34-30.gh-issue-120367.zDwffP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-18-21-34-30.gh-issue-120367.zDwffP.rst
@@ -1,1 +1,1 @@
-Fix bug where compiler creates a redundant jump during pseudo-op replacement. Can only happen with a synthetic AST that has a `try` on the same line as the instruction following the exception handler.
+Fix bug where compiler creates a redundant jump during pseudo-op replacement. Can only happen with a synthetic AST that has a try on the same line as the instruction following the exception handler.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-18-21-34-30.gh-issue-120367.zDwffP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-18-21-34-30.gh-issue-120367.zDwffP.rst
@@ -1,0 +1,1 @@
+Fix bug where compiler creates a redundant jump during pseudo-op replacement. Can only happen with a synthetic AST that has a `try` on the same line as the instruction following the exception handler.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2389,7 +2389,7 @@ convert_pseudo_ops(cfg_builder *g)
             }
         }
     }
-    return remove_redundant_nops(g);
+    return remove_redundant_nops_and_jumps(g);
 }
 
 static inline bool


### PR DESCRIPTION
Fixes #120367. 

This can't happen with an AST that comes from real code, because the try can't be on the same line as the following instruction. It can happen with a synthetic AST though.

<!-- gh-issue-number: gh-120367 -->
* Issue: gh-120367
<!-- /gh-issue-number -->
