### PR TITLE
[3.12] gh-123229: Fix valgrind warning by initializing the f-string buffers to 0 in the tokenizer (GH-123263)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-08-23-13-08-27.gh-issue-123229.aHm-dw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-08-23-13-08-27.gh-issue-123229.aHm-dw.rst
@@ -1,0 +1,2 @@
+Fix valgrind warning by initializing the f-string buffers to 0 in the
+tokenizer. Patch by Pablo Galindo

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -65,7 +65,7 @@ static const char *type_comment_prefix = "# type: ";
 
 static struct tok_state *tok_new(void) {
   struct tok_state *tok =
-      (struct tok_state *)PyMem_Malloc(sizeof(struct tok_state));
+      (struct tok_state *)PyMem_Calloc(1, sizeof(struct tok_state));
   if (tok == NULL)
     return NULL;
   tok->buf = tok->cur = tok->inp = NULL;

--- a/lel.patch
+++ b/lel.patch
@@ -1,0 +1,13 @@
+diff --git a/Parser/tokenizer.c b/Parser/tokenizer.c
+index 3118fb19846..9e0dee8cc38 100644
+--- a/Parser/tokenizer.c
++++ b/Parser/tokenizer.c
+@@ -65,7 +65,7 @@ static const char *type_comment_prefix = "# type: ";
+
+ static struct tok_state *tok_new(void) {
+   struct tok_state *tok =
+-      (struct tok_state *)PyMem_Malloc(sizeof(struct tok_state));
++      (struct tok_state *)PyMem_Calloc(1, sizeof(struct tok_state));
+   if (tok == NULL)
+     return NULL;
+   tok->buf = tok->cur = tok->inp = NULL;


### PR DESCRIPTION
…

(cherry picked from commit adc5190014efcf7b7a4c5dfc9998faa8345527ed)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123229 -->
* Issue: gh-123229
<!-- /gh-issue-number -->
