### PR TITLE
gh-122088: Copy the coroutine status of the underlying callable in `@warnings.deprecated`

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -1684,6 +1684,31 @@ class DeprecatedTests(unittest.TestCase):
             isinstance(cell.cell_contents, deprecated) for cell in d.__closure__
         ))
 
+    def test_inspect(self):
+        import inspect
+
+        @deprecated("depr")
+        def sync():
+            pass
+
+        @deprecated("depr")
+        async def coro():
+            pass
+
+        class Cls:
+            @deprecated("depr")
+            def sync(self):
+                pass
+
+            @deprecated("depr")
+            async def coro(self):
+                pass
+
+        self.assertFalse(inspect.iscoroutinefunction(sync))
+        self.assertTrue(inspect.iscoroutinefunction(coro))
+        self.assertFalse(inspect.iscoroutinefunction(Cls.sync))
+        self.assertTrue(inspect.iscoroutinefunction(Cls.coro))
+
 def setUpModule():
     py_warnings.onceregistry.clear()
     c_warnings.onceregistry.clear()

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 import linecache
 import os
+import inspect
 from io import StringIO
 import re
 import sys
@@ -1685,8 +1686,6 @@ class DeprecatedTests(unittest.TestCase):
         ))
 
     def test_inspect(self):
-        import inspect
-
         @deprecated("depr")
         def sync():
             pass

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -628,11 +628,15 @@ class deprecated:
             return arg
         elif callable(arg):
             import functools
+            import inspect
 
             @functools.wraps(arg)
             def wrapper(*args, **kwargs):
                 warn(msg, category=category, stacklevel=stacklevel + 1)
                 return arg(*args, **kwargs)
+
+            if inspect.iscoroutinefunction(arg):
+                wrapper = inspect.markcoroutinefunction(wrapper)
 
             arg.__deprecated__ = wrapper.__deprecated__ = msg
             return wrapper

--- a/Misc/NEWS.d/next/Library/2024-07-21-18-03-30.gh-issue-122088.vi2bP-.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-21-18-03-30.gh-issue-122088.vi2bP-.rst
@@ -1,4 +1,3 @@
 :func:`@warnings.deprecated <warnings.deprecated>` now copies the
-:data:`coroutine flag <inspect.CO_COROUTINE>` flag of functions and
-methods so that :func:`inspect.iscoroutinefunction` returns the correct
-result.
+coroutine status of functions and methods so that
+:func:`inspect.iscoroutinefunction` returns the correct result.

--- a/Misc/NEWS.d/next/Library/2024-07-21-18-03-30.gh-issue-122088.vi2bP-.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-21-18-03-30.gh-issue-122088.vi2bP-.rst
@@ -1,3 +1,4 @@
-``@warnings.deprecated`` now copies to coroutine flag of functions and
-methods so that ``inspect.iscoroutinefunction()`` returns the correct
+:func:`@warnings.deprecated <warnings.deprecated>` now copies the
+:data:`coroutine flag <inspect.CO_COROUTINE>` flag of functions and
+methods so that :func:`inspect.iscoroutinefunction` returns the correct
 result.

--- a/Misc/NEWS.d/next/Library/2024-07-21-18-03-30.gh-issue-122088.vi2bP-.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-21-18-03-30.gh-issue-122088.vi2bP-.rst
@@ -1,0 +1,3 @@
+``@warnings.deprecated`` now copies to coroutine flag of functions and
+methods so that ``inspect.iscoroutinefunction()`` returns the correct
+result.


### PR DESCRIPTION
~~(This needs python/cpython#122088 to be moved over to the cpython repository and then a NEWS entry.)~~