### PR TITLE
[3.12] Docs: spelling and grammar fixes (GH-122084)

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -499,7 +499,7 @@ PyConfig
       The :c:func:`PyConfig_Read` function only parses
       :c:member:`PyConfig.argv` arguments once: :c:member:`PyConfig.parse_argv`
       is set to ``2`` after arguments are parsed. Since Python arguments are
-      strippped from :c:member:`PyConfig.argv`, parsing arguments twice would
+      stripped from :c:member:`PyConfig.argv`, parsing arguments twice would
       parse the application options as Python options.
 
       :ref:`Preinitialize Python <c-preinit>` if needed.
@@ -1000,7 +1000,7 @@ PyConfig
       The :c:func:`PyConfig_Read` function only parses
       :c:member:`PyConfig.argv` arguments once: :c:member:`PyConfig.parse_argv`
       is set to ``2`` after arguments are parsed. Since Python arguments are
-      strippped from :c:member:`PyConfig.argv`, parsing arguments twice would
+      stripped from :c:member:`PyConfig.argv`, parsing arguments twice would
       parse the application options as Python options.
 
       Default: ``1`` in Python mode, ``0`` in isolated mode.

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -4022,7 +4022,7 @@ As you can see, this output isn't ideal. That's because the underlying code
 which writes to ``sys.stderr`` makes multiple writes, each of which results in a
 separate logged line (for example, the last three lines above). To get around
 this problem, you need to buffer things and only output log lines when newlines
-are seen. Let's use a slghtly better implementation of ``LoggerWriter``:
+are seen. Let's use a slightly better implementation of ``LoggerWriter``:
 
 .. code-block:: python
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -879,7 +879,7 @@ Statements
 .. class:: AnnAssign(target, annotation, value, simple)
 
    An assignment with a type annotation. ``target`` is a single node and can
-   be a :class:`Name`, a :class:`Attribute` or a :class:`Subscript`.
+   be a :class:`Name`, an :class:`Attribute` or a :class:`Subscript`.
    ``annotation`` is the annotation, such as a :class:`Constant` or :class:`Name`
    node. ``value`` is a single optional node.
 
@@ -2002,7 +2002,7 @@ Function and class definitions
            YieldFrom(value)
 
    A ``yield`` or ``yield from`` expression. Because these are expressions, they
-   must be wrapped in a :class:`Expr` node if the value sent back is not used.
+   must be wrapped in an :class:`Expr` node if the value sent back is not used.
 
    .. doctest::
 

--- a/Doc/library/asyncio-future.rst
+++ b/Doc/library/asyncio-future.rst
@@ -120,20 +120,20 @@ Future Object
       a :exc:`CancelledError` exception.
 
       If the Future's result isn't yet available, this method raises
-      a :exc:`InvalidStateError` exception.
+      an :exc:`InvalidStateError` exception.
 
    .. method:: set_result(result)
 
       Mark the Future as *done* and set its result.
 
-      Raises a :exc:`InvalidStateError` error if the Future is
+      Raises an :exc:`InvalidStateError` error if the Future is
       already *done*.
 
    .. method:: set_exception(exception)
 
       Mark the Future as *done* and set an exception.
 
-      Raises a :exc:`InvalidStateError` error if the Future is
+      Raises an :exc:`InvalidStateError` error if the Future is
       already *done*.
 
    .. method:: done()

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -1104,7 +1104,7 @@ Task Object
       a :exc:`CancelledError` exception.
 
       If the Task's result isn't yet available, this method raises
-      a :exc:`InvalidStateError` exception.
+      an :exc:`InvalidStateError` exception.
 
    .. method:: exception()
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -322,7 +322,7 @@ Functions and classes provided:
 
    .. versionchanged:: 3.12
       ``suppress`` now supports suppressing exceptions raised as
-      part of an :exc:`BaseExceptionGroup`.
+      part of a :exc:`BaseExceptionGroup`.
 
 .. function:: redirect_stdout(new_target)
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -107,7 +107,7 @@ Functions are accessed as attributes of dll objects::
 
 Note that win32 system dlls like ``kernel32`` and ``user32`` often export ANSI
 as well as UNICODE versions of a function. The UNICODE version is exported with
-an ``W`` appended to the name, while the ANSI version is exported with an ``A``
+a ``W`` appended to the name, while the ANSI version is exported with an ``A``
 appended to the name. The win32 ``GetModuleHandle`` function, which returns a
 *module handle* for a given module name, has the following C prototype, and a
 macro is used to expose one of them as ``GetModuleHandle`` depending on whether

--- a/Doc/library/fractions.rst
+++ b/Doc/library/fractions.rst
@@ -87,7 +87,7 @@ another rational number, or from a string.
 
    .. versionchanged:: 3.9
       The :func:`math.gcd` function is now used to normalize the *numerator*
-      and *denominator*. :func:`math.gcd` always return a :class:`int` type.
+      and *denominator*. :func:`math.gcd` always returns an :class:`int` type.
       Previously, the GCD type depended on *numerator* and *denominator*.
 
    .. versionchanged:: 3.11

--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -378,7 +378,7 @@ provides three different variants:
 
       If the request was mapped to a file, it is opened. Any :exc:`OSError`
       exception in opening the requested file is mapped to a ``404``,
-      ``'File not found'`` error. If there was a ``'If-Modified-Since'``
+      ``'File not found'`` error. If there was an ``'If-Modified-Since'``
       header in the request, and the file was not modified after this time,
       a ``304``, ``'Not Modified'`` response is sent. Otherwise, the content
       type is guessed by calling the :meth:`guess_type` method, which in turn

