### PR TITLE
gh-121288: improve error messages for `tuple.index`, `list.index` and `list.remove`

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -430,10 +430,10 @@ Simple example::
    >>> [1, 2, 3].remove(42)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
-   ValueError: list.remove(x): x not in list
+   ValueError: list.remove(): 42 not in list
 
-That doctest succeeds if :exc:`ValueError` is raised, with the ``list.remove(x):
-x not in list`` detail as shown.
+That doctest succeeds if :exc:`ValueError` is raised, with the ``list.remove():
+42 not in list`` detail as shown.
 
 The expected output for an exception must start with a traceback header, which
 may be either of the following two lines, indented the same as the first line of

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -430,9 +430,9 @@ Simple example::
    >>> [1, 2, 3].remove(42)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
-   ValueError: list.remove(): 42 not in list
+   ValueError: list.remove(x): 42 not in list
 
-That doctest succeeds if :exc:`ValueError` is raised, with the ``list.remove():
+That doctest succeeds if :exc:`ValueError` is raised, with the ``list.remove(x):
 42 not in list`` detail as shown.
 
 The expected output for an exception must start with a traceback header, which

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -2,6 +2,7 @@ import sys
 from test import list_tests
 from test.support import cpython_only
 import pickle
+import re
 import unittest
 
 class ListTest(list_tests.CommonTest):
@@ -299,6 +300,15 @@ class ListTest(list_tests.CommonTest):
         lst = [X(), X()]
         X() in lst
 
+    def test_list_index_error(self):
+        msg = re.escape("list.index(): 'a' is not in list")
+        with self.assertRaisesRegex(ValueError, msg):
+            [].index('a')
+
+    def test_list_remove_error(self):
+        msg = re.escape("list.remove(): 'a' is not in list")
+        with self.assertRaisesRegex(ValueError, msg):
+            [].remove('a')
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -301,12 +301,12 @@ class ListTest(list_tests.CommonTest):
         X() in lst
 
     def test_list_index_error(self):
-        msg = re.escape("list.index(): 'a' is not in list")
+        msg = re.escape("list.index(x): 'a' not in list")
         with self.assertRaisesRegex(ValueError, msg):
             [].index('a')
 
     def test_list_remove_error(self):
-        msg = re.escape("list.remove(): 'a' is not in list")
+        msg = re.escape("list.remove(x): 'a' not in list")
         with self.assertRaisesRegex(ValueError, msg):
             [].remove('a')
 

--- a/Lib/test/test_tuple.py
+++ b/Lib/test/test_tuple.py
@@ -26,7 +26,7 @@ class TupleTest(seq_tests.CommonTest):
             t['a']
 
     def test_index_error(self):
-        msg = re.escape("tuple.index(): 'a' is not in tuple")
+        msg = re.escape("tuple.index(x): 'a' not in tuple")
         with self.assertRaisesRegex(ValueError, msg):
             ().index('a')
 

--- a/Lib/test/test_tuple.py
+++ b/Lib/test/test_tuple.py
@@ -3,6 +3,7 @@ import unittest
 
 import gc
 import pickle
+import re
 
 # For tuple hashes, we normally only run a test to ensure that we get
 # the same results across platforms in a handful of cases.  If that's
@@ -23,6 +24,11 @@ class TupleTest(seq_tests.CommonTest):
         msg = "tuple indices must be integers or slices"
         with self.assertRaisesRegex(TypeError, msg):
             t['a']
+
+    def test_index_error(self):
+        msg = re.escape("tuple.index(): 'a' is not in tuple")
+        with self.assertRaisesRegex(ValueError, msg):
+            ().index('a')
 
     def test_constructors(self):
         super().test_constructors()

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -14,6 +14,7 @@ import operator
 import os
 import pickle
 import pyexpat
+import re
 import sys
 import textwrap
 import types
@@ -327,9 +328,9 @@ class ElementTreeTest(unittest.TestCase):
         self.serialize_check(element, '<tag key="value"><subtag /></tag>') # 4
         element.remove(subelement)
         self.serialize_check(element, '<tag key="value" />') # 5
