### PR TITLE
gh-120642: Move _PyCode_CODE() to the internal C API

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -194,9 +194,6 @@ Py_DEPRECATED(3.13) static inline int PyCode_GetFirstFree(PyCodeObject *op) {
     return PyUnstable_Code_GetFirstFree(op);
 }
 
-#define _PyCode_CODE(CO) _Py_RVALUE((_Py_CODEUNIT *)(CO)->co_code_adaptive)
-#define _PyCode_NBYTES(CO) (Py_SIZE(CO) * (Py_ssize_t)sizeof(_Py_CODEUNIT))
-
 /* Unstable public interface */
 PyAPI_FUNC(PyCodeObject *) PyUnstable_Code_New(
         int, int, int, int, int, PyObject *, PyObject *,

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -31,6 +31,9 @@ typedef union {
     _Py_BackoffCounter counter;  // First cache entry of specializable op
 } _Py_CODEUNIT;
 
+#define _PyCode_CODE(CO) _Py_RVALUE((_Py_CODEUNIT *)(CO)->co_code_adaptive)
+#define _PyCode_NBYTES(CO) (Py_SIZE(CO) * (Py_ssize_t)sizeof(_Py_CODEUNIT))
+
 
 /* These macros only remain defined for compatibility. */
 #define _Py_OPCODE(word) ((word).op.code)


### PR DESCRIPTION
Move _PyCode_CODE() and _PyCode_NBYTES() macros to the internal C API since they use _Py_CODEUNIT which is only part of the internal C API.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120642 -->
* Issue: gh-120642
<!-- /gh-issue-number -->
