### PR TITLE
Move macOS matrix to the calling workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,24 +202,51 @@ jobs:
     name: 'macOS'
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        # Cirrus and macos-14 are M1, macos-13 is default GHA Intel.
+        # Cirrus used for upstream, macos-14 for forks.
+        os:
+        - ghcr.io/cirruslabs/macos-runner:sonoma
+        - macos-14
+        - macos-13
+        is-fork:  # only used for the exclusion trick
+        - ${{ github.repository_owner != 'python' }}
+        exclude:
+        - os: ghcr.io/cirruslabs/macos-runner:sonoma
+          is-fork: true
+        - os: macos-14
+          is-fork: false
     uses: ./.github/workflows/reusable-macos.yml
     with:
       config_hash: ${{ needs.check_source.outputs.config_hash }}
-      # Cirrus and macos-14 are M1, macos-13 is default GHA Intel.
-      # Cirrus used for upstream, macos-14 for forks.
-      os-matrix: '["ghcr.io/cirruslabs/macos-runner:sonoma", "macos-14", "macos-13"]'
+      os: ${{ matrix.os }}
 
   build_macos_free_threading:
     name: 'macOS (free-threading)'
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        # Cirrus and macos-14 are M1.
+        # Cirrus used for upstream, macos-14 for forks.
+        os:
+        - ghcr.io/cirruslabs/macos-runner:sonoma
+        - macos-14
+        is-fork:  # only used for the exclusion trick
+        - ${{ github.repository_owner != 'python' }}
+        exclude:
+        - os: ghcr.io/cirruslabs/macos-runner:sonoma
+          is-fork: true
+        - os: macos-14
+          is-fork: false
     uses: ./.github/workflows/reusable-macos.yml
     with:
       config_hash: ${{ needs.check_source.outputs.config_hash }}
       free-threading: true
-      # Cirrus and macos-14 are M1.
-      # Cirrus used for upstream, macos-14 for forks.
-      os-matrix: '["ghcr.io/cirruslabs/macos-runner:sonoma", "macos-14"]'
+      os: ${{ matrix.os }}
 
   build_ubuntu:
     name: 'Ubuntu'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,13 +199,16 @@ jobs:
       free-threading: ${{ matrix.free-threading }}
 
   build_macos:
-    name: 'macOS'
+    name: >-
+      macOS
+      ${{ fromJSON(matrix.free-threading) && '(free-threading)' || '' }}
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
     strategy:
       fail-fast: false
       matrix:
         # Cirrus and macos-14 are M1, macos-13 is default GHA Intel.
+        # macOS 13 only runs tests against the GIL-enabled CPython.
         # Cirrus used for upstream, macos-14 for forks.
         os:
         - ghcr.io/cirruslabs/macos-runner:sonoma
@@ -213,39 +216,20 @@ jobs:
         - macos-13
         is-fork:  # only used for the exclusion trick
         - ${{ github.repository_owner != 'python' }}
+        free-threading:
+        - false
+        - true
         exclude:
         - os: ghcr.io/cirruslabs/macos-runner:sonoma
           is-fork: true
         - os: macos-14
           is-fork: false
+        - os: macos-13
+          free-threading: true
     uses: ./.github/workflows/reusable-macos.yml
     with:
       config_hash: ${{ needs.check_source.outputs.config_hash }}
-      os: ${{ matrix.os }}
-
-  build_macos_free_threading:
-    name: 'macOS (free-threading)'
-    needs: check_source
-    if: needs.check_source.outputs.run_tests == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        # Cirrus and macos-14 are M1.
-        # Cirrus used for upstream, macos-14 for forks.
-        os:
-        - ghcr.io/cirruslabs/macos-runner:sonoma
-        - macos-14
-        is-fork:  # only used for the exclusion trick
-        - ${{ github.repository_owner != 'python' }}
-        exclude:
-        - os: ghcr.io/cirruslabs/macos-runner:sonoma
-          is-fork: true
-        - os: macos-14
-          is-fork: false
-    uses: ./.github/workflows/reusable-macos.yml
-    with:
-      config_hash: ${{ needs.check_source.outputs.config_hash }}
-      free-threading: true
+      free-threading: ${{ matrix.free-threading }}
       os: ${{ matrix.os }}
 
   build_ubuntu:
@@ -583,7 +567,6 @@ jobs:
     - check-docs
     - check_generated_files
     - build_macos
-    - build_macos_free_threading
     - build_ubuntu
     - build_ubuntu_free_threading
     - build_ubuntu_ssltests
@@ -618,7 +601,6 @@ jobs:
             && '
             check_generated_files,
             build_macos,
-            build_macos_free_threading,
             build_ubuntu,
             build_ubuntu_free_threading,
             build_ubuntu_ssltests,

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -8,13 +8,14 @@ on:
         required: false
         type: boolean
         default: false
-      os-matrix:
-        required: false
+      os:
+        description: OS to run the job in
+        required: true
         type: string
 
 jobs:
   build_macos:
-    name: build and test (${{ matrix.os }})
+    name: build and test (${{ inputs.os }})
     timeout-minutes: 60
     env:
       HOMEBREW_NO_ANALYTICS: 1
@@ -23,18 +24,7 @@ jobs:
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       PYTHONSTRICTEXTENSIONBUILD: 1
       TERM: linux
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ${{fromJson(inputs.os-matrix)}}
-        is-fork:
-          - ${{ github.repository_owner != 'python' }}
-        exclude:
-          - os: "ghcr.io/cirruslabs/macos-runner:sonoma"
-            is-fork: true
-          - os: "macos-14"
-            is-fork: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ inputs.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Runner image version
@@ -43,7 +33,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: config.cache
-        key: ${{ github.job }}-${{ matrix.os }}-${{ env.IMAGE_VERSION }}-${{ inputs.config_hash }}
+        key: ${{ github.job }}-${{ inputs.os }}-${{ env.IMAGE_VERSION }}-${{ inputs.config_hash }}
     - name: Install Homebrew dependencies
       run: brew install pkg-config openssl@3.0 xz gdbm tcl-tk
     - name: Configure CPython

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -9,7 +9,7 @@ on:
         type: boolean
         default: false
       os:
-        description: OS to run the job in
+        description: OS to run the job
         required: true
         type: string
 


### PR DESCRIPTION
Previously, part of it was passed to the reusable workflow where
another part was being populated. Now, the entire matrix is defined
in a single place, in the calling workflow.