### PR TITLE
[3.12] gh-117482: Fix Builtin Types Slot Wrappers (gh-121602)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-10-15-43-54.gh-issue-117482.5WYaXR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-10-15-43-54.gh-issue-117482.5WYaXR.rst
@@ -1,0 +1,2 @@
+Unexpected slot wrappers are no longer created for builtin static types in
+subinterpreters.

--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -305,6 +305,11 @@ Objects/sliceobject.c	-	_Py_EllipsisObject	-
 Python/instrumentation.c	-	_PyInstrumentation_DISABLE	-
 Python/instrumentation.c	-	_PyInstrumentation_MISSING	-
 
+##-----------------------
+## other
+
+Objects/typeobject.c	-	static_type_defs	-
+
 
 ##################################
 ## global non-objects to fix in core code


### PR DESCRIPTION
When builtin static types are initialized for a subinterpreter, various "tp" slots have already been inherited (for the main interpreter).  This was interfering with the logic in add_operators() (in Objects/typeobject.c), causing a wrapper to get created when it shouldn't.  This change fixes that by preserving the original data from the static type struct and checking that.

(cherry picked from commit 5250a031332eb9499d5fc190d7287642e5a144b9)

Co-authored-by: Eric Snow <ericsnowcurrently@gmail.com>

<!-- gh-issue-number: gh-117482 -->
* Issue: gh-117482
<!-- /gh-issue-number -->
