### PR TITLE
gh-122586: itertools.count.(peek, consume)

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -341,9 +341,9 @@ loops that truncate the stream.
    achieved by substituting multiplicative code such as: ``(start + step * i
    for i in count())``.
 
-   :meth:`peek` method of returned iterator object retrieves the current value of
+   ``peek`` method of returned iterator object retrieves the current value of
    a counter (that is to be returned from the next :meth:`__next__` call).
-   Also, :meth:`consume` method accepts *iterable* and increments the counter while
+   Also, ``consume`` method accepts *iterable* and increments the counter while
    consuming the input.
 
       >>> counter = count(0)
@@ -357,7 +357,7 @@ loops that truncate the stream.
       Added *step* argument and allowed non-integer arguments.
 
    .. versionchanged:: 3.14
-      Added :meth:`peek` and :meth:`consume` methods to returned iterator object.
+      Added ``peek`` and ``consume`` methods to returned iterator object.
 
 
 .. function:: cycle(iterable)

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -341,10 +341,10 @@ loops that truncate the stream.
    achieved by substituting multiplicative code such as: ``(start + step * i
    for i in count())``.
 
-   ``peek`` method of returned iterator object retrieves the current value of
-   a counter (that is to be returned from the next ``__next__`` call).
-   Also, ``consume`` method accepts *iterable* and increments the counter while
-   consuming the input.
+   Use ``counter.peek()`` to get the current counter's value,
+   namely the value returned by the next ``next(counter)`` call,
+   and use ``counter.consume(iterable)`` to consume the *iterable*
+   and advance the counter by the number of consumed items.
 
       >>> counter = count(0)
       >>> counter.peek()

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -341,8 +341,23 @@ loops that truncate the stream.
    achieved by substituting multiplicative code such as: ``(start + step * i
    for i in count())``.
 
+   :meth:`peek` method of returned iterator object retrieves the current value of
+   a counter (that is to be returned from the next :meth:`__next__` call).
+   Also, :meth:`consume` method accepts *iterable* and increments the counter while
+   consuming the input.
+
+      >>> counter = count(0)
+      >>> counter.peek()
+      0
+      >>> counter.consume([1, 2, 3])
+      >>> counter.peek()
+      3
+
    .. versionchanged:: 3.1
       Added *step* argument and allowed non-integer arguments.
+
+   .. versionchanged:: 3.14
+      Added :meth:`peek` and :meth:`consume` methods to returned iterator object.
 
 
 .. function:: cycle(iterable)

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -342,7 +342,7 @@ loops that truncate the stream.
    for i in count())``.
 
    ``peek`` method of returned iterator object retrieves the current value of
-   a counter (that is to be returned from the next :meth:`__next__` call).
+   a counter (that is to be returned from the next ``__next__`` call).
    Also, ``consume`` method accepts *iterable* and increments the counter while
    consuming the input.
 

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -526,6 +526,12 @@ class TestBasicOps(unittest.TestCase):
         #check proper internal error handling for large "step' sizes
         count(1, maxsize+5); sys.exc_info()
 
+        # peek and consume
+        counter = count(0)
+        self.assertEqual(counter.peek(), 0)
+        counter.consume([1, 2, 3])
+        self.assertEqual(counter.peek(), 3)
+
     def test_count_with_step(self):
         self.assertEqual(lzip('abc',count(2,3)), [('a', 2), ('b', 5), ('c', 8)])
         self.assertEqual(lzip('abc',count(start=2,step=3)),

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -531,6 +531,19 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(counter.peek(), 0)
         counter.consume([1, 2, 3])
         self.assertEqual(counter.peek(), 3)
+        # Only accepts iterables
+        with self.assertRaises(TypeError):
+            counter.consume(1)
+        counter.consume(range(1000))
+        self.assertEqual(counter.peek(), 1003)
+        # Test for non-int step
+        counter = count(0, Fraction(1, 3))
+        counter.consume(range(9))
+        self.assertEqual(counter.peek(), Fraction(9, 3))
+        # Test for large int
+        counter = count(sys.maxsize - 2)
+        counter.consume(range(10))
+        self.assertEqual(counter.peek(), sys.maxsize + 8)
 
     def test_count_with_step(self):
         self.assertEqual(lzip('abc',count(2,3)), [('a', 2), ('b', 5), ('c', 8)])

--- a/Misc/NEWS.d/next/Library/2024-08-01-23-58-36.gh-issue-122586.XyzUoy.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-01-23-58-36.gh-issue-122586.XyzUoy.rst
@@ -1,1 +1,1 @@
-Added :meth:`peek` and :meth:`consume` methods to iterator object returned from :func:`itertools.count`.
+Added ``peek`` and ``consume`` methods to iterator object returned from :func:`itertools.count`.

--- a/Misc/NEWS.d/next/Library/2024-08-01-23-58-36.gh-issue-122586.XyzUoy.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-01-23-58-36.gh-issue-122586.XyzUoy.rst
@@ -1,0 +1,1 @@
+Added :meth:`peek` and :meth:`consume` methods to iterator object returned from :func:`itertools.count`.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3455,7 +3455,7 @@ count_repr(countobject *lz)
 }
 
 static PyObject *
