### PR TITLE
gh-87320: dont crash in code module with bad sys.excepthook

### DIFF
--- a/Lib/code.py
+++ b/Lib/code.py
@@ -157,7 +157,7 @@ class InteractiveInterpreter:
     def _call_excepthook(self, typ, value, tb):
         try:
             sys.excepthook(typ, value, tb)
-        except Exception as e:
+        except BaseException as e:
             e.__context__ = None
             print('Error in sys.excepthook:', file=sys.stderr)
             sys.__excepthook__(type(e), e, e.__traceback__.tb_next)

--- a/Lib/code.py
+++ b/Lib/code.py
@@ -144,8 +144,8 @@ class InteractiveInterpreter:
         sys.last_traceback = last_tb
         sys.last_exc = ei[1]
         try:
-            lines = traceback.format_exception(ei[0], ei[1], last_tb.tb_next, colorize=colorize)
             if sys.excepthook is sys.__excepthook__:
+                lines = traceback.format_exception(ei[0], ei[1], last_tb.tb_next, colorize=colorize)
                 self.write(''.join(lines))
             else:
                 # If someone has set sys.excepthook, we let that take precedence

--- a/Lib/code.py
+++ b/Lib/code.py
@@ -157,6 +157,8 @@ class InteractiveInterpreter:
     def _call_excepthook(self, typ, value, tb):
         try:
             sys.excepthook(typ, value, tb)
+        except SystemExit:
+            raise
         except BaseException as e:
             e.__context__ = None
             print('Error in sys.excepthook:', file=sys.stderr)

--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -97,7 +97,6 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         self.console.interact()
         self.assertEqual(['write', ('123', ), {}], self.stdout.method_calls[0])
         error = "".join(call.args[0] for call in self.stderr.method_calls if call[0] == 'write')
-        self.stack.close()
         self.assertIn("Error in sys.excepthook:", error)
         self.assertEqual(error.count("not so fast"), 1)
         self.assertIn("Original exception was:", error)

--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -88,6 +88,21 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         self.assertIn("Original exception was:", error)
         self.assertIn("division by zero", error)
 
+    def test_sysexcepthook_raising_BaseException(self):
+        self.infunc.side_effect = ["1/0", "a = 123", "print(a)", EOFError('Finished')]
+        s = "not so fast"
+        def raise_base(*args, **kwargs):
+            raise BaseException(s)
+        self.sysmod.excepthook = raise_base
+        self.console.interact()
+        self.assertEqual(['write', ('123', ), {}], self.stdout.method_calls[0])
+        error = "".join(call.args[0] for call in self.stderr.method_calls if call[0] == 'write')
+        self.stack.close()
+        self.assertIn("Error in sys.excepthook:", error)
+        self.assertEqual(error.count("not so fast"), 1)
+        self.assertIn("Original exception was:", error)
+        self.assertIn("division by zero", error)
+
     def test_banner(self):
         # with banner
         self.infunc.side_effect = EOFError('Finished')

--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -102,6 +102,14 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         self.assertIn("Original exception was:", error)
         self.assertIn("division by zero", error)
 
+    def test_sysexcepthook_raising_SystemExit_gets_through(self):
+        self.infunc.side_effect = ["1/0"]
+        def raise_base(*args, **kwargs):
+            raise SystemExit
+        self.sysmod.excepthook = raise_base
+        with self.assertRaises(SystemExit):
+            self.console.interact()
+
     def test_banner(self):
         # with banner
         self.infunc.side_effect = EOFError('Finished')

--- a/Misc/NEWS.d/next/Library/2024-07-30-14-46-16.gh-issue-87320.-Yk1wb.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-30-14-46-16.gh-issue-87320.-Yk1wb.rst
@@ -1,2 +1,3 @@
-Don't crash :class:`code.InteractiveInterpreter` when calling
-:func:`sys.excepthook` fails.
+In :class:`code.InteractiveInterpreter`, handle exceptions caused by calling a
+non-default :func:`sys.excepthook`. Before, the exception bubbled up to the
+caller, ending the :term:`REPL`.

--- a/Misc/NEWS.d/next/Library/2024-07-30-14-46-16.gh-issue-87320.-Yk1wb.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-30-14-46-16.gh-issue-87320.-Yk1wb.rst
@@ -1,0 +1,2 @@
+Don't crash :class:`code.InteractiveInterpreter` when calling
+:func:`sys.excepthook` fails.


### PR DESCRIPTION
Catch errors in `code.InteractiveCodeInterpreter` when calling `sys.excepthook` fails. Report them in the same style that the classic interpreter has reported them.


<!-- gh-issue-number: gh-87320 -->
* Issue: gh-87320
<!-- /gh-issue-number -->
