### PR TITLE
gh-123135: add support for path-like objects in `fnmatch.filter` on POSIX platforms

### DIFF
--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -83,6 +83,10 @@ cache the compiled regex patterns in the following functions: :func:`fnmatch`,
    It is the same as ``[n for n in names if fnmatch(n, pat)]``,
    but implemented more efficiently.
 
+   .. versionchanged:: 3.14
+      Added support for :term:`path-like objects <path-like object>` for
+      the *names* parameter.
+
 
 .. function:: translate(pat)
 

--- a/Lib/fnmatch.py
+++ b/Lib/fnmatch.py
@@ -10,7 +10,6 @@ The function translate(PATTERN) returns a regular expression
 corresponding to PATTERN.  (It does not compile it.)
 """
 import os
-import posixpath
 import re
 import functools
 
@@ -50,17 +49,9 @@ def filter(names, pat):
     result = []
     pat = os.path.normcase(pat)
     match = _compile_pattern(pat)
-    if os.path is posixpath:
-        # While os.path.normcase on POSIX is os.fspath, each name in NAMES is
-        # assumed to be of the same type as PAT, namely a str or bytes object.
-        # In particular, os.path.normcase can be optimized away from the loop.
-        for name in names:
-            if match(name):
-                result.append(name)
-    else:
-        for name in names:
-            if match(os.path.normcase(name)):
-                result.append(name)
+    for name in names:
+        if match(os.path.normcase(name)):
+            result.append(name)
     return result
 
 def fnmatchcase(name, pat):

--- a/Lib/fnmatch.py
+++ b/Lib/fnmatch.py
@@ -51,7 +51,9 @@ def filter(names, pat):
     pat = os.path.normcase(pat)
     match = _compile_pattern(pat)
     if os.path is posixpath:
-        # normcase on posix is NOP. Optimize it away from the loop.
+        # While normcase on POSIX is os.fspath, each NAME is assumed
+        # to have the same type as PAT, namely a str or bytes object.
+        # In particular, os.path.normcase is optimized away from the loop.
         for name in names:
             if match(name):
                 result.append(name)

--- a/Lib/fnmatch.py
+++ b/Lib/fnmatch.py
@@ -46,13 +46,10 @@ def _compile_pattern(pat):
 
 def filter(names, pat):
     """Construct a list from those elements of the iterable NAMES that match PAT."""
-    result = []
-    pat = os.path.normcase(pat)
+    normcase = os.path.normcase
+    pat = normcase(pat)
     match = _compile_pattern(pat)
-    for name in names:
-        if match(os.path.normcase(name)):
-            result.append(name)
-    return result
+    return [name for name in names if match(normcase(name))]
 
 def fnmatchcase(name, pat):
     """Test whether FILENAME matches PATTERN, including case.

--- a/Lib/fnmatch.py
+++ b/Lib/fnmatch.py
@@ -51,9 +51,9 @@ def filter(names, pat):
     pat = os.path.normcase(pat)
     match = _compile_pattern(pat)
     if os.path is posixpath:
