### PR TITLE
gh-82419: improve doc for ENABLE_USER_SITE

### DIFF
--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -181,7 +181,8 @@ Module contents
    was disabled by user request (with :option:`-s` or
    :envvar:`PYTHONNOUSERSITE`).  ``None`` means it was disabled for security
    reasons (mismatch between user or group id and effective id) or by an
-   administrator.
+   administrator. This no longer disables user site-packages even if it's set to
+   ``False``.
 
 
 .. data:: USER_SITE


### PR DESCRIPTION
- [x] improve doc according to the issue.

Not sure if did it correctly. My suggestion would be to just deprecate the whole `ENABLE_USER_SITE` configuration.

<!-- gh-issue-number: gh-82419 -->
* Issue: gh-82419
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121684.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->