### PR TITLE
[3.12] gh-121834: Improve `complex` C-API docs (GH-121835)

### DIFF
--- a/Doc/c-api/complex.rst
+++ b/Doc/c-api/complex.rst
@@ -131,8 +131,7 @@ Complex Numbers as Python Objects
 
    Return the imaginary part of *op* as a C :c:expr:`double`.
 
-   Upon failure, this method returns ``-1.0`` with an exception set, so one
-   should call :c:func:`PyErr_Occurred` to check for errors.
+   This function always succeeds.
 
 
 .. c:function:: Py_complex PyComplex_AsCComplex(PyObject *op)

--- a/Doc/c-api/complex.rst
+++ b/Doc/c-api/complex.rst
@@ -131,8 +131,6 @@ Complex Numbers as Python Objects
 
    Return the imaginary part of *op* as a C :c:expr:`double`.
 
-   This function always succeeds.
-
 
 .. c:function:: Py_complex PyComplex_AsCComplex(PyObject *op)
 

--- a/Doc/c-api/complex.rst
+++ b/Doc/c-api/complex.rst
@@ -25,12 +25,16 @@ pointers.  This is consistent throughout the API.
 
    The C structure which corresponds to the value portion of a Python complex
    number object.  Most of the functions for dealing with complex number objects
-   use structures of this type as input or output values, as appropriate.  It is
-   defined as::
+   use structures of this type as input or output values, as appropriate.
+
+   .. c:member:: double real
+                 double imag
+
+   The structure is defined as::
 
       typedef struct {
-         double real;
-         double imag;
+          double real;
+          double imag;
       } Py_complex;
 
 
@@ -106,21 +110,29 @@ Complex Numbers as Python Objects
 .. c:function:: PyObject* PyComplex_FromCComplex(Py_complex v)
 
    Create a new Python complex number object from a C :c:type:`Py_complex` value.
+   Return ``NULL`` with an exception set on error.
 
 
 .. c:function:: PyObject* PyComplex_FromDoubles(double real, double imag)
 
    Return a new :c:type:`PyComplexObject` object from *real* and *imag*.
+   Return ``NULL`` with an exception set on error.
 
 
 .. c:function:: double PyComplex_RealAsDouble(PyObject *op)
 
    Return the real part of *op* as a C :c:expr:`double`.
 
+   Upon failure, this method returns ``-1.0`` with an exception set, so one
+   should call :c:func:`PyErr_Occurred` to check for errors.
+
 
 .. c:function:: double PyComplex_ImagAsDouble(PyObject *op)
 
    Return the imaginary part of *op* as a C :c:expr:`double`.
+
+   Upon failure, this method returns ``-1.0`` with an exception set, so one
+   should call :c:func:`PyErr_Occurred` to check for errors.
 
 
 .. c:function:: Py_complex PyComplex_AsCComplex(PyObject *op)
@@ -131,8 +143,11 @@ Complex Numbers as Python Objects
    method, this method will first be called to convert *op* to a Python complex
    number object.  If :meth:`!__complex__` is not defined then it falls back to
    :meth:`~object.__float__`.  If :meth:`!__float__` is not defined then it falls back
-   to :meth:`~object.__index__`.  Upon failure, this method returns ``-1.0`` as a real
-   value.
+   to :meth:`~object.__index__`.
+
+   Upon failure, this method returns :c:type:`Py_complex`
+   with :c:member:`~Py_complex.real` set to ``-1.0`` and with an exception set, so one
+   should call :c:func:`PyErr_Occurred` to check for errors.
 
    .. versionchanged:: 3.8
       Use :meth:`~object.__index__` if available.


### PR DESCRIPTION
(cherry picked from commit 72dccd60735b597e99c007a7b69210763a746877)

Since `PyComplex_RealAsDouble` uses `PyFloat_AsDouble`, it can still fail there: https://github.com/python/cpython/blob/a15ed5661ff0cb516575d1d100dbbb40b418dd53/Objects/complexobject.c#L258-L267

While `PyComplex_ImagAsDouble` is always successful: https://github.com/python/cpython/blob/a15ed5661ff0cb516575d1d100dbbb40b418dd53/Objects/complexobject.c#L269-L278

<!-- gh-issue-number: gh-121834 -->
* Issue: gh-121834
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121897.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->