### PR TITLE
[3.13] Revert use of --rerun in iOS testbed.

### DIFF
--- a/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
+++ b/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
@@ -15,7 +15,6 @@
     const char *argv[] = {
         "iOSTestbed", // argv[0] is the process that is running.
         "-uall",  // Enable all resources
-        "--rerun",  // Re-run failed tests in verbose mode
         "-W",  // Display test output on failure
         // To run a subset of tests, add the test names below; e.g.,
         // "test_os",


### PR DESCRIPTION
Reverts #122993.

#122993 back ported the use of the `--rerun` option to the iOS testbed (introduced by #122992) to 3.13. 

However, the `--rerun` option reruns in a subprocess by default, and the `--single-process` option that disables this behaviour was added in #119728, which hasn't been backported to 3.13 (and probably shouldn't be in an RC window).