### PR TITLE
[3.13] gh-122478: Remove internal frames from tracebacks in REPL (GH-122528)

### DIFF
--- a/Lib/code.py
+++ b/Lib/code.py
@@ -13,6 +13,7 @@ from codeop import CommandCompiler, compile_command
 __all__ = ["InteractiveInterpreter", "InteractiveConsole", "interact",
            "compile_command"]
 
+
 class InteractiveInterpreter:
     """Base class for InteractiveConsole.
 
@@ -107,26 +108,14 @@ class InteractiveInterpreter:
 
         """
         colorize = kwargs.pop('colorize', False)
-        type, value, tb = sys.exc_info()
-        sys.last_exc = value
-        sys.last_type = type
-        sys.last_value = value
-        sys.last_traceback = tb
-        if filename and type is SyntaxError:
-            value.filename = filename
-        # Set the line of text that the exception refers to
-        source = kwargs.pop('source', '')
-        lines = source.splitlines()
-        if (source and type is SyntaxError
-                and not value.text and len(lines) >= value.lineno):
-            value.text = lines[value.lineno - 1]
-        if sys.excepthook is sys.__excepthook__:
-            lines = traceback.format_exception_only(type, value, colorize=colorize)
-            self.write(''.join(lines))
-        else:
-            # If someone has set sys.excepthook, we let that take precedence
-            # over self.write
-            self._call_excepthook(type, value, tb)
+        try:
+            typ, value, tb = sys.exc_info()
+            if filename and typ is SyntaxError:
+                value.filename = filename
+            source = kwargs.pop('source', "")
+            self._showtraceback(typ, value, None, colorize, source)
+        finally:
+            typ = value = tb = None
 
     def showtraceback(self, **kwargs):
         """Display the exception that just occurred.
@@ -137,32 +126,41 @@ class InteractiveInterpreter:
 
         """
         colorize = kwargs.pop('colorize', False)
-        sys.last_type, sys.last_value, last_tb = ei = sys.exc_info()
-        sys.last_traceback = last_tb
-        sys.last_exc = ei[1]
         try:
-            if sys.excepthook is sys.__excepthook__:
-                lines = traceback.format_exception(ei[0], ei[1], last_tb.tb_next, colorize=colorize)
-                self.write(''.join(lines))
-            else:
-                # If someone has set sys.excepthook, we let that take precedence
-                # over self.write
-                self._call_excepthook(ei[0], ei[1], last_tb)
+            typ, value, tb = sys.exc_info()
+            self._showtraceback(typ, value, tb.tb_next, colorize, '')
         finally:
-            last_tb = ei = None
+            typ = value = tb = None
 
