### PR TITLE
gh-107001:  Add a stdlib decorator that copies/applies the ParameterSpec from one function to another

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -281,7 +281,7 @@ callables, the :data:`Concatenate` operator may be used.  They
 take the form ``Callable[ParamSpecVariable, ReturnType]`` and
 ``Callable[Concatenate[Arg1Type, Arg2Type, ..., ParamSpecVariable], ReturnType]``
 respectively.
-To copy the call from one function to another use :func:`copy_kwargs`.
+To copy the call from one function to another use :func:`copy_func_params`.
 
 .. versionchanged:: 3.10
    ``Callable`` now supports :class:`ParamSpec` and :data:`Concatenate`.
@@ -2865,7 +2865,7 @@ Functions and decorators
    runtime we intentionally don't check anything (we want this
    to be as fast as possible).
 
-.. decorator:: copy_kwargs(source_func)
+.. decorator:: copy_func_params(source_func)
 
    Cast the decorated function's call signature to the *source_func*'s.
 
@@ -2875,12 +2875,12 @@ Functions and decorators
 
    Usage::
 
-      from typing import copy_kwargs, Any
+      from typing import copy_func_params, Any
 
       def upstream_func(a: int, b: float, *, double: bool = False) -> float:
          ...
 
-      @copy_kwargs(upstream_func)
+      @copy_func_params(upstream_func)
       def enhanced(
          a: int, b: float, *args: Any, double: bool = False, **kwargs: Any
       ) -> str:

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2871,7 +2871,7 @@ Functions and decorators
 
    Use this decorator enhancing an upstream function while keeping its
    call signature.
-   Returns the original function with the *source_funcs* call signature.
+   Returns the original function with the *source_func*'s call signature.
 
    Usage::
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2869,7 +2869,7 @@ Functions and decorators
 
     Cast the decorated function's call signature to the *source_func*'s.
 
-    Use this decorator enhancing an upstream function while keeping it's
+    Use this decorator enhancing an upstream function while keeping its
     call signature.
     Returns the original function with the *source_funcs* call signature.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2867,32 +2867,32 @@ Functions and decorators
 
 .. decorator:: copy_kwargs(source_func)
 
-    Cast the decorated function's call signature to the *source_func*'s.
+   Cast the decorated function's call signature to the *source_func*'s.
 
-    Use this decorator enhancing an upstream function while keeping its
-    call signature.
-    Returns the original function with the *source_funcs* call signature.
+   Use this decorator enhancing an upstream function while keeping its
+   call signature.
+   Returns the original function with the *source_funcs* call signature.
 
-    Usage::
+   Usage::
 
-        from typing import copy_kwargs, Any
+      from typing import copy_kwargs, Any
 
-        def upstream_func(a: int, b: float, *, double: bool = False) -> float:
-            ...
+      def upstream_func(a: int, b: float, *, double: bool = False) -> float:
+         ...
 
-        @copy_kwargs(upstream_func)
-        def enhanced(
-            a: int, b: float, *args: Any, double: bool = False, **kwargs: Any
-        ) -> str:
-            ...
+      @copy_kwargs(upstream_func)
+      def enhanced(
+         a: int, b: float, *args: Any, double: bool = False, **kwargs: Any
+      ) -> str:
+         ...
 
-    .. note::
+   .. note::
 
-       Include ``*args`` and ``**kwargs`` in the signature of the decorated
-       function in order to avoid a :py:class:`TypeError` when the call signature of
-       *source_func* changes.
+    Include ``*args`` and ``**kwargs`` in the signature of the decorated
+    function in order to avoid a :py:class:`TypeError` when the call signature of
+    *source_func* changes.
 
-   .. versionadded 3.14
+   .. versionadded:: 3.14
 
 .. function:: assert_type(val, typ, /)
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -281,6 +281,7 @@ callables, the :data:`Concatenate` operator may be used.  They
 take the form ``Callable[ParamSpecVariable, ReturnType]`` and
 ``Callable[Concatenate[Arg1Type, Arg2Type, ..., ParamSpecVariable], ReturnType]``
 respectively.
