### PR TITLE
gh-123523: Rework typing documentation for generators and coroutines, and link to it from `collections.abc` docs

### DIFF
--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -197,7 +197,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 ----------------------------------------------------------
 
 
-.. class:: Container[T_co]
+.. class:: Container(Generic[T_co])
 
    ABC for classes that provide the :meth:`~object.__contains__` method.
 
@@ -216,7 +216,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
    See :ref:`annotating-callables` for details on how to use
    :class:`Callable` and :class:`~typing.Callable` in type annotations.
 
-.. class:: Iterable[T_co]
+.. class:: Iterable(Generic[T_co])
 
    ABC for classes that provide the :meth:`~container.__iter__` method.
 
@@ -227,26 +227,26 @@ Collections Abstract Base Classes -- Detailed Descriptions
    The only reliable way to determine whether an object is :term:`iterable`
    is to call ``iter(obj)``.
 
-.. class:: Collection[T_co](Sized, Iterable[T_co], Container[T_co])
+.. class:: Collection(Sized, Iterable[T_co], Container[T_co])
 
    ABC for sized iterable container classes.
 
    .. versionadded:: 3.6
 
-.. class:: Iterator[T_co](Iterable[T_co])
+.. class:: Iterator(Iterable[T_co])
 
    ABC for classes that provide the :meth:`~iterator.__iter__` and
    :meth:`~iterator.__next__` methods.  See also the definition of
    :term:`iterator`.
 
-.. class:: Reversible[T_co](Iterable[T_co])
+.. class:: Reversible(Iterable[T_co])
 
    ABC for iterable classes that also provide the :meth:`~object.__reversed__`
    method.
 
    .. versionadded:: 3.6
 
-.. class:: Generator[YieldType_co, SendType_contra, ReturnType_co](Iterator[YieldType_co])
+.. class:: Generator(Iterator[YieldType_co], Generic[YieldType_co, SendType_contra, ReturnType_co])
 
    ABC for :term:`generator` classes that implement the protocol defined in
    :pep:`342` that extends :term:`iterators <iterator>` with the
@@ -259,7 +259,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    .. versionadded:: 3.5
 
-.. class:: Sequence[T_co](Reversible[T_co], Collection[T_co])
+.. class:: Sequence(Reversible[T_co], Collection[T_co])
            MutableSequence[T](Sequence[T])
 
    ABCs for read-only and mutable :term:`sequences <sequence>`.
@@ -277,12 +277,12 @@ Collections Abstract Base Classes -- Detailed Descriptions
       The index() method added support for *stop* and *start*
       arguments.
 
-.. class:: Set[T_co](Collection[T_co])
+.. class:: Set(Collection[T_co])
            MutableSet[T](Set[T])
 
    ABCs for read-only and mutable :ref:`sets <types-set>`.
 
-.. class:: Mapping[KT, VT_co](Collection[KT], Generic[KT, VT_co])
+.. class:: Mapping(Collection[KT], Generic[KT, VT_co])
            MutableMapping[KT, VT](Mapping[KT, VT])
 
    ABCs for read-only and mutable :term:`mappings <mapping>`.
@@ -299,7 +299,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    ABCs for mapping, items, keys, and values :term:`views <dictionary view>`.
 
-.. class:: Awaitable[T_co]
+.. class:: Awaitable(Generic[T_co])
 
    ABC for :term:`awaitable` objects, which can be used in :keyword:`await`
    expressions.  Custom implementations must provide the
@@ -317,7 +317,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    .. versionadded:: 3.5
 
-.. class:: Coroutine[YieldType_co, SendType_contra, ReturnType_co](Awaitable[ReturnType_co])
+.. class:: Coroutine(Awaitable[ReturnType_co], Generic(YieldType_co, SendType_contra, ReturnType_co))
 
    ABC for :term:`coroutine` compatible classes.  These implement the
    following methods, defined in :ref:`coroutine-objects`:
@@ -340,21 +340,21 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    .. versionadded:: 3.5
 
-.. class:: AsyncIterable[T_co]
+.. class:: AsyncIterable(Generic[T_co])
 
    ABC for classes that provide an ``__aiter__`` method.  See also the
    definition of :term:`asynchronous iterable`.
 
    .. versionadded:: 3.5
 
-.. class:: AsyncIterator[T_co](AsyncIterable[T_co])
+.. class:: AsyncIterator(AsyncIterable[T_co])
 
    ABC for classes that provide ``__aiter__`` and ``__anext__``
    methods.  See also the definition of :term:`asynchronous iterator`.
 
    .. versionadded:: 3.5
 
-.. class:: AsyncGenerator[YieldType_co, SendType_contra](AsyncIterator[YieldType_co])
+.. class:: AsyncGenerator(AsyncIterator[YieldType_co], Generic[YieldType_co, SendType_contra])
 
    ABC for :term:`asynchronous generator` classes that implement the protocol
    defined in :pep:`525` and :pep:`492`.

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -106,7 +106,7 @@ a :class:`Mapping`.
 
 .. versionadded:: 3.9
    These abstract classes now support ``[]``. See :ref:`types-genericalias`
-   and :pep:`585`. They, however, do not inherit from :class:`~typing.Generic` explicitly.
+   and :pep:`585`.
 
 .. _collections-abstract-base-classes:
 
@@ -336,7 +336,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
    Refer to
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
    for details on using this class in type annotations.
