### PR TITLE
[3.12]  gh-99113: restore behaviour of PyThreadState_Swap

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1914,7 +1914,7 @@ _PyThreadState_Swap(_PyRuntimeState *runtime, PyThreadState *newts)
 PyThreadState *
 PyThreadState_Swap(PyThreadState *newts)
 {
-    return _PyThreadState_Swap(&_PyRuntime, newts);
+    return _PyThreadState_SwapNoGIL(newts);
 }
 
 


### PR DESCRIPTION
in #104208 it was inadvertently (?) changed to acquire the GIL

for more context and a bisection see https://github.com/unbit/uwsgi/issues/2659

<!-- gh-issue-number: gh-99113 -->
* Issue: gh-99113
<!-- /gh-issue-number -->
