### PR TITLE
[3.8] gh-121957: Emit audit events for python -i and python -m asyncio

### DIFF
--- a/Doc/library/asyncio.rst
+++ b/Doc/library/asyncio.rst
@@ -57,6 +57,26 @@ Additionally, there are **low-level** APIs for
 * :ref:`bridge <asyncio-futures>` callback-based libraries and code
   with async/await syntax.
 
+.. _asyncio-cli:
+
+.. rubric:: asyncio REPL
+
+You can experiment with an ``asyncio`` concurrent context in the REPL:
+
+.. code-block:: pycon
+
+   $ python -m asyncio
+   asyncio REPL ...
+   Use "await" directly instead of "asyncio.run()".
+   Type "help", "copyright", "credits" or "license" for more information.
+   >>> import asyncio
+   >>> await asyncio.sleep(10, result='hello')
+   'hello'
+
+.. audit-event:: cpython.run_stdin "" ""
+
+.. versionchanged:: 3.9.20 (also 3.8.20)
+   Emits audit events.
 
 .. We use the "rubric" directive here to avoid creating
    the "Reference" subsection in the TOC.

--- a/Doc/library/asyncio.rst
+++ b/Doc/library/asyncio.rst
@@ -75,7 +75,7 @@ You can experiment with an ``asyncio`` concurrent context in the REPL:
 
 .. audit-event:: cpython.run_stdin "" ""
 
-.. versionchanged:: 3.9.20 (also 3.8.20)
+.. versionchanged:: 3.8.20
    Emits audit events.
 
 .. We use the "rubric" directive here to avoid creating

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -597,6 +597,11 @@ conflict.
    This variable can also be modified by Python code using :data:`os.environ`
    to force inspect mode on program termination.
 
+   .. audit-event:: cpython.run_stdin "" ""
+
+   .. versionchanged:: 3.9.20 (also 3.8.20)
+      Emits audit events.
+
 
 .. envvar:: PYTHONUNBUFFERED
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -599,7 +599,7 @@ conflict.
 
    .. audit-event:: cpython.run_stdin "" ""
 
-   .. versionchanged:: 3.9.20 (also 3.8.20)
+   .. versionchanged:: 3.8.20
       Emits audit events.
 
 

--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -90,6 +90,8 @@ class REPLThread(threading.Thread):
 
 
 if __name__ == '__main__':
+    sys.audit("cpython.run_stdin")
+
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 

--- a/Misc/NEWS.d/next/Security/2024-07-22-13-14-38.gh-issue-121957.FYkcOt.rst
+++ b/Misc/NEWS.d/next/Security/2024-07-22-13-14-38.gh-issue-121957.FYkcOt.rst
@@ -1,0 +1,3 @@
+Fixed missing audit events around interactive use of Python, now also
+properly firing for ``python -i``, as well as for ``python -m asyncio``. The
+event in question is ``cpython.run_stdin``.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -546,6 +546,10 @@ pymain_repl(PyConfig *config, PyCompilerFlags *cf, int *exitcode)
         return;
     }
 
+    if (PySys_Audit("cpython.run_stdin", NULL) < 0) {
+        return;
+    }
+
     int res = PyRun_AnyFileFlags(stdin, "<stdin>", cf);
     *exitcode = (res != 0);
 }


### PR DESCRIPTION


<!-- gh-issue-number: gh-121957 -->
* Issue: gh-121957
<!-- /gh-issue-number -->
