### PR TITLE
gh-113785: csv: fields starting with escapechar are not quoted

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -454,6 +454,8 @@ class Test_Csv(unittest.TestCase):
                           quoting=csv.QUOTE_STRINGS)
         self._read_test(['1,@,3,@,5'], [['1', ',3,', '5']], quotechar='@')
         self._read_test(['1,\0,3,\0,5'], [['1', ',3,', '5']], quotechar='\0')
+        self._read_test(['1\\.5,\\.5,.5'], [[1.5, 0.5, 0.5]],
+                        quoting=csv.QUOTE_NONNUMERIC, escapechar='\\')
 
     def test_read_skipinitialspace(self):
         self._read_test(['no space, space,  spaces,\ttab'],

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -456,6 +456,8 @@ class Test_Csv(unittest.TestCase):
         self._read_test(['1,\0,3,\0,5'], [['1', ',3,', '5']], quotechar='\0')
         self._read_test(['1\\.5,\\.5,.5'], [[1.5, 0.5, 0.5]],
                         quoting=csv.QUOTE_NONNUMERIC, escapechar='\\')
+        self._read_test(['1\\.5,\\.5,"\\.5"'], [[1.5, 0.5, ".5"]],
+                        quoting=csv.QUOTE_STRINGS, escapechar='\\')
 
     def test_read_skipinitialspace(self):
         self._read_test(['no space, space,  spaces,\ttab'],

--- a/Misc/NEWS.d/next/Library/2024-07-22-08-14-04.gh-issue-113785.6B_KNB.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-22-08-14-04.gh-issue-113785.6B_KNB.rst
@@ -1,0 +1,1 @@
+:mod:`csv` now correctly parses numeric fields (when used with :const:`csv.QUOTE_NONNUMERIC`) which start with an escape character.

--- a/Misc/NEWS.d/next/Library/2024-07-22-08-14-04.gh-issue-113785.6B_KNB.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-22-08-14-04.gh-issue-113785.6B_KNB.rst
@@ -1,1 +1,1 @@
-:mod:`csv` now correctly parses numeric fields (when used with :const:`csv.QUOTE_NONNUMERIC`) which start with an escape character.
+:mod:`csv` now correctly parses numeric fields (when used with :const:`csv.QUOTE_NONNUMERIC` or :const:`csv.QUOTE_STRINGS`) which start with an escape character.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -749,7 +749,6 @@ parse_process_char(ReaderObj *self, _csvstate *module_state, Py_UCS4 c)
         }
         else if (c == dialect->escapechar) {
             /* possible escaped character */
-            self->unquoted_field = false;
             self->state = ESCAPED_CHAR;
         }
         else if (c == ' ' && dialect->skipinitialspace)


### PR DESCRIPTION
This PR fixes an inconsistency in the _csv.c module, whereby escapechars at the beginning of the field imply that fields are quoted, but escape characters at any other position do not. This only really affects parsing with QUOTE_NONNUMERIC - fields starting with the escape character are incorrectly left as a string, instead of being parsed.

With this change escapechars do not imply a quoted field; which allows fields like `"\\.5"` with QUOTE_NONNUMERIC to be correctly parsed as `0.5`.

Closes #113785.

<!-- gh-issue-number: gh-113785 -->
* Issue: gh-113785
<!-- /gh-issue-number -->
