### PR TITLE
gh-123621: reference/datamodels misleading ellipsis removed from curly brackets at dictionary definition

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -499,7 +499,7 @@ in the same order they were added sequentially over the dictionary.
 Replacing an existing key does not change the order, however removing a key
 and re-inserting it will add it to the end instead of keeping its old place.
 
-Dictionaries are mutable; they can be created by the ``{...}`` notation (see
+Dictionaries are mutable; they can be created by the ``{}`` notation (see
 section :ref:`dict`).
 
 .. index::


### PR DESCRIPTION
Dictionary's default creation in the documentation was misleading because it was presented like this:

> {...}


This is misleading as this particular command creates a set with only an Ellipsis in it. 

<!-- gh-issue-number: gh-123621 -->
* Issue: gh-123621
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123648.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->