### PR TITLE
gh-123446: Fix empty function names in `TypeError`s in `typeobject`

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4021,6 +4021,14 @@ class ClassPropertiesAndMethods(unittest.TestCase):
             y = x ** 2
         self.assertIn('unsupported operand type(s) for **', str(cm.exception))
 
+    def test_pow_wrapper_error_messages(self):
+        self.assertRaisesRegex(TypeError,
+                               'expected 1 or 2 arguments, got 0',
+                               int().__pow__)
+        self.assertRaisesRegex(TypeError,
+                               'expected 1 or 2 arguments, got 3',
+                               int().__pow__, 1, 2, 3)
+
     def test_mutable_bases(self):
         # Testing mutable bases...
 

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4028,6 +4028,12 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         self.assertRaisesRegex(TypeError,
                                'expected 1 or 2 arguments, got 3',
                                int().__pow__, 1, 2, 3)
+        self.assertRaisesRegex(TypeError,
+                               'expected 1 or 2 arguments, got 0',
+                               int().__rpow__)
+        self.assertRaisesRegex(TypeError,
+                               'expected 1 or 2 arguments, got 3',
+                               int().__rpow__, 1, 2, 3)
 
     def test_mutable_bases(self):
         # Testing mutable bases...

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-29-13-18-18.gh-issue-123446.KWDrgq.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-29-13-18-18.gh-issue-123446.KWDrgq.rst
@@ -1,0 +1,2 @@
+Fix empty function name in :exc:`TypeError` when builtin magic methods are
+used without the required args.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8759,7 +8759,7 @@ wrap_ternaryfunc(PyObject *self, PyObject *args, void *wrapped)
 
     /* Note: This wrapper only works for __pow__() */
 
-    if (!PyArg_UnpackTuple(args, "", 1, 2, &other, &third))
+    if (!PyArg_UnpackTuple(args, "__pow__", 1, 2, &other, &third))
         return NULL;
     return (*func)(self, other, third);
 }
@@ -8773,7 +8773,7 @@ wrap_ternaryfunc_r(PyObject *self, PyObject *args, void *wrapped)
 
     /* Note: This wrapper only works for __pow__() */
 
-    if (!PyArg_UnpackTuple(args, "", 1, 2, &other, &third))
+    if (!PyArg_UnpackTuple(args, "__rpow__", 1, 2, &other, &third))
         return NULL;
     return (*func)(other, self, third);
 }
@@ -8795,7 +8795,7 @@ wrap_indexargfunc(PyObject *self, PyObject *args, void *wrapped)
     PyObject* o;
     Py_ssize_t i;
 
-    if (!PyArg_UnpackTuple(args, "", 1, 1, &o))
+    if (!PyArg_UnpackTuple(args, "__mul__", 1, 1, &o))
         return NULL;
     i = PyNumber_AsSsize_t(o, PyExc_OverflowError);
     if (i == -1 && PyErr_Occurred())
@@ -8852,7 +8852,7 @@ wrap_sq_setitem(PyObject *self, PyObject *args, void *wrapped)
     int res;
     PyObject *arg, *value;
 
-    if (!PyArg_UnpackTuple(args, "", 2, 2, &arg, &value))
+    if (!PyArg_UnpackTuple(args, "__setitem__", 2, 2, &arg, &value))
         return NULL;
     i = getindex(self, arg);
     if (i == -1 && PyErr_Occurred())
@@ -8908,7 +8908,7 @@ wrap_objobjargproc(PyObject *self, PyObject *args, void *wrapped)
     int res;
     PyObject *key, *value;
 
-    if (!PyArg_UnpackTuple(args, "", 2, 2, &key, &value))
+    if (!PyArg_UnpackTuple(args, "__setitem__", 2, 2, &key, &value))
         return NULL;
     res = (*func)(self, key, value);
     if (res == -1 && PyErr_Occurred())
@@ -9005,7 +9005,7 @@ wrap_setattr(PyObject *self, PyObject *args, void *wrapped)
     int res;
     PyObject *name, *value;
 
