### PR TITLE
gh-122728: Fix SystemError in PyEval_GetLocals()

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1157,6 +1157,16 @@ class CAPITest(unittest.TestCase):
         gen = genf()
         self.assertEqual(_testcapi.gen_get_code(gen), gen.gi_code)
 
+    def test_pyeval_getlocals(self):
+        # Test PyEval_GetLocals()
+        x = 1
+        y = 2
+        local_vars = _testcapi.pyeval_getlocals()
+        self.assertEqual(local_vars,
+            {'self': self,
+             'x': 1,
+             'y': 2})
+
 
 @requires_limited_api
 class TestHeapTypeRelative(unittest.TestCase):

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1160,9 +1160,12 @@ class CAPITest(unittest.TestCase):
     def test_pyeval_getlocals(self):
         # Test PyEval_GetLocals()
         x = 1
+        self.assertEqual(_testcapi.pyeval_getlocals(),
+            {'self': self,
+             'x': 1})
+
         y = 2
-        local_vars = _testcapi.pyeval_getlocals()
-        self.assertEqual(local_vars,
+        self.assertEqual(_testcapi.pyeval_getlocals(),
             {'self': self,
              'x': 1,
              'y': 2})

--- a/Misc/NEWS.d/next/C_API/2024-08-06-14-23-11.gh-issue-122728.l-fQ-v.rst
+++ b/Misc/NEWS.d/next/C_API/2024-08-06-14-23-11.gh-issue-122728.l-fQ-v.rst
@@ -1,0 +1,2 @@
+Fix :c:func:`PyEval_GetLocals` to avoid :exc:`SystemError` ("bad argument to
+internal function"). Patch by Victor Stinner.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3341,6 +3341,12 @@ test_critical_sections(PyObject *module, PyObject *Py_UNUSED(args))
     Py_RETURN_NONE;
 }
 
+static PyObject *
+pyeval_getlocals(PyObject *module, PyObject *Py_UNUSED(args))
+{
+    return Py_XNewRef(PyEval_GetLocals());
+}
+
 static PyMethodDef TestMethods[] = {
     {"set_errno",               set_errno,                       METH_VARARGS},
     {"test_config",             test_config,                     METH_NOARGS},
@@ -3483,6 +3489,7 @@ static PyMethodDef TestMethods[] = {
     {"test_weakref_capi", test_weakref_capi, METH_NOARGS},
     {"function_set_warning", function_set_warning, METH_NOARGS},
     {"test_critical_sections", test_critical_sections, METH_NOARGS},
+    {"pyeval_getlocals", pyeval_getlocals, METH_NOARGS},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2499,7 +2499,7 @@ PyEval_GetLocals(void)
         PyFrameObject *f = _PyFrame_GetFrameObject(current_frame);
         PyObject *ret = f->f_locals_cache;
         if (ret == NULL) {
-            PyObject *ret = PyDict_New();
+            ret = PyDict_New();
             if (ret == NULL) {
                 Py_DECREF(locals);
                 return NULL;


### PR DESCRIPTION
Fix PyEval_GetLocals() to avoid SystemError ("bad argument to internal function"). Don't redefine the 'ret' variable in the if block.

Add an unit test on PyEval_GetLocals().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122728 -->
* Issue: gh-122728
<!-- /gh-issue-number -->
