### PR TITLE
Fix override value in os.rst

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -6015,7 +6015,7 @@ Miscellaneous System Information
    in the **system**.
 
    If :option:`-X cpu_count <-X>` is given or :envvar:`PYTHON_CPU_COUNT` is set,
-   :func:`process_cpu_count` returns the overridden value *n*.
+   :func:`process_cpu_count` returns the override value *n*.
 
    See also the :func:`sched_getaffinity` function.
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -5993,7 +5993,7 @@ Miscellaneous System Information
 
    .. versionchanged:: 3.13
       If :option:`-X cpu_count <-X>` is given or :envvar:`PYTHON_CPU_COUNT` is set,
-      :func:`cpu_count` returns the overridden value *n*.
+      :func:`cpu_count` returns the override value *n*.
 
 
 .. function:: getloadavg()


### PR DESCRIPTION
In the `python -X cpu_count=n` command line, *n* value is not overridden by anything. It actually overrides the default `os.cpu_count()`'s return value. So the text should say "override value" instead of "overridden value".

Please backport to 3.13

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123522.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->