### PR TITLE
gh-121487: Fix deprecation warning for ATOMIC_VAR_INIT in mimalloc

### DIFF
--- a/Include/internal/mimalloc/mimalloc/atomic.h
+++ b/Include/internal/mimalloc/mimalloc/atomic.h
@@ -23,7 +23,9 @@ terms of the MIT license. A copy of the license can be found in the file
 #define  _Atomic(tp)            std::atomic<tp>
 #define  mi_atomic(name)        std::atomic_##name
 #define  mi_memory_order(name)  std::memory_order_##name
-#if !defined(ATOMIC_VAR_INIT) || (__cplusplus >= 202002L) // c++20, see issue #571
+#if (__cplusplus >= 202002L)    // c++20, see issue #571
+ #define MI_ATOMIC_VAR_INIT(x)  x
+#elif !defined(ATOMIC_VAR_INIT)
  #define MI_ATOMIC_VAR_INIT(x)  x
 #else
  #define MI_ATOMIC_VAR_INIT(x)  ATOMIC_VAR_INIT(x)
@@ -39,7 +41,9 @@ terms of the MIT license. A copy of the license can be found in the file
 #include <stdatomic.h>
 #define  mi_atomic(name)        atomic_##name
 #define  mi_memory_order(name)  memory_order_##name
-#if !defined(ATOMIC_VAR_INIT) || (__STDC_VERSION__ >= 201710L) // c17, see issue #735
+#if (__STDC_VERSION__ >= 201710L) // c17, see issue #735
+ #define MI_ATOMIC_VAR_INIT(x) x
+#elif !defined(ATOMIC_VAR_INIT)
  #define MI_ATOMIC_VAR_INIT(x) x
 #else
  #define MI_ATOMIC_VAR_INIT(x) ATOMIC_VAR_INIT(x)

--- a/Misc/NEWS.d/next/Build/2024-07-08-14-01-17.gh-issue-121487.ekHmpR.rst
+++ b/Misc/NEWS.d/next/Build/2024-07-08-14-01-17.gh-issue-121487.ekHmpR.rst
@@ -1,0 +1,1 @@
+Fix deprecation warning for ATOMIC_VAR_INIT in mimalloc.


### PR DESCRIPTION
Pull in upstream changes to fix deprecation warning with `ATOMIC_VAR_INIT`in mimalloc.
- https://github.com/microsoft/mimalloc/commit/36ee5f9024af87172fcb0fb8b20f8062fa3463d2
- https://github.com/microsoft/mimalloc/commit/1325ee640aa429ff4db080458895c8864e406a95

<!-- gh-issue-number: gh-121487 -->
* Issue: gh-121487
<!-- /gh-issue-number -->
