### PR TITLE
GH-73991: Disallow copying directory into itself via `pathlib.Path.copy()`

### DIFF
--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -11,10 +11,10 @@ Two base classes are defined here -- PurePathBase and PathBase -- that
 resemble pathlib's PurePath and Path respectively.
 """
 
-import errno
 import functools
 import operator
 import posixpath
+from errno import EINVAL
 from glob import _GlobberBase, _no_recurse_symlinks
 from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO
 from pathlib._os import copyfileobj
@@ -574,7 +574,7 @@ class PathBase(PurePathBase):
                 return
         except (OSError, ValueError):
             return
-        err = OSError(errno.EINVAL, "Source and target are the same file")
+        err = OSError(EINVAL, "Source and target are the same file")
         err.filename = str(self)
         err.filename2 = str(other_path)
         raise err
@@ -584,9 +584,9 @@ class PathBase(PurePathBase):
         Raise OSError(EINVAL) if the other path is within this path.
         """
         if self == other_path:
-            err = OSError(errno.EINVAL, "Source and target are the same path")
+            err = OSError(EINVAL, "Source and target are the same path")
         elif self in other_path.parents:
-            err = OSError(errno.EINVAL, "Source path is a parent of target path")
+            err = OSError(EINVAL, "Source path is a parent of target path")
         else:
             return
         err.filename = str(self)

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -584,10 +584,10 @@ class PathBase(PurePathBase):
         Raise OSError(EINVAL) if the other path is within this path.
         """
         # Note: there is no straightforward, foolproof algorithm to determine
-        # if one directory is within another. A particularly perverse example:
-        # consider a single network share mounted in one location via NFS, and
-        # in another location via CIFS. This method simply checks whether the
-        # other_path is lexically equal to, or within, this path.
+        # if one directory is within another (a particularly perverse example
+        # would be a single network share mounted in one location via NFS, and
+        # in another location via CIFS), so we simply checks whether the
+        # other path is lexically equal to, or within, this path.
         if self == other_path:
             err = OSError(EINVAL, "Source and target are the same path")
         elif self in other_path.parents:

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -583,6 +583,11 @@ class PathBase(PurePathBase):
         """
         Raise OSError(EINVAL) if the other path is within this path.
         """
+        # Note: there is no straightforward, foolproof algorithm to determine
+        # if one directory is within another. A particularly perverse example:
+        # consider a single network share mounted in one location via NFS, and
+        # in another location via CIFS. This method simply checks whether the
+        # other_path is lexically equal to, or within, this path.
         if self == other_path:
             err = OSError(EINVAL, "Source and target are the same path")
         elif self in other_path.parents:

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -11,6 +11,7 @@ Two base classes are defined here -- PurePathBase and PathBase -- that
 resemble pathlib's PurePath and Path respectively.
 """
 
+import errno
 import functools
 import operator
 import posixpath
@@ -564,14 +565,33 @@ class PathBase(PurePathBase):
         return (st.st_ino == other_st.st_ino and
                 st.st_dev == other_st.st_dev)
 
-    def _samefile_safe(self, other_path):
+    def _ensure_different_file(self, other_path):
         """
-        Like samefile(), but returns False rather than raising OSError.
+        Raise OSError(EINVAL) if both paths refer to the same file.
         """
         try:
-            return self.samefile(other_path)
+            if not self.samefile(other_path):
+                return
         except (OSError, ValueError):
-            return False
+            return
+        err = OSError(errno.EINVAL, "Source and target are the same file")
+        err.filename = str(self)
+        err.filename2 = str(other_path)
+        raise err
+
+    def _ensure_distinct_path(self, other_path):
+        """
+        Raise OSError(EINVAL) if the other path is within this path.
+        """
+        if self == other_path:
+            err = OSError(errno.EINVAL, "Source and target are the same path")
+        elif self in other_path.parents:
+            err = OSError(errno.EINVAL, "Source path is a parent of target path")
+        else:
+            return
+        err.filename = str(self)
+        err.filename2 = str(other_path)
+        raise err
 
     def open(self, mode='r', buffering=-1, encoding=None,
              errors=None, newline=None):
@@ -826,8 +846,7 @@ class PathBase(PurePathBase):
         """
         Copy the contents of this file to the given target.
         """
-        if self._samefile_safe(target):
-            raise OSError(f"{self!r} and {target!r} are the same file")
+        self._ensure_different_file(target)
         with self.open('rb') as source_f:
             try:
                 with target.open('wb') as target_f:
