### PR TITLE
gh-121459: Deferred LOAD_GLOBAL

### DIFF
--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -271,7 +271,7 @@ PyAPI_FUNC(PyObject **) _PyObjectArray_FromStackRefArray(_PyStackRef *input, Py_
 PyAPI_FUNC(void) _PyObjectArray_Free(PyObject **array, PyObject **scratch);
 
 PyAPI_FUNC(PyObject *) _PyEval_GetANext(PyObject *aiter);
-PyAPI_FUNC(PyObject *) _PyEval_LoadGlobal(PyObject *globals, PyObject *builtins, PyObject *name);
+PyAPI_FUNC(void) _PyEval_LoadGlobalStackRef(PyObject *globals, PyObject *builtins, PyObject *name, _PyStackRef *writeto);
 PyAPI_FUNC(PyObject *) _PyEval_GetAwaitable(PyObject *iterable, int oparg);
 PyAPI_FUNC(PyObject *) _PyEval_LoadName(PyThreadState *tstate, _PyInterpreterFrame *frame, PyObject *name);
 

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -10,6 +10,7 @@ extern "C" {
 
 #include "pycore_object.h"               // PyManagedDictPointer
 #include "pycore_pyatomic_ft_wrappers.h" // FT_ATOMIC_LOAD_SSIZE_ACQUIRE
+#include "pycore_stackref.h"             // _PyStackRef
 
 // Unsafe flavor of PyDict_GetItemWithError(): no error checking
 extern PyObject* _PyDict_GetItemWithError(PyObject *dp, PyObject *key);
@@ -100,10 +101,11 @@ extern void _PyDictKeys_DecRef(PyDictKeysObject *keys);
  */
 extern Py_ssize_t _Py_dict_lookup(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
 extern Py_ssize_t _Py_dict_lookup_threadsafe(PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
+extern Py_ssize_t _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject *key, Py_hash_t hash, _PyStackRef *value_addr);
 
 extern Py_ssize_t _PyDict_LookupIndex(PyDictObject *, PyObject *);
 extern Py_ssize_t _PyDictKeys_StringLookup(PyDictKeysObject* dictkeys, PyObject *key);
-PyAPI_FUNC(PyObject *)_PyDict_LoadGlobal(PyDictObject *, PyDictObject *, PyObject *);
+PyAPI_FUNC(void)_PyDict_LoadGlobalStackRef(PyDictObject *, PyDictObject *, PyObject *, _PyStackRef *);
 
 /* Consumes references to key and value */
 PyAPI_FUNC(int) _PyDict_SetItem_Take2(PyDictObject *op, PyObject *key, PyObject *value);

--- a/Include/internal/pycore_dict.h
+++ b/Include/internal/pycore_dict.h
@@ -105,7 +105,8 @@ extern Py_ssize_t _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject
 
 extern Py_ssize_t _PyDict_LookupIndex(PyDictObject *, PyObject *);
 extern Py_ssize_t _PyDictKeys_StringLookup(PyDictKeysObject* dictkeys, PyObject *key);
-PyAPI_FUNC(void)_PyDict_LoadGlobalStackRef(PyDictObject *, PyDictObject *, PyObject *, _PyStackRef *);
+PyAPI_FUNC(PyObject *)_PyDict_LoadGlobal(PyDictObject *, PyDictObject *, PyObject *);
+PyAPI_FUNC(void) _PyDict_LoadGlobalStackRef(PyDictObject *, PyDictObject *, PyObject *, _PyStackRef *);
 
 /* Consumes references to key and value */
 PyAPI_FUNC(int) _PyDict_SetItem_Take2(PyDictObject *op, PyObject *key, PyObject *value);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1535,7 +1535,6 @@ _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject *key, Py_hash_t h
                 if (PyStackRef_IsNull(*value_addr)) {
                     goto read_failed;
                 }
-
                 if (values != _Py_atomic_load_ptr(&mp->ma_values)) {
                     goto read_failed;
                 }
@@ -1545,7 +1544,6 @@ _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject *key, Py_hash_t h
                 if (PyStackRef_IsNull(*value_addr)) {
                     goto read_failed;
                 }
-
                 if (dk != _Py_atomic_load_ptr(&mp->ma_keys)) {
                     goto read_failed;
                 }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1575,7 +1575,7 @@ _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject *key, Py_hash_t h
 {
     PyObject *val;
     Py_ssize_t ix = _Py_dict_lookup(mp, key, hash, &val);
-	*value_addr = value == NULL ? PyStackRef_NULL : PyStackRef_FromPyObjectNew(value);
+	*value_addr = val == NULL ? PyStackRef_NULL : PyStackRef_FromPyObjectNew(val);
     return ix;
 }
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1522,12 +1522,14 @@ _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject *key, Py_hash_t h
         if (ix >= 0) {
             if (kind == DICT_KEYS_SPLIT) {
                 PyDictValues *values = _Py_atomic_load_ptr(&mp->ma_values);
-                if (values == NULL)
+                if (values == NULL) {
                     goto read_failed;
+                }
 
                 uint8_t capacity = _Py_atomic_load_uint8_relaxed(&values->capacity);
-                if (ix >= (Py_ssize_t)capacity)
+                if (ix >= (Py_ssize_t)capacity) {
                     goto read_failed;
+                }
 
                 *value_addr = PyStackRef_FromPyObjectNew(values->values[ix]);
                 if (PyStackRef_IsNull(*value_addr)) {

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1602,7 +1602,12 @@ _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject *key, Py_hash_t h
 {
     PyObject *val;
     Py_ssize_t ix = _Py_dict_lookup(mp, key, hash, &val);
-    *value_addr = PyStackRef_FromPyObjectNew(val);
+    if (val != NULL) {
+        *value_addr = PyStackRef_FromPyObjectNew(val);
+    }
+    else {
+        *value_addr = PyStackRef_NULL;
+    }
     return ix;
 }
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1602,12 +1602,7 @@ _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject *key, Py_hash_t h
 {
     PyObject *val;
     Py_ssize_t ix = _Py_dict_lookup(mp, key, hash, &val);
-    if (val != NULL) {
-        *value_addr = PyStackRef_FromPyObjectNew(val);
-    }
-    else {
-        *value_addr = PyStackRef_NULL;
-    }
+	*value_addr = value == NULL ? PyStackRef_NULL : PyStackRef_FromPyObjectNew(value);
     return ix;
 }
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1509,40 +1509,89 @@ _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject *key, Py_hash_t h
     kind = dk->dk_kind;
 
     if (kind != DICT_KEYS_GENERAL) {
-        PyObject *value;
-        ix = _Py_dict_lookup_threadsafe(mp, key, hash, &value);
-        assert (ix >= 0 || value == NULL);
-        *value_addr = PyStackRef_FromPyObjectSteal(value);
-    }
-    else {
-        ix = dictkeys_generic_lookup_threadsafe(mp, dk, key, hash);
+        if (PyUnicode_CheckExact(key)) {
+            ix = unicodekeys_lookup_unicode_threadsafe(dk, key, hash);
+        }
+        else {
+            ix = unicodekeys_lookup_generic_threadsafe(mp, dk, key, hash);
+        }
         if (ix == DKIX_KEY_CHANGED) {
             goto read_failed;
         }
+
         if (ix >= 0) {
-            PyObject **addr_of_value = &(DK_ENTRIES(dk)[ix].me_value);
-            PyObject *value = _Py_atomic_load_ptr(addr_of_value);
-            if (value == NULL) {
-                *value_addr = PyStackRef_NULL;
-            }
-            else if (_Py_IsImmortal(value) ||
-                     _PyObject_HasDeferredRefcount(value)) {
-                *value_addr = PyStackRef_FromPyObjectNew(value);
+            if (kind == DICT_KEYS_SPLIT) {
+                PyDictValues *values = _Py_atomic_load_ptr(&mp->ma_values);
+                if (values == NULL) {
+                    goto read_failed;
+                }
+
+                uint8_t capacity = _Py_atomic_load_uint8_relaxed(&values->capacity);
+                if (ix >= (Py_ssize_t)capacity) {
+                    goto read_failed;
+                }
+
+                PyObject **addr_of_value = &values->values[ix];
+                PyObject *value = _Py_atomic_load_ptr(addr_of_value);
+                if (value == NULL) {
+                    *value_addr = PyStackRef_NULL;
+                }
+                else if (_Py_IsImmortal(value) ||
+                         _PyObject_HasDeferredRefcount(value)) {
+                    *value_addr = PyStackRef_FromPyObjectNew(value);
+                }
+                else {
+                    PyObject *res = _Py_TryXGetRef(addr_of_value);
+                    if (res == NULL) {
+                        *value_addr = PyStackRef_NULL;
+                    }
+                    else {
+                        *value_addr = PyStackRef_FromPyObjectSteal(res);
+                    }
+                }
+                if (PyStackRef_IsNull(*value_addr)) {
+                    goto read_failed;
+                }
+                if (values != _Py_atomic_load_ptr(&mp->ma_values)) {
+                    goto read_failed;
+                }
             }
             else {
-                *value_addr = PyStackRef_FromPyObjectSteal(
-                    _Py_TryXGetRef(addr_of_value));
-            }
-            if (PyStackRef_IsNull(*value_addr)) {
-                goto read_failed;
-            }
-            if (dk != _Py_atomic_load_ptr(&mp->ma_keys)) {
-                goto read_failed;
+                PyObject **addr_of_value = &DK_UNICODE_ENTRIES(dk)[ix].me_value;
+                PyObject *value = _Py_atomic_load_ptr(addr_of_value);
+                if (value == NULL) {
+                    *value_addr = PyStackRef_NULL;
+                }
+                else if (_Py_IsImmortal(value) ||
+                         _PyObject_HasDeferredRefcount(value)) {
+                    *value_addr = PyStackRef_FromPyObjectNew(value);
+                }
+                else {
+                    PyObject *res = _Py_TryXGetRef(addr_of_value);
+                    if (res == NULL) {
+                        *value_addr = PyStackRef_NULL;
+                    }
+                    else {
+                        *value_addr = PyStackRef_FromPyObjectSteal(res);
+                    }
+                }
+                if (PyStackRef_IsNull(*value_addr)) {
+                    goto read_failed;
+                }
+                if (dk != _Py_atomic_load_ptr(&mp->ma_keys)) {
+                    goto read_failed;
+                }
             }
         }
         else {
             *value_addr = PyStackRef_NULL;
         }
+    }
+    else {
+        PyObject *value;
+        ix = _Py_dict_lookup_threadsafe(mp, key, hash, &value);
+        assert (ix >= 0 || value == NULL);
+        *value_addr = PyStackRef_FromPyObjectSteal(value);
     }
 
     return ix;

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1505,10 +1505,11 @@ dummy_func(
             #endif  /* ENABLE_SPECIALIZATION */
         }
 
-        op(_LOAD_GLOBAL, ( -- res, null if (oparg & 1))) {
+        // res[1] because we need a pointer to res to pass it to _PyEval_LoadGlobalStackRef
+        op(_LOAD_GLOBAL, ( -- res[1], null if (oparg & 1))) {
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg>>1);
-            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, &STACK_ENTRY(res));
-            ERROR_IF(PyStackRef_IsNull(res), error);
+            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, res);
+            ERROR_IF(PyStackRef_IsNull(*res), error);
             null = PyStackRef_NULL;
         }
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1447,9 +1447,9 @@ dummy_func(
                     && PyDict_CheckExact(BUILTINS()))
                 {
                     _PyDict_LoadGlobalStackRef((PyDictObject *)GLOBALS(),
-                                            (PyDictObject *)BUILTINS(),
-                                            name,
-                                            STACK_ENTRY(v));
+                                               (PyDictObject *)BUILTINS(),
+                                               name,
+                                               STACK_ENTRY(v));
                     if (PyStackRef_IsNull(v)) {
                         if (!_PyErr_Occurred(tstate)) {
                             /* _PyDict_LoadGlobalStackRef() sets NULL without raising

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1507,7 +1507,7 @@ dummy_func(
 
         op(_LOAD_GLOBAL, ( -- res, null if (oparg & 1))) {
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg>>1);
-            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, STACK_ENTRY(res));
+            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, &STACK_ENTRY(res));
             ERROR_IF(PyStackRef_IsNull(res), error);
             null = PyStackRef_NULL;
         }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1436,7 +1436,7 @@ dummy_func(
             locals = PyStackRef_FromPyObjectNew(l);
         }
 
-        inst(LOAD_FROM_DICT_OR_GLOBALS, (mod_or_class_dict -- v: _PyStackRef *)) {
+        inst(LOAD_FROM_DICT_OR_GLOBALS, (mod_or_class_dict -- v[1])) {
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             PyObject *v_o = NULL;
             if (PyMapping_GetOptionalItem(PyStackRef_AsPyObjectBorrow(mod_or_class_dict), name, &v_o) < 0) {
@@ -1509,40 +1509,8 @@ dummy_func(
 
         op(_LOAD_GLOBAL, ( -- res[1], null if (oparg & 1))) {
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg>>1);
-            if (PyDict_CheckExact(GLOBALS())
-                && PyDict_CheckExact(BUILTINS()))
-            {
-                _PyDict_LoadGlobalStackRef((PyDictObject *)GLOBALS(),
-                                         (PyDictObject *)BUILTINS(),
-                                         name,
-                                         res);
-                if (PyStackRef_IsNull(*res)) {
-                    if (!_PyErr_Occurred(tstate)) {
-                        /* _PyDict_LoadGlobalStackRef() sets NULL without raising
-                         * an exception if the key doesn't exist */
-                        _PyEval_FormatExcCheckArg(tstate, PyExc_NameError,
-                                                  NAME_ERROR_MSG, name);
-                    }
-                    ERROR_IF(true, error);
-                }
-            }
-            else {
-                PyObject *res_o;
-                /* Slow-path if globals or builtins is not a dict */
-                /* namespace 1: globals */
-                ERROR_IF(PyMapping_GetOptionalItem(GLOBALS(), name, &res_o) < 0, error);
-                if (res_o == NULL) {
-                    /* namespace 2: builtins */
-                    ERROR_IF(PyMapping_GetOptionalItem(BUILTINS(), name, &res_o) < 0, error);
-                    if (res_o == NULL) {
-                        _PyEval_FormatExcCheckArg(
-                                    tstate, PyExc_NameError,
-                                    NAME_ERROR_MSG, name);
-                        ERROR_IF(true, error);
-                    }
-                }
-                *res = PyStackRef_FromPyObjectSteal(res_o);
-            }
+            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, res);
+            ERROR_IF(PyStackRef_IsNull(*res), error);
             null = PyStackRef_NULL;
         }
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1436,7 +1436,7 @@ dummy_func(
             locals = PyStackRef_FromPyObjectNew(l);
         }
 
-        inst(LOAD_FROM_DICT_OR_GLOBALS, (mod_or_class_dict -- v[1])) {
+        inst(LOAD_FROM_DICT_OR_GLOBALS, (mod_or_class_dict -- v)) {
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
             PyObject *v_o = NULL;
             if (PyMapping_GetOptionalItem(PyStackRef_AsPyObjectBorrow(mod_or_class_dict), name, &v_o) < 0) {
@@ -1449,8 +1449,8 @@ dummy_func(
                     _PyDict_LoadGlobalStackRef((PyDictObject *)GLOBALS(),
                                             (PyDictObject *)BUILTINS(),
                                             name,
-                                            v);
-                    if (PyStackRef_IsNull(*v)) {
+                                            STACK_ENTRY(v));
+                    if (PyStackRef_IsNull(v)) {
                         if (!_PyErr_Occurred(tstate)) {
                             /* _PyDict_LoadGlobalStackRef() sets NULL without raising
                             * an exception if the key doesn't exist */
@@ -1477,7 +1477,7 @@ dummy_func(
                 }
             }
             if (v_o != NULL) {
-                *v = PyStackRef_FromPyObjectSteal(v_o);
+                v = PyStackRef_FromPyObjectSteal(v_o);
             }
             DECREF_INPUTS();
         }
@@ -1507,10 +1507,10 @@ dummy_func(
             #endif  /* ENABLE_SPECIALIZATION */
         }
 
-        op(_LOAD_GLOBAL, ( -- res[1], null if (oparg & 1))) {
+        op(_LOAD_GLOBAL, ( -- res, null if (oparg & 1))) {
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg>>1);
-            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, res);
-            ERROR_IF(PyStackRef_IsNull(*res), error);
+            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, STACK_ENTRY(res));
+            ERROR_IF(PyStackRef_IsNull(res), error);
             null = PyStackRef_NULL;
         }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3072,15 +3072,14 @@ _PyEval_GetANext(PyObject *aiter)
     return awaitable;
 }
 
-PyObject *
-_PyEval_LoadGlobal(PyObject *globals, PyObject *builtins, PyObject *name)
+void
+_PyEval_LoadGlobalStackRef(PyObject *globals, PyObject *builtins, PyObject *name, _PyStackRef *writeto)
 {
-    PyObject *res;
     if (PyDict_CheckExact(globals) && PyDict_CheckExact(builtins)) {
-        res = _PyDict_LoadGlobal((PyDictObject *)globals,
+        _PyDict_LoadGlobalStackRef((PyDictObject *)globals,
                                     (PyDictObject *)builtins,
-                                    name);
-        if (res == NULL && !PyErr_Occurred()) {
+                                    name, writeto);
+        if (PyStackRef_IsNull(*writeto) && !PyErr_Occurred()) {
             /* _PyDict_LoadGlobal() returns NULL without raising
                 * an exception if the key doesn't exist */
             _PyEval_FormatExcCheckArg(PyThreadState_GET(), PyExc_NameError,
@@ -3090,13 +3089,16 @@ _PyEval_LoadGlobal(PyObject *globals, PyObject *builtins, PyObject *name)
     else {
         /* Slow-path if globals or builtins is not a dict */
         /* namespace 1: globals */
+        PyObject *res;
         if (PyMapping_GetOptionalItem(globals, name, &res) < 0) {
-            return NULL;
+            *writeto = PyStackRef_NULL;
+            return;
         }
         if (res == NULL) {
             /* namespace 2: builtins */
             if (PyMapping_GetOptionalItem(builtins, name, &res) < 0) {
-                return NULL;
+                *writeto = PyStackRef_NULL;
+                return;
             }
             if (res == NULL) {
                 _PyEval_FormatExcCheckArg(
@@ -3104,8 +3106,8 @@ _PyEval_LoadGlobal(PyObject *globals, PyObject *builtins, PyObject *name)
                             NAME_ERROR_MSG, name);
             }
         }
+        *writeto = PyStackRef_FromPyObjectSteal(res);
     }
-    return res;
 }
 
 PyObject *

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1660,15 +1660,14 @@
         }
 
         case _LOAD_GLOBAL: {
-            _PyStackRef res;
+            _PyStackRef *res;
             _PyStackRef null = PyStackRef_NULL;
             oparg = CURRENT_OPARG();
+            res = &stack_pointer[0];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg>>1);
-            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, &stack_pointer[0]);
-            res = stack_pointer[0];
-            if (PyStackRef_IsNull(res)) JUMP_TO_ERROR();
+            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, res);
+            if (PyStackRef_IsNull(*res)) JUMP_TO_ERROR();
             null = PyStackRef_NULL;
-            stack_pointer[0] = res;
             if (oparg & 1) stack_pointer[1] = null;
             stack_pointer += 1 + (oparg & 1);
             assert(WITHIN_STACK_BOUNDS());

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1665,40 +1665,8 @@
             oparg = CURRENT_OPARG();
             res = &stack_pointer[0];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg>>1);
-            if (PyDict_CheckExact(GLOBALS())
-                && PyDict_CheckExact(BUILTINS()))
-            {
-                _PyDict_LoadGlobalStackRef((PyDictObject *)GLOBALS(),
-                    (PyDictObject *)BUILTINS(),
-                    name,
-                    res);
-                if (PyStackRef_IsNull(*res)) {
-                    if (!_PyErr_Occurred(tstate)) {
-                        /* _PyDict_LoadGlobalStackRef() sets NULL without raising
-                         * an exception if the key doesn't exist */
-                        _PyEval_FormatExcCheckArg(tstate, PyExc_NameError,
-                            NAME_ERROR_MSG, name);
-                    }
-                    if (true) JUMP_TO_ERROR();
-                }
-            }
-            else {
-                PyObject *res_o;
-                /* Slow-path if globals or builtins is not a dict */
-                /* namespace 1: globals */
-                if (PyMapping_GetOptionalItem(GLOBALS(), name, &res_o) < 0) JUMP_TO_ERROR();
-                if (res_o == NULL) {
-                    /* namespace 2: builtins */
-                    if (PyMapping_GetOptionalItem(BUILTINS(), name, &res_o) < 0) JUMP_TO_ERROR();
-                    if (res_o == NULL) {
-                        _PyEval_FormatExcCheckArg(
-                            tstate, PyExc_NameError,
-                            NAME_ERROR_MSG, name);
-                        if (true) JUMP_TO_ERROR();
-                    }
-                }
-                *res = PyStackRef_FromPyObjectSteal(res_o);
-            }
+            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, res);
+            if (PyStackRef_IsNull(*res)) JUMP_TO_ERROR();
             null = PyStackRef_NULL;
             if (oparg & 1) stack_pointer[1] = null;
             stack_pointer += 1 + (oparg & 1);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1660,14 +1660,15 @@
         }
 
         case _LOAD_GLOBAL: {
-            _PyStackRef *res;
+            _PyStackRef res;
             _PyStackRef null = PyStackRef_NULL;
             oparg = CURRENT_OPARG();
-            res = &stack_pointer[0];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg>>1);
-            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, res);
-            if (PyStackRef_IsNull(*res)) JUMP_TO_ERROR();
+            _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, &stack_pointer[0]);
+            res = stack_pointer[0];
+            if (PyStackRef_IsNull(res)) JUMP_TO_ERROR();
             null = PyStackRef_NULL;
