### PR TITLE
gh-122519: Adding socket module shutdown() constants description

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -708,7 +708,7 @@ Constants
           SHUT_WR
           SHUT_RDWR
 
-   These constants are used by the :meth:`shutdown` method of socket objects.
+   These constants are used by the :meth:`~socket.socket.shutdown` method of socket objects.
 
    .. availability:: not WASI.
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -708,7 +708,7 @@ Constants
           SHUT_WR
           SHUT_RDWR
 
-   These constants are used by the :meth:`socket.shutdown` method of socket object.
+   These constants are used by the :meth:`shutdown` method of socket object.
 
    .. availability:: not WASI.
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -704,6 +704,13 @@ Constants
 
    .. versionadded:: 3.12
 
+.. data:: SHUT_RD
+          SHUT_WR
+          SHUT_RDWR
+
+   These constants are used by the :meth:`socket.shutdown` method of socket object.
+
+   .. availability:: not WASI.
 
 Functions
 ^^^^^^^^^

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -708,7 +708,7 @@ Constants
           SHUT_WR
           SHUT_RDWR
 
-   These constants are used by the :meth:`shutdown` method of socket object.
+   These constants are used by the :meth:`shutdown` method of socket objects.
 
    .. availability:: not WASI.
 


### PR DESCRIPTION
According to ##122519, adding constant argument description for `socket.shutdown()` method.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122543.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-122519 -->
* Issue: gh-122519
<!-- /gh-issue-number -->
