### PR TITLE
GH-115776: Allow any fixed sized object to have inline values

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -230,7 +230,6 @@ struct _typeobject {
     /* bitset of which type-watchers care about this type */
     unsigned char tp_watched;
     uint16_t tp_versions_used;
-    uint16_t tp_inline_values_offset;
 };
 
 /* This struct is used by the specializer

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -230,6 +230,7 @@ struct _typeobject {
     /* bitset of which type-watchers care about this type */
     unsigned char tp_watched;
     uint16_t tp_versions_used;
+    uint16_t tp_inline_values_offset;
 };
 
 /* This struct is used by the specializer

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -803,10 +803,11 @@ _PyObject_GetManagedDict(PyObject *obj)
 static inline PyDictValues *
 _PyObject_InlineValues(PyObject *obj)
 {
+    PyTypeObject *tp = Py_TYPE(obj);
+    assert(tp->tp_inline_values_offset > 0 && tp->tp_inline_values_offset % sizeof(PyObject *) == 0);
     assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
     assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
-    assert(Py_TYPE(obj)->tp_basicsize == sizeof(PyObject));
-    return (PyDictValues *)((char *)obj + sizeof(PyObject));
+    return (PyDictValues *)((char *)obj + tp->tp_inline_values_offset);
 }
 
 extern PyObject ** _PyObject_ComputedDictPointer(PyObject *);

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -804,10 +804,10 @@ static inline PyDictValues *
 _PyObject_InlineValues(PyObject *obj)
 {
     PyTypeObject *tp = Py_TYPE(obj);
-    assert(tp->tp_inline_values_offset > 0 && tp->tp_inline_values_offset % sizeof(PyObject *) == 0);
+    assert(tp->tp_basicsize > 0 && tp->tp_basicsize % sizeof(PyObject *) == 0);
     assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
     assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
-    return (PyDictValues *)((char *)obj + tp->tp_inline_values_offset);
+    return (PyDictValues *)((char *)obj + tp->tp_basicsize);
 }
 
 extern PyObject ** _PyObject_ComputedDictPointer(PyObject *);

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-21-08-53-00.gh-issue-115776.9A7Dv_.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-21-08-53-00.gh-issue-115776.9A7Dv_.rst
@@ -1,0 +1,2 @@
+Enables inline values (Python's equivalent of hidden classes) on any class
+who's instances are of a fixed size.

--- a/Objects/object_layout.md
+++ b/Objects/object_layout.md
@@ -30,7 +30,7 @@ is set to `NULL`.
 
 In 3.13 only objects with no additional data could have inline values.
 That is, instances of classes with `tp_basicsize == sizeof(PyObject)`.
-In 3.14, any object who's class has `tp_itemsize == 0` can have inline values.
+In 3.14, any object whose class has `tp_itemsize == 0` can have inline values.
 In both versions, the inline values starts `tp_basicsize` bytes after the object.
 
 <details>

--- a/Objects/object_layout.md
+++ b/Objects/object_layout.md
@@ -28,6 +28,10 @@ So the pre-header is these two fields:
 If the object has no physical dictionary, then the ``dict_pointer``
 is set to `NULL`.
 
+In 3.13 only objects with no additional data could have inline values.
+That is, instances of classes with `tp_basicsize == sizeof(PyObject)`.
+In 3.14, any object who's class has `tp_itemsize == 0` can have inline values.
+In both versions, the inline values starts `tp_basicsize` bytes after the object.
 
 <details>
 <summary> 3.12 </summary>

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8340,7 +8340,8 @@ type_ready_managed_dict(PyTypeObject *type)
             return -1;
         }
     }
-    if (type->tp_itemsize == 0 && type->tp_basicsize == sizeof(PyObject)) {
+    if (type->tp_itemsize == 0) {
+        type->tp_inline_values_offset = type->tp_basicsize;
         type->tp_flags |= Py_TPFLAGS_INLINE_VALUES;
     }
     return 0;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8341,7 +8341,6 @@ type_ready_managed_dict(PyTypeObject *type)
         }
     }
     if (type->tp_itemsize == 0) {
-        type->tp_inline_values_offset = type->tp_basicsize;
         type->tp_flags |= Py_TPFLAGS_INLINE_VALUES;
     }
     return 0;

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2188,7 +2188,7 @@ dummy_func(
             DISPATCH_INLINED(new_frame);
         }
 
-        op(_GUARD_DORV_NO_DICT, (offset -- owner)) {
+        op(_GUARD_DORV_NO_DICT, (owner -- owner)) {
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
 
             assert(Py_TYPE(owner_o)->tp_dictoffset < 0);

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2012,9 +2012,10 @@ dummy_func(
             DEOPT_IF(!_PyObject_InlineValues(owner_o)->valid);
         }
 
-        split op(_LOAD_ATTR_INSTANCE_VALUE, (index/1, owner -- attr, null if (oparg & 1))) {
+        split op(_LOAD_ATTR_INSTANCE_VALUE, (offset/1, owner -- attr, null if (oparg & 1))) {
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-            PyObject *attr_o = _PyObject_InlineValues(owner_o)->values[index];
+            PyObject **value_ptr = (PyObject**)(((char *)owner_o) + offset);
+            PyObject *attr_o = *value_ptr;
             DEOPT_IF(attr_o == NULL);
             STAT_INC(LOAD_ATTR, hit);
             Py_INCREF(attr_o);
@@ -2187,7 +2188,7 @@ dummy_func(
             DISPATCH_INLINED(new_frame);
         }
 
-        op(_GUARD_DORV_NO_DICT, (owner -- owner)) {
+        op(_GUARD_DORV_NO_DICT, (offset -- owner)) {
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
 
             assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
@@ -2196,16 +2197,17 @@ dummy_func(
             EXIT_IF(_PyObject_InlineValues(owner_o)->valid == 0);
         }
 
-        op(_STORE_ATTR_INSTANCE_VALUE, (index/1, value, owner --)) {
+        op(_STORE_ATTR_INSTANCE_VALUE, (offset/1, value, owner --)) {
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
 
             STAT_INC(STORE_ATTR, hit);
             assert(_PyObject_GetManagedDict(owner_o) == NULL);
-            PyDictValues *values = _PyObject_InlineValues(owner_o);
-
-            PyObject *old_value = values->values[index];
-            values->values[index] = PyStackRef_AsPyObjectSteal(value);
+            PyObject **value_ptr = (PyObject**)(((char *)owner_o) + offset);
+            PyObject *old_value = *value_ptr;
+            *value_ptr = PyStackRef_AsPyObjectSteal(value);
             if (old_value == NULL) {
+                PyDictValues *values = _PyObject_InlineValues(owner_o);
+                int index = value_ptr - values->values;
                 _PyDictValues_AddToInsertionOrder(values, index);
             }
             else {

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -2565,6 +2565,7 @@
 
         case _GUARD_DORV_NO_DICT: {
             _PyStackRef owner;
+            owner = stack_pointer[-1];
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
             assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
             assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
@@ -2576,7 +2577,6 @@
                 UOP_STAT_INC(uopcode, miss);
                 JUMP_TO_JUMP_TARGET();
             }
-            stack_pointer[-1] = owner;
             break;
         }
 

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -2055,6 +2055,9 @@ _PyObject_GC_New(PyTypeObject *tp)
         return NULL;
     }
     _PyObject_Init(op, tp);
+    if (tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+        _PyObject_InitInlineValues(op, tp);
+    }
     return op;
 }
 

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1810,6 +1810,9 @@ _PyObject_GC_New(PyTypeObject *tp)
         return NULL;
     }
     _PyObject_Init(op, tp);
+    if (tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+        _PyObject_InitInlineValues(op, tp);
+    }
     return op;
 }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -4995,9 +4995,10 @@
             }
             // _LOAD_ATTR_INSTANCE_VALUE
             {
-                uint16_t index = read_u16(&this_instr[4].cache);
+                uint16_t offset = read_u16(&this_instr[4].cache);
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-                PyObject *attr_o = _PyObject_InlineValues(owner_o)->values[index];
+                PyObject **value_ptr = (PyObject**)(((char *)owner_o) + offset);
+                PyObject *attr_o = *value_ptr;
                 DEOPT_IF(attr_o == NULL, LOAD_ATTR);
                 STAT_INC(LOAD_ATTR, hit);
                 Py_INCREF(attr_o);
@@ -6825,14 +6826,16 @@
             // _STORE_ATTR_INSTANCE_VALUE
             value = stack_pointer[-2];
             {
-                uint16_t index = read_u16(&this_instr[4].cache);
+                uint16_t offset = read_u16(&this_instr[4].cache);
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
                 STAT_INC(STORE_ATTR, hit);
                 assert(_PyObject_GetManagedDict(owner_o) == NULL);
-                PyDictValues *values = _PyObject_InlineValues(owner_o);
-                PyObject *old_value = values->values[index];
-                values->values[index] = PyStackRef_AsPyObjectSteal(value);
+                PyObject **value_ptr = (PyObject**)(((char *)owner_o) + offset);
+                PyObject *old_value = *value_ptr;
+                *value_ptr = PyStackRef_AsPyObjectSteal(value);
                 if (old_value == NULL) {
+                    PyDictValues *values = _PyObject_InlineValues(owner_o);
+                    int index = value_ptr - values->values;
                     _PyDictValues_AddToInsertionOrder(values, index);
                 }
                 else {

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -452,10 +452,10 @@ dummy_func(void) {
         top, unused[oparg-2], bottom)) {
     }
 
-    op(_LOAD_ATTR_INSTANCE_VALUE, (index/1, owner -- attr, null if (oparg & 1))) {
+    op(_LOAD_ATTR_INSTANCE_VALUE, (offset/1, owner -- attr, null if (oparg & 1))) {
         attr = sym_new_not_null(ctx);
         null = sym_new_null(ctx);
-        (void)index;
+        (void)offset;
         (void)owner;
     }
 

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1067,7 +1067,7 @@
             uint16_t offset = (uint16_t)this_instr->operand;
             attr = sym_new_not_null(ctx);
             null = sym_new_null(ctx);
-            (void)index;
+            (void)offset;
             (void)owner;
             stack_pointer[-1] = attr;
             if (oparg & 1) stack_pointer[0] = null;
@@ -1204,9 +1204,6 @@
         /* _LOAD_ATTR_GETATTRIBUTE_OVERRIDDEN is not a viable micro-op for tier 2 */
 
         case _GUARD_DORV_NO_DICT: {
-            _Py_UopsSymbol *owner;
-            owner = sym_new_not_null(ctx);
-            stack_pointer[-1] = owner;
             break;
         }
 

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1064,7 +1064,7 @@
             _Py_UopsSymbol *attr;
             _Py_UopsSymbol *null = NULL;
             owner = stack_pointer[-1];
