### PR TITLE
GH-118093: Handle some polymorphism before requiring progress in tier two

### DIFF
--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -35,6 +35,7 @@ typedef struct {
     _PyBloomFilter bloom;
     _PyExecutorLinkListNode links;
     PyCodeObject *code;  // Weak (NULL if no corresponding ENTER_EXECUTOR).
+    int depth;
 } _PyVMData;
 
 /* Depending on the format,

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -35,7 +35,7 @@ typedef struct {
     _PyBloomFilter bloom;
     _PyExecutorLinkListNode links;
     PyCodeObject *code;  // Weak (NULL if no corresponding ENTER_EXECUTOR).
-    int depth;
+    int chain_depth;
 } _PyVMData;
 
 /* Depending on the format,
@@ -183,6 +183,12 @@ static inline uint16_t uop_get_error_target(const _PyUOpInstruction *inst)
 // Need extras for root frame and for overflow frame (see TRACE_STACK_PUSH())
 #define MAX_ABSTRACT_FRAME_DEPTH (TRACE_STACK_SIZE + 2)
 
+// The number of traces that will be stitched together via side exits for a
+// single instruction before requiring progress. In practice, this is the number
+// of different classes/functions/etc. that tier two can handle for a single
+// tier one instruction.
+#define MAX_CHAIN_DEPTH 4
+
 typedef struct _Py_UopsSymbol _Py_UopsSymbol;
 
 struct _Py_UOpsAbstractFrame {
@@ -258,7 +264,7 @@ extern int _Py_uop_frame_pop(_Py_UOpsContext *ctx);
 
 PyAPI_FUNC(PyObject *) _Py_uop_symbols_test(PyObject *self, PyObject *ignored);
 
-PyAPI_FUNC(int) _PyOptimizer_Optimize(struct _PyInterpreterFrame *frame, _Py_CODEUNIT *start, _PyStackRef *stack_pointer, _PyExecutorObject **exec_ptr, bool progress_needed);
+PyAPI_FUNC(int) _PyOptimizer_Optimize(struct _PyInterpreterFrame *frame, _Py_CODEUNIT *start, _PyStackRef *stack_pointer, _PyExecutorObject **exec_ptr, int chain_depth);
 
 static inline int is_terminator(const _PyUOpInstruction *uop)
 {

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -183,10 +183,10 @@ static inline uint16_t uop_get_error_target(const _PyUOpInstruction *inst)
 // Need extras for root frame and for overflow frame (see TRACE_STACK_PUSH())
 #define MAX_ABSTRACT_FRAME_DEPTH (TRACE_STACK_SIZE + 2)
 
-// The number of traces that will be stitched together via side exits for a
-// single instruction before requiring progress. In practice, this is the number
-// of different classes/functions/etc. that tier two can handle for a single
-// tier one instruction.
+// The maximum number of side exits that we can take before requiring forward
+// progress (and inserting a new ENTER_EXECUTOR instruction). In practice, this
+// is the "maximum amount of polymorphism" that an isolated trace tree can
+// handle before rejoining the rest of the program.
 #define MAX_CHAIN_DEPTH 4
 
 typedef struct _Py_UopsSymbol _Py_UopsSymbol;

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -29,13 +29,13 @@ typedef struct {
 typedef struct {
     uint8_t opcode;
     uint8_t oparg;
-    uint8_t valid;
-    uint8_t linked;
+    uint16_t valid:1;
+    uint16_t linked:1;
+    uint16_t chain_depth:14;  // Must be big engough for MAX_CHAIN_DEPTH - 1.
     int index;           // Index of ENTER_EXECUTOR (if code isn't NULL, below).
     _PyBloomFilter bloom;
     _PyExecutorLinkListNode links;
     PyCodeObject *code;  // Weak (NULL if no corresponding ENTER_EXECUTOR).
-    int chain_depth;
 } _PyVMData;
 
 /* Depending on the format,

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -83,7 +83,7 @@ typedef struct _PyOptimizerObject _PyOptimizerObject;
 typedef int (*_Py_optimize_func)(
     _PyOptimizerObject* self, struct _PyInterpreterFrame *frame,
     _Py_CODEUNIT *instr, _PyExecutorObject **exec_ptr,
-    int curr_stackentries);
+    int curr_stackentries, bool progress_needed);
 
 struct _PyOptimizerObject {
     PyObject_HEAD
@@ -257,7 +257,7 @@ extern int _Py_uop_frame_pop(_Py_UOpsContext *ctx);
 
 PyAPI_FUNC(PyObject *) _Py_uop_symbols_test(PyObject *self, PyObject *ignored);
 
-PyAPI_FUNC(int) _PyOptimizer_Optimize(struct _PyInterpreterFrame *frame, _Py_CODEUNIT *start, _PyStackRef *stack_pointer, _PyExecutorObject **exec_ptr);
+PyAPI_FUNC(int) _PyOptimizer_Optimize(struct _PyInterpreterFrame *frame, _Py_CODEUNIT *start, _PyStackRef *stack_pointer, _PyExecutorObject **exec_ptr, bool progress_needed);
 
 static inline int is_terminator(const _PyUOpInstruction *uop)
 {

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-08-16-02-28.gh-issue-118093.m6Mrvy.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-08-16-02-28.gh-issue-118093.m6Mrvy.rst
@@ -1,0 +1,1 @@
+Improve the experimental JIT's handling of polymorphic code.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2511,6 +2511,7 @@ dummy_func(
                 int optimized = _PyOptimizer_Optimize(frame, start, stack_pointer, &executor, true);
                 ERROR_IF(optimized < 0, error);
                 if (optimized) {
+                    executor->vm_data.depth = 0;
                     assert(tstate->previous_executor == NULL);
                     tstate->previous_executor = Py_None;
                     GOTO_TIER_TWO(executor);
@@ -4547,7 +4548,8 @@ dummy_func(
                     Py_INCREF(executor);
                 }
                 else {
-                    int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, false);
+                    int new_depth = (current_executor->vm_data.depth + 1) % 4;
+                    int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, new_depth == 0);
                     if (optimized <= 0) {
                         exit->temperature = restart_backoff_counter(temperature);
                         if (optimized < 0) {
@@ -4558,6 +4560,7 @@ dummy_func(
                         tstate->previous_executor = (PyObject *)current_executor;
                         GOTO_TIER_ONE(target);
                     }
+                    executor->vm_data.depth = new_depth;
                 }
                 exit->executor = executor;
             }
@@ -4630,7 +4633,7 @@ dummy_func(
                     exit->temperature = advance_backoff_counter(exit->temperature);
                     GOTO_TIER_ONE(target);
                 }
-                int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, false);
+                int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, true);
                 if (optimized <= 0) {
                     exit->temperature = restart_backoff_counter(exit->temperature);
                     if (optimized < 0) {
@@ -4641,6 +4644,7 @@ dummy_func(
                     GOTO_TIER_ONE(target);
                 }
                 else {
+                    executor->vm_data.depth = 0;
                     exit->temperature = initial_temperature_backoff_counter();
                 }
             }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2508,7 +2508,7 @@ dummy_func(
                     start--;
                 }
                 _PyExecutorObject *executor;
-                int optimized = _PyOptimizer_Optimize(frame, start, stack_pointer, &executor);
+                int optimized = _PyOptimizer_Optimize(frame, start, stack_pointer, &executor, true);
                 ERROR_IF(optimized < 0, error);
                 if (optimized) {
                     assert(tstate->previous_executor == NULL);
@@ -4547,7 +4547,7 @@ dummy_func(
                     Py_INCREF(executor);
                 }
                 else {
-                    int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor);
+                    int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, false);
                     if (optimized <= 0) {
                         exit->temperature = restart_backoff_counter(temperature);
                         if (optimized < 0) {
@@ -4630,7 +4630,7 @@ dummy_func(
                     exit->temperature = advance_backoff_counter(exit->temperature);
                     GOTO_TIER_ONE(target);
                 }
-                int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor);
+                int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, false);
                 if (optimized <= 0) {
                     exit->temperature = restart_backoff_counter(exit->temperature);
                     if (optimized < 0) {

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -5023,8 +5023,8 @@
                     Py_INCREF(executor);
                 }
                 else {
-                    int new_depth = (current_executor->vm_data.depth + 1) % 4;
-                    int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, new_depth == 0);
+                    int chain_depth = current_executor->vm_data.chain_depth + 1;
+                    int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, chain_depth);
                     if (optimized <= 0) {
                         exit->temperature = restart_backoff_counter(temperature);
                         if (optimized < 0) {
@@ -5035,7 +5035,6 @@
                         tstate->previous_executor = (PyObject *)current_executor;
                         GOTO_TIER_ONE(target);
                     }
-                    executor->vm_data.depth = new_depth;
                 }
                 exit->executor = executor;
             }
@@ -5157,7 +5156,7 @@
                     exit->temperature = advance_backoff_counter(exit->temperature);
                     GOTO_TIER_ONE(target);
                 }
-                int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, true);
+                int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, 0);
                 if (optimized <= 0) {
                     exit->temperature = restart_backoff_counter(exit->temperature);
                     if (optimized < 0) {
@@ -5168,7 +5167,6 @@
                     GOTO_TIER_ONE(target);
                 }
                 else {
-                    executor->vm_data.depth = 0;
                     exit->temperature = initial_temperature_backoff_counter();
                 }
             }

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -5023,7 +5023,7 @@
                     Py_INCREF(executor);
                 }
                 else {
-                    int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor);
+                    int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, false);
                     if (optimized <= 0) {
                         exit->temperature = restart_backoff_counter(temperature);
                         if (optimized < 0) {
@@ -5155,7 +5155,7 @@
                     exit->temperature = advance_backoff_counter(exit->temperature);
                     GOTO_TIER_ONE(target);
                 }
-                int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor);
+                int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, false);
                 if (optimized <= 0) {
                     exit->temperature = restart_backoff_counter(exit->temperature);
                     if (optimized < 0) {

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -5023,7 +5023,8 @@
                     Py_INCREF(executor);
                 }
                 else {
-                    int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, false);
+                    int new_depth = (current_executor->vm_data.depth + 1) % 4;
+                    int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, new_depth == 0);
                     if (optimized <= 0) {
                         exit->temperature = restart_backoff_counter(temperature);
                         if (optimized < 0) {
@@ -5034,6 +5035,7 @@
                         tstate->previous_executor = (PyObject *)current_executor;
                         GOTO_TIER_ONE(target);
                     }
+                    executor->vm_data.depth = new_depth;
                 }
                 exit->executor = executor;
             }
@@ -5155,7 +5157,7 @@
                     exit->temperature = advance_backoff_counter(exit->temperature);
                     GOTO_TIER_ONE(target);
                 }
-                int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, false);
+                int optimized = _PyOptimizer_Optimize(frame, target, stack_pointer, &executor, true);
                 if (optimized <= 0) {
                     exit->temperature = restart_backoff_counter(exit->temperature);
                     if (optimized < 0) {
@@ -5166,6 +5168,7 @@
                     GOTO_TIER_ONE(target);
                 }
                 else {
+                    executor->vm_data.depth = 0;
                     exit->temperature = initial_temperature_backoff_counter();
                 }
             }

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -4272,10 +4272,9 @@
                     start--;
                 }
                 _PyExecutorObject *executor;
-                int optimized = _PyOptimizer_Optimize(frame, start, stack_pointer, &executor, true);
+                int optimized = _PyOptimizer_Optimize(frame, start, stack_pointer, &executor, 0);
                 if (optimized < 0) goto error;
                 if (optimized) {
-                    executor->vm_data.depth = 0;
                     assert(tstate->previous_executor == NULL);
                     tstate->previous_executor = Py_None;
                     GOTO_TIER_TWO(executor);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -4272,7 +4272,7 @@
                     start--;
                 }
                 _PyExecutorObject *executor;
-                int optimized = _PyOptimizer_Optimize(frame, start, stack_pointer, &executor);
+                int optimized = _PyOptimizer_Optimize(frame, start, stack_pointer, &executor, true);
                 if (optimized < 0) goto error;
                 if (optimized) {
                     assert(tstate->previous_executor == NULL);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -4275,6 +4275,7 @@
                 int optimized = _PyOptimizer_Optimize(frame, start, stack_pointer, &executor, true);
                 if (optimized < 0) goto error;
                 if (optimized) {
+                    executor->vm_data.depth = 0;
                     assert(tstate->previous_executor == NULL);
                     tstate->previous_executor = Py_None;
                     GOTO_TIER_TWO(executor);

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -200,11 +200,11 @@ _PyOptimizer_Optimize(
         int index = get_index_for_executor(code, start);
         if (index < 0) {
             /* Out of memory. Don't raise and assume that the
-            * error will show up elsewhere.
-            *
-            * If an optimizer has already produced an executor,
-            * it might get confused by the executor disappearing,
-            * but there is not much we can do about that here. */
+             * error will show up elsewhere.
+             *
+             * If an optimizer has already produced an executor,
+             * it might get confused by the executor disappearing,
+             * but there is not much we can do about that here. */
             Py_DECREF(*executor_ptr);
             return 0;
         }
