### PR TITLE
GH-109975: Copyedit 3.13 What's New: Removals

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1651,7 +1651,7 @@ importlib.metadata
 ------------------
 
 * Remove deprecated subscript (:meth:`~object.__getitem__`) access for
-  :class:`~importlib.metadata.EntryPoint` objects.
+  :ref:`EntryPoint <entry-points>` objects.
   (Contributed by Jason R. Coombs in :gh:`113175`.)
 
 
@@ -1690,7 +1690,7 @@ re
 --
 
 * Remove the undocumented, deprecated, and broken
-  :func:`!re.template` function and :attr:`!re.TEMPLATE` / :attr:`re.T` flag.
+  :func:`!re.template` function and :attr:`!re.TEMPLATE` / :attr:`!re.T` flag.
   (Contributed by Serhiy Storchaka and Nikita Sobolev in :gh:`105687`.)
 
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -772,6 +772,14 @@ compileall
   (Contributed by Victor Stinner in :gh:`109649`.)
 
 
+configparser
+------------
+
+* The :class:`configparser.ConfigParser` now accepts unnamed sections
+  before named ones if configured to do so.
+  (Contributed by Pedro Sousa Lacerda in :gh:`66449`.)
+
+
 concurrent.futures
 ------------------
 
@@ -1514,146 +1522,146 @@ Optimizations
 Removed Modules And APIs
 ========================
 
+
 .. _whatsnew313-pep594:
 
-PEP 594: dead batteries (and other module removals)
----------------------------------------------------
+PEP 594: Remove "dead batteries" from the standard library
+----------------------------------------------------------
 
-* :pep:`594` removed 19 modules from the standard library,
-  deprecated in Python 3.11:
+:pep:`594` proposed removing 19 modules from the standard library,
+colloquially referred to as 'dead batteries' due to their
+historic, obsolete, or insecure status.
+All of the following modules were deprecated in Python 3.11,
+and are now removed:
 
-  * :mod:`!aifc`.
-    (Contributed by Victor Stinner in :gh:`104773`.)
+* :mod:`!aifc`.
+* :mod:`!audioop`.
+* :mod:`!chunk`.
+* :mod:`!cgi` and :mod:`!cgitb`.
 
-  * :mod:`!audioop`.
-    (Contributed by Victor Stinner in :gh:`104773`.)
+  * :class:`!cgi.FieldStorage` can typically be replaced with
+    :func:`urllib.parse.parse_qsl` for ``GET`` and ``HEAD`` requests,
+    and the :mod:`email.message` module or the :pypi:`multipart` library
+    for ``POST`` and ``PUT`` requests.
 
-  * :mod:`!chunk`.
-    (Contributed by Victor Stinner in :gh:`104773`.)
+  * :func:`!cgi.parse` can be replaced by calling
+    :func:`urllib.parse.parse_qs` directly on the desired query string,
+    unless the input is ``multipart/form-data``,
+    which should be replaced as described below for :func:`!cgi.parse_multipart`.
 
-  * :mod:`!cgi` and :mod:`!cgitb`.
+  * :func:`!cgi.parse_header` can be replaced with the functionality
+    in the :mod:`email` package, which implements the same MIME RFCs.
+    For example, with :class:`email.message.EmailMessage`:
 
-    * ``cgi.FieldStorage`` can typically be replaced with
-      :func:`urllib.parse.parse_qsl` for ``GET`` and ``HEAD`` requests,
-      and the :mod:`email.message` module or :pypi:`multipart`
-      PyPI project for ``POST`` and ``PUT``.
+    .. code-block:: python
 
-    * ``cgi.parse()`` can be replaced by calling :func:`urllib.parse.parse_qs`
-      directly on the desired query string, except for ``multipart/form-data``
-      input, which can be handled as described for ``cgi.parse_multipart()``.
+       from email.message import EmailMessage
 
-    * ``cgi.parse_header()`` can be replaced with the functionality in the
-      :mod:`email` package, which implements the same MIME RFCs. For example,
-      with :class:`email.message.EmailMessage`::
+       msg = EmailMessage()
+       msg['content-type'] = 'application/json; charset="utf8"'
+       main, params = msg.get_content_type(), msg['content-type'].params
 
-          from email.message import EmailMessage
-          msg = EmailMessage()
-          msg['content-type'] = 'application/json; charset="utf8"'
-          main, params = msg.get_content_type(), msg['content-type'].params
+  * :func:`!cgi.parse_multipart` can be replaced with the functionality
+    in the :mod:`email` package, which implements the same MIME RFCs,
+    or with the :pypi:`multipart` library.
+    For example, the :class:`email.message.EmailMessage`
+    and :class:`email.message.Message` classes.
 
