### PR TITLE
gh-59022: Added tests for `pkgutil.extend_path` (#59022)

### DIFF
--- a/Doc/library/pkgutil.rst
+++ b/Doc/library/pkgutil.rst
@@ -34,9 +34,9 @@ support.
    *name* argument.  This feature is similar to :file:`\*.pth` files (see the
    :mod:`site` module for more information), except that it doesn't special-case
    lines starting with ``import``.  A :file:`\*.pkg` file is trusted at face
-   value: apart from checking for duplicates, all entries found in a
-   :file:`\*.pkg` file are added to the path, regardless of whether they exist
-   on the filesystem.  (This is a feature.)
+   value: apart from skipping blank lines and ignoring comments, all entries
+   found in a :file:`\*.pkg` file are added to the path, regardless of whether
+   they exist on the filesystem (this is a feature).
 
    If the input path is not a list (as is the case for frozen packages) it is
    returned unchanged.  The input path is not modified; an extended copy is

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -550,8 +550,6 @@ class ExtendPathTests(unittest.TestCase):
                 '#comment'
             ]))
 
-        # A *.pkg file is trusted at face value. Apart from checking for duplicates, all entries found in a *.pkg
-        # file are added as-is to the resulting paths, regardless of whether they exist on the filesystem.
         extended_paths = pkgutil.extend_path(sys.path, 'bar')
 
         self.assertEqual(extended_paths[:-2], sys.path)

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -522,7 +522,45 @@ class ExtendPathTests(unittest.TestCase):
         del sys.modules['foo.bar']
         del sys.modules['foo.baz']
 
-    # XXX: test .pkg files
+
+    def test_extend_path_argument_types(self):
+        pkgname = 'foo'
+        dirname_0 = self.create_init(pkgname)
+
+        # If the input path is not a list it is returned unchanged
+        self.assertEqual('notalist', pkgutil.extend_path('notalist', 'foo'))
+        self.assertEqual(('not', 'a', 'list'), pkgutil.extend_path(('not', 'a', 'list'), 'foo'))
+        self.assertEqual(123, pkgutil.extend_path(123, 'foo'))
+        self.assertEqual(None, pkgutil.extend_path(None, 'foo'))
+
+        # Cleanup
+        shutil.rmtree(dirname_0)
+        del sys.path[0]
+
+
+    def test_extend_path_pkg_files(self):
+        pkgname = 'foo'
+        dirname_0 = self.create_init(pkgname)
+
+        with open(os.path.join(dirname_0, 'bar.pkg'), 'w') as pkg_file:
+            pkg_file.write('\n'.join([
+                'baz',
+                '/foo/bar/baz',
+                '',
+                '#comment'
+            ]))
+
+        # A *.pkg file is trusted at face value. Apart from checking for duplicates, all entries found in a *.pkg
+        # file are added as-is to the resulting paths, regardless of whether they exist on the filesystem.
+        extended_paths = pkgutil.extend_path(sys.path, 'bar')
+
+        self.assertEqual(extended_paths[:-2], sys.path)
+        self.assertEqual(extended_paths[-2], 'baz')
+        self.assertEqual(extended_paths[-1], '/foo/bar/baz')
+
+        # Cleanup
+        shutil.rmtree(dirname_0)
+        del sys.path[0]
 
 
 class NestedNamespacePackageTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Tests/2024-07-13-11-48-20.gh-issue-59022.fYNbQ8.rst
+++ b/Misc/NEWS.d/next/Tests/2024-07-13-11-48-20.gh-issue-59022.fYNbQ8.rst
@@ -1,0 +1,1 @@
+Add tests for :func:`pkgutil.extend_path`. Patch by Andreas Stocker.


### PR DESCRIPTION
This adds tests for the documented behaviour of `pkgutil.extend_path` regarding different argument types as well as for `*.pkg` files.

I took inspiration from the PR #12871 for the tests I've added. However, some of those tests did not seem to make sense to me, so I've ended up with the two test-cases in this PR.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-59022 -->
* Issue: gh-59022
<!-- /gh-issue-number -->
