### PR TITLE
GH-119462: Enforce invariants of type versioning

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1328,8 +1328,8 @@ and :c:data:`PyType_Type` effectively act as defaults.)
       To indicate that a class has changed call :c:func:`PyType_Modified`
 
       .. warning::
-         This flag is present in header files, but is an internal feature and should
-         not be used. It will be removed in a future version of CPython
+         This flag is present in header files, but is not be used.
+         It will be removed in a future version of CPython
 
 
 .. c:member:: const char* PyTypeObject.tp_doc

--- a/Include/object.h
+++ b/Include/object.h
@@ -556,7 +556,7 @@ given type object has a specified feature.
 /* Objects behave like an unbound method */
 #define Py_TPFLAGS_METHOD_DESCRIPTOR (1UL << 17)
 
-/* Object has up-to-date type attribute cache */
+/* Unused. Legacy flag */
 #define Py_TPFLAGS_VALID_VERSION_TAG  (1UL << 19)
 
 /* Type is abstract and cannot be instantiated */

--- a/Lib/test/test_type_cache.py
+++ b/Lib/test/test_type_cache.py
@@ -106,8 +106,10 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
         if type_get_version(type_) == 0:
             self.skipTest("Could not assign valid type version")
 
-    def _assign_and_check_version_0(self, user_type):
+    def _no_more_versions(self, user_type):
         type_modified(user_type)
+        for _ in range(1001):
+            type_assign_specific_version_unsafe(user_type, 1000_000_000)
         type_assign_specific_version_unsafe(user_type, 0)
         self.assertEqual(type_get_version(user_type), 0)
 
@@ -136,7 +138,7 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
         self._check_specialization(load_foo_1, A, "LOAD_ATTR", should_specialize=True)
         del load_foo_1
 
-        self._assign_and_check_version_0(A)
+        self._no_more_versions(A)
 
         def load_foo_2(type_):
             return type_.foo
@@ -187,7 +189,7 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
         self._check_specialization(load_x_1, G(), "LOAD_ATTR", should_specialize=True)
         del load_x_1
 
-        self._assign_and_check_version_0(G)
+        self._no_more_versions(G)
 
         def load_x_2(instance):
             instance.x
@@ -206,7 +208,7 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
         self._check_specialization(store_bar_1, B(), "STORE_ATTR", should_specialize=True)
         del store_bar_1
 
-        self._assign_and_check_version_0(B)
+        self._no_more_versions(B)
 
         def store_bar_2(type_):
             type_.bar = 10
@@ -226,7 +228,7 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
         self._check_specialization(call_class_1, F, "CALL", should_specialize=True)
         del call_class_1
 
-        self._assign_and_check_version_0(F)
+        self._no_more_versions(F)
 
         def call_class_2(type_):
             type_()
@@ -245,7 +247,7 @@ class TypeCacheWithSpecializationTests(unittest.TestCase):
         self._check_specialization(to_bool_1, H(), "TO_BOOL", should_specialize=True)
         del to_bool_1
 
-        self._assign_and_check_version_0(H)
+        self._no_more_versions(H)
 
         def to_bool_2(instance):
             not instance

--- a/Lib/test/test_type_cache.py
+++ b/Lib/test/test_type_cache.py
@@ -93,6 +93,21 @@ class TypeCacheTests(unittest.TestCase):
         new_version = type_get_version(C)
         self.assertEqual(new_version, 0)
 