@@ -847,6 +866,13 @@ class PathBase(PurePathBase):
         """
         if not isinstance(target, PathBase):
             target = self.with_segments(target)
+        try:
+            self._ensure_distinct_path(target)
+        except OSError as err:
+            if on_error is None:
+                raise
+            on_error(err)
+            return
         stack = [(self, target)]
         while stack:
             src, dst = stack.pop()

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1772,10 +1772,8 @@ class DummyPathTest(DummyPurePathTest):
         target = base / 'copyTarget'
         source.symlink_to(base / 'fileA')
         target.symlink_to(base / 'dirC')
-        with self.assertRaises(OSError):
-            source.copy(target)
-        with self.assertRaises(OSError):
-            source.copy(target, follow_symlinks=False)
+        self.assertRaises(OSError, source.copy, target)
+        self.assertRaises(OSError, source.copy, target, follow_symlinks=False)
 
     @needs_symlinks
     def test_copy_symlink_to_existing_directory_symlink(self):
@@ -1784,10 +1782,8 @@ class DummyPathTest(DummyPurePathTest):
         target = base / 'copyTarget'
         source.symlink_to(base / 'fileA')
         target.symlink_to(base / 'dirC')
-        with self.assertRaises(OSError):
-            source.copy(target)
-        with self.assertRaises(OSError):
-            source.copy(target, follow_symlinks=False)
+        self.assertRaises(OSError, source.copy, target)
+        self.assertRaises(OSError, source.copy, target, follow_symlinks=False)
 
     @needs_symlinks
     def test_copy_directory_symlink_follow_symlinks_false(self):
@@ -1805,6 +1801,7 @@ class DummyPathTest(DummyPurePathTest):
         base = self.cls(self.base)
         source = base / 'linkB'
         self.assertRaises(OSError, source.copy, source)
+        self.assertRaises(OSError, source.copy, source, follow_symlinks=False)
 
     @needs_symlinks
     def test_copy_directory_symlink_into_itself(self):
@@ -1812,6 +1809,7 @@ class DummyPathTest(DummyPurePathTest):
         source = base / 'linkB'
         target = base / 'linkB' / 'copyB'
         self.assertRaises(OSError, source.copy, target)
+        self.assertRaises(OSError, source.copy, target, follow_symlinks=False)
         self.assertFalse(target.exists())
 
     @needs_symlinks
@@ -1821,10 +1819,8 @@ class DummyPathTest(DummyPurePathTest):
         target = base / 'copyTarget'
         source.symlink_to(base / 'dirC')
         target.symlink_to(base / 'fileA')
-        with self.assertRaises(FileExistsError):
-            source.copy(target)
-        with self.assertRaises(FileExistsError):
-            source.copy(target, follow_symlinks=False)
+        self.assertRaises(FileExistsError, source.copy, target)
+        self.assertRaises(FileExistsError, source.copy, target, follow_symlinks=False)
 
     @needs_symlinks
     def test_copy_directory_symlink_to_existing_directory_symlink(self):
@@ -1833,10 +1829,8 @@ class DummyPathTest(DummyPurePathTest):
         target = base / 'copyTarget'
         source.symlink_to(base / 'dirC' / 'dirD')
         target.symlink_to(base / 'dirC')
-        with self.assertRaises(FileExistsError):
-            source.copy(target)
-        with self.assertRaises(FileExistsError):
-            source.copy(target, follow_symlinks=False)
+        self.assertRaises(FileExistsError, source.copy, target)
+        self.assertRaises(FileExistsError, source.copy, target, follow_symlinks=False)
 
     def test_copy_file_to_existing_file(self):
         base = self.cls(self.base)
@@ -1851,8 +1845,7 @@ class DummyPathTest(DummyPurePathTest):
         base = self.cls(self.base)
         source = base / 'fileA'
         target = base / 'dirA'
-        with self.assertRaises(OSError):
-            source.copy(target)
+        self.assertRaises(OSError, source.copy, target)
 
     @needs_symlinks
     def test_copy_file_to_existing_symlink(self):
@@ -1897,6 +1890,7 @@ class DummyPathTest(DummyPurePathTest):
         source = base / 'empty'
         source.write_bytes(b'')
         self.assertRaises(OSError, source.copy, source)
+        self.assertRaises(OSError, source.copy, source, follow_symlinks=False)
 
     def test_copy_dir_simple(self):
         base = self.cls(self.base)
@@ -1988,6 +1982,7 @@ class DummyPathTest(DummyPurePathTest):
         base = self.cls(self.base)
         source = base / 'dirC'
         self.assertRaises(OSError, source.copy, source)
+        self.assertRaises(OSError, source.copy, source, follow_symlinks=False)
 
     def test_copy_dir_to_itself_on_error(self):
         base = self.cls(self.base)
@@ -2002,6 +1997,7 @@ class DummyPathTest(DummyPurePathTest):
         source = base / 'dirC'
         target = base / 'dirC' / 'dirD' / 'copyC'
         self.assertRaises(OSError, source.copy, target)
+        self.assertRaises(OSError, source.copy, target, follow_symlinks=False)
         self.assertFalse(target.exists())
 
     def test_copy_missing_on_error(self):

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1772,7 +1772,7 @@ class DummyPathTest(DummyPurePathTest):
         target = base / 'copyTarget'
         source.symlink_to(base / 'fileA')
         target.symlink_to(base / 'dirC')
-        with self.assertRaises(IsADirectoryError):
+        with self.assertRaises(OSError):
             source.copy(target)
         with self.assertRaises(FileExistsError):
             source.copy(target, follow_symlinks=False)
@@ -1784,7 +1784,7 @@ class DummyPathTest(DummyPurePathTest):
         target = base / 'copyTarget'
         source.symlink_to(base / 'fileA')
         target.symlink_to(base / 'dirC')
-        with self.assertRaises(IsADirectoryError):
+        with self.assertRaises(OSError):
             source.copy(target)
         with self.assertRaises(FileExistsError):
             source.copy(target, follow_symlinks=False)

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1759,6 +1759,12 @@ class DummyPathTest(DummyPurePathTest):
         self.assertEqual(source.readlink(), target.readlink())
 
     @needs_symlinks
+    def test_copy_symlink_to_itself(self):
+        base = self.cls(self.base)
+        source = base / 'linkA'
+        self.assertRaises(OSError, source.copy, source)
+
+    @needs_symlinks
     def test_copy_directory_symlink_follow_symlinks_false(self):
         base = self.cls(self.base)
         source = base / 'linkB'
@@ -1768,6 +1774,20 @@ class DummyPathTest(DummyPurePathTest):
         self.assertTrue(target.exists())
         self.assertTrue(target.is_symlink())
         self.assertEqual(source.readlink(), target.readlink())
+
+    @needs_symlinks
+    def test_copy_directory_symlink_to_itself(self):
+        base = self.cls(self.base)
+        source = base / 'linkB'
+        self.assertRaises(OSError, source.copy, source)
+
+    @needs_symlinks
+    def test_copy_directory_symlink_into_itself(self):
+        base = self.cls(self.base)
+        source = base / 'linkB'
+        target = base / 'linkB' / 'copyB'
+        self.assertRaises(OSError, source.copy, target)
+        self.assertFalse(target.exists())
 
     def test_copy_file_to_existing_file(self):
         base = self.cls(self.base)
@@ -1933,6 +1953,7 @@ class DummyPathTest(DummyPurePathTest):
         source = base / 'dirC'
         target = base / 'dirC' / 'dirD' / 'copyC'
         self.assertRaises(OSError, source.copy, target)
+        self.assertFalse(target.exists())
 
     def test_copy_missing_on_error(self):
         base = self.cls(self.base)

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1774,7 +1774,7 @@ class DummyPathTest(DummyPurePathTest):
         target.symlink_to(base / 'dirC')
         with self.assertRaises(OSError):
             source.copy(target)
-        with self.assertRaises(FileExistsError):
+        with self.assertRaises(OSError):
             source.copy(target, follow_symlinks=False)
 
     @needs_symlinks
@@ -1786,7 +1786,7 @@ class DummyPathTest(DummyPurePathTest):
         target.symlink_to(base / 'dirC')
         with self.assertRaises(OSError):
             source.copy(target)
-        with self.assertRaises(FileExistsError):
+        with self.assertRaises(OSError):
             source.copy(target, follow_symlinks=False)
 
     @needs_symlinks

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1823,6 +1823,12 @@ class DummyPathTest(DummyPurePathTest):
         self.assertTrue(target.exists())
         self.assertEqual(target.read_bytes(), b'')
 
+    def test_copy_file_to_itself(self):
+        base = self.cls(self.base)
+        source = base / 'empty'
+        source.write_bytes(b'')
+        self.assertRaises(OSError, source.copy, source)
+
     def test_copy_dir_simple(self):
         base = self.cls(self.base)
         source = base / 'dirC'
@@ -1908,6 +1914,25 @@ class DummyPathTest(DummyPurePathTest):
         self.assertTrue(target.joinpath('fileC').is_file())
         self.assertTrue(target.joinpath('fileC').read_text(),
                         "this is file C\n")
+
+    def test_copy_dir_to_itself(self):
+        base = self.cls(self.base)
+        source = base / 'dirC'
+        self.assertRaises(OSError, source.copy, source)
+
+    def test_copy_dir_to_itself_on_error(self):
+        base = self.cls(self.base)
+        source = base / 'dirC'
+        errors = []
+        source.copy(source, on_error=errors.append)
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], OSError)
+
+    def test_copy_dir_into_itself(self):
+        base = self.cls(self.base)
+        source = base / 'dirC'
+        target = base / 'dirC' / 'dirD' / 'copyC'
+        self.assertRaises(OSError, source.copy, target)
 
     def test_copy_missing_on_error(self):
         base = self.cls(self.base)


### PR DESCRIPTION
No news blurb because `pathlib.Path.copy()` is still new.

<!-- gh-issue-number: gh-73991 -->
* Issue: gh-73991
<!-- /gh-issue-number -->
