### PR TITLE
NEWS: Fix Sphinx warnings and increase threshold for new news nits

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -272,6 +272,9 @@ nitpick_ignore += [
     ('c:data', 'PyExc_UnicodeWarning'),
     ('c:data', 'PyExc_UserWarning'),
     ('c:data', 'PyExc_Warning'),
+    # Undocumented public C macros
+    ('c:macro', 'Py_BUILD_ASSERT'),
+    ('c:macro', 'Py_BUILD_ASSERT_EXPR'),
     # Do not error nit-picky mode builds when _SubParsersAction.add_parser cannot
     # be resolved, as the method is currently undocumented. For context, see
     # https://github.com/python/cpython/pull/103289.

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -699,7 +699,7 @@ you are using :class:`profile.Profile` or :class:`cProfile.Profile`,
    As the :class:`cProfile.Profile` class cannot be calibrated, custom timer
    functions should be used with care and should be as fast as possible.  For
    the best results with a custom timer, it might be necessary to hard-code it
-   in the C source of the internal :mod:`_lsprof` module.
+   in the C source of the internal :mod:`!_lsprof` module.
 
 Python 3.3 adds several new functions in :mod:`time` that can be used to make
 precise measurements of process or wall-clock time. For example, see

--- a/Doc/tools/check-warnings.py
+++ b/Doc/tools/check-warnings.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import TextIO
 
 # Fail if NEWS nit found before this line number
-NEWS_NIT_THRESHOLD = 200
+NEWS_NIT_THRESHOLD = 1700
 
 # Exclude these whether they're dirty or clean,
 # because they trigger a rebuild of dirty files.

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -1495,7 +1495,7 @@ The dictionary returned by :meth:`.SSLSocket.getpeercert` contains additional
 stat
 ----
 
-The :mod:`stat` module is now backed by a C implementation in :mod:`_stat`. A C
+The :mod:`stat` module is now backed by a C implementation in :mod:`!_stat`. A C
 implementation is required as most of the values aren't standardized and
 are platform-dependent.  (Contributed by Christian Heimes in :issue:`11016`.)
 

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -1936,7 +1936,7 @@ tkinter
 -------
 
 The :mod:`tkinter._fix` module used for setting up the Tcl/Tk environment
-on Windows has been replaced by a private function in the :mod:`_tkinter`
+on Windows has been replaced by a private function in the :mod:`!_tkinter`
 module which makes no permanent changes to environment variables.
 (Contributed by Zachary Ware in :issue:`20035`.)
 

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -1935,7 +1935,7 @@ specifying the namespace in which the code will be running.
 tkinter
 -------
 
-The :mod:`tkinter._fix` module used for setting up the Tcl/Tk environment
+The :mod:`!tkinter._fix` module used for setting up the Tcl/Tk environment
 on Windows has been replaced by a private function in the :mod:`!_tkinter`
 module which makes no permanent changes to environment variables.
 (Contributed by Zachary Ware in :issue:`20035`.)

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2048,7 +2048,7 @@ The :mod:`macpath` is now deprecated and will be removed in Python 3.8.
 threading
 ---------
 
-:mod:`dummy_threading` and :mod:`_dummy_thread` have been deprecated.  It is
+:mod:`!dummy_threading` and :mod:`!_dummy_thread` have been deprecated.  It is
 no longer possible to build Python with threading disabled.
 Use :mod:`threading` instead.
 (Contributed by Antoine Pitrou in :issue:`31370`.)
@@ -2184,7 +2184,7 @@ The following features and APIs have been removed from Python 3.7:
   ``socket.socketpair`` on Python 3.5 and newer.
 
 * :mod:`asyncio` no longer exports the :mod:`selectors` and
-  :mod:`_overlapped` modules as ``asyncio.selectors`` and
+  :mod:`!_overlapped` modules as ``asyncio.selectors`` and
   ``asyncio._overlapped``. Replace ``from asyncio import selectors`` with
   ``import selectors``.
 

--- a/Misc/HISTORY
+++ b/Misc/HISTORY
@@ -3952,7 +3952,7 @@ Library
 - Issue #18626: the inspect module now offers a basic command line
   introspection interface (Initial patch by Claudiu Popa)
 
-- Issue #3015: Fixed tkinter with wantobject=False.  Any Tcl command call
+- Issue #3015: Fixed tkinter with ``wantobjects=False``.  Any Tcl command call
   returned empty string.
 
 - Issue #19037: The mailbox module now makes all changes to maildir files

--- a/Misc/NEWS.d/3.10.0a1.rst
+++ b/Misc/NEWS.d/3.10.0a1.rst
@@ -97,7 +97,7 @@ convention. Patch by Donghee Na.
 .. nonce: aJS9B3
 .. section: Core and Builtins
 
-Port the :mod:`_bisect` module to the multi-phase initialization API
+Port the :mod:`!_bisect` module to the multi-phase initialization API
 (:pep:`489`).
 
 ..
@@ -128,7 +128,7 @@ Taskaya.
 .. nonce: lh335O
 .. section: Core and Builtins
 
-Port the :mod:`_lsprof` extension module to multi-phase initialization
+Port the :mod:`!_lsprof` extension module to multi-phase initialization
 (:pep:`489`).
 
 ..
@@ -148,7 +148,7 @@ Port the :mod:`cmath` extension module to multi-phase initialization
 .. nonce: jiXmyT
 .. section: Core and Builtins
 
-Port the :mod:`_scproxy` extension module to multi-phase initialization
+Port the :mod:`!_scproxy` extension module to multi-phase initialization
 (:pep:`489`).
 
 ..
@@ -168,7 +168,7 @@ Port the :mod:`termios` extension module to multi-phase initialization
 .. nonce: QuDIut
 .. section: Core and Builtins
 
-Convert the :mod:`_sha256` extension module types to heap types.
+Convert the :mod:`!_sha256` extension module types to heap types.
 
 ..
 
@@ -187,7 +187,7 @@ classes with a huge amount of arguments. Patch by Pablo Galindo.
 .. nonce: CnRME3
 .. section: Core and Builtins
 
-Port the :mod:`_overlapped` extension module to multi-phase initialization
+Port the :mod:`!_overlapped` extension module to multi-phase initialization
 (:pep:`489`).
 
 ..
@@ -197,7 +197,7 @@ Port the :mod:`_overlapped` extension module to multi-phase initialization
 .. nonce: X9CZgo
 .. section: Core and Builtins
 
-Port the :mod:`_curses_panel` extension module to multi-phase initialization
+Port the :mod:`!_curses_panel` extension module to multi-phase initialization
 (:pep:`489`).
 
 ..
@@ -207,7 +207,7 @@ Port the :mod:`_curses_panel` extension module to multi-phase initialization
 .. nonce: 5jZymK
 .. section: Core and Builtins
 
-Port the :mod:`_opcode` extension module to multi-phase initialization
+Port the :mod:`!_opcode` extension module to multi-phase initialization
 (:pep:`489`).
 
 ..
@@ -282,7 +282,7 @@ initialized ``_ast`` module.
 .. nonce: vcxSUa
 .. section: Core and Builtins
 
-Convert :mod:`_operator` to use :c:func:`PyType_FromSpec`.
+Convert :mod:`!_operator` to use :c:func:`PyType_FromSpec`.
 
 ..
 
@@ -291,7 +291,7 @@ Convert :mod:`_operator` to use :c:func:`PyType_FromSpec`.
 .. nonce: fubBkb
 .. section: Core and Builtins
 
-Port :mod:`_sha3` to multi-phase init.  Convert static types to heap types.
+Port :mod:`!_sha3` to multi-phase init.  Convert static types to heap types.
 
 ..
 
@@ -300,7 +300,7 @@ Port :mod:`_sha3` to multi-phase init.  Convert static types to heap types.
 .. nonce: FC13e7
 .. section: Core and Builtins
 
-Port the :mod:`_blake2` extension module to the multi-phase initialization
+Port the :mod:`!_blake2` extension module to the multi-phase initialization
 API (:pep:`489`).
 
 ..
@@ -339,7 +339,7 @@ The output of ``python --help`` contains now only ASCII characters.
 .. nonce: O0d3ym
 .. section: Core and Builtins
 
-Port the :mod:`_sha1`, :mod:`_sha512`, and :mod:`_md5` extension modules to
+Port the :mod:`!_sha1`, :mod:`!_sha512`, and :mod:`!_md5` extension modules to
 multi-phase initialization API (:pep:`489`).
 
 ..
@@ -636,7 +636,7 @@ Remove the remaining files from the old parser and the :mod:`symbol` module.
 .. nonce: _yI-ax
 .. section: Core and Builtins
 
-Convert :mod:`_bz2` to use :c:func:`PyType_FromSpec`.
+Convert :mod:`!_bz2` to use :c:func:`PyType_FromSpec`.
 
 ..
 
@@ -666,7 +666,7 @@ by Brandt Bucher.
 .. nonce: 61iyYh
 .. section: Core and Builtins
 
-Port :mod:`_gdbm` to multiphase initialization.
+Port :mod:`!_gdbm` to multiphase initialization.
 
 ..
 
@@ -696,7 +696,7 @@ for emitting syntax errors. Patch by Pablo Galindo.
 .. nonce: mmlp3Q
 .. section: Core and Builtins
 
-Port :mod:`_dbm` to multiphase initialization.
+Port :mod:`!_dbm` to multiphase initialization.
 
 ..
 
@@ -1010,7 +1010,7 @@ Port :mod:`mmap` to multiphase initialization.
 .. nonce: Kfe9fT
 .. section: Core and Builtins
 
-Port :mod:`_lzma` to multiphase initialization.
+Port :mod:`!_lzma` to multiphase initialization.
 
 ..
 

--- a/Misc/NEWS.d/3.10.0a2.rst
+++ b/Misc/NEWS.d/3.10.0a2.rst
@@ -362,7 +362,7 @@ plistlib: fix parsing XML plists with hexadecimal integer values
 .. nonce: 85BsRA
 .. section: Library
 
-Fix an incorrectly formatted error from :meth:`_codecs.charmap_decode` when
+Fix an incorrectly formatted error from :meth:`!_codecs.charmap_decode` when
 called with a mapped value outside the range of valid Unicode code points.
 PR by Max Bernstein.
 

--- a/Misc/NEWS.d/3.10.0a3.rst
+++ b/Misc/NEWS.d/3.10.0a3.rst
@@ -1386,7 +1386,7 @@ Python already implicitly installs signal handlers: see
 
 The ``Py_TRASHCAN_BEGIN`` macro no longer accesses PyTypeObject attributes,
 but now can get the condition by calling the new private
-:c:func:`_PyTrash_cond()` function which hides implementation details.
+:c:func:`!_PyTrash_cond()` function which hides implementation details.
 
 ..
 

--- a/Misc/NEWS.d/3.10.0a4.rst
+++ b/Misc/NEWS.d/3.10.0a4.rst
@@ -193,7 +193,7 @@ subinterpreters. Patch by Victor Stinner.
 .. nonce: j7nl6A
 .. section: Core and Builtins
 
-Make :c:func:`_PyUnicode_FromId` function compatible with subinterpreters.
+Make :c:func:`!_PyUnicode_FromId` function compatible with subinterpreters.
 Each interpreter now has an array of identifier objects (interned strings
 decoded from UTF-8). Patch by Victor Stinner.
 
@@ -367,7 +367,7 @@ uses "options" instead.
 .. nonce: Quy3zn
 .. section: Library
 
-Port the :mod:`_thread` extension module to the multiphase initialization
+Port the :mod:`!_thread` extension module to the multiphase initialization
 API (:pep:`489`) and convert its static types to heap types.
 
 ..
@@ -960,8 +960,8 @@ explicitly and so not exported.
 .. nonce: Je08Ny
 .. section: C API
 
-Remove the private :c:func:`_Py_fopen` function which is no longer needed.
-Use :c:func:`_Py_wfopen` or :c:func:`_Py_fopen_obj` instead. Patch by Victor
+Remove the private :c:func:`!_Py_fopen` function which is no longer needed.
+Use :c:func:`!_Py_wfopen` or :c:func:`!_Py_fopen_obj` instead. Patch by Victor
 Stinner.
 
 ..

--- a/Misc/NEWS.d/3.10.0a5.rst
+++ b/Misc/NEWS.d/3.10.0a5.rst
@@ -108,7 +108,7 @@ a slice at the start of the ``bytearray`` to a shorter byte string).
 .. nonce: WfTdfg
 .. section: Core and Builtins
 
