### PR TITLE
gh-121871: Allow overriding docs build date with SOURCE_DATE_EPOCH

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -347,7 +347,8 @@ html_context = {
 }
 
 # This 'Last updated on:' timestamp is inserted at the bottom of every page.
-html_last_updated_fmt = time.strftime('%b %d, %Y (%H:%M UTC)', time.gmtime())
+html_time = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+html_last_updated_fmt = time.strftime('%b %d, %Y (%H:%M UTC)', time.gmtime(html_time))
 
 # Path to find HTML templates.
 templates_path = ['tools/templates']


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` to make builds reproducible.
See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

Fixes: #121871

<!-- gh-issue-number: gh-121871 -->
* Issue: gh-121871
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121872.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->