### PR TITLE
GH-109408: Add a ``make lint`` target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ PCbuild/arm64/
 PCbuild/obj/
 PCbuild/win32/
 Tools/unicode/data/
+/.venv-pre-commit/
 /autom4te.cache
 /build/
 /builddir/

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -3100,6 +3100,35 @@ funny:
 		-o -name MANIFEST \
 		-o -print
 
+.PHONY: clean-venv
+clean-venv:
+	rm -rf .venv-pre-commit
+
+# Create a virtual environment for pre-commit
+.PHONY: pre-commit-venv
+pre-commit-venv:
+	@if [ -d .venv-pre-commit ] ; then \
+		echo "pre-commit venv already exists."; \
+		echo "To recreate it, remove it first with \`make clean-venv'."; \
+	else \
+		echo "Creating venv for pre-commit in .venv-pre-commit"; \
+		if uv --version > /dev/null; then \
+			uv venv .venv-pre-commit; \
+			VIRTUAL_ENV=.venv-pre-commit uv pip install pre-commit; \
+		else \
+			$(PYTHON_FOR_REGEN) -m venv .venv-pre-commit; \
+			.venv-pre-commit/bin/python3 -m pip install --upgrade pip; \
+			.venv-pre-commit/bin/python3 -m pip install pre-commit; \
+		fi; \
+      echo "The venv has been created in the .venv-pre-commit directory"; \
+	fi
+
+# Run CPython's static analysis, verification, and style checks.
+.PHONY: lint
+lint: pre-commit-venv
+   .venv-pre-commit/bin/pre-commit run --all-files
+   $(PYTHON_FOR_REGEN) $(srcdir)/Tools/patchcheck/patchcheck.py
+
 # Perform some verification checks on any modified files.
 .PHONY: patchcheck
 patchcheck: all

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -3126,8 +3126,8 @@ pre-commit-venv:
 # Run CPython's static analysis, verification, and style checks.
 .PHONY: lint
 lint: pre-commit-venv
-   .venv-pre-commit/bin/pre-commit run --all-files
-   $(PYTHON_FOR_REGEN) $(srcdir)/Tools/patchcheck/patchcheck.py
+	.venv-pre-commit/bin/pre-commit run --all-files
+	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/patchcheck/patchcheck.py
 
 # Perform some verification checks on any modified files.
 .PHONY: patchcheck

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -3120,7 +3120,7 @@ pre-commit-venv:
 			.venv-pre-commit/bin/python3 -m pip install --upgrade pip; \
 			.venv-pre-commit/bin/python3 -m pip install pre-commit; \
 		fi; \
-      echo "The venv has been created in the .venv-pre-commit directory"; \
+		echo "The venv has been created in the .venv-pre-commit directory"; \
 	fi
 
 # Run CPython's static analysis, verification, and style checks.


### PR DESCRIPTION
I am almost certainly not the best person to do this, given I use Windows and I am not confident in testing changes to the Makefile.

However, this is a sketch of a solution to adding a ``make lint`` target, as [discussed in on Discourse](https://discuss.python.org/t/do-you-use-make-patchcheck/34743) and related to #109895.

Please feel free to push to this branch if you have improvements / spot glaring errors.

A

<!-- gh-issue-number: gh-109408 -->
* Issue: gh-109408
<!-- /gh-issue-number -->
