### PR TITLE
gh-121692: Remove `object` from classnames in unittest tests

### DIFF
--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -586,7 +586,7 @@ class TestContextDecorator(unittest.TestCase):
     def test_decorating_method(self):
         context = mycontext()
 
-        class Test(object):
+        class Test:
 
             @context
             def method(self, a, b, c=None):

--- a/Lib/test/test_contextlib_async.py
+++ b/Lib/test/test_contextlib_async.py
@@ -408,7 +408,7 @@ class AsyncContextManagerTestCase(unittest.IsolatedAsyncioTestCase):
             yield
 
 
-        class Test(object):
+        class Test:
 
             @context()
             async def method(self, a, b, c=None):

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -1963,7 +1963,7 @@ class TestIsDataDescriptor(unittest.TestCase):
                         'a property is a data descriptor')
 
     def test_functions(self):
-        class Test(object):
+        class Test:
             def instance_method(self): pass
             @classmethod
             def class_method(cls): pass

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -138,7 +138,7 @@ class FrFRCookedTest(BaseCookedTest):
     }
 
 
-class BaseFormattingTest(object):
+class BaseFormattingTest:
     #
     # Utility functions for formatting tests
     #

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -3082,7 +3082,7 @@ class TestCopyFileObj(unittest.TestCase):
         self.assert_files_eq(fname, TESTFN2)
 
 
-class _ZeroCopyFileTest(object):
+class _ZeroCopyFileTest:
     """Tests common to all zero-copy APIs."""
     FILESIZE = (10 * 1024 * 1024)  # 10 MiB
     FILEDATA = b""

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5324,7 +5324,7 @@ class UnicodeReadWriteFileObjectClassTestCase(FileObjectClassTestCase):
     newline = ''
 
 
-class NetworkConnectionTest(object):
+class NetworkConnectionTest:
     """Prove network connection."""
 
     def clientSetUp(self):

--- a/Lib/test/test_unittest/support.py
+++ b/Lib/test/test_unittest/support.py
@@ -1,7 +1,7 @@
 import unittest
 
 
-class TestEquality(object):
+class TestEquality:
     """Used as a mixin for TestCase"""
 
     # Check for a valid __eq__ implementation
@@ -16,7 +16,7 @@ class TestEquality(object):
             self.assertNotEqual(obj_1, obj_2)
             self.assertNotEqual(obj_2, obj_1)
 
-class TestHashing(object):
+class TestHashing:
     """Used as a mixin for TestCase"""
 
     # Check for a valid __hash__ implementation
@@ -107,7 +107,7 @@ class LoggingResult(_BaseLoggingResult):
         super().addSubTest(test, subtest, err)
 
 
-class ResultWithNoStartTestRunStopTestRun(object):
+class ResultWithNoStartTestRunStopTestRun:
     """An object honouring TestResult before startTestRun/stopTestRun."""
 
     def __init__(self):

--- a/Lib/test/test_unittest/test_break.py
+++ b/Lib/test/test_unittest/test_break.py
@@ -217,7 +217,7 @@ class TestBreak(unittest.TestCase):
         result = object()
         default_handler = signal.getsignal(signal.SIGINT)
 
-        class FakeRunner(object):
+        class FakeRunner:
             initArgs = []
             runArgs = []
             def __init__(self, *args, **kwargs):

--- a/Lib/test/test_unittest/test_case.py
+++ b/Lib/test/test_unittest/test_case.py
@@ -27,7 +27,7 @@ log_foobar = logging.getLogger('foo.bar')
 log_quux = logging.getLogger('quux')
 
 
-class Test(object):
+class Test:
     "Keep these TestCase classes out of the main namespace"
 
     class Foo(unittest.TestCase):
@@ -674,7 +674,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
             'Tests shortDescription() whitespace is trimmed, so that the first')
 
     def testAddTypeEqualityFunc(self):
-        class SadSnake(object):
+        class SadSnake:
             """Dummy class for test_addTypeEqualityFunc."""
         s1, s2 = SadSnake(), SadSnake()
         self.assertFalse(s1 == s2)

--- a/Lib/test/test_unittest/test_discovery.py
+++ b/Lib/test/test_unittest/test_discovery.py
@@ -155,7 +155,7 @@ class TestDiscovery(unittest.TestCase):
         os.path.isfile = lambda path: os.path.basename(path) not in directories
         self.addCleanup(restore_isfile)
 
-        class Module(object):
+        class Module:
             paths = []
             load_tests_args = []
 
