### PR TITLE
gh-120733: rename internal compiler functions according to naming convention

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1763,7 +1763,7 @@ compiler_apply_decorators(struct compiler *c, asdl_expr_seq* decos)
 }
 
 static int
-compiler_visit_kwonlydefaults(struct compiler *c, location loc,
+compiler_kwonlydefaults(struct compiler *c, location loc,
                               asdl_arg_seq *kwonlyargs, asdl_expr_seq *kw_defaults)
 {
     /* Push a dict of keyword-only default values.
@@ -1828,7 +1828,7 @@ compiler_visit_annexpr(struct compiler *c, expr_ty annotation)
 }
 
 static int
-compiler_visit_argannotation(struct compiler *c, identifier id,
+compiler_argannotation(struct compiler *c, identifier id,
     expr_ty annotation, Py_ssize_t *annotations_len, location loc)
 {
     if (!annotation) {
@@ -1862,14 +1862,14 @@ compiler_visit_argannotation(struct compiler *c, identifier id,
 }
 
 static int
-compiler_visit_argannotations(struct compiler *c, asdl_arg_seq* args,
-                              Py_ssize_t *annotations_len, location loc)
+compiler_argannotations(struct compiler *c, asdl_arg_seq* args,
+                        Py_ssize_t *annotations_len, location loc)
 {
     int i;
     for (i = 0; i < asdl_seq_LEN(args); i++) {
         arg_ty arg = (arg_ty)asdl_seq_GET(args, i);
         RETURN_IF_ERROR(
-            compiler_visit_argannotation(
+            compiler_argannotation(
                         c,
                         arg->arg,
                         arg->annotation,
@@ -1880,39 +1880,39 @@ compiler_visit_argannotations(struct compiler *c, asdl_arg_seq* args,
 }
 
 static int
-compiler_visit_annotations_in_scope(struct compiler *c, location loc,
-                                    arguments_ty args, expr_ty returns,
-                                    Py_ssize_t *annotations_len)
+compiler_annotations_in_scope(struct compiler *c, location loc,
+                              arguments_ty args, expr_ty returns,
+                              Py_ssize_t *annotations_len)
 {
     RETURN_IF_ERROR(
-        compiler_visit_argannotations(c, args->args, annotations_len, loc));
+        compiler_argannotations(c, args->args, annotations_len, loc));
 
     RETURN_IF_ERROR(
-        compiler_visit_argannotations(c, args->posonlyargs, annotations_len, loc));
+        compiler_argannotations(c, args->posonlyargs, annotations_len, loc));
 
     if (args->vararg && args->vararg->annotation) {
         RETURN_IF_ERROR(
-            compiler_visit_argannotation(c, args->vararg->arg,
+            compiler_argannotation(c, args->vararg->arg,
                                          args->vararg->annotation, annotations_len, loc));
     }
 
     RETURN_IF_ERROR(
-        compiler_visit_argannotations(c, args->kwonlyargs, annotations_len, loc));
+        compiler_argannotations(c, args->kwonlyargs, annotations_len, loc));
 
     if (args->kwarg && args->kwarg->annotation) {
         RETURN_IF_ERROR(
-            compiler_visit_argannotation(c, args->kwarg->arg,
+            compiler_argannotation(c, args->kwarg->arg,
                                          args->kwarg->annotation, annotations_len, loc));
     }
 
     RETURN_IF_ERROR(
-        compiler_visit_argannotation(c, &_Py_ID(return), returns, annotations_len, loc));
+        compiler_argannotation(c, &_Py_ID(return), returns, annotations_len, loc));
 
     return 0;
 }
 
 static int
-compiler_visit_annotations(struct compiler *c, location loc,
+compiler_annotations(struct compiler *c, location loc,
                            arguments_ty args, expr_ty returns)
 {
     /* Push arg annotation names and values.
@@ -1938,7 +1938,7 @@ compiler_visit_annotations(struct compiler *c, location loc,
     }
     Py_DECREF(ste);
 
-    if (compiler_visit_annotations_in_scope(c, loc, args, returns, &annotations_len) < 0) {
+    if (compiler_annotations_in_scope(c, loc, args, returns, &annotations_len) < 0) {
         if (annotations_used) {
             compiler_exit_scope(c);
         }
@@ -1956,7 +1956,7 @@ compiler_visit_annotations(struct compiler *c, location loc,
 }
 
 static int
-compiler_visit_defaults(struct compiler *c, arguments_ty args,
+compiler_defaults(struct compiler *c, arguments_ty args,
                         location loc)
 {
     VISIT_SEQ(c, expr, args->defaults);
@@ -1970,13 +1970,13 @@ compiler_default_arguments(struct compiler *c, location loc,
 {
     Py_ssize_t funcflags = 0;
     if (args->defaults && asdl_seq_LEN(args->defaults) > 0) {
-        RETURN_IF_ERROR(compiler_visit_defaults(c, args, loc));
+        RETURN_IF_ERROR(compiler_defaults(c, args, loc));
         funcflags |= MAKE_FUNCTION_DEFAULTS;
     }
     if (args->kwonlyargs) {
-        int res = compiler_visit_kwonlydefaults(c, loc,
-                                                args->kwonlyargs,
-                                                args->kw_defaults);
+        int res = compiler_kwonlydefaults(c, loc,
+                                          args->kwonlyargs,
+                                          args->kw_defaults);
         RETURN_IF_ERROR(res);
         if (res > 0) {
             funcflags |= MAKE_FUNCTION_KWDEFAULTS;
@@ -2342,7 +2342,7 @@ compiler_function(struct compiler *c, stmt_ty s, int is_async)
         }
     }
 
-    int annotations_flag = compiler_visit_annotations(c, loc, args, returns);
+    int annotations_flag = compiler_annotations(c, loc, args, returns);
     if (annotations_flag < 0) {
         if (is_generic) {
             compiler_exit_scope(c);
@@ -6111,7 +6111,7 @@ compiler_with(struct compiler *c, stmt_ty s, int pos)
 }
 
 static int
-compiler_visit_expr1(struct compiler *c, expr_ty e)
+compiler_visit_expr(struct compiler *c, expr_ty e)
 {
     location loc = LOC(e);
     switch (e->kind) {
@@ -6278,13 +6278,6 @@ compiler_visit_expr1(struct compiler *c, expr_ty e)
         return compiler_tuple(c, e);
     }
     return SUCCESS;
-}
-
-static int
-compiler_visit_expr(struct compiler *c, expr_ty e)
-{
-    int res = compiler_visit_expr1(c, e);
-    return res;
 }
 
 static bool


### PR DESCRIPTION
The naming convention is that compiler_visit_* are functions that interact with the VISIT_* macros. 

Also, we don't need visit_expr1. 

Fixes #120733 .

<!-- gh-issue-number: gh-120733 -->
* Issue: gh-120733
<!-- /gh-issue-number -->
