### PR TITLE
Generalize reusable Windows CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,13 +181,13 @@ jobs:
   build_windows:
     name: 'Windows'
     needs: check_source
-    if: needs.check_source.outputs.run_tests == 'true'
+    if: fromJSON(needs.check_source.outputs.run_tests)
     uses: ./.github/workflows/reusable-windows.yml
 
   build_windows_free_threading:
     name: 'Windows (free-threading)'
     needs: check_source
-    if: needs.check_source.outputs.run_tests == 'true'
+    if: fromJSON(needs.check_source.outputs.run_tests)
     uses: ./.github/workflows/reusable-windows.yml
     with:
       free-threading: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,9 @@ jobs:
         run: make check-c-globals
 
   build_windows:
-    name: 'Windows'
+    name: >-
+      Windows
+      ${{ fromJSON(matrix.free-threading) && '(free-threading)' || '' }}
     needs: check_source
     if: fromJSON(needs.check_source.outputs.run_tests)
     strategy:
@@ -188,24 +190,13 @@ jobs:
         - Win32
         - x64
         - arm64
+        free-threading:
+        - false
+        - true
     uses: ./.github/workflows/reusable-windows.yml
     with:
       arch: ${{ matrix.arch }}
-
-  build_windows_free_threading:
-    name: 'Windows (free-threading)'
-    needs: check_source
-    if: fromJSON(needs.check_source.outputs.run_tests)
-    strategy:
-      matrix:
-        arch:
-        - Win32
-        - x64
-        - arm64
-    uses: ./.github/workflows/reusable-windows.yml
-    with:
-      arch: ${{ matrix.arch }}
-      free-threading: true
+      free-threading: ${{ matrix.free-threading }}
 
   build_macos:
     name: 'macOS'
@@ -571,7 +562,6 @@ jobs:
     - build_ubuntu_ssltests
     - build_wasi
     - build_windows
-    - build_windows_free_threading
     - test_hypothesis
     - build_asan
     - build_tsan
@@ -607,7 +597,6 @@ jobs:
             build_ubuntu_ssltests,
             build_wasi,
             build_windows,
-            build_windows_free_threading,
             build_asan,
             build_tsan,
             build_tsan_free_threading,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,14 +182,29 @@ jobs:
     name: 'Windows'
     needs: check_source
     if: fromJSON(needs.check_source.outputs.run_tests)
+    strategy:
+      matrix:
+        arch:
+        - Win32
+        - x64
+        - arm64
     uses: ./.github/workflows/reusable-windows.yml
+    with:
+      arch: ${{ matrix.arch }}
 
   build_windows_free_threading:
     name: 'Windows (free-threading)'
     needs: check_source
     if: fromJSON(needs.check_source.outputs.run_tests)
+    strategy:
+      matrix:
+        arch:
+        - Win32
+        - x64
+        - arm64
     uses: ./.github/workflows/reusable-windows.yml
     with:
+      arch: ${{ matrix.arch }}
       free-threading: true
 
   build_macos:

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -2,6 +2,7 @@ on:
   workflow_call:
     inputs:
       free-threading:
+        description: Whether to use no-GIL mode
         required: false
         type: boolean
         default: false

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build CPython
-      run: .\PCbuild\build.bat -e -d -v -p Win32 ${{ inputs.free-threading && '--disable-gil' || '' }}
+      run: .\PCbuild\build.bat -e -d -v -p Win32 ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests
-      run: .\PCbuild\rt.bat -p Win32 -d -q --fast-ci ${{ inputs.free-threading && '--disable-gil' || '' }}
+      run: .\PCbuild\rt.bat -p Win32 -d -q --fast-ci ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
 
   build_win_amd64:
     name: 'build and test (x64)'
@@ -33,11 +33,11 @@ jobs:
     - name: Register MSVC problem matcher
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
-      run: .\PCbuild\build.bat -e -d -v -p x64 ${{ inputs.free-threading && '--disable-gil' || '' }}
+      run: .\PCbuild\build.bat -e -d -v -p x64 ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
     - name: Display build info
       run: .\python.bat -m test.pythoninfo
     - name: Tests
