### PR TITLE
doc: warn that md5 and sha1 are no longer considered secured

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -133,6 +133,10 @@ Using :func:`new` with an algorithm name:
    >>> h.hexdigest()
    '031edd7d41651593c5fe5c006fa5752b37fddff7bc4e843aa6af0c950f4b9406'
 
+.. warning::
+
+   :func:`md5` and :func:`sha1` algorithms are considered insecure and may
+   be removed from the python interpreter. Consider :func:`sha256` instead.
 
 .. function:: md5([, data], *, usedforsecurity=True)
 .. function:: sha1([, data], *, usedforsecurity=True)


### PR DESCRIPTION
Hello,

I had my new grad submit code using md5() last week. This was an instructive experience in obsolete algorithms :D
Obviously it's no longer considered secure and should not be used. 

It actually can't be used in many cases, md5/sha1 were removed from openssl and from the python interpreter in centos/rhel builds. The world is moving away.

I had a look at the python doc and it's still advertising md5 and sha1 as the first options.
Can we add a warning to nudge people away from md5/sha1 and toward sha256? that is the closest direct replacement.

Should I go further in the PR and separate them to a second list of "insecure algorithms"?

Thank you.

P.S. I don't think that we need a ticket number or a news items for this since it's a trivial doc update.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121366.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->