### PR TITLE
gh-122858: Deprecate `asyncio.iscoroutinefunction`

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -882,7 +882,7 @@ object::
   call is an awaitable.
 
     >>> mock = AsyncMock()
-    >>> asyncio.iscoroutinefunction(mock)
+    >>> inspect.iscoroutinefunction(mock)
     True
     >>> inspect.isawaitable(mock())  # doctest: +SKIP
     True

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -428,7 +428,7 @@ Deprecated
 * :func:`!asyncio.iscoroutinefunction` is deprecated
   and will be removed in Python 3.16,
   use :func:`inspect.iscoroutinefunction` instead.
-  (Contributed by Jiahao Li in :gh:`122875`.)
+  (Contributed by Jiahao Li and Kumar Aditya in :gh:`122875`.)
 
 .. Add deprecations above alphabetically, not here at the end.
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -425,7 +425,7 @@ Deprecated
   :c:macro:`!isfinite` available from :file:`math.h`
   since C99.  (Contributed by Sergey B Kirpichev in :gh:`119613`.)
 
-* :mod:`asyncio.coroutines`: :func:`iscoroutinefunction` is deprecated
+* :mod:`asyncio`: :func:`iscoroutinefunction` is deprecated
   and will be removed in Python 3.16;
   use :func:`inspect.iscoroutinefunction` instead.
   (Contributed by Jiahao Li in :gh:`122875`.)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -425,6 +425,11 @@ Deprecated
   :c:macro:`!isfinite` available from :file:`math.h`
   since C99.  (Contributed by Sergey B Kirpichev in :gh:`119613`.)
 
+* :mod:`asyncio`: :func:`asyncio.iscoroutinefunction` is deprecated
+  and will be removed in Python 3.16;
+  use :func:`inspect.iscoroutinefunction` instead.
+  (Contributed by Jiahao Li in :gh:`122868`.)
+
 .. Add deprecations above alphabetically, not here at the end.
 
 .. include:: ../deprecations/c-api-pending-removal-in-3.15.rst

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -425,8 +425,8 @@ Deprecated
   :c:macro:`!isfinite` available from :file:`math.h`
   since C99.  (Contributed by Sergey B Kirpichev in :gh:`119613`.)
 
-* :mod:`asyncio`: :func:`iscoroutinefunction` is deprecated
-  and will be removed in Python 3.16;
+* :func:`!asyncio.iscoroutinefunction` is deprecated
+  and will be removed in Python 3.16,
   use :func:`inspect.iscoroutinefunction` instead.
   (Contributed by Jiahao Li in :gh:`122875`.)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -428,7 +428,7 @@ Deprecated
 * :mod:`asyncio`: :func:`asyncio.iscoroutinefunction` is deprecated
   and will be removed in Python 3.16;
   use :func:`inspect.iscoroutinefunction` instead.
-  (Contributed by Jiahao Li in :gh:`122868`.)
+  (Contributed by Jiahao Li in :gh:`122875`.)
 
 .. Add deprecations above alphabetically, not here at the end.
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -425,7 +425,7 @@ Deprecated
   :c:macro:`!isfinite` available from :file:`math.h`
   since C99.  (Contributed by Sergey B Kirpichev in :gh:`119613`.)
 
-* :mod:`asyncio`: :func:`asyncio.coroutines.iscoroutinefunction` is deprecated
+* :mod:`asyncio.coroutines`: :func:`iscoroutinefunction` is deprecated
   and will be removed in Python 3.16;
   use :func:`inspect.iscoroutinefunction` instead.
   (Contributed by Jiahao Li in :gh:`122875`.)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -425,7 +425,7 @@ Deprecated
   :c:macro:`!isfinite` available from :file:`math.h`
   since C99.  (Contributed by Sergey B Kirpichev in :gh:`119613`.)
 
-* :mod:`asyncio`: :func:`asyncio.iscoroutinefunction` is deprecated
+* :mod:`asyncio`: :func:`asyncio.coroutines.iscoroutinefunction` is deprecated
   and will be removed in Python 3.16;
   use :func:`inspect.iscoroutinefunction` instead.
   (Contributed by Jiahao Li in :gh:`122875`.)

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -836,7 +836,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         return handle
 
     def _check_callback(self, callback, method):
