### PR TITLE
Allow PyTupleObjects with an ob_size of 20 in the free_list to be reused

### DIFF
--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -1153,8 +1153,8 @@ maybe_freelist_pop(Py_ssize_t size)
         return NULL;
     }
     assert(size > 0);
-    if (size < PyTuple_MAXSAVESIZE) {
-        Py_ssize_t index = size - 1;
+    Py_ssize_t index = size - 1;
+    if (index < PyTuple_MAXSAVESIZE) {
         PyTupleObject *op = TUPLE_FREELIST.items[index];
         if (op != NULL) {
             /* op is the head of a linked list, with the first item


### PR DESCRIPTION
In the `maybe_freelist_push` function, PyTupleObjects with an ob_size of 20 are cached. However, in the `maybe_freelist_pop` function, they are not reused.