### PR TITLE
gh-121577: fix compileall always recompiling pyc files with hash based invalidation

### DIFF
--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -227,12 +227,24 @@ def compile_file(fullname, ddir=None, force=False, rx=None, quiet=0,
         if tail == '.py':
             if not force:
                 try:
-                    mtime = int(os.stat(fullname).st_mtime)
-                    expect = struct.pack('<4sLL', importlib.util.MAGIC_NUMBER,
-                                         0, mtime & 0xFFFF_FFFF)
+                    with open(cfile, 'rb') as chandle:
+                        header = chandle.read(16)
+
+                    if header[4]:
+                        # hash-based invalidation
+                        with open(fullname, 'rb') as chandle:
+                            source_bytes = chandle.read()
+                        source_hash = importlib.util.source_hash(source_bytes)
+                        actual = header
+                        expect = struct.pack('<4sL8s', importlib.util.MAGIC_NUMBER,
+                                             header[4], source_hash)
+                    else:
+                        # timestamp-based invalidation
+                        mtime = int(os.stat(fullname).st_mtime)
+                        actual = header[:12]
+                        expect = struct.pack('<4sLL', importlib.util.MAGIC_NUMBER,
+                                             0, mtime & 0xFFFF_FFFF)
                     for cfile in opt_cfiles.values():
-                        with open(cfile, 'rb') as chandle:
-                            actual = chandle.read(12)
                         if expect != actual:
                             break
                     else:

--- a/Lib/compileall.py
+++ b/Lib/compileall.py
@@ -227,24 +227,24 @@ def compile_file(fullname, ddir=None, force=False, rx=None, quiet=0,
         if tail == '.py':
             if not force:
                 try:
-                    with open(cfile, 'rb') as chandle:
-                        header = chandle.read(16)
-
-                    if header[4]:
-                        # hash-based invalidation
-                        with open(fullname, 'rb') as chandle:
-                            source_bytes = chandle.read()
-                        source_hash = importlib.util.source_hash(source_bytes)
-                        actual = header
-                        expect = struct.pack('<4sL8s', importlib.util.MAGIC_NUMBER,
-                                             header[4], source_hash)
-                    else:
-                        # timestamp-based invalidation
-                        mtime = int(os.stat(fullname).st_mtime)
-                        actual = header[:12]
-                        expect = struct.pack('<4sLL', importlib.util.MAGIC_NUMBER,
-                                             0, mtime & 0xFFFF_FFFF)
                     for cfile in opt_cfiles.values():
+                        with open(cfile, 'rb') as chandle:
+                            header = chandle.read(16)
+
+                        if header[4]:
+                            # hash-based invalidation
+                            with open(fullname, 'rb') as chandle:
+                                source_bytes = chandle.read()
+                            source_hash = importlib.util.source_hash(source_bytes)
+                            actual = header
+                            expect = struct.pack('<4sL8s', importlib.util.MAGIC_NUMBER,
+                                                 header[4], source_hash)
+                        else:
+                            # timestamp-based invalidation
+                            mtime = int(os.stat(fullname).st_mtime)
+                            actual = header[:12]
+                            expect = struct.pack('<4sLL', importlib.util.MAGIC_NUMBER,
+                                                 0, mtime & 0xFFFF_FFFF)
                         if expect != actual:
                             break
                     else:

--- a/Lib/test/test_compileall.py
+++ b/Lib/test/test_compileall.py
@@ -845,7 +845,7 @@ class CommandLineTestsBase:
         with open(pyc, 'rb') as fp:
             data = fp.read()
         self.assertEqual(int.from_bytes(data[4:8], 'little'), 0b11)
-        self.assertRunOK('--invalidation-mode=unchecked-hash', self.pkgdir)
+        self.assertRunOK('--invalidation-mode=unchecked-hash', '-f', self.pkgdir)
         with open(pyc, 'rb') as fp:
             data = fp.read()
         self.assertEqual(int.from_bytes(data[4:8], 'little'), 0b01)

--- a/Misc/NEWS.d/next/Library/2024-07-18-13-48-18.gh-issue-121577.CAHKTY.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-18-13-48-18.gh-issue-121577.CAHKTY.rst
@@ -1,0 +1,2 @@
+mod:`compileall` now verifies whether recompilation is necessary with all
+``.pyc`` invalidation modes. Patch by Jakub Kulik.

--- a/Misc/NEWS.d/next/Library/2024-07-18-13-48-18.gh-issue-121577.CAHKTY.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-18-13-48-18.gh-issue-121577.CAHKTY.rst
@@ -1,2 +1,2 @@
-mod:`compileall` now verifies whether recompilation is necessary with all
+:mod:`compileall` now verifies whether recompilation is necessary with all
 ``.pyc`` invalidation modes. Patch by Jakub Kulik.


### PR DESCRIPTION


<!-- gh-issue-number: gh-121577 -->
* Issue: gh-121577
<!-- /gh-issue-number -->
