### PR TITLE
gh-120722: Propogate instruction location in optimization of LOAD_CONST + RETURN_VALUE with RETURN_CONST

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -2028,6 +2028,15 @@ class TestSourcePositions(unittest.TestCase):
             code, "LOAD_GLOBAL", line=3, end_line=3, column=4, end_column=9
         )
 
+    def test_constant_lambda(self):
+        namespace = {}
+        source = "f = lambda: 1"
+        code = compile(source, "<test>", "exec")
+        exec(code, namespace)
+        self.assertOpcodeSourcePositionIs(
+            namespace["f"].__code__, "RETURN_CONST", line=1, end_line=1,
+            column=12, end_column=13
+        )
 
 class TestExpectedAttributes(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-19-05-32-32.gh-issue-120722.4ZDtZr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-19-05-32-32.gh-issue-120722.4ZDtZr.rst
@@ -1,0 +1,1 @@
+Fixed an issue where the ``RETURN_CONST`` instruction in the code object of a lambda function returning a constant value was not accompanied with correct location information.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -116,6 +116,16 @@ is_jump(cfg_instr *i)
         _instr__ptr_->i_oparg = (ARG); \
     } while (0);
 
+/* One arg with location*/
+#define INSTR_SET_OP1_LOC(I, OP, ARG, LOC) \
+    do { \
+        assert(OPCODE_HAS_ARG(OP)); \
+        cfg_instr *_instr__ptr_ = (I); \
+        _instr__ptr_->i_opcode = (OP); \
+        _instr__ptr_->i_oparg = (ARG); \
+        _instr__ptr_->i_loc = (LOC); \
+    } while (0);
+
 /* No args*/
 #define INSTR_SET_OP0(I, OP) \
     do { \
@@ -1661,7 +1671,8 @@ basicblock_optimize_load_const(PyObject *const_cache, basicblock *bb, PyObject *
             case RETURN_VALUE:
             {
                 INSTR_SET_OP0(inst, NOP);
-                INSTR_SET_OP1(&bb->b_instr[++i], RETURN_CONST, oparg);
+                INSTR_SET_OP1_LOC(&bb->b_instr[++i], RETURN_CONST, oparg,
+                                  inst->i_loc);
                 break;
             }
             case TO_BOOL:


### PR DESCRIPTION
Currently a lambda function returning a constant value gets its pair of `LOAD_CONST` and `RETURN_VALUE` instructions optimized by the compiler into a `RETURN_CONST` instruction without the original location propagated.

This PR fixes the issue by propogating the location information for this optimization.

<!-- gh-issue-number: gh-120722 -->
* Issue: gh-120722
<!-- /gh-issue-number -->