-count_peek(countobject *lz)
+count_peek(countobject *lz, PyObject *Py_UNUSED(ignored))
 {
     if (lz->cnt != PY_SSIZE_T_MAX) {
         return PyLong_FromSsize_t(lz->cnt);

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3471,7 +3471,6 @@ count_consume(countobject *lz, PyObject *seq)
 {
     PyObject *it, *item;
     PyObject *(*iternext)(PyObject *);
-    Py_ssize_t cnt;
 
     /* Get iterator. */
     it = PyObject_GetIter(seq);
@@ -3494,7 +3493,7 @@ count_consume(countobject *lz, PyObject *seq)
         // free-threading version
         // fast mode uses compare-exchange loop
         // slow mode uses a critical section
-        cnt = _Py_atomic_load_ssize_relaxed(&lz->cnt);
+        Py_ssize_t cnt = _Py_atomic_load_ssize_relaxed(&lz->cnt);
         for (;;) {
             if (cnt == PY_SSIZE_T_MAX) {
                 Py_BEGIN_CRITICAL_SECTION(lz);

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3459,8 +3459,7 @@ count_peek(countobject *lz, PyObject *Py_UNUSED(ignored))
 {
     PyObject *long_cnt = lz->long_cnt;
     if (long_cnt != NULL) {
-        Py_INCREF(long_cnt);
-        return long_cnt;
+        return Py_NewRef(long_cnt);
     }
     else {
         return PyLong_FromSsize_t(lz->cnt);

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3457,10 +3457,13 @@ count_repr(countobject *lz)
 static PyObject *
 count_peek(countobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    if (lz->cnt != PY_SSIZE_T_MAX) {
+    PyObject *long_cnt = lz->long_cnt;
+    if (long_cnt != NULL) {
+        Py_INCREF(long_cnt);
+        return long_cnt;
+    }
+    else {
         return PyLong_FromSsize_t(lz->cnt);
-    } else {
-        return lz->long_cnt;
     }
 }
 
@@ -3503,23 +3506,22 @@ count_consume(countobject *lz, PyObject *seq)
         }
 #endif
     }
+    Py_DECREF(it);
     if (PyErr_Occurred()) {
         if (PyErr_ExceptionMatches(PyExc_StopIteration)) {
             PyErr_Clear();
         }
         else {
-            Py_DECREF(it);
             return NULL;
         }
     }
-    Py_DECREF(it);
     Py_RETURN_NONE;
 }
 
 static PyMethodDef count_methods[] = {
     {"peek", (PyCFunction)count_peek, METH_NOARGS},
     {"consume", (PyCFunction)count_consume, METH_O},
-    {NULL,              NULL}           /* sentinel */
+    {NULL, NULL} /* sentinel */
 };
 
 static PyType_Slot count_slots[] = {

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3454,7 +3454,6 @@ count_repr(countobject *lz)
                                 lz->long_cnt, lz->long_step);
 }
 
-
 static PyObject *
 count_peek(countobject *lz)
 {
@@ -3465,20 +3464,17 @@ count_peek(countobject *lz)
     }
 }
 
-
 static PyObject *
 count_consume(countobject *lz, PyObject *seq)
 {
     PyObject *it, *item;
     PyObject *(*iternext)(PyObject *);
 
-    /* Get iterator. */
     it = PyObject_GetIter(seq);
     if (it == NULL) {
         return NULL;
     }
 
-    /* Main Loop */
     iternext = *Py_TYPE(it)->tp_iternext;
     while ((item = iternext(it)) != NULL) {
         Py_DECREF(item);
@@ -3508,8 +3504,9 @@ count_consume(countobject *lz, PyObject *seq)
 #endif
     }
     if (PyErr_Occurred()) {
-        if (PyErr_ExceptionMatches(PyExc_StopIteration))
+        if (PyErr_ExceptionMatches(PyExc_StopIteration)) {
             PyErr_Clear();
+        }
         else {
             Py_DECREF(it);
             return NULL;
@@ -3519,13 +3516,11 @@ count_consume(countobject *lz, PyObject *seq)
     Py_RETURN_NONE;
 }
 
-
 static PyMethodDef count_methods[] = {
     {"peek", (PyCFunction)count_peek, METH_NOARGS},
     {"consume", (PyCFunction)count_consume, METH_O},
     {NULL,              NULL}           /* sentinel */
 };
-
 
 static PyType_Slot count_slots[] = {
     {Py_tp_dealloc, count_dealloc},


### PR DESCRIPTION
Additions:
1. Efficient retrieval of current (next one really) value of count
  * https://discuss.python.org/t/allow-accessing-retrieving-the-current-item-of-itertools-count/17271/16
  * In 3.14 `pickle` support is removed from `itertools` and currently the only option to retrieve the value without incrementing the counter is to parse `__repr__`. (previously it was possible to get it from `__reduce__`).
2. Efficient consumption of iterable while incrementing the counter with each consumed element.
  * This would be most performant solution to count items while consuming iterable. `more_itertools.ilen` would use this for counting in the same spirit as it uses `deque` for consuming.

```shell
PY_MAIN='/Users/Edu/local/code/cpython/main/python.exe'
SETUP='from collections import deque; from itertools import count; a = list(range(100_000))'
$PY_MAIN -m timeit -s "$SETUP" 'count().consume(a)' # 557 µs
$PY_MAIN -m timeit -s "$SETUP" 'deque(a, maxlen=0)' # 544 µs
```

I think semantics of `consume` are good. I.e. When counter is consumed it increments, when counter consumes it also increments.

`peek` name is as good as any to me. Open to changing it if there are better ideas for it.

<!-- gh-issue-number: gh-122586 -->
* Issue: gh-122586
<!-- /gh-issue-number -->