-    * ``cgi.parse_multipart()`` can be replaced with the functionality in the
-      :mod:`email` package (e.g. :class:`email.message.EmailMessage` and
-      :class:`email.message.Message`) which implements the same MIME RFCs, or
-      with the :pypi:`multipart` PyPI project.
+* :mod:`!crypt` and the private :mod:`!_crypt` extension.
+  The :mod:`hashlib` module may be an appropriate replacement
+  when simply hashing a value is required.
+  Otherwise, various third-party libraries on PyPI are available:
 
-    (Contributed by Victor Stinner in :gh:`104773`.)
+  * :pypi:`bcrypt`:
+    Modern password hashing for your software and your servers.
+  * :pypi:`passlib`:
+    Comprehensive password hashing framework supporting over 30 schemes.
+  * :pypi:`argon2-cffi`:
+    The secure Argon2 password hashing algorithm.
+  * :pypi:`legacycrypt`:
+    :mod:`ctypes` wrapper to the POSIX crypt library call
+    and associated functionality.
+  * :pypi:`crypt_r`:
+    Fork of the :mod:`!crypt` module,
+    wrapper to the :manpage:`crypt_r(3)` library call
+    and associated functionality.
 
-  * :mod:`!crypt` module and its private :mod:`!_crypt` extension.
-    The :mod:`hashlib` module is a potential replacement for certain use cases.
-    Otherwise, the following PyPI projects can be used:
+* :mod:`!imghdr`:
+  The :pypi:`filetype`, :pypi:`puremagic`, or :pypi:`python-magic` libraries
+  should be used as replacements.
+  For example, the :func:`!puremagic.what` function can be used
+  to replace the :func:`!imghdr.what` function for all file formats
+  that were supported by :mod:`!imghdr`.
+* :mod:`!mailcap`.
+  Use the :mod:`mimetypes` module instead.
+* :mod:`!msilib`.
+* :mod:`!nis`.
+* :mod:`!nntplib`:
+  Use the :pypi:`nntplib` library from PyPI instead.
+* :mod:`!ossaudiodev`:
+  For audio playback, use the :pypi:`pygame` library from PyPI instead.
+* :mod:`!pipes`:
+  Use the :mod:`subprocess` module instead.
+* :mod:`!sndhdr`:
+  The :pypi:`filetype`, :pypi:`puremagic`, or :pypi:`python-magic` libraries
+  should be used as replacements.
+* :mod:`!spwd`:
+  Use the :pypi:`python-pam` library from PyPI instead.
+* :mod:`!sunau`.
+* :mod:`!telnetlib`,
+  Use the :pypi:`telnetlib3` or :pypi:`Exscript` libraries from PyPI instead.
+* :mod:`!uu`:
+  Use the :mod:`base64` module instead, as a modern alternative.
+* :mod:`!xdrlib`.
 
-    * :pypi:`bcrypt`:
-      Modern password hashing for your software and your servers.
-    * :pypi:`passlib`:
-      Comprehensive password hashing framework supporting over 30 schemes.
-    * :pypi:`argon2-cffi`:
-      The secure Argon2 password hashing algorithm.
-    * :pypi:`legacycrypt`:
-      :mod:`ctypes` wrapper to the POSIX crypt library call and associated functionality.
-    * :pypi:`crypt_r`:
-      Fork of the :mod:`!crypt` module, wrapper to the :manpage:`crypt_r(3)` library
-      call and associated functionality.
+(Contributed by Victor Stinner and Zachary Ware in :gh:`104773` and :gh:`104780`.)
 
-    (Contributed by Victor Stinner in :gh:`104773`.)
 
-  * :mod:`!imghdr`: use the projects :pypi:`filetype`,
-    :pypi:`puremagic`, or :pypi:`python-magic` instead.
-    The ``puremagic.what()`` function can be used to replace
-    the ``imghdr.what()`` function for all file formats that
-    were supported by ``imghdr``.
-    (Contributed by Victor Stinner in :gh:`104773`.)
+2to3
+----
 
-  * :mod:`!mailcap`.
-    The :mod:`mimetypes` module provides an alternative.
-    (Contributed by Victor Stinner in :gh:`104773`.)
+Remove the :program:`2to3` program and the :mod:`!lib2to3` module,
+previously deprecated in Python 3.11.
+(Contributed by Victor Stinner in :gh:`104780`.)
 
