### PR TITLE
gh-120754: Update estimated_size in C truncate

### DIFF
--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -1094,6 +1094,12 @@ _io_FileIO_truncate_impl(fileio *self, PyTypeObject *cls, PyObject *posobj)
         return NULL;
     }
 
+    /* Sometimes a large file is truncated. While estimated_size is used as a
+    estimate, that it is much larger than the actual size can result in a
+    significant over allocation and sometimes a MemoryError / running out of
+    memory. */
+    self->estimated_size = pos;
+
     return posobj;
 }
 #endif /* HAVE_FTRUNCATE */


### PR DESCRIPTION
goal: Fix buildbot failure [https://github.com/python/cpython/pull/120755
](https://github.com/python/cpython/pull/120755#issuecomment-2208356460)

Sometimes a large file is truncated (test_largefile). While estimated_size is used as a estimate (the read will get all the bytes  in the file when it is wrong), that it is much larger than the actual size of data can result in a significant over allocation and sometimes lead to a MemoryError / running out of memory.

This brings the C implementation to match the Python _pyio implementation.

cc: @vstinner 

I've been unable to reproduce the failure locally so far by running `./build/python -bb -E -Wd -m test -r -w -uall test_largefile`. My suspicion is that the AMD64 box has limited memory. Working to try and test peak memory usage in the test / if that went down

<!-- gh-issue-number: gh-120754 -->
* Issue: gh-120754
<!-- /gh-issue-number -->
