### PR TITLE
gh-121192: Add fast path to `deepcopy()` for empty list/tuple/dict/set

### DIFF
--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -123,19 +123,23 @@ def deepcopy(x, memo=None, _nil=[]):
 
     cls = type(x)
 
-    if cls in _atomic_types:
+    if cls in _atomic_types or (cls in _immutable_iterables and len(x) == 0):
         return x
 
-    d = id(x)
     if memo is None:
+        if cls in _mutable_iterables and len(x) == 0:
+            return cls()
+        d = id(x)
         memo = {}
     else:
+        d = id(x)
         y = memo.get(d, _nil)
         if y is not _nil:
             return y
 
-    copier = _deepcopy_dispatch.get(cls)
-    if copier is not None:
+    if cls in _mutable_iterables and len(x) == 0:
+        y = cls()
+    elif copier := _deepcopy_dispatch.get(cls):
         y = copier(x, memo)
     else:
         if issubclass(cls, type):
@@ -173,6 +177,8 @@ def deepcopy(x, memo=None, _nil=[]):
 _atomic_types =  {types.NoneType, types.EllipsisType, types.NotImplementedType,
           int, float, bool, complex, bytes, str, types.CodeType, type, range,
           types.BuiltinFunctionType, types.FunctionType, weakref.ref, property}
+_mutable_iterables = {list, dict, set}
+_immutable_iterables = {tuple, frozenset}
 
 _deepcopy_dispatch = d = {}
 

--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -127,7 +127,7 @@ def deepcopy(x, memo=None, _nil=[]):
         return x
 
     if memo is None:
-        if cls in _builtin_iterables and len(x) == 0:
+        if cls in _builtin_iterables and not x:
             return cls()
         d = id(x)
         memo = {}
@@ -137,7 +137,7 @@ def deepcopy(x, memo=None, _nil=[]):
         if y is not _nil:
             return y
 
-    if cls in _builtin_iterables and len(x) == 0:
+    if cls in _builtin_iterables and not x:
         y = cls()
     elif copier := _deepcopy_dispatch.get(cls):
         y = copier(x, memo)

--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -123,11 +123,11 @@ def deepcopy(x, memo=None, _nil=[]):
 
     cls = type(x)
 
-    if cls in _atomic_types or (cls in _immutable_iterables and len(x) == 0):
+    if cls in _atomic_types:
         return x
 
     if memo is None:
-        if cls in _mutable_iterables and len(x) == 0:
+        if cls in _builtin_iterables and len(x) == 0:
             return cls()
         d = id(x)
         memo = {}
@@ -137,7 +137,7 @@ def deepcopy(x, memo=None, _nil=[]):
         if y is not _nil:
             return y
 
-    if cls in _mutable_iterables and len(x) == 0:
+    if cls in _builtin_iterables and len(x) == 0:
         y = cls()
     elif copier := _deepcopy_dispatch.get(cls):
         y = copier(x, memo)
@@ -177,8 +177,7 @@ def deepcopy(x, memo=None, _nil=[]):
 _atomic_types =  {types.NoneType, types.EllipsisType, types.NotImplementedType,
           int, float, bool, complex, bytes, str, types.CodeType, type, range,
           types.BuiltinFunctionType, types.FunctionType, weakref.ref, property}
-_mutable_iterables = {list, dict, set}
-_immutable_iterables = {tuple, frozenset}
+_builtin_iterables = {tuple, list, dict, set, frozenset}
 
 _deepcopy_dispatch = d = {}
 

--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -137,9 +137,8 @@ def deepcopy(x, memo=None, _nil=[]):
         if y is not _nil:
             return y
 
-    if cls in _builtin_iterables and not x:
-        y = cls()
-    elif copier := _deepcopy_dispatch.get(cls):
+    copier = _deepcopy_dispatch.get(cls)
+    if copier is not None:
         y = copier(x, memo)
     else:
         if issubclass(cls, type):

--- a/Misc/NEWS.d/next/Library/2024-07-01-00-32-33.gh-issue-121192.RZFhQP.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-01-00-32-33.gh-issue-121192.RZFhQP.rst
@@ -1,0 +1,2 @@
+Add fast path to :func:`copy.deepcopy` for empty lists, tuples, dicts, sets
+or frozensets.


### PR DESCRIPTION
`deepcopy()` can be surprisingly slow when called with empty containers like lists, tuples, dicts, sets or frozensets.

This adds a fast path for this case similar to #114266 which speeds up these cases by about 4x - 21x while having a small impact on the default path.

Here are some benchmarks comparing this PR against `main`. Let me know if there are more benchmarks that I can run to verify that there a no performance regressions for the common case:
```python
import pyperf
runner = pyperf.Runner()

setup = """
import copy

a = {"list": [1, 2 ,3 ,4], "t": (1, 2, 3), "str": "hello", "subdict": {"a": True}}

t = ()
fs = frozenset()
l = []
s = set()
d = {}
deep = [[], (), {}, set(), frozenset()]
"""

runner.timeit(name="deepcopy dict", stmt=f"b = copy.deepcopy(a)", setup=setup)
runner.timeit(name="deepcopy empty tuple", stmt=f"b = copy.deepcopy(t)", setup=setup)
runner.timeit(name="deepcopy empty frozenset", stmt=f"b = copy.deepcopy(fs)", setup=setup)
runner.timeit(name="deepcopy empty list", stmt=f"b = copy.deepcopy(l)", setup=setup)
runner.timeit(name="deepcopy empty set", stmt=f"b = copy.deepcopy(s)", setup=setup)
runner.timeit(name="deepcopy empty dict", stmt=f"b = copy.deepcopy(d)", setup=setup)
runner.timeit(name="deepcopy multiple empty containers", stmt=f"b = copy.deepcopy(deep)", setup=setup)

```
```
deepcopy empty tuple: Mean +- std dev: [baseline] 287 ns +- 4 ns -> [opt-empty] 49.8 ns +- 1.7 ns: 5.77x faster
deepcopy empty frozenset: Mean +- std dev: [baseline] 1.46 us +- 0.02 us -> [opt-empty] 67.1 ns +- 1.8 ns: 21.70x faster
deepcopy empty list: Mean +- std dev: [baseline] 327 ns +- 6 ns -> [opt-empty] 67.1 ns +- 8.2 ns: 4.88x faster
deepcopy empty set: Mean +- std dev: [baseline] 1.44 us +- 0.02 us -> [opt-empty] 67.9 ns +- 3.8 ns: 21.26x faster
deepcopy empty dict: Mean +- std dev: [baseline] 329 ns +- 4 ns -> [opt-empty] 68.1 ns +- 3.0 ns: 4.83x faster

Benchmark hidden because not significant (2): deepcopy dict, deepcopy multiple empty containers

Geometric mean: 4.85x faster
```

<!-- gh-issue-number: gh-121192 -->
* Issue: gh-121192
<!-- /gh-issue-number -->
