### PR TITLE
gh-122974: Suppress GCC array bound warnings in free-threaded build

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -301,6 +301,14 @@ _Py_INCREF_TYPE(PyTypeObject *type)
         return;
     }
 
+    // gh-122974: GCC 11 warns about the access to PyHeapTypeObject fields when
+    // _Py_INCREF_TYPE() is called on a statically allocated type.  The
+    // _PyType_HasFeature check above ensures that the type is a heap type.
+#if defined(__GNUC__) && __GNUC__ >= 11
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
     _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)_PyThreadState_GET();
     PyHeapTypeObject *ht = (PyHeapTypeObject *)type;
 
@@ -319,6 +327,10 @@ _Py_INCREF_TYPE(PyTypeObject *type)
         // It handles the unique_id=-1 case to keep the inlinable function smaller.
         _PyType_IncrefSlow(ht);
     }
+
+#if defined(__GNUC__) && __GNUC__ >= 11
+#  pragma GCC diagnostic pop
+#endif
 }
 
 static inline void


### PR DESCRIPTION
GCC 11 and newer warn about the access to `unique_id` in non-debug builds due to inlining the call on static non-heap types.


<!-- gh-issue-number: gh-122974 -->
* Issue: gh-122974
<!-- /gh-issue-number -->
