### PR TITLE
gh-99108: Inform HACL when explicit_bzero is unavailable

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -222,6 +222,7 @@ LIBMPDEC_A= Modules/_decimal/libmpdec/libmpdec.a
 LIBEXPAT_A= Modules/expat/libexpat.a
 LIBHACL_SHA2_A= Modules/_hacl/libHacl_Hash_SHA2.a
 LIBHACL_BLAKE2_A= Modules/_hacl/libHacl_Hash_Blake2.a
+LIBHACL_CFLAGS=@LIBHACL_CFLAGS@
 LIBHACL_SIMD128_FLAGS=@LIBHACL_SIMD128_FLAGS@
 LIBHACL_SIMD256_FLAGS=@LIBHACL_SIMD256_FLAGS@
 LIBHACL_SIMD128_OBJS=@LIBHACL_SIMD128_OBJS@
@@ -1368,7 +1369,6 @@ $(LIBEXPAT_A): $(LIBEXPAT_OBJS)
 # Build HACL* static libraries for hashlib: libHacl_Hash_SHA2.a, and
 # libHacl_Blake2.a -- the contents of the latter vary depending on whether we
 # have the ability to compile vectorized versions
-LIBHACL_CFLAGS=-I$(srcdir)/Modules/_hacl -I$(srcdir)/Modules/_hacl/include -D_BSD_SOURCE -D_DEFAULT_SOURCE $(PY_STDMODULE_CFLAGS) $(CCSHARED)
 
 Modules/_hacl/Hacl_Hash_SHA2.o: $(srcdir)/Modules/_hacl/Hacl_Hash_SHA2.c $(LIBHACL_SHA2_HEADERS)
 	$(CC) -c $(LIBHACL_CFLAGS) -o $@ $(srcdir)/Modules/_hacl/Hacl_Hash_SHA2.c

--- a/configure
+++ b/configure
@@ -717,6 +717,7 @@ LIBHACL_SIMD256_OBJS
 LIBHACL_SIMD256_FLAGS
 LIBHACL_SIMD128_OBJS
 LIBHACL_SIMD128_FLAGS
+LIBHACL_CFLAGS
 MODULE__BLAKE2_FALSE
 MODULE__BLAKE2_TRUE
 MODULE__SHA3_FALSE
@@ -30421,6 +30422,16 @@ fi
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $py_cv_module__blake2" >&5
 printf "%s\n" "$py_cv_module__blake2" >&6; }
+
+
+LIBHACL_CFLAGS='-I$(srcdir)/Modules/_hacl -I$(srcdir)/Modules/_hacl/include -D_BSD_SOURCE -D_DEFAULT_SOURCE $(PY_STDMODULE_CFLAGS) $(CCSHARED)'
+case "$ac_sys_system" in
+  Linux*)
+    if test "$ac_cv_func_explicit_bzero" = "no"; then
+      LIBHACL_CFLAGS="$LIBHACL_CFLAGS -DLINUX_NO_EXPLICIT_BZERO"
+    fi
+  ;;
+esac
 
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -msse -msse2 -msse3 -msse4.1 -msse4.2" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -7764,6 +7764,16 @@ PY_STDLIB_MOD([_sha2], [test "$with_builtin_sha2" = yes])
 PY_STDLIB_MOD([_sha3], [test "$with_builtin_sha3" = yes])
 PY_STDLIB_MOD([_blake2], [test "$with_builtin_blake2" = yes])
 
+LIBHACL_CFLAGS='-I$(srcdir)/Modules/_hacl -I$(srcdir)/Modules/_hacl/include -D_BSD_SOURCE -D_DEFAULT_SOURCE $(PY_STDMODULE_CFLAGS) $(CCSHARED)'
+case "$ac_sys_system" in
+  Linux*)
+    if test "$ac_cv_func_explicit_bzero" = "no"; then
+      LIBHACL_CFLAGS="$LIBHACL_CFLAGS -DLINUX_NO_EXPLICIT_BZERO"
+    fi
+  ;;
+esac
+AC_SUBST([LIBHACL_CFLAGS])
+
 dnl This can be extended here to detect e.g. Power8, which HACL* should also support.
 AX_CHECK_COMPILE_FLAG([-msse -msse2 -msse3 -msse4.1 -msse4.2],[
   [LIBHACL_SIMD128_FLAGS="-msse -msse2 -msse3 -msse4.1 -msse4.2"]


### PR DESCRIPTION
For context, see https://github.com/python/cpython/issues/99108#issuecomment-2288096365.

This PR fixes the build on Android and RHEL7 by defining LINUX_NO_EXPLICIT_BZERO when `explicit_bzero` is unavailable. It turns out there was already an autoconf check for this function, so I reused it.

Instead of creating a new Makefile variable, I appended the definition to LIBHACL_CFLAGS. This may be useful if HACL uses it in other files in the future.

<!-- gh-issue-number: gh-99108 -->
* Issue: gh-99108
<!-- /gh-issue-number -->
