### PR TITLE
gh-122334: Fix test_embed failure when missing _ssl module

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -469,7 +469,8 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
                 import _ssl
             except ModuleNotFoundError:
                 _ssl = None
-            _ssl.txt2obj(txt='1.3')
+            if _ssl is not None:
+                _ssl.txt2obj(txt='1.3')
             print('1')
 
             import _queue

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -465,8 +465,11 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
         # Test _PyArg_Parser initializations via _PyArg_UnpackKeywords()
         # https://github.com/python/cpython/issues/122334
         code = textwrap.dedent("""
-            import _ssl
-            _ssl.txt2obj(txt='1.3')
+            try:
+                import _ssl
+                _ssl.txt2obj(txt='1.3')
+            except ModuleNotFoundError:
+                pass
             print('1')
 
             import _queue

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -467,9 +467,9 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
         code = textwrap.dedent("""
             try:
                 import _ssl
-                _ssl.txt2obj(txt='1.3')
             except ModuleNotFoundError:
-                pass
+                _ssl = None
+            _ssl.txt2obj(txt='1.3')
             print('1')
 
             import _queue


### PR DESCRIPTION
Fixes the `test_embed` failure in some buildbots introduced by 9fc1c992d6fcea0b7558c581846eef6bdd811f6c (gh-122481).
If checking the `_ssl` module is not enough, I'll make the test more generic using `_testinternalcapi`.

This patch should be backportable to both 3.13 and 3.12.

cc @kumaraditya303 @ericsnowcurrently: Sorry for the trouble.

<!-- gh-issue-number: gh-122334 -->
* Issue: gh-122334
<!-- /gh-issue-number -->
