### PR TITLE
gh-113433: Automatically Clean Up Subinterpreters in Py_Finalize()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-26-13-42-36.gh-issue-113433.xKAtLB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-26-13-42-36.gh-issue-113433.xKAtLB.rst
@@ -1,0 +1,2 @@
+Subinterpreters now get cleaned up automatically during runtime
+finalization.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-26-14-09-31.gh-issue-120838.nFeTL9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-26-14-09-31.gh-issue-120838.nFeTL9.rst
@@ -1,0 +1,2 @@
+:c:func:`Py_Finalize()` and :c:func:`Py_FinalizeEx()` now always run with
+the main interpreter active.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1999,7 +1999,6 @@ _Py_Finalize(_PyRuntimeState *runtime)
     _PyAtExit_Call(tstate->interp);
 
     assert(_PyThreadState_GET() == tstate);
-    finalize_subinterpreters();
 
     /* Copy the core config, PyInterpreterState_Delete() free
        the core config memory */
@@ -2080,6 +2079,9 @@ _Py_Finalize(_PyRuntimeState *runtime)
     /* Destroy all modules */
     _PyImport_FiniExternal(tstate->interp);
     finalize_modules(tstate);
+
+    /* Clean up any lingering subinterpreters. */
+    finalize_subinterpreters();
 
     /* Print debug stats if any */
     _PyEval_Fini();

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1983,8 +1983,6 @@ _Py_Finalize(_PyRuntimeState *runtime)
     // Wrap up existing "threading"-module-created, non-daemon threads.
     wait_for_thread_shutdown(tstate);
 
-    finalize_subinterpreters();
-
     // Make any remaining pending calls.
     _Py_FinishPendingCalls(tstate);
 
@@ -1999,6 +1997,9 @@ _Py_Finalize(_PyRuntimeState *runtime)
      */
 
     _PyAtExit_Call(tstate->interp);
+
+    assert(_PyThreadState_GET() == tstate);
+    finalize_subinterpreters();
 
     /* Copy the core config, PyInterpreterState_Delete() free
        the core config memory */


### PR DESCRIPTION
This change makes things a little less painful for some users.  It also fixes a failing assert (gh-120765), by making sure all subinterpreters are destroyed before the main interpreter.  As part of that, we make sure `Py_Finalize()` always runs with the main interpreter active.

Some of the changes for gh-120838 build on this.

<!-- gh-issue-number: gh-113433 -->
* Issue: gh-113433
<!-- /gh-issue-number -->
