### PR TITLE
gh-121021: zipfile: Support for extended_mtime attribute

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -890,6 +890,11 @@ Instances have the following methods and attributes:
 
    Size of the uncompressed file.
 
+.. attribute:: ZipInfo.extended_mtime
+
+   Extended modified timestamp of the uncompressed file.
+
+   .. versionadded:: 3.14
 
 .. _zipfile-commandline:
 .. program:: zipfile

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -1,5 +1,6 @@
 import array
 import contextlib
+import datetime
 import importlib.util
 import io
 import itertools
@@ -1877,6 +1878,54 @@ class OtherTests(unittest.TestCase):
             zipfp.writestr('приклад', b'sample')
             self.assertEqual(zipfp.read('приклад'), b'sample')
 
+    def create_zipfile_with_extended_timestamp_extra_data(self, filename, extra_timestamp_data):
+        with zipfile.ZipFile(TESTFN, mode='w') as zf:
+            filename_encoded = filename.encode("utf-8")
+            zip_info = zipfile.ZipInfo(filename)
+
+            tag_for_extra_block = b'\x55\x54'
+
+            # Set only modification time
+            flags = b'\x01'
+
+            # modification time
+            if extra_timestamp_data is not None:
+                mtime = struct.pack('<l', extra_timestamp_data)
+            else:
+                mtime = b''
+            extra_data = flags + mtime
+
+            tsize = len(extra_data).to_bytes(2, 'little')
+
+            zip_info.extra = tag_for_extra_block + tsize + extra_data
+
+            # add the file to the ZIP archive
+            zf.writestr(zip_info, b'Hello World!')
+
+    def test_read_zipfile_containing_extended_timestamp_extra_field(self):
+        timestamp_data = int(datetime.datetime(2024, 6, 26, 9, 27, 30).timestamp())
+        self.create_zipfile_with_extended_timestamp_extra_data("aayush.txt", timestamp_data)
+        with zipfile.ZipFile(TESTFN, "r") as zf:
+            self.assertEqual(zf.filelist[0].extended_mtime, timestamp_data)
+
+    def test_read_zipfile_containing_timestamp_beyond_2038(self):
+        # Test for 2038 problem
+        timestamp_data = -1
+        self.create_zipfile_with_extended_timestamp_extra_data("aayush.txt", timestamp_data)
+        with zipfile.ZipFile(TESTFN, "r") as zf:
+            self.assertEqual(zf.filelist[0].extended_mtime, timestamp_data)
+
+    def test_read_zipfile_zero_timestamp_extra_field(self):
+        timestamp_data = 0
+        self.create_zipfile_with_extended_timestamp_extra_data("aayush.txt", timestamp_data)
+        with zipfile.ZipFile(TESTFN, "r") as zf:
+            self.assertEqual(zf.filelist[0].extended_mtime, timestamp_data)
+
+    def test_read_zipfile_none_timestamp_extra_field(self):
+        self.create_zipfile_with_extended_timestamp_extra_data("aayush.txt", None)
+        with zipfile.ZipFile(TESTFN, "r") as zf:
+            self.assertIsNone(zf.filelist[0].extended_mtime)
+
     def test_exclusive_create_zip_file(self):
         """Test exclusive creating a new zipfile."""
         unlink(TESTFN2)
@@ -2226,6 +2275,8 @@ class OtherTests(unittest.TestCase):
         # Before bpo-26185, both were missing
         self.assertEqual(zi.file_size, 0)
         self.assertEqual(zi.compress_size, 0)
+
+        self.assertIsNone(zi.extended_mtime)
 
     def test_zipfile_with_short_extra_field(self):
         """If an extra field in the header is less than 4 bytes, skip it."""

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -396,6 +396,7 @@ class ZipInfo:
         'file_size',
         '_raw_time',
         '_end_offset',
+        'extended_mtime',
     )
 
     def __init__(self, filename="NoName", date_time=(1980,1,1,0,0,0)):
@@ -431,6 +432,7 @@ class ZipInfo:
         self.compress_size = 0          # Size of the compressed file
         self.file_size = 0              # Size of the uncompressed file
         self._end_offset = None         # Start of the next local header or central directory
+        self.extended_mtime = None      # Extended modified timestamp
         # Other attributes are set by class ZipFile:
         # header_offset         Byte offset to the file header
         # CRC                   CRC-32 of the uncompressed file
@@ -563,6 +565,15 @@ class ZipInfo:
                 except UnicodeDecodeError as e:
                     raise BadZipFile('Corrupt unicode path extra field (0x7075): invalid utf-8 bytes') from e
 
+            elif tp == 0x5455:
+                if ln == 0:
+                    raise BadZipFile('Empty extended timestamp extra field (0x5455)')
+                flags = extra[4]
+                if flags & 0x1 and ln >= 5:
+                    try:
+                        self.extended_mtime, = unpack("<l", extra[5:9])
+                    except struct.error as e:
+                        raise BadZipFile("Corrupt extended stamp extra field (0x5455)") from e
             extra = extra[ln+4:]
 
     @classmethod

--- a/Misc/NEWS.d/next/Library/2024-06-25-20-53-57.gh-issue-121021.you8hf.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-25-20-53-57.gh-issue-121021.you8hf.rst
@@ -1,0 +1,1 @@
+Add attribute :attr:`zipfile.ZipInfo.extended_mtime`.


### PR DESCRIPTION
zipinfo now supports attribute - extended_mtime

fixes: #121021

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121020.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-121021 -->
* Issue: gh-121021
<!-- /gh-issue-number -->
