### PR TITLE
gh-121610: pyrepl - handle extending blocks when multi-statement blocks are pasted

### DIFF
--- a/Lib/test/test_pyrepl/test_interact.py
+++ b/Lib/test/test_pyrepl/test_interact.py
@@ -148,7 +148,7 @@ class TestMoreLines(unittest.TestCase):
         code = dedent("""\
         def foo():
             '''docs'''
-        
+
             return 1""")
         console = InteractiveColoredConsole(namespace, filename="<stdin>")
         self.assertTrue(_more_lines(console, code))
@@ -163,7 +163,7 @@ class TestMoreLines(unittest.TestCase):
         namespace = {}
         code = dedent("""\
         import time
-        
+
         foo = 1""")
         console = InteractiveColoredConsole(namespace, filename="<stdin>")
         self.assertTrue(_more_lines(console, code))
@@ -172,7 +172,7 @@ class TestMoreLines(unittest.TestCase):
         namespace = {}
         code = dedent("""\
         from dataclasses import dataclass
-        
+
         @dataclass
         class Point:
             x: float
@@ -184,7 +184,7 @@ class TestMoreLines(unittest.TestCase):
         namespace = {}
         code = dedent("""\
         from dataclasses import dataclass
-        
+
         @dataclass
         class Point:
             x: float

--- a/Lib/test/test_pyrepl/test_interact.py
+++ b/Lib/test/test_pyrepl/test_interact.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 from test.support import force_not_colorized
 
 from _pyrepl.console import InteractiveColoredConsole
-
+from _pyrepl.simple_interact import _more_lines
 
 class TestSimpleInteract(unittest.TestCase):
     def test_multiple_statements(self):
@@ -111,3 +111,104 @@ class TestSimpleInteract(unittest.TestCase):
             result = console.runsource(source)
         self.assertFalse(result)
         self.assertEqual(f.getvalue(), "{'x': <class 'int'>}\n")
+
+
+class TestMoreLines(unittest.TestCase):
+    def test_invalid_syntax_single_line(self):
+        namespace = {}
+        code = "if foo"
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        self.assertFalse(_more_lines(console, code))
+
+    def test_empty_line(self):
+        namespace = {}
+        code = ""
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        self.assertFalse(_more_lines(console, code))
+
+    def test_valid_single_statement(self):
+        namespace = {}
+        code = "foo = 1"
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        self.assertFalse(_more_lines(console, code))
+
+    def test_multiline_single_assignment(self):
+        namespace = {}
+        code = dedent("""\
+        foo = [
+            1,
+            2,
+            3,
+        ]""")
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        self.assertFalse(_more_lines(console, code))
+
+    def test_multiline_single_block(self):
+        namespace = {}
+        code = dedent("""\
+        def foo():
+            '''docs'''
+        
+            return 1""")
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        self.assertTrue(_more_lines(console, code))
+
+    def test_multiple_statements_single_line(self):
+        namespace = {}
+        code = "foo = 1;bar = 2"
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        self.assertFalse(_more_lines(console, code))
+
+    def test_multiple_statements(self):
+        namespace = {}
+        code = dedent("""\
+        import time
+        
+        foo = 1""")
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        self.assertTrue(_more_lines(console, code))
+
+    def test_multiple_blocks(self):
+        namespace = {}
+        code = dedent("""\
+        from dataclasses import dataclass
+        
+        @dataclass
+        class Point:
+            x: float
+            y: float""")
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        self.assertTrue(_more_lines(console, code))
+
+    def test_multiple_blocks_empty_newline(self):
+        namespace = {}
+        code = dedent("""\
+        from dataclasses import dataclass
+        
+        @dataclass
+        class Point:
+            x: float
+            y: float
+        """)
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        self.assertFalse(_more_lines(console, code))
+
+    def test_multiple_blocks_indented_newline(self):
+        namespace = {}
+        code = (
+            "from dataclasses import dataclass\n"
+            "\n"
+            "@dataclass\n"
+            "class Point:\n"
+            "    x: float\n"
+            "    y: float\n"
+            "    "
+        )
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        self.assertFalse(_more_lines(console, code))
+
+    def test_incomplete_statement(self):
+        namespace = {}
+        code = "if foo:"
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        self.assertTrue(_more_lines(console, code))


### PR DESCRIPTION
console.compile with the "single" param throws an exception when there are multiple statements, never allowing to add newlines to a pasted code block (gh-121610)

This adds a few extra checks to allow extending when in an indented block, and tests for a few examples

I moved the function out of the outer one to be able to test it more easily, the tests check for what i think is the "expected" behavior for when to add a newline vs executing but please check me on that :)