### PR TITLE
Add Additional Context Around Python Signal Handling on iOS

### DIFF
--- a/Doc/using/ios.rst
+++ b/Doc/using/ios.rst
@@ -284,7 +284,8 @@ To add Python to an iOS Xcode project:
    * :c:member:`UTF-8 mode <PyPreConfig.utf8_mode>` is *enabled*;
    * :c:member:`Buffered stdio <PyConfig.buffered_stdio>` is *disabled*;
    * :c:member:`Writing bytecode <PyConfig.write_bytecode>` is *disabled*;
-   * :c:member:`Signal handlers <PyConfig.install_signal_handlers>` are *enabled*;
+   * :c:member:`Signal handlers <PyConfig.install_signal_handlers>` are *enabled*
+
      - This is important because Python libraries may use SIGINT to communicate. Also, only the SIGPIPE and SIGINT signals are affected, meaning that third-party crash reporting libraries, which handle many signals but generally not those two, are unaffected.
    * ``PYTHONHOME`` for the interpreter is configured to point at the
      ``python`` subfolder of your app's bundle; and

--- a/Doc/using/ios.rst
+++ b/Doc/using/ios.rst
@@ -285,6 +285,7 @@ To add Python to an iOS Xcode project:
    * :c:member:`Buffered stdio <PyConfig.buffered_stdio>` is *disabled*;
    * :c:member:`Writing bytecode <PyConfig.write_bytecode>` is *disabled*;
    * :c:member:`Signal handlers <PyConfig.install_signal_handlers>` are *enabled*;
+     - This is important because Python libraries may use SIGINT to communicate. Also, only the SIGPIPE and SIGINT signals are affected, meaning that third-party crash reporting libraries, which handle many signals but generally not those two, are unaffected.
    * ``PYTHONHOME`` for the interpreter is configured to point at the
      ``python`` subfolder of your app's bundle; and
    * The ``PYTHONPATH`` for the interpreter includes:


### PR DESCRIPTION
My understanding of this stuff, particularly on the Python side, is somewhat shallow, but from a discussion with @freakboy3742 it appears we can use crash reporters with Python signal handling overrides.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121881.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->