### PR TITLE
Fixed an issue where building inside of a clone directory with spaces would result in not being able to build at all.

### DIFF
--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -82,7 +82,7 @@
   <Target Name="_RegenGlobalObjects"
           DependsOnTargets="FindPythonForBuild">
     <Message Text="Regenerate Global Objects" Importance="high" />
-    <Exec Command="$(PythonForBuild) Tools\build\generate_global_objects.py"
+    <Exec Command="$(PythonForBuild) &quot;Tools\build\generate_global_objects.py&quot;"
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 
@@ -90,23 +90,23 @@
           Inputs="@(_CasesSources)" Outputs="@(_CasesOutputs)"
           DependsOnTargets="FindPythonForBuild">
     <Message Text="Regenerate cases" Importance="high" />
-    <Exec Command="$(PythonForBuild) $(PySourcePath)Tools\cases_generator\opcode_id_generator.py $(PySourcePath)Python\bytecodes.c"
+    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\opcode_id_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) $(PySourcePath)Tools\cases_generator\target_generator.py $(PySourcePath)Python\bytecodes.c"
+    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\target_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) $(PySourcePath)Tools\cases_generator\uop_id_generator.py $(PySourcePath)Python\bytecodes.c"
+    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\uop_id_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) $(PySourcePath)Tools\cases_generator\py_metadata_generator.py $(PySourcePath)Python\bytecodes.c"
+    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\py_metadata_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) $(PySourcePath)Tools\cases_generator\tier1_generator.py $(PySourcePath)Python\bytecodes.c"
+    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\tier1_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) $(PySourcePath)Tools\cases_generator\tier2_generator.py $(PySourcePath)Python\bytecodes.c"
+    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\tier2_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) $(PySourcePath)Tools\cases_generator\optimizer_generator.py $(PySourcePath)Python\optimizer_bytecodes.c $(PySourcePath)Python\bytecodes.c"
+    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\optimizer_generator.py&quot; &quot;$(PySourcePath)Python\optimizer_bytecodes.c&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) $(PySourcePath)Tools\cases_generator\opcode_metadata_generator.py $(PySourcePath)Python\bytecodes.c"
+    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\opcode_metadata_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) $(PySourcePath)Tools\cases_generator\uop_metadata_generator.py $(PySourcePath)Python\bytecodes.c"
+    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\uop_metadata_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 

--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -90,23 +90,23 @@
           Inputs="@(_CasesSources)" Outputs="@(_CasesOutputs)"
           DependsOnTargets="FindPythonForBuild">
     <Message Text="Regenerate cases" Importance="high" />
-    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\opcode_id_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
+    <Exec Command="$(PythonForBuild) Tools\cases_generator\opcode_id_generator.py Python\bytecodes.c"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\target_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
+    <Exec Command="$(PythonForBuild) Tools\cases_generator\target_generator.py Python\bytecodes.c"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\uop_id_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
+    <Exec Command="$(PythonForBuild) Tools\cases_generator\uop_id_generator.py Python\bytecodes.c"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\py_metadata_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
+    <Exec Command="$(PythonForBuild) Tools\cases_generator\py_metadata_generator.py Python\bytecodes.c"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\tier1_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
+    <Exec Command="$(PythonForBuild) Tools\cases_generator\tier1_generator.py Python\bytecodes.c"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\tier2_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
+    <Exec Command="$(PythonForBuild) Tools\cases_generator\tier2_generator.py Python\bytecodes.c"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\optimizer_generator.py&quot; &quot;$(PySourcePath)Python\optimizer_bytecodes.c&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
+    <Exec Command="$(PythonForBuild) Tools\cases_generator\optimizer_generator.py Python\optimizer_bytecodes.c Python\bytecodes.c"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\opcode_metadata_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
+    <Exec Command="$(PythonForBuild) Tools\cases_generator\opcode_metadata_generator.py Python\bytecodes.c"
           WorkingDirectory="$(PySourcePath)" />
-    <Exec Command="$(PythonForBuild) &quot;$(PySourcePath)Tools\cases_generator\uop_metadata_generator.py&quot; &quot;$(PySourcePath)Python\bytecodes.c&quot;"
+    <Exec Command="$(PythonForBuild) Tools\cases_generator\uop_metadata_generator.py Python\bytecodes.c"
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 

--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -50,7 +50,7 @@
           DependsOnTargets="FindPythonForBuild">
     <Message Text="Regenerate @(_PegenOutputs->'%(Filename)%(Extension)',' ')" Importance="high" />
     <!-- Specify python.gram with POSIX-like path because the argument gets written into the file verbatim -->
-    <Exec Command="set PYTHONPATH=Tools\peg_generator%0D%0A$(PythonForBuild) -m pegen -q c &quot;./Grammar/python.gram&quot; &quot;Grammar\Tokens&quot; -o &quot;Parser\parser.c&quot;"
+    <Exec Command="set PYTHONPATH=Tools\peg_generator%0D%0A$(PythonForBuild) -m pegen -q c ./Grammar/python.gram Grammar\Tokens -o Parser\parser.c"
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 
@@ -58,7 +58,7 @@
           Inputs="@(_ASTSources)" Outputs="@(_ASTOutputs)"
           DependsOnTargets="FindPythonForBuild">
     <Message Text="Regenerate @(_ASTOutputs->'%(Filename)%(Extension)',' ')" Importance="high" />