@@ -588,6 +588,8 @@ translate_bytecode_to_trace(
         uint32_t opcode = instr->op.code;
         uint32_t oparg = instr->op.arg;
 
+        /* Special case the first instruction,
+         * so that we can guarantee forward progress */
         if (!first && instr == initial_instr) {
             // We have looped around to the start:
             RESERVE(1);
@@ -606,7 +608,6 @@ translate_bytecode_to_trace(
                 goto done;
             }
         }
-
         if (opcode == ENTER_EXECUTOR) {
             goto done;
         }

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -597,14 +597,6 @@ translate_bytecode_to_trace(
 
         DPRINTF(2, "%d: %s(%d)\n", target, _PyOpcode_OpName[opcode], oparg);
 
-        if (opcode == ENTER_EXECUTOR) {
-            assert(oparg < 256);
-            _PyExecutorObject *executor = code->co_executors->executors[oparg];
-            opcode = executor->vm_data.opcode;
-            DPRINTF(2, "  * ENTER_EXECUTOR -> %s\n",  _PyOpcode_OpName[opcode]);
-            oparg = executor->vm_data.oparg;
-        }
-
         if (opcode == EXTENDED_ARG) {
             instr++;
             opcode = instr->op.code;
@@ -613,6 +605,10 @@ translate_bytecode_to_trace(
                 instr--;
                 goto done;
             }
+        }
+
+        if (opcode == ENTER_EXECUTOR) {
+            goto done;
         }
         assert(opcode != ENTER_EXECUTOR && opcode != EXTENDED_ARG);
         RESERVE_RAW(2, "_CHECK_VALIDITY_AND_SET_IP");

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -588,8 +588,6 @@ translate_bytecode_to_trace(
         uint32_t opcode = instr->op.code;
         uint32_t oparg = instr->op.arg;
 
-        /* Special case the first instruction,
-         * so that we can guarantee forward progress */
         if (!first && instr == initial_instr) {
             // We have looped around to the start:
             RESERVE(1);
@@ -615,6 +613,8 @@ translate_bytecode_to_trace(
         RESERVE_RAW(2, "_CHECK_VALIDITY_AND_SET_IP");
         ADD_TO_TRACE(_CHECK_VALIDITY_AND_SET_IP, 0, (uintptr_t)instr, target);
 
+        /* Special case the first instruction,
+         * so that we can guarantee forward progress */
         if (first && progress_needed) {
             assert(first);
             if (OPCODE_HAS_EXIT(opcode) || OPCODE_HAS_DEOPT(opcode)) {

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -544,6 +544,7 @@ translate_bytecode_to_trace(
     int buffer_size,
     _PyBloomFilter *dependencies, bool progress_needed)
 {
+    bool first = true;
     PyCodeObject *code = _PyFrame_GetCode(frame);
     PyFunctionObject *func = (PyFunctionObject *)frame->f_funcobj;
     assert(PyFunction_Check(func));
@@ -578,7 +579,6 @@ translate_bytecode_to_trace(
             2 * INSTR_IP(initial_instr, code));
     ADD_TO_TRACE(_START_EXECUTOR, 0, (uintptr_t)instr, INSTR_IP(instr, code));
     uint32_t target = 0;
-    bool first = true;
 
     for (;;) {
         target = INSTR_IP(instr, code);

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -618,7 +618,8 @@ translate_bytecode_to_trace(
         RESERVE_RAW(2, "_CHECK_VALIDITY_AND_SET_IP");
         ADD_TO_TRACE(_CHECK_VALIDITY_AND_SET_IP, 0, (uintptr_t)instr, target);
 
-        if (progress_needed) {
+        if (first && progress_needed) {
+            assert(first);
             if (OPCODE_HAS_EXIT(opcode) || OPCODE_HAS_DEOPT(opcode)) {
                 opcode = _PyOpcode_Deopt[opcode];
             }
@@ -913,7 +914,6 @@ translate_bytecode_to_trace(
         }
     top:
         // Jump here after _PUSH_FRAME or likely branches.
-        progress_needed = false;
         first = false;
     }  // End for (;;)
 
@@ -923,7 +923,7 @@ done:
     }
     assert(code == initial_code);
     // Skip short traces where we can't even translate a single instruction:
-    if (progress_needed) {
+    if (first) {
         OPT_STAT_INC(trace_too_short);
         DPRINTF(2,
                 "No trace for %s (%s:%d) at byte offset %d (no progress)\n",

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -111,7 +111,7 @@ never_optimize(
     _PyInterpreterFrame *frame,
     _Py_CODEUNIT *instr,
     _PyExecutorObject **exec,
-    int Py_UNUSED(stack_entries))
+    int Py_UNUSED(stack_entries), bool Py_UNUSED(progress_needed))
 {
     // This may be called if the optimizer is reset
     return 0;
@@ -176,32 +176,37 @@ _Py_SetTier2Optimizer(_PyOptimizerObject *optimizer)
 int
 _PyOptimizer_Optimize(
     _PyInterpreterFrame *frame, _Py_CODEUNIT *start,
-    _PyStackRef *stack_pointer, _PyExecutorObject **executor_ptr)
+    _PyStackRef *stack_pointer, _PyExecutorObject **executor_ptr, bool progress_needed)
 {
     PyCodeObject *code = _PyFrame_GetCode(frame);
     assert(PyCode_Check(code));
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (!has_space_for_executor(code, start)) {
+    if (progress_needed && !has_space_for_executor(code, start)) {
         return 0;
     }
     _PyOptimizerObject *opt = interp->optimizer;
-    int err = opt->optimize(opt, frame, start, executor_ptr, (int)(stack_pointer - _PyFrame_Stackbase(frame)));
+    int err = opt->optimize(opt, frame, start, executor_ptr, (int)(stack_pointer - _PyFrame_Stackbase(frame)), progress_needed);
     if (err <= 0) {
         return err;
     }
     assert(*executor_ptr != NULL);
-    int index = get_index_for_executor(code, start);
-    if (index < 0) {
-        /* Out of memory. Don't raise and assume that the
-         * error will show up elsewhere.
-         *
-         * If an optimizer has already produced an executor,
-         * it might get confused by the executor disappearing,
-         * but there is not much we can do about that here. */
-        Py_DECREF(*executor_ptr);
-        return 0;
+    if (progress_needed) {
+        int index = get_index_for_executor(code, start);
+        if (index < 0) {
+            /* Out of memory. Don't raise and assume that the
+            * error will show up elsewhere.
+            *
+            * If an optimizer has already produced an executor,
+            * it might get confused by the executor disappearing,
+            * but there is not much we can do about that here. */
+            Py_DECREF(*executor_ptr);
+            return 0;
+        }
+        insert_executor(code, start, index, *executor_ptr);
     }
-    insert_executor(code, start, index, *executor_ptr);
+    else {
+        (*executor_ptr)->vm_data.code = NULL;
+    }
     assert((*executor_ptr)->vm_data.valid);
     return 1;
 }
@@ -530,9 +535,8 @@ translate_bytecode_to_trace(
     _Py_CODEUNIT *instr,
     _PyUOpInstruction *trace,
     int buffer_size,
-    _PyBloomFilter *dependencies)
+    _PyBloomFilter *dependencies, bool progress_needed)
 {
-    bool progress_needed = true;
     PyCodeObject *code = _PyFrame_GetCode(frame);
     PyFunctionObject *func = (PyFunctionObject *)frame->f_funcobj;
     assert(PyFunction_Check(func));
@@ -567,6 +571,7 @@ translate_bytecode_to_trace(
             2 * INSTR_IP(initial_instr, code));
     ADD_TO_TRACE(_START_EXECUTOR, 0, (uintptr_t)instr, INSTR_IP(instr, code));
     uint32_t target = 0;
+    bool first = true;
 
     for (;;) {
         target = INSTR_IP(instr, code);
@@ -576,7 +581,7 @@ translate_bytecode_to_trace(
         uint32_t opcode = instr->op.code;
         uint32_t oparg = instr->op.arg;
 
-        if (!progress_needed && instr == initial_instr) {
+        if (!first && instr == initial_instr) {
             // We have looped around to the start:
             RESERVE(1);
             ADD_TO_TRACE(_JUMP_TO_TOP, 0, 0, 0);
@@ -606,8 +611,6 @@ translate_bytecode_to_trace(
         RESERVE_RAW(2, "_CHECK_VALIDITY_AND_SET_IP");
         ADD_TO_TRACE(_CHECK_VALIDITY_AND_SET_IP, 0, (uintptr_t)instr, target);
 
-        /* Special case the first instruction,
-         * so that we can guarantee forward progress */
         if (progress_needed) {
             if (OPCODE_HAS_EXIT(opcode) || OPCODE_HAS_DEOPT(opcode)) {
                 opcode = _PyOpcode_Deopt[opcode];
@@ -904,6 +907,7 @@ translate_bytecode_to_trace(
     top:
         // Jump here after _PUSH_FRAME or likely branches.
         progress_needed = false;
+        first = false;
     }  // End for (;;)
 
 done:
@@ -1225,13 +1229,13 @@ uop_optimize(
     _PyInterpreterFrame *frame,
     _Py_CODEUNIT *instr,
     _PyExecutorObject **exec_ptr,
-    int curr_stackentries)
+    int curr_stackentries, bool progress_needed)
 {
     _PyBloomFilter dependencies;
     _Py_BloomFilter_Init(&dependencies);
     _PyUOpInstruction buffer[UOP_MAX_TRACE_LENGTH];
     OPT_STAT_INC(attempts);
-    int length = translate_bytecode_to_trace(frame, instr, buffer, UOP_MAX_TRACE_LENGTH, &dependencies);
+    int length = translate_bytecode_to_trace(frame, instr, buffer, UOP_MAX_TRACE_LENGTH, &dependencies, progress_needed);
     if (length <= 0) {
         // Error or nothing translated
         return length;
@@ -1328,7 +1332,7 @@ counter_optimize(
     _PyInterpreterFrame *frame,
     _Py_CODEUNIT *instr,
     _PyExecutorObject **exec_ptr,
-    int Py_UNUSED(curr_stackentries)
+    int Py_UNUSED(curr_stackentries), bool Py_UNUSED(progress_needed)
 )
 {
     PyCodeObject *code = _PyFrame_GetCode(frame);


### PR DESCRIPTION
Despite our best intentions, we currently don't handle polymorphism *at all* in tier two, since our current forward progress requirement means that we need to deopt the first instruction of every new trace.

This changes our trace stitching for side exits to *not* require progress until a certain tree depth is reached (currently four). It also changes the optimizer to rejoin with any traces encountered during projection, since this does a better job of keeping us on trace in loops (we can take four side exits *per iteration* before requiring progress) and keeps the amount of tier two code from exploding.

As a simple microbenchmark, this goes from *~10% slower* when run with the JIT enabled to *~25% faster* after this change.

```py
class A:
    def f(self):
        return True

class B:
    def f(self):
        return False

def main():
    a, b = A(), B()
    for _ in range(100_000_000):
        a, b = b, a
        a.f()

main()
```

Overall, the benchmarks are [0.6% faster](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240808-3.14.0a0-17a27d0-JIT/bm-20240808-linux-x86_64-brandtbucher-no_progress_needed-3.14.0a0-17a27d0-vs-base.svg), including nice improvements on all of our interpreter-heavy benchmarks. The [stats](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240808-3.14.0a0-17a27d0-JIT/bm-20240808-azure-x86_64-brandtbucher-no_progress_needed-3.14.0a0-17a27d0-pystats-vs-base.md) show that we're actually executing more traces and a bit (~1%) more tier one code now, but that's expected since side exit chains require up to 4x as much "warming up" as before.


<!-- gh-issue-number: gh-118093 -->
* Issue: gh-118093
<!-- /gh-issue-number -->
