### PR TITLE
gh-122584: Import mimalloc headers in a C++ context

### DIFF
--- a/Include/internal/pycore_mimalloc.h
+++ b/Include/internal/pycore_mimalloc.h
@@ -36,9 +36,18 @@ typedef enum {
 #  define MI_TSAN 1
 #endif
 
+#ifdef __cplusplus
+extern "C++" {
+#endif
+
 #include "mimalloc/mimalloc.h"
 #include "mimalloc/mimalloc/types.h"
 #include "mimalloc/mimalloc/internal.h"
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif
 
 #ifdef Py_GIL_DISABLED


### PR DESCRIPTION
The vendored mimalloc headers are designed to be used in a C++ context if imported from C++.  Therefore, we should switch the context back to C++ when using a C++ compiler here.  This seems like the most future-proof fix, because otherwise we would need to be careful what context we import `pycore_mimalloc.h` from.

<!-- gh-issue-number: gh-122584 -->
* Issue: gh-122584
<!-- /gh-issue-number -->
