### PR TITLE
gh-112301: Enable compiler flags with low performance impact and no warnings

### DIFF
--- a/Misc/NEWS.d/next/Security/2024-06-25-04-42-43.gh-issue-112301.god4IC.rst
+++ b/Misc/NEWS.d/next/Security/2024-06-25-04-42-43.gh-issue-112301.god4IC.rst
@@ -1,1 +1,2 @@
-Add default compiler options to improve security
+Add default compiler options to improve security. Enable 
+-Wimplicit-fallthrough, -fstack-protector-strong, -Wtrampolines.

--- a/Misc/NEWS.d/next/Security/2024-06-25-04-42-43.gh-issue-112301.god4IC.rst
+++ b/Misc/NEWS.d/next/Security/2024-06-25-04-42-43.gh-issue-112301.god4IC.rst
@@ -1,2 +1,2 @@
-Add default compiler options to improve security. Enable 
+Add default compiler options to improve security. Enable
 -Wimplicit-fallthrough, -fstack-protector-strong, -Wtrampolines.

--- a/Misc/NEWS.d/next/Security/2024-06-25-04-42-43.gh-issue-112301.god4IC.rst
+++ b/Misc/NEWS.d/next/Security/2024-06-25-04-42-43.gh-issue-112301.god4IC.rst
@@ -1,0 +1,1 @@
+Add default compiler options to improve security

--- a/configure
+++ b/configure
@@ -9605,7 +9605,6 @@ else $as_nop
   BASECFLAGS="$BASECFLAGS $NO_STRICT_OVERFLOW_CFLAGS"
 fi
 
-
 # Enable flags that warn and protect for potential security vulnerabilities.
 # These flags should be enabled by default for all builds.
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -Wimplicit-fallthrough" >&5
@@ -9684,45 +9683,6 @@ then :
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: -fstack-protector-strong not supported" >&5
 printf "%s\n" "$as_me: WARNING: -fstack-protector-strong not supported" >&2;}
-fi
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -fno-strict-overflow" >&5
-printf %s "checking whether C compiler accepts -fno-strict-overflow... " >&6; }
-if test ${ax_cv_check_cflags___fno_strict_overflow+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-
-  ax_check_save_flags=$CFLAGS
-  CFLAGS="$CFLAGS  -fno-strict-overflow"
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  ax_cv_check_cflags___fno_strict_overflow=yes
-else $as_nop
-  ax_cv_check_cflags___fno_strict_overflow=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-  CFLAGS=$ax_check_save_flags
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___fno_strict_overflow" >&5
-printf "%s\n" "$ax_cv_check_cflags___fno_strict_overflow" >&6; }
-if test "x$ax_cv_check_cflags___fno_strict_overflow" = xyes
-then :
-  BASECFLAGS="$BASECFLAGS -fno-strict-overflow"
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: -fno-strict-overflow not supported" >&5
-printf "%s\n" "$as_me: WARNING: -fno-strict-overflow not supported" >&2;}
 fi
 
 case $CC in

--- a/configure
+++ b/configure
@@ -9605,6 +9605,170 @@ else $as_nop
   BASECFLAGS="$BASECFLAGS $NO_STRICT_OVERFLOW_CFLAGS"
 fi
 
+
+# Enable flags that warn and protect for potential security vulnerabilities.
+# These flags should be enabled by default for all builds.
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -Wimplicit-fallthrough" >&5
+printf %s "checking whether C compiler accepts -Wimplicit-fallthrough... " >&6; }
+if test ${ax_cv_check_cflags___Wimplicit_fallthrough+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -Wimplicit-fallthrough"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___Wimplicit_fallthrough=yes
+else $as_nop
+  ax_cv_check_cflags___Wimplicit_fallthrough=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___Wimplicit_fallthrough" >&5
+printf "%s\n" "$ax_cv_check_cflags___Wimplicit_fallthrough" >&6; }
+if test "x$ax_cv_check_cflags___Wimplicit_fallthrough" = xyes
+then :
+  BASECFLAGS="$BASECFLAGS -Wimplicit-fallthrough"
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: -Wimplicit-fallthrough not supported" >&5
+printf "%s\n" "$as_me: WARNING: -Wimplicit-fallthrough not supported" >&2;}
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -fstack-protector-strong" >&5
+printf %s "checking whether C compiler accepts -fstack-protector-strong... " >&6; }
+if test ${ax_cv_check_cflags___fstack_protector_strong+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -fstack-protector-strong"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___fstack_protector_strong=yes
+else $as_nop
+  ax_cv_check_cflags___fstack_protector_strong=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___fstack_protector_strong" >&5
+printf "%s\n" "$ax_cv_check_cflags___fstack_protector_strong" >&6; }
+if test "x$ax_cv_check_cflags___fstack_protector_strong" = xyes
+then :
+  BASECFLAGS="$BASECFLAGS -fstack-protector-strong"
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: -fstack-protector-strong not supported" >&5
+printf "%s\n" "$as_me: WARNING: -fstack-protector-strong not supported" >&2;}
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -fno-strict-overflow" >&5
+printf %s "checking whether C compiler accepts -fno-strict-overflow... " >&6; }
+if test ${ax_cv_check_cflags___fno_strict_overflow+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -fno-strict-overflow"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___fno_strict_overflow=yes
+else $as_nop
+  ax_cv_check_cflags___fno_strict_overflow=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___fno_strict_overflow" >&5
+printf "%s\n" "$ax_cv_check_cflags___fno_strict_overflow" >&6; }
+if test "x$ax_cv_check_cflags___fno_strict_overflow" = xyes
+then :
+  BASECFLAGS="$BASECFLAGS -fno-strict-overflow"
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: -fno-strict-overflow not supported" >&5
+printf "%s\n" "$as_me: WARNING: -fno-strict-overflow not supported" >&2;}
+fi
+
+case $CC in
+  *gcc*)
+    # Add GCC-specific compiler flags
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -Wtrampolines" >&5
+printf %s "checking whether C compiler accepts -Wtrampolines... " >&6; }
+if test ${ax_cv_check_cflags___Wtrampolines+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -Wtrampolines"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___Wtrampolines=yes
+else $as_nop
+  ax_cv_check_cflags___Wtrampolines=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___Wtrampolines" >&5
+printf "%s\n" "$ax_cv_check_cflags___Wtrampolines" >&6; }
+if test "x$ax_cv_check_cflags___Wtrampolines" = xyes
+then :
+  BASECFLAGS="$BASECFLAGS -Wtrampolines"
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: -Wtrampolines not supported" >&5
+printf "%s\n" "$as_me: WARNING: -Wtrampolines not supported" >&2;}
+fi
+
+esac
+
 case $GCC in
 yes)
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c11"

