### PR TITLE
gh-122420: Fix accounting for immortal interned strings in refleak.py

### DIFF
--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -145,7 +145,7 @@ def runtest_refleak(test_name, test_func,
             # Use an internal-only keyword argument that mypy doesn't know yet
             _only_immortal=True)  # type: ignore[call-arg]
         alloc_after = getallocatedblocks() - interned_immortal_after
-        rc_after = gettotalrefcount() - interned_immortal_after * 2
+        rc_after = gettotalrefcount()
         fd_after = fd_count()
 
         rc_deltas[i] = get_pooled_int(rc_after - rc_before)


### PR DESCRIPTION
The `_PyUnicode_Intern*` functions already adjust the total refcount, so we don't want to readjust it in refleak.py.


<!-- gh-issue-number: gh-122420 -->
* Issue: gh-122420
<!-- /gh-issue-number -->
