### PR TITLE
gh-109523: Reading text from a non-blocking stream with read may now raise a BlockingIOError if the operation cannot immediately return bytes.

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -778,6 +778,7 @@ than raw I/O does.
       EOF or if the read call would block in non-blocking mode.
 
       .. note::
+
          When the underlying raw stream is non-blocking, a :exc:`BlockingIOError`
          may be raised if a read operation cannot be completed immediately.
 
@@ -791,6 +792,7 @@ than raw I/O does.
          The *size* argument is now optional.
 
       .. note::
+
          When the underlying raw stream is non-blocking, a :exc:`BlockingIOError`
          may be raised if a read operation cannot be completed immediately.
 
@@ -1022,6 +1024,7 @@ Text I/O
       The *encoding* argument now supports the ``"locale"`` dummy encoding name.
 
    .. note::
+
       When the underlying raw stream is non-blocking, a :exc:`BlockingIOError`
       may be raised if a read operation cannot be completed immediately.
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -66,8 +66,8 @@ In-memory text streams are also available as :class:`StringIO` objects::
 
 .. note::
 
-   When working with a non-blocking stream, be aware that operations on text I/O objects
-   might raise a :exc:`BlockingIOError` if the stream cannot perform a read operation
+   When working with a non-blocking stream, be aware that read operations on text I/O objects
+   might raise a :exc:`BlockingIOError` if the stream cannot perform the operation
    immediately.
 
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -70,7 +70,6 @@ In-memory text streams are also available as :class:`StringIO` objects::
    might raise a :exc:`BlockingIOError` if the stream cannot perform the operation
    immediately.
 
-
 The text stream API is described in detail in the documentation of
 :class:`TextIOBase`.
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -65,6 +65,7 @@ In-memory text streams are also available as :class:`StringIO` objects::
    f = io.StringIO("some initial text data")
 
 .. note::
+
    When working with a non-blocking stream, be aware that operations on text I/O objects
    might raise a :exc:`BlockingIOError` if the stream cannot perform a read operation
    immediately.

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -64,6 +64,13 @@ In-memory text streams are also available as :class:`StringIO` objects::
 
    f = io.StringIO("some initial text data")
 
+.. note::
+   If you are working with a non-blocking stream, be aware that operations on text I/O
+   objects may raise a `BlockingIOError`. This occurs when the underlying stream is
+   in non-blocking mode and a read operation cannot be completed immediately, potentially
+   leading to a `BlockingIOError`. To handle this, ensure your code properly catches and
+   manages such exceptions when working with non-blocking streams.
+
 The text stream API is described in detail in the documentation of
 :class:`TextIOBase`.
 
@@ -770,6 +777,11 @@ than raw I/O does.
       Read and return *size* bytes, or if *size* is not given or negative, until
       EOF or if the read call would block in non-blocking mode.
 
+      .. note::
+         When the underlying raw stream is non-blocking, a `BlockingIOError`
+         may be raised if the read operation cannot be completed immediately.
+         Ensure proper exception handling in such cases.
+
    .. method:: read1(size=-1, /)
 
       Read and return up to *size* bytes with only one call on the raw stream.
@@ -779,6 +791,10 @@ than raw I/O does.
       .. versionchanged:: 3.7
          The *size* argument is now optional.
 
+      .. note::
+         When the underlying raw stream is non-blocking, a `BlockingIOError`
+         may be raised if the read operation cannot be completed immediately.
+         Ensure proper exception handling in such cases.
 
 .. class:: BufferedWriter(raw, buffer_size=DEFAULT_BUFFER_SIZE)
 
@@ -1006,6 +1022,10 @@ Text I/O
 
    .. versionchanged:: 3.10
       The *encoding* argument now supports the ``"locale"`` dummy encoding name.
+
+   .. note::
+      If the underlying raw stream is non-blocking, the `read()` method may raise a
+      `BlockingIOError` if no data is available immediately.
 
    :class:`TextIOWrapper` provides these data attributes and methods in
    addition to those from :class:`TextIOBase` and :class:`IOBase`:

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -66,9 +66,9 @@ In-memory text streams are also available as :class:`StringIO` objects::
 
 .. note::
    If you are working with a non-blocking stream, be aware that operations on text I/O
