### PR TITLE
gh-117482: Fix Builtin Types Slot Wrappers

### DIFF
--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -33,6 +33,7 @@ struct _types_runtime_state {
     struct {
         struct {
             PyTypeObject *type;
+            PyTypeObject def;
             int64_t interp_count;
         } types[_Py_MAX_MANAGED_STATIC_TYPES];
     } managed_static;

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -10,6 +10,7 @@ import inspect
 import pickle
 import locale
 import sys
+import textwrap
 import types
 import unittest.mock
 import weakref
@@ -2343,6 +2344,41 @@ class FunctionTests(unittest.TestCase):
             types.FunctionType(
                 ex.__code__, {}, "func", None, None, 3,
             )
+
+
+class SubinterpreterTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        global interpreters
+        try:
+            from test.support import interpreters
+        except ModuleNotFoundError:
+            raise unittest.Skip('subinterpreters required')
+        import test.support.interpreters.channels
+
+    @cpython_only
+    def test_slot_wrappers(self):
+        rch, sch = interpreters.channels.create()
+
+        # For now it's sufficient to check int.__str__.
+        # See https://github.com/python/cpython/issues/117482
+        # and https://github.com/python/cpython/pull/117660.
+        script = textwrap.dedent('''
+            text = repr(int.__str__)
+            sch.send_nowait(text)
+            ''')
+
+        exec(script)
+        expected = rch.recv()
+
+        interp = interpreters.create()
+        interp.exec('from test.support import interpreters')
+        interp.prepare_main(sch=sch)
+        interp.exec(script)
+        results = rch.recv()
+
+        self.assertEqual(results, expected)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -2354,7 +2354,7 @@ class SubinterpreterTests(unittest.TestCase):
         try:
             from test.support import interpreters
         except ModuleNotFoundError:
-            raise unittest.Skip('subinterpreters required')
+            raise unittest.SkipTest('subinterpreters required')
         import test.support.interpreters.channels
 
     @cpython_only

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-10-15-43-54.gh-issue-117482.5WYaXR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-10-15-43-54.gh-issue-117482.5WYaXR.rst
@@ -1,0 +1,2 @@
+Unexpected slot wrappers are no longer created for builtin static types in
+subinterpreters.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8503,6 +8503,11 @@ init_static_type(PyInterpreterState *interp, PyTypeObject *self,
         _PyStaticType_ClearWeakRefs(interp, self);
         managed_static_type_state_clear(interp, self, isbuiltin, initial);
     }
+
+    if (initial) {
+        Py_SET_TYPE(def, Py_TYPE(self));
+    }
+
     return res;
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8490,6 +8490,9 @@ init_static_type(PyInterpreterState *interp, PyTypeObject *self,
     PyTypeObject *def = managed_static_type_get_def(self, isbuiltin);
     if (initial) {
         memcpy(def, self, sizeof(PyTypeObject));
+        /* For now we do not worry about preserving the index
+           at finalization. */
+        managed_static_type_index_clear(def);
     }
 
     int res;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -269,7 +269,7 @@ managed_static_type_state_init(PyInterpreterState *interp, PyTypeObject *self,
 
 /* Reset the type's per-interpreter state.
    This basically undoes what managed_static_type_state_init() did. */
-static PyTypeObject *
+static void
 managed_static_type_state_clear(PyInterpreterState *interp, PyTypeObject *self,
                                 int isbuiltin, int final)
 {
@@ -277,7 +277,6 @@ managed_static_type_state_clear(PyInterpreterState *interp, PyTypeObject *self,
     size_t full_index = isbuiltin
         ? index
         : index + _Py_MAX_MANAGED_STATIC_BUILTIN_TYPES;
-    PyTypeObject *def = &_PyRuntime.types.managed_static.types[full_index].def;
 
     managed_static_type_state *state = isbuiltin
         ? &(interp->types.builtins.initialized[index])
@@ -313,8 +312,6 @@ managed_static_type_state_clear(PyInterpreterState *interp, PyTypeObject *self,
         }
         PyMutex_Unlock(&interp->types.mutex);
     }
-
-    return def;
 }
 
 static PyTypeObject *
@@ -5852,15 +5849,7 @@ fini_static_type(PyInterpreterState *interp, PyTypeObject *type,
     }
 
     _PyStaticType_ClearWeakRefs(interp, type);
-    PyTypeObject *def =
-        managed_static_type_state_clear(interp, type, isbuiltin, final);
-    /* For now we exclude extension module types. */
-    if (final && isbuiltin) {
-        /* Restore the static type to it's (mostly) original values. */
-        destructor dealloc = type->tp_dealloc;
-        memcpy(type, def, sizeof(PyTypeObject));
-        type->tp_dealloc = dealloc;
-    }
+    managed_static_type_state_clear(interp, type, isbuiltin, final);
 }
 
 void
@@ -8492,9 +8481,6 @@ init_static_type(PyInterpreterState *interp, PyTypeObject *self,
     PyTypeObject *def = managed_static_type_get_def(self, isbuiltin);
     if (initial) {
         memcpy(def, self, sizeof(PyTypeObject));
-        /* For now we do not worry about preserving the index
-           at finalization. */
-        managed_static_type_index_clear(def);
     }
 
     int res;
@@ -8504,10 +8490,6 @@ init_static_type(PyInterpreterState *interp, PyTypeObject *self,
     if (res < 0) {
         _PyStaticType_ClearWeakRefs(interp, self);
         managed_static_type_state_clear(interp, self, isbuiltin, initial);
-    }
-
-    if (initial) {
-        Py_SET_TYPE(def, Py_TYPE(self));
     }
 
     return res;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -314,6 +314,16 @@ managed_static_type_state_clear(PyInterpreterState *interp, PyTypeObject *self,
     }
 }
 
+static PyTypeObject *
+managed_static_type_get_def(PyTypeObject *self, int isbuiltin)
+{
+    size_t index = managed_static_type_index_get(self);
+    size_t full_index = isbuiltin
+        ? index
+        : index + _Py_MAX_MANAGED_STATIC_BUILTIN_TYPES;
+    return &_PyRuntime.types.managed_static.types[full_index].def;
+}
+
 // Also see _PyStaticType_InitBuiltin() and _PyStaticType_FiniBuiltin().
 
 /* end static builtin helpers */
@@ -8468,6 +8478,11 @@ init_static_type(PyInterpreterState *interp, PyTypeObject *self,
     }
 
     managed_static_type_state_init(interp, self, isbuiltin, initial);
+
+    PyTypeObject *def = managed_static_type_get_def(self, isbuiltin);
+    if (initial) {
+        memcpy(def, self, sizeof(PyTypeObject));
+    }
 
     int res;
     BEGIN_TYPE_LOCK();

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5857,7 +5857,9 @@ fini_static_type(PyInterpreterState *interp, PyTypeObject *type,
     /* For now we exclude extension module types. */
     if (final && isbuiltin) {
         /* Restore the static type to it's (mostly) original values. */
+        destructor dealloc = type->tp_dealloc;
         memcpy(type, def, sizeof(PyTypeObject));
+        type->tp_dealloc = dealloc;
     }
 }
 


### PR DESCRIPTION
When builtin static types are initialized for a subinterpreter, various "tp" slots have already been inherited (for the main interpreter).  This was interfering with the logic in `add_operators()` (in Objects/typeobject.c), causing a wrapper to get created when it shouldn't.  This changes fixes that by preserving the original data from the static type struct and checking that.

<!-- gh-issue-number: gh-117482 -->
* Issue: gh-117482
<!-- /gh-issue-number -->
