### PR TITLE
gh-123467: Fix _gdbmmodule.c.h include path "internal/pycore_modsupport.h"

### DIFF
--- a/Modules/clinic/_gdbmmodule.c.h
+++ b/Modules/clinic/_gdbmmodule.c.h
@@ -5,7 +5,7 @@ preserve
 #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
 #  include "pycore_runtime.h"     // _Py_SINGLETON()
 #endif
-#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
+#include "internal/pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(_gdbm_gdbm_get__doc__,
 "get($self, key, default=None, /)\n"


### PR DESCRIPTION
This PR changes #include "internal/pycore_modsupport.h" to #include "internal/pycore_modsupport.h" in Modules/clinic/_gdbmmodule.c.h, which fixes the build for a test version of a python-gdbm@3.13 homebrew formula.

<!-- gh-issue-number: gh-123467 -->
* Issue: gh-123467
<!-- /gh-issue-number -->
