### PR TITLE
gh-112301: Make fortify source option check -Werror

### DIFF
--- a/configure
+++ b/configure
@@ -9788,13 +9788,13 @@ if test "$enable_slower_safety" = "yes"
 then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -D_FORTIFY_SOURCE=3" >&5
 printf %s "checking whether C compiler accepts -D_FORTIFY_SOURCE=3... " >&6; }
-if test ${ax_cv_check_cflags___D_FORTIFY_SOURCE_3+y}
+if test ${ax_cv_check_cflags__Werror__D_FORTIFY_SOURCE_3+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
 
   ax_check_save_flags=$CFLAGS
-  CFLAGS="$CFLAGS  -D_FORTIFY_SOURCE=3"
+  CFLAGS="$CFLAGS -Werror -D_FORTIFY_SOURCE=3"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -9808,16 +9808,16 @@ main (void)
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"
 then :
-  ax_cv_check_cflags___D_FORTIFY_SOURCE_3=yes
+  ax_cv_check_cflags__Werror__D_FORTIFY_SOURCE_3=yes
 else $as_nop
-  ax_cv_check_cflags___D_FORTIFY_SOURCE_3=no
+  ax_cv_check_cflags__Werror__D_FORTIFY_SOURCE_3=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
   CFLAGS=$ax_check_save_flags
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___D_FORTIFY_SOURCE_3" >&5
-printf "%s\n" "$ax_cv_check_cflags___D_FORTIFY_SOURCE_3" >&6; }
-if test "x$ax_cv_check_cflags___D_FORTIFY_SOURCE_3" = xyes
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags__Werror__D_FORTIFY_SOURCE_3" >&5
+printf "%s\n" "$ax_cv_check_cflags__Werror__D_FORTIFY_SOURCE_3" >&6; }
+if test "x$ax_cv_check_cflags__Werror__D_FORTIFY_SOURCE_3" = xyes
 then :
   BASECFLAGS="$BASECFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"
 else $as_nop

--- a/configure
+++ b/configure
@@ -9771,6 +9771,21 @@ else $as_nop
 printf "%s\n" "$as_me: WARNING: -Wtrampolines not supported" >&2;}
 fi
 
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --enable-slower-safety" >&5
+printf %s "checking for --enable-slower-safety... " >&6; }
+# Check whether --enable-slower-safety was given.
+if test ${enable_slower_safety+y}
+then :
+  enableval=$enable_slower_safety;
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enable_slower_safety" >&5
+printf "%s\n" "$enable_slower_safety" >&6; }
+
+if test "$enable_slower_safety" = "yes"
+then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -D_FORTIFY_SOURCE=3" >&5
 printf %s "checking whether C compiler accepts -D_FORTIFY_SOURCE=3... " >&6; }
 if test ${ax_cv_check_cflags__Werror__D_FORTIFY_SOURCE_3+y}
@@ -9811,17 +9826,6 @@ printf "%s\n" "$as_me: WARNING: -D_FORTIFY_SOURCE=3 not supported" >&2;}
 fi
 
 fi
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --enable-slower-safety" >&5
-printf %s "checking for --enable-slower-safety... " >&6; }
-# Check whether --enable-slower-safety was given.
-if test ${enable_slower_safety+y}
-then :
-  enableval=$enable_slower_safety;
-fi
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enable_slower_safety" >&5
-printf "%s\n" "$enable_slower_safety" >&6; }
 
 case $GCC in
 yes)

--- a/configure
+++ b/configure
@@ -9771,21 +9771,6 @@ else $as_nop
 printf "%s\n" "$as_me: WARNING: -Wtrampolines not supported" >&2;}
 fi
 
-fi
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --enable-slower-safety" >&5
-printf %s "checking for --enable-slower-safety... " >&6; }
-# Check whether --enable-slower-safety was given.
-if test ${enable_slower_safety+y}
-then :
-  enableval=$enable_slower_safety;
-fi
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enable_slower_safety" >&5
-printf "%s\n" "$enable_slower_safety" >&6; }
-
-if test "$enable_slower_safety" = "yes"
-then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -D_FORTIFY_SOURCE=3" >&5
 printf %s "checking whether C compiler accepts -D_FORTIFY_SOURCE=3... " >&6; }
 if test ${ax_cv_check_cflags__Werror__D_FORTIFY_SOURCE_3+y}
