### PR TITLE
gh-112301: Update disable safety and enable slow safety configure options documentation

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -911,16 +911,16 @@ Security Options
 
    Disable compiler options that are recommended by `OpenSSF`_ for security reasons with no performance overhead.
    If this option is not enabled, CPython will be built based on safety compiler options with no slow down.
-   When this option is enabled, CPython will not include the compiler options listed below.
+   When this option is enabled, CPython will not be built with the compiler options listed below.
 
    Compiler options that are disabled with this option:
 
-   * ``-fstack-protector-strong``: `Enable run-time checks for stack-based buffer overflows.`_
-   * ``-Wtrampolines``: `Enable warnings about trampolines that require executable stacks`_
+   * `-fstack-protector-strong`_: Enable run-time checks for stack-based buffer overflows.
+   * `-Wtrampolines`_: Enable warnings about trampolines that require executable stacks.
 
    .. _OpenSSF: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
-   .. _Enable run-time checks for stack-based buffer overflows.: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#enable-run-time-checks-for-stack-based-buffer-overflows
-   .. _Enable warnings about trampolines that require executable stacks: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#enable-warning-about-trampolines-that-require-executable-stacks
+   .. _-fstack-protector-strong: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#enable-run-time-checks-for-stack-based-buffer-overflows
+   .. _-Wtrampolines: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#enable-warning-about-trampolines-that-require-executable-stacks
 
    .. versionadded:: 3.14
 
@@ -928,14 +928,14 @@ Security Options
 
    Enable compiler options that are recommended by `OpenSSF`_ for security reasons which require overhead.
    If this option is not enabled, CPython will not be built based on safety compiler options which performance impact.
-   When this option is enabled, CPython will include the compiler options listed below.
+   When this option is enabled, CPython will be built with the compiler options listed below.
 
    Compiler options that are enabled with this option:
 
-   * ``-D_FORTIFY_SOURCE=3``: `Fortify sources with compile- and run-time checks for unsafe libc usage and buffer overflows`_
+   * `-D_FORTIFY_SOURCE=3`_: Fortify sources with compile- and run-time checks for unsafe libc usage and buffer overflows.
 
    .. _OpenSSF: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
-   .. _Fortify sources with compile- and run-time checks for unsafe libc usage and buffer overflows: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#fortify-sources-for-unsafe-libc-usage-and-buffer-overflows
+   .. _-D_FORTIFY_SOURCE=3: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#fortify-sources-for-unsafe-libc-usage-and-buffer-overflows
 
    .. versionadded:: 3.14
 

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -909,16 +909,16 @@ Security Options
 
 .. option:: --disable-safety
 
-   Disable compiler options that are recommended by `OpenSSF`_ for security reasons with no performance overhead.
+   Disable compiler options that are `recommended by OpenSSF`_ for security reasons with no performance overhead.
    If this option is not enabled, CPython will be built based on safety compiler options with no slow down.
    When this option is enabled, CPython will not be built with the compiler options listed below.
 
-   Compiler options that are disabled with this option:
+   The following compiler options are disabled with :option:`!--disable-safety`:
 
    * `-fstack-protector-strong`_: Enable run-time checks for stack-based buffer overflows.
    * `-Wtrampolines`_: Enable warnings about trampolines that require executable stacks.
 
-   .. _OpenSSF: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+   .. _recommended by OpenSSF: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
    .. _-fstack-protector-strong: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#enable-run-time-checks-for-stack-based-buffer-overflows
    .. _-Wtrampolines: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#enable-warning-about-trampolines-that-require-executable-stacks
 
@@ -926,15 +926,14 @@ Security Options
 
 .. option:: --enable-slower-safety
 
-   Enable compiler options that are recommended by `OpenSSF`_ for security reasons which require overhead.
+   Enable compiler options that are `recommended by OpenSSF`_ for security reasons which require overhead.
    If this option is not enabled, CPython will not be built based on safety compiler options which performance impact.
    When this option is enabled, CPython will be built with the compiler options listed below.
 
-   Compiler options that are enabled with this option:
+   The following compiler options are enabled with :option:`!--enable-slower-safety`:
 
    * `-D_FORTIFY_SOURCE=3`_: Fortify sources with compile- and run-time checks for unsafe libc usage and buffer overflows.
 
-   .. _OpenSSF: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
    .. _-D_FORTIFY_SOURCE=3: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#fortify-sources-for-unsafe-libc-usage-and-buffer-overflows
 
    .. versionadded:: 3.14

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -911,8 +911,16 @@ Security Options
 
    Disable compiler options that are recommended by `OpenSSF`_ for security reasons with no performance overhead.
    If this option is not enabled, CPython will be built based on safety compiler options with no slow down.
+   When this option is enabled, CPython will not include the compiler options listed below.
 
-   .. _OpenSSF: https://openssf.org/
+   Compiler options that are disabled with this option:
+
+   * ``-fstack-protector-strong``: `Enable run-time checks for stack-based buffer overflows.`_
+   * ``-Wtrampolines``: `Enable warnings about trampolines that require executable stacks`_
+
+   .. _OpenSSF: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+   .. _Enable run-time checks for stack-based buffer overflows.: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#enable-run-time-checks-for-stack-based-buffer-overflows
+   .. _Enable warnings about trampolines that require executable stacks: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#enable-warning-about-trampolines-that-require-executable-stacks
 
    .. versionadded:: 3.14
 
@@ -920,8 +928,14 @@ Security Options
 
    Enable compiler options that are recommended by `OpenSSF`_ for security reasons which require overhead.
    If this option is not enabled, CPython will not be built based on safety compiler options which performance impact.
+   When this option is enabled, CPython will include the compiler options listed below.
 
-   .. _OpenSSF: https://openssf.org/
+   Compiler options that are enabled with this option:
+
+   * ``-D_FORTIFY_SOURCE=3``: `Fortify sources with compile- and run-time checks for unsafe libc usage and buffer overflows`_
+
+   .. _OpenSSF: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+   .. _Fortify sources with compile- and run-time checks for unsafe libc usage and buffer overflows: https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md#fortify-sources-for-unsafe-libc-usage-and-buffer-overflows
 
    .. versionadded:: 3.14
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
These changes add more information to docs related to the new configure options `--disable-safety` and `--enable-slow-safety`. Links in docs point directly to the OpenSSF guidance for particular compiler options suggested in [this comment.](https://github.com/python/cpython/issues/112301#issuecomment-2262708531)

<!-- gh-issue-number: gh-112301 -->
* Issue: gh-112301
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122758.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->