### PR TITLE
gh-121671: Increase test coverage of `ast.get_docstring`

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1821,6 +1821,12 @@ Module(
         node = ast.parse('async def foo():\n  """spam\n  ham"""')
         self.assertEqual(ast.get_docstring(node.body[0]), 'spam\nham')
 
+        node = ast.parse('async def foo():\n  """spam\n  ham"""')
+        self.assertEqual(ast.get_docstring(node.body[0], clean=False), 'spam\n  ham')
+
+        node = ast.parse('x')
+        self.assertRaises(TypeError, ast.get_docstring, node.body[0])
+
     def test_get_docstring_none(self):
         self.assertIsNone(ast.get_docstring(ast.parse('')))
         node = ast.parse('x = "not docstring"')
@@ -1843,6 +1849,9 @@ Module(
         node = ast.parse('async def foo():\n  pass')
         self.assertIsNone(ast.get_docstring(node.body[0]))
         node = ast.parse('async def foo():\n  x = "not docstring"')
+        self.assertIsNone(ast.get_docstring(node.body[0]))
+
+        node = ast.parse('async def foo():\n  42')
         self.assertIsNone(ast.get_docstring(node.body[0]))
 
     def test_multi_line_docstring_col_offset_and_lineno_issue16806(self):


### PR DESCRIPTION
Generated as: `./python ../coveragepy run --pylib --branch --source=ast Lib/test/regrtest.py test_ast`
To get the HTML report: `./python ../coveragepy/ html -i --include=./Lib/* --omit="Lib/test/*,Lib/*/tests/*"`

Before:
![image](https://github.com/user-attachments/assets/82d0275e-79cd-4f91-a4c2-1683cdcfb0c9)

After:
![image](https://github.com/user-attachments/assets/ceae14d7-9887-490d-bae3-2aa13f03b51b)


<!-- gh-issue-number: gh-121671 -->
* Issue: gh-121671
<!-- /gh-issue-number -->
