### PR TITLE
gh-120896: Fix typo in version changed note of `urllib.parse.urlparse()`

### DIFF
--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -173,7 +173,7 @@ or on combining URL components into a URL string.
       Added IPv6 URL parsing capabilities.
 
    .. versionchanged:: 3.3
-      The fragment is now parsed for all URL schemes (unless *allow_fragment* is
+      The fragment is now parsed for all URL schemes (unless *allow_fragments* is
       false), in accordance with :rfc:`3986`.  Previously, an allowlist of
       schemes that support fragments existed.
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-120896 -->
* Issue: gh-120896
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120898.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->