### PR TITLE
gh-122781: fix time format bug

### DIFF
--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -256,9 +256,14 @@ class TimeRE(dict):
         while '%' in format:
             directive_index = format.index('%')+1
             format_char = format[directive_index]
-            processed_format = "%s%s%s" % (processed_format,
-                                           format[:directive_index-1],
-                                           self[format_char])
+            if format_char == 'z':
+                processed_format = "%s(?:%s%s)?" % (processed_format,
+                                            format[:directive_index - 1],
+                                            self[format_char])
+            else:
+                processed_format = "%s%s%s" % (processed_format,
+                                            format[:directive_index-1],
+                                            self[format_char])
             format = format[directive_index+1:]
             match format_char:
                 case 'Y' | 'y' | 'G':
@@ -450,7 +455,7 @@ def _strptime(data_string, format="%a %b %d %H:%M:%S %Y"):
             z = found_dict['z']
             if z == 'Z':
                 gmtoff = 0
-            else:
+            elif z is not None:
                 if z[3] == ':':
                     z = z[:3] + z[4:]
                     if len(z) > 5:

--- a/Misc/NEWS.d/next/Library/2024-08-08-15-02-37.gh-issue-122781.hEC0pk.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-08-15-02-37.gh-issue-122781.hEC0pk.rst
@@ -1,0 +1,1 @@
+Fixed it such that %z is optional

--- a/Misc/NEWS.d/next/Library/2024-08-08-15-29-34.gh-issue-122781.4gEwEt.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-08-15-29-34.gh-issue-122781.4gEwEt.rst
@@ -1,0 +1,1 @@
+Make %z represent an optional UTC offset instead of mandating a UTC offset


### PR DESCRIPTION
Fixed it such that %z is now read as optional and can be an empty string.

<!-- gh-issue-number: gh-122781 -->
* Issue: gh-122781
<!-- /gh-issue-number -->