-    <Exec Command="$(PythonForBuild) &quot;Parser\asdl_c.py&quot; &quot;Parser\Python.asdl&quot; @(_ASTOutputs->'%(Argument) &quot;%(Identity)&quot;',' ')"
+    <Exec Command="$(PythonForBuild) Parser\asdl_c.py Parser\Python.asdl @(_ASTOutputs->'%(Argument) &quot;%(Identity)&quot;',' ')"
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 
@@ -66,7 +66,7 @@
           Inputs="@(_TokenSources)" Outputs="@(_TokenOutputs)"
           DependsOnTargets="FindPythonForBuild">
     <Message Text="Regenerate @(_TokenOutputs->'%(Filename)%(Extension)',' ')" Importance="high" />
-    <Exec Command="$(PythonForBuild) &quot;Tools\build\generate_token.py&quot; %(_TokenOutputs.Format) &quot;Grammar\Tokens&quot; &quot;%(_TokenOutputs.Identity)&quot;"
+    <Exec Command="$(PythonForBuild) Tools\build\generate_token.py %(_TokenOutputs.Format) Grammar\Tokens &quot;%(_TokenOutputs.Identity)&quot;"
           WorkingDirectory="$(PySourcePath)" />
     <Touch Files="@(_TokenOutputs)" />
   </Target>
@@ -82,7 +82,7 @@
   <Target Name="_RegenGlobalObjects"
           DependsOnTargets="FindPythonForBuild">
     <Message Text="Regenerate Global Objects" Importance="high" />
-    <Exec Command="$(PythonForBuild) &quot;Tools\build\generate_global_objects.py&quot;"
+    <Exec Command="$(PythonForBuild) Tools\build\generate_global_objects.py"
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 

--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -50,7 +50,7 @@
           DependsOnTargets="FindPythonForBuild">
     <Message Text="Regenerate @(_PegenOutputs->'%(Filename)%(Extension)',' ')" Importance="high" />
     <!-- Specify python.gram with POSIX-like path because the argument gets written into the file verbatim -->
-    <Exec Command="set PYTHONPATH=Tools\peg_generator%0D%0A$(PythonForBuild) -m pegen -q c ./Grammar/python.gram Grammar\Tokens -o Parser\parser.c"
+    <Exec Command="set PYTHONPATH=Tools\peg_generator%0D%0A$(PythonForBuild) -m pegen -q c &quot;./Grammar/python.gram&quot; &quot;Grammar\Tokens&quot; -o &quot;Parser\parser.c&quot;"
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 
@@ -58,7 +58,7 @@
           Inputs="@(_ASTSources)" Outputs="@(_ASTOutputs)"
           DependsOnTargets="FindPythonForBuild">
     <Message Text="Regenerate @(_ASTOutputs->'%(Filename)%(Extension)',' ')" Importance="high" />
-    <Exec Command="$(PythonForBuild) Parser\asdl_c.py Parser\Python.asdl @(_ASTOutputs->'%(Argument) &quot;%(Identity)&quot;',' ')"
+    <Exec Command="$(PythonForBuild) &quot;Parser\asdl_c.py&quot; &quot;Parser\Python.asdl&quot; @(_ASTOutputs->'%(Argument) &quot;%(Identity)&quot;',' ')"
           WorkingDirectory="$(PySourcePath)" />
   </Target>
 
@@ -66,7 +66,7 @@
           Inputs="@(_TokenSources)" Outputs="@(_TokenOutputs)"
           DependsOnTargets="FindPythonForBuild">
     <Message Text="Regenerate @(_TokenOutputs->'%(Filename)%(Extension)',' ')" Importance="high" />
-    <Exec Command="$(PythonForBuild) Tools\build\generate_token.py %(_TokenOutputs.Format) Grammar\Tokens &quot;%(_TokenOutputs.Identity)&quot;"
+    <Exec Command="$(PythonForBuild) &quot;Tools\build\generate_token.py&quot; %(_TokenOutputs.Format) &quot;Grammar\Tokens&quot; &quot;%(_TokenOutputs.Identity)&quot;"
           WorkingDirectory="$(PySourcePath)" />
     <Touch Files="@(_TokenOutputs)" />
   </Target>


### PR DESCRIPTION
I felt this is a trivial change and did not need an issue.

This is an issue as some people have github repositories with spaces in name and has cpython as a submodule so they can test with the latest and greatest main branch and the feature branches (3.13, 3.12, etc)

Having regen.targets use the &quot; msbuild escape sequence for all input and output file paths ensures that this issue never happens again as long as the paths are wrapped in quotes. Also it's not acceptable to have to move the submodule out of the folder with a space nor is it acceptable to rename the folder that has a space sometimes. Using Quotes is a more acceptable solution to this.