+To copy the call from one function to another use :func:`copy_kwargs`.
 
 .. versionchanged:: 3.10
    ``Callable`` now supports :class:`ParamSpec` and :data:`Concatenate`.
@@ -2863,6 +2864,35 @@ Functions and decorators
    signals that the return value has the designated type, but at
    runtime we intentionally don't check anything (we want this
    to be as fast as possible).
+
+.. decorator:: copy_kwargs(source_func)
+
+    Cast the decorated function's call signature to the *source_func*'s.
+
+    Use this decorator enhancing an upstream function while keeping it's
+    call signature.
+    Returns the original function with the *source_funcs* call signature.
+
+    Usage::
+
+        from typing import copy_kwargs, Any
+
+        def upstream_func(a: int, b: float, *, double: bool = False) -> float:
+            ...
+
+        @copy_kwargs(upstream_func)
+        def enhanced(
+            a: int, b: float, *args: Any, double: bool = False, **kwargs: Any
+        ) -> str:
+            ...
+
+    .. note::
+
+       Include ``*args`` and ``**kwargs`` in the signature of the decorated
+       function in order to avoid a :py:class:`TypeError` when the call signature of
+       *source_func* changes.
+
+   .. versionadded 3.14
 
 .. function:: assert_type(val, typ, /)
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2894,6 +2894,16 @@ Functions and decorators
 
    .. versionadded:: 3.14
 
+
+.. decorator:: copy_method_params(source_method)
+
+   Cast the decorated method's call signature to the source_method's
+
+   Same as :py:func:`copy_func_params` but intended to be used with methods.
+   It keeps the first argument (``self``/``cls``) of the decorated method.
+
+   .. versionadded:: 3.14
+
 .. function:: assert_type(val, typ, /)
 
    Ask a static type checker to confirm that *val* has an inferred type of *typ*.

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1086,7 +1086,8 @@ symtable
 
 typing
 ------
-* Add :func:`~typing.copy_kwargs` to *typing* that copies/applies the ParameterSpec from one function to another.
+* Add :func:`~typing.copy_kwargs` to *typing* that copies/applies
+  the :class:`~typing.ParamSpec` from one function to another.
 
 sys
 ---

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1084,6 +1084,9 @@ symtable
 
   (Contributed by Bénédikt Tran in :gh:`120029`.)
 
+typing
+------
+* Add :func:`~typing.copy_kwargs` to *typing* that copies/applies the ParameterSpec from one function to another.
 
 sys
 ---

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1086,7 +1086,7 @@ symtable
 
 typing
 ------
-* Add :func:`~typing.copy_kwargs` that copies/applies
+* Add :func:`~typing.copy_func_params` that copies/applies
   the :class:`~typing.ParamSpec` from one function to another.
 
 sys

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1086,7 +1086,7 @@ symtable
 
 typing
 ------
