### PR TITLE
Add handling for files offset further than the ZIP64 limit

### DIFF
--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1734,6 +1734,12 @@ class ZipFile:
             self.fp.seek(self.start_dir)
         zinfo.header_offset = self.fp.tell()
 
+        #ZIP64 is needed to reference header offset over ZIP64_LIMIT
+        if zinfo.header_offset > ZIP64_LIMIT:
+            zinfo.extract_version = max(
+                zinfo.extract_version, ZIP64_VERSION
+            )
+
         self._writecheck(zinfo)
         self._didModify = True
 

--- a/Misc/NEWS.d/next/Library/2024-06-29-23-00-04.gh-issue-121171.IWRFkA.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-29-23-00-04.gh-issue-121171.IWRFkA.rst
@@ -1,0 +1,1 @@
+Ensured extract_version in local file headers is set to a minimum of the ZIP64_VERSION if offset further than the ZIP64_LIMIT when creating files with zipfile.


### PR DESCRIPTION
# Add handling for files offset further than the ZIP64 limit

```
gh-121171: Fixed ZIP64 offset bug in zipfile module
```