### PR TITLE
[3.12] gh-117482: Fix the Slot Wrapper Inheritance Tests

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -392,8 +392,7 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
 
     def test_static_types_inherited_slots(self):
         script = textwrap.dedent("""
-            import json
-            import sys
+            import test.support
 
             results = {}
             def add(cls, slot, own):
@@ -402,27 +401,24 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
                     subresults = results[cls.__name__]
                 except KeyError:
                     subresults = results[cls.__name__] = {}
-                subresults[slot] = repr(value)
+                subresults[slot] = [repr(value), own]
 
-            {body}
+            for cls in test.support.iter_builtin_types():
+                for slot, own in test.support.iter_slot_wrappers(cls):
+                    add(cls, slot, own)
+            """)
 
+        ns = {}
+        exec(script, ns, ns)
+        all_expected = ns['results']
+        del ns
+
+        script += textwrap.dedent("""
+            import json
+            import sys
             text = json.dumps(results)
             print(text, file=sys.stderr)
             """)
-        body = []
-        for cls in support.iter_builtin_types():
-            body.append('')
-            body.append(f'cls = {cls.__name__}')
-            for slot, own in support.iter_slot_wrappers(cls):
-                body.append(f'add(cls, {slot!r}, {own})')
-        body.pop(0)
-        script = script.replace('{body}', os.linesep.join(body))
-
-        with contextlib.redirect_stderr(io.StringIO()) as stderr:
-            ns = {}
-            exec(script, ns, ns)
-        expected = json.loads(stderr.getvalue())
-
         out, err = self.run_embedded_interpreter(
                 "test_repeated_init_exec", script, script)
         results = err.split('--- Loop #')[1:]
@@ -430,13 +426,12 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
 
         self.maxDiff = None
         for i, text in enumerate(results, start=1):
