### PR TITLE
gh-122306: Fix circular reference issue between MemoryView and PickleBuffer during garbage collection

### DIFF
--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -1102,10 +1102,6 @@ PyBuffer_ToContiguous(void *buf, const Py_buffer *src, Py_ssize_t len, char orde
 static int
 _memory_release(PyMemoryViewObject *self)
 {
-    /* this could be NULL if there is a PickleBuffer in cyclic references */
-    if(self->mbuf == NULL)
-        return 0;
-
     if (self->flags & _Py_MEMORYVIEW_RELEASED)
         return 0;
 
@@ -1168,8 +1164,8 @@ static int
 memory_clear(PyObject *_self)
 {
     PyMemoryViewObject *self = (PyMemoryViewObject *)_self;
-    (void)_memory_release(self);
-    Py_CLEAR(self->mbuf);
+    if(_memory_release(self) == 0)
+        Py_CLEAR(self->mbuf);
     return 0;
 }
 

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -1164,8 +1164,12 @@ static int
 memory_clear(PyObject *_self)
 {
     PyMemoryViewObject *self = (PyMemoryViewObject *)_self;
-    if(_memory_release(self) == 0)
+    if(_memory_release(self) == 0) {
         Py_CLEAR(self->mbuf);
+    }
+    else {
+        PyErr_FormatUnraisable("Exception ignored in memoryview clear");
+    }
     return 0;
 }
 

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -1102,6 +1102,10 @@ PyBuffer_ToContiguous(void *buf, const Py_buffer *src, Py_ssize_t len, char orde
 static int
 _memory_release(PyMemoryViewObject *self)
 {
+    /* this could be NULL if there is a PickleBuffer in cyclic references */
+    if(self->mbuf == NULL)
+        return 0;
+
     if (self->flags & _Py_MEMORYVIEW_RELEASED)
         return 0;
 


### PR DESCRIPTION
## Issues
- Issue:#122306

## Main Causes
1. Creating a circular reference through a constructed exception, preventing garbage collection of PickleBuffer and memory objects
2. Calling `gc.collect()`
3. During the collection of the memory object, PyMemoryViewObject->mbuf is cleared for the first time (mbuf is set to a null pointer)
4. When collecting PickleBuffer, memory_dealloc is called again through picklebuf_clear, at which point an exception occurs because mbuf was set to a null pointer in step `3`

## Next
I have no idea if this is a good way to fix this.But thank for any dev who reviewed this PR.


<!-- gh-issue-number: gh-122306 -->
* Issue: gh-122306
<!-- /gh-issue-number -->
