### PR TITLE
gh-120593: Fix const qualifier in _PyLong_CompactValue()

### DIFF
--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -119,7 +119,7 @@ PyAPI_FUNC(PyLongObject*) _PyLong_FromDigits(
 
 
 static inline int
-_PyLong_IsCompact(const PyLongObject* op) {
+_PyLong_IsCompact(PyLongObject* op) {
     assert(PyType_HasFeature(Py_TYPE(op), Py_TPFLAGS_LONG_SUBCLASS));
     return op->long_value.lv_tag < (2 << _PyLong_NON_SIZE_BITS);
 }
@@ -127,7 +127,7 @@ _PyLong_IsCompact(const PyLongObject* op) {
 #define PyUnstable_Long_IsCompact _PyLong_IsCompact
 
 static inline Py_ssize_t
-_PyLong_CompactValue(const PyLongObject *op)
+_PyLong_CompactValue(PyLongObject *op)
 {
     Py_ssize_t sign;
     assert(PyType_HasFeature(Py_TYPE(op), Py_TPFLAGS_LONG_SUBCLASS));

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -240,7 +240,7 @@ static inline int
 _PyLong_CompactSign(const PyLongObject *op)
 {
     assert(PyLong_Check(op));
-    assert(_PyLong_IsCompact(op));
+    assert(_PyLong_IsCompact((PyLongObject *)op));
     return 1 - (op->long_value.lv_tag & SIGN_MASK);
 }
 
@@ -248,7 +248,7 @@ static inline int
 _PyLong_NonCompactSign(const PyLongObject *op)
 {
     assert(PyLong_Check(op));
-    assert(!_PyLong_IsCompact(op));
+    assert(!_PyLong_IsCompact((PyLongObject *)op));
     return 1 - (op->long_value.lv_tag & SIGN_MASK);
 }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6672,12 +6672,12 @@ _PyLong_FiniTypes(PyInterpreterState *interp)
 
 int
 PyUnstable_Long_IsCompact(const PyLongObject* op) {
-    return _PyLong_IsCompact(op);
+    return _PyLong_IsCompact((PyLongObject*)op);
 }
 
 #undef PyUnstable_Long_CompactValue
 
 Py_ssize_t
 PyUnstable_Long_CompactValue(const PyLongObject* op) {
-    return _PyLong_CompactValue(op);
+    return _PyLong_CompactValue((PyLongObject*)op);
 }


### PR DESCRIPTION
Remove the const qualifier of the argument of functions:

* _PyLong_IsCompact()
* _PyLong_CompactValue()

Py_TYPE() argument is not const.

Fix the compiler warning:

```
  Include/cpython/longintrepr.h: In function ‘_PyLong_CompactValue’: Include/pyport.h:19:31: error: cast discards ‘const’ qualifier from pointer target type [-Werror=cast-qual]
  (...) 
  Include/cpython/longintrepr.h:133:30: note: in expansion of macro ‘Py_TYPE’ assert(PyType_HasFeature(Py_TYPE(op), Py_TPFLAGS_LONG_SUBCLASS));
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120593 -->
* Issue: gh-120593
<!-- /gh-issue-number -->
