### PR TITLE
gh-122026: Fix identification of mismatched parentheses inside f-strings

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -895,6 +895,7 @@ x = (
                              "f'{:2}'",
                              "f'''{\t\f\r\n:a}'''",
                              "f'{:'",
+                             "F'{[F'{:'}[F'{:'}]]]",
                              ])
 
         self.assertAllRaise(SyntaxError,

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-19-15-28-05.gh-issue-122026.sta2Ca.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-19-15-28-05.gh-issue-122026.sta2Ca.rst
@@ -1,2 +1,2 @@
-Fix a bug that caused the tokenizer to not correctly identified mismatched
+Fix a bug that caused the tokenizer to not correctly identify mismatched
 parentheses inside f-strings in some situations. Patch by Pablo Galindo

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-19-15-28-05.gh-issue-122026.sta2Ca.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-19-15-28-05.gh-issue-122026.sta2Ca.rst
@@ -1,0 +1,2 @@
+Fix a bug that caused the tokenizer to not correctly identified mismatched
+parentheses inside f-strings in some situations. Patch by Pablo Galindo

--- a/Parser/lexer/lexer.c
+++ b/Parser/lexer/lexer.c
@@ -1232,6 +1232,9 @@ tok_get_normal_mode(struct tok_state *tok, tokenizer_mode* current_tok, struct t
 
         if (INSIDE_FSTRING(tok)) {
             current_tok->curly_bracket_depth--;
+            if (current_tok->curly_bracket_depth < 0) {
+                return MAKE_TOKEN(_PyTokenizer_syntaxerror(tok, "f-string: unmatched '%c'", c));
+            }
             if (c == '}' && current_tok->curly_bracket_depth == current_tok->curly_bracket_expr_start_depth) {
                 current_tok->curly_bracket_expr_start_depth--;
                 current_tok->kind = TOK_FSTRING_MODE;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122026 -->
* Issue: gh-122026
<!-- /gh-issue-number -->
