### PR TITLE
gh-121621: Move asyncio_running_loop to private struct

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -68,8 +68,6 @@ struct _ts {
        pycore_ceval.h. */
     uintptr_t eval_breaker;
 
-    PyObject *asyncio_running_loop; // Strong reference
-
     struct {
         /* Has been initialized to a safe state.
 

--- a/Include/internal/pycore_tstate.h
+++ b/Include/internal/pycore_tstate.h
@@ -21,6 +21,8 @@ typedef struct _PyThreadStateImpl {
     // semi-public fields are in PyThreadState.
     PyThreadState base;
 
+    PyObject *asyncio_running_loop; // Strong reference
+
     struct _qsbr_thread_state *qsbr;  // only used by free-threaded build
     struct llist_node mem_free_queue; // delayed free queue
 

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -324,7 +324,7 @@ get_event_loop(asyncio_state *state)
     PyObject *loop;
     PyObject *policy;
 
-    PyThreadState *ts = _PyThreadState_GET();
+    _PyThreadStateImpl *ts = (_PyThreadStateImpl *)_PyThreadState_GET();
     loop = Py_XNewRef(ts->asyncio_running_loop);
 
     if (loop != NULL) {
@@ -3278,7 +3278,7 @@ static PyObject *
 _asyncio__get_running_loop_impl(PyObject *module)
 /*[clinic end generated code: output=b4390af721411a0a input=0a21627e25a4bd43]*/
 {
-    PyThreadState *ts = _PyThreadState_GET();
+    _PyThreadStateImpl *ts = (_PyThreadStateImpl *)_PyThreadState_GET();
     PyObject *loop = Py_XNewRef(ts->asyncio_running_loop);
     if (loop == NULL) {
         /* There's no currently running event loop */
@@ -3302,7 +3302,7 @@ static PyObject *
 _asyncio__set_running_loop(PyObject *module, PyObject *loop)
 /*[clinic end generated code: output=ae56bf7a28ca189a input=4c9720233d606604]*/
 {
-    PyThreadState *ts = _PyThreadState_GET();
+    _PyThreadStateImpl *ts = (_PyThreadStateImpl *)_PyThreadState_GET();
     if (loop == Py_None) {
         loop = NULL;
     }
@@ -3344,7 +3344,7 @@ _asyncio_get_running_loop_impl(PyObject *module)
 /*[clinic end generated code: output=c247b5f9e529530e input=2a3bf02ba39f173d]*/
 {
     PyObject *loop;
-    PyThreadState *ts = _PyThreadState_GET();
+    _PyThreadStateImpl *ts = (_PyThreadStateImpl *)_PyThreadState_GET();
     loop = Py_XNewRef(ts->asyncio_running_loop);
     if (loop == NULL) {
         /* There's no currently running event loop */

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1499,7 +1499,7 @@ init_threadstate(_PyThreadStateImpl *_tstate,
     tstate->previous_executor = NULL;
     tstate->dict_global_version = 0;
 
-    tstate->asyncio_running_loop = NULL;
+    _tstate->asyncio_running_loop = NULL;
 
     tstate->delete_later = NULL;
 
@@ -1702,7 +1702,7 @@ PyThreadState_Clear(PyThreadState *tstate)
 
     /* Don't clear tstate->pyframe: it is a borrowed reference */
 
-    Py_CLEAR(tstate->asyncio_running_loop);
+    Py_CLEAR(((_PyThreadStateImpl *)tstate)->asyncio_running_loop);
 
     Py_CLEAR(tstate->dict);
     Py_CLEAR(tstate->async_exc);


### PR DESCRIPTION
This avoids changing the ABI and places the field in the private struct.

<!-- gh-issue-number: gh-121621 -->
* Issue: gh-121621
<!-- /gh-issue-number -->
