### PR TITLE
gh-121199: Use _Py__has_attribute() in timemodule.c

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1488,7 +1488,7 @@ _PyTime_GetThreadTimeWithInfo(PyTime_t *tp, _Py_clock_info_t *info)
       !defined(__EMSCRIPTEN__) && !defined(__wasi__)
 #define HAVE_THREAD_TIME
 
-#if defined(__APPLE__) && defined(__has_attribute) && __has_attribute(availability)
+#if defined(__APPLE__) && _Py__has_attribute(availability)
 static int
 _PyTime_GetThreadTimeWithInfo(PyTime_t *tp, _Py_clock_info_t *info)
      __attribute__((availability(macos, introduced=10.12)))

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -199,7 +199,7 @@ py_getrandom(void *buffer, Py_ssize_t size, int blocking, int raise)
 
    getentropy() is retried if it failed with EINTR: interrupted by a signal. */
 
-#if defined(__APPLE__) && defined(__has_attribute) && __has_attribute(availability)
+#if defined(__APPLE__) && _Py__has_attribute(availability)
 static int
 py_getentropy(char *buffer, Py_ssize_t size, int raise)
         __attribute__((availability(macos,introduced=10.12)))


### PR DESCRIPTION
Use the _Py__has_attribute() macro in timemodule.c and bootstrap_hash.c to fix a build error on old GCC versions (GCC 4.8.5 on s390x).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121199 -->
* Issue: gh-121199
<!-- /gh-issue-number -->
