### PR TITLE
gh-121567: Improve `slice` C-API docs by mentioning exceptions

### DIFF
--- a/Doc/c-api/slice.rst
+++ b/Doc/c-api/slice.rst
@@ -54,7 +54,7 @@ Slice Objects
    of bounds indices are clipped in a manner consistent with the handling of
    normal slices.
 
-   Returns ``0`` on success and ``-1`` on error with an exception set.
+   Return ``0`` on success and ``-1`` on error with an exception set.
 
    .. note::
       This function is considered not safe for resizable sequences.

--- a/Doc/c-api/slice.rst
+++ b/Doc/c-api/slice.rst
@@ -23,7 +23,9 @@ Slice Objects
    Return a new slice object with the given values.  The *start*, *stop*, and
    *step* parameters are used as the values of the slice object attributes of
    the same names.  Any of the values may be ``NULL``, in which case the
-   ``None`` will be used for the corresponding attribute.  Return ``NULL`` if
+   ``None`` will be used for the corresponding attribute.
+
+   Return ``NULL`` with an exception set if
    the new object could not be allocated.
 
 
@@ -52,7 +54,7 @@ Slice Objects
    of bounds indices are clipped in a manner consistent with the handling of
    normal slices.
 
-   Returns ``0`` on success and ``-1`` on error with exception set.
+   Returns ``0`` on success and ``-1`` on error with an exception set.
 
    .. note::
       This function is considered not safe for resizable sequences.
@@ -95,7 +97,7 @@ Slice Objects
    ``PY_SSIZE_T_MIN`` to ``PY_SSIZE_T_MIN``, and silently boost the step
    values less than ``-PY_SSIZE_T_MAX`` to ``-PY_SSIZE_T_MAX``.
 
-   Return ``-1`` on error, ``0`` on success.
+   Return ``-1`` with an exception set on error, ``0`` on success.
 
    .. versionadded:: 3.6.1
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-121567 -->
* Issue: gh-121567
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121568.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->