### PR TITLE
[docs] fix a Sphinx directive in `c-api/object.rst`

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -52,6 +52,7 @@ Object Protocol
 
    The reference is borrowed from the interpreter, and is valid until the
    interpreter finalization.
+
    .. versionadded:: 3.13
 
 


### PR DESCRIPTION
I wouldn't have spotted this one if I wasn't looking at the page by mistake.

Without a new line, this renders as follows (current version)

![image](https://github.com/python/cpython/assets/10796600/82e5705f-9715-4e2d-990d-4ec5ad1c1adf)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121430.org.readthedocs.build/en/121430/c-api/object.html#c.Py_GetConstantBorrowed

<!-- readthedocs-preview cpython-previews end -->