### PR TITLE
gh-121711: Set `-m asyncio` return_code to 1 for ENOTTY

### DIFF
--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -106,7 +106,8 @@ class REPLThread(threading.Thread):
                 if os.getenv("PYTHON_BASIC_REPL"):
                     raise RuntimeError("user environment requested basic REPL")
                 if not os.isatty(sys.stdin.fileno()):
-                    raise OSError(errno.ENOTTY, "tty required", "stdin")
+                    return_code = errno.ENOTTY
+                    raise OSError(return_code, "tty required", "stdin")
 
                 # This import will fail on operating systems with no termios.
                 from _pyrepl.simple_interact import (

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -7,7 +7,7 @@ import unittest
 from textwrap import dedent
 from test import support
 from test.support import cpython_only, has_subprocess_support, SuppressCrashReport
-from test.support.script_helper import kill_python, assert_python_ok
+from test.support.script_helper import assert_python_failure, kill_python, assert_python_ok
 from test.support.import_helper import import_module
 
 
@@ -195,8 +195,8 @@ class TestInteractiveInterpreter(unittest.TestCase):
         expected = "(30, None, [\'def foo(x):\\n\', \'    return x + 1\\n\', \'\\n\'], \'<stdin>\')"
         self.assertIn(expected, output, expected)
 
-    def test_asyncio_repl_is_ok(self):
-        assert_python_ok("-m", "asyncio")
+    def test_asyncio_repl_no_tty_fails(self):
+        assert assert_python_failure("-m", "asyncio")
 
 
 class TestInteractiveModeSyntaxErrors(unittest.TestCase):


### PR DESCRIPTION
See #121711 for details

<!-- gh-issue-number: gh-121711 -->
* Issue: gh-121711
<!-- /gh-issue-number -->
