### PR TITLE
gh-123407: Docs: enable translations of code blocks

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -310,6 +310,7 @@ root_doc = 'contents'
 # Allow translation of index directives
 gettext_additional_targets = [
     'index',
+    'literal-block',
 ]
 
 # Options for HTML output


### PR DESCRIPTION
Closes #123407.

<!-- gh-issue-number: gh-123407 -->
* Issue: gh-123407
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123408.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->