### PR TITLE
gh-120782: Update internal type cache when reloading datetime

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -6870,6 +6870,23 @@ class ExtensionModuleTests(unittest.TestCase):
                 """)
             script_helper.assert_python_ok('-c', script)
 
+    def test_update_type_cache(self):
+        # gh-120782
+        script = textwrap.dedent("""
+            import sys
+            for i in range(5):
+                import _datetime
+                _datetime.date.max > _datetime.date.min
+                _datetime.time.max > _datetime.time.min
+                _datetime.datetime.max > _datetime.datetime.min
+                _datetime.timedelta.max > _datetime.timedelta.min
+                isinstance(_datetime.timezone.min, _datetime.tzinfo)
+                isinstance(_datetime.timezone.utc, _datetime.tzinfo)
+                isinstance(_datetime.timezone.max, _datetime.tzinfo)
+                del sys.modules['_datetime']
+            """)
+        script_helper.assert_python_ok('-c', script)
+
 
 def load_tests(loader, standard_tests, pattern):
     standard_tests.addTest(ZoneInfoCompleteTest())

--- a/Misc/NEWS.d/next/Library/2024-06-21-12-00-16.gh-issue-120782.LOE8tj.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-21-12-00-16.gh-issue-120782.LOE8tj.rst
@@ -1,0 +1,1 @@
+Fix wrong references of the :mod:`datetime` types after reloading the module.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -7296,6 +7296,12 @@ _datetime_exec(PyObject *module)
     static_assert(DI100Y == 25 * DI4Y - 1, "DI100Y");
     assert(DI100Y == days_before_year(100+1));
 
+    if (reloading) {
+        for (size_t i = 0; i < Py_ARRAY_LENGTH(capi_types); i++) {
+            PyType_Modified(capi_types[i]);
+        }
+    }
+
     if (set_current_module(interp, module) < 0) {
         goto error;
     }


### PR DESCRIPTION
When reloading `_datetime` module, the single-phase version did not invoke the `PyInit__datetime` function, whereas the current multi-phase version updates the static types through the module init.  The outdated static type cache in the interpreter state needs to be invalidated at the end of reloading the multi-phase module.


<!-- gh-issue-number: gh-120782 -->
* Issue: gh-120782
<!-- /gh-issue-number -->
