### PR TITLE
gh-121200: Log pwd entry in test_expanduser_pwd2()

### DIFF
--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -359,13 +359,14 @@ class PosixPathTest(unittest.TestCase):
                      "no home directory on VxWorks")
     def test_expanduser_pwd2(self):
         pwd = import_helper.import_module('pwd')
-        for e in pwd.getpwall():
-            name = e.pw_name
-            home = e.pw_dir
+        for entry in pwd.getpwall():
+            name = entry.pw_name
+            home = entry.pw_dir
             home = home.rstrip('/') or '/'
-            self.assertEqual(posixpath.expanduser('~' + name), home)
-            self.assertEqual(posixpath.expanduser(os.fsencode('~' + name)),
-                             os.fsencode(home))
+            with self.subTest(pwd=entry):
+                self.assertEqual(posixpath.expanduser('~' + name), home)
+                self.assertEqual(posixpath.expanduser(os.fsencode('~' + name)),
+                                 os.fsencode(home))
 
     NORMPATH_CASES = [
         ("", "."),


### PR DESCRIPTION
Use subTest() to log the pwd entry in test_expanduser_pwd2() of test_posixpath to help debugging.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121200 -->
* Issue: gh-121200
<!-- /gh-issue-number -->
