### PR TITLE
gh-123275: Support `-Xgil=1` and `PYTHON_GIL=1` on non-free-threaded builds

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -622,7 +622,7 @@ Miscellaneous options
      .. versionadded:: 3.13
 
    * :samp:`-X gil={0,1}` forces the GIL to be disabled or enabled,
-     respectively. Only available in builds configured with
+     respectively. Setting to ``0`` is only available in builds configured with
      :option:`--disable-gil`. See also :envvar:`PYTHON_GIL` and
      :ref:`whatsnew313-free-threaded-cpython`.
 
@@ -1221,12 +1221,11 @@ conflict.
 .. envvar:: PYTHON_GIL
 
    If this variable is set to ``1``, the global interpreter lock (GIL) will be
-   forced on. Setting it to ``0`` forces the GIL off.
+   forced on. Setting it to ``0`` forces the GIL off (needs Python configured with
+   the :option:`--disable-gil` build option.)
 
    See also the :option:`-X gil <-X>` command-line option, which takes
    precedence over this variable, and :ref:`whatsnew313-free-threaded-cpython`.
-
-   Needs Python configured with the :option:`--disable-gil` build option.
 
    .. versionadded:: 3.13
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -1222,7 +1222,7 @@ conflict.
 
    If this variable is set to ``1``, the global interpreter lock (GIL) will be
    forced on. Setting it to ``0`` forces the GIL off (needs Python configured with
-   the :option:`--disable-gil` build option.)
+   the :option:`--disable-gil` build option).
 
    See also the :option:`-X gil <-X>` command-line option, which takes
    precedence over this variable, and :ref:`whatsnew313-free-threaded-cpython`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-23-18-31-10.gh-issue-123275.DprIrj.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-23-18-31-10.gh-issue-123275.DprIrj.rst
@@ -1,0 +1,1 @@
+Support ``-Xgil=1`` and ``PYTHON_GIL=1`` on non-free-threaded builds.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-23-18-31-10.gh-issue-123275.DprIrj.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-23-18-31-10.gh-issue-123275.DprIrj.rst
@@ -1,1 +1,1 @@
-Support ``-Xgil=1`` and ``PYTHON_GIL=1`` on non-free-threaded builds.
+Support :option:`-X gil=1 <-X>` and :envvar:`PYTHON_GIL=1 <PYTHON_GIL>` on non-free-threaded builds.

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -1559,20 +1559,24 @@ config_wstr_to_int(const wchar_t *wstr, int *result)
 static PyStatus
 config_read_gil(PyConfig *config, size_t len, wchar_t first_char)
 {
-#ifdef Py_GIL_DISABLED
     if (len == 1 && first_char == L'0') {
+#ifdef Py_GIL_DISABLED
         config->enable_gil = _PyConfig_GIL_DISABLE;
+#else
+        return _PyStatus_ERR("Disabling the GIL is not supported by this build");
+#endif
     }
     else if (len == 1 && first_char == L'1') {
+#ifdef Py_GIL_DISABLED
         config->enable_gil = _PyConfig_GIL_ENABLE;
+#else
+        return _PyStatus_OK();
+#endif
     }
     else {
         return _PyStatus_ERR("PYTHON_GIL / -X gil must be \"0\" or \"1\"");
     }
     return _PyStatus_OK();
-#else
-    return _PyStatus_ERR("PYTHON_GIL / -X gil are not supported by this build");
-#endif
 }
 
 static PyStatus


### PR DESCRIPTION
cc @godlygeek

<!-- gh-issue-number: gh-123275 -->
* Issue: gh-123275
<!-- /gh-issue-number -->
