### PR TITLE
Docs: fix typo and duplicate word in configure.rst

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -427,7 +427,7 @@ Options for third-party dependencies
 .. option:: PANEL_CFLAGS
 .. option:: PANEL_LIBS
 
-   C compiler and Linker flags for PANEL, overriding ``pkg-config``.
+   C compiler and linker flags for PANEL, overriding ``pkg-config``.
 
    C compiler and linker flags for ``libpanel`` or ``libpanelw``, used by
    :mod:`curses.panel` module, overriding ``pkg-config``.
@@ -615,7 +615,7 @@ also be used to improve performance.
 
 .. option:: --without-mimalloc
 
-   Disable the fast mimalloc allocator :ref:`mimalloc <mimalloc>`
+   Disable the fast :ref:`mimalloc <mimalloc>` allocator
    (enabled by default).
 
    See also :envvar:`PYTHONMALLOC` environment variable.


### PR DESCRIPTION
The word "Linker" didn't need to be start with capital L in the middle of the sentence, considering the other option descriptions nearby.

Duplicate "mimalloc" in `--without-mimalloc`'s description seems to be unintentional, hence I removed the duplication.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121410.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->