### PR TITLE
GH-118093: Specialize calls to non-vectorcall classes as `CALL_NON_PY_GENERAL`

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -562,8 +562,6 @@ _PyCode_Quicken(PyCodeObject *code)
 #define SPEC_FAIL_CALL_INIT_NOT_PYTHON 21
 #define SPEC_FAIL_CALL_PEP_523 22
 #define SPEC_FAIL_CALL_BOUND_METHOD 23
-#define SPEC_FAIL_CALL_STR 24
-#define SPEC_FAIL_CALL_CLASS_NO_VECTORCALL 25
 #define SPEC_FAIL_CALL_CLASS_MUTABLE 26
 #define SPEC_FAIL_CALL_METHOD_WRAPPER 28
 #define SPEC_FAIL_CALL_OPERATOR_WRAPPER 29
@@ -1796,9 +1794,7 @@ specialize_class_call(PyObject *callable, _Py_CODEUNIT *instr, int nargs)
             instr->op.code = CALL_BUILTIN_CLASS;
             return 0;
         }
-        SPECIALIZATION_FAIL(CALL, tp == &PyUnicode_Type ?
-            SPEC_FAIL_CALL_STR : SPEC_FAIL_CALL_CLASS_NO_VECTORCALL);
-        return -1;
+        goto generic;
     }
     if (Py_TYPE(tp) != &PyType_Type) {
         goto generic;


### PR DESCRIPTION
Super minor change to the specializer. Performance impact is [in the noise](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240821-3.14.0a0-bfdd616-JIT/bm-20240821-linux-x86_64-brandtbucher-class_no_vectorcall-3.14.0a0-bfdd616-vs-base.svg), but [the stats](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240821-3.14.0a0-bfdd616-JIT/bm-20240821-azure-x86_64-brandtbucher-class_no_vectorcall-3.14.0a0-bfdd616-pystats-vs-base.md) indicate that this decreases our tier one instructions by 4% and increases our tier two instructions by 2%. It also gets rid of (basically) all unspecialized `CALL` instructions.

<!-- gh-issue-number: gh-118093 -->
* Issue: gh-118093
<!-- /gh-issue-number -->
