### PR TITLE
gh-120804: remove is_active method from internal child watchers implementation in asyncio

### DIFF
--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -867,9 +867,6 @@ class _PidfdChildWatcher:
     recent (5.3+) kernels.
     """
 
-    def is_active(self):
-        return True
-
     def add_child_handler(self, pid, callback, *args):
         loop = events.get_running_loop()
         pidfd = os.pidfd_open(pid)
@@ -910,9 +907,6 @@ class _ThreadedChildWatcher:
     def __init__(self):
         self._pid_counter = itertools.count(0)
         self._threads = {}
-
-    def is_active(self):
-        return True
 
     def __del__(self, _warn=warnings.warn):
         threads = [thread for thread in list(self._threads.values())


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120804 -->
* Issue: gh-120804
<!-- /gh-issue-number -->
