### PR TITLE
gh-122546: use same filename for different exceptions in new repl

### DIFF
--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -162,7 +162,7 @@ class InteractiveColoredConsole(code.InteractiveConsole):
         self.can_colorize = _colorize.can_colorize()
 
     def showsyntaxerror(self, filename=None, **kwargs):
-        super().showsyntaxerror(**kwargs)
+        super().showsyntaxerror(filename=filename, **kwargs)
 
     def _excepthook(self, typ, value, tb):
         import traceback

--- a/Lib/code.py
+++ b/Lib/code.py
@@ -109,15 +109,7 @@ class InteractiveInterpreter:
         try:
             typ, value, tb = sys.exc_info()
             if filename and typ is SyntaxError:
-                # Work hard to stuff the correct filename in the exception
-                try:
-                    msg, (dummy_filename, lineno, offset, line) = value.args
-                except ValueError:
-                    # Not the format we expect; leave it alone
-                    pass
-                else:
-                    # Stuff in the right filename
-                    value = SyntaxError(msg, (filename, lineno, offset, line))
+                value.filename = filename
             source = kwargs.pop('source', "")
             self._showtraceback(typ, value, None, source)
         finally:

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1101,6 +1101,14 @@ class TestMain(TestCase):
         self.assertNotEqual(pathlib.Path(hfile.name).stat().st_size, 0)
 
     @force_not_colorized
+    def test_correct_filename_in_syntaxerrors(self):
+        env = os.environ.copy()
+        commands = "a b c\nexit()\n"
+        output, exit_code = self.run_repl(commands, env=env)
+        self.assertIn("SyntaxError: invalid syntax", output)
+        self.assertIn("<python-input-0>", output)
+
+    @force_not_colorized
     def test_proper_tracebacklimit(self):
         env = os.environ.copy()
         for set_tracebacklimit in [True, False]:

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1105,6 +1105,8 @@ class TestMain(TestCase):
         env = os.environ.copy()
         commands = "a b c\nexit()\n"
         output, exit_code = self.run_repl(commands, env=env)
+        if "can't use pyrepl" in output:
+            self.skipTest("pyrepl not available")
         self.assertIn("SyntaxError: invalid syntax", output)
         self.assertIn("<python-input-0>", output)
 

--- a/Misc/NEWS.d/next/Library/2024-08-22-11-25-19.gh-issue-122546.BSmeE7.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-22-11-25-19.gh-issue-122546.BSmeE7.rst
@@ -1,0 +1,2 @@
+Consistently use same file name for different exceptions in the new repl.
+Patch by Sergey B Kirpichev.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122546 -->
* Issue: gh-122546
<!-- /gh-issue-number -->
