### PR TITLE
gh-82378: document the difference between sys.tracebacklimit and the limit arguments

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -42,11 +42,13 @@ The module defines the following functions:
    :term:`file <file object>` or :term:`file-like object` to
    receive the output.
 
-   Note that the meaning of the *limit* parameter is different than the meaning
-   of :const:`sys.tracebacklimit`. Negative *limit* values correspond to
-   positive values of :const:`sys.tracebacklimit`, whereas the behaviour of
-   positive *limit* values cannot be achieved with
-   :const:`sys.tracebacklimit`.
+   .. note::
+
+      The meaning of the *limit* parameter is different than the meaning
+      of :const:`sys.tracebacklimit`. A negative *limit* value corresponds to
+      a positive value of :const:`!sys.tracebacklimit`, whereas the behaviour of
+      a positive *limit* value cannot be achieved with
+      :const:`!sys.tracebacklimit`.
 
    .. versionchanged:: 3.5
        Added negative *limit* support.

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -44,8 +44,8 @@ The module defines the following functions:
 
    Note that the meaning of the *limit* parameter is different than the meaning
    of :const:`sys.tracebacklimit`. Negative *limit* values correspond to
-   positive values of  :const:`sys.tracebacklimit`, whereas the behaviour of
-   positive values of *limit* cannot be achieved with
+   positive values of :const:`sys.tracebacklimit`, whereas the behaviour of
+   positive *limit* values cannot be achieved with
    :const:`sys.tracebacklimit`.
 
    .. versionchanged:: 3.5

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -42,6 +42,12 @@ The module defines the following functions:
    :term:`file <file object>` or :term:`file-like object` to
    receive the output.
 
+   Note that the meaning of the *limit* parameter is different than the meaning
+   of :const:`sys.tracebacklimit`. Negative *limit* values correspond to
+   positive values of  :const:`sys.tracebacklimit`, whereas the behaviour of
+   positive values of *limit* cannot be achieved with
+   :const:`sys.tracebacklimit`.
+
    .. versionchanged:: 3.5
        Added negative *limit* support.
 


### PR DESCRIPTION

<!-- gh-issue-number: gh-82378 -->
* Issue: gh-82378
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123286.org.readthedocs.build/en/123286/library/traceback.html#traceback.print_tb

<!-- readthedocs-preview cpython-previews end -->