### PR TITLE
gh-91289: Reformat the text output of unittest

### DIFF
--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -555,12 +555,12 @@ class RunStringTests(TestBase):
 
     def setUp(self):
         super().setUp()
-        self.id = _interpreters.create()
+        self._id = _interpreters.create()
 
     def test_success(self):
         script, file = _captured_script('print("it worked!", end="")')
         with file:
-            _interpreters.run_string(self.id, script)
+            _interpreters.run_string(self._id, script)
             out = file.read()
 
         self.assertEqual(out, 'it worked!')
@@ -569,7 +569,7 @@ class RunStringTests(TestBase):
         script, file = _captured_script('print("it worked!", end="")')
         with file:
             def f():
-                _interpreters.run_string(self.id, script)
+                _interpreters.run_string(self._id, script)
 
             t = threading.Thread(target=f)
             t.start()
@@ -682,16 +682,16 @@ class RunStringTests(TestBase):
                     with open('{file.name}', 'w', encoding='utf-8') as out:
                         out.write('{expected}')
                 """)
-            _interpreters.run_string(self.id, script)
+            _interpreters.run_string(self._id, script)
 
             file.seek(0)
             content = file.read()
             self.assertEqual(content, expected)
 
     def test_already_running(self):
-        with _running(self.id):
+        with _running(self._id):
             with self.assertRaises(_interpreters.InterpreterError):
-                _interpreters.run_string(self.id, 'print("spam")')
+                _interpreters.run_string(self._id, 'print("spam")')
 
     def test_does_not_exist(self):
         id = 0
@@ -710,11 +710,11 @@ class RunStringTests(TestBase):
 
     def test_bad_script(self):
         with self.assertRaises(TypeError):
-            _interpreters.run_string(self.id, 10)
+            _interpreters.run_string(self._id, 10)
 
     def test_bytes_for_script(self):
         with self.assertRaises(TypeError):
-            _interpreters.run_string(self.id, b'print("spam")')
+            _interpreters.run_string(self._id, b'print("spam")')
 
     def test_with_shared(self):
         r, w = os.pipe()
@@ -735,8 +735,8 @@ class RunStringTests(TestBase):
             with open({w}, 'wb') as chan:
                 pickle.dump(ns, chan)
             """)
-        _interpreters.set___main___attrs(self.id, shared)
-        _interpreters.run_string(self.id, script)
+        _interpreters.set___main___attrs(self._id, shared)
+        _interpreters.run_string(self._id, script)
         with open(r, 'rb') as chan:
             ns = pickle.load(chan)
 
@@ -746,7 +746,7 @@ class RunStringTests(TestBase):
         self.assertIsNone(ns['cheddar'])
 
     def test_shared_overwrites(self):
