### PR TITLE
gh-82129: Fix `NameError` on `get_type_hints` in `dataclasses`

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1530,7 +1530,11 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
     for item in fields:
         if isinstance(item, str):
             name = item
-            tp = 'typing.Any'
+            typing = sys.modules.get('typing')
+            if typing:
+                tp = typing.Any
+            else:
+                tp = 'typing.Any'
         elif len(item) == 2:
             name, tp, = item
         elif len(item) == 3:

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1534,7 +1534,7 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
             if typing:
                 tp = typing.Any
             else:
-                tp = 'typing.Any'
+                tp = "__import__('typing').Any"
         elif len(item) == 2:
             name, tp, = item
         elif len(item) == 3:

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -4126,11 +4126,14 @@ class TestMakeDataclass(unittest.TestCase):
         self.assertEqual(C.__annotations__, {'x': typing.Any})
         self.assertEqual(get_type_hints(C), {'x': typing.Any})
 
-    def test_no_types_no_typing_fallback(self):
+    def test_no_types_no_NameError_no_typing_fallback(self):
         with import_helper.isolated_modules():
             del sys.modules['typing']
             C = make_dataclass('Point', ['x'])
-            self.assertEqual(C.__annotations__, {'x': 'typing.Any'})
+            self.assertEqual(C.__annotations__,
+                             {'x': "__import__('typing').Any"})
+            from typing import Any  # since we hack our modules
+            self.assertEqual(get_type_hints(C), {'x': Any})
 
     def test_module_attr(self):
         self.assertEqual(ByMakeDataClass.__module__, __name__)

--- a/Misc/NEWS.d/next/Library/2024-07-24-15-47-11.gh-issue-82129.7z5g8K.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-24-15-47-11.gh-issue-82129.7z5g8K.rst
@@ -1,0 +1,3 @@
+Fix name error in :func:`typing.get_type_hints` when calling it in a
+dataclass created without an annotation via
+:func:`dataclasses.make_dataclass` function.


### PR DESCRIPTION
Ok, here's my attempt at solving this.

When you call `typing.get_type_hints` you still have to import typing. 
There's a good chance that it will already be imported by something else in your `sys.modules`.

We already have this hack in other places: https://github.com/python/cpython/blob/e9681211b9ad11d1c1f471c43bc57cac46814779/Lib/dataclasses.py#L809-L815

So, this solution can be used to hide the problem for older versions of python (down to [3.12](https://github.com/python/cpython/blob/3.12/Lib/dataclasses.py#L800-L806)). While we can actually fully solve with `annotationlib` in 3.14+

I think that this hack + user-space one:

```python
S = make_dataclass('S', ['x'])
get_type_hints(S, {'typing': typing})
```

is good enough for now.

<!-- gh-issue-number: gh-82129 -->
* Issue: gh-82129
<!-- /gh-issue-number -->
