### PR TITLE
gh-123048: Fix missing source location in pattern matching code

### DIFF
--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -1,6 +1,7 @@
 import array
 import collections
 import dataclasses
+import dis
 import enum
 import inspect
 import sys
@@ -3377,6 +3378,24 @@ class TestValueErrors(unittest.TestCase):
         self.assertIs(y, None)
         self.assertIs(z, None)
 
+class TestSourceLocations(unittest.TestCase):
+    def test_jump_threading(self):
+        # See gh-123048
+        def f():
+            x = 0
+            v = 1
+            match v:
+                case 1:
+                    if x < 0:
+                        x = 1
+                case 2:
+                    if x < 0:
+                        x = 1
+            x += 1
+
+        for inst in dis.get_instructions(f):
+            if inst.opcode in dis.hasjump:
+                self.assertIsNotNone(inst.positions.lineno, "jump without location")
 
 class TestTracing(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2024-08-20-11-09-16.gh-issue-123048.2TISpv.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-08-20-11-09-16.gh-issue-123048.2TISpv.rst
@@ -1,0 +1,2 @@
+Fix a bug where pattern matching code could emit a :opcode:`JUMP_FORWARD`
+with no source location.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -7301,7 +7301,7 @@ codegen_match_inner(struct compiler *c, stmt_ty s, pattern_context *pc)
             ADDOP(c, LOC(m->pattern), POP_TOP);
         }
         VISIT_SEQ(c, stmt, m->body);
-        ADDOP_JUMP(c, NO_LOCATION, JUMP_NO_INTERRUPT, end);
+        ADDOP_JUMP(c, NO_LOCATION, JUMP, end);
         // If the pattern fails to match, we want the line number of the
         // cleanup to be associated with the failed pattern, not the last line
         // of the body


### PR DESCRIPTION
Threading doesn't work for ``JUMP_NO_INTERRUPT``. In this case it doesn't need to be ``JUMP_NO_INTERRUPT`` anyway because it's a forward jump so it makes no difference to the final bytecode.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123048 -->
* Issue: gh-123048
<!-- /gh-issue-number -->