+    def test_119462(self):
+
+        class Holder:
+            value = None
+
+            @classmethod
+            def set_value(cls):
+                cls.value = object()
+
+        class HolderSub(Holder):
+            pass
+
+        for _ in range(1050):
+            Holder.set_value()
+            HolderSub.value
 
 @support.cpython_only
 @requires_specialization

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-19-11-10-50.gh-issue-119462.DpcqSe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-19-11-10-50.gh-issue-119462.DpcqSe.rst
@@ -1,4 +1,4 @@
-Make sure that invariants of type versioning are maintained: * Superclasses
-always have their version number assigned before subclasses * The
-Py_TPFLAGS_VALID_VERSION_TAG is always set if the version tag is non-zero *
-The Py_TPFLAGS_VALID_VERSION_TAG is always unset if the version tag is zero
+Make sure that invariants of type versioning are maintained:
+* Superclasses always have their version number assigned before subclasses
+* The version tag is always zero if the tag is not valid.
+* The version tag is always non-if the tag is valid.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-19-11-10-50.gh-issue-119462.DpcqSe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-19-11-10-50.gh-issue-119462.DpcqSe.rst
@@ -1,0 +1,4 @@
+Make sure that invariants of type versioning are maintained: * Superclasses
+always have their version number assigned before subclasses * The
+Py_TPFLAGS_VALID_VERSION_TAG is always set if the version tag is non-zero *
+The Py_TPFLAGS_VALID_VERSION_TAG is always unset if the version tag is zero

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -2014,7 +2014,6 @@ type_assign_specific_version_unsafe(PyObject *self, PyObject *args)
     }
     assert(!PyType_HasFeature(type, Py_TPFLAGS_IMMUTABLETYPE));
     _PyType_SetVersion(type, version);
-    type->tp_flags |= Py_TPFLAGS_VALID_VERSION_TAG;
     Py_RETURN_NONE;
 }
 

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1651,7 +1651,7 @@ PyDoc_STRVAR(pyexpat_module_documentation,
 static int init_handler_descrs(pyexpat_state *state)
 {
     int i;
-    assert(!PyType_HasFeature(state->xml_parse_type, Py_TPFLAGS_VALID_VERSION_TAG));
+    assert(state->xml_parse_type->tp_version_tag == 0);
     for (i = 0; handler_info[i].name != NULL; i++) {
         struct HandlerInfo *hi = &handler_info[i];
         hi->getset.name = hi->name;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -988,43 +988,38 @@ PyType_Unwatch(int watcher_id, PyObject* obj)
     return 0;
 }
 
-#ifdef Py_GIL_DISABLED
-
 static void
-type_modification_starting_unlocked(PyTypeObject *type)
+set_version_unlocked(PyTypeObject *tp, unsigned int version)
 {
     ASSERT_TYPE_LOCK_HELD();
-
-    /* Clear version tags on all types, but leave the valid
-       version tag intact.  This prepares for a modification so that
-       any concurrent readers of the type cache will not see invalid
-       values.
-     */
-    if (!_PyType_HasFeature(type, Py_TPFLAGS_VALID_VERSION_TAG)) {
-        return;
+    assert(version_tag_consistency(tp));
+#ifndef Py_GIL_DISABLED
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    // lookup the old version and set to null
+    if (tp->tp_version_tag != 0) {
+        PyTypeObject **slot =
+            interp->types.type_version_cache
+            + (tp->tp_version_tag % TYPE_VERSION_CACHE_SIZE);
+        *slot = NULL;
     }
-
-    PyObject *subclasses = lookup_tp_subclasses(type);
-    if (subclasses != NULL) {
-        assert(PyDict_CheckExact(subclasses));
-
-        Py_ssize_t i = 0;
-        PyObject *ref;
-        while (PyDict_Next(subclasses, &i, NULL, &ref)) {
-            PyTypeObject *subclass = type_from_ref(ref);
-            if (subclass == NULL) {
-                continue;
-            }
-            type_modification_starting_unlocked(subclass);
-            Py_DECREF(subclass);
-        }
-    }
-
-    /* 0 is not a valid version tag */
-    _PyType_SetVersion(type, 0);
-}
-
 #endif
+    if (version) {
+        tp->tp_flags |= Py_TPFLAGS_VALID_VERSION_TAG;
+        tp->tp_versions_used++;
+    }
+    else {
+        tp->tp_flags &= ~Py_TPFLAGS_VALID_VERSION_TAG;
+    }
+    tp->tp_version_tag = version;
+#ifndef Py_GIL_DISABLED
+    if (version != 0) {
+        PyTypeObject **slot =
+            interp->types.type_version_cache
+            + (version % TYPE_VERSION_CACHE_SIZE);
+        *slot = tp;
+    }
+#endif
+}
 
 static void
 type_modified_unlocked(PyTypeObject *type)
@@ -1084,7 +1079,7 @@ type_modified_unlocked(PyTypeObject *type)
         }
     }
 
