### PR TITLE
gh-121617: Include string.h in pwdmodule.c if _Py_TYPEOF is undefined

### DIFF
--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -14,6 +14,10 @@
 #include <pwd.h>                  // getpwuid()
 #include <unistd.h>               // sysconf()
 
+#ifndef _Py_TYPEOF
+#  include <string.h>             // memcpy()
+#endif
+
 #include "clinic/pwdmodule.c.h"
 /*[clinic input]
 module pwd


### PR DESCRIPTION
If _Py_TYPEOF is undefined, Py_CLEAR falls back to an implementation with memcpy() call; conditionally include the missing string.h dependency.

<!-- gh-issue-number: gh-121617 -->
* Issue: gh-121617
<!-- /gh-issue-number -->
