### PR TITLE
GH-85633: Fix pathlib test failures on filesystems without world-write.

### DIFF
--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1605,7 +1605,9 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
     )
     @needs_posix
     def test_open_mode(self):
-        old_mask = os.umask(2)
+        # Unmask all permissions except world-write, which may
+        # not be supported on some filesystems (see GH-85633.)
+        old_mask = os.umask(0o002)
         self.addCleanup(os.umask, old_mask)
         p = self.cls(self.base)
         with (p / 'new_file').open('wb'):
@@ -1634,7 +1636,9 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
     )
     @needs_posix
     def test_touch_mode(self):
-        old_mask = os.umask(2)
+        # Unmask all permissions except world-write, which may
+        # not be supported on some filesystems (see GH-85633.)
+        old_mask = os.umask(0o002)
         self.addCleanup(os.umask, old_mask)
         p = self.cls(self.base)
         (p / 'new_file').touch()

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1605,18 +1605,18 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
     )
     @needs_posix
     def test_open_mode(self):
-        old_mask = os.umask(0)
+        old_mask = os.umask(2)
         self.addCleanup(os.umask, old_mask)
         p = self.cls(self.base)
         with (p / 'new_file').open('wb'):
             pass
         st = os.stat(self.parser.join(self.base, 'new_file'))
-        self.assertEqual(stat.S_IMODE(st.st_mode), 0o666)
-        os.umask(0o022)
+        self.assertEqual(stat.S_IMODE(st.st_mode), 0o664)
+        os.umask(0o026)
         with (p / 'other_new_file').open('wb'):
             pass
         st = os.stat(self.parser.join(self.base, 'other_new_file'))
-        self.assertEqual(stat.S_IMODE(st.st_mode), 0o644)
+        self.assertEqual(stat.S_IMODE(st.st_mode), 0o640)
 
     @needs_posix
     def test_resolve_root(self):
@@ -1634,16 +1634,16 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
     )
     @needs_posix
     def test_touch_mode(self):
-        old_mask = os.umask(0)
+        old_mask = os.umask(2)
         self.addCleanup(os.umask, old_mask)
         p = self.cls(self.base)
         (p / 'new_file').touch()
         st = os.stat(self.parser.join(self.base, 'new_file'))
-        self.assertEqual(stat.S_IMODE(st.st_mode), 0o666)
-        os.umask(0o022)
+        self.assertEqual(stat.S_IMODE(st.st_mode), 0o664)
+        os.umask(0o026)
         (p / 'other_new_file').touch()
         st = os.stat(self.parser.join(self.base, 'other_new_file'))
-        self.assertEqual(stat.S_IMODE(st.st_mode), 0o644)
+        self.assertEqual(stat.S_IMODE(st.st_mode), 0o640)
         (p / 'masked_new_file').touch(mode=0o750)
         st = os.stat(self.parser.join(self.base, 'masked_new_file'))
         self.assertEqual(stat.S_IMODE(st.st_mode), 0o750)


### PR DESCRIPTION
Replace `umask(0)` with `umask(2)` so the created files are not world-writable, and replace `umask(0o022)` with `umask(0o026)` to check that permissions for 'others' can still be set.

<!-- gh-issue-number: gh-85633 -->
* Issue: gh-85633
<!-- /gh-issue-number -->
