### PR TITLE
gh-120857: add a temporary global ``__name__`` within ``exec``

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -75,7 +75,9 @@ New Features
 Other Language Changes
 ======================
 
+* TODO.
 
+  (Contributed by Bénédikt Tran in :gh:`120857`.)
 
 New Modules
 ===========

--- a/Lib/test/test_subclassinit.py
+++ b/Lib/test/test_subclassinit.py
@@ -276,6 +276,19 @@ class Test(unittest.TestCase):
         with self.assertRaises(TypeError):
             type(name='NewClass', bases=(object,), dict={})
 
+    def test_type_set_module(self):
+        A = type('A', (), {})
+        self.assertTrue(hasattr(A, '__module__'))
+        self.assertEqual(A.__module__, __name__)
+
+        Parent = type('Parent', (), {'__module__': 'foo'})
+        self.assertTrue(hasattr(Parent, '__module__'))
+        self.assertEqual(Parent.__module__, 'foo')
+
+        Child = type('Child', (Parent,), {})
+        self.assertTrue(hasattr(Child, '__module__'))
+        self.assertEqual(Child.__module__, __name__)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-24-17-03-03.gh-issue-120857.nehV6X.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-24-17-03-03.gh-issue-120857.nehV6X.rst
@@ -1,0 +1,1 @@
+TODO. Patch by Bénédikt Tran.


### PR DESCRIPTION
This is a PoC to solve the following issue:

```python
>>> exec('class A: pass')
>>> A.__module__
'__main__'
>>> exec('class A: pass;\nB=type("B", (A,), {})')
>>> B.__module__
'__main__'
>>> exec('class A: pass', ns := {})
>>> ns['A'].__module__
'builtins'
>>> exec('class A: pass;\nB=type("B", (A,), {})', ns := {}); 
>>> ns['B'].__module__
...
AttributeError: __module__. Did you mean: '__reduce__'?
```

The issue is that when a user specifies their own globals(), we don't have `__name__`. However, this breaks the data model which guarantees that classes always have `__module__` attributes.

I'm not sure how to fix it differently so I'm open to comments!

<!-- gh-issue-number: gh-120857 -->
* Issue: gh-120857
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--120957.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->