-   The variance and order of type variables correspond to those of
+   The variance and order of type parameters correspond to those of
    :class:`Generator`.
 
    .. versionadded:: 3.5

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -197,7 +197,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 ----------------------------------------------------------
 
 
-.. class:: Container(Generic[T_co])
+.. class:: Container
 
    ABC for classes that provide the :meth:`~object.__contains__` method.
 
@@ -216,7 +216,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
    See :ref:`annotating-callables` for details on how to use
    :class:`Callable` and :class:`~typing.Callable` in type annotations.
 
-.. class:: Iterable(Generic[T_co])
+.. class:: Iterable
 
    ABC for classes that provide the :meth:`~container.__iter__` method.
 
@@ -227,26 +227,26 @@ Collections Abstract Base Classes -- Detailed Descriptions
    The only reliable way to determine whether an object is :term:`iterable`
    is to call ``iter(obj)``.
 
-.. class:: Collection(Sized, Iterable[T_co], Container[T_co])
+.. class:: Collection
 
    ABC for sized iterable container classes.
 
    .. versionadded:: 3.6
 
-.. class:: Iterator(Iterable[T_co])
+.. class:: Iterator
 
    ABC for classes that provide the :meth:`~iterator.__iter__` and
    :meth:`~iterator.__next__` methods.  See also the definition of
    :term:`iterator`.
 
-.. class:: Reversible(Iterable[T_co])
+.. class:: Reversible
 
    ABC for iterable classes that also provide the :meth:`~object.__reversed__`
    method.
 
    .. versionadded:: 3.6
 
-.. class:: Generator(Iterator[YieldType_co], Generic[YieldType_co, SendType_contra, ReturnType_co])
+.. class:: Generator
 
    ABC for :term:`generator` classes that implement the protocol defined in
    :pep:`342` that extends :term:`iterators <iterator>` with the
@@ -259,8 +259,8 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    .. versionadded:: 3.5
 
-.. class:: Sequence(Reversible[T_co], Collection[T_co])
-           MutableSequence[T](Sequence[T])
+.. class:: Sequence
+           MutableSequence
 
    ABCs for read-only and mutable :term:`sequences <sequence>`.
 
@@ -277,13 +277,13 @@ Collections Abstract Base Classes -- Detailed Descriptions
       The index() method added support for *stop* and *start*
       arguments.
 
-.. class:: Set(Collection[T_co])
-           MutableSet[T](Set[T])
+.. class:: Set
+           MutableSet
 
    ABCs for read-only and mutable :ref:`sets <types-set>`.
 
-.. class:: Mapping(Collection[KT], Generic[KT, VT_co])
-           MutableMapping[KT, VT](Mapping[KT, VT])
+.. class:: Mapping
+           MutableMapping
 
    ABCs for read-only and mutable :term:`mappings <mapping>`.
 
@@ -292,14 +292,14 @@ Collections Abstract Base Classes -- Detailed Descriptions
       def get_position_in_index(word_list: Mapping[str, int], word: str) -> int:
           return word_list[word]
 
-.. class:: MappingView(Sized)
-           ItemsView[KT_co, VT_co](MappingView, Set[tuple[KT_co, VT_co]])
-           KeysView[KT_co](MappingView, Set[KT_co])
-           ValuesView[VT_co](MappingView, Collection[VT_co])
+.. class:: MappingView
+           ItemsView
+           KeysView
+           ValuesView
 
    ABCs for mapping, items, keys, and values :term:`views <dictionary view>`.
 
-.. class:: Awaitable(Generic[T_co])
+.. class:: Awaitable
 
    ABC for :term:`awaitable` objects, which can be used in :keyword:`await`
    expressions.  Custom implementations must provide the
@@ -317,7 +317,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    .. versionadded:: 3.5
 
-.. class:: Coroutine(Awaitable[ReturnType_co], Generic(YieldType_co, SendType_contra, ReturnType_co))
+.. class:: Coroutine
 
    ABC for :term:`coroutine` compatible classes.  These implement the
    following methods, defined in :ref:`coroutine-objects`:
@@ -340,21 +340,21 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    .. versionadded:: 3.5
 
-.. class:: AsyncIterable(Generic[T_co])
+.. class:: AsyncIterable
 
    ABC for classes that provide an ``__aiter__`` method.  See also the
    definition of :term:`asynchronous iterable`.
 
    .. versionadded:: 3.5
 
-.. class:: AsyncIterator(AsyncIterable[T_co])
+.. class:: AsyncIterator
 
    ABC for classes that provide ``__aiter__`` and ``__anext__``
    methods.  See also the definition of :term:`asynchronous iterator`.
 
    .. versionadded:: 3.5
 
-.. class:: AsyncGenerator(AsyncIterator[YieldType_co], Generic[YieldType_co, SendType_contra])
+.. class:: AsyncGenerator
 
    ABC for :term:`asynchronous generator` classes that implement the protocol
    defined in :pep:`525` and :pep:`492`.

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -255,7 +255,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    Refer to
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details of using this class in type annotations.
+   for details on using this class in type annotations.
 
    .. versionadded:: 3.5
 
@@ -335,7 +335,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    Refer to
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details of using this class in type annotations.
+   for details on using this class in type annotations.
    The variance and order of type variables correspond to those of
    :class:`Generator`.
 
@@ -362,7 +362,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    Refer to
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details of using this class in type annotations.
+   for details on using this class in type annotations.
 
    .. versionadded:: 3.6
 

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -255,7 +255,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    Refer to
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   section for details of using this class in type annotations.
+   for details of using this class in type annotations.
 
    .. versionadded:: 3.5
 
