### PR TITLE
GH-122298: Restore printing of GC stats

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-23-11-26-54.gh-issue-122298.ZMyln4.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-23-11-26-54.gh-issue-122298.ZMyln4.rst
@@ -1,0 +1,3 @@
+Restore printout of GC stats when ``gc.set_debug(gc.DEBUG_STATS)`` is
+called. This featue was accidentally removed when implementing incremental
+GC.

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1300,6 +1300,7 @@ gc_collect_young(PyThreadState *tstate,
     GCState *gcstate = &tstate->interp->gc;
     PyGC_Head *young = &gcstate->young.head;
     PyGC_Head *visited = &gcstate->old[gcstate->visited_space].head;
+    GC_STAT_ADD(0, collections, 1);
 #ifdef Py_STATS
     {
         Py_ssize_t count = 0;
@@ -1428,6 +1429,7 @@ completed_cycle(GCState *gcstate)
 static void
 gc_collect_increment(PyThreadState *tstate, struct gc_collection_stats *stats)
 {
+    GC_STAT_ADD(1, collections, 1);
     GCState *gcstate = &tstate->interp->gc;
     PyGC_Head *not_visited = &gcstate->old[gcstate->visited_space^1].head;
     PyGC_Head *visited = &gcstate->old[gcstate->visited_space].head;
@@ -1473,6 +1475,7 @@ static void
 gc_collect_full(PyThreadState *tstate,
                 struct gc_collection_stats *stats)
 {
+    GC_STAT_ADD(2, collections, 1);
     GCState *gcstate = &tstate->interp->gc;
     validate_old(gcstate);
     PyGC_Head *young = &gcstate->young.head;
@@ -1795,6 +1798,24 @@ PyGC_IsEnabled(void)
     return gcstate->enabled;
 }
 
+// Show stats for objects in each generations
+static void
+show_stats_each_generations(GCState *gcstate)
+{
+    char buf[100];
+    size_t pos = 0;
+
+    for (int i = 0; i < NUM_GENERATIONS && pos < sizeof(buf); i++) {
+        pos += PyOS_snprintf(buf+pos, sizeof(buf)-pos,
+                             " %zd",
+                             gc_list_size(GEN_HEAD(gcstate, i)));
+    }
+    PySys_FormatStderr(
+        "gc: objects in each generation:%s\n"
+        "gc: objects in permanent generation: %zd\n",
+        buf, gc_list_size(&gcstate->permanent_generation.head));
+}
+
 Py_ssize_t
 _PyGC_Collect(PyThreadState *tstate, int generation, _PyGC_Reason reason)
 {
@@ -1809,6 +1830,10 @@ _PyGC_Collect(PyThreadState *tstate, int generation, _PyGC_Reason reason)
     struct gc_collection_stats stats = { 0 };
     if (reason != _Py_GC_REASON_SHUTDOWN) {
         invoke_gc_callback(gcstate, "start", generation, &stats);
+    }
+    if (gcstate->debug & _PyGC_DEBUG_STATS) {
+        PySys_WriteStderr("gc: collecting generation %d...\n", generation);
+        show_stats_each_generations(gcstate);
     }
     if (PyDTrace_GC_START_ENABLED()) {
         PyDTrace_GC_START(generation);


### PR DESCRIPTION
Printing of GC stats was accidentally removed when the GC was changed to incremental.
This PR adds them back.

<!-- gh-issue-number: gh-122298 -->
* Issue: gh-122298
<!-- /gh-issue-number -->
