### PR TITLE
gh-121137: Add missing Py_DECREF calls for ADDITEMS opcode of _pickle.c

### DIFF
--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6524,11 +6524,13 @@ load_additems(PickleState *state, UnpicklerObject *self)
             if (result == NULL) {
                 Pdata_clear(self->stack, i + 1);
                 Py_SET_SIZE(self->stack, mark);
+                Py_DECREF(add_func);
                 return -1;
             }
             Py_DECREF(result);
         }
         Py_SET_SIZE(self->stack, mark);
+        Py_DECREF(add_func);
     }
 
     return 0;


### PR DESCRIPTION
In the `load_additems` function of [`Modules/_pickle.c`](https://github.com/python/cpython/blob/3.11/Modules/_pickle.c#L6629) (which handles the `ADDITEMS` opcode), [PyObject_GetAttr](https://docs.python.org/3/c-api/object.html#c.PyObject_GetAttr) is called and returns `add_func` on [line 6660](https://github.com/python/cpython/blob/3.11/Modules/_pickle.c#L6660). PyObject_GetAttr returns a new reference, but this reference is never decremented using Py_DECREF, so 2x calls to this function are added (compare to `do_append` function in the same file).


<!-- gh-issue-number: gh-121137 -->
* Issue: gh-121137
<!-- /gh-issue-number -->