-Fix the :c:func:`_PyUnicode_FromId` function (_Py_IDENTIFIER(var) API) when
+Fix the :c:func:`!_PyUnicode_FromId` function (_Py_IDENTIFIER(var) API) when
 :c:func:`Py_Initialize` / :c:func:`Py_Finalize` is called multiple times:
 preserve ``_PyRuntime.unicode_ids.next_index`` value.
 

--- a/Misc/NEWS.d/3.10.0a6.rst
+++ b/Misc/NEWS.d/3.10.0a6.rst
@@ -315,7 +315,7 @@ Adds :const:`resource.RLIMIT_KQUEUES` constant from FreeBSD to the
 .. section: Library
 
 Make the pure Python implementation of :mod:`xml.etree.ElementTree` behave
-the same as the C implementation (:mod:`_elementree`) regarding default
+the same as the C implementation (:mod:`!_elementree`) regarding default
 attribute values (by not setting ``specified_attributes=1``).
 
 ..

--- a/Misc/NEWS.d/3.10.0a7.rst
+++ b/Misc/NEWS.d/3.10.0a7.rst
@@ -83,7 +83,7 @@ instruction dispatch a bit.
 .. nonce: PhaT-B
 .. section: Core and Builtins
 
-Fix reference leak in the :mod:`_hashopenssl` extension. Patch by Pablo
+Fix reference leak in the :mod:`!_hashopenssl` extension. Patch by Pablo
 Galindo.
 
 ..

