### PR TITLE
gh-121295: Fix blocked console after interrupting a long paste

### DIFF
--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -155,7 +155,7 @@ def run_multiline_interactive_console(
             input_n += 1
         except KeyboardInterrupt:
             r = _get_reader()
-            if 'isearch' in r.last_command.__name__:
+            if r.last_command and 'isearch' in r.last_command.__name__:
                 r.isearch_direction = ''
                 r.console.forgetinput()
                 r.pop_input_trans()

--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -154,7 +154,15 @@ def run_multiline_interactive_console(
             assert not more
             input_n += 1
         except KeyboardInterrupt:
-            console.write("KeyboardInterrupt\n")
+            r = _get_reader()
+            if 'isearch' in r.last_command.__name__:
+                r.isearch_direction = ''
+                r.console.forgetinput()
+                r.pop_input_trans()
+                r.dirty = True
+            r.refresh()
+            r.in_bracketed_paste = False
+            console.write("\nKeyboardInterrupt\n")
             console.resetbuffer()
         except MemoryError:
             console.write("\nMemoryError\n")

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-07-15-20-03-29.gh-issue-121295.w53ucI.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-07-15-20-03-29.gh-issue-121295.w53ucI.rst
@@ -1,0 +1,2 @@
+Fix PyREPL console getting into a blocked state after interrupting a long
+paste


### PR DESCRIPTION
This PR fixes the behaviour when sending a KeyboardInterrupt signal to the reader. I was unable to reproduce this behaviour on unit tests so I had to test it manually. I'm attaching a GIF of the tests I made to make the review easier:
![out](https://github.com/user-attachments/assets/04d5a64e-7148-42e3-9d08-e0d57762656a)


<!-- gh-issue-number: gh-121295 -->
* Issue: gh-121295
<!-- /gh-issue-number -->
