### PR TITLE
[3.13] gh-116608: Revert "[3.13] gh-116608: Apply style and compatibility changes from importlib_resources. (GH-123028) (#123051)"

### DIFF
--- a/Lib/importlib/resources/_functional.py
+++ b/Lib/importlib/resources/_functional.py
@@ -57,7 +57,11 @@ def contents(anchor, *path_names):
         DeprecationWarning,
         stacklevel=1,
     )
-    return (resource.name for resource in _get_resource(anchor, path_names).iterdir())
+    return (
+        resource.name
+        for resource
+        in _get_resource(anchor, path_names).iterdir()
+    )
 
 
 def _get_encoding_arg(path_names, encoding):

--- a/Lib/test/test_importlib/resources/test_functional.py
+++ b/Lib/test/test_importlib/resources/test_functional.py
@@ -1,9 +1,9 @@
 import unittest
 import os
 
-from test.support import warnings_helper
+from test.support.warnings_helper import ignore_warnings, check_warnings
 
-from importlib import resources
+import importlib.resources as resources
 
 # Since the functional API forwards to Traversable, we only test
 # filesystem resources here -- not zip files, namespace packages etc.
@@ -22,7 +22,8 @@ class ModuleAnchorMixin:
 
 class FunctionalAPIBase:
     def _gen_resourcetxt_path_parts(self):
