### PR TITLE
Check for compiler warnings in test_cext on Windows

### DIFF
--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -46,7 +46,8 @@
 /* Argument must be a char or an int in [-128, 127] or [0, 255]. */
 #define Py_CHARMASK(c) ((unsigned char)((c) & 0xff))
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
+     && !defined(_MSC_VER))
 #  define Py_BUILD_ASSERT_EXPR(cond) \
     ((void)sizeof(struct { int dummy; _Static_assert(cond, #cond); }), \
      0)

--- a/Lib/test/test_cext/__init__.py
+++ b/Lib/test/test_cext/__init__.py
@@ -86,6 +86,8 @@ class TestExt(unittest.TestCase):
         cmd = [python_exe, '-X', 'dev',
                '-m', 'pip', 'install', '--no-build-isolation',
                os.path.abspath(pkg_dir)]
+        if support.verbose:
+            cmd.append('-v')
         run_cmd('Install', cmd)
 
         # Do a reference run. Until we test that running python

--- a/Lib/test/test_cext/setup.py
+++ b/Lib/test/test_cext/setup.py
@@ -11,6 +11,7 @@ from setuptools import setup, Extension
 
 
 SOURCE = 'extension.c'
+
 if not support.MS_WINDOWS:
     # C compiler flags for GCC and clang
     CFLAGS = [
@@ -25,8 +26,11 @@ if not support.MS_WINDOWS:
             '-Werror=declaration-after-statement',
         )
 else:
-    # Don't pass any compiler flag to MSVC
-    CFLAGS = []
+    # MSVC compiler flags
+    CFLAGS = [
+        # Treat all compiler warnings as compiler errors
+        '/WX',
+    ]
 
 
 def main():

--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -76,6 +76,8 @@ class TestCPPExt(unittest.TestCase):
         cmd = [python_exe, '-X', 'dev',
                '-m', 'pip', 'install', '--no-build-isolation',
                os.path.abspath(pkg_dir)]
+        if support.verbose:
+            cmd.append('-v')
         run_cmd('Install', cmd)
 
         # Do a reference run. Until we test that running python

--- a/Lib/test/test_cppext/setup.py
+++ b/Lib/test/test_cppext/setup.py
@@ -10,6 +10,7 @@ from setuptools import setup, Extension
 
 
 SOURCE = 'extension.cpp'
+
 if not support.MS_WINDOWS:
     # C++ compiler flags for GCC and clang
     CPPFLAGS = [
@@ -19,8 +20,11 @@ if not support.MS_WINDOWS:
         '-Werror',
     ]
 else:
-    # Don't pass any compiler flag to MSVC
-    CPPFLAGS = []
+    # MSVC compiler flags
+    CPPFLAGS = [
+        # Treat all compiler warnings as compiler errors
+        '/WX',
+    ]
 
 
 def main():


### PR DESCRIPTION
On Windows, test_cext and test_cppext now pass /WX flag to the MSC compiler to treat all compiler warnings as errors. In verbose mode, these tests now log the compiler commands to help debugging.

Change Py_BUILD_ASSERT_EXPR implementation on Windows to avoid a compiler warning about an unnamed structure.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
