### PR TITLE
gh-123309: Remove check for redefined memo entry in pickletools.dis()

### DIFF
--- a/Lib/pickletools.py
+++ b/Lib/pickletools.py
@@ -2429,8 +2429,6 @@ def dis(pickle, out=None, memo=None, indentlevel=4, annotate=0):
     + A memo entry isn't referenced before it's defined.
 
     + The markobject isn't stored in the memo.
-
-    + A memo entry isn't redefined.
     """
 
     # Most of the hair here is for sanity checks, but most of it is needed
@@ -2484,7 +2482,7 @@ def dis(pickle, out=None, memo=None, indentlevel=4, annotate=0):
                     assert opcode.name == "POP"
                     numtopop = 0
             else:
-                errormsg = markmsg = "no MARK exists on stack"
+                errormsg = "no MARK exists on stack"
 
         # Check for correct memo usage.
         if opcode.name in ("PUT", "BINPUT", "LONG_BINPUT", "MEMOIZE"):
@@ -2494,9 +2492,7 @@ def dis(pickle, out=None, memo=None, indentlevel=4, annotate=0):
             else:
                 assert arg is not None
                 memo_idx = arg
-            if memo_idx in memo:
-                errormsg = "memo key %r already defined" % arg
-            elif not stack:
+            if not stack:
                 errormsg = "stack is empty -- can't store into memo"
             elif stack[-1] is markobject:
                 errormsg = "can't store markobject in the memo"

--- a/Lib/test/test_pickletools.py
+++ b/Lib/test/test_pickletools.py
@@ -206,7 +206,7 @@ highest protocol among opcodes = 0
     def test_no_mark(self):
         self.check_dis_error(b'Nt.', '''\
     0: N    NONE
-    1: t    TUPLE      no MARK exists on stack
+    1: t    TUPLE
 ''', 'no MARK exists on stack')
 
     def test_put(self):
@@ -221,26 +221,16 @@ highest protocol among opcodes = 4
 ''')
 
     def test_put_redefined(self):
-        self.check_dis_error(b'Np1\np1\n.', '''\
+        self.check_dis(b'Np1\np1\nq\x01r\x01\x00\x00\x00\x94.', '''\
     0: N    NONE
     1: p    PUT        1
     4: p    PUT        1
-''', 'memo key 1 already defined')
-        self.check_dis_error(b'Np1\nq\x01.', '''\
-    0: N    NONE
-    1: p    PUT        1
-    4: q    BINPUT     1
-''', 'memo key 1 already defined')
-        self.check_dis_error(b'Np1\nr\x01\x00\x00\x00.', '''\
-    0: N    NONE
-    1: p    PUT        1
-    4: r    LONG_BINPUT 1
-''', 'memo key 1 already defined')
-        self.check_dis_error(b'Np1\n\x94.', '''\
-    0: N    NONE
-    1: p    PUT        1
-    4: \\x94 MEMOIZE    (as 1)
-''', 'memo key None already defined')
+    7: q    BINPUT     1
+    9: r    LONG_BINPUT 1
+   14: \\x94 MEMOIZE    (as 1)
+   15: .    STOP
+highest protocol among opcodes = 4
+''')
 
     def test_put_empty_stack(self):
         self.check_dis_error(b'p0\n', '''\

--- a/Misc/NEWS.d/next/Library/2024-08-31-12-34-44.gh-issue-123374.3kE7rb.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-31-12-34-44.gh-issue-123374.3kE7rb.rst
@@ -1,0 +1,1 @@
+Remove check for redefined memo entry in :func:`pickletools.dis`.


### PR DESCRIPTION
Such pickles are supported by the Unpickler even if the Pickler does not produce them.


<!-- gh-issue-number: gh-123309 -->
* Issue: gh-123309
<!-- /gh-issue-number -->
