### PR TITLE
[3.13] gh-121489: Export private _PyBytes_Join() again

### DIFF
--- a/Include/cpython/bytesobject.h
+++ b/Include/cpython/bytesobject.h
@@ -31,3 +31,7 @@ static inline Py_ssize_t PyBytes_GET_SIZE(PyObject *op) {
     return Py_SIZE(self);
 }
 #define PyBytes_GET_SIZE(self) PyBytes_GET_SIZE(_PyObject_CAST(self))
+
+/* _PyBytes_Join(sep, x) is like sep.join(x).  sep must be PyBytesObject*,
+   x must be an iterable object. */
+PyAPI_FUNC(PyObject*) _PyBytes_Join(PyObject *sep, PyObject *x);

--- a/Include/internal/pycore_bytesobject.h
+++ b/Include/internal/pycore_bytesobject.h
@@ -23,10 +23,6 @@ extern PyObject* _PyBytes_FromHex(
 PyAPI_FUNC(PyObject*) _PyBytes_DecodeEscape(const char *, Py_ssize_t,
                                             const char *, const char **);
 
-/* _PyBytes_Join(sep, x) is like sep.join(x).  sep must be PyBytesObject*,
-   x must be an iterable object. */
-extern PyObject* _PyBytes_Join(PyObject *sep, PyObject *x);
-
 
 // Substring Search.
 //

--- a/Misc/NEWS.d/next/C API/2024-07-21-17-40-07.gh-issue-121489.SUMFCr.rst
+++ b/Misc/NEWS.d/next/C API/2024-07-21-17-40-07.gh-issue-121489.SUMFCr.rst
@@ -1,0 +1,1 @@
+Export private _PyBytes_Join() again.

--- a/Misc/NEWS.d/next/C API/2024-07-21-17-40-07.gh-issue-121489.SUMFCr.rst
+++ b/Misc/NEWS.d/next/C API/2024-07-21-17-40-07.gh-issue-121489.SUMFCr.rst
@@ -1,1 +1,1 @@
-Export private _PyBytes_Join() again.
+Export private :c:func:`_PyBytes_Join` again.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -8,7 +8,6 @@
 */
 
 #include "Python.h"
-#include "pycore_bytesobject.h"         // _PyBytes_Join()
 #include "pycore_call.h"                // _PyObject_CallNoArgs()
 #include "pycore_object.h"              // _PyObject_GC_UNTRACK()
 #include "pycore_pyerrors.h"            // _Py_FatalErrorFormat()


### PR DESCRIPTION
Followup from #121489 and https://github.com/python/cpython/pull/121646#discussion_r1676955344. Export the `_PyBytes_Join()` again until the new public `PyBytes_Join()` is added. If backported to `3.13`, this would make transitioning easier.

This partially reverts #107144.

/CC @vstinner


<!-- gh-issue-number: gh-121489 -->
* Issue: gh-121489
<!-- /gh-issue-number -->
