### PR TITLE
gh-122931: Include multiarch tuple in abi3t filenames

### DIFF
--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -75,6 +75,14 @@ New features
 Other language changes
 ======================
 
+* Stable ABI extensions may now include a multiarch tuple in the
+  filename, e.g. ``foo.abi3-x86-64-linux-gnu.so``.
+  This permits stable ABI extensions for multiple architectures to be
+  co-installed into the same directory, without clashing with each
+  other, as regular dynamic extensions do. Build tools will not generate
+  these multiarch tagged filenames, by default, while still supporting
+  older Python versions that don't recognize these filenames.
+  (Contributed by Stefano Rivera in :gh:`122931`.)
 
 
 New modules

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -79,9 +79,9 @@ Other language changes
   filename, e.g. ``foo.abi3-x86-64-linux-gnu.so``.
   This permits stable ABI extensions for multiple architectures to be
   co-installed into the same directory, without clashing with each
-  other, as regular dynamic extensions do. Build tools will not generate
-  these multiarch tagged filenames, by default, while still supporting
-  older Python versions that don't recognize these filenames.
+  other, as regular dynamic extensions do. Build may tools will generate
+  these multiarch tagged filenames, by default, when targeting
+  compatibility with at least Python 3.15.
   (Contributed by Stefano Rivera in :gh:`122931`.)
 
 

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -75,11 +75,11 @@ New features
 Other language changes
 ======================
 
-* Stable ABI extensions may now include a multiarch tuple in the
+* Stable ABI extensions now include a multiarch tuple in the
   filename, e.g. ``foo.abi3-x86-64-linux-gnu.so``.
   This permits stable ABI extensions for multiple architectures to be
   co-installed into the same directory, without clashing with each
-  other, as regular dynamic extensions do. Build may tools will generate
+  other, as regular dynamic extensions do. Build tools will generate
   these multiarch tagged filenames, by default, when targeting
   compatibility with at least Python 3.15.
   (Contributed by Stefano Rivera in :gh:`122931`.)

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -81,6 +81,15 @@ Other language changes
   they reference) alive indefinitely.
   (Contributed by Łukasz Langa in :gh:`102960`.)
 
+* Stable ABI extensions may now include a multiarch tuple in the
+  filename, e.g. ``foo.abi3-x86-64-linux-gnu.so``.
+  This permits stable ABI extensions for multiple architectures to be
+  co-installed into the same directory, without clashing with each
+  other, as regular dynamic extensions do. Build tools will not generate
+  these multiarch tagged filenames, by default, while still supporting
+  older Python versions that don't recognize these filenames.
+  (Contributed by Stefano Rivera in :gh:`122931`.)
+
 
 New modules
 ===========

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -85,9 +85,9 @@ Other language changes
   filename, e.g. ``foo.abi3-x86-64-linux-gnu.so``.
   This permits stable ABI extensions for multiple architectures to be
   co-installed into the same directory, without clashing with each
-  other, as regular dynamic extensions do. Build tools will not generate
-  these multiarch tagged filenames, by default, while still supporting
-  older Python versions that don't recognize these filenames.
+  other, as regular dynamic extensions do. Build may tools will generate
+  these multiarch tagged filenames, by default, when targeting
+  compatibility with at least Python 3.15.
   (Contributed by Stefano Rivera in :gh:`122931`.)
 
 

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -81,8 +81,9 @@ Other language changes
   they reference) alive indefinitely.
   (Contributed by Łukasz Langa in :gh:`102960`.)
 
-* Stable ABI extensions may now include a multiarch tuple in the
-  filename, e.g. ``foo.abi3-x86-64-linux-gnu.so``.
+* Stable ABI extensions (with free-threaded compatibility) may now
+  include a multiarch tuple in the filename, e.g.
+  ``foo.abi3t-x86-64-linux-gnu.so``.
   This permits stable ABI extensions for multiple architectures to be
   co-installed into the same directory, without clashing with each
   other, as regular dynamic extensions do. Build tools will generate

--- a/Doc/whatsnew/3.16.rst
+++ b/Doc/whatsnew/3.16.rst
@@ -85,7 +85,7 @@ Other language changes
   filename, e.g. ``foo.abi3-x86-64-linux-gnu.so``.
   This permits stable ABI extensions for multiple architectures to be
   co-installed into the same directory, without clashing with each
