### PR TITLE
gh-120838: Disallow Py_Finalize() if Py_RunMain() is Running

### DIFF
--- a/Include/internal/pycore_pylifecycle.h
+++ b/Include/internal/pycore_pylifecycle.h
@@ -114,6 +114,14 @@ PyAPI_FUNC(char*) _Py_SetLocaleFromEnv(int category);
 // Export for special main.c string compiling with source tracebacks
 int _PyRun_SimpleStringFlagsWithName(const char *command, const char* name, PyCompilerFlags *flags);
 
+struct pyfinalize_args {
+    const char *caller;
+    int check_pymain;
+};
+
+// Export for _testembed
+extern int _Py_Finalize(_PyRuntimeState *, struct pyfinalize_args *);
+
 
 /* interpreter config */
 

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -209,6 +209,8 @@ typedef struct pyruntimestate {
     unsigned long main_thread;
     PyThreadState *main_tstate;
 
+    int is_pymain;
+
     /* ---------- IMPORTANT ---------------------------
      The fields above this line are declared as early as
      possible to facilitate out-of-process observability

--- a/Misc/NEWS.d/next/C API/2024-06-21-09-55-56.gh-issue-120838.-xuGRW.rst
+++ b/Misc/NEWS.d/next/C API/2024-06-21-09-55-56.gh-issue-120838.-xuGRW.rst
@@ -1,0 +1,3 @@
+Calling :c:func:`Py_Finalize` while :c:func:`Py_RunMain` is running is now a
+failure.  When used, ``Py_RunMain()`` is solely responsible for finalizing
+the runtime.

--- a/Misc/NEWS.d/next/C API/2024-06-25-11-25-09.gh-issue-120838.hOb-9v.rst
+++ b/Misc/NEWS.d/next/C API/2024-06-25-11-25-09.gh-issue-120838.hOb-9v.rst
@@ -1,0 +1,2 @@
+:c:func:`PyFinalize` and :c:func:`PyFinalizeEx` now explicitly fail if you
+try to call them while :c:func:`Py_RunMain` is running.

--- a/Misc/NEWS.d/next/C API/2024-06-25-11-25-09.gh-issue-120838.hOb-9v.rst
+++ b/Misc/NEWS.d/next/C API/2024-06-25-11-25-09.gh-issue-120838.hOb-9v.rst
@@ -1,2 +1,0 @@
-:c:func:`PyFinalize` and :c:func:`PyFinalizeEx` now explicitly fail if you
-try to call them while :c:func:`Py_RunMain` is running.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -711,18 +711,24 @@ pymain_exit_error(PyStatus status)
 }
 
 
+extern int _Py_FinalizeMain(void);
+
 int
 Py_RunMain(void)
 {
     int exitcode = 0;
 
+    _PyRuntime.is_pymain = 1;
+
     pymain_run_python(&exitcode);
 
-    if (Py_FinalizeEx() < 0) {
+    if (_Py_FinalizeMain() < 0) {
         /* Value unlikely to be confused with a non-error exit status or
            other special meaning */
         exitcode = 120;
     }
+
+    _PyRuntime.is_pymain = 0;
 
     pymain_free();
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1914,19 +1914,21 @@ _Py_Finalize(_PyRuntimeState *runtime, struct pyfinalize_args *args)
 {
     int status = 0;
 
+    /* Bail out early if already finalized. */
     if (!runtime->initialized) {
         assert(!runtime->is_pymain);
         return status;
     }
 
+    /* Make sure Py_RunMain() users aren't calling Py_Finalize(). */
     if (args->check_pymain && runtime->is_pymain) {
         fprintf(stderr,
-                "%s() should not be called while Py_RunMain() is running",
+                "%s() should not be called while Py_RunMain() is running\n",
                 args->caller);
-        return 1;
+        return -1;
     }
 
-    /* Get current thread state and interpreter pointer */
+    /* Get final thread state pointer. */
     PyThreadState *tstate = _PyThreadState_GET();
     assert(tstate->interp->runtime == runtime);
     // XXX assert(_Py_IsMainInterpreter(tstate->interp));

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3255,7 +3255,11 @@ Py_Exit(int sts)
     if (tstate != NULL && _PyThreadState_IsRunningMain(tstate)) {
         _PyInterpreterState_SetNotRunningMain(tstate->interp);
     }
-    if (Py_FinalizeEx() < 0) {
+    struct pyfinalize_args args = {
+        .caller = "Py_Exit",
+        /* We don't worry about checking if Py_RunMain() is running. */
+    };
+    if (_Py_Finalize(&_PyRuntime, &args) < 0) {
         sts = 120;
     }
 


### PR DESCRIPTION
`Py_RunMain()` is responsible for finalizing the runtime.  Extension modules should never call `Py_Finalize()`.  Enforcing this helps keep finalization conceptually simpler and helps get closer to making the `Py_Finalize()` implementation simpler in practice.

Note that the relevant docs change is part of gh-120839.

<!-- gh-issue-number: gh-120838 -->
* Issue: gh-120838
<!-- /gh-issue-number -->
