### PR TITLE
gh-120937: Reference weakref from the __del__ documentation

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1667,7 +1667,7 @@ Basic customization
 
    It is not guaranteed that :meth:`__del__` methods are called for objects
    that still exist when the interpreter exits.
-   :class:`~weakref.finalize` provides a straight forward way to register
+   :class:`weakref.finalize` provides a straightforward way to register
    a cleanup function to be called when an object is garbage collected.
 
    .. note::

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1667,6 +1667,8 @@ Basic customization
 
    It is not guaranteed that :meth:`__del__` methods are called for objects
    that still exist when the interpreter exits.
+   :class:`~weakref.finalize` provides a straight forward way to register
+   a cleanup function to be called when an object is garbage collected.
 
    .. note::
 


### PR DESCRIPTION
#120937 

The weakref documentation refers to `__del__`, but not the other way around.

I am not sure the phrasing (copy/paste from weakref doc) is the best one, but it seems important to me redirect developers to what they are most probably looking for. 





<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120940.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->