-  * :mod:`!msilib`.
-    (Contributed by Zachary Ware in :gh:`104773`.)
 
-  * :mod:`!nis`.
-    (Contributed by Victor Stinner in :gh:`104773`.)
+builtins
+--------
 
-  * :mod:`!nntplib`:
-    the :pypi:`nntplib` PyPI project can be used instead.
-    (Contributed by Victor Stinner in :gh:`104773`.)
+* Remove support for chained :class:`classmethod` descriptors
+  (introduced in :gh:`63272`).
+  These can no longer be used to wrap other descriptors,
+  such as :class:`property`.
+  The core design of this feature was flawed and led to several problems.
+  To "pass-through" a :class:`classmethod`, consider using
+  the :attr:`!__wrapped__` attribute that was added in Python 3.10.
+  (Contributed by Raymond Hettinger in :gh:`89519`.)
 
-  * :mod:`!ossaudiodev`: use the
-    `pygame project <https://www.pygame.org/>`_ for audio playback.
-    (Contributed by Victor Stinner in :gh:`104780`.)
-
-  * :mod:`!pipes`: use the :mod:`subprocess` module instead.
-    (Contributed by Victor Stinner in :gh:`104773`.)
-
-  * :mod:`!sndhdr`: use the projects :pypi:`filetype`,
-    :pypi:`puremagic`, or :pypi:`python-magic` instead.
-    (Contributed by Victor Stinner in :gh:`104773`.)
-
-  * :mod:`!spwd`:
-    the :pypi:`python-pam` project can be used instead.
-    (Contributed by Victor Stinner in :gh:`104773`.)
-
-  * :mod:`!sunau`.
-    (Contributed by Victor Stinner in :gh:`104773`.)
-
-  * :mod:`!telnetlib`, use the projects :pypi:`telnetlib3` or
-    :pypi:`Exscript` instead.
-    (Contributed by Victor Stinner in :gh:`104773`.)
-
-  * :mod:`!uu`: the :mod:`base64` module is a modern alternative.
-    (Contributed by Victor Stinner in :gh:`104773`.)
-
-  * :mod:`!xdrlib`.
-    (Contributed by Victor Stinner in :gh:`104773`.)
-
-* Remove the ``2to3`` program and the :mod:`!lib2to3` module,
-  deprecated in Python 3.11.
-  (Contributed by Victor Stinner in :gh:`104780`.)
-
-* Remove the :mod:`!tkinter.tix` module, deprecated in Python 3.6.  The
-  third-party Tix library which the module wrapped is unmaintained.
-  (Contributed by Zachary Ware in :gh:`75552`.)
 
 configparser
 ------------
 
-* Remove the undocumented :class:`!configparser.LegacyInterpolation` class,
+* Remove the undocumented :class:`!LegacyInterpolation` class,
   deprecated in the docstring since Python 3.2,
-  and with a deprecation warning since Python 3.11.
+  and at runtime since Python 3.11.
   (Contributed by Hugo van Kemenade in :gh:`104886`.)
 
-importlib
----------
 
-* Remove deprecated :meth:`~object.__getitem__` access for
-  :class:`!importlib.metadata.EntryPoint` objects.
+importlib.metadata
+------------------
+
+* Remove deprecated subscript (:meth:`~object.__getitem__`) access for
+  :class:`~importlib.metadata.EntryPoint` objects.
   (Contributed by Jason R. Coombs in :gh:`113175`.)
+
 
 locale
 ------
 
-* Remove ``locale.resetlocale()`` function deprecated in Python 3.11:
-  use ``locale.setlocale(locale.LC_ALL, "")`` instead.
+* Remove the :func:`!locale.resetlocale` function, deprecated in Python 3.11.
+  Use ``locale.setlocale(locale.LC_ALL, "")`` instead.
   (Contributed by Victor Stinner in :gh:`104783`.)
+
 
 opcode
 ------
@@ -1663,43 +1671,59 @@ opcode
   and is not intended for external use.
   (Contributed by Irit Katriel in :gh:`105481`.)
 
-* Removed :func:`!opcode.is_pseudo`, :attr:`!opcode.MIN_PSEUDO_OPCODE`,
-  and :attr:`!opcode.MAX_PSEUDO_OPCODE`, which were added in 3.12,
-  but were neither documented nor exposed through ``dis``,
+* Remove :func:`!opcode.is_pseudo`, :attr:`!opcode.MIN_PSEUDO_OPCODE`,
+  and :attr:`!opcode.MAX_PSEUDO_OPCODE`, which were added in Python 3.12,
+  but were neither documented nor exposed through :mod:`dis`,
   and were not intended to be used externally.
