### PR TITLE
gh-121583: Remove dependency from pystats.h to internal header file

### DIFF
--- a/Include/cpython/pystats.h
+++ b/Include/cpython/pystats.h
@@ -19,11 +19,11 @@
 // Define _PY_INTERPRETER macro to increment interpreter_increfs and
 // interpreter_decrefs. Otherwise, increment increfs and decrefs.
 
-#include "pycore_uop_ids.h"
-
 #ifndef Py_CPYTHON_PYSTATS_H
 #  error "this header file must not be included directly"
 #endif
+
+#define PYSTATS_MAX_UOP_ID 512
 
 #define SPECIALIZATION_FAILURE_KINDS 36
 
@@ -100,7 +100,7 @@ typedef struct _gc_stats {
 typedef struct _uop_stats {
     uint64_t execution_count;
     uint64_t miss;
-    uint64_t pair_count[MAX_UOP_ID + 1];
+    uint64_t pair_count[PYSTATS_MAX_UOP_ID + 1];
 } UOpStats;
 
 #define _Py_UOP_HIST_SIZE 32
@@ -118,7 +118,7 @@ typedef struct _optimization_stats {
     uint64_t recursive_call;
     uint64_t low_confidence;
     uint64_t executors_invalidated;
-    UOpStats opcode[MAX_UOP_ID+1];
+    UOpStats opcode[PYSTATS_MAX_UOP_ID+1];
     uint64_t unsupported_opcode[256];
     uint64_t trace_length_hist[_Py_UOP_HIST_SIZE];
     uint64_t trace_run_length_hist[_Py_UOP_HIST_SIZE];
@@ -128,7 +128,7 @@ typedef struct _optimization_stats {
     uint64_t optimizer_failure_reason_no_memory;
     uint64_t remove_globals_builtins_changed;
     uint64_t remove_globals_incorrect_keys;
-    uint64_t error_in_opcode[MAX_UOP_ID+1];
+    uint64_t error_in_opcode[PYSTATS_MAX_UOP_ID+1];
 } OptimizationStats;
 
 typedef struct _rare_event_stats {

--- a/Include/cpython/pystats.h
+++ b/Include/cpython/pystats.h
@@ -118,7 +118,7 @@ typedef struct _optimization_stats {
     uint64_t recursive_call;
     uint64_t low_confidence;
     uint64_t executors_invalidated;
-    UOpStats opcode[PYSTATS_MAX_UOP_ID+1];
+    UOpStats opcode[PYSTATS_MAX_UOP_ID + 1];
     uint64_t unsupported_opcode[256];
     uint64_t trace_length_hist[_Py_UOP_HIST_SIZE];
     uint64_t trace_run_length_hist[_Py_UOP_HIST_SIZE];

--- a/Include/cpython/pystats.h
+++ b/Include/cpython/pystats.h
@@ -128,7 +128,7 @@ typedef struct _optimization_stats {
     uint64_t optimizer_failure_reason_no_memory;
     uint64_t remove_globals_builtins_changed;
     uint64_t remove_globals_incorrect_keys;
-    uint64_t error_in_opcode[PYSTATS_MAX_UOP_ID+1];
+    uint64_t error_in_opcode[PYSTATS_MAX_UOP_ID + 1];
 } OptimizationStats;
 
 typedef struct _rare_event_stats {

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -29,6 +29,10 @@ GCStats _py_gc_stats[NUM_GENERATIONS] = { 0 };
 static PyStats _Py_stats_struct = { .gc_stats = _py_gc_stats };
 PyStats *_Py_stats = NULL;
 
+#if PYSTATS_MAX_UOP_ID < MAX_UOP_ID
+#error "Not enough space allocated for pystats. Increase PYSTATS_MAX_UOP_ID to at least MAX_UOP_ID"
+#endif
+
 #define ADD_STAT_TO_DICT(res, field) \
     do { \
         PyObject *val = PyLong_FromUnsignedLongLong(stats->field); \


### PR DESCRIPTION
This just uses a fixed number of slots for recording uops stats that is enforced to be big enough.

Alternatively, we could generate the correct number and put it in a public header, but that seems like overkill.

<!-- gh-issue-number: gh-121583 -->
* Issue: gh-121583
<!-- /gh-issue-number -->
