### PR TITLE
gh-121605: Fix test hang when pyrepl is not available

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -901,7 +901,7 @@ class TestMain(TestCase):
     def test_exposed_globals_in_repl(self):
         pre = "['__annotations__', '__builtins__'"
         post = "'__loader__', '__name__', '__package__', '__spec__']"
-        output, exit_code = self.run_repl(["sorted(dir())", "exit"])
+        output, exit_code = self.run_repl(["sorted(dir())", "exit()"])
         if "can't use pyrepl" in output:
             self.skipTest("pyrepl not available")
         self.assertEqual(exit_code, 0)


### PR DESCRIPTION
The fallback repl does not support "exit" without parentheses, so the test would hang until the timeout expired if pyrepl is not available.

<!-- gh-issue-number: gh-121605 -->
* Issue: gh-121605
<!-- /gh-issue-number -->
