### PR TITLE
gh-121342: Fixed `pkgutil.iter_zipimport_modules` on an invalidated cache (#121342)

### DIFF
--- a/Lib/pkgutil.py
+++ b/Lib/pkgutil.py
@@ -176,7 +176,15 @@ try:
     from zipimport import zipimporter
 
     def iter_zipimport_modules(importer, prefix=''):
-        dirlist = sorted(zipimport._zip_directory_cache[importer.archive])
+        """Iterate through the modules available within a zipfile
+
+        For each module found in the zipfile, a tuple containing the module's
+        name and boolean indicating whether the module is a package
+        gets yielded.
+
+        It is assumed that importer is an instance of zipimport.zipimporter.
+        """
+        dirlist = sorted(zipimporter(importer.archive)._get_files())
         _prefix = importer.prefix
         plen = len(_prefix)
         yielded = {}

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -522,6 +522,51 @@ class ExtendPathTests(unittest.TestCase):
         del sys.modules['foo.bar']
         del sys.modules['foo.baz']
 
+    def test_iter_zipimport_modules(self):
+        with zipfile.ZipFile(
+            tempfile.NamedTemporaryFile(suffix='.zip', delete=False),
+            mode='w'
+        ) as tmp_file_zip:
+            tmp_file_zip.writestr(
+                'foo.py',
+                'print("foot")'
+            )
+            tmp_file_zip.writestr(
+                'bar/__init__.py',
+                'print("bar")'
+            )
+
+        module_zip = pkgutil.zipimporter(tmp_file_zip.filename)
+
+        self.assertIn(('foo', False), pkgutil.iter_zipimport_modules(module_zip, prefix=''))
+        self.assertIn(('bar', True), pkgutil.iter_zipimport_modules(module_zip, prefix=''))
+
+        # Cleanup
+        os.remove(tmp_file_zip.filename)
+
+    def test_iter_zipimport_modules_invalidate_caches(self):
+        with zipfile.ZipFile(
+            tempfile.NamedTemporaryFile(suffix='.zip', delete=False),
+            mode='w'
+        ) as tmp_file_zip:
+            tmp_file_zip.writestr(
+                'foo.py',
+                'print("foo")'
+            )
+            tmp_file_zip.writestr(
+                'bar/__init__.py',
+                'print("bar")'
+            )
+
+        module_zip = pkgutil.zipimporter(tmp_file_zip.filename)
+        module_zip.invalidate_caches()
+
+        self.assertIn(('foo', False), pkgutil.iter_zipimport_modules(module_zip, prefix=''))
+        self.assertIn(('bar', True), pkgutil.iter_zipimport_modules(module_zip, prefix=''))
+
+        # Cleanup
+        os.remove(tmp_file_zip.filename)
+
     # XXX: test .pkg files
 
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-13-15-58-52.gh-issue-121342.NyuGnr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-13-15-58-52.gh-issue-121342.NyuGnr.rst
@@ -1,0 +1,2 @@
+Fix :func:`pkgutil.iter_zipimport_modules` when called on an invalidated
+cache. Patch by Andreas Stocker.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-13-15-58-52.gh-issue-121342.NyuGnr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-13-15-58-52.gh-issue-121342.NyuGnr.rst
@@ -1,2 +1,2 @@
-Fix :func:`pkgutil.iter_zipimport_modules` when called on an invalidated
-cache. Patch by Andreas Stocker.
+Fix `pkgutil.iter_zipimport_modules` when called on an invalidated cache.
+Patch by Andreas Stocker.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-13-15-58-52.gh-issue-121342.NyuGnr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-13-15-58-52.gh-issue-121342.NyuGnr.rst
@@ -1,2 +1,2 @@
-Fix `pkgutil.iter_zipimport_modules` when called on an invalidated cache.
+Fix ``pkgutil.iter_zipimport_modules`` when called on an invalidated cache.
 Patch by Andreas Stocker.


### PR DESCRIPTION
It is no longer safe to directly access `zipimport._zip_directory_cache` since #103208. It is not guaranteed that the cache is acutally filled. This changed fixes this by using the internal method `_get_files` instead, which may not be the best solution, but fixes the issue.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121342 -->
* Issue: gh-121342
<!-- /gh-issue-number -->
