### PR TITLE
gh-121268: remove workarounds for non-IEEE 754 systems in cmath

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-07-17-12-55-22.gh-issue-121268.41RmjR.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-17-12-55-22.gh-issue-121268.41RmjR.rst
@@ -1,0 +1,1 @@
+Remove workarounds for non-IEEE 754 systems in :mod:`cmath`.

--- a/Modules/cmathmodule.c
+++ b/Modules/cmathmodule.c
@@ -185,15 +185,8 @@ cmath_acos_impl(PyObject *module, Py_complex z)
     if (fabs(z.real) > CM_LARGE_DOUBLE || fabs(z.imag) > CM_LARGE_DOUBLE) {
         /* avoid unnecessary overflow for large arguments */
         r.real = atan2(fabs(z.imag), z.real);
-        /* split into cases to make sure that the branch cut has the
-           correct continuity on systems with unsigned zeros */
-        if (z.real < 0.) {
-            r.imag = -copysign(log(hypot(z.real/2., z.imag/2.)) +
-                               M_LN2*2., z.imag);
-        } else {
-            r.imag = copysign(log(hypot(z.real/2., z.imag/2.)) +
-                              M_LN2*2., -z.imag);
-        }
+        r.imag = -copysign(log(hypot(z.real/2., z.imag/2.)) +
+                           M_LN2*2., z.imag);
     } else {
         s1.real = 1.-z.real;
         s1.imag = -z.imag;
@@ -386,11 +379,7 @@ cmath_atanh_impl(PyObject *module, Py_complex z)
         */
         h = hypot(z.real/2., z.imag/2.);  /* safe from overflow */
         r.real = z.real/4./h/h;
-        /* the two negations in the next line cancel each other out
-           except when working with unsigned zeros: they're there to
-           ensure that the branch cut has the correct continuity on
-           systems that don't support signed zeros */
-        r.imag = -copysign(Py_MATH_PI/2., -z.imag);
+        r.imag = copysign(Py_MATH_PI/2., z.imag);
         errno = 0;
     } else if (z.real == 1. && ay < CM_SQRT_DBL_MIN) {
         /* C99 standard says:  atanh(1+/-0.) should be inf +/- 0i */


### PR DESCRIPTION
as now building Python now requires support of IEEE 754 floating point numbers.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121268 -->
* Issue: gh-121268
<!-- /gh-issue-number -->
