### PR TITLE
gh-122136: test_asyncio: Don't fail if the kernel buffers more data than advertised

### DIFF
--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -227,7 +227,7 @@ class TestServer2(unittest.IsolatedAsyncioTestCase):
 
         (s_rd, s_wr) = await fut
 
-        # Limit the socket buffers so we can reliably overfill them
+        # Limit the socket buffers so we can more reliably overfill them
         s_sock = s_wr.get_extra_info('socket')
         s_sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 65536)
         c_sock = c_wr.get_extra_info('socket')
@@ -242,10 +242,18 @@ class TestServer2(unittest.IsolatedAsyncioTestCase):
             await asyncio.sleep(0)
 
         # Get the writer in a waiting state by sending data until the
-        # socket buffers are full on both server and client sockets and
-        # the kernel stops accepting more data
-        s_wr.write(b'a' * c_sock.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF))
-        s_wr.write(b'a' * s_sock.getsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF))
+        # kernel stops accepting more data in the send buffer.
+        # gh-122136: getsockopt() does not reliably report the buffer size
+        # available for message content.
+        # We loop until we start filling up the asyncio buffer.
+        # To avoid an infinite loop we cap at 10 times the expected value
+        c_bufsize = c_sock.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
+        s_bufsize = s_sock.getsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF)
+        for i in range(10):
+            s_wr.write(b'a' * c_bufsize)
+            s_wr.write(b'a' * s_bufsize)
+            if s_wr.transport.get_write_buffer_size() > 0:
+                break
         self.assertNotEqual(s_wr.transport.get_write_buffer_size(), 0)
 
         task = asyncio.create_task(srv.wait_closed())


### PR DESCRIPTION
Apparently, Linux kernel 6.10.6 can buffer much more data than advertised by `getsockopt({SO_RCVBUF,SO_SNDBUF})` -- see https://github.com/python/cpython/issues/122136#issuecomment-2315123039
This breaks expectations of a test added in GH-116784.

This fix loops until the the asyncio buffer starts filling up, which should mean the kernel ones are full.
I capped the loop at 10 iterations to avoid looping forever if there's a bug.

This partially reverts the idea in one commit from GH-116784: https://github.com/python/cpython/pull/116784/commits/1158151d212afb03c0ab58f267b67178a2158454

@CendioOssman, does this preserve the intent of the test?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-122136 -->
* Issue: gh-122136
<!-- /gh-issue-number -->