-      run: .\PCbuild\rt.bat -p x64 -d -q --fast-ci ${{ inputs.free-threading && '--disable-gil' || '' }}
+      run: .\PCbuild\rt.bat -p x64 -d -q --fast-ci ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
 
   build_win_arm64:
     name: 'build (arm64)'
@@ -50,4 +50,4 @@ jobs:
     - name: Register MSVC problem matcher
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
-      run: .\PCbuild\build.bat -e -d -v -p arm64 ${{ inputs.free-threading && '--disable-gil' || '' }}
+      run: .\PCbuild\build.bat -e -d -v -p arm64 ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -7,13 +7,15 @@ on:
         type: boolean
         default: false
 
+env:
+  IncludeUwp: >-
+    true
+
 jobs:
   build_win32:
     name: 'build and test (x86)'
     runs-on: windows-latest
     timeout-minutes: 60
-    env:
-      IncludeUwp: 'true'
     steps:
     - uses: actions/checkout@v4
     - name: Build CPython
@@ -27,8 +29,6 @@ jobs:
     name: 'build and test (x64)'
     runs-on: windows-latest
     timeout-minutes: 60
-    env:
-       IncludeUwp: 'true'
     steps:
     - uses: actions/checkout@v4
     - name: Register MSVC problem matcher
@@ -44,8 +44,6 @@ jobs:
     name: 'build (arm64)'
     runs-on: windows-latest
     timeout-minutes: 60
-    env:
-      IncludeUwp: 'true'
     steps:
     - uses: actions/checkout@v4
     - name: Register MSVC problem matcher

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -1,6 +1,10 @@
 on:
   workflow_call:
     inputs:
+      arch:
+        description: CPU architecture
+        required: true
+        type: string
       free-threading:
         description: Whether to use no-GIL mode
         required: false
@@ -12,41 +16,30 @@ env:
     true
 
 jobs:
-  build_win32:
-    name: 'build and test (x86)'
-    runs-on: windows-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v4
-    - name: Build CPython
-      run: .\PCbuild\build.bat -e -d -v -p Win32 ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
-    - name: Display build info
-      run: .\python.bat -m test.pythoninfo
-    - name: Tests
-      run: .\PCbuild\rt.bat -p Win32 -d -q --fast-ci ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
-
-  build_win_amd64:
-    name: 'build and test (x64)'
+  build:
+    name: >-
+      build${{ inputs.arch != 'arm64' && ' and test' || '' }}
+      (${{ inputs.arch }})
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
     - name: Register MSVC problem matcher
+      if: inputs.arch != 'Win32'
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
-      run: .\PCbuild\build.bat -e -d -v -p x64 ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
+      run: >-
+        .\PCbuild\build.bat
+        -e -d -v
+        -p ${{ inputs.arch }}
+        ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
     - name: Display build info
+      if: inputs.arch != 'arm64'
       run: .\python.bat -m test.pythoninfo
     - name: Tests
-      run: .\PCbuild\rt.bat -p x64 -d -q --fast-ci ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
-
-  build_win_arm64:
-    name: 'build (arm64)'
-    runs-on: windows-latest
-    timeout-minutes: 60
-    steps:
-    - uses: actions/checkout@v4
-    - name: Register MSVC problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/msvc.json"
-    - name: Build CPython
-      run: .\PCbuild\build.bat -e -d -v -p arm64 ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
+      if: inputs.arch != 'arm64'
+      run: >-
+        .\PCbuild\rt.bat
+        -p ${{ inputs.arch }}
+        -d -q --fast-ci
+        ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}


### PR DESCRIPTION
Previously, both the reusable and calling workflows had a lot of unnecessary duplication in the windows job definitions. This patch simplifies that into a single parametrized job that is included though a matrix in different modes.