### PR TITLE
gh-121404: avoid accessing compiler internals in codegen functions

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -85,8 +85,6 @@ static int compiler_future_features(struct compiler *c);
 typedef _Py_SourceLocation location;
 typedef struct _PyCfgBuilder cfg_builder;
 
-struct compiler;
-
 static PyObject *compiler_maybe_mangle(struct compiler *c, PyObject *name);
 
 #define LOCATION(LNO, END_LNO, COL, END_COL) \
@@ -320,7 +318,6 @@ static int compiler_call_helper(struct compiler *c, location loc,
                                 asdl_keyword_seq *keywords);
 static int compiler_try_except(struct compiler *, stmt_ty);
 static int compiler_try_star_except(struct compiler *, stmt_ty);
-static int compiler_set_qualname(struct compiler *);
 
 static int compiler_sync_comprehension_generator(
                                       struct compiler *c, location loc,

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7484,8 +7484,6 @@ compute_code_flags(struct compiler *c)
             flags |= CO_NESTED;
         if (ste->ste_generator && !ste->ste_coroutine)
             flags |= CO_GENERATOR;
-        if (!ste->ste_generator && ste->ste_coroutine)
-            flags |= CO_COROUTINE;
         if (ste->ste_generator && ste->ste_coroutine)
             flags |= CO_ASYNC_GENERATOR;
         if (ste->ste_varargs)
@@ -7494,14 +7492,13 @@ compute_code_flags(struct compiler *c)
             flags |= CO_VARKEYWORDS;
     }
 
-    /* (Only) inherit compilerflags in PyCF_MASK */
-    flags |= (c->c_flags.cf_flags & PyCF_MASK);
-
-    if ((IS_TOP_LEVEL_AWAIT(c)) &&
-         ste->ste_coroutine &&
-         !ste->ste_generator) {
+    if (ste->ste_coroutine && !ste->ste_generator) {
+        assert (IS_TOP_LEVEL_AWAIT(c) || _PyST_IsFunctionLike(c->u->u_ste));
         flags |= CO_COROUTINE;
     }
+
+    /* (Only) inherit compilerflags in PyCF_MASK */
+    flags |= (c->c_flags.cf_flags & PyCF_MASK);
 
     return flags;
 }

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -73,8 +73,13 @@
 
 struct compiler;
 
+typedef _PyInstruction instruction;
+typedef _PyInstructionSequence instr_sequence;
+
+static instr_sequence *compiler_instr_sequence(struct compiler *c);
 static int compiler_future_features(struct compiler *c);
 
+#define INSTR_SEQUENCE(C) compiler_instr_sequence(C)
 #define FUTURE_FEATURES(C) compiler_future_features(C)
 
 typedef _Py_SourceLocation location;
@@ -138,12 +143,6 @@ enum {
     COMPILER_SCOPE_ANNOTATIONS,
 };
 
-
-typedef _PyInstruction instruction;
-typedef _PyInstructionSequence instr_sequence;
-
-#define INITIAL_INSTR_SEQUENCE_SIZE 100
-#define INITIAL_INSTR_SEQUENCE_LABELS_MAP_SIZE 10
 
 static const int compare_masks[] = {
     [Py_LT] = COMPARISON_LESS_THAN,
@@ -263,8 +262,6 @@ struct compiler {
                                   * (including instructions for nested code objects)
                                   */
 };
-
-#define INSTR_SEQUENCE(C) ((C)->u->u_instr_sequence)
 
 
 typedef struct {
@@ -7473,6 +7470,12 @@ static PyObject *
 compiler_maybe_mangle(struct compiler *c, PyObject *name)
 {
     return _Py_MaybeMangle(c->u->u_private, c->u->u_ste, name);
+}
+
+static instr_sequence *
+compiler_instr_sequence(struct compiler *c)
+{
+    return c->u->u_instr_sequence;
 }
 
 static int

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1631,11 +1631,6 @@ finally:
     return co;
 }
 
-/* The test for LOCAL must come before the test for FREE in order to
-   handle classes where name is both local and free.  The local var is
-   a method and the free var is a free var referenced within a method.
-*/
-
 static int
 compiler_get_ref_type(struct compiler *c, PyObject *name)
 {


### PR DESCRIPTION
These are some simple transformations to hide compiler internals, as part of the work to split compile.c into codegen and compiler.
The individual commits should be easy to review.



<!-- gh-issue-number: gh-121404 -->
* Issue: gh-121404
<!-- /gh-issue-number -->
