### PR TITLE
gh-120671: Fix as_fn_append CFLAGS

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-06-21-09-24-03.gh-issue-120671.Z8sBQB.rst
+++ b/Misc/NEWS.d/next/Build/2024-06-21-09-24-03.gh-issue-120671.Z8sBQB.rst
@@ -1,0 +1,1 @@
+Fix failing configure tests due to a missing space when appending to CFLAGS.

--- a/configure
+++ b/configure
@@ -9619,7 +9619,7 @@ then :
 else $as_nop
 
     py_cflags=$CFLAGS
-    as_fn_append CFLAGS "-Wextra -Werror"
+    as_fn_append CFLAGS " -Wextra -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9737,7 +9737,7 @@ then :
 else $as_nop
 
     py_cflags=$CFLAGS
-    as_fn_append CFLAGS "-Wunused-result -Werror"
+    as_fn_append CFLAGS " -Wunused-result -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9782,7 +9782,7 @@ then :
 else $as_nop
 
     py_cflags=$CFLAGS
-    as_fn_append CFLAGS "-Wunused-parameter -Werror"
+    as_fn_append CFLAGS " -Wunused-parameter -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9823,7 +9823,7 @@ then :
 else $as_nop
 
     py_cflags=$CFLAGS
-    as_fn_append CFLAGS "-Wint-conversion -Werror"
+    as_fn_append CFLAGS " -Wint-conversion -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9864,7 +9864,7 @@ then :
 else $as_nop
 
     py_cflags=$CFLAGS
-    as_fn_append CFLAGS "-Wmissing-field-initializers -Werror"
+    as_fn_append CFLAGS " -Wmissing-field-initializers -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9905,7 +9905,7 @@ then :
 else $as_nop
 
     py_cflags=$CFLAGS
-    as_fn_append CFLAGS "-Wsign-compare -Werror"
+    as_fn_append CFLAGS " -Wsign-compare -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9946,7 +9946,7 @@ then :
 else $as_nop
 
     py_cflags=$CFLAGS
-    as_fn_append CFLAGS "-Wunreachable-code -Werror"
+    as_fn_append CFLAGS " -Wunreachable-code -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9998,7 +9998,7 @@ then :
 else $as_nop
 
     py_cflags=$CFLAGS
-    as_fn_append CFLAGS "-Wstrict-prototypes -Werror"
+    as_fn_append CFLAGS " -Wstrict-prototypes -Werror"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 

--- a/configure.ac
+++ b/configure.ac
@@ -2437,7 +2437,7 @@ AC_DEFUN([PY_CHECK_CC_WARNING], [
   AS_VAR_PUSHDEF([py_var], [ac_cv_$1_]m4_normalize($2)[_warning])
   AC_CACHE_CHECK([m4_ifblank([$3], [if we can $1 $CC $2 warning], [$3])], [py_var], [
     AS_VAR_COPY([py_cflags], [CFLAGS])
-    AS_VAR_APPEND([CFLAGS], ["-W$2 -Werror"])
+    AS_VAR_APPEND([CFLAGS], [" -W$2 -Werror"])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
                       [AS_VAR_SET([py_var], [yes])],
                       [AS_VAR_SET([py_var], [no])])


### PR DESCRIPTION
This fixes an issue with failing configure tests due to a missing space when appending to `CFLAGS`. @eli-schwartz tracked down the source of this bug as follows:

> In commit [76d14fa](https://github.com/python/cpython/commit/76d14fac72479e0f5f5b144d6968ecd9e594db34) ([GH-29485](https://github.com/python/cpython/pull/29485)), some code was refactored to be more compact and use more advanced autoconf tricks. In the process, it switched
> 
> ```
> AS_VAR_SET([XXX], ["$XXX other values"])
> ```
> 
> to
> 
> ```
> AS_VAR_APPEND([XXX], ["other values"])
> ```
> 
> This was a functional logic break, since it elided the space in between the existing and appended values -- and that space is mandatory for command-line flags stuffed into a variable.
> 
> The same problem occurred for LDFLAGS, but was silently fixed as a side effect of commit [bb8b931](https://github.com/python/cpython/commit/bb8b931385ba9df4e01f7dd3ce4575d49f60efdf) ([GH-32229](https://github.com/python/cpython/pull/32229)).

Resolves #120671

<!-- gh-issue-number: gh-120671 -->
* Issue: gh-120671
<!-- /gh-issue-number -->
