### PR TITLE
Manually override bytecode definition in optimizer, to avoid build error

### DIFF
--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -596,6 +596,14 @@ dummy_func(void) {
         }
     }
 
+    op(_MAYBE_EXPAND_METHOD, (callable, self_or_null, args[oparg] -- func, maybe_self, args[oparg])) {
+        (void)callable;
+        (void)self_or_null;
+        (void)args;
+        func = sym_new_not_null(ctx);
+        maybe_self = sym_new_not_null(ctx);
+    }
+
     op(_PY_FRAME_GENERAL, (callable, self_or_null, args[oparg] -- new_frame: _Py_UOpsAbstractFrame *)) {
         /* The _Py_UOpsAbstractFrame design assumes that we can copy arguments across directly */
         (void)callable;

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1599,14 +1599,19 @@
         }
 
         case _MAYBE_EXPAND_METHOD: {
+            _Py_UopsSymbol **args;
+            _Py_UopsSymbol *self_or_null;
+            _Py_UopsSymbol *callable;
             _Py_UopsSymbol *func;
             _Py_UopsSymbol *maybe_self;
-            _Py_UopsSymbol **args;
+            args = &stack_pointer[-oparg];
+            self_or_null = stack_pointer[-1 - oparg];
+            callable = stack_pointer[-2 - oparg];
+            (void)callable;
+            (void)self_or_null;
+            (void)args;
             func = sym_new_not_null(ctx);
             maybe_self = sym_new_not_null(ctx);
-            for (int _i = oparg; --_i >= 0;) {
-                args[_i] = sym_new_not_null(ctx);
-            }
             stack_pointer[-2 - oparg] = func;
             stack_pointer[-1 - oparg] = maybe_self;
             break;


### PR DESCRIPTION
Small fix up to fix semantic merge error from merging https://github.com/python/cpython/pull/122177 and https://github.com/python/cpython/pull/122174