### PR TITLE
gh-122494: Fix incorrect name in 3.3.2. Customizing attribute access document

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1978,7 +1978,7 @@ access (use of, assignment to, or deletion of ``x.name``) for class instances.
    .. audit-event:: object.__getattr__ obj,name object.__getattribute__
 
       For certain sensitive attribute accesses, raises an
-      :ref:`auditing event <auditing>` ``object.__getattr__`` with arguments
+      :ref:`auditing event <auditing>` ``obj.__getattribute__`` with arguments
       ``obj`` and ``name``.
 
 


### PR DESCRIPTION
According to the issue #122494

>  For certain sensitive attribute accesses, raises an [auditing event](https://docs.python.org/3/library/sys.html#auditing) `object.__getattr__`with arguments obj and name.

Change the description in 
`object.__getattr__` to `obj.__getattribute__`


<!-- gh-issue-number: gh-122494 -->
* Issue: gh-122494
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122498.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->