### PR TITLE
gh-123046: Fix regexp to catch cases where the module name is omitted from the weakref repr

### DIFF
--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -125,7 +125,7 @@ class ReferencesTestCase(TestBase):
         ref = weakref.ref(obj)
         self.assertRegex(repr(ref),
                          rf"<weakref at 0x[0-9a-fA-F]+; "
-                         rf"to '{C.__module__}.{C.__qualname__}' "
+                         rf"to '({C.__module__}.)?{C.__qualname__}' "
                          rf"at 0x[0-9a-fA-F]+>")
 
         obj = None
@@ -143,7 +143,7 @@ class ReferencesTestCase(TestBase):
         ref2 = weakref.ref(obj2)
         self.assertRegex(repr(ref2),
                          rf"<weakref at 0x[0-9a-fA-F]+; "
-                         rf"to '{WithName.__module__}.{WithName.__qualname__}' "
+                         rf"to '({WithName.__module__}.)?{WithName.__qualname__}' "
                          rf"at 0x[0-9a-fA-F]+ \(custom_name\)>")
 
     def test_repr_failure_gh99184(self):
@@ -231,7 +231,7 @@ class ReferencesTestCase(TestBase):
         ref = weakref.proxy(obj, self.callback)
         self.assertRegex(repr(ref),
                          rf"<weakproxy at 0x[0-9a-fA-F]+; "
-                         rf"to '{C.__module__}.{C.__qualname__}' "
+                         rf"to '({C.__module__}.)?{C.__qualname__}' "
                          rf"at 0x[0-9a-fA-F]+>")
 
         obj = None

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -143,18 +143,12 @@ class ReferencesTestCase(TestBase):
 
         obj2 = WithName()
         ref2 = weakref.ref(obj2)
-        if __name__ == "__main__":
-            regex = (
-                rf"<weakref at 0x[0-9a-fA-F]+; "
-                rf"to '{WithName.__qualname__}' "
-                rf"at 0x[0-9a-fA-F]+ \(custom_name\)>"
-            )
-        else:
-            regex = (
-                rf"<weakref at 0x[0-9a-fA-F]+; "
-                rf"to '{WithName.__module__}.{WithName.__qualname__}' "
-                rf"at 0x[0-9a-fA-F]+ \(custom_name\)>"
-            )
+        regex = (
+            rf"<weakref at 0x[0-9a-fA-F]+; "
+            rf"to '{'' if __name__ == '__main__' else WithName.__module__ + '.'}"
+            rf"{WithName.__qualname__}' "
+            rf"at 0x[0-9a-fA-F]+ +\(custom_name\)>"
+        )
         self.assertRegex(repr(ref2), regex)
 
     def test_repr_failure_gh99184(self):
@@ -240,18 +234,11 @@ class ReferencesTestCase(TestBase):
     def test_proxy_repr(self):
         obj = C()
         ref = weakref.proxy(obj, self.callback)
-        if __name__ == "__main__":
-            regex = (
-                rf"<weakproxy at 0x[0-9a-fA-F]+; "
-                rf"to '{C.__qualname__}' "
-                rf"at 0x[0-9a-fA-F]+>"
-            )
-        else:
-            regex = (
-                rf"<weakproxy at 0x[0-9a-fA-F]+; "
-                rf"to '{C.__module__}.{C.__qualname__}' "
-                rf"at 0x[0-9a-fA-F]+>"
-            )
+        regex = (
+            rf"<weakproxy at 0x[0-9a-fA-F]+; "
+            rf"to '{'' if __name__ == '__main__' else C.__module__ + '.'}{C.__qualname__}' "
+            rf"at 0x[0-9a-fA-F]+>"
+        )
         self.assertRegex(repr(ref), regex)
 
         obj = None

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -123,18 +123,11 @@ class ReferencesTestCase(TestBase):
     def test_ref_repr(self):
         obj = C()
         ref = weakref.ref(obj)
