### PR TITLE
gh-122544: Change OS image in readthedocs.yml to ubuntu-24.04

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ sphinx:
    configuration: Doc/conf.py
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3"
 


### PR DESCRIPTION
Change base OS image in `readthedocs.yml` from ubuntu-22.04 to ubuntu-24.04

<!-- gh-issue-number: gh-122544 -->
* Issue: gh-122544
<!-- /gh-issue-number -->
