### PR TITLE
Remove comment from pystate created in 2003

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2384,7 +2384,6 @@ PyGILState_Release(PyGILState_STATE oldstate)
                              "thread state %p must be current when releasing",
                              tstate);
     }
-    assert(holds_gil(tstate));
     --tstate->gilstate_counter;
     assert(tstate->gilstate_counter >= 0); /* illegal counter value */
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2379,10 +2379,6 @@ PyGILState_Release(PyGILState_STATE oldstate)
     }
 
     /* We must hold the GIL and have our thread state current */
-    /* XXX - remove the check - the assert should be fine,
-       but while this is very new (April 2003), the extra check
-       by release-only users can't hurt.
-    */
     if (!holds_gil(tstate)) {
         _Py_FatalErrorFormat(__func__,
                              "thread state %p must be current when releasing",


### PR DESCRIPTION
This is a very minor change, but in pystate there's a check that thread state shouldn't be null when releasing the GIL.

This is a very useful check. If someone accidentally calls release GIL and didn't acquire the GIL from a native thread in an embedded Python scenario, they get this helpful fatal error message because there is no thread state. 

I noticed there is a TODO above this check speculating that it isn't required dating back to 2003. 

It is required because it avoids a crash and null lookup. 

This PR removes the comment. 