--- a/Doc/library/importlib.resources.abc.rst
+++ b/Doc/library/importlib.resources.abc.rst
@@ -22,7 +22,7 @@
     something like a data file that lives next to the ``__init__.py``
     file of the package. The purpose of this class is to help abstract
     out the accessing of such data files so that it does not matter if
-    the package and its data file(s) are stored in a e.g. zip file
+    the package and its data file(s) are stored e.g. in a zip file
     versus on the file system.
 
     For any of methods of this class, a *resource* argument is

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -657,7 +657,7 @@ ABC hierarchy::
     something like a data file that lives next to the ``__init__.py``
     file of the package. The purpose of this class is to help abstract
     out the accessing of such data files so that it does not matter if
-    the package and its data file(s) are stored in a e.g. zip file
+    the package and its data file(s) are stored e.g. in a zip file
     versus on the file system.
 
     For any of methods of this class, a *resource* argument is

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -450,7 +450,7 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
 
    .. versionchanged:: 3.8
       Functions wrapped in :func:`functools.partial` now return ``True`` if the
-      wrapped function is a :term:`asynchronous generator` function.
+      wrapped function is an :term:`asynchronous generator` function.
 
 
 .. function:: isasyncgen(object)
@@ -909,7 +909,7 @@ function.
 
    .. attribute:: Parameter.kind.description
 
-      Describes a enum value of :attr:`Parameter.kind`.
+      Describes an enum value of :attr:`Parameter.kind`.
 
       .. versionadded:: 3.8
 

--- a/Doc/library/mailbox.rst
+++ b/Doc/library/mailbox.rst
@@ -1278,7 +1278,7 @@ When an :class:`!MHMessage` instance is created based upon a
 
    .. method:: get_visible()
 
-      Return an :class:`Message` instance whose headers are the message's
+      Return a :class:`Message` instance whose headers are the message's
       visible headers and whose body is empty.
 
 

--- a/Doc/library/optparse.rst
+++ b/Doc/library/optparse.rst
@@ -1351,7 +1351,7 @@ The whole point of creating and populating an OptionParser is to call its
       the list of arguments to process (default: ``sys.argv[1:]``)
 
    ``values``
-      an :class:`Values` object to store option arguments in (default: a
+      a :class:`Values` object to store option arguments in (default: a
       new instance of :class:`Values`) -- if you give an existing object, the
       option defaults will not be initialized on it
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1497,7 +1497,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
 
 .. function:: pwritev(fd, buffers, offset, flags=0, /)
 
-   Write the *buffers* contents to file descriptor *fd* at a offset *offset*,
+   Write the *buffers* contents to file descriptor *fd* at an offset *offset*,
    leaving the file offset unchanged.  *buffers* must be a sequence of
    :term:`bytes-like objects <bytes-like object>`. Buffers are processed in
    array order. Entire contents of the first buffer is written before
@@ -3701,7 +3701,7 @@ features:
    new file descriptor is :ref:`non-inheritable <fd_inheritance>`.
 
    *initval* is the initial value of the event counter. The initial value
-   must be an 32 bit unsigned integer. Please note that the initial value is
+   must be a 32 bit unsigned integer. Please note that the initial value is
    limited to a 32 bit unsigned int although the event counter is an unsigned
    64 bit integer with a maximum value of 2\ :sup:`64`\ -\ 2.
 
@@ -3780,7 +3780,7 @@ features:
 
 .. data:: EFD_SEMAPHORE
 
-   Provide semaphore-like semantics for reads from a :func:`eventfd` file
+   Provide semaphore-like semantics for reads from an :func:`eventfd` file
    descriptor. On read the internal counter is decremented by one.
 
    .. availability:: Linux >= 2.6.30

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -907,7 +907,7 @@ Querying file type and status
 
 .. method:: Path.stat(*, follow_symlinks=True)
 
-   Return a :class:`os.stat_result` object containing information about this path, like :func:`os.stat`.
+   Return an :class:`os.stat_result` object containing information about this path, like :func:`os.stat`.
    The result is looked up at each call to this method.
 
    This method normally follows symlinks; to stat a symlink add the argument

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1697,7 +1697,7 @@ to speed up repeated connections from the same clients.
    IDN-encoded internationalized domain name, the *server_name_callback*
    receives a decoded U-label (``"pythön.org"``).
 
-   If there is an decoding error on the server name, the TLS connection will
+   If there is a decoding error on the server name, the TLS connection will
    terminate with an :const:`ALERT_DESCRIPTION_INTERNAL_ERROR` fatal TLS
    alert message to the client.
 

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1110,7 +1110,7 @@ The :mod:`subprocess` module exposes the following constants.
 .. data:: NORMAL_PRIORITY_CLASS
 
    A :class:`Popen` ``creationflags`` parameter to specify that a new process
-   will have an normal priority. (default)
+   will have a normal priority. (default)
 
    .. versionadded:: 3.7
 

--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -1103,7 +1103,7 @@ FileHandler Objects
 
    .. versionchanged:: 3.2
       This method is applicable only for local hostnames.  When a remote
-      hostname is given, an :exc:`~urllib.error.URLError` is raised.
+      hostname is given, a :exc:`~urllib.error.URLError` is raised.
 
 
 .. _data-handler-objects:
@@ -1118,7 +1118,7 @@ DataHandler Objects
    ignores white spaces in base64 encoded data URLs so the URL may be wrapped
    in whatever source file it comes from. But even though some browsers don't
    mind about a missing padding at the end of a base64 encoded data URL, this
-   implementation will raise an :exc:`ValueError` in that case.
+   implementation will raise a :exc:`ValueError` in that case.
 
 
 .. _ftp-handler-objects:


### PR DESCRIPTION
Corrected some grammar and spelling issues in documentation.

(cherry picked from commit bc264eac3ad14dab748e33b3d714c2674872791f)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122107.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->