### PR TITLE
gh-120930: Remove extra blank occuring in wrapped encoded words in email headers

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2988,6 +2988,7 @@ def _fold_as_ew(to_encode, lines, maxlen, last_ew, ew_combine_allowed, charset, 
             excess = len(encoded_word) - remaining_space
         lines[-1] += encoded_word
         to_encode = to_encode[len(to_encode_word):]
+        leading_whitespace = ''
 
         if to_encode:
             lines.append(' ')

--- a/Lib/test/test_email/test_generator.py
+++ b/Lib/test/test_email/test_generator.py
@@ -294,6 +294,19 @@ class TestBytesGenerator(TestGeneratorBase, TestEmailBase):
         g.flatten(msg)
         self.assertEqual(s.getvalue(), expected)
 
+    def test_defaults_handle_spaces_when_encoded_words_is_folded_in_middle(self):
+        source = ('A very long long long long long long long long long long long long '
+                  'long long long long long long long long long long long súmmäry')
+        expected = ('Subject: A very long long long long long long long long long long long long\n'
+                    ' long long long long long long long long long long long =?utf-8?q?s=C3=BAmm?=\n'
+                    ' =?utf-8?q?=C3=A4ry?=\n\n').encode('ascii')
+        msg = EmailMessage()
+        msg['Subject'] = source
+        s = io.BytesIO()
+        g = BytesGenerator(s)
+        g.flatten(msg)
+        self.assertEqual(s.getvalue(), expected)
+
     def test_defaults_handle_spaces_at_start_of_subject(self):
         source = " Уведомление"
         expected = b"Subject:  =?utf-8?b?0KPQstC10LTQvtC80LvQtdC90LjQtQ==?=\n\n"

--- a/Misc/NEWS.d/next/Library/2024-07-14-11-18-28.gh-issue-120930.Kuo4L0.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-14-11-18-28.gh-issue-120930.Kuo4L0.rst
@@ -1,2 +1,2 @@
-Do not add additional space within encoded word when folding
-:class:`email.message.EmailMessage`.
+Fixed a bug introduced by gh-92081 that added an incorrect extra
+blank to encoded words occurring in wrapped headers.

--- a/Misc/NEWS.d/next/Library/2024-07-14-11-18-28.gh-issue-120930.Kuo4L0.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-14-11-18-28.gh-issue-120930.Kuo4L0.rst
@@ -1,0 +1,2 @@
+Do not add additional space within encoded word when folding
+:class:`email.message.EmailMessage`.


### PR DESCRIPTION
After some changes applied in ffe9ba04778f852a14f2404b5fcf13cb3ba1bf45 to fix whitespace between encoded words when folding an EmailMessage, the following issue was introduced:
- When an encoded word is split in two parts in the folding process (to fit the first part on the end of one line, and the second part on the beginning of the next line), an encoded whitespace character is added at the beginning of the second line.

This patch fixes the special case.

<!-- gh-issue-number: gh-120930 -->
* Issue: gh-120930
<!-- /gh-issue-number -->