-   objects may raise a `BlockingIOError`. This occurs when the underlying stream is
+   objects may raise a ``BlockingIOError``. This occurs when the underlying stream is
    in non-blocking mode and a read operation cannot be completed immediately, potentially
-   leading to a `BlockingIOError`. To handle this, ensure your code properly catches and
+   leading to a `BlockingIOError``. To handle this, ensure your code properly catches and
    manages such exceptions when working with non-blocking streams.
 
 The text stream API is described in detail in the documentation of
@@ -778,7 +778,7 @@ than raw I/O does.
       EOF or if the read call would block in non-blocking mode.
 
       .. note::
-         When the underlying raw stream is non-blocking, a `BlockingIOError`
+         When the underlying raw stream is non-blocking, a ``BlockingIOError``
          may be raised if the read operation cannot be completed immediately.
          Ensure proper exception handling in such cases.
 
@@ -792,7 +792,7 @@ than raw I/O does.
          The *size* argument is now optional.
 
       .. note::
-         When the underlying raw stream is non-blocking, a `BlockingIOError`
+         When the underlying raw stream is non-blocking, a ``BlockingIOError``
          may be raised if the read operation cannot be completed immediately.
          Ensure proper exception handling in such cases.
 
@@ -1024,8 +1024,8 @@ Text I/O
       The *encoding* argument now supports the ``"locale"`` dummy encoding name.
 
    .. note::
-      If the underlying raw stream is non-blocking, the `read()` method may raise a
-      `BlockingIOError` if no data is available immediately.
+      If the underlying raw stream is non-blocking, the ``read()`` method may raise a
+      ``BlockingIOError`` if no data is available immediately.
 
    :class:`TextIOWrapper` provides these data attributes and methods in
    addition to those from :class:`TextIOBase` and :class:`IOBase`:

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -65,11 +65,10 @@ In-memory text streams are also available as :class:`StringIO` objects::
    f = io.StringIO("some initial text data")
 
 .. note::
-   If you are working with a non-blocking stream, be aware that operations on text I/O
-   objects may raise a ``BlockingIOError``. This occurs when the underlying stream is
-   in non-blocking mode and a read operation cannot be completed immediately, potentially
-   leading to a ``BlockingIOError``. To handle this, ensure your code properly catches and
-   manages such exceptions when working with non-blocking streams.
+   When working with a non-blocking stream, be aware that operations on text I/O objects
+   might raise a :exc:`BlockingIOError` if the stream cannot perform a read operation
+   immediately.
+
 
 The text stream API is described in detail in the documentation of
 :class:`TextIOBase`.
@@ -778,9 +777,8 @@ than raw I/O does.
       EOF or if the read call would block in non-blocking mode.
 
       .. note::
-         When the underlying raw stream is non-blocking, a ``BlockingIOError``
-         may be raised if the read operation cannot be completed immediately.
-         Ensure proper exception handling in such cases.
+         When the underlying raw stream is non-blocking, a :exc:`BlockingIOError`
+         may be raised if a read operation cannot be completed immediately.
 
    .. method:: read1(size=-1, /)
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -790,9 +790,8 @@ than raw I/O does.
          The *size* argument is now optional.
 
       .. note::
-         When the underlying raw stream is non-blocking, a ``BlockingIOError``
-         may be raised if the read operation cannot be completed immediately.
-         Ensure proper exception handling in such cases.
+         When the underlying raw stream is non-blocking, a :exc:`BlockingIOError`
+         may be raised if a read operation cannot be completed immediately.
 
 .. class:: BufferedWriter(raw, buffer_size=DEFAULT_BUFFER_SIZE)
 
@@ -1022,8 +1021,8 @@ Text I/O
       The *encoding* argument now supports the ``"locale"`` dummy encoding name.
 
    .. note::
-      If the underlying raw stream is non-blocking, the ``read()`` method may raise a
-      ``BlockingIOError`` if no data is available immediately.
+      When the underlying raw stream is non-blocking, a :exc:`BlockingIOError`
+      may be raised if a read operation cannot be completed immediately.
 
    :class:`TextIOWrapper` provides these data attributes and methods in
    addition to those from :class:`TextIOBase` and :class:`IOBase`:

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -68,7 +68,7 @@ In-memory text streams are also available as :class:`StringIO` objects::
    If you are working with a non-blocking stream, be aware that operations on text I/O
    objects may raise a ``BlockingIOError``. This occurs when the underlying stream is
    in non-blocking mode and a read operation cannot be completed immediately, potentially
-   leading to a `BlockingIOError``. To handle this, ensure your code properly catches and
+   leading to a ``BlockingIOError``. To handle this, ensure your code properly catches and
    manages such exceptions when working with non-blocking streams.
 
 The text stream API is described in detail in the documentation of

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -117,11 +117,14 @@ Added support for converting any objects that have the
 :meth:`!as_integer_ratio` method to a :class:`~fractions.Fraction`.
 (Contributed by Serhiy Storchaka in :gh:`82017`.)
 
