### PR TITLE
Replace PyObject_Del with PyObject_Free

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -650,7 +650,7 @@ and :c:data:`PyType_Type` effectively act as defaults.)
    (doesn't have the :c:macro:`Py_TPFLAGS_BASETYPE` flag bit set), it is
    permissible to call the object deallocator directly instead of via
    :c:member:`~PyTypeObject.tp_free`.  The object deallocator should be the one used to allocate the
-   instance; this is normally :c:func:`PyObject_Del` if the instance was allocated
+   instance; this is normally :c:func:`PyObject_Free` if the instance was allocated
    using :c:macro:`PyObject_New` or :c:macro:`PyObject_NewVar`, or
    :c:func:`PyObject_GC_Del` if the instance was allocated using
    :c:macro:`PyObject_GC_New` or :c:macro:`PyObject_GC_NewVar`.
@@ -1954,7 +1954,7 @@ and :c:data:`PyType_Type` effectively act as defaults.)
    match :c:func:`PyType_GenericAlloc` and the value of the
    :c:macro:`Py_TPFLAGS_HAVE_GC` flag bit.
 
-   For static subtypes, :c:data:`PyBaseObject_Type` uses :c:func:`PyObject_Del`.
+   For static subtypes, :c:data:`PyBaseObject_Type` uses :c:func:`PyObject_Free`.
 
 
 .. c:member:: inquiry PyTypeObject.tp_is_gc

--- a/Modules/_testcapi/gc.c
+++ b/Modules/_testcapi/gc.c
@@ -72,7 +72,7 @@ without_gc(PyObject *Py_UNUSED(self), PyObject *obj)
     if (PyType_IS_GC(tp)) {
         // Don't try this at home, kids:
         tp->tp_flags -= Py_TPFLAGS_HAVE_GC;
-        tp->tp_free = PyObject_Del;
+        tp->tp_free = PyObject_Free;
         tp->tp_traverse = NULL;
         tp->tp_clear = NULL;
     }

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -289,7 +289,7 @@ static PyTypeObject _HashInheritanceTester_Type = {
     "hashinheritancetester",            /* Name of this type */
     sizeof(PyObject),           /* Basic object size */
     0,                          /* Item size for varobject */
-    (destructor)PyObject_Del, /* tp_dealloc */
+    (destructor)PyObject_Free,  /* tp_dealloc */
     0,                          /* tp_vectorcall_offset */
     0,                          /* tp_getattr */
     0,                          /* tp_setattr */
@@ -3587,7 +3587,7 @@ static PyTypeObject matmulType = {
     0,
     0,
     PyType_GenericNew,                  /* tp_new */
-    PyObject_Del,                       /* tp_free */
+    PyObject_Free,                      /* tp_free */
 };
 
 typedef struct {
@@ -3699,7 +3699,7 @@ static PyTypeObject awaitType = {
     0,
     0,
     awaitObject_new,                    /* tp_new */
-    PyObject_Del,                       /* tp_free */
+    PyObject_Free,                      /* tp_free */
 };
 
 

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2426,7 +2426,7 @@ PyTypeObject PyByteArray_Type = {
     (initproc)bytearray___init__,       /* tp_init */
     PyType_GenericAlloc,                /* tp_alloc */
     PyType_GenericNew,                  /* tp_new */
-    PyObject_Del,                       /* tp_free */
+    PyObject_Free,                      /* tp_free */
 };
 
 /*********************** Bytearray Iterator ****************************/

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3066,7 +3066,7 @@ PyTypeObject PyBytes_Type = {
     0,                                          /* tp_init */
     bytes_alloc,                                /* tp_alloc */
     bytes_new,                                  /* tp_new */
-    PyObject_Del,                               /* tp_free */
+    PyObject_Free,                              /* tp_free */
 };
 
 void

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1352,7 +1352,7 @@ PyTypeObject _PyLineIterator = {
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
     0,                                  /* tp_new */
-    PyObject_Del,                       /* tp_free */
+    PyObject_Free,                      /* tp_free */
 };
 
 static lineiterator *
@@ -1443,7 +1443,7 @@ PyTypeObject _PyPositionsIterator = {
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
     0,                                  /* tp_new */
-    PyObject_Del,                       /* tp_free */
+    PyObject_Free,                      /* tp_free */
 };
 
 static PyObject*

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -1247,5 +1247,5 @@ PyTypeObject PyComplex_Type = {
     0,                                          /* tp_init */
     PyType_GenericAlloc,                        /* tp_alloc */
     actual_complex_new,                         /* tp_new */
-    PyObject_Del,                               /* tp_free */
+    PyObject_Free,                              /* tp_free */
 };

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -462,7 +462,7 @@ PyTypeObject PyStdPrinter_Type = {
     0,                                          /* tp_init */
     PyType_GenericAlloc,                        /* tp_alloc */
     0,                                          /* tp_new */
-    PyObject_Del,                               /* tp_free */
+    PyObject_Free,                              /* tp_free */
 };
 
 

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -276,7 +276,7 @@ tp_dictoffset     (__dict__)       -                   -
 tp_init           __init__         object_init         dict_init
 tp_alloc          -                PyType_GenericAlloc (repeated)
 tp_new            __new__          object_new          dict_new
-tp_free           -                PyObject_Del        PyObject_GC_Del
+tp_free           -                PyObject_Free       PyObject_GC_Del
 ================= ================ =================== ================
 
 Relevant Methods

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -899,7 +899,7 @@ PyTypeObject PyRangeIter_Type = {
         sizeof(_PyRangeIterObject),             /* tp_basicsize */
         0,                                      /* tp_itemsize */
         /* methods */
-        (destructor)PyObject_Del,               /* tp_dealloc */
+        (destructor)PyObject_Free,              /* tp_dealloc */
         0,                                      /* tp_vectorcall_offset */
         0,                                      /* tp_getattr */
         0,                                      /* tp_setattr */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -7456,7 +7456,7 @@ PyTypeObject PyBaseObject_Type = {
     object_init,                                /* tp_init */
     PyType_GenericAlloc,                        /* tp_alloc */
     object_new,                                 /* tp_new */
-    PyObject_Del,                               /* tp_free */
+    PyObject_Free,                              /* tp_free */
 };
 
 
@@ -8180,7 +8180,7 @@ type_ready_inherit(PyTypeObject *type)
 
     /* Sanity check for tp_free. */
     if (_PyType_IS_GC(type) && (type->tp_flags & Py_TPFLAGS_BASETYPE) &&
-        (type->tp_free == NULL || type->tp_free == PyObject_Del))
+        (type->tp_free == NULL || type->tp_free == PyObject_Free))
     {
         /* This base class needs to call tp_free, but doesn't have
          * one, or its tp_free is for non-gc'ed objects.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15265,7 +15265,7 @@ PyTypeObject PyUnicode_Type = {
     0,                            /* tp_init */
     0,                            /* tp_alloc */
     unicode_new,                  /* tp_new */
-    PyObject_Del,                 /* tp_free */
+    PyObject_Free,                /* tp_free */
     .tp_vectorcall = unicode_vectorcall,
 };
 

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1374,7 +1374,7 @@ PyTypeObject _PyCounterOptimizer_Type = {
     .tp_itemsize = 0,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .tp_methods = counter_optimizer_methods,
-    .tp_dealloc = (destructor)PyObject_Del,
+    .tp_dealloc = (destructor)PyObject_Free,
 };
 
 PyObject *


### PR DESCRIPTION
PyObject_Del() is just a alias to PyObject_Free() kept for backward compatibility. Use directly PyObject_Free() instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122453.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->