### PR TITLE
gh-123142: fix too wide source location of GET_ITER/GET_AITER

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2850,14 +2850,17 @@ def get_signal_name(exitcode):
     return None
 
 class BrokenIter:
-    def __init__(self, init_raises=False, next_raises=False):
+    def __init__(self, init_raises=False, next_raises=False, iter_raises=False):
         if init_raises:
             1/0
         self.next_raises = next_raises
+        self.iter_raises = iter_raises
 
     def __next__(self):
         if self.next_raises:
             1/0
 
     def __iter__(self):
+        if self.iter_raises:
+            1/0
         return self

--- a/Lib/test/test_dictcomps.py
+++ b/Lib/test/test_dictcomps.py
@@ -145,8 +145,15 @@ class DictComprehensionTest(unittest.TestCase):
             except Exception as e:
                 return e
 
+        def iter_raises():
+            try:
+                {x:x for x in BrokenIter(iter_raises=True)}
+            except Exception as e:
+                return e
+
         for func, expected in [(init_raises, "BrokenIter(init_raises=True)"),
                                (next_raises, "BrokenIter(next_raises=True)"),
+                               (iter_raises, "BrokenIter(iter_raises=True)"),
                               ]:
             with self.subTest(func):
                 exc = func()

--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -1163,8 +1163,16 @@ class TestCase(unittest.TestCase):
             except Exception as e:
                 return e
 
+        def iter_raises():
+            try:
+                for x in BrokenIter(iter_raises=True):
+                    pass
+            except Exception as e:
+                return e
+
         for func, expected in [(init_raises, "BrokenIter(init_raises=True)"),
                                (next_raises, "BrokenIter(next_raises=True)"),
+                               (iter_raises, "BrokenIter(iter_raises=True)"),
                               ]:
             with self.subTest(func):
                 exc = func()

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -730,8 +730,15 @@ class ListComprehensionTest(unittest.TestCase):
             except Exception as e:
                 return e
 
+        def iter_raises():
+            try:
+                [x for x in BrokenIter(iter_raises=True)]
+            except Exception as e:
+                return e
+
         for func, expected in [(init_raises, "BrokenIter(init_raises=True)"),
                                (next_raises, "BrokenIter(next_raises=True)"),
+                               (iter_raises, "BrokenIter(iter_raises=True)"),
                               ]:
             with self.subTest(func):
                 exc = func()

--- a/Lib/test/test_setcomps.py
+++ b/Lib/test/test_setcomps.py
@@ -168,8 +168,15 @@ class SetComprehensionTest(unittest.TestCase):
             except Exception as e:
                 return e
 
+        def iter_raises():
+            try:
+                {x for x in BrokenIter(iter_raises=True)}
+            except Exception as e:
+                return e
+
         for func, expected in [(init_raises, "BrokenIter(init_raises=True)"),
                                (next_raises, "BrokenIter(next_raises=True)"),
+                               (iter_raises, "BrokenIter(iter_raises=True)"),
                               ]:
             with self.subTest(func):
                 exc = func()

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2990,7 +2990,7 @@ codegen_async_for(struct compiler *c, stmt_ty s)
     NEW_JUMP_TARGET_LABEL(c, end);
 
     VISIT(c, expr, s->v.AsyncFor.iter);
-    ADDOP(c, loc, GET_AITER);
+    ADDOP(c, LOC(s->v.AsyncFor.iter), GET_AITER);
 
     USE_LABEL(c, start);
     RETURN_IF_ERROR(compiler_push_fblock(c, loc, FOR_LOOP, start, end, NULL));
@@ -5284,7 +5284,7 @@ codegen_async_comprehension_generator(struct compiler *c, location loc,
         else {
             /* Sub-iter - calculate on the fly */
             VISIT(c, expr, gen->iter);
-            ADDOP(c, loc, GET_AITER);
+            ADDOP(c, LOC(gen->iter), GET_AITER);
         }
     }
 
@@ -5618,15 +5618,14 @@ pop_inlined_comprehension_state(struct compiler *c, location loc,
 }
 
 static inline int
-codegen_comprehension_iter(struct compiler *c, location loc,
-                           comprehension_ty comp)
+codegen_comprehension_iter(struct compiler *c, comprehension_ty comp)
 {
     VISIT(c, expr, comp->iter);
     if (comp->is_async) {
-        ADDOP(c, loc, GET_AITER);
+        ADDOP(c, LOC(comp->iter), GET_AITER);
     }
     else {
-        ADDOP(c, loc, GET_ITER);
+        ADDOP(c, LOC(comp->iter), GET_ITER);
     }
     return SUCCESS;
 }
@@ -5654,7 +5653,7 @@ codegen_comprehension(struct compiler *c, expr_ty e, int type,
 
     outermost = (comprehension_ty) asdl_seq_GET(generators, 0);
     if (is_inlined) {
-        if (codegen_comprehension_iter(c, loc, outermost)) {
+        if (codegen_comprehension_iter(c, outermost)) {
             goto error;
         }
         if (push_inlined_comprehension_state(c, loc, entry, &inline_state)) {
@@ -5736,7 +5735,7 @@ codegen_comprehension(struct compiler *c, expr_ty e, int type,
     }
     Py_CLEAR(co);
 
-    if (codegen_comprehension_iter(c, loc, outermost)) {
+    if (codegen_comprehension_iter(c, outermost)) {
         goto error;
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123142 -->
* Issue: gh-123142
<!-- /gh-issue-number -->