-    _PyType_SetVersion(type, 0); /* 0 is not a valid version tag */
+    set_version_unlocked(type, 0); /* 0 is not a valid version tag */
     if (PyType_HasFeature(type, Py_TPFLAGS_HEAPTYPE)) {
         // This field *must* be invalidated if the type is modified (see the
         // comment on struct _specialization_cache):
@@ -1095,13 +1090,13 @@ type_modified_unlocked(PyTypeObject *type)
 void
 PyType_Modified(PyTypeObject *type)
 {
-    assert(version_tag_consistency(type));
     // Quick check without the lock held
     if (!_PyType_HasFeature(type, Py_TPFLAGS_VALID_VERSION_TAG)) {
         return;
     }
 
     BEGIN_TYPE_LOCK()
+    assert(version_tag_consistency(type));
     type_modified_unlocked(type);
     END_TYPE_LOCK()
 }
@@ -1161,7 +1156,7 @@ type_mro_modified(PyTypeObject *type, PyObject *bases) {
 
  clear:
     assert(!(type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN));
-    _PyType_SetVersion(type, 0); /* 0 is not a valid version tag */
+    set_version_unlocked(type, 0); /* 0 is not a valid version tag */
     if (PyType_HasFeature(type, Py_TPFLAGS_HEAPTYPE)) {
         // This field *must* be invalidated if the type is modified (see the
         // comment on struct _specialization_cache):
@@ -1181,33 +1176,10 @@ This is similar to func_version_cache.
 void
 _PyType_SetVersion(PyTypeObject *tp, unsigned int version)
 {
-    assert(version_tag_consistency(tp));
-#ifndef Py_GIL_DISABLED
-    PyInterpreterState *interp = _PyInterpreterState_GET();
-    // lookup the old version and set to null
-    if (tp->tp_version_tag != 0) {
-        PyTypeObject **slot =
-            interp->types.type_version_cache
-            + (tp->tp_version_tag % TYPE_VERSION_CACHE_SIZE);
-        *slot = NULL;
-    }
-#endif
-    if (version) {
-        tp->tp_flags |= Py_TPFLAGS_VALID_VERSION_TAG;
-        tp->tp_versions_used++;
-    }
-    else {
-        tp->tp_flags &= ~Py_TPFLAGS_VALID_VERSION_TAG;
-    }
-    FT_ATOMIC_STORE_UINT32_RELAXED(tp->tp_version_tag, version);
-#ifndef Py_GIL_DISABLED
-    if (version != 0) {
-        PyTypeObject **slot =
-            interp->types.type_version_cache
-            + (version % TYPE_VERSION_CACHE_SIZE);
-        *slot = tp;
-    }
-#endif
+
+    BEGIN_TYPE_LOCK()
+    set_version_unlocked(tp, version);
+    END_TYPE_LOCK()
 }
 
 PyTypeObject *
@@ -1271,7 +1243,7 @@ assign_version_tag(PyInterpreterState *interp, PyTypeObject *type)
             /* We have run out of version numbers */
             return 0;
         }
-        _PyType_SetVersion(type, NEXT_GLOBAL_VERSION_TAG++);
+        set_version_unlocked(type, NEXT_GLOBAL_VERSION_TAG++);
         assert (type->tp_version_tag <= _Py_MAX_GLOBAL_TYPE_VERSION_TAG);
     }
     else {
@@ -1280,7 +1252,7 @@ assign_version_tag(PyInterpreterState *interp, PyTypeObject *type)
             /* We have run out of version numbers */
             return 0;
         }
-        _PyType_SetVersion(type, NEXT_VERSION_TAG(interp)++);
+        set_version_unlocked(type, NEXT_VERSION_TAG(interp)++);
         assert (type->tp_version_tag != 0);
     }
     assert(version_tag_consistency(type));
