### PR TITLE
GH-103484: Tell linkcheck to ignore debian manpage redirects

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -546,6 +546,8 @@ linkcheck_allowed_redirects = {
     r'https://msdn.microsoft.com/.*': 'https://learn.microsoft.com/.*',
     r'https://docs.microsoft.com/.*': 'https://learn.microsoft.com/.*',
     r'https://go.microsoft.com/fwlink/\?LinkID=\d+': 'https://learn.microsoft.com/.*',
+    # Debian's man page redirects to its current stable version
+    r'https://manpages.debian.org/\w+\(\d(\w+)?\)': r'https://manpages.debian.org/\w+/[\w/\-\.]*\.\d(\w+)?\.en\.html',
     # Language redirects
     r'https://toml.io': 'https://toml.io/en/',
     r'https://www.redhat.com': 'https://www.redhat.com/en',


### PR DESCRIPTION
This is another patch required to fix the current state of `make linkcheck` in Python Docs. This pull request fixes occurrences of "redirected temporarily" as reported by make linkcheck, which consists solely of Debian's man pages.

The Debian's man page website is used as [manpages_url](https://www.sphinx-doc.org/pt-br/master/usage/configuration.html#confval-manpages_url) config value, and it gets redirected to the current stable version (that's "bookworm" as of this PR).

Please consider backporting to 3.13 and 3.12 branches. The patch should applies without issues.

