### PR TITLE
gh-116181: Remove Py_BUILD_CORE_MODULE and Py_BUILD_CORE_MODULE in rotatingtree.c

### DIFF
--- a/Modules/rotatingtree.c
+++ b/Modules/rotatingtree.c
@@ -1,9 +1,4 @@
-#ifndef Py_BUILD_CORE_BUILTIN
-#  define Py_BUILD_CORE_MODULE 1
-#endif
-
 #include "Python.h"
-#include "pycore_lock.h"
 #include "rotatingtree.h"
 
 #define KEY_LOWER_THAN(key1, key2)  ((char*)(key1) < (char*)(key2))


### PR DESCRIPTION
Since #117511 has been finished and `PyMutex` is a public API now, we can remove the `Py_BUILD_CORE_BUILTIN` and `Py_BUILD_CORE_MODULE` macro define.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116181 -->
* Issue: gh-116181
<!-- /gh-issue-number -->
