### PR TITLE
gh-81742 Omit platform from _sysconfigdata filename for multiarch

### DIFF
--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -337,9 +337,10 @@ def get_makefile_filename():
 
 def _get_sysconfigdata_name():
     multiarch = getattr(sys.implementation, '_multiarch', '')
+    platform = multiarch or sys.platform
     return os.environ.get(
         '_PYTHON_SYSCONFIGDATA_NAME',
-        f'_sysconfigdata_{sys.abiflags}_{sys.platform}_{multiarch}',
+        f'_sysconfigdata_{sys.abiflags}_{platform}',
     )
 
 def _init_posix(vars):

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -1354,7 +1354,7 @@ def buildPython():
     if getVersionMajorMinor() >= (3, 6):
         # XXX this is extra-fragile
         path = os.path.join(path_to_lib,
-            '_sysconfigdata_%s_darwin_darwin.py' % (ABIFLAGS,))
+            '_sysconfigdata_%s_darwin.py' % (ABIFLAGS,))
     else:
         path = os.path.join(path_to_lib, '_sysconfigdata.py')
     fp = open(path, 'r')

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2641,8 +2641,8 @@ libinstall:	all $(srcdir)/Modules/xxmodule.c
 			esac; \
 		done; \
 	done
-	$(INSTALL_DATA) `cat pybuilddir.txt`/_sysconfigdata_$(ABIFLAGS)_$(MACHDEP)_$(MULTIARCH).py $(DESTDIR)$(LIBDEST); \
-	$(INSTALL_DATA) `cat pybuilddir.txt`/_sysconfig_vars_$(ABIFLAGS)_$(MACHDEP)_$(MULTIARCH).json $(DESTDIR)$(LIBDEST); \
+	$(INSTALL_DATA) `cat pybuilddir.txt`/_sysconfigdata_$(ABIFLAGS)_$(firstword $(MULTIARCH) $(MACHDEP)).py $(DESTDIR)$(LIBDEST); \
+	$(INSTALL_DATA) `cat pybuilddir.txt`/_sysconfig_vars_$(ABIFLAGS)_$(firstword $(MULTIARCH) $(MACHDEP)).json $(DESTDIR)$(LIBDEST); \
 	$(INSTALL_DATA) $(srcdir)/LICENSE $(DESTDIR)$(LIBDEST)/LICENSE.txt
 	@ # If app store compliance has been configured, apply the patch to the
 	@ # installed library code. The patch has been previously validated against

--- a/Misc/NEWS.d/next/Build/2024-09-21-11-04-22.gh-issue-81742.xqR6f1.rst
+++ b/Misc/NEWS.d/next/Build/2024-09-21-11-04-22.gh-issue-81742.xqR6f1.rst
@@ -1,0 +1,4 @@
+The ``_sysconfigdata`` module filename (``_PYTHON_SYSCONFIGDATA_NAME``) no
+longer includes both the platform and multiarch triplet, on platforms that
+use multiarch triplets (e.g. Linux). This filename is specified in
+cross-compilation.

--- a/Tools/wasm/emscripten/web_example/wasm_assets.py
+++ b/Tools/wasm/emscripten/web_example/wasm_assets.py
@@ -93,10 +93,10 @@ OMIT_MODULE_FILES = {
 }
 
 SYSCONFIG_NAMES = (
-    "_sysconfigdata__emscripten_wasm32-emscripten",
-    "_sysconfigdata__emscripten_wasm32-emscripten",
-    "_sysconfigdata__wasi_wasm32-wasi",
-    "_sysconfigdata__wasi_wasm64-wasi",
+    "_sysconfigdata__wasm32-emscripten",
+    "_sysconfigdata__wasm32-emscripten",
+    "_sysconfigdata__wasm32-wasi",
+    "_sysconfigdata__wasm64-wasi",
 )
 
 

--- a/configure
+++ b/configure
@@ -3706,7 +3706,7 @@ fi
     fi
         ac_cv_prog_PYTHON_FOR_REGEN=$with_build_python
     PYTHON_FOR_FREEZE="$with_build_python"
-    PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(srcdir)/Lib _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata_$(ABIFLAGS)_$(MACHDEP)_$(MULTIARCH) _PYTHON_SYSCONFIGDATA_PATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`) '$with_build_python
+	PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(srcdir)/Lib _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata_$(ABIFLAGS)_$(firstword $(MULTIARCH) $(MACHDEP)) _PYTHON_SYSCONFIGDATA_PATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`) '$with_build_python
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_build_python" >&5
 printf "%s\n" "$with_build_python" >&6; }
 

--- a/configure.ac
+++ b/configure.ac
@@ -164,7 +164,7 @@ AC_ARG_WITH([build-python],
     dnl Build Python interpreter is used for regeneration and freezing.
     ac_cv_prog_PYTHON_FOR_REGEN=$with_build_python
     PYTHON_FOR_FREEZE="$with_build_python"
-    PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(srcdir)/Lib _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata_$(ABIFLAGS)_$(MACHDEP)_$(MULTIARCH) _PYTHON_SYSCONFIGDATA_PATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`) '$with_build_python
+	PYTHON_FOR_BUILD='_PYTHON_PROJECT_BASE=$(abs_builddir) _PYTHON_HOST_PLATFORM=$(_PYTHON_HOST_PLATFORM) PYTHONPATH=$(srcdir)/Lib _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata_$(ABIFLAGS)_$(firstword $(MULTIARCH) $(MULTIARCH)) _PYTHON_SYSCONFIGDATA_PATH=$(shell test -f pybuilddir.txt && echo $(abs_builddir)/`cat pybuilddir.txt`) '$with_build_python
     AC_MSG_RESULT([$with_build_python])
   ], [
     AS_VAR_IF([cross_compiling], [yes],


### PR DESCRIPTION
The multiarch triple encodes the platform name, so there is no need to have both in the _sysconfigdata filename.

Debian has been carrying a (dumber) variant of this patch for a while.

Fixes: #81742

<!-- gh-issue-number: gh-81742 -->
* Issue: gh-81742
<!-- /gh-issue-number -->
