### PR TITLE
gh-121292: Don't call key function for size-1 inputs to min()/max()/list.sort()

### DIFF
--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2884,7 +2884,7 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
     FT_ATOMIC_STORE_PTR_RELEASE(self->ob_item, NULL);
     self->allocated = -1; /* any operation will reset it to >= 0 */
 
-    if (keyfunc == NULL) {
+    if (keyfunc == NULL || saved_ob_size <= 1) {
         keys = NULL;
         lo.keys = saved_ob_item;
         lo.values = NULL;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1851,27 +1851,27 @@ min_max(PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames, int op)
                 break;
             }
         }
-        assert(item != NULL);
 
-        /* first iteration; just set maxitem, defer maxval since we may not need it */
-        if (maxitem == NULL) {
-            maxitem = item;
-            continue;
-        }
-
-        /* second iteration; set deferred maxval before comparisons */
         if (maxval == NULL) {
-            /* get the value from the key function */
-            if (keyfunc != NULL) {
-                val = PyObject_CallOneArg(keyfunc, maxitem);
-                if (val == NULL)
-                    goto Fail_it_item;
+            /* first iteration; just set maxitem, defer maxval since we may not need it */
+            if (maxitem == NULL) {
+                maxitem = item;
+                continue;
             }
-            /* no key function; the value is the item */
+            /* second iteration; set deferred maxval before comparisons */
             else {
-                val = Py_NewRef(maxitem);
+                /* get the value from the key function */
+                if (keyfunc != NULL) {
+                    val = PyObject_CallOneArg(keyfunc, maxitem);
+                    if (val == NULL)
+                        goto Fail_it_item;
+                }
+                /* no key function; the value is the item */
+                else {
+                    val = Py_NewRef(maxitem);
+                }
+                maxval = val;
             }
-            maxval = val;
         }
 
         /* get the value from the key function */


### PR DESCRIPTION
Calling the key function is unnecessary for size-1 inputs, as no comparisons are done.

This PR defers calling the key until a comparison is required in `min()`/`max()`, and skips it for `list.sort()` with size 1.

<!-- gh-issue-number: gh-121292 -->
* Issue: gh-121292
<!-- /gh-issue-number -->
