### PR TITLE
gh-123446: Fix empty function names in `TypeError`s in `_csv` module

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-08-29-09-27-12.gh-issue-123446._I_mMr.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-29-09-27-12.gh-issue-123446._I_mMr.rst
@@ -1,0 +1,3 @@
+Fix empty function name in :exc:`TypeError` when :func:`csv.reader`,
+:func:`csv.writer`, or :func:`csv.register_dialect` are used without the
+required args.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1072,7 +1072,7 @@ csv_reader(PyObject *module, PyObject *args, PyObject *keyword_args)
         return NULL;
     }
 
-    if (!PyArg_UnpackTuple(args, "", 1, 2, &iterator, &dialect)) {
+    if (!PyArg_UnpackTuple(args, "_csv.reader", 1, 2, &iterator, &dialect)) {
         Py_DECREF(self);
         return NULL;
     }
@@ -1519,7 +1519,7 @@ csv_writer(PyObject *module, PyObject *args, PyObject *keyword_args)
 
     self->error_obj = Py_NewRef(module_state->error_obj);
 
-    if (!PyArg_UnpackTuple(args, "", 1, 2, &output_file, &dialect)) {
+    if (!PyArg_UnpackTuple(args, "_csv.writer", 1, 2, &output_file, &dialect)) {
         Py_DECREF(self);
         return NULL;
     }
@@ -1571,7 +1571,7 @@ csv_register_dialect(PyObject *module, PyObject *args, PyObject *kwargs)
     _csvstate *module_state = get_csv_state(module);
     PyObject *dialect;
 
-    if (!PyArg_UnpackTuple(args, "", 1, 2, &name_obj, &dialect_obj))
+    if (!PyArg_UnpackTuple(args, "_csv.register_dialect", 1, 2, &name_obj, &dialect_obj))
         return NULL;
     if (!PyUnicode_Check(name_obj)) {
         PyErr_SetString(PyExc_TypeError,


### PR DESCRIPTION
After:

```python
>>> import _csv
>>> _csv.reader()
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    _csv.reader()
    ~~~~~~~~~~~^^
TypeError: _csv.reader expected at least 1 argument, got 0
>>> _csv.writer()
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    _csv.writer()
    ~~~~~~~~~~~^^
TypeError: _csv.writer expected at least 1 argument, got 0
>>> _csv.register_dialect()
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    _csv.register_dialect()
    ~~~~~~~~~~~~~~~~~~~~~^^
TypeError: _csv.register_dialect expected at least 1 argument, got 0
```

Questions:
1. Do I need to test this? Seems minor enough
2. `_csv.` or `csv.`? Technically the module is `_csv`, but users can see this when these names are re-exported in `csv` module. I prefer to show the real name.

CC @hauntsaninja, because you have several recent commits to this module.
CC @serhiy-storchaka, because you commented on the issue.

<!-- gh-issue-number: gh-123446 -->
* Issue: gh-123446
<!-- /gh-issue-number -->
