### PR TITLE
gh-121160: Add a test for readline.set_history_length

### DIFF
--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -132,6 +132,32 @@ class TestHistoryManipulation (unittest.TestCase):
         self.assertEqual(readline.get_history_item(1), "entrée 1")
         self.assertEqual(readline.get_history_item(2), "entrée 22")
 
+    def test_write_read_limited_history(self):
+        previous_length = readline.get_history_length()
+        self.addCleanup(readline.set_history_length, previous_length)
+
+        readline.clear_history()
+        readline.add_history("first line")
+        readline.add_history("second line")
+        readline.add_history("third line")
+
+        readline.set_history_length(2)
+        self.assertEqual(readline.get_history_length(), 2)
+        readline.write_history_file(TESTFN)
+        self.addCleanup(os.remove, TESTFN)
+
+        readline.clear_history()
+        self.assertEqual(readline.get_current_history_length(), 0)
+        self.assertEqual(readline.get_history_length(), 2)
+
+        readline.read_history_file(TESTFN)
+        self.assertEqual(readline.get_history_item(1), "second line")
+        self.assertEqual(readline.get_history_item(2), "third line")
+        self.assertEqual(readline.get_history_item(3), None)
+
+        # Readline seems to report an additional history element.
+        self.assertIn(readline.get_current_history_length(), (2, 3))
+
 
 class TestReadline(unittest.TestCase):
 

--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -349,6 +349,26 @@ readline.write_history_file(history_file)
             self.assertEqual(len(lines), history_size)
             self.assertEqual(lines[-1].strip(), b"last input")
 
+    def test_write_read_limited_history(self):
+        previous_length = readline.get_history_length()
+        self.addCleanup(readline.set_history_length, previous_length)
+
+        readline.add_history("first line")
+        readline.add_history("second line")
+        readline.add_history("third line")
+
+        readline.set_history_length(2)
+        self.assertEqual(readline.get_history_length(), 2)
+        readline.write_history_file(TESTFN)
+        self.addCleanup(os.remove, TESTFN)
+
+        readline.read_history_file(TESTFN)
+        # Without clear_history() there's no good way to test if
+        # the correct entries are present (we're combining history limiting and
+        # possible deduplication with arbitrary previous content).
+        # So, we've only tested that the read did not fail.
+        # See TestHistoryManipulation for the full test.
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Tests/2024-07-03-14-41-00.gh-issue-121160.LEtiTd.rst
+++ b/Misc/NEWS.d/next/Tests/2024-07-03-14-41-00.gh-issue-121160.LEtiTd.rst
@@ -1,0 +1,2 @@
+Add a test for :func:`readline.set_history_length`. Note that this test may
+fail on readline libraries.


### PR DESCRIPTION
I could not reproduce the reported issue, but, I didn't try very hard to test on various readline libraries.
Regardless, `set_history_length` was missing a test. This PR should show if the error exists on CPython's buildbot platforms. (And if it doesn't and it's merged, it should fail for redistributors with who build with different libraries.)

My copy of readline (Fedora 40) reports an extra history element after reading the file; IMO that's not the end of the world.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121160 -->
* Issue: gh-121160
<!-- /gh-issue-number -->