-    if (!PyArg_UnpackTuple(args, "", 2, 2, &name, &value))
+    if (!PyArg_UnpackTuple(args, "__setattr__", 2, 2, &name, &value))
         return NULL;
     if (!hackcheck(self, func, "__setattr__"))
         return NULL;
@@ -9115,7 +9115,7 @@ wrap_descr_get(PyObject *self, PyObject *args, void *wrapped)
     PyObject *obj;
     PyObject *type = NULL;
 
-    if (!PyArg_UnpackTuple(args, "", 1, 2, &obj, &type))
+    if (!PyArg_UnpackTuple(args, "__get__", 1, 2, &obj, &type))
         return NULL;
     if (obj == Py_None)
         obj = NULL;
@@ -9136,7 +9136,7 @@ wrap_descr_set(PyObject *self, PyObject *args, void *wrapped)
     PyObject *obj, *value;
     int ret;
 
-    if (!PyArg_UnpackTuple(args, "", 2, 2, &obj, &value))
+    if (!PyArg_UnpackTuple(args, "__set__", 2, 2, &obj, &value))
         return NULL;
     ret = (*func)(self, obj, value);
     if (ret < 0)
@@ -9165,7 +9165,7 @@ wrap_buffer(PyObject *self, PyObject *args, void *wrapped)
 {
     PyObject *arg = NULL;
 
-    if (!PyArg_UnpackTuple(args, "", 1, 1, &arg)) {
+    if (!PyArg_UnpackTuple(args, "__buffer__", 1, 1, &arg)) {
         return NULL;
     }
     Py_ssize_t flags = PyNumber_AsSsize_t(arg, PyExc_OverflowError);
@@ -9186,7 +9186,7 @@ static PyObject *
 wrap_releasebuffer(PyObject *self, PyObject *args, void *wrapped)
 {
     PyObject *arg = NULL;
-    if (!PyArg_UnpackTuple(args, "", 1, 1, &arg)) {
+    if (!PyArg_UnpackTuple(args, "__release_buffer__", 1, 1, &arg)) {
         return NULL;
     }
     if (!PyMemoryView_Check(arg)) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8679,11 +8679,11 @@ check_num_args(PyObject *ob, int n)
 }
 
 static Py_ssize_t
-check_num_varargs(PyObject *ob, int min, int max)
+check_pow_args(PyObject *ob)
 {
     // Returns the argument count on success or `-1` on error.
-    assert(min >= 0);
-    assert(min < max);
+    int min = 1;
+    int max = 2;
     if (!PyTuple_CheckExact(ob)) {
         PyErr_SetString(PyExc_SystemError,
             "PyArg_UnpackTuple() argument list is not a tuple");
@@ -8780,7 +8780,7 @@ wrap_ternaryfunc(PyObject *self, PyObject *args, void *wrapped)
 
     /* Note: This wrapper only works for __pow__() */
 
-    Py_ssize_t size = check_num_varargs(args, 1, 2);
+    Py_ssize_t size = check_pow_args(args);
     if (size == -1) {
         return NULL;
     }
@@ -8801,8 +8801,15 @@ wrap_ternaryfunc_r(PyObject *self, PyObject *args, void *wrapped)
 
     /* Note: This wrapper only works for __rpow__() */
 
-    if (!PyArg_UnpackTuple(args, "__rpow__", 1, 2, &other, &third))
+    Py_ssize_t size = check_pow_args(args);
+    if (size == -1) {
         return NULL;
+    }
+    other = PyTuple_GET_ITEM(args, 0);
+    if (size == 2) {
+       third = PyTuple_GET_ITEM(args, 1);
+    }
+
     return (*func)(other, self, third);
 }
 


### PR DESCRIPTION
The second option was to convert these functions to use `check_num_args(args, ...)`, but this feels like a simplier solution.

After:

```python
>>> str.join.__get__()
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    str.join.__get__()
    ~~~~~~~~~~~~~~~~^^
TypeError: __get__ expected at least 1 argument, got 0
```

<!-- gh-issue-number: gh-123446 -->
* Issue: gh-123446
<!-- /gh-issue-number -->
