### PR TITLE
gh-120771: Refactor xml.etree.ElementTree._namespaces

### DIFF
--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -843,7 +843,7 @@ def _namespaces(elem, default_namespace=None):
     if default_namespace:
         namespaces[default_namespace] = ""
 
-    seen_prefixes = set(_namespace_map.keys())
+    seen_prefixes = set(_namespace_map.values())
     has_unqual_el = False
     for qname in _qnames_iter(elem):
         try:

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -880,7 +880,6 @@ def _namespaces(elem, default_namespace=None):
         del namespaces["http://www.w3.org/XML/1998/namespace"]
     return qnames, namespaces
 
-
 def _serialize_xml(write, elem, qnames, namespaces,
                    short_empty_elements, **kwargs):
     tag = elem.tag

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -786,6 +786,52 @@ def _get_writer(file_or_filename, encoding):
                 stack.callback(file.detach)
                 yield file.write, encoding
 
+
+def _make_new_ns_prefix(nsmap_scope, seen_prefixes):
+    i = len(nsmap_scope)
+    while True:
+        prefix = f"ns{i}"
+        if prefix not in seen_prefixes:
+            return prefix
+        i += 1
+
+
+def _qnames_iter(elem):
+    """Iterate through all the qualified names in elem"""
+    seen_qnames = set()
+    for elem in elem.iter():
+        tag = elem.tag
+        if isinstance(tag, str):
+            if tag not in seen_qnames:
+                seen_qnames.add(tag)
+                yield tag
+        elif isinstance(tag, QName):
+            tag = tag.text
+            if tag not in seen_qnames:
+                seen_qnames.add(tag)
+                yield tag
+        elif tag is not None and tag is not Comment and tag is not PI:
+            _raise_serialization_error(tag)
+
+        for key, value in elem.items():
+            if isinstance(key, QName):
+                key = key.text
+            if key not in seen_qnames:
+                seen_qnames.add(key)
+                yield key
+
+            if isinstance(value, QName):
+                if value.text not in seen_qnames:
+                    seen_qnames.add(value.text)
+                    yield value.text
+
+        text = elem.text
+        if isinstance(text, QName):
+            if text.text not in seen_qnames:
+                seen_qnames.add(text.text)
+                yield text.text
+
+
 def _namespaces(elem, default_namespace=None):
     # identify namespaces used in this tree
 
@@ -797,55 +843,43 @@ def _namespaces(elem, default_namespace=None):
     if default_namespace:
         namespaces[default_namespace] = ""
 
-    def add_qname(qname):
-        # calculate serialized qname representation
+    seen_prefixes = set(_namespace_map.keys())
+    has_unqual_el = False
+    for qname in _qnames_iter(elem):
         try:
             if qname[:1] == "{":
-                uri, tag = qname[1:].rsplit("}", 1)
-                prefix = namespaces.get(uri)
+                uri_and_name = qname[1:].rsplit("}", 1)
+
+                prefix = namespaces.get(uri_and_name[0])
                 if prefix is None:
-                    prefix = _namespace_map.get(uri)
+                    prefix = _namespace_map.get(uri_and_name[0])
                     if prefix is None:
-                        prefix = "ns%d" % len(namespaces)
-                    if prefix != "xml":
-                        namespaces[uri] = prefix
+                        prefix = _make_new_ns_prefix(namespaces, seen_prefixes)
+                    seen_prefixes.add(prefix)
+                    namespaces[uri_and_name[0]] = prefix
+
                 if prefix:
-                    qnames[qname] = "%s:%s" % (prefix, tag)
+                    qnames[qname] = f"{prefix}:{uri_and_name[1]}"
                 else:
-                    qnames[qname] = tag # default element
+                    qnames[qname] = uri_and_name[1]  # default element
             else:
-                if default_namespace:
-                    # FIXME: can this be handled in XML 1.0?
-                    raise ValueError(
-                        "cannot use non-qualified names with "
-                        "default_namespace option"
-                        )
                 qnames[qname] = qname
+                has_unqual_el = True
         except TypeError:
             _raise_serialization_error(qname)
 
-    # populate qname and namespaces table
-    for elem in elem.iter():
-        tag = elem.tag
-        if isinstance(tag, QName):
-            if tag.text not in qnames:
-                add_qname(tag.text)
-        elif isinstance(tag, str):
-            if tag not in qnames:
-                add_qname(tag)
-        elif tag is not None and tag is not Comment and tag is not PI:
-            _raise_serialization_error(tag)
-        for key, value in elem.items():
-            if isinstance(key, QName):
-                key = key.text
-            if key not in qnames:
-                add_qname(key)
-            if isinstance(value, QName) and value.text not in qnames:
-                add_qname(value.text)
-        text = elem.text
-        if isinstance(text, QName) and text.text not in qnames:
-            add_qname(text.text)
+    if default_namespace is not None and has_unqual_el:
+        # FIXME: can this be handled in XML 1.0?
+        raise ValueError(
+            "cannot use non-qualified names with default_namespace option"
+        )
+
+    # This namespace doesn't need to be declared but may be used to prefix
+    # names so let's remove it if it has been used
+    if "http://www.w3.org/XML/1998/namespace" in namespaces:
+        del namespaces["http://www.w3.org/XML/1998/namespace"]
     return qnames, namespaces
+
 
 def _serialize_xml(write, elem, qnames, namespaces,
                    short_empty_elements, **kwargs):

--- a/Misc/NEWS.d/next/Library/2024-06-20-12-40-25.gh-issue-120771.gFwc4X.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-20-12-40-25.gh-issue-120771.gFwc4X.rst
@@ -1,0 +1,1 @@
+Refactor ``xml.etree.ElementTree._namespaces`` for further enhancements.


