### PR TITLE
gh-123370: Fix the canvas not clearing after running turtledemo.clock

### DIFF
--- a/Lib/turtledemo/clock.py
+++ b/Lib/turtledemo/clock.py
@@ -54,12 +54,6 @@ def clockface(radius):
             jump(-radius)
         rt(6)
 
-def wochentag(t):
-    return t.strftime(format="%A")
-
-def datum(z):
-    return z.strftime(format="%Y/%m/%d")
-
 def display_date_time():
     global current_day
     writer.clear()
@@ -72,15 +66,6 @@ def display_date_time():
     writer.write(datum(now), align="center", font=dtfont)
     writer.forward(distance=85)
 
-def initialize_hand(shape, color):
-    hand = Turtle()
-    hand.shape(shape)
-    hand.color(*color)
-    hand.resizemode("user")
-    hand.shapesize(1, 1, 3)
-    hand.speed(0)
-    return hand
-
 def setup():
     global second_hand, minute_hand, hour_hand, writer
     mode("logo")
@@ -88,11 +73,19 @@ def setup():
     make_hand_shape("minute_hand",  115, 25)
     make_hand_shape("hour_hand", 90, 25)
     clockface(160)
-
-    second_hand = initialize_hand("second_hand", ("gray20", "gray80"))
-    minute_hand = initialize_hand("minute_hand", ("blue1", "red1"))
-    hour_hand = initialize_hand("hour_hand", ("blue3", "red3"))
-
+    second_hand = Turtle()
+    second_hand.shape("second_hand")
+    second_hand.color("gray20", "gray80")
+    minute_hand = Turtle()
+    minute_hand.shape("minute_hand")
+    minute_hand.color("blue1", "red1")
+    hour_hand = Turtle()
+    hour_hand.shape("hour_hand")
+    hour_hand.color("blue3", "red3")
+    for hand in second_hand, minute_hand, hour_hand:
+        hand.resizemode("user")
+        hand.shapesize(1, 1, 3)
+        hand.speed(0)
     ht()
     writer = Turtle()
     writer.ht()
@@ -100,19 +93,30 @@ def setup():
     writer.bk(85)
     display_date_time()
 
-def tick():
-    global current_day
-    now = datetime.now()
-    sekunde = now.second + now.microsecond * 0.000001
-    minute = now.minute + sekunde / 60.0
-    stunde = now.hour + minute / 60.0
+def wochentag(t):
+    wochentag = ["Monday", "Tuesday", "Wednesday",
+        "Thursday", "Friday", "Saturday", "Sunday"]
+    return wochentag[t.weekday()]
 
+def datum(z):
+    monat = ["Jan.", "Feb.", "Mar.", "Apr.", "May", "June",
+             "July", "Aug.", "Sep.", "Oct.", "Nov.", "Dec."]
+    j = z.year
+    m = monat[z.month - 1]
+    t = z.day
+    return "%s %d %d" % (m, t, j)
+
+def tick():
+    t = datetime.today()
+    sekunde = t.second + t.microsecond*0.000001
+    minute = t.minute + sekunde/60.0
+    stunde = t.hour + minute/60.0
     try:
         tracer(False)  # Terminator can occur here
         second_hand.setheading(6*sekunde)  # or here
         minute_hand.setheading(6*minute)
         hour_hand.setheading(30*stunde)
-        if now.day != current_day:
+        if t.day != current_day:
             display_date_time()
         tracer(True)
         ontimer(tick, 100)