-        _interpreters.run_string(self.id, dedent("""
+        _interpreters.run_string(self._id, dedent("""
             spam = 'eggs'
             ns1 = dict(vars())
             del ns1['__builtins__']
@@ -757,8 +757,8 @@ class RunStringTests(TestBase):
             ns2 = dict(vars())
             del ns2['__builtins__']
         """)
-        _interpreters.set___main___attrs(self.id, shared)
-        _interpreters.run_string(self.id, script)
+        _interpreters.set___main___attrs(self._id, shared)
+        _interpreters.run_string(self._id, script)
 
         r, w = os.pipe()
         script = dedent(f"""
@@ -768,7 +768,7 @@ class RunStringTests(TestBase):
             with open({w}, 'wb') as chan:
                 pickle.dump(ns, chan)
             """)
-        _interpreters.run_string(self.id, script)
+        _interpreters.run_string(self._id, script)
         with open(r, 'rb') as chan:
             ns = pickle.load(chan)
 
@@ -789,8 +789,8 @@ class RunStringTests(TestBase):
             with open({w}, 'wb') as chan:
                 pickle.dump(ns, chan)
             """)
-        _interpreters.set___main___attrs(self.id, shared)
-        _interpreters.run_string(self.id, script)
+        _interpreters.set___main___attrs(self._id, shared)
+        _interpreters.run_string(self._id, script)
         with open(r, 'rb') as chan:
             ns = pickle.load(chan)
 
@@ -798,7 +798,7 @@ class RunStringTests(TestBase):
 
     def test_main_reused(self):
         r, w = os.pipe()
-        _interpreters.run_string(self.id, dedent(f"""
+        _interpreters.run_string(self._id, dedent(f"""
             spam = True
 
             ns = dict(vars())
@@ -812,7 +812,7 @@ class RunStringTests(TestBase):
             ns1 = pickle.load(chan)
 
         r, w = os.pipe()
-        _interpreters.run_string(self.id, dedent(f"""
+        _interpreters.run_string(self._id, dedent(f"""
             eggs = False
 
             ns = dict(vars())
@@ -841,7 +841,7 @@ class RunStringTests(TestBase):
             with open({w}, 'wb') as chan:
                 pickle.dump(ns, chan)
             """)
-        _interpreters.run_string(self.id, script)
+        _interpreters.run_string(self._id, script)
         with open(r, 'rb') as chan:
             ns = pickle.load(chan)
 
@@ -886,13 +886,13 @@ class RunFailedTests(TestBase):
 
     def setUp(self):
         super().setUp()
-        self.id = _interpreters.create()
+        self._id = _interpreters.create()
 
     def add_module(self, modname, text):
         import tempfile
         tempdir = tempfile.mkdtemp()
         self.addCleanup(lambda: os_helper.rmtree(tempdir))
-        _interpreters.run_string(self.id, dedent(f"""
+        _interpreters.run_string(self._id, dedent(f"""
             import sys
             sys.path.insert(0, {tempdir!r})
             """))
@@ -914,11 +914,11 @@ class RunFailedTests(TestBase):
                 raise NeverError  # never raised
                 """).format(dedent(text))
             if fails:
-                err = _interpreters.run_string(self.id, script)
+                err = _interpreters.run_string(self._id, script)
                 self.assertIsNot(err, None)
                 return err
             else:
-                err = _interpreters.run_string(self.id, script)
+                err = _interpreters.run_string(self._id, script)
                 self.assertIs(err, None)
                 return None
         except:
@@ -1043,7 +1043,7 @@ class RunFuncTests(TestBase):
 
     def setUp(self):
         super().setUp()
-        self.id = _interpreters.create()
+        self._id = _interpreters.create()
 
     def test_success(self):
         r, w = os.pipe()
@@ -1053,8 +1053,8 @@ class RunFuncTests(TestBase):
             with open(w, 'w', encoding="utf-8") as spipe:
                 with contextlib.redirect_stdout(spipe):
                     print('it worked!', end='')
-        _interpreters.set___main___attrs(self.id, dict(w=w))
-        _interpreters.run_func(self.id, script)
+        _interpreters.set___main___attrs(self._id, dict(w=w))
+        _interpreters.run_func(self._id, script)
 
         with open(r, encoding="utf-8") as outfile:
             out = outfile.read()
@@ -1070,8 +1070,8 @@ class RunFuncTests(TestBase):
                 with contextlib.redirect_stdout(spipe):
                     print('it worked!', end='')
         def f():
-            _interpreters.set___main___attrs(self.id, dict(w=w))
-            _interpreters.run_func(self.id, script)
+            _interpreters.set___main___attrs(self._id, dict(w=w))
+            _interpreters.run_func(self._id, script)
         t = threading.Thread(target=f)
         t.start()
         t.join()
@@ -1091,8 +1091,8 @@ class RunFuncTests(TestBase):
                 with contextlib.redirect_stdout(spipe):
                     print('it worked!', end='')
         code = script.__code__
-        _interpreters.set___main___attrs(self.id, dict(w=w))
-        _interpreters.run_func(self.id, code)
+        _interpreters.set___main___attrs(self._id, dict(w=w))
+        _interpreters.run_func(self._id, code)
 
         with open(r, encoding="utf-8") as outfile:
             out = outfile.read()
@@ -1105,7 +1105,7 @@ class RunFuncTests(TestBase):
             assert spam
 
         with self.assertRaises(ValueError):
-            _interpreters.run_func(self.id, script)
+            _interpreters.run_func(self._id, script)
 
     # XXX This hasn't been fixed yet.
     @unittest.expectedFailure
@@ -1113,38 +1113,38 @@ class RunFuncTests(TestBase):
         def script():
             return 'spam'
         with self.assertRaises(ValueError):
-            _interpreters.run_func(self.id, script)
+            _interpreters.run_func(self._id, script)
 
     def test_args(self):
         with self.subTest('args'):
             def script(a, b=0):
                 assert a == b
             with self.assertRaises(ValueError):
-                _interpreters.run_func(self.id, script)
+                _interpreters.run_func(self._id, script)
 
         with self.subTest('*args'):
             def script(*args):
                 assert not args
             with self.assertRaises(ValueError):
-                _interpreters.run_func(self.id, script)
+                _interpreters.run_func(self._id, script)
 
         with self.subTest('**kwargs'):
             def script(**kwargs):
                 assert not kwargs
             with self.assertRaises(ValueError):
-                _interpreters.run_func(self.id, script)
+                _interpreters.run_func(self._id, script)
 
         with self.subTest('kwonly'):
             def script(*, spam=True):
                 assert spam
             with self.assertRaises(ValueError):
-                _interpreters.run_func(self.id, script)
+                _interpreters.run_func(self._id, script)
 
         with self.subTest('posonly'):
             def script(spam, /):
                 assert spam
             with self.assertRaises(ValueError):
-                _interpreters.run_func(self.id, script)
+                _interpreters.run_func(self._id, script)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -555,6 +555,7 @@ class RunStringTests(TestBase):
 
     def setUp(self):
         super().setUp()
+        # Use `_id`, because `id()` is part of TestCase API.
         self._id = _interpreters.create()
 
     def test_success(self):
@@ -886,6 +887,7 @@ class RunFailedTests(TestBase):
 
     def setUp(self):
         super().setUp()
+        # Use `_id`, because `id()` is part of TestCase API.
         self._id = _interpreters.create()
 
     def add_module(self, modname, text):
@@ -1043,6 +1045,7 @@ class RunFuncTests(TestBase):
 
     def setUp(self):
         super().setUp()
+        # Use `_id`, because `id()` is part of TestCase API.
         self._id = _interpreters.create()
 
     def test_success(self):

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1326,7 +1326,7 @@ class ArgsTestCase(BaseTestCase):
                                   parallel=True, stats=0)
 
     def parse_methods(self, output):
-        regex = re.compile("^test_regrtest_noop[\d]+\.Tests\.(test[^ .]+).*ok$", flags=re.MULTILINE)
+        regex = re.compile(r"^test_regrtest_noop\d+\.Tests\.(test[^ .]+).*ok$", flags=re.MULTILINE)
         return [match.group(1) for match in regex.finditer(output)]
 
     def test_ignorefile(self):
@@ -1452,7 +1452,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("--rerun", testname, exitcode=EXITCODE_BAD_TEST)
         self.check_executed_tests(output, [testname],
                                   rerun=Rerun(testname,
-                                              "test_regrtest_noop[\d]+.Tests.test_fail_always",
+                                              "test_regrtest_noop\d+.Tests.test_fail_always",
                                               success=False),
                                   stats=TestStats(3, 2))
 
@@ -1483,7 +1483,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("--rerun", testname, exitcode=0)
         self.check_executed_tests(output, [testname],
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop[\d]+.Tests.test_fail_once",
+                                              match="test_regrtest_noop\d+.Tests.test_fail_once",
                                               success=True),
                                   stats=TestStats(3, 1))
         os_helper.unlink(marker_filename)
@@ -1494,7 +1494,7 @@ class ArgsTestCase(BaseTestCase):
                                 exitcode=EXITCODE_RERUN_FAIL)
         self.check_executed_tests(output, [testname],
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop[\d]+.Tests.test_fail_once",
+                                              match="test_regrtest_noop\d+.Tests.test_fail_once",
                                               success=True),
                                   stats=TestStats(3, 1))
         os_helper.unlink(marker_filename)
@@ -1607,7 +1607,7 @@ class ArgsTestCase(BaseTestCase):
         self.check_executed_tests(output, testname,
                                   failed=[testname],
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop[\d]+.ExampleTests.test_success",
+                                              match="test_regrtest_noop\d+.ExampleTests.test_success",
                                               success=False),
                                   stats=2)
 
@@ -1629,7 +1629,7 @@ class ArgsTestCase(BaseTestCase):
         self.check_executed_tests(output, testname,
                                   failed=[testname],
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop[\d]+.ExampleTests.test_success",
+                                              match="test_regrtest_noop\d+.ExampleTests.test_success",
                                               success=False),
                                   stats=2)
 
@@ -1650,7 +1650,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("--rerun", testname, exitcode=EXITCODE_BAD_TEST)
         self.check_executed_tests(output, testname,
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop[\d]+.ExampleTests.test_success",
+                                              match="test_regrtest_noop\d+.ExampleTests.test_success",
                                               success=False),
                                   stats=2)
 
@@ -1672,7 +1672,7 @@ class ArgsTestCase(BaseTestCase):
         self.check_executed_tests(output, testname,
                                   failed=[testname],
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop[\d]+.ExampleTests.test_success",
+                                              match="test_regrtest_noop\d+.ExampleTests.test_success",
                                               success=False),
                                   stats=2)
 

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1176,7 +1176,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests('--forever', '--rerun', test, exitcode=0)
         self.check_executed_tests(output, [test]*3,
                                   rerun=Rerun(test,
-                                              match='test_regrtest_forever.ForeverTester.test_run',
+                                              match=r'test_regrtest_forever\.ForeverTester\.test_run',
                                               success=True),
                                   stats=TestStats(4, 1),
                                   forever=True)
@@ -1452,7 +1452,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("--rerun", testname, exitcode=EXITCODE_BAD_TEST)
         self.check_executed_tests(output, [testname],
                                   rerun=Rerun(testname,
-                                              "test_regrtest_noop\d+.Tests.test_fail_always",
+                                              match=r"test_regrtest_noop\d+\.Tests\.test_fail_always",
                                               success=False),
                                   stats=TestStats(3, 2))
 
@@ -1483,7 +1483,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("--rerun", testname, exitcode=0)
         self.check_executed_tests(output, [testname],
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop\d+.Tests.test_fail_once",
+                                              match=r"test_regrtest_noop\d+\.Tests\.test_fail_once",
                                               success=True),
                                   stats=TestStats(3, 1))
         os_helper.unlink(marker_filename)
@@ -1494,7 +1494,7 @@ class ArgsTestCase(BaseTestCase):
                                 exitcode=EXITCODE_RERUN_FAIL)
         self.check_executed_tests(output, [testname],
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop\d+.Tests.test_fail_once",
+                                              match=r"test_regrtest_noop\d+\.Tests\.test_fail_once",
                                               success=True),
                                   stats=TestStats(3, 1))
         os_helper.unlink(marker_filename)
@@ -1607,7 +1607,7 @@ class ArgsTestCase(BaseTestCase):
         self.check_executed_tests(output, testname,
                                   failed=[testname],
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop\d+.ExampleTests.test_success",
+                                              match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
                                               success=False),
                                   stats=2)
 
@@ -1629,7 +1629,7 @@ class ArgsTestCase(BaseTestCase):
         self.check_executed_tests(output, testname,
                                   failed=[testname],
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop\d+.ExampleTests.test_success",
+                                              match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
                                               success=False),
                                   stats=2)
 
@@ -1650,7 +1650,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("--rerun", testname, exitcode=EXITCODE_BAD_TEST)
         self.check_executed_tests(output, testname,
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop\d+.ExampleTests.test_success",
+                                              match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
                                               success=False),
                                   stats=2)
 
@@ -1672,7 +1672,7 @@ class ArgsTestCase(BaseTestCase):
         self.check_executed_tests(output, testname,
                                   failed=[testname],
                                   rerun=Rerun(testname,
-                                              match="test_regrtest_noop\d+.ExampleTests.test_success",
+                                              match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
                                               success=False),
                                   stats=2)
 

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1176,7 +1176,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests('--forever', '--rerun', test, exitcode=0)
         self.check_executed_tests(output, [test]*3,
                                   rerun=Rerun(test,
-                                              match='test_run',
+                                              match='test_regrtest_forever.ForeverTester.test_run',
                                               success=True),
                                   stats=TestStats(4, 1),
                                   forever=True)
@@ -1326,7 +1326,7 @@ class ArgsTestCase(BaseTestCase):
                                   parallel=True, stats=0)
 
     def parse_methods(self, output):
-        regex = re.compile("^(test[^ ]+).*ok$", flags=re.MULTILINE)
+        regex = re.compile("^test_regrtest_noop[\d]+\.Tests\.(test[^ .]+).*ok$", flags=re.MULTILINE)
         return [match.group(1) for match in regex.finditer(output)]
 
     def test_ignorefile(self):
@@ -1452,7 +1452,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("--rerun", testname, exitcode=EXITCODE_BAD_TEST)
         self.check_executed_tests(output, [testname],
                                   rerun=Rerun(testname,
-                                              "test_fail_always",
+                                              "test_regrtest_noop[\d]+.Tests.test_fail_always",
                                               success=False),
                                   stats=TestStats(3, 2))
 
@@ -1483,7 +1483,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("--rerun", testname, exitcode=0)
         self.check_executed_tests(output, [testname],
                                   rerun=Rerun(testname,
-                                              match="test_fail_once",
+                                              match="test_regrtest_noop[\d]+.Tests.test_fail_once",
                                               success=True),
                                   stats=TestStats(3, 1))
         os_helper.unlink(marker_filename)
@@ -1494,7 +1494,7 @@ class ArgsTestCase(BaseTestCase):
                                 exitcode=EXITCODE_RERUN_FAIL)
         self.check_executed_tests(output, [testname],
                                   rerun=Rerun(testname,
-                                              match="test_fail_once",
+                                              match="test_regrtest_noop[\d]+.Tests.test_fail_once",
                                               success=True),
                                   stats=TestStats(3, 1))
         os_helper.unlink(marker_filename)
@@ -1607,7 +1607,7 @@ class ArgsTestCase(BaseTestCase):
         self.check_executed_tests(output, testname,
                                   failed=[testname],
                                   rerun=Rerun(testname,
-                                              match="test_success",
+                                              match="test_regrtest_noop[\d]+.ExampleTests.test_success",
                                               success=False),
                                   stats=2)
 
@@ -1629,7 +1629,7 @@ class ArgsTestCase(BaseTestCase):
         self.check_executed_tests(output, testname,
                                   failed=[testname],
                                   rerun=Rerun(testname,
-                                              match="test_success",
+                                              match="test_regrtest_noop[\d]+.ExampleTests.test_success",
                                               success=False),
                                   stats=2)
 
@@ -1650,7 +1650,7 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("--rerun", testname, exitcode=EXITCODE_BAD_TEST)
         self.check_executed_tests(output, testname,
                                   rerun=Rerun(testname,
-                                              match="test_success",
+                                              match="test_regrtest_noop[\d]+.ExampleTests.test_success",
                                               success=False),
                                   stats=2)
 
@@ -1672,7 +1672,7 @@ class ArgsTestCase(BaseTestCase):
         self.check_executed_tests(output, testname,
                                   failed=[testname],
                                   rerun=Rerun(testname,
-                                              match="test_success",
+                                              match="test_regrtest_noop[\d]+.ExampleTests.test_success",
                                               success=False),
                                   stats=2)
 

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -1174,10 +1174,11 @@ class ArgsTestCase(BaseTestCase):
 
         # --forever --rerun
         output = self.run_tests('--forever', '--rerun', test, exitcode=0)
+        rerun = Rerun(test,
+                      match=r'test_regrtest_forever\.ForeverTester\.test_run',
+                      success=True)
         self.check_executed_tests(output, [test]*3,
-                                  rerun=Rerun(test,
-                                              match=r'test_regrtest_forever\.ForeverTester\.test_run',
-                                              success=True),
+                                  rerun=rerun,
                                   stats=TestStats(4, 1),
                                   forever=True)
 
@@ -1326,7 +1327,8 @@ class ArgsTestCase(BaseTestCase):
                                   parallel=True, stats=0)
 
     def parse_methods(self, output):
-        regex = re.compile(r"^test_regrtest_noop\d+\.Tests\.(test[^ .]+).*ok$", flags=re.MULTILINE)
+        regex = re.compile(r"^test_regrtest_noop\d+\.Tests\.(test[^ .]+).*ok$",
+                           flags=re.MULTILINE)
         return [match.group(1) for match in regex.finditer(output)]
 
     def test_ignorefile(self):
@@ -1450,10 +1452,11 @@ class ArgsTestCase(BaseTestCase):
         testname = self.create_test(code=code)
 
         output = self.run_tests("--rerun", testname, exitcode=EXITCODE_BAD_TEST)
+        rerun = Rerun(testname,
+                      match=r"test_regrtest_noop\d+\.Tests\.test_fail_always",
+                      success=False)
         self.check_executed_tests(output, [testname],
-                                  rerun=Rerun(testname,
-                                              match=r"test_regrtest_noop\d+\.Tests\.test_fail_always",
-                                              success=False),
+                                  rerun=rerun,
                                   stats=TestStats(3, 2))
 
     def test_rerun_success(self):
@@ -1481,10 +1484,11 @@ class ArgsTestCase(BaseTestCase):
 
         # FAILURE then SUCCESS => exit code 0
         output = self.run_tests("--rerun", testname, exitcode=0)
+        rerun = Rerun(testname,
+                      match=r"test_regrtest_noop\d+\.Tests\.test_fail_once",
+                      success=True)
         self.check_executed_tests(output, [testname],
-                                  rerun=Rerun(testname,
-                                              match=r"test_regrtest_noop\d+\.Tests\.test_fail_once",
-                                              success=True),
+                                  rerun=rerun,
                                   stats=TestStats(3, 1))
         os_helper.unlink(marker_filename)
 
@@ -1492,10 +1496,11 @@ class ArgsTestCase(BaseTestCase):
         # on "FAILURE then SUCCESS" state.
         output = self.run_tests("--rerun", "--fail-rerun", testname,
                                 exitcode=EXITCODE_RERUN_FAIL)
+        rerun = Rerun(testname,
+                      match=r"test_regrtest_noop\d+\.Tests\.test_fail_once",
+                      success=True)
         self.check_executed_tests(output, [testname],
-                                  rerun=Rerun(testname,
-                                              match=r"test_regrtest_noop\d+\.Tests\.test_fail_once",
-                                              success=True),
+                                  rerun=rerun,
                                   stats=TestStats(3, 1))
         os_helper.unlink(marker_filename)
 
@@ -1604,11 +1609,12 @@ class ArgsTestCase(BaseTestCase):
         testname = self.create_test(code=code)
 
         output = self.run_tests("--rerun", testname, exitcode=EXITCODE_BAD_TEST)
+        rerun = Rerun(testname,
+                      match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
+                      success=False)
         self.check_executed_tests(output, testname,
                                   failed=[testname],
-                                  rerun=Rerun(testname,
-                                              match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
-                                              success=False),
+                                  rerun=rerun,
                                   stats=2)
 
     def test_rerun_teardown_hook_failure(self):
@@ -1626,11 +1632,12 @@ class ArgsTestCase(BaseTestCase):
         testname = self.create_test(code=code)
 
         output = self.run_tests("--rerun", testname, exitcode=EXITCODE_BAD_TEST)
+        rerun = Rerun(testname,
+                      match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
+                      success=False)
         self.check_executed_tests(output, testname,
                                   failed=[testname],
-                                  rerun=Rerun(testname,
-                                              match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
-                                              success=False),
+                                  rerun=rerun,
                                   stats=2)
 
     def test_rerun_async_setup_hook_failure(self):
@@ -1648,10 +1655,11 @@ class ArgsTestCase(BaseTestCase):
         testname = self.create_test(code=code)
 
         output = self.run_tests("--rerun", testname, exitcode=EXITCODE_BAD_TEST)
+        rerun = Rerun(testname,
+                      match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
+                      success=False)
         self.check_executed_tests(output, testname,
-                                  rerun=Rerun(testname,
-                                              match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
-                                              success=False),
+                                  rerun=rerun,
                                   stats=2)
 
     def test_rerun_async_teardown_hook_failure(self):
@@ -1669,11 +1677,12 @@ class ArgsTestCase(BaseTestCase):
         testname = self.create_test(code=code)
 
         output = self.run_tests("--rerun", testname, exitcode=EXITCODE_BAD_TEST)
+        rerun = Rerun(testname,
+                      match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
+                      success=False)
         self.check_executed_tests(output, testname,
                                   failed=[testname],
-                                  rerun=Rerun(testname,
-                                              match=r"test_regrtest_noop\d+\.ExampleTests\.test_success",
-                                              success=False),
+                                  rerun=rerun,
                                   stats=2)
 
     def test_no_tests_ran(self):

--- a/Lib/test/test_unittest/test_program.py
+++ b/Lib/test/test_unittest/test_program.py
@@ -128,9 +128,9 @@ class Test_TestProgram(unittest.TestCase):
                                 testLoader=self.TestLoader(self.FooBar))
         self.assertTrue(hasattr(program, 'result'))
         out = stream.getvalue()
-        self.assertIn('\nFAIL: testFail ', out)
-        self.assertIn('\nERROR: testError ', out)
-        self.assertIn('\nUNEXPECTED SUCCESS: testUnexpectedSuccess ', out)
+        self.assertIn('\nFAIL: test.test_unittest.test_program.Test_TestProgram.FooBar.testFail\n', out)
+        self.assertIn('\nERROR: test.test_unittest.test_program.Test_TestProgram.FooBar.testError\n', out)
+        self.assertIn('\nUNEXPECTED SUCCESS: test.test_unittest.test_program.Test_TestProgram.FooBar.testUnexpectedSuccess\n', out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
         self.assertTrue(out.endswith(expected))
@@ -145,9 +145,9 @@ class Test_TestProgram(unittest.TestCase):
                 testLoader=self.TestLoader(self.FooBar))
         self.assertEqual(cm.exception.code, 1)
         out = stream.getvalue()
-        self.assertIn('\nFAIL: testFail ', out)
-        self.assertIn('\nERROR: testError ', out)
-        self.assertIn('\nUNEXPECTED SUCCESS: testUnexpectedSuccess ', out)
+        self.assertIn('\nFAIL: test.test_unittest.test_program.Test_TestProgram.FooBar.testFail\n', out)
+        self.assertIn('\nERROR: test.test_unittest.test_program.Test_TestProgram.FooBar.testError\n', out)
+        self.assertIn('\nUNEXPECTED SUCCESS: test.test_unittest.test_program.Test_TestProgram.FooBar.testUnexpectedSuccess\n', out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
         self.assertTrue(out.endswith(expected))
@@ -160,9 +160,9 @@ class Test_TestProgram(unittest.TestCase):
                 testRunner=unittest.TextTestRunner(stream=stream),
                 testLoader=self.TestLoader(self.FooBar))
         out = stream.getvalue()
-        self.assertIn('\nFAIL: testFail ', out)
-        self.assertIn('\nERROR: testError ', out)
-        self.assertIn('\nUNEXPECTED SUCCESS: testUnexpectedSuccess ', out)
+        self.assertIn('\nFAIL: test.test_unittest.test_program.Test_TestProgram.FooBar.testFail\n', out)
+        self.assertIn('\nERROR: test.test_unittest.test_program.Test_TestProgram.FooBar.testError\n', out)
+        self.assertIn('\nUNEXPECTED SUCCESS: test.test_unittest.test_program.Test_TestProgram.FooBar.testUnexpectedSuccess\n', out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
         self.assertTrue(out.endswith(expected))

--- a/Lib/test/test_unittest/test_program.py
+++ b/Lib/test/test_unittest/test_program.py
@@ -128,9 +128,16 @@ class Test_TestProgram(unittest.TestCase):
                                 testLoader=self.TestLoader(self.FooBar))
         self.assertTrue(hasattr(program, 'result'))
         out = stream.getvalue()
-        self.assertIn('\nFAIL: test.test_unittest.test_program.Test_TestProgram.FooBar.testFail\n', out)
-        self.assertIn('\nERROR: test.test_unittest.test_program.Test_TestProgram.FooBar.testError\n', out)
-        self.assertIn('\nUNEXPECTED SUCCESS: test.test_unittest.test_program.Test_TestProgram.FooBar.testUnexpectedSuccess\n', out)
+        self.assertIn(
+            '\nFAIL: test.test_unittest.test_program.Test_TestProgram.FooBar.testFail\n',
+            out)
+        self.assertIn(
+            '\nERROR: test.test_unittest.test_program.Test_TestProgram.FooBar.testError\n',
+            out)
+        self.assertIn(
+            ('\nUNEXPECTED SUCCESS: test.test_unittest.test_program.Test_TestProgram.'
+             'FooBar.testUnexpectedSuccess\n'),
+            out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
         self.assertTrue(out.endswith(expected))
@@ -145,9 +152,16 @@ class Test_TestProgram(unittest.TestCase):
                 testLoader=self.TestLoader(self.FooBar))
         self.assertEqual(cm.exception.code, 1)
         out = stream.getvalue()
-        self.assertIn('\nFAIL: test.test_unittest.test_program.Test_TestProgram.FooBar.testFail\n', out)
-        self.assertIn('\nERROR: test.test_unittest.test_program.Test_TestProgram.FooBar.testError\n', out)
-        self.assertIn('\nUNEXPECTED SUCCESS: test.test_unittest.test_program.Test_TestProgram.FooBar.testUnexpectedSuccess\n', out)
+        self.assertIn(
+            '\nFAIL: test.test_unittest.test_program.Test_TestProgram.FooBar.testFail\n',
+            out)
+        self.assertIn(
+            '\nERROR: test.test_unittest.test_program.Test_TestProgram.FooBar.testError\n',
+            out)
+        self.assertIn(
+            ('\nUNEXPECTED SUCCESS: test.test_unittest.test_program.Test_TestProgram.'
+             'FooBar.testUnexpectedSuccess\n'),
+            out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
         self.assertTrue(out.endswith(expected))
@@ -160,9 +174,16 @@ class Test_TestProgram(unittest.TestCase):
                 testRunner=unittest.TextTestRunner(stream=stream),
                 testLoader=self.TestLoader(self.FooBar))
         out = stream.getvalue()
-        self.assertIn('\nFAIL: test.test_unittest.test_program.Test_TestProgram.FooBar.testFail\n', out)
-        self.assertIn('\nERROR: test.test_unittest.test_program.Test_TestProgram.FooBar.testError\n', out)
-        self.assertIn('\nUNEXPECTED SUCCESS: test.test_unittest.test_program.Test_TestProgram.FooBar.testUnexpectedSuccess\n', out)
+        self.assertIn(
+            '\nFAIL: test.test_unittest.test_program.Test_TestProgram.FooBar.testFail\n',
+            out)
+        self.assertIn(
+            '\nERROR: test.test_unittest.test_program.Test_TestProgram.FooBar.testError\n',
+            out)
+        self.assertIn(
+            ('\nUNEXPECTED SUCCESS: test.test_unittest.test_program.Test_TestProgram.'
+             'FooBar.testUnexpectedSuccess\n'),
+            out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
         self.assertTrue(out.endswith(expected))

--- a/Lib/test/test_unittest/test_result.py
+++ b/Lib/test/test_unittest/test_result.py
@@ -464,35 +464,34 @@ class Test_TextTestResult(unittest.TestCase):
         result = unittest.TextTestResult(None, True, 1)
         self.assertEqual(
                 result.getDescription(self),
-                'testGetDescriptionWithoutDocstring (' + __name__ +
-                '.Test_TextTestResult.testGetDescriptionWithoutDocstring)')
+                __name__ +
+                '.Test_TextTestResult.testGetDescriptionWithoutDocstring')
 
     def testGetSubTestDescriptionWithoutDocstring(self):
         with self.subTest(foo=1, bar=2):
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
                     result.getDescription(self._subtest),
-                    'testGetSubTestDescriptionWithoutDocstring (' + __name__ +
-                    '.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring) (foo=1, bar=2)')
+                    __name__ +
+                    '.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring (foo=1, bar=2)')
 
         with self.subTest('some message'):
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
                     result.getDescription(self._subtest),
-                    'testGetSubTestDescriptionWithoutDocstring (' + __name__ +
-                    '.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring) [some message]')
+                    __name__ +
+                    '.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring [some message]')
 
     def testGetSubTestDescriptionWithoutDocstringAndParams(self):
         with self.subTest():
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
                     result.getDescription(self._subtest),
-                    'testGetSubTestDescriptionWithoutDocstringAndParams '
-                    '(' + __name__ + '.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstringAndParams) '
+                    __name__ + '.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstringAndParams '
                     '(<subtest>)')
 
     def testGetSubTestDescriptionForFalseValues(self):
-        expected = 'testGetSubTestDescriptionForFalseValues (%s.Test_TextTestResult.testGetSubTestDescriptionForFalseValues) [%s]'
+        expected = '%s.Test_TextTestResult.testGetSubTestDescriptionForFalseValues [%s]'
         result = unittest.TextTestResult(None, True, 1)
         for arg in [0, None, []]:
             with self.subTest(arg):
@@ -507,8 +506,7 @@ class Test_TextTestResult(unittest.TestCase):
                 result = unittest.TextTestResult(None, True, 1)
                 self.assertEqual(
                         result.getDescription(self._subtest),
-                        'testGetNestedSubTestDescriptionWithoutDocstring '
-                        '(' + __name__ + '.Test_TextTestResult.testGetNestedSubTestDescriptionWithoutDocstring) '
+                        __name__ + '.Test_TextTestResult.testGetNestedSubTestDescriptionWithoutDocstring '
                         '(baz=2, bar=3, foo=1)')
 
     def testGetDuplicatedNestedSubTestDescriptionWithoutDocstring(self):
@@ -517,8 +515,7 @@ class Test_TextTestResult(unittest.TestCase):
                 result = unittest.TextTestResult(None, True, 1)
                 self.assertEqual(
                         result.getDescription(self._subtest),
-                        'testGetDuplicatedNestedSubTestDescriptionWithoutDocstring '
-                        '(' + __name__ + '.Test_TextTestResult.testGetDuplicatedNestedSubTestDescriptionWithoutDocstring) (baz=3, bar=4, foo=1)')
+                        __name__ + '.Test_TextTestResult.testGetDuplicatedNestedSubTestDescriptionWithoutDocstring (baz=3, bar=4, foo=1)')
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
@@ -527,9 +524,9 @@ class Test_TextTestResult(unittest.TestCase):
         result = unittest.TextTestResult(None, True, 1)
         self.assertEqual(
                 result.getDescription(self),
-               ('testGetDescriptionWithOneLineDocstring '
-                '(' + __name__ + '.Test_TextTestResult.testGetDescriptionWithOneLineDocstring)\n'
-                'Tests getDescription() for a method with a docstring.'))
+               ('Tests getDescription() for a method with a docstring. '
+                '(' + __name__ + '.Test_TextTestResult.testGetDescriptionWithOneLineDocstring)'
+                ))
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
@@ -539,11 +536,10 @@ class Test_TextTestResult(unittest.TestCase):
         with self.subTest(foo=1, bar=2):
             self.assertEqual(
                 result.getDescription(self._subtest),
-               ('testGetSubTestDescriptionWithOneLineDocstring '
-                '(' + __name__ + '.Test_TextTestResult.testGetSubTestDescriptionWithOneLineDocstring) '
-                '(foo=1, bar=2)\n'
-
-                'Tests getDescription() for a method with a docstring.'))
+               ('Tests getDescription() for a method with a docstring. '
+                '(' + __name__ + '.Test_TextTestResult.testGetSubTestDescriptionWithOneLineDocstring '
+                '(foo=1, bar=2))'
+                ))
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
@@ -554,10 +550,10 @@ class Test_TextTestResult(unittest.TestCase):
         result = unittest.TextTestResult(None, True, 1)
         self.assertEqual(
                 result.getDescription(self),
-               ('testGetDescriptionWithMultiLineDocstring '
-                '(' + __name__ + '.Test_TextTestResult.testGetDescriptionWithMultiLineDocstring)\n'
-                'Tests getDescription() for a method with a longer '
-                'docstring.'))
+               ('Tests getDescription() for a method with a longer '
+                'docstring. '
+                '(' + __name__ + '.Test_TextTestResult.testGetDescriptionWithMultiLineDocstring)'
+                ))
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
@@ -569,11 +565,11 @@ class Test_TextTestResult(unittest.TestCase):
         with self.subTest(foo=1, bar=2):
             self.assertEqual(
                 result.getDescription(self._subtest),
-               ('testGetSubTestDescriptionWithMultiLineDocstring '
-                '(' + __name__ + '.Test_TextTestResult.testGetSubTestDescriptionWithMultiLineDocstring) '
-                '(foo=1, bar=2)\n'
-                'Tests getDescription() for a method with a longer '
-                'docstring.'))
+               ('Tests getDescription() for a method with a longer '
+                'docstring. '
+                '(' + __name__ + '.Test_TextTestResult.testGetSubTestDescriptionWithMultiLineDocstring '
+                '(foo=1, bar=2))'
+                ))
 
     class Test(unittest.TestCase):
         def testSuccess(self):
@@ -630,17 +626,17 @@ class Test_TextTestResult(unittest.TestCase):
     def testLongOutput(self):
         classname = f'{__name__}.{self.Test.__qualname__}'
         self.assertEqual(self._run_test('testSuccess', 2),
-                         f'testSuccess ({classname}.testSuccess) ... ok\n')
+                         f'{classname}.testSuccess ... ok\n')
         self.assertEqual(self._run_test('testSkip', 2),
-                         f"testSkip ({classname}.testSkip) ... skipped 'skip'\n")
+                         f"{classname}.testSkip ... skipped 'skip'\n")
         self.assertEqual(self._run_test('testFail', 2),
-                         f'testFail ({classname}.testFail) ... FAIL\n')
+                         f'{classname}.testFail ... FAIL\n')
         self.assertEqual(self._run_test('testError', 2),
-                         f'testError ({classname}.testError) ... ERROR\n')
+                         f'{classname}.testError ... ERROR\n')
         self.assertEqual(self._run_test('testExpectedFailure', 2),
-                         f'testExpectedFailure ({classname}.testExpectedFailure) ... expected failure\n')
+                         f'{classname}.testExpectedFailure ... expected failure\n')
         self.assertEqual(self._run_test('testUnexpectedSuccess', 2),
-                         f'testUnexpectedSuccess ({classname}.testUnexpectedSuccess) ... unexpected success\n')
+                         f'{classname}.testUnexpectedSuccess ... unexpected success\n')
 
     def testDotsOutputSubTestSuccess(self):
         self.assertEqual(self._run_test('testSubTestSuccess', 1), '.')
@@ -648,7 +644,7 @@ class Test_TextTestResult(unittest.TestCase):
     def testLongOutputSubTestSuccess(self):
         classname = f'{__name__}.{self.Test.__qualname__}'
         self.assertEqual(self._run_test('testSubTestSuccess', 2),
-                         f'testSubTestSuccess ({classname}.testSubTestSuccess) ... ok\n')
+                         f'{classname}.testSubTestSuccess ... ok\n')
 
     def testDotsOutputSubTestMixed(self):
         self.assertEqual(self._run_test('testSubTestMixed', 1), 'sFE')
@@ -656,10 +652,10 @@ class Test_TextTestResult(unittest.TestCase):
     def testLongOutputSubTestMixed(self):
         classname = f'{__name__}.{self.Test.__qualname__}'
         self.assertEqual(self._run_test('testSubTestMixed', 2),
-                f'testSubTestMixed ({classname}.testSubTestMixed) ... \n'
-                f"  testSubTestMixed ({classname}.testSubTestMixed) [skip] (b=2) ... skipped 'skip'\n"
-                f'  testSubTestMixed ({classname}.testSubTestMixed) [fail] (c=3) ... FAIL\n'
-                f'  testSubTestMixed ({classname}.testSubTestMixed) [error] (d=4) ... ERROR\n')
+                f'{classname}.testSubTestMixed ... \n'
+                f"  {classname}.testSubTestMixed [skip] (b=2) ... skipped 'skip'\n"
+                f'  {classname}.testSubTestMixed [fail] (c=3) ... FAIL\n'
+                f'  {classname}.testSubTestMixed [error] (d=4) ... ERROR\n')
 
     def testDotsOutputTearDownFail(self):
         out = self._run_test('testSuccess', 1, AssertionError('fail'))
@@ -675,19 +671,19 @@ class Test_TextTestResult(unittest.TestCase):
         classname = f'{__name__}.{self.Test.__qualname__}'
         out = self._run_test('testSuccess', 2, AssertionError('fail'))
         self.assertEqual(out,
-                         f'testSuccess ({classname}.testSuccess) ... FAIL\n')
+                         f'{classname}.testSuccess ... FAIL\n')
         out = self._run_test('testError', 2, AssertionError('fail'))
         self.assertEqual(out,
-                         f'testError ({classname}.testError) ... ERROR\n'
-                         f'testError ({classname}.testError) ... FAIL\n')
+                         f'{classname}.testError ... ERROR\n'
+                         f'{classname}.testError ... FAIL\n')
         out = self._run_test('testFail', 2, Exception('error'))
         self.assertEqual(out,
-                         f'testFail ({classname}.testFail) ... FAIL\n'
-                         f'testFail ({classname}.testFail) ... ERROR\n')
+                         f'{classname}.testFail ... FAIL\n'
+                         f'{classname}.testFail ... ERROR\n')
         out = self._run_test('testSkip', 2, AssertionError('fail'))
         self.assertEqual(out,
-                         f"testSkip ({classname}.testSkip) ... skipped 'skip'\n"
-                         f'testSkip ({classname}.testSkip) ... FAIL\n')
+                         f"{classname}.testSkip ... skipped 'skip'\n"
+                         f'{classname}.testSkip ... FAIL\n')
 
 
 classDict = dict(unittest.TestResult.__dict__)
@@ -900,7 +896,7 @@ class TestOutputBuffering(unittest.TestCase):
         expected_out = '\nStdout:\nset up\n'
         self.assertEqual(stdout.getvalue(), expected_out)
         self.assertEqual(len(result.errors), 1)
-        description = f'test_foo ({strclass(Foo)}.test_foo)'
+        description = f'{strclass(Foo)}.test_foo'
         test_case, formatted_exc = result.errors[0]
         self.assertEqual(str(test_case), description)
         self.assertIn('ZeroDivisionError: division by zero', formatted_exc)
@@ -922,7 +918,7 @@ class TestOutputBuffering(unittest.TestCase):
         expected_out = '\nStdout:\ntear down\n'
         self.assertEqual(stdout.getvalue(), expected_out)
         self.assertEqual(len(result.errors), 1)
-        description = f'test_foo ({strclass(Foo)}.test_foo)'
+        description = f'{strclass(Foo)}.test_foo'
         test_case, formatted_exc = result.errors[0]
         self.assertEqual(str(test_case), description)
         self.assertIn('ZeroDivisionError: division by zero', formatted_exc)
@@ -945,7 +941,7 @@ class TestOutputBuffering(unittest.TestCase):
         expected_out = '\nStdout:\nset up\ndo cleanup2\ndo cleanup1\n'
         self.assertEqual(stdout.getvalue(), expected_out)
         self.assertEqual(len(result.errors), 2)
-        description = f'test_foo ({strclass(Foo)}.test_foo)'
+        description = f'{strclass(Foo)}.test_foo'
         test_case, formatted_exc = result.errors[0]
         self.assertEqual(str(test_case), description)
         self.assertIn('ValueError: bad cleanup2', formatted_exc)
@@ -976,7 +972,7 @@ class TestOutputBuffering(unittest.TestCase):
         expected_out = '\nStdout:\nset up\ndo cleanup2\ndo cleanup1\n'
         self.assertEqual(stdout.getvalue(), expected_out)
         self.assertEqual(len(result.errors), 3)
-        description = f'test_foo ({strclass(Foo)}.test_foo)'
+        description = f'{strclass(Foo)}.test_foo'
         test_case, formatted_exc = result.errors[0]
         self.assertEqual(str(test_case), description)
         self.assertIn('ZeroDivisionError: division by zero', formatted_exc)
@@ -1019,7 +1015,7 @@ class TestOutputBuffering(unittest.TestCase):
         expected_out = '\nStdout:\nset up\ntear down\ndo cleanup2\ndo cleanup1\n'
         self.assertEqual(stdout.getvalue(), expected_out)
         self.assertEqual(len(result.errors), 3)
-        description = f'test_foo ({strclass(Foo)}.test_foo)'
+        description = f'{strclass(Foo)}.test_foo'
         test_case, formatted_exc = result.errors[0]
         self.assertEqual(str(test_case), description)
         self.assertIn('ZeroDivisionError: division by zero', formatted_exc)

--- a/Lib/test/test_unittest/test_result.py
+++ b/Lib/test/test_unittest/test_result.py
@@ -464,30 +464,27 @@ class Test_TextTestResult(unittest.TestCase):
         result = unittest.TextTestResult(None, True, 1)
         self.assertEqual(
                 result.getDescription(self),
-                __name__ +
-                '.Test_TextTestResult.testGetDescriptionWithoutDocstring')
+                f'{__name__}.Test_TextTestResult.testGetDescriptionWithoutDocstring')
 
     def testGetSubTestDescriptionWithoutDocstring(self):
         with self.subTest(foo=1, bar=2):
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
                     result.getDescription(self._subtest),
-                    __name__ +
-                    '.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring (foo=1, bar=2)')
+                    f'{__name__}.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring (foo=1, bar=2)')
 
         with self.subTest('some message'):
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
                     result.getDescription(self._subtest),
-                    __name__ +
-                    '.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring [some message]')
+                    f'{__name__}.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring [some message]')
 
     def testGetSubTestDescriptionWithoutDocstringAndParams(self):
         with self.subTest():
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
                     result.getDescription(self._subtest),
-                    __name__ + '.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstringAndParams '
+                    f'{__name__}.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstringAndParams '
                     '(<subtest>)')
 
     def testGetSubTestDescriptionForFalseValues(self):
@@ -506,7 +503,7 @@ class Test_TextTestResult(unittest.TestCase):
                 result = unittest.TextTestResult(None, True, 1)
                 self.assertEqual(
                         result.getDescription(self._subtest),
-                        __name__ + '.Test_TextTestResult.testGetNestedSubTestDescriptionWithoutDocstring '
+                        f'{__name__}.Test_TextTestResult.testGetNestedSubTestDescriptionWithoutDocstring '
                         '(baz=2, bar=3, foo=1)')
 
     def testGetDuplicatedNestedSubTestDescriptionWithoutDocstring(self):
@@ -515,7 +512,7 @@ class Test_TextTestResult(unittest.TestCase):
                 result = unittest.TextTestResult(None, True, 1)
                 self.assertEqual(
                         result.getDescription(self._subtest),
-                        __name__ + '.Test_TextTestResult.testGetDuplicatedNestedSubTestDescriptionWithoutDocstring (baz=3, bar=4, foo=1)')
+                        f'{__name__}.Test_TextTestResult.testGetDuplicatedNestedSubTestDescriptionWithoutDocstring (baz=3, bar=4, foo=1)')
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
@@ -525,7 +522,7 @@ class Test_TextTestResult(unittest.TestCase):
         self.assertEqual(
                 result.getDescription(self),
                ('Tests getDescription() for a method with a docstring. '
-                '(' + __name__ + '.Test_TextTestResult.testGetDescriptionWithOneLineDocstring)'
+                f'({__name__}.Test_TextTestResult.testGetDescriptionWithOneLineDocstring)'
                 ))
 
     @unittest.skipIf(sys.flags.optimize >= 2,
@@ -537,7 +534,7 @@ class Test_TextTestResult(unittest.TestCase):
             self.assertEqual(
                 result.getDescription(self._subtest),
                ('Tests getDescription() for a method with a docstring. '
-                '(' + __name__ + '.Test_TextTestResult.testGetSubTestDescriptionWithOneLineDocstring '
+                f'({__name__}.Test_TextTestResult.testGetSubTestDescriptionWithOneLineDocstring '
                 '(foo=1, bar=2))'
                 ))
 
@@ -552,7 +549,7 @@ class Test_TextTestResult(unittest.TestCase):
                 result.getDescription(self),
                ('Tests getDescription() for a method with a longer '
                 'docstring. '
-                '(' + __name__ + '.Test_TextTestResult.testGetDescriptionWithMultiLineDocstring)'
+                f'({__name__}.Test_TextTestResult.testGetDescriptionWithMultiLineDocstring)'
                 ))
 
     @unittest.skipIf(sys.flags.optimize >= 2,
@@ -567,7 +564,7 @@ class Test_TextTestResult(unittest.TestCase):
                 result.getDescription(self._subtest),
                ('Tests getDescription() for a method with a longer '
                 'docstring. '
-                '(' + __name__ + '.Test_TextTestResult.testGetSubTestDescriptionWithMultiLineDocstring '
+                f'({__name__}.Test_TextTestResult.testGetSubTestDescriptionWithMultiLineDocstring '
                 '(foo=1, bar=2))'
                 ))
 

--- a/Lib/test/test_unittest/test_result.py
+++ b/Lib/test/test_unittest/test_result.py
@@ -470,22 +470,24 @@ class Test_TextTestResult(unittest.TestCase):
         with self.subTest(foo=1, bar=2):
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
-                    result.getDescription(self._subtest),
-                    f'{__name__}.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring (foo=1, bar=2)')
+                result.getDescription(self._subtest),
+                f'{__name__}.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring '
+                '(foo=1, bar=2)')
 
         with self.subTest('some message'):
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
-                    result.getDescription(self._subtest),
-                    f'{__name__}.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring [some message]')
+                result.getDescription(self._subtest),
+                f'{__name__}.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstring '
+                '[some message]')
 
     def testGetSubTestDescriptionWithoutDocstringAndParams(self):
         with self.subTest():
             result = unittest.TextTestResult(None, True, 1)
             self.assertEqual(
-                    result.getDescription(self._subtest),
-                    f'{__name__}.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstringAndParams '
-                    '(<subtest>)')
+                result.getDescription(self._subtest),
+                f'{__name__}.Test_TextTestResult.testGetSubTestDescriptionWithoutDocstringAndParams '
+                '(<subtest>)')
 
     def testGetSubTestDescriptionForFalseValues(self):
         expected = '%s.Test_TextTestResult.testGetSubTestDescriptionForFalseValues [%s]'
@@ -502,17 +504,18 @@ class Test_TextTestResult(unittest.TestCase):
             with self.subTest(baz=2, bar=3):
                 result = unittest.TextTestResult(None, True, 1)
                 self.assertEqual(
-                        result.getDescription(self._subtest),
-                        f'{__name__}.Test_TextTestResult.testGetNestedSubTestDescriptionWithoutDocstring '
-                        '(baz=2, bar=3, foo=1)')
+                    result.getDescription(self._subtest),
+                    f'{__name__}.Test_TextTestResult.testGetNestedSubTestDescriptionWithoutDocstring '
+                    '(baz=2, bar=3, foo=1)')
 
     def testGetDuplicatedNestedSubTestDescriptionWithoutDocstring(self):
         with self.subTest(foo=1, bar=2):
             with self.subTest(baz=3, bar=4):
                 result = unittest.TextTestResult(None, True, 1)
                 self.assertEqual(
-                        result.getDescription(self._subtest),
-                        f'{__name__}.Test_TextTestResult.testGetDuplicatedNestedSubTestDescriptionWithoutDocstring (baz=3, bar=4, foo=1)')
+                    result.getDescription(self._subtest),
+                    f'{__name__}.Test_TextTestResult.testGetDuplicatedNestedSubTestDescriptionWithoutDocstring '
+                    '(baz=3, bar=4, foo=1)')
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")

--- a/Lib/test/test_unittest/test_runner.py
+++ b/Lib/test/test_unittest/test_runner.py
@@ -7,6 +7,7 @@ from test import support
 
 import unittest
 from unittest.case import _Outcome
+from unittest.runner import _WritelnDecorator
 
 from test.test_unittest.support import (
     BufferedWriter,

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -528,7 +528,7 @@ class TestCase(object):
         return hash((type(self), self._testMethodName))
 
     def __str__(self):
-        return "%s (%s.%s)" % (self._testMethodName, strclass(self.__class__), self._testMethodName)
+        return self.id()
 
     def __repr__(self):
         return "<%s testMethod=%s>" % \

--- a/Lib/unittest/runner.py
+++ b/Lib/unittest/runner.py
@@ -49,7 +49,7 @@ class TextTestResult(result.TestResult):
     def getDescription(self, test):
         doc_first_line = test.shortDescription()
         if self.descriptions and doc_first_line:
-            return '\n'.join((str(test), doc_first_line))
+            return doc_first_line + ' (' + str(test) + ')'
         else:
             return str(test)
 

--- a/Lib/unittest/runner.py
+++ b/Lib/unittest/runner.py
@@ -49,7 +49,7 @@ class TextTestResult(result.TestResult):
     def getDescription(self, test):
         doc_first_line = test.shortDescription()
         if self.descriptions and doc_first_line:
-            return doc_first_line + ' (' + str(test) + ')'
+            return f'{doc_first_line} ({test})'
         else:
             return str(test)
 

--- a/Misc/NEWS.d/next/Library/2024-07-13-14-19-27.gh-issue-91289.JmxDdo.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-13-14-19-27.gh-issue-91289.JmxDdo.rst
@@ -1,0 +1,2 @@
+Reformat the text output of :mod:`unittest`. Print the test description on a
+single line, even if the test has a docstring.


### PR DESCRIPTION
Fixed at EuroPython 24 sprints.

Based on the discussions at #91289 and EuroPython 24 sprints, I reformatted the text output of unittests to a single line for each test.

Example output:
```
This is an error docstring. (test_docstring.Foo.test_error) ... ERROR
test_docstring.Foo.test_error_no_doc ... ERROR
This is OK docstring. (test_docstring.Foo.test_ok) ... ok
test_docstring.Foo.test_ok_no_doc ... ok

======================================================================
ERROR: This is an error docstring. (test_docstring.Foo.test_error)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/pokus_unittest/test_docstring.py", line 9, in test_error
    raise Exception('Gazpacho!')
Exception: Gazpacho!

======================================================================
ERROR: test_docstring.Foo.test_error_no_doc
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/pokus_unittest/test_docstring.py", line 26, in test_error_no_doc
    raise Exception('Gazpacho!')
Exception: Gazpacho!

----------------------------------------------------------------------
Ran 4 tests in 0.004s

FAILED (errors=2)
```

The line contains docstring if conditions are met and removes the duplicate name of test method. It  produces longer lines, but I think this is acceptable
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Closes #91289

<!-- gh-issue-number: gh-91289 -->
* Issue: gh-91289
<!-- /gh-issue-number -->
