### PR TITLE
GH-119169: Speed up `os.fwalk(topdown=False)`

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -544,7 +544,6 @@ if {open, stat} <= supports_dir_fd and {scandir, stat} <= supports_fd:
         nondirs = []
         topprefix = path.join(toppath, toppath[:0])  # Add trailing slash.
         if not topdown:
-            # Yield after sub-directory traversal if going bottom up.
             stack.append((_fwalk_yield, (toppath, dirs, nondirs, topfd)))
         for entry in scandir_it:
             name = entry.name

--- a/Misc/NEWS.d/next/Library/2024-07-06-15-31-01.gh-issue-119169.bfpdsr.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-06-15-31-01.gh-issue-119169.bfpdsr.rst
@@ -1,0 +1,1 @@
+Speed up :func:`os.fwalk` in bottom-up mode.


### PR DESCRIPTION
Add entries to the stack while iterating over `os.scandir()` results, rather than afterwards. This removes the need for an `entries` list and some zipping.

Requires #119473.

<!-- gh-issue-number: gh-119169 -->
* Issue: gh-119169
<!-- /gh-issue-number -->
