### PR TITLE
gh-123149: Suppress verbose repr in new REPL

### DIFF
--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -338,14 +338,14 @@ class backspace_dedent(commands.Command):
 # ____________________________________________________________
 
 
-@dataclass(slots=True, repr=False)
+@dataclass(slots=True)
 class _ReadlineWrapper:
     f_in: int = -1
     f_out: int = -1
-    reader: ReadlineAlikeReader | None = None
+    reader: ReadlineAlikeReader | None = field(default=None, repr=False)
     saved_history_length: int = -1
     startup_hook: Callback | None = None
-    config: ReadlineConfig = field(default_factory=ReadlineConfig)
+    config: ReadlineConfig = field(default_factory=ReadlineConfig, repr=False)
 
     def __post_init__(self) -> None:
         if self.f_in == -1:

--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -338,7 +338,7 @@ class backspace_dedent(commands.Command):
 # ____________________________________________________________
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, repr=False)
 class _ReadlineWrapper:
     f_in: int = -1
     f_out: int = -1

--- a/Misc/NEWS.d/next/Library/2024-08-19-12-35-28.gh-issue-123149.7QbpJ4.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-19-12-35-28.gh-issue-123149.7QbpJ4.rst
@@ -1,0 +1,1 @@
+Disable verbose repr of ``_ReadlineWrapper`` objects

--- a/Misc/NEWS.d/next/Library/2024-08-19-12-35-28.gh-issue-123149.7QbpJ4.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-19-12-35-28.gh-issue-123149.7QbpJ4.rst
@@ -1,1 +1,0 @@
-Disable verbose repr of ``_ReadlineWrapper`` objects


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This changeset disables the automatic generation of a verbose (listing every registered field) repr for `_ReadlineWrapper`

Fixes #123149.

<!-- gh-issue-number: gh-123149 -->
* Issue: gh-123149
<!-- /gh-issue-number -->