--- a/Misc/NEWS.d/3.10.0b1.rst
+++ b/Misc/NEWS.d/3.10.0b1.rst
@@ -182,7 +182,7 @@ normally be possible, but might occur in some unusual circumstances.
 .. nonce: u5Y6bS
 .. section: Core and Builtins
 
-Importing the :mod:`_signal` module in a subinterpreter has no longer side
+Importing the :mod:`!_signal` module in a subinterpreter has no longer side
 effects.
 
 ..
@@ -776,11 +776,11 @@ builtins.open() is now io.open().
 .. nonce: o1zEk_
 .. section: Library
 
-The Python :func:`_pyio.open` function becomes a static method to behave as
+The Python :func:`!_pyio.open` function becomes a static method to behave as
 :func:`io.open` built-in function: don't become a bound method when stored
 as a class variable. It becomes possible since static methods are now
-callable in Python 3.10. Moreover, :func:`_pyio.OpenWrapper` becomes a
-simple alias to :func:`_pyio.open`. Patch by Victor Stinner.
+callable in Python 3.10. Moreover, :func:`!_pyio.OpenWrapper` becomes a
+simple alias to :func:`!_pyio.open`. Patch by Victor Stinner.
 
 ..
 

--- a/Misc/NEWS.d/3.11.0a1.rst
+++ b/Misc/NEWS.d/3.11.0a1.rst
@@ -613,7 +613,7 @@ Rename ``types.Union`` to ``types.UnionType``.
 .. section: Core and Builtins
 
 Expose specialization stats in python via
-:func:`_opcode.get_specialization_stats`.
+:func:`!_opcode.get_specialization_stats`.
 
 ..
 
@@ -1701,7 +1701,7 @@ Remove many old deprecated :mod:`unittest` features:
 .. nonce: y1kEfP
 .. section: Library
 
-Remove the deprecated ``split()`` method of :class:`_tkinter.TkappType`.
+Remove the deprecated ``split()`` method of :class:`!_tkinter.TkappType`.
 Patch by Erlend E. Aasland.
 
 ..
@@ -2298,9 +2298,9 @@ Adopt *binacii.a2b_base64*'s strict mode in *base64.b64decode*.
 .. nonce: ThuDMI
 .. section: Library
 