@@ -333,10 +333,11 @@ Collections Abstract Base Classes -- Detailed Descriptions
       Using ``isinstance(gencoro, Coroutine)`` for them will return ``False``.
       Use :func:`inspect.isawaitable` to detect them.
 
-   The variance and order of type variables
-   correspond to those of :class:`Generator`. Refer to
+   Refer to
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   section for details of using this class in type annotations.
+   for details of using this class in type annotations.
+   The variance and order of type variables correspond to those of
+   :class:`Generator`.
 
    .. versionadded:: 3.5
 
@@ -361,7 +362,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    Refer to
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   section for details of using this class in type annotations.
+   for details of using this class in type annotations.
 
    .. versionadded:: 3.6
 

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -214,7 +214,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
    ABC for classes that provide the :meth:`~object.__call__` method.
 
    See :ref:`annotating-callables` for details on how to use
-   :class:`Callable` and :class:`~typing.Callable` in type annotations.
+   :class:`!Callable` in type annotations.
 
 .. class:: Iterable
 
@@ -255,7 +255,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    Refer to
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details on using this class in type annotations.
+   for details on using :class:`!Generator` in type annotations.
 
    .. versionadded:: 3.5
 
@@ -330,7 +330,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    Refer to
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details on using this class in type annotations.
+   for details on using :class:`!Coroutine` in type annotations.
    The variance and order of type parameters correspond to those of
    :class:`Generator`.
 
@@ -357,7 +357,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    Refer to
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details on using this class in type annotations.
+   for details on using :class:`!AsyncGenerator` in type annotations.
 
    .. versionadded:: 3.6
 

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -253,7 +253,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
    :meth:`~generator.send`,
    :meth:`~generator.throw` and :meth:`~generator.close` methods.
 
-   Refer to :ref:`annotating-generators-and-coroutines`
+   See :ref:`annotating-generators-and-coroutines`
    for details on using :class:`!Generator` in type annotations.
 
    .. versionadded:: 3.5
@@ -327,7 +327,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
       Using ``isinstance(gencoro, Coroutine)`` for them will return ``False``.
       Use :func:`inspect.isawaitable` to detect them.
 
-   Refer to :ref:`annotating-generators-and-coroutines`
+   See :ref:`annotating-generators-and-coroutines`
    for details on using :class:`!Coroutine` in type annotations.
    The variance and order of type parameters correspond to those of
    :class:`Generator`.
@@ -353,7 +353,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
    ABC for :term:`asynchronous generator` classes that implement the protocol
    defined in :pep:`525` and :pep:`492`.
 
-   Refer to :ref:`annotating-generators-and-coroutines`
+   See :ref:`annotating-generators-and-coroutines`
    for details on using :class:`!AsyncGenerator` in type annotations.
 
    .. versionadded:: 3.6

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -253,40 +253,9 @@ Collections Abstract Base Classes -- Detailed Descriptions
    :meth:`~generator.send`,
    :meth:`~generator.throw` and :meth:`~generator.close` methods.
 
-   A generator can be annotated by the generic type
-   ``Generator[YieldType, SendType, ReturnType]``. For example::
-
-      def echo_round() -> Generator[int, float, str]:
-          sent = yield 0
-          while sent >= 0:
-              sent = yield round(sent)
-          return 'Done'
-
-   Note that unlike many other generics in the typing module, the ``SendType``
-   of :class:`Generator` behaves contravariantly, not covariantly or
-   invariantly.
-
-   The ``SendType`` and ``ReturnType`` parameters default to :const:`!None`::
-
-      def infinite_stream(start: int) -> Generator[int]:
-          while True:
-              yield start
-              start += 1
-
-   It is also possible to set these types explicitly::
-
-      def infinite_stream(start: int) -> Generator[int, None, None]:
-          while True:
-              yield start
-              start += 1
-
-   Alternatively, annotate your generator as having a return type of
-   either ``Iterable[YieldType]`` or ``Iterator[YieldType]``::
-
-      def infinite_stream(start: int) -> Iterator[int]:
-          while True:
-              yield start
-              start += 1
+   Refer to
+   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   section for details of using this class in type annotations.
 
    .. versionadded:: 3.5
 
@@ -365,13 +334,9 @@ Collections Abstract Base Classes -- Detailed Descriptions
       Use :func:`inspect.isawaitable` to detect them.
 
    The variance and order of type variables
-   correspond to those of :class:`Generator`, for example::
-
-      from collections.abc import Coroutine
-      c: Coroutine[list[str], str, int]  # Some coroutine defined elsewhere
-      x = c.send('hi')                   # Inferred type of 'x' is list[str]
-      async def bar() -> None:
-          y = await c                    # Inferred type of 'y' is int
+   correspond to those of :class:`Generator`. Refer to
+   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   section for details of using this class in type annotations.
 
    .. versionadded:: 3.5
 
@@ -394,40 +359,9 @@ Collections Abstract Base Classes -- Detailed Descriptions
    ABC for :term:`asynchronous generator` classes that implement the protocol
    defined in :pep:`525` and :pep:`492`.
 
