### PR TITLE
GH-122482: Make About IDLE direct discussion to DPO

### DIFF
--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -4,6 +4,9 @@ Released on 2024-10-xx
 =========================
 
 
+gh-122482: Change About IDLE to direct users to discuss.python.org
+instead of the now unused idle-dev email and mailing list.
+
 gh-78889: Stop Shell freezes by blocking user access to non-method
 sys.stdout.shell attributes, which are all private.
 

--- a/Lib/idlelib/help_about.py
+++ b/Lib/idlelib/help_about.py
@@ -85,15 +85,18 @@ class AboutDialog(Toplevel):
         byline = Label(frame_background, text=byline_text, justify=LEFT,
                        fg=self.fg, bg=self.bg)
         byline.grid(row=2, column=0, sticky=W, columnspan=3, padx=10, pady=5)
-        email = Label(frame_background, text='email:  idle-dev@python.org',
-                      justify=LEFT, fg=self.fg, bg=self.bg)
-        email.grid(row=6, column=0, columnspan=2, sticky=W, padx=10, pady=0)
+
+        forums_url = "https://discuss.python.org"
+        forums = Label(frame_background, text="Python forums: "+forums_url,
+                        justify=LEFT, fg=self.fg, bg=self.bg)
+        forums.grid(row=6, column=0, sticky=W, padx=10, pady=0)
+        forums.bind("<Button-1>", lambda event: webbrowser.open(forums_url))
         docs_url = ("https://docs.python.org/%d.%d/library/idle.html" %
                     sys.version_info[:2])
         docs = Label(frame_background, text=docs_url,
                      justify=LEFT, fg=self.fg, bg=self.bg)
         docs.grid(row=7, column=0, columnspan=2, sticky=W, padx=10, pady=0)
-        docs.bind("<Button-1>", lambda event: webbrowser.open(docs['text']))
+        docs.bind("<Button-1>", lambda event: webbrowser.open(docs_url))
 
         Frame(frame_background, borderwidth=1, relief=SUNKEN,
               height=2, bg=self.bg).grid(row=8, column=0, sticky=EW,
@@ -123,9 +126,7 @@ class AboutDialog(Toplevel):
               height=2, bg=self.bg).grid(row=11, column=0, sticky=EW,
                                          columnspan=3, padx=5, pady=5)
 
-        idle = Label(frame_background,
-                        text='IDLE',
-                        fg=self.fg, bg=self.bg)
+        idle = Label(frame_background, text='IDLE', fg=self.fg, bg=self.bg)
         idle.grid(row=12, column=0, sticky=W, padx=10, pady=0)
         idle_buttons = Frame(frame_background, bg=self.bg)
         idle_buttons.grid(row=13, column=0, columnspan=3, sticky=NSEW)

--- a/Misc/NEWS.d/next/IDLE/2024-07-30-18-02-55.gh-issue-122482.TerE0g.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-07-30-18-02-55.gh-issue-122482.TerE0g.rst
@@ -1,0 +1,2 @@
+Change About IDLE to direct users to discuss.python.org instead of the now
+unused idle-dev email and mailing list.


### PR DESCRIPTION
Change About IDLE to direct discussions to discuss.python.org instead of the unused idle-dev list.  Users have already shifted.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122482 -->
* Issue: gh-122482
<!-- /gh-issue-number -->
