### PR TITLE
GH-119518: Stop interning strings in pathlib

### DIFF
--- a/Lib/pathlib/_local.py
+++ b/Lib/pathlib/_local.py
@@ -273,8 +273,7 @@ class PurePath(PurePathBase):
             elif len(drv_parts) == 6:
                 # e.g. //?/unc/server/share
                 root = sep
-        parsed = [sys.intern(str(x)) for x in rel.split(sep) if x and x != '.']
-        return drv, root, parsed
+        return drv, root, [x for x in rel.split(sep) if x and x != '.']
 
     @property
     def _raw_path(self):

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -163,15 +163,6 @@ class PurePathTest(test_pathlib_abc.DummyPurePathTest):
         # Special case for the empty path.
         self._check_str('.', ('',))
 
-    def test_parts_interning(self):
-        P = self.cls
-        p = P('/usr/bin/foo')
-        q = P('/usr/local/bin')
-        # 'usr'
-        self.assertIs(p.parts[1], q.parts[1])
-        # 'bin'
-        self.assertIs(p.parts[2], q.parts[3])
-
     def test_join_nested(self):
         P = self.cls
         p = P('a/b').joinpath(P('c'))

--- a/Misc/NEWS.d/next/Library/2024-08-26-18-48-13.gh-issue-119518.QFYH9q.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-26-18-48-13.gh-issue-119518.QFYH9q.rst
@@ -1,0 +1,2 @@
+Speed up normalization of :class:`pathlib.PurePath` and
+:class:`~pathlib.Path` objects by not interning string parts.


### PR DESCRIPTION
Remove `sys.intern(str(x))` calls when normalizing a path in pathlib. This speeds up `str(Path('foo/bar'))` by about 10%.

As mentioned in the issue, I've never been able to establish if/when string interning is useful in pathlib, nor that we're using it in the best way. It feels negligent to leave it in the code.

<!-- gh-issue-number: gh-119518 -->
* Issue: gh-119518
<!-- /gh-issue-number -->
