### PR TITLE
gh-89004: add attribute filemode in zipinfo

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -890,6 +890,11 @@ Instances have the following methods and attributes:
 
    Size of the uncompressed file.
 
+.. attribute:: ZipInfo.file_mode
+
+   External attributes of the uncompressed file.
+
+   .. versionadded:: 3.14
 
 .. _zipfile-commandline:
 .. program:: zipfile

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -381,7 +381,7 @@ class AbstractTestsWithSourceFile:
                 self.assertIn("mode='r'", r)
                 r = repr(zipfp.getinfo(fname))
                 self.assertIn('filename=%r' % fname, r)
-                self.assertIn('filemode=', r)
+                self.assertIn('file_mode=', r)
                 self.assertIn('file_size=', r)
                 if self.compression != zipfile.ZIP_STORED:
                     self.assertIn('compress_type=', r)
@@ -2203,7 +2203,7 @@ class OtherTests(unittest.TestCase):
     def test_create_empty_zipinfo_repr(self):
         """Before bpo-26185, repr() on empty ZipInfo object was failing."""
         zi = zipfile.ZipInfo(filename="empty")
-        self.assertEqual(repr(zi), "<ZipInfo filename='empty' file_size=0>")
+        self.assertEqual(repr(zi), "<ZipInfo filename='empty' file_mode=b'' file_size=0>")
 
     def test_create_empty_zipinfo_default_attributes(self):
         """Ensure all required attributes are set."""
@@ -2226,6 +2226,8 @@ class OtherTests(unittest.TestCase):
         # Before bpo-26185, both were missing
         self.assertEqual(zi.file_size, 0)
         self.assertEqual(zi.compress_size, 0)
