### PR TITLE
gh-120593: Make _PyLong_CompactValue() parameter const again

### DIFF
--- a/Include/cpython/longintrepr.h
+++ b/Include/cpython/longintrepr.h
@@ -119,18 +119,18 @@ PyAPI_FUNC(PyLongObject*) _PyLong_FromDigits(
 
 
 static inline int
-_PyLong_IsCompact(PyLongObject* op) {
-    assert(PyType_HasFeature(Py_TYPE(op), Py_TPFLAGS_LONG_SUBCLASS));
+_PyLong_IsCompact(const PyLongObject* op) {
+    assert(PyType_HasFeature(op->ob_base.ob_type, Py_TPFLAGS_LONG_SUBCLASS));
     return op->long_value.lv_tag < (2 << _PyLong_NON_SIZE_BITS);
 }
 
 #define PyUnstable_Long_IsCompact _PyLong_IsCompact
 
 static inline Py_ssize_t
-_PyLong_CompactValue(PyLongObject *op)
+_PyLong_CompactValue(const PyLongObject *op)
 {
     Py_ssize_t sign;
-    assert(PyType_HasFeature(Py_TYPE(op), Py_TPFLAGS_LONG_SUBCLASS));
+    assert(PyType_HasFeature(op->ob_base.ob_type, Py_TPFLAGS_LONG_SUBCLASS));
     assert(PyUnstable_Long_IsCompact(op));
     sign = 1 - (op->long_value.lv_tag & _PyLong_SIGN_MASK);
     return sign * (Py_ssize_t)op->long_value.ob_digit[0];


### PR DESCRIPTION
Change _PyLong_IsCompact() and _PyLong_CompactValue() parameter type from 'PyObject*' to 'const PyObject*'. Avoid the Py_TYPE() macro which does not support const parameter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120593 -->
* Issue: gh-120593
<!-- /gh-issue-number -->
