### PR TITLE
gh-122885: Improve os.scandir (and os.walk) performance on Windows

### DIFF
--- a/Include/internal/pycore_fileutils_windows.h
+++ b/Include/internal/pycore_fileutils_windows.h
@@ -9,9 +9,7 @@ extern "C" {
 #endif
 
 #ifdef MS_WINDOWS
-// #include <ntdef.h>
 #include <winternl.h>
-// #include <ntstatus.h>
 
 #pragma region NTSTATUS
 /* Unfortunately, we cannot include <ntstatus.h> due to many includes of <Windows.h> (macro redefinition conflicts). */

--- a/Include/internal/pycore_fileutils_windows.h
+++ b/Include/internal/pycore_fileutils_windows.h
@@ -9,6 +9,50 @@ extern "C" {
 #endif
 
 #ifdef MS_WINDOWS
+// #include <ntdef.h>
+#include <winternl.h>
+// #include <ntstatus.h>
+
+#pragma region NTSTATUS
+/* Unfortunately, we cannot include <ntstatus.h> due to many includes of <Windows.h> (macro redefinition conflicts). */
+/* The proper solution would be to have a single WindowsHeaders.h header which uses WIN32_NO_STATUS. */
+
+/* MessageId: STATUS_SUCCESS */
+/* MessageText: */
+/* STATUS_SUCCESS */
+#define STATUS_SUCCESS                   ((NTSTATUS)0x00000000L)    // ntsubauth
+
+/* MessageId: STATUS_BUFFER_OVERFLOW */
+/* MessageText: */
+/* The data was too large to fit into the specified buffer. */
+#define STATUS_BUFFER_OVERFLOW           ((NTSTATUS)0x80000005L)
+
+/* MessageId: STATUS_NO_MORE_FILES */
+/* MessageText: */
+/* No more files were found which match the file specification. */
+#define STATUS_NO_MORE_FILES             ((NTSTATUS)0x80000006L)
+
+/* MessageId: STATUS_INVALID_INFO_CLASS */
+/* MessageText: */
+/* The specified information class is not a valid information class for the specified object. */
+#define STATUS_INVALID_INFO_CLASS        ((NTSTATUS)0xC0000003L)    // ntsubauth
+
+/* MessageId: STATUS_INFO_LENGTH_MISMATCH */
+/* MessageText: */
+/* The specified information record length does not match the length required for the specified information class. */
+#define STATUS_INFO_LENGTH_MISMATCH      ((NTSTATUS)0xC0000004L)
+
+/* MessageId: STATUS_BUFFER_TOO_SMALL */
+/* MessageText: */
+/* The buffer is too small to contain the entry. No information has been written to the buffer. */
+#define STATUS_BUFFER_TOO_SMALL          ((NTSTATUS)0xC0000023L)
+
+/* MessageId: STATUS_NOT_SUPPORTED */
+/* MessageText: */
+/* The request is not supported. */
+#define STATUS_NOT_SUPPORTED             ((NTSTATUS)0xC00000BBL)
+
+#pragma endregion
 
 #if !defined(NTDDI_WIN10_NI) || !(NTDDI_VERSION >= NTDDI_WIN10_NI)
 typedef struct _FILE_STAT_BASIC_INFORMATION {
@@ -38,11 +82,73 @@ typedef enum _FILE_INFO_BY_NAME_CLASS {
 } FILE_INFO_BY_NAME_CLASS;
 #endif
 
+#if !defined(FILE_DIRECTORY_INFORMATION)
+typedef struct _FILE_DIRECTORY_INFORMATION {
+  ULONG         NextEntryOffset;
+  ULONG         FileIndex;
+  LARGE_INTEGER CreationTime;
+  LARGE_INTEGER LastAccessTime;
+  LARGE_INTEGER LastWriteTime;
+  LARGE_INTEGER ChangeTime;
+  LARGE_INTEGER EndOfFile;
+  LARGE_INTEGER AllocationSize;
+  ULONG         FileAttributes;
+  ULONG         FileNameLength;
+  WCHAR         FileName[1];
+} FILE_DIRECTORY_INFORMATION, *PFILE_DIRECTORY_INFORMATION;
+#endif
+
+/* Initial allocation size - includes buffer memory for FileName */
+#define INITIAL_FILE_DIRECTORY_INFORMATION_ENTRY_SIE ((ULONG)(sizeof(FILE_DIRECTORY_INFORMATION) + MAX_PATH))
+/* Paranoid overflow check. */
+_STATIC_ASSERT(INITIAL_FILE_DIRECTORY_INFORMATION_ENTRY_SIE > MAX_PATH && INITIAL_FILE_DIRECTORY_INFORMATION_ENTRY_SIE > sizeof(FILE_DIRECTORY_INFORMATION));
+
 typedef BOOL (WINAPI *PGetFileInformationByName)(
     PCWSTR FileName,
     FILE_INFO_BY_NAME_CLASS FileInformationClass,
     PVOID FileInfoBuffer,
     ULONG FileInfoBufferSize
+);
+
+typedef NTSTATUS (NTAPI *PNtCreateFile)(
+    PHANDLE            FileHandle,
+    ACCESS_MASK        DesiredAccess,
+    POBJECT_ATTRIBUTES ObjectAttributes,
+    PIO_STATUS_BLOCK   IoStatusBlock,
+    PLARGE_INTEGER     AllocationSize,
+    ULONG              FileAttributes,
+    ULONG              ShareAccess,
+    ULONG              CreateDisposition,
+    ULONG              CreateOptions,
+    PVOID              EaBuffer,
+    ULONG              EaLength
+);
+
+typedef NTSTATUS (NTAPI *PNtQueryDirectoryFile)(
+    HANDLE                 FileHandle,
+    HANDLE                 Event,
+    PIO_APC_ROUTINE        ApcRoutine,
+    PVOID                  ApcContext,
+    PIO_STATUS_BLOCK       IoStatusBlock,
+    PVOID                  FileInformation,
+    ULONG                  Length,
+    FILE_INFORMATION_CLASS FileInformationClass,
+    BOOLEAN                ReturnSingleEntry,
+    PUNICODE_STRING        FileName,
+    BOOLEAN                RestartScan
+);
+
+typedef NTSTATUS (NTAPI *PNtClose)(
+    HANDLE Handle
+);
+
+typedef ULONG (NTAPI *PRtlNtStatusToDosError)(
+    NTSTATUS Status
+);
+
+typedef void (*PRtlInitUnicodeString)(
+    PUNICODE_STRING DestinationString,
+    PCWSTR          SourceString
 );
 
 static inline BOOL _Py_GetFileInformationByName(
@@ -91,6 +197,191 @@ static inline BOOL _Py_GetFileInformationByName_ErrorIsTrustworthy(int error)
             return FALSE;
     }
     return FALSE;
+}
+
+static inline NTSTATUS _Py_NtCreateFile(
+    PHANDLE            FileHandle,
+    ACCESS_MASK        DesiredAccess,
+    POBJECT_ATTRIBUTES ObjectAttributes,
+    PIO_STATUS_BLOCK   IoStatusBlock,
+    PLARGE_INTEGER     AllocationSize,
+    ULONG              FileAttributes,
+    ULONG              ShareAccess,
+    ULONG              CreateDisposition,
+    ULONG              CreateOptions,
+    PVOID              EaBuffer,
+    ULONG              EaLength
+) {
+    static PNtCreateFile NtCreateFile = NULL;
+    static int NtCreateFile_init = -1;
+
+    if (NtCreateFile_init < 0) {
+        HMODULE hMod = LoadLibraryW(L"ntdll.dll");
+        NtCreateFile_init = 0;
+        if (hMod) {
+            NtCreateFile = (PNtCreateFile)GetProcAddress(
+                hMod, "NtCreateFile");
+            if (NtCreateFile) {
+                NtCreateFile_init = 1;
+            } else {
+                FreeLibrary(hMod);
+            }
+        }
+    }
+
+    if (NtCreateFile_init <= 0) {
+        SetLastError(ERROR_NOT_SUPPORTED);
+        return STATUS_NOT_SUPPORTED;
+    }
+    return NtCreateFile(
+        FileHandle,
+        DesiredAccess,
+        ObjectAttributes,
+        IoStatusBlock,
+        AllocationSize,
+        FileAttributes,
+        ShareAccess,
+        CreateDisposition,
+        CreateOptions,
+        EaBuffer,
+        EaLength
+    );
+}
+
+static inline NTSTATUS _Py_NtQueryDirectoryFile(
+    HANDLE                 FileHandle,
+    HANDLE                 Event,
+    PIO_APC_ROUTINE        ApcRoutine,
+    PVOID                  ApcContext,
+    PIO_STATUS_BLOCK       IoStatusBlock,
+    PVOID                  FileInformation,
+    ULONG                  Length,
+    FILE_INFORMATION_CLASS FileInformationClass,
+    BOOLEAN                ReturnSingleEntry,
+    PUNICODE_STRING        FileName,
+    BOOLEAN                RestartScan
+) {
+    static PNtQueryDirectoryFile NtQueryDirectoryFile = NULL;
+    static int NtQueryDirectoryFile_init = -1;
+
+    if (NtQueryDirectoryFile_init < 0) {
+        HMODULE hMod = LoadLibraryW(L"ntdll.dll");
+        NtQueryDirectoryFile_init = 0;
+        if (hMod) {
+            NtQueryDirectoryFile = (PNtQueryDirectoryFile)GetProcAddress(
+                hMod, "NtQueryDirectoryFile");
+            if (NtQueryDirectoryFile) {
+                NtQueryDirectoryFile_init = 1;
+            } else {
+                FreeLibrary(hMod);
+            }
+        }
+    }
+
+    if (NtQueryDirectoryFile_init <= 0) {
+        SetLastError(ERROR_NOT_SUPPORTED);
+        return STATUS_NOT_SUPPORTED;
+    }
+    return NtQueryDirectoryFile(
+        FileHandle,
+        Event,
+        ApcRoutine,
+        ApcContext,
+        IoStatusBlock,
+        FileInformation,
+        Length,
+        FileInformationClass,
+        ReturnSingleEntry,
+        FileName,
+        RestartScan
+    );
+}
+
+static inline NTSTATUS _Py_NtClose(
+    HANDLE Handle
+) {
+    static PNtClose NtClose = NULL;
+    static int NtClose_init = -1;
+
+    if (NtClose_init < 0) {
+        HMODULE hMod = LoadLibraryW(L"ntdll.dll");
+        NtClose_init = 0;
+        if (hMod) {
+            NtClose = (PNtClose)GetProcAddress(
+                hMod, "NtClose");
+            if (NtClose) {
+                NtClose_init = 1;
+            } else {
+                FreeLibrary(hMod);
+            }
+        }
+    }
+
+    if (NtClose_init <= 0) {
+        SetLastError(ERROR_NOT_SUPPORTED);
+        return STATUS_NOT_SUPPORTED;
+    }
+    return NtClose(Handle);
+}
+
+static inline ULONG _Py_RtlNtStatusToDosError(
+    NTSTATUS Status
+) {
+    static PRtlNtStatusToDosError RtlNtStatusToDosError = NULL;
+    static int RtlNtStatusToDosError_init = -1;
+
+    if (RtlNtStatusToDosError_init < 0) {
+        HMODULE hMod = LoadLibraryW(L"ntdll.dll");
+        RtlNtStatusToDosError_init = 0;
+        if (hMod) {
+            RtlNtStatusToDosError = (PRtlNtStatusToDosError)GetProcAddress(
+                hMod, "RtlNtStatusToDosError");
+            if (RtlNtStatusToDosError) {
+                RtlNtStatusToDosError_init = 1;
+            } else {
+                FreeLibrary(hMod);
+            }
+        }
+    }
+
+    if (RtlNtStatusToDosError_init <= 0) {
+        return ERROR_NOT_SUPPORTED;
+    }
+    return RtlNtStatusToDosError(Status);
+}
+
+
+static inline NTSTATUS _Py_RtlInitUnicodeString(
+    PUNICODE_STRING DestinationString,
+    PCWSTR          SourceString
+) {
+    static PRtlInitUnicodeString RtlInitUnicodeString = NULL;
+    static int RtlInitUnicodeString_init = -1;
+
+    if (RtlInitUnicodeString_init < 0) {
+        HMODULE hMod = LoadLibraryW(L"ntdll.dll");
+        RtlInitUnicodeString_init = 0;
+        if (hMod) {
+            RtlInitUnicodeString = (PRtlInitUnicodeString)GetProcAddress(
+                hMod, "RtlInitUnicodeString");
+            if (RtlInitUnicodeString) {
+                RtlInitUnicodeString_init = 1;
+            } else {
+                FreeLibrary(hMod);
+            }
+        }
+    }
+
+    if (RtlInitUnicodeString_init <= 0) {
+        SetLastError(ERROR_NOT_SUPPORTED);
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    RtlInitUnicodeString(
+        DestinationString,
+        SourceString
+    );
+    return STATUS_SUCCESS;
 }
 
 #endif

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -16307,7 +16307,7 @@ ScandirIterator_iternext(ScandirIterator *iterator)
         /* Check for specific ntstatus-es which do not merit an actual error. */
         if (STATUS_NO_MORE_FILES == ntstatus)
         {
-            /* We have successfully finished the iteration. */   
+            /* We have successfully finished the iteration. */
             break;
         }
 
@@ -16336,7 +16336,7 @@ ScandirIterator_iternext(ScandirIterator *iterator)
         _STATIC_ASSERT(!NT_SUCCESS(STATUS_INVALID_PARAMETER));
         _STATIC_ASSERT(!NT_SUCCESS(STATUS_INFO_LENGTH_MISMATCH));
         if (!NT_SUCCESS(ntstatus))
-        { 
+        {
             /* TODO: Debug assert (STATUS_BUFFER_TOO_SMALL != ntstatus). */
             /* This error happens if-and-only-if the buffer is LT the minimal information structure size. */
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -16083,7 +16083,7 @@ DirEntry_from_file_directory_information(PyObject *module, path_t *path, FILE_DI
         result->st_ino = fileDirectoryInformation->FileIndex;
     }
 
-#if 0 /* Fix this */
+#if 0 /* TODO: Fix this */
     /* bpo-37834: Only actual symlinks set the S_IFLNK flag. But lstat() will
     open other name surrogate reparse points without traversing them. To
     detect/handle these, check st_file_attributes and st_reparse_tag. */
@@ -16654,31 +16654,6 @@ os_scandir_impl(PyObject *module, path_t *path)
         goto error;
     }
     iterator->fileDirectoryInformationSize = INITIAL_FILE_DIRECTORY_INFORMATION_ENTRY_SIE;
-
-#if 0 /* Does not seem to be neccessary according to MS-Docs */
-    Py_BEGIN_ALLOW_THREADS
-    ntstatus = _Py_NtQueryDirectoryFile(
-        iterator->directoryHandle, /* FileHandle */
-        NULL, /* Event */
-        NULL, /* ApcRoutine (callback) */
-        NULL, /* ApcContext (for callback routine) */
-        &ioStatusBlock, /* IoStatusBlock */
-        NULL, /* FileInformation (output) */
-        0, /* Length (maximum length of output buffer) */
-        FileDirectoryInformation, /* FileInformationClass */
-        TRUE, /* ReturnSingleEntry */
-        NULL, /* FileName */
-        TRUE /* RestartScan */
-    );
-    Py_END_ALLOW_THREADS
-    if (!NT_SUCCESS(ntstatus))
-    {
-        path_error(&iterator->path);
-        dosErrorCode = _Py_RtlNtStatusToDosError(ntstatus);
-        SetLastError(dosErrorCode);
-        goto error;
-    }
-#endif
 
 #else /* POSIX */
     errno = 0;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -726,6 +726,9 @@ void _Py_attribute_data_to_stat(BY_HANDLE_FILE_INFORMATION *, ULONG,
                                 struct _Py_stat_struct *);
 void _Py_stat_basic_info_to_stat(FILE_STAT_BASIC_INFORMATION *,
                                  struct _Py_stat_struct *);
+void LARGE_INTEGER_to_time_t_nsec(LARGE_INTEGER *in_ptr, time_t *time_out, int* nsec_out);
+int attributes_to_mode(DWORD attr);
+
 #endif
 
 
@@ -15897,36 +15900,51 @@ static PyType_Spec DirEntryType_spec = {
 #ifdef MS_WINDOWS
 
 static wchar_t *
-join_path_filenameW(const wchar_t *path_wide, const wchar_t *filename)
+join_path_filenameW_n(const wchar_t *path_wide, const wchar_t *filename, size_t filename_length)
 {
     Py_ssize_t path_len;
     Py_ssize_t size;
     wchar_t *result;
     wchar_t ch;
 
-    if (!path_wide) { /* Default arg: "." */
+    if (!path_wide)
+    {
+        /* Default arg: "." */
         path_wide = L".";
         path_len = 1;
     }
-    else {
+    else
+    {
         path_len = wcslen(path_wide);
     }
 
     /* The +1's are for the path separator and the NUL */
-    size = path_len + 1 + wcslen(filename) + 1;
+    size = path_len + 1 + filename_length + 1;
     result = PyMem_New(wchar_t, size);
-    if (!result) {
+    if (!result)
+    {
         PyErr_NoMemory();
         return NULL;
     }
+
     wcscpy(result, path_wide);
-    if (path_len > 0) {
+    if (path_len > 0)
+    {
         ch = result[path_len - 1];
         if (ch != SEP && ch != ALTSEP && ch != L':')
+        {
             result[path_len++] = SEP;
-        wcscpy(result + path_len, filename);
+        }
+        wcsncpy(result + path_len, filename, filename_length);
+
     }
     return result;
+}
+
+static wchar_t *
+join_path_filenameW(const wchar_t *path_wide, const wchar_t *filename)
+{
+    return join_path_filenameW_n(path_wide, filename, wcslen(filename));
 }
 
 static PyObject *
@@ -15973,6 +15991,109 @@ DirEntry_from_find_data(PyObject *module, path_t *path, WIN32_FIND_DATAW *dataW)
 
     find_data_to_file_info(dataW, &file_info, &reparse_tag);
     _Py_attribute_data_to_stat(&file_info, reparse_tag, NULL, NULL, &entry->win32_lstat);
+
+    /* ctime is only deprecated from 3.12, so we copy birthtime across */
+    entry->win32_lstat.st_ctime = entry->win32_lstat.st_birthtime;
+    entry->win32_lstat.st_ctime_nsec = entry->win32_lstat.st_birthtime_nsec;
+
+    return (PyObject *)entry;
+
+error:
+    Py_DECREF(entry);
+    return NULL;
+}
+
+
+static PyObject *
+DirEntry_from_file_directory_information(PyObject *module, path_t *path, FILE_DIRECTORY_INFORMATION *fileDirectoryInformation)
+{
+    DirEntry *entry;
+    wchar_t *joined_path;
+    struct _Py_stat_struct *result;
+
+    PyObject *DirEntryType = get_posix_state(module)->DirEntryType;
+    entry = PyObject_New(DirEntry, (PyTypeObject *)DirEntryType);
+    if (!entry)
+    {
+        return NULL;
+    }
+    entry->name = NULL;
+    entry->path = NULL;
+    entry->stat = NULL;
+    entry->lstat = NULL;
+    entry->got_file_index = 0;
+
+    entry->name = PyUnicode_FromWideChar(fileDirectoryInformation->FileName, fileDirectoryInformation->FileNameLength);
+    if (!entry->name)
+    {
+        goto error;
+    }
+
+    int return_bytes = path->wide && PyBytes_Check(path->object);
+    if (return_bytes)
+    {
+        Py_SETREF(entry->name, PyUnicode_EncodeFSDefault(entry->name));
+        if (!entry->name)
+        {
+            goto error;
+        }
+    }
+
+    joined_path = join_path_filenameW_n(path->wide, fileDirectoryInformation->FileName, fileDirectoryInformation->FileNameLength);
+    if (!joined_path)
+    {
+        goto error;
+    }
+
+    entry->path = PyUnicode_FromWideChar(joined_path, -1);
+    PyMem_Free(joined_path);
+    if (!entry->path)
+    {
+        goto error;
+    }
+    if (return_bytes)
+    {
+        Py_SETREF(entry->path, PyUnicode_EncodeFSDefault(entry->path));
+        if (!entry->path)
+        {
+            goto error;
+        }
+    }
+
+
+    result = &entry->win32_lstat;
+    memset(result, 0, sizeof(*result));
+    result->st_mode = attributes_to_mode(fileDirectoryInformation->FileAttributes);
+
+    result->st_size = (((long long)(fileDirectoryInformation->EndOfFile.HighPart)) << 32) + fileDirectoryInformation->EndOfFile.LowPart;
+    result->st_dev = 0; /* Not returned from NtQueryDirectoryFile */
+    result->st_rdev = 0;
+
+    LARGE_INTEGER_to_time_t_nsec(&fileDirectoryInformation->CreationTime, &result->st_birthtime, &result->st_birthtime_nsec);
+    LARGE_INTEGER_to_time_t_nsec(&fileDirectoryInformation->ChangeTime, &result->st_ctime, &result->st_ctime_nsec);
+    LARGE_INTEGER_to_time_t_nsec(&fileDirectoryInformation->LastWriteTime, &result->st_mtime, &result->st_mtime_nsec);
+    LARGE_INTEGER_to_time_t_nsec(&fileDirectoryInformation->LastAccessTime, &result->st_atime, &result->st_atime_nsec);
+
+    result->st_nlink = 0; /* Not returned from NtQueryDirectoryFile */
+
+    if (!result->st_ino && !result->st_ino_high) {
+        /* This really should always be zero (According to MS-Docs it should actually be completely ignored) */
+        result->st_ino = fileDirectoryInformation->FileIndex;
+    }
+
+#if 0 /* Fix this */
+    /* bpo-37834: Only actual symlinks set the S_IFLNK flag. But lstat() will
+    open other name surrogate reparse points without traversing them. To
+    detect/handle these, check st_file_attributes and st_reparse_tag. */
+    result->st_reparse_tag = reparse_tag;
+    if (info->dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT &&
+        reparse_tag == IO_REPARSE_TAG_SYMLINK) {
+        /* set the bits that make this a symlink */
+        result->st_mode = (result->st_mode & ~S_IFMT) | S_IFLNK;
+    }
+#endif
+    result->st_file_attributes = fileDirectoryInformation->FileAttributes;
+
 
     /* ctime is only deprecated from 3.12, so we copy birthtime across */
     entry->win32_lstat.st_ctime = entry->win32_lstat.st_birthtime;
@@ -16089,9 +16210,10 @@ typedef struct {
     PyObject_HEAD
     path_t path;
 #ifdef MS_WINDOWS
-    HANDLE handle;
-    WIN32_FIND_DATAW file_data;
-    int first_time;
+    HANDLE directoryHandle;
+    UNICODE_STRING fullyQualifiedDirectoryName;
+    FILE_DIRECTORY_INFORMATION *fileDirectoryInformation; /* Re-use the dynamically allocated buffer to reduce redundant mallocs */
+    ULONG fileDirectoryInformationSize; /* The currently allocated size of fileDirectoryInformation. Windows does not support this buffer being larger than ULONG_MAX. */
 #else /* POSIX */
     DIR *dirp;
 #endif
@@ -16105,61 +16227,150 @@ typedef struct {
 static int
 ScandirIterator_is_closed(ScandirIterator *iterator)
 {
-    return iterator->handle == INVALID_HANDLE_VALUE;
+    return NULL == iterator->directoryHandle;
 }
 
 static void
 ScandirIterator_closedir(ScandirIterator *iterator)
 {
-    HANDLE handle = iterator->handle;
+    HANDLE directoryHandle = iterator->directoryHandle;
 
-    if (handle == INVALID_HANDLE_VALUE)
+    if (NULL == _Py_atomic_exchange_ptr(&directoryHandle, NULL))
+    {
         return;
+    }
 
-    iterator->handle = INVALID_HANDLE_VALUE;
     Py_BEGIN_ALLOW_THREADS
-    FindClose(handle);
+    _Py_NtClose(directoryHandle);
     Py_END_ALLOW_THREADS
+
+    if (iterator->fullyQualifiedDirectoryName.Buffer)
+    {
+        /* The buffer will never again be used, it must be freed */
+        PyMem_Free(iterator->fullyQualifiedDirectoryName.Buffer);
+        iterator->fullyQualifiedDirectoryName.Buffer = NULL;
+    }
+    /* De-init the UNICODE_STRING struct (notice that this is not the Buffer we just freed) */
+    memset(&iterator->fullyQualifiedDirectoryName, 0, sizeof(iterator->fullyQualifiedDirectoryName));
+
+    if (iterator->fileDirectoryInformation)
+    {
+        PyMem_Free(iterator->fileDirectoryInformation);
+        iterator->fileDirectoryInformation = NULL;
+        iterator->fileDirectoryInformationSize = 0;
+    }
 }
 
 static PyObject *
 ScandirIterator_iternext(ScandirIterator *iterator)
 {
-    WIN32_FIND_DATAW *file_data = &iterator->file_data;
-    BOOL success;
+    NTSTATUS ntstatus;
+    FILE_DIRECTORY_INFORMATION directoryEntry;
+    IO_STATUS_BLOCK ioStatusBlock;
     PyObject *entry;
+    ULONG dosErrorCode;
 
     /* Happens if the iterator is iterated twice, or closed explicitly */
-    if (iterator->handle == INVALID_HANDLE_VALUE)
+    if (NULL == iterator->directoryHandle)
+    {
         return NULL;
+    }
 
-    while (1) {
-        if (!iterator->first_time) {
-            Py_BEGIN_ALLOW_THREADS
-            success = FindNextFileW(iterator->handle, file_data);
-            Py_END_ALLOW_THREADS
-            if (!success) {
-                /* Error or no more files */
-                if (GetLastError() != ERROR_NO_MORE_FILES)
-                    path_error(&iterator->path);
+    ntstatus = STATUS_NO_MORE_FILES;
+    memset(&directoryEntry, 0, sizeof(directoryEntry));
+    memset(&ioStatusBlock, 0, sizeof(ioStatusBlock));
+
+    do
+    {
+        Py_BEGIN_ALLOW_THREADS
+        ntstatus = _Py_NtQueryDirectoryFile(
+            iterator->directoryHandle, /* FileHandle */
+            NULL, /* Event */
+            NULL, /* ApcRoutine (callback) */
+            NULL, /* ApcContext (for callback routine) */
+            &ioStatusBlock, /* IoStatusBlock */
+            iterator->fileDirectoryInformation, /* FileInformation (output) */
+            iterator->fileDirectoryInformationSize, /* Length (maximum length of output buffer) */
+            FileDirectoryInformation, /* FileInformationClass */
+            TRUE, /* ReturnSingleEntry */
+            NULL, /* FileName */
+            FALSE /* RestartScan */
+        );
+        Py_END_ALLOW_THREADS
+        
+        /* TODO: Debug assert ioStatusBlock.Information LEQ iterator->fileDirectoryInformationSize */
+        /* TODO: Should ioStatusBlock.Status be equal to ntstatus since this is a synchronous call? */
+
+        /* Check for specific ntstatus-es which do not merit an actual error. */
+        if (STATUS_BUFFER_OVERFLOW == ntstatus || 0 == ioStatusBlock.Information)
+        {
+            /* Contrary to the name, this means that fileDirectoryInformationSize was not sufficient to hold the entry(ies) we requested. */
+            /* Re-allocate fileDirectoryInformation to be larger and try again. */
+            /* On each attempt, try to double the size of the buffer. This should really only ever happen once or twice. */
+            iterator->fileDirectoryInformationSize = iterator->fileDirectoryInformationSize << 1;
+            iterator->fileDirectoryInformation = PyMem_Realloc(iterator->fileDirectoryInformation, iterator->fileDirectoryInformationSize);
+            if (NULL == iterator->fileDirectoryInformation)
+            {
+                /* Mark the size down to avoid accidentally writing to this NULL buffer */
+                iterator->fileDirectoryInformationSize = 0;
+                PyErr_NoMemory();
                 break;
             }
+            /* Try the query again with this resized buffer. */
+            continue;
         }
-        iterator->first_time = 0;
+        else if (STATUS_NO_MORE_FILES == ntstatus)
+        {
+            /* We have successfully finished the iteration. */   
+            break;
+        }
+
+        _STATIC_ASSERT(!NT_SUCCESS(STATUS_NO_MORE_FILES));
+        _STATIC_ASSERT(!NT_SUCCESS(STATUS_BUFFER_OVERFLOW));
+        _STATIC_ASSERT(!NT_SUCCESS(STATUS_BUFFER_TOO_SMALL));
+        _STATIC_ASSERT(!NT_SUCCESS(STATUS_INVALID_INFO_CLASS));
+        _STATIC_ASSERT(!NT_SUCCESS(STATUS_INVALID_PARAMETER));
+        _STATIC_ASSERT(!NT_SUCCESS(STATUS_INFO_LENGTH_MISMATCH));
+        if (!NT_SUCCESS(ntstatus))
+        { 
+            /* TODO: Debug assert (STATUS_BUFFER_TOO_SMALL != ntstatus). */
+            /* This error happens if-and-only-if the buffer is LT the minimal information structure size. */
+
+            /* TODO: Debug assert (STATUS_INFO_LENGTH_MISMATCH != ntstatus). */
+            /* Not sure in what case this is plausible (subject to this flow). */
+
+            /* TODO: Debug assert (STATUS_INVALID_INFO_CLASS != ntstatus). */
+            /* This should be deterministic considering we are using a valid Windows NTOS version. (Windows XP (5.1.2600) according to MS-Docs). */
+
+            /* Unexpected error. */
+            /* TODO: STATUS_INVALID_PARAMETER is a FileSystem incompatibility issue, this might be worth treating differently. */
+            path_error(&iterator->path);
+            dosErrorCode = _Py_RtlNtStatusToDosError(ntstatus);
+            SetLastError(dosErrorCode);
+            break;;
+        }
 
         /* Skip over . and .. */
-        if (wcscmp(file_data->cFileName, L".") != 0 &&
-            wcscmp(file_data->cFileName, L"..") != 0)
-        {
+        /* According to MS-Docs, you may NOT assume that the FileName buffer is null terminated. */
+        /* TODO: Debug assert iterator->fileDirectoryInformation is not NULL. */
+        /* TODO: Debug assert iterator->fileDirectoryInformation->FileName is not NULL. */
+        /* TODO: Debug assert iterator->fileDirectoryInformation->FileNameLength is not 0. */
+        if (
+            /* TODO: Are these checks still relevant? */
+            0 != wcsncmp(iterator->fileDirectoryInformation->FileName, L".", iterator->fileDirectoryInformation->FileNameLength) &&
+            0 != wcsncmp(iterator->fileDirectoryInformation->FileName, L"..", iterator->fileDirectoryInformation->FileNameLength)
+        ) {
             PyObject *module = PyType_GetModule(Py_TYPE(iterator));
-            entry = DirEntry_from_find_data(module, &iterator->path, file_data);
+            entry = DirEntry_from_file_directory_information(module, &iterator->path, iterator->fileDirectoryInformation);
             if (!entry)
+            {
                 break;
+            }
             return entry;
         }
 
         /* Loop till we get a non-dot directory or finish iterating */
-    }
+    } while (TRUE);
 
     /* Error or no more files */
     ScandirIterator_closedir(iterator);
@@ -16350,7 +16561,13 @@ os_scandir_impl(PyObject *module, path_t *path)
 {
     ScandirIterator *iterator;
 #ifdef MS_WINDOWS
-    wchar_t *path_strW;
+    HANDLE directoryHandle;
+    OBJECT_ATTRIBUTES directoryObjectAttributes;
+    NTSTATUS ntstatus;
+    wchar_t *fullyQuallifiedDirectoryNameWstr;
+    DWORD fullyQuallifiedDirectoryNameLength;
+    IO_STATUS_BLOCK ioStatusBlock;
+    ULONG dosErrorCode;
 #else
     const char *path_str;
 #ifdef HAVE_FDOPENDIR
@@ -16369,7 +16586,14 @@ os_scandir_impl(PyObject *module, path_t *path)
         return NULL;
 
 #ifdef MS_WINDOWS
-    iterator->handle = INVALID_HANDLE_VALUE;
+    iterator->directoryHandle = NULL;
+    iterator->fileDirectoryInformation = NULL;
+    iterator->fileDirectoryInformationSize = 0;
+    fullyQuallifiedDirectoryNameWstr = NULL;
+    fullyQuallifiedDirectoryNameLength = 0;
+    ntstatus = STATUS_SUCCESS;
+    memset(&iterator->fullyQualifiedDirectoryName, 0, sizeof(iterator->fullyQualifiedDirectoryName));
+    memset(&ioStatusBlock, 0, sizeof(ioStatusBlock));
 #else
     iterator->dirp = NULL;
 #endif
@@ -16379,22 +16603,98 @@ os_scandir_impl(PyObject *module, path_t *path)
     memset(path, 0, sizeof(path_t));
 
 #ifdef MS_WINDOWS
-    iterator->first_time = 1;
-
-    path_strW = join_path_filenameW(iterator->path.wide, L"*.*");
-    if (!path_strW)
-        goto error;
-
-    Py_BEGIN_ALLOW_THREADS
-    iterator->handle = FindFirstFileW(path_strW, &iterator->file_data);
-    Py_END_ALLOW_THREADS
-
-    if (iterator->handle == INVALID_HANDLE_VALUE) {
+    /* Get the required length of the fully qualified path */
+    fullyQuallifiedDirectoryNameLength = GetFullPathNameW(iterator->path.wide, 0, NULL, NULL);
+    if (0 == fullyQuallifiedDirectoryNameLength)
+    {
         path_error(&iterator->path);
-        PyMem_Free(path_strW);
         goto error;
     }
-    PyMem_Free(path_strW);
+
+    fullyQuallifiedDirectoryNameWstr = PyMem_New(wchar_t, fullyQuallifiedDirectoryNameLength);
+    if (!fullyQuallifiedDirectoryNameWstr) {
+        PyErr_NoMemory();
+        goto error;
+    }
+    (void)GetFullPathNameW(iterator->path.wide, fullyQuallifiedDirectoryNameLength, fullyQuallifiedDirectoryNameWstr, NULL);
+
+    ntstatus = _Py_RtlInitUnicodeString(&iterator->fullyQualifiedDirectoryName, fullyQuallifiedDirectoryNameWstr);
+    if (!NT_SUCCESS(ntstatus))
+    {
+        dosErrorCode = _Py_RtlNtStatusToDosError(ntstatus);
+        SetLastError(dosErrorCode);
+        goto error;
+    }
+    fullyQuallifiedDirectoryNameWstr = NULL; /* Ownership is now held by the iterator itself */
+
+    InitializeObjectAttributes(
+        &directoryObjectAttributes, /* Out parameter */
+        &iterator->fullyQualifiedDirectoryName, /* Object name */
+        0, /* Attributes, use default */
+        NULL, /* Root directory, irrelevant for fully qualified object names */
+        NULL /* SecurityDescriptor, use default object's security */
+    );
+
+    Py_BEGIN_ALLOW_THREADS
+    ntstatus = _Py_NtCreateFile(
+        &directoryHandle, /* FileHandle, output handle */
+        FILE_LIST_DIRECTORY | FILE_TRAVERSE | SYNCHRONIZE | FILE_READ_ATTRIBUTES | FILE_READ_EA | READ_CONTROL, /* DesiredAccess, read access and directory listing */
+        &directoryObjectAttributes, /* ObjectAttributes */
+        &ioStatusBlock, /* IoStatusBlock */
+        NULL, /* AllocationSize, irrelevant when openning a directory */
+        FILE_ATTRIBUTE_NORMAL, /* FileAttributes, irrelevant when openning a directory */
+        FILE_SHARE_READ, /* ShareAccess */
+        FILE_OPEN, /* CreateDisposition, only open the directory, never create it */
+        FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_ALERT, /* CreateOptions */
+        NULL, /* EaBuffer */
+        0 /* EaLength */
+    );
+    Py_END_ALLOW_THREADS
+
+    if (!NT_SUCCESS(ntstatus))
+    {
+        path_error(&iterator->path);
+        dosErrorCode = _Py_RtlNtStatusToDosError(ntstatus);
+        SetLastError(dosErrorCode);
+        goto error;
+    }
+
+    iterator->directoryHandle = directoryHandle;
+    /* Premptively allocate a buffer suitable for a file's information, taking into account the variable length of a file name. */
+    /* Although a file name _may_ be longer than MAX_PATH, in most flows this malloc will suffice. Otherwise, we will lazily re-allocate. */
+    iterator->fileDirectoryInformation = (FILE_DIRECTORY_INFORMATION*)PyMem_Malloc(INITIAL_FILE_DIRECTORY_INFORMATION_ENTRY_SIE);
+    if (!iterator->fileDirectoryInformation)
+    {
+        PyErr_NoMemory();
+        goto error;
+    }
+    iterator->fileDirectoryInformationSize = INITIAL_FILE_DIRECTORY_INFORMATION_ENTRY_SIE;
+
+#if 0 /* Does not seem to be neccessary according to MS-Docs */
+    Py_BEGIN_ALLOW_THREADS
+    ntstatus = _Py_NtQueryDirectoryFile(
+        iterator->directoryHandle, /* FileHandle */
+        NULL, /* Event */
+        NULL, /* ApcRoutine (callback) */
+        NULL, /* ApcContext (for callback routine) */
+        &ioStatusBlock, /* IoStatusBlock */
+        NULL, /* FileInformation (output) */
+        0, /* Length (maximum length of output buffer) */
+        FileDirectoryInformation, /* FileInformationClass */
+        TRUE, /* ReturnSingleEntry */
+        NULL, /* FileName */
+        TRUE /* RestartScan */
+    );
+    Py_END_ALLOW_THREADS
+    if (!NT_SUCCESS(ntstatus))
+    {
+        path_error(&iterator->path);
+        dosErrorCode = _Py_RtlNtStatusToDosError(ntstatus);
+        SetLastError(dosErrorCode);
+        goto error;
+    }
+#endif
+
 #else /* POSIX */
     errno = 0;
 #ifdef HAVE_FDOPENDIR

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1061,7 +1061,7 @@ FILE_TIME_to_time_t_nsec(FILETIME *in_ptr, time_t *time_out, int* nsec_out)
     *time_out = Py_SAFE_DOWNCAST((in / 10000000) - secs_between_epochs, __int64, time_t);
 }
 
-static void
+void
 LARGE_INTEGER_to_time_t_nsec(LARGE_INTEGER *in_ptr, time_t *time_out, int* nsec_out)
 {
     *nsec_out = (int)(in_ptr->QuadPart % 10000000) * 100; /* FILETIME is in units of 100 nsec. */
@@ -1082,7 +1082,7 @@ _Py_time_t_to_FILE_TIME(time_t time_in, int nsec_in, FILETIME *out_ptr)
 #if _S_IREAD != 0400
 #error Unsupported C library
 #endif
-static int
+int
 attributes_to_mode(DWORD attr)
 {
     int m = 0;


### PR DESCRIPTION
# Improve os.scandir (and os.walk) performance on Windows
## Use native NT syscalls to implement os.scandir rather than WinAPI and POSIX functions.

<!-- gh-issue-number: gh-122885 -->
* Issue: gh-122885
<!-- /gh-issue-number -->
