### PR TITLE
gh-121288: Make error message for index() methods consistent

### DIFF
--- a/Lib/multiprocessing/shared_memory.py
+++ b/Lib/multiprocessing/shared_memory.py
@@ -539,6 +539,6 @@ class ShareableList:
             if value == entry:
                 return position
         else:
-            raise ValueError(f"{value!r} not in this container")
+            raise ValueError("ShareableList.index(x): x not in list")
 
     __class_getitem__ = classmethod(types.GenericAlias)

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-05-11-29-27.gh-issue-121288.lYKYYP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-05-11-29-27.gh-issue-121288.lYKYYP.rst
@@ -1,5 +1,5 @@
-:exc:`ValueError` messages for :meth:`list.index()`, :meth:`range.index()`,
-:meth:`deque.index()`, :meth:`deque.remove()` and
-:meth:`ShareableList.index()` no longer contain the repr of the searched
+:exc:`ValueError` messages for :meth:`!list.index()`, :meth:`!range.index()`,
+:meth:`!deque.index()`, :meth:`!deque.remove()` and
+:meth:`!ShareableList.index()` no longer contain the repr of the searched
 value (which can be arbitrary large) and are consistent with error messages
-for other ``index()`` and ``remove()`` methods.
+for other :meth:`!index()` and :meth:`!remove()` methods.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-05-11-29-27.gh-issue-121288.lYKYYP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-05-11-29-27.gh-issue-121288.lYKYYP.rst
@@ -1,0 +1,5 @@
+:exc:`ValueError` messages for :meth:`list.index()`, :meth:`range.index()`,
+:meth:`deque.index()`, :meth:`deque.remove()` and
+:meth:`ShareableList.index()` no longer contain the repr of the searched
+value (which can be arbitrary large) and are consistent with error messages
+for other ``index()`` and ``remove()`` methods.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1293,7 +1293,7 @@ deque_index_impl(dequeobject *deque, PyObject *v, Py_ssize_t start,
             index = 0;
         }
     }
-    PyErr_Format(PyExc_ValueError, "%R is not in deque", v);
+    PyErr_SetString(PyExc_ValueError, "deque.index(x): x not in deque");
     return NULL;
 }
 
@@ -1462,7 +1462,7 @@ deque_remove_impl(dequeobject *deque, PyObject *value)
         }
     }
     if (i == n) {
-        PyErr_Format(PyExc_ValueError, "%R is not in deque", value);
+        PyErr_SetString(PyExc_ValueError, "deque.remove(x): x not in deque");
         return NULL;
     }
     rv = deque_del_item(deque, i);

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3244,7 +3244,7 @@ list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_Format(PyExc_ValueError, "%R is not in list", value);
+    PyErr_SetString(PyExc_ValueError, "list.index(x): x not in list");
     return NULL;
 }
 

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -655,7 +655,7 @@ range_index(rangeobject *r, PyObject *ob)
     }
 
     /* object is not in the range */
-    PyErr_Format(PyExc_ValueError, "%R is not in range", ob);
+    PyErr_SetString(PyExc_ValueError, "range.index(x): x not in range");
     return NULL;
 }
 


### PR DESCRIPTION
Remove the repr of the searched value (which can be arbitrary large) from ValueError messages for list.index(), range.index(), deque.index(), deque.remove() and ShareableList.index().  Make the error messages consistent with error messages for other index() and remove() methods.


<!-- gh-issue-number: gh-121288 -->
* Issue: gh-121288
<!-- /gh-issue-number -->
