### PR TITLE
gh-83648: Use versionadded in 'deprecated' description

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1466,7 +1466,7 @@ printed to standard error when the argument is used::
    snake.py: warning: option '--legs' is deprecated
    Namespace(legs=4)
 
-.. versionchanged:: 3.13
+.. versionadded:: 3.13
 
 
 Action classes


### PR DESCRIPTION


<!-- gh-issue-number: gh-83648 -->
* Issue: gh-83648
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121877.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->