### PR TITLE
gh-119896: Fix repl ctrl-z on Windows

### DIFF
--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -21,6 +21,8 @@
 
 from __future__ import annotations
 
+import sys
+
 from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
 import unicodedata
@@ -52,7 +54,10 @@ def disp_str(buffer: str) -> tuple[str, list[int]]:
     b: list[int] = []
     s: list[str] = []
     for c in buffer:
-        if ord(c) < 128:
+        if c == '\x1a':
+            s.append(c)
+            b.append(2)
+        elif ord(c) < 128:
             s.append(c)
             b.append(1)
         elif unicodedata.category(c).startswith("C"):
@@ -110,7 +115,7 @@ default_keymap: tuple[tuple[KeySpec, CommandName], ...] = tuple(
         (r"\C-w", "unix-word-rubout"),
         (r"\C-x\C-u", "upcase-region"),
         (r"\C-y", "yank"),
-        (r"\C-z", "suspend"),
+        *(() if sys.platform == "win32" else ((r"\C-z", "suspend"), )),
         (r"\M-b", "backward-word"),
         (r"\M-c", "capitalize-word"),
         (r"\M-d", "kill-word"),

--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -76,6 +76,7 @@ REPL_COMMANDS = {
     "copyright": _sitebuiltins._Printer('copyright', sys.copyright),
     "help": "help",
     "clear": _clear_screen,
+    "\x1a": _sitebuiltins.Quitter('\x1a', ''),
 }
 
 

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -21,4 +21,5 @@ def wlen(s: str) -> int:
     length = sum(str_width(i) for i in s)
     # remove lengths of any escape sequences
     sequence = ANSI_ESCAPE_SEQUENCE.findall(s)
-    return length - sum(len(i) for i in sequence)
+    ctrl_z_cnt = s.count('\x1a')
+    return length - sum(len(i) for i in sequence) + ctrl_z_cnt

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -253,7 +253,7 @@ class WindowsConsole(Console):
         else:
             self.__posxy = wlen(newline), y
 
-            if "\x1b" in newline or y != self.__posxy[1]:
+            if "\x1b" in newline or y != self.__posxy[1] or '\x1a' in newline:
                 # ANSI escape characters are present, so we can't assume
                 # anything about the position of the cursor.  Moving the cursor
                 # to the left margin should work to get to a known position.
@@ -291,6 +291,9 @@ class WindowsConsole(Console):
         self.__write("\x1b[?12l")
 
     def __write(self, text: str) -> None:
+        if "\x1a" in text:
+            text = ''.join(["^Z" if x == '\x1a' else x for x in text])
+
         if self.out is not None:
             self.out.write(text.encode(self.encoding, "replace"))
             self.out.flush()


### PR DESCRIPTION
Fixes Ctrl-Z to behave like the existing Windows REPL:
 1) Ctrl-Z displays as a "^Z"
 2) Ctrl-Z + Enter is required to exit
 3) Ctrl-Z at the end of an input reports a SyntaxError

Basically we get the ability to output the '\x1a' character as `^Z` (knowing it has a length of 2) and we account for it's length in the output. To get the ability to quit we register a new command like "exit" or "quit".  Finally we no longer register the keyboard shortcut on Windows.

More of this could be wrapped up in sys.platform checks for win32, but I don't think they're strictly necessary - Ctrl-Z will just immediately do a suspend on Linux and will never be in the input.

We could extend this to more Ctrl-characters  (e.g. you can type "Ctrl-E" and get `^E` in the input and there's many more that don't map to useful control keys) but I'm not sure it has any value. We could also drop making Ctrl-D exit the process on Windows but I suspect this is a general usability improvement for people working on both platforms.

<!-- gh-issue-number: gh-119896 -->
* Issue: gh-119896
<!-- /gh-issue-number -->
