### PR TITLE
gh-123243: Fix reference leak in _decimal

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-08-22-20-10-13.gh-issue-123243.Kifj1L.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-22-20-10-13.gh-issue-123243.Kifj1L.rst
@@ -1,0 +1,1 @@
+Fix memory leak in :mod:`!_decimal`.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1390,6 +1390,9 @@ context_new(PyTypeObject *type, PyObject *args UNUSED, PyObject *kwds UNUSED)
     CtxCaps(self) = 1;
     self->tstate = NULL;
 
+    if (type == state->PyDecContext_Type) {
+        PyObject_GC_Track(self);
+    }
     return (PyObject *)self;
 }
 
@@ -2038,6 +2041,9 @@ PyDecType_New(PyTypeObject *type)
     MPD(dec)->alloc = _Py_DEC_MINALLOC;
     MPD(dec)->data = dec->data;
 
+    if (type == state->PyDec_Type) {
+        PyObject_GC_Track(dec);
+    }
     return (PyObject *)dec;
 }
 #define dec_alloc(st) PyDecType_New((st)->PyDec_Type)

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1357,6 +1357,7 @@ context_new(PyTypeObject *type, PyObject *args UNUSED, PyObject *kwds UNUSED)
     }
     else {
         self = (PyDecContextObject *)type->tp_alloc(type, 0);
+        assert(PyObject_GC_IsTracked(self));
     }
 
     if (self == NULL) {
@@ -2027,6 +2028,7 @@ PyDecType_New(PyTypeObject *type)
     }
     else {
         dec = (PyDecObject *)type->tp_alloc(type, 0);
+        assert(PyObject_GC_IsTracked(dec));
     }
     if (dec == NULL) {
         return NULL;
@@ -6158,7 +6160,7 @@ decimal_clear(PyObject *module)
     }
 
     if (state->cond_map != NULL) {
-        // signal_map[0] is assigned to cond_map[0]
+        state->cond_map[0].ex = NULL;  // decref'ed at signal_map[0].ex
         for (DecCondMap *cm = state->cond_map + 1; cm->name != NULL; cm++) {
             Py_CLEAR(cm->ex);
         }

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1357,7 +1357,7 @@ context_new(PyTypeObject *type, PyObject *args UNUSED, PyObject *kwds UNUSED)
     }
     else {
         self = (PyDecContextObject *)type->tp_alloc(type, 0);
-        assert(PyObject_GC_IsTracked(self));
+        assert(PyObject_GC_IsTracked((PyObject *)self));
     }
 
     if (self == NULL) {
@@ -2028,7 +2028,7 @@ PyDecType_New(PyTypeObject *type)
     }
     else {
         dec = (PyDecObject *)type->tp_alloc(type, 0);
-        assert(PyObject_GC_IsTracked(dec));
+        assert(PyObject_GC_IsTracked((PyObject *)dec));
     }
     if (dec == NULL) {
         return NULL;

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -6149,10 +6149,22 @@ decimal_clear(PyObject *module)
     Py_CLEAR(state->SignalTuple);
     Py_CLEAR(state->PyDecimal);
 
-    PyMem_Free(state->signal_map);
-    PyMem_Free(state->cond_map);
-    state->signal_map = NULL;
-    state->cond_map = NULL;
+    if (state->signal_map != NULL) {
+        for (DecCondMap *cm = state->signal_map; cm->name != NULL; cm++) {
+            Py_CLEAR(cm->ex);
+        }
+        PyMem_Free(state->signal_map);
+        state->signal_map = NULL;
+    }
+
+    if (state->cond_map != NULL) {
+        // signal_map[0] is assigned to cond_map[0]
+        for (DecCondMap *cm = state->cond_map + 1; cm->name != NULL; cm++) {
+            Py_CLEAR(cm->ex);
+        }
+        PyMem_Free(state->cond_map);
+        state->cond_map = NULL;
+    }
     return 0;
 }
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -6151,6 +6151,8 @@ decimal_clear(PyObject *module)
 
     PyMem_Free(state->signal_map);
     PyMem_Free(state->cond_map);
+    state->signal_map = NULL;
+    state->cond_map = NULL;
     return 0;
 }
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -6153,16 +6153,16 @@ decimal_clear(PyObject *module)
 
     if (state->signal_map != NULL) {
         for (DecCondMap *cm = state->signal_map; cm->name != NULL; cm++) {
-            Py_CLEAR(cm->ex);
+            Py_DECREF(cm->ex);
         }
         PyMem_Free(state->signal_map);
         state->signal_map = NULL;
     }
 
     if (state->cond_map != NULL) {
-        state->cond_map[0].ex = NULL;  // decref'ed at signal_map[0].ex
+        // cond_map[0].ex has borrowed a reference from signal_map[0].ex
         for (DecCondMap *cm = state->cond_map + 1; cm->name != NULL; cm++) {
-            Py_CLEAR(cm->ex);
+            Py_DECREF(cm->ex);
         }
         PyMem_Free(state->cond_map);
         state->cond_map = NULL;

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1357,7 +1357,6 @@ context_new(PyTypeObject *type, PyObject *args UNUSED, PyObject *kwds UNUSED)
     }
     else {
         self = (PyDecContextObject *)type->tp_alloc(type, 0);
-        assert(PyObject_GC_IsTracked((PyObject *)self));
     }
 
     if (self == NULL) {
@@ -1394,6 +1393,7 @@ context_new(PyTypeObject *type, PyObject *args UNUSED, PyObject *kwds UNUSED)
     if (type == state->PyDecContext_Type) {
         PyObject_GC_Track(self);
     }
+    assert(PyObject_GC_IsTracked((PyObject *)self));
     return (PyObject *)self;
 }
 
@@ -2028,7 +2028,6 @@ PyDecType_New(PyTypeObject *type)
     }
     else {
         dec = (PyDecObject *)type->tp_alloc(type, 0);
-        assert(PyObject_GC_IsTracked((PyObject *)dec));
     }
     if (dec == NULL) {
         return NULL;
@@ -2046,6 +2045,7 @@ PyDecType_New(PyTypeObject *type)
     if (type == state->PyDec_Type) {
         PyObject_GC_Track(dec);
     }
+    assert(PyObject_GC_IsTracked((PyObject *)dec));
     return (PyObject *)dec;
 }
 #define dec_alloc(st) PyDecType_New((st)->PyDec_Type)


### PR DESCRIPTION
```
>python -X showrefcount -c "import _decimal"
[7117 refs, 4232 blocks]   # Before
[0 refs, 0 blocks]         # After
```

cc @kumaraditya303 @erlend-aasland



<!-- gh-issue-number: gh-123243 -->
* Issue: gh-123243
<!-- /gh-issue-number -->
