### PR TITLE
gh-120743: Soft deprecate os.popen() function

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4992,10 +4992,6 @@ written in Python, such as a mail server's external command delivery program.
 
    .. availability:: Unix, Windows, not WASI, not iOS.
 
-   .. deprecated:: 3.14
-      The function is :term:`soft deprecated` and should no longer be used to
-      write new code. The :mod:`subprocess` module is recommended instead.
-
 
 .. function:: times()
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4642,6 +4642,10 @@ written in Python, such as a mail server's external command delivery program.
       Use :class:`subprocess.Popen` or :func:`subprocess.run` to
       control options like encodings.
 
+   .. deprecated:: 3.14
+      The function is :term:`soft deprecated` and should no longer be used to
+      write new code. The :mod:`subprocess` module is recommended instead.
+
 
 .. function:: posix_spawn(path, argv, env, *, file_actions=None, \
                           setpgroup=None, resetids=False, setsid=False, setsigmask=(), \
@@ -4868,6 +4872,10 @@ written in Python, such as a mail server's external command delivery program.
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
 
+   .. deprecated:: 3.14
+      These functions are :term:`soft deprecated` and should no longer be used
+      to write new code. The :mod:`subprocess` module is recommended instead.
+
 
 .. data:: P_NOWAIT
           P_NOWAITO
@@ -4972,7 +4980,7 @@ written in Python, such as a mail server's external command delivery program.
    shell documentation.
 
    The :mod:`subprocess` module provides more powerful facilities for spawning
-   new processes and retrieving their results; using that module is preferable
+   new processes and retrieving their results; using that module is recommended
    to using this function.  See the :ref:`subprocess-replacements` section in
    the :mod:`subprocess` documentation for some helpful recipes.
 
@@ -4983,6 +4991,10 @@ written in Python, such as a mail server's external command delivery program.
    .. audit-event:: os.system command os.system
 
    .. availability:: Unix, Windows, not WASI, not iOS.
+
+   .. deprecated:: 3.14
+      The function is :term:`soft deprecated` and should no longer be used to
+      write new code. The :mod:`subprocess` module is recommended instead.
 
 
 .. function:: times()

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -133,10 +133,9 @@ Deprecated
   as a single positional argument.
   (Contributed by Serhiy Storchaka in :gh:`109218`.)
 
-* :term:`Soft deprecate <soft deprecated>` :func:`os.popen`,
-  :func:`os.spawn* <os.spawnl>` and :func:`os.system` functions. They should no
-  longer be used to write new code.  The :mod:`subprocess` module is
-  recommended instead.
+* :term:`Soft deprecate <soft deprecated>` :func:`os.popen` and
+  :func:`os.spawn* <os.spawnl>` functions. They should no longer be used to
+  write new code.  The :mod:`subprocess` module is recommended instead.
   (Contributed by Victor Stinner in :gh:`120743`.)
 
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -133,6 +133,12 @@ Deprecated
   as a single positional argument.
   (Contributed by Serhiy Storchaka in :gh:`109218`.)
 
+* :term:`Soft deprecate <soft deprecated>` :func:`os.popen`,
+  :func:`os.spawn* <os.spawnl>` and :func:`os.system` functions. They should no
+  longer be used to write new code.  The :mod:`subprocess` module is
+  recommended instead.
+  (Contributed by Victor Stinner in :gh:`120743`.)
+
 
 Removed
 =======

--- a/Misc/NEWS.d/next/Library/2024-06-19-15-43-04.gh-issue-120743.CMMl2P.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-19-15-43-04.gh-issue-120743.CMMl2P.rst
@@ -1,4 +1,3 @@
-:term:`Soft deprecate <soft deprecated>` :func:`os.popen`, :func:`os.spawn*
-<os.spawnl>` and :func:`os.system` functions. They should no longer be used to
-write new code. The :mod:`subprocess` module is recommended instead. Patch by
-Victor Stinner.
+:term:`Soft deprecate <soft deprecated>` :func:`os.popen` and :func:`os.spawn*
+<os.spawnl>` functions. They should no longer be used to write new code. The
+:mod:`subprocess` module is recommended instead. Patch by Victor Stinner.

--- a/Misc/NEWS.d/next/Library/2024-06-19-15-43-04.gh-issue-120743.CMMl2P.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-19-15-43-04.gh-issue-120743.CMMl2P.rst
@@ -1,0 +1,4 @@
+:term:`Soft deprecate <soft deprecated>` :func:`os.popen`, :func:`os.spawn*
+<os.spawnl>` and :func:`os.system` functions. They should no longer be used to
+write new code. The :mod:`subprocess` module is recommended instead. Patch by
+Victor Stinner.


### PR DESCRIPTION
Soft deprecate os.popen(), os.spawn*() and os.system() functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120743 -->
* Issue: gh-120743
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120744.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->