### PR TITLE
gh-112136: Restore removed _PyArg_Parser

### DIFF
--- a/Include/cpython/modsupport.h
+++ b/Include/cpython/modsupport.h
@@ -1,0 +1,26 @@
+#ifndef Py_CPYTHON_MODSUPPORT_H
+#  error "this header file must not be included directly"
+#endif
+
+// A data structure that can be used to run initialization code once in a
+// thread-safe manner. The C++11 equivalent is std::call_once.
+typedef struct {
+    uint8_t v;
+} _PyOnceFlag;
+
+typedef struct _PyArg_Parser {
+    const char *format;
+    const char * const *keywords;
+    const char *fname;
+    const char *custom_msg;
+    _PyOnceFlag once;       /* atomic one-time initialization flag */
+    int is_kwtuple_owned;   /* does this parser own the kwtuple object? */
+    int pos;                /* number of positional-only arguments */
+    int min;                /* minimal number of arguments */
+    int max;                /* maximal number of positional arguments */
+    PyObject *kwtuple;      /* tuple of keyword parameter names */
+    struct _PyArg_Parser *next;
+} _PyArg_Parser;
+
+PyAPI_FUNC(int) _PyArg_ParseTupleAndKeywordsFast(PyObject *, PyObject *,
+                                                 struct _PyArg_Parser *, ...);

--- a/Include/internal/pycore_lock.h
+++ b/Include/internal/pycore_lock.h
@@ -128,12 +128,6 @@ _PyRawMutex_Unlock(_PyRawMutex *m)
     _PyRawMutex_UnlockSlow(m);
 }
 
-// A data structure that can be used to run initialization code once in a
-// thread-safe manner. The C++11 equivalent is std::call_once.
-typedef struct {
-    uint8_t v;
-} _PyOnceFlag;
-
 // Type signature for one-time initialization functions. The function should
 // return 0 on success and -1 on failure.
 typedef int _Py_once_fn_t(void *arg);

--- a/Include/internal/pycore_modsupport.h
+++ b/Include/internal/pycore_modsupport.h
@@ -67,24 +67,6 @@ PyAPI_FUNC(void) _PyArg_BadArgument(
 
 // --- _PyArg_Parser API ---------------------------------------------------
 
-typedef struct _PyArg_Parser {
-    const char *format;
-    const char * const *keywords;
-    const char *fname;
-    const char *custom_msg;
-    _PyOnceFlag once;       /* atomic one-time initialization flag */
-    int is_kwtuple_owned;   /* does this parser own the kwtuple object? */
-    int pos;                /* number of positional-only arguments */
-    int min;                /* minimal number of arguments */
-    int max;                /* maximal number of positional arguments */
-    PyObject *kwtuple;      /* tuple of keyword parameter names */
-    struct _PyArg_Parser *next;
-} _PyArg_Parser;
-
-// Export for '_testclinic' shared extension
-PyAPI_FUNC(int) _PyArg_ParseTupleAndKeywordsFast(PyObject *, PyObject *,
-                                                 struct _PyArg_Parser *, ...);
-
 // Export for '_dbm' shared extension
 PyAPI_FUNC(int) _PyArg_ParseStackAndKeywords(
     PyObject *const *args,

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -134,6 +134,12 @@ PyAPI_FUNC(PyObject *) PyModule_FromDefAndSpec2(PyModuleDef *def,
 
 #endif /* New in 3.5 */
 
+#ifndef Py_LIMITED_API
+#  define Py_CPYTHON_MODSUPPORT_H
+#  include "cpython/modsupport.h"
+#  undef Py_CPYTHON_MODSUPPORT_H
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1115,6 +1115,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/cpython/longobject.h \
 		$(srcdir)/Include/cpython/memoryobject.h \
 		$(srcdir)/Include/cpython/methodobject.h \
+		$(srcdir)/Include/cpython/modsupport.h \
 		$(srcdir)/Include/cpython/monitoring.h \
 		$(srcdir)/Include/cpython/object.h \
 		$(srcdir)/Include/cpython/objimpl.h \

--- a/Misc/NEWS.d/next/C API/2024-07-02-11-03-40.gh-issue-112136.f3fiY8.rst
+++ b/Misc/NEWS.d/next/C API/2024-07-02-11-03-40.gh-issue-112136.f3fiY8.rst
@@ -1,0 +1,3 @@
+Restore the private ``_PyArg_Parser`` structure and the private
+``_PyArg_ParseTupleAndKeywordsFast()`` function, previously removed in Python
+3.13 alpha 1. Patch by Victor Stinner.

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -163,6 +163,7 @@
     <ClInclude Include="..\Include\cpython\longobject.h" />
     <ClInclude Include="..\Include\cpython\memoryobject.h" />
     <ClInclude Include="..\Include\cpython\methodobject.h" />
+    <ClInclude Include="..\Include\cpython\modsupport.h" />
     <ClInclude Include="..\Include\cpython\object.h" />
     <ClInclude Include="..\Include\cpython\objimpl.h" />
     <ClInclude Include="..\Include\cpython\odictobject.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -432,6 +432,9 @@
     <ClInclude Include="..\Include\cpython\methodobject.h">
       <Filter>Include\cpython</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\cpython\modsupport.h">
+      <Filter>Include\cpython</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\cpython\objimpl.h">
       <Filter>Include\cpython</Filter>
     </ClInclude>


### PR DESCRIPTION
Restore removed private _PyArg_Parser structure and private _PyArg_ParseTupleAndKeywordsFast() function.

Recreate Include/cpython/modsupport.h header file.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112136 -->
* Issue: gh-112136
<!-- /gh-issue-number -->
