### PR TITLE
gh-119521: Use `PyAPI_DATA`, not `extern`, for `_PyExc_IncompleteInpu…tError`

### DIFF
--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -168,7 +168,8 @@ void _PyErr_FormatNote(const char *format, ...);
 Py_DEPRECATED(3.12) extern void _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);
 
 // implementation detail for the codeop module.
-extern PyTypeObject _PyExc_IncompleteInputError;
+// Exported for test.test_peg_generator.test_c_parser
+PyAPI_DATA(PyTypeObject) _PyExc_IncompleteInputError;
 #define PyExc_IncompleteInputError ((PyObject *)(&_PyExc_IncompleteInputError))
 
 #ifdef __cplusplus


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119521 -->
* Issue: gh-119521
<!-- /gh-issue-number -->
