### PR TITLE
[3.12] GH-119054: Fix pathlib docs subtitle word order

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1473,7 +1473,7 @@ Renaming and deleting
    Remove this directory.  The directory must be empty.
 
 
-Ownership and permissions
+Permissions and ownership
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. method:: Path.owner()


### PR DESCRIPTION
When backporting GH-120505 to 3.12, I accidentally transposed "Permissions and ownership" into "Ownership and permissions". Swap it back for consistency with 3.13 and main.

<!-- gh-issue-number: gh-119054 -->
* Issue: gh-119054
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121167.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->