### PR TITLE
gh-118761: Improve import time of `pprint`

### DIFF
--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -193,7 +193,7 @@ class PrettyPrinter:
                 p(self, object, stream, indent, allowance, context, level + 1)
                 del context[objid]
                 return
-            elif (_dataclasses.is_dataclass(object) and
+            elif (is_dataclass(object) and
                   not isinstance(object, type) and
                   object.__dataclass_params__.repr and
                   # Check dataclass has generated repr method.

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -52,6 +52,7 @@ def pprint(object, stream=None, indent=1, width=80, depth=None, *,
         underscore_numbers=underscore_numbers)
     printer.pprint(object)
 
+
 def pformat(object, indent=1, width=80, depth=None, *,
             compact=False, sort_dicts=True, underscore_numbers=False):
     """Format a Python object into a pretty-printed representation."""
@@ -59,21 +60,26 @@ def pformat(object, indent=1, width=80, depth=None, *,
                          compact=compact, sort_dicts=sort_dicts,
                          underscore_numbers=underscore_numbers).pformat(object)
 
+
 def pp(object, *args, sort_dicts=False, **kwargs):
     """Pretty-print a Python object"""
     pprint(object, *args, sort_dicts=sort_dicts, **kwargs)
+
 
 def saferepr(object):
     """Version of repr() which can handle recursive data structures."""
     return PrettyPrinter()._safe_repr(object, {}, None, 0)[0]
 
+
 def isreadable(object):
     """Determine if saferepr(object) is readable by eval()."""
     return PrettyPrinter()._safe_repr(object, {}, None, 0)[1]
 
+
 def isrecursive(object):
     """Determine if object requires a recursive representation."""
     return PrettyPrinter()._safe_repr(object, {}, None, 0)[2]
+
 
 class _safe_key:
     """Helper function for key functions when sorting unorderable objects.
@@ -97,9 +103,11 @@ class _safe_key:
             return ((str(type(self.obj)), id(self.obj)) < \
                     (str(type(other.obj)), id(other.obj)))
 
+
 def _safe_tuple(t):
     "Helper function for comparing 2-tuples"
     return _safe_key(t[0]), _safe_key(t[1])
+
 
 class PrettyPrinter:
     def __init__(self, indent=1, width=80, depth=None, stream=None, *,
@@ -639,8 +647,10 @@ class PrettyPrinter:
         rep = repr(object)
         return rep, (rep and not rep.startswith('<')), False
 
+
 _builtin_scalars = frozenset({str, bytes, bytearray, float, complex,
                               bool, type(None)})
+
 
 def _recursion(object):
     return ("<Recursion on %s with id=%s>"

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -186,7 +186,7 @@ class PrettyPrinter:
         if len(rep) > max_width:
             p = self._dispatch.get(type(object).__repr__, None)
             # Lazy import to improve module import time
-            import dataclasses as _dataclasses
+            from dataclasses import is_dataclass
 
             if p is not None:
                 context[objid] = 1
@@ -207,11 +207,11 @@ class PrettyPrinter:
 
     def _pprint_dataclass(self, object, stream, indent, allowance, context, level):
         # Lazy import to improve module import time
-        import dataclasses as _dataclasses
+        from dataclasses import fields as dataclass_fields
 
         cls_name = object.__class__.__name__
         indent += len(cls_name) + 1
-        items = [(f.name, getattr(object, f.name)) for f in _dataclasses.fields(object) if f.repr]
+        items = [(f.name, getattr(object, f.name)) for f in dataclass_fields(object) if f.repr]
         stream.write(cls_name + '(')
         self._format_namespace_items(items, stream, indent, allowance, context, level)
         stream.write(')')

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -35,8 +35,6 @@ saferepr()
 """
 
 import collections as _collections
-import dataclasses as _dataclasses
-import re
 import sys as _sys
 import types as _types
 from io import StringIO as _StringIO
@@ -179,6 +177,9 @@ class PrettyPrinter:
         max_width = self._width - indent - allowance
         if len(rep) > max_width:
             p = self._dispatch.get(type(object).__repr__, None)
+            # Lazy import to improve module import time
+            import dataclasses as _dataclasses
+
             if p is not None:
                 context[objid] = 1
                 p(self, object, stream, indent, allowance, context, level + 1)
@@ -197,6 +198,9 @@ class PrettyPrinter:
         stream.write(rep)
 
     def _pprint_dataclass(self, object, stream, indent, allowance, context, level):
+        # Lazy import to improve module import time
+        import dataclasses as _dataclasses
+
         cls_name = object.__class__.__name__
         indent += len(cls_name) + 1
         items = [(f.name, getattr(object, f.name)) for f in _dataclasses.fields(object) if f.repr]
@@ -291,6 +295,9 @@ class PrettyPrinter:
             if len(rep) <= max_width1:
                 chunks.append(rep)
             else:
+                # Lazy import to improve module import time
+                import re
+
                 # A list of alternating (non-space, space) strings
                 parts = re.findall(r'\S*\s*', line)
                 assert parts

--- a/Misc/NEWS.d/next/Library/2024-08-06-10-36-55.gh-issue-118761.q_x_1A.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-06-10-36-55.gh-issue-118761.q_x_1A.rst
@@ -1,0 +1,2 @@
+Improve import time of :mod:`pprint` by around seven times. Patch by Hugo
+van Kemenade.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Improves import time by up to seven times. Measured with a PGO and LTO non-debug build on macOS.

* The slowest import in `pprint` is `dataclasses` (taking 0.0012s / 55.2% of import time), and used in only two functions. 

* After deferring `dataclasses`, the next is `re` (0.005s / 30.1% of the new import time), only used in one function.

* After deferring `re`, the next are `collections` (0.002s / 14.8%) and `types` (0.000s / 2.4%). I left these, as their times are low and they're less straightforward to defer.

## `-X importtime`

Running: `pip install tuna && ./python.exe -X importtime -c 'import pprint' 2> import.log && tuna import.log`

### total import time: 0.022s -> 0.011s = x2 as fast

<table>
<tr>
<th><code>main</code>
<th>PR
<tr>
<td><img width="1624" alt="image" src="https://github.com/user-attachments/assets/4c37ccd5-21b7-43a4-bb2e-6c2bfedad0f3">
<td><img width="1624" alt="image" src="https://github.com/user-attachments/assets/f570333a-7cb5-47c6-9d23-e49c551bbc23">
</table>

### `pprint` import time: 0.014s -> 0.002s = x7 as fast

<table>
<tr>
<th><code>main</code>
<th>PR
<tr>
<td><img width="1624" alt="image" src="https://github.com/user-attachments/assets/02e7983a-8b74-4766-8cfa-2a683582676b">
<td><img width="1624" alt="image" src="https://github.com/user-attachments/assets/7ec02191-025d-47d5-b53b-19be10ee2bba">
</table>



## hyperfine: 19.2 ms -> 10.4 ms = x1.8 as fast

### main

```console
❯ hyperfine --warmup 8 "./python.exe -c 'import pprint'"
Benchmark 1: ./python.exe -c 'import pprint'
  Time (mean ± σ):      19.2 ms ±   0.7 ms    [User: 15.8 ms, System: 2.8 ms]
  Range (min … max):    18.1 ms …  21.3 ms    135 runs
```

### PR

```console
❯ hyperfine --warmup 8 "./python.exe -c 'import pprint'"
Benchmark 1: ./python.exe -c 'import pprint'
  Time (mean ± σ):      10.4 ms ±   0.4 ms    [User: 8.1 ms, System: 1.8 ms]
  Range (min … max):     9.8 ms …  12.4 ms    212 runs
```

Also add some PEP 8 whitespace to remove some distracting IDE warnings.


<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
