### PR TITLE
GH-122155: Fix cases generator to correctly compute 'peek' offset for error handling

### DIFF
--- a/Tools/cases_generator/analyzer.py
+++ b/Tools/cases_generator/analyzer.py
@@ -317,9 +317,13 @@ def analyze_stack(op: parser.InstDef | parser.Pseudo, replace_op_arg_1: str | No
         convert_stack_item(i, replace_op_arg_1) for i in op.inputs if isinstance(i, parser.StackEffect)
     ]
     outputs: list[StackItem] = [convert_stack_item(i, replace_op_arg_1) for i in op.outputs]
+    # Mark variables with matching names at the base of the stack as "peek"
+    modified = False
     for input, output in zip(inputs, outputs):
-        if input.name == output.name:
+        if input.name == output.name and not modified:
             input.peek = output.peek = True
+        else:
+            modified = True
     if isinstance(op, parser.InstDef):
         output_names = [out.name for out in outputs]
         for input in inputs:

--- a/Tools/cases_generator/generators_common.py
+++ b/Tools/cases_generator/generators_common.py
@@ -92,7 +92,7 @@ def replace_error(
     next(tkn_iter)  # RPAREN
     next(tkn_iter)  # Semi colon
     out.emit(") ")
-    c_offset = stack.peek_offset.to_c()
+    c_offset = stack.peek_offset()
     try:
         offset = -int(c_offset)
         close = ";\n"

--- a/Tools/cases_generator/stack.py
+++ b/Tools/cases_generator/stack.py
@@ -49,6 +49,9 @@ class StackOffset:
     def empty() -> "StackOffset":
         return StackOffset([], [])
 
+    def copy(self):
+        return StackOffset(self.popped[:], self.pushed[:])
+
     def pop(self, item: StackItem) -> None:
         self.popped.append(var_size(item))
 
@@ -122,14 +125,11 @@ class Stack:
     def __init__(self) -> None:
         self.top_offset = StackOffset.empty()
         self.base_offset = StackOffset.empty()
-        self.peek_offset = StackOffset.empty()
         self.variables: list[StackItem] = []
         self.defined: set[str] = set()
 
     def pop(self, var: StackItem, extract_bits: bool = False) -> str:
         self.top_offset.pop(var)
-        if not var.peek:
-            self.peek_offset.pop(var)
         indirect = "&" if var.is_array() else ""
         if self.variables:
             popped = self.variables.pop()
@@ -210,8 +210,15 @@ class Stack:
         self.variables = []
         self.base_offset.clear()
         self.top_offset.clear()
-        self.peek_offset.clear()
         out.start_line()
+
+    def peek_offset(self):
+        peek = self.base_offset.copy()
+        for var in self.variables:
+            if not var.peek:
+                break
+            peek.push(var)
+        return peek.to_c()
 
     def as_comment(self) -> str:
         return f"/* Variables: {[v.name for v in self.variables]}. Base offset: {self.base_offset.to_c()}. Top offset: {self.top_offset.to_c()} */"

--- a/Tools/cases_generator/stack.py
+++ b/Tools/cases_generator/stack.py
@@ -49,7 +49,7 @@ class StackOffset:
     def empty() -> "StackOffset":
         return StackOffset([], [])
 
-    def copy(self):
+    def copy(self) -> "StackOffset":
         return StackOffset(self.popped[:], self.pushed[:])
 
     def pop(self, item: StackItem) -> None:
@@ -212,7 +212,7 @@ class Stack:
         self.top_offset.clear()
         out.start_line()
 
-    def peek_offset(self):
+    def peek_offset(self) -> str:
         peek = self.base_offset.copy()
         for var in self.variables:
             if not var.peek:


### PR DESCRIPTION
Computes the "peek" offset on demand, rather than attempting to keep it up to date as the stack is modified.
This is simpler and less error prone.

I'll like to backport this to 3.13, so that the fix for https://github.com/python/cpython/issues/122029 can be more easily backported.


<!-- gh-issue-number: gh-122155 -->
* Issue: gh-122155
<!-- /gh-issue-number -->
