### PR TITLE
gh-120522: Apply App Store compliance patch to installed products, not source

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -695,7 +695,7 @@ list-targets:
 	@grep -E '^[A-Za-z][-A-Za-z0-9]+:' Makefile | awk -F : '{print $$1}'
 
 .PHONY: build_all
-build_all:	check-clean-src @APP_STORE_COMPLIANCE_PATCH_TARGET@ $(BUILDPYTHON) platform sharedmods \
+build_all:	check-clean-src $(BUILDPYTHON) platform sharedmods \
 		gdbhooks Programs/_testembed scripts checksharedmods rundsymutil
 
 .PHONY: build_wasm
@@ -936,12 +936,9 @@ $(BUILDPYTHON)-gdb.py: $(SRC_GDB_HOOKS)
 # known modifications to the source tree before building. The patch will be
 # applied in a dry-run mode (validating, but not applying the patch) on builds
 # that *have* a compliance patch, but where compliance has not been enabled.
-build/app-store-compliant:
-	patch @APP_STORE_COMPLIANCE_PATCH_FLAGS@ --forward --strip=1 --directory="$(srcdir)" --input "$(APP_STORE_COMPLIANCE_PATCH)"
-	@if test "@APP_STORE_COMPLIANCE_PATCH_FLAGS@" == ""; then \
-		mkdir -p build ; \
-		echo "$(APP_STORE_COMPLIANCE_PATCH)" > build/app-store-compliant ; \
-	fi
+.PHONY: app-store-compliant
+app-store-compliant: libinstall
+	patch @APP_STORE_COMPLIANCE_PATCH_FLAGS@ --forward --strip=2 --directory="$(LIBDEST)" --input "$(abs_srcdir)/$(APP_STORE_COMPLIANCE_PATCH)"
 
 # This rule is here for OPENSTEP/Rhapsody/MacOSX. It builds a temporary
 # minimal framework (not including the Lib directory and such) in the current

--- a/Misc/NEWS.d/next/Build/2024-07-16-11-18-43.gh-issue-120522.exdb3D.rst
+++ b/Misc/NEWS.d/next/Build/2024-07-16-11-18-43.gh-issue-120522.exdb3D.rst
@@ -1,0 +1,2 @@
+The app store compliance patch is now applied to the installed products,
+rather than to the original source tree.

--- a/configure
+++ b/configure
@@ -981,7 +981,6 @@ EXPORT_MACOSX_DEPLOYMENT_TARGET
 CONFIGURE_MACOSX_DEPLOYMENT_TARGET
 _PYTHON_HOST_PLATFORM
 APP_STORE_COMPLIANCE_PATCH_FLAGS
-APP_STORE_COMPLIANCE_PATCH_TARGET
 APP_STORE_COMPLIANCE_PATCH
 INSTALLTARGETS
 FRAMEWORKINSTALLAPPSPREFIX
@@ -4450,8 +4449,8 @@ then :
         Darwin|iOS)
           # iOS is able to share the macOS patch
           APP_STORE_COMPLIANCE_PATCH="Mac/Resources/app-store-compliance.patch"
-          APP_STORE_COMPLIANCE_PATCH_TARGET="build/app-store-compliant"
           APP_STORE_COMPLIANCE_PATCH_FLAGS=
+          INSTALLTARGETS="$INSTALLTARGETS app-store-compliant"
           ;;
         *) as_fn_error $? "no default app store compliance patch available for $ac_sys_system" "$LINENO" 5 ;;
       esac
@@ -4460,8 +4459,8 @@ printf "%s\n" "applying default app store compliance patch" >&6; }
       ;;
     *)
       APP_STORE_COMPLIANCE_PATCH="${withval}"
-      APP_STORE_COMPLIANCE_PATCH_TARGET="build/app-store-compliant"
       APP_STORE_COMPLIANCE_PATCH_FLAGS=
+      INSTALLTARGETS="$INSTALLTARGETS app-store-compliant"
       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: applying custom app store compliance patch" >&5
 printf "%s\n" "applying custom app store compliance patch" >&6; }
       ;;
@@ -4473,23 +4472,22 @@ else $as_nop
       iOS)
         # Always apply the compliance patch on iOS; we can use the macOS patch
         APP_STORE_COMPLIANCE_PATCH="Mac/Resources/app-store-compliance.patch"
-        APP_STORE_COMPLIANCE_PATCH_TARGET="build/app-store-compliant"
         APP_STORE_COMPLIANCE_PATCH_FLAGS=
+        INSTALLTARGETS="$INSTALLTARGETS app-store-compliant"
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: applying default app store compliance patch" >&5
 printf "%s\n" "applying default app store compliance patch" >&6; }
         ;;
       Darwin)
         # Always *check* the compliance patch on macOS
         APP_STORE_COMPLIANCE_PATCH="Mac/Resources/app-store-compliance.patch"
