### PR TITLE
gh-123215: support path-like objects in `fnmatch.fnmatchcase`

### DIFF
--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -52,7 +52,7 @@ cache the compiled regex patterns in the following functions: :func:`fnmatch`,
 
 .. function:: fnmatch(name, pat)
 
-   Test whether the filename string *name* matches the pattern string *pat*,
+   Test whether the filename *name* matches the pattern string *pat*,
    returning ``True`` or ``False``.  Both parameters are case-normalized
    using :func:`os.path.normcase`. :func:`fnmatchcase` can be used to perform a
    case-sensitive comparison, regardless of whether that's standard for the
@@ -71,9 +71,13 @@ cache the compiled regex patterns in the following functions: :func:`fnmatch`,
 
 .. function:: fnmatchcase(name, pat)
 
-   Test whether the filename string *name* matches the pattern string *pat*,
+   Test whether the filename *name* matches the pattern string *pat*,
    returning ``True`` or ``False``;
    the comparison is case-sensitive and does not apply :func:`os.path.normcase`.
+
+   .. versionchanged:: 3.14
+      Added support for :term:`path-like objects <path-like object>` for
+      the *name* parameter.
 
 
 .. function:: filter(names, pat)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -126,6 +126,14 @@ dis
 
   (Contributed by Bénédikt Tran in :gh:`123165`.)
 
+fnmatch
+-------
+
+* Added support for :term:`path-like objects <path-like object>` for
+  the *name* parameter of :func:`fnmatch.fnmatchcase`.
+
+  (Contributed by Bénédikt Tran in :gh:`123215`.)
+
 fractions
 ---------
 

--- a/Lib/fnmatch.py
+++ b/Lib/fnmatch.py
@@ -68,7 +68,7 @@ def fnmatchcase(name, pat):
     its arguments.
     """
     match = _compile_pattern(pat)
-    return match(name) is not None
+    return match(os.fspath(name)) is not None
 
 
 def translate(pat):

--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -14,12 +14,12 @@ class FnmatchTestCase(unittest.TestCase):
     def check_match(self, filename, pattern, should_match=True, fn=fnmatch):
         if should_match:
             self.assertTrue(fn(filename, pattern),
-                         "expected %r to match pattern %r"
-                         % (filename, pattern))
+                         "expected %r (%r) to match pattern %r"
+                         % (filename, os.fspath(filename), pattern))
         else:
             self.assertFalse(fn(filename, pattern),
-                         "expected %r not to match pattern %r"
-                         % (filename, pattern))
+                         "expected %r (%r) not to match pattern %r"
+                         % (filename, os.fspath(filename), pattern))
 
     def test_fnmatch(self):
         check = self.check_match

--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -4,6 +4,8 @@ import unittest
 import os
 import string
 import warnings
+from pathlib import Path
+from test.support.os_helper import FakePath
 
 from fnmatch import fnmatch, fnmatchcase, translate, filter
 
@@ -61,15 +63,17 @@ class FnmatchTestCase(unittest.TestCase):
 
     def test_fnmatchcase(self):
         check = self.check_match
-        check('abc', 'abc', True, fnmatchcase)
-        check('AbC', 'abc', False, fnmatchcase)
-        check('abc', 'AbC', False, fnmatchcase)
-        check('AbC', 'AbC', True, fnmatchcase)
+        for cls in (str, Path, FakePath):
+            with self.subTest(cls=cls):
+                check(cls('abc'), 'abc', True, fnmatchcase)
+                check(cls('AbC'), 'abc', False, fnmatchcase)
+                check(cls('abc'), 'AbC', False, fnmatchcase)
+                check(cls('AbC'), 'AbC', True, fnmatchcase)
 
-        check('usr/bin', 'usr/bin', True, fnmatchcase)
-        check('usr\\bin', 'usr/bin', False, fnmatchcase)
-        check('usr/bin', 'usr\\bin', False, fnmatchcase)
-        check('usr\\bin', 'usr\\bin', True, fnmatchcase)
+                check(cls('usr/bin'), 'usr/bin', True, fnmatchcase)
+                check(cls('usr\\bin'), 'usr/bin', False, fnmatchcase)
+                check(cls('usr/bin'), 'usr\\bin', False, fnmatchcase)
+                check(cls('usr\\bin'), 'usr\\bin', True, fnmatchcase)
 
     def test_bytes(self):
         self.check_match(b'test', b'te*')

--- a/Lib/test/test_fnmatch.py
+++ b/Lib/test/test_fnmatch.py
@@ -70,10 +70,10 @@ class FnmatchTestCase(unittest.TestCase):
                 check(cls('abc'), 'AbC', False, fnmatchcase)
                 check(cls('AbC'), 'AbC', True, fnmatchcase)
 
-                check(cls('usr/bin'), 'usr/bin', True, fnmatchcase)
-                check(cls('usr\\bin'), 'usr/bin', False, fnmatchcase)
-                check(cls('usr/bin'), 'usr\\bin', False, fnmatchcase)
-                check(cls('usr\\bin'), 'usr\\bin', True, fnmatchcase)
+                check(cls('usr/bin'), 'usr/bin', os.fspath(cls('/')) == '/', fnmatchcase)
+                check(cls('usr\\bin'), 'usr/bin', os.fspath(cls('\\')) == '/', fnmatchcase)
+                check(cls('usr/bin'), 'usr\\bin', os.fspath(cls('/')) == '\\', fnmatchcase)
+                check(cls('usr\\bin'), 'usr\\bin', os.fspath(cls('\\')) == '\\', fnmatchcase)
 
     def test_bytes(self):
         self.check_match(b'test', b'te*')

--- a/Misc/NEWS.d/next/Library/2024-08-22-09-33-17.gh-issue-123215.MpDzeC.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-22-09-33-17.gh-issue-123215.MpDzeC.rst
@@ -1,0 +1,2 @@
+Added support for :term:`path-like objects <path-like object>` for the
+*name* parameter of :func:`fnmatch.fnmatchcase`. Patch by Bénédikt Tran.


### PR DESCRIPTION


<!-- gh-issue-number: gh-123215 -->
* Issue: gh-123215
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123216.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->