### PR TITLE
gh-120593: Fix const qualifier in pyatomic.h

### DIFF
--- a/Include/cpython/pyatomic.h
+++ b/Include/cpython/pyatomic.h
@@ -312,7 +312,7 @@ static inline Py_ssize_t
 _Py_atomic_load_ssize(const Py_ssize_t *obj);
 
 static inline void *
-_Py_atomic_load_ptr(const void *obj);
+_Py_atomic_load_ptr(void *obj);
 
 
 // --- _Py_atomic_load_relaxed -----------------------------------------------
@@ -358,7 +358,7 @@ static inline Py_ssize_t
 _Py_atomic_load_ssize_relaxed(const Py_ssize_t *obj);
 
 static inline void *
-_Py_atomic_load_ptr_relaxed(const void *obj);
+_Py_atomic_load_ptr_relaxed(void *obj);
 
 static inline unsigned long long
 _Py_atomic_load_ullong_relaxed(const unsigned long long *obj);
@@ -463,7 +463,7 @@ _Py_atomic_store_ullong_relaxed(unsigned long long *obj,
 
 // Loads `*obj` (acquire operation)
 static inline void *
-_Py_atomic_load_ptr_acquire(const void *obj);
+_Py_atomic_load_ptr_acquire(void *obj);
 
 static inline uintptr_t
 _Py_atomic_load_uintptr_acquire(const uintptr_t *obj);

--- a/Include/cpython/pyatomic_gcc.h
+++ b/Include/cpython/pyatomic_gcc.h
@@ -296,7 +296,7 @@ _Py_atomic_load_ssize(const Py_ssize_t *obj)
 { return __atomic_load_n(obj, __ATOMIC_SEQ_CST); }
 
 static inline void *
-_Py_atomic_load_ptr(const void *obj)
+_Py_atomic_load_ptr(void *obj)
 { return (void *)__atomic_load_n((void **)obj, __ATOMIC_SEQ_CST); }
 
 
@@ -355,8 +355,8 @@ _Py_atomic_load_ssize_relaxed(const Py_ssize_t *obj)
 { return __atomic_load_n(obj, __ATOMIC_RELAXED); }
 
 static inline void *
-_Py_atomic_load_ptr_relaxed(const void *obj)
-{ return (void *)__atomic_load_n((const void **)obj, __ATOMIC_RELAXED); }
+_Py_atomic_load_ptr_relaxed(void *obj)
+{ return (void *)__atomic_load_n((void **)obj, __ATOMIC_RELAXED); }
 
 static inline unsigned long long
 _Py_atomic_load_ullong_relaxed(const unsigned long long *obj)
@@ -489,12 +489,12 @@ _Py_atomic_store_ullong_relaxed(unsigned long long *obj,
 // --- _Py_atomic_load_ptr_acquire / _Py_atomic_store_ptr_release ------------
 
 static inline void *
-_Py_atomic_load_ptr_acquire(const void *obj)
+_Py_atomic_load_ptr_acquire(void *obj)
 { return (void *)__atomic_load_n((void **)obj, __ATOMIC_ACQUIRE); }
 
 static inline uintptr_t
 _Py_atomic_load_uintptr_acquire(const uintptr_t *obj)
-{ return (uintptr_t)__atomic_load_n((uintptr_t *)obj, __ATOMIC_ACQUIRE); }
+{ return (uintptr_t)__atomic_load_n(obj, __ATOMIC_ACQUIRE); }
 
 static inline void
 _Py_atomic_store_ptr_release(void *obj, void *value)

--- a/Include/cpython/pyatomic_msc.h
+++ b/Include/cpython/pyatomic_msc.h
@@ -595,12 +595,12 @@ _Py_atomic_load_int64(const int64_t *obj)
 }
 
 static inline void*
-_Py_atomic_load_ptr(const void *obj)
+_Py_atomic_load_ptr(void *obj)
 {
 #if SIZEOF_VOID_P == 8
-    return (void*)_Py_atomic_load_uint64((const uint64_t *)obj);
+    return (void*)_Py_atomic_load_uint64((uint64_t *)obj);
 #else
-    return (void*)_Py_atomic_load_uint32((const uint32_t *)obj);
+    return (void*)_Py_atomic_load_uint32((uint32_t *)obj);
 #endif
 }
 
@@ -707,7 +707,7 @@ _Py_atomic_load_ssize_relaxed(const Py_ssize_t *obj)
 }
 
 static inline void*
-_Py_atomic_load_ptr_relaxed(const void *obj)
+_Py_atomic_load_ptr_relaxed(void *obj)
 {
     return *(void * volatile *)obj;
 }
@@ -903,7 +903,7 @@ _Py_atomic_store_ullong_relaxed(unsigned long long *obj,
 // --- _Py_atomic_load_ptr_acquire / _Py_atomic_store_ptr_release ------------
 
 static inline void *
-_Py_atomic_load_ptr_acquire(const void *obj)
+_Py_atomic_load_ptr_acquire(void *obj)
 {
 #if defined(_M_X64) || defined(_M_IX86)
     return *(void * volatile *)obj;

--- a/Include/cpython/pyatomic_std.h
+++ b/Include/cpython/pyatomic_std.h
@@ -498,10 +498,10 @@ _Py_atomic_load_ssize(const Py_ssize_t *obj)
 }
 
 static inline void*
-_Py_atomic_load_ptr(const void *obj)
+_Py_atomic_load_ptr(void *obj)
 {
     _Py_USING_STD;
-    return atomic_load((const _Atomic(void*)*)obj);
+    return atomic_load((_Atomic(void*)*)obj);
 }
 
 
@@ -612,10 +612,10 @@ _Py_atomic_load_ssize_relaxed(const Py_ssize_t *obj)
 }
 
 static inline void*
-_Py_atomic_load_ptr_relaxed(const void *obj)
+_Py_atomic_load_ptr_relaxed(void *obj)
 {
     _Py_USING_STD;
-    return atomic_load_explicit((const _Atomic(void*)*)obj,
+    return atomic_load_explicit((_Atomic(void*)*)obj,
                                 memory_order_relaxed);
 }
 
@@ -856,10 +856,10 @@ _Py_atomic_store_ullong_relaxed(unsigned long long *obj,
 // --- _Py_atomic_load_ptr_acquire / _Py_atomic_store_ptr_release ------------
 
 static inline void *
-_Py_atomic_load_ptr_acquire(const void *obj)
+_Py_atomic_load_ptr_acquire(void *obj)
 {
     _Py_USING_STD;
-    return atomic_load_explicit((const _Atomic(void*)*)obj,
+    return atomic_load_explicit((_Atomic(void*)*)obj,
                                 memory_order_acquire);
 }
 


### PR DESCRIPTION
Remove the 'const' qualifier of the argument of functions:

* _Py_atomic_load_ptr()
* _Py_atomic_load_ptr_relaxed()
* _Py_atomic_load_ptr_acquire()

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120593 -->
* Issue: gh-120593
<!-- /gh-issue-number -->
