### PR TITLE
gh-123614: Add save function to turtle.py

### DIFF
--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -2274,7 +2274,7 @@ Methods specific to Screen, not inherited from TurtleScreen
 
    Save the current turtle drawing (and turtles) as a PostScript file.
 
-   :param filename: the path of the saved postscript file
+   :param filename: the path of the saved PostScript file
    :param overwrite: if ``False`` and there already exists a file with the given
                      filename, then the function will raise a
                      ``FileExistsError``. If it is ``True``, the file will be

--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -2285,7 +2285,7 @@ Methods specific to Screen, not inherited from TurtleScreen
 
       >>> screen.save("my_drawing.ps")
       >>> screen.save("my_drawing.ps", overwrite=True)
-      
+
    .. versionadded:: 3.14
 
 .. function:: setup(width=_CFG["width"], height=_CFG["height"], startx=_CFG["leftright"], starty=_CFG["topbottom"])

--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -2285,6 +2285,8 @@ Methods specific to Screen, not inherited from TurtleScreen
 
       >>> screen.save("my_drawing.ps")
       >>> screen.save("my_drawing.ps", overwrite=True)
+      
+   .. versionadded:: 3.14
 
 .. function:: setup(width=_CFG["width"], height=_CFG["height"], startx=_CFG["leftright"], starty=_CFG["topbottom"])
 

--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -427,6 +427,7 @@ Input methods
 Methods specific to Screen
    | :func:`bye`
    | :func:`exitonclick`
+   | :func:`save`
    | :func:`setup`
    | :func:`title`
 
@@ -2268,6 +2269,22 @@ Methods specific to Screen, not inherited from TurtleScreen
    :file:`turtle.cfg`.  In this case IDLE's own mainloop is active also for the
    client script.
 
+
+.. function:: save(filename, overwrite=False)
+
+   Save the current turtle drawing (and turtles) as a PostScript file.
+
+   :param filename: the path of the saved postscript file
+   :param overwrite: if ``False`` and there already exists a file with the given
+                     filename, then the function will raise a
+                     ``FileExistsError``. If it is ``True``, the file will be
+                     overwritten.
+
+   .. doctest::
+      :skipif: _tkinter is None
+
+      >>> screen.save("my_drawing.ps")
+      >>> screen.save("my_drawing.ps", overwrite=True)
 
 .. function:: setup(width=_CFG["width"], height=_CFG["height"], startx=_CFG["leftright"], starty=_CFG["topbottom"])
 

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -481,7 +481,9 @@ class TestTurtleScreen(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             parent = os.path.join(tmpdir, "unknown_parent")
-            msg = f"the directory '{parent}' does not exist. Cannot save to it"
+            msg = (
+                f"the directory '{parent}' does not exist. Cannot save to it"
+            ).replace("\\", "\\"*2)  # Escape backslashes in Windows paths
 
             with self.assertRaisesRegex(FileNotFoundError, msg):
                 turtle.TurtleScreen.save(screen, os.path.join(parent, "a.ps"))

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -1,5 +1,8 @@
+import os
 import pickle
 import unittest
+import unittest.mock
+import tempfile
 from test import support
 from test.support import import_helper
 from test.support import os_helper
@@ -129,6 +132,7 @@ class VectorComparisonMixin:
         for idx, (i, j) in enumerate(zip(vec1, vec2)):
             self.assertAlmostEqual(
                 i, j, msg='values at index {} do not match'.format(idx))
+
 
 class Multiplier:
 
@@ -459,6 +463,67 @@ class TestTPen(unittest.TestCase):
             tpen.pendown()
             tpen.teleport(-100, -100, fill_gap=fill_gap_value)
             self.assertTrue(tpen.isdown())
+
+
+class TestTurtleScreen(unittest.TestCase):
+    def test_save_raises_if_wrong_extension(self) -> None:
+        screen = unittest.mock.Mock()
+
+        msg = "unknown file extension: '.png', must be one of {'.ps', '.eps'}"
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            self.assertRaisesRegex(ValueError, msg)
+        ):
+            turtle.TurtleScreen.save(screen, os.path.join(tmpdir, "file.png"))
+
+    def test_save_raises_if_parent_not_found(self) -> None:
+        screen = unittest.mock.Mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            parent = os.path.join(tmpdir, "unknown_parent")
+            msg = f"the directory '{parent}' does not exist. Cannot save to it"
+
+            with self.assertRaisesRegex(FileNotFoundError, msg):
+                turtle.TurtleScreen.save(screen, os.path.join(parent, "a.ps"))
+
+    def test_save_raises_if_file_found(self) -> None:
+        screen = unittest.mock.Mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "some_file.ps")
+            with open(file_path, "w") as f:
+                f.write("some text")
+
+            msg = (
+                f"the file '{file_path}' already exists. To overwrite it use"
+                " the 'overwrite=True' argument of the save function."
+            )
+            with self.assertRaisesRegex(ValueError, msg):
+                turtle.TurtleScreen.save(screen, file_path)
+
+    def test_save_overwrites_if_specified(self) -> None:
+        screen = unittest.mock.Mock()
+        screen.cv.postscript.return_value = "postscript"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "some_file.ps")
+            with open(file_path, "w") as f:
+                f.write("some text")
+
+            turtle.TurtleScreen.save(screen, file_path, overwrite=True)
+            with open(file_path) as f:
+                assert f.read() == "postscript"
+
+    def test_save(self) -> None:
+        screen = unittest.mock.Mock()
+        screen.cv.postscript.return_value = "postscript"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "some_file.ps")
+
+            turtle.TurtleScreen.save(screen, file_path)
+            with open(file_path) as f:
+                assert f.read() == "postscript"
 
 
 class TestModuleLevel(unittest.TestCase):

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -497,7 +497,7 @@ class TestTurtleScreen(unittest.TestCase):
             msg = (
                 f"the file '{file_path}' already exists. To overwrite it use"
                 " the 'overwrite=True' argument of the save function."
-            )
+            ).replace("\\", "\\"*2)  # Escape backslashes in Windows paths
             with self.assertRaisesRegex(FileExistsError, msg):
                 turtle.TurtleScreen.save(screen, file_path)
 

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -498,7 +498,7 @@ class TestTurtleScreen(unittest.TestCase):
                 f"the file '{file_path}' already exists. To overwrite it use"
                 " the 'overwrite=True' argument of the save function."
             )
