### PR TITLE
gh-123463: Include logging_flow.png in PDF docs

### DIFF
--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -382,6 +382,10 @@ Logging Flow
 The flow of log event information in loggers and handlers is illustrated in the
 following diagram.
 
+.. only:: not html
+
+   .. image:: logging_flow.*
+
 .. raw:: html
    :file: logging_flow.svg
 


### PR DESCRIPTION
Use sphinx `.. only` directive to include logging_flow.png when using latex builder.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123463 -->
* Issue: gh-123463
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123464.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->