### PR TITLE
gh-123484: Fix the debug offsets for PyLongObject

### DIFF
--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -117,8 +117,8 @@ extern PyTypeObject _PyExc_MemoryError;
             }, \
             .long_object = { \
                 .size = sizeof(PyLongObject), \
-                .lv_tag = offsetof(_PyLongValue, lv_tag), \
-                .ob_digit = offsetof(_PyLongValue, ob_digit), \
+                .lv_tag = offsetof(PyLongObject, long_value.lv_tag), \
+                .ob_digit = offsetof(PyLongObject, long_value.ob_digit), \
             }, \
             .bytes_object = { \
                 .size = sizeof(PyBytesObject), \

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-29-19-46-07.gh-issue-123484.rjUn_F.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-29-19-46-07.gh-issue-123484.rjUn_F.rst
@@ -1,0 +1,2 @@
+Fix ``_Py_DebugOffsets`` for long objects to be relative to the start of the
+object rather than the start of a subobject.


### PR DESCRIPTION
All other debug offsets are relative to the start of the object, but the offsets for PyLongObject's fields are relative to the start of an inner object, and so each field's value is too small by `sizeof(PyObject)`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123484 -->
* Issue: gh-123484
<!-- /gh-issue-number -->
