### PR TITLE
gh-123503: Replace deprecated members from ```urllib/request```

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -305,7 +305,6 @@ class MockResponse(io.StringIO):
         io.StringIO.__init__(self, data)
         self.status, self.msg, self.headers, self.url = code, msg, headers, url
 
-
     def info(self):
         return self.headers
 

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -301,9 +301,9 @@ class MockHeaders(dict):
 
 
 class MockResponse(io.StringIO):
-    def __init__(self, status, msg, headers, data, url=None):
+    def __init__(self, code, msg, headers, data, url=None):
         io.StringIO.__init__(self, data)
-        self.status, self.msg, self.headers, self.url = status, msg, headers, url
+        self.status, self.msg, self.headers, self.url = code, msg, headers, url
 
 
     def info(self):

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -301,9 +301,10 @@ class MockHeaders(dict):
 
 
 class MockResponse(io.StringIO):
-    def __init__(self, code, msg, headers, data, url=None):
+    def __init__(self, status, msg, headers, data, url=None):
         io.StringIO.__init__(self, data)
-        self.code, self.msg, self.headers, self.url = code, msg, headers, url
+        self.status, self.msg, self.headers, self.url = status, msg, headers, url
+
 
     def info(self):
         return self.headers

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -596,7 +596,7 @@ class HTTPErrorProcessor(BaseHandler):
     handler_order = 1000  # after all other processing
 
     def http_response(self, request, response):
-        code, msg, hdrs = response.code, response.msg, response.info()
+        code, msg, hdrs = response.status, response.msg, response.headers
 
         # According to RFC 2616, "2xx" code indicates that the client's
         # request was successfully received, understood, and accepted.
@@ -1336,8 +1336,7 @@ class AbstractHTTPHandler(BaseHandler):
         # This line replaces the .msg attribute of the HTTPResponse
         # with .headers, because urllib clients expect the response to
         # have the reason in .msg.  It would be good to mark this
-        # attribute is deprecated and get then to use info() or
-        # .headers.
+        # attribute is deprecated and get then to use .headers.
         r.msg = r.reason
         return r
 

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1788,14 +1788,14 @@ class URLopener:
         if filename is None and (not type or type == 'file'):
             try:
                 fp = self.open_local_file(url1)
-                hdrs = fp.status
+                hdrs = fp.headers
                 fp.close()
                 return url2pathname(_splithost(url1)[1]), hdrs
             except OSError:
                 pass
         fp = self.open(url, data)
         try:
-            headers = fp.status
+            headers = fp.headers
             if filename:
                 tfp = open(filename, 'wb')
             else:

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -596,13 +596,13 @@ class HTTPErrorProcessor(BaseHandler):
     handler_order = 1000  # after all other processing
 
     def http_response(self, request, response):
-        code, msg, hdrs = response.status, response.msg, response.headers
+        status, msg, hdrs = response.status, response.msg, response.headers
 
         # According to RFC 2616, "2xx" code indicates that the client's
         # request was successfully received, understood, and accepted.
-        if not (200 <= code < 300):
+        if not (200 <= status < 300):
             response = self.parent.error(
-                'http', request, response, code, msg, hdrs)
+                'http', request, response, status, msg, hdrs)
 
         return response
 
@@ -1007,7 +1007,7 @@ class AbstractBasicAuthHandler:
 
     def http_response(self, req, response):
         if hasattr(self.passwd, 'is_authenticated'):
-            if 200 <= response.code < 300:
+            if 200 <= response.status < 300:
                 self.passwd.update_authenticated(req.full_url, True)
             else:
                 self.passwd.update_authenticated(req.full_url, False)

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -212,7 +212,7 @@ def urlretrieve(url, filename=None, reporthook=None, data=None):
     url_type, path = _splittype(url)
 
     with contextlib.closing(urlopen(url, data)) as fp:
-        headers = fp.info()
+        headers = fp.headers
 
         # Just return the local path and the "headers" for file://
         # URLs. No sense in performing a copy unless requested.
@@ -1788,14 +1788,14 @@ class URLopener:
         if filename is None and (not type or type == 'file'):
             try:
                 fp = self.open_local_file(url1)
-                hdrs = fp.info()
+                hdrs = fp.status
                 fp.close()
                 return url2pathname(_splithost(url1)[1]), hdrs
             except OSError:
                 pass
         fp = self.open(url, data)
         try:
-            headers = fp.info()
+            headers = fp.status
             if filename:
                 tfp = open(filename, 'wb')
             else:

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -596,13 +596,13 @@ class HTTPErrorProcessor(BaseHandler):
     handler_order = 1000  # after all other processing
 
     def http_response(self, request, response):
-        status, msg, hdrs = response.status, response.msg, response.headers
+        code, msg, hdrs = response.status, response.msg, response.headers
 
         # According to RFC 2616, "2xx" code indicates that the client's
         # request was successfully received, understood, and accepted.
-        if not (200 <= status < 300):
+        if not (200 <= code < 300):
             response = self.parent.error(
-                'http', request, response, status, msg, hdrs)
+                'http', request, response, code, msg, hdrs)
 
         return response
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1252,6 +1252,7 @@ Dustin J. Mitchell
 Gideon Mitchell
 Tim Mitchell
 Zubin Mithra
+Alexandr Mitin
 Florian Mladitsch
 Kevin Modzelewski
 Doug Moen


### PR DESCRIPTION
I replaced deprecated features with the recommended current features

Result:

```
code, msg, hdrs = response.status, response.msg, response.headers
```

<!-- gh-issue-number: gh-123503 -->
* Issue: gh-123503
<!-- /gh-issue-number -->