<details>
<summary>See here a list of links currently reported as "redirected temporarily"</summary>
<pre>
c-api/conversion.rst:13: [redirected temporarily] https://manpages.debian.org/snprintf(3) to https://manpages.debian.org/bookworm/manpages-dev/snprintf.3.en.html
c-api/conversion.rst:19: [redirected temporarily] https://manpages.debian.org/vsnprintf(3) to https://manpages.debian.org/bookworm/manpages-dev/vsnprintf.3.en.html
c-api/conversion.rst:68: [redirected temporarily] https://manpages.debian.org/strtoul(3) to https://manpages.debian.org/bookworm/manpages-dev/strtoul.3.en.html
c-api/conversion.rst:82: [redirected temporarily] https://manpages.debian.org/strtol(3) to https://manpages.debian.org/bookworm/manpages-dev/strtol.3.en.html
library/ctypes.rst:1466: [redirected temporarily] https://manpages.debian.org/dlopen(3) to https://manpages.debian.org/bookworm/manpages-dev/dlopen.3.en.html
library/datetime.rst:2531: [redirected temporarily] https://manpages.debian.org/strftime(3) to https://manpages.debian.org/bookworm/manpages-dev/strftime.3.en.html
library/fcntl.rst:162: [redirected temporarily] https://manpages.debian.org/flock(2) to https://manpages.debian.org/bookworm/manpages-dev/flock.2.en.html
library/fcntl.rst:16: [redirected temporarily] https://manpages.debian.org/fcntl(2) to https://manpages.debian.org/bookworm/manpages-dev/fcntl.2.en.html
library/fcntl.rst:16: [redirected temporarily] https://manpages.debian.org/ioctl(2) to https://manpages.debian.org/bookworm/manpages-dev/ioctl.2.en.html
library/io.rst:1164: [redirected temporarily] https://manpages.debian.org/read(2) to https://manpages.debian.org/bookworm/manpages-dev/read.2.en.html
library/os.rst:1298: [redirected temporarily] https://manpages.debian.org/open(2) to https://manpages.debian.org/bookworm/manpages-dev/open.2.en.html
library/os.rst:1766: [redirected temporarily] https://manpages.debian.org/splice(2) to https://manpages.debian.org/bookworm/manpages-dev/splice.2.en.html
library/os.rst:2009: [redirected temporarily] https://manpages.debian.org/access(2) to https://manpages.debian.org/bookworm/manpages-dev/access.2.en.html
library/os.rst:3801: [redirected temporarily] https://manpages.debian.org/eventfd(2) to https://manpages.debian.org/bookworm/manpages-dev/eventfd.2.en.html
library/os.rst:3958: [redirected temporarily] https://manpages.debian.org/timerfd_create(2) to https://manpages.debian.org/bookworm/manpages-dev/timerfd_create.2.en.html
library/os.rst:4019: [redirected temporarily] https://manpages.debian.org/clock_settime(2) to https://manpages.debian.org/bookworm/manpages-dev/clock_settime.2.en.html
library/os.rst:4019: [redirected temporarily] https://manpages.debian.org/date(1) to https://manpages.debian.org/bookworm/coreutils/date.1.en.html
library/os.rst:4019: [redirected temporarily] https://manpages.debian.org/settimeofday(2) to https://manpages.debian.org/bookworm/manpages-dev/settimeofday.2.en.html
library/os.rst:4019: [redirected temporarily] https://manpages.debian.org/timerfd_settime(2) to https://manpages.debian.org/bookworm/manpages-dev/timerfd_settime.2.en.html
library/os.rst:4049: [redirected temporarily] https://manpages.debian.org/timerfd_gettime(2) to https://manpages.debian.org/bookworm/manpages-dev/timerfd_gettime.2.en.html
library/os.rst:4601: [redirected temporarily] https://manpages.debian.org/pidfd_open(2) to https://manpages.debian.org/bookworm/manpages-dev/pidfd_open.2.en.html
library/os.rst:4608: [redirected temporarily] https://manpages.debian.org/waitid(2) to https://manpages.debian.org/bookworm/manpages-dev/waitid.2.en.html
library/os.rst:5030: [redirected temporarily] https://manpages.debian.org/times(2) to https://manpages.debian.org/bookworm/manpages-dev/times.2.en.html
library/os.rst:5335: [redirected temporarily] https://manpages.debian.org/ptrace(2) to https://manpages.debian.org/bookworm/manpages-dev/ptrace.2.en.html
library/os.rst:620: [redirected temporarily] https://manpages.debian.org/namespaces(7) to https://manpages.debian.org/bookworm/manpages/namespaces.7.en.html
library/os.rst:620: [redirected temporarily] https://manpages.debian.org/setns(2) to https://manpages.debian.org/bookworm/manpages-dev/setns.2.en.html
library/os.rst:831: [redirected temporarily] https://manpages.debian.org/unshare(2) to https://manpages.debian.org/bookworm/manpages-dev/unshare.2.en.html
library/pty.rst:93: [redirected temporarily] https://manpages.debian.org/script(1) to https://manpages.debian.org/bookworm/bsdutils/script.1.en.html
library/resource.rst:307: [redirected temporarily] https://manpages.debian.org/getrusage(2) to https://manpages.debian.org/bookworm/manpages-dev/getrusage.2.en.html
library/resource.rst:43: [redirected temporarily] https://manpages.debian.org/getrlimit(2) to https://manpages.debian.org/bookworm/manpages-dev/getrlimit.2.en.html
library/signal.rst:105: [redirected temporarily] https://manpages.debian.org/pthread_sigmask(3) to https://manpages.debian.org/bookworm/manpages-dev/pthread_sigmask.3.en.html
library/signal.rst:105: [redirected temporarily] https://manpages.debian.org/sigprocmask(2) to https://manpages.debian.org/bookworm/manpages-dev/sigprocmask.2.en.html
library/signal.rst:130: [redirected temporarily] https://manpages.debian.org/abort(3) to https://manpages.debian.org/bookworm/manpages-dev/abort.3.en.html
library/signal.rst:134: [redirected temporarily] https://manpages.debian.org/alarm(2) to https://manpages.debian.org/bookworm/manpages-dev/alarm.2.en.html
library/signal.rst:219: [redirected temporarily] https://manpages.debian.org/signal(7) to https://manpages.debian.org/bookworm/manpages/signal.7.en.html
library/signal.rst:248: [redirected temporarily] https://manpages.debian.org/signal(2) to https://manpages.debian.org/bookworm/manpages-dev/signal.2.en.html
library/signal.rst:412: [redirected temporarily] https://manpages.debian.org/pidfd_send_signal(2) to https://manpages.debian.org/bookworm/manpages-dev/pidfd_send_signal.2.en.html
library/signal.rst:439: [redirected temporarily] https://manpages.debian.org/pthread_kill(3) to https://manpages.debian.org/bookworm/manpages-dev/pthread_kill.3.en.html
library/signal.rst:563: [redirected temporarily] https://manpages.debian.org/siginterrupt(3) to https://manpages.debian.org/bookworm/manpages-dev/siginterrupt.3.en.html
library/signal.rst:605: [redirected temporarily] https://manpages.debian.org/sigpending(2) to https://manpages.debian.org/bookworm/manpages-dev/sigpending.2.en.html
library/signal.rst:620: [redirected temporarily] https://manpages.debian.org/sigwait(3) to https://manpages.debian.org/bookworm/manpages-dev/sigwait.3.en.html
library/signal.rst:646: [redirected temporarily] https://manpages.debian.org/sigwaitinfo(2) to https://manpages.debian.org/bookworm/manpages-dev/sigwaitinfo.2.en.html
library/signal.rst:666: [redirected temporarily] https://manpages.debian.org/sigtimedwait(2) to https://manpages.debian.org/bookworm/manpages-dev/sigtimedwait.2.en.html
library/signal.rst:709: [redirected temporarily] https://manpages.debian.org/head(1) to https://manpages.debian.org/bookworm/coreutils/head.1.en.html
library/socket.rst:1048: [redirected temporarily] https://manpages.debian.org/getnameinfo(3) to https://manpages.debian.org/bookworm/manpages-dev/getnameinfo.3.en.html
library/socket.rst:1132: [redirected temporarily] https://manpages.debian.org/inet(3) to https://manpages.debian.org/bookworm/manpages-dev/inet.3.en.html
library/socket.rst:1528: [redirected temporarily] https://manpages.debian.org/getsockopt(2) to https://manpages.debian.org/bookworm/manpages-dev/getsockopt.2.en.html
library/socket.rst:1616: [redirected temporarily] https://manpages.debian.org/recv(2) to https://manpages.debian.org/bookworm/manpages-dev/recv.2.en.html
library/socket.rst:183: [redirected temporarily] https://manpages.debian.org/vsock(7) to https://manpages.debian.org/bookworm/manpages/vsock.7.en.html
library/socket.rst:1950: [redirected temporarily] https://manpages.debian.org/setsockopt(2) to https://manpages.debian.org/bookworm/manpages-dev/setsockopt.2.en.html
library/socket.rst:555: [redirected temporarily] https://manpages.debian.org/packet(7) to https://manpages.debian.org/bookworm/manpages/packet.7.en.html
library/stat.rst:459: [redirected temporarily] https://manpages.debian.org/chflags(2) to https://manpages.debian.org/bookworm/freebsd-manpages/chflags.2freebsd.en.html
library/termios.rst:14: [redirected temporarily] https://manpages.debian.org/termios(3) to https://manpages.debian.org/bookworm/manpages-dev/termios.3.en.html
library/time.rst:151: [redirected temporarily] https://manpages.debian.org/pthread_getcpuclockid(3) to https://manpages.debian.org/bookworm/manpages-dev/pthread_getcpuclockid.3.en.html
library/time.rst:805: [redirected temporarily] https://manpages.debian.org/tzfile(5) to https://manpages.debian.org/bookworm/manpages/tzfile.5.en.html
library/tkinter.rst:586: [redirected temporarily] https://manpages.debian.org/options(3) to https://manpages.debian.org/bookworm/libcvc4-dev/options.3cvc.en.html
library/tkinter.rst:879: [redirected temporarily] https://manpages.debian.org/bind(3tk) to https://manpages.debian.org/bookworm/tk8.6-doc/bind.3tk.en.html
whatsnew/3.13.rst:1315: [redirected temporarily] https://manpages.debian.org/crypt_r(3) to https://manpages.debian.org/bookworm/libcrypt-dev/crypt_r.3.en.html
</pre>
</details>

<!-- gh-issue-number: gh-103484 -->
* Issue: gh-103484
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123019.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->