@@ -229,7 +229,7 @@ class TestDiscovery(unittest.TestCase):
         os.path.isfile = lambda path: os.path.basename(path) not in directories
         self.addCleanup(restore_isfile)
 
-        class Module(object):
+        class Module:
             paths = []
             load_tests_args = []
 
@@ -314,7 +314,7 @@ class TestDiscovery(unittest.TestCase):
         os.path.isdir = lambda path: not path.endswith('.py')
         os.path.isfile = lambda path: path.endswith('.py')
 
-        class Module(object):
+        class Module:
             paths = []
             load_tests_args = []
 
@@ -455,7 +455,7 @@ class TestDiscovery(unittest.TestCase):
         os.path.isdir = lambda path: not path.endswith('.py')
         self.addCleanup(sys.path.remove, abspath('/toplevel'))
 
-        class Module(object):
+        class Module:
             paths = []
             load_tests_args = []
 
@@ -655,7 +655,7 @@ class TestDiscovery(unittest.TestCase):
         program = object.__new__(unittest.TestProgram)
         program._initArgParsers()
 
-        class Loader(object):
+        class Loader:
             args = []
             def discover(self, start_dir, pattern, top_level_dir):
                 self.args.append((start_dir, pattern, top_level_dir))
@@ -668,7 +668,7 @@ class TestDiscovery(unittest.TestCase):
     def test_command_line_handling_do_discovery_calls_loader(self):
         program = TestableTestProgram()
 
-        class Loader(object):
+        class Loader:
             args = []
             def discover(self, start_dir, pattern, top_level_dir):
                 self.args.append((start_dir, pattern, top_level_dir))
@@ -740,7 +740,7 @@ class TestDiscovery(unittest.TestCase):
         self.assertTrue(program.catchbreak)
 
     def setup_module_clash(self):
-        class Module(object):
+        class Module:
             __file__ = 'bar/foo.py'
         sys.modules['foo'] = Module
         full_path = os.path.abspath('foo')

--- a/Lib/test/test_unittest/test_loader.py
+++ b/Lib/test/test_unittest/test_loader.py
@@ -173,7 +173,7 @@ class Test_TestLoader(unittest.TestCase):
             def test(self):
                 pass
 
-        class NotAModule(object):
+        class NotAModule:
             test_2 = MyTestCase
 
         loader = unittest.TestLoader()
@@ -419,7 +419,7 @@ class Test_TestLoader(unittest.TestCase):
             def test(self):
                 pass
 
-        class NotAModule(object):
+        class NotAModule:
             test_2 = MyTestCase
 
         loader = unittest.TestLoader()
@@ -843,7 +843,7 @@ class Test_TestLoader(unittest.TestCase):
             def test(self):
                 pass
 
-        class NotAModule(object):
+        class NotAModule:
             test_2 = MyTestCase
 
         loader = unittest.TestLoader()

--- a/Lib/test/test_unittest/test_program.py
+++ b/Lib/test/test_unittest/test_program.py
@@ -30,7 +30,7 @@ class Test_TestProgram(unittest.TestCase):
         result = object()
         test = object()
 
-        class FakeRunner(object):
+        class FakeRunner:
             def run(self, test):
                 self.test = test
                 return result
@@ -89,7 +89,7 @@ class Test_TestProgram(unittest.TestCase):
                 [self.loadTestsFromTestCase(self.testcase)])
 
     def test_defaultTest_with_string(self):
-        class FakeRunner(object):
+        class FakeRunner:
             def run(self, test):
                 self.test = test
                 return True
@@ -104,7 +104,7 @@ class Test_TestProgram(unittest.TestCase):
         self.assertEqual(('test.test_unittest',), program.testNames)
 
     def test_defaultTest_with_iterable(self):
-        class FakeRunner(object):
+        class FakeRunner:
             def run(self, test):
                 self.test = test
                 return True
@@ -207,7 +207,7 @@ class InitialisableProgram(unittest.TestProgram):
 
 RESULT = object()
 
-class FakeRunner(object):
+class FakeRunner:
     initArgs = None
     test = None
     raiseError = 0

--- a/Lib/test/test_unittest/test_result.py
+++ b/Lib/test/test_unittest/test_result.py
@@ -10,7 +10,7 @@ from unittest.util import strclass
 from test.test_unittest.support import BufferedWriter
 
 
-class MockTraceback(object):
+class MockTraceback:
     class TracebackException:
         def __init__(self, *args, **kwargs):
             self.capture_locals = kwargs.get('capture_locals', False)
