### PR TITLE
gh-122170: Fix interpreter exiting due to ValueError from `os.stat` for too long filename on Windows

### DIFF
--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -135,7 +135,7 @@ def updatecache(filename, module_globals=None):
             try:
                 stat = os.stat(fullname)
                 break
-            except OSError:
+            except (OSError, ValueError):
                 pass
         else:
             return []

--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -98,7 +98,7 @@ def updatecache(filename, module_globals=None):
     fullname = filename
     try:
         stat = os.stat(fullname)
-    except OSError:
+    except (OSError, ValueError):
         basename = filename
 
         # Realise a lazy loader based lookup if there is one

--- a/Lib/test/test_linecache.py
+++ b/Lib/test/test_linecache.py
@@ -280,6 +280,7 @@ class LineCacheTests(unittest.TestCase):
         self.assertEqual(linecache.getlines(filename, module_globals),
                          ['source for x.y.z\n'])
 
+    @unittest.skipUnless(support.MS_WINDOWS, "Test only relevant in Windows.")
     def test_filename_too_long(self):
         self.assertEqual(linecache.updatecache("s" * 999999), [])
 

--- a/Lib/test/test_linecache.py
+++ b/Lib/test/test_linecache.py
@@ -280,6 +280,9 @@ class LineCacheTests(unittest.TestCase):
         self.assertEqual(linecache.getlines(filename, module_globals),
                          ['source for x.y.z\n'])
 
+    def test_filename_too_long(self):
+        self.assertEqual(linecache.updatecache("s" * 999999), [])
+
 
 class LineCacheInvalidationTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR fixes the interpreter exiting on Windows in 3.13.0b4 and main due to `ValueError: stat: path too long for Windows` being raised by `os.stat()` in `updatecache()` in linecache.py when trying to print a traceback with a too long filename.

<!-- gh-issue-number: gh-122170 -->
* Issue: gh-122170
<!-- /gh-issue-number -->
