### PR TITLE
Add a --rerun option to the iOS testbed.

### DIFF
--- a/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
+++ b/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
@@ -15,6 +15,7 @@
     const char *argv[] = {
         "iOSTestbed", // argv[0] is the process that is running.
         "-uall",  // Enable all resources
+        "--rerun",  // Re-run failed tests in verbose mode
         "-W",  // Display test output on failure
         // To run a subset of tests, add the test names below; e.g.,
         // "test_os",


### PR DESCRIPTION
Adds a `--rerun` option to the iOS testbed runner.

We've seen a small number of transient failures in the iOS buildbot - mostly in socket-related tests, due to socket availability. These tests pass on the next test, and can't be easily reproduced. The test runner has a `--rerun` option that may help with the resilience of these tests, and is enabled in the `--slow/fast-ci` configurations; this PR enables that option for the iOS test runner.