### PR TITLE
[3.13] gh-121804: Always show error location for SyntaxError's in new repl (GH-121886)

### DIFF
--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -161,8 +161,8 @@ class InteractiveColoredConsole(code.InteractiveConsole):
         super().__init__(locals=locals, filename=filename, local_exit=local_exit)  # type: ignore[call-arg]
         self.can_colorize = _colorize.can_colorize()
 
-    def showsyntaxerror(self, filename=None):
-        super().showsyntaxerror(colorize=self.can_colorize)
+    def showsyntaxerror(self, filename=None, **kwargs):
+        super().showsyntaxerror(colorize=self.can_colorize, **kwargs)
 
     def showtraceback(self):
         super().showtraceback(colorize=self.can_colorize)
@@ -171,7 +171,7 @@ class InteractiveColoredConsole(code.InteractiveConsole):
         try:
             tree = ast.parse(source)
         except (SyntaxError, OverflowError, ValueError):
-            self.showsyntaxerror(filename)
+            self.showsyntaxerror(filename, source=source)
             return False
         if tree.body:
             *_, last_stmt = tree.body
@@ -188,10 +188,10 @@ class InteractiveColoredConsole(code.InteractiveConsole):
                         f"Try the asyncio REPL ({python} -m asyncio) to use"
                         f" top-level 'await' and run background asyncio tasks."
                     )
-                self.showsyntaxerror(filename)
+                self.showsyntaxerror(filename, source=source)
                 return False
             except (OverflowError, ValueError):
-                self.showsyntaxerror(filename)
+                self.showsyntaxerror(filename, source=source)
                 return False
 
             if code is None:

--- a/Lib/code.py
+++ b/Lib/code.py
@@ -64,7 +64,7 @@ class InteractiveInterpreter:
             code = self.compile(source, filename, symbol)
         except (OverflowError, SyntaxError, ValueError):
             # Case 1
-            self.showsyntaxerror(filename)
+            self.showsyntaxerror(filename, source=source)
             return False
 
         if code is None:
@@ -123,6 +123,12 @@ class InteractiveInterpreter:
                 # Stuff in the right filename
                 value = SyntaxError(msg, (filename, lineno, offset, line))
                 sys.last_exc = sys.last_value = value
+        # Set the line of text that the exception refers to
+        source = kwargs.pop('source', '')
+        lines = source.splitlines()
+        if (source and type is SyntaxError
+                and not value.text and len(lines) >= value.lineno):
+            value.text = lines[value.lineno - 1]
         if sys.excepthook is sys.__excepthook__:
             lines = traceback.format_exception_only(type, value, colorize=colorize)
             self.write(''.join(lines))

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -706,7 +706,7 @@ class ModifiedInterpreter(InteractiveInterpreter):
             del _filename, _sys, _dirname, _dir
             \n""".format(filename))
 
-    def showsyntaxerror(self, filename=None):
+    def showsyntaxerror(self, filename=None, **kwargs):
         """Override Interactive Interpreter method: Use Colorizing
 
         Color the offending position instead of printing it and pointing at it

--- a/Lib/test/test_pyrepl/test_interact.py
+++ b/Lib/test/test_pyrepl/test_interact.py
@@ -88,6 +88,20 @@ class TestSimpleInteract(unittest.TestCase):
         self.assertFalse(result)
         self.assertIn('SyntaxError', f.getvalue())
 
+    @force_not_colorized
+    def test_runsource_show_syntax_error_location(self):
+        console = InteractiveColoredConsole()
+        source = "def f(x, x): ..."
+        f = io.StringIO()
+        with contextlib.redirect_stderr(f):
+            result = console.runsource(source)
+        self.assertFalse(result)
+        r = """
+    def f(x, x): ...
+             ^
+SyntaxError: duplicate argument 'x' in function definition"""
+        self.assertIn(r, f.getvalue())
+
     def test_runsource_shows_syntax_error_for_failed_compilation(self):
         console = InteractiveColoredConsole()
         source = "print('Hello, world!'"

--- a/Misc/NEWS.d/next/Library/2024-07-16-20-49-07.gh-issue-121804.gYN-In.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-16-20-49-07.gh-issue-121804.gYN-In.rst
@@ -1,0 +1,2 @@
+Correctly show error locations, when :exc:`SyntaxError` raised in new repl.
+Patch by Sergey B Kirpichev.


### PR DESCRIPTION
(cherry picked from commit 354d55eb1fa40f272419aa6459ee5d2c4804c8ea)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121804 -->
* Issue: gh-121804
<!-- /gh-issue-number -->
