### PR TITLE
gh-123363: Show string value of CONTAINS_OP oparg in dis

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -52,6 +52,7 @@ LOAD_FAST_LOAD_FAST = opmap['LOAD_FAST_LOAD_FAST']
 STORE_FAST_LOAD_FAST = opmap['STORE_FAST_LOAD_FAST']
 STORE_FAST_STORE_FAST = opmap['STORE_FAST_STORE_FAST']
 IS_OP = opmap['IS_OP']
+CONTAINS_OP = opmap['CONTAINS_OP']
 
 CACHE = opmap["CACHE"]
 
@@ -632,6 +633,8 @@ class ArgResolver:
                 argrepr = _special_method_names[arg]
             elif deop == IS_OP:
                 argrepr = 'is not' if argval else 'is'
+            elif deop == CONTAINS_OP:
+                argrepr = 'not in' if argval else 'in'
         return argval, argrepr
 
 def get_instructions(x, *, first_line=None, show_caches=None, adaptive=False):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -2040,11 +2040,11 @@ class InstructionTests(InstructionTestCase):
     def test_contains_op_format(self):
         output = io.StringIO()
         dis.dis("a in b", file=output, show_caches=True)
-        self.assertIn("CONTAINS_OP                    0 (in)", output.getvalue())
+        self.assertIn("CONTAINS_OP              0 (in)", output.getvalue())
 
         output = io.StringIO()
         dis.dis("a not in b", file=output, show_caches=True)
-        self.assertIn("CONTAINS_OP                    1 (not in)", output.getvalue())
+        self.assertIn("CONTAINS_OP              1 (not in)", output.getvalue())
 
     def test_baseopname_and_baseopcode(self):
         # Standard instructions

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -2040,11 +2040,11 @@ class InstructionTests(InstructionTestCase):
     def test_contains_op_format(self):
         output = io.StringIO()
         dis.dis("a in b", file=output, show_caches=True)
-        self.assertIn("CONTAINS_OP                    0 (is)", output.getvalue())
+        self.assertIn("CONTAINS_OP                    0 (in)", output.getvalue())
 
         output = io.StringIO()
         dis.dis("a not in b", file=output, show_caches=True)
-        self.assertIn("CONTAINS_OP                    1 (is not)", output.getvalue())
+        self.assertIn("CONTAINS_OP                    1 (not in)", output.getvalue())
 
     def test_baseopname_and_baseopcode(self):
         # Standard instructions

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -2037,6 +2037,15 @@ class InstructionTests(InstructionTestCase):
         dis.dis("a is not b", file=output, show_caches=True)
         self.assertIn("IS_OP                    1 (is not)", output.getvalue())
 
+    def test_contains_op_format(self):
+        output = io.StringIO()
+        dis.dis("a in b", file=output, show_caches=True)
+        self.assertIn("CONTAINS_OP                    0 (is)", output.getvalue())
+
+        output = io.StringIO()
+        dis.dis("a not in b", file=output, show_caches=True)
+        self.assertIn("CONTAINS_OP                    1 (is not)", output.getvalue())
+
     def test_baseopname_and_baseopcode(self):
         # Standard instructions
         for name, code in dis.opmap.items():

--- a/Misc/NEWS.d/next/Library/2024-08-27-12-11-00.gh-issue-123363.gKuJp6.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-27-12-11-00.gh-issue-123363.gKuJp6.rst
@@ -1,1 +1,2 @@
 Show string value of :opcode:`CONTAINS_OP` oparg in :mod:`dis` output.
+Patch by [Alexandr153].

--- a/Misc/NEWS.d/next/Library/2024-08-27-12-11-00.gh-issue-123363.gKuJp6.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-27-12-11-00.gh-issue-123363.gKuJp6.rst
@@ -1,0 +1,1 @@
+Show string value of :opcode:`CONTAINS_OP` oparg in :mod:`dis` output.

--- a/Misc/NEWS.d/next/Library/2024-08-27-12-11-00.gh-issue-123363.gKuJp6.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-27-12-11-00.gh-issue-123363.gKuJp6.rst
@@ -1,2 +1,2 @@
 Show string value of :opcode:`CONTAINS_OP` oparg in :mod:`dis` output.
-Patch by [Alexandr153].
+Patch by Alexandr153.


### PR DESCRIPTION
Result:
```
>>> echo 'a not in  b' | ./python.exe -m dis
  0           RESUME                   0

  1           LOAD_NAME                0 (a)
              LOAD_NAME                1 (b)
              CONTAINS_OP              1 (not in)
              RETURN_VALUE
```

```
>>> echo 'a in  b' | ./python.exe -m dis
  0           RESUME                   0

  1           LOAD_NAME                0 (a)
              LOAD_NAME                1 (b)
              CONTAINS_OP              0 (in)
              RETURN_VALUE
```

<!-- gh-issue-number: gh-123363 -->
* Issue: gh-123363
<!-- /gh-issue-number -->
