### PR TITLE
gh-122868: Add lower bounds for sphinxcontrib dependencies

### DIFF
--- a/Doc/constraints.txt
+++ b/Doc/constraints.txt
@@ -13,11 +13,11 @@ packaging<25
 Pygments<3
 requests<3
 snowballstemmer<3
-sphinxcontrib-applehelp<2.1
-sphinxcontrib-devhelp<2.1
+sphinxcontrib-applehelp>=1.0.6<2.1
+sphinxcontrib-devhelp>=1.0.6<2.1
 sphinxcontrib-htmlhelp<2.2
 sphinxcontrib-jsmath<1.1
-sphinxcontrib-qthelp<2.1
+sphinxcontrib-qthelp>=1.0.6<2.1
 sphinxcontrib-serializinghtml<2.1
 
 # Direct dependencies of Jinja2 (Jinja is a dependency of Sphinx, see above)

--- a/Doc/constraints.txt
+++ b/Doc/constraints.txt
@@ -13,11 +13,11 @@ packaging<25
 Pygments<3
 requests<3
 snowballstemmer<3
-sphinxcontrib-applehelp>=1.0.6<2.1
-sphinxcontrib-devhelp>=1.0.6<2.1
+sphinxcontrib-applehelp>=1.0.6,<2.1
+sphinxcontrib-devhelp>=1.0.6,<2.1
 sphinxcontrib-htmlhelp<2.2
 sphinxcontrib-jsmath<1.1
-sphinxcontrib-qthelp>=1.0.6<2.1
+sphinxcontrib-qthelp>=1.0.6,<2.1
 sphinxcontrib-serializinghtml<2.1
 
 # Direct dependencies of Jinja2 (Jinja is a dependency of Sphinx, see above)


### PR DESCRIPTION
Partially resolves #122868

A

<!-- gh-issue-number: gh-122868 -->
* Issue: gh-122868
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122870.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->