### PR TITLE
gh-123572: fix virtual keyboard constants on Windows (REPL)

### DIFF
--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -87,10 +87,10 @@ VK_MAP: dict[int, str] = {
     0x7D: "f14",  # VK_F14
     0x7E: "f15",  # VK_F15
     0x7F: "f16",  # VK_F16
-    0x79: "f17",  # VK_F17
-    0x80: "f18",  # VK_F18
-    0x81: "f19",  # VK_F19
-    0x82: "f20",  # VK_F20
+    0x80: "f17",  # VK_F17
+    0x81: "f18",  # VK_F18
+    0x82: "f19",  # VK_F19
+    0x83: "f20",  # VK_F20
 }
 
 # Console escape codes: https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences

--- a/Misc/NEWS.d/next/Library/2024-09-01-13-52-01.gh-issue-123572.DDtUWy.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-01-13-52-01.gh-issue-123572.DDtUWy.rst
@@ -1,0 +1,2 @@
+Fix REPL Windows virtual keyboard support. Keys F17 to F20 were previously
+handled incorrectly. Patch by Bénédikt Tran.


### PR DESCRIPTION
I don't have a better title for this one and I have no way to test it locally. I don't have the bandwidith for adding the tests for virtual keys for now (and I wouldn't know how to do it).

<!-- gh-issue-number: gh-123572 -->
* Issue: gh-123572
<!-- /gh-issue-number -->