@@ -418,8 +418,8 @@ class Test_TestResult(unittest.TestCase):
         self.assertIn("some recognizable failure", formatted_exc)
 
     def testStackFrameTrimming(self):
-        class Frame(object):
-            class tb_frame(object):
+        class Frame:
+            class tb_frame:
                 f_globals = {}
         result = unittest.TestResult()
         self.assertFalse(result._is_relevant_tb_level(Frame))
@@ -1210,7 +1210,7 @@ class TestOutputBuffering(unittest.TestCase):
         class Foo(unittest.TestCase):
             def test_foo(self):
                 pass
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 print('set up module')
@@ -1238,7 +1238,7 @@ class TestOutputBuffering(unittest.TestCase):
         class Foo(unittest.TestCase):
             def test_foo(self):
                 pass
-        class Module(object):
+        class Module:
             @staticmethod
             def tearDownModule():
                 print('tear down module')
@@ -1266,7 +1266,7 @@ class TestOutputBuffering(unittest.TestCase):
         class Foo(unittest.TestCase):
             def test_foo(self):
                 pass
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 print('set up module')
@@ -1296,7 +1296,7 @@ class TestOutputBuffering(unittest.TestCase):
         class Foo(unittest.TestCase):
             def test_foo(self):
                 pass
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 print('set up module')
@@ -1335,7 +1335,7 @@ class TestOutputBuffering(unittest.TestCase):
         class Foo(unittest.TestCase):
             def test_foo(self):
                 pass
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 print('set up module')

--- a/Lib/test/test_unittest/test_runner.py
+++ b/Lib/test/test_unittest/test_runner.py
@@ -611,7 +611,7 @@ class TestModuleCleanUp(unittest.TestCase):
         def module_cleanup2(*args, **kwargs):
             module_cleanups.append((4, args, kwargs))
 
-        class Module(object):
+        class Module:
             unittest.addModuleCleanup(module_cleanup1, 1, 2, 3,
                                       four='hello', five='goodbye')
             unittest.addModuleCleanup(module_cleanup2)
@@ -635,7 +635,7 @@ class TestModuleCleanUp(unittest.TestCase):
         def module_cleanup_bad(*args, **kwargs):
             raise CustomError('CleanUpExc')
 
-        class Module(object):
+        class Module:
             unittest.addModuleCleanup(module_cleanup_good, 1, 2, 3,
                                       four='hello', five='goodbye')
             unittest.addModuleCleanup(module_cleanup_bad)
@@ -653,7 +653,7 @@ class TestModuleCleanUp(unittest.TestCase):
         def cleanup(*args, **kwargs):
             cleanups.append((args, kwargs))
 
-        class Module(object):
+        class Module:
             unittest.addModuleCleanup(cleanup, 1, 2, function='hello')
             with self.assertRaises(TypeError):
                 unittest.addModuleCleanup(function=cleanup, arg='hello')
@@ -666,7 +666,7 @@ class TestModuleCleanUp(unittest.TestCase):
     def test_run_module_cleanUp(self):
         blowUp = True
         ordering = []
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -706,7 +706,7 @@ class TestModuleCleanUp(unittest.TestCase):
         blowUp = True
         blowUp2 = False
         ordering = []
-        class Module1(object):
+        class Module1:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -717,7 +717,7 @@ class TestModuleCleanUp(unittest.TestCase):
             def tearDownModule():
                 ordering.append('tearDownModule')
 
-        class Module2(object):
+        class Module2:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule2')
@@ -779,7 +779,7 @@ class TestModuleCleanUp(unittest.TestCase):
 
     def test_run_module_cleanUp_without_teardown(self):
         ordering = []
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -804,7 +804,7 @@ class TestModuleCleanUp(unittest.TestCase):
 
     def test_run_module_cleanUp_when_teardown_exception(self):
         ordering = []
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -837,7 +837,7 @@ class TestModuleCleanUp(unittest.TestCase):
     def test_debug_module_executes_cleanUp(self):
         ordering = []
         blowUp = False
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -878,7 +878,7 @@ class TestModuleCleanUp(unittest.TestCase):
     def test_debug_module_cleanUp_when_teardown_exception(self):
         ordering = []
         blowUp = False
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -966,7 +966,7 @@ class TestModuleCleanUp(unittest.TestCase):
     def test_with_errors_in_addClassCleanup(self):
         ordering = []
 
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -998,7 +998,7 @@ class TestModuleCleanUp(unittest.TestCase):
 
     def test_with_errors_in_addCleanup(self):
         ordering = []
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -1031,7 +1031,7 @@ class TestModuleCleanUp(unittest.TestCase):
         module_blow_up = False
         class_blow_up = False
         method_blow_up = False
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -1116,7 +1116,7 @@ class TestModuleCleanUp(unittest.TestCase):
         def cleanup3():
             ordering.append('cleanup3')
 
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')

