### PR TITLE
gh-122868: Add more lower bounds for sphinxcontrib dependencies

### DIFF
--- a/Doc/constraints.txt
+++ b/Doc/constraints.txt
@@ -7,20 +7,20 @@
 # Direct dependencies of Sphinx
 babel<3
 colorama<0.5
-imagesize<1.5
-Jinja2<3.2
+imagesize<2
+Jinja2<4
 packaging<25
 Pygments<3
 requests<3
 snowballstemmer<3
 # keep lower-bounds until Sphinx 8.1 is released
 # https://github.com/sphinx-doc/sphinx/pull/12756
-sphinxcontrib-applehelp>=1.0.7,<2.1
-sphinxcontrib-devhelp>=1.0.6,<2.1
-sphinxcontrib-htmlhelp>=2.0.6,<2.2
-sphinxcontrib-jsmath>=1.0.1,<1.1
-sphinxcontrib-qthelp>=1.0.6,<2.1
-sphinxcontrib-serializinghtml>=1.1.9,<2.1
+sphinxcontrib-applehelp>=1.0.7,<3
+sphinxcontrib-devhelp>=1.0.6,<3
+sphinxcontrib-htmlhelp>=2.0.6,<3
+sphinxcontrib-jsmath>=1.0.1,<2
+sphinxcontrib-qthelp>=1.0.6,<3
+sphinxcontrib-serializinghtml>=1.1.9,<3
 
 # Direct dependencies of Jinja2 (Jinja is a dependency of Sphinx, see above)
-MarkupSafe<2.2
+MarkupSafe<3

--- a/Doc/constraints.txt
+++ b/Doc/constraints.txt
@@ -13,12 +13,14 @@ packaging<25
 Pygments<3
 requests<3
 snowballstemmer<3
-sphinxcontrib-applehelp>=1.0.6,<2.1
+# keep lower-bounds until Sphinx 8.1 is released
+# https://github.com/sphinx-doc/sphinx/pull/12756
+sphinxcontrib-applehelp>=1.0.7,<2.1
 sphinxcontrib-devhelp>=1.0.6,<2.1
-sphinxcontrib-htmlhelp<2.2
-sphinxcontrib-jsmath<1.1
+sphinxcontrib-htmlhelp>=2.0.6,<2.2
+sphinxcontrib-jsmath>=1.0.1,<1.1
 sphinxcontrib-qthelp>=1.0.6,<2.1
-sphinxcontrib-serializinghtml<2.1
+sphinxcontrib-serializinghtml>=1.1.9,<2.1
 
 # Direct dependencies of Jinja2 (Jinja is a dependency of Sphinx, see above)
 MarkupSafe<2.2


### PR DESCRIPTION
Replicates the lower bounds at https://github.com/sphinx-doc/sphinx/pull/12756

Second time lucky?

A

<!-- gh-issue-number: gh-122868 -->
* Issue: gh-122868
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122891.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->