### PR TITLE
gh-123174: Add proto parameter to sock_connect

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -618,10 +618,14 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         else:
             fut.set_result(n)
 
-    async def sock_connect(self, sock, address):
+    async def sock_connect(self, sock, address, proto_addr_info = None):
         """Connect to a remote socket at address.
 
         This method is a coroutine.
+        
+        The proto_addr info parameter allows to specify a protocol to use for the 
+        resolution of the address. If not specified, default to the protocol used
+        by sock
         """
         base_events._check_ssl_socket(sock)
         if self._debug and sock.gettimeout() != 0:
@@ -629,8 +633,9 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
 
         if sock.family == socket.AF_INET or (
                 base_events._HAS_IPv6 and sock.family == socket.AF_INET6):
+            proto = proto_addr_info if proto_addr_info is not None else sock.proto
             resolved = await self._ensure_resolved(
-                address, family=sock.family, type=sock.type, proto=sock.proto,
+                address, family=sock.family, type=sock.type, proto=proto,
                 loop=self,
             )
             _, _, _, _, address = resolved[0]

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -618,14 +618,10 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
         else:
             fut.set_result(n)
 
-    async def sock_connect(self, sock, address, proto_addr_info = None):
+    async def sock_connect(self, sock, address, proto_addr_info=None):
         """Connect to a remote socket at address.
 
         This method is a coroutine.
-        
-        The proto_addr info parameter allows to specify a protocol to use for the 
-        resolution of the address. If not specified, default to the protocol used
-        by sock
         """
         base_events._check_ssl_socket(sock)
         if self._debug and sock.gettimeout() != 0:

--- a/Misc/NEWS.d/next/Library/2024-08-20-12-51-58.gh-issue-123174.nXCVYU.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-20-12-51-58.gh-issue-123174.nXCVYU.rst
@@ -1,0 +1,2 @@
+Allow the selection of the protocol used by getaddrinfo by adding an additional, optional parameter proto_addr_info
+If not specified, use the protocol used by the socket (= previous behaviour)


### PR DESCRIPTION
Allow the selection of the protocol used by `getaddrinfo` by adding an additional, optional parameter `proto_addr_info`.

If not specified, use the protocol used by the socket (= previous behaviour).

This change is needed to allow custom protocols to be used with `sock_connect`, because these protocols may raise an error when calling `getaddrinfo` (result in a `ai_proto not supported` error).
An example of such protocol is MPTCP (https://mptcp.dev)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123174 -->
* Issue: gh-123174
<!-- /gh-issue-number -->