-        with self.assertRaises(ValueError) as cm:
+        msg = re.escape('list.remove(x): %r not in list' % subelement)
+        with self.assertRaisesRegex(ValueError, msg):
             element.remove(subelement)
-        self.assertEqual(str(cm.exception), 'list.remove(x): x not in list')
         self.serialize_check(element, '<tag key="value" />') # 6
         element[0:0] = [subelement, subelement, subelement]
         self.serialize_check(element[1], '<subtag />')

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-03-09-59-11.gh-issue-121288.fngKQT.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-03-09-59-11.gh-issue-121288.fngKQT.rst
@@ -1,2 +1,2 @@
-Improve error messages for :meth:`tuple.index`, :meth:`list.index` and
-:meth:`list.remove`. Patch by Bénédikt Tran.
+Improve error messages for :meth:`!tuple.index`, :meth:`!list.index` and
+:meth:`!list.remove`. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-03-09-59-11.gh-issue-121288.fngKQT.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-03-09-59-11.gh-issue-121288.fngKQT.rst
@@ -1,0 +1,2 @@
+Improve error messages for :meth:`tuple.index`, :meth:`list.index` and
+:meth:`list.remove`. Patch by Bénédikt Tran.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1642,10 +1642,9 @@ _elementtree_Element_remove_impl(ElementObject *self, PyObject *subelement)
 
     if (!self->extra) {
         /* element has no children, so raise exception */
-        PyErr_SetString(
-            PyExc_ValueError,
-            "list.remove(x): x not in list"
-            );
+        PyErr_Format(PyExc_ValueError,
+                     "list.remove(x): %R not in list",
+                     subelement);
         return NULL;
     }
 
@@ -1661,10 +1660,9 @@ _elementtree_Element_remove_impl(ElementObject *self, PyObject *subelement)
 
     if (i >= self->extra->length) {
         /* subelement is not in children, so raise exception */
-        PyErr_SetString(
-            PyExc_ValueError,
-            "list.remove(x): x not in list"
-            );
+        PyErr_Format(PyExc_ValueError,
+                     "list.remove(x): %R not in list",
+                     subelement);
         return NULL;
     }
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3244,7 +3244,7 @@ list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_Format(PyExc_ValueError, "%R is not in list", value);
+    PyErr_Format(PyExc_ValueError, "list.index(): %R is not in list", value);
     return NULL;
 }
 
@@ -3314,7 +3314,7 @@ list_remove_impl(PyListObject *self, PyObject *value)
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_SetString(PyExc_ValueError, "list.remove(x): x not in list");
+    PyErr_Format(PyExc_ValueError, "list.remove(): %R is not in list", value);
     return NULL;
 }
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3244,7 +3244,7 @@ list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_Format(PyExc_ValueError, "list.index(): %R is not in list", value);
+    PyErr_Format(PyExc_ValueError, "list.index(x): %R not in list", value);
     return NULL;
 }
 
@@ -3314,7 +3314,7 @@ list_remove_impl(PyListObject *self, PyObject *value)
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_Format(PyExc_ValueError, "list.remove(): %R is not in list", value);
+    PyErr_Format(PyExc_ValueError, "list.remove(x): %R not in list", value);
     return NULL;
 }
 

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -571,7 +571,7 @@ tuple_index_impl(PyTupleObject *self, PyObject *value, Py_ssize_t start,
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_SetString(PyExc_ValueError, "tuple.index(x): x not in tuple");
+    PyErr_Format(PyExc_ValueError, "tuple.index(): %R is not in tuple", value);
     return NULL;
 }
 

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -571,7 +571,7 @@ tuple_index_impl(PyTupleObject *self, PyObject *value, Py_ssize_t start,
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_Format(PyExc_ValueError, "tuple.index(): %R is not in tuple", value);
+    PyErr_Format(PyExc_ValueError, "tuple.index(x): %R not in tuple", value);
     return NULL;
 }
 


### PR DESCRIPTION
The formulation can be changed if you think a smaller message is needed. I put the method in the exception message because it's not always clear whether the traceback is available or not. At least, you will know which method caused the issue but I can remove it if you think it's too much.

<!-- gh-issue-number: gh-121288 -->
* Issue: gh-121288
<!-- /gh-issue-number -->
