### PR TITLE
gh-120953: Add UOp Paircounts to JIT when Built with PyStats

### DIFF
--- a/Include/cpython/optimizer.h
+++ b/Include/cpython/optimizer.h
@@ -72,6 +72,7 @@ typedef struct _PyExecutorObject {
     uint32_t exit_count;
     uint32_t code_size;
     size_t jit_size;
+    uint16_t last_uop;
     void *jit_code;
     void *jit_side_entry;
     _PyExitData exits[1];

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1215,6 +1215,7 @@ make_executor_from_uops(_PyUOpInstruction *buffer, int length, const _PyBloomFil
     executor->jit_code = NULL;
     executor->jit_side_entry = NULL;
     executor->jit_size = 0;
+    executor->last_uop = 0;
     if (_PyJIT_Compile(executor, executor->trace, length)) {
         Py_DECREF(executor);
         return NULL;

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -44,11 +44,13 @@ class _Target(typing.Generic[_S, _R]):
     stable: bool = False
     debug: bool = False
     verbose: bool = False
+    pystats: bool = False
 
     def _compute_digest(self, out: pathlib.Path) -> str:
         hasher = hashlib.sha256()
         hasher.update(self.triple.encode())
         hasher.update(self.debug.to_bytes())
+        hasher.update(self.pystats.to_bytes())
         # These dependencies are also reflected in _JITSources in regen.targets:
         hasher.update(PYTHON_EXECUTOR_CASES_C_H.read_bytes())
         hasher.update((out / "pyconfig.h").read_bytes())
@@ -142,6 +144,8 @@ class _Target(typing.Generic[_S, _R]):
             "-std=c11",
             *self.args,
         ]
+        if self.pystats:
+            args.append("-DPy_STATS=1")
         if self.ghccc:
             # This is a bit of an ugly workaround, but it makes the code much
             # smaller and faster, so it's worth it. We want to use the GHC

--- a/Tools/jit/build.py
+++ b/Tools/jit/build.py
@@ -14,6 +14,9 @@ if __name__ == "__main__":
         "target", type=_targets.get_target, help="a PEP 11 target triple to compile for"
     )
     parser.add_argument(
+        "--pystats", action="store_true", help="compile for a pystats build of Python"
+    )
+    parser.add_argument(
         "-d", "--debug", action="store_true", help="compile for a debug build of Python"
     )
     parser.add_argument(
@@ -25,4 +28,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
     args.target.debug = args.debug
     args.target.verbose = args.verbose
+    args.target.pystats = args.pystats
     args.target.build(pathlib.Path.cwd(), comment=comment, force=args.force)

--- a/Tools/jit/template.c
+++ b/Tools/jit/template.c
@@ -102,8 +102,15 @@ _JIT_ENTRY(_PyInterpreterFrame *frame, PyObject **stack_pointer, PyThreadState *
     PATCH_VALUE(uint32_t, _target, _JIT_TARGET)
     PATCH_VALUE(uint16_t, _exit_index, _JIT_EXIT_INDEX)
 
+    int uopcode = uopcode_array[0];
+
     OPT_STAT_INC(uops_executed);
     UOP_STAT_INC(uopcode, execution_count);
+
+#ifdef Py_STATS
+    UOP_PAIR_INC(uopcode, current_executor->last_uop);
+    current_executor->last_uop = uopcode;
+#endif
 
     // The actual instruction definitions (only one will be used):
     if (uopcode == _JUMP_TO_TOP) {

--- a/Tools/jit/template.c
+++ b/Tools/jit/template.c
@@ -4,6 +4,7 @@
 #include "pycore_call.h"
 #include "pycore_ceval.h"
 #include "pycore_cell.h"
+#include "pycore_code.h"
 #include "pycore_dict.h"
 #include "pycore_emscripten_signal.h"
 #include "pycore_intrinsics.h"

--- a/Tools/jit/template.c
+++ b/Tools/jit/template.c
@@ -102,8 +102,6 @@ _JIT_ENTRY(_PyInterpreterFrame *frame, PyObject **stack_pointer, PyThreadState *
     PATCH_VALUE(uint32_t, _target, _JIT_TARGET)
     PATCH_VALUE(uint16_t, _exit_index, _JIT_EXIT_INDEX)
 
-    int uopcode = uopcode_array[0];
-
     OPT_STAT_INC(uops_executed);
     UOP_STAT_INC(uopcode, execution_count);
 

--- a/configure
+++ b/configure
@@ -8260,6 +8260,11 @@ else $as_nop
 then :
   as_fn_append REGEN_JIT_COMMAND " --debug"
 fi
+           if test "x$enable_pystats" = xyes
+then :
+  as_fn_append REGEN_JIT_COMMAND " --pystats"
+fi
+
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1798,7 +1798,12 @@ AS_VAR_IF([jit_flags],
            AS_VAR_IF([Py_DEBUG],
                      [true],
                      [AS_VAR_APPEND([REGEN_JIT_COMMAND], [" --debug"])],
-                     [])])
+                     [])
+           AS_VAR_IF([enable_pystats],
+                     [yes],
+                     [AS_VAR_APPEND([REGEN_JIT_COMMAND], [" --pystats"])],
+                     [])
+                    ])
 AC_SUBST([REGEN_JIT_COMMAND])
 AC_SUBST([JIT_STENCILS_H])
 AC_MSG_RESULT([$tier2_flags $jit_flags])


### PR DESCRIPTION
Currently, uop pairs are only counted in a PyStats build when it is build with just the Tier 2 interpreter *without the JIT*. This PR adds uop pair counting when running with the JIT, by adding an additional `last_uop` field to the `_PyExecutorObject` struct.

It also adds a new `--pystats` flag to `Tools/jit/build.py`. This enables/disables the lines which cause the executor to track its last uop, since there's no point in doing so if we're not tracking pystats. This flag is included in the hash that is used to determine whether the jit stencils need to be rebuilt, so that pystats stencils are not accidently used in a non-pystats build and vice-versa.

The performance of this could potentially be improved by using a local variable inside `_PyJIT_Compile` to track the last uop, and emit that into the stencils directly?

<!-- gh-issue-number: gh-120953 -->
* Issue: gh-120953
<!-- /gh-issue-number -->
