### PR TITLE
gh-120784: Reword utcnow/utcfromtimestamp deprecation warning to use datetime.timezone.utc

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -1811,7 +1811,7 @@ class datetime(date):
         warnings.warn("datetime.datetime.utcfromtimestamp() is deprecated and scheduled "
                       "for removal in a future version. Use timezone-aware "
                       "objects to represent datetimes in UTC: "
-                      "datetime.datetime.fromtimestamp(t, datetime.UTC).",
+                      "datetime.datetime.fromtimestamp(t, datetime.timezone.utc).",
                       DeprecationWarning,
                       stacklevel=2)
         return cls._fromtimestamp(t, True, None)
@@ -1829,7 +1829,7 @@ class datetime(date):
         warnings.warn("datetime.datetime.utcnow() is deprecated and scheduled for "
                       "removal in a future version. Use timezone-aware "
                       "objects to represent datetimes in UTC: "
-                      "datetime.datetime.now(datetime.UTC).",
+                      "datetime.datetime.now(datetime.timezone.utc).",
                       DeprecationWarning,
                       stacklevel=2)
         t = _time.time()

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -1811,7 +1811,8 @@ class datetime(date):
         warnings.warn("datetime.datetime.utcfromtimestamp() is deprecated and scheduled "
                       "for removal in a future version. Use timezone-aware "
                       "objects to represent datetimes in UTC: "
-                      "datetime.datetime.fromtimestamp(t, datetime.timezone.utc).",
+                      "datetime.datetime.fromtimestamp(t, datetime.timezone.utc) or "
+                      "datetime.datetime.fromtimestamp(t, datetime.UTC) when targetting 3.11.",
                       DeprecationWarning,
                       stacklevel=2)
         return cls._fromtimestamp(t, True, None)
@@ -1829,7 +1830,8 @@ class datetime(date):
         warnings.warn("datetime.datetime.utcnow() is deprecated and scheduled for "
                       "removal in a future version. Use timezone-aware "
                       "objects to represent datetimes in UTC: "
-                      "datetime.datetime.now(datetime.timezone.utc).",
+                      "datetime.datetime.now(datetime.timezone.utc) or "
+                      "datetime.datetime.now(datetime.UTC) when targetting 3.11.",
                       DeprecationWarning,
                       stacklevel=2)
         t = _time.time()

--- a/Misc/NEWS.d/next/Library/2024-06-21-19-00-43.gh-issue-120784.w2IUby.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-21-19-00-43.gh-issue-120784.w2IUby.rst
@@ -1,0 +1,1 @@
+Reword ``utcnow()``/``utcfromtimestamp()`` deprecation warning to use :attr:`datetime.timezone.utc`.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5454,7 +5454,7 @@ datetime_utcnow(PyObject *cls, PyObject *dummy)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.datetime.utcnow() is deprecated and scheduled for removal in a "
         "future version. Use timezone-aware objects to represent datetimes "
-        "in UTC: datetime.datetime.now(datetime.UTC).", 1))
+        "in UTC: datetime.datetime.now(datetime.timezone.utc).", 1))
     {
         return NULL;
     }
@@ -5497,7 +5497,7 @@ datetime_utcfromtimestamp(PyObject *cls, PyObject *args)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal "
         "in a future version. Use timezone-aware objects to represent "
-        "datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).", 1))
+        "datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).", 1))
     {
         return NULL;
     }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5454,7 +5454,8 @@ datetime_utcnow(PyObject *cls, PyObject *dummy)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.datetime.utcnow() is deprecated and scheduled for removal in a "
         "future version. Use timezone-aware objects to represent datetimes "
-        "in UTC: datetime.datetime.now(datetime.timezone.utc).", 1))
+        "in UTC: datetime.datetime.now(datetime.timezone.utc) or "
+        "datetime.datetime.now(datetime.UTC) when targetting 3.11.", 1))
     {
         return NULL;
     }
@@ -5497,7 +5498,8 @@ datetime_utcfromtimestamp(PyObject *cls, PyObject *args)
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
         "datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal "
         "in a future version. Use timezone-aware objects to represent "
-        "datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc).", 1))
+        "datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc) or "
+        "datetime.datetime.fromtimestamp(timestamp, datetime.UTC) when targetting 3.11", 1))
     {
         return NULL;
     }


### PR DESCRIPTION
It's better to point to `datetime.timezone.utc` as `datetime.UTC` was only added in Python 3.11.
No need to suggest to make code backwards incompatible without a good reason.

<!-- gh-issue-number: gh-120784 -->
* Issue: gh-120784
<!-- /gh-issue-number -->