-            with self.assertRaisesRegex(ValueError, msg):
+            with self.assertRaisesRegex(FileExistsError, msg):
                 turtle.TurtleScreen.save(screen, file_path)
 
     def test_save_overwrites_if_specified(self) -> None:

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -469,7 +469,7 @@ class TestTurtleScreen(unittest.TestCase):
     def test_save_raises_if_wrong_extension(self) -> None:
         screen = unittest.mock.Mock()
 
-        msg = "unknown file extension: '.png', must be one of {'.ps', '.eps'}"
+        msg = "Unknown file extension: '.png', must be one of {'.ps', '.eps'}"
         with (
             tempfile.TemporaryDirectory() as tmpdir,
             self.assertRaisesRegex(ValueError, msg)
@@ -482,7 +482,7 @@ class TestTurtleScreen(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             parent = os.path.join(tmpdir, "unknown_parent")
             msg = (
-                f"the directory '{parent}' does not exist. Cannot save to it"
+                f"The directory '{parent}' does not exist. Cannot save to it"
             ).replace("\\", "\\"*2)  # Escape backslashes in Windows paths
 
             with self.assertRaisesRegex(FileNotFoundError, msg):
@@ -497,7 +497,7 @@ class TestTurtleScreen(unittest.TestCase):
                 f.write("some text")
 
             msg = (
-                f"the file '{file_path}' already exists. To overwrite it use"
+                f"The file '{file_path}' already exists. To overwrite it use"
                 " the 'overwrite=True' argument of the save function."
             ).replace("\\", "\\"*2)  # Escape backslashes in Windows paths
             with self.assertRaisesRegex(FileExistsError, msg):

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import re
 import unittest
 import unittest.mock
 import tempfile
@@ -472,7 +473,7 @@ class TestTurtleScreen(unittest.TestCase):
         msg = "Unknown file extension: '.png', must be one of {'.ps', '.eps'}"
         with (
             tempfile.TemporaryDirectory() as tmpdir,
-            self.assertRaises(ValueError, msg=msg)
+            self.assertRaisesRegex(ValueError, re.escape(msg))
         ):
             turtle.TurtleScreen.save(screen, os.path.join(tmpdir, "file.png"))
 
@@ -482,7 +483,8 @@ class TestTurtleScreen(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             parent = os.path.join(tmpdir, "unknown_parent")
             msg = f"The directory '{parent}' does not exist. Cannot save to it"
-            with self.assertRaises(FileNotFoundError, msg=msg):
+
+            with self.assertRaisesRegex(FileNotFoundError, re.escape(msg)):
                 turtle.TurtleScreen.save(screen, os.path.join(parent, "a.ps"))
 
     def test_save_raises_if_file_found(self) -> None:
@@ -497,7 +499,7 @@ class TestTurtleScreen(unittest.TestCase):
                 f"The file '{file_path}' already exists. To overwrite it use"
                 " the 'overwrite=True' argument of the save function."
             )
-            with self.assertRaises(FileExistsError, msg=msg):
+            with self.assertRaisesRegex(FileExistsError, re.escape(msg)):
                 turtle.TurtleScreen.save(screen, file_path)
 
     def test_save_overwrites_if_specified(self) -> None:

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -472,7 +472,7 @@ class TestTurtleScreen(unittest.TestCase):
         msg = "Unknown file extension: '.png', must be one of {'.ps', '.eps'}"
         with (
             tempfile.TemporaryDirectory() as tmpdir,
-            self.assertRaisesRegex(ValueError, msg)
+            self.assertRaises(ValueError, msg=msg)
         ):
             turtle.TurtleScreen.save(screen, os.path.join(tmpdir, "file.png"))
 
@@ -481,11 +481,8 @@ class TestTurtleScreen(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             parent = os.path.join(tmpdir, "unknown_parent")
-            msg = (
-                f"The directory '{parent}' does not exist. Cannot save to it"
-            ).replace("\\", "\\"*2)  # Escape backslashes in Windows paths
-
-            with self.assertRaisesRegex(FileNotFoundError, msg):
+            msg = f"The directory '{parent}' does not exist. Cannot save to it"
+            with self.assertRaises(FileNotFoundError, msg=msg):
                 turtle.TurtleScreen.save(screen, os.path.join(parent, "a.ps"))
 
     def test_save_raises_if_file_found(self) -> None:
@@ -499,8 +496,8 @@ class TestTurtleScreen(unittest.TestCase):
             msg = (
                 f"The file '{file_path}' already exists. To overwrite it use"
                 " the 'overwrite=True' argument of the save function."
-            ).replace("\\", "\\"*2)  # Escape backslashes in Windows paths
-            with self.assertRaisesRegex(FileExistsError, msg):
+            )
+            with self.assertRaises(FileExistsError, msg=msg):
                 turtle.TurtleScreen.save(screen, file_path)
 
     def test_save_overwrites_if_specified(self) -> None:

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -1493,12 +1493,12 @@ class TurtleScreen(TurtleScreenBase):
         """
         return self._resize(canvwidth, canvheight, bg)
 
-    def save(self, filename, overwrite=False):
-        """Save the drawing as a postscript file
+    def save(self, filename, *, overwrite=False):
+        """Save the drawing as a PostScript file
 
         Arguments:
         filename -- a string, the path of the created file.
-                    Must end with '.ps' or '.eps'
+                    Must end with '.ps' or '.eps'.
 
         Optional arguments:
         overwrite -- boolean, if true, then existing files will be overwritten
@@ -1510,7 +1510,7 @@ class TurtleScreen(TurtleScreenBase):
         if not filename.parent.exists():
             raise FileNotFoundError(
                 f"The directory '{filename.parent}' does not exist."
-                " Cannot save to it"
+                " Cannot save to it."
             )
         if not overwrite and filename.exists():
             raise FileExistsError(

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -1494,6 +1494,18 @@ class TurtleScreen(TurtleScreenBase):
         return self._resize(canvwidth, canvheight, bg)
 
     def save(self, filename, overwrite=False):
+        """Save the drawing as a postscript file
+
+        Arguments:
+        filename -- a string, the path of the created file.
+                    Must end with '.ps' or '.eps'
+
+        Optional arguments:
+        overwrite -- boolean, if true, then existing files will be overwritten
+
+        Example (for a TurtleScreen instance named screen):
+        >>> screen.save('my_drawing.eps')
+        """
         filename = Path(filename)
         if not filename.parent.exists():
             raise FileNotFoundError(

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -106,6 +106,7 @@ import inspect
 import sys
 
 from os.path import isfile, split, join
+from pathlib import Path
 from copy import deepcopy
 from tkinter import simpledialog
 
@@ -115,7 +116,7 @@ _tg_screen_functions = ['addshape', 'bgcolor', 'bgpic', 'bye',
         'clearscreen', 'colormode', 'delay', 'exitonclick', 'getcanvas',
         'getshapes', 'listen', 'mainloop', 'mode', 'numinput',
         'onkey', 'onkeypress', 'onkeyrelease', 'onscreenclick', 'ontimer',
-        'register_shape', 'resetscreen', 'screensize', 'setup',
+        'register_shape', 'resetscreen', 'screensize', 'save', 'setup',
         'setworldcoordinates', 'textinput', 'title', 'tracer', 'turtles', 'update',
         'window_height', 'window_width']
 _tg_turtle_functions = ['back', 'backward', 'begin_fill', 'begin_poly', 'bk',
@@ -1491,6 +1492,27 @@ class TurtleScreen(TurtleScreenBase):
         >>> # e.g. to search for an erroneously escaped turtle ;-)
         """
         return self._resize(canvwidth, canvheight, bg)
+
+    def save(self, filename, overwrite=False):
+        filename = Path(filename)
+        if not filename.parent.exists():
+            raise FileNotFoundError(
+                f"the directory '{filename.parent}' does not exist."
+                " Cannot save to it"
+            )
+        if not overwrite and filename.exists():
+            raise ValueError(
+                f"the file '{filename}' already exists. To overwrite it use"
+                " the 'overwrite=True' argument of the save function."
+            )
+        if (ext := filename.suffix) not in {".ps", ".eps"}:
+            raise ValueError(
+                f"unknown file extension: '{ext}',"
+                 " must be one of {'.ps', '.eps'}"
+            )
+
+        postscript = self.cv.postscript()
+        filename.write_text(postscript)
 
     onscreenclick = onclick
     resetscreen = reset

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -1509,17 +1509,17 @@ class TurtleScreen(TurtleScreenBase):
         filename = Path(filename)
         if not filename.parent.exists():
             raise FileNotFoundError(
-                f"the directory '{filename.parent}' does not exist."
+                f"The directory '{filename.parent}' does not exist."
                 " Cannot save to it"
             )
         if not overwrite and filename.exists():
             raise FileExistsError(
-                f"the file '{filename}' already exists. To overwrite it use"
+                f"The file '{filename}' already exists. To overwrite it use"
                 " the 'overwrite=True' argument of the save function."
             )
         if (ext := filename.suffix) not in {".ps", ".eps"}:
             raise ValueError(
-                f"unknown file extension: '{ext}',"
+                f"Unknown file extension: '{ext}',"
                  " must be one of {'.ps', '.eps'}"
             )
 

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -1513,7 +1513,7 @@ class TurtleScreen(TurtleScreenBase):
                 " Cannot save to it"
             )
         if not overwrite and filename.exists():
-            raise ValueError(
+            raise FileExistsError(
                 f"the file '{filename}' already exists. To overwrite it use"
                 " the 'overwrite=True' argument of the save function."
             )

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-02-20-39-10.gh-issue-123614.26TMHp.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-02-20-39-10.gh-issue-123614.26TMHp.rst
@@ -1,1 +1,2 @@
 Add :func:`turtle.save` to easily save Turtle drawings as PostScript files.
+Patch by Marie Roald and Yngve Mardal Moe.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-02-20-39-10.gh-issue-123614.26TMHp.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-02-20-39-10.gh-issue-123614.26TMHp.rst
@@ -1,1 +1,1 @@
-Add :func:`turtle.save` to easily save Turtle drawings as postscript files
+Add :func:`turtle.save` to easily save Turtle drawings as PostScript files.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-02-20-39-10.gh-issue-123614.26TMHp.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-02-20-39-10.gh-issue-123614.26TMHp.rst
@@ -1,0 +1,1 @@
+Add :func:`turtle.save` to easily save Turtle drawings as postscript files


### PR DESCRIPTION
Adds a `save(filename: str, overwrite: bool = False)`-function to `turtle.py` with the following input validation:
* `FileNotFoundError` that explicitly state that the directory is missing if someone tries to save to an non-existing directory
* `ValueError` if the file exists and `overwrite=False`
* `ValueError` if the file does not end with `ps` or `eps`


Co-authored-by: Marie Roald <3594989+MarieRoald@users.noreply.github.com>

<!-- gh-issue-number: gh-123614 -->
* Issue: gh-123614
<!-- /gh-issue-number -->
