### PR TITLE
GH-121970: Fix ``gettext`` for audit events

### DIFF
--- a/Doc/tools/extensions/audit_events.py
+++ b/Doc/tools/extensions/audit_events.py
@@ -149,6 +149,7 @@ class AuditEvent(SphinxDirective):
         node = nodes.paragraph("", classes=["audit-hook"], ids=ids)
         self.set_source_info(node)
         if self.content:
+            node.rawsource = '\n'.join(self.content)  # for gettext
             self.state.nested_parse(self.content, self.content_offset, node)
         else:
             num_args = min(2, len(args))
@@ -156,6 +157,7 @@ class AuditEvent(SphinxDirective):
                 name=f"``{name}``",
                 args=", ".join(f"``{a}``" for a in args),
             )
+            node.rawsource = text  # for gettext
             parsed, messages = self.state.inline_text(text, self.lineno)
             node += parsed
             node += messages


### PR DESCRIPTION
cc @rffontenelle 

This improves upon the previous situation slightly, as now we don't output strings for translation that will never be used (e.g. `sys.addaudithook`, where the `audit-event` directive has content.

Fixes #122629.

A

<!-- gh-issue-number: gh-121970 -->
* Issue: gh-121970
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122651.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->