### PR TITLE
Add link to grammar specification for lambda parameters

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1892,7 +1892,8 @@ object.  The unnamed object behaves like a function object defined with:
 
 See section :ref:`function` for the syntax of parameter lists.  Note that
 functions created with lambda expressions cannot contain statements or
-annotations.
+annotations. See :doc:`standard Python grammar <./grammar>`
+for precise grammar specification of lambda parameters.
 
 
 .. _exprlists:

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -1003,7 +1003,7 @@ The following tokens are operators:
 
    +       -       *       **      /       //      %      @
    <<      >>      &       |       ^       ~       :=
-   <       >       <=      >=      ==      !=
+   <       >       <=      >=      ==      !=      !
 
 
 .. _delimiters:


### PR DESCRIPTION

Sorry for the notification I accidentally pushed merge commits and cannot remove reviewers.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123611.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->