### PR TITLE
gh-121746: Bind Alt+Enter to "accept" in the REPL

### DIFF
--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -131,7 +131,7 @@ default_keymap: tuple[tuple[KeySpec, CommandName], ...] = tuple(
         (r"\M-7", "digit-arg"),
         (r"\M-8", "digit-arg"),
         (r"\M-9", "digit-arg"),
-        # (r'\M-\n', 'insert-nl'),
+        (r"\M-\n", "accept"),
         ("\\\\", "self-insert"),
         (r"\x1b[200~", "enable_bracketed_paste"),
         (r"\x1b[201~", "disable_bracketed_paste"),

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1670,6 +1670,7 @@ Fred Sells
 Jiwon Seo
 Iñigo Serna
 Joakim Sernbrant
+Rodrigo Girão Serrão
 Roger D. Serwy
 Jerry Seutter
 Pete Sevander


### PR DESCRIPTION
This fixes #121746.

The binding fixed is consistent with the experience in IPython and ptpython.

<!-- gh-issue-number: gh-121746 -->
* Issue: gh-121746
<!-- /gh-issue-number -->
