### PR TITLE
 [3.13] gh-120437: Fix `_CHECK_STACK_SPACE` optimization problems introduced in gh-118322 (GH-120712)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-19-01-58-54.gh-issue-120437.nCkIoI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-19-01-58-54.gh-issue-120437.nCkIoI.rst
@@ -1,0 +1,1 @@
+Fix ``_CHECK_STACK_SPACE`` optimization problems introduced in :gh:`118322`.

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -634,7 +634,6 @@ dummy_func(void) {
         (void)callable;
         (void)self_or_null;
         (void)args;
-        first_valid_check_stack = NULL;
         goto done;
     }
 

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1565,7 +1565,6 @@
             (void)callable;
             (void)self_or_null;
             (void)args;
-            first_valid_check_stack = NULL;
             goto done;
             stack_pointer[-2 - oparg] = (_Py_UopsSymbol *)new_frame;
             stack_pointer += -1 - oparg;


### PR DESCRIPTION
Backport of #120712 

Issues: #120437 

<!-- gh-issue-number: gh-120437 -->
* Issue: gh-120437
<!-- /gh-issue-number -->