-        APP_STORE_COMPLIANCE_PATCH_TARGET="build/app-store-compliant"
         APP_STORE_COMPLIANCE_PATCH_FLAGS="--dry-run"
+        INSTALLTARGETS="$INSTALLTARGETS app-store-compliant"
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: checking (not applying) default app store compliance patch" >&5
 printf "%s\n" "checking (not applying) default app store compliance patch" >&6; }
         ;;
       *)
         # No app compliance patching on any other platform
         APP_STORE_COMPLIANCE_PATCH=
-        APP_STORE_COMPLIANCE_PATCH_TARGET=
         APP_STORE_COMPLIANCE_PATCH_FLAGS=
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: not patching for app store compliance" >&5
 printf "%s\n" "not patching for app store compliance" >&6; }
@@ -4497,7 +4495,6 @@ printf "%s\n" "not patching for app store compliance" >&6; }
     esac
 
 fi
-
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -710,8 +710,8 @@ AC_ARG_WITH(
         Darwin|iOS)
           # iOS is able to share the macOS patch
           APP_STORE_COMPLIANCE_PATCH="Mac/Resources/app-store-compliance.patch"
-          APP_STORE_COMPLIANCE_PATCH_TARGET="build/app-store-compliant"
           APP_STORE_COMPLIANCE_PATCH_FLAGS=
+          INSTALLTARGETS="$INSTALLTARGETS app-store-compliant"
           ;;
         *) AC_MSG_ERROR([no default app store compliance patch available for $ac_sys_system]) ;;
       esac
@@ -719,8 +719,8 @@ AC_ARG_WITH(
       ;;
     *)
       APP_STORE_COMPLIANCE_PATCH="${withval}"
-      APP_STORE_COMPLIANCE_PATCH_TARGET="build/app-store-compliant"
       APP_STORE_COMPLIANCE_PATCH_FLAGS=
+      INSTALLTARGETS="$INSTALLTARGETS app-store-compliant"
       AC_MSG_RESULT([applying custom app store compliance patch])
       ;;
     esac
@@ -729,28 +729,26 @@ AC_ARG_WITH(
       iOS)
         # Always apply the compliance patch on iOS; we can use the macOS patch
         APP_STORE_COMPLIANCE_PATCH="Mac/Resources/app-store-compliance.patch"
-        APP_STORE_COMPLIANCE_PATCH_TARGET="build/app-store-compliant"
         APP_STORE_COMPLIANCE_PATCH_FLAGS=
+        INSTALLTARGETS="$INSTALLTARGETS app-store-compliant"
         AC_MSG_RESULT([applying default app store compliance patch])
         ;;
       Darwin)
         # Always *check* the compliance patch on macOS
         APP_STORE_COMPLIANCE_PATCH="Mac/Resources/app-store-compliance.patch"
-        APP_STORE_COMPLIANCE_PATCH_TARGET="build/app-store-compliant"
         APP_STORE_COMPLIANCE_PATCH_FLAGS="--dry-run"
+        INSTALLTARGETS="$INSTALLTARGETS app-store-compliant"
         AC_MSG_RESULT([checking (not applying) default app store compliance patch])
         ;;
       *)
         # No app compliance patching on any other platform
         APP_STORE_COMPLIANCE_PATCH=
-        APP_STORE_COMPLIANCE_PATCH_TARGET=
         APP_STORE_COMPLIANCE_PATCH_FLAGS=
         AC_MSG_RESULT([not patching for app store compliance])
         ;;
     esac
 ])
 AC_SUBST([APP_STORE_COMPLIANCE_PATCH])
-AC_SUBST([APP_STORE_COMPLIANCE_PATCH_TARGET])
 AC_SUBST([APP_STORE_COMPLIANCE_PATCH_FLAGS])
 
 AC_SUBST([_PYTHON_HOST_PLATFORM])


### PR DESCRIPTION
This PR modifies the App Store compliance handling added in #120984 (backported to 3.13 as #121173, 3.12 as #121174).

@ned-deily pointed out in a review after the original PRs were merged that patching the original source location could be problematic as it prevented a single source directory being used for multiple builds. It was also a potential foot-gun, as it would be trivial to accidentally command and submit the patched version of the source files as part of an unrelated PR.

This PR takes a slightly different approach - instead of patching the original source location, it patches the *installed* location. On macOS, this means the patched version of the file won't be tested (at least, not until we add an explicit installed framework test); but on iOS, the patch is applied to every build, and the `install` target is a pre-requisite for the `testios` target, so we will have some validation that the patch remains valid over time. 

This also allows us to simplify the Makefile.pre.in configuration, as we can use the existing `INSTALLTARGETS` variable rather than adding a variable just for including the `app-store-compliance` target.

As with #120984, I've marked this for backport to 3.12 as the underlying problem exists on 3.12; however, it isn't a security issue in the traditional sense, and addressing the problem requires adding a `configure` flag.

<!-- gh-issue-number: gh-120522 -->
* Issue: gh-120522
<!-- /gh-issue-number -->