-    def _call_excepthook(self, typ, value, tb):
-        try:
-            sys.excepthook(typ, value, tb)
-        except SystemExit:
-            raise
-        except BaseException as e:
-            e.__context__ = None
-            print('Error in sys.excepthook:', file=sys.stderr)
-            sys.__excepthook__(type(e), e, e.__traceback__.tb_next)
-            print(file=sys.stderr)
-            print('Original exception was:', file=sys.stderr)
-            sys.__excepthook__(typ, value, tb)
+    def _showtraceback(self, typ, value, tb, colorize, source):
+        sys.last_type = typ
+        sys.last_traceback = tb
+        value = value.with_traceback(tb)
+        # Set the line of text that the exception refers to
+        lines = source.splitlines()
+        if (source and typ is SyntaxError
+                and not value.text and len(lines) >= value.lineno):
+            value.text = lines[value.lineno - 1]
+        sys.last_exc = sys.last_value = value = value.with_traceback(tb)
+        if sys.excepthook is sys.__excepthook__:
+            lines = traceback.format_exception(typ, value, tb,
+                                               colorize=colorize)
+            self.write(''.join(lines))
+        else:
+            # If someone has set sys.excepthook, we let that take precedence
+            # over self.write
+            try:
+                sys.excepthook(typ, value, tb)
+            except SystemExit:
+                raise
+            except BaseException as e:
+                e.__context__ = None
+                e = e.with_traceback(e.__traceback__.tb_next)
+                print('Error in sys.excepthook:', file=sys.stderr)
+                sys.__excepthook__(type(e), e, e.__traceback__)
+                print(file=sys.stderr)
+                print('Original exception was:', file=sys.stderr)
+                sys.__excepthook__(typ, value, tb)
 
     def write(self, data):
         """Write a string.
@@ -376,7 +374,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-q', action='store_true',
-                       help="don't print version and copyright messages")
+                        help="don't print version and copyright messages")
     args = parser.parse_args()
     if args.q or sys.flags.quiet:
         banner = ''

--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -1,5 +1,6 @@
 "Test InteractiveConsole and InteractiveInterpreter from code module"
 import sys
+import traceback
 import unittest
 from textwrap import dedent
 from contextlib import ExitStack
@@ -30,6 +31,7 @@ class MockSys:
 
 
 class TestInteractiveConsole(unittest.TestCase, MockSys):
+    maxDiff = None
 
     def setUp(self):
         self.console = code.InteractiveConsole()
@@ -61,21 +63,118 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
             raise AssertionError("no console stdout")
 
     def test_syntax_error(self):
-        self.infunc.side_effect = ["undefined", EOFError('Finished')]
+        self.infunc.side_effect = ["def f():",
+                                   "    x = ?",
+                                   "",
+                                    EOFError('Finished')]
         self.console.interact()
-        for call in self.stderr.method_calls:
-            if 'NameError' in ''.join(call[1]):
-                break
-        else:
-            raise AssertionError("No syntax error from console")
+        output = ''.join(''.join(call[1]) for call in self.stderr.method_calls)
+        output = output[output.index('(InteractiveConsole)'):]
+        output = output[:output.index('\nnow exiting')]
+        self.assertEqual(output.splitlines()[1:], [
+            '  File "<console>", line 2',
+            '    x = ?',
+            '        ^',
+            'SyntaxError: invalid syntax'])
+        self.assertIs(self.sysmod.last_type, SyntaxError)
+        self.assertIs(type(self.sysmod.last_value), SyntaxError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+
+    def test_indentation_error(self):
+        self.infunc.side_effect = ["  1", EOFError('Finished')]
+        self.console.interact()
+        output = ''.join(''.join(call[1]) for call in self.stderr.method_calls)
+        output = output[output.index('(InteractiveConsole)'):]
+        output = output[:output.index('\nnow exiting')]
+        self.assertEqual(output.splitlines()[1:], [
+            '  File "<console>", line 1',
+            '    1',
+            'IndentationError: unexpected indent'])
+        self.assertIs(self.sysmod.last_type, IndentationError)
+        self.assertIs(type(self.sysmod.last_value), IndentationError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+
+    def test_unicode_error(self):
+        self.infunc.side_effect = ["'\ud800'", EOFError('Finished')]
+        self.console.interact()
+        output = ''.join(''.join(call[1]) for call in self.stderr.method_calls)
+        output = output[output.index('(InteractiveConsole)'):]
+        output = output[output.index('\n') + 1:]
+        self.assertTrue(output.startswith('UnicodeEncodeError: '), output)
+        self.assertIs(self.sysmod.last_type, UnicodeEncodeError)
+        self.assertIs(type(self.sysmod.last_value), UnicodeEncodeError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
 
     def test_sysexcepthook(self):
-        self.infunc.side_effect = ["raise ValueError('')",
+        self.infunc.side_effect = ["def f():",
+                                   "    raise ValueError('BOOM!')",
+                                   "",
+                                   "f()",
                                     EOFError('Finished')]
         hook = mock.Mock()
         self.sysmod.excepthook = hook
         self.console.interact()
-        self.assertTrue(hook.called)
+        hook.assert_called()
+        hook.assert_called_with(self.sysmod.last_type,
+                                self.sysmod.last_value,
+                                self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_type, ValueError)
+        self.assertIs(type(self.sysmod.last_value), ValueError)
+        self.assertIs(self.sysmod.last_traceback, self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+        self.assertEqual(traceback.format_exception(self.sysmod.last_exc), [
+            'Traceback (most recent call last):\n',
+            '  File "<console>", line 1, in <module>\n',
+            '  File "<console>", line 2, in f\n',
+            'ValueError: BOOM!\n'])
+
+    def test_sysexcepthook_syntax_error(self):
+        self.infunc.side_effect = ["def f():",
+                                   "    x = ?",
+                                   "",
+                                    EOFError('Finished')]
+        hook = mock.Mock()
+        self.sysmod.excepthook = hook
+        self.console.interact()
+        hook.assert_called()
+        hook.assert_called_with(self.sysmod.last_type,
+                                self.sysmod.last_value,
+                                self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_type, SyntaxError)
+        self.assertIs(type(self.sysmod.last_value), SyntaxError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+        self.assertEqual(traceback.format_exception(self.sysmod.last_exc), [
+            '  File "<console>", line 2\n',
+            '    x = ?\n',
+            '        ^\n',
+            'SyntaxError: invalid syntax\n'])
+
+    def test_sysexcepthook_indentation_error(self):
+        self.infunc.side_effect = ["  1", EOFError('Finished')]
+        hook = mock.Mock()
+        self.sysmod.excepthook = hook
+        self.console.interact()
+        hook.assert_called()
+        hook.assert_called_with(self.sysmod.last_type,
+                                self.sysmod.last_value,
+                                self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_type, IndentationError)
+        self.assertIs(type(self.sysmod.last_value), IndentationError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+        self.assertEqual(traceback.format_exception(self.sysmod.last_exc), [
+            '  File "<console>", line 1\n',
+            '    1\n',
+            'IndentationError: unexpected indent\n'])
 
     def test_sysexcepthook_crashing_doesnt_close_repl(self):
         self.infunc.side_effect = ["1/0", "a = 123", "print(a)", EOFError('Finished')]
@@ -167,6 +266,11 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         ValueError
         """)
         self.assertIn(expected, output)
