### PR TITLE
Fix cache restoration for Hypothesis CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,7 +393,7 @@ jobs:
         path: ${{ env.CPYTHON_BUILDDIR }}/.hypothesis/
         key: hypothesis-database-${{ github.head_ref || github.run_id }}
         restore-keys: |
-          - hypothesis-database-
+          hypothesis-database-
     - name: "Run tests"
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: |


### PR DESCRIPTION
Previously, the CI workflow job running Hypothesis was mistakenly set up to use a cache restoration key prefixed with a leading hyphen [[1]]. This was done in an attempt to figure out the right format for the `actions/cache` input argument called `restore-keys` as the official examples tend to be confusing [[2]].

This results no cache being found for the Hypothesis database on lookup [[3]] and the logs contain the following:

    Cache not found for input keys: hypothesis-database-9927179210, - hypothesis-database-

The patch corrects that by dropping the unintended characters from the catch-all cache key.

[1]: https://github.com/python/cpython/pull/104468/commits/ccbb010#r1677102123
[2]: https://github.com/actions/cache/issues/1173
[3]: https://github.com/python/cpython/actions/runs/9927179210/job/27421821417#step:21:24