### PR TITLE
gh-121196: Document `dict.fromkeys` params as pos-only

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4565,7 +4565,7 @@ can be used interchangeably to index the same dictionary entry.
 
       Return a shallow copy of the dictionary.
 
-   .. classmethod:: fromkeys(iterable, value=None)
+   .. classmethod:: fromkeys(iterable, value=None, /)
 
       Create a new dictionary with keys from *iterable* and values set to *value*.
 


### PR DESCRIPTION
Please, consider that some subtypes of `dict` change the signature back to pos-or-keyword args.
But, since this is only about `dict`, I guess we can be very specific about it.

Do we backport this change?

<!-- gh-issue-number: gh-121196 -->
* Issue: gh-121196
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121197.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->