### PR TITLE
[3.13] gh-121832: Revert test skip introduced by GH-122150. (GH-122340)

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -2379,7 +2379,6 @@ class SubinterpreterTests(unittest.TestCase):
         import test.support.interpreters.channels
 
     @cpython_only
-    @unittest.skipIf(is_apple_mobile, "Fails on iOS due to test ordering; see #121832.")
     @no_rerun('channels (and queues) might have a refleak; see gh-122199')
     def test_slot_wrappers(self):
         rch, sch = interpreters.channels.create()


### PR DESCRIPTION
Revert test skip introduced by GH-122150.
(cherry picked from commit 863a92f2bc708b9e3dfa9828bb8155b8d371e09c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121832 -->
* Issue: gh-121832
<!-- /gh-issue-number -->
