### PR TITLE
gh-121084: Call _abc_registry_clear() when checking refleaks

### DIFF
--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -246,9 +246,12 @@ def dash_R_cleanup(fs, ps, pic, zdc, abcs):
     abs_classes = filter(isabstract, abs_classes)
     for abc in abs_classes:
         for obj in abc.__subclasses__() + [abc]:
-            for ref in abcs.get(obj, set()):
-                if ref() is not None:
-                    obj.register(ref())
+            refs = abcs.get(obj, None)
+            if refs is not None:
+                obj._abc_registry_clear()
+                for ref in refs:
+                    if ref() is not None:
+                        obj.register(ref())
             obj._abc_caches_clear()
 
     # Clear caches

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -250,8 +250,9 @@ def dash_R_cleanup(fs, ps, pic, zdc, abcs):
             if refs is not None:
                 obj._abc_registry_clear()
                 for ref in refs:
-                    if ref() is not None:
-                        obj.register(ref())
+                    subclass = ref()
+                    if subclass is not None:
+                        obj.register(subclass)
             obj._abc_caches_clear()
 
     # Clear caches


### PR DESCRIPTION
dash_R_cleanup() now calls _abc_registry_clear() before calling again register().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121084 -->
* Issue: gh-121084
<!-- /gh-issue-number -->