-io
-___
 
-* Reading text from a non-blocking stream with ``read`` may now raise a :exc:`BlockingIOError` if the operation cannot immediately return bytes.
-(Contributed by Giovanni Siragusa in :gh:`109523`.)
+io
+--
+
+* Reading text from a non-blocking stream with ``read`` may now raise a
+  :exc:`BlockingIOError` if the operation cannot immediately return bytes.
+  (Contributed by Giovanni Siragusa in :gh:`109523`.)
+
 
 json
 ----

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -117,6 +117,12 @@ Added support for converting any objects that have the
 :meth:`!as_integer_ratio` method to a :class:`~fractions.Fraction`.
 (Contributed by Serhiy Storchaka in :gh:`82017`.)
 
+io
+___
+
+* Reading text from a non-blocking stream with ``read`` may now raise a :exc:`BlockingIOError` if the operation cannot immediately return bytes.
+(Contributed by Giovanni Siragusa in :gh:`109523`.)
+
 json
 ----
 

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2523,12 +2523,10 @@ class TextIOWrapper(TextIOBase):
                 size = size_index()
         decoder = self._decoder or self._get_decoder()
         if size < 0:
-
             chunk = self.buffer.read()
             if chunk is None:
                 raise BlockingIOError("Unexpected None encountered. This may be due to non-blocking I/O or an issue "
                                       "with the underlying I/O implementation.")
-
             # Read everything.
             result = (self._get_decoded_chars() +
                       decoder.decode(chunk, final=True))

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2525,8 +2525,7 @@ class TextIOWrapper(TextIOBase):
         if size < 0:
             chunk = self.buffer.read()
             if chunk is None:
-                raise BlockingIOError("Unexpected None encountered. This may be due to non-blocking I/O or an issue "
-                                      "with the underlying I/O implementation.")
+                raise BlockingIOError("Read returned None.")
             # Read everything.
             result = (self._get_decoded_chars() +
                       decoder.decode(chunk, final=True))

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2526,7 +2526,8 @@ class TextIOWrapper(TextIOBase):
 
             chunk = self.buffer.read()
             if chunk is None:
-                raise BlockingIOError
+                raise BlockingIOError("Unexpected None encountered. This may be due to non-blocking I/O or an issue "
+                                      "with the underlying I/O implementation.")
 
             # Read everything.
             result = (self._get_decoded_chars() +

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2524,13 +2524,13 @@ class TextIOWrapper(TextIOBase):
         decoder = self._decoder or self._get_decoder()
         if size < 0:
 
-            b = self.buffer.read()
-            if b is None:
+            chunk = self.buffer.read()
+            if chunk is None:
                 raise BlockingIOError
 
             # Read everything.
             result = (self._get_decoded_chars() +
-                      decoder.decode(b, final=True))
+                      decoder.decode(chunk, final=True))
             if self._snapshot is not None:
                 self._set_decoded_chars('')
                 self._snapshot = None

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2523,9 +2523,14 @@ class TextIOWrapper(TextIOBase):
                 size = size_index()
         decoder = self._decoder or self._get_decoder()
         if size < 0:
