### PR TITLE
[3.13] gh-122087: Restore ismethoddescriptor() and isroutine() for partial objects

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -325,6 +325,11 @@ def ismethoddescriptor(object):
     if isclass(object) or ismethod(object) or isfunction(object):
         # mutual exclusion
         return False
+    if isinstance(object, functools.partial):
+        # Lie for children.  The addition of partial.__get__
+        # doesn't currently change the partial objects behaviour,
+        # not counting a warning about future changes.
+        return False
     tp = type(object)
     return (hasattr(tp, "__get__")
             and not hasattr(tp, "__set__")

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -405,6 +405,8 @@ class TestPredicates(IsTestBase):
         self.assertFalse(inspect.isroutine(type))
         self.assertFalse(inspect.isroutine(int))
         self.assertFalse(inspect.isroutine(type('some_class', (), {})))
+        # partial
+        self.assertFalse(inspect.isroutine(functools.partial(mod.spam)))
 
     def test_isclass(self):
         self.istest(inspect.isclass, 'mod.StupidGit')
@@ -1906,6 +1908,7 @@ class TestIsMethodDescriptor(unittest.TestCase):
         self.assertFalse(inspect.ismethoddescriptor(Owner.static_method))
         self.assertFalse(inspect.ismethoddescriptor(function))
         self.assertFalse(inspect.ismethoddescriptor(a_lambda))
+        self.assertFalse(inspect.ismethoddescriptor(functools.partial(function)))
 
     def test_descriptor_being_a_class(self):
         class MethodDescriptorMeta(type):

--- a/Misc/NEWS.d/next/Library/2024-07-24-09-29-55.gh-issue-122087.FdBrWo.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-24-09-29-55.gh-issue-122087.FdBrWo.rst
@@ -1,0 +1,2 @@
+Restore :func:`inspect.ismethoddescriptor` and :func:`inspect.isroutine`
+returning ``False`` for :class:`functools.partial` objects.


### PR DESCRIPTION
They return now False again.


<!-- gh-issue-number: gh-122087 -->
* Issue: gh-122087
<!-- /gh-issue-number -->
