### PR TITLE
gh-108297: Update crashers README for test_crashers removal

### DIFF
--- a/Lib/test/crashers/README
+++ b/Lib/test/crashers/README
@@ -15,7 +15,3 @@ what the variables are.
 Once the crash is fixed, the test case should be moved into an appropriate test
 (even if it was originally from the test suite).  This ensures the regression
 doesn't happen again.  And if it does, it should be easier to track down.
-
-Also see Lib/test_crashers.py which exercises the crashers in this directory.
-In particular, make sure to add any new infinite loop crashers to the black
-list so it doesn't try to run them.


### PR DESCRIPTION
Follow up to gh-108690 to also remove the reference to `test_crashers`
from the `test/crashers/README` file.

<!-- gh-issue-number: gh-108297 -->
* Issue: gh-108297
<!-- /gh-issue-number -->