@@ -9825,6 +9810,21 @@ else $as_nop
 printf "%s\n" "$as_me: WARNING: -D_FORTIFY_SOURCE=3 not supported" >&2;}
 fi
 
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --enable-slower-safety" >&5
+printf %s "checking for --enable-slower-safety... " >&6; }
+# Check whether --enable-slower-safety was given.
+if test ${enable_slower_safety+y}
+then :
+  enableval=$enable_slower_safety;
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enable_slower_safety" >&5
+printf "%s\n" "$enable_slower_safety" >&6; }
+
+if test "$enable_slower_safety" = "yes"
+then
 fi
 
 case $GCC in

--- a/configure
+++ b/configure
@@ -9823,10 +9823,6 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enable_slower_safety" >&5
 printf "%s\n" "$enable_slower_safety" >&6; }
 
-if test "$enable_slower_safety" = "yes"
-then
-fi
-
 case $GCC in
 yes)
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c11"

--- a/configure.ac
+++ b/configure.ac
@@ -2510,13 +2510,17 @@ if test "$disable_safety" = "no"
 then
   AX_CHECK_COMPILE_FLAG([-fstack-protector-strong], [BASECFLAGS="$BASECFLAGS -fstack-protector-strong"], [AC_MSG_WARN([-fstack-protector-strong not supported])], [-Werror])
   AX_CHECK_COMPILE_FLAG([-Wtrampolines], [BASECFLAGS="$BASECFLAGS -Wtrampolines"], [AC_MSG_WARN([-Wtrampolines not supported])], [-Werror])
-  AX_CHECK_COMPILE_FLAG([-D_FORTIFY_SOURCE=3], [BASECFLAGS="$BASECFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"], [AC_MSG_WARN([-D_FORTIFY_SOURCE=3 not supported])], [-Werror])
 fi
 
 AC_MSG_CHECKING([for --enable-slower-safety])
 AC_ARG_ENABLE([slower-safety],
   [AS_HELP_STRING([--enable-slower-safety], [enable usage of the security compiler options with performance overhead])],[])
 AC_MSG_RESULT([$enable_slower_safety])
+
+if test "$enable_slower_safety" = "yes"
+then
+  AX_CHECK_COMPILE_FLAG([-D_FORTIFY_SOURCE=3], [BASECFLAGS="$BASECFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"], [AC_MSG_WARN([-D_FORTIFY_SOURCE=3 not supported])], [-Werror])
+fi
 
 case $GCC in
 yes)

--- a/configure.ac
+++ b/configure.ac
@@ -2510,6 +2510,7 @@ if test "$disable_safety" = "no"
 then
   AX_CHECK_COMPILE_FLAG([-fstack-protector-strong], [BASECFLAGS="$BASECFLAGS -fstack-protector-strong"], [AC_MSG_WARN([-fstack-protector-strong not supported])], [-Werror])
   AX_CHECK_COMPILE_FLAG([-Wtrampolines], [BASECFLAGS="$BASECFLAGS -Wtrampolines"], [AC_MSG_WARN([-Wtrampolines not supported])], [-Werror])
+  AX_CHECK_COMPILE_FLAG([-D_FORTIFY_SOURCE=3], [BASECFLAGS="$BASECFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"], [AC_MSG_WARN([-D_FORTIFY_SOURCE=3 not supported])], [-Werror])
 fi
 
 AC_MSG_CHECKING([for --enable-slower-safety])
@@ -2519,7 +2520,6 @@ AC_MSG_RESULT([$enable_slower_safety])
 
 if test "$enable_slower_safety" = "yes"
 then
-  AX_CHECK_COMPILE_FLAG([-D_FORTIFY_SOURCE=3], [BASECFLAGS="$BASECFLAGS -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3"], [AC_MSG_WARN([-D_FORTIFY_SOURCE=3 not supported])])
 fi
 
 case $GCC in

--- a/configure.ac
+++ b/configure.ac
@@ -2518,10 +2518,6 @@ AC_ARG_ENABLE([slower-safety],
   [AS_HELP_STRING([--enable-slower-safety], [enable usage of the security compiler options with performance overhead])],[])
 AC_MSG_RESULT([$enable_slower_safety])
 
-if test "$enable_slower_safety" = "yes"
-then
-fi
-
 case $GCC in
 yes)
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c11"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Add autoconf option to `AX_CHECK_COMPILE_FLAG` in `configure.ac` to treat checking for `-D_FORTIFY_SOURCE=3` compiler option availability with `-Werror` to match other options.

Suggested in previous PR for adding this option: https://github.com/python/cpython/pull/121520#issuecomment-2241261723

<!-- gh-issue-number: gh-112301 -->
* Issue: gh-112301
<!-- /gh-issue-number -->