-        """Yield various names of a text file in anchor02, each in a subTest"""
+        """Yield various names of a text file in anchor02, each in a subTest
+        """
         for path_parts in (
             ('subdirectory', 'subsubdir', 'resource.txt'),
             ('subdirectory/subsubdir/resource.txt',),
@@ -35,7 +36,7 @@ class FunctionalAPIBase:
         """Assert that `string` ends with `suffix`.
 
         Used to ignore an architecture-specific UTF-16 byte-order mark."""
-        self.assertEqual(string[-len(suffix) :], suffix)
+        self.assertEqual(string[-len(suffix):], suffix)
 
     def test_read_text(self):
         self.assertEqual(
@@ -44,10 +45,7 @@ class FunctionalAPIBase:
         )
         self.assertEqual(
             resources.read_text(
-                self.anchor02,
-                'subdirectory',
-                'subsubdir',
-                'resource.txt',
+                self.anchor02, 'subdirectory', 'subsubdir', 'resource.txt',
                 encoding='utf-8',
             ),
             'a resource',
@@ -55,9 +53,7 @@ class FunctionalAPIBase:
         for path_parts in self._gen_resourcetxt_path_parts():
             self.assertEqual(
                 resources.read_text(
-                    self.anchor02,
-                    *path_parts,
-                    encoding='utf-8',
+                    self.anchor02, *path_parts, encoding='utf-8',
                 ),
                 'a resource',
             )
@@ -71,16 +67,13 @@ class FunctionalAPIBase:
             resources.read_text(self.anchor01, 'utf-16.file')
         self.assertEqual(
             resources.read_text(
-                self.anchor01,
-                'binary.file',
-                encoding='latin1',
+                self.anchor01, 'binary.file', encoding='latin1',
             ),
             '\x00\x01\x02\x03',
         )
         self.assertEndsWith(  # ignore the BOM
             resources.read_text(
-                self.anchor01,
-                'utf-16.file',
+                self.anchor01, 'utf-16.file',
                 errors='backslashreplace',
             ),
             'Hello, UTF-16 world!\n'.encode('utf-16-le').decode(
@@ -104,8 +97,7 @@ class FunctionalAPIBase:
             self.assertEqual(f.read(), 'Hello, UTF-8 world!\n')
         for path_parts in self._gen_resourcetxt_path_parts():
             with resources.open_text(
-                self.anchor02,
-                *path_parts,
+                self.anchor02, *path_parts,
                 encoding='utf-8',
             ) as f:
                 self.assertEqual(f.read(), 'a resource')
@@ -119,14 +111,11 @@ class FunctionalAPIBase:
             with self.assertRaises(UnicodeDecodeError):
                 f.read()
         with resources.open_text(
-            self.anchor01,
-            'binary.file',
-            encoding='latin1',
+            self.anchor01, 'binary.file', encoding='latin1',
         ) as f:
             self.assertEqual(f.read(), '\x00\x01\x02\x03')
         with resources.open_text(
-            self.anchor01,
-            'utf-16.file',
+            self.anchor01, 'utf-16.file',
             errors='backslashreplace',
         ) as f:
             self.assertEndsWith(  # ignore the BOM
@@ -141,17 +130,16 @@ class FunctionalAPIBase:
             self.assertEqual(f.read(), b'Hello, UTF-8 world!\n')
         for path_parts in self._gen_resourcetxt_path_parts():
             with resources.open_binary(
-                self.anchor02,
-                *path_parts,
+                self.anchor02, *path_parts,
             ) as f:
                 self.assertEqual(f.read(), b'a resource')
 
     def test_path(self):
         with resources.path(self.anchor01, 'utf-8.file') as path:
-            with open(str(path), encoding='utf-8') as f:
+            with open(str(path)) as f:
                 self.assertEqual(f.read(), 'Hello, UTF-8 world!\n')
         with resources.path(self.anchor01) as path:
-            with open(os.path.join(path, 'utf-8.file'), encoding='utf-8') as f:
+            with open(os.path.join(path, 'utf-8.file')) as f:
                 self.assertEqual(f.read(), 'Hello, UTF-8 world!\n')
 
     def test_is_resource(self):
@@ -164,32 +152,32 @@ class FunctionalAPIBase:
             self.assertTrue(is_resource(self.anchor02, *path_parts))
 
     def test_contents(self):
-        with warnings_helper.check_warnings((".*contents.*", DeprecationWarning)):
+        is_resource = resources.is_resource
+        with check_warnings((".*contents.*", DeprecationWarning)):
             c = resources.contents(self.anchor01)
         self.assertGreaterEqual(
             set(c),
             {'utf-8.file', 'utf-16.file', 'binary.file', 'subdirectory'},
         )
-        with self.assertRaises(OSError), warnings_helper.check_warnings((
-            ".*contents.*",
-            DeprecationWarning,
-        )):
+        with (
+            self.assertRaises(OSError),
+            check_warnings((".*contents.*", DeprecationWarning)),
+        ):
             list(resources.contents(self.anchor01, 'utf-8.file'))
-
         for path_parts in self._gen_resourcetxt_path_parts():
-            with self.assertRaises(OSError), warnings_helper.check_warnings((
-                ".*contents.*",
-                DeprecationWarning,
-            )):
+            with (
+                self.assertRaises(OSError),
+                check_warnings((".*contents.*", DeprecationWarning)),
+            ):
                 list(resources.contents(self.anchor01, *path_parts))
-        with warnings_helper.check_warnings((".*contents.*", DeprecationWarning)):
+        with check_warnings((".*contents.*", DeprecationWarning)):
             c = resources.contents(self.anchor01, 'subdirectory')
         self.assertGreaterEqual(
             set(c),
             {'binary.file'},
         )
 
-    @warnings_helper.ignore_warnings(category=DeprecationWarning)
+    @ignore_warnings(category=DeprecationWarning)
     def test_common_errors(self):
         for func in (
             resources.read_text,
@@ -220,24 +208,18 @@ class FunctionalAPIBase:
                 # Multiple path arguments need explicit encoding argument.
                 with self.assertRaises(TypeError):
                     func(
-                        self.anchor02,
-                        'subdirectory',
-                        'subsubdir',
-                        'resource.txt',
+                        self.anchor02, 'subdirectory',
+                        'subsubdir', 'resource.txt',
                     )
 
 
 class FunctionalAPITest_StringAnchor(
-    unittest.TestCase,
-    FunctionalAPIBase,
-    StringAnchorMixin,
+    unittest.TestCase, FunctionalAPIBase, StringAnchorMixin,
 ):
     pass
 
 
 class FunctionalAPITest_ModuleAnchor(
-    unittest.TestCase,
-    FunctionalAPIBase,
-    ModuleAnchorMixin,
+    unittest.TestCase, FunctionalAPIBase, ModuleAnchorMixin,
 ):
     pass


### PR DESCRIPTION
This reverts commit 5ac14eeea60328128ea9e7a588e2fad241db957d.

This commit should be re-applied after 3.13.0 final.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116608 -->
* Issue: gh-116608
<!-- /gh-issue-number -->
