### PR TITLE
gh-120831: Correct default minimum iOS version.

### DIFF
--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -642,7 +642,7 @@ def get_platform():
             release = m.group()
     elif osname[:6] == "darwin":
         if sys.platform == "ios":
-            release = get_config_vars().get("IPHONEOS_DEPLOYMENT_TARGET", "12.0")
+            release = get_config_vars().get("IPHONEOS_DEPLOYMENT_TARGET", "13.0")
             osname = sys.platform
             machine = sys.implementation._multiarch
         else:


### PR DESCRIPTION
#121250 increased the default iOS minimum version to 13.0; however, it missed one reference in the `sysconfig` module. 

<!-- gh-issue-number: gh-120831 -->
* Issue: gh-120831
<!-- /gh-issue-number -->
