### PR TITLE
GH-120754: Remove isatty call during regular open

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1625,9 +1625,10 @@ class FileIO(RawIOBase):
     @property
     def _blksize(self):
         if self._stat_atopen:
-            return getattr(self._stat_atopen, "st_blksize", DEFAULT_BUFFER_SIZE)
+            res = getattr(self._stat_atopen, "st_blksize", 0)
 
-        return DEFAULT_BUFFER_SIZE
+        # WASI sets blksize to 0
+        return res if res > 0 else DEFAULT_BUFFER_SIZE
 
     def _checkReadable(self):
         if not self._readable:

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-10-01-55-33.gh-issue-120754.KSWAmz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-10-01-55-33.gh-issue-120754.KSWAmz.rst
@@ -1,0 +1,2 @@
+Skip the ``isatty`` system call on just-opened regular files. This provides a
+slight performance improvement when reading whole files.

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -730,8 +730,8 @@ _io_FileIO_readall_impl(fileio *self)
         return err_closed();
     }
 
-    if (self->stat_atopen != NULL) {
-        end = (Py_off_t)Py_MIN(self->stat_atopen->st_size, _PY_READ_MAX);
+    if (self->stat_atopen != NULL && self->stat_atopen->st_size < _PY_READ_MAX) {
+        end = (Py_off_t)self->stat_atopen->st_size;
     }
     else {
         end = -1;
@@ -774,7 +774,6 @@ _io_FileIO_readall_impl(fileio *self)
             }
         }
     }
-
 
     result = PyBytes_FromStringAndSize(NULL, bufsize);
     if (result == NULL)

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -731,7 +731,7 @@ _io_FileIO_readall_impl(fileio *self)
     }
 
     if (self->stat_atopen != NULL) {
-        end = (Py_off_t)Py_MIN(self->stat_atopen->st_size, PY_SSIZE_T_MAX);
+        end = (Py_off_t)Py_MIN(self->stat_atopen->st_size, _PY_READ_MAX);
     }
     else {
         end = -1;


### PR DESCRIPTION
For POSIX, TTYs are never regular files, so if the interpreter knows the file is regular it doesn't need to do an additional system call to check if the file is a TTY.

The `open()` Python builtin requires a `stat` call at present in order to ensure the file being opened isn't a directory. That result includes the file mode which tells us if it is a regular file. There are a number of attributes from the stat which are stashed one off currently, move to stashing the whole object rather than just individual members.

The stat object is reasonably large and currently the `stat_result.st_size` member cannot be modified from Python, which is needed by the `_pyio` implementation, so make the whole stat object optional. In the `_io` implementation this makes handling a stat failure simpler. At present there is no explicit user call to clear it, but if one is needed (ex. a program which has a lot of open FileIO objects and the memory becomes a problem) it would be straightforward to add. Ideally would be able to automatically clear (the values are generally used during I/O object initialization and not after. After a `write` they are no longer useful in current cases).

It is fairly common pattern to scan a directory, look at the `stat` results (ex. is this file changed), and then open/read the file. In this PR I didn't update open's API to allow passing in a stat result to use, but that could be beneficial for some cases (ex. `importlib`).

With this change on my Linux machine reading a small plain text file is down to 6 system calls.

```python
openat(AT_FDCWD, "read_one.py", O_RDONLY|O_CLOEXEC) = 3
fstat(3, {st_mode=S_IFREG|0644, st_size=87, ...}) = 0
lseek(3, 0, SEEK_CUR)                   = 0
read(3, "from pathlib import Path\n\npath ="..., 88) = 87
read(3, "", 1)                          = 0
close(3)                                = 0
```

## Performance

On my Mac:

`python bm_readall.py`
```python
import pyperf
from pathlib import Path


def read_all(all_paths):
    for p in all_paths:
        p.read_bytes()


def read_file(path_obj):
    path_obj.read_text()


all_rst = list(Path("Doc").glob("**/*.rst"))
all_py = list(Path(".").glob("**/*.py"))
assert all_rst, "Should have found rst files"
assert all_py, "Should have found python source files"


runner = pyperf.Runner()
runner.bench_func("read_file_small", read_file, Path("Doc/howto/clinic.rst"))
runner.bench_func("read_file_large", read_file, Path("Doc/c-api/typeobj.rst"))

runner.bench_func("read_all_rst", read_all, all_rst)
runner.bench_func("read_all_py", read_all, all_py)
```

`main`
```
.....................
read_file_small: Mean +- std dev: 7.89 us +- 0.06 us
.....................
read_file_large: Mean +- std dev: 21.1 us +- 0.3 us
.....................
read_all_rst: Mean +- std dev: 4.17 ms +- 0.07 ms
.....................
read_all_py: Mean +- std dev: 19.3 ms +- 0.2 ms
```

`cmaloney/stash_fstat`
```
.....................
read_file_small: Mean +- std dev: 7.47 us +- 0.05 us
.....................
read_file_large: Mean +- std dev: 20.5 us +- 0.3 us
.....................
read_all_rst: Mean +- std dev: 3.92 ms +- 0.07 ms
.....................
read_all_py: Mean +- std dev: 18.4 ms +- 0.2 ms
```

On Linux the performance change is in the noise on my machine. For both MacOS and Linux I suspect removing the remaining `lseek` will provide a bit more performance swing based on profiles, but it also touches very differently shaped code than the system call removals so far.

<!-- gh-issue-number: gh-120754 -->
* Issue: gh-120754
<!-- /gh-issue-number -->
