### PR TITLE
gh-112301: Add fortify source level 3 to default compiler options

### DIFF
--- a/Misc/NEWS.d/next/Security/2024-07-08-23-39-04.gh-issue-112301.TD8G01.rst
+++ b/Misc/NEWS.d/next/Security/2024-07-08-23-39-04.gh-issue-112301.TD8G01.rst
@@ -1,1 +1,2 @@
-Enable -D_FORTIFY_SOURCE=3 option for all builds to enhance security
+Enable runtime protections for glibc to abort execution when unsafe behavior is encountered,
+for all platforms except Windows.

--- a/Misc/NEWS.d/next/Security/2024-07-08-23-39-04.gh-issue-112301.TD8G01.rst
+++ b/Misc/NEWS.d/next/Security/2024-07-08-23-39-04.gh-issue-112301.TD8G01.rst
@@ -1,0 +1,1 @@
+Enable -D_FORTIFY_SOURCE=3 option for all builds to enhance security

--- a/configure
+++ b/configure
@@ -9760,6 +9760,45 @@ else $as_nop
 printf "%s\n" "$as_me: WARNING: -Wtrampolines not supported" >&2;}
 fi
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -D_FORTIFY_SOURCE=3" >&5
+printf %s "checking whether C compiler accepts -D_FORTIFY_SOURCE=3... " >&6; }
+if test ${ax_cv_check_cflags___D_FORTIFY_SOURCE_3+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS  -D_FORTIFY_SOURCE=3"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags___D_FORTIFY_SOURCE_3=yes
+else $as_nop
+  ax_cv_check_cflags___D_FORTIFY_SOURCE_3=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___D_FORTIFY_SOURCE_3" >&5
+printf "%s\n" "$ax_cv_check_cflags___D_FORTIFY_SOURCE_3" >&6; }
+if test "x$ax_cv_check_cflags___D_FORTIFY_SOURCE_3" = xyes
+then :
+  BASECFLAGS="$BASECFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"
+else $as_nop
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: -D_FORTIFY_SOURCE=3 not supported" >&5
+printf "%s\n" "$as_me: WARNING: -D_FORTIFY_SOURCE=3 not supported" >&2;}
+fi
+
 
 case $GCC in
 yes)

--- a/configure.ac
+++ b/configure.ac
@@ -2516,6 +2516,7 @@ AS_VAR_IF([with_strict_overflow], [yes],
 # These flags should be enabled by default for all builds.
 AX_CHECK_COMPILE_FLAG([-fstack-protector-strong], [BASECFLAGS="$BASECFLAGS -fstack-protector-strong"], [AC_MSG_WARN([-fstack-protector-strong not supported])], [-Werror])
 AX_CHECK_COMPILE_FLAG([-Wtrampolines], [BASECFLAGS="$BASECFLAGS -Wtrampolines"], [AC_MSG_WARN([-Wtrampolines not supported])], [-Werror])
+AX_CHECK_COMPILE_FLAG([-D_FORTIFY_SOURCE=3], [BASECFLAGS="$BASECFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"], [AC_MSG_WARN([-D_FORTIFY_SOURCE=3 not supported])])
 
 case $GCC in
 yes)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

gh-112301: Added `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3` to default compiler options for all builds

This option adds runtime protections for glibc to abort execution when unsafe behavior is encountered.[ Here are the GNU docs on the option](https://www.gnu.org/software/libc/manual/html_node/Source-Fortification.html
)

[This is a very brief writeup that I found useful from Red Hat explaining some benefits](https://developers.redhat.com/articles/2022/09/17/gccs-new-fortification-level#)

[Also the OpenSSF compiler hardening guidance gives a very good description of the option](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C%2B%2B.md#user-content-fn-Wang2012-0814f69691ee26235fe576885eaaf523) 

This is an option that theoretically affects the runtime so pyperformance benchmarks were run. [The benchmark for this branch ](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240708-3.14.0a0-26aa174/bm-20240708-linux-x86_64-nohlson-enable_fortify_sourc-3.14.0a0-26aa174-vs-base.md) shows little overall impact but does impact some benchmark types:

> **_NOTE:_**  I would recommend looking into the details of the benchmarks in the links

| Tag | Geometric Mean |
|-----|----------------|
| apps | 1.00x slower |
| asyncio | Not Significant |
| math | 1.01x faster |
| regex | 1.03x slower |
| serialize | 1.01x faster |
| startup | 1.00x faster |
| template | 1.00x slower |
| overall | 1.00x faster |

[A benchmark was run a few weeks ago ](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240625-3.14.0a0-0a5aba7/bm-20240625-linux-x86_64-nohlson-enable_fortify_sourc-3.14.0a0-0a5aba7-vs-base.md) with this option that was slightly different:

| Tag | Geometric Mean |
|-----|----------------|
| apps | 1.03x slower |
| asyncio | 1.01x slower |
| math | 1.00x slower |
| regex | 1.02x faster |
| serialize | 1.01x slower |
| startup | 1.01x slower |
| template | 1.01x slower |
| overall | 1.01x slower |


The benchmarks show that overall there is little memory impact and overall very small performance impact but within benchmark types there is some movement . Many compilers use `-D_FORTIFY_SOURCE=2` by default. Level 3 adds additional bounds checking. My recommendation and the recommendation of the OpenSSF guidance is to raise to level 3 for this protection but would like to discuss further.

Attn: @mdboom 





