### PR TITLE
gh-122029: Log call events in sys.setprofile when it's a method with c function

### DIFF
--- a/Lib/test/test_sys_setprofile.py
+++ b/Lib/test/test_sys_setprofile.py
@@ -479,6 +479,20 @@ class TestEdgeCases(unittest.TestCase):
         sys.setprofile(lambda *args: None)
         f()
 
+    def test_method_with_c_function(self):
+        # gh-122029
+        # When we have a PyMethodObject whose im_func is a C function, we
+        # should record both the call and the return. f = classmethod(repr)
+        # is just a way to create a PyMethodObject with a C function.
+        class A:
+            f = classmethod(repr)
+        events = []
+        sys.setprofile(lambda frame, event, args: events.append(event))
+        A().f()
+        sys.setprofile(None)
+        # The last c_call is the call to sys.setprofile
+        self.assertEqual(events, ['c_call', 'c_return', 'c_call'])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-21-01-23-54.gh-issue-122029.gKv-e2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-21-01-23-54.gh-issue-122029.gKv-e2.rst
@@ -1,1 +1,1 @@
-Emit ``c_call`` events in :func:`sys.setprofile` when a ``PyMethodObject`` pointing to a `PyCFunction` is called.
+Emit ``c_call`` events in :func:`sys.setprofile` when a ``PyMethodObject`` pointing to a ``PyCFunction`` is called.

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-21-01-23-54.gh-issue-122029.gKv-e2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-21-01-23-54.gh-issue-122029.gKv-e2.rst
@@ -1,0 +1,1 @@
+Emit ``c_call`` events in :func:`sys.setprofile` when a ``PyMethodObject`` pointing to a `PyCFunction` is called.

--- a/Python/legacy_tracing.c
+++ b/Python/legacy_tracing.c
@@ -121,6 +121,19 @@ sys_profile_call_or_return(
         Py_DECREF(meth);
         return res;
     }
+    else if (Py_TYPE(callable) == &PyMethod_Type) {
+        // CALL instruction will grab the function from the method,
+        // so if the function is a C function, the return event will
+        // be emitted. However, CALL event happens before CALL
+        // instruction, so we need to handle this case here.
+        PyObject* func = PyMethod_GET_FUNCTION(callable);
+        if (func == NULL) {
+            return NULL;
+        }
+        if (PyCFunction_Check(func)) {
+            return call_profile_func(self, func);
+        }
+    }
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Currently `sys.setprofile` logs the `c_return` event, but not `c_call` event, when the function is a `PyMethodObject` that points to a `PyCFunction`. This patch fixed that.

<!-- gh-issue-number: gh-122029 -->
* Issue: gh-122029
<!-- /gh-issue-number -->
