### PR TITLE
gh-121921: Make bogus_code_obj.py crash the interpreter

### DIFF
--- a/Lib/test/crashers/bogus_code_obj.py
+++ b/Lib/test/crashers/bogus_code_obj.py
@@ -12,8 +12,8 @@ the user build or load random bytecodes anyway.  Otherwise, this is a
 
 """
 
-import types
+def f():
+    pass
 
-co = types.CodeType(0, 0, 0, 0, 0, 0, b'\x04\x00\x71\x00',
-                    (), (), (), '', '', 1, b'')
-exec(co)
+f.__code__ = f.__code__.replace(co_code=b"")
+f()

--- a/Misc/NEWS.d/next/Tests/2024-07-17-08-25-06.gh-issue-121921.HW8CIS.rst
+++ b/Misc/NEWS.d/next/Tests/2024-07-17-08-25-06.gh-issue-121921.HW8CIS.rst
@@ -1,0 +1,2 @@
+Update ``Lib/test/crashers/bogus_code_obj.py`` so that it crashes properly
+again.


### PR DESCRIPTION
On a debug build I now get:

```
% ./python.exe Lib/test/crashers/bogus_code_obj.py          
Assertion failed: (STACK_LEVEL() > 0), function _PyEval_EvalFrameDefault, file generated_cases.c.h, line 3740.
zsh: abort      ./python.exe Lib/test/crashers/bogus_code_obj.py
```

On a release build it segfaults:

```
% ~/.pyenv/versions/3.13.0b1/bin/python Lib/test/crashers/bogus_code_obj.py 
zsh: segmentation fault  ~/.pyenv/versions/3.13.0b1/bin/python Lib/test/crashers/bogus_code_obj.py
```

You could do more interesting things if you write some actual bytecode that does funny things, but I'd prefer to keep the crasher as simple as possible.

<!-- gh-issue-number: gh-121921 -->
* Issue: gh-121921
<!-- /gh-issue-number -->
