### PR TITLE
gh-122399: change webbrowser.rst to better describe the contents of controller object

### DIFF
--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -210,8 +210,8 @@ Here are some simple examples::
 Browser Controller Objects
 --------------------------
 
-Browser controllers provide these methods which parallel three of the
-module-level convenience functions:
+Browser controllers provide the :attr:`name` attribute, and these three methods
+which parallel module-level convenience functions:
 
 
 .. attribute:: controller.name

--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -210,8 +210,8 @@ Here are some simple examples::
 Browser Controller Objects
 --------------------------
 
-Browser controllers provide the :attr:`name` attribute, and these three methods
-which parallel module-level convenience functions:
+Browser controllers provide the :attr:`~controller.name` attribute,
+and the following three methods which parallel module-level convenience functions:
 
 
 .. attribute:: controller.name


### PR DESCRIPTION
This is a minor change that addresses https://github.com/python/cpython/issues/122399

It just mentions that the controller object has a `name` attribute too, before mentioning it with the other methods.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122399 -->
* Issue: gh-122399
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122407.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->