### PR TITLE
GH-73991: Support copying directory symlinks on older Windows

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1447,11 +1447,6 @@ Copying, renaming and deleting
       permissions. After the copy is complete, users may wish to call
       :meth:`Path.chmod` to set the permissions of the target file.
 
-   .. warning::
-      On old builds of Windows (before Windows 10 build 19041), this method
-      raises :exc:`OSError` when a symlink to a directory is encountered and
-      *follow_symlinks* is false.
-
    .. versionadded:: 3.14
 
 

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -5,8 +5,8 @@ paths with operations that have semantics appropriate for different
 operating systems.
 """
 
-from ._abc import *
+from ._os import *
 from ._local import *
 
-__all__ = (_abc.__all__ +
+__all__ = (_os.__all__ +
            _local.__all__)

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -16,22 +16,13 @@ import operator
 import posixpath
 from glob import _GlobberBase, _no_recurse_symlinks
 from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO
-from ._os import copyfileobj
-
-
-__all__ = ["UnsupportedOperation"]
+from ._os import UnsupportedOperation, copyfileobj
 
 
 @functools.cache
 def _is_case_sensitive(parser):
     return parser.normcase('Aa') == 'Aa'
 
-
-class UnsupportedOperation(NotImplementedError):
-    """An exception that is raised when an unsupported operation is called on
-    a path object.
-    """
-    pass
 
 
 class ParserBase:

--- a/Lib/pathlib/_local.py
+++ b/Lib/pathlib/_local.py
@@ -17,8 +17,8 @@ try:
 except ImportError:
     grp = None
 
-from ._abc import UnsupportedOperation, PurePathBase, PathBase
-from ._os import copyfile
+from ._os import UnsupportedOperation, copyfile
+from ._abc import PurePathBase, PathBase
 
 
 __all__ = [
@@ -791,12 +791,15 @@ class Path(PathBase, PurePath):
             try:
                 target = os.fspath(target)
             except TypeError:
-                if isinstance(target, PathBase):
-                    # Target is an instance of PathBase but not os.PathLike.
-                    # Use generic implementation from PathBase.
-                    return PathBase.copy(self, target, follow_symlinks=follow_symlinks)
-                raise
-            copyfile(os.fspath(self), target, follow_symlinks)
+                if not isinstance(target, PathBase):
+                    raise
+            else:
+                try:
+                    copyfile(os.fspath(self), target, follow_symlinks)
+                    return
+                except UnsupportedOperation:
+                    pass  # Fall through to generic code.
+            PathBase.copy(self, target, follow_symlinks=follow_symlinks)
 
     def chmod(self, mode, *, follow_symlinks=True):
         """

--- a/Lib/pathlib/_os.py
+++ b/Lib/pathlib/_os.py
@@ -115,24 +115,30 @@ if _winapi and hasattr(_winapi, 'CopyFile2') and hasattr(os.stat_result, 'st_fil
         Copy from one file to another using CopyFile2 (Windows only).
         """
         if follow_symlinks:
-            flags = 0
+            _winapi.CopyFile2(source, target, 0)
         else:
+            # Use COPY_FILE_COPY_SYMLINK to copy a file symlink.
             flags = _winapi.COPY_FILE_COPY_SYMLINK
             try:
                 _winapi.CopyFile2(source, target, flags)
                 return
             except OSError as err:
                 # Check for ERROR_ACCESS_DENIED
-                if err.winerror != 5 or not _is_dirlink(source):
-                    raise  # Some other error.
+                if err.winerror == 5 and _is_dirlink(source):
+                    pass
+                else:
+                    raise
+
+            # Add COPY_FILE_DIRECTORY to copy a directory symlink.
             flags |= _winapi.COPY_FILE_DIRECTORY
-        try:
-            _winapi.CopyFile2(source, target, flags)
-        except OSError as err:
-            # Check for ERROR_INVALID_PARAMETER
-            if err.winerror != 87:
-                raise  # Some other error.
-            raise UnsupportedOperation(err)
+            try:
+                _winapi.CopyFile2(source, target, flags)
+            except OSError as err:
+                # Check for ERROR_INVALID_PARAMETER
+                if err.winerror == 87:
+                    raise UnsupportedOperation(err) from None
+                else:
+                    raise
 else:
     copyfile = None
 

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -5,7 +5,8 @@ import errno
 import stat
 import unittest
 
-from pathlib._abc import UnsupportedOperation, ParserBase, PurePathBase, PathBase
+from pathlib._os import UnsupportedOperation
+from pathlib._abc import ParserBase, PurePathBase, PathBase
 import posixpath
 
 from test.support import is_wasi


### PR DESCRIPTION
Check for `ERROR_INVALID_PARAMETER` when calling `_winapi.CopyFile2()` and raise `UnsupportedOperation`. In `Path.copy()`, handle this exception and fall back to the `PathBase.copy()` implementation.

No news as `Path.copy()` is brand new.

<!-- gh-issue-number: gh-73991 -->
* Issue: gh-73991
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120807.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->