### PR TITLE
[3.12] gh-122208: Don't delivery PyDict_EVENT_ADDED until it can't fail

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-07-26-21-38-47.gh-issue-122208.z8KHsY.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-07-26-21-38-47.gh-issue-122208.z8KHsY.rst
@@ -1,0 +1,1 @@
+Dictionary watchers now only deliver the PyDict_EVENT_ADDED event when the insertion is in a known good state to succeed.


### PR DESCRIPTION
Currently PyDict_EVENT_ADDED can be delivered when the insert is going to fail due to an OOM. This means the listener has no capability of knowing the true state of the dictionary if it fails.

This modifies the events to be delivaered before the change has happened but only after any underlying necessary allocations have occurred.

Backported from main: https://github.com/python/cpython/pull/122207

<!-- gh-issue-number: gh-122208 -->
* Issue: gh-122208
<!-- /gh-issue-number -->
