### PR TITLE
gh-123465: Allow Py_RELATIVE_OFFSET for __*offset__ members

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -485,7 +485,8 @@ Accessing attributes of extension types
    ``PyMemberDef`` may contain a definition for the special member
    ``"__vectorcalloffset__"``, corresponding to
    :c:member:`~PyTypeObject.tp_vectorcall_offset` in type objects.
-   These must be defined with ``Py_T_PYSSIZET`` and ``Py_READONLY``, for example::
+   This member must be defined with ``Py_T_PYSSIZET``, and either
+   ``Py_READONLY`` or ``Py_READONLY | Py_RELATIVE_OFFSET``. For example::
 
       static PyMemberDef spam_type_members[] = {
           {"__vectorcalloffset__", Py_T_PYSSIZET,
@@ -505,6 +506,12 @@ Accessing attributes of extension types
 
       ``PyMemberDef`` is always available.
       Previously, it required including ``"structmember.h"``.
+
+   .. versionchanged:: 3.14
+
+      :c:macro:`Py_RELATIVE_OFFSET` is now allowed for
+      ``"__vectorcalloffset__"``, ``"__dictoffset__"`` and
+      ``"__weaklistoffset__"``.
 
 .. c:function:: PyObject* PyMember_GetOne(const char *obj_addr, struct PyMemberDef *m)
 

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -851,8 +851,13 @@ class TestPEP590(unittest.TestCase):
     @requires_limited_api
     def test_vectorcall_limited_incoming(self):
         from _testcapi import pyobject_vectorcall
-        obj = _testlimitedcapi.LimitedVectorCallClass()
-        self.assertEqual(pyobject_vectorcall(obj, (), ()), "vectorcall called")
+        for cls in (_testlimitedcapi.LimitedVectorCallClass,
+                    _testlimitedcapi.LimitedRelativeVectorCallClass):
+            with self.subTest(cls=cls):
+                obj = cls()
+                self.assertEqual(
+                    pyobject_vectorcall(obj, (), ()),
+                    "vectorcall called")
 
     @requires_limited_api
     def test_vectorcall_limited_outgoing(self):

--- a/Misc/NEWS.d/next/C_API/2024-08-29-15-05-19.gh-issue-123465.eqwNWq.rst
+++ b/Misc/NEWS.d/next/C_API/2024-08-29-15-05-19.gh-issue-123465.eqwNWq.rst
@@ -1,0 +1,4 @@
+:c:macro:`Py_RELATIVE_OFFSET` is now allowed in :c:type:`PyMemberDef` for
+the special offset member ``"__vectorcalloffset__"``, as well as the
+discouraged special offset members ``"__dictoffset__"`` and
+``"__weaklistoffset__"``

--- a/Modules/_testlimitedcapi/clinic/heaptype_relative.c.h
+++ b/Modules/_testlimitedcapi/clinic/heaptype_relative.c.h
@@ -1,0 +1,44 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(make_heaptype_with_member__doc__,
+"make_heaptype_with_member($module, /, extra_base_size=0, basicsize=0,\n"
+"                          member_offset=0, add_relative_flag=False, *,\n"
+"                          member_name=\'memb\', member_flags=0,\n"
+"                          member_type=-1)\n"
+"--\n"
+"\n");
+
+#define MAKE_HEAPTYPE_WITH_MEMBER_METHODDEF    \
+    {"make_heaptype_with_member", (PyCFunction)(void(*)(void))make_heaptype_with_member, METH_VARARGS|METH_KEYWORDS, make_heaptype_with_member__doc__},
+
+static PyObject *
+make_heaptype_with_member_impl(PyObject *module, int extra_base_size,
+                               int basicsize, int member_offset,
+                               int add_relative_flag,
+                               const char *member_name, int member_flags,
+                               int member_type);
+
+static PyObject *
+make_heaptype_with_member(PyObject *module, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static char *_keywords[] = {"extra_base_size", "basicsize", "member_offset", "add_relative_flag", "member_name", "member_flags", "member_type", NULL};
+    int extra_base_size = 0;
+    int basicsize = 0;
+    int member_offset = 0;
+    int add_relative_flag = 0;
+    const char *member_name = "memb";
+    int member_flags = 0;
+    int member_type = Py_T_BYTE;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|iiip$sii:make_heaptype_with_member", _keywords,
+        &extra_base_size, &basicsize, &member_offset, &add_relative_flag, &member_name, &member_flags, &member_type))
+        goto exit;
+    return_value = make_heaptype_with_member_impl(module, extra_base_size, basicsize, member_offset, add_relative_flag, member_name, member_flags, member_type);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=01933185947faecc input=a9049054013a1b77]*/