-            failed = True
-            with self.subTest(loop=i):
-                result = json.loads(text)
-                self.assertEqual(result, expected)
-                failed = False
-            if failed:
-                break
+            result = json.loads(text)
+            for classname, expected in all_expected.items():
+                with self.subTest(loop=i, cls=classname):
+                    slots = result.pop(classname)
+                    self.assertEqual(slots, expected)
+            self.assertEqual(result, {})
         self.assertEqual(out, '')
 
 

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -410,11 +410,10 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
             print(text, file=sys.stderr)
             """)
         body = []
-        from test.test_types import iter_builtin_types, iter_slot_wrappers
-        for cls in iter_builtin_types():
+        for cls in support.iter_builtin_types():
             body.append('')
             body.append(f'cls = {cls.__name__}')
-            for slot, own in iter_slot_wrappers(cls):
+            for slot, own in support.iter_slot_wrappers(cls):
                 body.append(f'add(cls, {slot!r}, {own})')
         body.pop(0)
         script = script.replace('{body}', os.linesep.join(body))

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -391,29 +391,53 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
         self.assertEqual(out, '9\n' * INIT_LOOPS)
 
     def test_static_types_inherited_slots(self):
-        slots = []
-        script = ['import sys']
-        from test.test_types import iter_builtin_types, iter_own_slot_wrappers
+        script = textwrap.dedent("""
+            import json
+            import sys
+
+            results = {}
+            def add(cls, slot, own):
+                value = getattr(cls, slot)
+                try:
+                    subresults = results[cls.__name__]
+                except KeyError:
+                    subresults = results[cls.__name__] = {}
+                subresults[slot] = repr(value)
+
+            {body}
+
+            text = json.dumps(results)
+            print(text, file=sys.stderr)
+            """)
+        body = []
+        from test.test_types import iter_builtin_types, iter_slot_wrappers
         for cls in iter_builtin_types():
-            for slot in iter_own_slot_wrappers(cls):
-                slots.append((cls, slot))
-                attr = f'{cls.__name__}.{slot}'
-                script.append(f'print("{attr}:", {attr}, file=sys.stderr)')
-            script.append('')
-        script = os.linesep.join(script)
+            body.append('')
+            body.append(f'cls = {cls.__name__}')
+            for slot, own in iter_slot_wrappers(cls):
+                body.append(f'add(cls, {slot!r}, {own})')
+        body.pop(0)
+        script = script.replace('{body}', os.linesep.join(body))
 
         with contextlib.redirect_stderr(io.StringIO()) as stderr:
-            exec(script)
-        expected = stderr.getvalue().splitlines()
+            ns = {}
+            exec(script, ns, ns)
+        expected = json.loads(stderr.getvalue())
 
-        out, err = self.run_embedded_interpreter("test_repeated_init_exec", script)
+        out, err = self.run_embedded_interpreter(
+                "test_repeated_init_exec", script, script)
         results = err.split('--- Loop #')[1:]
         results = [res.rpartition(' ---\n')[-1] for res in results]
 
         self.maxDiff = None
-        for i, result in enumerate(results, start=1):
+        for i, text in enumerate(results, start=1):
+            failed = True
             with self.subTest(loop=i):
-                self.assertEqual(result.splitlines(), expected)
+                result = json.loads(text)
+                self.assertEqual(result, expected)
+                failed = False
+            if failed:
+                break
         self.assertEqual(out, '')
 
 

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -2322,7 +2322,7 @@ class SubinterpreterTests(unittest.TestCase):
 
     @cpython_only
     @no_rerun('channels (and queues) might have a refleak; see gh-122199')
-    def test_slot_wrappers(self):
+    def test_static_types_inherited_slots(self):
         rch, sch = interpreters.create_channel()
 
         slots = []

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1,6 +1,9 @@
 # Python test set -- part 6, built-in types
 
-from test.support import run_with_locale, cpython_only, MISSING_C_DOCSTRINGS
+from test.support import (
+    run_with_locale, cpython_only, iter_builtin_types, iter_slot_wrappers,
+    MISSING_C_DOCSTRINGS,
+)
 from test.test_import import no_rerun
 import collections.abc
 from collections import namedtuple
@@ -27,62 +30,6 @@ class Forward: ...
 def clear_typing_caches():
     for f in typing._cleanups:
         f()
-
-
-def iter_builtin_types():
-    for obj in __builtins__.values():
-        if not isinstance(obj, type):
-            continue
-        cls = obj
-        if cls.__module__ != 'builtins':
-            continue
-        yield cls
-
-
-@cpython_only
-def iter_slot_wrappers(cls):
-    assert cls.__module__ == 'builtins', cls
-
-    def is_slot_wrapper(name, value):
-        if not isinstance(value, types.WrapperDescriptorType):
-            assert not repr(value).startswith('<slot wrapper '), (cls, name, value)
-            return False
-        assert repr(value).startswith('<slot wrapper '), (cls, name, value)
-        assert callable(value), (cls, name, value)
-        assert name.startswith('__') and name.endswith('__'), (cls, name, value)
-        return True
-
-    ns = vars(cls)
-    unused = set(ns)
-    for name in dir(cls):
-        if name in ns:
-            unused.remove(name)
-
-        try:
-            value = getattr(cls, name)
-        except AttributeError:
-            # It's as though it weren't in __dir__.
-            assert name in ('__annotate__', '__annotations__', '__abstractmethods__'), (cls, name)
-            if name in ns and is_slot_wrapper(name, ns[name]):
-                unused.add(name)
-            continue
-
-        if not name.startswith('__') or not name.endswith('__'):
-            assert not is_slot_wrapper(name, value), (cls, name, value)
-        if not is_slot_wrapper(name, value):
-            if name in ns:
-                assert not is_slot_wrapper(name, ns[name]), (cls, name, value, ns[name])
-        else:
-            if name in ns:
-                assert ns[name] is value, (cls, name, value, ns[name])
-                yield name, True
-            else:
-                yield name, False
-
-    for name in unused:
-        value = ns[name]
-        if is_slot_wrapper(cls, name, value):
-            yield name, True
 
 
 class TypesTests(unittest.TestCase):

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -10094,7 +10094,25 @@ expect_manually_inherited(PyTypeObject *type, void **slot)
             && typeobj != PyExc_StopIteration
             && typeobj != PyExc_SyntaxError
             && typeobj != PyExc_UnicodeDecodeError
-            && typeobj != PyExc_UnicodeEncodeError)
+            && typeobj != PyExc_UnicodeEncodeError
+
+            && type != &PyBool_Type
+            && type != &PyBytes_Type
+            && type != &PyMemoryView_Type
+            && type != &PyComplex_Type
+            && type != &PyEnum_Type
+            && type != &PyFilter_Type
+            && type != &PyFloat_Type
+            && type != &PyFrozenSet_Type
+            && type != &PyLong_Type
+            && type != &PyMap_Type
+            && type != &PyRange_Type
+            && type != &PyReversed_Type
+            && type != &PySlice_Type
+            && type != &PyTuple_Type
+            && type != &PyUnicode_Type
+            && type != &PyZip_Type)
+
         {
             return 1;
         }
@@ -10112,10 +10130,8 @@ expect_manually_inherited(PyTypeObject *type, void **slot)
         /* This is a best-effort list of builtin types
            that have their own tp_getattr function. */
         if (typeobj == PyExc_BaseException
-            || type == &PyBool_Type
             || type == &PyByteArray_Type
             || type == &PyBytes_Type
-            || type == &PyClassMethod_Type
             || type == &PyComplex_Type
             || type == &PyDict_Type
             || type == &PyEnum_Type
@@ -10129,7 +10145,6 @@ expect_manually_inherited(PyTypeObject *type, void **slot)
             || type == &PyReversed_Type
             || type == &PySet_Type
             || type == &PySlice_Type
-            || type == &PyStaticMethod_Type
             || type == &PySuper_Type
             || type == &PyTuple_Type
             || type == &PyZip_Type)

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -163,14 +163,22 @@ PyInit_embedded_ext(void)
 static int test_repeated_init_exec(void)
 {
     if (main_argc < 3) {
-        fprintf(stderr, "usage: %s test_repeated_init_exec CODE\n", PROGRAM);
+        fprintf(stderr,
+                "usage: %s test_repeated_init_exec CODE ...\n", PROGRAM);
         exit(1);
     }
     const char *code = main_argv[2];
+    int loops = main_argc > 3
+        ? main_argc - 2
+        : INIT_LOOPS;
 
-    for (int i=1; i <= INIT_LOOPS; i++) {
-        fprintf(stderr, "--- Loop #%d ---\n", i);
+    for (int i=0; i < loops; i++) {
+        fprintf(stderr, "--- Loop #%d ---\n", i+1);
         fflush(stderr);
+
+        if (main_argc > 3) {
+            code = main_argv[i+2];
+        }
 
         _testembed_Py_InitializeFromConfig();
         int err = PyRun_SimpleString(code);


### PR DESCRIPTION
The tests were only checking cases where the slot wrapper was present in the initial case.  They were missing when the slot wrapper was added in the additional initializations.  This fixes that.

(This is effectively a backport of gh-122248.)

<!-- gh-issue-number: gh-117482 -->
* Issue: gh-117482
<!-- /gh-issue-number -->
