### PR TITLE
gh-123229: Fix valgrind warning by initializing the f-string buffers to 0 in the tokenizer

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-08-23-13-08-27.gh-issue-123229.aHm-dw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-08-23-13-08-27.gh-issue-123229.aHm-dw.rst
@@ -1,0 +1,2 @@
+Fix valgrind warning by initializing the f-string buffers to 0 in the
+tokenizer. Patch by Pablo Galindo

--- a/Parser/lexer/state.c
+++ b/Parser/lexer/state.c
@@ -12,7 +12,8 @@
 struct tok_state *
 _PyTokenizer_tok_new(void)
 {
-    struct tok_state *tok = (struct tok_state *)PyMem_Malloc(
+    struct tok_state *tok = (struct tok_state *)PyMem_Calloc(
+                                            1,
                                             sizeof(struct tok_state));
     if (tok == NULL)
         return NULL;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123229 -->
* Issue: gh-123229
<!-- /gh-issue-number -->
