### PR TITLE
gh-121402: Fix ZipFile.open() to set current time by default, add .newfile()

### DIFF
--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -13,6 +13,7 @@ import struct
 import sys
 import threading
 import time
+import datetime
 
 try:
     import zlib # We may need its compression method
@@ -404,11 +405,13 @@ class ZipInfo:
         # Terminate the file name at the first null byte and
         # ensure paths always use forward slashes as the directory separator.
         filename = _sanitize_filename(filename)
-
         self.filename = filename        # Normalized file name
-        self.date_time = date_time      # year, month, day, hour, min, sec
 
-        if date_time[0] < 1980:
+        # Use current time if year parameter is set to zero or None
+        self.date_time = date_time      # year, month, day, hour, min, sec
+        if not self.date_time[0]:
+            self.date_time = datetime.datetime.now().timetuple()
+        if self.date_time[0] < 1980:
             raise ValueError('ZIP does not support timestamps before 1980')
 
         # Standard values:
@@ -1565,6 +1568,19 @@ class ZipFile:
 
         return info
 
+    def newinfo(self, name):
+        """Return new instance of ZipInfo for file 'name'.
+        It will be set to the currently configured compression algorithm of this archive.
+        The timestamp for the new file will be set to the current time.
+        """
+        info = ZipInfo(name, [None]) # passing None defaults to now instead of 1980
+        if self.compression is not None:
+            info.compress_type = self.compression
+        if self.compresslevel is not None:
+            info.compress_level = self.compresslevel
+
+        return info
+
     def setpassword(self, pwd):
         """Set default password for encrypted files."""
         if pwd and not isinstance(pwd, bytes):
@@ -1627,9 +1643,7 @@ class ZipFile:
             # 'name' is already an info object
             zinfo = name
         elif mode == 'w':
-            zinfo = ZipInfo(name)
-            zinfo.compress_type = self.compression
-            zinfo.compress_level = self.compresslevel
+            zinfo = self.newinfo(name)
         else:
             # Get info object for name
             zinfo = self.getinfo(name)


### PR DESCRIPTION
When streaming, writing data to a zip file, it sets a timestamp of 1980. I believe this is never the intention so here's a fix to use the current time.

See issue #121402 for details, so this is my suggestion...

I'm also adding a newfile() method that returns a ZipInfo object which inherits the previously configured compression so that the user can pass that object to open() without having to remember to set the compression and _compresslevel/compresslevel atributes again (otherwise the previously set compression is ignored and the added file is written uncompressed). This is for creating new archives.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121402 -->
* Issue: gh-121402
<!-- /gh-issue-number -->
