### PR TITLE
gh-120767: Add REPL history navigation with partial text

### DIFF
--- a/Lib/_pyrepl/historical_reader.py
+++ b/Lib/_pyrepl/historical_reader.py
@@ -274,21 +274,10 @@ class HistoricalReader(Reader):
     def select_item(self, i: int) -> None:
         self.transient_history[self.historyi] = self.get_unicode()
         buf = self.transient_history.get(i)
-        self.historyi = i
-
-        if self.buffer:
-            filtered_history = [
-                (index, item)
-                for index, item in enumerate(self.history)
-                if item.startswith(self.get_unicode())
-                and item.strip() not in self.transient_history.values()
-            ]
-            if filtered_history:
-                self.historyi, buf = filtered_history[min(i, len(filtered_history) - 1)]
-
         if buf is None:
             buf = self.history[i].rstrip()
         self.buffer = list(buf)
+        self.historyi = i
         self.pos = len(self.buffer)
         self.dirty = True
         self.last_refresh_cache.invalidated = True

--- a/Lib/_pyrepl/historical_reader.py
+++ b/Lib/_pyrepl/historical_reader.py
@@ -274,10 +274,21 @@ class HistoricalReader(Reader):
     def select_item(self, i: int) -> None:
         self.transient_history[self.historyi] = self.get_unicode()
         buf = self.transient_history.get(i)
+        self.historyi = i
+
+        if self.buffer:
+            filtered_history = [
+                (index, item)
+                for index, item in enumerate(self.history)
+                if item.startswith(self.get_unicode())
+                and item.strip() not in self.transient_history.values()
+            ]
+            if filtered_history:
+                self.historyi, buf = filtered_history[min(i, len(filtered_history) - 1)]
+
         if buf is None:
             buf = self.history[i].rstrip()
         self.buffer = list(buf)
-        self.historyi = i
         self.pos = len(self.buffer)
         self.dirty = True
         self.last_refresh_cache.invalidated = True

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -143,8 +143,8 @@ default_keymap: tuple[tuple[KeySpec, CommandName], ...] = tuple(
     + [(c, "self-insert") for c in map(chr, range(32, 127)) if c != "\\"]
     + [(c, "self-insert") for c in map(chr, range(128, 256)) if c.isalpha()]
     + [
-        (r"\<up>", "up"),
-        (r"\<down>", "down"),
+        (r"\<up>", "history-search-backward"),
+        (r"\<down>", "history-search-forward"),
         (r"\<left>", "left"),
         (r"\C-\<left>", "backward-word"),
         (r"\<right>", "right"),

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -689,6 +689,46 @@ class TestPyReplOutput(TestCase):
         self.assertEqual(output, "1+1")
         self.assertEqual(clean_screen(reader.screen), "1+1")
 
+    def test_history_navigation_with_up_arrow_and_partial_text(self):
+        events = itertools.chain(
+            code_to_events("spam = 1\nham = 2\neggs = 3\nsp"),
+            [
+                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+            ],
+        )
+
+        reader = self.prepare_reader(events)
+
+        output = multiline_input(reader)
+        self.assertEqual(output, "spam = 1")
+
+    def test_history_navigation_with_up_arrow_and_partial_text_with_similar_entries(self):
+        events = itertools.chain(
+            code_to_events("a=111\na=11\na=1\na="),
+            [
+                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="up", raw=bytearray(b"\x1bOA")),
+                Event(evt="key", data="\n", raw=bytearray(b"\n")),
+            ],
+        )
+
+        reader = self.prepare_reader(events)
+        print()
+        output = multiline_input(reader)
+        self.assertEqual(output, "a=111")
+        self.assertEqual(clean_screen(reader.screen), "a=111")
+        output = multiline_input(reader)
+        self.assertEqual(output, "a=11")
+        self.assertEqual(clean_screen(reader.screen), "a=11")
+        output = multiline_input(reader)
+        self.assertEqual(output, "a=1")
+        self.assertEqual(clean_screen(reader.screen), "a=1")
+        output = multiline_input(reader)
+        self.assertEqual(output, "a=111")
+        self.assertEqual(clean_screen(reader.screen), "a=111")
+
     def test_history_with_multiline_entries(self):
         code = "def foo():\nx = 1\ny = 2\nz = 3\n\ndef bar():\nreturn 42\n\n"
         events = list(itertools.chain(

--- a/Misc/NEWS.d/next/Library/2024-07-17-12-13-30.gh-issue-120767.BKyogz.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-17-12-13-30.gh-issue-120767.BKyogz.rst
@@ -1,0 +1,4 @@
+Enhance REPL history navigation with partial text support
+
+The REPL now correctly navigates history based on partial text
+in the buffer when using the up arrow.


### PR DESCRIPTION
cc @pablogsal 

These changes add support for navigating the REPL history with the up arrow key based on partial text in the buffer. 

When partial text is in the buffer, the up arrow key will navigate through history entries that start with this partial text. 

Example:
```
>>> spam = 1
>>> ham = 2
>>> eggs = 3
>>> sp
<arrow-up>
```
This correctly shows `spam = 1`.

With the following history:
```
>>> a=1111
>>> a=111
>>> a=11
>>> a=1
```
Typing `a=` and pressing the up arrow key will correctly navigate to `a=1` and up. 

**Preserving existing behaviour** 

The standard navigation remains intact, ensuring that pressing the up arrow key without partial text continues to retrieve the most recent history entry. For example:

```
>>> 1+1
>>> 2+2
```
first `<arrow-up>` shows `2+2`, second `<arrow-up>` shows `1+1`. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.=
# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120767 -->
* Issue: gh-120767
<!-- /gh-issue-number -->
