### PR TITLE
gh-121973: Fix flaky test_pyrepl tests

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -963,7 +963,7 @@ class TestMain(TestCase):
             mod = blue / "calx.py"
             mod.write_text("FOO = 42", encoding="utf-8")
             commands = [
-                "print(f'{" + var + "=}')" for var in expectations
+                "print(f'^{" + var + "=}')" for var in expectations
             ] + ["exit()"]
             if as_file and as_module:
                 self.fail("as_file and as_module are mutually exclusive")
@@ -989,10 +989,10 @@ class TestMain(TestCase):
         self.assertEqual(exit_code, 0)
         for var, expected in expectations.items():
             with self.subTest(var=var, expected=expected):
-                if m := re.search(rf"[^{{]{var}=(.+?)[\r\n]", output):
+                if m := re.search(rf"\^{var}=(.+?)[\r\n]", output):
                     self._assertMatchOK(var, expected, actual=m.group(1))
                 else:
-                    self.fail(f"{var}= not found in output")
+                    self.fail(f"{var}= not found in output: {output!r}\n\n{output}")
 
         self.assertNotIn("Exception", output)
         self.assertNotIn("Traceback", output)

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -989,7 +989,7 @@ class TestMain(TestCase):
         self.assertEqual(exit_code, 0)
         for var, expected in expectations.items():
             with self.subTest(var=var, expected=expected):
-                if m := re.search(rf"[\r\n]{var}=(.+?)[\r\n]", output):
+                if m := re.search(rf"[^{{]{var}=(.+?)[\r\n]", output):
                     self._assertMatchOK(var, expected, actual=m.group(1))
                 else:
                     self.fail(f"{var}= not found in output")
@@ -1126,4 +1126,4 @@ class TestMain(TestCase):
         except subprocess.TimeoutExpired:
             process.kill()
             exit_code = process.wait()
-        return "\n".join(output), exit_code
+        return "".join(output), exit_code


### PR DESCRIPTION
This fixes the flakiness in:
* test_inspect_keeps_globals_from_inspected_file
* test_inspect_keeps_globals_from_inspected_module

The output already includes newlines. Adding newlines for every entry in the output list introduces non-determinism because it added '\n' in places where stdout is flushed or some buffer becomes full.

The regex also needed to be updated because pyrepl includes control characters -- the visible output on each line doesn't immediately follow a newline character.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121973 -->
* Issue: gh-121973
<!-- /gh-issue-number -->