-        if (coroutines._iscoroutine(callback) or
+        if (coroutines.iscoroutine(callback) or
                 coroutines._iscoroutinefunction(callback)):
             raise TypeError(
                 f"coroutines cannot be used with {method}()")

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -836,8 +836,8 @@ class BaseEventLoop(events.AbstractEventLoop):
         return handle
 
     def _check_callback(self, callback, method):
-        if (coroutines.iscoroutine(callback) or
-                coroutines.iscoroutinefunction(callback)):
+        if (coroutines._iscoroutine(callback) or
+                coroutines._iscoroutinefunction(callback)):
             raise TypeError(
                 f"coroutines cannot be used with {method}()")
         if not callable(callback):

--- a/Lib/asyncio/coroutines.py
+++ b/Lib/asyncio/coroutines.py
@@ -5,7 +5,6 @@ import inspect
 import os
 import sys
 import types
-import warnings
 
 
 def _is_debug_mode():
@@ -19,11 +18,12 @@ _is_coroutine = object()
 
 
 def iscoroutinefunction(func):
+    import warnings
     """Return True if func is a decorated coroutine function."""
     warnings._deprecated("asyncio.iscoroutinefunction",
-                         f"{warnings._DEPRECATED_MSG};"
+                         f"{warnings._DEPRECATED_MSG}; "
                          "use inspect.iscoroutinefunction() instead",
-                         remove=(3, 16))
+                         remove=(3,16))
     return _iscoroutinefunction(func)
 
 

--- a/Lib/asyncio/coroutines.py
+++ b/Lib/asyncio/coroutines.py
@@ -1,4 +1,4 @@
-__all__ = ['iscoroutinefunction', 'iscoroutine']
+__all__ = 'iscoroutinefunction', 'iscoroutine'
 
 import collections.abc
 import inspect

--- a/Lib/asyncio/coroutines.py
+++ b/Lib/asyncio/coroutines.py
@@ -1,10 +1,11 @@
-__all__ = 'iscoroutinefunction', 'iscoroutine'
+__all__ = ['iscoroutinefunction', 'iscoroutine']
 
 import collections.abc
 import inspect
 import os
 import sys
 import types
+import warnings
 
 
 def _is_debug_mode():
@@ -19,6 +20,14 @@ _is_coroutine = object()
 
 def iscoroutinefunction(func):
     """Return True if func is a decorated coroutine function."""
+    warnings._deprecated("asyncio.iscoroutinefunction",
+                         f"{warnings._DEPRECATED_MSG};"
+                         "use inspect.iscoroutinefunction() instead",
+                         remove=(3, 16))
+    return _iscoroutinefunction(func)
+
+
+def _iscoroutinefunction(func):
     return (inspect.iscoroutinefunction(func) or
             getattr(func, '_is_coroutine', None) is _is_coroutine)
 

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -93,9 +93,8 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
         Raise ValueError if the signal number is invalid or uncatchable.
         Raise RuntimeError if there is a problem setting up the handler.
         """
-        import inspect
-        if (inspect.iscoroutine(callback) or
-                inspect.iscoroutinefunction(callback)):
+        if (coroutines.iscoroutine(callback) or
+                coroutines._iscoroutinefunction(callback)):
             raise TypeError("coroutines cannot be used "
                             "with add_signal_handler()")
         self._check_signal(sig)

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -16,6 +16,7 @@ import warnings
 from . import base_events
 from . import base_subprocess
 from . import constants
+from . import coroutines
 from . import events
 from . import exceptions
 from . import futures

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -16,7 +16,6 @@ import warnings
 from . import base_events
 from . import base_subprocess
 from . import constants
-from . import coroutines
 from . import events
 from . import exceptions
 from . import futures
@@ -94,8 +93,9 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
         Raise ValueError if the signal number is invalid or uncatchable.
         Raise RuntimeError if there is a problem setting up the handler.
         """
-        if (coroutines.iscoroutine(callback) or
-                coroutines.iscoroutinefunction(callback)):
+        import inspect
+        if (inspect.iscoroutine(callback) or
+                inspect.iscoroutinefunction(callback)):
             raise TypeError("coroutines cannot be used "
                             "with add_signal_handler()")
         self._check_signal(sig)

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import asyncio
 from test.test_asyncio import utils as test_utils
-from test.support.warnings_helper import ignore_warnings
 
 
 def tearDownModule():
@@ -125,10 +124,10 @@ class CoroutineTests(BaseTest):
 
         self.assertFalse(asyncio.iscoroutine(foo()))
 
-    @ignore_warnings(category=DeprecationWarning)
     def test_iscoroutinefunction(self):
         async def foo(): pass
-        self.assertTrue(asyncio.iscoroutinefunction(foo))
+        with self.assertWarns(DeprecationWarning):
+            self.assertTrue(asyncio.iscoroutinefunction(foo))
 
     def test_async_def_coroutines(self):
         async def bar():

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -125,7 +125,6 @@ class CoroutineTests(BaseTest):
         self.assertFalse(asyncio.iscoroutine(foo()))
 
 
-    
     def test_iscoroutinefunction(self):
         async def foo(): pass
         self.assertTrue(asyncio.iscoroutinefunction(foo))

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import asyncio
 from test.test_asyncio import utils as test_utils
