### PR TITLE
Remove unneeded verb in the phrase in sys.rst

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1712,7 +1712,7 @@ always available.
 
    To enable, pass a *depth* value greater than zero; this sets the
    number of frames whose information will be captured. To disable,
-   pass set *depth* to zero.
+   set *depth* to zero.
 
    This setting is thread-specific.
 


### PR DESCRIPTION
This removes "pass" from the paragraph's second phrase below.

> To enable, pass a *depth* value greater than zero; this sets the number of frames whose information will be captured. To disable, pass set *depth* to zero.

It seems that "pass" was to match to first phrase, but meaning of the sentence matches "set", hence I've removed "pass".

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122718.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->