### PR TITLE
Docs: Fix duplicate object description warnings

### DIFF
--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -7,6 +7,7 @@
    :synopsis: The base class representing email messages in a fashion
               backward compatible with Python 3.2
    :noindex:
+   :no-index:
 
 
 The :class:`Message` class is very similar to the

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -874,6 +874,7 @@ Element Objects
 
 .. module:: xml.etree.ElementTree
    :noindex:
+   :no-index:
 
 .. class:: Element(tag, attrib={}, **extra)
 

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -18,11 +18,12 @@ from pprint import pformat
 import sphinx
 from docutils import nodes
 from docutils.io import StringOutput
+from docutils.parsers.rst import directives
 from docutils.utils import new_document, unescape
 from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.domains.changeset import VersionChange, versionlabels, versionlabel_classes
-from sphinx.domains.python import PyFunction, PyMethod
+from sphinx.domains.python import PyFunction, PyMethod, PyModule
 from sphinx.errors import NoUri
 from sphinx.locale import _ as sphinx_gettext
 from sphinx.util import logging
@@ -48,6 +49,9 @@ Body.enum.converters['loweralpha'] = \
 from sphinx.domains import std
 
 std.token_re = re.compile(r'`((~?[\w-]*:)?\w+)`')
+
+# backport :no-index:
+PyModule.option_spec['no-index'] = directives.flag
 
 
 # Support for marking up and linking to bugs.python.org issues


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122068.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->