### PR TITLE
gh-121814: Only check f_trace_opcodes if Python frame exists

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-15-20-41-06.gh-issue-121814.oR2ixR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-15-20-41-06.gh-issue-121814.oR2ixR.rst
@@ -1,0 +1,1 @@
+Fixed the SegFault when :func:`PyEval_SetTrace` is used with no Python frame on stack.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-15-20-41-06.gh-issue-121814.oR2ixR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-15-20-41-06.gh-issue-121814.oR2ixR.rst
@@ -1,1 +1,1 @@
-Fixed the SegFault when :func:`PyEval_SetTrace` is used with no Python frame on stack.
+Fixed the SegFault when :c:func:`PyEval_SetTrace` is used with no Python frame on stack.

--- a/Python/legacy_tracing.c
+++ b/Python/legacy_tracing.c
@@ -605,7 +605,7 @@ _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
             (1 << PY_MONITORING_EVENT_STOP_ITERATION);
 
         PyFrameObject* frame = PyEval_GetFrame();
-        if (frame->f_trace_opcodes) {
+        if (frame && frame->f_trace_opcodes) {
             int ret = _PyEval_SetOpcodeTrace(frame, true);
             if (ret != 0) {
                 return ret;


### PR DESCRIPTION
Co-authored-by: Matt Wozniski <godlygeek@gmail.com>

<!-- gh-issue-number: gh-121814 -->
* Issue: gh-121814
<!-- /gh-issue-number -->
