### PR TITLE
gh-121171: Fix zip64 extract version in local headers

### DIFF
--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1733,6 +1733,12 @@ class ZipFile:
         if self._seekable:
             self.fp.seek(self.start_dir)
         zinfo.header_offset = self.fp.tell()
+        # exceptions raised in _writecheck if _allowZip64 is False
+        zip64 = (
+            zip64
+            or zinfo.header_offset > ZIP64_LIMIT
+            or len(self.filelist) >= ZIP_FILECOUNT_LIMIT
+        )
 
         self._writecheck(zinfo)
         self._didModify = True

--- a/Misc/NEWS.d/next/Library/2024-06-30-21-32-11.gh-issue-121171.na1LoU.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-30-21-32-11.gh-issue-121171.na1LoU.rst
@@ -1,0 +1,3 @@
+zipfile: Write the correct minimum extract version indicating zip64 support
+is required to the local header when the archive exceeds the zip64 archive
+filesize or file count thresholds.


### PR DESCRIPTION
Fix: Wrong extract version set in local headers for files located beyond zip64 limit #121171


<!-- gh-issue-number: gh-121171 -->
* Issue: gh-121171
<!-- /gh-issue-number -->
