### PR TITLE
gh-117657: Avoid race in `PAUSE_ADAPTIVE_COUNTER` in free-threaded build

### DIFF
--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -316,17 +316,18 @@ GETITEM(PyObject *v, Py_ssize_t i) {
         /* gh-115999 tracks progress on addressing this. */ \
         static_assert(0, "The specializing interpreter is not yet thread-safe"); \
     } while (0);
+#define PAUSE_ADAPTIVE_COUNTER(COUNTER) ((void)COUNTER)
 #else
 #define ADVANCE_ADAPTIVE_COUNTER(COUNTER) \
     do { \
         (COUNTER) = advance_backoff_counter((COUNTER)); \
     } while (0);
-#endif
 
 #define PAUSE_ADAPTIVE_COUNTER(COUNTER) \
     do { \
         (COUNTER) = pause_backoff_counter((COUNTER)); \
     } while (0);
+#endif
 
 #define UNBOUNDLOCAL_ERROR_MSG \
     "cannot access local variable '%s' where it is not associated with a value"

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -23,7 +23,6 @@ race:free_threadstate
 
 # These warnings trigger directly in a CPython function.
 
-race_top:_PyEval_EvalFrameDefault
 race_top:assign_version_tag
 race_top:new_reference
 race_top:_multiprocessing_SemLock_acquire_impl


### PR DESCRIPTION
The adaptive counter doesn't do anything currently in the free-threaded build and TSan reports a data race due to concurrent modifications to the counter.

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
