### PR TITLE
gh-122928: asserting that the tstate pointer is non-NULL using assert

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-12-10-02-40.gh-issue-122928.e6_yVr.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-12-10-02-40.gh-issue-122928.e6_yVr.rst
@@ -1,1 +1,0 @@
-Make thread state(tstate) pointer safe

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-12-10-02-40.gh-issue-122928.e6_yVr.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-12-10-02-40.gh-issue-122928.e6_yVr.rst
@@ -1,0 +1,1 @@
+Make thread state(tstate) pointer safe

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -3002,7 +3002,7 @@ _PyThreadState_CheckConsistency(PyThreadState *tstate)
 //
 // tstate can be a dangling pointer (point to freed memory): only tstate value
 // is used, the pointer is not deferenced.
-// 
+//
 // tstate must be non-NULL.
 int
 _PyThreadState_MustExit(PyThreadState *tstate)

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -3016,8 +3016,6 @@ _PyThreadState_MustExit(PyThreadState *tstate)
     unsigned long finalizing_id = _PyRuntimeState_GetFinalizingID(&_PyRuntime);
     PyThreadState *finalizing = _PyRuntimeState_GetFinalizing(&_PyRuntime);
     if (finalizing == NULL) {
-        // XXX This isn't completely safe from daemon thraeds,
-        // since tstate might be a dangling pointer.
         finalizing = _PyInterpreterState_GetFinalizing(tstate->interp);
         finalizing_id = _PyInterpreterState_GetFinalizingID(tstate->interp);
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -3002,13 +3002,12 @@ _PyThreadState_CheckConsistency(PyThreadState *tstate)
 //
 // tstate can be a dangling pointer (point to freed memory): only tstate value
 // is used, the pointer is not deferenced.
+// 
+// tstate must be non-NULL.
 int
 _PyThreadState_MustExit(PyThreadState *tstate)
 {
-    // tstate must be non-NULL.
-    if (tstate == NULL) {
-        return 1;
-    }
+    assert(tstate != NULL);
     /* bpo-39877: Access _PyRuntime directly rather than using
        tstate->interp->runtime to support calls from Python daemon threads.
        After Py_Finalize() has been called, tstate can be a dangling pointer:
@@ -3016,6 +3015,8 @@ _PyThreadState_MustExit(PyThreadState *tstate)
     unsigned long finalizing_id = _PyRuntimeState_GetFinalizingID(&_PyRuntime);
     PyThreadState *finalizing = _PyRuntimeState_GetFinalizing(&_PyRuntime);
     if (finalizing == NULL) {
+        // XXX This isn't completely safe from daemon threads,
+        // since tstate might be a dangling pointer.
         finalizing = _PyInterpreterState_GetFinalizing(tstate->interp);
         finalizing_id = _PyInterpreterState_GetFinalizingID(tstate->interp);
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -3002,11 +3002,13 @@ _PyThreadState_CheckConsistency(PyThreadState *tstate)
 //
 // tstate can be a dangling pointer (point to freed memory): only tstate value
 // is used, the pointer is not deferenced.
-//
-// tstate must be non-NULL.
 int
 _PyThreadState_MustExit(PyThreadState *tstate)
 {
+    // tstate must be non-NULL.
+    if (tstate == NULL) {
+        return 1;
+    }
     /* bpo-39877: Access _PyRuntime directly rather than using
        tstate->interp->runtime to support calls from Python daemon threads.
        After Py_Finalize() has been called, tstate can be a dangling pointer:


### PR DESCRIPTION
To prevent dangling pointer issues, adding a check for NULL ensures that invalid pointers are not dereferenced

This is my first time contributing to the C part of python and maybe there will be some issues
<!-- gh-issue-number: gh-122928 -->
* Issue: gh-122928
<!-- /gh-issue-number -->
