### PR TITLE
Support the "pager" binary in _pyrepl

### DIFF
--- a/Lib/_pyrepl/pager.py
+++ b/Lib/_pyrepl/pager.py
@@ -36,6 +36,8 @@ def get_pager() -> Pager:
         return plain_pager
     if sys.platform == 'win32':
         return lambda text, title='': tempfile_pager(plain(text), 'more <')
+    if hasattr(os, 'system') and os.system('(pager) 2>/dev/null') == 0:
+        return lambda text, title='': pipe_pager(text, 'pager', title)
     if hasattr(os, 'system') and os.system('(less) 2>/dev/null') == 0:
         return lambda text, title='': pipe_pager(text, 'less', title)
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-19-13-17-31.gh-issue-122878.4iFpsB.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-19-13-17-31.gh-issue-122878.4iFpsB.rst
@@ -1,0 +1,1 @@
+Use the `pager` binary on Debian and derivatives, to display REPL `help()`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-19-13-17-31.gh-issue-122878.4iFpsB.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-19-13-17-31.gh-issue-122878.4iFpsB.rst
@@ -1,1 +1,1 @@
-Use the `pager` binary on Debian and derivatives, to display REPL `help()`.
+Use the ``pager`` binary on Debian and derivatives, to display REPL ``help()``.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-19-13-17-31.gh-issue-122878.4iFpsB.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-19-13-17-31.gh-issue-122878.4iFpsB.rst
@@ -1,1 +1,1 @@
-Use the ``pager`` binary on Debian and derivatives, to display REPL ``help()``.
+Use the ``pager`` binary, if available (e.g. on Debian and derivatives), to display REPL ``help()``.


### PR DESCRIPTION
Debian (and derivatives) provide a /usr/bin/pager binary, managed by the alternatives system, that always points to an available pager utility. Allow _pyrepl to use it, to follow system policy

This is a very trivial change, from a patch that Debian has been carrying since 2.7 era. Seems appropriate to upstream. https://bugs.debian.org/799555