### PR TITLE
gh-121832: Skip subinterpreter static type check on iOS to restore test suite.

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1,6 +1,6 @@
 # Python test set -- part 6, built-in types
 
-from test.support import run_with_locale, cpython_only, MISSING_C_DOCSTRINGS
+from test.support import run_with_locale, is_apple_mobile, cpython_only, MISSING_C_DOCSTRINGS
 import collections.abc
 from collections import namedtuple, UserDict
 import copy
@@ -2358,6 +2358,7 @@ class SubinterpreterTests(unittest.TestCase):
         import test.support.interpreters.channels
 
     @cpython_only
+    @unittest.skipIf(is_apple_mobile, "Fails on iOS due to test ordering; see #121832.")
     def test_slot_wrappers(self):
         rch, sch = interpreters.channels.create()
 


### PR DESCRIPTION
The CPython test suite will crash if you run any test that creates a subinterpreter after running the `test_type_cache` test. 

This bug affects all platforms; but iOS is the only platform that reliably hits the bug as part of test suite execution, as it is the only platform that runs the test suite in a single process. 

`test_types` is the only test that creates a subinterpreter after `test_type_cache`. This PR skips the subinterpreter slot tests that are part of `test_types` on iOS as a temporary measure so that we can observe other failures that might be occurring in iOS.

When a final fix for #121832 is in place, this test skip can be removed.



<!-- gh-issue-number: gh-121832 -->
* Issue: gh-121832
<!-- /gh-issue-number -->
