### PR TITLE
gh-122909: Pass ftp error strings to URLError constructor

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import os
 import io
+import ftplib
 import socket
 import array
 import sys
@@ -754,7 +755,6 @@ class HandlerTests(unittest.TestCase):
                 self.ftpwrapper = MockFTPWrapper(self.data)
                 return self.ftpwrapper
 
-        import ftplib
         data = "rheum rhaponicum"
         h = NullFTPHandler(data)
         h.parent = MockOpener()
@@ -793,6 +793,25 @@ class HandlerTests(unittest.TestCase):
             headers = r.info()
             self.assertEqual(headers.get("Content-type"), mimetype)
             self.assertEqual(int(headers["Content-length"]), len(data))
+
+    def test_ftp_error(self):
+        class ErrorFTPHandler(urllib.request.FTPHandler):
+            def __init__(self, exception):
+                self._exception = exception
+
+            def connect_ftp(self, user, passwd, host, port, dirs,
+                            timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
+                raise self._exception
+
+        exception = ftplib.error_perm("500 OOPS: cannot change directory:/nonexistent")
+        h = ErrorFTPHandler(exception)
+        urlopen = urllib.request.build_opener(h).open
+        try:
+            urlopen("ftp://www.pythontest.net/")
+        except urllib.error.URLError as raised:
+            self.assertEqual(raised.reason, exception.args[0])
+        else:
+            self.fail("Did not raise ftplib exception")
 
     def test_file(self):
         import email.utils

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -803,13 +803,15 @@ class HandlerTests(unittest.TestCase):
                             timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
                 raise self._exception
 
-        exception = ftplib.error_perm("500 OOPS: cannot change directory:/nonexistent")
+        exception = ftplib.error_perm(
+            "500 OOPS: cannot change directory:/nonexistent")
         h = ErrorFTPHandler(exception)
         urlopen = urllib.request.build_opener(h).open
         try:
             urlopen("ftp://www.pythontest.net/")
         except urllib.error.URLError as raised:
-            self.assertEqual(raised.reason, exception.args[0])
+            self.assertEqual(raised.reason,
+                             f"ftp error: {exception.args[0]}")
         else:
             self.fail("Did not raise ftplib exception")
 

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1555,7 +1555,7 @@ class FTPHandler(BaseHandler):
             headers = email.message_from_string(headers)
             return addinfourl(fp, headers, req.full_url)
         except ftplib.all_errors as exp:
-            raise URLError(exp) from exp
+            raise URLError(exp.args[0]) from exp
 
     def connect_ftp(self, user, passwd, host, port, dirs, timeout):
         return ftpwrapper(user, passwd, host, port, dirs, timeout,

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1555,7 +1555,7 @@ class FTPHandler(BaseHandler):
             headers = email.message_from_string(headers)
             return addinfourl(fp, headers, req.full_url)
         except ftplib.all_errors as exp:
-            raise URLError(exp.args[0]) from exp
+            raise URLError(f"ftp error: {exp}") from exp
 
     def connect_ftp(self, user, passwd, host, port, dirs, timeout):
         return ftpwrapper(user, passwd, host, port, dirs, timeout,

--- a/Misc/NEWS.d/next/Library/2024-08-19-17-37-18.gh-issue-122909.kP12SK.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-19-17-37-18.gh-issue-122909.kP12SK.rst
@@ -1,0 +1,3 @@
+In urllib.request when URLError is raised opening an ftp URL, the exception
+argument is now consistently a string. Earlier versions passed either a
+string or an ftplib exception instance as the argument to URLError.


### PR DESCRIPTION
ftplib exceptions are very simple. They inherit from Exception and define no additional behavior. The modules raises exceptions that just take a single string argument.

The URLError exception constructor takes a string that description the error.

Fix the handler for ftp errors to pass the original error string to URLError() instead of the ftplib.Error() instance.


<!-- gh-issue-number: gh-122909 -->
* Issue: gh-122909
<!-- /gh-issue-number -->