--- a/Modules/_testlimitedcapi/heaptype_relative.c
+++ b/Modules/_testlimitedcapi/heaptype_relative.c
@@ -8,6 +8,8 @@
 #include <stddef.h>               // max_align_t
 #include <string.h>               // memset
 
+#include "clinic/heaptype_relative.c.h"
+
 static PyType_Slot empty_slots[] = {
     {0, NULL},
 };
@@ -247,6 +249,81 @@ heaptype_with_member_set_memb_relative(PyObject *self, PyObject *value)
     Py_RETURN_NONE;
 }
 
+typedef struct {
+    int padding;  // just so the offset isn't 0
+    PyObject *dict;
+} HeapCTypeWithDictStruct;
+
+static void
+heapctypewithrelativedict_dealloc(PyObject* self)
+{
+    PyTypeObject *tp = Py_TYPE(self);
+    HeapCTypeWithDictStruct *data = PyObject_GetTypeData(self, tp);
+    Py_XDECREF(data->dict);
+    PyObject_Free(self);
+    Py_DECREF(tp);
+}
+
+static PyType_Spec HeapCTypeWithRelativeDict_spec = {
+    .name = "_testcapi.HeapCTypeWithRelativeDict",
+    .basicsize = (int) -sizeof(HeapCTypeWithDictStruct),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .slots = (PyType_Slot[]) {
+        {Py_tp_dealloc, heapctypewithrelativedict_dealloc},
+        {Py_tp_getset, (PyGetSetDef[]) {
+            {"__dict__", PyObject_GenericGetDict, PyObject_GenericSetDict},
+            {NULL} /* Sentinel */
+        }},
+        {Py_tp_members, (PyMemberDef[]) {
+            {"dictobj", _Py_T_OBJECT,
+             offsetof(HeapCTypeWithDictStruct, dict),
+             Py_RELATIVE_OFFSET},
+            {"__dictoffset__", Py_T_PYSSIZET,
+             offsetof(HeapCTypeWithDictStruct, dict),
+             Py_READONLY | Py_RELATIVE_OFFSET},
+            {NULL} /* Sentinel */
+        }},
+        {0, 0},
+    }
+};
+
+typedef struct {
+    char padding;  // just so the offset isn't 0
+    PyObject *weakreflist;
+} HeapCTypeWithWeakrefStruct;
+
+static void
+heapctypewithrelativeweakref_dealloc(PyObject* self)
+{
+    PyTypeObject *tp = Py_TYPE(self);
+    HeapCTypeWithWeakrefStruct *data = PyObject_GetTypeData(self, tp);
+    if (data->weakreflist != NULL) {
+        PyObject_ClearWeakRefs(self);
+    }
+    Py_XDECREF(data->weakreflist);
+    PyObject_Free(self);
+    Py_DECREF(tp);
+}
+
+static PyType_Spec HeapCTypeWithRelativeWeakref_spec = {
+    .name = "_testcapi.HeapCTypeWithRelativeWeakref",
+    .basicsize = (int) -sizeof(HeapCTypeWithWeakrefStruct),
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .slots = (PyType_Slot[]) {
+        {Py_tp_dealloc, heapctypewithrelativeweakref_dealloc},
+        {Py_tp_members, (PyMemberDef[]) {
+            {"weakreflist", _Py_T_OBJECT,
+             offsetof(HeapCTypeWithWeakrefStruct, weakreflist),
+             Py_RELATIVE_OFFSET},
+            {"__weaklistoffset__", Py_T_PYSSIZET,
+             offsetof(HeapCTypeWithWeakrefStruct, weakreflist),
+             Py_READONLY | Py_RELATIVE_OFFSET},
+            {NULL} /* Sentinel */
+        }},
+        {0, 0},
+    }
+};
+
 static PyMethodDef heaptype_with_member_methods[] = {
     {"get_memb", heaptype_with_member_get_memb, METH_NOARGS},
     {"set_memb", heaptype_with_member_set_memb, METH_O},
@@ -256,18 +333,30 @@ static PyMethodDef heaptype_with_member_methods[] = {
     {NULL},
 };
 
+/*[clinic input]
+make_heaptype_with_member
+
+    extra_base_size: int = 0
+    basicsize: int = 0
+    member_offset: int = 0
+    add_relative_flag: bool = False
+    *
+    member_name: str = "memb"
+    member_flags: int = 0
+    member_type: int(c_default="Py_T_BYTE") = -1
+
+[clinic start generated code]*/
+
 static PyObject *
-make_heaptype_with_member(PyObject *module, PyObject *args)
+make_heaptype_with_member_impl(PyObject *module, int extra_base_size,
+                               int basicsize, int member_offset,
+                               int add_relative_flag,
+                               const char *member_name, int member_flags,
+                               int member_type)
+/*[clinic end generated code: output=7005db9a07396997 input=007e29cdbe1d3390]*/
 {
     PyObject *base = NULL;
     PyObject *result = NULL;
-
-    int extra_base_size, basicsize, offset, add_flag;
-
-    int r = PyArg_ParseTuple(args, "iiip", &extra_base_size, &basicsize, &offset, &add_flag);
-    if (!r) {
-        goto finally;
-    }
 
     PyType_Spec base_spec = {
         .name = "_testcapi.Base",
@@ -281,7 +370,8 @@ make_heaptype_with_member(PyObject *module, PyObject *args)
     }
 
     PyMemberDef members[] = {
-        {"memb", Py_T_BYTE, offset, add_flag ? Py_RELATIVE_OFFSET : 0},
+        {member_name, member_type, member_offset,
+            member_flags | (add_relative_flag ? Py_RELATIVE_OFFSET : 0)},
         {0},
     };
     PyType_Slot slots[] = {
@@ -325,7 +415,7 @@ static PyMethodDef TestMethods[] = {
     {"make_sized_heaptypes", make_sized_heaptypes, METH_VARARGS},
     {"subclass_var_heaptype", subclass_var_heaptype, METH_VARARGS},
     {"subclass_heaptype", subclass_heaptype, METH_VARARGS},
-    {"make_heaptype_with_member", make_heaptype_with_member, METH_VARARGS},
+    MAKE_HEAPTYPE_WITH_MEMBER_METHODDEF
     {"test_alignof_max_align_t", test_alignof_max_align_t, METH_NOARGS},
     {NULL},
 };
@@ -338,6 +428,43 @@ _PyTestLimitedCAPI_Init_HeaptypeRelative(PyObject *m)
     }
 
     if (PyModule_AddIntMacro(m, ALIGNOF_MAX_ALIGN_T) < 0) {
+        return -1;
+    }
+
+#define ADD_FROM_SPEC(SPEC) do {                                \
+        PyObject *tp = PyType_FromSpec(SPEC);                   \
+        if (!tp) {                                              \
+            return -1;                                          \
+        }                                                       \
+        if (PyModule_AddType(m, (PyTypeObject *)tp) < 0) {      \
+            return -1;                                          \
+        }                                                       \
+    } while (0)
+
+    PyObject *tp;
+
+    tp = PyType_FromSpec(&HeapCTypeWithRelativeDict_spec);
+    if (!tp) {
+        return -1;
+    }
+    if (PyModule_AddType(m, (PyTypeObject *)tp) < 0) {
+        return -1;
+    }
+    Py_DECREF(tp);
+
+    tp = PyType_FromSpec(&HeapCTypeWithRelativeWeakref_spec);
+    if (!tp) {
+        return -1;
+    }
+    if (PyModule_AddType(m, (PyTypeObject *)tp) < 0) {
+        return -1;
+    }
+    Py_DECREF(tp);
+
+    if (PyModule_AddIntMacro(m, Py_T_PYSSIZET) < 0) {
+        return -1;
+    }
+    if (PyModule_AddIntMacro(m, Py_READONLY) < 0) {
         return -1;
     }
 

--- a/Modules/_testlimitedcapi/heaptype_relative.c
+++ b/Modules/_testlimitedcapi/heaptype_relative.c
@@ -266,7 +266,7 @@ heapctypewithrelativedict_dealloc(PyObject* self)
 
 static PyType_Spec HeapCTypeWithRelativeDict_spec = {
     .name = "_testcapi.HeapCTypeWithRelativeDict",
-    .basicsize = (int) -sizeof(HeapCTypeWithDictStruct),
+    .basicsize = -(int)sizeof(HeapCTypeWithDictStruct),
     .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     .slots = (PyType_Slot[]) {
         {Py_tp_dealloc, heapctypewithrelativedict_dealloc},
@@ -307,7 +307,7 @@ heapctypewithrelativeweakref_dealloc(PyObject* self)
 
 static PyType_Spec HeapCTypeWithRelativeWeakref_spec = {
     .name = "_testcapi.HeapCTypeWithRelativeWeakref",
-    .basicsize = (int) -sizeof(HeapCTypeWithWeakrefStruct),
+    .basicsize = -(int)sizeof(HeapCTypeWithWeakrefStruct),
     .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     .slots = (PyType_Slot[]) {
         {Py_tp_dealloc, heapctypewithrelativeweakref_dealloc},

--- a/Modules/_testlimitedcapi/vectorcall_limited.c
+++ b/Modules/_testlimitedcapi/vectorcall_limited.c
@@ -175,6 +175,25 @@ static PyType_Spec LimitedVectorCallClass_spec = {
     .slots = LimitedVectorallClass_slots,
 };
 
+static PyType_Spec LimitedRelativeVectorCallClass_spec = {
+    .name = "_testlimitedcapi.LimitedRelativeVectorCallClass",
+    .basicsize = (int) -sizeof(vectorcallfunc),
+    .flags = Py_TPFLAGS_DEFAULT
+        | Py_TPFLAGS_HAVE_VECTORCALL
+        | Py_TPFLAGS_BASETYPE,
+    .slots = (PyType_Slot[]) {
+        {Py_tp_new, LimitedVectorCallClass_new},
+        {Py_tp_call, LimitedVectorCallClass_tpcall},
+        {Py_tp_members, (PyMemberDef[]){
+            {"__vectorcalloffset__", Py_T_PYSSIZET,
+             0,
+             Py_READONLY | Py_RELATIVE_OFFSET},
+            {NULL}
+        }},
+        {0}
+    },
+};
+
 static PyMethodDef TestMethods[] = {
     _TESTLIMITEDCAPI_CALL_VECTORCALL_METHODDEF
     _TESTLIMITEDCAPI_CALL_VECTORCALL_METHOD_METHODDEF
@@ -197,5 +216,16 @@ _PyTestLimitedCAPI_Init_VectorcallLimited(PyObject *m)
         return -1;
     }
     Py_DECREF(LimitedVectorCallClass);
+
+    PyObject *LimitedRelativeVectorCallClass = PyType_FromModuleAndSpec(
+        m, &LimitedRelativeVectorCallClass_spec, NULL);
+    if (!LimitedRelativeVectorCallClass) {
+        return -1;
+    }
+    if (PyModule_AddType(m, (PyTypeObject *)LimitedRelativeVectorCallClass) < 0) {
+        return -1;
+    }
+    Py_DECREF(LimitedRelativeVectorCallClass);
+
     return 0;
 }

--- a/Modules/_testlimitedcapi/vectorcall_limited.c
+++ b/Modules/_testlimitedcapi/vectorcall_limited.c
@@ -196,7 +196,7 @@ LimitedRelativeVectorCallClass_new(PyTypeObject *tp, PyTypeObject *a, PyTypeObje
 
 static PyType_Spec LimitedRelativeVectorCallClass_spec = {
     .name = "_testlimitedcapi.LimitedRelativeVectorCallClass",
-    .basicsize = (int) -sizeof(LimitedRelativeVectorCallStruct),
+    .basicsize = -(int)sizeof(LimitedRelativeVectorCallStruct),
     .flags = Py_TPFLAGS_DEFAULT
         | Py_TPFLAGS_HAVE_VECTORCALL,
     .slots = (PyType_Slot[]) {


### PR DESCRIPTION
Allow `flags = Py_READONLY | Py_RELATIVE_OFFSET` for the special offset members,
which previously required `Py_READONLY`.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123465 -->
* Issue: gh-123465
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123474.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->