### PR TITLE
gh-121160: Note that readline libraries using different history formats.

### DIFF
--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -45,6 +45,10 @@ Readline library in general.
     python:bind -v
     python:bind ^I rl_complete
 
+  Also note that different libraries may use different history file formats.
+  When switching the underlying library, existing history files may become
+  unusable.
+
 .. data:: backend
 
    The name of the underlying Readline library being used, either


### PR DESCRIPTION
This is not something we can do too much about, without help from the underlying libraries.

The file formats seem to be treated as implementation details, hidden behind [API calls](https://www.man7.org/linux/man-pages/man3/history.3.html).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121160 -->
* Issue: gh-121160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121327.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->