### PR TITLE
gh-120713: normalize year with century for datetime.strftime

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -755,7 +755,6 @@ Instance methods:
    Format codes referring to hours, minutes or seconds will see 0 values.
    See also :ref:`strftime-strptime-behavior` and :meth:`date.isoformat`.
 
-
 .. method:: date.__format__(format)
 
    Same as :meth:`.date.strftime`. This makes it possible to specify a format
@@ -2539,6 +2538,10 @@ differences between platforms in handling of unsupported format specifiers.
 
 .. versionadded:: 3.12
    ``%:z`` was added.
+
+.. versionchanged:: 3.14
+   ``%Y`` and ``%G`` are now guaranteed to 0-pad year with century to 4 digits. Previously
+   they would not 0-pad years less than 1000 on certain platforms such as Linux.
 
 Technical Detail
 ^^^^^^^^^^^^^^^^

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -755,6 +755,7 @@ Instance methods:
    Format codes referring to hours, minutes or seconds will see 0 values.
    See also :ref:`strftime-strptime-behavior` and :meth:`date.isoformat`.
 
+
 .. method:: date.__format__(format)
 
    Same as :meth:`.date.strftime`. This makes it possible to specify a format
@@ -2538,10 +2539,6 @@ differences between platforms in handling of unsupported format specifiers.
 
 .. versionadded:: 3.12
    ``%:z`` was added.
-
-.. versionchanged:: 3.14
-   ``%Y`` and ``%G`` are now guaranteed to 0-pad year with century to 4 digits. Previously
-   they would not 0-pad years less than 1000 on certain platforms such as Linux.
 
 Technical Detail
 ^^^^^^^^^^^^^^^^

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -274,9 +274,7 @@ def _wrap_strftime(object, format, timetuple):
                                 Zreplace = s.replace('%', '%%')
                     newformat.append(Zreplace)
                 elif ch == 'Y' and _need_normalize_century():
-                    push('%')
-                    push('4')
-                    push(ch)
+                    push('%4Y')
                 else:
                     push('%')
                     push(ch)

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -210,9 +210,9 @@ def _need_normalize_century():
     if _normalize_century is None:
         try:
             _normalize_century = (
-                _time.strftime("%Y", (99, 1, 1, 0, 0, 0, 0, 1, 0)) == "99")
+                _time.strftime("%Y", (99, 1, 1, 0, 0, 0, 0, 1, 0)) != "0099")
         except ValueError:
-            _normalize_century = False
+            _normalize_century = True
     return _normalize_century
 
 # Correctly substitute for %z and %Z escapes in strftime formats.

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -272,7 +272,7 @@ def _wrap_strftime(object, format, timetuple):
                                 # strftime is going to have at this: escape %
                                 Zreplace = s.replace('%', '%%')
                     newformat.append(Zreplace)
-                elif ch in 'YG' and _need_normalize_century():
+                elif ch in 'YG' and object.year <= 1000 and _need_normalize_century():
                     if ch == 'G':
                         year = int(_time.strftime("%G", timetuple))
                     else:

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -210,8 +210,7 @@ def _need_normalize_century():
     if _normalize_century is None:
         try:
             _normalize_century = (
-                _time.strftime("%Y", (99, 1, 1, 0, 0, 0, 0, 1, 0)) == "99" and
-                _time.strftime("%4Y", (99, 1, 1, 0, 0, 0, 0, 1, 0)) == "0099")
+                _time.strftime("%Y", (99, 1, 1, 0, 0, 0, 0, 1, 0)) == "99")
         except ValueError:
             _normalize_century = False
     return _normalize_century
@@ -274,7 +273,7 @@ def _wrap_strftime(object, format, timetuple):
                                 Zreplace = s.replace('%', '%%')
                     newformat.append(Zreplace)
                 elif ch == 'Y' and _need_normalize_century():
-                    push('%4Y')
+                    push('{:04}'.format(object.year))
                 else:
                     push('%')
                     push(ch)

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -204,6 +204,18 @@ def _format_offset(off, sep=':'):
                 s += '.%06d' % ss.microseconds
     return s
 
+_normalize_century = None
+def _need_normalize_century():
+    global _normalize_century
+    if _normalize_century is None:
+        try:
+            _normalize_century = (
+                _time.strftime("%Y", (99, 1, 1, 0, 0, 0, 0, 1, 0)) == "99" and
+                _time.strftime("%4Y", (99, 1, 1, 0, 0, 0, 0, 1, 0)) == "0099")
+        except ValueError:
+            _normalize_century = False
+    return _normalize_century
+
 # Correctly substitute for %z and %Z escapes in strftime formats.
 def _wrap_strftime(object, format, timetuple):
     # Don't call utcoffset() or tzname() unless actually needed.
@@ -261,6 +273,10 @@ def _wrap_strftime(object, format, timetuple):
                                 # strftime is going to have at this: escape %
                                 Zreplace = s.replace('%', '%%')
                     newformat.append(Zreplace)
+                elif ch == 'Y' and _need_normalize_century():
+                    push('%')
+                    push('4')
+                    push(ch)
                 else:
                     push('%')
                     push(ch)

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -273,7 +273,11 @@ def _wrap_strftime(object, format, timetuple):
                                 Zreplace = s.replace('%', '%%')
                     newformat.append(Zreplace)
                 elif ch in 'YG' and _need_normalize_century():
-                    push('{:04}'.format(object.year))
+                    if ch == 'G':
+                        year = int(_time.strftime("%G", timetuple))
+                    else:
+                        year = object.year
+                    push('{:04}'.format(year))
                 else:
                     push('%')
                     push(ch)

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -272,7 +272,7 @@ def _wrap_strftime(object, format, timetuple):
                                 # strftime is going to have at this: escape %
                                 Zreplace = s.replace('%', '%%')
                     newformat.append(Zreplace)
