### PR TITLE
gh-122555: Remove removed functions from `Doc/data/refcounts.dat`

### DIFF
--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -364,8 +364,6 @@ PyComplex_RealAsDouble:PyObject*:op:0:
 PyContext_CheckExact:int:::
 PyContext_CheckExact:PyObject*:o:0:
 
-PyContext_ClearFreeList:int:::
-
 PyContext_Copy:PyObject*::+1:
 PyContext_Copy:PyObject*:ctx:0:
 
@@ -1029,8 +1027,6 @@ PyImport_AddModule:const char*:name::
 
 PyImport_AddModuleObject:PyObject*::0:reference borrowed from sys.modules
 PyImport_AddModuleObject:PyObject*:name:0:
-
-PyImport_Cleanup:void:::
 
 PyImport_ExecCodeModule:PyObject*::+1:
 PyImport_ExecCodeModule:const char*:name::
@@ -2404,12 +2400,6 @@ PyUnicode_DATA:PyObject*:o:0:
 
 PyUnicode_GET_LENGTH:Py_ssize_t:::
 PyUnicode_GET_LENGTH:PyObject*:o:0:
-
-PyUnicode_GET_SIZE:Py_ssize_t:::
-PyUnicode_GET_SIZE:PyObject*:o:0:
-
-PyUnicode_GET_DATA_SIZE:Py_ssize_t:::
-PyUnicode_GET_DATA_SIZE:PyObject*:o:0:
 
 PyUnicode_KIND:int:::
 PyUnicode_KIND:PyObject*:o:0:

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -1241,7 +1241,6 @@ def _find_spec(name, path, target=None):
     """Find a module's spec."""
     meta_path = sys.meta_path
     if meta_path is None:
-        # PyImport_Cleanup() is running or has been called.
         raise ImportError("sys.meta_path is None, Python is likely "
                           "shutting down")
 


### PR DESCRIPTION
Generated using the following script:

```sh
while read -r pat ; do grep -m1 -q -F $pat -r . --include='*.[ch]' || echo $pat
done < <(cut -d: -f1 "Doc/data/refcounts.dat" | grep -v '#' | sort -u | tr -d ' ')
```

You can do a grep on the sources if you want to be sure that there are not occurrences remaining (except in docs).

<!-- gh-issue-number: gh-122555 -->
* Issue: gh-122555
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122556.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->