### PR TITLE
gh-121874: Define audit-event open parameters consistently

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1509,7 +1509,7 @@ are always available.  They are listed here in alphabetical order.
    (where :func:`open` is declared), :mod:`os`, :mod:`os.path`, :mod:`tempfile`,
    and :mod:`shutil`.
 
-   .. audit-event:: open file,mode,flags open
+   .. audit-event:: open path,mode,flags open
 
    The ``mode`` and ``flags`` arguments may have been modified or inferred from
    the original call.


### PR DESCRIPTION
Define `audit-event` `open` parameters consistently to be the same as in
```
Doc/library/io.rst:   .. audit-event:: open path,mode,flags io.open
Doc/library/os.rst:   .. audit-event:: open path,mode,flags os.open
```
to avoid triggering a race-condition in Sphinx
that causes non-deterministic output.

See https://reproducible-builds.org/ for why this matters.

Fixes: #121874

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121874 -->
* Issue: gh-121874
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121883.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->