--- a/Lib/turtledemo/clock.py
+++ b/Lib/turtledemo/clock.py
@@ -1,4 +1,3 @@
-# -*- coding: cp1252 -*-
 """       turtle-example-suite:
 
              tdemo_clock.py
@@ -52,62 +51,54 @@ def clockface(radius):
             jump(-radius)
         rt(6)
 
+def display_date_time():
+    writer.clear()
+    now = datetime.now()
+    writer.home()
+    writer.forward(distance=65)
+    writer.write(now.strftime(format="%A"),
+                 align="center", font=("TkFixedFont", 14, "bold"))
+    writer.back(distance=150)
+    writer.write(now.strftime(format="%Y/%m/%d"),
+                 align="center", font=("TkFixedFont", 14, "bold"))
+    writer.forward(distance=85)
+
+def initialize_hand(shape, color):
+    hand = Turtle()
+    hand.shape(shape)
+    hand.color(*color)
+    hand.resizemode("user")
+    hand.shapesize(1, 1, 3)
+    hand.speed(0)
+    return hand
+
 def setup():
     global second_hand, minute_hand, hour_hand, writer
     mode("logo")
     make_hand_shape("second_hand", 125, 25)
-    make_hand_shape("minute_hand",  130, 25)
+    make_hand_shape("minute_hand",  115, 25)
     make_hand_shape("hour_hand", 90, 25)
     clockface(160)
-    second_hand = Turtle()
-    second_hand.shape("second_hand")
-    second_hand.color("gray20", "gray80")
-    minute_hand = Turtle()
-    minute_hand.shape("minute_hand")
-    minute_hand.color("blue1", "red1")
-    hour_hand = Turtle()
-    hour_hand.shape("hour_hand")
-    hour_hand.color("blue3", "red3")
-    for hand in second_hand, minute_hand, hour_hand:
-        hand.resizemode("user")
-        hand.shapesize(1, 1, 3)
-        hand.speed(0)
+
+    second_hand = initialize_hand("second_hand", ("gray20", "gray80"))
+    minute_hand = initialize_hand( "minute_hand", ("blue1", "red1"))
+    hour_hand = initialize_hand( "hour_hand", ("blue3", "red3"))
+
     ht()
     writer = Turtle()
-    #writer.mode("logo")
     writer.ht()
     writer.pu()
     writer.bk(85)
-
-def wochentag(t):
-    wochentag = ["Monday", "Tuesday", "Wednesday",
-        "Thursday", "Friday", "Saturday", "Sunday"]
-    return wochentag[t.weekday()]
-
-def datum(z):
-    monat = ["Jan.", "Feb.", "Mar.", "Apr.", "May", "June",
-             "July", "Aug.", "Sep.", "Oct.", "Nov.", "Dec."]
-    j = z.year
-    m = monat[z.month - 1]
-    t = z.day
-    return "%s %d %d" % (m, t, j)
+    display_date_time()
 
 def tick():
-    t = datetime.today()
-    sekunde = t.second + t.microsecond*0.000001
-    minute = t.minute + sekunde/60.0
-    stunde = t.hour + minute/60.0
+    now = datetime.now()
+    sekunde = now.second + now.microsecond * 0.000001
+    minute = now.minute + sekunde / 60.0
+    stunde = now.hour + minute / 60.0
+
     try:
         tracer(False)  # Terminator can occur here
-        writer.clear()
-        writer.home()
-        writer.forward(65)
-        writer.write(wochentag(t),
-                     align="center", font=("Courier", 14, "bold"))
-        writer.back(150)
-        writer.write(datum(t),
-                     align="center", font=("Courier", 14, "bold"))
-        writer.forward(85)
         second_hand.setheading(6*sekunde)  # or here
         minute_hand.setheading(6*minute)
         hour_hand.setheading(30*stunde)

--- a/Lib/turtledemo/clock.py
+++ b/Lib/turtledemo/clock.py
@@ -54,6 +54,12 @@ def clockface(radius):
             jump(-radius)
         rt(6)
 
+def wochentag(t):
+    return t.strftime(format="%A")
+
+def datum(z):
+    return z.strftime(format="%Y/%m/%d")
+
 def display_date_time():
     global current_day
     writer.clear()
@@ -61,9 +67,9 @@ def display_date_time():
     current_day = now.day
     writer.home()
     writer.forward(distance=65)
-    writer.write(now.strftime(format="%A"), align="center", font=dtfont)
+    writer.write(wochentag(now), align="center", font=dtfont)
     writer.back(distance=150)
-    writer.write(now.strftime(format="%Y/%m/%d"), align="center", font=dtfont)
+    writer.write(datum(now), align="center", font=dtfont)
     writer.forward(distance=85)
 
 def initialize_hand(shape, color):

--- a/Lib/turtledemo/clock.py
+++ b/Lib/turtledemo/clock.py
@@ -12,6 +12,7 @@ from turtle import *
 from datetime import datetime
 
 dtfont = "TkFixedFont", 14, "bold"
+current_day = None
 
 def jump(distanz, winkel=0):
     penup()
@@ -54,6 +55,7 @@ def clockface(radius):
         rt(6)
 
 def display_date_time():
+    global current_day
     writer.clear()
     now = datetime.now()
     writer.home()
@@ -81,8 +83,8 @@ def setup():
     clockface(160)
 
     second_hand = initialize_hand("second_hand", ("gray20", "gray80"))
-    minute_hand = initialize_hand( "minute_hand", ("blue1", "red1"))
-    hour_hand = initialize_hand( "hour_hand", ("blue3", "red3"))
+    minute_hand = initialize_hand("minute_hand", ("blue1", "red1"))
+    hour_hand = initialize_hand("hour_hand", ("blue3", "red3"))
 
     ht()
     writer = Turtle()
@@ -92,6 +94,7 @@ def setup():
     display_date_time()
 
 def tick():
+    global current_day
     now = datetime.now()
     sekunde = now.second + now.microsecond * 0.000001
     minute = now.minute + sekunde / 60.0
@@ -102,6 +105,8 @@ def tick():
         second_hand.setheading(6*sekunde)  # or here
         minute_hand.setheading(6*minute)
         hour_hand.setheading(30*stunde)
+        if now.day != current_day:
+            display_date_time()
         tracer(True)
         ontimer(tick, 100)
     except Terminator:

--- a/Lib/turtledemo/clock.py
+++ b/Lib/turtledemo/clock.py
@@ -1,6 +1,6 @@
 """       turtle-example-suite:
 