+  (Contributed by Irit Katriel in :gh:`105481`.)
+
 
 pathlib
 -------
 
-* Remove support for using :class:`pathlib.Path` objects as context managers.
-  This functionality was deprecated and made a no-op in Python 3.9.
+* Remove the ability to use :class:`~pathlib.Path` objects as context managers.
+  This functionality was deprecated and has had no effect since Python 3.9.
+  (Contributed by Barney Gale in :gh:`83863`.)
+
 
 re
 --
 
-* Remove undocumented, never working, and deprecated ``re.template`` function
-  and ``re.TEMPLATE`` flag (and ``re.T`` alias).
+* Remove the undocumented, deprecated, and broken
+  :func:`!re.template` function and :attr:`!re.TEMPLATE` / :attr:`re.T` flag.
   (Contributed by Serhiy Storchaka and Nikita Sobolev in :gh:`105687`.)
+
+
+tkinter.tix
+-----------
+
+* Remove the :mod:`!tkinter.tix` module, deprecated in Python 3.6.
+  The third-party Tix library which the module wrapped is unmaintained.
+  (Contributed by Zachary Ware in :gh:`75552`.)
 
 
 turtle
 ------
 
-* Remove the :meth:`!turtle.RawTurtle.settiltangle` method,
-  deprecated in docs since Python 3.1
-  and with a deprecation warning since Python 3.11.
+* Remove the :meth:`!RawTurtle.settiltangle` method,
+  deprecated in the documentation since Python 3.1
+  and at runtime since Python 3.11.
   (Contributed by Hugo van Kemenade in :gh:`104876`.)
+
 
 typing
 ------
 
-* Namespaces ``typing.io`` and ``typing.re``, deprecated in Python 3.8,
-  are now removed. The items in those namespaces can be imported directly
-  from :mod:`typing`. (Contributed by Sebastian Rittau in :gh:`92871`.)
+* Remove the :mod:`!typing.io` and :mod:`!typing.re` namespaces,
+  deprecated since Python 3.8.
+  The items in those namespaces can be imported directly
+  from the :mod:`typing` module.
+  (Contributed by Sebastian Rittau in :gh:`92871`.)
 
-* Remove support for the keyword-argument method of creating
-  :class:`typing.TypedDict` types, deprecated in Python 3.11.
+* Remove the keyword-argument method of creating
+  :class:`~typing.TypedDict` types, deprecated in Python 3.11.
   (Contributed by Tomas Roun in :gh:`104786`.)
+
 
 unittest
 --------
@@ -1712,50 +1736,46 @@ unittest
 
   Use :class:`~unittest.TestLoader` methods instead:
 
-  * :meth:`unittest.TestLoader.loadTestsFromModule`
-  * :meth:`unittest.TestLoader.loadTestsFromTestCase`
-  * :meth:`unittest.TestLoader.getTestCaseNames`
+  * :meth:`~unittest.TestLoader.loadTestsFromModule`
+  * :meth:`~unittest.TestLoader.loadTestsFromTestCase`
+  * :meth:`~unittest.TestLoader.getTestCaseNames`
 
   (Contributed by Hugo van Kemenade in :gh:`104835`.)
 
-* Remove the untested and undocumented :meth:`!unittest.TestProgram.usageExit`
+* Remove the untested and undocumented :meth:`!TestProgram.usageExit`
   method, deprecated in Python 3.11.
   (Contributed by Hugo van Kemenade in :gh:`104992`.)
+
 
 urllib
 ------
 
-* Remove *cafile*, *capath* and *cadefault* parameters of the
-  :func:`urllib.request.urlopen` function, deprecated in Python 3.6: pass
-  the *context* parameter instead. Use
-  :meth:`ssl.SSLContext.load_cert_chain` to load specific certificates, or
-  let :func:`ssl.create_default_context` select the system's trusted CA
-  certificates for you.
+* Remove the *cafile*, *capath*, and *cadefault* parameters of the
+  :func:`urllib.request.urlopen` function, deprecated in Python 3.6.
+  Use the *context* parameter instead with an :class:`~ssl.SSLContext` instance.
+  The :meth:`ssl.SSLContext.load_cert_chain` function
+  can be used to load specific certificates,
+  or let :func:`ssl.create_default_context` select
+  the operating system's trusted certificate authority (CA) certificates.
   (Contributed by Victor Stinner in :gh:`105382`.)
