### PR TITLE
[3.13] gh-123091: Use more _Py_IsImmortalLoose() (GH-123602)

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1333,7 +1333,7 @@ FutureObj_get_state(FutureObj *fut, void *Py_UNUSED(ignored))
     default:
         assert (0);
     }
-    assert(_Py_IsImmortal(ret));
+    assert(_Py_IsImmortalLoose(ret));
     return ret;
 }
 

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -725,7 +725,7 @@ _PyStructSequence_FiniBuiltin(PyInterpreterState *interp, PyTypeObject *type)
     assert(type->tp_name != NULL);
     assert(type->tp_base == &PyTuple_Type);
     assert((type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN));
-    assert(_Py_IsImmortal(type));
+    assert(_Py_IsImmortalLoose(type));
 
     // Cannot delete a type if it still has subclasses
     if (_PyType_HasSubclasses(type)) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -1048,7 +1048,7 @@ del_cached_def(struct extensions_cache_value *value)
        However, this decref would be problematic if the module def were
        dynamically allocated, it were the last ref, and this function
        were called with an interpreter other than the def's owner. */
-    assert(value->def == NULL || _Py_IsImmortal(value->def));
+    assert(value->def == NULL || _Py_IsImmortalLoose(value->def));
 
     Py_XDECREF(value->def->m_base.m_copy);
     value->def->m_base.m_copy = NULL;


### PR DESCRIPTION
Switch more _Py_IsImmortal(...) assertions to _Py_IsImmortalLoose(...)

The remaining calls to _Py_IsImmortal are in free-threaded-only code, initialization of core objects, tests, and guards that fall back to code that works with mortal objects.

(cherry picked from commit 57c471a6880956338549380fc5fb35c986937901)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123091 -->
* Issue: gh-123091
<!-- /gh-issue-number -->