-                elif ch == 'Y' and _need_normalize_century():
+                elif ch in 'YG' and _need_normalize_century():
                     push('{:04}'.format(object.year))
                 else:
                     push('%')

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -272,7 +272,9 @@ def _wrap_strftime(object, format, timetuple):
                                 # strftime is going to have at this: escape %
                                 Zreplace = s.replace('%', '%%')
                     newformat.append(Zreplace)
-                elif ch in 'YG' and object.year <= 1000 and _need_normalize_century():
+                elif ch in 'YG' and object.year < 1000 and _need_normalize_century():
+                    # note that datetime(1000, 1, 1).strftime('%G') == '1000' so
+                    # year 1000 for %G can go on the fast path
                     if ch == 'G':
                         year = int(_time.strftime("%G", timetuple))
                     else:

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -273,8 +273,8 @@ def _wrap_strftime(object, format, timetuple):
                                 Zreplace = s.replace('%', '%%')
                     newformat.append(Zreplace)
                 elif ch in 'YG' and object.year < 1000 and _need_normalize_century():
-                    # note that datetime(1000, 1, 1).strftime('%G') == '1000' so
-                    # year 1000 for %G can go on the fast path
+                    # Note that datetime(1000, 1, 1).strftime('%G') == '1000' so
+                    # year 1000 for %G can go on the fast path.
                     if ch == 'G':
                         year = int(_time.strftime("%G", timetuple))
                     else:

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1697,10 +1697,14 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         self.assertTrue(self.theclass.max)
 
     def test_strftime_y2k(self):
-        for y in (1, 49, 70, 99, 100, 999, 1000, 1970):
+        for y, o in ((1, 0), (49, -1), (70, 0), (99, 0), (100, -1),
+                            (999, 0), (1000, 0), (1970, 0)):
             for s in 'YG':
-                d = self.theclass(y, 1, 1)
-                self.assertEqual(d.strftime("%" + s), '%04d' % y)
+                with self.subTest(year=y, specifier=s):
+                    d = self.theclass(y, 1, 1)
+                    if s == 'G':
+                        y += o
+                    self.assertEqual(d.strftime("%" + s), '%04d' % y)
 
     def test_replace(self):
         cls = self.theclass

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1699,16 +1699,7 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
     def test_strftime_y2k(self):
         for y in (1, 49, 70, 99, 100, 999, 1000, 1970):
             d = self.theclass(y, 1, 1)
-            # Issue 13305:  For years < 1000, the value is not always
-            # padded to 4 digits across platforms.  The C standard
-            # assumes year >= 1900, so it does not specify the number
-            # of digits.
-            if d.strftime("%Y") != '%04d' % y:
-                # Year 42 returns '42', not padded
-                self.assertEqual(d.strftime("%Y"), '%d' % y)
-                # '0042' is obtained anyway
-                if support.has_strftime_extensions:
-                    self.assertEqual(d.strftime("%4Y"), '%04d' % y)
+            self.assertEqual(d.strftime("%Y"), '%04d' % y)
 
     def test_replace(self):
         cls = self.theclass

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1711,12 +1711,12 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
             (1970, 0),
         )
         for year, offset in dataset:
-            for s in 'YG':
-                with self.subTest(year=y, specifier=s):
-                    d = self.theclass(y, 1, 1)
-                    if s == 'G':
-                        y += o
-                    self.assertEqual(d.strftime("%" + s), '%04d' % y)
+            for specifier in 'YG':
+                with self.subTest(year=year, specifier=specifier):
+                    d = self.theclass(year, 1, 1)
+                    if specifier == 'G':
+                        year += offset
+                    self.assertEqual(d.strftime(f"%{specifier}"), f"{year:04d}")
 
     def test_replace(self):
         cls = self.theclass

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1699,7 +1699,7 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
     def test_strftime_y2k(self):
         for y in (1, 49, 70, 99, 100, 999, 1000, 1970):
             d = self.theclass(y, 1, 1)
-                        # Issue 13305:  For years < 1000, the value is not always
+            # Issue 13305:  For years < 1000, the value is not always
             # padded to 4 digits across platforms.  The C standard
             # assumes year >= 1900, so it does not specify the number
             # of digits.

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1700,8 +1700,17 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         # Test that years less than 1000 are 0-padded; note that the beginning
         # of an ISO 8601 year may fall in an ISO week of the year before, and
         # therefore needs an offset of -1 when formatting with '%G'.
-        for y, o in ((1, 0), (49, -1), (70, 0), (99, 0), (100, -1), (999, 0),
-                     (1000, 0), (1970, 0)):
+        dataset = (
+            (1, 0),
+            (49, -1),
+            (70, 0),
+            (99, 0),
+            (100, -1),
+            (999, 0),
+            (1000, 0),
+            (1970, 0),
+        )
+        for year, offset in dataset:
             for s in 'YG':
                 with self.subTest(year=y, specifier=s):
                     d = self.theclass(y, 1, 1)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1699,7 +1699,16 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
     def test_strftime_y2k(self):
         for y in (1, 49, 70, 99, 100, 999, 1000, 1970):
             d = self.theclass(y, 1, 1)
-            self.assertEqual(d.strftime("%Y"), '%04d' % y)
+                        # Issue 13305:  For years < 1000, the value is not always
+            # padded to 4 digits across platforms.  The C standard
+            # assumes year >= 1900, so it does not specify the number
+            # of digits.
+            if d.strftime("%Y") != '%04d' % y:
+                # Year 42 returns '42', not padded
+                self.assertEqual(d.strftime("%Y"), '%d' % y)
+                # '0042' is obtained anyway
+                if support.has_strftime_extensions:
+                    self.assertEqual(d.strftime("%4Y"), '%04d' % y)
 
     def test_replace(self):
         cls = self.theclass

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1697,8 +1697,11 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         self.assertTrue(self.theclass.max)
 
     def test_strftime_y2k(self):
