### PR TITLE
gh-96765: Update ConfigParser.read() docs with multi-file read example

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -988,8 +988,8 @@ ConfigParser Objects
    :class:`ConfigParser`, where the most recently added configuration has the
    highest priority. Any conflicting keys are taken from the more recent
    configuration while the previously existing keys are retained. The example
-   below reads in an `override.ini` file, which will override any conflicting
-   keys from the `example.ini` file.
+   below reads in an ``override.ini`` file, which will override any conflicting
+   keys from the ``example.ini`` file.
 
    .. code-block:: ini
 

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -984,6 +984,24 @@ ConfigParser Objects
    converter gets its own corresponding :meth:`!get*()` method on the parser
    object and section proxies.
 
+   It is possible to read several configurations into a single
+   :class:`ConfigParser`, where the most recently added configuration has the
+   highest priority. Any conflicting keys are taken from the more recent
+   configuration while the previously existing keys are retained. The example
+   below reads in an `override.ini` file, which will override any conflicting
+   keys from the `example.ini` file.
+
+   .. code-block:: ini
+
+      [DEFAULT]
+      ServerAliveInterval = -1
+
+   .. doctest::
+
+      >>> config = configparser.ConfigParser()
+      >>> config.read(['example.ini','override.ini'])
+      >>> print(config.get('DEFAULT', 'ServerAliveInterval')) # 45 -> -1
+
    .. versionchanged:: 3.1
       The default *dict_type* is :class:`collections.OrderedDict`.
 

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -999,8 +999,15 @@ ConfigParser Objects
    .. doctest::
 
       >>> config = configparser.ConfigParser()
+      >>> config['DEFAULT'] = {'ServerAliveInterval': '-1'}
+      >>> with open('override.ini', 'w') as configfile:
+      ...     config.write(configfile)
+      ...
+      >>> config = configparser.ConfigParser()
       >>> config.read(['example.ini','override.ini'])
-      >>> print(config.get('DEFAULT', 'ServerAliveInterval')) # 45 -> -1
+      ['example.ini', 'override.ini']
+      >>> print(config.get('DEFAULT', 'ServerAliveInterval'))
+      -1
 
    .. versionchanged:: 3.1
       The default *dict_type* is :class:`collections.OrderedDict`.

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -147,23 +147,28 @@ case-insensitive and stored in lowercase [1]_.
 It is possible to read several configurations into a single
 :class:`ConfigParser`, where the most recently added configuration has the
 highest priority. Any conflicting keys are taken from the more recent
-configuration while the previously existing keys are retained.
+configuration while the previously existing keys are retained. The example
+below reads in an ``override.ini`` file, which will override any conflicting
+keys from the ``example.ini`` file.
+
+.. code-block:: ini
+
+   [DEFAULT]
+   ServerAliveInterval = -1
 
 .. doctest::
 
-   >>> another_config = configparser.ConfigParser()
-   >>> another_config.read('example.ini')
-   ['example.ini']
-   >>> another_config['topsecret.server.example']['Port']
-   '50022'
-   >>> another_config.read_string("[topsecret.server.example]\nPort=48484")
-   >>> another_config['topsecret.server.example']['Port']
-   '48484'
-   >>> another_config.read_dict({"topsecret.server.example": {"Port": 21212}})
-   >>> another_config['topsecret.server.example']['Port']
-   '21212'
-   >>> another_config['topsecret.server.example']['ForwardX11']
-   'no'
+   >>> config = configparser.ConfigParser()
+   >>> config['DEFAULT'] = {'ServerAliveInterval': '-1'}
+   >>> with open('override.ini', 'w') as configfile:
+   ...     config.write(configfile)
+   ...
+   >>> config = configparser.ConfigParser()
+   >>> config.read(['example.ini','override.ini'])
+   ['example.ini', 'override.ini']
+   >>> print(config.get('DEFAULT', 'ServerAliveInterval'))
+   -1
+
 
 This behaviour is equivalent to a :meth:`ConfigParser.read` call with several
 files passed to the *filenames* parameter.

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -158,15 +158,15 @@ keys from the ``example.ini`` file.
 
 .. doctest::
 
-   >>> config = configparser.ConfigParser()
-   >>> config['DEFAULT'] = {'ServerAliveInterval': '-1'}
+   >>> config_override = configparser.ConfigParser()
+   >>> config_override['DEFAULT'] = {'ServerAliveInterval': '-1'}
    >>> with open('override.ini', 'w') as configfile:
-   ...     config.write(configfile)
+   ...     config_override.write(configfile)
    ...
-   >>> config = configparser.ConfigParser()
-   >>> config.read(['example.ini','override.ini'])
+   >>> config_override = configparser.ConfigParser()
+   >>> config_override.read(['example.ini','override.ini'])
    ['example.ini', 'override.ini']
-   >>> print(config.get('DEFAULT', 'ServerAliveInterval'))
+   >>> print(config_override.get('DEFAULT', 'ServerAliveInterval'))
    -1
 
 
@@ -1003,15 +1003,15 @@ ConfigParser Objects
 
    .. doctest::
 
-      >>> config = configparser.ConfigParser()
-      >>> config['DEFAULT'] = {'ServerAliveInterval': '-1'}
+      >>> config_override = configparser.ConfigParser()
+      >>> config_override['DEFAULT'] = {'ServerAliveInterval': '-1'}
       >>> with open('override.ini', 'w') as configfile:
-      ...     config.write(configfile)
+      ...     config_override.write(configfile)
       ...
-      >>> config = configparser.ConfigParser()
-      >>> config.read(['example.ini','override.ini'])
+      >>> config_override = configparser.ConfigParser()
+      >>> config_override.read(['example.ini','override.ini'])
       ['example.ini', 'override.ini']
-      >>> print(config.get('DEFAULT', 'ServerAliveInterval'))
+      >>> print(config_override.get('DEFAULT', 'ServerAliveInterval'))
       -1
 
    .. versionchanged:: 3.1

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -164,7 +164,7 @@ keys from the ``example.ini`` file.
    ...     config_override.write(configfile)
    ...
    >>> config_override = configparser.ConfigParser()
-   >>> config_override.read(['example.ini','override.ini'])
+   >>> config_override.read(['example.ini', 'override.ini'])
    ['example.ini', 'override.ini']
    >>> print(config_override.get('DEFAULT', 'ServerAliveInterval'))
    -1
@@ -1009,7 +1009,7 @@ ConfigParser Objects
       ...     config_override.write(configfile)
       ...
       >>> config_override = configparser.ConfigParser()
-      >>> config_override.read(['example.ini','override.ini'])
+      >>> config_override.read(['example.ini', 'override.ini'])
       ['example.ini', 'override.ini']
       >>> print(config_override.get('DEFAULT', 'ServerAliveInterval'))
       -1


### PR DESCRIPTION
gh-96765: Update ConfigParser.read() docs with multi-file read example


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121664.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->