### PR TITLE
[3.12] CI: Fix using `check_source` flags as bool (GH-121848)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
+      # Some of the referenced steps set outputs conditionally and there may be
+      # cases when referencing them evaluates to empty strings. It is nice to
+      # work with proper booleans so they have to be evaluated through JSON
+      # conversion in the expressions. However, empty strings used like that
+      # may trigger all sorts of undefined and hard-to-debug behaviors in
+      # GitHub Actions CI/CD. To help with this, all of the outputs set here
+      # that are meant to be used as boolean flags (and not arbitrary strings),
+      # MUST have fallbacks with default values set. A common pattern would be
+      # to add ` || false` to all such expressions here, in the output
+      # definitions. They can then later be safely used through the following
+      # idiom in job conditionals and other expressions. Here's some examples:
+      #
+      #   if: fromJSON(needs.check_source.outputs.run-docs)
+      #
+      #   ${{
+      #        fromJSON(needs.check_source.outputs.run_tests)
+      #        && 'truthy-branch'
+      #        || 'falsy-branch'
+      #   }}
+      #
       run-docs: ${{ steps.docs-changes.outputs.run-docs || false }}
-      run_tests: ${{ steps.check.outputs.run_tests }}
-      run_hypothesis: ${{ steps.check.outputs.run_hypothesis }}
-      config_hash: ${{ steps.config_hash.outputs.hash }}
+      run_tests: ${{ steps.check.outputs.run_tests || false }}
+      run_hypothesis: ${{ steps.check.outputs.run_hypothesis || false }}
+      config_hash: ${{ steps.config_hash.outputs.hash }}  # str
     steps:
       - uses: actions/checkout@v4
       - name: Check for source changes

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -2,6 +2,7 @@ on:
   workflow_call:
     inputs:
       free-threading:
+        description: Whether to compile CPython in free-threading mode
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
Previously, those flags would sometimes end up having empty string values, which tends to break evaluating them as JSON. This patch adds `false` fallbacks to all such outputs.

This allows feeding them to `fromJSON()` without a fear of them causing surprising internal behaviors in the GitHub Actions CI/CD workflows platform itself [[1]]. The behavior observed was that some skipped jobs wouldn't show up in the workflow sidebar view at all, would display in the graph view as `Waiting for pending jobs` and in the `${{ needs }}` context, they would have a `result: failure` entry [[2]].

This should help make PRs like #121831 mergeable again.

[1]: https://github.com/python/cpython/pull/121766#issuecomment-2230023214
[2]: https://github.com/python/cpython/actions/runs/9950331379/job/27501637459?pr=121831#step:2:244

(cherry picked from commit a0b205bba555dd9c702b9a856cd9a8153277c9b0)