### PR TITLE
gh-117657: Skip tests that use threads after fork

### DIFF
--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -1212,6 +1212,7 @@ class TestFork(unittest.IsolatedAsyncioTestCase):
             wait_process(pid, exitcode=0)
 
     @hashlib_helper.requires_hashdigest('md5')
+    @support.skip_if_sanitizer("TSAN doesn't support threads after fork", thread=True)
     def test_fork_signal_handling(self):
         self.addCleanup(multiprocessing_cleanup_tests)
 
@@ -1258,6 +1259,7 @@ class TestFork(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(child_handled.is_set())
 
     @hashlib_helper.requires_hashdigest('md5')
+    @support.skip_if_sanitizer("TSAN doesn't support threads after fork", thread=True)
     def test_fork_asyncio_run(self):
         self.addCleanup(multiprocessing_cleanup_tests)
 
@@ -1277,6 +1279,7 @@ class TestFork(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.value, 42)
 
     @hashlib_helper.requires_hashdigest('md5')
+    @support.skip_if_sanitizer("TSAN doesn't support threads after fork", thread=True)
     def test_fork_asyncio_subprocess(self):
         self.addCleanup(multiprocessing_cleanup_tests)
 


### PR DESCRIPTION
These tests fail when run under thread sanitizer due to the use of fork and threads.

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
