### PR TITLE
gh-120155: Fix Coverity issue in parse_string()

### DIFF
--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -229,9 +229,14 @@ _PyPegen_parse_string(Parser *p, Token *t)
         PyErr_BadInternalCall();
         return NULL;
     }
+
     /* Skip the leading quote char. */
     s++;
     len = strlen(s);
+    // gh-120155: 's' contains at least the trailing quote,
+    // so the code '--len' below is safe.
+    assert(len >= 1);
+
     if (len > INT_MAX) {
         PyErr_SetString(PyExc_OverflowError, "string to parse is too long");
         return NULL;


### PR DESCRIPTION
Add an assertion to make sure that the 'len' variable is at least 1, to make sure that the code '--len' below is safe.

Fix the Coverity issue on Python-3.12.2:

Error: INTEGER_OVERFLOW (CWE-190):
Parser/string_parser.c:236:5: underflow: The decrement operator on
    the unsigned variable "len" might result in an underflow.
Parser/string_parser.c:246:9: overflow: The expression "len -= 2UL"
    is deemed underflowed because at least one of its arguments has
    underflowed.
Parser/string_parser.c:269:13: overflow_sink: "len", which might
    have underflowed, is passed to
    "PyBytes_FromStringAndSize(s, len)".
  267|           }
  268|           if (rawmode) {
  269|->             return PyBytes_FromStringAndSize(s, len);
  270|           }
  271|           return decode_bytes_with_escapes(p, s, len, t);

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120155 -->
* Issue: gh-120155
<!-- /gh-issue-number -->