-  other, as regular dynamic extensions do. Build may tools will generate
+  other, as regular dynamic extensions do. Build tools will generate
   these multiarch tagged filenames, by default, when targeting
   compatibility with at least Python 3.15.
   (Contributed by Stefano Rivera in :gh:`122931`.)

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -570,6 +570,7 @@ def collect_sysconfig(info_add):
 
     for name in (
         'ABIFLAGS',
+        'ALT_SOABI',
         'ANDROID_API_LEVEL',
         'CC',
         'CCSHARED',
@@ -595,6 +596,7 @@ def collect_sysconfig(info_add):
         'Py_REMOTE_DEBUG',
         'SHELL',
         'SOABI',
+        'SOABI_PLATFORM',
         'TEST_MODULES',
         'VAPTH',
         'abs_builddir',
@@ -1316,6 +1318,12 @@ def collect_system(info_add):
             info_add('system.hardware', hardware)
 
 
+def collect_importlib(info_add):
+    import importlib.machinery
+    info_add('importlib.extension_suffixes',
+             importlib.machinery.EXTENSION_SUFFIXES)
+
+
 def collect_info(info):
     error = False
     info_add = info.add
@@ -1358,6 +1366,7 @@ def collect_info(info):
         collect_zstd,
         collect_libregrtest_utils,
         collect_system,
+        collect_importlib,
 
         # Collecting from tests should be last as they have side effects.
         collect_test_socket,

--- a/Lib/test/test_importlib/extension/test_finder.py
+++ b/Lib/test/test_importlib/extension/test_finder.py
@@ -69,19 +69,21 @@ class FinderTests(abc.FinderTests):
             pass
         else:
             if Py_GIL_DISABLED:
-                self.assertFalse(any(".abi3" in suffix) for suffix in suffixes)
+                self.assertNotIn(".abi3.so", suffixes)
             else:
                 self.assertIn(".abi3.so", suffixes)
             self.assertIn(".abi3t.so", suffixes)
 
     @unittest.skipIf(
-        not sysconfig.get_config_var("SOABI_PLATFORM").strip('"'),
+        not (sysconfig.get_config_var("SOABI_PLATFORM") or "").strip('"'),
         "Linux-only test"
     )
     def test_multiarch_abi3_extension_suffixes(self):
         suffixes = self.machinery.EXTENSION_SUFFIXES
         platform = sysconfig.get_config_var("SOABI_PLATFORM").strip('"')
         if Py_GIL_DISABLED:
+            self.assertNotIn(f".abi3-{platform}.so", suffixes)
+        else:
             self.assertIn(f".abi3-{platform}.so", suffixes)
         self.assertIn(f".abi3t-{platform}.so", suffixes)
 

--- a/Lib/test/test_importlib/extension/test_finder.py
+++ b/Lib/test/test_importlib/extension/test_finder.py
@@ -62,6 +62,7 @@ class FinderTests(abc.FinderTests):
 
     def test_abi3_extension_suffixes(self):
         suffixes = self.machinery.EXTENSION_SUFFIXES
+        platform = sysconfig.get_config_var("SOABI_PLATFORM")
         if 'win32' in sys.platform:
             # Either "_d.pyd" or ".pyd" must be in suffixes
             self.assertTrue({"_d.pyd", ".pyd"}.intersection(suffixes))
@@ -72,20 +73,10 @@ class FinderTests(abc.FinderTests):
                 self.assertNotIn(".abi3.so", suffixes)
             else:
                 self.assertIn(".abi3.so", suffixes)
-            self.assertIn(".abi3t.so", suffixes)
-
-    @unittest.skipIf(
-        not (sysconfig.get_config_var("SOABI_PLATFORM") or "").strip('"'),
-        "Linux-only test"
-    )
-    def test_multiarch_abi3_extension_suffixes(self):
-        suffixes = self.machinery.EXTENSION_SUFFIXES
-        platform = sysconfig.get_config_var("SOABI_PLATFORM").strip('"')
-        if Py_GIL_DISABLED:
-            self.assertNotIn(f".abi3-{platform}.so", suffixes)
-        else:
-            self.assertIn(f".abi3-{platform}.so", suffixes)
-        self.assertIn(f".abi3t-{platform}.so", suffixes)
+            if platform:
+                self.assertIn(f".abi3t-{platform}.so", suffixes)
+            else:
+                self.assertIn(".abi3t.so", suffixes)
 
 
 (Frozen_FinderTests,

--- a/Lib/test/test_importlib/extension/test_finder.py
+++ b/Lib/test/test_importlib/extension/test_finder.py
@@ -5,6 +5,7 @@ machinery = util.import_importlib('importlib.machinery')
 
 import unittest
 import sys
+import sysconfig
 
 
 class FinderTests(abc.FinderTests):
@@ -68,10 +69,21 @@ class FinderTests(abc.FinderTests):
             pass
         else:
             if Py_GIL_DISABLED:
-                self.assertNotIn(".abi3.so", suffixes)
+                self.assertFalse(any(".abi3" in suffix) for suffix in suffixes)
             else:
                 self.assertIn(".abi3.so", suffixes)
             self.assertIn(".abi3t.so", suffixes)
+
+    @unittest.skipIf(
+        not sysconfig.get_config_var("SOABI_PLATFORM").strip('"'),
+        "Linux-only test"
+    )
+    def test_multiarch_abi3_extension_suffixes(self):
+        suffixes = self.machinery.EXTENSION_SUFFIXES
+        platform = sysconfig.get_config_var("SOABI_PLATFORM").strip('"')
+        if Py_GIL_DISABLED:
+            self.assertIn(f".abi3-{platform}.so", suffixes)
+        self.assertIn(f".abi3t-{platform}.so", suffixes)
 
 
 (Frozen_FinderTests,

--- a/Lib/test/test_importlib/extension/test_finder.py
+++ b/Lib/test/test_importlib/extension/test_finder.py
@@ -75,8 +75,7 @@ class FinderTests(abc.FinderTests):
                 self.assertIn(".abi3.so", suffixes)
             if platform:
                 self.assertIn(f".abi3t-{platform}.so", suffixes)
-            else:
-                self.assertIn(".abi3t.so", suffixes)
+            self.assertIn(".abi3t.so", suffixes)
 
 
 (Frozen_FinderTests,

--- a/Misc/NEWS.d/next/C_API/2024-08-12-09-48-04.gh-issue-122931.QwHc2l.rst
+++ b/Misc/NEWS.d/next/C_API/2024-08-12-09-48-04.gh-issue-122931.QwHc2l.rst
@@ -1,0 +1,2 @@
+Allow importing stable ABI C extensions that include a multiarch tuple
+in their filename, e.g. ``foo.abi3-x86-64-linux-gnu.so``.

--- a/Misc/NEWS.d/next/C_API/2024-08-12-09-48-04.gh-issue-122931.QwHc2l.rst
+++ b/Misc/NEWS.d/next/C_API/2024-08-12-09-48-04.gh-issue-122931.QwHc2l.rst
@@ -1,2 +1,1 @@
-Allow importing stable ABI C extensions that include a multiarch tuple
-in their filename, e.g. ``foo.abi3-x86-64-linux-gnu.so``.
+Linux: Include multiarch tuples in ``abi3t`` stable ABI C extension filenames, e.g. ``foo.abi3t-x86-64-linux-gnu.so``.

--- a/Misc/NEWS.d/next/C_API/2024-08-12-09-48-04.gh-issue-122931.QwHc2l.rst
+++ b/Misc/NEWS.d/next/C_API/2024-08-12-09-48-04.gh-issue-122931.QwHc2l.rst
@@ -1,1 +1,1 @@
-Linux: Include multiarch tuples in ``abi3t`` stable ABI C extension filenames, e.g. ``foo.abi3t-x86-64-linux-gnu.so``.
+Linux: Include multiarch tuples in ``abi3t`` stable ABI C extension filenames, e.g. ``foo.abi3t-x86-64-linux-gnu.so``, by default.

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -46,15 +46,13 @@ const char *_PyImport_DynLoadFiletab[] = {
     "." ALT_SOABI ".so",
 #endif
 #ifndef Py_GIL_DISABLED
-#ifdef SOABI_PLATFORM
-    ".abi" PYTHON_ABI_STRING "-" SOABI_PLATFORM ".so",
-#endif  /* SOABI_PLATFORM */
     ".abi" PYTHON_ABI_STRING ".so",
 #endif  /* Py_GIL_DISABLED */
 #ifdef SOABI_PLATFORM
     ".abi" PYTHON_ABI_STRING "t-" SOABI_PLATFORM ".so",
-#endif  /* SOABI_PLATFORM */
+#else
     ".abi" PYTHON_ABI_STRING "t.so",
+#endif  /* SOABI_PLATFORM */
     ".so",
 #endif  /* __CYGWIN__ */
     NULL,

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -47,8 +47,14 @@ const char *_PyImport_DynLoadFiletab[] = {
 #endif
 #ifndef Py_GIL_DISABLED
     ".abi" PYTHON_ABI_STRING ".so",
+#ifdef SOABI_PLATFORM
+    ".abi" PYTHON_ABI_STRING "-" SOABI_PLATFORM ".so",
+#endif  /* SOABI_PLATFORM */
 #endif  /* Py_GIL_DISABLED */
     ".abi" PYTHON_ABI_STRING "t.so",
+#ifdef SOABI_PLATFORM
+    ".abi" PYTHON_ABI_STRING "t-" SOABI_PLATFORM ".so",
+#endif  /* SOABI_PLATFORM */
     ".so",
 #endif  /* __CYGWIN__ */
     NULL,

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -46,15 +46,15 @@ const char *_PyImport_DynLoadFiletab[] = {
     "." ALT_SOABI ".so",
 #endif
 #ifndef Py_GIL_DISABLED
-    ".abi" PYTHON_ABI_STRING ".so",
 #ifdef SOABI_PLATFORM
     ".abi" PYTHON_ABI_STRING "-" SOABI_PLATFORM ".so",
 #endif  /* SOABI_PLATFORM */
+    ".abi" PYTHON_ABI_STRING ".so",
 #endif  /* Py_GIL_DISABLED */
-    ".abi" PYTHON_ABI_STRING "t.so",
 #ifdef SOABI_PLATFORM
     ".abi" PYTHON_ABI_STRING "t-" SOABI_PLATFORM ".so",
 #endif  /* SOABI_PLATFORM */
+    ".abi" PYTHON_ABI_STRING "t.so",
     ".so",
 #endif  /* __CYGWIN__ */
     NULL,

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -50,9 +50,8 @@ const char *_PyImport_DynLoadFiletab[] = {
 #endif  /* Py_GIL_DISABLED */
 #ifdef SOABI_PLATFORM
     ".abi" PYTHON_ABI_STRING "t-" SOABI_PLATFORM ".so",
-#else
-    ".abi" PYTHON_ABI_STRING "t.so",
 #endif  /* SOABI_PLATFORM */
+    ".abi" PYTHON_ABI_STRING "t.so",
     ".so",
 #endif  /* __CYGWIN__ */
     NULL,

--- a/configure
+++ b/configure
@@ -7266,6 +7266,10 @@ case $ac_sys_system in #(
  ;;
 esac
 
+
+printf "%s\n" "#define SOABI_PLATFORM \"${SOABI_PLATFORM}\"" >>confdefs.h
+
+
 if test x$MULTIARCH != x; then
   MULTIARCH_CPPFLAGS="-DMULTIARCH=\\\"$MULTIARCH\\\""
 fi

--- a/configure
+++ b/configure
@@ -7266,9 +7266,11 @@ case $ac_sys_system in #(
  ;;
 esac
 
+if test x$SOABI_PLATFORM != x; then
 
 printf "%s\n" "#define SOABI_PLATFORM \"${SOABI_PLATFORM}\"" >>confdefs.h
 
+fi
 
 if test x$MULTIARCH != x; then
   MULTIARCH_CPPFLAGS="-DMULTIARCH=\\\"$MULTIARCH\\\""

--- a/configure
+++ b/configure
@@ -7252,6 +7252,10 @@ case $ac_sys_system in #(
  ;;
 esac
 
+
+printf "%s\n" "#define SOABI_PLATFORM \"${SOABI_PLATFORM}\"" >>confdefs.h
+
+
 if test x$MULTIARCH != x; then
   MULTIARCH_CPPFLAGS="-DMULTIARCH=\\\"$MULTIARCH\\\""
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1212,6 +1212,8 @@ AS_CASE([$ac_sys_system],
   [SOABI_PLATFORM=$PLATFORM_TRIPLET]
 )
 
+AC_DEFINE_UNQUOTED([SOABI_PLATFORM], ["${SOABI_PLATFORM}"], [Platform tag, used in binary module extension filenames.])
+
 if test x$MULTIARCH != x; then
   MULTIARCH_CPPFLAGS="-DMULTIARCH=\\\"$MULTIARCH\\\""
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1212,7 +1212,9 @@ AS_CASE([$ac_sys_system],
   [SOABI_PLATFORM=$PLATFORM_TRIPLET]
 )
 
-AC_DEFINE_UNQUOTED([SOABI_PLATFORM], ["${SOABI_PLATFORM}"], [Platform tag, used in binary module extension filenames.])
+if test x$SOABI_PLATFORM != x; then
+    AC_DEFINE_UNQUOTED([SOABI_PLATFORM], ["${SOABI_PLATFORM}"], [Platform tag, used in binary module extension filenames.])
+fi
 
 if test x$MULTIARCH != x; then
   MULTIARCH_CPPFLAGS="-DMULTIARCH=\\\"$MULTIARCH\\\""

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1938,6 +1938,9 @@
 /* The size of '_Bool', as computed by sizeof. */
 #undef SIZEOF__BOOL
 
+/* Platform tag, used in binary module extension filenames. */
+#undef SOABI_PLATFORM
+
 /* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS
 

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1851,6 +1851,9 @@
 /* The size of '_Bool', as computed by sizeof. */
 #undef SIZEOF__BOOL
 
+/* Platform tag, used in binary module extension filenames. */
+#undef SOABI_PLATFORM
+
 /* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS
 


### PR DESCRIPTION
This permits `abi3t` stable ABI extensions for multiple architectures to be co-installed into the same directory, without clashing with each other, the same way (non-stable ABI) regular extensions can.

<!-- gh-issue-number: gh-122931 -->
* Issue: gh-122931
<!-- /gh-issue-number -->