-        # While normcase on POSIX is os.fspath, each NAME is assumed
-        # to have the same type as PAT, namely a str or bytes object.
-        # In particular, os.path.normcase is optimized away from the loop.
+        # While os.path.normcase on POSIX is os.fspath, each name in NAMES is
+        # assumed to be of the same type as PAT, namely a str or bytes object.
+        # In particular, os.path.normcase can be optimized away from the loop.
         for name in names:
             if match(name):
                 result.append(name)

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -600,6 +600,9 @@ class FakePath:
     def __repr__(self):
         return f'<FakePath {self.path!r}>'
 
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and self.path == other.path
+
     def __fspath__(self):
         if (isinstance(self.path, BaseException) or
             isinstance(self.path, type) and

--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -5,7 +5,9 @@ import os
 import string
 import warnings
 
+from pathlib import Path
 from fnmatch import fnmatch, fnmatchcase, translate, filter
+from test import support
 
 class FnmatchTestCase(unittest.TestCase):
 
@@ -261,6 +263,20 @@ class FilterTestCase(unittest.TestCase):
     def test_mix_bytes_str(self):
         self.assertRaises(TypeError, filter, ['test'], b'*')
         self.assertRaises(TypeError, filter, [b'test'], '*')
+
+    def test_path_like_objects(self):
+        path = Path(__file__)
+
+        if support.MS_WINDOWS:
+            # On non-POSIX platforms, we call os.path.normcase, which
+            # itself calls os.fspath, thus allowing path-like objects.
+            self.assertListEqual(filter([path], '*'), [path])
+            self.assertListEqual(filter([path], b'*'), [path])
+        else:
+            # On POSIX platforms, we assume that os.path.normcase is
+            # a no-op, thereby rejecting path-like objects.
+            self.assertRaises(TypeError, filter, [path], '*')
+            self.assertRaises(TypeError, filter, [path], b'*')
 
     def test_case(self):
         ignorecase = os.path.normcase('P') == os.path.normcase('p')

--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -271,7 +271,7 @@ class FilterTestCase(unittest.TestCase):
             # On non-POSIX platforms, we call os.path.normcase, which
             # itself calls os.fspath, thus allowing path-like objects.
             self.assertListEqual(filter([path], '*'), [path])
-            self.assertListEqual(filter([path], b'*'), [path])
+            self.assertRaises(TypeError, filter, [path], b'*')
         else:
             # On POSIX platforms, we assume that os.path.normcase is
             # a no-op, thereby rejecting path-like objects.

--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -271,12 +271,11 @@ class FilterTestCase(unittest.TestCase):
             # On non-POSIX platforms, we call os.path.normcase, which
             # itself calls os.fspath, thus allowing path-like objects.
             self.assertListEqual(filter([path], '*'), [path])
-            self.assertRaises(TypeError, filter, [path], b'*')
         else:
             # On POSIX platforms, we assume that os.path.normcase is
             # a no-op, thereby rejecting path-like objects.
             self.assertRaises(TypeError, filter, [path], '*')
-            self.assertRaises(TypeError, filter, [path], b'*')
+        self.assertRaises(TypeError, filter, [path], b'*')
 
     def test_case(self):
         ignorecase = os.path.normcase('P') == os.path.normcase('p')

--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -266,15 +266,8 @@ class FilterTestCase(unittest.TestCase):
 
     def test_path_like_objects(self):
         path = Path(__file__)
-
-        if support.MS_WINDOWS:
-            # On non-POSIX platforms, we call os.path.normcase, which
-            # itself calls os.fspath, thus allowing path-like objects.
-            self.assertListEqual(filter([path], '*'), [path])
-        else:
-            # On POSIX platforms, we assume that os.path.normcase is
-            # a no-op, thereby rejecting path-like objects.
-            self.assertRaises(TypeError, filter, [path], '*')
+        self.assertListEqual(filter([path], '*'), [path])
+        # os.path.normcase() always returns a string
         self.assertRaises(TypeError, filter, [path], b'*')
 
     def test_case(self):

--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -267,7 +267,8 @@ class FilterTestCase(unittest.TestCase):
     def test_path_like_objects(self):
         path = Path(__file__)
         self.assertListEqual(filter([path], '*'), [path])
-        # os.path.normcase() always returns a string
+        # os.path.normcase() always returns a string for Path objects
+        # since Path objects expect strings paths and not bytes ones.
         self.assertRaises(TypeError, filter, [path], b'*')
 
     def test_case(self):

--- a/Misc/NEWS.d/next/Library/2024-08-19-09-36-50.gh-issue-123135.w_ZNAs.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-19-09-36-50.gh-issue-123135.w_ZNAs.rst
@@ -1,0 +1,2 @@
+Fix :term:`path-like objects <path-like object>` support in
+:func:`fnmatch.filter`.  Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2024-08-19-09-36-50.gh-issue-123135.w_ZNAs.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-19-09-36-50.gh-issue-123135.w_ZNAs.rst
@@ -1,2 +1,3 @@
-Fix :term:`path-like objects <path-like object>` support in
-:func:`fnmatch.filter`.  Patch by Bénédikt Tran.
+Added support for supplying :term:`path-like objects <path-like object>`
+to the *names* parameter of :func:`fnmatch.filter`. Previously, such
+objects were only accepted on non-POSIX platforms. Patch by Bénédikt Tran.


### PR DESCRIPTION
This fixes an inconsistency in the `fnmatch` module where path-like objects are allowed on Windows but not on POSIX platforms.

cc @barneygale since you were recently interested in `fnmatch`!

<!-- gh-issue-number: gh-123135 -->
* Issue: gh-123135
<!-- /gh-issue-number -->