--- a/configure.ac
+++ b/configure.ac
@@ -2451,12 +2451,10 @@ AS_VAR_IF([with_strict_overflow], [yes],
           [BASECFLAGS="$BASECFLAGS $STRICT_OVERFLOW_CFLAGS"],
           [BASECFLAGS="$BASECFLAGS $NO_STRICT_OVERFLOW_CFLAGS"])
 
-
 # Enable flags that warn and protect for potential security vulnerabilities.
 # These flags should be enabled by default for all builds.
 AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough], [BASECFLAGS="$BASECFLAGS -Wimplicit-fallthrough"], [AC_MSG_WARN([-Wimplicit-fallthrough not supported])])
 AX_CHECK_COMPILE_FLAG([-fstack-protector-strong], [BASECFLAGS="$BASECFLAGS -fstack-protector-strong"], [AC_MSG_WARN([-fstack-protector-strong not supported])])
-AX_CHECK_COMPILE_FLAG([-fno-strict-overflow], [BASECFLAGS="$BASECFLAGS -fno-strict-overflow"], [AC_MSG_WARN([-fno-strict-overflow not supported])])
 case $CC in
   *gcc*)
     # Add GCC-specific compiler flags          

--- a/configure.ac
+++ b/configure.ac
@@ -2451,6 +2451,18 @@ AS_VAR_IF([with_strict_overflow], [yes],
           [BASECFLAGS="$BASECFLAGS $STRICT_OVERFLOW_CFLAGS"],
           [BASECFLAGS="$BASECFLAGS $NO_STRICT_OVERFLOW_CFLAGS"])
 
+
+# Enable flags that warn and protect for potential security vulnerabilities.
+# These flags should be enabled by default for all builds.
+AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough], [BASECFLAGS="$BASECFLAGS -Wimplicit-fallthrough"], [AC_MSG_WARN([-Wimplicit-fallthrough not supported])])
+AX_CHECK_COMPILE_FLAG([-fstack-protector-strong], [BASECFLAGS="$BASECFLAGS -fstack-protector-strong"], [AC_MSG_WARN([-fstack-protector-strong not supported])])
+AX_CHECK_COMPILE_FLAG([-fno-strict-overflow], [BASECFLAGS="$BASECFLAGS -fno-strict-overflow"], [AC_MSG_WARN([-fno-strict-overflow not supported])])
+case $CC in
+  *gcc*)
+    # Add GCC-specific compiler flags          
+    AX_CHECK_COMPILE_FLAG([-Wtrampolines], [BASECFLAGS="$BASECFLAGS -Wtrampolines"], [AC_MSG_WARN([-Wtrampolines not supported])])
+esac
+
 case $GCC in
 yes)
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c11"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This PR enables a few default compiler options in an effort to improve security. The options enabled here are:

`-Wimplicit-fallthrough -fstack-protector-strong -fno-strict-overflow -Wtrampolines`

These have been found to have little to no pyperformance benchmark impact and don't introduce any new warnings.

The pyperf benchmark for this configuration can be viewed here: https://github.com/faster-cpython/benchmarking-public/tree/main/results/bm-20240620-3.14.0a0-98d9ea0

This will be one of several PRs addressing the issue: #112301 

<!-- gh-issue-number: gh-112301 -->
* Issue: gh-112301
<!-- /gh-issue-number -->
