### PR TITLE
Merge Ubuntu test matrices in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,31 +222,20 @@ jobs:
       os-matrix: '["ghcr.io/cirruslabs/macos-runner:sonoma", "macos-14"]'
 
   build_ubuntu:
-    name: 'Ubuntu'
+    name: >-
+      Ubuntu
+      ${{ fromJSON(matrix.free-threading) && '(free-threading)' || '' }}
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
+    strategy:
+      matrix:
+        free-threading:
+        - false
+        - true
     uses: ./.github/workflows/reusable-ubuntu.yml
     with:
       config_hash: ${{ needs.check_source.outputs.config_hash }}
-      options: |
-        ../cpython-ro-srcdir/configure \
-          --config-cache \
-          --with-pydebug \
-          --with-openssl=$OPENSSL_DIR
-
-  build_ubuntu_free_threading:
-    name: 'Ubuntu (free-threading)'
-    needs: check_source
-    if: needs.check_source.outputs.run_tests == 'true'
-    uses: ./.github/workflows/reusable-ubuntu.yml
-    with:
-      config_hash: ${{ needs.check_source.outputs.config_hash }}
-      options: |
-        ../cpython-ro-srcdir/configure \
-          --config-cache \
-          --with-pydebug \
-          --with-openssl=$OPENSSL_DIR \
-          --disable-gil
+      free-threading: ${{ matrix.free-threading }}
 
   build_ubuntu_ssltests:
     name: 'Ubuntu SSL tests with OpenSSL'
@@ -558,7 +547,6 @@ jobs:
     - build_macos
     - build_macos_free_threading
     - build_ubuntu
-    - build_ubuntu_free_threading
     - build_ubuntu_ssltests
     - build_wasi
     - build_windows
@@ -593,7 +581,6 @@ jobs:
             build_macos,
             build_macos_free_threading,
             build_ubuntu,
-            build_ubuntu_free_threading,
             build_ubuntu_ssltests,
             build_wasi,
             build_windows,

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -4,9 +4,11 @@ on:
       config_hash:
         required: true
         type: string
-      options:
-        required: true
-        type: string
+      free-threading:
+        description: Whether to use no-GIL mode
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_ubuntu_reusable:
@@ -63,7 +65,12 @@ jobs:
         key: ${{ github.job }}-${{ runner.os }}-${{ env.IMAGE_VERSION }}-${{ inputs.config_hash }}
     - name: Configure CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
-      run: ${{ inputs.options }}
+      run: >-
+        ../cpython-ro-srcdir/configure
+        --config-cache
+        --with-pydebug
+        --with-openssl=$OPENSSL_DIR
+        ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
     - name: Build CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: make -j4

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -5,7 +5,7 @@ on:
         required: true
         type: string
       free-threading:
-        description: Whether to use no-GIL mode
+        description: Whether to use free-threaded mode
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
Previously, they were duplicated, with custom commands being passed to the same reusable workflow. This patch moves the commands in and adds a matrix resembling the interface of other OS tests.

