### PR TITLE
[3.12] gh-101830: Fix Tcl_Obj to string conversion (GH-120884)

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-06-22-22-23-56.gh-issue-101830.1BAoxH.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-22-22-23-56.gh-issue-101830.1BAoxH.rst
@@ -1,0 +1,2 @@
+Accessing the :mod:`tkinter` object's string representation no longer converts
+the underlying Tcl object to a string on Windows.


### PR DESCRIPTION
Accessing the Tkinter object's string representation no longer converts the underlying Tcl object to a string on Windows.
(cherry picked from commit f4ddaa396715855ffbd94590f89ab7d55feeec07)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-101830 -->
* Issue: gh-101830
<!-- /gh-issue-number -->
