### PR TITLE
gh-120732: Fix `name` passing to `Mock`, when using kwargs to `create_autospec`

### DIFF
--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -129,6 +129,11 @@ class MockTest(unittest.TestCase):
         # pass kwargs with respect to the parent mock.
         self.assertEqual(class_mock().return_value.meth.side_effect, None)
 
+    def test_create_autospec_correctly_handles_name(self):
+        class X: ...
+        mock = create_autospec(X, spec_set=True, name="Y")
+        self.assertEqual(mock._mock_name, "Y")
+
     def test_repr(self):
         mock = Mock(name='foo')
         self.assertIn('foo', repr(mock))

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2755,6 +2755,12 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
     if not unsafe:
         _check_spec_arg_typos(kwargs)
 
+    _name = kwargs.pop('name', _name)
+    _new_name = _name
+    if _parent is None:
+        # for a top level object no _new_name should be set
+        _new_name = ''
+
     _kwargs.update(kwargs)
 
     Klass = MagicMock
@@ -2771,13 +2777,6 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
         Klass = NonCallableMagicMock
     elif is_type and instance and not _instance_callable(spec):
         Klass = NonCallableMagicMock
-
-    _name = _kwargs.pop('name', _name)
-
-    _new_name = _name
-    if _parent is None:
-        # for a top level object no _new_name should be set
-        _new_name = ''
 
     mock = Klass(parent=_parent, _new_parent=_parent, _new_name=_new_name,
                  name=_name, **_kwargs)

--- a/Misc/NEWS.d/next/Library/2024-06-19-15-06-58.gh-issue-120732.OvYV9b.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-19-15-06-58.gh-issue-120732.OvYV9b.rst
@@ -1,0 +1,2 @@
+Fix ``name`` passing to :class:`unittest.mock.Mock` object when using
+:func:`unittest.mock.create_autospec`.


### PR DESCRIPTION
Simple idea about how to fix this. I think that we should not add `name` to `_kwargs` if we don't need it there.

<!-- gh-issue-number: gh-120732 -->
* Issue: gh-120732
<!-- /gh-issue-number -->
