### PR TITLE
gh-122201: Lock mutex when setting handling_thread to NULL

### DIFF
--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -901,6 +901,18 @@ unsignal_pending_calls(PyThreadState *tstate, PyInterpreterState *interp)
 #endif
 }
 
+static void
+clear_pending_handling_thread(struct _pending_calls *pending)
+{
+#ifdef Py_GIL_DISABLED
+    PyMutex_Lock(&pending->mutex);
+    pending->handling_thread = NULL;
+    PyMutex_Unlock(&pending->mutex);
+#else
+    pending->handling_thread = NULL;
+#endif
+}
+
 static int
 make_pending_calls(PyThreadState *tstate)
 {
@@ -933,7 +945,7 @@ make_pending_calls(PyThreadState *tstate)
 
     int32_t npending;
     if (_make_pending_calls(pending, &npending) != 0) {
-        pending->handling_thread = NULL;
+        clear_pending_handling_thread(pending);
         /* There might not be more calls to make, but we play it safe. */
         signal_pending_calls(tstate, interp);
         return -1;
@@ -945,7 +957,7 @@ make_pending_calls(PyThreadState *tstate)
 
     if (_Py_IsMainThread() && _Py_IsMainInterpreter(interp)) {
         if (_make_pending_calls(pending_main, &npending) != 0) {
-            pending->handling_thread = NULL;
+            clear_pending_handling_thread(pending);
             /* There might not be more calls to make, but we play it safe. */
             signal_pending_calls(tstate, interp);
             return -1;
@@ -956,7 +968,7 @@ make_pending_calls(PyThreadState *tstate)
         }
     }
 
-    pending->handling_thread = NULL;
+    clear_pending_handling_thread(pending);
     return 0;
 }
 

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -28,7 +28,6 @@ race_top:assign_version_tag
 race_top:new_reference
 race_top:_multiprocessing_SemLock_acquire_impl
 race_top:list_get_item_ref
-race_top:make_pending_calls
 race_top:_Py_slot_tp_getattr_hook
 race_top:add_threadstate
 race_top:dump_traceback


### PR DESCRIPTION
In the free-threaded build, we need to lock `pending->mutex` when clearing the `handling_thread` in order to avoid a race with a concurrent `make_pending_calls()` from the same interpreter.


<!-- gh-issue-number: gh-122201 -->
* Issue: gh-122201
<!-- /gh-issue-number -->
