### PR TITLE
docs: puremagic.what() as replacement for imghdr.what()

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1307,6 +1307,9 @@ PEP 594: dead batteries (and other module removals)
 
   * :mod:`!imghdr`: use the projects :pypi:`filetype`,
     :pypi:`puremagic`, or :pypi:`python-magic` instead.
+    The `puremagic.what()` function can be used to replace
+    the `imghdr.what()` function for all file formats that
+    were supported by `imghdr`.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
   * :mod:`!mailcap`.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1307,9 +1307,9 @@ PEP 594: dead batteries (and other module removals)
 
   * :mod:`!imghdr`: use the projects :pypi:`filetype`,
     :pypi:`puremagic`, or :pypi:`python-magic` instead.
-    The `puremagic.what()` function can be used to replace
-    the `imghdr.what()` function for all file formats that
-    were supported by `imghdr`.
+    The ``puremagic.what()`` function can be used to replace
+    the ``imghdr.what()`` function for all file formats that
+    were supported by ``imghdr``.
     (Contributed by Victor Stinner in :gh:`104773`.)
 
   * :mod:`!mailcap`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
### `puremagic.what()` was created as a drop-in replacement for `imghdr.what()`
```diff
  * :mod:`!imghdr`: use the projects :pypi:`filetype`,
    :pypi:`puremagic`, or :pypi:`python-magic` instead.
+   The `puremagic.what()` function can be used to replace
+   the `imghdr.what()` function for all file formats that
+   were supported by `imghdr`.
    (Contributed by Victor Stinner in :gh:`104773`.)
```
`puremagic` was chosen for file format compatibility and ease of installation.
* https://github.com/cdgriffith/puremagic#imghdr-replacement
* cdgriffith/puremagic#72
* cdgriffith/puremagic#76
* cdgriffith/puremagic#81

Implementation and tests:
* https://github.com/cdgriffith/puremagic/blob/096bc339cdd3660ec930a8b41a5c4849e5bdbc42/puremagic/main.py#L400
* https://github.com/cdgriffith/puremagic/blob/master/test/test_main.py

Other attempts for `filetype.py` and `python-magic` that were not merged:
* h2non/filetype.py#178
* ahupp/python-magic#326

@Yhg1s @vstinner @cdgriffith Your reviews, please.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120871.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->