### PR TITLE
[3.13] gh-122695: Fix double-free when using `gc.get_referents` with a freed `_asyncio.FutureIter`

### DIFF
--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -680,6 +680,7 @@ class CFutureTests(BaseFutureTests, test_utils.TestCase):
         import _asyncio
         it = iter(self._new_future(loop=self.loop))
         del it
+        gc.collect()
         evil = gc.get_referents(_asyncio)
 
 

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -680,8 +680,8 @@ class CFutureTests(BaseFutureTests, test_utils.TestCase):
         import _asyncio
         it = iter(self._new_future(loop=self.loop))
         del it
-        gc.collect()
         evil = gc.get_referents(_asyncio)
+        gc.collect()
 
 
 @unittest.skipUnless(hasattr(futures, '_CFuture'),

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -675,6 +675,13 @@ class CFutureTests(BaseFutureTests, test_utils.TestCase):
         with self.assertRaises(AttributeError):
             del fut._log_traceback
 
+    def test_future_iter_get_referents_segfault(self):
+        # See https://github.com/python/cpython/issues/122695
+        import _asyncio
+        it = iter(self._new_future(loop=self.loop))
+        del it
+        evil = gc.get_referents(_asyncio)
+
 
 @unittest.skipUnless(hasattr(futures, '_CFuture'),
                      'requires the C _asyncio module')

--- a/Misc/NEWS.d/next/Library/2024-08-08-15-05-58.gh-issue-122695.f7pwBv.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-08-15-05-58.gh-issue-122695.f7pwBv.rst
@@ -1,0 +1,2 @@
+Fixed double-free when using :func:`gc.get_referents` with a freed
+:class:`asyncio.Future` iterator.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -3530,16 +3530,8 @@ module_traverse(PyObject *mod, visitproc visit, void *arg)
 
     Py_VISIT(state->context_kwname);
 
-#ifndef Py_GIL_DISABLED
-    // Visit freelist.
-    PyObject *next = (PyObject*) state->fi_freelist;
-    while (next != NULL) {
-        PyObject *current = next;
-        Py_VISIT(current);
-        next = (PyObject*) ((futureiterobject*) current)->future;
-    }
-#endif
-
+    // GH-122695: Do not traverse the freelist here, as that can cause problems
+    // with gc.get_referents()
     return 0;
 }
 

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -3529,9 +3529,6 @@ module_traverse(PyObject *mod, visitproc visit, void *arg)
     Py_VISIT(state->iscoroutine_typecache);
 
     Py_VISIT(state->context_kwname);
-
-    // GH-122695: Do not traverse the freelist here, as that can cause problems
-    // with gc.get_referents()
     return 0;
 }
 


### PR DESCRIPTION
CC @colesbury

<!-- gh-issue-number: gh-122695 -->
* Issue: gh-122695
<!-- /gh-issue-number -->