-        for y, o in ((1, 0), (49, -1), (70, 0), (99, 0), (100, -1),
-                            (999, 0), (1000, 0), (1970, 0)):
+        # Test that years less than 1000 are 0-padded; note that the beginning
+        # an ISO 8601 year may fall in an ISO week of the year before, and
+        # therefore needs an offset of -1 when formatting with '%G'.
+        for y, o in ((1, 0), (49, -1), (70, 0), (99, 0), (100, -1), (999, 0),
+                     (1000, 0), (1970, 0)):
             for s in 'YG':
                 with self.subTest(year=y, specifier=s):
                     d = self.theclass(y, 1, 1)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1698,8 +1698,9 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
 
     def test_strftime_y2k(self):
         for y in (1, 49, 70, 99, 100, 999, 1000, 1970):
-            d = self.theclass(y, 1, 1)
-            self.assertEqual(d.strftime("%Y"), '%04d' % y)
+            for s in 'YG':
+                d = self.theclass(y, 1, 1)
+                self.assertEqual(d.strftime("%" + s), '%04d' % y)
 
     def test_replace(self):
         cls = self.theclass

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1699,7 +1699,7 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
     def test_strftime_y2k(self):
         for y in (1, 49, 70, 99, 100, 999, 1000, 1970):
             d = self.theclass(y, 1, 1)
-            self.assertEqual(d.strftime("%4Y"), '%04d' % y)
+            self.assertEqual(d.strftime("%Y"), '%04d' % y)
 
     def test_replace(self):
         cls = self.theclass

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1699,16 +1699,7 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
     def test_strftime_y2k(self):
         for y in (1, 49, 70, 99, 100, 999, 1000, 1970):
             d = self.theclass(y, 1, 1)
-            # Issue 13305:  For years < 1000, the value is not always
-            # padded to 4 digits across platforms.  The C standard
-            # assumes year >= 1900, so it does not specify the number
-            # of digits.
-            if d.strftime("%Y") != '%04d' % y:
-                # Year 42 returns '42', not padded
-                self.assertEqual(d.strftime("%Y"), '%d' % y)
-                # '0042' is obtained anyway
-                if support.has_strftime_extensions:
-                    self.assertEqual(d.strftime("%4Y"), '%04d' % y)
+            self.assertEqual(d.strftime("%4Y"), '%04d' % y)
 
     def test_replace(self):
         cls = self.theclass

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1698,7 +1698,7 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
 
     def test_strftime_y2k(self):
         # Test that years less than 1000 are 0-padded; note that the beginning
-        # an ISO 8601 year may fall in an ISO week of the year before, and
+        # of an ISO 8601 year may fall in an ISO week of the year before, and
         # therefore needs an offset of -1 when formatting with '%G'.
         for y, o in ((1, 0), (49, -1), (70, 0), (99, 0), (100, -1), (999, 0),
                      (1000, 0), (1970, 0)):

--- a/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
@@ -1,2 +1,2 @@
-:meth:`datetime.datetime.strftime` now 0-pads a year <= 999 for the format specifiers ``%Y`` and ``%G`` on Linux.
+:meth:`datetime.datetime.strftime` now 0-pads years with less than four digits for the format specifiers ``%Y`` and ``%G`` on Linux.
 Patch by Ben Hsing

--- a/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
@@ -1,2 +1,2 @@
-:func:`datetime.datetime.strftime` now 0-pads a year <= 999 for the format specifier ``%Y`` on Linux.
+:meth:`!datetime.datetime.strftime` now 0-pads a year <= 999 for the format specifier ``%Y`` on Linux.
 Patch by Ben Hsing

--- a/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
@@ -1,2 +1,2 @@
-:meth:`!datetime.datetime.strftime` now 0-pads a year <= 999 for the format specifiers ``%Y`` and ``%G`` on Linux.
+:meth:`datetime.datetime.strftime` now 0-pads a year <= 999 for the format specifiers ``%Y`` and ``%G`` on Linux.
 Patch by Ben Hsing

--- a/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
@@ -1,0 +1,1 @@
+:func:`datetime.datetime.strftime` now 0-pads a year <= 999 for the format specifier ``%Y`` on Linux.

--- a/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
@@ -1,1 +1,2 @@
 :func:`datetime.datetime.strftime` now 0-pads a year <= 999 for the format specifier ``%Y`` on Linux.
+Patch by Ben Hsing

--- a/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-21-06-37-46.gh-issue-120713.WBbQx4.rst
@@ -1,2 +1,2 @@
-:meth:`!datetime.datetime.strftime` now 0-pads a year <= 999 for the format specifier ``%Y`` on Linux.
+:meth:`!datetime.datetime.strftime` now 0-pads a year <= 999 for the format specifiers ``%Y`` and ``%G`` on Linux.
 Patch by Ben Hsing

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1837,13 +1837,13 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     PyObject *colonzreplacement = NULL; /* py string, replacement for %:z */
     PyObject *Zreplacement = NULL;      /* py string, replacement for %Z */
     PyObject *freplacement = NULL;      /* py string, replacement for %f */
+#ifdef NORMALIZE_CENTURY
     char year_formatted[5];             /* formatted year with century for %Y */
+#endif
 
     const char *pin;            /* pointer to next char in input format */
     Py_ssize_t flen;            /* length of input format */
-#ifdef NORMALIZE_CENTURY
     char ch;                    /* next char in input format */
