### PR TITLE
gh-117364: Add `doctest.SkipTest` to skip all or some doctest examples

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -524,6 +524,41 @@ Some details you should read once, but won't need to remember:
      TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
 
 
+Skipping Tests
+^^^^^^^^^^^^^^
+
+You can skip all or some test examples with :exc:`SkipTest` exception.
+
+Let's say that you have some Python-version-specific API:
+
+.. doctest::
+
+   >>> import sys
+
+   >>> if sys.version_info >= (3, 14):
+   ...    def process_data():
+   ...       return 'processed data'
+
+And you want to mention it in the doctest and only run it
+for the appropriate Python versions:
+
+.. doctest::
+
+   >>> if sys.version_info < (3, 14):
+   ...     import doctest
+   ...     raise doctest.SkipTest('This test is only for 3.14+')
+
+   >>> # This line and below will only be executed by doctest on 3.14+
+   >>> process_data()
+   'processed data'
+
+.. exception:: SkipTest
+
+   Special exception after raising it, all test examples will be skipped.
+
+   .. versionadded:: 3.14
+
+
 .. _option-flags-and-directives:
 .. _doctest-options:
 
@@ -630,6 +665,8 @@ doctest decides whether actual output matches an example's expected output:
    depend on resources which would be unavailable to the test driver.
 
    The SKIP flag can also be used for temporarily "commenting out" examples.
+
+   See also: :class:`~SkipTest`.
 
 
 .. data:: COMPARISON_FLAGS

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -666,7 +666,7 @@ doctest decides whether actual output matches an example's expected output:
 
    The SKIP flag can also be used for temporarily "commenting out" examples.
 
-   See also: :class:`~SkipTest`.
+   See also: :exc:`~SkipTest`.
 
 
 .. data:: COMPARISON_FLAGS

--- a/Lib/test/test_doctest/test_doctest.py
+++ b/Lib/test/test_doctest/test_doctest.py
@@ -1950,6 +1950,22 @@ source:
     ValueError: line 0 of the doctest for s has an option directive on a line with no example: '# doctest: +ELLIPSIS'
 
     >>> _colorize.COLORIZE = save_colorize
+
+You can skip following examples via `raise SkipTest`:
+
+    >>> def f(x):
+    ...     r'''
+    ...     >>> print(1) # first success
+    ...     1
+    ...     >>> raise doctest.SkipTest("All tests after this line will be skipped")
+    ...     >>> print(4) # second skipped success
+    ...     4
+    ...     >>> print(5) # first skipped failure
+    ...     500
+    ...     '''
+    >>> test = doctest.DocTestFinder().find(f)[0]
+    >>> doctest.DocTestRunner(verbose=False).run(test)
+    TestResults(failed=0, attempted=4, skipped=3)
 """
 
 def test_testsource(): r"""
@@ -2474,12 +2490,13 @@ def test_DocFileSuite():
 
          >>> suite = doctest.DocFileSuite('test_doctest.txt',
          ...                              'test_doctest4.txt',
-         ...                              'test_doctest_skip.txt')
+         ...                              'test_doctest_skip.txt',
+         ...                              'test_doctest_skip2.txt')
          >>> result = suite.run(unittest.TestResult())
          >>> result
-         <unittest.result.TestResult run=3 errors=0 failures=1>
-        >>> len(result.skipped)
-        1
+         <unittest.result.TestResult run=4 errors=0 failures=1>
+         >>> len(result.skipped)  # not all examples in test_doctest_skip2 are skipped
+         1
 
        You can specify initial global variables:
 

--- a/Lib/test/test_doctest/test_doctest_skip2.txt
+++ b/Lib/test/test_doctest/test_doctest_skip2.txt
@@ -1,0 +1,6 @@
+This is a sample doctest in a text file, in which all examples are skipped.
+
+  >>> import doctest  # this example is not skipped
+  >>> raise doctest.SkipTest("All tests after this line are skipped")
+  >>> 2 + 2
+  5

--- a/Misc/NEWS.d/next/Library/2024-08-12-14-00-18.gh-issue-117364.4d55Ex.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-12-14-00-18.gh-issue-117364.4d55Ex.rst
@@ -1,0 +1,2 @@
+Add :exc:`doctest.SkipTest` to conditionally skip all or some doctest
+examples.


### PR DESCRIPTION
I ended up with an exception instead of a decorator. Several reasons:
1. Exception allows skipping some parts of doctest, giving more flexibility:

```python
>>> 'is not ' + 'skipped'
'is not skipped'

>>> import doctest
>>> raise doctest.SkipTest("All examples after are skipped")

>>> 'skipped'
'not checked'
```

2. It will work with `testsource` and other text-based features. While `@skip_if` decorator required real objects with attributes.
3. The API change is simplier with an exception. It only adds one new object. While decorator required a lot of new parameters in existing functions.



<!-- gh-issue-number: gh-117364 -->
* Issue: gh-117364
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--122935.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->