### PR TITLE
gh-120754: Reduce system calls in full-file readall case

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1668,6 +1668,11 @@ class FileIO(RawIOBase):
                 except OSError:
                     pass
 
+        # Cap read size so we don't try reading larger than a long on x86
+        # can hold.
+        if bufsize > sys.maxsize:
+            bufsize = sys.maxsize
+
         result = bytearray()
         while True:
             if len(result) >= bufsize:

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1575,9 +1575,9 @@ class FileIO(RawIOBase):
                 # don't exist.
                 pass
             self._blksize = getattr(fdfstat, 'st_blksize', 0)
-            self._estimated_size = getattr(fdfstat, 'st_size', -1)
             if self._blksize <= 1:
                 self._blksize = DEFAULT_BUFFER_SIZE
+            self._estimated_size = fdfstat.st_size
 
             if _setmode:
                 # don't translate newlines (\r\n <=> \n)
@@ -1668,11 +1668,6 @@ class FileIO(RawIOBase):
                 except OSError:
                     pass
 
-        # Cap read size so we don't try reading larger than a long on x86
-        # can hold.
-        if bufsize > sys.maxsize:
-            bufsize = sys.maxsize
-
         result = bytearray()
         while True:
             if len(result) >= bufsize:
@@ -1747,6 +1742,7 @@ class FileIO(RawIOBase):
         if size is None:
             size = self.tell()
         os.ftruncate(self._fd, size)
+        self._estimated_size = size
         return size
 
     def close(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-19-19-54-35.gh-issue-120754.uF29sj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-19-19-54-35.gh-issue-120754.uF29sj.rst
@@ -1,1 +1,1 @@
-Reduce the number of system calls invoked when reading a whole file (ex. ``open('a.txt').read()``). For a sample program that reads the contents of the 400+ ``.rst`` files in the cpython repository ``Doc`` folder, there is a over 10% reduction in system call count.
+Reduce the number of system calls invoked when reading a whole file (ex. ``open('a.txt').read()``). For a sample program that reads the contents of the 400+ ``.rst`` files in the cpython repository ``Doc`` folder, there is an over 10% reduction in system call count.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-19-19-54-35.gh-issue-120754.uF29sj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-19-19-54-35.gh-issue-120754.uF29sj.rst
@@ -1,0 +1,1 @@
+Reduce the number of system calls invoked when reading a whole file (ex. `open('a.txt').read()`). For a sample program that reads the contents of the 400+ `.rst` files in the cpython `Doc` code folder, there is a over 10% reduction in system call count.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-19-19-54-35.gh-issue-120754.uF29sj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-19-19-54-35.gh-issue-120754.uF29sj.rst
@@ -1,1 +1,1 @@
-Reduce the number of system calls invoked when reading a whole file (ex. `open('a.txt').read()`). For a sample program that reads the contents of the 400+ `.rst` files in the cpython `Doc` code folder, there is a over 10% reduction in system call count.
+Reduce the number of system calls invoked when reading a whole file (ex. ``open('a.txt').read()``). For a sample program that reads the contents of the 400+ ``.rst`` files in the cpython repository ``Doc`` folder, there is a over 10% reduction in system call count.

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -739,7 +739,7 @@ _io_FileIO_readall_impl(fileio *self)
             bufsize = _PY_READ_MAX;
         }
         else {
-            bufsize = Py_SAFE_DOWNCAST(end, Py_off_t, size_t) + 1;
+            bufsize = (size_t)end + 1;
         }
 
         /* While a lot of code does open().read() to get the whole contents
@@ -759,7 +759,7 @@ _io_FileIO_readall_impl(fileio *self)
             Py_END_ALLOW_THREADS
 
             if (end >= pos && pos >= 0 && end - pos < _PY_READ_MAX) {
-                bufsize = Py_SAFE_DOWNCAST(end - pos, Py_off_t, size_t) + 1;
+                bufsize = (size_t)(end - pos) + 1;
             }
         }
     }

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -751,7 +751,7 @@ _io_FileIO_readall_impl(fileio *self)
             Py_END_ALLOW_THREADS
 
             if (end >= pos && pos >= 0 && end - pos < PY_SSIZE_T_MAX) {
-                bufsize = bufsize - pos;
+                bufsize = bufsize - (size_t)(pos);
             }
         }
     }

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -735,7 +735,7 @@ _io_FileIO_readall_impl(fileio *self)
            buffer one byte larger than the rest of the file.  If the
            calculation is right then we should get EOF without having
            to enlarge the buffer. */
