### PR TITLE
gh-123067: Denial of Service Vulnerability in `http.cookies._unquote()`

### DIFF
--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -184,51 +184,29 @@ def _quote(str):
         return '"' + str.translate(_Translator) + '"'
 
 
-_OctalPatt = re.compile(r"\\[0-3][0-7][0-7]")
-_QuotePatt = re.compile(r"[\\].")
+_OctalPatt = re.compile(r"\\([0-3][0-7][0-7])")
+_QuotePatt = re.compile(r'\\"')
 
 def _unquote(str):
-    # If there aren't any doublequotes,
-    # then there can't be any special characters.  See RFC 2109.
     if str is None or len(str) < 2:
         return str
     if str[0] != '"' or str[-1] != '"':
         return str
 
-    # We have to assume that we must decode this string.
-    # Down to work.
-
-    # Remove the "s
+    # Remove the surrounding quotes
     str = str[1:-1]
 
-    # Check for special sequences.  Examples:
-    #    \012 --> \n
-    #    \"   --> "
-    #
-    i = 0
-    n = len(str)
-    res = []
-    while 0 <= i < n:
-        o_match = _OctalPatt.search(str, i)
-        q_match = _QuotePatt.search(str, i)
-        if not o_match and not q_match:              # Neither matched
-            res.append(str[i:])
-            break
-        # else:
-        j = k = -1
-        if o_match:
-            j = o_match.start(0)
-        if q_match:
-            k = q_match.start(0)
-        if q_match and (not o_match or k < j):     # QuotePatt matched
-            res.append(str[i:k])
-            res.append(str[k+1])
-            i = k + 2
-        else:                                      # OctalPatt matched
-            res.append(str[i:j])
-            res.append(chr(int(str[j+1:j+4], 8)))
-            i = j + 4
-    return _nulljoin(res)
+    # Function to replace octal patterns
+    def replace_octal(match):
+        octal_value = match.group(1)
+        return chr(int(octal_value, 8))
+
+    # Replace octal escape sequences
+    str = _OctalPatt.sub(replace_octal, str)
+    # Replace escaped quotes
+    str = _QuotePatt.sub('"', str)
+
+    return str
 
 # The _getdate() routine is used to set the expiration time in the cookie's HTTP
 # header.  By default, _getdate() returns the current time in the appropriate


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
### Summary
Refactor and improve the `_unquote()` method in `http.cookies` to address the performance issues identified in CVE-2024-7592, enhancing the handling of escape sequences to prevent potential DoS vulnerabilities.

### Changes
- Updated regex patterns to optimize matching and substitution.
- Removed inefficient loop constructs, replacing them with a streamlined regex substitution process.

### Context
This update comes after the Django team acknowledged the potential for a DoS vulnerability within their use of the `http.cookies` module. The vulnerability has been formally reserved CVE-2024-7592.

---

Please review these changes and provide your feedback.


<!-- gh-issue-number: gh-123067 -->
* Issue: gh-123067
<!-- /gh-issue-number -->
