### PR TITLE
gh-123228: don't leak file descriptors in pyrepl test

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -519,7 +519,7 @@ class TestPyReplOutput(TestCase):
 
     def test_get_line_buffer_returns_str(self):
         reader = self.prepare_reader(code_to_events("\n"))
-        wrapper = _ReadlineWrapper(reader=reader)
+        wrapper = _ReadlineWrapper(f_in=None, f_out=None, reader=reader)
         self.assertIs(type(wrapper.get_line_buffer()), str)
 
     def test_multiline_edit(self):


### PR DESCRIPTION
if no f_in and f_out arguments are given, _ReadlineWrapper calls os.dup on fd 0 and 1. Instead, just pass None, because the fds aren't needed anyway in this test.

<!-- gh-issue-number: gh-123228 -->
* Issue: gh-123228
<!-- /gh-issue-number -->