+            stack_pointer[0] = res;
             if (oparg & 1) stack_pointer[1] = null;
             stack_pointer += 1 + (oparg & 1);
             assert(WITHIN_STACK_BOUNDS());

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -5341,7 +5341,7 @@
             PREDICTED(LOAD_GLOBAL);
             _Py_CODEUNIT *this_instr = next_instr - 5;
             (void)this_instr;
-            _PyStackRef res;
+            _PyStackRef *res;
             _PyStackRef null = PyStackRef_NULL;
             // _SPECIALIZE_LOAD_GLOBAL
             {
@@ -5363,13 +5363,12 @@
             /* Skip 1 cache entry */
             // _LOAD_GLOBAL
             {
+                res = &stack_pointer[0];
                 PyObject *name = GETITEM(FRAME_CO_NAMES, oparg>>1);
-                _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, &stack_pointer[0]);
-                res = stack_pointer[0];
-                if (PyStackRef_IsNull(res)) goto error;
+                _PyEval_LoadGlobalStackRef(GLOBALS(), BUILTINS(), name, res);
+                if (PyStackRef_IsNull(*res)) goto error;
                 null = PyStackRef_NULL;
             }
-            stack_pointer[0] = res;
             if (oparg & 1) stack_pointer[1] = null;
             stack_pointer += 1 + (oparg & 1);
             assert(WITHIN_STACK_BOUNDS());

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -5287,24 +5287,24 @@
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_FROM_DICT_OR_GLOBALS);
             _PyStackRef mod_or_class_dict;
