### PR TITLE
gh-122478: Remove internal frames from tracebacks in REPL

### DIFF
--- a/Lib/code.py
+++ b/Lib/code.py
@@ -134,10 +134,7 @@ class InteractiveInterpreter:
         colorize = kwargs.pop('colorize', False)
         try:
             typ, value, tb = sys.exc_info()
-            # Remove internal frames (in modules code and codeop) from traceback.
-            while tb and tb.tb_frame.f_globals.get('__name__') in ('code', 'codeop'):
-                tb = tb.tb_next
-            self._showtraceback(typ, value, tb, colorize)
+            self._showtraceback(typ, value, tb.tb_next, colorize)
         finally:
             typ = value = tb = None
 

--- a/Lib/code.py
+++ b/Lib/code.py
@@ -107,29 +107,21 @@ class InteractiveInterpreter:
 
         """
         colorize = kwargs.pop('colorize', False)
-        type, value, tb = sys.exc_info()
-        sys.last_exc = value
-        sys.last_type = type
-        sys.last_value = value
-        sys.last_traceback = tb
-        if filename and type is SyntaxError:
-            # Work hard to stuff the correct filename in the exception
-            try:
-                msg, (dummy_filename, lineno, offset, line) = value.args
-            except ValueError:
-                # Not the format we expect; leave it alone
-                pass
-            else:
-                # Stuff in the right filename
-                value = SyntaxError(msg, (filename, lineno, offset, line))
-                sys.last_exc = sys.last_value = value
-        if sys.excepthook is sys.__excepthook__:
-            lines = traceback.format_exception_only(type, value, colorize=colorize)
-            self.write(''.join(lines))
-        else:
-            # If someone has set sys.excepthook, we let that take precedence
-            # over self.write
-            self._call_excepthook(type, value, tb)
+        try:
+            typ, value, tb = sys.exc_info()
+            if filename and typ is SyntaxError:
+                # Work hard to stuff the correct filename in the exception
+                try:
+                    msg, (dummy_filename, lineno, offset, line) = value.args
+                except ValueError:
+                    # Not the format we expect; leave it alone
+                    pass
+                else:
+                    # Stuff in the right filename
+                    value = SyntaxError(msg, (filename, lineno, offset, line))
+            self._showtraceback(typ, value, None, colorize)
+        finally:
+            typ = value = tb = None
 
     def showtraceback(self, **kwargs):
         """Display the exception that just occurred.
@@ -140,32 +132,38 @@ class InteractiveInterpreter:
 
         """
         colorize = kwargs.pop('colorize', False)
-        sys.last_type, sys.last_value, last_tb = ei = sys.exc_info()
-        sys.last_traceback = last_tb
-        sys.last_exc = ei[1]
         try:
-            if sys.excepthook is sys.__excepthook__:
-                lines = traceback.format_exception(ei[0], ei[1], last_tb.tb_next, colorize=colorize)
-                self.write(''.join(lines))
-            else:
-                # If someone has set sys.excepthook, we let that take precedence
-                # over self.write
-                self._call_excepthook(ei[0], ei[1], last_tb)
+            typ, value, tb = sys.exc_info()
+            # Remove internal frames (in modules code and codeop) from traceback.
+            while tb and tb.tb_frame.f_globals.get('__name__') in ('code', 'codeop'):
+                tb = tb.tb_next
+            self._showtraceback(typ, value, tb, colorize)
         finally:
-            last_tb = ei = None
+            typ = value = tb = None
 
-    def _call_excepthook(self, typ, value, tb):
-        try:
-            sys.excepthook(typ, value, tb)
-        except SystemExit:
-            raise
-        except BaseException as e:
-            e.__context__ = None
-            print('Error in sys.excepthook:', file=sys.stderr)
-            sys.__excepthook__(type(e), e, e.__traceback__.tb_next)
-            print(file=sys.stderr)
-            print('Original exception was:', file=sys.stderr)
-            sys.__excepthook__(typ, value, tb)
+    def _showtraceback(self, typ, value, tb, colorize):
+        sys.last_type = typ
+        sys.last_traceback = tb
+        sys.last_exc = sys.last_value = value = value.with_traceback(tb)
+        if sys.excepthook is sys.__excepthook__:
+            lines = traceback.format_exception(typ, value, tb,
+                                                colorize=colorize)
+            self.write(''.join(lines))
+        else:
+            # If someone has set sys.excepthook, we let that take precedence
+            # over self.write
+            try:
+                sys.excepthook(typ, value, tb)
+            except SystemExit:
+                raise
+            except BaseException as e:
+                e.__context__ = None
+                e = e.with_traceback(e.__traceback__.tb_next)
+                print('Error in sys.excepthook:', file=sys.stderr)
+                sys.__excepthook__(type(e), e, e.__traceback__)
+                print(file=sys.stderr)
+                print('Original exception was:', file=sys.stderr)
+                sys.__excepthook__(typ, value, tb)
 
     def write(self, data):
         """Write a string.

