### PR TITLE
[3.13] gh-122546: use same filename for different exceptions in new repl (GH-123217)

### DIFF
--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -162,7 +162,7 @@ class InteractiveColoredConsole(code.InteractiveConsole):
         self.can_colorize = _colorize.can_colorize()
 
     def showsyntaxerror(self, filename=None, **kwargs):
-        super().showsyntaxerror(colorize=self.can_colorize, **kwargs)
+        super().showsyntaxerror(filename=filename, **kwargs)
 
     def showtraceback(self):
         super().showtraceback(colorize=self.can_colorize)

--- a/Lib/code.py
+++ b/Lib/code.py
@@ -113,16 +113,7 @@ class InteractiveInterpreter:
         sys.last_value = value
         sys.last_traceback = tb
         if filename and type is SyntaxError:
-            # Work hard to stuff the correct filename in the exception
-            try:
-                msg, (dummy_filename, lineno, offset, line) = value.args
-            except ValueError:
-                # Not the format we expect; leave it alone
-                pass
-            else:
-                # Stuff in the right filename
-                value = SyntaxError(msg, (filename, lineno, offset, line))
-                sys.last_exc = sys.last_value = value
+            value.filename = filename
         # Set the line of text that the exception refers to
         source = kwargs.pop('source', '')
         lines = source.splitlines()

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1100,6 +1100,16 @@ class TestMain(TestCase):
         self.assertIn("spam", output)
         self.assertNotEqual(pathlib.Path(hfile.name).stat().st_size, 0)
 
+    @force_not_colorized
+    def test_correct_filename_in_syntaxerrors(self):
+        env = os.environ.copy()
+        commands = "a b c\nexit()\n"
+        output, exit_code = self.run_repl(commands, env=env)
+        if "can't use pyrepl" in output:
+            self.skipTest("pyrepl not available")
+        self.assertIn("SyntaxError: invalid syntax", output)
+        self.assertIn("<python-input-0>", output)
+
     def run_repl(
         self,
         repl_input: str | list[str],

--- a/Misc/NEWS.d/next/Library/2024-08-22-11-25-19.gh-issue-122546.BSmeE7.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-22-11-25-19.gh-issue-122546.BSmeE7.rst
@@ -1,0 +1,2 @@
+Consistently use same file name for different exceptions in the new repl.
+Patch by Sergey B Kirpichev.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122546 -->
* Issue: gh-122546
<!-- /gh-issue-number -->
