### PR TITLE
gh-116622: Don't expose `FICLONE` ioctl on Android

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-07-31-15-08-42.gh-issue-116622.aKxIQA.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-31-15-08-42.gh-issue-116622.aKxIQA.rst
@@ -1,0 +1,2 @@
+On Android, the ``FICLONE`` and ``FICLONERANGE`` constants are no longer
+exposed by :mod:`fcntl`, as these ioctls are blocked by SELinux.

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -580,12 +580,17 @@ all_ins(PyObject* m)
 #ifdef F_GETPIPE_SZ
     if (PyModule_AddIntMacro(m, F_GETPIPE_SZ)) return -1;
 #endif
+
+/* On Android, FICLONE is blocked by SELinux. */
+#ifndef __ANDROID__
 #ifdef FICLONE
     if (PyModule_AddIntMacro(m, FICLONE)) return -1;
 #endif
 #ifdef FICLONERANGE
     if (PyModule_AddIntMacro(m, FICLONERANGE)) return -1;
 #endif
+#endif
+
 #ifdef F_GETOWN_EX
     // since Linux 2.6.32
     if (PyModule_AddIntMacro(m, F_GETOWN_EX)) return -1;


### PR DESCRIPTION
Although this ioctl exists in the system headers, it's blocked by SELinux with a message like this:

`type=1400 audit(0.0:18729): avc:  denied  { ioctl } for  path=2F646174612F646174612F6F72672E707974686F6E2E746573746265642F63616368652F746573745F707974686F6E5F776F726B65725F36373532C3A62F40746573745F363735325F746D70C3A62F636F707941 dev="dm-39" ino=369303 ioctlcmd=0x9409 scontext=u:r:untrusted_app:s0:c225,c256,c512,c768 tcontext=u:object_r:app_data_file:s0:c225,c256,c512,c768 tclass=file permissive=0 app=org.python.testbed`

On Python 3.14 this breaks the test for `Path.copy`, which was added in #119058:

```
======================================================================
ERROR: test_copytree_to_existing_directory_dirs_exist_ok (test.test_pathlib.test_pathlib.PosixPathTest.test_copytree_to_existing_directory_dirs_exist_ok)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/test/test_pathlib/test_pathlib_abc.py", line 1899, in test_copytree_to_existing_directory_dirs_exist_ok
    source.copytree(target, dirs_exist_ok=True)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/pathlib/_abc.py", line 870, in copytree
    on_error(err)
    ~~~~~~~~^^^^^
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/pathlib/_abc.py", line 848, in on_error
    raise err
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/pathlib/_abc.py", line 868, in copytree
    on_error(err)
    ~~~~~~~~^^^^^
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/pathlib/_abc.py", line 848, in on_error
    raise err
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/pathlib/_abc.py", line 864, in copytree
    source.copy(target_dir.joinpath(source.name),
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                follow_symlinks=follow_symlinks,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                preserve_metadata=preserve_metadata)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/pathlib/_abc.py", line 827, in copy
    copyfileobj(source_f, target_f)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/pathlib/_os.py", line 174, in copyfileobj
    raise err
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/pathlib/_os.py", line 164, in copyfileobj
    raise err
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/pathlib/_os.py", line 160, in copyfileobj
    clonefd(source_fd, target_fd)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/pathlib/_os.py", line 58, in clonefd
    fcntl.ioctl(target_fd, fcntl.FICLONE, source_fd)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/data/data/org.python.testbed/cache/test_python_worker_7506æ/@test_7506_tmpæ/dirC/fileC' -> '/data/data/org.python.testbed/cache/test_python_worker_7506æ/@test_7506_tmpæ/copyC/fileC'
```

On Python 3.13 I don't think Python ever uses this ioctl itself, but it's still worth backporting this PR for the benefit of user code.

<!-- gh-issue-number: gh-116622 -->
* Issue: gh-116622
<!-- /gh-issue-number -->
