### PR TITLE
GH-120804: Remove `get_child_watcher` and `set_child_watcher` from asyncio

### DIFF
--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -10,7 +10,6 @@ __all__ = (
     'Handle', 'TimerHandle',
     'get_event_loop_policy', 'set_event_loop_policy',
     'get_event_loop', 'set_event_loop', 'new_event_loop',
-    'get_child_watcher', 'set_child_watcher',
     '_set_running_loop', 'get_running_loop',
     '_get_running_loop',
 )
@@ -652,17 +651,6 @@ class AbstractEventLoopPolicy:
         the current context, set_event_loop must be called explicitly."""
         raise NotImplementedError
 
-    # Child processes handling (Unix only).
-
-    def get_child_watcher(self):
-        "Get the watcher for child processes."
-        raise NotImplementedError
-
-    def set_child_watcher(self, watcher):
-        """Set the watcher for child processes."""
-        raise NotImplementedError
-
-
 class BaseDefaultEventLoopPolicy(AbstractEventLoopPolicy):
     """Default policy implementation for accessing the event loop.
 
@@ -835,17 +823,6 @@ def set_event_loop(loop):
 def new_event_loop():
     """Equivalent to calling get_event_loop_policy().new_event_loop()."""
     return get_event_loop_policy().new_event_loop()
-
-
-def get_child_watcher():
-    """Equivalent to calling get_event_loop_policy().get_child_watcher()."""
-    return get_event_loop_policy().get_child_watcher()
-
-
-def set_child_watcher(watcher):
-    """Equivalent to calling
-    get_event_loop_policy().set_child_watcher(watcher)."""
-    return get_event_loop_policy().set_child_watcher(watcher)
 
 
 # Alias pure-Python implementations for testing purposes.

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -880,16 +880,13 @@ if sys.platform != 'win32':
             watcher = self._get_watcher()
             watcher.attach_loop(self.loop)
             with warnings.catch_warnings():
-                warnings.simplefilter('ignore', DeprecationWarning)
-                policy.set_child_watcher(watcher)
+                policy._watcher = watcher
 
         def tearDown(self):
             super().tearDown()
             policy = asyncio.get_event_loop_policy()
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', DeprecationWarning)
-                watcher = policy.get_child_watcher()
-                policy.set_child_watcher(None)
+            watcher = policy._watcher
+            policy._watcher = None
             watcher.attach_loop(None)
             watcher.close()
 
@@ -910,66 +907,6 @@ if sys.platform != 'win32':
             return unix_events.PidfdChildWatcher()
 
 
-    class GenericWatcherTests(test_utils.TestCase):
-
-        def test_create_subprocess_fails_with_inactive_watcher(self):
-            watcher = mock.create_autospec(asyncio.AbstractChildWatcher)
-            watcher.is_active.return_value = False
-
-            async def execute():
-                asyncio.set_child_watcher(watcher)
-
-                with self.assertRaises(RuntimeError):
-                    await subprocess.create_subprocess_exec(
-                        os_helper.FakePath(sys.executable), '-c', 'pass')
-
-                watcher.add_child_handler.assert_not_called()
-
-            with asyncio.Runner(loop_factory=asyncio.new_event_loop) as runner:
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore', DeprecationWarning)
-                    self.assertIsNone(runner.run(execute()))
-            self.assertListEqual(watcher.mock_calls, [
-                mock.call.__enter__(),
-                mock.call.is_active(),
-                mock.call.__exit__(RuntimeError, mock.ANY, mock.ANY),
-            ], watcher.mock_calls)
-
-
-        @unittest.skipUnless(
-            unix_events.can_use_pidfd(),
-            "operating system does not support pidfds",
-        )
-        def test_create_subprocess_with_pidfd(self):
-            async def in_thread():
-                proc = await asyncio.create_subprocess_exec(
-                    *PROGRAM_CAT,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                )
-                stdout, stderr = await proc.communicate(b"some data")
-                return proc.returncode, stdout
-
-            async def main():
-                # asyncio.Runner did not call asyncio.set_event_loop()
-                with warnings.catch_warnings():
-                    warnings.simplefilter('error', DeprecationWarning)
-                    # get_event_loop() raises DeprecationWarning if
-                    # set_event_loop() was never called and RuntimeError if
-                    # it was called at least once.
-                    with self.assertRaises((RuntimeError, DeprecationWarning)):
-                        asyncio.get_event_loop_policy().get_event_loop()
-                return await asyncio.to_thread(asyncio.run, in_thread())
-            with self.assertWarns(DeprecationWarning):
-                asyncio.set_child_watcher(asyncio.PidfdChildWatcher())
-            try:
-                with asyncio.Runner(loop_factory=asyncio.new_event_loop) as runner:
-                    returncode, stdout = runner.run(main())
-                self.assertEqual(returncode, 0)
-                self.assertEqual(stdout, b'some data')
-            finally:
-                with self.assertWarns(DeprecationWarning):
-                    asyncio.set_child_watcher(None)
 else:
     # Windows
     class SubprocessProactorTests(SubprocessMixin, test_utils.TestCase):

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -879,8 +879,7 @@ if sys.platform != 'win32':
 
             watcher = self._get_watcher()
             watcher.attach_loop(self.loop)
