### PR TITLE
gh-121272: move async for/with validation from compiler to symtable

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3058,11 +3058,6 @@ static int
 compiler_async_for(struct compiler *c, stmt_ty s)
 {
     location loc = LOC(s);
-    if (IS_TOP_LEVEL_AWAIT(c)){
-        assert(c->u->u_ste->ste_coroutine == 1);
-    } else if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION) {
-        return compiler_error(c, loc, "'async for' outside async function");
-    }
 
     NEW_JUMP_TARGET_LABEL(c, start);
     NEW_JUMP_TARGET_LABEL(c, except);
@@ -5781,9 +5776,6 @@ compiler_comprehension(struct compiler *c, expr_ty e, int type,
 
     co = optimize_and_assemble(c, 1);
     compiler_exit_scope(c);
-    if (is_top_level_await && is_async_generator){
-        assert(c->u->u_ste->ste_coroutine == 1);
-    }
     if (co == NULL) {
         goto error;
     }
@@ -5925,11 +5917,6 @@ compiler_async_with(struct compiler *c, stmt_ty s, int pos)
     withitem_ty item = asdl_seq_GET(s->v.AsyncWith.items, pos);
 
     assert(s->kind == AsyncWith_kind);
-    if (IS_TOP_LEVEL_AWAIT(c)){
-        assert(c->u->u_ste->ste_coroutine == 1);
-    } else if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION){
-        return compiler_error(c, loc, "'async with' outside async function");
-    }
 
     NEW_JUMP_TARGET_LABEL(c, block);
     NEW_JUMP_TARGET_LABEL(c, final);


### PR DESCRIPTION
Test are tested in test_bultin: `test_compile_top_level_await_invalid_cases` and `test_compile_top_level_await`.


<!-- gh-issue-number: gh-121272 -->
* Issue: gh-121272
<!-- /gh-issue-number -->
