### PR TITLE
gh-78889: Stop IDLE Shell freezes from sys.stdout.shell.xyz

### DIFF
--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -4,6 +4,8 @@ Released on 2024-10-xx
 =========================
 
 
+gh-78889: Stop Shell freezes by blocking user access to sys.stdout.shell attributes, which are all private.
+
 gh-78955: Use user-selected color theme for Help => IDLE Doc.
 
 gh-96905: In idlelib code, stop redefining built-ins 'dict' and 'object'.

--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -4,7 +4,8 @@ Released on 2024-10-xx
 =========================
 
 
-gh-78889: Stop Shell freezes by blocking user access to sys.stdout.shell attributes, which are all private.
+gh-78889: Stop Shell freezes by blocking user access to non-method
+sys.stdout.shell attributes, which are all private.
 
 gh-78955: Use user-selected color theme for Help => IDLE Doc.
 

--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -443,6 +443,9 @@ class StdioFile(io.TextIOBase):
 
     def __init__(self, shell, tags, encoding='utf-8', errors='strict'):
         self.shell = shell
+        # GH-78889: accessing unpickleable attributes freezes Shell.
+        # IDLE only needs methods; allow 'width' for possible use.
+        self.shell._RPCProxy__attributes = {'width': 1}
         self.tags = tags
         self._encoding = encoding
         self._errors = errors

--- a/Misc/NEWS.d/next/IDLE/2024-07-16-16-57-03.gh-issue-78889.U7ghFD.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-07-16-16-57-03.gh-issue-78889.U7ghFD.rst
@@ -1,2 +1,2 @@
-Stop Shell freezes by blocking user access to sys.stdout.shell attributes,
+Stop Shell freezes by blocking user access to non-method sys.stdout.shell attributes,
 which are all private.

--- a/Misc/NEWS.d/next/IDLE/2024-07-16-16-57-03.gh-issue-78889.U7ghFD.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-07-16-16-57-03.gh-issue-78889.U7ghFD.rst
@@ -1,0 +1,2 @@
+Stop Shell freezes by blocking user access to sys.stdout.shell attributes,
+which are all private.


### PR DESCRIPTION
Problem occurred when attribute xyz could not be pickled. Since this is not trivial to selectively fix, block all non-method attributes (other than 'width').  IDLE does not access them and they are private implementation details.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-78889 -->
* Issue: gh-78889
<!-- /gh-issue-number -->