-#endif
 
     PyObject *newfmt = NULL;            /* py string, the output format */
     char *pnew;         /* pointer to available byte in output format */

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1959,10 +1959,10 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
                     goto Done;
                 }
                 year = PyNumber_Long(result);
+                Py_DECREF(result);
                 if (year == NULL) {
                     goto Done;
                 }
-                Py_DECREF(result);
             } else {
                 year = PyTuple_GET_ITEM(timetuple, 0);
             }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1858,6 +1858,11 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     if (!pin)
         return NULL;
 
+    PyObject *strftime = _PyImport_GetModuleAttrString("time", "strftime");
+    if (strftime == NULL) {
+        goto Done;
+    }
+
     /* Scan the input format, looking for %z/%Z/%f escapes, building
      * a new format.  Since computing the replacements for those codes
      * is expensive, don't unless they're actually used.
@@ -1872,11 +1877,6 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     if (newfmt == NULL) goto Done;
     pnew = PyBytes_AsString(newfmt);
     usednew = 0;
-
-    PyObject *strftime = _PyImport_GetModuleAttrString("time", "strftime");
-    if (strftime == NULL) {
-        goto Done;
-    }
 
     while ((ch = *pin++) != '\0') {
         if (ch != '%') {

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1839,7 +1839,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     PyObject *Zreplacement = NULL;      /* py string, replacement for %Z */
     PyObject *freplacement = NULL;      /* py string, replacement for %f */
 #ifdef NORMALIZE_CENTURY
-    long year;                           /* year of timetuple as long */
+    long year;                          /* year of timetuple as long */
     char year_formatted[12];            /* formatted year with century for %Y */
 #endif
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1976,11 +1976,10 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
                 }
             }
 
-            /* Maximum size of formatted year permitted by long. */
-            size_t buf_size = SIZEOF_LONG*5/2+2;
-            char buf[buf_size];                  /* formatted year for %Y/%G */
+            /* Buffer of maximum size of formatted year permitted by long. */
+            char buf[SIZEOF_LONG*5/2+2];
 
-            ntoappend = PyOS_snprintf(buf, buf_size, "%04ld", year_long);
+            ntoappend = PyOS_snprintf(buf, sizeof(buf), "%04ld", year_long);
             ptoappend = buf;
         }
 #endif

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1837,6 +1837,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     PyObject *colonzreplacement = NULL; /* py string, replacement for %:z */
     PyObject *Zreplacement = NULL;      /* py string, replacement for %Z */
     PyObject *freplacement = NULL;      /* py string, replacement for %f */
+    char year_formatted[5];             /* formatted year with century for %Y */
 
     const char *pin;            /* pointer to next char in input format */
     Py_ssize_t flen;            /* length of input format */
@@ -1942,10 +1943,9 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
 #ifdef NORMALIZE_CENTURY
         else if (ch == 'Y') {
             /* 0-pad year with century on platforms that do not do so */
-            char formatted[5];
-            ntoappend = sprintf(formatted, "%04ld",
+            ntoappend = sprintf(year_formatted, "%04ld",
                                 PyLong_AsLong(PyTuple_GET_ITEM(timetuple, 0)));
-            ptoappend = formatted;
+            ptoappend = year_formatted;
         }
 #endif
         else {

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1942,13 +1942,10 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
 #ifdef NORMALIZE_CENTURY
         else if (ch == 'Y') {
             /* 0-pad year with century on platforms that do not do so */
-            PyObject *year = PyObject_GetAttrString(object, "year");
-            if (year == NULL)
-                goto Done;
             char formatted[5];
-            ntoappend = sprintf(formatted, "%04d", (int)PyLong_AsLong(year));
+            ntoappend = sprintf(formatted, "%04ld",
+                                PyLong_AsLong(PyTuple_GET_ITEM(timetuple, 0)));
             ptoappend = formatted;
-            Py_DECREF(year);
         }
 #endif
         else {

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1851,7 +1851,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     const char *ptoappend;      /* ptr to string to append to output buffer */
     Py_ssize_t ntoappend;       /* # of bytes to append to output buffer */
 
-#ifdef NORMALIZE_CENTURY
+#ifdef Py_NORMALIZE_CENTURY
     /* Buffer of maximum size of formatted year permitted by long. */
     char buf[SIZEOF_LONG*5/2+2];
 #endif

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1832,7 +1832,6 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
               PyObject *tzinfoarg)
 {
     PyObject *result = NULL;            /* guilty until proved innocent */
-    PyObject *strftime = NULL;          /* time.strftime */
 
     PyObject *zreplacement = NULL;      /* py string, replacement for %z */
     PyObject *colonzreplacement = NULL; /* py string, replacement for %:z */
@@ -1874,7 +1873,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     pnew = PyBytes_AsString(newfmt);
     usednew = 0;
 
-    strftime = _PyImport_GetModuleAttrString("time", "strftime");
+    PyObject *strftime = _PyImport_GetModuleAttrString("time", "strftime");
     if (strftime == NULL) {
         goto Done;
     }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1976,7 +1976,8 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
                 }
             }
 
-            size_t buf_size = SIZEOF_LONG*5/2+2; /* maximum size of formatted year permitted by long */
+            /* Maximum size of formatted year permitted by long. */
+            size_t buf_size = SIZEOF_LONG*5/2+2;
             char buf[buf_size];                  /* formatted year for %Y/%G */
 
             ntoappend = PyOS_snprintf(buf, buf_size, "%04ld", year_long);

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1953,8 +1953,8 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
             if (year_long == -1 && PyErr_Occurred()) {
                 goto Done;
             }
-            /* note that datetime(1000, 1, 1).strftime('%G') == '1000' so year
-               1000 for %G can go on the fast path */
+            /* Note that datetime(1000, 1, 1).strftime('%G') == '1000' so year
+               1000 for %G can go on the fast path. */
             if (year_long >= 1000) {
                 goto PassThrough;
             }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1939,6 +1939,13 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
             ptoappend = PyBytes_AS_STRING(freplacement);
             ntoappend = PyBytes_GET_SIZE(freplacement);
         }
