### PR TITLE
gh-118124: fix assert related C++ checks on Solaris/Illumos

### DIFF
--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -15,10 +15,10 @@
 // MSVC makes static_assert a keyword in C11-17, contrary to the standards.
 //
 // In C++11 and C2x, static_assert is a keyword, redefining is undefined
-// behaviour. So only define if building as C (if __STDC_VERSION__ is defined),
-// not C++, and only for C11-17.
+// behaviour. So only define if building as C, not C++ (if __cplusplus is
+// not defined), and only for C11-17.
 #if !defined(static_assert) && (defined(__GNUC__) || defined(__clang__)) \
-     && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
+     && !defined(__cplusplus) && __STDC_VERSION__ >= 201112L \
      && __STDC_VERSION__ <= 201710L
 #  define static_assert _Static_assert
 #endif
@@ -46,7 +46,7 @@
 /* Argument must be a char or an int in [-128, 127] or [0, 255]. */
 #define Py_CHARMASK(c) ((unsigned char)((c) & 0xff))
 
-#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
+#if (!defined(__cplusplus) && __STDC_VERSION__ >= 201112L \
      && !defined(_MSC_VER))
 #  define Py_BUILD_ASSERT_EXPR(cond) \
     ((void)sizeof(struct { int dummy; _Static_assert(cond, #cond); }), \

--- a/Include/pymacro.h
+++ b/Include/pymacro.h
@@ -18,8 +18,8 @@
 // behaviour. So only define if building as C, not C++ (if __cplusplus is
 // not defined), and only for C11-17.
 #if !defined(static_assert) && (defined(__GNUC__) || defined(__clang__)) \
-     && !defined(__cplusplus) && __STDC_VERSION__ >= 201112L \
-     && __STDC_VERSION__ <= 201710L
+     && !defined(__cplusplus) && defined(__STDC_VERSION__) \
+     && __STDC_VERSION__ >= 201112L && __STDC_VERSION__ <= 201710L
 #  define static_assert _Static_assert
 #endif
 
@@ -46,8 +46,8 @@
 /* Argument must be a char or an int in [-128, 127] or [0, 255]. */
 #define Py_CHARMASK(c) ((unsigned char)((c) & 0xff))
 
-#if (!defined(__cplusplus) && __STDC_VERSION__ >= 201112L \
-     && !defined(_MSC_VER))
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
+     && !defined(__cplusplus) && !defined(_MSC_VER))
 #  define Py_BUILD_ASSERT_EXPR(cond) \
     ((void)sizeof(struct { int dummy; _Static_assert(cond, #cond); }), \
      0)


### PR DESCRIPTION
`__STDC_VERSION__` can be defined for C++ builds on some platforms (in my case, Solaris/Illumos).

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57025


<!-- gh-issue-number: gh-118124 -->
* Issue: gh-118124
<!-- /gh-issue-number -->
