### PR TITLE
gh-122798: Make tests for warnings in the re module more strict

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1115,47 +1115,76 @@ class ReTests(unittest.TestCase):
 
     def test_possible_set_operations(self):
         s = bytes(range(128)).decode()
-        with self.assertWarns(FutureWarning):
+        with self.assertWarnsRegex(FutureWarning, 'Possible set difference') as w:
             p = re.compile(r'[0-9--1]')
+        self.assertEqual(w.filename, __file__)
         self.assertEqual(p.findall(s), list('-./0123456789'))
+        with self.assertWarnsRegex(FutureWarning, 'Possible set difference') as w:
+            self.assertEqual(re.findall(r'[0-9--2]', s), list('-./0123456789'))
+        self.assertEqual(w.filename, __file__)
+
         self.assertEqual(re.findall(r'[--1]', s), list('-./01'))
-        with self.assertWarns(FutureWarning):
+
+        with self.assertWarnsRegex(FutureWarning, 'Possible set difference') as w:
             p = re.compile(r'[%--1]')
+        self.assertEqual(w.filename, __file__)
         self.assertEqual(p.findall(s), list("%&'()*+,-1"))
-        with self.assertWarns(FutureWarning):
+
+        with self.assertWarnsRegex(FutureWarning, 'Possible set difference ') as w:
             p = re.compile(r'[%--]')
+        self.assertEqual(w.filename, __file__)
         self.assertEqual(p.findall(s), list("%&'()*+,-"))
 
-        with self.assertWarns(FutureWarning):
+        with self.assertWarnsRegex(FutureWarning, 'Possible set intersection ') as w:
             p = re.compile(r'[0-9&&1]')
+        self.assertEqual(w.filename, __file__)
         self.assertEqual(p.findall(s), list('&0123456789'))
-        with self.assertWarns(FutureWarning):
+        with self.assertWarnsRegex(FutureWarning, 'Possible set intersection ') as w:
+            self.assertEqual(re.findall(r'[0-8&&1]', s), list('&012345678'))
+        self.assertEqual(w.filename, __file__)
+
+        with self.assertWarnsRegex(FutureWarning, 'Possible set intersection ') as w:
             p = re.compile(r'[\d&&1]')
+        self.assertEqual(w.filename, __file__)
         self.assertEqual(p.findall(s), list('&0123456789'))
+
         self.assertEqual(re.findall(r'[&&1]', s), list('&1'))
 
-        with self.assertWarns(FutureWarning):
+        with self.assertWarnsRegex(FutureWarning, 'Possible set union ') as w:
             p = re.compile(r'[0-9||a]')
+        self.assertEqual(w.filename, __file__)
         self.assertEqual(p.findall(s), list('0123456789a|'))
-        with self.assertWarns(FutureWarning):
+
+        with self.assertWarnsRegex(FutureWarning, 'Possible set union ') as w:
             p = re.compile(r'[\d||a]')
+        self.assertEqual(w.filename, __file__)
         self.assertEqual(p.findall(s), list('0123456789a|'))
+
         self.assertEqual(re.findall(r'[||1]', s), list('1|'))
 
-        with self.assertWarns(FutureWarning):
+        with self.assertWarnsRegex(FutureWarning, 'Possible set symmetric difference ') as w:
             p = re.compile(r'[0-9~~1]')
+        self.assertEqual(w.filename, __file__)
         self.assertEqual(p.findall(s), list('0123456789~'))
-        with self.assertWarns(FutureWarning):
+
+        with self.assertWarnsRegex(FutureWarning, 'Possible set symmetric difference ') as w:
             p = re.compile(r'[\d~~1]')
+        self.assertEqual(w.filename, __file__)
         self.assertEqual(p.findall(s), list('0123456789~'))
+
         self.assertEqual(re.findall(r'[~~1]', s), list('1~'))
 
-        with self.assertWarns(FutureWarning):
+        with self.assertWarnsRegex(FutureWarning, 'Possible nested set ') as w:
             p = re.compile(r'[[0-9]|]')
+        self.assertEqual(w.filename, __file__)
         self.assertEqual(p.findall(s), list('0123456789[]'))
+        with self.assertWarnsRegex(FutureWarning, 'Possible nested set ') as w:
+            self.assertEqual(re.findall(r'[[0-8]|]', s), list('012345678[]'))
+        self.assertEqual(w.filename, __file__)
 
-        with self.assertWarns(FutureWarning):
+        with self.assertWarnsRegex(FutureWarning, 'Possible nested set ') as w:
             p = re.compile(r'[[:digit:]|]')
+        self.assertEqual(w.filename, __file__)
         self.assertEqual(p.findall(s), list(':[]dgit'))
 
     def test_search_coverage(self):


### PR DESCRIPTION
* Test warning messages.
* Test stack level for re.compile() and re.findall().


<!-- gh-issue-number: gh-122798 -->
* Issue: gh-122798
<!-- /gh-issue-number -->