-             tdemo_clock.py
+           turtledemo/clock.py
 
 Enhanced clock-program, showing date
 and time
@@ -11,29 +11,29 @@ and time
 from turtle import *
 from datetime import datetime
 
-def jump(distanz, winkel=0):
+def jump(distanz, angle=0):
     penup()
-    right(winkel)
+    right(angle)
     forward(distanz)
-    left(winkel)
+    left(angle)
     pendown()
 
-def hand(laenge, spitze):
-    fd(laenge*1.15)
+def hand(spitze, tip):
+    fd(spitze*1.15)
     rt(90)
-    fd(spitze/2.0)
+    fd(tip/2.0)
     lt(120)
-    fd(spitze)
+    fd(tip)
     lt(120)
-    fd(spitze)
+    fd(tip)
     lt(120)
-    fd(spitze/2.0)
+    fd(tip/2.0)
 
-def make_hand_shape(name, laenge, spitze):
+def make_hand_shape(name, spitze, tip):
     reset()
-    jump(-laenge*0.15)
+    jump(-spitze*0.15)
     begin_poly()
-    hand(laenge, spitze)
+    hand(spitze, tip)
     end_poly()
     hand_form = get_poly()
     register_shape(name, hand_form)

--- a/Lib/turtledemo/clock.py
+++ b/Lib/turtledemo/clock.py
@@ -58,6 +58,7 @@ def display_date_time():
     global current_day
     writer.clear()
     now = datetime.now()
+    current_day = now.day
     writer.home()
     writer.forward(distance=65)
     writer.write(now.strftime(format="%A"), align="center", font=dtfont)

--- a/Lib/turtledemo/clock.py
+++ b/Lib/turtledemo/clock.py
@@ -11,29 +11,31 @@ and time
 from turtle import *
 from datetime import datetime
 
-def jump(distanz, angle=0):
+dtfont = "TkFixedFont", 14, "bold"
+
+def jump(distanz, winkel=0):
     penup()
-    right(angle)
+    right(winkel)
     forward(distanz)
-    left(angle)
+    left(winkel)
     pendown()
 
-def hand(spitze, tip):
-    fd(spitze*1.15)
+def hand(laenge, spitze):
+    fd(laenge*1.15)
     rt(90)
-    fd(tip/2.0)
+    fd(spitze/2.0)
     lt(120)
-    fd(tip)
+    fd(spitze)
     lt(120)
-    fd(tip)
+    fd(spitze)
     lt(120)
-    fd(tip/2.0)
+    fd(spitze/2.0)
 
-def make_hand_shape(name, spitze, tip):
+def make_hand_shape(name, laenge, spitze):
     reset()
-    jump(-spitze*0.15)
+    jump(-laenge*0.15)
     begin_poly()
-    hand(spitze, tip)
+    hand(laenge, spitze)
     end_poly()
     hand_form = get_poly()
     register_shape(name, hand_form)
@@ -56,11 +58,9 @@ def display_date_time():
     now = datetime.now()
     writer.home()
     writer.forward(distance=65)
-    writer.write(now.strftime(format="%A"),
-                 align="center", font=("TkFixedFont", 14, "bold"))
+    writer.write(now.strftime(format="%A"), align="center", font=dtfont)
     writer.back(distance=150)
-    writer.write(now.strftime(format="%Y/%m/%d"),
-                 align="center", font=("TkFixedFont", 14, "bold"))
+    writer.write(now.strftime(format="%Y/%m/%d"), align="center", font=dtfont)
     writer.forward(distance=85)
 
 def initialize_hand(shape, color):

--- a/Misc/NEWS.d/next/Library/2024-08-28-19-27-35.gh-issue-123370.SPZ9Ux.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-28-19-27-35.gh-issue-123370.SPZ9Ux.rst
@@ -1,0 +1,2 @@
+Fix the canvas not clearing after running turtledemo clock, and improve the
+clock example suite

--- a/Misc/NEWS.d/next/Library/2024-08-28-19-27-35.gh-issue-123370.SPZ9Ux.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-28-19-27-35.gh-issue-123370.SPZ9Ux.rst
@@ -1,2 +1,1 @@
-Fix the canvas not clearing after running turtledemo clock, and improve the
-clock example suite
+Fix the canvas not clearing after running turtledemo clock.


### PR DESCRIPTION
In addition to fixing this bug, I also made some changes. 
1. The second hand was shorter than the minute hand, which was incorrect, and this has now been fixed. (minute hand 130 → 115)
2. Remove the first line's `coding: cp1252`, as this file has always been utf8. 
<img width="711" alt="2024-08-29 093847" src="https://github.com/user-attachments/assets/740d6cf3-50f9-4211-aaa3-3ce7b4e14ce5">
<img width="711" alt="2024-08-29 093936" src="https://github.com/user-attachments/assets/1c9796f3-d838-4033-a95c-4186c969f2dc">

<!-- gh-issue-number: gh-123370 -->
* Issue: gh-123370
<!-- /gh-issue-number -->
