### PR TITLE
Fixes loop variable types to be the same size as their limit

### DIFF
--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -202,7 +202,7 @@ _io_open_impl(PyObject *module, PyObject *file, const char *mode,
               const char *newline, int closefd, PyObject *opener)
 /*[clinic end generated code: output=aefafc4ce2b46dc0 input=cd034e7cdfbf4e78]*/
 {
-    unsigned i;
+    size_t i;
 
     int creating = 0, reading = 0, writing = 0, appending = 0, updating = 0;
     int text = 0, binary = 0;

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -99,7 +99,7 @@ blob_close_impl(pysqlite_Blob *self)
 void
 pysqlite_close_all_blobs(pysqlite_Connection *self)
 {
-    for (int i = 0; i < PyList_GET_SIZE(self->blobs); i++) {
+    for (Py_ssize_t i = 0; i < PyList_GET_SIZE(self->blobs); i++) {
         PyObject *weakref = PyList_GET_ITEM(self->blobs, i);
         PyObject *blob;
         if (!PyWeakref_GetRef(weakref, &blob)) {

--- a/Modules/_testinternalcapi/test_critical_sections.c
+++ b/Modules/_testinternalcapi/test_critical_sections.c
@@ -185,7 +185,7 @@ test_critical_sections_threads(PyObject *self, PyObject *Py_UNUSED(args))
     assert(test_data.obj2 != NULL);
     assert(test_data.obj3 != NULL);
 
-    for (int i = 0; i < NUM_THREADS; i++) {
+    for (Py_ssize_t i = 0; i < NUM_THREADS; i++) {
         PyThread_start_new_thread(&thread_critical_sections, &test_data);
     }
     PyEvent_Wait(&test_data.done_event);
@@ -271,7 +271,7 @@ test_critical_sections_gc(PyObject *self, PyObject *Py_UNUSED(args))
     };
     assert(test_data.obj != NULL);
 
-    for (int i = 0; i < NUM_THREADS; i++) {
+    for (Py_ssize_t i = 0; i < NUM_THREADS; i++) {
         PyThread_start_new_thread(&thread_gc, &test_data);
     }
     PyEvent_Wait(&test_data.done_event);

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -573,7 +573,7 @@ get_line_delta(const uint8_t *ptr)
 static PyObject *
 remove_column_info(PyObject *locations)
 {
-    int offset = 0;
+    Py_ssize_t offset = 0;
     const uint8_t *data = (const uint8_t *)PyBytes_AS_STRING(locations);
     PyObject *res = PyBytes_FromStringAndSize(NULL, 32);
     if (res == NULL) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8380,7 +8380,7 @@ PyUnicode_BuildEncodingMap(PyObject* string)
                 Py_DECREF(result);
                 return NULL;
             }
-            PyObject *value = PyLong_FromSsize_t(i);
+            PyObject *value = PyLong_FromLong(i);
             if (value == NULL) {
                 Py_DECREF(key);
                 Py_DECREF(result);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8321,7 +8321,7 @@ PyUnicode_BuildEncodingMap(PyObject* string)
     int count2 = 0, count3 = 0;
     int kind;
     const void *data;
-    Py_ssize_t length;
+    int length;
     Py_UCS4 ch;
 
     if (!PyUnicode_Check(string) || !PyUnicode_GET_LENGTH(string)) {
@@ -8330,8 +8330,7 @@ PyUnicode_BuildEncodingMap(PyObject* string)
     }
     kind = PyUnicode_KIND(string);
     data = PyUnicode_DATA(string);
-    length = PyUnicode_GET_LENGTH(string);
-    length = Py_MIN(length, 256);
+    length = (int)Py_MIN(PyUnicode_GET_LENGTH(string), 256);
     memset(level1, 0xFF, sizeof level1);
     memset(level2, 0xFF, sizeof level2);
 
@@ -8372,7 +8371,7 @@ PyUnicode_BuildEncodingMap(PyObject* string)
                 Py_DECREF(result);
                 return NULL;
             }
-            PyObject *value = PyLong_FromLong(i);
+            PyObject *value = PyLong_FromSsize_t(i);
             if (value == NULL) {
                 Py_DECREF(key);
                 Py_DECREF(result);

--- a/Objects/unionobject.c
+++ b/Objects/unionobject.c
@@ -81,7 +81,7 @@ is_same(PyObject *left, PyObject *right)
 static int
 contains(PyObject **items, Py_ssize_t size, PyObject *obj)
 {
-    for (int i = 0; i < size; i++) {
+    for (Py_ssize_t i = 0; i < size; i++) {
         int is_duplicate = is_same(items[i], obj);
         if (is_duplicate) {  // -1 or 1
             return is_duplicate;
@@ -97,7 +97,7 @@ merge(PyObject **items1, Py_ssize_t size1,
     PyObject *tuple = NULL;
     Py_ssize_t pos = 0;
 
-    for (int i = 0; i < size2; i++) {
+    for (Py_ssize_t i = 0; i < size2; i++) {
         PyObject *arg = items2[i];
         int is_duplicate = contains(items1, size1, arg);
         if (is_duplicate < 0) {

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -864,7 +864,7 @@ _PyPegen_make_module(Parser *p, asdl_stmt_seq *a) {
         if (type_ignores == NULL) {
             return NULL;
         }
-        for (int i = 0; i < num; i++) {
+        for (Py_ssize_t i = 0; i < num; i++) {
             PyObject *tag = _PyPegen_new_type_comment(p, p->type_ignore_comments.items[i].comment);
             if (tag == NULL) {
                 return NULL;

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -521,7 +521,7 @@ fold_binop(expr_ty node, PyArena *arena, _PyASTOptimizeState *state)
 static PyObject*
 make_const_tuple(asdl_expr_seq *elts)
 {
-    for (int i = 0; i < asdl_seq_LEN(elts); i++) {
+    for (Py_ssize_t i = 0; i < asdl_seq_LEN(elts); i++) {
         expr_ty e = (expr_ty)asdl_seq_GET(elts, i);
         if (e->kind != Constant_kind) {
             return NULL;
@@ -533,7 +533,7 @@ make_const_tuple(asdl_expr_seq *elts)
         return NULL;
     }
 
-    for (int i = 0; i < asdl_seq_LEN(elts); i++) {
+    for (Py_ssize_t i = 0; i < asdl_seq_LEN(elts); i++) {
         expr_ty e = (expr_ty)asdl_seq_GET(elts, i);
         PyObject *v = e->v.Constant.value;
         PyTuple_SET_ITEM(newval, i, Py_NewRef(v));
@@ -650,7 +650,7 @@ static int astfold_type_param(type_param_ty node_, PyArena *ctx_, _PyASTOptimize
         return 0;
 
 #define CALL_SEQ(FUNC, TYPE, ARG) { \
-    int i; \
+    Py_ssize_t i; \
     asdl_ ## TYPE ## _seq *seq = (ARG); /* avoid variable capture */ \
     for (i = 0; i < asdl_seq_LEN(seq); i++) { \
         TYPE ## _ty elt = (TYPE ## _ty)asdl_seq_GET(seq, i); \

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5109,7 +5109,7 @@ compiler_call_simple_kw_helper(struct compiler *c, location loc,
     if (names == NULL) {
         return ERROR;
     }
-    for (int i = 0; i < nkwelts; i++) {
+    for (Py_ssize_t i = 0; i < nkwelts; i++) {
         keyword_ty kw = asdl_seq_GET(keywords, i);
         PyTuple_SET_ITEM(names, i, Py_NewRef(kw->arg));
     }

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2095,7 +2095,7 @@ remove_unused_consts(basicblock *entryblock, PyObject *consts)
     /* now index_map[i] == i if consts[i] is used, -1 otherwise */
     /* condense consts */
     Py_ssize_t n_used_consts = 0;
-    for (int i = 0; i < nconsts; i++) {
+    for (Py_ssize_t i = 0; i < nconsts; i++) {
         if (index_map[i] != -1) {
             assert(index_map[i] == i);
             index_map[n_used_consts++] = index_map[i];

--- a/Python/future.c
+++ b/Python/future.c
@@ -8,7 +8,7 @@
 static int
 future_check_features(_PyFutureFeatures *ff, stmt_ty s, PyObject *filename)
 {
-    int i;
+    Py_ssize_t i;
 
     assert(s->kind == ImportFrom_kind);
 

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2070,7 +2070,8 @@ vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
     const char *format;
     const char *msg;
     PyObject *keyword;
-    int i, pos, len;
+    Py_ssize_t i;
+    int pos, len;
     Py_ssize_t nkwargs;
     freelistentry_t static_entries[STATIC_FREELIST_ENTRIES];
     freelist_t freelist;

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -146,7 +146,7 @@ _Py_CalculateSuggestions(PyObject *dir,
     if (buffer == NULL) {
         return PyErr_NoMemory();
     }
-    for (int i = 0; i < dir_size; ++i) {
+    for (Py_ssize_t i = 0; i < dir_size; ++i) {
         PyObject *item = PyList_GET_ITEM(dir, i);
         if (_PyUnicode_Equal(name, item)) {
             continue;

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -398,7 +398,7 @@ _PySymtable_Build(mod_ty mod, PyObject *filename, _PyFutureFeatures *future)
 {
     struct symtable *st = symtable_new();
     asdl_stmt_seq *seq;
-    int i;
+    Py_ssize_t i;
     PyThreadState *tstate;
     int starting_recursion_depth;
 
@@ -1594,7 +1594,7 @@ symtable_enter_type_param_block(struct symtable *st, identifier name,
 
 #define VISIT_SEQ(ST, TYPE, SEQ) \
     do { \
-        int i; \
+        Py_ssize_t i; \
         asdl_ ## TYPE ## _seq *seq = (SEQ); /* avoid variable capture */ \
         for (i = 0; i < asdl_seq_LEN(seq); i++) { \
             TYPE ## _ty elt = (TYPE ## _ty)asdl_seq_GET(seq, i); \
@@ -1605,7 +1605,7 @@ symtable_enter_type_param_block(struct symtable *st, identifier name,
 
 #define VISIT_SEQ_TAIL(ST, TYPE, SEQ, START) \
     do { \
-        int i; \
+        Py_ssize_t i; \
         asdl_ ## TYPE ## _seq *seq = (SEQ); /* avoid variable capture */ \
         for (i = (START); i < asdl_seq_LEN(seq); i++) { \
             TYPE ## _ty elt = (TYPE ## _ty)asdl_seq_GET(seq, i); \
@@ -1916,7 +1916,7 @@ symtable_visit_stmt(struct symtable *st, stmt_ty s)
         VISIT_SEQ(st, alias, s->v.ImportFrom.names);
         break;
     case Global_kind: {
-        int i;
+        Py_ssize_t i;
         asdl_identifier_seq *seq = s->v.Global.names;
         for (i = 0; i < asdl_seq_LEN(seq); i++) {
             identifier name = (identifier)asdl_seq_GET(seq, i);
@@ -1952,7 +1952,7 @@ symtable_visit_stmt(struct symtable *st, stmt_ty s)
         break;
     }
     case Nonlocal_kind: {
-        int i;
+        Py_ssize_t i;
         asdl_identifier_seq *seq = s->v.Nonlocal.names;
         for (i = 0; i < asdl_seq_LEN(seq); i++) {
             identifier name = (identifier)asdl_seq_GET(seq, i);
@@ -2494,7 +2494,7 @@ symtable_implicit_arg(struct symtable *st, int pos)
 static int
 symtable_visit_params(struct symtable *st, asdl_arg_seq *args)
 {
-    int i;
+    Py_ssize_t i;
 
     if (!args)
         return -1;
@@ -2555,7 +2555,7 @@ symtable_visit_annotation(struct symtable *st, expr_ty annotation, void *key)
 static int
 symtable_visit_argannotations(struct symtable *st, asdl_arg_seq *args)
 {
-    int i;
+    Py_ssize_t i;
 
     if (!args)
         return -1;


### PR DESCRIPTION
Apologies to all the code owners, but I can't keep you from being pinged. Just satisfying a static analyser that recognises these could potentially become infinite loops, by turning the `for (int i ...` pattern into `for (Py_ssize_t i` (with one exception in Unicode object that was better with an early truncation).