### PR TITLE
gh-120782: Update datetime test for static type immutability

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -6884,13 +6884,28 @@ class ExtensionModuleTests(unittest.TestCase):
             import sys
             for i in range(5):
                 import _datetime
-                _datetime.date.max > _datetime.date.min
-                _datetime.time.max > _datetime.time.min
-                _datetime.datetime.max > _datetime.datetime.min
-                _datetime.timedelta.max > _datetime.timedelta.min
-                isinstance(_datetime.timezone.min, _datetime.tzinfo)
-                isinstance(_datetime.timezone.utc, _datetime.tzinfo)
-                isinstance(_datetime.timezone.max, _datetime.tzinfo)
+                assert _datetime.date.max > _datetime.date.min
+                assert _datetime.time.max > _datetime.time.min
+                assert _datetime.datetime.max > _datetime.datetime.min
+                assert _datetime.timedelta.max > _datetime.timedelta.min
+                assert _datetime.date.__dict__["min"] is _datetime.date.min
+                assert _datetime.date.__dict__["max"] is _datetime.date.max
+                assert _datetime.date.__dict__["resolution"] is _datetime.date.resolution
+                assert _datetime.time.__dict__["min"] is _datetime.time.min
+                assert _datetime.time.__dict__["max"] is _datetime.time.max
+                assert _datetime.time.__dict__["resolution"] is _datetime.time.resolution
+                assert _datetime.datetime.__dict__["min"] is _datetime.datetime.min
+                assert _datetime.datetime.__dict__["max"] is _datetime.datetime.max
+                assert _datetime.datetime.__dict__["resolution"] is _datetime.datetime.resolution
+                assert _datetime.timedelta.__dict__["min"] is _datetime.timedelta.min
+                assert _datetime.timedelta.__dict__["max"] is _datetime.timedelta.max
+                assert _datetime.timedelta.__dict__["resolution"] is _datetime.timedelta.resolution
+                assert _datetime.timezone.__dict__["min"] is _datetime.timezone.min
+                assert _datetime.timezone.__dict__["max"] is _datetime.timezone.max
+                assert _datetime.timezone.__dict__["utc"] is _datetime.timezone.utc
+                assert isinstance(_datetime.timezone.min, _datetime.tzinfo)
+                assert isinstance(_datetime.timezone.max, _datetime.tzinfo)
+                assert isinstance(_datetime.timezone.utc, _datetime.tzinfo)
                 del sys.modules['_datetime']
             """)
         script_helper.assert_python_ok('-c', script)


### PR DESCRIPTION
This forward-ports a `_datetime` test from 3.13, which should be more friendly with the latest solution (e55b05f29ee62cd92b6b9990fd699b78f19432ba).

<!-- gh-issue-number: gh-120782 -->
* Issue: gh-120782
<!-- /gh-issue-number -->
