### PR TITLE
fix: timedelta str, repr are not human readable when td is negative

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -719,6 +719,9 @@ class timedelta:
         return self
 
     def __repr__(self):
+        # handle negative values
+        if self._days < 0:
+            return f"- {-self!r}"
         args = []
         if self._days:
             args.append("days=%d" % self._days)
@@ -733,6 +736,9 @@ class timedelta:
                               ', '.join(args))
 
     def __str__(self):
+        # handle negative values
+        if self._days < 0:
+            return f"-{-self}"
         mm, ss = divmod(self._seconds, 60)
         hh, mm = divmod(mm, 60)
         s = "%d:%02d:%02d" % (hh, mm, ss)

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2910,27 +2910,44 @@ delta_repr(PyDateTime_Delta *self)
     }
 
     const char *sep = "";
+    int days = GET_TD_DAYS(self);
+    int multiplier = 1;
+    if (days < 0){
+        multiplier = -1;
+        days = days * -1;
+    }
+    int microseconds = GET_TD_MICROSECONDS(self) * multiplier;
+    int seconds = GET_TD_SECONDS(self) * multiplier;
+    if(multiplier == -1)
+        normalize_d_s_us(&days, &seconds, &microseconds);
 
-    if (GET_TD_DAYS(self) != 0) {
-        Py_SETREF(args, PyUnicode_FromFormat("days=%d", GET_TD_DAYS(self)));
+    if (multiplier == -1) {
+        Py_SETREF(args, PyUnicode_FromString("- "));
+        if (args == NULL) {
+            return NULL;
+        }
+    }
+
+    if (days != 0) {
+        Py_SETREF(args, PyUnicode_FromFormat("days=%d", days));
         if (args == NULL) {
             return NULL;
         }
         sep = ", ";
     }
 
-    if (GET_TD_SECONDS(self) != 0) {
+    if (seconds != 0) {
         Py_SETREF(args, PyUnicode_FromFormat("%U%sseconds=%d", args, sep,
-                                             GET_TD_SECONDS(self)));
+                                             seconds));
         if (args == NULL) {
             return NULL;
         }
         sep = ", ";
     }
 
-    if (GET_TD_MICROSECONDS(self) != 0) {
+    if (microseconds != 0) {
         Py_SETREF(args, PyUnicode_FromFormat("%U%smicroseconds=%d", args, sep,
-                                             GET_TD_MICROSECONDS(self)));
+                                             microseconds));
         if (args == NULL) {
             return NULL;
         }
@@ -2952,27 +2969,38 @@ delta_repr(PyDateTime_Delta *self)
 static PyObject *
 delta_str(PyDateTime_Delta *self)
 {
-    int us = GET_TD_MICROSECONDS(self);
-    int seconds = GET_TD_SECONDS(self);
+    int days = GET_TD_DAYS(self);
+    int multiplier = 1;
+    if (days < 0){
+        multiplier = -1;
+        days = days * -1;
+    }
+    int us = GET_TD_MICROSECONDS(self) * multiplier;
+    int seconds = GET_TD_SECONDS(self) * multiplier;
+    if(multiplier == -1)
+        normalize_d_s_us(&days, &seconds, &us);
     int minutes = divmod(seconds, 60, &seconds);
     int hours = divmod(minutes, 60, &minutes);
-    int days = GET_TD_DAYS(self);
 
     if (days) {
         if (us)
-            return PyUnicode_FromFormat("%d day%s, %d:%02d:%02d.%06d",
-                                        days, (days == 1 || days == -1) ? "" : "s",
+            return PyUnicode_FromFormat("%s%d day%s, %d:%02d:%02d.%06d",
+                                        multiplier == -1 ? "-" : "",
+                                        days, days == 1 ? "" : "s",
                                         hours, minutes, seconds, us);
         else
-            return PyUnicode_FromFormat("%d day%s, %d:%02d:%02d",
-                                        days, (days == 1 || days == -1) ? "" : "s",
+            return PyUnicode_FromFormat("%s%d day%s, %d:%02d:%02d",
+                                        multiplier == -1 ? "-" : "",
+                                        days, days == 1 ? "" : "s",
                                         hours, minutes, seconds);
     } else {
         if (us)
-            return PyUnicode_FromFormat("%d:%02d:%02d.%06d",
+            return PyUnicode_FromFormat("%s%d:%02d:%02d.%06d",
+                                        multiplier == -1 ? "-" : "",
                                         hours, minutes, seconds, us);
         else
-            return PyUnicode_FromFormat("%d:%02d:%02d",
+            return PyUnicode_FromFormat("%s%d:%02d:%02d",
+                                        multiplier == -1 ? "-" : "",
                                         hours, minutes, seconds);
     }
 


### PR DESCRIPTION
What:

Currently the str and repr output is not human readable when 
the timedelta is negative.

This is because of the special logic of timedeltas.

This PR tries to fix it.

It needs some testing though but for this I will need some guidance.

