### PR TITLE
[3.12] gh-123446: Fix empty function names in `TypeError`s in `_csv` module (GH-123462)

### DIFF
--- a/Doc/Misc/NEWS.d/next/Library/2024-08-29-09-27-12.gh-issue-123446._I_mMr.rst
+++ b/Doc/Misc/NEWS.d/next/Library/2024-08-29-09-27-12.gh-issue-123446._I_mMr.rst
@@ -1,0 +1,3 @@
+Fix empty function name in :exc:`TypeError` when :func:`csv.reader`,
+:func:`csv.writer`, or :func:`csv.register_dialect` are used without the
+required args.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1032,7 +1032,7 @@ csv_reader(PyObject *module, PyObject *args, PyObject *keyword_args)
         return NULL;
     }
 
-    if (!PyArg_UnpackTuple(args, "", 1, 2, &iterator, &dialect)) {
+    if (!PyArg_UnpackTuple(args, "reader", 1, 2, &iterator, &dialect)) {
         Py_DECREF(self);
         return NULL;
     }
@@ -1481,7 +1481,7 @@ csv_writer(PyObject *module, PyObject *args, PyObject *keyword_args)
 
     self->error_obj = Py_NewRef(module_state->error_obj);
 
-    if (!PyArg_UnpackTuple(args, "", 1, 2, &output_file, &dialect)) {
+    if (!PyArg_UnpackTuple(args, "writer", 1, 2, &output_file, &dialect)) {
         Py_DECREF(self);
         return NULL;
     }
@@ -1533,7 +1533,7 @@ csv_register_dialect(PyObject *module, PyObject *args, PyObject *kwargs)
     _csvstate *module_state = get_csv_state(module);
     PyObject *dialect;
 
-    if (!PyArg_UnpackTuple(args, "", 1, 2, &name_obj, &dialect_obj))
+    if (!PyArg_UnpackTuple(args, "register_dialect", 1, 2, &name_obj, &dialect_obj))
         return NULL;
     if (!PyUnicode_Check(name_obj)) {
         PyErr_SetString(PyExc_TypeError,


### PR DESCRIPTION
(cherry picked from commit 58ce131037ecb34d506a613f21993cde2056f628)


<!-- gh-issue-number: gh-123446 -->
* Issue: gh-123446
<!-- /gh-issue-number -->
