### PR TITLE
gh-122676: Fix incorrect description in concurrent.futures.Future.add_done_callback

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -523,7 +523,7 @@ The :class:`Future` class encapsulates the asynchronous execution of a callable.
       running.
 
       Added callables are called in the order that they were added and are
-      always called in where :meth:`Future.set_result` is called according to its source.  If
+      always called in :meth:`Future.set_result` is called according to its source.  If
       the callable raises an :exc:`Exception` subclass, it will be logged and
       ignored.  If the callable raises a :exc:`BaseException` subclass, the
       behavior is undefined.

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -523,7 +523,7 @@ The :class:`Future` class encapsulates the asynchronous execution of a callable.
       running.
 
       Added callables are called in the order that they were added and are
-      always called in a thread belonging to the process that added them.  If
+      always called in where :meth:`Future.set_result` is called according to its source.  If
       the callable raises an :exc:`Exception` subclass, it will be logged and
       ignored.  If the callable raises a :exc:`BaseException` subclass, the
       behavior is undefined.


### PR DESCRIPTION
According to #122676, modify incoreect description. 

<!-- gh-issue-number: gh-122676 -->
* Issue: gh-122676
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122678.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->