### PR TITLE
gh-121657: Display correct error message for yield from outside of a …

### DIFF
--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -2247,6 +2247,11 @@ Traceback (most recent call last):
   ...
 SyntaxError: 'yield' outside function
 
+>>> yield from [1,2]
+Traceback (most recent call last):
+  ...
+SyntaxError: 'yield from' outside function
+
 >>> def f(): x = yield = y
 Traceback (most recent call last):
   ...

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-13-12-27-31.gh-issue-121657.wgOYLw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-13-12-27-31.gh-issue-121657.wgOYLw.rst
@@ -1,1 +1,2 @@
-Show the correct ``SyntaxError`` if the user tries to use ``yield from`` outside a function
+Improve the :exc:`SyntaxError` message if the user tries to use
+:keyword:`yield from <yield>` outside a function.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-13-12-27-31.gh-issue-121657.wgOYLw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-13-12-27-31.gh-issue-121657.wgOYLw.rst
@@ -1,0 +1,1 @@
+Show the correct ``SyntaxError`` if the user tries to use ``yield from`` outside a function

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -6119,7 +6119,7 @@ compiler_visit_expr(struct compiler *c, expr_ty e)
         break;
     case YieldFrom_kind:
         if (!_PyST_IsFunctionLike(SYMTABLE_ENTRY(c))) {
-            return compiler_error(c, loc, "'yield' outside function");
+            return compiler_error(c, loc, "'yield from' outside function");
         }
         if (c->u->u_scope_type == COMPILER_SCOPE_ASYNC_FUNCTION) {
             return compiler_error(c, loc, "'yield from' inside async function");


### PR DESCRIPTION
Display correct error message for yield from outside of a function

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121657 -->
* Issue: gh-121657
<!-- /gh-issue-number -->
