### PR TITLE
[3.13] gh-121279: Re-add prematurely removed import warnings to importlib.abc

### DIFF
--- a/Lib/importlib/abc.py
+++ b/Lib/importlib/abc.py
@@ -13,6 +13,7 @@ except ImportError:
     _frozen_importlib_external = _bootstrap_external
 from ._abc import Loader
 import abc
+import warnings
 
 from .resources import abc as _resources_abc
 

--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -913,5 +913,27 @@ class SourceLoaderGetSourceTests:
                          SourceOnlyLoaderMock=SPLIT_SOL)
 
 
+class DeprecatedAttrsTests:
+
+    """Test the deprecated attributes can be accessed."""
+
+    def test_deprecated_attr_ResourceReader(self):
+        with self.assertWarns(DeprecationWarning):
+            self.abc.ResourceReader
+
+    def test_deprecated_attr_Traversable(self):
+        with self.assertWarns(DeprecationWarning):
+            self.abc.Traversable
+
+    def test_deprecated_attr_TraversableResources(self):
+        with self.assertWarns(DeprecationWarning):
+            self.abc.TraversableResources
+
+
+(Frozen_DeprecatedAttrsTests,
+ Source_DeprecatedAttrsTests
+ ) = test_util.test_both(DeprecatedAttrsTests, abc=abc)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2024-07-02-19-36-54.gh-issue-121279.BltDo9.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-02-19-36-54.gh-issue-121279.BltDo9.rst
@@ -1,0 +1,2 @@
+Avoid :exc:`NameError` for the :mod:`warnings` module when accessing the
+depracated atributes of the :mod:`importlib.abc` module.


### PR DESCRIPTION
Fixup for 51724620e868512bbedb1547aca441bcd27bbe0c

Fixes https://github.com/python/cpython/issues/121279

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121279 -->
* Issue: gh-121279
<!-- /gh-issue-number -->
