### PR TITLE
gh-58546: Adds documentation on how to handle redirects with urllib

### DIFF
--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -335,6 +335,39 @@ geturl, and info, methods as returned by the ``urllib.response`` module::
       <title>Page Not Found</title>\n
       ...
 
+Handling redirects
+~~~~~~~~~~~~~~~~~~~
+
+Since a redirect also raises a :exc:`~urllib.error.HTTPError`, you can implement
+an exception handler to make follow-up requests and handle the redirects.
+
+For example ::
+
+    >>> import urllib.request
+    >>> import urllib.parse
+    >>> url = 'http://example.com/redirect'
+    >>> data = 'example=data'.encode('utf-8')
+    >>> req = urllib.request.Request(url, data)
+    >>> while True:
+    ...     try:
+    ...         print(f'{req.get_method()}: {req.get_full_url()}')
+    ...         resp = urllib.request.urlopen(req)
+    ...         break
+    ...     except urllib.error.HTTPError as e:
+    ...         if e.status != 307:
+    ...             raise
+    ...         redirected_url = urllib.parse.urljoin(url, e.headers['Location'])
+    ...         req = urllib.request.Request(redirected_url, data)
+    ...
+    POST: http://example.com/url
+    POST: http://example.com/redirect-1
+    POST: http://example.com/redirect-2
+    POST: http://example.com/final-url
+    b'{"example":"response"}\n'
+
+Since a new request is created for each redirect, any necessary data or other
+parameters must be explicitly passed to the new request.
+
 Wrapping it Up
 --------------
 


### PR DESCRIPTION
Adds an example in the documentation of urllib on how to handle redirects and forward request data.

<!-- gh-issue-number: gh-58546 -->
* Issue: gh-58546
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121681.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->