### PR TITLE
gh-123223: Adding hyperlink of argument in warnings.catch_warnings:

### DIFF
--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -588,9 +588,6 @@ Available Context Managers
     Each object in the list has attributes with the same names as the arguments to
     :func:`showwarning`.
 
-    The definition of *category* and *lineno* are same as defined
-    at the top of :ref:`warning-filter` field.
-
     The *module* argument takes a module that will be used instead of the
     module returned when you import :mod:`warnings` whose filter will be
     protected. This argument exists primarily for testing the :mod:`warnings`
@@ -599,6 +596,9 @@ Available Context Managers
     If the *action* argument is not ``None``, the remaining arguments are
     passed to :func:`simplefilter` as if it were called immediately on
     entering the context.
+
+    See :ref:`warning-filter` for the meaning of the *category* and *lineno*
+    parameters.
 
     .. note::
 

--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -588,6 +588,9 @@ Available Context Managers
     Each object in the list has attributes with the same names as the arguments to
     :func:`showwarning`.
 
+    The definition of *category* and *lineno* are same as defined
+    at the top of :ref:`warning-filter` field.
+
     The *module* argument takes a module that will be used instead of the
     module returned when you import :mod:`warnings` whose filter will be
     protected. This argument exists primarily for testing the :mod:`warnings`


### PR DESCRIPTION
As in #123223, these arugment are mentioned at the top of the same page, so adding hyperlink so that when user at the buttom of the page, they are able to review the definition of those argument convinently.

<!-- gh-issue-number: gh-123223 -->
* Issue: gh-123223
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123231.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->