### PR TITLE
gh-121016: Add test for `PYTHON_BASIC_REPL` envioronment variable

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2626,3 +2626,9 @@ def force_not_colorized(func):
                 if value is not None:
                     os.environ[key] = value
     return wrapper
+
+
+def initialized_with_pyrepl():
+    """Detect whether PyREPL was used during Python initialization."""
+    # If the main module has a __file__ attribute it's a Python module, which means PyREPL.
+    return hasattr(sys.modules["__main__"], "__file__")

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -969,7 +969,7 @@ class CmdLineTest(unittest.TestCase):
         self.assertIn(expected.encode(), out)
 
     def test_python_basic_repl(self):
-        # Currently this only tests that the env var is set
+        # Currently this only tests that the env var is set. See test_pyrepl.test_python_basic_repl.
         code = "import os; print('PYTHON_BASIC_REPL' in os.environ)"
         expected = "True"
         rc, out, err = assert_python_ok('-c', code, PYTHON_BASIC_REPL='1')

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -862,6 +862,26 @@ class TestMain(TestCase):
         self.assertNotIn("Exception", output)
         self.assertNotIn("Traceback", output)
 
+    def test_python_basic_repl(self):
+        env = os.environ.copy()
+        commands = ("from test.support import initialized_with_pyrepl\n"
+                    "initialized_with_pyrepl()\n"
+                    "exit()\n")
+
+        env.pop("PYTHON_BASIC_REPL", None)
+        output, exit_code = self.run_repl(commands, env=env)
+        self.assertEqual(exit_code, 0)
+        self.assertIn("True", output)
+        self.assertNotIn("Exception", output)
+        self.assertNotIn("Traceback", output)
+
+        env["PYTHON_BASIC_REPL"] = "1"
+        output, exit_code = self.run_repl(commands, env=env)
+        self.assertEqual(exit_code, 0)
+        self.assertIn("False", output)
+        self.assertNotIn("Exception", output)
+        self.assertNotIn("Traceback", output)
+
     def run_repl(self, repl_input: str | list[str], env: dict | None = None) -> tuple[str, int]:
         master_fd, slave_fd = pty.openpty()
         process = subprocess.Popen(

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -875,6 +875,7 @@ class TestMain(TestCase):
             self.skipTest("pyrepl not available")
         self.assertEqual(exit_code, 0)
         self.assertIn("True", output)
+        self.assertNotIn("False", output)
         self.assertNotIn("Exception", output)
         self.assertNotIn("Traceback", output)
 
@@ -882,6 +883,7 @@ class TestMain(TestCase):
         output, exit_code = self.run_repl(commands, env=env)
         self.assertEqual(exit_code, 0)
         self.assertIn("False", output)
+        self.assertNotIn("True", output)
         self.assertNotIn("Exception", output)
         self.assertNotIn("Traceback", output)
 

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -862,6 +862,7 @@ class TestMain(TestCase):
         self.assertNotIn("Exception", output)
         self.assertNotIn("Traceback", output)
 
+    @force_not_colorized
     def test_python_basic_repl(self):
         env = os.environ.copy()
         commands = ("from test.support import initialized_with_pyrepl\n"
@@ -870,6 +871,8 @@ class TestMain(TestCase):
 
         env.pop("PYTHON_BASIC_REPL", None)
         output, exit_code = self.run_repl(commands, env=env)
+        if "can\'t use pyrepl" in output:
+            self.skipTest("pyrepl not available")
         self.assertEqual(exit_code, 0)
         self.assertIn("True", output)
         self.assertNotIn("Exception", output)


### PR DESCRIPTION
This PR adds a test for `PYTHON_BASIC_REPL` setting the interpreter to use the basic REPL, using a technique suggested by @AlexWaygood on Discord.

<!-- gh-issue-number: gh-121016 -->
* Issue: gh-121016
<!-- /gh-issue-number -->
