### PR TITLE
gh-76960: Fix urljoin() and urldefrag() for URIs with empty components

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-08-23-22-01-30.gh-issue-76960.vsANPu.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-23-22-01-30.gh-issue-76960.vsANPu.rst
@@ -1,0 +1,4 @@
+Fix :func:`urllib.parse.urljoin` and :func:`urllib.parse.urldefrag` for URIs
+containing empty components. For example, :func:`!urljoin()` with relative
+reference "?" now sets empty query and removes fragment. Empty components are
+preserved in the result.

--- a/Misc/NEWS.d/next/Library/2024-08-23-22-01-30.gh-issue-76960.vsANPu.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-23-22-01-30.gh-issue-76960.vsANPu.rst
@@ -1,4 +1,5 @@
 Fix :func:`urllib.parse.urljoin` and :func:`urllib.parse.urldefrag` for URIs
 containing empty components. For example, :func:`!urljoin()` with relative
-reference "?" now sets empty query and removes fragment. Empty components are
-preserved in the result.
+reference "?" now sets empty query and removes fragment.
+Preserve empty components (authority, params, query, fragment) in :func:`!urljoin`.
+Preserve empty components (authority, params, query) in :func:`!urldefrag`.


### PR DESCRIPTION
* urljoin() with relative reference "?" sets empty query and removes fragment.
* Preserve empty components (authority, params, query, fragment) in urljoin().
* Preserve empty components (authority, params, query) in urldefrag().

Also refactor the code and get rid of double _coerce_args() and _coerce_result() calls in urljoin(), urldefrag(), urlparse() and urlunparse().


<!-- gh-issue-number: gh-76960 -->
* Issue: gh-76960
<!-- /gh-issue-number -->
