### PR TITLE
gh-64308: Remove TestProgram from the unittest docs

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -2317,7 +2317,7 @@ Loading and running tests
    otherwise it will be set to ``'default'``.
 
    Calling ``main`` returns an object with the ``result`` attribute that contains
-   the result of the tests run.
+   the result of the tests run as a :class:`unittest.TestResult`.
 
    .. versionchanged:: 3.1
       The *exit* parameter was added.

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -2316,8 +2316,8 @@ Loading and running tests
    (see :ref:`Warning control <using-on-warnings>`),
    otherwise it will be set to ``'default'``.
 
-   Calling ``main`` actually returns an instance of the ``TestProgram`` class.
-   This stores the result of the tests run as the ``result`` attribute.
+   Calling ``main`` returns an object with the ``result`` attribute that contains
+   the result of the tests run.
 
    .. versionchanged:: 3.1
       The *exit* parameter was added.


### PR DESCRIPTION
Closes #64308.

Remove sole mention of `TestProgram` from `unittest` docs.

<!-- gh-issue-number: gh-64308 -->
* Issue: gh-64308
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121675.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->