+from test.support.warnings_helper import ignore_warnings
 
 
 def tearDownModule():
@@ -124,7 +125,7 @@ class CoroutineTests(BaseTest):
 
         self.assertFalse(asyncio.iscoroutine(foo()))
 
-
+    @ignore_warnings(category=DeprecationWarning)
     def test_iscoroutinefunction(self):
         async def foo(): pass
         self.assertTrue(asyncio.iscoroutinefunction(foo))

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 import asyncio
 from test.test_asyncio import utils as test_utils
-from test.support.warnings_helper import ignore_warnings
 
 
 def tearDownModule():
@@ -126,7 +125,7 @@ class CoroutineTests(BaseTest):
         self.assertFalse(asyncio.iscoroutine(foo()))
 
 
-    @ignore_warnings(category=DeprecationWarning)
+    
     def test_iscoroutinefunction(self):
         async def foo(): pass
         self.assertTrue(asyncio.iscoroutinefunction(foo))

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import asyncio
 from test.test_asyncio import utils as test_utils
+from test.support.warnings_helper import ignore_warnings
 
 
 def tearDownModule():
@@ -125,6 +126,7 @@ class CoroutineTests(BaseTest):
         self.assertFalse(asyncio.iscoroutine(foo()))
 
 
+    @ignore_warnings(category=DeprecationWarning)
     def test_iscoroutinefunction(self):
         async def foo(): pass
         self.assertTrue(asyncio.iscoroutinefunction(foo))

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -20,6 +20,7 @@ from asyncio import tasks
 from test.test_asyncio import utils as test_utils
 from test import support
 from test.support.script_helper import assert_python_ok
+from test.support.warnings_helper import ignore_warnings
 
 
 def tearDownModule():
@@ -1939,6 +1940,7 @@ class BaseTaskTests:
         self.assertFalse(task.cancelled())
         self.assertIs(task.exception(), base_exc)
 
+    @ignore_warnings(category=DeprecationWarning)
     def test_iscoroutinefunction(self):
         def fn():
             pass
@@ -1956,6 +1958,7 @@ class BaseTaskTests:
         self.assertFalse(asyncio.iscoroutinefunction(mock.Mock()))
         self.assertTrue(asyncio.iscoroutinefunction(mock.AsyncMock()))
 
+    @ignore_warnings(category=DeprecationWarning)
     def test_coroutine_non_gen_function(self):
         async def func():
             return 'test'

--- a/Lib/test/test_unittest/testmock/testmagicmethods.py
+++ b/Lib/test/test_unittest/testmock/testmagicmethods.py
@@ -1,7 +1,7 @@
 import math
 import unittest
 import os
-from asyncio import iscoroutinefunction
+from inspect import iscoroutinefunction
 from unittest.mock import AsyncMock, Mock, MagicMock, _magics
 
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -62,7 +62,7 @@ def _is_async_obj(obj):
 
 def _is_async_func(func):
     if getattr(func, '__code__', None):
-        return inspect.iscoroutinefunction(func)
+        return iscoroutinefunction(func)
     else:
         return False
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -32,6 +32,7 @@ import pprint
 import sys
 import builtins
 import pkgutil
+from inspect import iscoroutinefunction
 import threading
 from types import CodeType, ModuleType, MethodType
 from unittest.util import safe_repr
@@ -56,7 +57,7 @@ def _is_async_obj(obj):
         return False
     if hasattr(obj, '__func__'):
         obj = getattr(obj, '__func__')
-    return inspect.iscoroutinefunction(obj) or inspect.isawaitable(obj)
+    return iscoroutinefunction(obj) or inspect.isawaitable(obj)
 
 
 def _is_async_func(func):
@@ -555,7 +556,7 @@ class NonCallableMock(Base):
                     unwrapped_attr = inspect.unwrap(unwrapped_attr)
                 except ValueError:
                     pass
-                if inspect.iscoroutinefunction(unwrapped_attr):
+                if iscoroutinefunction(unwrapped_attr):
                     _spec_asyncs.append(attr)
 
             spec = spec_list
@@ -2306,7 +2307,7 @@ class AsyncMockMixin(Base):
                     raise StopAsyncIteration
                 if _is_exception(result):
                     raise result
-            elif inspect.iscoroutinefunction(effect):
+            elif iscoroutinefunction(effect):
                 result = await effect(*args, **kwargs)
             else:
                 result = effect(*args, **kwargs)
@@ -2318,7 +2319,7 @@ class AsyncMockMixin(Base):
             return self.return_value
 
         if self._mock_wraps is not None:
-            if inspect.iscoroutinefunction(self._mock_wraps):
+            if iscoroutinefunction(self._mock_wraps):
                 return await self._mock_wraps(*args, **kwargs)
             return self._mock_wraps(*args, **kwargs)
 
