### PR TITLE
gh-101860: document `property.__name__`

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1700,6 +1700,13 @@ are always available.  They are listed here in alphabetical order.
    .. versionchanged:: 3.5
       The docstrings of property objects are now writeable.
 
+   .. attribute:: __name__
+
+      Attribute holding the name of the property. The name of the property
+      can be changed at runtime.
+
+      .. versionadded:: 3.13
+
 
 .. _func-range:
 .. class:: range(stop)

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -607,6 +607,9 @@ Other Language Changes
   the :mod:`bz2`, :mod:`lzma`, :mod:`tarfile`, and :mod:`zipfile` modules.
   (Contributed by Serhiy Storchaka in :gh:`115961`.)
 
+* Add a :attr:`~property.__name__` attribute on :class:`property` objects.
+  (Contributed by Eugene Toder in :gh:`101860`.)
+
 
 New Modules
 ===========


### PR DESCRIPTION
I *think* I need to change 3.13 What's New since this change was introduced in 3.13. Not sure if Sphinx will complain with how I documented. (waiting for the docs to build to see how it renders)

cc @eltoder @JelleZijlstra 

<!-- gh-issue-number: gh-101860 -->
* Issue: gh-101860
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123399.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->