### PR TITLE
gh-121849: Fix `NULL` pointer dereference when `length` is zero in `PyUnicodeWriter_Create`

### DIFF
--- a/Lib/test/test_capi/test_unicode.py
+++ b/Lib/test/test_capi/test_unicode.py
@@ -1862,6 +1862,11 @@ class PyUnicodeWriterTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             writer.write_ucs4("text", -1)
 
+    def test_zero_length(self):
+        writer = self.create_writer(0)
+        writer.write_substring("abc", 3, 3)
+        self.assertEqual(writer.finish(), "")
+
 
 
 @unittest.skipIf(ctypes is None, 'need ctypes')

--- a/Misc/NEWS.d/next/C API/2024-07-16-16-35-43.gh-issue-121849.9iH3Sk.rst
+++ b/Misc/NEWS.d/next/C API/2024-07-16-16-35-43.gh-issue-121849.9iH3Sk.rst
@@ -1,0 +1,2 @@
+Fixed crash when a length of zero was passed to
+:c:func:`PyUnicodeWriter_Create`.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -13410,6 +13410,11 @@ PyUnicodeWriter_Create(Py_ssize_t length)
                         "length must be positive");
         return NULL;
     }
+    if (length == 0) {
+        /* gh-121849: _PyUnicodeWriter_Prepare leaves writer->buffer as NULL
+         * if the length is zero. */
+        length = 1;
+    }
 
     const size_t size = sizeof(_PyUnicodeWriter);
     PyUnicodeWriter *pub_writer = (PyUnicodeWriter *)PyMem_Malloc(size);


### PR DESCRIPTION
This simply allocates 1 byte instead of letting `buffer` be `NULL` when the length is 0.

<!-- gh-issue-number: gh-121849 -->
* Issue: gh-121849
<!-- /gh-issue-number -->