+        self.assertIs(self.sysmod.last_type, ValueError)
+        self.assertIs(type(self.sysmod.last_value), ValueError)
+        self.assertIs(self.sysmod.last_traceback, self.sysmod.last_value.__traceback__)
+        self.assertIsNotNone(self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
 
     def test_context_tb(self):
         self.infunc.side_effect = ["try: ham\nexcept: eggs\n",
@@ -185,6 +289,11 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         NameError: name 'eggs' is not defined
         """)
         self.assertIn(expected, output)
+        self.assertIs(self.sysmod.last_type, NameError)
+        self.assertIs(type(self.sysmod.last_value), NameError)
+        self.assertIs(self.sysmod.last_traceback, self.sysmod.last_value.__traceback__)
+        self.assertIsNotNone(self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
 
 
 class TestInteractiveConsoleLocalExit(unittest.TestCase, MockSys):

--- a/Misc/NEWS.d/next/Library/2024-07-31-20-43-21.gh-issue-122478.sCU2Le.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-31-20-43-21.gh-issue-122478.sCU2Le.rst
@@ -1,0 +1,3 @@
+Remove internal frames from tracebacks shown in
+:class:`code.InteractiveInterpreter` with non-default :func:`sys.excepthook`.
+Save correct tracebacks in :attr:`sys.last_traceback` and update ``__traceback__`` attribute of :attr:`sys.last_value` and :attr:`sys.last_exc`.


### PR DESCRIPTION
Attempt to redo the missing backport of gh-122528, superseding https://github.com/python/cpython/pull/122817 (which is conflicting now). /cc @pablogsal 

Frames of methods in code and codeop modules was show with non-default sys.excepthook.

Save correct tracebacks in sys.last_traceback and update __traceback__ attribute of sys.last_value and sys.last_exc.
(cherry picked from commit e73e7a7abdc3fed252affcb1629df1b3c8fff2ef)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122478 -->
* Issue: gh-122478
<!-- /gh-issue-number -->
