### PR TITLE
gh-112301: Revert "Add fortify source level 3 to default compiler options (gh-121520)

### DIFF
--- a/Misc/NEWS.d/next/Security/2024-07-08-23-39-04.gh-issue-112301.TD8G01.rst
+++ b/Misc/NEWS.d/next/Security/2024-07-08-23-39-04.gh-issue-112301.TD8G01.rst
@@ -1,2 +1,0 @@
-Enable runtime protections for glibc to abort execution when unsafe behavior is encountered,
-for all platforms except Windows.

--- a/configure
+++ b/configure
@@ -9691,45 +9691,6 @@ else $as_nop
 printf "%s\n" "$as_me: WARNING: -Wtrampolines not supported" >&2;}
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -D_FORTIFY_SOURCE=3" >&5
-printf %s "checking whether C compiler accepts -D_FORTIFY_SOURCE=3... " >&6; }
-if test ${ax_cv_check_cflags___D_FORTIFY_SOURCE_3+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-
-  ax_check_save_flags=$CFLAGS
-  CFLAGS="$CFLAGS  -D_FORTIFY_SOURCE=3"
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  ax_cv_check_cflags___D_FORTIFY_SOURCE_3=yes
-else $as_nop
-  ax_cv_check_cflags___D_FORTIFY_SOURCE_3=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-  CFLAGS=$ax_check_save_flags
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___D_FORTIFY_SOURCE_3" >&5
-printf "%s\n" "$ax_cv_check_cflags___D_FORTIFY_SOURCE_3" >&6; }
-if test "x$ax_cv_check_cflags___D_FORTIFY_SOURCE_3" = xyes
-then :
-  BASECFLAGS="$BASECFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: -D_FORTIFY_SOURCE=3 not supported" >&5
-printf "%s\n" "$as_me: WARNING: -D_FORTIFY_SOURCE=3 not supported" >&2;}
-fi
-
 
 case $GCC in
 yes)

--- a/configure.ac
+++ b/configure.ac
@@ -2460,7 +2460,6 @@ AS_VAR_IF([with_strict_overflow], [yes],
 # These flags should be enabled by default for all builds.
 AX_CHECK_COMPILE_FLAG([-fstack-protector-strong], [BASECFLAGS="$BASECFLAGS -fstack-protector-strong"], [AC_MSG_WARN([-fstack-protector-strong not supported])], [-Werror])
 AX_CHECK_COMPILE_FLAG([-Wtrampolines], [BASECFLAGS="$BASECFLAGS -Wtrampolines"], [AC_MSG_WARN([-Wtrampolines not supported])], [-Werror])
-AX_CHECK_COMPILE_FLAG([-D_FORTIFY_SOURCE=3], [BASECFLAGS="$BASECFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"], [AC_MSG_WARN([-D_FORTIFY_SOURCE=3 not supported])])
 
 case $GCC in
 yes)


### PR DESCRIPTION
Adding the flag broke stable buildbots.

This reverts commit bdab67e1c795443a0d8f8a5bbeb3a91ac4fd5a19
so the change can be re-evaluated.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112301 -->
* Issue: gh-112301
<!-- /gh-issue-number -->
