### PR TITLE
chore: remove redundant f-strings

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -936,7 +936,7 @@ class _Unparser(NodeVisitor):
         self.fill("raise")
         if not node.exc:
             if node.cause:
-                raise ValueError(f"Node can't use cause without an exception.")
+                raise ValueError("Node can't use cause without an exception.")
             return
         self.write(" ")
         self.traverse(node.exc)

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -677,14 +677,14 @@ def _frozen_get_del_attr(cls, fields, func_builder):
                         ('self', 'name', 'value'),
                         (f'  if {condition}:',
                           '   raise FrozenInstanceError(f"cannot assign to field {name!r}")',
-                         f'  super(cls, self).__setattr__(name, value)'),
+                          '  super(cls, self).__setattr__(name, value)'),
                         locals=locals,
                         overwrite_error=True)
     func_builder.add_fn('__delattr__',
                         ('self', 'name'),
                         (f'  if {condition}:',
                           '   raise FrozenInstanceError(f"cannot delete field {name!r}")',
-                         f'  super(cls, self).__delattr__(name)'),
+                          '  super(cls, self).__delattr__(name)'),
                         locals=locals,
                         overwrite_error=True)
 

--- a/Lib/idlelib/idle_test/test_sidebar.py
+++ b/Lib/idlelib/idle_test/test_sidebar.py
@@ -554,7 +554,7 @@ class ShellSidebarTest(unittest.TestCase):
         yield
         self.assert_sidebar_lines_end_with(['>>>', None, None, None, '>>>'])
 
-        text.mark_set('insert', f'insert -1line linestart')
+        text.mark_set('insert', 'insert -1line linestart')
         text.event_generate('<<squeeze-current-text>>')
         yield
         self.assert_sidebar_lines_end_with(['>>>', None, '>>>'])

--- a/Lib/idlelib/sidebar.py
+++ b/Lib/idlelib/sidebar.py
@@ -349,7 +349,7 @@ class LineNumbers(BaseSideBar):
                     [''],
                     map(str, range(self.prev_end + 1, end + 1)),
                 ))
-                self.sidebar_text.insert(f'end -1c', new_text, 'linenumber')
+                self.sidebar_text.insert('end -1c', new_text, 'linenumber')
             else:
                 self.sidebar_text.delete(f'{end+1}.0 -1c', 'end -1c')
 

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -453,7 +453,7 @@ def median_grouped(data, interval=1.0):
         interval = float(interval)
         x = float(x)
     except ValueError:
-        raise TypeError(f'Value cannot be converted to a float')
+        raise TypeError('Value cannot be converted to a float')
 
     # Interpolate the median using the formula found at:
     # https://www.cuemath.com/data/median-of-grouped-data/

--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -216,9 +216,7 @@ class TestLoader(object):
             testFunc = getattr(testCaseClass, attrname)
             if not callable(testFunc):
                 return False
-            fullName = f'%s.%s.%s' % (
-                testCaseClass.__module__, testCaseClass.__qualname__, attrname
-            )
+            fullName = f'{testCaseClass.__module__}.{testCaseClass.__qualname__}.{attrname}'
             return self.testNamePatterns is None or \
                 any(fnmatchcase(fullName, pattern) for pattern in self.testNamePatterns)
         testFnNames = list(filter(shouldIncludeMethod, dir(testCaseClass)))

--- a/Lib/unittest/loader.py
+++ b/Lib/unittest/loader.py
@@ -216,7 +216,9 @@ class TestLoader(object):
             testFunc = getattr(testCaseClass, attrname)
             if not callable(testFunc):
                 return False
-            fullName = f'{testCaseClass.__module__}.{testCaseClass.__qualname__}.{attrname}'
+            fullName = '%s.%s.%s' % (
+                testCaseClass.__module__, testCaseClass.__qualname__, attrname
+            )
             return self.testNamePatterns is None or \
                 any(fnmatchcase(fullName, pattern) for pattern in self.testNamePatterns)
         testFnNames = list(filter(shouldIncludeMethod, dir(testCaseClass)))

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -444,11 +444,11 @@ def _checknetloc(netloc):
 def _check_bracketed_host(hostname):
     if hostname.startswith('v'):
         if not re.match(r"\Av[a-fA-F0-9]+\..+\Z", hostname):
-            raise ValueError(f"IPvFuture address is invalid")
+            raise ValueError("IPvFuture address is invalid")
     else:
         ip = ipaddress.ip_address(hostname) # Throws Value Error if not IPv6 or IPv4
         if isinstance(ip, ipaddress.IPv4Address):
-            raise ValueError(f"An IPv4 address cannot be in brackets")
+            raise ValueError("An IPv4 address cannot be in brackets")
 
 # typed=True avoids BytesWarnings being emitted during cache key
 # comparison since this API supports both bytes and str input.

--- a/Lib/zoneinfo/_tzpath.py
+++ b/Lib/zoneinfo/_tzpath.py
@@ -9,8 +9,8 @@ def _reset_tzpath(to=None, stacklevel=4):
     if tzpaths is not None:
         if isinstance(tzpaths, (str, bytes)):
             raise TypeError(
-                f"tzpaths must be a list or tuple, "
-                + f"not {type(tzpaths)}: {tzpaths!r}"
+                "tzpaths must be a list or tuple, "
+                f"not {type(tzpaths)}: {tzpaths!r}"
             )
 
         if not all(map(os.path.isabs, tzpaths)):


### PR DESCRIPTION
Most modifications have no runtime effects, but some of them do (e.g., changing `%s` into f-string). I did not change everything I could find, only what ruff told me. I put a skip issue tag because I think we should instead have a "chore" issue for gathering those kind of PRs, but if you want a true issue I can open one.