### PR TITLE
GH-105879: Note exec/eval keyword change in What's New

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -422,6 +422,10 @@ free-threaded build.
 Other Language Changes
 ======================
 
+* The :func:`exec` and :func:`eval` built-ins now accept their ``globals``
+  and ``locals`` namespace arguments as keywords.
+  (Contibuted by Raphael Gaschignard in :gh:`105879`)
+
 * Allow the *count* argument of :meth:`str.replace` to be a keyword.
   (Contributed by Hugo van Kemenade in :gh:`106487`.)
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-105879 -->
* Issue: gh-105879
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121831.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->