### PR TITLE
gh-121200: Fix test_expanduser_pwd2() of test_posixpath

### DIFF
--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -359,11 +359,16 @@ class PosixPathTest(unittest.TestCase):
                      "no home directory on VxWorks")
     def test_expanduser_pwd2(self):
         pwd = import_helper.import_module('pwd')
-        for entry in pwd.getpwall():
-            name = entry.pw_name
+        for all_entry in pwd.getpwall():
+            name = all_entry.pw_name
+
+            # gh-121200: pw_dir can be different between getpwall() and
+            # getpwnam(), so use getpwnam() pw_dir as expanduser() does.
+            entry = pwd.getpwnam(name)
             home = entry.pw_dir
             home = home.rstrip('/') or '/'
-            with self.subTest(pwd=entry):
+
+            with self.subTest(all_entry=all_entry, entry=entry):
                 self.assertEqual(posixpath.expanduser('~' + name), home)
                 self.assertEqual(posixpath.expanduser(os.fsencode('~' + name)),
                                  os.fsencode(home))

--- a/Misc/NEWS.d/next/Tests/2024-07-01-16-15-06.gh-issue-121200.4Pc-gc.rst
+++ b/Misc/NEWS.d/next/Tests/2024-07-01-16-15-06.gh-issue-121200.4Pc-gc.rst
@@ -1,0 +1,3 @@
+Fix ``test_expanduser_pwd2()`` of ``test_posixpath``.  Call ``getpwnam()``
+to get ``pw_dir``, since it can be different than ``getpwall()`` ``pw_dir``.
+Patch by Victor Stinner.


### PR DESCRIPTION
Call getpwnam() to get pw_dir, since it can be different than getpwall() pw_dir.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121200 -->
* Issue: gh-121200
<!-- /gh-issue-number -->
