### PR TITLE
gh-123553: Fix compile warning in `compile.c`

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -102,7 +102,9 @@ typedef _PyJumpTargetLabel jump_target_label;
 
 enum fblocktype;
 
+#ifndef NDEBUG
 static int compiler_is_top_level_await(struct compiler *c);
+#endif
 static PyObject *compiler_mangle(struct compiler *c, PyObject *name);
 static PyObject *compiler_maybe_mangle(struct compiler *c, PyObject *name);
 static int compiler_optimization_level(struct compiler *c);


### PR DESCRIPTION
This issue was not fully fixed: https://github.com/python/cpython/issues/123553

See 
<img width="993" alt="Снимок экрана 2024-09-01 в 18 18 26" src="https://github.com/user-attachments/assets/95262898-839f-4824-b619-903594e04efa">

Local repro:

```
Python/compile.c:105:12: warning: unused function 'compiler_is_top_level_await' [-Wunused-function]
static int compiler_is_top_level_await(struct compiler *c);
           ^
1 warning generated.
```

After:

```
» make
gcc -c -fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -g -O3 -Wall -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include  -fstack-protector-strong -std=c11 -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wstrict-prototypes -Werror=implicit-function-declaration -fvisibility=hidden  -I./Include/internal -I./Include/internal/mimalloc  -I. -I./Include -I/opt/homebrew/opt/openssl/include -I/opt/homebrew/opt/openssl/include  -DPy_BUILD_CORE -o Python/compile.o Python/compile.c
```

Refs https://github.com/python/cpython/pull/123554 
CC @Eclips4 

<!-- gh-issue-number: gh-123553 -->
* Issue: gh-123553
<!-- /gh-issue-number -->
