### PR TITLE
gh-122044: Don't error during gitignore filtering with no files

### DIFF
--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -108,6 +108,10 @@ def filter_gitignored_paths(paths: list[str]) -> list[str]:
 
         '.gitignore:9:*.a    Tools/lib.a'
     """
+    # No paths means no filtering to be done.
+    if not paths:
+        return []
+
     # Filter out files in gitignore.
     # Non-matching files show up as '::<whitespace><path>'
     git_check_ignore_proc = subprocess.run(


### PR DESCRIPTION
When a package doesn't have any files the script errors during gitignore filtering instead of the helpful error message.

<!-- gh-issue-number: gh-122044 -->
* Issue: gh-122044
<!-- /gh-issue-number -->
