### PR TITLE
InternalDocs: Fix typo in link to instruction_sequence.c inside compiler docs

### DIFF
--- a/InternalDocs/compiler.md
+++ b/InternalDocs/compiler.md
@@ -555,7 +555,7 @@ Important files
   * [Python/assemble.c](https://github.com/python/cpython/blob/main/Python/assemble.c):
     Constructs a code object from a sequence of pseudo instructions.
 
-  * [Python/instruction_sequence.c.c](https://github.com/python/cpython/blob/main/Python/instruction_sequence.c.c):
+  * [Python/instruction_sequence.c](https://github.com/python/cpython/blob/main/Python/instruction_sequence.c):
     A data structure representing a sequence of bytecode-like pseudo-instructions.
 
 * [Include/](https://github.com/python/cpython/blob/main/Include/)


### PR DESCRIPTION
I found a bad link in the internal documentations, that had an additional .c both int he name but in the link too so it loads a 404 not found site.