+
+        self.assertEqual(zi.file_mode, b"")
 
     def test_zipfile_with_short_extra_field(self):
         """If an extra field in the header is less than 4 bytes, skip it."""

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -22,7 +22,7 @@ from test.support import script_helper
 from test.support import (
     findfile, requires_zlib, requires_bz2, requires_lzma,
     captured_stdout, captured_stderr, requires_subprocess,
-    MS_WINDOWS
+    MS_WINDOWS, is_wasi
 )
 from test.support.os_helper import (
     TESTFN, unlink, rmtree, temp_dir, temp_cwd, fd_count, FakePath
@@ -3077,6 +3077,8 @@ class ZipInfoTests(unittest.TestCase):
         self.assertFalse(zi.is_dir())
         self.assertEqual(zi.file_size, os.path.getsize(__file__))
         if MS_WINDOWS:
+            self.assertEqual(zi.file_mode, '-rw-rw-rw-')
+        elif is_wasi:
             self.assertEqual(zi.file_mode, '----------')
         else:
             self.assertEqual(zi.file_mode, '-rw-r--r--')
@@ -3087,6 +3089,8 @@ class ZipInfoTests(unittest.TestCase):
         self.assertFalse(zi.is_dir())
         self.assertEqual(zi.file_size, os.path.getsize(__file__))
         if MS_WINDOWS:
+            self.assertEqual(zi.file_mode, '-rw-rw-rw-')
+        elif is_wasi:
             self.assertEqual(zi.file_mode, '----------')
         else:
             self.assertEqual(zi.file_mode, '-rw-r--r--')
@@ -3097,6 +3101,8 @@ class ZipInfoTests(unittest.TestCase):
         self.assertFalse(zi.is_dir())
         self.assertEqual(zi.file_size, os.path.getsize(__file__))
         if MS_WINDOWS:
+            self.assertEqual(zi.file_mode, '-rw-rw-rw-')
+        elif is_wasi:
             self.assertEqual(zi.file_mode, '----------')
         else:
             self.assertEqual(zi.file_mode, '-rw-r--r--')
@@ -3116,6 +3122,8 @@ class ZipInfoTests(unittest.TestCase):
         self.assertEqual(zi.compress_type, zipfile.ZIP_STORED)
         self.assertEqual(zi.file_size, 0)
         if MS_WINDOWS:
+            self.assertEqual(zi.file_mode, 'drwxrwxrwx')
+        elif is_wasi:
             self.assertEqual(zi.file_mode, 'd---------')
         else:
             self.assertEqual(zi.file_mode, 'drwxr-xr-x')

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -21,7 +21,8 @@ from test import archiver_tests
 from test.support import script_helper
 from test.support import (
     findfile, requires_zlib, requires_bz2, requires_lzma,
-    captured_stdout, captured_stderr, requires_subprocess
+    captured_stdout, captured_stderr, requires_subprocess,
+    MS_WINDOWS
 )
 from test.support.os_helper import (
     TESTFN, unlink, rmtree, temp_dir, temp_cwd, fd_count, FakePath
@@ -3075,21 +3076,30 @@ class ZipInfoTests(unittest.TestCase):
         self.assertEqual(posixpath.basename(zi.filename), 'test_core.py')
         self.assertFalse(zi.is_dir())
         self.assertEqual(zi.file_size, os.path.getsize(__file__))
-        self.assertEqual(zi.file_mode, '-rw-r--r--')
+        if MS_WINDOWS:
+            self.assertEqual(zi.file_mode, '----------')
+        else:
+            self.assertEqual(zi.file_mode, '-rw-r--r--')
 
     def test_from_file_pathlike(self):
         zi = zipfile.ZipInfo.from_file(FakePath(__file__))
         self.assertEqual(posixpath.basename(zi.filename), 'test_core.py')
         self.assertFalse(zi.is_dir())
         self.assertEqual(zi.file_size, os.path.getsize(__file__))
-        self.assertEqual(zi.file_mode, '-rw-r--r--')
+        if MS_WINDOWS:
+            self.assertEqual(zi.file_mode, '----------')
+        else:
+            self.assertEqual(zi.file_mode, '-rw-r--r--')
 
     def test_from_file_bytes(self):
         zi = zipfile.ZipInfo.from_file(os.fsencode(__file__), 'test')
         self.assertEqual(posixpath.basename(zi.filename), 'test')
         self.assertFalse(zi.is_dir())
         self.assertEqual(zi.file_size, os.path.getsize(__file__))
-        self.assertEqual(zi.file_mode, '-rw-r--r--')
+        if MS_WINDOWS:
+            self.assertEqual(zi.file_mode, '----------')
+        else:
+            self.assertEqual(zi.file_mode, '-rw-r--r--')
 
     def test_from_file_fileno(self):
         with open(__file__, 'rb') as f:
@@ -3105,7 +3115,10 @@ class ZipInfoTests(unittest.TestCase):
         self.assertTrue(zi.is_dir())
         self.assertEqual(zi.compress_type, zipfile.ZIP_STORED)
         self.assertEqual(zi.file_size, 0)
-        self.assertEqual(zi.file_mode, 'drwxr-xr-x')
+        if MS_WINDOWS:
+            self.assertEqual(zi.file_mode, 'd---------')
+        else:
+            self.assertEqual(zi.file_mode, 'drwxr-xr-x')
 
     def test_compresslevel_property(self):
         zinfo = zipfile.ZipInfo("xxx")

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -381,7 +381,6 @@ class AbstractTestsWithSourceFile:
                 self.assertIn("mode='r'", r)
                 r = repr(zipfp.getinfo(fname))
                 self.assertIn('filename=%r' % fname, r)
-                self.assertIn('file_mode=', r)
                 self.assertIn('file_size=', r)
                 if self.compression != zipfile.ZIP_STORED:
                     self.assertIn('compress_type=', r)
@@ -2203,7 +2202,7 @@ class OtherTests(unittest.TestCase):
     def test_create_empty_zipinfo_repr(self):
         """Before bpo-26185, repr() on empty ZipInfo object was failing."""
         zi = zipfile.ZipInfo(filename="empty")
-        self.assertEqual(repr(zi), "<ZipInfo filename='empty' file_mode=b'' file_size=0>")
+        self.assertEqual(repr(zi), "<ZipInfo filename='empty' file_size=0>")
 
     def test_create_empty_zipinfo_default_attributes(self):
         """Ensure all required attributes are set."""
@@ -2226,8 +2225,7 @@ class OtherTests(unittest.TestCase):
         # Before bpo-26185, both were missing
         self.assertEqual(zi.file_size, 0)
         self.assertEqual(zi.compress_size, 0)
-
-        self.assertEqual(zi.file_mode, b"")
+        self.assertIsNone(zi.file_mode)
 
     def test_zipfile_with_short_extra_field(self):
         """If an extra field in the header is less than 4 bytes, skip it."""
@@ -3077,18 +3075,21 @@ class ZipInfoTests(unittest.TestCase):
         self.assertEqual(posixpath.basename(zi.filename), 'test_core.py')
         self.assertFalse(zi.is_dir())
         self.assertEqual(zi.file_size, os.path.getsize(__file__))
+        self.assertEqual(zi.file_mode, '-rw-r--r--')
 
     def test_from_file_pathlike(self):
         zi = zipfile.ZipInfo.from_file(FakePath(__file__))
         self.assertEqual(posixpath.basename(zi.filename), 'test_core.py')
         self.assertFalse(zi.is_dir())
         self.assertEqual(zi.file_size, os.path.getsize(__file__))
+        self.assertEqual(zi.file_mode, '-rw-r--r--')
 
     def test_from_file_bytes(self):
         zi = zipfile.ZipInfo.from_file(os.fsencode(__file__), 'test')
         self.assertEqual(posixpath.basename(zi.filename), 'test')
         self.assertFalse(zi.is_dir())
         self.assertEqual(zi.file_size, os.path.getsize(__file__))
+        self.assertEqual(zi.file_mode, '-rw-r--r--')
 
     def test_from_file_fileno(self):
         with open(__file__, 'rb') as f:
@@ -3104,6 +3105,7 @@ class ZipInfoTests(unittest.TestCase):
         self.assertTrue(zi.is_dir())
         self.assertEqual(zi.compress_type, zipfile.ZIP_STORED)
         self.assertEqual(zi.file_size, 0)
+        self.assertEqual(zi.file_mode, 'drwxr-xr-x')
 
     def test_compresslevel_property(self):
         zinfo = zipfile.ZipInfo("xxx")

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -396,7 +396,6 @@ class ZipInfo:
         'file_size',
         '_raw_time',
         '_end_offset',
-        'file_mode',
     )
 
     def __init__(self, filename="NoName", date_time=(1980,1,1,0,0,0)):
@@ -431,7 +430,6 @@ class ZipInfo:
         self.external_attr = 0          # External file attributes
         self.compress_size = 0          # Size of the compressed file
         self.file_size = 0              # Size of the uncompressed file
-        self.file_mode = b""            # External attributes of the uncompressed file
         self._end_offset = None         # Start of the next local header or central directory
         # Other attributes are set by class ZipFile:
         # header_offset         Byte offset to the file header
@@ -458,7 +456,8 @@ class ZipInfo:
             result.append(' compress_type=%s' %
                           compressor_names.get(self.compress_type,
                                                self.compress_type))
-        result.append(' file_mode=%r' % self.file_mode)
+        if self.file_mode:
+            result.append(' file_mode=%r' % self.file_mode)
         lo = self.external_attr & 0xFFFF
         if lo:
             result.append(' external_attr=%#x' % lo)

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -396,6 +396,7 @@ class ZipInfo:
         'file_size',
         '_raw_time',
         '_end_offset',
+        'file_mode',
     )
 
     def __init__(self, filename="NoName", date_time=(1980,1,1,0,0,0)):
