### PR TITLE
gh-119909: Fix ``NameError`` in ``asyncio`` REPL

### DIFF
--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -116,7 +116,7 @@ class REPLThread(threading.Thread):
                 if err := check():
                     raise RuntimeError(err)
             except Exception as e:
-                console.interact(banner="", exitmsg=exit_message)
+                console.interact(banner="", exitmsg="")
             else:
                 try:
                     run_multiline_interactive_console(console=console)


### PR DESCRIPTION
Seems that was a culprit, with that I cannot reproduce failure in ``test_asyncio_repl_is_ok``:
```python
./python -m test -R 100:100 test_repl test_list -j 2
Using random seed: 985022535
0:00:00 load avg: 0.21 Run 2 tests in parallel using 2 worker processes
0:00:30 load avg: 0.92 running (2): test_repl (30.0 sec), test_list (30.0 sec)
0:01:00 load avg: 1.34 running (2): test_repl (1 min), test_list (1 min)
0:01:30 load avg: 1.60 running (2): test_repl (1 min 30 sec), test_list (1 min 30 sec)
0:01:55 load avg: 1.74 [1/2] test_list passed (1 min 55 sec) -- running (1): test_repl (1 min 55 sec)
beginning 200 repetitions. Showing number of leaks (. for 0 or less, X for 10 or more)
1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890:1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
XX.................................................................................................. ....................................................................................................
0:02:25 load avg: 1.45 running (1): test_repl (2 min 25 sec)
0:02:55 load avg: 1.27 running (1): test_repl (2 min 55 sec)
0:03:23 load avg: 1.16 [2/2] test_repl passed (3 min 23 sec)
beginning 200 repetitions. Showing number of leaks (. for 0 or less, X for 10 or more)
1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890:1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
XX.................................................................................................. ....................................................................................................

== Tests result: SUCCESS ==

All 2 tests OK.

Total duration: 3 min 23 sec
Total tests: run=70
Total test files: run=2/2
Result: SUCCESS
```

<!-- gh-issue-number: gh-119909 -->
* Issue: gh-119909
<!-- /gh-issue-number -->
