### PR TITLE
Ensure that iOS test re-runs don't try to spawn a process.

### DIFF
--- a/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
+++ b/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
@@ -15,6 +15,7 @@
     const char *argv[] = {
         "iOSTestbed", // argv[0] is the process that is running.
         "-uall",  // Enable all resources
+        "--single-process",  // always run all tests sequentially in a single process
         "--rerun",  // Re-run failed tests in verbose mode
         "-W",  // Display test output on failure
         // To run a subset of tests, add the test names below; e.g.,


### PR DESCRIPTION
#122992 added a `--rerun` option to the iOS testbed... which was then exercised on the run merging to main, revealing that `--rerun` reruns in a subprocess by default.

This PR also enables the `--single-process` option, ensuring that reruns are executed in the same process.
