### PR TITLE
gh-120762: fix make_ssl_certs.py - no SKID or AKID in CSR

### DIFF
--- a/Lib/test/certdata/make_ssl_certs.py
+++ b/Lib/test/certdata/make_ssl_certs.py
@@ -125,6 +125,10 @@ def make_cert_key(hostname, sign=False, extra_san='',
         with tempfile.NamedTemporaryFile(delete=False) as f:
             tempnames.append(f.name)
     req_file, cert_file, key_file = tempnames
+    if sign:
+        reqext = 'req_x509_extensions_simple'
+    else:
+        reqext = ext
     try:
         req = req_template.format(
             hostname=hostname,
@@ -136,7 +140,7 @@ def make_cert_key(hostname, sign=False, extra_san='',
             f.write(req)
         args = ['req', '-new', '-nodes', '-days', '7000',
                 '-newkey', key, '-keyout', key_file,
-                '-extensions', ext,
+                '-extensions', reqext,
                 '-config', req_file]
         if sign:
             with tempfile.NamedTemporaryFile(delete=False) as f:


### PR DESCRIPTION
Per https://github.com/openssl/openssl/issues/22966 , it is not valid to have a subjectKeyIdentifier or an authorityKeyIdentifier in a CSR. Up until openssl 3.2.0 this happened not to cause an error, but since a bugfix in 3.2.0 it does:

80D2CF679F7F0000:error:11000079:X509 V3 routines:v2i_AUTHORITY_KEYID:no issuer certificate:crypto/x509/v3_akid.c:156:

To fix this, when generating a signed certificate, let's always use req_x509_extensions_simple for the CSR, and use the specified req (usually req_x509_extensions_full) only when asking the CA to process the CSR and produce the final signed certificate.

<!-- gh-issue-number: gh-120762 -->
* Issue: gh-120762
<!-- /gh-issue-number -->
