### PR TITLE
[3.12] gh-122695: Fix double-free when using `gc.get_referents` with a freed `_asyncio.FutureIter`

### DIFF
--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -641,6 +641,14 @@ class CFutureTests(BaseFutureTests, test_utils.TestCase):
         with self.assertRaises(AttributeError):
             del fut._log_traceback
 
+    def test_future_iter_get_referents_segfault(self):
+        # See https://github.com/python/cpython/issues/122695
+        import _asyncio
+        it = iter(self._new_future(loop=self.loop))
+        del it
+        evil = gc.get_referents(_asyncio)
+
+
 
 @unittest.skipUnless(hasattr(futures, '_CFuture'),
                      'requires the C _asyncio module')

--- a/Misc/NEWS.d/next/Library/2024-08-08-14-16-41.gh-issue-122695.f7pwBv.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-08-14-16-41.gh-issue-122695.f7pwBv.rst
@@ -1,0 +1,2 @@
+Fixed double-free when using :func:`gc.get_referents` with a freed
+:class:`asyncio.Future` iterator.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1610,8 +1610,14 @@ FutureIter_dealloc(futureiterobject *it)
 
     if (state && state->fi_freelist_len < FI_FREELIST_MAXLEN) {
         state->fi_freelist_len++;
+        assert(state->fi_freelist != it);
         it->future = (FutureObj*) state->fi_freelist;
         state->fi_freelist = it;
+
+        // GH-122695: Since the freelist is traversed, gc.get_referents()
+        // can return this object, causing a double free when the object
+        // is deallocated for a second time.
+        Py_INCREF(it);
     }
     else {
         PyObject_GC_Del(it);
@@ -3573,6 +3579,10 @@ module_free_freelists(asyncio_state *state)
 
         current = next;
         next = (PyObject*) ((futureiterobject*) current)->future;
+
+        // GH-122695: We need to own a reference to this to prevent
+        // a double free.
+        assert(Py_REFCNT(current) == 1);
         PyObject_GC_Del(current);
     }
     assert(state->fi_freelist_len == 0);


### PR DESCRIPTION
CC @vstinner, @douglas-raillard-arm

This is a (somewhat hacky) way to do it while keeping items in the freelist returned by `gc.get_referents`. The ideal solution would be to remove the traversal of the freelist all together, but that might be a breaking change (depending on how `lisa` relied on it).

<!-- gh-issue-number: gh-122695 -->
* Issue: gh-122695
<!-- /gh-issue-number -->
