### PR TITLE
gh-117657: Skip test when running under TSan

### DIFF
--- a/Lib/test/test_concurrent_futures/test_init.py
+++ b/Lib/test/test_concurrent_futures/test_init.py
@@ -139,6 +139,7 @@ class FailingInitializerResourcesTest(unittest.TestCase):
     def test_spawn(self):
         self._test(ProcessPoolSpawnFailingInitializerTest)
 
+    @support.skip_if_sanitizer("TSAN doesn't support threads after fork", thread=True)
     def test_forkserver(self):
         self._test(ProcessPoolForkserverFailingInitializerTest)
 

--- a/Lib/test/test_multiprocessing_fork/__init__.py
+++ b/Lib/test/test_multiprocessing_fork/__init__.py
@@ -12,5 +12,8 @@ if sys.platform == "win32":
 if sys.platform == 'darwin':
     raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 
+if support.check_sanitizer(thread=True):
+    raise unittest.SkipTest("TSAN doesn't support threads after fork")
+
 def load_tests(*args):
     return support.load_package_tests(os.path.dirname(__file__), *args)


### PR DESCRIPTION
The ProcessPoolForkserver and test_multiprocessing_fork tests use thread after forking in a multi-threaded program, which is not supported by TSan.

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
