### PR TITLE
gh-121109: Fix performance of tarfile reading with "r|*"

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -401,7 +401,6 @@ class _Stream:
                 except ImportError:
                     raise CompressionError("compression.zstd module is not available") from None
                 if mode == "r":
-                    self.dbuf = b""
                     self.cmp = zstd.ZstdDecompressor()
                     self.exception = zstd.ZstdError
                 else:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -576,11 +576,7 @@ class _Stream:
             t.append(dbuf)
             c += len(dbuf)
 
-        t = b"".join(t)
-        if len(t) > size:
-            # This would only happen if decompress() has a bug.
-            raise ReadError("decompress() returned too much data")
-        return t
+        return b"".join(t)
 
     def __read(self, size):
         """Return size bytes from stream. If internal buffer is empty,

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -542,26 +542,43 @@ class _Stream:
         c = 0
         t = []
         while c < size:
-            # Skip underlying buffer to avoid unaligned double buffering.
-            if self.buf:
-                buf = self.buf
-                self.buf = b""
-            elif self.comptype != "gz" and not self.cmp.needs_input:
-                buf = b""
-            else:
-                buf = self.fileobj.read(self.bufsize)
-                if not buf:
-                    break
-            try:
-                buf = self.cmp.decompress(buf, size - c)
-                if self.comptype == "gz":
+            if self.comptype == "gz":
+                # zlib interface is different than others.
+                # It returns data in unconsumed_tail.
+                if self.buf:
+                    cbuf = self.buf
+                    self.buf = b""
+                else:
+                    cbuf = self.fileobj.read(self.bufsize)
+                    if not cbuf:
+                        break
+
+                try:
+                    dbuf = self.cmp.decompress(cbuf, size - c)
                     self.buf = self.cmp.unconsumed_tail
-            except self.exception as e:
-                raise ReadError("invalid compressed data") from e
-            t.append(buf)
-            c += len(buf)
+                except self.exception as e:
+                    raise ReadError("invalid compressed data") from e
+            else:
+                # Other decompressors have needs_input.
+                # decompress() can buffer data internally.
+                if self.cmp.needs_input:
+                    cbuf = self.fileobj.read(self.bufsize)
+                    if not cbuf:
+                        break
+                else:
+                    cbuf = b""
+
+                try:
+                    dbuf = self.cmp.decompress(cbuf, size - c)
+                except self.exception as e:
+                    raise ReadError("invalid compressed data") from e
+
+            t.append(dbuf)
+            c += len(dbuf)
+
         t = b"".join(t)
         if len(t) > size:
+            # This would only happen if decompress() has a bug.
             raise ReadError("decompress() returned too much data")
         return t
 

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -380,7 +380,6 @@ class _Stream:
                 except ImportError:
                     raise CompressionError("bz2 module is not available") from None
                 if mode == "r":
-                    self.dbuf = b""
                     self.cmp = bz2.BZ2Decompressor()
                     self.exception = OSError
                 else:
@@ -392,7 +391,6 @@ class _Stream:
                 except ImportError:
                     raise CompressionError("lzma module is not available") from None
                 if mode == "r":
-                    self.dbuf = b""
                     self.cmp = lzma.LZMADecompressor()
                     self.exception = lzma.LZMAError
                 else:
@@ -485,7 +483,6 @@ class _Stream:
         """Initialize for reading a gzip compressed fileobj.
         """
         self.cmp = self.zlib.decompressobj(-self.zlib.MAX_WBITS)
-        self.dbuf = b""
 
         # taken from gzip.GzipFile with some alterations
         if self.__read(2) != b"\037\213":
@@ -543,26 +540,31 @@ class _Stream:
         if self.comptype == "tar":
             return self.__read(size)
 
-        c = len(self.dbuf)
-        t = [self.dbuf]
+        c = 0
+        t = []
         while c < size:
             # Skip underlying buffer to avoid unaligned double buffering.
             if self.buf:
                 buf = self.buf
                 self.buf = b""
+            elif self.comptype != "gz" and not self.cmp.needs_input:
+                buf = b""
             else:
                 buf = self.fileobj.read(self.bufsize)
                 if not buf:
                     break
             try:
-                buf = self.cmp.decompress(buf)
+                buf = self.cmp.decompress(buf, size - c)
+                if self.comptype == "gz":
+                    self.buf = self.cmp.unconsumed_tail
             except self.exception as e:
                 raise ReadError("invalid compressed data") from e
             t.append(buf)
             c += len(buf)
         t = b"".join(t)
-        self.dbuf = t[size:]
-        return t[:size]
+        if len(t) > size:
+            raise ReadError("decompress() returned too much data")
+        return t
 
     def __read(self, size):
         """Return size bytes from stream. If internal buffer is empty,

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -144,6 +144,7 @@ Bas van Beek
 Ian Beer
 Stefan Behnel
 Reimer Behrends
+Tomi Belan
 Maxime Bélanger
 Ben Bell
 Thomas Bellman

--- a/Misc/NEWS.d/next/Library/2024-07-02-20-57-43.gh-issue-121109.Tp6R2s.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-02-20-57-43.gh-issue-121109.Tp6R2s.rst
@@ -1,0 +1,2 @@
+Fix :mod:`tarfile` performance issue when reading archives in streaming mode
+(e.g. ``r|*``).


### PR DESCRIPTION
This PR fixes #121109.

Using the test files and test script described in the issue:

| filename | mode | time with PR |
| --- | --- | --- |
| `test.tar.gz` | `r:*` | 1.075s |
| `test.tar.gz` | `r\|*` | 0.812s |
| `test.tar.xz` | `r:*` | 1.066s |
| `test.tar.xz` | `r\|*` | 1.053s |
| `test.tar.bz2` | `r:*` | 0.913s |
| `test.tar.bz2` | `r\|*` | 0.896s |

After this PR, tf.list() of `r|*` is the same speed as `r:*`, as expected. Not orders of magnitude slower.

<!-- gh-issue-number: gh-121109 -->
* Issue: gh-121109
<!-- /gh-issue-number -->
