### PR TITLE
gh-123572: Fix key codes in VK_MAP in windows_console.py

### DIFF
--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -63,6 +63,7 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import IO
 
+# Virtual-Key Codes: https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
 VK_MAP: dict[int, str] = {
     0x23: "end",  # VK_END
     0x24: "home",  # VK_HOME
@@ -87,10 +88,10 @@ VK_MAP: dict[int, str] = {
     0x7D: "f14",  # VK_F14
     0x7E: "f15",  # VK_F15
     0x7F: "f16",  # VK_F16
-    0x79: "f17",  # VK_F17
-    0x80: "f18",  # VK_F18
-    0x81: "f19",  # VK_F19
-    0x82: "f20",  # VK_F20
+    0x80: "f17",  # VK_F17
+    0x81: "f18",  # VK_F18
+    0x82: "f19",  # VK_F19
+    0x83: "f20",  # VK_F20
 }
 
 # Console escape codes: https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-03-13-34-35.gh-issue-123572.uuqoYV.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-03-13-34-35.gh-issue-123572.uuqoYV.rst
@@ -1,0 +1,2 @@
+Fix key mappings for various F-keys in Windows for the new REPL. Patch by
+devdanzin


### PR DESCRIPTION
This trivial PR corrects a couple Virtual-Key Codes found in `VK_MAP` in windows_console.py. It should have no impact on real use of the new REPL, as AFAIK those VKs are unused.

cc @DinoV 

<!-- gh-issue-number: gh-123572 -->
* Issue: gh-123572
<!-- /gh-issue-number -->
