### PR TITLE
GH-119169: Simplify `os.fwalk()` exception handling

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -548,19 +548,16 @@ if {open, stat} <= supports_dir_fd and {scandir, stat} <= supports_fd:
             if isbytes:
                 name = fsencode(name)
             try:
-                if entry.is_dir():
-                    dirs.append(name)
-                    if entries is not None:
-                        entries.append(entry)
-                else:
-                    nondirs.append(name)
+                is_dir = entry.is_dir()
             except OSError:
-                try:
-                    # Add dangling symlinks, ignore disappeared files
-                    if entry.is_symlink():
-                        nondirs.append(name)
-                except OSError:
-                    pass
+                is_dir = False
+
+            if is_dir:
+                dirs.append(name)
+                if entries is not None:
+                    entries.append(entry)
+            else:
+                nondirs.append(name)
 
         if topdown:
             yield toppath, dirs, nondirs, topfd

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -532,15 +532,13 @@ if {open, stat} <= supports_dir_fd and {scandir, stat} <= supports_fd:
             if isbytes:
                 name = fsencode(name)
             try:
-                is_dir = entry.is_dir()
+                if entry.is_dir():
+                    dirs.append(name)
+                    if entries is not None:
+                        entries.append(entry)
+                else:
+                    nondirs.append(name)
             except OSError:
-                is_dir = False
-
-            if is_dir:
-                dirs.append(name)
-                if entries is not None:
-                    entries.append(entry)
-            else:
                 nondirs.append(name)
 
         if topdown:

--- a/Misc/NEWS.d/next/Library/2024-07-06-15-19-20.gh-issue-119169.v_JQyl.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-06-15-19-20.gh-issue-119169.v_JQyl.rst
@@ -1,0 +1,2 @@
+Slightly speed up :func:`os.fwalk` by simplifying handling of inaccessible
+files.


### PR DESCRIPTION
`os.DirEntry.is_dir()` already returns false when a file disappears, so the `is_symlink()` call is redundant. This brings `fwalk()`'s exception handling more in line with `walk()`.


<!-- gh-issue-number: gh-119169 -->
* Issue: gh-119169
<!-- /gh-issue-number -->
