### PR TITLE
Uniformize text from versionchangeds in weakref.rst

### DIFF
--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -197,7 +197,7 @@ See :ref:`__slots__ documentation <slots>` for details.
       >>> del k1      # d = {k2: 2}
 
    .. versionchanged:: 3.9
-      Added support for ``|`` and ``|=`` operators, specified in :pep:`584`.
+      Added support for ``|`` and ``|=`` operators, as specified in :pep:`584`.
 
 :class:`WeakKeyDictionary` objects have an additional method that
 exposes the internal references directly.  The references are not guaranteed to


### PR DESCRIPTION
This minor edit will make

https://github.com/python/cpython/blob/363374cf69a7e2292fe3f1c6bedd199088958cc2/Doc/library/weakref.rst?plain=1#L199-L200

be exactly the same as the reference below

https://github.com/python/cpython/blob/363374cf69a7e2292fe3f1c6bedd199088958cc2/Doc/library/weakref.rst?plain=1#L220-L221

reducing one translation string for translations and avoiding possible inconsistency in the resulting translated doc.



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122898.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->