-* Add :func:`~typing.copy_kwargs` to *typing* that copies/applies
+* Add :func:`~typing.copy_kwargs` that copies/applies
   the :class:`~typing.ParamSpec` from one function to another.
 
 sys

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -125,7 +125,7 @@ __all__ = [
     'assert_never',
     'cast',
     'clear_overloads',
-    'copy_kwargs',
+    'copy_func_params',
     'dataclass_transform',
     'evaluate_forward_ref',
     'final',
@@ -3756,7 +3756,7 @@ def get_protocol_members(tp: type, /) -> frozenset[str]:
 _P = ParamSpec("_P")
 
 
-def copy_kwargs(
+def copy_func_params(
     source_func: Callable[_P, Any]
 ) -> Callable[[Callable[..., T]], Callable[_P, T]]:
     """Cast the decorated function's call signature to the source_func's.
@@ -3767,12 +3767,12 @@ def copy_kwargs(
 
     Usage::
 
-        from typing import copy_kwargs, Any
+        from typing import copy_func_params, Any
 
         def upstream_func(a: int, b: float, *, double: bool = False) -> float:
             ...
 
-        @copy_kwargs(upstream_func)
+        @copy_func_params(upstream_func)
         def enhanced(
             a: int, b: float, *args: Any, double: bool = False, **kwargs: Any
         ) -> str:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -125,6 +125,7 @@ __all__ = [
     'assert_never',
     'cast',
     'clear_overloads',
+    'copy_kwargs',
     'dataclass_transform',
     'evaluate_forward_ref',
     'final',

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -126,6 +126,7 @@ __all__ = [
     'cast',
     'clear_overloads',
     'copy_func_params',
+    'copy_method_params',
     'dataclass_transform',
     'evaluate_forward_ref',
     'final',

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3753,12 +3753,9 @@ def get_protocol_members(tp: type, /) -> frozenset[str]:
     return frozenset(tp.__protocol_attrs__)
 
 
-_P = ParamSpec("_P")
-
-
-def copy_func_params(
-    source_func: Callable[_P, Any]
-) -> Callable[[Callable[..., T]], Callable[_P, T]]:
+def copy_func_params[**Param, RV](
+    source_func: Callable[Param, Any]
+) -> Callable[[Callable[..., RV]], Callable[Param, RV]]:
     """Cast the decorated function's call signature to the source_func's.
 
     Use this decorator enhancing an upstream function while keeping its
@@ -3785,8 +3782,8 @@ def copy_func_params(
        *source_func* changes.
     """
 
-    def return_func(func: Callable[..., T]) -> Callable[_P, T]:
-        return cast(Callable[_P, T], func)
+    def return_func(func: Callable[..., RV]) -> Callable[Param, RV]:
+        return cast(Callable[Param, RV], func)
 
     return return_func
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3788,6 +3788,26 @@ def copy_func_params[**Param, RV](
     return return_func
 
 
+def copy_method_params[**Param, Arg1, RV](
+    source_method: Callable[Concatenate[Any, Param], Any]
+) -> Callable[
+    [Callable[Concatenate[Arg1, ...], RV]],
+    Callable[Concatenate[Arg1, Param], RV]
+]:
+    """Cast the decorated method's call signature to the source_method's.
+
+    Same as :func:`copy_func_params` but intended to be used with methods.
+    It keeps the first argument (``self``/``cls``) of the decorated method.
+    """
+
+    def return_func(
+        func: Callable[Concatenate[Arg1, ...], RV]
+    ) -> Callable[Concatenate[Arg1, Param], RV]:
+        return cast(Callable[Concatenate[Arg1, Param], RV], func)
+
+    return return_func
+
+
 def __getattr__(attr):
     """Improve the import time of the typing module.
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3763,7 +3763,7 @@ def copy_kwargs(
 
     Use this decorator enhancing an upstream function while keeping its
     call signature.
-    Returns the original function with the *source_funcs* call signature.
+    Returns the original function with the source_func's call signature.
 
     Usage::
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3752,6 +3752,44 @@ def get_protocol_members(tp: type, /) -> frozenset[str]:
     return frozenset(tp.__protocol_attrs__)
 
 
+_P = ParamSpec("_P")
+
+
+def copy_kwargs(
+    source_func: Callable[_P, Any]
+) -> Callable[[Callable[..., T]], Callable[_P, T]]:
+    """Cast the decorated function's call signature to the source_func's.
+
+    Use this decorator enhancing an upstream function while keeping it's
+    call signature.
+    Returns the original function with the *source_funcs* call signature.
+
+    Usage::
+
+        from typing import copy_kwargs, Any
+
+        def upstream_func(a: int, b: float, *, double: bool = False) -> float:
+            ...
+
+        @copy_kwargs(upstream_func)
+        def enhanced(
+            a: int, b: float, *args: Any, double: bool = False, **kwargs: Any
+        ) -> str:
+            ...
+
+    .. note::
+
+       Include ``*args`` and ``**kwargs`` in the signature of the decorated
+       function in order to avoid TypeErrors when the call signature of
+       *source_func* changes.
+    """
+
+    def return_func(func: Callable[..., T]) -> Callable[_P, T]:
+        return cast(Callable[_P, T], func)
+
+    return return_func
+
+
 def __getattr__(attr):
     """Improve the import time of the typing module.
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3760,7 +3760,7 @@ def copy_kwargs(
 ) -> Callable[[Callable[..., T]], Callable[_P, T]]:
     """Cast the decorated function's call signature to the source_func's.
 
-    Use this decorator enhancing an upstream function while keeping it's
+    Use this decorator enhancing an upstream function while keeping its
     call signature.
     Returns the original function with the *source_funcs* call signature.
 

--- a/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
@@ -1,1 +1,1 @@
-Add :func:`~typing.copy_kwargs` to *typing* that copies/applies the ParameterSpec from one function to another.
+Add :func:`~typing.copy_kwargs` to *typing* that copies/applies the ParameterSpec from one function to another. Patch by Carli Freudenberg.

--- a/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
@@ -1,0 +1,1 @@
+Add :func:`copy_kwargs` to *typing* that copies/applies the ParameterSpec from one function to another.

--- a/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
@@ -1,3 +1,4 @@
-Add :func:`~typing.copy_func_params` to :mod:`typing` that copies/applies the
-:class:`~typing.ParamSpec` from one function to another.
+Add :func:`~typing.copy_func_params` and :func:`~typing.copy_func_params`
+to :mod:`typing` that copies/applies the
+:class:`~typing.ParamSpec` from one function/method to another.
 Patch by Carli Freudenberg.

--- a/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
@@ -1,2 +1,3 @@
 Add :func:`~typing.copy_kwargs` to :mod:`typing` that copies/applies the
-ParameterSpec from one function to another. Patch by Carli Freudenberg.
+:class:`~typing.ParamSpec` from one function to another.
+Patch by Carli Freudenberg.

--- a/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
@@ -1,1 +1,2 @@
-Add :func:`~typing.copy_kwargs` to *typing* that copies/applies the ParameterSpec from one function to another. Patch by Carli Freudenberg.
+Add :func:`~typing.copy_kwargs` to :mod:`typing` that copies/applies the
+ParameterSpec from one function to another. Patch by Carli Freudenberg.

--- a/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
@@ -1,1 +1,1 @@
-Add :func:`copy_kwargs` to *typing* that copies/applies the ParameterSpec from one function to another.
+Add :func:`~typing.copy_kwargs` to *typing* that copies/applies the ParameterSpec from one function to another.

--- a/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-13-13-20-43.gh-issue-107001.fRSPOX.rst
@@ -1,3 +1,3 @@
-Add :func:`~typing.copy_kwargs` to :mod:`typing` that copies/applies the
+Add :func:`~typing.copy_func_params` to :mod:`typing` that copies/applies the
 :class:`~typing.ParamSpec` from one function to another.
 Patch by Carli Freudenberg.


### PR DESCRIPTION
Add a stdlib decorator that copies/applies the ParameterSpec from one function to another.

All information can be found in [the related issue](https://github.com/python/cpython/issues/107001)

Note for review for JelleZijlstra  and AlexWaygood (and maybe the typing council)

- [MyPy Play with Examples](https://mypy-play.net/?mypy=latest&python=3.12&gist=555ca0adffd6e1c4aa67fbdba787dd18) explaining why `copy_method_params` is also needed
- [Argument for including in typing](https://github.com/python/cpython/pull/121693#issuecomment-2438031544)
- [Naming Thread](https://github.com/python/cpython/pull/121693#discussion_r1677219610)

<!-- gh-issue-number: gh-107001 -->
* Issue: gh-107001
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121693.org.readthedocs.build/en/121693/library/typing.html#typing.copy_func_params

<!-- readthedocs-preview cpython-previews end -->