### PR TITLE
Fix documentation for time.ctime()

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1026,11 +1026,11 @@ time_ctime(PyObject *self, PyObject *args)
 }
 
 PyDoc_STRVAR(ctime_doc,
-"ctime(seconds) -> string\n\
+"ctime([seconds]) -> string\n\
 \n\
 Convert a time in seconds since the Epoch to a string in local time.\n\
-This is equivalent to asctime(localtime(seconds)). When the time tuple is\n\
-not present, current time as returned by localtime() is used.");
+This is equivalent to asctime(localtime(seconds)). When 'seconds' is not\n\
+passed in, the current time as returned by time() is used.");
 
 #ifdef HAVE_MKTIME
 static PyObject *


### PR DESCRIPTION
The previous documentation had text copied from the documentation for time.asctime() which does not apply to time.ctime().

Added square brackets around "seconds" to indicate an optional argument.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
