### PR TITLE
[Doc] Fix os.spawn* functions

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -279,4 +279,3 @@ Examples::
 
    `NumPy <https://numpy.org/>`_
       The NumPy package defines another array type.
-

--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -279,3 +279,4 @@ Examples::
 
    `NumPy <https://numpy.org/>`_
       The NumPy package defines another array type.
+

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4794,16 +4794,16 @@ written in Python, such as a mail server's external command delivery program.
    .. versionadded:: 3.7
 
 
-.. function:: spawnl(mode, path, ...)
-              spawnle(mode, path, ..., env)
+.. function:: spawnl(mode, file, ...)
+              spawnle(mode, file, ..., env)
               spawnlp(mode, file, ...)
               spawnlpe(mode, file, ..., env)
-              spawnv(mode, path, args)
-              spawnve(mode, path, args, env)
+              spawnv(mode, file, args)
+              spawnve(mode, file, args, env)
               spawnvp(mode, file, args)
               spawnvpe(mode, file, args, env)
 
-   Execute the program *path* in a new process.
+   Execute the program *file* in a new process.
 
    (Note that the :mod:`subprocess` module provides more powerful facilities for
    spawning new processes and retrieving their results; using that module is
@@ -4835,7 +4835,7 @@ written in Python, such as a mail server's external command delivery program.
    discussed in the next paragraph), the new environment is used as the source of
    the :envvar:`PATH` variable.  The other variants, :func:`spawnl`,
    :func:`spawnle`, :func:`spawnv`, and :func:`spawnve`, will not use the
-   :envvar:`PATH` variable to locate the executable; *path* must contain an
+   :envvar:`PATH` variable to locate the executable; *file* must contain an
    appropriate absolute or relative path.
 
    For :func:`spawnle`, :func:`spawnlpe`, :func:`spawnve`, and :func:`spawnvpe`
@@ -4856,7 +4856,7 @@ written in Python, such as a mail server's external command delivery program.
       L = ['cp', 'index.html', '/dev/null']
       os.spawnvpe(os.P_WAIT, 'cp', L, os.environ)
 
-   .. audit-event:: os.spawn mode,path,args,env os.spawnl
+   .. audit-event:: os.spawn mode,file,args,env os.spawnl
 
    .. availability:: Unix, Windows, not WASI, not iOS.
 


### PR DESCRIPTION
This PR makes the documentation more suitable with the [functions definitions in the source code](https://github.com/python/cpython/blob/main/Lib/os.py#L979) and removes a inconsistency when the reader reads `file` in the functions assignature, but the first line below cites `path`.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121094.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->