### PR TITLE
[3.13] gh-121279: Fix importlib DeprecatedAttrsTests

### DIFF
--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -920,14 +920,17 @@ class DeprecatedAttrsTests:
     def test_deprecated_attr_ResourceReader(self):
         with self.assertWarns(DeprecationWarning):
             self.abc.ResourceReader
+        del self.abc.ResourceReader
 
     def test_deprecated_attr_Traversable(self):
         with self.assertWarns(DeprecationWarning):
             self.abc.Traversable
+        del self.abc.Traversable
 
     def test_deprecated_attr_TraversableResources(self):
         with self.assertWarns(DeprecationWarning):
             self.abc.TraversableResources
+        del self.abc.TraversableResources
 
 
 (Frozen_DeprecatedAttrsTests,


### PR DESCRIPTION
Delete attributes after getting them, so the warning is emitted again when the test is run multiple times (ex: when checking for reference leaks).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121279 -->
* Issue: gh-121279
<!-- /gh-issue-number -->