+#ifdef NORMALIZE_CENTURY
+        else if (ch == 'Y') {
+            /* default to 4 digits for year with century */
+            ptoappend = "%4Y";
+            ntoappend = 3;
+        }
+#endif
         else {
             /* percent followed by something else */
             ptoappend = pin - 2;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1851,6 +1851,11 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     const char *ptoappend;      /* ptr to string to append to output buffer */
     Py_ssize_t ntoappend;       /* # of bytes to append to output buffer */
 
+#ifdef NORMALIZE_CENTURY
+    /* Buffer of maximum size of formatted year permitted by long. */
+    char buf[SIZEOF_LONG*5/2+2];
+#endif
+
     assert(object && format && timetuple);
     assert(PyUnicode_Check(format));
     /* Convert the input format to a C string and size */
@@ -1976,11 +1981,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
                 }
             }
 
-/* Maximum size of formatted year permitted by long. */
-#define MAX_YEAR_BUFFER_LEN SIZEOF_LONG*5/2+2
-            char buf[MAX_YEAR_BUFFER_LEN];
-
-            ntoappend = PyOS_snprintf(buf, MAX_YEAR_BUFFER_LEN, "%04ld", year_long);
+            ntoappend = PyOS_snprintf(buf, sizeof(buf), "%04ld", year_long);
             ptoappend = buf;
         }
 #endif

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1839,8 +1839,9 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     PyObject *Zreplacement = NULL;      /* py string, replacement for %Z */
     PyObject *freplacement = NULL;      /* py string, replacement for %f */
 #ifdef NORMALIZE_CENTURY
-    PyObject *year;                     /* year of timetuple */
-    long year_long;                     /* year of timetuple as long int */
+    PyObject *year_str;                 /* py string, year */
+    PyObject *year;                     /* py int, year */
+    long year_long;                     /* year as long int */
     char year_formatted[12];            /* formatted year with century for %Y/G */
 #endif
 