@@ -5454,7 +5426,6 @@ _PyType_LookupRef(PyTypeObject *type, PyObject *name)
     unsigned int h = MCACHE_HASH_METHOD(type, name);
     struct type_cache *cache = get_type_cache();
     struct type_cache_entry *entry = &cache->hashtable[h];
-    assert(version_tag_consistency(type));
 #ifdef Py_GIL_DISABLED
     // synchronize-with other writing threads by doing an acquire load on the sequence
     while (1) {
@@ -5484,6 +5455,7 @@ _PyType_LookupRef(PyTypeObject *type, PyObject *name)
         }
     }
 #else
+    assert(version_tag_consistency(type));
     if (entry->version == type->tp_version_tag &&
         entry->name == name) {
         assert(_PyType_HasFeature(type, Py_TPFLAGS_VALID_VERSION_TAG));
@@ -5793,22 +5765,14 @@ type_setattro(PyObject *self, PyObject *name, PyObject *value)
         return -1;
     }
 
-#ifdef Py_GIL_DISABLED
-    // In free-threaded builds readers can race with the lock-free portion
-    // of the type cache and the assignment into the dict.  We clear all of the
-    // versions initially so no readers will succeed in the lock-free case.
-    // They'll then block on the type lock until the update below is done.
-    type_modification_starting_unlocked(type);
-#endif
-
-    res = _PyDict_SetItem_LockHeld((PyDictObject *)dict, name, value);
-
     /* Clear the VALID_VERSION flag of 'type' and all its
         subclasses.  This could possibly be unified with the
         update_subclasses() recursion in update_slot(), but carefully:
         they each have their own conditions on which to stop
         recursing into subclasses. */
     type_modified_unlocked(type);
+
+    res = _PyDict_SetItem_LockHeld((PyDictObject *)dict, name, value);
 
     if (res == 0) {
         if (is_dunder_name(name)) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -988,11 +988,11 @@ set_version_unlocked(PyTypeObject *tp, unsigned int version)
         *slot = NULL;
     }
     if (version) {
-        _Py_atomic_add_uint16(&tp->tp_versions_used, 1);
+        tp->tp_versions_used++;
     }
 #else
     if (version) {
-        tp->tp_versions_used++;
+        _Py_atomic_add_uint16(&tp->tp_versions_used, 1);
     }
 #endif
     FT_ATOMIC_STORE_UINT32_RELAXED(tp->tp_version_tag, version);
@@ -1216,8 +1216,9 @@ assign_version_tag(PyInterpreterState *interp, PyTypeObject *type)
     Py_ssize_t n = PyTuple_GET_SIZE(bases);
     for (Py_ssize_t i = 0; i < n; i++) {
         PyObject *b = PyTuple_GET_ITEM(bases, i);
-        if (!assign_version_tag(interp, _PyType_CAST(b)))
+        if (!assign_version_tag(interp, _PyType_CAST(b))) {
             return 0;
+        }
     }
     if (type->tp_flags & Py_TPFLAGS_IMMUTABLETYPE) {
         /* static types */


### PR DESCRIPTION
This PR enforces the following invariants:
1. The version of all superclasses is always set if the version of any subclass is set.
2. The version tag is valid iff the version tag is non-zero
3. The version tag is invalid iff the version tag is zero

1 is required for correct functioning of the method cache and is an explicitly documented requirement.
2 and 3 are necessary for correct operation of the specializing interpreter.

<!-- gh-issue-number: gh-119462 -->
* Issue: gh-119462
<!-- /gh-issue-number -->
