### PR TITLE
gh-40889: Fix `email.utils.parseaddr` to handle multiple hops

### DIFF
--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -349,6 +349,8 @@ class AddrlistClass:
             elif self.field[self.pos] == '@':
                 self.pos += 1
                 expectroute = True
+            elif self.field[self.pos] == ',':
+                self.pos += 1
             elif self.field[self.pos] == ':':
                 self.pos += 1
             else:

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3289,6 +3289,12 @@ class TestMiscellaneous(TestEmailBase):
         self.assertEqual(('', 'merwok.wok.wok@xample.com'),
             utils.parseaddr('merwok. wok .  wok@xample.com'))
 
+    def test_parseaddr_handles_obsolete_addressing(self):
+        self.assertEqual(('foobar', 'foo@bar.com'),
+            utils.parseaddr('"foobar" <@hop.org:foo@bar.com>'))
+        self.assertEqual(('foobar', 'foo@bar.com'),
+            utils.parseaddr('"foobar" <@hop1.org,@hop2.org:foo@bar.com>'))
+
     def test_formataddr_does_not_quote_parens_in_quoted_string(self):
         addr = ("'foo@example.com' (foo@example.com)",
                 'foo@example.com')

--- a/Misc/NEWS.d/next/Library/2024-08-25-15-24-16.gh-issue-40889.TbsSM1.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-25-15-24-16.gh-issue-40889.TbsSM1.rst
@@ -1,0 +1,2 @@
+Fix :func:`email.utils.parseaddr` to handle routes with multiple intermediate hops
+(see :rfc:`RFC 2822, §4.4 <2822#section-4.4>`).  Patch by Ioana Tagirta.


### PR DESCRIPTION
Same as #6917  but creating a new pr since the old one was closed by it's author.
Fixes #40889 

<!-- gh-issue-number: gh-40889 -->
* Issue: gh-40889
<!-- /gh-issue-number -->
