### PR TITLE
gh-120868: Fix breaking change in `logging.config` when using `QueueHandler`

### DIFF
--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -780,25 +780,37 @@ class DictConfigurator(BaseConfigurator):
                 # if 'handlers' not in config:
                     # raise ValueError('No handlers specified for a QueueHandler')
                 if 'queue' in config:
-                    from multiprocessing.queues import Queue as MPQueue
-                    from multiprocessing import Manager as MM
-                    proxy_queue = MM().Queue()
-                    proxy_joinable_queue = MM().JoinableQueue()
                     qspec = config['queue']
-                    if not isinstance(qspec, (queue.Queue, MPQueue,
-                                      type(proxy_queue), type(proxy_joinable_queue))):
-                        if isinstance(qspec, str):
-                            q = self.resolve(qspec)
-                            if not callable(q):
-                                raise TypeError('Invalid queue specifier %r' % qspec)
-                            q = q()
-                        elif isinstance(qspec, dict):
-                            if '()' not in qspec:
-                                raise TypeError('Invalid queue specifier %r' % qspec)
-                            q = self.configure_custom(dict(qspec))
-                        else:
+
+                    if isinstance(qspec, str):
+                        q = self.resolve(qspec)
+                        if not callable(q):
                             raise TypeError('Invalid queue specifier %r' % qspec)
-                        config['queue'] = q
+                        config['queue'] = q()
+                    elif isinstance(qspec, dict):
+                        if '()' not in qspec:
+                            raise TypeError('Invalid queue specifier %r' % qspec)
+                        config['queue'] = self.configure_custom(dict(qspec))
+                    else:
+                        from multiprocessing.queues import Queue as MPQueue
+
+                        if not isinstance(qspec, (queue.Queue, MPQueue)):
+                            # Safely check if 'qspec' is an instance of Manager.Queue
+                            # / Manager.JoinableQueue
+
+                            from multiprocessing import Manager as MM
+                            from multiprocessing.managers import BaseProxy
+
+                            # if it's not an instance of BaseProxy, it also can't be
+                            # an instance of Manager.Queue / Manager.JoinableQueue
+                            if isinstance(qspec, BaseProxy):
+                                proxy_queue = MM().Queue()
+                                proxy_joinable_queue = MM().JoinableQueue()
+                                if not isinstance(qspec, (type(proxy_queue), type(proxy_joinable_queue))):
+                                    raise TypeError('Invalid queue specifier %r' % qspec)
+                            else:
+                                raise TypeError('Invalid queue specifier %r' % qspec)
+
                 if 'listener' in config:
                     lspec = config['listener']
                     if isinstance(lspec, type):

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -804,8 +804,15 @@ class DictConfigurator(BaseConfigurator):
                             # if it's not an instance of BaseProxy, it also can't be
                             # an instance of Manager.Queue / Manager.JoinableQueue
                             if isinstance(qspec, BaseProxy):
-                                proxy_queue = MM().Queue()
-                                proxy_joinable_queue = MM().JoinableQueue()
+                                # Sometimes manager or queue creation might fail
+                                # (e.g. see issue gh-120868). In that case, any
+                                # exception during the creation of these queues will
+                                # propagate up to the caller and be wrapped in a
+                                # `ValueError`, whose cause will indicate the details of
+                                # the failure.
+                                mm = MM()
+                                proxy_queue = mm.Queue()
+                                proxy_joinable_queue = mm.JoinableQueue()
                                 if not isinstance(qspec, (type(proxy_queue), type(proxy_joinable_queue))):
                                     raise TypeError('Invalid queue specifier %r' % qspec)
                             else:

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3928,6 +3928,50 @@ class ConfigDictTest(BaseTest):
             msg = str(ctx.exception)
             self.assertEqual(msg, "Unable to configure handler 'ah'")
 
+    @threading_helper.requires_working_threading()
+    @support.requires_subprocess()
+    @patch("multiprocessing.Manager")
+    def test_config_queue_handler_does_not_create_multiprocessing_manager(self, manager):
+        # gh-120868
+
+        from multiprocessing import Queue as MQ
+
+        q1 = {"()": "queue.Queue", "maxsize": -1}
+        q2 = MQ()
+        q3 = queue.Queue()
+
+        for qspec in (q1, q2, q3):
+            self.apply_config(
+                {
+                    "version": 1,
+                    "handlers": {
+                        "queue_listener": {
+                            "class": "logging.handlers.QueueHandler",
+                            "queue": qspec,
+                        },
+                    },
+                }
+            )
+            manager.assert_not_called()
+
+    @patch("multiprocessing.Manager")
+    def test_config_queue_handler_invalid_config_does_not_create_multiprocessing_manager(self, manager):
+        # gh-120868
+
+        with self.assertRaises(ValueError):
+            self.apply_config(
+                {
+                    "version": 1,
+                    "handlers": {
+                        "queue_listener": {
+                            "class": "logging.handlers.QueueHandler",
+                            "queue": object(),
+                        },
+                    },
+                }
+            )
+        manager.assert_not_called()
+
     @support.requires_subprocess()
     def test_multiprocessing_queues(self):
         # See gh-119819

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1318,6 +1318,7 @@ Hrvoje Nikšić
 Gregory Nofi
 Jesse Noller
 Bill Noon
+Janek Nouvertné
 Stefan Norberg
 Tim Northover
 Joe Norton

--- a/Misc/NEWS.d/next/Library/2024-06-22-11-59-13.gh-issue-120868.XHJ12L.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-22-11-59-13.gh-issue-120868.XHJ12L.rst
@@ -1,0 +1,6 @@
+Fix a bug in :mod:`logging.config` that would eagerly create an instance of
+:class:`multiprocessing.Manager` when configuring a queue_listener with
+:class:`logging.handlers.QueueHandler`. This could cause issue in environments where
+``multiprocessing.Manager`` does not work. The new implementation will only check for
+these types when it has been verified that ``multiprocessing.Manager`` has been used to
+create the ``queue`` in the logging configuration in question.

--- a/Misc/NEWS.d/next/Library/2024-06-22-11-59-13.gh-issue-120868.XHJ12L.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-22-11-59-13.gh-issue-120868.XHJ12L.rst
@@ -1,6 +1,0 @@
-Fix a bug in :mod:`logging.config` that would eagerly create an instance of
-:class:`multiprocessing.Manager` when configuring a queue_listener with
-:class:`logging.handlers.QueueHandler`. This could cause issue in environments where
-``multiprocessing.Manager`` does not work. The new implementation will only check for
-these types when it has been verified that ``multiprocessing.Manager`` has been used to
-create the ``queue`` in the logging configuration in question.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

#120868 was caused by an eager construction of `multiprocessing.Manager` used to check if the `queue` passed in to the logging config was an instance of `multiprocessing.Manager.Queue` / `multiprocessing.Manager.JoinableQueue`. This could cause unexpected exceptions in environments where a `multiprocessing.Manager` couldn't be created. 

The proposed fix moves the check for these classes, and creation of `multiprocessing.Manager` which is necessary for this, to a point where we've ruled out all other valid options for `queue`, and are certain that `multiprocessing.Manager` has been used to produce the object passed via `queue`.

<!-- gh-issue-number: gh-120868 -->
* Issue: gh-120868
<!-- /gh-issue-number -->
