### PR TITLE
[3.13] gh-122085: Use include files for `whatsnew/3.14.rst` deprecations (GH-122242)

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.16.rst
+++ b/Doc/deprecations/pending-removal-in-3.16.rst
@@ -1,5 +1,10 @@
 Pending Removal in Python 3.16
 ------------------------------
 
-* :class:`array.array` ``'u'`` type (:c:type:`wchar_t`):
+* :mod:`array`:
+  :class:`array.array` ``'u'`` type (:c:type:`wchar_t`):
   use the ``'w'`` type instead (``Py_UCS4``).
+
+* :mod:`symtable`:
+  Deprecate :meth:`symtable.Class.get_methods` due to the lack of interest.
+  (Contributed by Bénédikt Tran in :gh:`119698`.)

--- a/Doc/deprecations/pending-removal-in-future.rst
+++ b/Doc/deprecations/pending-removal-in-future.rst
@@ -34,6 +34,10 @@ although there is currently no date scheduled for their removal.
     :class:`complex`: these methods will be required to return an instance of
     :class:`complex`.
   * Delegation of ``int()`` to ``__trunc__()`` method.
+  * Passing a complex number as the *real* or *imag* argument in the
+    :func:`complex` constructor is now deprecated; it should only be passed
+    as a single positional argument.
+    (Contributed by Serhiy Storchaka in :gh:`109218`.)
 
 * :mod:`calendar`: ``calendar.January`` and ``calendar.February`` constants are
   deprecated and replaced by :data:`calendar.JANUARY` and


### PR DESCRIPTION
(cherry picked from commit 4e7550934941050f54c86338cd5e40cd565ceaf2)

This backport only updates the includes; we don't have `whatsnew/3.14.rst` in the 3.13 branch.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122085 -->
* Issue: gh-122085
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122350.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->