### PR TITLE
[3.12] gh-117482: Simplify the Fix For Builtin Types Slot Wrappers

### DIFF
--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -305,11 +305,6 @@ Objects/sliceobject.c	-	_Py_EllipsisObject	-
 Python/instrumentation.c	-	_PyInstrumentation_DISABLE	-
 Python/instrumentation.c	-	_PyInstrumentation_MISSING	-
 
-##-----------------------
-## other
-
-Objects/typeobject.c	-	static_type_defs	-
-
 
 ##################################
 ## global non-objects to fix in core code


### PR DESCRIPTION
In gh-121602, I applied a fix to a builtin types initialization bug. That fix made sense in the context of some broader future changes, but introduced a little bit of extra complexity.  For earlier versions those future changes are not relevant; we can avoid the extra complexity. Thus we can revert that earlier change and replace it with this one, which is more focused and conceptually simpler.  This is essentially the implementation of an idea that @markshannon pointed out to me.

Note that this change would be much smaller if we didn't have to deal with repr compatibility for builtin types that explicitly inherit tp slots (see expect_manually_inherited()).  The alternative is to stop *explicitly* inheriting tp slots in static PyTypeObject values, which is churn that we can do separately.

(cherry picked from commit 716c6771fcfd3be90bba9f888a579b36c02cdb13, AKA gh-121932)

<!-- gh-issue-number: gh-117482 -->
* Issue: gh-117482
<!-- /gh-issue-number -->