### PR DESCRIPTION
The refactor also makes `_namespaces` slightly faster in most scenarios except when more than ~85% of tags are unique and qualified with a namespace. Above 85% it performs similarly to the current implementation. See below for the benchmark code.

```python
import timeit
import xml.etree.ElementTree as ET

# Element = ET._Element_Py
Element = ET.Element

def print_res(name, results):
    results = ", ".join([f"{t:0.6f}" for t in results])
    print(f"{name} [{results}]")


def low_el_cnt_low_cardinality():
    e = Element("root")
    for i in range(10):
        e.append(Element(f"tagtag{i//2}"))

    def run_namespaces():
        ET._namespaces(e)
    print_res("no ns, low el cnt, unique low", timeit.repeat(run_namespaces, number=10000))


def high_el_cnt_high_cardinality():
    e = Element("root")
    for i in range(1000):
        e1 = Element(f"tagtag{i}")
        e.append(e1)

    def run_namespaces():
        ET._namespaces(e)
    print_res("no ns, high el cnt, unique high", timeit.repeat(run_namespaces, number=10000))


def ns_high_el_cnt_cardinality(unique_ratio, el_cnt=1000):
    e = Element("{one}root")
    for i in range(el_cnt):
        if i < el_cnt * (1 - unique_ratio):
            e1 = Element(f"{{nsns1}}tagtag1")
        else:
            e1 = Element(f"{{nsns1{i}}}tagtag{i}")
        e.append(e1)

    def run_namespaces():
        ET._namespaces(e)
    print_res(f"ns unique: {unique_ratio:0.2f}", timeit.repeat(run_namespaces, number=1000))


def ns_deep_cardinality(unique_ratio, el_cnt=1000):
    root = Element("{one}root")
    e = root
    for i in range(el_cnt):
        if i < el_cnt * (1 - unique_ratio):
            e1 = Element(f"{{nsns1}}tagtag1")
        else:
            e1 = Element(f"{{nsns1{i}}}tagtag{i}")
        e.append(e1)
        e = e1

    def run_namespaces():
        ET._namespaces(root)
    print_res(f"deep unique: {unique_ratio:0.2f}", timeit.repeat(run_namespaces, number=1000))


if __name__ == "__main__":
    # no namespaces
    low_el_cnt_low_cardinality()
    high_el_cnt_high_cardinality()

    # namespaces
    ns_high_el_cnt_cardinality(0.05)
    ns_high_el_cnt_cardinality(0.10)
    ns_high_el_cnt_cardinality(1/6)
    ns_high_el_cnt_cardinality(1/3)
    ns_high_el_cnt_cardinality(0.5)
    ns_high_el_cnt_cardinality(2/3)
    ns_high_el_cnt_cardinality(5/6)
    ns_high_el_cnt_cardinality(1)

    # deeply nested
    ns_deep_cardinality(.5)
    ns_deep_cardinality(5/6)
    ns_deep_cardinality(1)
```

and some results using this PR:

```
no ns, low el cnt, unique low [0.025025, 0.022563, 0.022072, 0.022136, 0.022028]
no ns, high el cnt, unique high [1.910636, 1.912451, 1.908962, 1.913008, 1.915974]
ns unique: 0.05 [0.132233, 0.131049, 0.130947, 0.131039, 0.131328]
ns unique: 0.10 [0.153051, 0.152679, 0.152685, 0.152955, 0.155044]
ns unique: 0.17 [0.180587, 0.179584, 0.180579, 0.181862, 0.181909]
ns unique: 0.33 [0.258851, 0.260982, 0.255448, 0.259111, 0.260048]
ns unique: 0.50 [0.324508, 0.326558, 0.322348, 0.323117, 0.323377]
ns unique: 0.67 [0.395765, 0.395696, 0.396616, 0.393595, 0.395383]
ns unique: 0.83 [0.470373, 0.468449, 0.465425, 0.465609, 0.466742]
ns unique: 1.00 [0.542408, 0.540645, 0.535599, 0.536222, 0.536216]
deep unique: 0.50 [0.328341, 0.330177, 0.330926, 0.331375, 0.331178]
deep unique: 0.83 [0.477198, 0.473172, 0.477037, 0.477402, 0.476627]
deep unique: 1.00 [0.546563, 0.546853, 0.545765, 0.547028, 0.547592]
```

main:

```
no ns, low el cnt, unique low [0.033431, 0.025402, 0.023029, 0.022654, 0.022640]
no ns, high el cnt, unique high [2.134641, 2.137859, 2.134739, 2.137339, 2.137709]
ns unique: 0.05 [0.156102, 0.155261, 0.156591, 0.155523, 0.155656]
ns unique: 0.10 [0.175433, 0.175223, 0.175160, 0.175437, 0.175383]
ns unique: 0.17 [0.202930, 0.202039, 0.202463, 0.202432, 0.202182]
ns unique: 0.33 [0.269995, 0.269267, 0.269315, 0.271844, 0.269823]
ns unique: 0.50 [0.334945, 0.334450, 0.335319, 0.334948, 0.335212]
ns unique: 0.67 [0.406310, 0.408849, 0.407256, 0.405006, 0.407780]
ns unique: 0.83 [0.476466, 0.473063, 0.478798, 0.480725, 0.480755]
ns unique: 1.00 [0.547285, 0.544387, 0.538366, 0.544754, 0.545708]
deep unique: 0.50 [0.340939, 0.339714, 0.337369, 0.341901, 0.340457]
deep unique: 0.83 [0.475656, 0.478056, 0.482441, 0.478939, 0.484476]
deep unique: 1.00 [0.543982, 0.547592, 0.547508, 0.544792, 0.545608]
```


<!-- gh-issue-number: gh-120771 -->
* Issue: gh-120771
<!-- /gh-issue-number -->
