### PR TITLE
gh-117657: Remove TSAN suppressions for _abc.c

### DIFF
--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -23,8 +23,6 @@ race:free_threadstate
 
 # These warnings trigger directly in a CPython function.
 
-race_top:_add_to_weak_set
-race_top:_in_weak_set
 race_top:_PyEval_EvalFrameDefault
 race_top:assign_version_tag
 race_top:insertdict


### PR DESCRIPTION
The functions look thread-safe and I haven't seen any warnings issued when running the tests locally.


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
