### PR TITLE
Enable colour for doctest on GitHub Actions

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build_doc:
     name: 'Docs'


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

In https://github.com/python/cpython/issues/117225 for Python 3.13, we added colour to doctest output. Let's take advantage of it and show colour in our docs CI.

For example, here's a run which has a failing doctest:

<img width="991" alt="image" src="https://github.com/user-attachments/assets/a1938560-7f6f-4598-bcf6-ccd614613e08">

https://github.com/hugovk/cpython/actions/runs/10644817841/job/29509999831?pr=67

We also get coloured Sphinx output:

<img width="1055" alt="image" src="https://github.com/user-attachments/assets/c03327a3-b2d9-47c7-b3e9-856b683aa16c">

https://github.com/hugovk/cpython/actions/runs/10644817841/job/29509999681?pr=67
