### PR TITLE
gh-122332: Fix missing `NULL` check in `asyncio.Task.get_coro`

### DIFF
--- a/Lib/test/test_asyncio/test_eager_task_factory.py
+++ b/Lib/test/test_asyncio/test_eager_task_factory.py
@@ -241,6 +241,18 @@ class CEagerTaskFactoryLoopTests(EagerTaskFactoryLoopTests, test_utils.TestCase)
         _, out, err = assert_python_ok("-c", code)
         self.assertFalse(err)
 
+    def test_issue122332(self):
+       async def coro():
+           pass
+
+       async def run():
+           task = self.loop.create_task(coro())
+           await task
+           self.assertIsNone(task.get_coro())
+
+       self.run_coro(run())
+
+
 class AsyncTaskCounter:
     def __init__(self, loop, *, task_class, eager):
         self.suspense_count = 0

--- a/Misc/NEWS.d/next/Library/2024-07-26-21-21-13.gh-issue-122332.fvw88r.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-26-21-21-13.gh-issue-122332.fvw88r.rst
@@ -1,0 +1,2 @@
+Fixed segfault with :meth:`asyncio.Task.get_coro` when using an eager task
+factory.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2500,7 +2500,12 @@ static PyObject *
 _asyncio_Task_get_coro_impl(TaskObj *self)
 /*[clinic end generated code: output=bcac27c8cc6c8073 input=d2e8606c42a7b403]*/
 {
-    return Py_NewRef(self->task_coro);
+    if (self->task_coro)
+    {
+        return Py_NewRef(self->task_coro);
+    }
+
+    Py_RETURN_NONE;
 }
 
 /*[clinic input]

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2500,8 +2500,7 @@ static PyObject *
 _asyncio_Task_get_coro_impl(TaskObj *self)
 /*[clinic end generated code: output=bcac27c8cc6c8073 input=d2e8606c42a7b403]*/
 {
-    if (self->task_coro)
-    {
+    if (self->task_coro) {
         return Py_NewRef(self->task_coro);
     }
 


### PR DESCRIPTION
<!-- gh-issue-number: gh-121058 -->
* Issue: gh-122332
<!-- /gh-issue-number -->