### PR TITLE
gh-121660: Fix `ga_getitem` by explicitly checking for `NULL` result

### DIFF
--- a/Objects/genericaliasobject.c
+++ b/Objects/genericaliasobject.c
@@ -563,6 +563,10 @@ ga_getitem(PyObject *self, PyObject *item)
     }
 
     PyObject *res = Py_GenericAlias(alias->origin, newargs);
+    if (res == NULL) {
+        Py_DECREF(newargs);
+        return NULL;
+    }
     ((gaobject *)res)->starred = alias->starred;
 
     Py_DECREF(newargs);


### PR DESCRIPTION


<!-- gh-issue-number: gh-121660 -->
* Issue: gh-121660
<!-- /gh-issue-number -->
