### PR TITLE
gh-122199: Skip test_slot_wrappers When Checking For Refleaks

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1,6 +1,9 @@
 # Python test set -- part 6, built-in types
 
-from test.support import run_with_locale, is_apple_mobile, cpython_only, MISSING_C_DOCSTRINGS
+from test.support import (
+    run_with_locale, is_apple_mobile, cpython_only, no_rerun,
+    MISSING_C_DOCSTRINGS,
+)
 import collections.abc
 from collections import namedtuple, UserDict
 import copy
@@ -2378,6 +2381,7 @@ class SubinterpreterTests(unittest.TestCase):
         import test.support.interpreters.channels
 
     @cpython_only
+    @no_rerun('channels (and queues) might have a refleak; see gh-122199')
     @unittest.skipIf(is_apple_mobile, "Fails on iOS due to test ordering; see #121832.")
     def test_slot_wrappers(self):
         rch, sch = interpreters.channels.create()


### PR DESCRIPTION


<!-- gh-issue-number: gh-122199 -->
* Issue: gh-122199
<!-- /gh-issue-number -->
