### PR TITLE
gh-121458: update minimum windows version from 8.1 to 10

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -23,8 +23,7 @@ available for application-local distributions.
 
 As specified in :pep:`11`, a Python release only supports a Windows platform
 while Microsoft considers the platform under extended support. This means that
-Python |version| supports Windows 10 and newer. If you require Windows 7
-support, please install Python 3.8.
+Python |version| supports Windows 10 and newer.
 
 There are a number of different installers available for Windows, each with
 certain benefits and downsides.

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -23,7 +23,7 @@ available for application-local distributions.
 
 As specified in :pep:`11`, a Python release only supports a Windows platform
 while Microsoft considers the platform under extended support. This means that
-Python |version| supports Windows 8.1 and newer. If you require Windows 7
+Python |version| supports Windows 10 and newer. If you require Windows 7
 support, please install Python 3.8.
 
 There are a number of different installers available for Windows, each with


### PR DESCRIPTION
According to PEP 11, new python releases support windows version whose ESU hasn't expired yet, however Windows 8.1 already expired:

https://support.microsoft.com/en-us/windows/windows-8-1-support-ended-on-january-10-2023-3cfd4cde-f611-496a-8057-923fba401e93

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121452.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-121458 -->
* Issue: gh-121458
<!-- /gh-issue-number -->
