### PR TITLE
gh-119180: Alternative approach to metaclass annotations: never use the dict

### DIFF
--- a/Lib/test/test_type_annotations.py
+++ b/Lib/test/test_type_annotations.py
@@ -16,28 +16,20 @@ class TypeAnnotationTests(unittest.TestCase):
         # a freshly created type shouldn't have an annotations dict yet.
         foo = type("Foo", (), {})
         for i in range(3):
-            self.assertFalse("__annotations__" in foo.__dict__)
             d = foo.__annotations__
-            self.assertTrue("__annotations__" in foo.__dict__)
             self.assertEqual(foo.__annotations__, d)
-            self.assertEqual(foo.__dict__['__annotations__'], d)
             del foo.__annotations__
 
     def test_setting_annotations(self):
         foo = type("Foo", (), {})
         for i in range(3):
-            self.assertFalse("__annotations__" in foo.__dict__)
             d = {'a': int}
             foo.__annotations__ = d
-            self.assertTrue("__annotations__" in foo.__dict__)
             self.assertEqual(foo.__annotations__, d)
-            self.assertEqual(foo.__dict__['__annotations__'], d)
             del foo.__annotations__
 
     def test_annotations_getset_raises(self):
-        # builtin types don't have __annotations__ (yet!)
-        with self.assertRaises(AttributeError):
-            print(float.__annotations__)
+        self.assertEqual(float.__annotations__, {})
         with self.assertRaises(TypeError):
             float.__annotations__ = {}
         with self.assertRaises(TypeError):
@@ -47,17 +39,15 @@ class TypeAnnotationTests(unittest.TestCase):
         foo = type("Foo", (), {})
         foo.__annotations__ = {}
         del foo.__annotations__
-        with self.assertRaises(AttributeError):
-            del foo.__annotations__
+        del foo.__annotations__
 
     def test_annotations_are_created_correctly(self):
         class C:
             a:int=3
             b:str=4
         self.assertEqual(C.__annotations__, {"a": int, "b": str})
-        self.assertTrue("__annotations__" in C.__dict__)
         del C.__annotations__
-        self.assertFalse("__annotations__" in C.__dict__)
+        self.assertEqual(C.__annotations__, {})
 
     def test_descriptor_still_works(self):
         class C:


### PR DESCRIPTION
Like #120719, this is an experimental way to fix the issues discussed in python/peps#3847.

This PR takes the approach of "never use the class dict". Instead, we repurpose the unused `tp_cache` field to hold annotation information. It can hold any of:
- NULL: the class has no annotations
- a dict: the class has `__annotations__`, but no `__annotate__`
- a callable: the class has only `__annotate__`
- a tuple: the class has both annotate and annotations

<!-- gh-issue-number: gh-119180 -->
* Issue: gh-119180
<!-- /gh-issue-number -->
