### PR TITLE
gh-116622: Fix testPyObjectPrintOSError on Android

### DIFF
--- a/Android/testbed/app/build.gradle.kts
+++ b/Android/testbed/app/build.gradle.kts
@@ -7,10 +7,17 @@ plugins {
 
 val PYTHON_DIR = File(projectDir, "../../..").canonicalPath
 val PYTHON_CROSS_DIR = "$PYTHON_DIR/cross-build"
+
 val ABIS = mapOf(
     "arm64-v8a" to "aarch64-linux-android",
     "x86_64" to "x86_64-linux-android",
-)
+).filter { File("$PYTHON_CROSS_DIR/${it.value}").exists() }
+if (ABIS.isEmpty()) {
+    throw GradleException(
+        "No Android ABIs found in $PYTHON_CROSS_DIR: see Android/README.md " +
+        "for building instructions."
+    )
+}
 
 val PYTHON_VERSION = File("$PYTHON_DIR/Include/patchlevel.h").useLines {
     for (line in it) {

--- a/Misc/NEWS.d/next/C API/2024-07-30-23-48-26.gh-issue-116622.yTTtil.rst
+++ b/Misc/NEWS.d/next/C API/2024-07-30-23-48-26.gh-issue-116622.yTTtil.rst
@@ -1,0 +1,3 @@
+Make :any:`PyObject_Print` work around a bug in Android and OpenBSD which
+prevented it from throwing an exception when trying to write to a read-only
+stream.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -536,6 +536,7 @@ int
 PyObject_Print(PyObject *op, FILE *fp, int flags)
 {
     int ret = 0;
+    int write_error = 0;
     if (PyErr_CheckSignals())
         return -1;
 #ifdef USE_STACKCHECK
@@ -574,14 +575,20 @@ PyObject_Print(PyObject *op, FILE *fp, int flags)
                     ret = -1;
                 }
                 else {
-                    fwrite(t, 1, len, fp);
+                    /* Versions of Android and OpenBSD from before 2023 fail to
+                       set the `ferror` indicator when writing to a read-only
+                       stream, so we need to check the return value.
+                       (https://github.com/openbsd/src/commit/fc99cf9338942ecd9adc94ea08bf6188f0428c15) */
+                    if (fwrite(t, 1, len, fp) != (size_t)len) {
+                        write_error = 1;
+                    }
                 }
                 Py_DECREF(s);
             }
         }
     }
     if (ret == 0) {
-        if (ferror(fp)) {
+        if (write_error || ferror(fp)) {
             PyErr_SetFromErrno(PyExc_OSError);
             clearerr(fp);
             ret = -1;


### PR DESCRIPTION
This test, which was added in #98749, was failing on Android as follows:

```
17:43:48.804  W  ======================================================================
17:43:48.804  W  FAIL: testPyObjectPrintOSError (test.test_capi.test_object.PrintTest.testPyObjectPrintOSError)
17:43:48.804  W  ----------------------------------------------------------------------
17:43:48.804  W  Traceback (most recent call last):
17:43:48.804  W    File "/data/user/0/org.python.testbed/files/python/lib/python3.13/test/test_capi/test_object.py", line 103, in testPyObjectPrintOSError
17:43:48.804  W      with self.assertRaises(OSError):
17:43:48.804  W          _testcapi.pyobject_print_os_error(output_filename)
17:43:48.804  W  AssertionError: OSError not raised
17:43:48.804  W
17:43:48.804  W  ----------------------------------------------------------------------
```

This was caused by a [recently-fixed bug](https://github.com/openbsd/src/commit/fc99cf9338942ecd9adc94ea08bf6188f0428c15) in OpenBSD's libc, on which Android's libc is based. Luckily there's a simple workaround.

This PR also addresses the comment in #121595 about it being inconvenient to build all architectures before running the testbed. The build script now allows architectures to be missing, as long as at least one is present.

<!-- gh-issue-number: gh-116622 -->
* Issue: gh-116622
<!-- /gh-issue-number -->