--- a/Lib/test/test_unittest/test_setups.py
+++ b/Lib/test/test_unittest/test_setups.py
@@ -183,7 +183,7 @@ class TestSetups(unittest.TestCase):
     def test_setup_teardown_order_with_pathological_suite(self):
         results = []
 
-        class Module1(object):
+        class Module1:
             @staticmethod
             def setUpModule():
                 results.append('Module1.setUpModule')
@@ -191,7 +191,7 @@ class TestSetups(unittest.TestCase):
             def tearDownModule():
                 results.append('Module1.tearDownModule')
 
-        class Module2(object):
+        class Module2:
             @staticmethod
             def setUpModule():
                 results.append('Module2.setUpModule')
@@ -263,7 +263,7 @@ class TestSetups(unittest.TestCase):
                           'teardown 3', 'Module2.tearDownModule'])
 
     def test_setup_module(self):
-        class Module(object):
+        class Module:
             moduleSetup = 0
             @staticmethod
             def setUpModule():
@@ -283,7 +283,7 @@ class TestSetups(unittest.TestCase):
         self.assertEqual(len(result.errors), 0)
 
     def test_error_in_setup_module(self):
-        class Module(object):
+        class Module:
             moduleSetup = 0
             moduleTornDown = 0
             @staticmethod
@@ -340,7 +340,7 @@ class TestSetups(unittest.TestCase):
         self.assertEqual(result.testsRun, 2)
 
     def test_teardown_module(self):
-        class Module(object):
+        class Module:
             moduleTornDown = 0
             @staticmethod
             def tearDownModule():
@@ -360,7 +360,7 @@ class TestSetups(unittest.TestCase):
         self.assertEqual(len(result.errors), 0)
 
     def test_error_in_teardown_module(self):
-        class Module(object):
+        class Module:
             moduleTornDown = 0
             @staticmethod
             def tearDownModule():
@@ -424,7 +424,7 @@ class TestSetups(unittest.TestCase):
             def test_two(self):
                 pass
 
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 raise unittest.SkipTest('foo')
@@ -442,7 +442,7 @@ class TestSetups(unittest.TestCase):
     def test_suite_debug_executes_setups_and_teardowns(self):
         ordering = []
 
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 ordering.append('setUpModule')
@@ -469,7 +469,7 @@ class TestSetups(unittest.TestCase):
         self.assertEqual(ordering, expectedOrder)
 
     def test_suite_debug_propagates_exceptions(self):
-        class Module(object):
+        class Module:
             @staticmethod
             def setUpModule():
                 if phase == 0:

--- a/Lib/test/test_unittest/test_suite.py
+++ b/Lib/test/test_unittest/test_suite.py
@@ -9,7 +9,7 @@ from test.test_unittest.support import LoggingResult, TestEquality
 ### Support code for Test_TestSuite
 ################################################################
 
-class Test(object):
+class Test:
     class Foo(unittest.TestCase):
         def test_1(self): pass
         def test_2(self): pass
@@ -395,7 +395,7 @@ class Test_TestSuite(unittest.TestCase, TestEquality):
                 pass
             def testFail(self):
                 fail
-        class Module(object):
+        class Module:
             wasSetUp = False
             wasTornDown = False
             @staticmethod

--- a/Lib/test/test_unittest/testmock/support.py
+++ b/Lib/test/test_unittest/testmock/support.py
@@ -6,13 +6,13 @@ def is_instance(obj, klass):
     return issubclass(type(obj), klass)
 
 
-class SomeClass(object):
+class SomeClass:
     class_attribute = None
 
     def wibble(self): pass
 
 
-class X(object):
+class X:
     pass
 
 # A standin for weurkzeug.local.LocalProxy - issue 119600

--- a/Lib/test/test_unittest/testmock/testasync.py
+++ b/Lib/test/test_unittest/testmock/testasync.py
@@ -39,7 +39,7 @@ async def async_func_args(a, b, *, c): pass
 
 def normal_func(): pass
 
-class NormalClass(object):
+class NormalClass:
     def a(self): pass
 
 
