### PR TITLE
gh-121658: Add MimeTypes.add_type docs

### DIFF
--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -241,6 +241,12 @@ than one MIME-type database; it provides an interface similar to the one of the
       :data:`common_types` and :data:`types_map`.
 
 
+   .. method:: MimeTypes.add_type(type, ext, strict=True)
+
+      Similar to the :func:`add_type` function, using the tables stored as part of
+      the object.
+
+
    .. method:: MimeTypes.guess_extension(type, strict=True)
 
       Similar to the :func:`guess_extension` function, using the tables stored as part

--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -246,6 +246,8 @@ than one MIME-type database; it provides an interface similar to the one of the
       Similar to the :func:`add_type` function, using the tables stored as part of
       the object.
 
+      .. versionadded:: 2.3
+
 
    .. method:: MimeTypes.guess_extension(type, strict=True)
 


### PR DESCRIPTION
Closes #121658.

Add missing MimeTypes.add_type documentation.

<!-- gh-issue-number: gh-121658 -->
* Issue: gh-121658
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121665.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->