-Fixed a bug in the :mod:`_ssl` module that was throwing :exc:`OverflowError`
-when using :meth:`_ssl._SSLSocket.write` and :meth:`_ssl._SSLSocket.read`
-for a big value of the ``len`` parameter. Patch by Pablo Galindo
+Fixed a bug in the :mod:`!_ssl` module that was throwing :exc:`OverflowError`
+when using :meth:`!_ssl._SSLSocket.write` and :meth:`!_ssl._SSLSocket.read`
+for a big value of the ``len`` parameter. Patch by Pablo Galindo.
 
 ..
 
@@ -2398,7 +2398,7 @@ class in the interactive session. Instead of :exc:`TypeError`, it should be
 .. nonce: R3IcM1
 .. section: Library
 
-Fix memory leak in :func:`_tkinter._flatten` if it is called with a sequence
+Fix memory leak in :func:`!_tkinter._flatten` if it is called with a sequence
 or set, but not list or tuple.
 
 ..
@@ -4187,7 +4187,7 @@ Add calls of :func:`gc.collect` in tests to support PyPy.
 .. nonce: mQZdXU
 .. section: Tests
 
-Made tests relying on the :mod:`_asyncio` C extension module optional to
+Made tests relying on the :mod:`!_asyncio` C extension module optional to
 allow running on alternative Python implementations. Patch by Serhiy
 Storchaka.
 

--- a/Misc/NEWS.d/3.11.0a2.rst
+++ b/Misc/NEWS.d/3.11.0a2.rst
@@ -15,7 +15,7 @@ Improve the :exc:`SyntaxError` message when using ``True``, ``None`` or
 .. section: Core and Builtins
 
 :data:`sys.stdlib_module_names` now contains the macOS-specific module
-:mod:`_scproxy`.
+:mod:`!_scproxy`.
 
 ..
 
@@ -1023,7 +1023,7 @@ compile shared modules.
 .. nonce: 61gM2A
 .. section: Build
 
-:mod:`pyexpat` and :mod:`_elementtree` no longer define obsolete macros
+:mod:`pyexpat` and :mod:`!_elementtree` no longer define obsolete macros
 ``HAVE_EXPAT_CONFIG_H`` and ``USE_PYEXPAT_CAPI``. ``XML_POOR_ENTROPY`` is
 now defined in ``expat_config.h``.
 

--- a/Misc/NEWS.d/3.11.0a3.rst
+++ b/Misc/NEWS.d/3.11.0a3.rst
@@ -27,7 +27,7 @@ invalid targets. Patch by Pablo Galindo
 .. nonce: 3TmTSw
 .. section: Core and Builtins
 
