### PR TITLE
GH-123514: Add `goto found_unused_or_dummy` in the set_add_entry function

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-08-30-16-36-16.gh-issue-123514.nmfNjt.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-08-30-16-36-16.gh-issue-123514.nmfNjt.rst
@@ -1,0 +1,1 @@
+Add a 'goto found_unused_or_dummy' in the set_add_entry function.

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -174,6 +174,7 @@ set_add_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
             else if (entry->hash == -1) {
                 assert (entry->key == dummy);
                 freeslot = entry;
+                goto found_unused_or_dummy;
             }
             entry++;
         } while (probes--);


### PR DESCRIPTION
There's a missing line of code inside the set_add_entry function in the Objects/setobject.c file

![image](https://github.com/user-attachments/assets/bf25ba45-00ab-49a3-8092-3bfb99938f85)

When a dummy entry is found, it should jump directly to the found_unused_or_dummy label.

<!-- gh-issue-number: gh-123514 -->
* Issue: gh-123514
<!-- /gh-issue-number -->
