### PR TITLE
gh-122744: test_venv: ignore pip's complaint about missing ssl

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -886,6 +886,14 @@ class EnsurePipTest(BaseTest):
         err = re.sub("^(WARNING: )?The directory .* or its parent directory "
                      "is not owned or is not writable by the current user.*$", "",
                      err, flags=re.MULTILINE)
+        # Ignore warning about missing optional module:
+        try:
+            import ssl
+        except ImportError:
+            err = re.sub(
+                "^WARNING: Disabling truststore since ssl support is missing$",
+                "",
+                err, flags=re.MULTILINE)
         self.assertEqual(err.rstrip(), "")
         # Being fairly specific regarding the expected behaviour for the
         # initial bundling phase in Python 3.4. If the output changes in


### PR DESCRIPTION
This is a new warning emitted by pip for its [“Using system certificate stores” feature](https://pip.pypa.io/en/stable/topics/https-certificates/#using-system-certificate-stores).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122744 -->
* Issue: gh-122744
<!-- /gh-issue-number -->
