### PR TITLE
gh-120823: Fix doc for ftplib.FTP.retrbinary()

### DIFF
--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -243,7 +243,7 @@ FTP objects
       Retrieve a file in binary transfer mode.
 
       :param str cmd:
-        An appropriate ``STOR`` command: :samp:`"STOR {filename}"`.
+        An appropriate ``RETR`` command: :samp:`"RETR {filename}"`.
 
       :param callback:
          A single parameter callable that is called


### PR DESCRIPTION
Fix typo in the documentation of ftplib.FTP.retrbinary().

<!-- gh-issue-number: gh-120823 -->
* Issue: gh-120823
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121697.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->