### PR TITLE
gh-120838: Make Sure Py_Finalize() Always Runs Against the Main Interpreter

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-26-14-09-31.gh-issue-120838.nFeTL9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-26-14-09-31.gh-issue-120838.nFeTL9.rst
@@ -1,0 +1,2 @@
+:c:func:`Py_Finalize()` and :c:func:`Py_FinalizeEx()` now always run with
+the main interpreter active.


### PR DESCRIPTION
We can't easily force `Py_Finalize()` to run in the main thread (especially because of `Py_Exit()`), but we can at least ensure the main interpreter is active.

(We'll be backporting this since the fix for gh-120765 needs it.)

<!-- gh-issue-number: gh-120838 -->
* Issue: gh-120838
<!-- /gh-issue-number -->
