### PR TITLE
gh-121651: Fix pdb header test

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3391,9 +3391,9 @@ def bœr():
             resources.enter_context(patch('sys.stdout', stdout))
             # patch pdb.Pdb.set_trace() to avoid entering the debugger
             resources.enter_context(patch.object(pdb.Pdb, 'set_trace'))
-            # Because pdb.Pdb.set_trace() is patched, we need to manually
-            # clear _last_pdb_instance so a new instance with stdout redirected
-            # could be created when pdb.set_trace() is called.
+            # We need to manually clear pdb.Pdb._last_pdb_instance so a
+            # new instance with stdout redirected could be created when
+            # pdb.set_trace() is called.
             pdb.Pdb._last_pdb_instance = None
             pdb.set_trace(header=header)
         self.assertEqual(stdout.getvalue(), header + '\n')

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3389,7 +3389,12 @@ def bœr():
         header = 'Nobody expects... blah, blah, blah'
         with ExitStack() as resources:
             resources.enter_context(patch('sys.stdout', stdout))
+            # patch pdb.Pdb.set_trace() to avoid entering the debugger
             resources.enter_context(patch.object(pdb.Pdb, 'set_trace'))
+            # Because pdb.Pdb.set_trace() is patched, we need to manually
+            # clear _last_pdb_instance so a new instance with stdout redirected
+            # could be created when pdb.set_trace() is called.
+            pdb.Pdb._last_pdb_instance = None
             pdb.set_trace(header=header)
         self.assertEqual(stdout.getvalue(), header + '\n')
 


### PR DESCRIPTION
In the header test for `pdb.set_trace`, we redirected `stdout` to a string buffer, but that would only work when we create the `Pdb` instance after the patch. Due to the changes in #121451 , that's not always guaranteed. So for this test, we clear the `Pdb._last_pdb_instance` before `pdb.set_trace()`, which enforces `pdb.set_trace()` to create a new `Pdb` instance which has the redirected `stdout`.

<!-- gh-issue-number: gh-121651 -->
* Issue: gh-121651
<!-- /gh-issue-number -->
