### PR TITLE
gh-122454: Handle `ValueError` in `configparser.RawConfigParser.read` [not ready for review]

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -732,7 +732,7 @@ class RawConfigParser(MutableMapping):
         for filename in filenames:
             try:
                 fp = open(filename, encoding=encoding)
-            except (OSError, ValueError):
+            except OSError:
                 continue
             with fp:
                 self._read(fp, filename)

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -724,6 +724,9 @@ class RawConfigParser(MutableMapping):
         filename may also be given.
 
         Return list of successfully read files.
+
+        Any exception other than an OSError raised while
+        parsing the file is propogated to the caller.
         """
         if isinstance(filenames, (str, bytes, os.PathLike)):
             filenames = [filenames]
@@ -731,9 +734,15 @@ class RawConfigParser(MutableMapping):
         read_ok = []
         for filename in filenames:
             try:
-                with open(filename, encoding=encoding) as fp:
+                fp = open(filename, encoding=encoding)
+            except (OSError, ValueError):
+                continue
+            try:
+                with fp:
                     self._read(fp, filename)
             except OSError:
+                # Do not silence ValueError during the parsing
+                # phase such as those due to a wrong encoding.
                 continue
             if isinstance(filename, os.PathLike):
                 filename = os.fspath(filename)

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -724,9 +724,6 @@ class RawConfigParser(MutableMapping):
         filename may also be given.
 
         Return list of successfully read files.
-
-        Any exception other than an OSError raised while
-        parsing the file is propogated to the caller.
         """
         if isinstance(filenames, (str, bytes, os.PathLike)):
             filenames = [filenames]
@@ -737,13 +734,8 @@ class RawConfigParser(MutableMapping):
                 fp = open(filename, encoding=encoding)
             except (OSError, ValueError):
                 continue
-            try:
-                with fp:
-                    self._read(fp, filename)
-            except OSError:
-                # Do not silence ValueError during the parsing
-                # phase such as those due to a wrong encoding.
-                continue
+            with fp:
+                self._read(fp, filename)
             if isinstance(filename, os.PathLike):
                 filename = os.fspath(filename)
             read_ok.append(filename)

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -760,6 +760,15 @@ boolean {0[0]} NO
         cf = self.newconfig()
         parsed_files = cf.read([], encoding="utf-8")
         self.assertEqual(parsed_files, [])
+        # check when we pass invalid file names:
+        cf = self.newconfig()
+        parsed_files = cf.read([
+            '\x00',                 # NUL bytes filename
+            __file__ + '\x00.ini',  # filename with embedded NUL bytes
+            "\uD834\uDD1E.ini",     # surrogate codes (MUSICAL SYMBOL G CLEF)
+            'a' * 1_000_000         # very long filename
+        ], encoding='utf-8')
+        self.assertListEqual(parsed_files, [])
 
     def test_read_returns_file_list_with_bytestring_path(self):
         if self.delimiters[0] != '=':

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -764,14 +764,6 @@ boolean {0[0]} NO
     def test_invalid_filenames(self):
         # check when we pass invalid file names:
         for name, desc in [
-            ('\x00', 'NUL bytes filename'),
-            (__file__ + '\x00.ini', 'filename with embedded NUL bytes'),
-            # A filename with surrogate codes. A UnicodeEncodeError is raised
-            # by open() upon querying, which is a subclass of ValueError.
-            ("\uD834\uDD1E.ini", 'surrogate codes (MUSICAL SYMBOL G CLEF)'),
-            # For POSIX platforms, an OSError will be raised but for Windows
-            # platforms, a ValueError is raised due to the path_t converter.
-            # See: https://github.com/python/cpython/issues/122170
             ('a' * 1_000_000, 'very long filename'),
         ]:
             cf = self.newconfig()

--- a/Misc/NEWS.d/next/Library/2024-07-30-14-44-29.gh-issue-122454.P4977E.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-30-14-44-29.gh-issue-122454.P4977E.rst
@@ -1,0 +1,2 @@
+Handle :exc:`ValueError`\s raised by :func:`open` in
+:meth:`configparser.RawConfigParser.read`. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2024-07-30-14-44-29.gh-issue-122454.P4977E.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-30-14-44-29.gh-issue-122454.P4977E.rst
@@ -1,2 +1,3 @@
 Handle :exc:`ValueError`\s raised by :func:`open` in
-:meth:`configparser.RawConfigParser.read`. Patch by Bénédikt Tran.
+:meth:`ConfigParser.read <configparser.ConfigParser.read>`.
+Patch by Bénédikt Tran.


### PR DESCRIPTION
See the issue for details.

<!-- gh-issue-number: gh-122454 -->
* Issue: gh-122454
<!-- /gh-issue-number -->
