### PR TITLE
gh-123340: Show string value of `IS_OP` oparg in `dis`

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -51,6 +51,7 @@ LOAD_SPECIAL = opmap['LOAD_SPECIAL']
 LOAD_FAST_LOAD_FAST = opmap['LOAD_FAST_LOAD_FAST']
 STORE_FAST_LOAD_FAST = opmap['STORE_FAST_LOAD_FAST']
 STORE_FAST_STORE_FAST = opmap['STORE_FAST_STORE_FAST']
+IS_OP = opmap['IS_OP']
 
 CACHE = opmap["CACHE"]
 
@@ -629,6 +630,8 @@ class ArgResolver:
                     argrepr = repr(obj)
             elif deop == LOAD_SPECIAL:
                 argrepr = _special_method_names[arg]
+            elif deop == IS_OP:
+                argrepr = 'is not' if argval else 'is'
         return argval, argrepr
 
 def get_instructions(x, *, first_line=None, show_caches=None, adaptive=False):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -2028,6 +2028,15 @@ class InstructionTests(InstructionTestCase):
         dis.dis(f.__code__, file=output, show_caches=True)
         self.assertIn("L1:", output.getvalue())
 
+    def test_is_op_format(self):
+        output = io.StringIO()
+        dis.dis("a is b", file=output, show_caches=True)
+        self.assertIn("IS_OP                    0 (is)", output.getvalue())
+
+        output = io.StringIO()
+        dis.dis("a is not b", file=output, show_caches=True)
+        self.assertIn("IS_OP                    1 (is not)", output.getvalue())
+
     def test_baseopname_and_baseopcode(self):
         # Standard instructions
         for name, code in dis.opmap.items():

--- a/Misc/NEWS.d/next/Library/2024-08-26-19-36-00.gh-issue-123340.mQKI1H.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-26-19-36-00.gh-issue-123340.mQKI1H.rst
@@ -1,0 +1,1 @@
+Show string value of IS_OP oparg in :mod:`dis` output.

--- a/Misc/NEWS.d/next/Library/2024-08-26-19-36-00.gh-issue-123340.mQKI1H.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-26-19-36-00.gh-issue-123340.mQKI1H.rst
@@ -1,1 +1,1 @@
-Show string value of IS_OP oparg in :mod:`dis` output.
+Show string value of :opcode:`IS_OP` oparg in :mod:`dis` output.


### PR DESCRIPTION
After:

```
» echo 'a is not b' | ./python.exe -m dis
  0           RESUME                   0

  1           LOAD_NAME                0 (a)
              LOAD_NAME                1 (b)
              IS_OP                    1 (is not)
              POP_TOP
              RETURN_CONST             0 (None)
```

and

```
» echo 'a is b' | ./python.exe -m dis    
  0           RESUME                   0

  1           LOAD_NAME                0 (a)
              LOAD_NAME                1 (b)
              IS_OP                    0 (is)
              POP_TOP
              RETURN_CONST             0 (None)
```

<!-- gh-issue-number: gh-123340 -->
* Issue: gh-123340
<!-- /gh-issue-number -->
