### PR TITLE
gh-109975: Fix a typo in What's New in Python 3.13

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1480,7 +1480,7 @@ Optimizations
   Other modules to enjoy import-time speedups include
   :mod:`email.utils`, :mod:`enum`, :mod:`functools`,
   :mod:`importlib.metadata`, and :mod:`threading`.
-  (Contributed by Alex Waygood, Shantanu Jain, Adam Turner, Daniel Holla,
+  (Contributed by Alex Waygood, Shantanu Jain, Adam Turner, Daniel Hollas,
   and others in :gh:`109653`.)
 
 * :func:`textwrap.indent` is now around 30% faster than before for large input.


### PR DESCRIPTION
Typo introduced in #123301

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123393.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->
