### PR TITLE
gh-121708: Improve test coverage for `unittest.util`

### DIFF
--- a/Lib/test/test_unittest/test_util.py
+++ b/Lib/test/test_unittest/test_util.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.util import safe_repr, sorted_list_difference, unorderable_list_difference
+
+
+class TestUtil(unittest.TestCase):
+    def test_safe_repr(self):
+        class RaisingRepr:
+            def __repr__(self):
+                raise ValueError("Invalid repr()")
+
+        class LongRepr:
+            def __repr__(self):
+                return 'x' * 100
+
+        safe_repr(RaisingRepr())
+        self.assertEqual(safe_repr('foo'), "'foo'")
+        self.assertEqual(safe_repr(LongRepr(), short=True), 'x'*80 + ' [truncated]...')
+
+    def test_sorted_list_difference(self):
+        self.assertEqual(sorted_list_difference([], []), ([], []))
+        self.assertEqual(sorted_list_difference([1, 2], [2, 3]), ([1], [3]))
+        self.assertEqual(sorted_list_difference([1, 2], [1, 3]), ([2], [3]))
+        self.assertEqual(sorted_list_difference([1, 1, 1], [1, 2, 3]), ([], [2, 3]))
+        self.assertEqual(sorted_list_difference([4], [1, 2, 3, 4]), ([], [1, 2, 3]))
+        self.assertEqual(sorted_list_difference([1, 1], [2]), ([1], [2]))
+        self.assertEqual(sorted_list_difference([2], [1, 1]), ([2], [1]))
+        self.assertEqual(sorted_list_difference([1, 2], [1, 1]), ([2], []))
+
+    def test_unorderable_list_difference(self):
+        self.assertEqual(unorderable_list_difference([], []), ([], []))
+        self.assertEqual(unorderable_list_difference([1, 2], []), ([2, 1], []))
+        self.assertEqual(unorderable_list_difference([], [1, 2]), ([], [1, 2]))
+        self.assertEqual(unorderable_list_difference([1, 2], [1, 3]), ([2], [3]))


### PR DESCRIPTION
Adds tests for `safe_repr`, `sorted_list_difference` and `unorderable_list_difference`.

Getting the coverage: `./python ../coveragepy run --pylib --branch --source=unittest Lib/test/regrtest.py test_unittest`
To get the HTML report: `./python ../coveragepy/ html -i --include=`pwd`/Lib/* --omit="Lib/test/*,Lib/*/tests/*"`

Before:

![image](https://github.com/user-attachments/assets/643b2953-598b-4631-ae84-39aea058511f)
![image](https://github.com/user-attachments/assets/b578b7eb-2918-4be8-8677-dffceadbe0ab)
![image](https://github.com/user-attachments/assets/e31dfc6c-8e33-4384-9e77-3e94dd0a06b0)

After:

![image](https://github.com/user-attachments/assets/e2dba1b5-58a1-4af3-998b-19e36a2dd2b0)
![image](https://github.com/user-attachments/assets/44f95441-dfb0-41fe-a82a-7fc091452ef1)
![image](https://github.com/user-attachments/assets/75297d38-ec69-49ea-9c14-ef877c00205f)


<!-- gh-issue-number: gh-121708 -->
* Issue: gh-121708
<!-- /gh-issue-number -->
