### PR TITLE
gh-123240: Raise input audit events in the new REPL

### DIFF
--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -365,8 +365,12 @@ class _ReadlineWrapper:
         except _error:
             assert raw_input is not None
             return raw_input(prompt)
-        reader.ps1 = str(prompt)
-        return reader.readline(startup_hook=self.startup_hook)
+        prompt_str = str(prompt)
+        reader.ps1 = prompt_str
+        sys.audit("builtins.input", prompt_str)
+        result = reader.readline(startup_hook=self.startup_hook)
+        sys.audit("builtins.input/result", result)
+        return result
 
     def multiline_input(self, more_lines: MoreLinesCallable, ps1: str, ps2: str) -> str:
         """Read an input on possibly multiple lines, asking for more

--- a/Misc/NEWS.d/next/Library/2024-08-24-00-03-01.gh-issue-123240.uFPG3l.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-24-00-03-01.gh-issue-123240.uFPG3l.rst
@@ -1,0 +1,1 @@
+Raise audit events for the :func:`input` in the new REPL.


### PR DESCRIPTION
There are no tests for `input()` function in general, so I didn't include any unittests.

Manual testing:

```python
>>> def audithook(name, *args):
...     if "input" in name: print(name, args)
...     
>>> import sys
>>> sys.addaudithook(audithook)
>>> input("abc ")
builtins.input (('abc ',),)
abc xyz
builtins.input/result (('xyz',),)
'xyz'
```

<!-- gh-issue-number: gh-123240 -->
* Issue: gh-123240
<!-- /gh-issue-number -->
