### PR TITLE
gh-122400: Handle `ValueError` in `filecmp`

### DIFF
--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -138,10 +138,20 @@ class dircmp:
         self.shallow = shallow
 
     def phase0(self): # Compare everything except common subdirectories
-        self.left_list = _filter(os.listdir(self.left),
-                                 self.hide+self.ignore)
-        self.right_list = _filter(os.listdir(self.right),
-                                  self.hide+self.ignore)
+        try:
+            left_full_list = os.listdir(self.left)
+        except (OSError, ValueError):
+            self.left_list = []
+        else:
+            self.left_list = _filter(left_full_list, self.hide + self.ignore)
+
+        try:
+            right_full_list = os.listdir(self.right)
+        except (OSError, ValueError):
+            self.right_list = []
+        else:
+            self.right_list = _filter(right_full_list, self.hide + self.ignore)
+
         self.left_list.sort()
         self.right_list.sort()
 
@@ -164,12 +174,12 @@ class dircmp:
             ok = True
             try:
                 a_stat = os.stat(a_path)
-            except OSError:
+            except (OSError, ValueError):
                 # print('Can\'t stat', a_path, ':', why.args[1])
                 ok = False
             try:
                 b_stat = os.stat(b_path)
-            except OSError:
+            except (OSError, ValueError):
                 # print('Can\'t stat', b_path, ':', why.args[1])
                 ok = False
 
@@ -285,12 +295,12 @@ def cmpfiles(a, b, common, shallow=True):
 # Return:
 #       0 for equal
 #       1 for different
-#       2 for funny cases (can't stat, etc.)
+#       2 for funny cases (can't stat, NUL bytes, etc.)
 #
 def _cmp(a, b, sh, abs=abs, cmp=cmp):
     try:
         return not abs(cmp(a, b, sh))
-    except OSError:
+    except (OSError, ValueError):
         return 2
 
 

--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -138,20 +138,12 @@ class dircmp:
         self.shallow = shallow
 
     def phase0(self): # Compare everything except common subdirectories
-        try:
-            left_full_list = os.listdir(self.left)
-        except (OSError, ValueError):
-            self.left_list = []
-        else:
-            self.left_list = _filter(left_full_list, self.hide + self.ignore)
-
-        try:
-            right_full_list = os.listdir(self.right)
-        except (OSError, ValueError):
-            self.right_list = []
-        else:
-            self.right_list = _filter(right_full_list, self.hide + self.ignore)
-
+        # Do not protect os.listdir() against OSError or ValueError.
+        # See https://github.com/python/cpython/issues/122400.
+        self.left_list = _filter(os.listdir(self.left),
+                                 self.hide + self.ignore)
+        self.right_list = _filter(os.listdir(self.right),
+                                  self.hide+self.ignore)
         self.left_list.sort()
         self.right_list.sort()
 
@@ -175,6 +167,8 @@ class dircmp:
             try:
                 a_stat = os.stat(a_path)
             except (OSError, ValueError):
+                # See https://github.com/python/cpython/issues/122400
+                # for the rationale for protecting against ValueError.
                 # print('Can\'t stat', a_path, ':', why.args[1])
                 ok = False
             try:

--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -141,7 +141,7 @@ class dircmp:
         # Do not protect os.listdir() against OSError or ValueError.
         # See https://github.com/python/cpython/issues/122400.
         self.left_list = _filter(os.listdir(self.left),
-                                 self.hide + self.ignore)
+                                 self.hide+self.ignore)
         self.right_list = _filter(os.listdir(self.right),
                                   self.hide+self.ignore)
         self.left_list.sort()

--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -138,8 +138,6 @@ class dircmp:
         self.shallow = shallow
 
     def phase0(self): # Compare everything except common subdirectories
-        # Do not protect os.listdir() against OSError or ValueError.
-        # See https://github.com/python/cpython/issues/122400.
         self.left_list = _filter(os.listdir(self.left),
                                  self.hide+self.ignore)
         self.right_list = _filter(os.listdir(self.right),

--- a/Lib/test/test_filecmp.py
+++ b/Lib/test/test_filecmp.py
@@ -156,6 +156,17 @@ class DirCompareTestCase(unittest.TestCase):
                     (['file'], ['file2'], []),
                     "Comparing mismatched directories fails")
 