@@ -1954,23 +1955,24 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
         else if (ch == 'Y' || ch == 'G') {
             /* 0-pad year with century as necessary */
             if (ch == 'G') {
-                result = PyObject_CallFunction(strftime, "sO", "%G", timetuple);
-                if (result == NULL) {
+                year_str = PyObject_CallFunction(strftime, "sO", "%G", timetuple);
+                if (year_str == NULL) {
                     goto Done;
                 }
-                year = PyNumber_Long(result);
-                Py_DECREF(result);
+                year = PyNumber_Long(year_str);
+                Py_DECREF(year_str);
                 if (year == NULL) {
                     goto Done;
                 }
-            } else {
+            }
+            else {
                 year = PyTuple_GET_ITEM(timetuple, 0);
             }
             year_long = PyLong_AsLong(year);
             if (ch == 'G') {
                 Py_DECREF(year);
             }
-            if (year_long == -1 && PyErr_Occurred() != NULL) {
+            if (year_long == -1 && PyErr_Occurred()) {
                 goto Done;
             }
             ntoappend = sprintf(year_formatted, "%04ld", year_long);

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1838,12 +1838,6 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     PyObject *colonzreplacement = NULL; /* py string, replacement for %:z */
     PyObject *Zreplacement = NULL;      /* py string, replacement for %Z */
     PyObject *freplacement = NULL;      /* py string, replacement for %f */
-#ifdef NORMALIZE_CENTURY
-    PyObject *year_str;                     /* py string, year */
-    PyObject *year;                         /* py int, year */
-    long year_long;                         /* year as long int */
-    char year_formatted[SIZEOF_LONG*5/2+2]; /* formatted year for %Y/%G */
-#endif
 
     const char *pin;            /* pointer to next char in input format */
     Py_ssize_t flen;            /* length of input format */
@@ -1951,9 +1945,14 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
             ptoappend = PyBytes_AS_STRING(freplacement);
             ntoappend = PyBytes_GET_SIZE(freplacement);
         }
-#ifdef NORMALIZE_CENTURY
+#ifdef Py_NORMALIZE_CENTURY
         else if (ch == 'Y' || ch == 'G') {
             /* 0-pad year with century as necessary */
+            PyObject *year_str;                     /* py string, year */
+            PyObject *year;                         /* py int, year */
+            long year_long;                         /* year as long int */
+            char year_formatted[SIZEOF_LONG*5/2+2]; /* formatted year for %Y/%G */
+
             year_long = PyLong_AsLong(PyTuple_GET_ITEM(timetuple, 0));
             if (year_long == -1 && PyErr_Occurred()) {
                 goto Done;
@@ -1983,7 +1982,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
 #endif
         else {
             /* percent followed by something else */
-#ifdef NORMALIZE_CENTURY
+#ifdef Py_NORMALIZE_CENTURY
  PassThrough:
 #endif
             ptoappend = pin - 2;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1959,7 +1959,8 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
                 goto PassThrough;
             }
             if (ch == 'G') {
-                PyObject *year_str = PyObject_CallFunction(strftime, "sO", "%G", timetuple);
+                PyObject *year_str = PyObject_CallFunction(strftime, "sO",
+                                                           "%G", timetuple);
                 if (year_str == NULL) {
                     goto Done;
                 }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1841,7 +1841,9 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
 
     const char *pin;            /* pointer to next char in input format */
     Py_ssize_t flen;            /* length of input format */
+#ifdef NORMALIZE_CENTURY
     char ch;                    /* next char in input format */
+#endif
 
     PyObject *newfmt = NULL;            /* py string, the output format */
     char *pnew;         /* pointer to available byte in output format */

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1947,12 +1947,12 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
 #ifdef Py_NORMALIZE_CENTURY
         else if (ch == 'Y' || ch == 'G') {
             /* 0-pad year with century as necessary */
-            PyObject *year_str;                     /* py string, year */
-            PyObject *year;                         /* py int, year */
-            long year_long;                         /* year as long int */
-            char year_formatted[SIZEOF_LONG*5/2+2]; /* formatted year for %Y/%G */
+            size_t buf_size = SIZEOF_LONG*5/2+2; /* maximum size of formatted year permitted by long */
+            char buf[buf_size];                  /* formatted year for %Y/%G */
 
-            year_long = PyLong_AsLong(PyTuple_GET_ITEM(timetuple, 0));
+            PyObject *item = PyTuple_GET_ITEM(timetuple, 0);
+            long year_long = PyLong_AsLong(item);
+
             if (year_long == -1 && PyErr_Occurred()) {
                 goto Done;
             }
@@ -1960,6 +1960,9 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
                 goto PassThrough;
             }
             if (ch == 'G') {
+                PyObject *year_str;              /* py string, year */
+                PyObject *year;                  /* py int, year */
+
                 year_str = PyObject_CallFunction(strftime, "sO", "%G", timetuple);
                 if (year_str == NULL) {
                     goto Done;
@@ -1975,8 +1978,8 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
                     goto Done;
                 }
             }
-            ntoappend = sprintf(year_formatted, "%04ld", year_long);
-            ptoappend = year_formatted;
+            ntoappend = PyOS_snprintf(buf, buf_size, "%04ld", year_long);
+            ptoappend = buf;
         }
 #endif
         else {

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1967,6 +1967,9 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
                 year = PyTuple_GET_ITEM(timetuple, 0);
             }
             year_long = PyLong_AsLong(year);
+            if (ch == 'G') {
+                Py_DECREF(year);
+            }
             if (year_long == -1 && PyErr_Occurred() != NULL) {
                 goto Done;
             }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1953,7 +1953,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
             if (year_long == -1 && PyErr_Occurred()) {
                 goto Done;
             }
-            if (year_long > 1000) {
+            if (year_long >= 1000) {
                 goto PassThrough;
             }
             if (ch == 'G') {

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1953,6 +1953,8 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
             if (year_long == -1 && PyErr_Occurred()) {
                 goto Done;
             }
+            /* note that datetime(1000, 1, 1).strftime('%G') == '1000' so year
+               1000 for %G can go on the fast path */
             if (year_long >= 1000) {
                 goto PassThrough;
             }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1947,9 +1947,6 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
 #ifdef Py_NORMALIZE_CENTURY
         else if (ch == 'Y' || ch == 'G') {
             /* 0-pad year with century as necessary */
-            size_t buf_size = SIZEOF_LONG*5/2+2; /* maximum size of formatted year permitted by long */
-            char buf[buf_size];                  /* formatted year for %Y/%G */
-
             PyObject *item = PyTuple_GET_ITEM(timetuple, 0);
             long year_long = PyLong_AsLong(item);
 
@@ -1978,6 +1975,10 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
                     goto Done;
                 }
             }
+
+            size_t buf_size = SIZEOF_LONG*5/2+2; /* maximum size of formatted year permitted by long */
+            char buf[buf_size];                  /* formatted year for %Y/%G */
+
             ntoappend = PyOS_snprintf(buf, buf_size, "%04ld", year_long);
             ptoappend = buf;
         }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1839,10 +1839,10 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     PyObject *Zreplacement = NULL;      /* py string, replacement for %Z */
     PyObject *freplacement = NULL;      /* py string, replacement for %f */
 #ifdef NORMALIZE_CENTURY
-    PyObject *year_str;                 /* py string, year */
-    PyObject *year;                     /* py int, year */
-    long year_long;                     /* year as long int */
-    char year_formatted[12];            /* formatted year with century for %Y/G */
+    PyObject *year_str;                     /* py string, year */
+    PyObject *year;                         /* py int, year */
+    long year_long;                         /* year as long int */
+    char year_formatted[SIZEOF_LONG*5/2+2]; /* formatted year for %Y/%G */
 #endif
 
     const char *pin;            /* pointer to next char in input format */

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1957,14 +1957,11 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
                 goto PassThrough;
             }
             if (ch == 'G') {
-                PyObject *year_str;              /* py string, year */
-                PyObject *year;                  /* py int, year */
-
-                year_str = PyObject_CallFunction(strftime, "sO", "%G", timetuple);
+                PyObject *year_str = PyObject_CallFunction(strftime, "sO", "%G", timetuple);
                 if (year_str == NULL) {
                     goto Done;
                 }
-                year = PyNumber_Long(year_str);
+                PyObject *year = PyNumber_Long(year_str);
                 Py_DECREF(year_str);
                 if (year == NULL) {
                     goto Done;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1838,7 +1838,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     PyObject *Zreplacement = NULL;      /* py string, replacement for %Z */
     PyObject *freplacement = NULL;      /* py string, replacement for %f */
 #ifdef NORMALIZE_CENTURY
-    char year_formatted[5];             /* formatted year with century for %Y */
+    char year_formatted[12];            /* formatted year with century for %Y */
 #endif
 
     const char *pin;            /* pointer to next char in input format */
@@ -1943,7 +1943,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
             ntoappend = PyBytes_GET_SIZE(freplacement);
         }
 #ifdef NORMALIZE_CENTURY
-        else if (ch == 'Y') {
+        else if (ch == 'Y' || ch == 'G') {
             /* 0-pad year with century on platforms that do not do so */
             ntoappend = sprintf(year_formatted, "%04ld",
                                 PyLong_AsLong(PyTuple_GET_ITEM(timetuple, 0)));

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1941,9 +1941,14 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
         }
 #ifdef NORMALIZE_CENTURY
         else if (ch == 'Y') {
-            /* default to 4 digits for year with century */
-            ptoappend = "%4Y";
-            ntoappend = 3;
+            /* 0-pad year with century on platforms that do not do so */
+            PyObject *year = PyObject_GetAttrString(object, "year");
+            if (year == NULL)
+                goto Done;
+            char formatted[5];
+            ntoappend = sprintf(formatted, "%04d", (int)PyLong_AsLong(year));
+            ptoappend = formatted;
+            Py_DECREF(year);
         }
 #endif
         else {

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1976,10 +1976,11 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
                 }
             }
 
-            /* Buffer of maximum size of formatted year permitted by long. */
-            char buf[SIZEOF_LONG*5/2+2];
+/* Maximum size of formatted year permitted by long. */
+#define MAX_YEAR_BUFFER_LEN SIZEOF_LONG*5/2+2
+            char buf[MAX_YEAR_BUFFER_LEN];
 
-            ntoappend = PyOS_snprintf(buf, sizeof(buf), "%04ld", year_long);
+            ntoappend = PyOS_snprintf(buf, MAX_YEAR_BUFFER_LEN, "%04ld", year_long);
             ptoappend = buf;
         }
 #endif

--- a/configure
+++ b/configure
@@ -25898,7 +25898,10 @@ int main(void)
     .tm_mon = 0,
     .tm_mday = 1
   };
-  exit(strftime(year, sizeof year, "%Y", &date) && !strcmp(year, "0099"));
+  if (strftime(year, sizeof(year), "%Y", &date) && !strcmp(year, "0099")) {
+    return 1;
+  }
+  return 0;
 }
 
 _ACEOF

--- a/configure
+++ b/configure
@@ -25871,7 +25871,6 @@ printf "%s\n" "#define HAVE_STAT_TV_NSEC2 1" >>confdefs.h
 
 fi
 
-# Check if year with century should be normalized for strftime
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether year with century should be normalized for strftime" >&5
 printf %s "checking whether year with century should be normalized for strftime... " >&6; }
 if test ${ac_cv_normalize_century+y}

