### PR TITLE
[3.12] gh-122695: Fix double-free when using `gc.get_referents` with a freed `_asyncio.FutureIter` (#122837)

### DIFF
--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -641,6 +641,14 @@ class CFutureTests(BaseFutureTests, test_utils.TestCase):
         with self.assertRaises(AttributeError):
             del fut._log_traceback
 
+    def test_future_iter_get_referents_segfault(self):
+        # See https://github.com/python/cpython/issues/122695
+        import _asyncio
+        it = iter(self._new_future(loop=self.loop))
+        del it
+        evil = gc.get_referents(_asyncio)
+        gc.collect()
+
 
 @unittest.skipUnless(hasattr(futures, '_CFuture'),
                      'requires the C _asyncio module')

--- a/Misc/NEWS.d/next/Library/2024-08-08-15-05-58.gh-issue-122695.f7pwBv.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-08-15-05-58.gh-issue-122695.f7pwBv.rst
@@ -1,0 +1,2 @@
+Fixed double-free when using :func:`gc.get_referents` with a freed
+:class:`asyncio.Future` iterator.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -3606,14 +3606,6 @@ module_traverse(PyObject *mod, visitproc visit, void *arg)
     Py_VISIT(state->iscoroutine_typecache);
 
     Py_VISIT(state->context_kwname);
-
-    // Visit freelist.
-    PyObject *next = (PyObject*) state->fi_freelist;
-    while (next != NULL) {
-        PyObject *current = next;
-        Py_VISIT(current);
-        next = (PyObject*) ((futureiterobject*) current)->future;
-    }
     return 0;
 }
 


### PR DESCRIPTION
* Backport #122834 for 3.13

(cherry picked from commit e8fb088dbaa71dd5f0146b2f4a8f7ecbe2ce9625)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122695 -->
* Issue: gh-122695
<!-- /gh-issue-number -->
