### PR TITLE
gh-121832: Revert test skip introduced by #122150.

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -2382,7 +2382,6 @@ class SubinterpreterTests(unittest.TestCase):
 
     @cpython_only
     @no_rerun('channels (and queues) might have a refleak; see gh-122199')
-    @unittest.skipIf(is_apple_mobile, "Fails on iOS due to test ordering; see #121832.")
     def test_slot_wrappers(self):
         rch, sch = interpreters.channels.create()
 


### PR DESCRIPTION
#122150 introduced a test skip to restore CI for iOS as a temporary measure. This PR reverts the skip.

Fixes #121832.

<!-- gh-issue-number: gh-121832 -->
* Issue: gh-121832
<!-- /gh-issue-number -->
