### PR TITLE
gh-123570: Add link to `weakref.ref` from `weakref_slot` docs in `dataclasses`

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -215,7 +215,8 @@ Module contents
 
    - *weakref_slot*: If true (the default is ``False``), add a slot
      named "__weakref__", which is required to make an instance
-     weakref-able.  It is an error to specify ``weakref_slot=True``
+     :func:`weakref-able <weakref.ref>`.
+     It is an error to specify ``weakref_slot=True``
      without also specifying ``slots=True``.
 
     .. versionadded:: 3.11


### PR DESCRIPTION


<!-- gh-issue-number: gh-123570 -->
* Issue: gh-123570
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123571.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->