-:c:func:`_PyErr_ChainStackItem` no longer normalizes ``exc_info`` (including
+:c:func:`!_PyErr_ChainStackItem` no longer normalizes ``exc_info`` (including
 setting the traceback on the exception instance) because ``exc_info`` is
 always normalized.
 

--- a/Misc/NEWS.d/3.11.0a4.rst
+++ b/Misc/NEWS.d/3.11.0a4.rst
@@ -258,7 +258,7 @@ instruction which performs the same operation, but without the loop.
 .. nonce: ADVaPT
 .. section: Core and Builtins
 
-The code called from :c:func:`_PyErr_Display` was refactored to improve
+The code called from :c:func:`!_PyErr_Display` was refactored to improve
 error handling. It now exits immediately upon an unrecoverable error.
 
 ..

--- a/Misc/NEWS.d/3.11.0b1.rst
+++ b/Misc/NEWS.d/3.11.0b1.rst
@@ -285,7 +285,7 @@ macros.
 .. nonce: 11YXHQ
 .. section: Core and Builtins
 
-Add a new :c:func:`_PyFrame_IsEntryFrame` API function, to check if a
+Add a new :c:func:`!_PyFrame_IsEntryFrame` API function, to check if a
 :c:type:`PyFrameObject` is an entry frame. Patch by Pablo Galindo.
 
 ..

--- a/Misc/NEWS.d/3.12.0a1.rst
+++ b/Misc/NEWS.d/3.12.0a1.rst
@@ -102,7 +102,7 @@ well as generator expressions.
 .. section: Core and Builtins
 
 Added unicode check for ``name`` attribute of ``spec`` argument passed in
-:func:`_imp.create_builtin` function.
+:func:`!_imp.create_builtin` function.
 
 ..
 
@@ -483,7 +483,7 @@ Fix case of undefined behavior in ceval.c
 .. nonce: AfCi36
 .. section: Core and Builtins
 
-Convert :mod:`_functools` to argument clinic.
+Convert :mod:`!_functools` to argument clinic.
 
 ..
 
@@ -492,7 +492,7 @@ Convert :mod:`_functools` to argument clinic.
 .. nonce: wky0Fc
 .. section: Core and Builtins
 
-Do not expose ``KeyWrapper`` in :mod:`_functools`.
+Do not expose ``KeyWrapper`` in :mod:`!_functools`.
 
 ..
 
@@ -1731,7 +1731,7 @@ tracing functions implemented in C.
 .. nonce: lenv9h
 .. section: Core and Builtins
 
-:meth:`_warnings.warn_explicit` is ported to Argument Clinic.
+:meth:`!_warnings.warn_explicit` is ported to Argument Clinic.
 
 ..
 
@@ -3142,8 +3142,8 @@ test.test_codecs.EncodedFileTest`` instead.
 .. nonce: VhS1eS
 .. section: Library
 
-Made :class:`_struct.Struct` GC-tracked in order to fix a reference leak in
-the :mod:`_struct` module.
+Made :class:`!_struct.Struct` GC-tracked in order to fix a reference leak in
+the :mod:`!_struct` module.
 
 ..
 
@@ -3258,7 +3258,7 @@ on the main thread
 
 Remove ``io.OpenWrapper`` and ``_pyio.OpenWrapper``, deprecated in Python
 3.10: just use :func:`open` instead. The :func:`open` (:func:`io.open`)
-function is a built-in function. Since Python 3.10, :func:`_pyio.open` is
+function is a built-in function. Since Python 3.10, :func:`!_pyio.open` is
 also a static method. Patch by Victor Stinner.
 
 ..
@@ -5610,7 +5610,7 @@ Accept os.PathLike for the argument to winsound.PlaySound
 
 Support native Windows case-insensitive path comparisons by using
 ``LCMapStringEx`` instead of :func:`str.lower` in :func:`ntpath.normcase`.
-Add ``LCMapStringEx`` to the :mod:`_winapi` module.
+Add ``LCMapStringEx`` to the :mod:`!_winapi` module.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0a2.rst
+++ b/Misc/NEWS.d/3.12.0a2.rst
@@ -527,7 +527,7 @@ Stinner.
 .. nonce: Ai2KDh
 .. section: Library
 
-Now :mod:`_pyio` is consistent with :mod:`_io` in raising ``ValueError``
+Now :mod:`!_pyio` is consistent with :mod:`!_io` in raising ``ValueError``
 when executing methods over closed buffers.
 
 ..
@@ -537,7 +537,7 @@ when executing methods over closed buffers.
 .. nonce: 0v8iyw
 .. section: Library
 
-Clean up refleak on failed module initialisation in :mod:`_zoneinfo`
+Clean up refleak on failed module initialisation in :mod:`!_zoneinfo`
 
 ..
 
@@ -546,7 +546,7 @@ Clean up refleak on failed module initialisation in :mod:`_zoneinfo`
 .. nonce: qc_KHr
 .. section: Library
 
-Clean up refleaks on failed module initialisation in :mod:`_pickle`
+Clean up refleaks on failed module initialisation in :mod:`!_pickle`
 
 ..
 
@@ -555,7 +555,7 @@ Clean up refleaks on failed module initialisation in :mod:`_pickle`
 .. nonce: LBl79O
 .. section: Library
 
-Clean up refleak on failed module initialisation in :mod:`_io`.
+Clean up refleak on failed module initialisation in :mod:`!_io`.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0a3.rst
+++ b/Misc/NEWS.d/3.12.0a3.rst
@@ -70,7 +70,7 @@ Fix bug where compiler crashes on an if expression with an empty body block.
 .. nonce: DcKoBJ
 .. section: Core and Builtins
 
-Fix a reference bug in :func:`_imp.create_builtin()` after the creation of
+Fix a reference bug in :func:`!_imp.create_builtin` after the creation of
 the first sub-interpreter for modules ``builtins`` and ``sys``. Patch by
 Victor Stinner.
 

--- a/Misc/NEWS.d/3.12.0a4.rst
+++ b/Misc/NEWS.d/3.12.0a4.rst
@@ -241,7 +241,7 @@ are now always dumped, even if switched off.
 Improve ``BUILD_LIST`` opcode so that it works similarly to the
 ``BUILD_TUPLE`` opcode, by stealing references from the stack rather than
 repeatedly using stack operations to set list elements.  Implementation
-details are in a new private API :c:func:`_PyList_FromArraySteal`.
+details are in a new private API :c:func:`!_PyList_FromArraySteal`.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0b1.rst
+++ b/Misc/NEWS.d/3.12.0b1.rst
@@ -1828,7 +1828,7 @@ is relative.
 .. nonce: 511Tbh
 .. section: Library
 
-Convert private :meth:`_posixsubprocess.fork_exec` to use Argument Clinic.
+Convert private :meth:`!_posixsubprocess.fork_exec` to use Argument Clinic.
 
 ..
 

--- a/Misc/NEWS.d/3.13.0a1.rst
+++ b/Misc/NEWS.d/3.13.0a1.rst
@@ -2888,9 +2888,9 @@ documented and were not intended to be used externally.
 .. nonce: vMbmj_
 .. section: Library
 
-:data:`opcode.ENABLE_SPECIALIZATION` (which was added in 3.12 but never
+:data:`!opcode.ENABLE_SPECIALIZATION` (which was added in 3.12 but never
 documented or intended for external usage) is moved to
-:data:`_opcode.ENABLE_SPECIALIZATION` where tests can access it.
+:data:`!_opcode.ENABLE_SPECIALIZATION` where tests can access it.
 
 ..
 
@@ -3053,7 +3053,7 @@ Donghee Na.
 .. nonce: U9nD_B
 .. section: Library
 
-Optimize :meth:`_PollLikeSelector.select` for many iteration case.
+Optimize :meth:`!_PollLikeSelector.select` for many iteration case.
 
 ..
 
@@ -3173,7 +3173,7 @@ Disable tab completion in multiline mode of :mod:`pdb`
 .. nonce: pYSwMj
 .. section: Library
 
-Expose opcode metadata through :mod:`_opcode`.
+Expose opcode metadata through :mod:`!_opcode`.
 
 ..
 
@@ -3735,7 +3735,7 @@ overwritten.
 .. nonce: _sZilh
 .. section: Library
 
-Fix bugs in :mod:`_ctypes` where exceptions could end up being overwritten.
+Fix bugs in :mod:`!_ctypes` where exceptions could end up being overwritten.
 
 ..
 

--- a/Misc/NEWS.d/3.13.0a2.rst
+++ b/Misc/NEWS.d/3.13.0a2.rst
@@ -777,7 +777,7 @@ Add error checking during :mod:`!_socket` module init.
 .. nonce: urFYtn
 .. section: Library
 
-Fix :mod:`_blake2` not checking for errors when initializing.
+Fix :mod:`!_blake2` not checking for errors when initializing.
 
 ..
 

--- a/Misc/NEWS.d/3.13.0a3.rst
+++ b/Misc/NEWS.d/3.13.0a3.rst
@@ -449,8 +449,8 @@ well-formed for surrogateescape encoding. Patch by Sidney Markowitz.
 .. nonce: N8E1zw
 .. section: Core and Builtins
 
-Use the object's actual class name in :meth:`_io.FileIO.__repr__`,
-:meth:`_io._WindowsConsoleIO` and :meth:`_io.TextIOWrapper.__repr__`, to
+Use the object's actual class name in :meth:`!_io.FileIO.__repr__`,
+:meth:`!_io._WindowsConsoleIO` and :meth:`!_io.TextIOWrapper.__repr__`, to
 make these methods subclass friendly.
 
 ..

--- a/Misc/NEWS.d/3.13.0a5.rst
+++ b/Misc/NEWS.d/3.13.0a5.rst
@@ -541,7 +541,7 @@ descriptors in :meth:`inspect.Signature.from_callable`.
 .. nonce: sGMKr0
 .. section: Library
 
-Isolate :mod:`_lsprof` (apply :pep:`687`).
+Isolate :mod:`!_lsprof` (apply :pep:`687`).
 
 ..
 
@@ -773,8 +773,8 @@ combination with unicode encoding.
 .. section: Library
 
 Fix :func:`io.BufferedReader.tell`, :func:`io.BufferedReader.seek`,
-:func:`_pyio.BufferedReader.tell`, :func:`io.BufferedRandom.tell`,
-:func:`io.BufferedRandom.seek` and :func:`_pyio.BufferedRandom.tell` being
+:func:`!_pyio.BufferedReader.tell`, :func:`io.BufferedRandom.tell`,
+:func:`io.BufferedRandom.seek` and :func:`!_pyio.BufferedRandom.tell` being
 able to return negative offsets.
 
 ..

--- a/Misc/NEWS.d/3.13.0a6.rst
+++ b/Misc/NEWS.d/3.13.0a6.rst
@@ -550,7 +550,7 @@ or DuplicateOptionError.
 .. nonce: PBiRQB
 .. section: Library
 
-:class:`_io.WindowsConsoleIO` now emit a warning if a boolean value is
+:class:`!_io.WindowsConsoleIO` now emit a warning if a boolean value is
 passed as a filedescriptor argument.
 
 ..

--- a/Misc/NEWS.d/3.13.0b1.rst
+++ b/Misc/NEWS.d/3.13.0b1.rst
@@ -1595,7 +1595,7 @@ Use user-selected color theme for Help => IDLE Doc.
 .. nonce: czQQ9G
 .. section: C API
 
-Fix :c:macro:`!Py_BUILD_ASSERT` and :c:macro:`!Py_BUILD_ASSERT_EXPR` for
+Fix :c:macro:`Py_BUILD_ASSERT` and :c:macro:`Py_BUILD_ASSERT_EXPR` for
 non-constant expressions: use ``static_assert()`` on C11 and newer. Patch by
 Victor Stinner.
 

--- a/Misc/NEWS.d/3.13.0b1.rst
+++ b/Misc/NEWS.d/3.13.0b1.rst
@@ -666,7 +666,7 @@ by :pep:`738`.
 .. section: Library
 
 Allow to specify the signature of custom callable instances of extension
-type by the :attr:`__text_signature__` attribute. Specify signatures of
+type by the ``__text_signature__`` attribute. Specify signatures of
 :class:`operator.attrgetter`, :class:`operator.itemgetter`, and
 :class:`operator.methodcaller` instances.
 
@@ -687,10 +687,10 @@ padding is not detected when no padding is necessary.
 .. nonce: 5N2Xcy
 .. section: Library
 
-Add the :class:`!PhotoImage` methods :meth:`~tkinter.PhotoImage.read` to
-read an image from a file and :meth:`~tkinter.PhotoImage.data` to get the
+Add the :class:`!PhotoImage` methods :meth:`!read` to
+read an image from a file and :meth:`!data` to get the
 image data. Add *background* and *grayscale* parameters to
-:class:`!PhotoImage` method :meth:`~tkinter.PhotoImage.write`.
+:class:`!PhotoImage` method :meth:`!write`.
 
 ..
 
@@ -855,7 +855,7 @@ is used to bind indexed, nameless placeholders. See also :gh:`100668`.
 .. nonce: RstWg-
 .. section: Library
 
-Fix TypeError in :func:`email.Message.get_payload` when the charset is
+Fix TypeError in :func:`email.message.Message.get_payload` when the charset is
 :rfc:`2231` encoded.
 
 ..
@@ -953,7 +953,7 @@ Speed up :meth:`pathlib.Path.walk` by working with strings internally.
 .. nonce: oxIUEI
 .. section: Library
 
-Change the new multi-separator support in :meth:`asyncio.Stream.readuntil`
+Change the new multi-separator support in :meth:`asyncio.StreamReader.readuntil`
 to only accept tuples of separators rather than arbitrary iterables.
 
 ..
@@ -1260,7 +1260,7 @@ Support opcode events in :mod:`bdb`
 .. nonce: YoI8TV
 .. section: Library
 
-:mod:`ncurses`: fixed a crash that could occur on macOS 13 or earlier when
+:mod:`!ncurses`: fixed a crash that could occur on macOS 13 or earlier when
 Python was built with Apple Xcode 15's SDK.
 
 ..
@@ -1347,13 +1347,13 @@ urllib.
 .. nonce: du4UKW
 .. section: Library
 
-Setting the :mod:`!tkinter` module global :data:`~tkinter.wantobject` to ``2``
+Setting the :mod:`!tkinter` module global :data:`!wantobjects` to ``2``
 before creating the :class:`~tkinter.Tk` object or call the
-:meth:`~tkinter.Tk.wantobject` method of the :class:`!Tk` object with argument
+:meth:`!wantobjects` method of the :class:`!Tk` object with argument
 ``2`` makes now arguments to callbacks registered in the :mod:`tkinter` module
 to be passed as various Python objects (``int``, ``float``, ``bytes``, ``tuple``),
 depending on their internal representation in Tcl, instead of always ``str``.
-:data:`!tkinter.wantobject` is now set to ``2`` by default.
+:data:`!tkinter.wantobjects` is now set to ``2`` by default.
 
 ..
 
@@ -1595,7 +1595,7 @@ Use user-selected color theme for Help => IDLE Doc.
 .. nonce: czQQ9G
 .. section: C API
 
-Fix :c:macro:`Py_BUILD_ASSERT` and :c:macro:`Py_BUILD_ASSERT_EXPR` for
+Fix :c:macro:`!Py_BUILD_ASSERT` and :c:macro:`!Py_BUILD_ASSERT_EXPR` for
 non-constant expressions: use ``static_assert()`` on C11 and newer. Patch by
 Victor Stinner.
 

--- a/Misc/NEWS.d/3.5.0a1.rst
+++ b/Misc/NEWS.d/3.5.0a1.rst
@@ -3447,7 +3447,8 @@ tkinter.ttk now works when default root window is not set.
 .. nonce: FE_PII
 .. section: Library
 
-_tkinter.create() now creates tkapp object with wantobject=1 by default.
+``_tkinter.create()`` now creates ``tkapp`` object with ``wantobjects=1`` by
+default.
 
 ..
 

--- a/Misc/NEWS.d/3.6.0a1.rst
+++ b/Misc/NEWS.d/3.6.0a1.rst
@@ -1484,9 +1484,9 @@ on UNIX signals (SIGSEGV, SIGFPE, SIGABRT).
 .. nonce: RWN1jR
 .. section: Library
 
-Add C functions :c:func:`_PyTraceMalloc_Track` and
-:c:func:`_PyTraceMalloc_Untrack` to track memory blocks using the
-:mod:`tracemalloc` module. Add :c:func:`_PyTraceMalloc_GetTraceback` to get
+Add C functions :c:func:`!_PyTraceMalloc_Track` and
+:c:func:`!_PyTraceMalloc_Untrack` to track memory blocks using the
+:mod:`tracemalloc` module. Add :c:func:`!_PyTraceMalloc_GetTraceback` to get
 the traceback of an object.
 
 ..

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -2519,7 +2519,7 @@ non-Windows systems.
 .. nonce: dQS1ng
 .. section: Library
 
-Fix incorrect parsing of :class:`!_io.IncrementalNewlineDecoder`'s
+Fix incorrect parsing of :class:`io.IncrementalNewlineDecoder`'s
 *translate* argument.
 
 ..

--- a/Misc/NEWS.d/3.8.0a1.rst
+++ b/Misc/NEWS.d/3.8.0a1.rst
@@ -2519,7 +2519,7 @@ non-Windows systems.
 .. nonce: dQS1ng
 .. section: Library
 
-Fix incorrect parsing of :class:`_io.IncrementalNewlineDecoder`'s
+Fix incorrect parsing of :class:`!_io.IncrementalNewlineDecoder`'s
 *translate* argument.
 
 ..
@@ -8051,7 +8051,7 @@ Update macOS 10.9+ installer to Tcl/Tk 8.6.8.
 .. nonce: K6jCVG
 .. section: macOS
 
-In :mod:`_scproxy`, drop the GIL when calling into ``SystemConfiguration``
+In :mod:`!_scproxy`, drop the GIL when calling into ``SystemConfiguration``
 to avoid deadlocks.
 
 ..

--- a/Misc/NEWS.d/3.8.0a4.rst
+++ b/Misc/NEWS.d/3.8.0a4.rst
@@ -945,7 +945,7 @@ P. Hemsley.
 .. nonce: __FTq9
 .. section: Tests
 
-Add a new :mod:`_testinternalcapi` module to test the internal C API.
+Add a new :mod:`!_testinternalcapi` module to test the internal C API.
 
 ..
 
@@ -1383,7 +1383,7 @@ Since Python 3.7.0, calling :c:func:`Py_DecodeLocale` before
 coerced and/or if the UTF-8 Mode is enabled by the user configuration. The
 LC_CTYPE coercion and UTF-8 Mode are now disabled by default to fix the
 mojibake issue. They must now be enabled explicitly (opt-in) using the new
-:c:func:`_Py_PreInitialize` API with ``_PyPreConfig``.
+:c:func:`!_Py_PreInitialize` API with ``_PyPreConfig``.
 
 ..
 

--- a/Misc/NEWS.d/3.8.0b1.rst
+++ b/Misc/NEWS.d/3.8.0b1.rst
@@ -600,7 +600,7 @@ default.
 .. nonce: sLULGQ
 .. section: Library
 
-Fix destructor :class:`_pyio.BytesIO` and :class:`_pyio.TextIOWrapper`:
+Fix destructor :class:`!_pyio.BytesIO` and :class:`!_pyio.TextIOWrapper`:
 initialize their ``_buffer`` attribute as soon as possible (in the class
 body), because it's used by ``__del__()`` which calls ``close()``.
 

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -1384,7 +1384,7 @@ Nested subclasses of :class:`typing.NamedTuple` are now pickleable.
 .. nonce: hwrPN7
 .. section: Library
 
-Prevent :exc:`KeyError` thrown by :func:`_encoded_words.decode` when given
+Prevent :exc:`KeyError` thrown by :func:`!_encoded_words.decode` when given
 an encoded-word with invalid content-type encoding from propagating all the
 way to :func:`email.message.get`.
 
@@ -1395,7 +1395,7 @@ way to :func:`email.message.get`.
 .. nonce: S6Klvm
 .. section: Library
 
-Deprecated the ``split()`` method in :class:`_tkinter.TkappType` in favour
+Deprecated the ``split()`` method in :class:`!_tkinter.TkappType` in favour
 of the ``splitlist()`` method which has more consistent and predictable
 behavior.
 
@@ -3013,7 +3013,7 @@ thread was still running.
 .. section: Library
 
 Allow pure Python implementation of :mod:`pickle` to work even when the C
-:mod:`_pickle` module is unavailable.
+:mod:`!_pickle` module is unavailable.
 
 ..
 
@@ -3064,8 +3064,8 @@ internal tasks weak set is changed by another thread during iteration.
 .. nonce: ADqCkq
 .. section: Library
 
-:class:`_pyio.IOBase` destructor now does nothing if getting the ``closed``
-attribute fails to better mimic :class:`_io.IOBase` finalizer.
+:class:`!_pyio.IOBase` destructor now does nothing if getting the ``closed``
+attribute fails to better mimic :class:`!_io.IOBase` finalizer.
 
 ..
 
@@ -4993,7 +4993,7 @@ Make :const:`winreg.REG_MULTI_SZ` support zero-length strings.
 .. section: Windows
 
 Replace use of :c:func:`strcasecmp` for the system function
-:c:func:`_stricmp`. Patch by Minmin Gong.
+:c:func:`!_stricmp`. Patch by Minmin Gong.
 
 ..
 
@@ -5696,8 +5696,8 @@ Add :c:func:`PyConfig_SetWideStringList` function.
 .. section: C API
 
 Add fast functions for calling methods:
-:c:func:`_PyObject_VectorcallMethod`, :c:func:`_PyObject_CallMethodNoArgs`
-and :c:func:`_PyObject_CallMethodOneArg`.
+:c:func:`"_PyObject_VectorcallMethod`, :c:func:`!_PyObject_CallMethodNoArgs`
+and :c:func:`!_PyObject_CallMethodOneArg`.
 
 ..
 

--- a/Misc/NEWS.d/3.9.0a1.rst
+++ b/Misc/NEWS.d/3.9.0a1.rst
@@ -5696,7 +5696,7 @@ Add :c:func:`PyConfig_SetWideStringList` function.
 .. section: C API
 
 Add fast functions for calling methods:
-:c:func:`"_PyObject_VectorcallMethod`, :c:func:`!_PyObject_CallMethodNoArgs`
+:c:func:`!_PyObject_VectorcallMethod`, :c:func:`!_PyObject_CallMethodNoArgs`
 and :c:func:`!_PyObject_CallMethodOneArg`.
 
 ..

--- a/Misc/NEWS.d/3.9.0a6.rst
+++ b/Misc/NEWS.d/3.9.0a6.rst
@@ -111,7 +111,7 @@ str.decode().
 .. nonce: m15TTX
 .. section: Core and Builtins
 
-Fix possible refleaks in :mod:`_json`, memo of PyScannerObject should be
+Fix possible refleaks in :mod:`!_json`, memo of PyScannerObject should be
 traversed.
 
 ..
@@ -666,8 +666,8 @@ for _main_thread, instead of a _DummyThread instance.
 .. nonce: VTq_8s
 .. section: Library
 
-Add a private ``_at_fork_reinit()`` method to :class:`_thread.Lock`,
-:class:`_thread.RLock`, :class:`threading.RLock` and
+Add a private ``_at_fork_reinit()`` method to :class:`!_thread.Lock`,
+:class:`!_thread.RLock`, :class:`threading.RLock` and
 :class:`threading.Condition` classes: reinitialize the lock at fork in the
 child process, reset the lock to the unlocked state. Rename also the private
 ``_reset_internal_locks()`` method of :class:`threading.Event` to

--- a/Misc/NEWS.d/next/Library/2023-04-24-05-34-23.gh-issue-103194.GwBwWL.rst
+++ b/Misc/NEWS.d/next/Library/2023-04-24-05-34-23.gh-issue-103194.GwBwWL.rst
@@ -1,4 +1,4 @@
 Prepare Tkinter for C API changes in Tcl 8.7/9.0 to avoid
-:class:`_tkinter.Tcl_Obj` being unexpectedly returned
+:class:`!_tkinter.Tcl_Obj` being unexpectedly returned
 instead of :class:`bool`, :class:`str`,
 :class:`bytearray`, or :class:`int`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Follow on from https://github.com/python/cpython/pull/119221.

Fix some more `NEWS` warnings and increase the threshold to fail if NEWS nits are found in the first 1700 lines (previously 200).

Also fix Sphinx warnings in NEWS files for references beginning with a single underscore.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121482.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->