--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -1,5 +1,6 @@
 "Test InteractiveConsole and InteractiveInterpreter from code module"
 import sys
+import traceback
 import unittest
 from textwrap import dedent
 from contextlib import ExitStack
@@ -30,6 +31,7 @@ class MockSys:
 
 
 class TestInteractiveConsole(unittest.TestCase, MockSys):
+    maxDiff = None
 
     def setUp(self):
         self.console = code.InteractiveConsole()
@@ -61,21 +63,118 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
             raise AssertionError("no console stdout")
 
     def test_syntax_error(self):
-        self.infunc.side_effect = ["undefined", EOFError('Finished')]
+        self.infunc.side_effect = ["def f():",
+                                   "    x = ?",
+                                   "",
+                                    EOFError('Finished')]
         self.console.interact()
-        for call in self.stderr.method_calls:
-            if 'NameError' in ''.join(call[1]):
-                break
-        else:
-            raise AssertionError("No syntax error from console")
+        output = ''.join(''.join(call[1]) for call in self.stderr.method_calls)
+        output = output[output.index('(InteractiveConsole)'):]
+        output = output[:output.index('\nnow exiting')]
+        self.assertEqual(output.splitlines()[1:], [
+            '  File "<console>", line 2',
+            '    x = ?',
+            '        ^',
+            'SyntaxError: invalid syntax'])
+        self.assertIs(self.sysmod.last_type, SyntaxError)
+        self.assertIs(type(self.sysmod.last_value), SyntaxError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+
+    def test_indentation_error(self):
+        self.infunc.side_effect = ["  1", EOFError('Finished')]
+        self.console.interact()
+        output = ''.join(''.join(call[1]) for call in self.stderr.method_calls)
+        output = output[output.index('(InteractiveConsole)'):]
+        output = output[:output.index('\nnow exiting')]
+        self.assertEqual(output.splitlines()[1:], [
+            '  File "<console>", line 1',
+            '    1',
+            'IndentationError: unexpected indent'])
+        self.assertIs(self.sysmod.last_type, IndentationError)
+        self.assertIs(type(self.sysmod.last_value), IndentationError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+
+    def test_unicode_error(self):
+        self.infunc.side_effect = ["'\ud800'", EOFError('Finished')]
+        self.console.interact()
+        output = ''.join(''.join(call[1]) for call in self.stderr.method_calls)
+        output = output[output.index('(InteractiveConsole)'):]
+        output = output[output.index('\n') + 1:]
+        self.assertTrue(output.startswith('UnicodeEncodeError: '), output)
+        self.assertIs(self.sysmod.last_type, UnicodeEncodeError)
+        self.assertIs(type(self.sysmod.last_value), UnicodeEncodeError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
 
     def test_sysexcepthook(self):
-        self.infunc.side_effect = ["raise ValueError('')",
+        self.infunc.side_effect = ["def f():",
+                                   "    raise ValueError('BOOM!')",
+                                   "",
+                                   "f()",
                                     EOFError('Finished')]
         hook = mock.Mock()
         self.sysmod.excepthook = hook
         self.console.interact()
-        self.assertTrue(hook.called)
+        hook.assert_called()
+        hook.assert_called_with(self.sysmod.last_type,
+                                self.sysmod.last_value,
+                                self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_type, ValueError)
+        self.assertIs(type(self.sysmod.last_value), ValueError)
+        self.assertIs(self.sysmod.last_traceback, self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+        self.assertEqual(traceback.format_exception(self.sysmod.last_exc), [
+            'Traceback (most recent call last):\n',
+            '  File "<console>", line 1, in <module>\n',
+            '  File "<console>", line 2, in f\n',
+            'ValueError: BOOM!\n'])
+
+    def test_sysexcepthook_syntax_error(self):
+        self.infunc.side_effect = ["def f():",
+                                   "    x = ?",
+                                   "",
+                                    EOFError('Finished')]
+        hook = mock.Mock()
+        self.sysmod.excepthook = hook
+        self.console.interact()
+        hook.assert_called()
+        hook.assert_called_with(self.sysmod.last_type,
+                                self.sysmod.last_value,
+                                self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_type, SyntaxError)
+        self.assertIs(type(self.sysmod.last_value), SyntaxError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+        self.assertEqual(traceback.format_exception(self.sysmod.last_exc), [
+            '  File "<console>", line 2\n',
+            '    x = ?\n',
+            '        ^\n',
+            'SyntaxError: invalid syntax\n'])
+
+    def test_sysexcepthook_indentation_error(self):
+        self.infunc.side_effect = ["  1", EOFError('Finished')]
+        hook = mock.Mock()
+        self.sysmod.excepthook = hook
+        self.console.interact()
+        hook.assert_called()
+        hook.assert_called_with(self.sysmod.last_type,
+                                self.sysmod.last_value,
+                                self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_type, IndentationError)
+        self.assertIs(type(self.sysmod.last_value), IndentationError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+        self.assertEqual(traceback.format_exception(self.sysmod.last_exc), [
+            '  File "<console>", line 1\n',
+            '    1\n',
+            'IndentationError: unexpected indent\n'])
 
     def test_sysexcepthook_crashing_doesnt_close_repl(self):
         self.infunc.side_effect = ["1/0", "a = 123", "print(a)", EOFError('Finished')]
@@ -167,6 +266,11 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         ValueError
         """)
         self.assertIn(expected, output)
+        self.assertIs(self.sysmod.last_type, ValueError)
+        self.assertIs(type(self.sysmod.last_value), ValueError)
+        self.assertIs(self.sysmod.last_traceback, self.sysmod.last_value.__traceback__)
+        self.assertIsNotNone(self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
 
     def test_context_tb(self):
         self.infunc.side_effect = ["try: ham\nexcept: eggs\n",
@@ -185,6 +289,11 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         NameError: name 'eggs' is not defined
         """)
         self.assertIn(expected, output)
+        self.assertIs(self.sysmod.last_type, NameError)
+        self.assertIs(type(self.sysmod.last_value), NameError)
+        self.assertIs(self.sysmod.last_traceback, self.sysmod.last_value.__traceback__)
+        self.assertIsNotNone(self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
 
 
 class TestInteractiveConsoleLocalExit(unittest.TestCase, MockSys):

--- a/Misc/NEWS.d/next/Library/2024-07-31-20-43-21.gh-issue-122478.sCU2Le.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-31-20-43-21.gh-issue-122478.sCU2Le.rst
@@ -1,0 +1,3 @@
+Remove internal frames from tracebacks shown in
+:class:`code.InteractiveInterpreter` with non-default :func:`sys.excepthook`.
+Save correct tracebacks in :attr:`sys.last_traceback` and update ``__traceback__`` attribute of :attr:`sys.last_value` and :attr:`sys.last_exc`.


### PR DESCRIPTION
Frames of methods in code and codeop modules was show with non-default sys.excepthook.

Save correct tracebacks in sys.last_traceback and update __traceback__ attribute of sys.last_value and sys.last_exc.


<!-- gh-issue-number: gh-122478 -->
* Issue: gh-122478
<!-- /gh-issue-number -->
