### PR TITLE
gh-119109: functool.partial vectorcall supports pto->kw & fallback to tp_call removed

### DIFF
--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -39,51 +39,6 @@ get_functools_state(PyObject *module)
 }
 
 
-
-const char *getrepr(PyObject *obj) {
-    PyObject* repr = PyObject_Repr(obj);
-    PyObject* str = PyUnicode_AsEncodedString(repr, "utf-8", "~E~");
-    const char *string = PyBytes_AS_STRING(str);
-    Py_XDECREF(repr);
-    Py_XDECREF(str);
-    return string;
-}
-
-
-const char *gettype(PyObject *obj) {
-    PyTypeObject* tp = Py_TYPE(obj);
-    PyObject* tp_name = PyType_GetName(tp);
-    PyObject* str = PyUnicode_AsEncodedString(tp_name, "utf-8", "~E~");
-    const char *string = PyBytes_AS_STRING(str);
-    Py_XDECREF(tp_name);
-    Py_XDECREF(str);
-    return string;
-}
-
-
-static void pprint_tp(PyObject *obj) {
-    printf("TYPE: %s\n", gettype(obj));
-}
-
-
-static void pprint_rpr(PyObject *obj) {
-    printf("REPR: %s\n", getrepr(obj));
-}
-
-
-static void pprint_msg(PyObject *obj, const char *msg) {
-    if (strcmp(msg, "") == 0)
-        printf("%s\n", msg);
-    pprint_tp(obj);
-    pprint_rpr(obj);
-}
-
-
-static void pprint(PyObject *obj) {
-    pprint_msg(obj, ">");
-}
-
-
 /* partial object **********************************************************/
 
 typedef struct {


### PR DESCRIPTION
Although comment stated that "merging keyword arguments for vector call is messy" (not exact quote), but I have found that it is fairly straight forward.

This achieves 2 goals:
1. Solves the raised issue of `partial` being stuck in `tp_call` after keywords are deleted even if function supports `vectorcall`.
2. Improves performance when `len(pto-kw) != 0` and function supports `vectorcall`.

Number 1. is solved better than it was in https://github.com/python/cpython/pull/119125 as there are no more switching between methods and faster `vectorcall` is used whenever appropriate. Also, this does not require additional variable in class struct.

Comparison of performance:
```python
def sub(a, b):
    return a - b

p = partial(sub, b=2)
# Before
%timeit p(1)    # 240 ns
# After
%timeit p(1)    # 180 ns
# Using simpler but slower approach with `_PyObject_VectorcallDictTstate`
%timeit p(1)    # 200 ns
```

This is only initial attempt and I think the code can be made simpler. (much simpler if decide to use `_PyObject_VectorcallDictTstate`).

This will need to be adjusted to https://github.com/python/cpython/pull/119827 so do not merge.

<!-- gh-issue-number: gh-119109 -->
* Issue: gh-119109
<!-- /gh-issue-number -->
