### PR TITLE
gh-122575: Include `sys.flags.gil` as a sequence attribute

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -587,6 +587,9 @@ always available.
       * - .. attribute:: flags.warn_default_encoding
         - :option:`-X warn_default_encoding <-X>`
 
+      * - .. attribute:: flags.gil
+        - :option:`-X gil <-X>`
+
    .. versionchanged:: 3.2
       Added ``quiet`` attribute for the new :option:`-q` flag.
 
@@ -612,6 +615,9 @@ always available.
 
    .. versionchanged:: 3.11
       Added the ``int_max_str_digits`` attribute.
+
+   .. versionchanged:: 3.13
+      Added the ``gil`` attribute.
 
 
 .. data:: float_info

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -803,7 +803,8 @@ class SysModuleTest(unittest.TestCase):
                  "dont_write_bytecode", "no_user_site", "no_site",
                  "ignore_environment", "verbose", "bytes_warning", "quiet",
                  "hash_randomization", "isolated", "dev_mode", "utf8_mode",
-                 "warn_default_encoding", "safe_path", "int_max_str_digits")
+                 "warn_default_encoding", "safe_path", "int_max_str_digits",
+                 "gil")
         for attr in attrs:
             self.assertTrue(hasattr(sys.flags, attr), attr)
             attr_type = bool if attr in ("dev_mode", "safe_path") else int

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -805,10 +805,15 @@ class SysModuleTest(unittest.TestCase):
                  "hash_randomization", "isolated", "dev_mode", "utf8_mode",
                  "warn_default_encoding", "safe_path", "int_max_str_digits",
                  "gil")
+        attr_types = {
+            "dev_mode": bool,
+            "safe_path": bool,
+            "gil": (int, type(None)),
+        }
         for attr in attrs:
             self.assertTrue(hasattr(sys.flags, attr), attr)
-            attr_type = bool if attr in ("dev_mode", "safe_path") else int
-            self.assertEqual(type(getattr(sys.flags, attr)), attr_type, attr)
+            expected_type = attr_types.get(attr, int)
+            self.assertIsInstance(getattr(sys.flags, attr), expected_type, attr)
         self.assertTrue(repr(sys.flags))
         self.assertEqual(len(sys.flags), len(attrs))
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-01-18-35-54.gh-issue-122575.JTvKx9.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-01-18-35-54.gh-issue-122575.JTvKx9.rst
@@ -1,0 +1,2 @@
+Include :attr:`sys.flags.gil` as part of the sequence when :data:`sys.flags`
+is treated as a tuple.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3124,7 +3124,7 @@ static PyStructSequence_Desc flags_desc = {
     "sys.flags",        /* name */
     flags__doc__,       /* doc */
     flags_fields,       /* fields */
-    18
+    sizeof(flags_fields) / sizeof(flags_fields[0]) - 1
 };
 
 static int

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -3124,7 +3124,7 @@ static PyStructSequence_Desc flags_desc = {
     "sys.flags",        /* name */
     flags__doc__,       /* doc */
     flags_fields,       /* fields */
-    sizeof(flags_fields) / sizeof(flags_fields[0]) - 1
+    Py_ARRAY_LENGTH(flags_fields) - 1
 };
 
 static int


### PR DESCRIPTION
Make sure that `sys.flags.gil` is included when `sys.flags` is treated as a tuple or named tuple.

<!-- gh-issue-number: gh-122575 -->
* Issue: gh-122575
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122576.org.readthedocs.build/en/122576/library/sys.html#sys.flags

<!-- readthedocs-preview cpython-previews end -->