@@ -724,7 +724,7 @@ class AsyncContextManagerTest(unittest.TestCase):
 
 
 class AsyncIteratorTest(unittest.TestCase):
-    class WithAsyncIterator(object):
+    class WithAsyncIterator:
         def __init__(self):
             self.items = ["foo", "NormalFoo", "baz"]
 

--- a/Lib/test/test_unittest/testmock/testhelpers.py
+++ b/Lib/test/test_unittest/testmock/testhelpers.py
@@ -11,7 +11,7 @@ from unittest.mock import (
 from datetime import datetime
 from functools import partial
 
-class SomeClass(object):
+class SomeClass:
     def one(self, a, b): pass
     def two(self): pass
     def three(self, a=None): pass
@@ -45,7 +45,7 @@ class AnyTest(unittest.TestCase):
 
     def test_any_mock_calls_comparison_order(self):
         mock = Mock()
-        class Foo(object):
+        class Foo:
             def __eq__(self, other): pass
             def __ne__(self, other): pass
 
@@ -417,7 +417,7 @@ class SpecSignatureTest(unittest.TestCase):
         mock = create_autospec(f, return_value='foo')
         self.assertEqual(mock(), 'foo')
 
-        class Foo(object):
+        class Foo:
             pass
 
         mock = create_autospec(Foo, return_value='foo')
@@ -432,7 +432,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_mocking_unbound_methods(self):
-        class Foo(object):
+        class Foo:
             def foo(self, foo): pass
         p = patch.object(Foo, 'foo')
         mock_foo = p.start()
@@ -442,7 +442,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_create_autospec_keyword_arguments(self):
-        class Foo(object):
+        class Foo:
             a = 3
         m = create_autospec(Foo, a='3')
         self.assertEqual(m.a, '3')
@@ -479,7 +479,7 @@ class SpecSignatureTest(unittest.TestCase):
 
         self.assertRaises(AttributeError, getattr, mock, 'foo')
 
-        class Foo(object):
+        class Foo:
             foo = []
 
         mock = create_autospec(Foo)
@@ -500,13 +500,13 @@ class SpecSignatureTest(unittest.TestCase):
 
     def test_spec_has_descriptor_returning_function(self):
 
-        class CrazyDescriptor(object):
+        class CrazyDescriptor:
 
             def __get__(self, obj, type_):
                 if obj is None:
                     return lambda x: None
 
-        class MyClass(object):
+        class MyClass:
 
             some_attr = CrazyDescriptor()
 
@@ -520,7 +520,7 @@ class SpecSignatureTest(unittest.TestCase):
 
     def test_spec_has_function_not_in_bases(self):
 
-        class CrazyClass(object):
+        class CrazyClass:
 
             def __dir__(self):
                 return super(CrazyClass, self).__dir__()+['crazy']
@@ -620,7 +620,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_descriptors(self):
-        class Foo(object):
+        class Foo:
             @classmethod
             def f(cls, a, b): pass
             @staticmethod
@@ -640,7 +640,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_recursive(self):
-        class A(object):
+        class A:
             def a(self): pass
             foo = 'foo bar baz'
             bar = foo
@@ -662,9 +662,9 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_spec_inheritance_for_classes(self):
-        class Foo(object):
+        class Foo:
             def a(self, x): pass
-            class Bar(object):
+            class Bar:
                 def f(self, y): pass
 
         class_mock = create_autospec(Foo)
@@ -700,7 +700,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_inherit(self):
-        class Foo(object):
+        class Foo:
             a = 3
 
         Foo.Foo = Foo
@@ -763,12 +763,12 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_skip_attributeerrors(self):
-        class Raiser(object):
+        class Raiser:
             def __get__(self, obj, type=None):
                 if obj is None:
                     raise AttributeError('Can only be accessed via an instance')
 
-        class RaiserClass(object):
+        class RaiserClass:
             raiser = Raiser()
 
             @staticmethod
@@ -787,7 +787,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_signature_class(self):
-        class Foo(object):
+        class Foo:
             def __init__(self, a, b=3): pass
 
         mock = create_autospec(Foo)
@@ -807,13 +807,13 @@ class SpecSignatureTest(unittest.TestCase):
     def test_class_with_no_init(self):
         # this used to raise an exception
         # due to trying to get a signature from object.__init__
-        class Foo(object):
+        class Foo:
             pass
         create_autospec(Foo)
 
 
     def test_signature_callable(self):
-        class Callable(object):
+        class Callable:
             def __init__(self, x, y): pass
             def __call__(self, a): pass
 
@@ -841,7 +841,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_signature_noncallable(self):
-        class NonCallable(object):
+        class NonCallable:
             def __init__(self):
                 pass
 
@@ -858,7 +858,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_create_autospec_none(self):
-        class Foo(object):
+        class Foo:
             bar = None
 
         mock = create_autospec(Foo)
@@ -870,7 +870,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_autospec_functions_with_self_in_odd_place(self):
-        class Foo(object):
+        class Foo:
             def f(a, self): pass
 
         a = create_autospec(Foo)
@@ -883,7 +883,7 @@ class SpecSignatureTest(unittest.TestCase):
 
 
     def test_autospec_data_descriptor(self):
-        class Descriptor(object):
+        class Descriptor:
             def __init__(self, value):
                 self.value = value
 
@@ -895,7 +895,7 @@ class SpecSignatureTest(unittest.TestCase):
         class MyProperty(property):
             pass
 
-        class Foo(object):
+        class Foo:
             __slots__ = ['slot']
 
             @property

--- a/Lib/test/test_unittest/testmock/testmagicmethods.py
+++ b/Lib/test/test_unittest/testmock/testmagicmethods.py
@@ -333,7 +333,7 @@ class TestMockingMagicMethods(unittest.TestCase):
 
 
     def test_magic_methods_and_spec(self):
-        class Iterable(object):
+        class Iterable:
             def __iter__(self): pass
 
         mock = Mock(spec=Iterable)
@@ -342,7 +342,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock.__iter__ = Mock(return_value=iter([]))
         self.assertEqual(list(mock), [])
 
-        class NonIterable(object):
+        class NonIterable:
             pass
         mock = Mock(spec=NonIterable)
         self.assertRaises(AttributeError, lambda: mock.__iter__)
@@ -357,7 +357,7 @@ class TestMockingMagicMethods(unittest.TestCase):
 
 
     def test_magic_methods_and_spec_set(self):
-        class Iterable(object):
+        class Iterable:
             def __iter__(self): pass
 
         mock = Mock(spec_set=Iterable)
@@ -366,7 +366,7 @@ class TestMockingMagicMethods(unittest.TestCase):
         mock.__iter__ = Mock(return_value=iter([]))
         self.assertEqual(list(mock), [])
 
-        class NonIterable(object):
+        class NonIterable:
             pass
         mock = Mock(spec_set=NonIterable)
         self.assertRaises(AttributeError, lambda: mock.__iter__)

--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -15,7 +15,7 @@ from unittest.mock import (
 )
 
 
-class Iter(object):
+class Iter:
     def __init__(self):
         self.thing = iter(['this', 'is', 'an', 'iter'])
 
@@ -28,7 +28,7 @@ class Iter(object):
     __next__ = next
 
 
-class Something(object):
+class Something:
     def meth(self, a, b, c, d=None): pass
 
     @classmethod
@@ -38,7 +38,7 @@ class Something(object):
     def smeth(a, b, c, d=None): pass
 
 
-class SomethingElse(object):
+class SomethingElse:
     def __init__(self):
         self._instance = None
 
@@ -151,7 +151,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_repr_with_spec(self):
-        class X(object):
+        class X:
             pass
 
         mock = Mock(spec=X)
@@ -235,8 +235,8 @@ class MockTest(unittest.TestCase):
 
 
     def test_autospec_mock(self):
-        class A(object):
-            class B(object):
+        class A:
+            class B:
                 C = None
 
         with mock.patch.object(A, 'B'):
@@ -670,7 +670,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_from_spec(self):
-        class Something(object):
+        class Something:
             x = 3
             __something__ = None
             def y(self): pass
@@ -716,7 +716,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_wraps_prevents_automatic_creation_of_mocks(self):
-        class Real(object):
+        class Real:
             pass
 
         real = Real()
@@ -736,7 +736,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_wraps_attributes(self):
-        class Real(object):
+        class Real:
             attribute = Mock()
 
         real = Real()
@@ -752,7 +752,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_side_effect_iterable_with_default(self):
-        class Real(object):
+        class Real:
             def method(self):
                 return sentinel.ORIGINAL_VALUE
 
@@ -766,7 +766,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_side_effect_iterable(self):
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -779,7 +779,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_side_effect_exception(self):
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -790,7 +790,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_side_effect_function(self):
-        class Real(object):
+        class Real:
             def method(self): pass
         def side_effect():
             return sentinel.VALUE
@@ -803,7 +803,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_return_value(self):
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -815,7 +815,7 @@ class MockTest(unittest.TestCase):
 
     def test_customize_wrapped_object_with_return_value_and_side_effect(self):
         # side_effect should always take precedence over return_value.
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -830,7 +830,7 @@ class MockTest(unittest.TestCase):
 
     def test_customize_wrapped_object_with_return_value_and_side_effect2(self):
         # side_effect can return DEFAULT to default to return_value
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -842,7 +842,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_customize_wrapped_object_with_return_value_and_side_effect_default(self):
-        class Real(object):
+        class Real:
             def method(self): pass
 
         real = Real()
@@ -954,7 +954,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_spec_class(self):
-        class X(object):
+        class X:
             pass
 
         mock = Mock(spec=X)
@@ -994,7 +994,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_setting_attribute_with_spec_set(self):
-        class X(object):
+        class X:
             y = 3
 
         mock = Mock(spec=X)
@@ -1416,7 +1416,7 @@ class MockTest(unittest.TestCase):
         self.assertEqual([mock(), mock(), mock()], ['g', 'h', 'i'])
         self.assertRaises(StopIteration, mock)
 
-        class Foo(object):
+        class Foo:
             pass
         mock = MagicMock(side_effect=Foo)
         self.assertIsInstance(mock(), Foo)
@@ -1764,7 +1764,7 @@ class MockTest(unittest.TestCase):
         with self.assertRaisesRegex(AttributeError, msg):
             m.has_calls()
 
-        class Foo(object):
+        class Foo:
             def called_once(self): pass
 
             def has_calls(self): pass
@@ -1788,7 +1788,7 @@ class MockTest(unittest.TestCase):
 
     # gh-100739
     def test_mock_safe_with_spec(self):
-        class Foo(object):
+        class Foo:
             def assert_bar(self): pass
 
             def assertSome(self): pass
@@ -1898,11 +1898,11 @@ class MockTest(unittest.TestCase):
         self.assertEqual(m.f.side_effect, None)
 
     def test_mock_add_spec(self):
-        class _One(object):
+        class _One:
             one = 1
-        class _Two(object):
+        class _Two:
             two = 2
-        class Anything(object):
+        class Anything:
             one = two = three = 'four'
 
         klasses = [
@@ -2002,7 +2002,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_manager_mock(self):
-        class Foo(object):
+        class Foo:
             one = 'one'
             two = 'two'
         manager = Mock()

--- a/Lib/test/test_unittest/testmock/testpatch.py
+++ b/Lib/test/test_unittest/testmock/testpatch.py
@@ -27,7 +27,7 @@ MODNAME = '%s.PTModule' % __name__
 
 
 def _get_proxy(obj, get_only=True):
-    class Proxy(object):
+    class Proxy:
         def __getattr__(self, name):
             return getattr(obj, name)
     if not get_only:
@@ -45,7 +45,7 @@ something  = sentinel.Something
 something_else  = sentinel.SomethingElse
 
 
-class Foo(object):
+class Foo:
     def __init__(self, a): pass
     def f(self, a): pass
     def g(self): pass
@@ -57,7 +57,7 @@ class Foo(object):
     @classmethod
     def class_method(cls): pass
 
-    class Bar(object):
+    class Bar:
         def a(self): pass
 
 foo_name = '%s.Foo' % __name__
@@ -66,7 +66,7 @@ foo_name = '%s.Foo' % __name__
 def function(a, b=Foo): pass
 
 
-class Container(object):
+class Container:
     def __init__(self):
         self.values = {}
 
@@ -97,7 +97,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_single_patchobject(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
 
         @patch.object(Something, 'attribute', sentinel.Patched)
@@ -114,7 +114,7 @@ class PatchTest(unittest.TestCase):
             patch.object('Something', 'do_something')
 
     def test_patchobject_with_none(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
 
         @patch.object(Something, 'attribute', None)
@@ -127,7 +127,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_multiple_patchobject(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
             next_attribute = sentinel.Original2
 
@@ -217,7 +217,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patchobject_with_default_mock(self):
-        class Test(object):
+        class Test:
             something = sentinel.Original
             something2 = sentinel.Original2
 
@@ -407,7 +407,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patch_with_static_methods(self):
-        class Foo(object):
+        class Foo:
             @staticmethod
             def woot():
                 return sentinel.Static
@@ -431,7 +431,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patch_slots(self):
-        class Foo(object):
+        class Foo:
             __slots__ = ('Foo',)
 
         foo = Foo()
@@ -446,10 +446,10 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patchobject_class_decorator(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
 
-        class Foo(object):
+        class Foo:
             def test_method(other_self):
                 self.assertEqual(Something.attribute, sentinel.Patched,
                                  "unpatched")
@@ -468,10 +468,10 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patch_class_decorator(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
 
-        class Foo(object):
+        class Foo:
 
             test_class_attr = 'whatever'
 
@@ -494,7 +494,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patchobject_twice(self):
-        class Something(object):
+        class Something:
             attribute = sentinel.Original
             next_attribute = sentinel.Original2
 
@@ -785,7 +785,7 @@ class PatchTest(unittest.TestCase):
         d = {'spam': 'eggs'}
         original = d.copy()
 
-        class Test(object):
+        class Test:
             def test_first(self):
                 this.assertEqual(d, {'foo': 'bar'})
             def test_second(self):
@@ -812,7 +812,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_get_only_proxy(self):
-        class Something(object):
+        class Something:
             foo = 'foo'
         class SomethingElse:
             foo = 'foo'
@@ -830,7 +830,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_get_set_delete_proxy(self):
-        class Something(object):
+        class Something:
             foo = 'foo'
         class SomethingElse:
             foo = 'foo'
@@ -889,13 +889,13 @@ class PatchTest(unittest.TestCase):
 
 
     def test_autospec(self):
-        class Boo(object):
+        class Boo:
             def __init__(self, a): pass
             def f(self, a): pass
             def g(self): pass
             foo = 'bar'
 
-            class Bar(object):
+            class Bar:
                 def a(self): pass
 
         def _test(mock):
@@ -1115,7 +1115,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_new_callable_keyword_arguments(self):
-        class Bar(object):
+        class Bar:
             kwargs = None
             def __init__(self, **kwargs):
                 Bar.kwargs = kwargs
@@ -1130,7 +1130,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_new_callable_spec(self):
-        class Bar(object):
+        class Bar:
             kwargs = None
             def __init__(self, **kwargs):
                 Bar.kwargs = kwargs
@@ -1205,7 +1205,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_new_callable_inherit_non_mock(self):
-        class NotAMock(object):
+        class NotAMock:
             def __init__(self, spec):
                 self.spec = spec
 
@@ -1223,7 +1223,7 @@ class PatchTest(unittest.TestCase):
     def test_new_callable_class_decorating(self):
         test = self
         original = Foo
-        class SomeTest(object):
+        class SomeTest:
 
             def _test(self, mock_foo):
                 test.assertIsNot(Foo, original)
@@ -1391,7 +1391,7 @@ class PatchTest(unittest.TestCase):
         original_f = Foo.f
         original_g = Foo.g
 
-        class SomeTest(object):
+        class SomeTest:
 
             def _test(self, f, foo):
                 test.assertIs(Foo, original_foo)
@@ -1449,7 +1449,7 @@ class PatchTest(unittest.TestCase):
 
 
     def test_patch_multiple_new_callable(self):
-        class Thing(object):
+        class Thing:
             pass
 
         patcher = patch.multiple(
@@ -1587,7 +1587,7 @@ class PatchTest(unittest.TestCase):
 
     @patch('unittest.mock.patch.TEST_PREFIX', 'foo')
     def test_patch_test_prefix(self):
-        class Foo(object):
+        class Foo:
             thing = 'original'
 
             def foo_one(self):
@@ -1610,7 +1610,7 @@ class PatchTest(unittest.TestCase):
 
     @patch('unittest.mock.patch.TEST_PREFIX', 'bar')
     def test_patch_dict_test_prefix(self):
-        class Foo(object):
+        class Foo:
             def bar_one(self):
                 return dict(the_dict)
             def bar_two(self):
@@ -1898,7 +1898,7 @@ class PatchTest(unittest.TestCase):
 
     def test_stopall_lifo(self):
         stopped = []
-        class thing(object):
+        class thing:
             one = two = three = None
 
         def get_patch(attribute):

--- a/Lib/test/test_unittest/testmock/testwith.py
+++ b/Lib/test/test_unittest/testmock/testwith.py
@@ -38,7 +38,7 @@ class WithTest(unittest.TestCase):
 
 
     def test_patch_object_with_statement(self):
-        class Foo(object):
+        class Foo:
             something = 'foo'
         original = Foo.something
         with patch.object(Foo, 'something'):


### PR DESCRIPTION


<!-- gh-issue-number: gh-121692 -->
* Issue: gh-121692
<!-- /gh-issue-number -->
