### PR TITLE
Fix underline for 'pty' in What's New in Python 3.14

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -309,7 +309,7 @@ pathlib
   arguments are joined onto *other*.
 
 pty
-___
+---
 
 * Remove deprecated :func:`!pty.master_open` and :func:`!pty.slave_open`.
   They had previously raised a :exc:`DeprecationWarning` since Python 3.12.


### PR DESCRIPTION
| Before | After|
|--------|--------|
| ![image](https://github.com/user-attachments/assets/d8e137e3-473a-4ad8-9bd3-ee8ae73a3593) | ![image](https://github.com/user-attachments/assets/519c2b44-f00a-4904-ab37-29370e08b6dc) |

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122337.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->