-            _PyStackRef v;
+            _PyStackRef *v;
             mod_or_class_dict = stack_pointer[-1];
             PyObject *name = GETITEM(FRAME_CO_NAMES, oparg);
-            PyObject *v_o;
-            int err = PyMapping_GetOptionalItem(PyStackRef_AsPyObjectBorrow(mod_or_class_dict), name, &v_o);
-            if (err < 0) {
+            PyObject *v_o = NULL;
+            if (PyMapping_GetOptionalItem(PyStackRef_AsPyObjectBorrow(mod_or_class_dict), name, &v_o) < 0) {
                 goto error;
             }
             if (v_o == NULL) {
                 if (PyDict_CheckExact(GLOBALS())
                     && PyDict_CheckExact(BUILTINS()))
                 {
-                    v_o = _PyDict_LoadGlobal((PyDictObject *)GLOBALS(),
+                    _PyDict_LoadGlobalStackRef((PyDictObject *)GLOBALS(),
                         (PyDictObject *)BUILTINS(),
-                        name);
-                    if (v_o == NULL) {
+                        name,
+                        v);
+                    if (PyStackRef_IsNull(*v)) {
                         if (!_PyErr_Occurred(tstate)) {
-                            /* _PyDict_LoadGlobal() returns NULL without raising
+                            /* _PyDict_LoadGlobalStackRef() sets NULL without raising
                              * an exception if the key doesn't exist */
                             _PyEval_FormatExcCheckArg(tstate, PyExc_NameError,
                                 NAME_ERROR_MSG, name);
@@ -5328,9 +5328,11 @@
                     }
                 }
             }
+            if (v_o != NULL) {
+                *v = PyStackRef_FromPyObjectSteal(v_o);
+            }
             PyStackRef_CLOSE(mod_or_class_dict);
-            v = PyStackRef_FromPyObjectSteal(v_o);
-            stack_pointer[-1] = v;
+            stack_pointer[-1].bits = (uintptr_t)v;
             DISPATCH();
         }
 
@@ -5341,7 +5343,7 @@
             PREDICTED(LOAD_GLOBAL);
             _Py_CODEUNIT *this_instr = next_instr - 5;
             (void)this_instr;
-            _PyStackRef res;
+            _PyStackRef *res;
             _PyStackRef null = PyStackRef_NULL;
             // _SPECIALIZE_LOAD_GLOBAL
             {
@@ -5363,13 +5365,44 @@
             /* Skip 1 cache entry */
             // _LOAD_GLOBAL
             {
+                res = &stack_pointer[0];
                 PyObject *name = GETITEM(FRAME_CO_NAMES, oparg>>1);
-                PyObject *res_o = _PyEval_LoadGlobal(GLOBALS(), BUILTINS(), name);
-                if (res_o == NULL) goto error;
+                if (PyDict_CheckExact(GLOBALS())
+                    && PyDict_CheckExact(BUILTINS()))
+                {
+                    _PyDict_LoadGlobalStackRef((PyDictObject *)GLOBALS(),
+                        (PyDictObject *)BUILTINS(),
+                        name,
+                        res);
+                    if (PyStackRef_IsNull(*res)) {
+                        if (!_PyErr_Occurred(tstate)) {
+                            /* _PyDict_LoadGlobalStackRef() sets NULL without raising
+                             * an exception if the key doesn't exist */
+                            _PyEval_FormatExcCheckArg(tstate, PyExc_NameError,
+                                NAME_ERROR_MSG, name);
+                        }
+                        if (true) goto error;
+                    }
+                }
+                else {
+                    PyObject *res_o;
+                    /* Slow-path if globals or builtins is not a dict */
+                    /* namespace 1: globals */
+                    if (PyMapping_GetOptionalItem(GLOBALS(), name, &res_o) < 0) goto error;
+                    if (res_o == NULL) {
+                        /* namespace 2: builtins */
+                        if (PyMapping_GetOptionalItem(BUILTINS(), name, &res_o) < 0) goto error;
+                        if (res_o == NULL) {
+                            _PyEval_FormatExcCheckArg(
+                                tstate, PyExc_NameError,
+                                NAME_ERROR_MSG, name);
+                            if (true) goto error;
+                        }
+                    }
+                    *res = PyStackRef_FromPyObjectSteal(res_o);
+                }
                 null = PyStackRef_NULL;
-                res = PyStackRef_FromPyObjectSteal(res_o);
             }
-            stack_pointer[0] = res;
             if (oparg & 1) stack_pointer[1] = null;
             stack_pointer += 1 + (oparg & 1);
             assert(WITHIN_STACK_BOUNDS());

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -829,11 +829,13 @@
         }
 
         case _LOAD_GLOBAL: {
-            _Py_UopsSymbol *res;
+            _Py_UopsSymbol **res;
             _Py_UopsSymbol *null = NULL;
-            res = sym_new_not_null(ctx);
+            res = &stack_pointer[0];
+            for (int _i = 1; --_i >= 0;) {
+                res[_i] = sym_new_not_null(ctx);
+            }
             null = sym_new_null(ctx);
-            stack_pointer[0] = res;
             if (oparg & 1) stack_pointer[1] = null;
             stack_pointer += 1 + (oparg & 1);
             assert(WITHIN_STACK_BOUNDS());

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -829,13 +829,11 @@
         }
 
         case _LOAD_GLOBAL: {
-            _Py_UopsSymbol **res;
+            _Py_UopsSymbol *res;
             _Py_UopsSymbol *null = NULL;
-            res = &stack_pointer[0];
-            for (int _i = 1; --_i >= 0;) {
-                res[_i] = sym_new_not_null(ctx);
-            }
+            res = sym_new_not_null(ctx);
             null = sym_new_null(ctx);
+            stack_pointer[0] = res;
             if (oparg & 1) stack_pointer[1] = null;
             stack_pointer += 1 + (oparg & 1);
             assert(WITHIN_STACK_BOUNDS());

--- a/Tools/cases_generator/generators_common.py
+++ b/Tools/cases_generator/generators_common.py
@@ -47,7 +47,7 @@ def write_header(
     )
 
 
-def emit_to(out: CWriter, tkn_iter: Iterator[Token], end: str, allow_unbalanced_parens: bool = False) -> None:
+def emit_to(out: CWriter, tkn_iter: Iterator[Token], end: str, *, allow_unbalanced_parens: bool = False) -> None:
     parens = 0
     for tkn in tkn_iter:
         if tkn.kind == end and (parens == 0 or allow_unbalanced_parens):
@@ -233,7 +233,7 @@ class Emitter:
         else:
             raise analysis_error("STACK_ENTRY operand is not a stack output", target)
 
-        next(tkn_iter) # Consume )
+        next(tkn_iter)  # Consume )
         emit_to(self.out, tkn_iter, "SEMI", allow_unbalanced_parens=True)
         self.emit(";\n")
         # Update the variable

--- a/Tools/cases_generator/generators_common.py
+++ b/Tools/cases_generator/generators_common.py
@@ -227,7 +227,7 @@ class Emitter:
             size += f" - {output.size or 1}"
         for output in uop.stack.outputs:
             if output.name == target.text:
-                self.out.emit(f" &stack_pointer[{size}]")
+                self.out.emit(f"stack_pointer[{size}]")
                 break
             size += f" + {output.size or 1}"
         else:

--- a/Tools/cases_generator/generators_common.py
+++ b/Tools/cases_generator/generators_common.py
@@ -47,10 +47,10 @@ def write_header(
     )
 
 
-def emit_to(out: CWriter, tkn_iter: Iterator[Token], end: str, *, allow_unbalanced_parens: bool = False) -> None:
+def emit_to(out: CWriter, tkn_iter: Iterator[Token], end: str) -> None:
     parens = 0
     for tkn in tkn_iter:
-        if tkn.kind == end and (parens == 0 or allow_unbalanced_parens):
+        if tkn.kind == end and parens == 0:
             return
         if tkn.kind == "LPAREN":
             parens += 1
@@ -234,8 +234,12 @@ class Emitter:
             raise analysis_error("STACK_ENTRY operand is not a stack output", target)
 
         next(tkn_iter)  # Consume )
-        emit_to(self.out, tkn_iter, "SEMI", allow_unbalanced_parens=True)
-        self.emit(";\n")
+        # Emit all the way to SEMI
+        for tkn in tkn_iter:
+            self.out.emit(tkn)
+            if tkn.kind == "SEMI":
+                break
+        self.emit("\n")
         # Update the variable
         self.out.emit(f"{target.text} = stack_pointer[{size}];\n")
 

--- a/Tools/cases_generator/generators_common.py
+++ b/Tools/cases_generator/generators_common.py
@@ -47,7 +47,7 @@ def write_header(
     )
 
 
-def emit_to(out: CWriter, tkn_iter: Iterator[Token], end: str, allow_unbalanced_parens=False) -> None:
+def emit_to(out: CWriter, tkn_iter: Iterator[Token], end: str, allow_unbalanced_parens: bool = False) -> None:
     parens = 0
     for tkn in tkn_iter:
         if tkn.kind == end and (parens == 0 or allow_unbalanced_parens):


### PR DESCRIPTION
This implements PEP 703 deferred refcounting for LOAD_GLOBAL in an agnostic way using the cases generator. So it won't block full deferring of references in the future.

For now, we need to write directly to a stackref entry to keep the global alive. Changing the dictionary lookup to stackref variants is also a prerequisite for LOAD_ATTR and friends.

<!-- gh-issue-number: gh-121459 -->
* Issue: gh-121459
<!-- /gh-issue-number -->
