### PR TITLE
gh-123446: Fix empty function names in `TypeError`s in `_csv` module (follow-up to gh-123461)

### DIFF
--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1072,7 +1072,7 @@ csv_reader(PyObject *module, PyObject *args, PyObject *keyword_args)
         return NULL;
     }
 
-    if (!PyArg_UnpackTuple(args, "_csv.reader", 1, 2, &iterator, &dialect)) {
+    if (!PyArg_UnpackTuple(args, "reader", 1, 2, &iterator, &dialect)) {
         Py_DECREF(self);
         return NULL;
     }
@@ -1519,7 +1519,7 @@ csv_writer(PyObject *module, PyObject *args, PyObject *keyword_args)
 
     self->error_obj = Py_NewRef(module_state->error_obj);
 
-    if (!PyArg_UnpackTuple(args, "_csv.writer", 1, 2, &output_file, &dialect)) {
+    if (!PyArg_UnpackTuple(args, "writer", 1, 2, &output_file, &dialect)) {
         Py_DECREF(self);
         return NULL;
     }
@@ -1571,7 +1571,7 @@ csv_register_dialect(PyObject *module, PyObject *args, PyObject *kwargs)
     _csvstate *module_state = get_csv_state(module);
     PyObject *dialect;
 
-    if (!PyArg_UnpackTuple(args, "_csv.register_dialect", 1, 2, &name_obj, &dialect_obj))
+    if (!PyArg_UnpackTuple(args, "register_dialect", 1, 2, &name_obj, &dialect_obj))
         return NULL;
     if (!PyUnicode_Check(name_obj)) {
         PyErr_SetString(PyExc_TypeError,


### PR DESCRIPTION
After:

```python
>>> import csv
>>> csv.reader()
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    csv.reader()
    ~~~~~~~~~~^^
TypeError: reader expected at least 1 argument, got 0
>>> csv.writer()
Traceback (most recent call last):
  File "<python-input-4>", line 1, in <module>
    csv.writer()
    ~~~~~~~~~~^^
TypeError: writer expected at least 1 argument, got 0
>>> csv.register_dialect()
Traceback (most recent call last):
  File "<python-input-5>", line 1, in <module>
    csv.register_dialect()
    ~~~~~~~~~~~~~~~~~~~~^^
TypeError: register_dialect expected at least 1 argument, got 0
```

Follow up to https://github.com/python/cpython/pull/123461

<!-- gh-issue-number: gh-123446 -->
* Issue: gh-123446
<!-- /gh-issue-number -->
