### PR TITLE
[3.13] gh-120906: Support arbitrary hashable keys in FrameLocalsProxy (GH-122309)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-07-26-13-56-32.gh-issue-120906.qBh2I9.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-07-26-13-56-32.gh-issue-120906.qBh2I9.rst
@@ -1,0 +1,1 @@
+:attr:`frame.f_locals` now supports arbitrary hashable objects as keys.


### PR DESCRIPTION

Co-authored-by: Alyssa Coghlan <ncoghlan@gmail.com>
(cherry picked from commit 5912487938ac4b517209082ab9e6d2d3d0fb4f4d)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120906 -->
* Issue: gh-120906
<!-- /gh-issue-number -->
