### PR TITLE
gh-121497: Make Pyrepl respect correctly the history with input hook set

### DIFF
--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -383,6 +383,8 @@ class UnixConsole(Console):
         Returns:
         - Event: Event object from the event queue.
         """
+        if not block and not self.wait(timeout=0):
+            return None
         while self.event_queue.empty():
             while True:
                 try:
@@ -397,8 +399,6 @@ class UnixConsole(Console):
                         raise
                 else:
                     break
-            if not block:
-                break
         return self.event_queue.get()
 
     def wait(self, timeout: float | None = None) -> bool:

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-08-17-15-14.gh-issue-121497.I8hMDC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-08-17-15-14.gh-issue-121497.I8hMDC.rst
@@ -1,0 +1,2 @@
+Fix a bug that was preventing the REPL to correctly respect the history when
+an input hook was set. Patch by Pablo Galindo


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121497 -->
* Issue: gh-121497
<!-- /gh-issue-number -->
