### PR TITLE
Fix doctrees dir of gettext builder

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -144,7 +144,7 @@ pydoc-topics: build
 
 .PHONY: gettext
 gettext: BUILDER = gettext
-gettext: SPHINXOPTS += '-d build/doctrees-gettext'
+gettext: SPHINXOPTS += -d build/doctrees-gettext
 gettext: build
 
 .PHONY: htmlview


### PR DESCRIPTION
The single quote around `-d build/doctrees-gettext` causes Sphinx to consider as the ' build' first directory instead of 'build'. Let's keep all builders' output inside 'build' directory.