@@ -430,6 +431,7 @@ class ZipInfo:
         self.external_attr = 0          # External file attributes
         self.compress_size = 0          # Size of the compressed file
         self.file_size = 0              # Size of the uncompressed file
+        self.file_mode = b""            # External attributes of the uncompressed file
         self._end_offset = None         # Start of the next local header or central directory
         # Other attributes are set by class ZipFile:
         # header_offset         Byte offset to the file header
@@ -444,16 +446,20 @@ class ZipInfo:
     def _compresslevel(self, value):
         self.compress_level = value
 
+    @property
+    def file_mode(self):
+        hi = self.external_attr >> 16
+        if hi:
+            return stat.filemode(hi)
+
     def __repr__(self):
         result = ['<%s filename=%r' % (self.__class__.__name__, self.filename)]
         if self.compress_type != ZIP_STORED:
             result.append(' compress_type=%s' %
                           compressor_names.get(self.compress_type,
                                                self.compress_type))
-        hi = self.external_attr >> 16
+        result.append(' file_mode=%r' % self.file_mode)
         lo = self.external_attr & 0xFFFF
-        if hi:
-            result.append(' filemode=%r' % stat.filemode(hi))
         if lo:
             result.append(' external_attr=%#x' % lo)
         isdir = self.is_dir()

--- a/Misc/NEWS.d/next/Library/2024-06-25-07-49-16.gh-issue-89004.uJfz2B.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-25-07-49-16.gh-issue-89004.uJfz2B.rst
@@ -1,0 +1,1 @@
+Add attribute :attr:`zipfile.ZipInfo.file_mode`.


### PR DESCRIPTION
Add attribute zipfile.ZipInfo.filemode.

Fixes: #89004

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-89004 -->
* Issue: gh-89004
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121299.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->