-   An async generator can be annotated by the generic type
-   ``AsyncGenerator[YieldType, SendType]``. For example::
-
-      async def echo_round() -> AsyncGenerator[int, float]:
-          sent = yield 0
-          while sent >= 0.0:
-              rounded = await round(sent)
-              sent = yield rounded
-
-   Unlike normal generators, async generators cannot return a value, so there
-   is no ``ReturnType`` type parameter. As with :class:`Generator`, the
-   ``SendType`` behaves contravariantly.
-
-   The ``SendType`` defaults to :const:`!None`::
-
-      async def infinite_stream(start: int) -> AsyncGenerator[int]:
-          while True:
-              yield start
-              start = await increment(start)
-
-   It is also possible to set this type explicitly::
-
-      async def infinite_stream(start: int) -> AsyncGenerator[int, None]:
-          while True:
-              yield start
-              start = await increment(start)
-
-   Alternatively, annotate your generator as having a return type of
-   either ``AsyncIterable[YieldType]`` or ``AsyncIterator[YieldType]``::
-
-      async def infinite_stream(start: int) -> AsyncIterator[int]:
-          while True:
-              yield start
-              start = await increment(start)
+   Refer to
+   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   section for details of using this class in type annotations.
 
    .. versionadded:: 3.6
 

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -253,8 +253,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
    :meth:`~generator.send`,
    :meth:`~generator.throw` and :meth:`~generator.close` methods.
 
-   Refer to
-   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   Refer to :ref:`annotating-generators-and-coroutines`
    for details on using :class:`!Generator` in type annotations.
 
    .. versionadded:: 3.5
@@ -328,8 +327,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
       Using ``isinstance(gencoro, Coroutine)`` for them will return ``False``.
       Use :func:`inspect.isawaitable` to detect them.
 
-   Refer to
-   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   Refer to :ref:`annotating-generators-and-coroutines`
    for details on using :class:`!Coroutine` in type annotations.
    The variance and order of type parameters correspond to those of
    :class:`Generator`.
@@ -355,8 +353,7 @@ Collections Abstract Base Classes -- Detailed Descriptions
    ABC for :term:`asynchronous generator` classes that implement the protocol
    defined in :pep:`525` and :pep:`492`.
 
-   Refer to
-   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   Refer to :ref:`annotating-generators-and-coroutines`
    for details on using :class:`!AsyncGenerator` in type annotations.
 
    .. versionadded:: 3.6

--- a/Doc/library/collections.abc.rst
+++ b/Doc/library/collections.abc.rst
@@ -287,11 +287,6 @@ Collections Abstract Base Classes -- Detailed Descriptions
 
    ABCs for read-only and mutable :term:`mappings <mapping>`.
 
-   Example use in type annotations::
-
-      def get_position_in_index(word_list: Mapping[str, int], word: str) -> int:
-          return word_list[word]
-
 .. class:: MappingView
            ItemsView
            KeysView

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -18,7 +18,7 @@ Utilities
 
 Functions and classes provided:
 
-.. class:: AbstractContextManager
+.. class:: AbstractContextManager[T_co, ExitT_co]
 
    An :term:`abstract base class` for classes that implement
    :meth:`object.__enter__` and :meth:`object.__exit__`. A default
@@ -26,10 +26,15 @@ Functions and classes provided:
    ``self`` while :meth:`object.__exit__` is an abstract method which by default
    returns ``None``. See also the definition of :ref:`typecontextmanager`.
 
+   The first type parameter, ``T_co``, represents the type returned by
+   the :meth:`~object.__enter__` method. The optional second type parameter, ``ExitT_co``,
+   which defaults to ``bool | None``, represents the type returned by the
+   :meth:`~object.__exit__` method.
+
    .. versionadded:: 3.6
 
 
-.. class:: AbstractAsyncContextManager
+.. class:: AbstractAsyncContextManager[T_co, AExitT_co]
 
    An :term:`abstract base class` for classes that implement
    :meth:`object.__aenter__` and :meth:`object.__aexit__`. A default
@@ -37,6 +42,11 @@ Functions and classes provided:
    ``self`` while :meth:`object.__aexit__` is an abstract method which by default
    returns ``None``. See also the definition of
    :ref:`async-context-managers`.
+
+   The first type parameter, ``T_co``, represents the type returned by
+   the :meth:`~object.__aenter__` method. The optional second type parameter, ``AExitT_co``,
+   which defaults to ``bool | None``, represents the type returned by the
+   :meth:`~object.__aexit__` method.
 
    .. versionadded:: 3.7
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -18,7 +18,7 @@ Utilities
 
 Functions and classes provided:
 
-.. class:: AbstractContextManager[T_co, ExitT_co]
+.. class:: AbstractContextManager
 
    An :term:`abstract base class` for classes that implement
    :meth:`object.__enter__` and :meth:`object.__exit__`. A default
@@ -26,15 +26,10 @@ Functions and classes provided:
    ``self`` while :meth:`object.__exit__` is an abstract method which by default
    returns ``None``. See also the definition of :ref:`typecontextmanager`.
 
-   The first type parameter, ``T_co``, represents the type returned by
-   the :meth:`~object.__enter__` method. The optional second type parameter, ``ExitT_co``,
-   which defaults to ``bool | None``, represents the type returned by the
-   :meth:`~object.__exit__` method.
-
    .. versionadded:: 3.6
 
 
-.. class:: AbstractAsyncContextManager[T_co, AExitT_co]
+.. class:: AbstractAsyncContextManager
 
    An :term:`abstract base class` for classes that implement
    :meth:`object.__aenter__` and :meth:`object.__aexit__`. A default
@@ -42,11 +37,6 @@ Functions and classes provided:
    ``self`` while :meth:`object.__aexit__` is an abstract method which by default
    returns ``None``. See also the definition of
    :ref:`async-context-managers`.
