### PR TITLE
gh-111495: Remove test_capi test_rshift_print()

### DIFF
--- a/Lib/test/test_capi/test_number.py
+++ b/Lib/test/test_capi/test_number.py
@@ -217,21 +217,6 @@ class CAPITest(unittest.TestCase):
         self.assertRaises(TypeError, power, 4, 11, HasPow.with_val(NotImplemented))
         self.assertRaises(TypeError, power, 4, 11, object())
 
-    @cpython_only
-    def test_rshift_print(self):
-        # This tests correct syntax hint for py2 redirection (>>).
-        rshift = _testcapi.number_rshift
-
-        with self.assertRaises(TypeError) as context:
-            rshift(print, 42)
-        self.assertIn('Did you mean "print(<message>, '
-                      'file=<output_stream>)"?', str(context.exception))
-        with self.assertRaises(TypeError) as context:
-            rshift(max, sys.stderr)
-        self.assertNotIn('Did you mean ', str(context.exception))
-        with self.assertRaises(TypeError) as context:
-            rshift(1, "spam")
-
     def test_long(self):
         # Test PyNumber_Long()
         long = _testcapi.number_long


### PR DESCRIPTION
The suggestion for "print >> value" was removed recently: commit 9375b9ca3a4998678ba74ff5c77ed540a4dcf887.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111495 -->
* Issue: gh-111495
<!-- /gh-issue-number -->
