### PR TITLE
gh-121018: ensure ArgumentParser.parse_args with exit_on_error=False raises instead of exiting when given unrecognized arguments

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1843,8 +1843,10 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     def parse_args(self, args=None, namespace=None):
         args, argv = self.parse_known_args(args, namespace)
         if argv:
-            msg = _('unrecognized arguments: %s')
-            self.error(msg % ' '.join(argv))
+            msg = _('unrecognized arguments: %s') % ' '.join(argv)
+            if self.exit_on_error:
+                self.error(msg)
+            raise ArgumentError(None, msg)
         return args
 
     def parse_known_args(self, args=None, namespace=None):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -6053,7 +6053,7 @@ class TestExitOnError(TestCase):
         with self.assertRaises(argparse.ArgumentError):
             self.parser.parse_args('--integers a'.split())
 
-    def test_exit_on_error_with_unrecoginized_args(self):
+    def test_exit_on_error_with_unrecognized_args(self):
         with self.assertRaises(argparse.ArgumentError):
             self.parser.parse_args('--foo bar'.split())
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -6053,6 +6053,9 @@ class TestExitOnError(TestCase):
         with self.assertRaises(argparse.ArgumentError):
             self.parser.parse_args('--integers a'.split())
 
+    def test_exit_on_error_with_unrecoginized_args(self):
+        with self.assertRaises(argparse.ArgumentError):
+            self.parser.parse_args('--foo bar'.split())
 
 def tearDownModule():
     # Remove global references to avoid looking like we have refleaks.

--- a/Misc/NEWS.d/next/Library/2024-06-26-03-04-24.gh-issue-121018.clVSc4.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-26-03-04-24.gh-issue-121018.clVSc4.rst
@@ -1,0 +1,2 @@
+Fixed an issue where :func:`argparse.ArgumentParser.parses_args` did not honor ``exit_on_error=False`` when given unrecognized arguments.
+Patch by Ben Hsing


### PR DESCRIPTION


<!-- gh-issue-number: gh-121018 -->
* Issue: gh-121018
<!-- /gh-issue-number -->
