### PR TITLE
[3.12] gh-122478: Remove internal frames from tracebacks in REPL (GH-122528)

### DIFF
--- a/Lib/code.py
+++ b/Lib/code.py
@@ -105,29 +105,21 @@ class InteractiveInterpreter:
         The output is written by self.write(), below.
 
         """
-        type, value, tb = sys.exc_info()
-        sys.last_exc = value
-        sys.last_type = type
-        sys.last_value = value
-        sys.last_traceback = tb
-        if filename and type is SyntaxError:
-            # Work hard to stuff the correct filename in the exception
-            try:
-                msg, (dummy_filename, lineno, offset, line) = value.args
-            except ValueError:
-                # Not the format we expect; leave it alone
-                pass
-            else:
-                # Stuff in the right filename
-                value = SyntaxError(msg, (filename, lineno, offset, line))
-                sys.last_exc = sys.last_value = value
-        if sys.excepthook is sys.__excepthook__:
-            lines = traceback.format_exception_only(type, value)
-            self.write(''.join(lines))
-        else:
-            # If someone has set sys.excepthook, we let that take precedence
-            # over self.write
-            self._call_excepthook(type, value, tb)
+        try:
+            typ, value, tb = sys.exc_info()
+            if filename and typ is SyntaxError:
+                # Work hard to stuff the correct filename in the exception
+                try:
+                    msg, (dummy_filename, lineno, offset, line) = value.args
+                except ValueError:
+                    # Not the format we expect; leave it alone
+                    pass
+                else:
+                    # Stuff in the right filename
+                    value = SyntaxError(msg, (filename, lineno, offset, line))
+            self._showtraceback(typ, value, None)
+        finally:
+            typ = value = tb = None
 
     def showtraceback(self):
         """Display the exception that just occurred.
@@ -137,32 +129,34 @@ class InteractiveInterpreter:
         The output is written by self.write(), below.
 
         """
-        sys.last_type, sys.last_value, last_tb = ei = sys.exc_info()
-        sys.last_traceback = last_tb
-        sys.last_exc = ei[1]
         try:
-            if sys.excepthook is sys.__excepthook__:
-                lines = traceback.format_exception(ei[0], ei[1], last_tb.tb_next)
-                self.write(''.join(lines))
-            else:
-                # If someone has set sys.excepthook, we let that take precedence
-                # over self.write
-                self._call_excepthook(ei[0], ei[1], last_tb)
+            typ, value, tb = sys.exc_info()
+            self._showtraceback(typ, value, tb.tb_next)
         finally:
-            last_tb = ei = None
+            typ = value = tb = None
 
-    def _call_excepthook(self, typ, value, tb):
-        try:
-            sys.excepthook(typ, value, tb)
-        except SystemExit:
-            raise
-        except BaseException as e:
-            e.__context__ = None
-            print('Error in sys.excepthook:', file=sys.stderr)
-            sys.__excepthook__(type(e), e, e.__traceback__.tb_next)
-            print(file=sys.stderr)
-            print('Original exception was:', file=sys.stderr)
-            sys.__excepthook__(typ, value, tb)
+    def _showtraceback(self, typ, value, tb):
+        sys.last_type = typ
+        sys.last_traceback = tb
+        sys.last_exc = sys.last_value = value = value.with_traceback(tb)
+        if sys.excepthook is sys.__excepthook__:
+            lines = traceback.format_exception(typ, value, tb)
+            self.write(''.join(lines))
+        else:
+            # If someone has set sys.excepthook, we let that take precedence
+            # over self.write
+            try:
+                sys.excepthook(typ, value, tb)
+            except SystemExit:
+                raise
+            except BaseException as e:
+                e.__context__ = None
+                e = e.with_traceback(e.__traceback__.tb_next)
+                print('Error in sys.excepthook:', file=sys.stderr)
+                sys.__excepthook__(type(e), e, e.__traceback__)
+                print(file=sys.stderr)
+                print('Original exception was:', file=sys.stderr)
+                sys.__excepthook__(typ, value, tb)
 
     def write(self, data):
         """Write a string.

--- a/Misc/NEWS.d/next/Library/2024-07-31-20-43-21.gh-issue-122478.sCU2Le.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-31-20-43-21.gh-issue-122478.sCU2Le.rst
@@ -1,0 +1,3 @@
+Remove internal frames from tracebacks shown in
+:class:`code.InteractiveInterpreter` with non-default :func:`sys.excepthook`.
+Save correct tracebacks in :attr:`sys.last_traceback` and update ``__traceback__`` attribute of :attr:`sys.last_value` and :attr:`sys.last_exc`.


### PR DESCRIPTION
Frames of methods in code and codeop modules was show with non-default sys.excepthook.

Save correct tracebacks in sys.last_traceback and update __traceback__ attribute of sys.last_value and sys.last_exc.
(cherry picked from commit e73e7a7abdc3fed252affcb1629df1b3c8fff2ef)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122478 -->
* Issue: gh-122478
<!-- /gh-issue-number -->
