### PR TITLE
gh-123550: Fix code snippet of `BUILD_TUPLE` in `dis` docs

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1118,8 +1118,8 @@ iterations of the loop.
       if count == 0:
           value = ()
       else:
-          STACK = STACK[:-count]
           value = tuple(STACK[-count:])
+          STACK = STACK[:-count]
 
       STACK.append(value)
 


### PR DESCRIPTION
Fixes #123550 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123551.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-123550 -->
* Issue: gh-123550
<!-- /gh-issue-number -->
