### PR TITLE
Add fast path in count_elements

### DIFF
--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2575,7 +2575,11 @@ _collections__count_elements_impl(PyObject *module, PyObject *mapping,
             oldval = PyObject_CallFunctionObjArgs(bound_get, key, zero, NULL);
             if (oldval == NULL)
                 break;
-            newval = PyNumber_Add(oldval, one);
+            if (oldval == zero) {
+                newval = Py_NewRef(one);
+            } else {
+                newval = PyNumber_Add(oldval, one);
+            }
             Py_DECREF(oldval);
             if (newval == NULL)
                 break;


### PR DESCRIPTION
A common case is that bound `get()` returns the default.  In this case, the addition step can be skipped because we already know the result.