### PR TITLE
gh-123213: Fixed xml.etree.ElementTree.Element.extend and assignment to no longer hide exceptions

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -971,7 +971,7 @@ Element Objects
 
    .. method:: extend(subelements)
 
-      Appends *subelements* from a sequence object with zero or more elements.
+      Appends *subelements* from an iterable of elements.
       Raises :exc:`TypeError` if a subelement is not an :class:`Element`.
 
       .. versionadded:: 3.2

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2427,6 +2427,7 @@ class BugsTest(unittest.TestCase):
         # Does not hide the internal exception when extending the element
         self.assertRaises(ZeroDivisionError, ET.Element('tag').extend,
                           (1/0 for i in range(2)))
+
         # Still raises the TypeError when extending with a non-iterable
         self.assertRaises(TypeError, ET.Element('tag').extend, None)
 
@@ -3760,7 +3761,7 @@ class ElementSlicingTest(unittest.TestCase):
         # Does not hide the internal exception when assigning to the element
         with self.assertRaises(ZeroDivisionError):
             e[:1] = (1/0 for i in range(2))
-        
+
         # Still raises the TypeError when assigning with a non-iterable
         with self.assertRaises(TypeError):
             e[:1] = None

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2423,7 +2423,7 @@ class BugsTest(unittest.TestCase):
         self.assertRaises(TypeError, ET.TreeBuilder().start, "tag")
         self.assertRaises(TypeError, ET.TreeBuilder().start, "tag", None)
 
-    def test_123213_correct_extend_exception(self):
+    def test_issue123213_correct_extend_exception(self):
         # Does not hide the internal exception when extending the element
         self.assertRaises(ZeroDivisionError, ET.Element('tag').extend,
                           (1/0 for i in range(2)))
@@ -3755,6 +3755,15 @@ class ElementSlicingTest(unittest.TestCase):
         e[1::-sys.maxsize<<64] = [ET.Element('d')]
         self.assertEqual(self._subelem_tags(e), ['a0', 'd', 'a2', 'a3'])
 
+    def test_issue123213_setslice_exception(self):
+        e = ET.Element('tag')
+        # Does not hide the internal exception when assigning to the element
+        with self.assertRaises(ZeroDivisionError):
+            e[:1] = (1/0 for i in range(2))
+        
+        # Still raises the TypeError when assigning with a non-iterable
+        with self.assertRaises(TypeError):
+            e[:1] = None
 
 class IOTest(unittest.TestCase):
     def test_encoding(self):

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2423,6 +2423,13 @@ class BugsTest(unittest.TestCase):
         self.assertRaises(TypeError, ET.TreeBuilder().start, "tag")
         self.assertRaises(TypeError, ET.TreeBuilder().start, "tag", None)
 
+    def test_123213_correct_extend_exception(self):
+        # Does not hide the internal exception when extending the element
+        self.assertRaises(ZeroDivisionError, ET.Element('tag').extend,
+                          (1/0 for i in range(2)))
+        # Still raises the TypeError when extending with a non-iterable
+        self.assertRaises(TypeError, ET.Element('tag').extend, None)
+
 
 
 # --------------------------------------------------------------------

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2431,6 +2431,14 @@ class BugsTest(unittest.TestCase):
         # Still raises the TypeError when extending with a non-iterable
         self.assertRaises(TypeError, ET.Element('tag').extend, None)
 
+        # Preserves the TypeError message when extending with a generator
+        def f():
+            raise TypeError("mymessage")
+
+        self.assertRaisesRegex(
+            TypeError, 'mymessage',
+            ET.Element('tag').extend, (f() for i in range(2)))
+
 
 
 # --------------------------------------------------------------------
@@ -3765,6 +3773,13 @@ class ElementSlicingTest(unittest.TestCase):
         # Still raises the TypeError when assigning with a non-iterable
         with self.assertRaises(TypeError):
             e[:1] = None
+
+        # Preserve the original TypeError message when assigning.
+        def f():
+            raise TypeError("mymessage")
+
+        with self.assertRaisesRegex(TypeError, 'mymessage'):
+            e[:1] = (f() for i in range(2))
 
 class IOTest(unittest.TestCase):
     def test_encoding(self):

--- a/Misc/NEWS.d/next/Library/2024-08-22-09-37-48.gh-issue-123213.owmXnP.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-22-09-37-48.gh-issue-123213.owmXnP.rst
@@ -1,3 +1,3 @@
-:meth:`xml.etree.ElementTree.Element.extend` and Element assignment no
-longer hide the internal exception if an erronous generator is passed. Patch
-by Bar Harel.
+:meth:`xml.etree.ElementTree.Element.extend` and
+:class:`~xml.etree.ElementTree.Element` assignment no longer hide the internal
+exception if an erronous generator is passed. Patch by Bar Harel.

--- a/Misc/NEWS.d/next/Library/2024-08-22-09-37-48.gh-issue-123213.owmXnP.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-22-09-37-48.gh-issue-123213.owmXnP.rst
@@ -1,3 +1,3 @@
 :meth:`xml.etree.ElementTree.Element.extend` and Element assignment no
 longer hide the internal exception if an erronous generator is passed. Patch
-by Bar Harel
+by Bar Harel.

--- a/Misc/NEWS.d/next/Library/2024-08-22-09-37-48.gh-issue-123213.owmXnP.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-22-09-37-48.gh-issue-123213.owmXnP.rst
@@ -1,0 +1,3 @@
+:meth:`xml.etree.ElementTree.Element.extend` and Element assignment no
+longer hide the internal exception if an erronous generator is passed. Patch
+by Bar Harel

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1213,7 +1213,7 @@ _elementtree_Element_extend_impl(ElementObject *self, PyTypeObject *cls,
     PyObject* seq;
     Py_ssize_t i;
 
-    seq = PySequence_Fast(elements, "argument must be an iterable");
+    seq = PySequence_Fast(elements, "'elements' must be an iterable");
     if (!seq) {
         return NULL;
     }

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1213,12 +1213,8 @@ _elementtree_Element_extend_impl(ElementObject *self, PyTypeObject *cls,
     PyObject* seq;
     Py_ssize_t i;
 
-    seq = PySequence_Fast(elements, "");
+    seq = PySequence_Fast(elements, "argument must be an iterable");
     if (!seq) {
-        PyErr_Format(
-            PyExc_TypeError,
-            "expected sequence, not \"%.200s\"", Py_TYPE(elements)->tp_name
-            );
         return NULL;
     }
 
@@ -1918,12 +1914,8 @@ element_ass_subscr(PyObject* self_, PyObject* item, PyObject* value)
         }
 
         /* A new slice is actually being assigned */
-        seq = PySequence_Fast(value, "");
+        seq = PySequence_Fast(value, "assignment expects an iterable");
         if (!seq) {
-            PyErr_Format(
-                PyExc_TypeError,
-                "expected sequence, not \"%.200s\"", Py_TYPE(value)->tp_name
-                );
             return -1;
         }
         newlen = PySequence_Fast_GET_SIZE(seq);


### PR DESCRIPTION
Backport to 3.12 please.

Not formatting the exception message with the type (i.e "expected iterable not '...'") per `PySequence_Fast` standard usage across all modules.

Apparently this bug exists for 15 years ☹️ 

Typeshed already expects an Iterable for `.extend()` and `__setitem__`, so it does not require an update ❤️ 

<!-- gh-issue-number: gh-123213 -->
* Issue: gh-123213
<!-- /gh-issue-number -->
