### PR TITLE
GH-73991: Prune `pathlib.Path.delete()` arguments

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1637,19 +1637,10 @@ Copying, renaming and deleting
    :meth:`Path.delete` to remove a non-empty directory.
 
 
-.. method:: Path.delete(ignore_errors=False, on_error=None)
+.. method:: Path.delete()
 
    Delete this file or directory. If this path refers to a non-empty
    directory, its files and sub-directories are deleted recursively.
-
-   If *ignore_errors* is true, errors resulting from failed deletions will be
-   ignored. If *ignore_errors* is false or omitted, and a callable is given as
-   the optional *on_error* argument, it will be called with one argument of
-   type :exc:`OSError` each time an exception is raised. The callable can
-   handle the error to continue the deletion process or re-raise it to stop.
-   Note that the filename is available as the :attr:`~OSError.filename`
-   attribute of the exception object. If neither *ignore_errors* nor
-   *on_error* are supplied, exceptions are propagated to the caller.
 
    .. note::
 

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -927,7 +927,9 @@ class PathBase(PurePathBase):
         """
         Delete this file or directory (including all sub-directories).
         """
-        if self.is_dir(follow_symlinks=False):
+        if self.is_symlink() or self.is_junction():
+            self.unlink()
+        elif self.is_dir():
             def on_error(err):
                 raise err
             results = self.walk(

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -927,9 +927,7 @@ class PathBase(PurePathBase):
         """
         Delete this file or directory (including all sub-directories).
         """
-        if self.is_symlink() or self.is_junction():
-            self.unlink()
-        elif self.is_dir():
+        if self.is_dir(follow_symlinks=False):
             def on_error(err):
                 raise err
             results = self.walk(

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -923,23 +923,13 @@ class PathBase(PurePathBase):
         """
         raise UnsupportedOperation(self._unsupported_msg('rmdir()'))
 
-    def delete(self, ignore_errors=False, on_error=None):
+    def delete(self):
         """
         Delete this file or directory (including all sub-directories).
-
-        If *ignore_errors* is true, exceptions raised from scanning the
-        filesystem and removing files and directories are ignored. Otherwise,
-        if *on_error* is set, it will be called to handle the error. If
-        neither *ignore_errors* nor *on_error* are set, exceptions are
-        propagated to the caller.
         """
-        if ignore_errors:
-            def on_error(err):
-                pass
-        elif on_error is None:
+        if self.is_dir(follow_symlinks=False):
             def on_error(err):
                 raise err
-        if self.is_dir(follow_symlinks=False):
             results = self.walk(
                 on_error=on_error,
                 top_down=False,  # So we rmdir() empty directories.
@@ -955,14 +945,9 @@ class PathBase(PurePathBase):
                         dirpath.joinpath(name).rmdir()
                     except OSError as err:
                         on_error(err)
-            delete_self = self.rmdir
+            self.rmdir()
         else:
-            delete_self = self.unlink
-        try:
-            delete_self()
-        except OSError as err:
-            err.filename = str(self)
-            on_error(err)
+            self.unlink()
     delete.avoids_symlink_attacks = False
 
     def owner(self, *, follow_symlinks=True):

--- a/Lib/pathlib/_local.py
+++ b/Lib/pathlib/_local.py
@@ -828,7 +828,9 @@ class Path(PathBase, PurePath):
         """
         Delete this file or directory (including all sub-directories).
         """
-        if self.is_dir(follow_symlinks=False):
+        if self.is_symlink() or self.is_junction():
+            self.unlink()
+        elif self.is_dir():
             shutil.rmtree(str(self))
         else:
             self.unlink()

--- a/Lib/pathlib/_local.py
+++ b/Lib/pathlib/_local.py
@@ -824,32 +824,14 @@ class Path(PathBase, PurePath):
         """
         os.rmdir(self)
 
-    def delete(self, ignore_errors=False, on_error=None):
+    def delete(self):
         """
         Delete this file or directory (including all sub-directories).
-
-        If *ignore_errors* is true, exceptions raised from scanning the
-        filesystem and removing files and directories are ignored. Otherwise,
-        if *on_error* is set, it will be called to handle the error. If
-        neither *ignore_errors* nor *on_error* are set, exceptions are
-        propagated to the caller.
         """
         if self.is_dir(follow_symlinks=False):
-            onexc = None
-            if on_error:
-                def onexc(func, filename, err):
-                    err.filename = filename
-                    on_error(err)
-            shutil.rmtree(str(self), ignore_errors, onexc=onexc)
+            shutil.rmtree(str(self))
         else:
-            try:
-                self.unlink()
-            except OSError as err:
-                if not ignore_errors:
-                    if on_error:
-                        on_error(err)
-                    else:
-                        raise
+            self.unlink()
 
     delete.avoids_symlink_attacks = shutil.rmtree.avoids_symlink_attacks
 

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -940,7 +940,10 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         spam = src / 'spam'
         spam.write_text('')
         _winapi.CreateJunction(str(src), str(dst))
-        self.assertRaises(OSError, dst.delete)
+        dst.delete()
+        self.assertFalse(dst.exists())
+        self.assertTrue(spam.exists())
+        self.assertTrue(src.exists())
 
     @unittest.skipUnless(delete_use_fd_functions, "requires safe delete")
     def test_delete_fails_on_close(self):

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -715,11 +715,6 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         target = base / 'copyE'
         self.assertRaises(PermissionError, source.copy, target)
         self.assertFalse(target.exists())
-        errors = []
-        source.copy(target, on_error=errors.append)
-        self.assertEqual(len(errors), 1)
-        self.assertIsInstance(errors[0], PermissionError)
-        self.assertFalse(target.exists())
 
     def test_copy_dir_preserve_metadata(self):
         base = self.cls(self.base)
@@ -939,42 +934,13 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         import _winapi
         tmp = self.cls(self.base, 'delete')
         tmp.mkdir()
-        try:
-            src = tmp / 'cheese'
-            dst = tmp / 'shop'
-            src.mkdir()
-            spam = src / 'spam'
-            spam.write_text('')
-            _winapi.CreateJunction(str(src), str(dst))
-            self.assertRaises(OSError, dst.delete)
-            dst.delete(ignore_errors=True)
-        finally:
-            tmp.delete(ignore_errors=True)
-
-    @needs_windows
-    def test_delete_outer_junction_on_error(self):
-        import _winapi
-        tmp = self.cls(self.base, 'delete')
-        tmp.mkdir()
-        dir_ = tmp / 'dir'
-        dir_.mkdir()
-        link = tmp / 'link'
-        _winapi.CreateJunction(str(dir_), str(link))
-        try:
-            self.assertRaises(OSError, link.delete)
-            self.assertTrue(dir_.exists())
-            self.assertTrue(link.exists(follow_symlinks=False))
-            errors = []
-
-            def on_error(error):
-                errors.append(error)
-
-            link.delete(on_error=on_error)
-            self.assertEqual(len(errors), 1)
-            self.assertIsInstance(errors[0], OSError)
-            self.assertEqual(errors[0].filename, str(link))
-        finally:
-            os.unlink(str(link))
+        src = tmp / 'cheese'
+        dst = tmp / 'shop'
+        src.mkdir()
+        spam = src / 'spam'
+        spam.write_text('')
+        _winapi.CreateJunction(str(src), str(dst))
+        self.assertRaises(OSError, dst.delete)
 
     @unittest.skipUnless(delete_use_fd_functions, "requires safe delete")
     def test_delete_fails_on_close(self):

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -2705,14 +2705,6 @@ class DummyPathTest(DummyPurePathTest):
         # filename is guaranteed not to exist
         filename = tmp / 'foo'
         self.assertRaises(FileNotFoundError, filename.delete)
-        # test that ignore_errors option is honored
-        filename.delete(ignore_errors=True)
-        # test on_error
-        errors = []
-        filename.delete(on_error=errors.append)
-        self.assertEqual(len(errors), 1)
-        self.assertIsInstance(errors[0], FileNotFoundError)
-        self.assertEqual(errors[0].filename, str(filename))
 
     def setUpWalk(self):
         # Build:


### PR DESCRIPTION
Remove the *ignore_errors* and *on_error* arguments from `Path.delete()`. This functionality was carried over from `shutil.rmtree()`, but its design needs to be re-evaluated in its new context. Some possible alternate designs:

- We may wish to support a *missing_ok* argument (like `Path.unlink()`)
- Or automatically `chmod()` and retry operations when we hit a permission error (like `tempfile.TemporaryDirectory`)
- Or retry operations with a backoff (like `test.support.os_helper.rmtree()`), 
- Or utilise exception groups

It's best to leave our options open for now. I don't want to risk these arguments landing in 3.14 final because I got hit by a bus or something.

No news because `Path.delete()` remains unreleased.

<!-- gh-issue-number: gh-73991 -->
* Issue: gh-73991
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123158.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->