-        if (end >= _PY_READ_MAX) {
+        if (end > _PY_READ_MAX - 1) {
             bufsize = _PY_READ_MAX;
         }
         else {
@@ -758,7 +758,7 @@ _io_FileIO_readall_impl(fileio *self)
             _Py_END_SUPPRESS_IPH
             Py_END_ALLOW_THREADS
 
-            if (end >= pos && pos >= 0 && end - pos < _PY_READ_MAX) {
+            if (end >= pos && pos >= 0 && (end - pos) < (_PY_READ_MAX - 1)) {
                 bufsize = (size_t)(end - pos) + 1;
             }
         }

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -54,6 +54,9 @@
 #  define SMALLCHUNK BUFSIZ
 #endif
 
+/* Size at which a buffer is considered "large" and behavior should change to
+   avoid excessive memory allocation */
+#define LARGE_BUFFER_CUTOFF_SIZE 65536
 
 /*[clinic input]
 module _io
@@ -689,7 +692,7 @@ new_buffersize(fileio *self, size_t currentsize)
        giving us amortized linear-time behavior.  For bigger sizes, use a
        less-than-double growth factor to avoid excessive allocation. */
     assert(currentsize <= PY_SSIZE_T_MAX);
-    if (currentsize > 65536)
+    if (currentsize > LARGE_BUFFER_CUTOFF_SIZE)
         addend = currentsize >> 3;
     else
         addend = 256 + currentsize;
@@ -739,7 +742,7 @@ _io_FileIO_readall_impl(fileio *self)
         then calls readall() to get the rest, which would result in allocating
         more than required. Guard against that for larger files where we expect
         the I/O time to dominate anyways while keeping small files fast. */
-        if (bufsize > 65536) {
+        if (bufsize > LARGE_BUFFER_CUTOFF_SIZE) {
             Py_BEGIN_ALLOW_THREADS
             _Py_BEGIN_SUPPRESS_IPH
 #ifdef MS_WINDOWS

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -754,7 +754,7 @@ _io_FileIO_readall_impl(fileio *self)
             Py_END_ALLOW_THREADS
 
             if (end >= pos && pos >= 0 && end - pos < PY_SSIZE_T_MAX) {
-                bufsize = bufsize - (size_t)(pos);
+                bufsize = bufsize - Py_SAFE_DOWNCAST(pos, Py_off_t, size_t);
             }
         }
     }

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -732,9 +732,9 @@ _io_FileIO_readall_impl(fileio *self)
     }
     else {
         /* This is probably a real file, so we try to allocate a
-        buffer one byte larger than the rest of the file.  If the
-        calculation is right then we should get EOF without having
-        to enlarge the buffer. */
+           buffer one byte larger than the rest of the file.  If the
+           calculation is right then we should get EOF without having
+           to enlarge the buffer. */
         if (end >= _PY_READ_MAX) {
             bufsize = _PY_READ_MAX;
         }
@@ -743,10 +743,10 @@ _io_FileIO_readall_impl(fileio *self)
         }
 
         /* While a lot of code does open().read() to get the whole contents
-        of a file it is possible a caller seeks/reads a ways into the file
-        then calls readall() to get the rest, which would result in allocating
-        more than required. Guard against that for larger files where we expect
-        the I/O time to dominate anyways while keeping small files fast. */
+           of a file it is possible a caller seeks/reads a ways into the file
+           then calls readall() to get the rest, which would result in allocating
+           more than required. Guard against that for larger files where we expect
+           the I/O time to dominate anyways while keeping small files fast. */
         if (bufsize > LARGE_BUFFER_CUTOFF_SIZE) {
             Py_BEGIN_ALLOW_THREADS
             _Py_BEGIN_SUPPRESS_IPH

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -75,7 +75,7 @@ typedef struct {
     unsigned int closefd : 1;
     char finalizing;
     unsigned int blksize;
-    Py_off_t size_estimated;
+    Py_off_t estimated_size;
     PyObject *weakreflist;
     PyObject *dict;
 } fileio;
@@ -200,7 +200,7 @@ fileio_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         self->appending = 0;
         self->seekable = -1;
         self->blksize = 0;
-        self->size_estimated = -1;
+        self->estimated_size = -1;
         self->closefd = 1;
         self->weakreflist = NULL;
     }
@@ -488,7 +488,7 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
             self->blksize = fdfstat.st_blksize;
 #endif /* HAVE_STRUCT_STAT_ST_BLKSIZE */
         if (fdfstat.st_size < PY_SSIZE_T_MAX) {
-            self->size_estimated = (Py_off_t)fdfstat.st_size;
+            self->estimated_size = (Py_off_t)fdfstat.st_size;
         }
     }
 
@@ -725,7 +725,7 @@ _io_FileIO_readall_impl(fileio *self)
         return err_closed();
     }
 
-    end = self->size_estimated;
+    end = self->estimated_size;
     if (end <= 0) {
         /* Use a default size and resize as needed. */
         bufsize = SMALLCHUNK;


### PR DESCRIPTION
This reduces the system call count of a simple program (see commits) that reads all the `.rst` files in Doc by over 10% (5706 -> 4734 system calls on my linux system, 5813 -> 4875 on my macOS)

This reduces the number of `fstat()` calls always and seek calls most the time. Stat was always called twice, once at open (to error early on directories), and a second time to get the size of the file to be able to read the whole file in one read. Now the size is cached with the first call.

- Fixes https://github.com/python/cpython/issues/120754

<!-- gh-issue-number: gh-120754 -->
* Issue: gh-120754
<!-- /gh-issue-number -->