+
 
 webbrowser
 ----------
 
-* Remove the untested and undocumented :mod:`webbrowser` :class:`!MacOSX` class,
+* Remove the untested and undocumented :class:`!MacOSX` class,
   deprecated in Python 3.11.
   Use the :class:`!MacOSXOSAScript` class (introduced in Python 3.2) instead.
   (Contributed by Hugo van Kemenade in :gh:`104804`.)
 
-* Remove deprecated ``webbrowser.MacOSXOSAScript._name`` attribute.
-  Use :attr:`webbrowser.MacOSXOSAScript.name <webbrowser.controller.name>`
+* Remove the deprecated :attr:`!MacOSXOSAScript._name` attribute.
+  Use the :attr:`MacOSXOSAScript.name <webbrowser.controller.name>`
   attribute instead.
   (Contributed by Nikita Sobolev in :gh:`105546`.)
 
+
 New Deprecations
 ================
-
-* Removed chained :class:`classmethod` descriptors (introduced in
-  :gh:`63272`).  This can no longer be used to wrap other descriptors
-  such as :class:`property`.  The core design of this feature was flawed
-  and caused a number of downstream problems.  To "pass-through" a
-  :class:`classmethod`, consider using the :attr:`!__wrapped__`
-  attribute that was added in Python 3.10.  (Contributed by Raymond
-  Hettinger in :gh:`89519`.)
 
 * :mod:`array`: :mod:`array`'s ``'u'`` format code, deprecated in docs since Python 3.3,
   emits :exc:`DeprecationWarning` since 3.13

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1534,10 +1534,10 @@ historic, obsolete, or insecure status.
 All of the following modules were deprecated in Python 3.11,
 and are now removed:
 
-* :mod:`!aifc`.
-* :mod:`!audioop`.
-* :mod:`!chunk`.
-* :mod:`!cgi` and :mod:`!cgitb`.
+* :mod:`!aifc`
+* :mod:`!audioop`
+* :mod:`!chunk`
+* :mod:`!cgi` and :mod:`!cgitb`
 
   * :class:`!cgi.FieldStorage` can typically be replaced with
     :func:`urllib.parse.parse_qsl` for ``GET`` and ``HEAD`` requests,
@@ -1592,10 +1592,10 @@ and are now removed:
   For example, the :func:`!puremagic.what` function can be used
   to replace the :func:`!imghdr.what` function for all file formats
   that were supported by :mod:`!imghdr`.
-* :mod:`!mailcap`.
+* :mod:`!mailcap`:
   Use the :mod:`mimetypes` module instead.
-* :mod:`!msilib`.
-* :mod:`!nis`.
+* :mod:`!msilib`
+* :mod:`!nis`
 * :mod:`!nntplib`:
   Use the :pypi:`nntplib` library from PyPI instead.
 * :mod:`!ossaudiodev`:
@@ -1607,12 +1607,12 @@ and are now removed:
   should be used as replacements.
 * :mod:`!spwd`:
   Use the :pypi:`python-pam` library from PyPI instead.
-* :mod:`!sunau`.
+* :mod:`!sunau`
 * :mod:`!telnetlib`,
   Use the :pypi:`telnetlib3` or :pypi:`Exscript` libraries from PyPI instead.
 * :mod:`!uu`:
   Use the :mod:`base64` module instead, as a modern alternative.
-* :mod:`!xdrlib`.
+* :mod:`!xdrlib`
 
 (Contributed by Victor Stinner and Zachary Ware in :gh:`104773` and :gh:`104780`.)
 
@@ -1620,9 +1620,9 @@ and are now removed:
 2to3
 ----
 
-Remove the :program:`2to3` program and the :mod:`!lib2to3` module,
-previously deprecated in Python 3.11.
-(Contributed by Victor Stinner in :gh:`104780`.)
+* Remove the :program:`2to3` program and the :mod:`!lib2to3` module,
+  previously deprecated in Python 3.11.
+  (Contributed by Victor Stinner in :gh:`104780`.)
 
 
 builtins


### PR DESCRIPTION
A copy-editing pass for _removals_. Next will be _new deprecations_ (hopefully with less travel-induced delay).

A


<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123529.org.readthedocs.build/en/123529/whatsnew/3.13.html

<!-- readthedocs-preview cpython-previews end -->