### PR TITLE
gh-121188: Escape invalid XML characters in regrtest

### DIFF
--- a/Lib/test/libregrtest/testresult.py
+++ b/Lib/test/libregrtest/testresult.py
@@ -9,7 +9,7 @@ import time
 import traceback
 import unittest
 from test import support
-from test.libregrtest.utils import escape_xml
+from test.libregrtest.utils import sanitize_xml
 
 class RegressionTestResult(unittest.TextTestResult):
     USE_XML = False
@@ -66,10 +66,10 @@ class RegressionTestResult(unittest.TextTestResult):
         if capture:
             if self._stdout_buffer is not None:
                 stdout = self._stdout_buffer.getvalue().rstrip()
-                ET.SubElement(e, 'system-out').text = escape_xml(stdout)
+                ET.SubElement(e, 'system-out').text = sanitize_xml(stdout)
             if self._stderr_buffer is not None:
                 stderr = self._stderr_buffer.getvalue().rstrip()
-                ET.SubElement(e, 'system-err').text = escape_xml(stderr)
+                ET.SubElement(e, 'system-err').text = sanitize_xml(stderr)
 
         for k, v in args.items():
             if not k or not v:
@@ -79,11 +79,11 @@ class RegressionTestResult(unittest.TextTestResult):
             if hasattr(v, 'items'):
                 for k2, v2 in v.items():
                     if k2:
-                        e2.set(k2, escape_xml(str(v2)))
+                        e2.set(k2, sanitize_xml(str(v2)))
                     else:
-                        e2.text = escape_xml(str(v2))
+                        e2.text = sanitize_xml(str(v2))
             else:
-                e2.text = escape_xml(str(v))
+                e2.text = sanitize_xml(str(v))
 
     @classmethod
     def __makeErrorDict(cls, err_type, err_value, err_tb):

--- a/Lib/test/libregrtest/testresult.py
+++ b/Lib/test/libregrtest/testresult.py
@@ -9,6 +9,7 @@ import time
 import traceback
 import unittest
 from test import support
+from test.libregrtest.utils import escape_xml
 
 class RegressionTestResult(unittest.TextTestResult):
     USE_XML = False
@@ -65,23 +66,24 @@ class RegressionTestResult(unittest.TextTestResult):
         if capture:
             if self._stdout_buffer is not None:
                 stdout = self._stdout_buffer.getvalue().rstrip()
-                ET.SubElement(e, 'system-out').text = stdout
+                ET.SubElement(e, 'system-out').text = escape_xml(stdout)
             if self._stderr_buffer is not None:
                 stderr = self._stderr_buffer.getvalue().rstrip()
-                ET.SubElement(e, 'system-err').text = stderr
+                ET.SubElement(e, 'system-err').text = escape_xml(stderr)
 
         for k, v in args.items():
             if not k or not v:
                 continue
+
             e2 = ET.SubElement(e, k)
             if hasattr(v, 'items'):
                 for k2, v2 in v.items():
                     if k2:
-                        e2.set(k2, str(v2))
+                        e2.set(k2, escape_xml(str(v2)))
                     else:
-                        e2.text = str(v2)
+                        e2.text = escape_xml(str(v2))
             else:
-                e2.text = str(v)
+                e2.text = escape_xml(str(v))
 
     @classmethod
     def __makeErrorDict(cls, err_type, err_value, err_tb):

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -5,6 +5,7 @@ import math
 import os.path
 import platform
 import random
+import re
 import shlex
 import signal
 import subprocess
@@ -712,3 +713,19 @@ def get_signal_name(exitcode):
         pass
 
     return None