@@ -2837,7 +2838,7 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
 
             skipfirst = _must_skip(spec, entry, is_type)
             child_kwargs['_eat_self'] = skipfirst
-            if inspect.iscoroutinefunction(original):
+            if iscoroutinefunction(original):
                 child_klass = AsyncMock
             else:
                 child_klass = MagicMock

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2837,7 +2837,7 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
 
             skipfirst = _must_skip(spec, entry, is_type)
             child_kwargs['_eat_self'] = skipfirst
-            if iscoroutinefunction(original):
+            if inspect.iscoroutinefunction(original):
                 child_klass = AsyncMock
             else:
                 child_klass = MagicMock

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -32,7 +32,6 @@ import pprint
 import sys
 import builtins
 import pkgutil
-from asyncio import iscoroutinefunction
 import threading
 from types import CodeType, ModuleType, MethodType
 from unittest.util import safe_repr
@@ -57,12 +56,12 @@ def _is_async_obj(obj):
         return False
     if hasattr(obj, '__func__'):
         obj = getattr(obj, '__func__')
-    return iscoroutinefunction(obj) or inspect.isawaitable(obj)
+    return inspect.iscoroutinefunction(obj) or inspect.isawaitable(obj)
 
 
 def _is_async_func(func):
     if getattr(func, '__code__', None):
-        return iscoroutinefunction(func)
+        return inspect.iscoroutinefunction(func)
     else:
         return False
 
@@ -556,7 +555,7 @@ class NonCallableMock(Base):
                     unwrapped_attr = inspect.unwrap(unwrapped_attr)
                 except ValueError:
                     pass
-                if iscoroutinefunction(unwrapped_attr):
+                if inspect.iscoroutinefunction(unwrapped_attr):
                     _spec_asyncs.append(attr)
 
             spec = spec_list
@@ -2456,8 +2455,8 @@ class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock):
     recognized as an async function, and the result of a call is an awaitable:
 
     >>> mock = AsyncMock()
-    >>> iscoroutinefunction(mock)
-    True
+    >>> inspect.iscoroutinefunction(mock)
+    Trues
     >>> inspect.isawaitable(mock())
     True
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2306,7 +2306,7 @@ class AsyncMockMixin(Base):
                     raise StopAsyncIteration
                 if _is_exception(result):
                     raise result
-            elif iscoroutinefunction(effect):
+            elif inspect.iscoroutinefunction(effect):
                 result = await effect(*args, **kwargs)
             else:
                 result = effect(*args, **kwargs)
@@ -2318,7 +2318,7 @@ class AsyncMockMixin(Base):
             return self.return_value
 
         if self._mock_wraps is not None:
-            if iscoroutinefunction(self._mock_wraps):
+            if inspect.iscoroutinefunction(self._mock_wraps):
                 return await self._mock_wraps(*args, **kwargs)
             return self._mock_wraps(*args, **kwargs)
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2456,7 +2456,7 @@ class AsyncMock(AsyncMockMixin, AsyncMagicMixin, Mock):
 
     >>> mock = AsyncMock()
     >>> inspect.iscoroutinefunction(mock)
-    Trues
+    True
     >>> inspect.isawaitable(mock())
     True
 

--- a/Misc/NEWS.d/next/Library/2024-08-10-10-21-44.gh-issue-122858.ZC1rJD.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-10-10-21-44.gh-issue-122858.ZC1rJD.rst
@@ -1,0 +1,2 @@
+Deprecate :func:`asyncio.iscoroutinefunction` in favor of
+:func:`inspect.iscoroutinefunction`.

--- a/Misc/NEWS.d/next/Library/2024-08-10-10-21-44.gh-issue-122858.ZC1rJD.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-10-10-21-44.gh-issue-122858.ZC1rJD.rst
@@ -1,2 +1,2 @@
-Deprecate :func:`asyncio.iscoroutinefunction` in favor of
+Deprecate :func:`asyncio.coroutines.iscoroutinefunction` in favor of
 :func:`inspect.iscoroutinefunction`.

--- a/Misc/NEWS.d/next/Library/2024-08-10-10-21-44.gh-issue-122858.ZC1rJD.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-10-10-21-44.gh-issue-122858.ZC1rJD.rst
@@ -1,2 +1,2 @@
-Deprecate :func:`asyncio.coroutines.iscoroutinefunction` in favor of
+Deprecate :func:`!asyncio.iscoroutinefunction` in favor of
 :func:`inspect.iscoroutinefunction`.


### PR DESCRIPTION
Same `inspect.iscoroutinefunction`, we don't need two different functions to do the same thing.

<!-- gh-issue-number: gh-122858 -->
* Issue: gh-122858
<!-- /gh-issue-number -->