-            with warnings.catch_warnings():
-                policy._watcher = watcher
+            policy._watcher = watcher
 
         def tearDown(self):
             super().tearDown()

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -1138,35 +1138,6 @@ class AbstractChildWatcherTests(unittest.TestCase):
             NotImplementedError, watcher.__exit__, f, f, f)
 
 
-class PolicyTests(unittest.TestCase):
-
-    def create_policy(self):
-        return asyncio.DefaultEventLoopPolicy()
-
-    @mock.patch('asyncio.unix_events.can_use_pidfd')
-    def test_get_default_child_watcher(self, m_can_use_pidfd):
-        m_can_use_pidfd.return_value = False
-        policy = self.create_policy()
-        self.assertIsNone(policy._watcher)
-        with self.assertWarns(DeprecationWarning):
-            watcher = policy.get_child_watcher()
-        self.assertIsInstance(watcher, asyncio.ThreadedChildWatcher)
-
-        self.assertIs(policy._watcher, watcher)
-        with self.assertWarns(DeprecationWarning):
-            self.assertIs(watcher, policy.get_child_watcher())
-
-        m_can_use_pidfd.return_value = True
-        policy = self.create_policy()
-        self.assertIsNone(policy._watcher)
-        with self.assertWarns(DeprecationWarning):
-            watcher = policy.get_child_watcher()
-        self.assertIsInstance(watcher, asyncio.PidfdChildWatcher)
-
-        self.assertIs(policy._watcher, watcher)
-        with self.assertWarns(DeprecationWarning):
-            self.assertIs(watcher, policy.get_child_watcher())
-
 class TestFunctional(unittest.TestCase):
 
     def setUp(self):

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -552,7 +552,7 @@ class TestCase(unittest.TestCase):
             try:
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore', DeprecationWarning)
-                    watcher = policy.get_child_watcher()
+                    watcher = policy._watcher
             except NotImplementedError:
                 # watcher is not implemented by EventLoopPolicy, e.g. Windows
                 pass

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -550,10 +550,8 @@ class TestCase(unittest.TestCase):
         policy = support.maybe_get_event_loop_policy()
         if policy is not None:
             try:
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore', DeprecationWarning)
-                    watcher = policy._watcher
-            except NotImplementedError:
+                watcher = policy._watcher
+            except AttributeError:
                 # watcher is not implemented by EventLoopPolicy, e.g. Windows
                 pass
             else:


### PR DESCRIPTION
This PR removes `get_child_watcher` and `set_child_watcher` from asyncio. At some place currently we directly write to `policy._watcher` as there are no apis to do that for testing. This is temporary and will change in subsequent PRs when subprocesses will be rewritten to not use child watchers at all and then this "hack" will become unnecessary and be removed.

<!-- gh-issue-number: gh-120804 -->
* Issue: gh-120804
<!-- /gh-issue-number -->
