### PR TITLE
gh-119521: Remove _IncompleteInputError from the docs

### DIFF
--- a/Lib/test/exception_hierarchy.txt
+++ b/Lib/test/exception_hierarchy.txt
@@ -45,7 +45,6 @@ BaseException
       ├── StopAsyncIteration
       ├── StopIteration
       ├── SyntaxError
-      │    └── _IncompleteInputError
       │    └── IndentationError
       │         └── TabError
       ├── SystemError

--- a/Lib/test/test_baseexception.py
+++ b/Lib/test/test_baseexception.py
@@ -78,6 +78,9 @@ class ExceptionClassTests(unittest.TestCase):
                 last_depth = depth
         finally:
             inheritance_tree.close()
+
+        # Underscore-prefixed (private) exceptions don't need to be documented
+        exc_set = set(e for e in exc_set if not e.startswith('_'))
         self.assertEqual(len(exc_set), 0, "%s not accounted for" % exc_set)
 
     interface_tests = ("length", "args", "str", "repr")


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119521 -->
* Issue: gh-119521
<!-- /gh-issue-number -->
