### PR TITLE
gh-122404: Fix reference leak in ``sum`` implementation

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2694,6 +2694,8 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
                     continue;
                 }
                 else {
+                    Py_DECREF(item);
+                    Py_DECREF(iter);
                     return NULL;
                 }
             }
@@ -2745,6 +2747,8 @@ builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
                     continue;
                 }
                 else {
+                    Py_DECREF(item);
+                    Py_DECREF(iter);
                     return NULL;
                 }
             }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122404 -->
* Issue: gh-122404
<!-- /gh-issue-number -->
