### PR TITLE
GH-120754: Make PY_READ_MAX smaller than max byteobject size

### DIFF
--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -70,8 +70,13 @@ extern PyObject* _Py_device_encoding(int);
 #   define _PY_WRITE_MAX INT_MAX
 #else
     /* write() should truncate the input to PY_SSIZE_T_MAX bytes,
-       but it's safer to do it ourself to have a portable behaviour */
-#   define _PY_READ_MAX  PY_SSIZE_T_MAX
+       but it's safer to do it ourself to have a portable behaviour
+
+       read() fills a PyBytes object, which has a capped size defined in
+       bytesobject.c. Prefer reading less data (meets the API spec) to causing
+       an overflow error.
+    */
+#   define _PY_READ_MAX  PY_SSIZE_T_MAX - 4096
 #   define _PY_WRITE_MAX PY_SSIZE_T_MAX
 #endif
 

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -234,10 +234,6 @@ class FileTests(unittest.TestCase):
             self.assertEqual(s, b"spam")
 
     @support.cpython_only
-    # Skip the test on 32-bit platforms: the number of bytes must fit in a
-    # Py_ssize_t type
-    @unittest.skipUnless(INT_MAX < PY_SSIZE_T_MAX,
-                         "needs INT_MAX < PY_SSIZE_T_MAX")
     @support.bigmemtest(size=INT_MAX + 10, memuse=1, dry_run=False)
     def test_large_read(self, size):
         self.addCleanup(os_helper.unlink, os_helper.TESTFN)
@@ -245,6 +241,9 @@ class FileTests(unittest.TestCase):
 
         # Issue #21932: Make sure that os.read() does not raise an
         # OverflowError for size larger than INT_MAX
+        #
+        # For 32 bit systems, it is expected the read doesn't read all the bytes
+        # but rather caps to a number it can reasonably read.
         with open(os_helper.TESTFN, "rb") as fp:
             data = os.read(fp.fileno(), size)
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-11-13-57-50.gh-issue-120754.C1HedA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-11-13-57-50.gh-issue-120754.C1HedA.rst
@@ -1,4 +1,3 @@
-Cap read size to smaller than the max BytesObject size. read() in POSIX
-returns at most the number of requseted bytes, this updates python ``os.read``
-to do similarly, and rather than throw an OverflowError in this case, return
-a smaller than requseted byte object.
+``os.read()`` now caps read size to a size which is smaller than the max
+BytesObject size. Previously, passing a size larger than max bytes object size
+would result in an OverflowError, now the call is made.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-11-13-57-50.gh-issue-120754.C1HedA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-11-13-57-50.gh-issue-120754.C1HedA.rst
@@ -1,0 +1,4 @@
+Cap read size to smaller than the max BytesObject size. read() in POSIX
+returns at most the number of requseted bytes, this updates python ``os.read``
+to do similarly, and rather than throw an OverflowError in this case, return
+a smaller than requseted byte object.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-11-13-57-50.gh-issue-120754.C1HedA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-11-13-57-50.gh-issue-120754.C1HedA.rst
@@ -1,3 +1,3 @@
-``os.read()`` now caps read size to a size which is smaller than the max
-BytesObject size. Previously, passing a size larger than max bytes object size
-would result in an OverflowError, now the call is made.
+``os.read()``  caps read size smaller than the max bytes object size to avoid
+getting an OverflowError that 'byte string is too large'. This makes it so the
+read call is attempted (although still may fail for other reasons).


### PR DESCRIPTION
Currently if code tries to do a os.read larger than the max bytes object length, the size to read gets capped to `_PY_READ_MAX`, then the code tries to allocate a PyBytes which fails with an OverflowError as the size  is longer than what is allocatable.

Since os.read is capping the max size anyways, cap it to a size which is always allocatable as a PyBytes.

This changes behavior from bpo-21932 and enables the large file os.read test on 32 bit platforms, as it should cap the read to a platform acceptable size.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120754 -->
* Issue: gh-120754
<!-- /gh-issue-number -->