-
-   The first type parameter, ``T_co``, represents the type returned by
-   the :meth:`~object.__aenter__` method. The optional second type parameter, ``AExitT_co``,
-   which defaults to ``bool | None``, represents the type returned by the
-   :meth:`~object.__aexit__` method.
 
    .. versionadded:: 3.7
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3424,7 +3424,7 @@ Aliases to built-in types
    Deprecated alias to :class:`builtins.set <set>`.
 
    Note that to annotate arguments, it is preferred
-   to use an abstract collection type such as :class:`~collections.abc.Set`
+   to use an abstract collection type such as :class:`collections.abc.Set`
    rather than to use :class:`set` or :class:`!typing.Set`.
 
    .. deprecated:: 3.9

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -457,9 +457,9 @@ For example::
            sent = yield round(sent)
        return 'Done'
 
-Note that unlike many other generics in the typing module, the ``SendType``
-of :class:`~collections.abc.Generator` behaves contravariantly, not covariantly or
-invariantly.
+Note that unlike many other generic classes in the standard library,
+the ``SendType`` of :class:`~collections.abc.Generator` behaves
+contravariantly, not covariantly or invariantly.
 
 The ``SendType`` and ``ReturnType`` parameters default to :const:`!None`::
 
@@ -3690,8 +3690,8 @@ Aliases to asynchronous ABCs in :mod:`collections.abc`
 
    See
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details on using :class:`collections.abc.Coroutine` and this class
-   in type annotations.
+   for details on using :class:`collections.abc.Coroutine`
+   and ``typing.Coroutine`` in type annotations.
 
    .. versionadded:: 3.5.3
 
@@ -3705,8 +3705,8 @@ Aliases to asynchronous ABCs in :mod:`collections.abc`
 
    See
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details on using :class:`collections.abc.AsyncGenerator` and this class
-   in type annotations.
+   for details on using :class:`collections.abc.AsyncGenerator`
+   and ``typing.AsyncGenerator`` in type annotations.
 
    .. versionadded:: 3.6.1
 
@@ -3790,8 +3790,8 @@ Aliases to other ABCs in :mod:`collections.abc`
 
    See
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details on using :class:`collections.abc.Generator` and this class
-   in type annotations.
+   for details on using :class:`collections.abc.Generator`
+   and ``typing.Generator`` in type annotations.
 
    .. deprecated:: 3.9
       :class:`collections.abc.Generator` now supports subscripting (``[]``).

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -485,9 +485,9 @@ or :class:`Iterator[YieldType] <collections.abc.Iterator>`::
            start += 1
 
 Async generators are handled in a similar fashion, but don't
-expect a `ReturnType` type argument
+expect a ``ReturnType`` type argument
 (:class:`AsyncGenerator[YieldType, SendType] <collections.abc.AsyncGenerator>`).
-The `SendType` argument defaults to :const:`!None`, so the following definitions
+The ``SendType`` argument defaults to :const:`!None`, so the following definitions
 are equivalent::
 
    async def infinite_stream(start: int) -> AsyncGenerator[int]:

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3732,11 +3732,6 @@ Aliases to :mod:`contextlib` ABCs
 
    Deprecated alias to :class:`contextlib.AbstractContextManager`.
 
-   The first type parameter, ``T_co``, represents the type returned by
-   the :meth:`~object.__enter__` method. The optional second type parameter, ``ExitT_co``,
-   which defaults to ``bool | None``, represents the type returned by the
-   :meth:`~object.__exit__` method.
-
    .. versionadded:: 3.5.4
 
    .. deprecated:: 3.9
@@ -3750,11 +3745,6 @@ Aliases to :mod:`contextlib` ABCs
 .. class:: AsyncContextManager(Generic[T_co, AExitT_co])
 
    Deprecated alias to :class:`contextlib.AbstractAsyncContextManager`.
-
-   The first type parameter, ``T_co``, represents the type returned by
-   the :meth:`~object.__aenter__` method. The optional second type parameter, ``AExitT_co``,
-   which defaults to ``bool | None``, represents the type returned by the
-   :meth:`~object.__aexit__` method.
 
    .. versionadded:: 3.6.2
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -208,7 +208,7 @@ Annotating callable objects
 ===========================
 
 Functions -- or other :term:`callable` objects -- can be annotated using
-:class:`collections.abc.Callable` or :data:`typing.Callable`.
+:class:`collections.abc.Callable` or deprecated :data:`typing.Callable`.
 ``Callable[[int], str]`` signifies a function that takes a single parameter
 of type :class:`int` and returns a :class:`str`.
 
@@ -401,7 +401,7 @@ The type of class objects
 =========================
 
 A variable annotated with ``C`` may accept a value of type ``C``. In