+
+            b = self.buffer.read()
+            if b is None:
+                raise BlockingIOError
+
             # Read everything.
             result = (self._get_decoded_chars() +
-                      decoder.decode(self.buffer.read(), final=True))
+                      decoder.decode(b, final=True))
             if self._snapshot is not None:
                 self._set_decoded_chars('')
                 self._snapshot = None

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3919,6 +3919,22 @@ class TextIOWrapperTest(unittest.TestCase):
         f.write(res)
         self.assertEqual(res + f.readline(), 'foo\nbar\n')
 
+    @unittest.skipUnless(hasattr(os, "pipe"), "requires os.pipe()")
+    def test_read_non_blocking(self):
+        import os
+        r, w = os.pipe()
+        try:
+            os.set_blocking(r, False)
+            with open(r, 'r') as textfile:
+                r = None
+                # Nothing has been written so a non-blocking read raises a BlockingIOError exception.
+                with self.assertRaises(BlockingIOError):
+                    textfile.read()
+        finally:
+            if r is not None:
+                os.close(r)
+            os.close(w)
+
 
 class MemviewBytesIO(io.BytesIO):
     '''A BytesIO object whose read method returns memoryviews

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3925,7 +3925,7 @@ class TextIOWrapperTest(unittest.TestCase):
         r, w = os.pipe()
         try:
             os.set_blocking(r, False)
-            with open(r, 'r') as textfile:
+            with self.io.open(r, 'rt') as textfile:
                 r = None
                 # Nothing has been written so a non-blocking read raises a BlockingIOError exception.
                 with self.assertRaises(BlockingIOError):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1726,6 +1726,7 @@ Ng Pheng Siong
 Yann Sionneau
 George Sipe
 J. Sipprell
+Giovanni Siragusa
 Ngalim Siregar
 Kragen Sitaker
 Kaartic Sivaraam

--- a/Misc/NEWS.d/next/C_API/2024-08-12-10-15-19.gh-issue-109523.S2c3fi.rst
+++ b/Misc/NEWS.d/next/C_API/2024-08-12-10-15-19.gh-issue-109523.S2c3fi.rst
@@ -1,0 +1,1 @@
+In _io_TextIOWrapper_read_impl, raise BlockingIOError when read() from a non-blocking pipe does not return bytes.

--- a/Misc/NEWS.d/next/C_API/2024-08-12-10-15-19.gh-issue-109523.S2c3fi.rst
+++ b/Misc/NEWS.d/next/C_API/2024-08-12-10-15-19.gh-issue-109523.S2c3fi.rst
@@ -1,1 +1,1 @@
-In _io_TextIOWrapper_read_impl, raise BlockingIOError when read() from a non-blocking pipe does not return bytes.
+Reading text from a non-blocking stream with `.read()` may now raise a `BlockingIOError` if the operation cannot immediately return bytes.

--- a/Misc/NEWS.d/next/C_API/2024-08-12-10-15-19.gh-issue-109523.S2c3fi.rst
+++ b/Misc/NEWS.d/next/C_API/2024-08-12-10-15-19.gh-issue-109523.S2c3fi.rst
@@ -1,1 +1,1 @@
-Reading text from a non-blocking stream with `read` may now raise a :exc:`BlockingIOError` if the operation cannot immediately return bytes.
+Reading text from a non-blocking stream with ``read`` may now raise a :exc:`BlockingIOError` if the operation cannot immediately return bytes.

--- a/Misc/NEWS.d/next/C_API/2024-08-12-10-15-19.gh-issue-109523.S2c3fi.rst
+++ b/Misc/NEWS.d/next/C_API/2024-08-12-10-15-19.gh-issue-109523.S2c3fi.rst
@@ -1,1 +1,1 @@
-Reading text from a non-blocking stream with :meth:`.read()` may now raise a :exc:`BlockingIOError` if the operation cannot immediately return bytes.
+Reading text from a non-blocking stream with `read` may now raise a :exc:`BlockingIOError` if the operation cannot immediately return bytes.

--- a/Misc/NEWS.d/next/C_API/2024-08-12-10-15-19.gh-issue-109523.S2c3fi.rst
+++ b/Misc/NEWS.d/next/C_API/2024-08-12-10-15-19.gh-issue-109523.S2c3fi.rst
@@ -1,1 +1,1 @@
-Reading text from a non-blocking stream with `.read()` may now raise a `BlockingIOError` if the operation cannot immediately return bytes.
+Reading text from a non-blocking stream with :meth:`.read()` may now raise a :exc:`BlockingIOError` if the operation cannot immediately return bytes.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1993,8 +1993,7 @@ _io_TextIOWrapper_read_impl(textio *self, Py_ssize_t n)
             goto fail;
 
         if (bytes == Py_None){
-            PyErr_SetString(PyExc_BlockingIOError, "Unexpected None encountered. This may be due to non-blocking I/O "
-                                                   "or an issue with the underlying I/O implementation.");
+            PyErr_SetString(PyExc_BlockingIOError, "Read returned None.");
             return NULL;
 
         }

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1996,7 +1996,6 @@ _io_TextIOWrapper_read_impl(textio *self, Py_ssize_t n)
             Py_DECREF(bytes);
             PyErr_SetString(PyExc_BlockingIOError, "Read returned None.");
             return NULL;
-
         }
 
         _PyIO_State *state = self->state;

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1993,6 +1993,7 @@ _io_TextIOWrapper_read_impl(textio *self, Py_ssize_t n)
             goto fail;
 
         if (bytes == Py_None){
+            Py_DECREF(bytes);
             PyErr_SetString(PyExc_BlockingIOError, "Read returned None.");
             return NULL;
 

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1992,6 +1992,12 @@ _io_TextIOWrapper_read_impl(textio *self, Py_ssize_t n)
         if (bytes == NULL)
             goto fail;
 
+        if (bytes == Py_None){
+            PyErr_SetString(PyExc_BlockingIOError, "read() should return bytes");
+            return NULL;
+
+        }
+
         _PyIO_State *state = self->state;
         if (Py_IS_TYPE(self->decoder, state->PyIncrementalNewlineDecoder_Type))
             decoded = _PyIncrementalNewlineDecoder_decode(self->decoder,

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1994,9 +1994,7 @@ _io_TextIOWrapper_read_impl(textio *self, Py_ssize_t n)
 
         if (bytes == Py_None){
             PyErr_SetString(PyExc_BlockingIOError, "Unexpected None encountered. This may be due to non-blocking I/O "
-                                                   "or an issue with the underlying I/O implementation. Please refer to "
-                                                   "the documentation or ensure that the I/O operation is properly "
-                                                   "configured.");
+                                                   "or an issue with the underlying I/O implementation.");
             return NULL;
 
         }

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1993,7 +1993,10 @@ _io_TextIOWrapper_read_impl(textio *self, Py_ssize_t n)
             goto fail;
 
         if (bytes == Py_None){
-            PyErr_SetString(PyExc_BlockingIOError, "read() should return bytes");
+            PyErr_SetString(PyExc_BlockingIOError, "Unexpected None encountered. This may be due to non-blocking I/O "
+                                                   "or an issue with the underlying I/O implementation. Please refer to "
+                                                   "the documentation or ensure that the I/O operation is properly "
+                                                   "configured.");
             return NULL;
 
         }


### PR DESCRIPTION
- Updated `_io_TextIOWrapper_read_impl` to raise a `BlockingIOError` when `read()` does not return bytes.
- Introduced `test_read_non_blocking` to ensure that a `BlockingIOError` is raised when attempting to read from a non-blocking pipe with no data using `os.pipe()`.

<!-- gh-issue-number: gh-109523 -->
* Issue: gh-109523
<!-- /gh-issue-number -->
