### PR TITLE
Add shims for iOS C++ compilation

### DIFF
--- a/iOS/Resources/bin/arm64-apple-ios-clang++
+++ b/iOS/Resources/bin/arm64-apple-ios-clang++
@@ -1,0 +1,2 @@
+#!/bin/sh
+xcrun --sdk iphoneos${IOS_SDK_VERSION} clang++ -target arm64-apple-ios $@

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-clang++
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-clang++
@@ -1,0 +1,2 @@
+#!/bin/sh
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target arm64-apple-ios-simulator $@

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-clang++
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-clang++
@@ -1,0 +1,2 @@
+#!/bin/sh
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target x86_64-apple-ios-simulator $@


### PR DESCRIPTION
The iOS directory contains shims that can be used as a proxy for invoking the iOS compilers. These shims are required because tools often assume that the first word on a command line is the compiler; but iOS compiler invocation requires multiple words. Setting `CC="xcrun --sdk iphoneos -target arm64-apple-ios"` can cause problems with some build tooling (including, but not limited to distutils).

This PR adds shims for the C++ compiler. It is technically possible to use `clang` as a C++ compiler; however, invoking `clang++` implies the `-lstdc++` argument, and most C++ build systems don't explicitly list `-lstdc++` as a required argument.

CPython itself doesn't use these shims itself for compilation, but `CXX` *is* captured as part of `sysconfig`, and is that configuration is used extensively by packages in the third-party packaging ecosystem. Providing these shims is an entirely a convenience for compiling those packages.