### PR TITLE
gh-122191: Fix test_warnings failure if run with -Werror

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 import linecache
 import os
+import importlib
 import inspect
 from io import StringIO
 import re
@@ -887,37 +888,37 @@ class _WarningsTests(BaseTest, unittest.TestCase):
         # warn_explicit() should neither raise a SystemError nor cause an
         # assertion failure, in case the return value of get_source() has a
         # bad splitlines() method.
-        def get_bad_loader(splitlines_ret_val):
-            class BadLoader:
-                def get_source(self, fullname):
-                    class BadSource(str):
-                        def splitlines(self):
-                            return splitlines_ret_val
-                    return BadSource('spam')
-            return BadLoader()
+        class BadLoader:
+            def get_source(self, fullname):
+                class BadSource(str):
+                    def splitlines(self):
+                        return splitlines_ret_val
+                return BadSource('spam')
 
+        loader = BadLoader()
+        spec = importlib.machinery.ModuleSpec('foobar', loader)
+        module_globals = {'__loader__': loader,
+                          '__spec__': spec,
+                          '__name__': 'foobar'}
         wmod = self.module
         with original_warnings.catch_warnings(module=wmod):
             wmod.filterwarnings('default', category=UserWarning)
 
+            splitlines_ret_val = 42
             with support.captured_stderr() as stderr:
                 wmod.warn_explicit(
                     'foo', UserWarning, 'bar', 1,
-                    module_globals={'__loader__': get_bad_loader(42),
-                                    '__name__': 'foobar'})
+                    module_globals=module_globals)
             self.assertIn('UserWarning: foo', stderr.getvalue())
 
-            show = wmod._showwarnmsg
-            try:
+            with support.swap_attr(wmod, '_showwarnmsg', None):
                 del wmod._showwarnmsg
+                splitlines_ret_val = [42]
                 with support.captured_stderr() as stderr:
                     wmod.warn_explicit(
                         'eggs', UserWarning, 'bar', 1,
-                        module_globals={'__loader__': get_bad_loader([42]),
-                                        '__name__': 'foobar'})
+                        module_globals=module_globals)
                 self.assertIn('UserWarning: eggs', stderr.getvalue())
-            finally:
-                wmod._showwarnmsg = show
 
     @support.cpython_only
     def test_issue31411(self):

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -890,11 +890,11 @@ class _WarningsTests(BaseTest, unittest.TestCase):
         # bad splitlines() method.
         def get_module_globals(*, splitlines_ret_val):
             class BadSource(str):
-                def splitilines(self):
+                def splitlines(self):
                     return splitlines_ret_val
 
             class BadLoader:
-                def getsource(self, fullname):
+                def get_source(self, fullname):
                     return BadSource('spam')
 
             loader = BadLoader()


### PR DESCRIPTION
`__spec__.loader` is now required in the module globals (see gh-86298).


<!-- gh-issue-number: gh-122191 -->
* Issue: gh-122191
<!-- /gh-issue-number -->
