### PR TITLE
gh-121082: Fix build failure when the developer use `--enable-pystats` arguments in configuration command after #118450

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-06-27-18-03-20.gh-issue-121082.w3AfRx.rst
+++ b/Misc/NEWS.d/next/Build/2024-06-27-18-03-20.gh-issue-121082.w3AfRx.rst
@@ -1,2 +1,1 @@
-Fix build failure when the developer use ``--enable-pystats`` arguments in 
-configuration command after #118450
+Fix build failure when the developer use ``--enable-pystats`` arguments in configuration command after #118450.

--- a/Misc/NEWS.d/next/Build/2024-06-27-18-03-20.gh-issue-121082.w3AfRx.rst
+++ b/Misc/NEWS.d/next/Build/2024-06-27-18-03-20.gh-issue-121082.w3AfRx.rst
@@ -1,2 +1,2 @@
-Fix build failure when the developer use `--enable-pystats` arguments in 
+Fix build failure when the developer use ``--enable-pystats`` arguments in 
 configuration command after #118450

--- a/Misc/NEWS.d/next/Build/2024-06-27-18-03-20.gh-issue-121082.w3AfRx.rst
+++ b/Misc/NEWS.d/next/Build/2024-06-27-18-03-20.gh-issue-121082.w3AfRx.rst
@@ -1,1 +1,2 @@
-Fix build failure when the developer use `--enable-pystats` arguments in configuration command after #118450
+Fix build failure when the developer use `--enable-pystats` arguments in 
+configuration command after #118450

--- a/Misc/NEWS.d/next/Build/2024-06-27-18-03-20.gh-issue-121082.w3AfRx.rst
+++ b/Misc/NEWS.d/next/Build/2024-06-27-18-03-20.gh-issue-121082.w3AfRx.rst
@@ -1,0 +1,1 @@
+Fix build failure when the developer use `--enable-pystats` arguments in configuration command after #118450

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2364,7 +2364,8 @@ _Py_Specialize_ForIter(_PyStackRef iter, _Py_CODEUNIT *instr, int oparg)
     assert(ENABLE_SPECIALIZATION);
     assert(_PyOpcode_Caches[FOR_ITER] == INLINE_CACHE_ENTRIES_FOR_ITER);
     _PyForIterCache *cache = (_PyForIterCache *)(instr + 1);
-    PyTypeObject *tp = Py_TYPE(PyStackRef_AsPyObjectBorrow(iter));
+    PyObject *iterObject = PyStackRef_AsPyObjectBorrow(iter);
+    PyTypeObject *tp = Py_TYPE(iterObject);
     if (tp == &PyListIter_Type) {
         instr->op.code = FOR_ITER_LIST;
         goto success;
@@ -2389,7 +2390,7 @@ _Py_Specialize_ForIter(_PyStackRef iter, _Py_CODEUNIT *instr, int oparg)
         goto success;
     }
     SPECIALIZATION_FAIL(FOR_ITER,
-                        _PySpecialization_ClassifyIterator(iter));
+                        _PySpecialization_ClassifyIterator(iterObject));
 failure:
     STAT_INC(FOR_ITER, failure);
     instr->op.code = FOR_ITER;

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2364,8 +2364,8 @@ _Py_Specialize_ForIter(_PyStackRef iter, _Py_CODEUNIT *instr, int oparg)
     assert(ENABLE_SPECIALIZATION);
     assert(_PyOpcode_Caches[FOR_ITER] == INLINE_CACHE_ENTRIES_FOR_ITER);
     _PyForIterCache *cache = (_PyForIterCache *)(instr + 1);
-    PyObject *iterObject = PyStackRef_AsPyObjectBorrow(iter);
-    PyTypeObject *tp = Py_TYPE(iterObject);
+    PyObject *iter_o = PyStackRef_AsPyObjectBorrow(iter);
+    PyTypeObject *tp = Py_TYPE(iter_o);
     if (tp == &PyListIter_Type) {
         instr->op.code = FOR_ITER_LIST;
         goto success;
@@ -2390,7 +2390,7 @@ _Py_Specialize_ForIter(_PyStackRef iter, _Py_CODEUNIT *instr, int oparg)
         goto success;
     }
     SPECIALIZATION_FAIL(FOR_ITER,
-                        _PySpecialization_ClassifyIterator(iterObject));
+                        _PySpecialization_ClassifyIterator(iter_o));
 failure:
     STAT_INC(FOR_ITER, failure);
     instr->op.code = FOR_ITER;


### PR DESCRIPTION
Fix: #121082

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121082 -->
* Issue: gh-121082
<!-- /gh-issue-number -->
