### PR TITLE
Add structure sizes to the _Py_DebugOffsets structure

### DIFF
--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -55,12 +55,14 @@ typedef struct _Py_DebugOffsets {
     uint64_t version;
     // Runtime state offset;
     struct _runtime_state {
+        uint64_t size;
         uint64_t finalizing;
         uint64_t interpreters_head;
     } runtime_state;
 
     // Interpreter state offset;
     struct _interpreter_state {
+        uint64_t size;
         uint64_t next;
         uint64_t threads_head;
         uint64_t gc;
@@ -74,6 +76,7 @@ typedef struct _Py_DebugOffsets {
 
     // Thread state offset;
     struct _thread_state{
+        uint64_t size;
         uint64_t prev;
         uint64_t next;
         uint64_t interp;
@@ -84,6 +87,7 @@ typedef struct _Py_DebugOffsets {
 
     // InterpreterFrame offset;
     struct _interpreter_frame {
+        uint64_t size;
         uint64_t previous;
         uint64_t executable;
         uint64_t instr_ptr;
@@ -93,12 +97,14 @@ typedef struct _Py_DebugOffsets {
 
     // CFrame offset;
     struct _cframe {
+        uint64_t size;
         uint64_t current_frame;
         uint64_t previous;
     } cframe;
 
     // Code object offset;
     struct _code_object {
+        uint64_t size;
         uint64_t filename;
         uint64_t name;
         uint64_t linetable;
@@ -111,21 +117,25 @@ typedef struct _Py_DebugOffsets {
 
     // PyObject offset;
     struct _pyobject {
+        uint64_t size;
         uint64_t ob_type;
     } pyobject;
 
     // PyTypeObject object offset;
     struct _type_object {
+        uint64_t size;
         uint64_t tp_name;
     } type_object;
 
     // PyTuple object offset;
     struct _tuple_object {
+        uint64_t size;
         uint64_t ob_item;
     } tuple_object;
 
     // Unicode object offset;
     struct _unicode_object {
+        uint64_t size;
         uint64_t state;
         uint64_t length;
         size_t asciiobject_size;

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -35,10 +35,12 @@ extern PyTypeObject _PyExc_MemoryError;
             .cookie = "xdebugpy", \
             .version = PY_VERSION_HEX, \
             .runtime_state = { \
+                .size = sizeof(_PyRuntimeState), \
                 .finalizing = offsetof(_PyRuntimeState, _finalizing), \
                 .interpreters_head = offsetof(_PyRuntimeState, interpreters.head), \
             }, \
             .interpreter_state = { \
+                .size = sizeof(PyInterpreterState), \
                 .next = offsetof(PyInterpreterState, next), \
                 .threads_head = offsetof(PyInterpreterState, threads.head), \
                 .gc = offsetof(PyInterpreterState, gc), \
@@ -50,6 +52,7 @@ extern PyTypeObject _PyExc_MemoryError;
                 .gil_runtime_state_holder = offsetof(PyInterpreterState, _gil.last_holder), \
             }, \
             .thread_state = { \
+                .size = sizeof(PyThreadState), \
                 .prev = offsetof(PyThreadState, prev), \
                 .next = offsetof(PyThreadState, next), \
                 .interp = offsetof(PyThreadState, interp), \
@@ -58,6 +61,7 @@ extern PyTypeObject _PyExc_MemoryError;
                 .native_thread_id = offsetof(PyThreadState, native_thread_id), \
             }, \
             .interpreter_frame = { \
+                .size = sizeof(_PyInterpreterFrame), \
                 .previous = offsetof(_PyInterpreterFrame, previous), \
                 .executable = offsetof(_PyInterpreterFrame, f_executable), \
                 .instr_ptr = offsetof(_PyInterpreterFrame, instr_ptr), \
@@ -65,6 +69,7 @@ extern PyTypeObject _PyExc_MemoryError;
                 .owner = offsetof(_PyInterpreterFrame, owner), \
             }, \
             .code_object = { \
+                .size = sizeof(PyCodeObject), \
                 .filename = offsetof(PyCodeObject, co_filename), \
                 .name = offsetof(PyCodeObject, co_name), \
                 .linetable = offsetof(PyCodeObject, co_linetable), \
@@ -75,15 +80,19 @@ extern PyTypeObject _PyExc_MemoryError;
                 .co_code_adaptive = offsetof(PyCodeObject, co_code_adaptive), \
             }, \
             .pyobject = { \
+                .size = sizeof(PyObject), \
                 .ob_type = offsetof(PyObject, ob_type), \
             }, \
             .type_object = { \
+                .size = sizeof(PyTypeObject), \
                 .tp_name = offsetof(PyTypeObject, tp_name), \
             }, \
             .tuple_object = { \
+                .size = sizeof(PyTupleObject), \
                 .ob_item = offsetof(PyTupleObject, ob_item), \
             }, \
             .unicode_object = { \
+                .size = sizeof(PyUnicodeObject), \
                 .state = offsetof(PyUnicodeObject, _base._base.state), \
                 .length = offsetof(PyUnicodeObject, _base._base.length), \
                 .asciiobject_size = sizeof(PyASCIIObject), \


### PR DESCRIPTION
We add the size field to each of the structures referenced by the new _Py_DebugOffsets structure. This allows out-of-process tools to make a reduced number of system calls when resolving multiple fields from the same remote structures by making a local copy of the whole structure, and then using this to resolve the required fields.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
