### PR TITLE
gh-123369: IDLE now support for REPL-specific commands, like help exit license and quit without the need to call them as functions

### DIFF
--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -102,8 +102,12 @@ Print Window
 
 Close Window
    Close the current window (if an unsaved editor, ask to save; if an unsaved
-   Shell, ask to quit execution).  Calling ``exit()`` or ``close()`` in the Shell
-   window also closes Shell.  If this is the only window, also exit IDLE.
+   Shell, ask to quit execution).
+
+   You can call ``exit()`` or ``quit()`` to close the Shell.
+   If the :ref:`new interactive interpreter <tut-interac>` is enabled,
+   IDLE also supports using ``exit`` or ``quit`` without the need to call them
+   as functions. If this is the only window, closing it will also exit IDLE.
 
 Exit IDLE
    Close all windows and quit IDLE (ask to save unsaved edit windows).

--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -3,6 +3,8 @@ What's New in IDLE 3.14.0
 Released on 2025-10-07
 =========================
 
+gh-123369: IDLE now support for REPL-specific commands, like help, exit,
+license and quit, without the need to call them as functions.
 
 gh-112936: IDLE - Include Shell menu in single-process mode,
 though with Restart Shell and View Last Restart disabled.

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -682,6 +682,19 @@ class ModifiedInterpreter(InteractiveInterpreter):
     def runsource(self, source):
         "Extend base class method: Stuff the source in the line cache first"
         filename = self.stuffsource(source)
+
+        # Synchronize the new interactive shell in Python 3.13
+        # help, exit, license and quit without the need to call them as functions
+        # To disable, set the PYTHON_BASIC_REPL environment variable
+        if not os.getenv('PYTHON_BASIC_REPL'):
+            REPL_COMMANDS = {
+                "quit": "quit()",
+                "exit": "exit()",
+                "help": "help()",
+                "license": "license()"
+            }
+            source = REPL_COMMANDS.get(source, source)
+
         # at the moment, InteractiveInterpreter expects str
         assert isinstance(source, str)
         # InteractiveInterpreter.runsource() calls its runcode() method,

--- a/Misc/NEWS.d/next/IDLE/2024-08-30-19-27-28.gh-issue-123369.zPMFHo.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-08-30-19-27-28.gh-issue-123369.zPMFHo.rst
@@ -1,0 +1,2 @@
+IDLE now support for REPL-specific commands, like :kbd:`help`, :kbd:`exit`,
+:kbd:`license` and :kbd:`quit`, without the need to call them as functions.


### PR DESCRIPTION
In the Shell, you can call `exit()` and `quit()` to close the Shell.
   If the `new interactive interpreter` is enabled,
   IDLE also supports using `exit` and `quit` without the need to call them
   as functions. If this is the only window, closing it will also exit IDLE.

<img width="560" alt="2024-08-31 104854" src="https://github.com/user-attachments/assets/40b21187-df0a-4476-baee-5c351acdb141">

This solution is simple, just replaces what was entered

Not change help.html

<!-- gh-issue-number: gh-123369 -->
* Issue: gh-123369
<!-- /gh-issue-number -->



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123525.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->