### PR TITLE
gh-123780: Make test_pkgutil clean up `spam` module

### DIFF
--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -624,8 +624,11 @@ class ImportlibMigrationTests(unittest.TestCase):
         mod = type(sys)(name)
         del mod.__spec__
         with CleanImport(name):
-            sys.modules[name] = mod
-            loader = pkgutil.get_loader(name)
+            try:
+                sys.modules[name] = mod
+                loader = pkgutil.get_loader(name)
+            finally:
+                sys.modules.pop(name, None)
         self.assertIsNone(loader)
 
     @ignore_warnings(category=DeprecationWarning)
@@ -634,8 +637,11 @@ class ImportlibMigrationTests(unittest.TestCase):
         mod = type(sys)(name)
         mod.__spec__ = None
         with CleanImport(name):
-            sys.modules[name] = mod
-            loader = pkgutil.get_loader(name)
+            try:
+                sys.modules[name] = mod
+                loader = pkgutil.get_loader(name)
+            finally:
+                sys.modules.pop(name, None)
         self.assertIsNone(loader)
 
     @ignore_warnings(category=DeprecationWarning)


### PR DESCRIPTION
When running the tests with --randomize, as is done by the buildbots, I came across this failure:

```
======================================================================
ERROR: test_find_class (test.test_pickle.CUnpicklerTests.test_find_class)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/msmith/git/python/cpython/Lib/test/pickletester.py", line 1265, in test_find_class
    self.assertRaises(ModuleNotFoundError, unpickler.find_class, 'spam', 'log')
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/msmith/git/python/cpython/Lib/unittest/case.py", line 804, in assertRaises
    return context.handle('assertRaises', args, kwargs)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/msmith/git/python/cpython/Lib/unittest/case.py", line 238, in handle
    callable_obj(*args, **kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
AttributeError: module 'spam' has no attribute 'log'

======================================================================
ERROR: test_find_class (test.test_pickle.PyUnpicklerTests.test_find_class)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/msmith/git/python/cpython/Lib/test/pickletester.py", line 1265, in test_find_class
    self.assertRaises(ModuleNotFoundError, unpickler.find_class, 'spam', 'log')
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/msmith/git/python/cpython/Lib/unittest/case.py", line 804, in assertRaises
    return context.handle('assertRaises', args, kwargs)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/msmith/git/python/cpython/Lib/unittest/case.py", line 238, in handle
    callable_obj(*args, **kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/msmith/git/python/cpython/Lib/pickle.py", line 1620, in find_class
    return getattr(sys.modules[module], name)
AttributeError: module 'spam' has no attribute 'log'

----------------------------------------------------------------------
Ran 857 tests in 2.954s

FAILED (errors=2, skipped=31)
test test_pickle failed
```

This can be reproduced by running only test_pkgutil and test_pickle, in that order. test_pkgutil leaves behind a `spam` module in `sys.modules`, while test_pickle assumes there is no such module.

<!-- gh-issue-number: gh-123780 -->
* Issue: gh-123780
<!-- /gh-issue-number -->
