### PR TITLE
[3.12] gh-121018: Fix typo in NEWS entry (GH-121510)

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-06-26-03-04-24.gh-issue-121018.clVSc4.rst
+++ b/Misc/NEWS.d/next/Library/2024-06-26-03-04-24.gh-issue-121018.clVSc4.rst
@@ -1,3 +1,3 @@
-Fixed issues where :meth:`!argparse.ArgumentParser.parses_args` did not honor
+Fixed issues where :meth:`!argparse.ArgumentParser.parse_args` did not honor
 ``exit_on_error=False``.
 Based on patch by Ben Hsing.


### PR DESCRIPTION
(cherry picked from commit 218edaf0ffe6ef38349047f378649f93d280e23e)

<!-- gh-issue-number: gh-121018 -->
* Issue: gh-121018
<!-- /gh-issue-number -->
