### PR TITLE
gh-123228: fix return type for _ReadlineWrapper.get_line_buffer()

### DIFF
--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -479,15 +479,14 @@ class _ReadlineWrapper:
     def set_startup_hook(self, function: Callback | None = None) -> None:
         self.startup_hook = function
 
-    def get_line_buffer(self) -> bytes:
-        buf_str = self.get_reader().get_unicode()
-        return buf_str.encode(ENCODING)
+    def get_line_buffer(self) -> str:
+        return self.get_reader().get_unicode()
 
     def _get_idxs(self) -> tuple[int, int]:
         start = cursor = self.get_reader().pos
         buf = self.get_line_buffer()
         for i in range(cursor - 1, -1, -1):
-            if str(buf[i]) in self.get_completer_delims():
+            if buf[i] in self.get_completer_delims():
                 break
             start = i
         return start, cursor

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -516,6 +516,9 @@ class TestPyReplOutput(TestCase):
         output = multiline_input(reader)
         self.assertEqual(output, "1+1")
         self.assertEqual(clean_screen(reader.screen), "1+1")
+
+        # skip, if readline module is not available
+        import_module('readline')
         self.assertIs(type(get_line_buffer()), str)
 
     def test_multiline_edit(self):

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -26,8 +26,7 @@ from .support import (
     make_clean_env,
 )
 from _pyrepl.console import Event
-from _pyrepl.readline import (ReadlineAlikeReader, ReadlineConfig,
-                              get_line_buffer)
+from _pyrepl.readline import ReadlineAlikeReader, ReadlineConfig
 from _pyrepl.readline import multiline_input as readline_multiline_input
 
 try:
@@ -516,10 +515,6 @@ class TestPyReplOutput(TestCase):
         output = multiline_input(reader)
         self.assertEqual(output, "1+1")
         self.assertEqual(clean_screen(reader.screen), "1+1")
-
-        # skip, if readline module is not available
-        import_module('readline')
-        self.assertIs(type(get_line_buffer()), str)
 
     def test_multiline_edit(self):
         events = itertools.chain(

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1,4 +1,3 @@
-import curses
 import io
 import itertools
 import os

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -26,7 +26,8 @@ from .support import (
     make_clean_env,
 )
 from _pyrepl.console import Event
-from _pyrepl.readline import ReadlineAlikeReader, ReadlineConfig
+from _pyrepl.readline import (ReadlineAlikeReader, ReadlineConfig,
+                              get_line_buffer)
 from _pyrepl.readline import multiline_input as readline_multiline_input
 
 try:
@@ -515,6 +516,7 @@ class TestPyReplOutput(TestCase):
         output = multiline_input(reader)
         self.assertEqual(output, "1+1")
         self.assertEqual(clean_screen(reader.screen), "1+1")
+        self.assertIs(type(get_line_buffer()), str)
 
     def test_multiline_edit(self):
         events = itertools.chain(

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -27,7 +27,7 @@ from .support import (
 )
 from _pyrepl.console import Event
 from _pyrepl.readline import (ReadlineAlikeReader, ReadlineConfig,
-                              get_line_buffer)
+                              _ReadlineWrapper)
 from _pyrepl.readline import multiline_input as readline_multiline_input
 
 try:
@@ -517,10 +517,10 @@ class TestPyReplOutput(TestCase):
         self.assertEqual(output, "1+1")
         self.assertEqual(clean_screen(reader.screen), "1+1")
 
-        try:
-            self.assertIs(type(get_line_buffer()), str)
-        except curses.error:
-            pass
+    def test_get_line_buffer_returns_str(self):
+        reader = self.prepare_reader(code_to_events("\n"))
+        wrapper = _ReadlineWrapper(reader=reader)
+        self.assertIs(type(wrapper.get_line_buffer()), str)
 
     def test_multiline_edit(self):
         events = itertools.chain(

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -26,7 +26,8 @@ from .support import (
     make_clean_env,
 )
 from _pyrepl.console import Event
-from _pyrepl.readline import ReadlineAlikeReader, ReadlineConfig
+from _pyrepl.readline import (ReadlineAlikeReader, ReadlineConfig,
+                              get_line_buffer)
 from _pyrepl.readline import multiline_input as readline_multiline_input
 
 try:
@@ -515,6 +516,10 @@ class TestPyReplOutput(TestCase):
         output = multiline_input(reader)
         self.assertEqual(output, "1+1")
         self.assertEqual(clean_screen(reader.screen), "1+1")
+
+        # skip, if readline module is not available
+        import_module('readline')
+        self.assertIs(type(get_line_buffer()), str)
 
     def test_multiline_edit(self):
         events = itertools.chain(

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1,3 +1,4 @@
+import curses
 import io
 import itertools
 import os
@@ -517,9 +518,10 @@ class TestPyReplOutput(TestCase):
         self.assertEqual(output, "1+1")
         self.assertEqual(clean_screen(reader.screen), "1+1")
 
-        # skip, if readline module is not available
-        import_module('readline')
-        self.assertIs(type(get_line_buffer()), str)
+        try:
+            self.assertIs(type(get_line_buffer()), str)
+        except curses.error:
+            pass
 
     def test_multiline_edit(self):
         events = itertools.chain(

--- a/Misc/NEWS.d/next/Library/2024-08-24-06-05-41.gh-issue-123228.jR_5O5.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-24-06-05-41.gh-issue-123228.jR_5O5.rst
@@ -1,0 +1,3 @@
+Fix return type for
+:func:`!_pyrepl.readline._ReadlineWrapper.get_line_buffer` to be
+:func:`str`.  Patch by Sergey B Kirpichev.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123228 -->
* Issue: gh-123228
<!-- /gh-issue-number -->
