### PR TITLE
gh-121201: Disable perf_trampoline on riscv64 for now

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-05-06-26-04.gh-issue-
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-05-06-26-04.gh-issue-
@@ -1,1 +1,0 @@
-Support Linux perf profiler to see Python calls on RISC-V architecture

--- a/Misc/NEWS.d/next/Core and Builtins/2024-06-12-12-29-45.gh-issue-120400.lZYHVS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-06-12-12-29-45.gh-issue-120400.lZYHVS.rst
@@ -1,1 +1,0 @@
-Support Linux perf profiler to see Python calls on RISC-V architecture.

--- a/configure
+++ b/configure
@@ -13292,8 +13292,6 @@ case $PLATFORM_TRIPLET in #(
     perf_trampoline=yes ;; #(
   aarch64-linux-gnu) :
     perf_trampoline=yes ;; #(
-  riscv64-linux-gnu) :
-    perf_trampoline=yes ;; #(
   *) :
     perf_trampoline=no
  ;;

--- a/configure.ac
+++ b/configure.ac
@@ -3709,7 +3709,6 @@ AC_MSG_CHECKING([perf trampoline])
 AS_CASE([$PLATFORM_TRIPLET],
   [x86_64-linux-gnu], [perf_trampoline=yes],
   [aarch64-linux-gnu], [perf_trampoline=yes],
-  [riscv64-linux-gnu], [perf_trampoline=yes],
   [perf_trampoline=no]
 )
 AC_MSG_RESULT([$perf_trampoline])


### PR DESCRIPTION
Until support is added in `perf_jit_trampoline.c`. 

gh-120089 was incomplete.

<!-- gh-issue-number: gh-120400 -->
* Issue: gh-120400
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-121201 -->
* Issue: gh-121201
<!-- /gh-issue-number -->
