### PR TITLE
GH-120754: Add more tests around seek + readall

### DIFF
--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -141,6 +141,9 @@ class TestFileMethods(LargeFileTest):
             f.truncate(1)
             self.assertEqual(f.tell(), 0)       # else pointer moved
             f.seek(0)
+            # Verify readall on a truncated file is well behaved. read()
+            # without a size can be unbounded, this should get just the byte
+            # that remains.
             self.assertEqual(len(f.read()), 1)  # else wasn't truncated
 
     def test_seekable(self):
@@ -151,6 +154,22 @@ class TestFileMethods(LargeFileTest):
                 f.seek(pos)
                 self.assertTrue(f.seekable())
 
+    @bigmemtest(size=size, memuse=2, dry_run=False)
+    def test_seek_readall(self, _size):
+        # Seek which doesn't change position should readall successfully.
+        with self.open(TESTFN, 'rb') as f:
+            self.assertEqual(f.seek(0, os.SEEK_CUR), 0)
+            self.assertEqual(len(f.read()), size+1)
+
+        # Seek which changes (or might change) position should readall
+        # successfully.
+        with self.open(TESTFN, 'rb') as f:
+            self.assertEqual(f.seek(20, os.SEEK_SET), 20)
+            self.assertEqual(len(f.read()), size-19)
+
+        with self.open(TESTFN, 'rb') as f:
+            self.assertEqual(f.seek(-3, os.SEEK_END), size - 2)
+            self.assertEqual(len(f.read()), 3)
 
 def skip_no_disk_space(path, required):
     def decorator(fun):

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -165,7 +165,7 @@ class TestFileMethods(LargeFileTest):
         # successfully.
         with self.open(TESTFN, 'rb') as f:
             self.assertEqual(f.seek(20, os.SEEK_SET), 20)
-            self.assertEqual(len(f.read()), size-19)
+            self.assertEqual(len(f.read()), size - 19)
 
         with self.open(TESTFN, 'rb') as f:
             self.assertEqual(f.seek(-3, os.SEEK_END), size - 2)

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -159,7 +159,7 @@ class TestFileMethods(LargeFileTest):
         # Seek which doesn't change position should readall successfully.
         with self.open(TESTFN, 'rb') as f:
             self.assertEqual(f.seek(0, os.SEEK_CUR), 0)
-            self.assertEqual(len(f.read()), size+1)
+            self.assertEqual(len(f.read()), size + 1)
 
         # Seek which changes (or might change) position should readall
         # successfully.


### PR DESCRIPTION
In the process of speeding up readall, A number of related tests (ex. large file tests in test_zipfile) found problems with the change I was making. This adds I/O tests to specifically test these cases to help ensure they don't regress and hopefully make debugging easier.

This is part of the improvements from https://github.com/python/cpython/pull/121593#issuecomment-2222261986

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120754 -->
* Issue: gh-120754
<!-- /gh-issue-number -->
