### PR TITLE
gh-100256: Skip inaccessible registry keys in the WinAPI mimetype implementation

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -521,6 +521,7 @@ Michael Ernst
 Ben Escoto
 Andy Eskilsson
 André Espaze
+Lucas Esposito
 Stefan Esser
 Nicolas Estibals
 Jonathan Eunice
@@ -2104,6 +2105,5 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
-Lucas Esposito
 
 (Entries should be added in rough alphabetical order by last names)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -2104,5 +2104,6 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
+Lucas Esposito
 
 (Entries should be added in rough alphabetical order by last names)

--- a/Misc/NEWS.d/next/Windows/2024-07-19-21-50-54.gh-issue-100256.GDrKba.rst
+++ b/Misc/NEWS.d/next/Windows/2024-07-19-21-50-54.gh-issue-100256.GDrKba.rst
@@ -1,0 +1,2 @@
+Skip inaccessible registry keys in the WinAPI mimetype implementation (similar to the
+behavior of the WinReg implementation)

--- a/Misc/NEWS.d/next/Windows/2024-07-19-21-50-54.gh-issue-100256.GDrKba.rst
+++ b/Misc/NEWS.d/next/Windows/2024-07-19-21-50-54.gh-issue-100256.GDrKba.rst
@@ -1,2 +1,1 @@
-Skip inaccessible registry keys in the WinAPI mimetype implementation (similar to the
-behavior of the WinReg implementation)
+:mod:`mimetypes` no longer fails when it encounters an inaccessible registry key.

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -2803,7 +2803,7 @@ _winapi__mimetypes_read_windows_registry_impl(PyObject *module,
         }
 
         err = RegOpenKeyExW(hkcr, ext, 0, KEY_READ, &subkey);
-        if (err == ERROR_FILE_NOT_FOUND || ERROR_ACCESS_DENIED) {
+        if (err == ERROR_FILE_NOT_FOUND || err == ERROR_ACCESS_DENIED) {
             err = ERROR_SUCCESS;
             continue;
         } else if (err != ERROR_SUCCESS) {

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -2808,7 +2808,7 @@ _winapi__mimetypes_read_windows_registry_impl(PyObject *module,
             continue;
         } else if (err == ERROR_ACCESS_DENIED) {
             /* Skip keys we can't access, as we do on the fallback WinReg implementation */
-            PyErr_SetFromWindowsErr(err);
+            PyErr_SetFromWindowsErr((int) err);
             err = ERROR_SUCCESS;
             continue;
         } else if (err != ERROR_SUCCESS) {

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -2806,6 +2806,11 @@ _winapi__mimetypes_read_windows_registry_impl(PyObject *module,
         if (err == ERROR_FILE_NOT_FOUND) {
             err = ERROR_SUCCESS;
             continue;
+        } else if (err == ERROR_ACCESS_DENIED) {
+            /* Skip keys we can't access, as we do on the fallback WinReg implementation */
+            PyErr_SetFromWindowsErr(err);
+            err = ERROR_SUCCESS;
+            continue;
         } else if (err != ERROR_SUCCESS) {
             continue;
         }

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -2803,12 +2803,7 @@ _winapi__mimetypes_read_windows_registry_impl(PyObject *module,
         }
 
         err = RegOpenKeyExW(hkcr, ext, 0, KEY_READ, &subkey);
-        if (err == ERROR_FILE_NOT_FOUND) {
-            err = ERROR_SUCCESS;
-            continue;
-        } else if (err == ERROR_ACCESS_DENIED) {
-            /* Skip keys we can't access, as we do on the fallback WinReg implementation */
-            PyErr_SetFromWindowsErr((int) err);
+        if (err == ERROR_FILE_NOT_FOUND || ERROR_ACCESS_DENIED) {
             err = ERROR_SUCCESS;
             continue;
         } else if (err != ERROR_SUCCESS) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-100256 -->
* Issue: gh-100256
<!-- /gh-issue-number -->

Currently there are two implementations to load mimetypes in Windows from registry keys:
* WinReg: Former and slower implementation written in Python. Currently used as fallback. If it can't access a registry key, that key is just skipped and continues with the next.
* WinAPI: Faster implementation in C. It's prioritized over WinReg one. If it can't access a registry key, it fails.

The current behavior of WinAPI results in some problems, as you can read in the issue description and comments.

This PR addresses those discrepancies in the behavior across different implenentations, making the new WinAPI behave on the same way as the fallback WinReg solution.
