### PR TITLE
GH-73991: Add `pathlib.Path.copytree()`

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1455,7 +1455,7 @@ Copying, renaming and deleting
    .. versionadded:: 3.14
 
 
-.. method:: Path.copytree(target, *, follow_symlinks=True, dirs_exist_ok=False,
+.. method:: Path.copytree(target, *, follow_symlinks=True, dirs_exist_ok=False, \
                           ignore=None, on_error=None)
 
    Recursively copy this directory tree to the given destination.

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1455,6 +1455,33 @@ Copying, renaming and deleting
    .. versionadded:: 3.14
 
 
+.. method:: Path.copytree(target, *, follow_symlinks=True, dirs_exist_ok=False,
+                          ignore=None, on_error=None)
+
+   Recursively copy this directory tree to the given destination.
+
+   If a symlink is encountered in the source tree, and *follow_symlinks* is
+   true (the default), the symlink's target is copied. Otherwise, the symlink
+   is recreated in the destination tree.
+
+   If the destination is an existing directory and *dirs_exist_ok* is false
+   (the default), a :exc:`FileExistsError` is raised. Otherwise, the copying
+   operation will continue if it encounters existing directories, and files
+   within the destination tree will be overwritten by corresponding files from
+   the source tree.
+
+   If *ignore* is given, it should be a callable accepting one argument: a
+   file or directory path within the source tree. The callable may return true
+   to suppress copying of the path.
+
+   If *on_error* is given, it should be a callable accepting one argument: an
+   instance of :exc:`OSError`. The callable may re-raise the exception or do
+   nothing, in which case the copying operation continues. If *on_error* isn't
+   given, exceptions are propagated to the caller.
+
+   .. versionadded:: 3.14
+
+
 .. method:: Path.rename(target)
 
    Rename this file or directory to the given *target*, and return a new

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -106,6 +106,9 @@ pathlib
 * Add :meth:`pathlib.Path.copy`, which copies the content of one file to
   another, like :func:`shutil.copyfile`.
   (Contributed by Barney Gale in :gh:`73991`.)
+* Add :meth:`pathlib.Path.copytree`, which copies one directory tree to
+  another.
+  (Contributed by Barney Gale in :gh:`73991`.)
 
 symtable
 --------

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -513,17 +513,14 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         os.chmod(self.parser.join(self.base, 'dirE'), 0)
 
     def tearDown(self):
-        try:
-            os.chmod(self.parser.join(self.base, 'dirE'), 0o777)
-        except FileNotFoundError:
-            pass
+        os.chmod(self.parser.join(self.base, 'dirE'), 0o777)
         os_helper.rmtree(self.base)
 
     def tempdir(self):
         d = os_helper._longpath(tempfile.mkdtemp(suffix='-dirD',
                                                  dir=os.getcwd()))
         self.addCleanup(os_helper.rmtree, d)
-        return self.cls(d)
+        return d
 
     def test_matches_pathbase_api(self):
         our_names = {name for name in dir(self.cls) if name[0] != '_'}

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -656,6 +656,7 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
             self.assertIsInstance(f, io.RawIOBase)
             self.assertEqual(f.read().strip(), b"this is file A")
 
+    @unittest.skipIf(sys.platform == "win32", "directories are always readable on Windows")
     def test_copytree_no_read_permission(self):
         base = self.cls(self.base)
         source = base / 'dirE'

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -656,7 +656,7 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
             self.assertIsInstance(f, io.RawIOBase)
             self.assertEqual(f.read().strip(), b"this is file A")
 
-    @unittest.skipIf(sys.platform == "win32", "directories are always readable on Windows")
+    @unittest.skipIf(sys.platform == "win32" or sys.platform == "wasi", "directories are always readable on Windows and WASI")
     def test_copytree_no_read_permission(self):
         base = self.cls(self.base)
         source = base / 'dirE'

--- a/Misc/NEWS.d/next/Library/2024-06-19-03-09-11.gh-issue-73991.lU_jK9.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-19-03-09-11.gh-issue-73991.lU_jK9.rst
@@ -1,0 +1,1 @@
+Add :meth:`pathlib.Path.copytree`, which recursively copies a directory.


### PR DESCRIPTION
Add `pathlib.Path.copytree()` method, which recursively copies one directory to another.

This differs from `shutil.copytree()` in the following respects:

1. Our method has a *follow_symlinks* argument, whereas shutil's has a *symlinks* argument with an inverted meaning.
2. Our method lacks something like a *copy_function* argument. It always uses `Path.copy()` to copy files.
3. Our method lacks something like a *ignore_dangling_symlinks* argument. Instead, users can filter out danging symlinks with *ignore*, or ignore exceptions with *on_error*
4. Our *ignore* argument is a callable that accepts a single path object, whereas shutil's accepts a path and a list of child filenames.
5. We add an *on_error* argument, which is a callable that accepts an `OSError` instance. (`Path.walk()` also accepts such a callable). This is done instead of aggregating exceptions into an `shutil.Error` instance.


<!-- gh-issue-number: gh-73991 -->
* Issue: gh-73991
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120718.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->