### PR TITLE
gh-99242 Ignore error when running regression tests under certain conditions.

### DIFF
--- a/Lib/test/libregrtest/logger.py
+++ b/Lib/test/libregrtest/logger.py
@@ -43,7 +43,10 @@ class Logger:
 
     def get_load_avg(self) -> float | None:
         if hasattr(os, 'getloadavg'):
-            return os.getloadavg()[0]
+            try:
+                return os.getloadavg()[0]
+            except OSError:
+                pass
         if self.win_load_tracker is not None:
             return self.win_load_tracker.getloadavg()
         return None

--- a/Misc/NEWS.d/next/Tests/2024-07-13-11-04-44.gh-issue-99242.aGxnwz.rst
+++ b/Misc/NEWS.d/next/Tests/2024-07-13-11-04-44.gh-issue-99242.aGxnwz.rst
@@ -1,0 +1,3 @@
+:func:`os.getloadavg` may throw :exc:`OSError` when running regression tests
+under certain conditions (e.g. chroot). This error is now caught and
+ignored, since reporting load average is optional.


### PR DESCRIPTION
This is a port of #106705 to the current codebase.

PR made at EuroPython's sprint

<!-- gh-issue-number: gh-99242 -->
* Issue: gh-99242
<!-- /gh-issue-number -->