+
+
+ILLEGAL_XML_CHARS_RE = re.compile(
+    '['
+    '\x00-\x1F'      # ASCII control characters
+    '\uD800-\uDFFF'  # surrogate characters
+    '\uFFFE'
+    '\uFFFF'
+    ']')
+
+def _escape_xml_replace(regs):
+    code_point = ord(regs[0])
+    return f"&#{code_point};"
+
+def escape_xml(text):
+    return ILLEGAL_XML_CHARS_RE.sub(_escape_xml_replace, text)

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -2292,7 +2292,7 @@ class ArgsTestCase(BaseTestCase):
         self.assertEqual(testcase.get('result'), 'completed')
         self.assertGreater(float(testcase.get('time')), 0)
         for out in testcase.iter('system-out'):
-            self.assertEqual(out.text, "abc &#27; def")
+            self.assertEqual(out.text, r"abc \x1b def")
 
 
 class TestUtils(unittest.TestCase):
@@ -2477,21 +2477,23 @@ class TestUtils(unittest.TestCase):
             self.assertTrue(match_test(test_chdir))
             self.assertFalse(match_test(test_copy))
 
-    def test_escape_xml(self):
-        escape_xml = utils.escape_xml
+    def test_sanitize_xml(self):
+        sanitize_xml = utils.sanitize_xml
 
         # escape invalid XML characters
-        self.assertEqual(escape_xml('abc \x1b def'),
-                         'abc &#27; def')
-        self.assertEqual(escape_xml('nul:\x00, bell:\x07'),
-                         'nul:&#0;, bell:&#7;')
-        self.assertEqual(escape_xml('surrogate:\uDC80'),
-                         'surrogate:&#56448;')
-        self.assertEqual(escape_xml('illegal \uFFFE and \uFFFF'),
-                         'illegal &#65534; and &#65535;')
+        self.assertEqual(sanitize_xml('abc \x1b\x1f def'),
+                         r'abc \x1b\x1f def')
+        self.assertEqual(sanitize_xml('nul:\x00, bell:\x07'),
+                         r'nul:\x00, bell:\x07')
+        self.assertEqual(sanitize_xml('surrogate:\uDC80'),
+                         r'surrogate:\udc80')
+        self.assertEqual(sanitize_xml('illegal \uFFFE and \uFFFF'),
+                         r'illegal \ufffe and \uffff')
 
         # no escape for valid XML characters
-        self.assertEqual(escape_xml('valid t\xe9xt \u20ac'),
+        self.assertEqual(sanitize_xml('a\n\tb'),
+                         'a\n\tb')
+        self.assertEqual(sanitize_xml('valid t\xe9xt \u20ac'),
                          'valid t\xe9xt \u20ac')
 
 

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -2479,8 +2479,20 @@ class TestUtils(unittest.TestCase):
 
     def test_escape_xml(self):
         escape_xml = utils.escape_xml
+
+        # escape invalid XML characters
         self.assertEqual(escape_xml('abc \x1b def'),
                          'abc &#27; def')
+        self.assertEqual(escape_xml('nul:\x00, bell:\x07'),
+                         'nul:&#0;, bell:&#7;')
+        self.assertEqual(escape_xml('surrogate:\uDC80'),
+                         'surrogate:&#56448;')
+        self.assertEqual(escape_xml('illegal \uFFFE and \uFFFF'),
+                         'illegal &#65534; and &#65535;')
+
+        # no escape for valid XML characters
+        self.assertEqual(escape_xml('valid t\xe9xt \u20ac'),
+                         'valid t\xe9xt \u20ac')
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Tests/2024-07-01-09-04-32.gh-issue-121188.XbuTVa.rst
+++ b/Misc/NEWS.d/next/Tests/2024-07-01-09-04-32.gh-issue-121188.XbuTVa.rst
@@ -1,0 +1,3 @@
+When creating the JUnit XML file, regrtest now escapes characters which are
+invalid in XML, such as the chr(27) control character used in ANSI escape
+sequences. Patch by Victor Stinner.


### PR DESCRIPTION
When creating the JUnit XML file, regrtest now escapes characters which are invalid in XML, such as the chr(27) control character used in ANSI escape sequences.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121188 -->
* Issue: gh-121188
<!-- /gh-issue-number -->
