### PR TITLE
Remove "print >>obj" exception hint for Python 2

### DIFF
--- a/Lib/test/test_print.py
+++ b/Lib/test/test_print.py
@@ -188,38 +188,6 @@ class TestPy2MigrationHint(unittest.TestCase):
         self.assertIn("Missing parentheses in call to 'print'. Did you mean print(...)",
                 str(context.exception))
 
-    def test_stream_redirection_hint_for_py2_migration(self):
-        # Test correct hint produced for Py2 redirection syntax
-        with self.assertRaises(TypeError) as context:
-            print >> sys.stderr, "message"
-        self.assertIn('Did you mean "print(<message>, '
-                'file=<output_stream>)"?', str(context.exception))
-
-        # Test correct hint is produced in the case where RHS implements
-        # __rrshift__ but returns NotImplemented
-        with self.assertRaises(TypeError) as context:
-            print >> 42
-        self.assertIn('Did you mean "print(<message>, '
-                'file=<output_stream>)"?', str(context.exception))
-
-        # Test stream redirection hint is specific to print
-        with self.assertRaises(TypeError) as context:
-            max >> sys.stderr
-        self.assertNotIn('Did you mean ', str(context.exception))
-
-        # Test stream redirection hint is specific to rshift
-        with self.assertRaises(TypeError) as context:
-            print << sys.stderr
-        self.assertNotIn('Did you mean', str(context.exception))
-
-        # Ensure right operand implementing rrshift still works
-        class OverrideRRShift:
-            def __rrshift__(self, lhs):
-                return 42 # Force result independent of LHS
-
-        self.assertEqual(print >> OverrideRRShift(), 42)
-
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -1000,20 +1000,6 @@ binary_op(PyObject *v, PyObject *w, const int op_slot, const char *op_name)
     PyObject *result = BINARY_OP1(v, w, op_slot, op_name);
     if (result == Py_NotImplemented) {
         Py_DECREF(result);
-
-        if (op_slot == NB_SLOT(nb_rshift) &&
-            PyCFunction_CheckExact(v) &&
-            strcmp(((PyCFunctionObject *)v)->m_ml->ml_name, "print") == 0)
-        {
-            PyErr_Format(PyExc_TypeError,
-                "unsupported operand type(s) for %.100s: "
-                "'%.100s' and '%.100s'. Did you mean \"print(<message>, "
-                "file=<output_stream>)\"?",
-                op_name,
-                Py_TYPE(v)->tp_name,
-                Py_TYPE(w)->tp_name);
-            return NULL;
-        }
         return binop_type_error(v, w, op_name);
     }
     return result;


### PR DESCRIPTION
Python 2 reached end of life on January 1st, 2020. The Python ecosystem is now using Python 3.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
