### PR TITLE
gh-122247: Move instruction instrumentation sanity check after tracing check

### DIFF
--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -1840,6 +1840,21 @@ class TestRegressions(MonitoringTestBase, unittest.TestCase):
         self.assertEqual(call_data[0], (f, 1))
         self.assertEqual(call_data[1], (f, sys.monitoring.MISSING))
 
+    def test_instruction_explicit_callback(self):
+        # gh-122247
+        # Calling the instruction event callback explicitly should not
+        # crash CPython
+        def callback(code, instruction_offset):
+            pass
+
+        sys.monitoring.use_tool_id(0, "test")
+        self.addCleanup(sys.monitoring.free_tool_id, 0)
+        sys.monitoring.register_callback(0, sys.monitoring.events.INSTRUCTION, callback)
+        sys.monitoring.set_events(0, sys.monitoring.events.INSTRUCTION)
+        callback(None, 0)  # call the *same* handler while it is registered
+        sys.monitoring.restart_events()
+        sys.monitoring.set_events(0, 0)
+
 
 class TestOptimizer(MonitoringTestBase, unittest.TestCase):
 

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1344,7 +1344,6 @@ int
 _Py_call_instrumentation_instruction(PyThreadState *tstate, _PyInterpreterFrame* frame, _Py_CODEUNIT *instr)
 {
     PyCodeObject *code = _PyFrame_GetCode(frame);
-    assert(debug_check_sanity(tstate->interp, code));
     int offset = (int)(instr - _PyCode_CODE(code));
     _PyCoMonitoringData *instrumentation_data = code->_co_monitoring;
     assert(instrumentation_data->per_instruction_opcodes);
@@ -1352,6 +1351,7 @@ _Py_call_instrumentation_instruction(PyThreadState *tstate, _PyInterpreterFrame*
     if (tstate->tracing) {
         return next_opcode;
     }
+    assert(debug_check_sanity(tstate->interp, code));
     PyInterpreterState *interp = tstate->interp;
     uint8_t tools = instrumentation_data->per_instruction_tools != NULL ?
         instrumentation_data->per_instruction_tools[offset] :


### PR DESCRIPTION
Due to #117133, code objects are not *always* up to date. We do not instrument them if we are tracing - because no events will be generated anyway. Therefore, we should check `tstate->tracing` first for instruction instrumentation, and do the sanity check only when an event is about to be generated.

News is skipped because it's an assertion move. No actual behavior is changed to the end user.

<!-- gh-issue-number: gh-122247 -->
* Issue: gh-122247
<!-- /gh-issue-number -->
