### PR TITLE
gh-121723: Relax constraints on queue objects for `logging.handlers.QueueHandler`.

### DIFF
--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -753,9 +753,12 @@ The ``queue`` and ``listener`` keys are optional.
 
 If the ``queue`` key is present, the corresponding value can be one of the following:
 
-* An actual instance of :class:`queue.Queue` or a subclass thereof. This is of course
-  only possible if you are constructing or modifying the configuration dictionary in
-  code.
+* An object implementing the :class:`queue.Queue` public API. For instance,
+  this may be an actual instance of :class:`queue.Queue` or a subclass thereof,
+  or a proxy obtained by :meth:`multiprocessing.SyncManager.Queue`.
+
+  This is of course only possible if you are constructing or modifying
+  the configuration dictionary in code.
 
 * A string that resolves to a callable which, when called with no arguments, returns
   the :class:`queue.Queue` instance to use. That callable could be a

--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -755,7 +755,7 @@ If the ``queue`` key is present, the corresponding value can be one of the follo
 
 * An object implementing the :class:`queue.Queue` public API. For instance,
   this may be an actual instance of :class:`queue.Queue` or a subclass thereof,
-  or a proxy obtained by :meth:`multiprocessing.SyncManager.Queue`.
+  or a proxy obtained by :meth:`multiprocessing.managers.SyncManager.Queue`.
 
   This is of course only possible if you are constructing or modifying
   the configuration dictionary in code.

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -515,7 +515,7 @@ def _is_queue_like_object(obj):
     # and typing.Protocol to reduce import time (see gh-121723).
     #
     # Ideally, we would have wanted to simply use strict type checking