-            uint16_t index = (uint16_t)this_instr->operand;
+            uint16_t offset = (uint16_t)this_instr->operand;
             attr = sym_new_not_null(ctx);
             null = sym_new_null(ctx);
             (void)index;
@@ -1204,6 +1204,9 @@
         /* _LOAD_ATTR_GETATTRIBUTE_OVERRIDDEN is not a viable micro-op for tier 2 */
 
         case _GUARD_DORV_NO_DICT: {
+            _Py_UopsSymbol *owner;
+            owner = sym_new_not_null(ctx);
+            stack_pointer[-1] = owner;
             break;
         }
 

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -69,9 +69,6 @@ def _type_unsigned_int_ptr():
 def _sizeof_void_p():
     return gdb.lookup_type('void').pointer().sizeof
 
-def _sizeof_pyobject():
-    return gdb.lookup_type('PyObject').sizeof
-
 def _managed_dict_offset():
     # See pycore_object.h
     pyobj = gdb.lookup_type("PyObject")
@@ -505,7 +502,7 @@ class HeapTypeObjectPtr(PyObjectPtr):
         dict_ptr = dict_ptr_ptr.cast(_type_char_ptr().pointer()).dereference()
         if int(dict_ptr):
             return None
-        char_ptr = obj_ptr + _sizeof_pyobject()
+        char_ptr = obj_ptr + typeobj.field('tp_basicsize')
         values_ptr = char_ptr.cast(gdb.lookup_type("PyDictValues").pointer())
         values = values_ptr['values']
         return PyKeysValuesPair(self.get_cached_keys(), values)


### PR DESCRIPTION
Currently only objects with `Py_TYPE(obj)->tp_basicsize == sizeof(PyObject)` are allowed to have inline values.
This PR changes that to allow any object where all instances of the class have the same size to have inline values.

[Performance](https://github.com/faster-cpython/benchmarking-public/tree/main/results/bm-20240820-3.14.0a0-a3e6464) is in the noise, but the [stats](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240820-3.14.0a0-a3e6464/bm-20240820-azure-x86_64-faster%252dcpython-variable_offset_inli-3.14.0a0-a3e6464-pystats-vs-base.md) show a clear reduction in the number of `LOAD_ATTR`s executed.
Oddly, the number of `LOAD_ATTR_INSTANCE_VALUE`s executed is roughly unchanged, the new specializations being for class attributes. Fixing [the shadowing issue](https://github.com/python/cpython/issues/123040) should improve things further and show an increase in `LOAD_ATTR_INSTANCE_VALUE`s.



<!-- gh-issue-number: gh-115776 -->
* Issue: gh-115776
<!-- /gh-issue-number -->