-contrast, a variable annotated with ``type[C]`` (or
+contrast, a variable annotated with ``type[C]`` (or deprecated
 :class:`typing.Type[C] <Type>`) may accept values that are classes
 themselves -- specifically, it will accept the *class object* of ``C``. For
 example::

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3812,6 +3812,11 @@ Aliases to :mod:`contextlib` ABCs
 
    Deprecated alias to :class:`contextlib.AbstractContextManager`.
 
+   The first type parameter, ``T_co``, represents the type returned by
+   the :meth:`~object.__enter__` method. The optional second type parameter, ``ExitT_co``,
+   which defaults to ``bool | None``, represents the type returned by the
+   :meth:`~object.__exit__` method.
+
    .. versionadded:: 3.5.4
 
    .. deprecated:: 3.9
@@ -3825,6 +3830,11 @@ Aliases to :mod:`contextlib` ABCs
 .. class:: AsyncContextManager(Generic[T_co, AExitT_co])
 
    Deprecated alias to :class:`contextlib.AbstractAsyncContextManager`.
+
+   The first type parameter, ``T_co``, represents the type returned by
+   the :meth:`~object.__aenter__` method. The optional second type parameter, ``AExitT_co``,
+   which defaults to ``bool | None``, represents the type returned by the
+   :meth:`~object.__aexit__` method.
 
    .. versionadded:: 3.6.2
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3425,7 +3425,7 @@ Aliases to built-in types
 
    Note that to annotate arguments, it is preferred
    to use an abstract collection type such as :class:`collections.abc.Set`
-   rather than to use :class:`set` or :class:`!typing.Set`.
+   rather than to use :class:`set` or :class:`typing.Set`.
 
    .. deprecated:: 3.9
       :class:`builtins.set <set>` now supports subscripting (``[]``).

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -447,7 +447,7 @@ For example::
 Annotating generators and coroutines
 ====================================
 
-A generator can be annotated by the generic type
+A generator can be annotated using the generic type
 :class:`Generator[YieldType, SendType, ReturnType] <collections.abc.Generator>`.
 For example::
 
@@ -475,8 +475,9 @@ It is also possible to set these types explicitly::
            yield start
            start += 1
 
-Alternatively, annotate your generator as having a return type of
-either :class:`Iterable[YieldType] <collections.abc.Iterable>`
+Simple generators that only ever yield values can also be annotated
+as having a return type of either
+:class:`Iterable[YieldType] <collections.abc.Iterable>`
 or :class:`Iterator[YieldType] <collections.abc.Iterator>`::
 
    def infinite_stream(start: int) -> Iterator[int]:
@@ -500,7 +501,7 @@ are equivalent::
            yield start
            start = await increment(start)
 
-As in synchronous case,
+As in the synchronous case,
 :class:`AsyncIterable[YieldType] <collections.abc.AsyncIterable>`
 and :class:`AsyncIterator[YieldType] <collections.abc.AsyncIterator>` are
 available as well::
@@ -3687,6 +3688,11 @@ Aliases to asynchronous ABCs in :mod:`collections.abc`
 
    Deprecated alias to :class:`collections.abc.Coroutine`.
 
+   See
+   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   for details of using :class:`collections.abc.Coroutine` and this class
+   in type annotations.
+
    .. versionadded:: 3.5.3
 
    .. deprecated:: 3.9
@@ -3696,6 +3702,11 @@ Aliases to asynchronous ABCs in :mod:`collections.abc`
 .. class:: AsyncGenerator(AsyncIterator[YieldType], Generic[YieldType, SendType])
 
    Deprecated alias to :class:`collections.abc.AsyncGenerator`.
+
+   See
+   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   for details of using :class:`collections.abc.AsyncGenerator` and this class
+   in type annotations.
 
    .. versionadded:: 3.6.1
 
@@ -3762,6 +3773,9 @@ Aliases to other ABCs in :mod:`collections.abc`
 
    Deprecated alias to :class:`collections.abc.Callable`.
 
+   See :ref:`annotating-callables` for details on how to use
+   :class:`collections.abc.Callable` and ``typing.Callable`` in type annotations.
+
    .. deprecated:: 3.9
       :class:`collections.abc.Callable` now supports subscripting (``[]``).
       See :pep:`585` and :ref:`types-genericalias`.
@@ -3773,6 +3787,11 @@ Aliases to other ABCs in :mod:`collections.abc`
 .. class:: Generator(Iterator[YieldType], Generic[YieldType, SendType, ReturnType])
 
    Deprecated alias to :class:`collections.abc.Generator`.
+
+   See
+   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   for details of using :class:`collections.abc.Generator` and this class
+   in type annotations.
 
    .. deprecated:: 3.9
       :class:`collections.abc.Generator` now supports subscripting (``[]``).

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3402,11 +3402,6 @@ Aliases to built-in types
    to use an abstract collection type such as :class:`Mapping`
    rather than to use :class:`dict` or :class:`!typing.Dict`.
 
-   This type can be used as follows::
-
-      def count_words(text: str) -> Dict[str, int]:
-          ...
-
    .. deprecated:: 3.9
       :class:`builtins.dict <dict>` now supports subscripting (``[]``).
       See :pep:`585` and :ref:`types-genericalias`.
@@ -3418,14 +3413,6 @@ Aliases to built-in types
    Note that to annotate arguments, it is preferred
    to use an abstract collection type such as :class:`Sequence` or
    :class:`Iterable` rather than to use :class:`list` or :class:`!typing.List`.
-
-   This type may be used as follows::
-
-      def vec2[T: (int, float)](x: T, y: T) -> List[T]:
-          return [x, y]
-
-      def keep_positives[T: (int, float)](vector: Sequence[T]) -> List[T]:
-          return [item for item in vector if item > 0]
 
    .. deprecated:: 3.9
       :class:`builtins.list <list>` now supports subscripting (``[]``).

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3675,8 +3675,7 @@ Aliases to asynchronous ABCs in :mod:`collections.abc`
 
    Deprecated alias to :class:`collections.abc.Coroutine`.
 
-   See
-   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   See :ref:`annotating-generators-and-coroutines`
    for details on using :class:`collections.abc.Coroutine`
    and ``typing.Coroutine`` in type annotations.
 
@@ -3690,8 +3689,7 @@ Aliases to asynchronous ABCs in :mod:`collections.abc`
 
    Deprecated alias to :class:`collections.abc.AsyncGenerator`.
 
-   See
-   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   See :ref:`annotating-generators-and-coroutines`
    for details on using :class:`collections.abc.AsyncGenerator`
    and ``typing.AsyncGenerator`` in type annotations.
 
@@ -3775,8 +3773,7 @@ Aliases to other ABCs in :mod:`collections.abc`
 
    Deprecated alias to :class:`collections.abc.Generator`.
 
-   See
-   :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
+   See :ref:`annotating-generators-and-coroutines`
    for details on using :class:`collections.abc.Generator`
    and ``typing.Generator`` in type annotations.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3399,7 +3399,7 @@ Aliases to built-in types
    Deprecated alias to :class:`dict`.
 
    Note that to annotate arguments, it is preferred
-   to use an abstract collection type such as :class:`Mapping`
+   to use an abstract collection type such as :class:`~collections.abc.Mapping`
    rather than to use :class:`dict` or :class:`!typing.Dict`.
 
    .. deprecated:: 3.9
@@ -3411,8 +3411,9 @@ Aliases to built-in types
    Deprecated alias to :class:`list`.
 
    Note that to annotate arguments, it is preferred
-   to use an abstract collection type such as :class:`Sequence` or
-   :class:`Iterable` rather than to use :class:`list` or :class:`!typing.List`.
+   to use an abstract collection type such as
+   :class:`~collections.abc.Sequence` or :class:`~collections.abc.Iterable`
+   rather than to use :class:`list` or :class:`!typing.List`.
 
    .. deprecated:: 3.9
       :class:`builtins.list <list>` now supports subscripting (``[]``).
@@ -3423,7 +3424,7 @@ Aliases to built-in types
    Deprecated alias to :class:`builtins.set <set>`.
 
    Note that to annotate arguments, it is preferred
-   to use an abstract collection type such as :class:`AbstractSet`
+   to use an abstract collection type such as :class:`~collections.abc.Set`
    rather than to use :class:`set` or :class:`!typing.Set`.
 
    .. deprecated:: 3.9

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -441,6 +441,86 @@ For example::
 ``type[Any]`` is equivalent to :class:`type`, which is the root of Python's
 :ref:`metaclass hierarchy <metaclasses>`.
 
+
+.. _annotating-generators-and-coroutines:
+
+Annotating generators and coroutines
+====================================
+
+A generator can be annotated by the generic type
+:class:`Generator[YieldType, SendType, ReturnType] <collections.abc.Generator>`.
+For example::
+
+   def echo_round() -> Generator[int, float, str]:
+       sent = yield 0
+       while sent >= 0:
+           sent = yield round(sent)
+       return 'Done'
+
+Note that unlike many other generics in the typing module, the ``SendType``
+of :class:`~collections.abc.Generator` behaves contravariantly, not covariantly or
+invariantly.
+
+The ``SendType`` and ``ReturnType`` parameters default to :const:`!None`::
+
+   def infinite_stream(start: int) -> Generator[int]:
+       while True:
+           yield start
+           start += 1
+
+It is also possible to set these types explicitly::
+
+   def infinite_stream(start: int) -> Generator[int, None, None]:
+       while True:
+           yield start
+           start += 1
+
+Alternatively, annotate your generator as having a return type of
+either :class:`Iterable[YieldType] <collections.abc.Iterable>`
+or :class:`Iterator[YieldType] <collections.abc.Iterator>`::
+
+   def infinite_stream(start: int) -> Iterator[int]:
+       while True:
+           yield start
+           start += 1
+
+Async generators are handled in a similar fashion, but don't
+expect a `ReturnType` type argument
+(:class:`AsyncGenerator[YieldType, SendType] <collections.abc.AsyncGenerator>`).
+The `SendType` argument defaults to :const:`!None`, so the following definitions
+are equivalent::
+
+   async def infinite_stream(start: int) -> AsyncGenerator[int]:
+       while True:
+           yield start
+           start = await increment(start)
+
+   async def infinite_stream(start: int) -> AsyncGenerator[int, None]:
+       while True:
+           yield start
+           start = await increment(start)
+
+As in synchronous case,
+:class:`AsyncIterable[YieldType] <collections.abc.AsyncIterable>`
+and :class:`AsyncIterator[YieldType] <collections.abc.AsyncIterator>` are
+available as well::
+
+   async def infinite_stream(start: int) -> AsyncIterator[int]:
+       while True:
+           yield start
+           start = await increment(start)
+
+Coroutines can be annotated using
+:class:`Coroutine[YieldType, SendType, ReturnType] <collections.abc.Coroutine>`.
+Generic arguments correspond to those of :class:`~collections.abc.Generator`,
+for example::
+
+   from collections.abc import Coroutine
+   c: Coroutine[list[str], str, int]  # Some coroutine defined elsewhere
+   x = c.send('hi')                   # Inferred type of 'x' is list[str]
+   async def bar() -> None:
+       y = await c                    # Inferred type of 'y' is int
+
 .. _user-defined-generics:
 
 User-defined generic types

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3690,7 +3690,7 @@ Aliases to asynchronous ABCs in :mod:`collections.abc`
 
    See
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details of using :class:`collections.abc.Coroutine` and this class
+   for details on using :class:`collections.abc.Coroutine` and this class
    in type annotations.
 
    .. versionadded:: 3.5.3
@@ -3705,7 +3705,7 @@ Aliases to asynchronous ABCs in :mod:`collections.abc`
 
    See
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details of using :class:`collections.abc.AsyncGenerator` and this class
+   for details on using :class:`collections.abc.AsyncGenerator` and this class
    in type annotations.
 
    .. versionadded:: 3.6.1
@@ -3790,7 +3790,7 @@ Aliases to other ABCs in :mod:`collections.abc`
 
    See
    :ref:`annotating generators and coroutines <annotating-generators-and-coroutines>`
-   for details of using :class:`collections.abc.Generator` and this class
+   for details on using :class:`collections.abc.Generator` and this class
    in type annotations.
 
    .. deprecated:: 3.9

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3544,11 +3544,6 @@ Aliases to container ABCs in :mod:`collections.abc`
 
    Deprecated alias to :class:`collections.abc.Mapping`.
 
-   This type can be used as follows::
-
-      def get_position_in_index(word_list: Mapping[str, int], word: str) -> int:
-          return word_list[word]
-
    .. deprecated:: 3.9
       :class:`collections.abc.Mapping` now supports subscripting (``[]``).
       See :pep:`585` and :ref:`types-genericalias`.
@@ -3612,15 +3607,6 @@ Aliases to asynchronous ABCs in :mod:`collections.abc`
 
    Deprecated alias to :class:`collections.abc.Coroutine`.
 
-   The variance and order of type variables
-   correspond to those of :class:`Generator`, for example::
-
-      from collections.abc import Coroutine
-      c: Coroutine[list[str], str, int]  # Some coroutine defined elsewhere
-      x = c.send('hi')                   # Inferred type of 'x' is list[str]
-      async def bar() -> None:
-          y = await c                    # Inferred type of 'y' is int
-
    .. versionadded:: 3.5.3
 
    .. deprecated:: 3.9
@@ -3630,41 +3616,6 @@ Aliases to asynchronous ABCs in :mod:`collections.abc`
 .. class:: AsyncGenerator(AsyncIterator[YieldType], Generic[YieldType, SendType])
 
    Deprecated alias to :class:`collections.abc.AsyncGenerator`.
-
-   An async generator can be annotated by the generic type
-   ``AsyncGenerator[YieldType, SendType]``. For example::
-
-      async def echo_round() -> AsyncGenerator[int, float]:
-          sent = yield 0
-          while sent >= 0.0:
-              rounded = await round(sent)
-              sent = yield rounded
-
-   Unlike normal generators, async generators cannot return a value, so there
-   is no ``ReturnType`` type parameter. As with :class:`Generator`, the
-   ``SendType`` behaves contravariantly.
-
-   The ``SendType`` defaults to :const:`!None`::
-
-      async def infinite_stream(start: int) -> AsyncGenerator[int]:
-          while True:
-              yield start
-              start = await increment(start)
-
-   It is also possible to set this type explicitly::
-
-      async def infinite_stream(start: int) -> AsyncGenerator[int, None]:
-          while True:
-              yield start
-              start = await increment(start)
-
-   Alternatively, annotate your generator as having a return type of
-   either ``AsyncIterable[YieldType]`` or ``AsyncIterator[YieldType]``::
-
-      async def infinite_stream(start: int) -> AsyncIterator[int]:
-          while True:
-              yield start
-              start = await increment(start)
 
    .. versionadded:: 3.6.1
 
@@ -3731,9 +3682,6 @@ Aliases to other ABCs in :mod:`collections.abc`
 
    Deprecated alias to :class:`collections.abc.Callable`.
 
-   See :ref:`annotating-callables` for details on how to use
-   :class:`collections.abc.Callable` and ``typing.Callable`` in type annotations.
-
    .. deprecated:: 3.9
       :class:`collections.abc.Callable` now supports subscripting (``[]``).
       See :pep:`585` and :ref:`types-genericalias`.
@@ -3745,41 +3693,6 @@ Aliases to other ABCs in :mod:`collections.abc`
 .. class:: Generator(Iterator[YieldType], Generic[YieldType, SendType, ReturnType])
 
    Deprecated alias to :class:`collections.abc.Generator`.
-
-   A generator can be annotated by the generic type
-   ``Generator[YieldType, SendType, ReturnType]``. For example::
-
-      def echo_round() -> Generator[int, float, str]:
-          sent = yield 0
-          while sent >= 0:
-              sent = yield round(sent)
-          return 'Done'
-
-   Note that unlike many other generics in the typing module, the ``SendType``
-   of :class:`Generator` behaves contravariantly, not covariantly or
-   invariantly.
-
-   The ``SendType`` and ``ReturnType`` parameters default to :const:`!None`::
-
-      def infinite_stream(start: int) -> Generator[int]:
-          while True:
-              yield start
-              start += 1
-
-   It is also possible to set these types explicitly::
-
-      def infinite_stream(start: int) -> Generator[int, None, None]:
-          while True:
-              yield start
-              start += 1
-
-   Alternatively, annotate your generator as having a return type of
-   either ``Iterable[YieldType]`` or ``Iterator[YieldType]``::
-
-      def infinite_stream(start: int) -> Iterator[int]:
-          while True:
-              yield start
-              start += 1
 
    .. deprecated:: 3.9
       :class:`collections.abc.Generator` now supports subscripting (``[]``).


### PR DESCRIPTION
Fixes #123523.

Aliases from `typing` to `collections.abc` and `contextlib` modules are deprecated for a long time, and typing-related documentation should be easily reachable from the modern pages.

This PR moves all non-trivial descriptions between these pages and lists generic arguments for these aliases.

I'm using PEP695 syntax for these classes - it doesn't seem right to document them as inheriting from `Generic`, since they do not in fact (they define `__class_getitem__` directly).

<!-- gh-issue-number: gh-123523 -->
* Issue: gh-123523
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123544.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->