### PR TITLE
GH-117928: Bump the minimum Sphinx version to 6.2.1

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -82,7 +82,7 @@ today_fmt = '%B %d, %Y'
 highlight_language = 'python3'
 
 # Minimum version of sphinx required
-needs_sphinx = '4.2'
+needs_sphinx = '6.2.1'
 
 # Create table of contents entries for domain objects (e.g. functions, classes,
 # attributes, etc.). Default is True.


### PR DESCRIPTION
Seems this was missed in the original PR (#117853).

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--121986.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-117928 -->
* Issue: gh-117928
<!-- /gh-issue-number -->