--- a/configure
+++ b/configure
@@ -25919,7 +25919,7 @@ printf "%s\n" "$ac_cv_normalize_century" >&6; }
 if test "$ac_cv_normalize_century" = yes
 then
 
-printf "%s\n" "#define NORMALIZE_CENTURY 1" >>confdefs.h
+printf "%s\n" "#define Py_NORMALIZE_CENTURY 1" >>confdefs.h
 
 fi
 

--- a/configure
+++ b/configure
@@ -25898,10 +25898,7 @@ int main(void)
     .tm_mon = 0,
     .tm_mday = 1
   };
-  if (strftime(year, sizeof year, "%Y", &date) && !strcmp(year, "99") &&
-      strftime(year, sizeof year, "%4Y", &date) && !strcmp(year, "0099"))
-    exit(0);
-  exit(1);
+  exit(strftime(year, sizeof year, "%Y", &date) && !strcmp(year, "0099"));
 }
 
 _ACEOF

--- a/configure
+++ b/configure
@@ -25871,6 +25871,60 @@ printf "%s\n" "#define HAVE_STAT_TV_NSEC2 1" >>confdefs.h
 
 fi
 
+# Check if year with century should be normalized for strftime
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether year with century should be normalized for strftime" >&5
+printf %s "checking whether year with century should be normalized for strftime... " >&6; }
+if test ${ac_cv_normalize_century+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+if test "$cross_compiling" = yes
+then :
+  ac_cv_normalize_century=no
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <stdlib.h>
+#include <time.h>
+#include <string.h>
+
+int main(void)
+{
+  char year[5];
+  struct tm date = {
+    .tm_year = -1801,
+    .tm_mon = 0,
+    .tm_mday = 1
+  };
+  if (strftime(year, sizeof year, "%Y", &date) && !strcmp(year, "99") &&
+      strftime(year, sizeof year, "%4Y", &date) && !strcmp(year, "0099"))
+    exit(0);
+  exit(1);
+}
+
+_ACEOF
+if ac_fn_c_try_run "$LINENO"
+then :
+  ac_cv_normalize_century=yes
+else $as_nop
+  ac_cv_normalize_century=no
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_normalize_century" >&5
+printf "%s\n" "$ac_cv_normalize_century" >&6; }
+if test "$ac_cv_normalize_century" = yes
+then
+
+printf "%s\n" "#define NORMALIZE_CENTURY 1" >>confdefs.h
+
+fi
+
 have_curses=no
 have_panel=no
 

--- a/configure
+++ b/configure
@@ -25881,7 +25881,7 @@ else $as_nop
 
 if test "$cross_compiling" = yes
 then :
-  ac_cv_normalize_century=no
+  ac_cv_normalize_century=yes
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */

--- a/configure
+++ b/configure
@@ -25886,7 +25886,6 @@ else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#include <stdlib.h>
 #include <time.h>
 #include <string.h>
 

--- a/configure.ac
+++ b/configure.ac
@@ -6592,7 +6592,7 @@ int main(void)
 ]])],
 [ac_cv_normalize_century=yes],
 [ac_cv_normalize_century=no],
