### PR TITLE
gh-119447: Fix build with _PY_SHORT_FLOAT_REPR == 0

### DIFF
--- a/Include/internal/pycore_dtoa.h
+++ b/Include/internal/pycore_dtoa.h
@@ -11,8 +11,6 @@ extern "C" {
 #include "pycore_pymath.h"        // _PY_SHORT_FLOAT_REPR
 
 
-#if _PY_SHORT_FLOAT_REPR == 1
-
 typedef uint32_t ULong;
 
 struct
@@ -22,15 +20,15 @@ Bigint {
     ULong x[1];
 };
 
-#ifdef Py_USING_MEMORY_DEBUGGER
+#if defined(Py_USING_MEMORY_DEBUGGER) || _PY_SHORT_FLOAT_REPR == 0
 
 struct _dtoa_state {
     int _not_used;
 };
-#define _dtoa_interp_state_INIT(INTERP) \
+#define _dtoa_state_INIT(INTERP) \
     {0}
 
-#else  // !Py_USING_MEMORY_DEBUGGER
+#else  // !Py_USING_MEMORY_DEBUGGER && _PY_SHORT_FLOAT_REPR != 0
 
 /* The size of the Bigint freelist */
 #define Bigint_Kmax 7
@@ -65,8 +63,6 @@ extern double _Py_dg_strtod(const char *str, char **ptr);
 extern char* _Py_dg_dtoa(double d, int mode, int ndigits,
                          int *decpt, int *sign, char **rve);
 extern void _Py_dg_freedtoa(char *s);
-
-#endif // _PY_SHORT_FLOAT_REPR == 1
 
 
 extern PyStatus _PyDtoa_Init(PyInterpreterState *interp);


### PR DESCRIPTION
After https://github.com/python/cpython/commit/3c57971a2d3b6d2c6fd1f525ba2108fccb35add2 the dtoa_runtime_state is referenced from pycore_runtime.h (later moved to Include/internal/pycore_interp.h) unconditionally, but the dtoa_runtime_state struct is not defined in all cases. Use the "not_used" definition of dtoa_runtime_state which already exists for the Py_USING_MEMORY_DEBUGGER case on those platforms as well.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119447 -->
* Issue: gh-119447
<!-- /gh-issue-number -->