-    # instead of a protocol-based type checking since the latetr does
+    # instead of a protocol-based type checking since the latter does
     # not check the method signatures.
     queue_interface = [
         'empty', 'full', 'get', 'get_nowait',

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -501,7 +501,6 @@ def _is_queue_like_object(obj):
     """Check that *obj* implements the Queue API."""
     if isinstance(obj, queue.Queue):
         return True
-
     # defer importing multiprocessing as much as possible
     from multiprocessing.queues import Queue as MPQueue
     if isinstance(obj, MPQueue):

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -501,21 +501,22 @@ def _is_queue_like_object(obj):
     """Check that *obj* implements the Queue API."""
     if isinstance(obj, queue.Queue):
         return True
+
     # defer importing multiprocessing as much as possible
     from multiprocessing.queues import Queue as MPQueue
     if isinstance(obj, MPQueue):
         return True
     # Depending on the multiprocessing start context, we cannot create
     # a multiprocessing.managers.BaseManager instance 'mm' to get the
-    # runtime type of mm.Queue() or mm.JoinableQueue() (see gh-121723).
+    # runtime type of mm.Queue() or mm.JoinableQueue() (see gh-119819).
     #
     # Since we only need an object implementing the Queue API, we only
-    # do a protocol check without relying on typing.runtime_checkable
+    # do a protocol check, but we do not use typing.runtime_checkable()
     # and typing.Protocol to reduce import time (see gh-121723).
     #
     # Ideally, we would have wanted to simply use strict type checking
-    # instead of protocol-based type checking since this approach does
-    # not consider incompatible signatures.
+    # instead of a protocol-based type checking since the latetr does
+    # not check the method signatures.
     queue_interface = [
         'empty', 'full', 'get', 'get_nowait',
         'put', 'put_nowait', 'join', 'qsize',

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -791,31 +791,30 @@ class DictConfigurator(BaseConfigurator):
                         if '()' not in qspec:
                             raise TypeError('Invalid queue specifier %r' % qspec)
                         config['queue'] = self.configure_custom(dict(qspec))
+                    elif isinstance(qspec, queue.Queue):
+                        pass
                     else:
+                        # defer importing multiprocessing as much as possible
                         from multiprocessing.queues import Queue as MPQueue
 
-                        if not isinstance(qspec, (queue.Queue, MPQueue)):
-                            # Safely check if 'qspec' is an instance of Manager.Queue
-                            # / Manager.JoinableQueue
-
-                            from multiprocessing import Manager as MM
-                            from multiprocessing.managers import BaseProxy
-
-                            # if it's not an instance of BaseProxy, it also can't be
-                            # an instance of Manager.Queue / Manager.JoinableQueue
-                            if isinstance(qspec, BaseProxy):
-                                # Sometimes manager or queue creation might fail
-                                # (e.g. see issue gh-120868). In that case, any
-                                # exception during the creation of these queues will
-                                # propagate up to the caller and be wrapped in a
-                                # `ValueError`, whose cause will indicate the details of
-                                # the failure.
-                                mm = MM()
-                                proxy_queue = mm.Queue()
-                                proxy_joinable_queue = mm.JoinableQueue()
-                                if not isinstance(qspec, (type(proxy_queue), type(proxy_joinable_queue))):
-                                    raise TypeError('Invalid queue specifier %r' % qspec)
-                            else:
+                        if not isinstance(qspec, MPQueue):
+                            # Depending on the multiprocessing context,
+                            # we cannot create a Manager instance here
+                            # to get the runtime type of Manager.Queue()
+                            # or Manager.JoinableQueue() (see gh-121723).
+                            #
+                            # Since we only need to support an object
+                            # implementing the Queue API (see gh-120868),
+                            # we only do a protocol check but do not rely
+                            # on typing.runtime_checkable and typing.Protocol
+                            # to reduce import time.
+                            queue_interface = [
+                                'empty', 'full', 'get', 'get_nowait',
+                                'put', 'put_nowait', 'join', 'qsize',
+                                'task_done',
+                            ]
+                            if not all(callable(getattr(qspec, method, None))
+                                       for method in queue_interface):
                                 raise TypeError('Invalid queue specifier %r' % qspec)
 
                 if 'listener' in config:

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4002,9 +4002,13 @@ class ConfigDictTest(BaseTest):
     @unittest.skipUnless(support.Py_DEBUG, "requires a debug build")
     def test_config_queue_handler_multiprocessing_context(self):
         # regression test for gh-121723
-        for startmethod in ['fork', 'spawn', 'forkserver']:
-            with self.subTest(startmethod=startmethod):
-                ctx = multiprocessing.get_context(startmethod)
+        if support.MS_WINDOWS:
+            start_methods = ['spawn']
+        else:
+            start_methods = ['spawn', 'fork', 'forkserver']
+        for start_method in start_methods:
+            with self.subTest(start_method=start_method):
+                ctx = multiprocessing.get_context(start_method)
                 with ctx.Manager() as manager:
                     q = manager.Queue()
                     records = []

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -2380,7 +2380,7 @@ class FuzzyCustomQueueProtocol(CustomQueueProtocol):
     # An object implementing the Queue API (incorrect signatures).
     # The object will be considered a valid queue class since we
     # do not check the signatures (only callability of methods)
-    # but will NOT be usable in production since a ValueError will
+    # but will NOT be usable in production since a TypeError will
     # be raised due to a missing argument.
     def empty(self, x):
         pass
@@ -3957,11 +3957,11 @@ class ConfigDictTest(BaseTest):
         q1 = {"()": "queue.Queue", "maxsize": -1}
         q2 = MQ()
         q3 = queue.Queue()
-        # FuzzyCustomQueueProtocol pass the checks but will not be usable
+        # FuzzyCustomQueueProtocol passes the checks but will not be usable
         # since the signatures are incompatible. Checking the Queue API
         # without testing the type of the actual queue is a trade-off
         # between usability and the work we need to do in order to safely
-        # check that the queue object is a valid queue object.
+        # check that the queue object correctly implements the API.
         q4 = FuzzyCustomQueueProtocol()
 
         for qspec in (q1, q2, q3, q4):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3957,7 +3957,7 @@ class ConfigDictTest(BaseTest):
         q1 = {"()": "queue.Queue", "maxsize": -1}
         q2 = MQ()
         q3 = queue.Queue()
-        # FuzzyCustomQueueProtocol passes the checks but will not be usable
+        # CustomQueueFakeProtocol passes the checks but will not be usable
         # since the signatures are incompatible. Checking the Queue API
         # without testing the type of the actual queue is a trade-off
         # between usability and the work we need to do in order to safely

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4015,7 +4015,7 @@ class ConfigDictTest(BaseTest):
                     # use 1 process and 1 task per child to put 1 record
                     with ctx.Pool(1, initializer=self._mpinit_issue121723,
                                   initargs=(q, "text"), maxtasksperchild=1):
-                        records.append(q.get(timeout=0.5))
+                        records.append(q.get(timeout=2))
                     self.assertTrue(q.empty())
                 self.assertEqual(len(records), 1)
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4016,7 +4016,7 @@ class ConfigDictTest(BaseTest):
                     # use 1 process and 1 task per child to put 1 record
                     with ctx.Pool(1, initializer=self._mpinit_issue121723,
                                   initargs=(q, "text"), maxtasksperchild=1):
-                        records.append(q.get(timeout=2))
+                        records.append(q.get(timeout=60))
                     self.assertTrue(q.empty())
                 self.assertEqual(len(records), 1)
 

--- a/Misc/NEWS.d/next/Library/2024-07-23-10-59-38.gh-issue-121723.iJEf7e.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-23-10-59-38.gh-issue-121723.iJEf7e.rst
@@ -1,0 +1,3 @@
+Make :func:`logging.config.dictConfig` accept any object implementing the
+Queue public API. See the :ref:`queue configuration <configure-queue>`
+section for details. Patch by Bénédikt Tran.


### PR DESCRIPTION
Not sure if I need to explain what the Queue public API is. I think people are smart enough to understand that we expect a Queue-like object but tell me if you want me to put more details here. 

<!-- gh-issue-number: gh-121723 -->
* Issue: gh-121723
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122154.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->