### PR TITLE
gh-84808: Handle errors returned by internal_connect()

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-09-06-10-17-54.gh-issue-84808.ION67Z.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-06-10-17-54.gh-issue-84808.ION67Z.rst
@@ -1,1 +1,3 @@
-socketmodule: Handle errors returned by internal_connect()
+Fix error handling in :py:class:`~socket.socket` method
+:py:func:`~socket.socket.connect_ex` on platforms where
+:c:data:`errno` can be negative.

--- a/Misc/NEWS.d/next/Library/2024-09-06-10-17-54.gh-issue-84808.ION67Z.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-06-10-17-54.gh-issue-84808.ION67Z.rst
@@ -1,0 +1,1 @@
+socketmodule: Handle errors returned by internal_connect()

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3405,6 +3405,18 @@ sock_connect_impl(PySocketSockObject *s, void* Py_UNUSED(data))
     return 1;
 }
 
+/* Common functionality for socket.connect and socket.connect_ex.
+ *
+ * If *raise* is set:
+ * - On success, return 0.
+ * - On any failure, return -1 with an exception set.
+ * If *raise* is zero:
+ * - On success, return 0.
+ * - On connect() failure, return errno (without an exception set)
+ * - On other error, return -1 with an exception set.
+ *
+ *   Note that -1 is a valid errno value on some systems.
+ */
 static int
 internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
                  int raise)
@@ -3489,8 +3501,10 @@ sock_connect(PySocketSockObject *s, PyObject *addro)
     }
 
     res = internal_connect(s, SAS2SA(&addrbuf), addrlen, 1);
-    if (res < 0)
+    if (res < 0) {
+        assert(PyErr_Occurred());
         return NULL;
+    }
 
     Py_RETURN_NONE;
 }
@@ -3520,8 +3534,9 @@ sock_connect_ex(PySocketSockObject *s, PyObject *addro)
     }
 
     res = internal_connect(s, SAS2SA(&addrbuf), addrlen, 0);
-    if (res < 0)
+    if (res == -1 && PyErr_Occurred()) {
         return NULL;
+    }
 
     return PyLong_FromLong((long) res);
 }


### PR DESCRIPTION
Python shouldn't assume that errno codes are positive.

reported and proposed by Ryan C. Gordon


<!-- gh-issue-number: gh-84808 -->
* Issue: gh-84808
<!-- /gh-issue-number -->
