### PR TITLE
GH-118926: Better distinguish between pointer and arrays in interpreter generator

### DIFF
--- a/Tools/cases_generator/analyzer.py
+++ b/Tools/cases_generator/analyzer.py
@@ -106,13 +106,15 @@ class StackItem:
 
     def __str__(self) -> str:
         cond = f" if ({self.condition})" if self.condition else ""
-        size = f"[{self.size}]" if self.size != "1" else ""
+        size = f"[{self.size}]" if self.size else ""
         type = "" if self.type is None else f"{self.type} "
         return f"{type}{self.name}{size}{cond} {self.peek}"
 
     def is_array(self) -> bool:
-        return self.type == "_PyStackRef *"
+        return self.size != ""
 
+    def get_size(self) -> str:
+        return self.size if self.size else "1"
 
 @dataclass
 class StackEffect:
@@ -293,7 +295,7 @@ def convert_stack_item(item: parser.StackEffect, replace_op_arg_1: str | None) -
     if replace_op_arg_1 and OPARG_AND_1.match(item.cond):
         cond = replace_op_arg_1
     return StackItem(
-        item.name, item.type, cond, (item.size or "1")
+        item.name, item.type, cond, item.size
     )
 
 def analyze_stack(op: parser.InstDef | parser.Pseudo, replace_op_arg_1: str | None = None) -> StackEffect:

--- a/Tools/cases_generator/generators_common.py
+++ b/Tools/cases_generator/generators_common.py
@@ -5,6 +5,7 @@ from analyzer import (
     Instruction,
     Uop,
     Properties,
+    StackItem,
 )
 from cwriter import CWriter
 from typing import Callable, Mapping, TextIO, Iterator
@@ -22,6 +23,15 @@ def root_relative_path(filename: str) -> str:
     except ValueError:
         # Not relative to root, just return original path.
         return filename
+
+
+def type_and_null(var: StackItem):
+    if var.type:
+        return var.type, "NULL"
+    elif var.is_array():
+        return "_PyStackRef *", "NULL"
+    else:
+        return "_PyStackRef", "PyStackRef_NULL"
 
 
 def write_header(
@@ -126,7 +136,7 @@ def replace_decrefs(
     for var in uop.stack.inputs:
         if var.name == "unused" or var.name == "null" or var.peek:
             continue
-        if var.size != "1":
+        if var.size:
             out.emit(f"for (int _i = {var.size}; --_i >= 0;) {{\n")
             out.emit(f"PyStackRef_CLOSE({var.name}[_i]);\n")
             out.emit("}\n")

--- a/Tools/cases_generator/generators_common.py
+++ b/Tools/cases_generator/generators_common.py
@@ -8,7 +8,7 @@ from analyzer import (
     StackItem,
 )
 from cwriter import CWriter
-from typing import Callable, Mapping, TextIO, Iterator
+from typing import Callable, Mapping, TextIO, Iterator, Tuple
 from lexer import Token
 from stack import Stack
 

--- a/Tools/cases_generator/generators_common.py
+++ b/Tools/cases_generator/generators_common.py
@@ -25,7 +25,7 @@ def root_relative_path(filename: str) -> str:
         return filename
 
 
-def type_and_null(var: StackItem):
+def type_and_null(var: StackItem) -> Tuple[str, str]:
     if var.type:
         return var.type, "NULL"
     elif var.is_array():

--- a/Tools/cases_generator/parsing.py
+++ b/Tools/cases_generator/parsing.py
@@ -285,7 +285,6 @@ class Parser(PLexer):
                 if not (size := self.expression()):
                     raise self.make_syntax_error("Expected expression")
                 self.require(lx.RBRACKET)
-                type_text = "_PyStackRef *"
                 size_text = size.text.strip()
             return StackEffect(tkn.text, type_text, cond_text, size_text)
         return None

--- a/Tools/cases_generator/stack.py
+++ b/Tools/cases_generator/stack.py
@@ -28,14 +28,15 @@ def var_size(var: StackItem) -> str:
         if var.condition == "0":
             return "0"
         elif var.condition == "1":
-            return var.size
-        elif var.condition == "oparg & 1" and var.size == "1":
+            return var.get_size()
+        elif var.condition == "oparg & 1" and not var.size:
             return f"({var.condition})"
         else:
-            return f"(({var.condition}) ? {var.size} : 0)"
-    else:
+            return f"(({var.condition}) ? {var.get_size()} : 0)"
+    elif var.size:
         return var.size
-
+    else:
+        return "1"
 
 @dataclass
 class StackOffset:

--- a/Tools/cases_generator/tier1_generator.py
+++ b/Tools/cases_generator/tier1_generator.py
@@ -13,12 +13,14 @@ from analyzer import (
     analyze_files,
     Skip,
     analysis_error,
+    StackItem,
 )
 from generators_common import (
     DEFAULT_INPUT,
     ROOT,
     write_header,
     emit_tokens,
+    type_and_null,
 )
 from cwriter import CWriter
 from typing import TextIO
@@ -38,19 +40,16 @@ def declare_variables(inst: Instruction, out: CWriter) -> None:
             for var in reversed(uop.stack.inputs):
                 if var.name not in variables:
                     variables.add(var.name)
-                    type, null = (var.type, "NULL") if var.type else ("_PyStackRef", "PyStackRef_NULL")
+                    type, null = type_and_null(var)
                     space = " " if type[-1].isalnum() else ""
                     if var.condition:
                         out.emit(f"{type}{space}{var.name} = {null};\n")
                     else:
-                        if var.is_array():
-                            out.emit(f"{var.type}{space}{var.name};\n")
-                        else:
-                            out.emit(f"{type}{space}{var.name};\n")
+                        out.emit(f"{type}{space}{var.name};\n")
             for var in uop.stack.outputs:
                 if var.name not in variables:
                     variables.add(var.name)
-                    type, null = (var.type, "NULL") if var.type else ("_PyStackRef", "PyStackRef_NULL")
+                    type, null = type_and_null(var)
                     space = " " if type[-1].isalnum() else ""
                     if var.condition:
                         out.emit(f"{type}{space}{var.name} = {null};\n")

--- a/Tools/cases_generator/tier2_generator.py
+++ b/Tools/cases_generator/tier2_generator.py
@@ -20,6 +20,7 @@ from generators_common import (
     emit_tokens,
     emit_to,
     REPLACEMENT_FUNCTIONS,
+    type_and_null,
 )
 from cwriter import CWriter
 from typing import TextIO, Iterator
@@ -35,7 +36,7 @@ def declare_variable(
     if var.name in variables:
         return
     variables.add(var.name)
-    type, null = (var.type, "NULL") if var.type else ("_PyStackRef", "PyStackRef_NULL")
+    type, null = type_and_null(var)
     space = " " if type[-1].isalnum() else ""
     if var.condition:
         out.emit(f"{type}{space}{var.name} = {null};\n")


### PR DESCRIPTION
This is a supporting PR for https://github.com/python/cpython/pull/121318.

The code generator treats stack items of type `PyStackRef *` the same as arrays, which is incorrect.
This PR fixes that.

<!-- gh-issue-number: gh-118926 -->
* Issue: gh-118926
<!-- /gh-issue-number -->
