### PR TITLE
gh-106597: Remove unnecessary CFrame offsets

### DIFF
--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -98,13 +98,6 @@ typedef struct _Py_DebugOffsets {
         uint64_t owner;
     } interpreter_frame;
 
-    // CFrame offset;
-    struct _cframe {
-        uint64_t size;
-        uint64_t current_frame;
-        uint64_t previous;
-    } cframe;
-
     // Code object offset;
     struct _code_object {
         uint64_t size;


### PR DESCRIPTION
The PyCFrame structure has been removed in 3.13 therefore its offsets are no longer available to be exported via the debug offsets structure.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106597 -->
* Issue: gh-106597
<!-- /gh-issue-number -->
