### PR TITLE
gh-112301: Add argument aliases and tee compiler output for check warnings

### DIFF
--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -75,7 +75,7 @@ jobs:
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
     - name: Build CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
-      run: make -j4 &> compiler_output.txt
+      run: set -o pipefail; make -j4 2>&1 | tee compiler_output.txt
     - name: Display build info
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: make pythoninfo

--- a/Tools/build/check_warnings.py
+++ b/Tools/build/check_warnings.py
@@ -114,24 +114,28 @@ def get_unexpected_improvements(
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "-c",
         "--compiler-output-file-path",
         type=str,
         required=True,
         help="Path to the compiler output file",
     )
     parser.add_argument(
+        "-i",
         "--warning-ignore-file-path",
         type=str,
         required=True,
         help="Path to the warning ignore file",
     )
     parser.add_argument(
+        "-x",
         "--fail-on-regression",
         action="store_true",
         default=False,
         help="Flag to fail if new warnings are found",
     )
     parser.add_argument(
+        "-X",
         "--fail-on-improvement",
         action="store_true",
         default=False,

--- a/Tools/build/check_warnings.py
+++ b/Tools/build/check_warnings.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Parses compiler output with -fdiagnostics-format=json and checks that warnings
 exist only in files that are expected to have warnings.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
#112301
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This adds argument aliases for the `check_warnings.py` script per suggestions: https://github.com/python/cpython/pull/121730#discussion_r1693929698

Also includes re-adding compiler output to the `build_ubuntu` job log using tee as suggested: https://github.com/python/cpython/pull/121730#discussion_r1693929698


<!-- gh-issue-number: gh-112301 -->
* Issue: gh-112301
<!-- /gh-issue-number -->
