### PR TITLE
gh-122461: Document that compile() and ast.parse() raise SyntaxError for null bytes

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2155,6 +2155,10 @@ and classes for traversing abstract syntax trees:
    is no guarantee that the parse (or success of the parse) is the same as
    when run on the Python version corresponding to ``feature_version``.
 
+   This function raises :exc:`SyntaxError` if the parsed source is invalid.
+   It can also raise :exc:`ValueError`, :exc:`OverflowError` and
+   :exc:`RecursionError`.
+
    .. warning::
       Note that successfully parsing source code into an AST object doesn't
       guarantee that the source code provided is valid Python code that can

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2155,7 +2155,7 @@ and classes for traversing abstract syntax trees:
    is no guarantee that the parse (or success of the parse) is the same as
    when run on the Python version corresponding to ``feature_version``.
 
-   If source contains a null character (``\0``), :exc:`ValueError` is raised.
+   If source contains a null character (``\0``), :exc:`SyntaxError` is raised.
 
    .. warning::
       Note that successfully parsing source code into an AST object doesn't
@@ -2175,6 +2175,10 @@ and classes for traversing abstract syntax trees:
 
    .. versionchanged:: 3.8
       Added ``type_comments``, ``mode='func_type'`` and ``feature_version``.
+
+   .. versionchanged:: 3.12
+      Previously, :exc:`ValueError` was raised when null bytes were encountered
+      in *source*.
 
    .. versionchanged:: 3.13
       The minimum supported version for ``feature_version`` is now ``(3, 7)``.

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2155,8 +2155,6 @@ and classes for traversing abstract syntax trees:
    is no guarantee that the parse (or success of the parse) is the same as
    when run on the Python version corresponding to ``feature_version``.
 
-   If source contains a null character (``\0``), :exc:`SyntaxError` is raised.
-
    .. warning::
       Note that successfully parsing source code into an AST object doesn't
       guarantee that the source code provided is valid Python code that can
@@ -2177,8 +2175,8 @@ and classes for traversing abstract syntax trees:
       Added ``type_comments``, ``mode='func_type'`` and ``feature_version``.
 
    .. versionchanged:: 3.12
-      Previously, :exc:`ValueError` was raised when null bytes were encountered
-      in *source*.
+      Previously, :exc:`ValueError` was raised instead of :exc:`SyntaxError`
+      when null characters (``\0``) were encountered in *source*.
 
    .. versionchanged:: 3.13
       The minimum supported version for ``feature_version`` is now ``(3, 7)``.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -335,6 +335,8 @@ are always available.  They are listed here in alphabetical order.
    or ``2`` (docstrings are removed too).
 
    This function raises :exc:`SyntaxError` if the compiled source is invalid.
+   It can also raise :exc:`ValueError`, :exc:`OverflowError` and
+   :exc:`RecursionError`.
 
    If you want to parse Python code into its AST representation, see
    :func:`ast.parse`.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -334,8 +334,7 @@ are always available.  They are listed here in alphabetical order.
    ``__debug__`` is true), ``1`` (asserts are removed, ``__debug__`` is false)
    or ``2`` (docstrings are removed too).
 
-   This function raises :exc:`SyntaxError` if the compiled source is invalid or
-   contains null bytes.
+   This function raises :exc:`SyntaxError` if the compiled source is invalid.
 
    If you want to parse Python code into its AST representation, see
    :func:`ast.parse`.
@@ -372,8 +371,8 @@ are always available.  They are listed here in alphabetical order.
       support for top-level ``await``, ``async for``, and ``async with``.
 
    .. versionchanged:: 3.12
-      Previously, :exc:`ValueError` was raised when null bytes were encountered
-      in *source*.
+      Previously, :exc:`ValueError` was raised instead of :exc:`SyntaxError` when
+      null characters (``\0``) were encountered in *source*.
 
 .. class:: complex(number=0, /)
            complex(string, /)

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -334,8 +334,8 @@ are always available.  They are listed here in alphabetical order.
    ``__debug__`` is true), ``1`` (asserts are removed, ``__debug__`` is false)
    or ``2`` (docstrings are removed too).
 
-   This function raises :exc:`SyntaxError` if the compiled source is invalid,
-   and :exc:`ValueError` if the source contains null bytes.
+   This function raises :exc:`SyntaxError` if the compiled source is invalid or
+   contains null bytes.
 
    If you want to parse Python code into its AST representation, see
    :func:`ast.parse`.
@@ -371,6 +371,9 @@ are always available.  They are listed here in alphabetical order.
       ``ast.PyCF_ALLOW_TOP_LEVEL_AWAIT`` can now be passed in flags to enable
       support for top-level ``await``, ``async for``, and ``async with``.
 
+   .. versionchanged:: 3.12
+      Previously, :exc:`ValueError` was raised when null bytes were encountered
+      in *source*.
 
 .. class:: complex(number=0, /)
            complex(string, /)


### PR DESCRIPTION
Update docs for `compile()` and `ast.parse()` because they raise `SyntaxError` instead of `ValueError` for null bytes since https://github.com/python/cpython/pull/97594.


<!-- gh-issue-number: gh-122461 -->
* Issue: gh-122461
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122462.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->