### PR TITLE
gh-121652: Handle `allocate_weakref` returning NULL

### DIFF
--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -426,6 +426,10 @@ get_or_create_weakref(PyTypeObject *type, PyObject *obj, PyObject *callback)
             return basic_ref;
         }
         PyWeakReference *newref = allocate_weakref(type, obj, callback);
+        if (newref == NULL) {
+            UNLOCK_WEAKREFS(obj);
+            return NULL;
+        }
         insert_weakref(newref, list);
         UNLOCK_WEAKREFS(obj);
         return newref;
@@ -433,6 +437,9 @@ get_or_create_weakref(PyTypeObject *type, PyObject *obj, PyObject *callback)
     else {
         // We may not be able to safely allocate inside the lock
         PyWeakReference *newref = allocate_weakref(type, obj, callback);
+        if (newref == NULL) {
+            return NULL;
+        }
         LOCK_WEAKREFS(obj);
         insert_weakref(newref, list);
         UNLOCK_WEAKREFS(obj);


### PR DESCRIPTION
The `allocate_weakref` may return NULL when out of memory. We need to handle that case and propagate the error.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121652 -->
* Issue: gh-121652
<!-- /gh-issue-number -->
