### PR TITLE
Remove now unused function from itertools tests

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -15,26 +15,6 @@ import sys
 import struct
 import threading
 import gc
-import warnings
-
-def pickle_deprecated(testfunc):
-    """ Run the test three times.
-    First, verify that a Deprecation Warning is raised.
-    Second, run normally but with DeprecationWarnings temporarily disabled.
-    Third, run with warnings promoted to errors.
-    """
-    def inner(self):
-        with self.assertWarns(DeprecationWarning):
-            testfunc(self)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            testfunc(self)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", category=DeprecationWarning)
-            with self.assertRaises((DeprecationWarning, AssertionError, SystemError)):
-                testfunc(self)
-
-    return inner
 
 maxsize = support.MAX_Py_ssize_t
 minsize = -maxsize-1


### PR DESCRIPTION
Follow up to https://github.com/python/cpython/pull/118816

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