-        if __name__ == "__main__":
-            regex = (
-                rf"<weakref at 0x[0-9a-fA-F]+; "
-                rf"to '{C.__qualname__}' "
-                rf"at 0x[0-9a-fA-F]+>"
-            )
-        else:
-            regex = (
-                rf"<weakref at 0x[0-9a-fA-F]+; "
-                rf"to '{C.__module__}.{C.__qualname__}' "
-                rf"at 0x[0-9a-fA-F]+>"
-            )
+        regex = (
+            rf"<weakref at 0x[0-9a-fA-F]+; "
+            rf"to '{'' if __name__ == '__main__' else C.__module__ + '.'}{C.__qualname__}' "
+            rf"at 0x[0-9a-fA-F]+>"
+        )
         self.assertRegex(repr(ref), regex)
 
         obj = None

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -152,14 +152,14 @@ class ReferencesTestCase(TestBase):
         ref2 = weakref.ref(obj2)
         if __name__ == "__main__":
             regex = (
-                rf"<weakref at 0x[0-9a-fA-F]+; " 
-                rf"to '{WithName.__qualname__}' " 
+                rf"<weakref at 0x[0-9a-fA-F]+; "
+                rf"to '{WithName.__qualname__}' "
                 rf"at 0x[0-9a-fA-F]+ \(custom_name\)>"
             )
         else:
             regex = (
-                rf"<weakref at 0x[0-9a-fA-F]+; " 
-                rf"to '{WithName.__module__}.{WithName.__qualname__}' " 
+                rf"<weakref at 0x[0-9a-fA-F]+; "
+                rf"to '{WithName.__module__}.{WithName.__qualname__}' "
                 rf"at 0x[0-9a-fA-F]+ \(custom_name\)>"
             )
         self.assertRegex(repr(ref2), regex)

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -123,10 +123,19 @@ class ReferencesTestCase(TestBase):
     def test_ref_repr(self):
         obj = C()
         ref = weakref.ref(obj)
-        self.assertRegex(repr(ref),
-                         rf"<weakref at 0x[0-9a-fA-F]+; "
-                         rf"to '({C.__module__}.)?{C.__qualname__}' "
-                         rf"at 0x[0-9a-fA-F]+>")
+        if __name__ == "__main__":
+            regex = (
+                rf"<weakref at 0x[0-9a-fA-F]+; "
+                rf"to '{C.__qualname__}' "
+                rf"at 0x[0-9a-fA-F]+>"
+            )
+        else:
+            regex = (
+                rf"<weakref at 0x[0-9a-fA-F]+; "
+                rf"to '{C.__module__}.{C.__qualname__}' "
+                rf"at 0x[0-9a-fA-F]+>"
+            )
+        self.assertRegex(repr(ref), regex)
 
         obj = None
         gc_collect()
@@ -141,10 +150,19 @@ class ReferencesTestCase(TestBase):
 
         obj2 = WithName()
         ref2 = weakref.ref(obj2)
-        self.assertRegex(repr(ref2),
-                         rf"<weakref at 0x[0-9a-fA-F]+; "
-                         rf"to '({WithName.__module__}.)?{WithName.__qualname__}' "
-                         rf"at 0x[0-9a-fA-F]+ \(custom_name\)>")
+        if __name__ == "__main__":
+            regex = (
+                rf"<weakref at 0x[0-9a-fA-F]+; " 
+                rf"to '{WithName.__qualname__}' " 
+                rf"at 0x[0-9a-fA-F]+ \(custom_name\)>"
+            )
+        else:
+            regex = (
+                rf"<weakref at 0x[0-9a-fA-F]+; " 
+                rf"to '{WithName.__module__}.{WithName.__qualname__}' " 
+                rf"at 0x[0-9a-fA-F]+ \(custom_name\)>"
+            )
+        self.assertRegex(repr(ref2), regex)
 
     def test_repr_failure_gh99184(self):
         class MyConfig(dict):
@@ -229,10 +247,19 @@ class ReferencesTestCase(TestBase):
     def test_proxy_repr(self):
         obj = C()
         ref = weakref.proxy(obj, self.callback)
-        self.assertRegex(repr(ref),
-                         rf"<weakproxy at 0x[0-9a-fA-F]+; "
-                         rf"to '({C.__module__}.)?{C.__qualname__}' "
-                         rf"at 0x[0-9a-fA-F]+>")
+        if __name__ == "__main__":
+            regex = (
+                rf"<weakproxy at 0x[0-9a-fA-F]+; "
+                rf"to '{C.__qualname__}' "
+                rf"at 0x[0-9a-fA-F]+>"
+            )
+        else:
+            regex = (
+                rf"<weakproxy at 0x[0-9a-fA-F]+; "
+                rf"to '{C.__module__}.{C.__qualname__}' "
+                rf"at 0x[0-9a-fA-F]+>"
+            )
+        self.assertRegex(repr(ref), regex)
 
         obj = None
         gc_collect()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123046 -->
* Issue: gh-123046
<!-- /gh-issue-number -->
