### PR TITLE
gh-119726: replace AArch64 trampolines with LDR

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-25-16-26-44.gh-issue-119726.WqvHxB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-25-16-26-44.gh-issue-119726.WqvHxB.rst
@@ -1,1 +1,2 @@
-Replace AArch64 trampolines with LDR of a PC relative literal. Patch from Diego Russo
+Improve the speed and memory use of C function calls from JIT code on AArch64.
+Patch by Diego Russo

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-25-16-26-44.gh-issue-119726.WqvHxB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-25-16-26-44.gh-issue-119726.WqvHxB.rst
@@ -1,0 +1,1 @@
+Replace AArch64 trampolines with LDR of a PC relative literal. Patch from Diego Russo

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -207,33 +207,20 @@ class Stencil:
             return
 
         self.disassembly += [
-            f"{base + 4 * 0:x}: d2800008      mov     x8, #0x0",
-            f"{base + 4 * 0:016x}:  R_AARCH64_MOVW_UABS_G0_NC    {hole.symbol}",
-            f"{base + 4 * 1:x}: f2a00008      movk    x8, #0x0, lsl #16",
-            f"{base + 4 * 1:016x}:  R_AARCH64_MOVW_UABS_G1_NC    {hole.symbol}",
-            f"{base + 4 * 2:x}: f2c00008      movk    x8, #0x0, lsl #32",
-            f"{base + 4 * 2:016x}:  R_AARCH64_MOVW_UABS_G2_NC    {hole.symbol}",
-            f"{base + 4 * 3:x}: f2e00008      movk    x8, #0x0, lsl #48",
-            f"{base + 4 * 3:016x}:  R_AARCH64_MOVW_UABS_G3       {hole.symbol}",
-            f"{base + 4 * 4:x}: d61f0100      br      x8",
+            f"{base + 4 * 0:x}: 58000048      ldr     x8, 8",
+            f"{base + 4 * 1:x}: d61f0100      br      x8",
+            f"{base + 4 * 2:x}: 00000000",
+            f"{base + 4 * 2:016x}:  R_AARCH64_ABS64    {hole.symbol}",
+            f"{base + 4 * 3:x}: 00000000",
         ]
         for code in [
-            0xD2800008.to_bytes(4, sys.byteorder),
-            0xF2A00008.to_bytes(4, sys.byteorder),
-            0xF2C00008.to_bytes(4, sys.byteorder),
-            0xF2E00008.to_bytes(4, sys.byteorder),
-            0xD61F0100.to_bytes(4, sys.byteorder),
+            0x58000048.to_bytes(4, sys.byteorder),
+            0xd61f0100.to_bytes(4, sys.byteorder),
+            0x00000000.to_bytes(4, sys.byteorder),
+            0x00000000.to_bytes(4, sys.byteorder),
         ]:
             self.body.extend(code)
-        for i, kind in enumerate(
-            [
-                "R_AARCH64_MOVW_UABS_G0_NC",
-                "R_AARCH64_MOVW_UABS_G1_NC",
-                "R_AARCH64_MOVW_UABS_G2_NC",
-                "R_AARCH64_MOVW_UABS_G3",
-            ]
-        ):
-            self.holes.append(hole.replace(offset=base + 4 * i, kind=kind))
+        self.holes.append(hole.replace(offset=base + 8, kind="R_AARCH64_ABS64"))
         self.trampolines[hole.symbol] = base
 
     def remove_jump(self, *, alignment: int = 1) -> None:

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -215,7 +215,7 @@ class Stencil:
         ]
         for code in [
             0x58000048.to_bytes(4, sys.byteorder),
-            0xd61f0100.to_bytes(4, sys.byteorder),
+            0xD61F0100.to_bytes(4, sys.byteorder),
             0x00000000.to_bytes(4, sys.byteorder),
             0x00000000.to_bytes(4, sys.byteorder),
         ]:


### PR DESCRIPTION
Replace AArch64 trampolines with LDR of a PC relative literal. It saves 8 bytes in code size per trampoline and decreases the number of patches functions from 4 to 1 per stencil.
It decreases by 17% the size of the stencil header file generated.



<!-- gh-issue-number: gh-119726 -->
* Issue: gh-119726
<!-- /gh-issue-number -->
