### PR TITLE
Remove reference to docs mailing list for bug reports

### DIFF
--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -16,20 +16,15 @@ Documentation bugs
 ==================
 
 If you find a bug in this documentation or would like to propose an improvement,
-please submit a bug report on the :ref:`tracker <using-the-tracker>`.  If you
+please submit a bug report on the :ref:`issue tracker <using-the-tracker>`.  If you
 have a suggestion on how to fix it, include that as well.
 
 You can also open a discussion item on our
 `Documentation Discourse forum <https://discuss.python.org/c/documentation/26>`_.
 
 If you find a bug in the theme (HTML / CSS / JavaScript) of the
-documentation, please submit a bug report on the `python-doc-theme bug
+documentation, please submit a bug report on the `python-doc-theme issue
 tracker <https://github.com/python/python-docs-theme>`_.
-
-If you're short on time, you can also email documentation bug reports to
-docs@python.org (behavioral bugs can be sent to python-list@python.org).
-'docs@' is a mailing list run by volunteers; your request will be noticed,
-though it may take a while to be processed.
 
 .. seealso::
 


### PR DESCRIPTION
This PR updates the preferred workflow for documentation issues.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122323.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->