### PR TITLE
gh-120823: The ftplib.FTP.retrbinary `cmd` argument should be a "RETR" command

### DIFF
--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -243,7 +243,7 @@ FTP objects
       Retrieve a file in binary transfer mode.
 
       :param str cmd:
-        An appropriate ``STOR`` command: :samp:`"STOR {filename}"`.
+        An appropriate ``RETR`` command: :samp:`"RETR {filename}"`.
 
       :param callback:
          A single parameter callable that is called


### PR DESCRIPTION
Documentation of `ftplib`: The ftplib.FTP.retrbinary `cmd` argument should be a `"RETR"` command not a `"STOR"` command.

<!-- gh-issue-number: gh-120823 -->
* Issue: gh-120823
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120869.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->