### PR TITLE
gh-123350: add `python -m sysconfig –json` option

### DIFF
--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -462,7 +462,7 @@ This call will print in the standard output the information returned by
 :func:`get_platform`, :func:`get_python_version`, :func:`get_path` and
 :func:`get_config_vars`.
 
-You can also pass a **--json** flag to have a json-formatted output
+You can also pass a ``--json`` flag to have a JSON-formatted output:
 
 .. code-block:: shell-session
 

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -461,3 +461,31 @@ You can use :mod:`sysconfig` as a script with Python's *-m* option:
 This call will print in the standard output the information returned by
 :func:`get_platform`, :func:`get_python_version`, :func:`get_path` and
 :func:`get_config_vars`.
+
+You can also pass a **--json** flag to have a json-formatted output
+
+.. code-block:: shell-session
+
+    $ python -m sysconfig --json
+      {
+          "platform": "macosx-14.6-arm64",
+          "pyversion": "3.14",
+          "default_scheme": "posix_prefix",
+          "paths": {
+              "stdlib": "/Users/flo/cpython/build/lib/python3.14",
+              "platstdlib": "/Users/flo/cpython/build/lib/python3.14",
+              "purelib": "/Users/flo/cpython/build/lib/python3.14/site-packages",
+              ...
+          },
+          "variables": {
+              "prefix": "/Users/flo/cpython/build",
+              "exec_prefix": "/Users/flo/cpython/build",
+              "py_version": "3.14.0a0",
+              "py_version_short": "3.14",
+              "py_version_nodot": "314",
+              "installed_base": "/Users/flo/cpython/build",
+              "base": "/Users/flo/cpython/build",
+              ...
+          }
+      }
+

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -469,8 +469,8 @@ You can also pass a ``--json`` flag to have a JSON-formatted output:
    $ python -m sysconfig --json
    {
        "platform": "macosx-14.6-arm64",
-       "pyversion": "3.14",
-       "default_scheme": "posix_prefix",
+       "python_version": "3.14",
+       "installation_scheme": "posix_prefix",
        "paths": {
            ...
        },

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -466,26 +466,16 @@ You can also pass a ``--json`` flag to have a JSON-formatted output:
 
 .. code-block:: shell-session
 
-    $ python -m sysconfig --json
-      {
-          "platform": "macosx-14.6-arm64",
-          "pyversion": "3.14",
-          "default_scheme": "posix_prefix",
-          "paths": {
-              "stdlib": "/Users/flo/cpython/build/lib/python3.14",
-              "platstdlib": "/Users/flo/cpython/build/lib/python3.14",
-              "purelib": "/Users/flo/cpython/build/lib/python3.14/site-packages",
-              ...
-          },
-          "variables": {
-              "prefix": "/Users/flo/cpython/build",
-              "exec_prefix": "/Users/flo/cpython/build",
-              "py_version": "3.14.0a0",
-              "py_version_short": "3.14",
-              "py_version_nodot": "314",
-              "installed_base": "/Users/flo/cpython/build",
-              "base": "/Users/flo/cpython/build",
-              ...
-          }
-      }
+   $ python -m sysconfig --json
+   {
+       "platform": "macosx-14.6-arm64",
+       "pyversion": "3.14",
+       "default_scheme": "posix_prefix",
+       "paths": {
+           ...
+       },
+       "variables": {
+           ...
+       }
+   }
 

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -432,7 +432,10 @@ Other functions
 Using :mod:`sysconfig` as a script
 ----------------------------------
 
-You can use :mod:`sysconfig` as a script with Python's *-m* option:
+You can use :mod:`sysconfig` as a script with Python's ``-m`` option,
+to print to the standard output information
+about the ``platform``, ``python_version`` and ``installation_scheme``,
+as well as two additional sets of ``paths`` and ``variables``:
 
 .. code-block:: shell-session
 
@@ -458,9 +461,8 @@ You can use :mod:`sysconfig` as a script with Python's *-m* option:
             ARFLAGS = "rc"
             ...
 
-This call will print in the standard output the information returned by
-:func:`get_platform`, :func:`get_python_version`, :func:`get_path` and
-:func:`get_config_vars`.
+To retrieve these, the above mentioned :func:`get_platform`, :func:`get_python_version`, :func:`get_path` and
+:func:`get_config_vars` functions are used.
 
 You can also pass a ``--json`` flag to have a JSON-formatted output:
 

--- a/Lib/sysconfig/__main__.py
+++ b/Lib/sysconfig/__main__.py
@@ -15,6 +15,7 @@ from sysconfig import (
     parse_config_h,
 )
 
+
 # Regexes needed for parsing Makefile (and similar syntaxes,
 # like old-style Setup files).
 _variable_rx = r"([a-zA-Z][a-zA-Z0-9_]+)\s*=\s*(.*)"

--- a/Lib/sysconfig/__main__.py
+++ b/Lib/sysconfig/__main__.py
@@ -235,7 +235,7 @@ def _main():
     if '--json' in sys.argv:
         data = {
             'platform': get_platform(),
-            'pyversion': get_python_version(),
+            'python_version': get_python_version(),
             'installation_scheme': get_default_scheme(),
             'paths': get_paths(),
             'variables': get_config_vars()

--- a/Lib/sysconfig/__main__.py
+++ b/Lib/sysconfig/__main__.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from sysconfig import (
@@ -13,7 +14,6 @@ from sysconfig import (
     get_python_version,
     parse_config_h,
 )
-
 
 # Regexes needed for parsing Makefile (and similar syntaxes,
 # like old-style Setup files).
@@ -125,7 +125,7 @@ def _parse_makefile(filename, vars=None, keep_unresolved=True):
                         variables.remove(name)
 
                         if name.startswith('PY_') \
-                        and name[3:] in renamed_variables:
+                            and name[3:] in renamed_variables:
 
                             name = name[3:]
                             if name not in done:
@@ -151,10 +151,10 @@ def _parse_makefile(filename, vars=None, keep_unresolved=True):
 
 
 def _print_config_dict(d, stream):
-    print ("{", file=stream)
+    print("{", file=stream)
     for k, v in sorted(d.items()):
         print(f"    {k!r}: {v!r},", file=stream)
-    print ("}", file=stream)
+    print("}", file=stream)
 
 
 def _generate_posix_vars():
@@ -232,13 +232,23 @@ def _main():
     if '--generate-posix-vars' in sys.argv:
         _generate_posix_vars()
         return
-    print(f'Platform: "{get_platform()}"')
-    print(f'Python version: "{get_python_version()}"')
-    print(f'Current installation scheme: "{get_default_scheme()}"')
-    print()
-    _print_dict('Paths', get_paths())
-    print()
-    _print_dict('Variables', get_config_vars())
+    if '--json' in sys.argv:
+        data = {
+            'platform': get_platform(),
+            'pyversion': get_python_version(),
+            'default_scheme': get_default_scheme(),
+            'paths': get_paths(),
+            'variables': get_config_vars()
+        }
+        print(json.dumps(data, indent=4))
+    else:
+        print(f'Platform: "{get_platform()}"')
+        print(f'Python version: "{get_python_version()}"')
+        print(f'Current installation scheme: "{get_default_scheme()}"')
+        print()
+        _print_dict('Paths', get_paths())
+        print()
+        _print_dict('Variables', get_config_vars())
 
 
 if __name__ == '__main__':

--- a/Lib/sysconfig/__main__.py
+++ b/Lib/sysconfig/__main__.py
@@ -236,7 +236,7 @@ def _main():
         data = {
             'platform': get_platform(),
             'pyversion': get_python_version(),
-            'default_scheme': get_default_scheme(),
+            'installation_scheme': get_default_scheme(),
             'paths': get_paths(),
             'variables': get_config_vars()
         }

--- a/Misc/NEWS.d/next/Library/2024-08-26-16-55-17.gh-issue-123350.fBJPF-.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-26-16-55-17.gh-issue-123350.fBJPF-.rst
@@ -1,1 +1,1 @@
-Add ``--json`` output option to the ``python -m sysconfig script``
+Add ``--json`` output option to the ``python -m sysconfig`` script

--- a/Misc/NEWS.d/next/Library/2024-08-26-16-55-17.gh-issue-123350.fBJPF-.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-26-16-55-17.gh-issue-123350.fBJPF-.rst
@@ -1,0 +1,1 @@
+Add ``--json`` output option to the ``python -m sysconfig script``

--- a/Misc/NEWS.d/next/Library/2024-08-26-16-55-17.gh-issue-123350.fBJPF-.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-26-16-55-17.gh-issue-123350.fBJPF-.rst
@@ -1,1 +1,1 @@
-Add ``--json`` output option to the ``python -m sysconfig`` script
+Add ``--json`` output option to the ``python -m sysconfig`` script.


### PR DESCRIPTION
Currently `python -m sysconfig` prints only tab-ed textual output which is useful for debugging, but cumbersome to extract speicific information from.

I think it makes sense to have a json-formatted output too 
`python -m sysconfig --json | jq ".variables.prefix"`.
With the eventual goal of having to avoid `python -c 'import sysconfig; print(sysconfig.get_*(*)))'?`

```shell

python -m sysconfig --json
    {
       "platform": "macosx-14.6-arm64",
       "pyversion": "3.14",
       "default_scheme": "posix_prefix",
       "paths": {
           "stdlib": "/Users/flo/cpython/build/lib/python3.14",
           "platstdlib": "/Users/flo/cpython/build/lib/python3.14",
           "purelib": "/Users/flo/cpython/build/lib/python3.14/site-packages",
           ...
       },
       "variables": {
           "prefix": "/Users/flo/cpython/build",
           "exec_prefix": "/Users/flo/cpython/build",
           "py_version": "3.14.0a0",
           "py_version_short": "3.14",
           "py_version_nodot": "314",
           "installed_base": "/Users/flo/cpython/build",
           "base": "/Users/flo/cpython/build",
           ...
       }
   }
```

There is some discussion here https://discuss.python.org/t/add-python-m-sysconfig-json-option/61918/1

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123318.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-123350 -->
* Issue: gh-123350
<!-- /gh-issue-number -->
