### PR TITLE
[3.12] gh-122334: Fix crash when importing ssl after re-initialization (GH-122481)

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -434,6 +434,21 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
             self.assertEqual(result, {})
         self.assertEqual(out, '')
 
+    def test_getargs_reset_static_parser(self):
+        # Test _PyArg_Parser initializations via _PyArg_UnpackKeywords()
+        # https://github.com/python/cpython/issues/122334
+        code = textwrap.dedent("""
+            import _ssl
+            _ssl.txt2obj(txt='1.3')
+            print('1')
+
+            import _queue
+            _queue.SimpleQueue().put_nowait(item=None)
+            print('2')
+        """)
+        out, err = self.run_embedded_interpreter("test_repeated_init_exec", code)
+        self.assertEqual(out, '1\n2\n' * INIT_LOOPS)
+
 
 class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
     maxDiff = 4096

--- a/Misc/NEWS.d/next/Library/2024-07-30-21-29-30.gh-issue-122334.LeoE1x.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-30-21-29-30.gh-issue-122334.LeoE1x.rst
@@ -1,0 +1,1 @@
+Fix crash when importing :mod:`ssl` after the main interpreter restarts.

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2071,6 +2071,18 @@ parser_clear(struct _PyArg_Parser *parser)
     if (parser->initialized == 1) {
         Py_CLEAR(parser->kwtuple);
     }
+
+    if (parser->format) {
+        parser->fname = NULL;
+    }
+    else {
+        assert(parser->fname != NULL);
+    }
+    parser->custom_msg = NULL;
+    parser->pos = 0;
+    parser->min = 0;
+    parser->max = 0;
+    parser->initialized = 0;
 }
 
 static PyObject*


### PR DESCRIPTION
The current `METH_FASTCALL|METH_KEYWORDS` functions in a non-builtin module can cause segfaults after restarting the main interpreter, invoking `_PyArg_UnpackKeywords()` with an insufficiently cleared `_PyArg_Parser` struct.

This patch fixes the invalidation of the static argument parsers.

This backport cannot test `_zoneinfo` extension since `_datetime` does single-phase init in 3.12.

(cherry picked from commit 9fc1c992d6fcea0b7558c581846eef6bdd811f6c AKA gh-122481)


<!-- gh-issue-number: gh-122334 -->
* Issue: gh-122334
<!-- /gh-issue-number -->
