### PR TITLE
gh-120769: Add pdb meta command to print frame status.

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -517,7 +517,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     # Called before loop, handles display expressions
     # Set up convenience variable containers
-    def preloop(self):
+    def _show_display(self):
         displaying = self.displaying.get(self.curframe)
         if displaying:
             for expr, oldvalue in displaying.items():
@@ -605,15 +605,13 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             self.setup(frame, tb)
             # We should print the stack entry if and only if the user input
             # is expected, and we should print it right before the user input.
-            # If self.cmdqueue is not empty, we append a "w 0" command to the
-            # queue, which is equivalent to print_stack_entry
-            if self.cmdqueue:
-                self.cmdqueue.append('w 0')
-            else:
-                self.print_stack_entry(self.stack[self.curindex])
+            # We achieve this by appending _pdbcmd_print_frame_status to the
+            # command queue. If cmdqueue is not exausted, the user input is
+            # not expected and we will not print the stack entry.
+            self.cmdqueue.append('_pdbcmd_print_frame_status')
             self._cmdloop()
-            # If "w 0" is not used, pop it out
-            if self.cmdqueue and self.cmdqueue[-1] == 'w 0':
+            # If _pdbcmd_print_frame_status is not used, pop it out
+            if self.cmdqueue and self.cmdqueue[-1] == '_pdbcmd_print_frame_status':
                 self.cmdqueue.pop()
             self.forget()
 
@@ -846,6 +844,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         """
         if not self.commands_defining:
             self._validate_file_mtime()
+            if line.startswith('_pdbcmd'):
+                command, arg, line = self.parseline(line)
+                if hasattr(self, command):
+                    return getattr(self, command)(arg)
             return cmd.Cmd.onecmd(self, line)
         else:
             return self.handle_command_def(line)
@@ -981,6 +983,12 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             matches.append(match)
             state += 1
         return matches
+
+    # Pdb meta commands, only intended to be used internally by pdb
+
+    def _pdbcmd_print_frame_status(self, arg):
+        self.print_stack_trace(0)
+        self._show_display()
 
     # Command definitions, called by cmdloop()
     # The argument is the remaining string on the command line

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -516,14 +516,14 @@ def test_pdb_empty_line():
     -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     (Pdb) p x
     1
-    (Pdb) 
+    (Pdb)
     1
     (Pdb) n ;; p 0 ;; p x
     0
     1
     > <doctest test.test_pdb.test_pdb_empty_line[0]>(4)test_function()
     -> y = 2
-    (Pdb) 
+    (Pdb)
     1
     (Pdb) continue
     """

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -496,6 +496,37 @@ def test_pdb_pp_repr_exc():
     (Pdb) continue
     """
 
+def test_pdb_empty_line():
+    """Test that empty line repeats the last command.
+
+    >>> def test_function():
+    ...     x = 1
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     y = 2
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'p x',
+    ...     '',  # Should repeat p x
+    ...     'n ;; p 0 ;; p x',  # Fill cmdqueue with multiple commands
+    ...     '',  # Should still repeat p x
+    ...     'continue',
+    ... ]):
+    ...    test_function()
+    > <doctest test.test_pdb.test_pdb_empty_line[0]>(3)test_function()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) p x
+    1
+    (Pdb) 
+    1
+    (Pdb) n ;; p 0 ;; p x
+    0
+    1
+    > <doctest test.test_pdb.test_pdb_empty_line[0]>(4)test_function()
+    -> y = 2
+    (Pdb) 
+    1
+    (Pdb) continue
+    """
 
 def do_nothing():
     pass

--- a/Misc/NEWS.d/next/Library/2024-06-20-01-31-24.gh-issue-120769.PfiMrc.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-20-01-31-24.gh-issue-120769.PfiMrc.rst
@@ -1,0 +1,1 @@
+Make empty line in :mod:`pdb` repeats the last command even when the command is from ``cmdqueue``.


### PR DESCRIPTION
Using `w 0` is a neat trick but it messed up with `cmd.Cmd`. We lost the last command with executing a valid command.

I came up with a way to sneak in secret commands (what I call a meta command) without changing too much of the current structure. The meta commands will not be recorded by `cmd.Cmd` and we can do whatever we want with it.

With this feature, we can unify the way to print the stack entry with or without the commands in `cmdqueue`.

I also renamed `preloop` - that's only used for display and it is only supposed to be displayed when user input is expected ("stops in the current frame" according to the [docs](https://docs.python.org/3/library/pdb.html#pdbcommand-display)). The test coverage is not great but for now it will display while commands from `cmdqueue` are executing.

The reason I changed `display` in a seemingly unrelated fix is because this is the way to ensure display still shows *after* stack entry print, not *before*.

By unifying the way to print frame status, we can print more stuff per stop, like async/thread info.

Meta commands could be useful in the future for us to sneak in other secret commands without messing with the core cmdloop and the command completion.

<!-- gh-issue-number: gh-120769 -->
* Issue: gh-120769
<!-- /gh-issue-number -->