-[ac_cv_normalize_century=no])])
+[ac_cv_normalize_century=yes])])
 if test "$ac_cv_normalize_century" = yes
 then
   AC_DEFINE([NORMALIZE_CENTURY], [1],

--- a/configure.ac
+++ b/configure.ac
@@ -6587,7 +6587,10 @@ int main(void)
     .tm_mon = 0,
     .tm_mday = 1
   };
-  exit(strftime(year, sizeof year, "%Y", &date) && !strcmp(year, "0099"));
+  if (strftime(year, sizeof(year), "%Y", &date) && !strcmp(year, "0099")) {
+    return 1;
+  }
+  return 0;
 }
 ]])],
 [ac_cv_normalize_century=yes],

--- a/configure.ac
+++ b/configure.ac
@@ -6572,7 +6572,6 @@ then
   [Define if you have struct stat.st_mtimensec])
 fi
 
-# Check if year with century should be normalized for strftime
 AC_CACHE_CHECK([whether year with century should be normalized for strftime], [ac_cv_normalize_century], [
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <time.h>

--- a/configure.ac
+++ b/configure.ac
@@ -6587,10 +6587,7 @@ int main(void)
     .tm_mon = 0,
     .tm_mday = 1
   };
-  if (strftime(year, sizeof year, "%Y", &date) && !strcmp(year, "99") &&
-      strftime(year, sizeof year, "%4Y", &date) && !strcmp(year, "0099"))
-    exit(0);
-  exit(1);
+  exit(strftime(year, sizeof year, "%Y", &date) && !strcmp(year, "0099"));
 }
 ]])],
 [ac_cv_normalize_century=yes],

--- a/configure.ac
+++ b/configure.ac
@@ -6572,6 +6572,36 @@ then
   [Define if you have struct stat.st_mtimensec])
 fi
 
+# Check if year with century should be normalized for strftime
+AC_CACHE_CHECK([whether year with century should be normalized for strftime], [ac_cv_normalize_century], [
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <stdlib.h>
+#include <time.h>
+#include <string.h>
+
+int main(void)
+{
+  char year[5];
+  struct tm date = {
+    .tm_year = -1801,
+    .tm_mon = 0,
+    .tm_mday = 1
+  };
+  if (strftime(year, sizeof year, "%Y", &date) && !strcmp(year, "99") &&
+      strftime(year, sizeof year, "%4Y", &date) && !strcmp(year, "0099"))
+    exit(0);
+  exit(1);
+}
+]])],
+[ac_cv_normalize_century=yes],
+[ac_cv_normalize_century=no],
+[ac_cv_normalize_century=no])])
+if test "$ac_cv_normalize_century" = yes
+then
+  AC_DEFINE([NORMALIZE_CENTURY], [1],
+  [Define if year with century should be normalized for strftime.])
+fi
+
 dnl check for ncurses/ncursesw and panel/panelw
 dnl NOTE: old curses is not detected.
 dnl have_curses=[no, ncursesw, ncurses]

--- a/configure.ac
+++ b/configure.ac
@@ -6596,7 +6596,7 @@ int main(void)
 [ac_cv_normalize_century=yes])])
 if test "$ac_cv_normalize_century" = yes
 then
-  AC_DEFINE([NORMALIZE_CENTURY], [1],
+  AC_DEFINE([Py_NORMALIZE_CENTURY], [1],
   [Define if year with century should be normalized for strftime.])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -6575,7 +6575,6 @@ fi
 # Check if year with century should be normalized for strftime
 AC_CACHE_CHECK([whether year with century should be normalized for strftime], [ac_cv_normalize_century], [
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <stdlib.h>
 #include <time.h>
 #include <string.h>
 

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1222,6 +1222,9 @@
 /* Define if you have struct stat.st_mtimensec */
 #undef HAVE_STAT_TV_NSEC2
 
+/* Define if year with century should be normalized for strftime. */
+#undef NORMALIZE_CENTURY
+
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
 

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1222,9 +1222,6 @@
 /* Define if you have struct stat.st_mtimensec */
 #undef HAVE_STAT_TV_NSEC2
 
-/* Define if year with century should be normalized for strftime. */
-#undef NORMALIZE_CENTURY
-
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
 
@@ -1593,6 +1590,9 @@
 
 /* Define if mvwdelch in curses.h is an expression. */
 #undef MVWDELCH_IS_EXPRESSION
+
+/* Define if year with century should be normalized for strftime. */
+#undef NORMALIZE_CENTURY
 
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1591,9 +1591,6 @@
 /* Define if mvwdelch in curses.h is an expression. */
 #undef MVWDELCH_IS_EXPRESSION
 
-/* Define if year with century should be normalized for strftime. */
-#undef NORMALIZE_CENTURY
-
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT
 
@@ -1661,6 +1658,9 @@
 /* Define hash algorithm for str, bytes and memoryview. SipHash24: 1, FNV: 2,
    SipHash13: 3, externally defined: 0 */
 #undef Py_HASH_ALGORITHM
+
+/* Define if year with century should be normalized for strftime. */
+#undef Py_NORMALIZE_CENTURY
 
 /* Define if rl_startup_hook takes arguments */
 #undef Py_RL_STARTUP_HOOK_TAKES_ARGS


### PR DESCRIPTION
On some platforms such as Linux, `datetime.strftime` does not 0-pad a year <= 999 when formatting with `'%Y'` despite the documentation claiming an example output of "0001, 0002, …". The same issue applies when formatting with `"%G"`.

This PR fixes the issue by formatting a year with century with `'%04ld'` using `sprintf` (in C) or `'{:04}'` using `str.format` (in Python) if the platform is found to show the aforementioned behavior.

<!-- gh-issue-number: gh-120713 -->
* Issue: gh-120713
* Issue: gh-57514
<!-- /gh-issue-number -->
