### PR TITLE
gh-120857: set __module__ to None for class created with unavailable module

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -2715,7 +2715,7 @@ class TestType(unittest.TestCase):
         ns = {}
         exec("A = type('A', (), {})", ns)
         self.assertIs(ns['A'].__module__, None)
-    
+
     def test_namespace_order(self):
         # bpo-34320: namespace should preserve order
         od = collections.OrderedDict([('a', 1), ('b', 2)])

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -2711,6 +2711,11 @@ class TestType(unittest.TestCase):
         with self.assertRaises(TypeError):
             type('A', (B,), {'__slots__': '__weakref__'})
 
+    def test_type_unavailable_module(self):
+        ns = {}
+        exec("A = type('A', (), {})", ns)
+        self.assertIs(ns['A'].__module__, None)
+    
     def test_namespace_order(self):
         # bpo-34320: namespace should preserve order
         od = collections.OrderedDict([('a', 1), ('b', 2)])

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-25-01-40-37.gh-issue-120857.tXeihl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-25-01-40-37.gh-issue-120857.tXeihl.rst
@@ -1,0 +1,1 @@
+The ``__module__`` attribute of a class is now set to ``None`` when the module name is unavailable, like how it is for function and method.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-25-01-40-37.gh-issue-120857.tXeihl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-25-01-40-37.gh-issue-120857.tXeihl.rst
@@ -1,1 +1,2 @@
 The ``__module__`` attribute of a class is now set to ``None`` when the module name is unavailable, like how it is for function and method.
+Patch by Ben Hsing

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3946,9 +3946,8 @@ type_new_set_module(PyTypeObject *type)
         return 0;
     }
 
-    PyObject *globals = PyEval_GetGlobals();
     PyObject *module;
-    if (globals != NULL &&
+    if (PyEval_GetGlobals() != NULL &&
         PyDict_GetItemRef(globals, &_Py_ID(__name__), &module) == 1 && module) {
         r = PyDict_SetItem(dict, &_Py_ID(__module__), module);
         Py_DECREF(module);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3946,8 +3946,9 @@ type_new_set_module(PyTypeObject *type)
         return 0;
     }
 
+    PyObject *globals = PyEval_GetGlobals();
     PyObject *module;
-    if (PyEval_GetGlobals() != NULL &&
+    if (globals != NULL &&
         PyDict_GetItemRef(globals, &_Py_ID(__name__), &module) == 1 && module) {
         r = PyDict_SetItem(dict, &_Py_ID(__module__), module);
         Py_DECREF(module);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3947,16 +3947,13 @@ type_new_set_module(PyTypeObject *type)
     }
 
     PyObject *globals = PyEval_GetGlobals();
-    if (globals == NULL) {
-        return 0;
-    }
-
     PyObject *module;
-    r = PyDict_GetItemRef(globals, &_Py_ID(__name__), &module);
-    if (module) {
+    if (globals != NULL &&
+        PyDict_GetItemRef(globals, &_Py_ID(__name__), &module) == 1 && module) {
         r = PyDict_SetItem(dict, &_Py_ID(__module__), module);
         Py_DECREF(module);
-    }
+    } else
+        r = PyDict_SetItem(dict, &_Py_ID(__module__), Py_None);
     return r;
 }
 


### PR DESCRIPTION
# Set __module__ to None for a class created with no module name available

Although class, function and method all have the `__module__` attribute, only with the latter two is the attribute set to `None` when created with no module name available. A class created with no module name available is currently missing the `__module__` attribute.

This PR brings the behavior of `class.__module__` to parity with those of function and method so that the `__module__` attribute is always set to `None` when the module name isn't available.

<!-- gh-issue-number: gh-120857 -->
* Issue: gh-120857
<!-- /gh-issue-number -->
