### PR TITLE
gh-116622: Skip `PosixPathTest.test_expanduser_pwd2` on platforms which don't support `pwd.getpwall`

### DIFF
--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 from posixpath import realpath, abspath, dirname, basename
 from test import test_genericpath
-from test.support import import_helper
+from test.support import get_attribute, import_helper
 from test.support import cpython_only, os_helper
 from test.support.os_helper import FakePath
 from unittest import mock
@@ -359,10 +359,7 @@ class PosixPathTest(unittest.TestCase):
                      "no home directory on VxWorks")
     def test_expanduser_pwd2(self):
         pwd = import_helper.import_module('pwd')
-        if not hasattr(pwd, "getpwall"):
-            self.skipTest("Does not have getpwall()")
-
-        for all_entry in pwd.getpwall():
+        for all_entry in get_attribute(pwd, 'getpwall')():
             name = all_entry.pw_name
 
             # gh-121200: pw_dir can be different between getpwall() and

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -359,6 +359,9 @@ class PosixPathTest(unittest.TestCase):
                      "no home directory on VxWorks")
     def test_expanduser_pwd2(self):
         pwd = import_helper.import_module('pwd')
+        if not hasattr(pwd, "getpwall"):
+            self.skipTest("Does not have getpwall()")
+
         for all_entry in pwd.getpwall():
             name = all_entry.pw_name
 


### PR DESCRIPTION
This is consistent with the similar skip in test_pwd.

<!-- gh-issue-number: gh-116622 -->
* Issue: gh-116622
<!-- /gh-issue-number -->