+    def test_compfiles_invalid_names(self):
+        for file, desc in [
+            ('\x00', 'NUL bytes filename'),
+            (__file__ + '\x00', 'filename with embedded NUL bytes'),
+            ("\uD834\uDD1E.py", 'surrogate codes (MUSICAL SYMBOL G CLEF)'),
+            ('a' * 1_000_000, 'very long filename'),
+        ]:
+            for other_dir in [self.dir, self.dir_same, self.dir_diff]:
+                with self.subTest(desc, other_dir=other_dir):
+                    res = filecmp.cmpfiles(self.dir, other_dir, [file])
+                    self.assertTupleEqual(res, ([], [], [file]))
 
     def _assert_lists(self, actual, expected):
         """Assert that two lists are equal, up to ordering."""

--- a/Lib/test/test_filecmp.py
+++ b/Lib/test/test_filecmp.py
@@ -176,15 +176,19 @@ class DirCompareTestCase(unittest.TestCase):
             ("\uD834\uDD1E", 'surrogate codes (MUSICAL SYMBOL G CLEF)'),
             ('a' * 1_000_000, 'very long dirname'),
         ]:
-            d = filecmp.dircmp(self.dir, bad_dir)
+            d1 = filecmp.dircmp(self.dir, bad_dir)
+            d2 = filecmp.dircmp(bad_dir, self.dir)
             for target in [
                 # attributes where os.listdir() raises OSError or ValueError
                 'left_list', 'right_list',
                 'left_only', 'right_only', 'common',
             ]:
-                with self.subTest(f'dircmp: {desc}', target=target):
+                with self.subTest(f'dircmp(ok, bad): {desc}', target=target):
                     with self.assertRaises((OSError, ValueError)):
-                        getattr(d, target)
+                        getattr(d1, target)
+                with self.subTest(f'dircmp(bad, ok): {desc}', target=target):
+                    with self.assertRaises((OSError, ValueError)):
+                        getattr(d2, target)
 
     def _assert_lists(self, actual, expected):
         """Assert that two lists are equal, up to ordering."""

--- a/Misc/NEWS.d/next/Library/2024-07-29-16-47-08.gh-issue-122400.fM0YSv.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-29-16-47-08.gh-issue-122400.fM0YSv.rst
@@ -1,3 +1,2 @@
-Handle :exc:`ValueError`\s raised by OS-related functions
-in :class:`filecmp.dircmp` and :func:`filecmp.cmpfiles`.
-Patch by Bénédikt Tran.
+Handle :exc:`ValueError`\s raised by :func:`os.stat` in
+:attr:`filecmp.dircmp.`in :func:`filecmp.cmpfiles`. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2024-07-29-16-47-08.gh-issue-122400.fM0YSv.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-29-16-47-08.gh-issue-122400.fM0YSv.rst
@@ -1,2 +1,3 @@
 Handle :exc:`ValueError`\s raised by :func:`os.stat` in
-:attr:`filecmp.dircmp.`in :func:`filecmp.cmpfiles`. Patch by Bénédikt Tran.
+:class:`filecmp.dircmp` and :func:`filecmp.cmpfiles`.
+Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2024-07-29-16-47-08.gh-issue-122400.fM0YSv.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-29-16-47-08.gh-issue-122400.fM0YSv.rst
@@ -1,0 +1,3 @@
+Handle :exc:`ValueError`\s raised by OS-related functions
+in :class:`filecmp.dircmp` and :func:`filecmp.cmpfiles`.
+Patch by Bénédikt Tran.


### PR DESCRIPTION
This could be backported to 3.12 and 3.13 but I need confirmation before applying the labels.

<!-- gh-issue-number: gh-122400 -->
* Issue: gh-122400
<!-- /gh-issue-number -->
