### PR TITLE
gh-120289: Add external timer in traverse of _lsprof.Profiler

### DIFF
--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -856,6 +856,7 @@ static int
 profiler_traverse(ProfilerObject *op, visitproc visit, void *arg)
 {
     Py_VISIT(Py_TYPE(op));
+    Py_VISIT(op->externalTimer);
     return 0;
 }
 


### PR DESCRIPTION
It turned out that we did not include the external timer in `tp_traverse`, and the external timer could be a container that causes a ref cycle - this could lead to ref leak.

Confirmed that `./python -m test -R3:3 test_cprofile` passed after the change.

<!-- gh-issue-number: gh-120289 -->
* Issue: gh-120289
<!-- /gh-issue-number -->
