### PR TITLE
gh-122371: Separate nturl2path module test from `test_urllib.py`

### DIFF
--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -3,7 +3,9 @@
 This module only exists to provide OS-specific code
 for urllib.requests, thus do not use directly.
 """
-# Testing is done through test_urllib.
+__all__ = ["url2pathname", "pathname2url"]
+
+import urllib.parse
 
 def url2pathname(url):
     """OS-specific conversion from a relative URL of the 'file' scheme
@@ -14,7 +16,7 @@ def url2pathname(url):
     #   ///C:/foo/bar/spam.foo
     # become
     #   C:\foo\bar\spam.foo
-    import string, urllib.parse
+    import string
     # Windows itself uses ":" even in URLs.
     url = url.replace(':', '|')
     if not '|' in url:
@@ -49,7 +51,6 @@ def pathname2url(p):
     #   C:\foo\bar\spam.foo
     # becomes
     #   ///C:/foo/bar/spam.foo
-    import urllib.parse
     # First, clean up some special forms. We are going to sacrifice
     # the additional information anyway
     if p[:4] == '\\\\?\\':

--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -5,8 +5,6 @@ for urllib.requests, thus do not use directly.
 """
 __all__ = ["url2pathname", "pathname2url"]
 
-import urllib.parse
-
 def url2pathname(url):
     """OS-specific conversion from a relative URL of the 'file' scheme
     to a file system path; not recommended for general use."""
@@ -16,7 +14,7 @@ def url2pathname(url):
     #   ///C:/foo/bar/spam.foo
     # become
     #   C:\foo\bar\spam.foo
-    import string
+    import string, urllib.parse
     # Windows itself uses ":" even in URLs.
     url = url.replace(':', '|')
     if not '|' in url:
@@ -51,6 +49,7 @@ def pathname2url(p):
     #   C:\foo\bar\spam.foo
     # becomes
     #   ///C:/foo/bar/spam.foo
+    import urllib.parse
     # First, clean up some special forms. We are going to sacrifice
     # the additional information anyway
     if p[:4] == '\\\\?\\':

--- a/Lib/test/test_nturl2path.py
+++ b/Lib/test/test_nturl2path.py
@@ -1,0 +1,61 @@
+import unittest
+from nturl2path import url2pathname, pathname2url
+
+
+class URL2PathNameTests(unittest.TestCase):
+
+    def test_converting_drive_letter(self):
+        self.assertEqual(url2pathname("///C|"), 'C:')
+        self.assertEqual(url2pathname("///C:"), 'C:')
+        self.assertEqual(url2pathname("///C|/"), 'C:\\')
+
+    def test_converting_when_no_drive_letter(self):
+        # cannot end a raw string in \
+        self.assertEqual(url2pathname("///C/test/"), r'\\\C\test' '\\')
+        self.assertEqual(url2pathname("////C/test/"), r'\\C\test' '\\')
+
+    def test_simple_compare(self):
+        self.assertEqual(url2pathname("///C|/foo/bar/spam.foo"),
+                         r'C:\foo\bar\spam.foo')
+
+    def test_non_ascii_drive_letter(self):
+        self.assertRaises(IOError, url2pathname, "///\u00e8|/")
+
+    def test_roundtrip_url2pathname(self):
+        list_of_paths = ['C:',
+                         r'\\\C\test\\',
+                         r'C:\foo\bar\spam.foo'
+                         ]
+        for path in list_of_paths:
+            self.assertEqual(url2pathname(pathname2url(path)), path)
+
+class PathName2URLTests(unittest.TestCase):
+    def test_converting_drive_letter(self):
+        self.assertEqual(pathname2url("C:"), '///C:')
+        self.assertEqual(pathname2url("C:\\"), '///C:')
+
+    def test_converting_when_no_drive_letter(self):
+        self.assertEqual(pathname2url(r"\\\folder\test" "\\"),
+                         '/////folder/test/')
+        self.assertEqual(pathname2url(r"\\folder\test" "\\"),
+                         '////folder/test/')
+        self.assertEqual(pathname2url(r"\folder\test" "\\"),
+                         '/folder/test/')
+
+    def test_simple_compare(self):
+        self.assertEqual(pathname2url(r'C:\foo\bar\spam.foo'),
+                         "///C:/foo/bar/spam.foo" )
+
+    def test_long_drive_letter(self):
+        self.assertRaises(IOError, pathname2url, "XX:\\")
+
+    def test_roundtrip_pathname2url(self):
+        list_of_paths = ['///C:',
+                         '/////folder/test/',
+                         '///C:/foo/bar/spam.foo']
+        for path in list_of_paths:
+            self.assertEqual(pathname2url(url2pathname(path)), path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -19,7 +19,6 @@ except ImportError:
     ssl = None
 import sys
 import tempfile
-from nturl2path import url2pathname, pathname2url
 
 from base64 import b64encode
 import collections
@@ -1634,62 +1633,6 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(request.get_method(), 'GET')
         request.method = 'HEAD'
         self.assertEqual(request.get_method(), 'HEAD')
-
-
-class URL2PathNameTests(unittest.TestCase):
-
-    def test_converting_drive_letter(self):
-        self.assertEqual(url2pathname("///C|"), 'C:')
-        self.assertEqual(url2pathname("///C:"), 'C:')
-        self.assertEqual(url2pathname("///C|/"), 'C:\\')
-
-    def test_converting_when_no_drive_letter(self):
-        # cannot end a raw string in \
-        self.assertEqual(url2pathname("///C/test/"), r'\\\C\test' '\\')
-        self.assertEqual(url2pathname("////C/test/"), r'\\C\test' '\\')
-
-    def test_simple_compare(self):
-        self.assertEqual(url2pathname("///C|/foo/bar/spam.foo"),
-                         r'C:\foo\bar\spam.foo')
-
-    def test_non_ascii_drive_letter(self):
-        self.assertRaises(IOError, url2pathname, "///\u00e8|/")
-
-    def test_roundtrip_url2pathname(self):
-        list_of_paths = ['C:',
-                         r'\\\C\test\\',
-                         r'C:\foo\bar\spam.foo'
-                         ]
-        for path in list_of_paths:
-            self.assertEqual(url2pathname(pathname2url(path)), path)
-
-class PathName2URLTests(unittest.TestCase):
-
-    def test_converting_drive_letter(self):
-        self.assertEqual(pathname2url("C:"), '///C:')
-        self.assertEqual(pathname2url("C:\\"), '///C:')
-
-    def test_converting_when_no_drive_letter(self):
-        self.assertEqual(pathname2url(r"\\\folder\test" "\\"),
-                         '/////folder/test/')
-        self.assertEqual(pathname2url(r"\\folder\test" "\\"),
-                         '////folder/test/')
-        self.assertEqual(pathname2url(r"\folder\test" "\\"),
-                         '/folder/test/')
-
-    def test_simple_compare(self):
-        self.assertEqual(pathname2url(r'C:\foo\bar\spam.foo'),
-                         "///C:/foo/bar/spam.foo" )
-
-    def test_long_drive_letter(self):
-        self.assertRaises(IOError, pathname2url, "XX:\\")
-
-    def test_roundtrip_pathname2url(self):
-        list_of_paths = ['///C:',
-                         '/////folder/test/',
-                         '///C:/foo/bar/spam.foo']
-        for path in list_of_paths:
-            self.assertEqual(pathname2url(url2pathname(path)), path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Tests/2024-07-28-13-41-49.gh-issue-122371.6IYf_p.rst
+++ b/Misc/NEWS.d/next/Tests/2024-07-28-13-41-49.gh-issue-122371.6IYf_p.rst
@@ -1,0 +1,1 @@
+Separate nturl2path module test from test_urllib.py


### PR DESCRIPTION
`Lib/test/test_urllib.py` currently contains a `nturl2path` module test cases

I propose to move the snippets which nturl2path module test into a separate file.

Also add missing __all__

Ignore docs CI failed

<!-- gh-issue-number: gh-122371 -->
* Issue: gh-122371
<!-- /gh-issue-number -->
