### PR TITLE
Update http client to remove template in comment

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1,8 +1,5 @@
 r"""HTTP/1.1 client library
 
-<intro stuff goes here>
-<other stuff, too>
-
 HTTPConnection goes through a number of "states", which define when a client
 may legally make another request or fetch the response for a particular
 request. This diagram details these state transitions:


### PR DESCRIPTION
Removes template lines in the comment so that hovering over the library in an IDE shows the documentation rather than these lines