### PR TITLE
gh-111259: Document idiomatic RE pattern (?s:.) that matches any character

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -101,7 +101,7 @@ The special characters are:
 ``.``
    (Dot.)  In the default mode, this matches any character except a newline.  If
    the :const:`DOTALL` flag has been specified, this matches any character
-   including a newline.
+   including a newline.  ``(?s:.)`` matches any character regardless of flags.
 
 .. index:: single: ^ (caret); in regular expressions
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120745.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-111259 -->
* Issue: gh-111259
<!-- /gh-issue-number -->
