### PR TITLE
gh-122634: Deprecate `__class_getitem__` on metaclasses

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -189,6 +189,11 @@ asyncio
 Deprecated
 ==========
 
+* Using :meth:`~object.__class_getitem__` on a metaclass
+  is deprecated since 3.14 and will be removed in 3.16,
+  instead, use :meth:`~object.__class_getitem__` on regular classes
+  or use :meth:`~object.__getitem__` on metaclasses.
+
 * :mod:`builtins`:
   Passing a complex number as the *real* or *imag* argument in the
   :func:`complex` constructor is now deprecated; it should only be passed

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -189,10 +189,12 @@ asyncio
 Deprecated
 ==========
 
-* Using :meth:`~object.__class_getitem__` on a metaclass
-  is deprecated since 3.14 and will be removed in 3.16,
-  instead, use :meth:`~object.__class_getitem__` on regular classes
-  or use :meth:`~object.__getitem__` on metaclasses.
+* Currently, subscripting a class object with a metaclass
+  that defines the :meth:`~object.__class_getitem__` method
+  would invoke the metaclass's method. This behavior is now deprecated
+  and will be removed in Python 3.16.
+  To make instances of a metaclass subscriptable,
+  define a :meth:`~object.__getitem__` method on the metaclass.
 
 * :mod:`builtins`:
   Passing a complex number as the *real* or *imag* argument in the

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-06-20-20-56.gh-issue-122634.BUON7A.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-06-20-20-56.gh-issue-122634.BUON7A.rst
@@ -1,4 +1,6 @@
-Using :meth:`~object.__class_getitem__` on a metaclass is deprecated since
-3.14 and will be removed in 3.16, instead, use
-:meth:`~object.__class_getitem__` on regular classes or use
-:meth:`~object.__getitem__` on metaclasses.
+Currently, subscripting a class object with a metaclass
+that defines the :meth:`~object.__class_getitem__` method
+would invoke the metaclass's method. This behavior is now deprecated
+and will be removed in Python 3.16.
+To make instances of a metaclass subscriptable,
+define a :meth:`~object.__getitem__` method on the metaclass.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-06-20-20-56.gh-issue-122634.BUON7A.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-06-20-20-56.gh-issue-122634.BUON7A.rst
@@ -1,0 +1,4 @@
+Using :meth:`~object.__class_getitem__` on a metaclass is deprecated since
+3.14 and will be removed in 3.16, instead, use
+:meth:`~object.__class_getitem__` on regular classes or use
+:meth:`~object.__getitem__` on metaclasses.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5616,6 +5616,16 @@ _Py_type_getattro_impl(PyTypeObject *type, PyObject *name, int * suppress_missin
         res = meta_get(meta_attribute, (PyObject *)type,
                        (PyObject *)metatype);
         Py_DECREF(meta_attribute);
+        if (res && PyUnicode_EqualToUTF8(name, "__class_getitem__")) {
+            if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                             "Accessing __class_getitem__ on a metaclass is deprecated "
+                             "since 3.14 and will be removed in 3.16. "
+                             "Instead, define a regular __getitem__ method on a metaclass, "
+                             "if you need this behavior.",
+                             1) < 0) {
+                return NULL;
+            }
+        }
         return res;
     }
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-122634 -->
* Issue: gh-122634
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122743.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->