### PR TITLE
gh-123205: fix MSVC warnings due to pointer arithmetic in `bytecodes.c`

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -39,6 +39,8 @@
 #include "pydtrace.h"
 #include "setobject.h"
 
+#include <stddef.h>               // ptrdiff_t
+
 
 #define USE_COMPUTED_GOTOS 0
 #include "ceval_macros.h"
@@ -2207,8 +2209,8 @@ dummy_func(
             *value_ptr = PyStackRef_AsPyObjectSteal(value);
             if (old_value == NULL) {
                 PyDictValues *values = _PyObject_InlineValues(owner_o);
-                int index = value_ptr - values->values;
-                _PyDictValues_AddToInsertionOrder(values, index);
+                ptrdiff_t index = value_ptr - values->values;
+                _PyDictValues_AddToInsertionOrder(values, (Py_ssize_t)index);
             }
             else {
                 Py_DECREF(old_value);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -2594,8 +2594,8 @@
             *value_ptr = PyStackRef_AsPyObjectSteal(value);
             if (old_value == NULL) {
                 PyDictValues *values = _PyObject_InlineValues(owner_o);
-                int index = value_ptr - values->values;
-                _PyDictValues_AddToInsertionOrder(values, index);
+                ptrdiff_t index = value_ptr - values->values;
+                _PyDictValues_AddToInsertionOrder(values, (Py_ssize_t)index);
             }
             else {
                 Py_DECREF(old_value);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -6839,8 +6839,8 @@
                 *value_ptr = PyStackRef_AsPyObjectSteal(value);
                 if (old_value == NULL) {
                     PyDictValues *values = _PyObject_InlineValues(owner_o);
-                    int index = value_ptr - values->values;
-                    _PyDictValues_AddToInsertionOrder(values, index);
+                    ptrdiff_t index = value_ptr - values->values;
+                    _PyDictValues_AddToInsertionOrder(values, (Py_ssize_t)index);
                 }
                 else {
                     Py_DECREF(old_value);


### PR DESCRIPTION
Warnings were emitted on Windows platforms due to pointer arithmetic (GHA is reporting them on my PRs). This should take care of them.