### PR TITLE
gh-122193: simplify object.__rpow__() signature (no modulo)

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -3013,7 +3013,7 @@ left undefined.
             object.__rfloordiv__(self, other)
             object.__rmod__(self, other)
             object.__rdivmod__(self, other)
-            object.__rpow__(self, other[, modulo])
+            object.__rpow__(self, other)
             object.__rlshift__(self, other)
             object.__rrshift__(self, other)
             object.__rand__(self, other)


### PR DESCRIPTION
Docs says: "Note that ternary ``pow()`` will not try calling ``__rpow__()`` (the coercion rules would become too complicated)."

Probably, this is not something, that might be changed (see recent discussion in https://discuss.python.org/t/35185).  Lets simplify signature of this dunder method.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122193 -->
* Issue: gh-122193
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122260.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->