### PR TITLE
gh-123660: Internal macros for accessing empty tuple singleton

### DIFF
--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -257,7 +257,7 @@ extern PyTypeObject _PyExc_MemoryError;
                 }, \
                 .last_resort_memory_error = { \
                     _PyObject_HEAD_INIT(&_PyExc_MemoryError), \
-                    .args = (PyObject*)&_Py_SINGLETON(tuple_empty) \
+                    .args = _Py_EMPTY_TUPLE \
                 }, \
             }, \
         }, \

--- a/Include/internal/pycore_tuple.h
+++ b/Include/internal/pycore_tuple.h
@@ -18,6 +18,7 @@ extern PyStatus _PyTuple_InitGlobalObjects(PyInterpreterState *);
 
 /* other API */
 
+#define _Py_EMPTY_TUPLE    ((PyObject *)&_Py_SINGLETON(tuple_empty))
 #define _PyTuple_ITEMS(op) _Py_RVALUE(_PyTuple_CAST(op)->ob_item)
 
 extern PyObject *_PyTuple_FromArray(PyObject *const *, Py_ssize_t);

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -16,10 +16,12 @@
 #endif
 
 #include "Python.h"
-#include "pycore_import.h"        // _PyImport_GetModuleAttrString()
-#include "pycore_pyhash.h"        // _Py_HashSecret
+#include "pycore_import.h"          // _PyImport_GetModuleAttrString()
+#include "pycore_pyhash.h"          // _Py_HashSecret
+#include "pycore_runtime.h"         // _PyRuntime
+#include "pycore_tuple.h"           // _Py_EMPTY_TUPLE
 
-#include <stddef.h>               // offsetof()
+#include <stddef.h>                 // offsetof()
 #include "expat.h"
 #include "pyexpat.h"
 
@@ -1095,23 +1097,17 @@ element_setstate_from_Python(elementtreestate *st, ElementObject *self,
 {
     static char *kwlist[] = {PICKLED_TAG, PICKLED_ATTRIB, PICKLED_TEXT,
                              PICKLED_TAIL, PICKLED_CHILDREN, 0};
-    PyObject *args;
     PyObject *tag, *attrib, *text, *tail, *children;
     PyObject *retval;
 
     tag = attrib = text = tail = children = NULL;
-    args = PyTuple_New(0);
-    if (!args)
-        return NULL;
-
-    if (PyArg_ParseTupleAndKeywords(args, state, "|$OOOOO", kwlist, &tag,
-                                    &attrib, &text, &tail, &children))
+    if (PyArg_ParseTupleAndKeywords(_Py_EMPTY_TUPLE, state, "|$OOOOO", kwlist,
+                                    &tag, &attrib, &text, &tail, &children))
         retval = element_setstate_from_attributes(st, self, tag, attrib, text,
                                                   tail, children);
     else
         retval = NULL;
 
-    Py_DECREF(args);
     return retval;
 }
 

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -10,9 +10,11 @@
 #endif
 
 #include "Python.h"
+#include "pycore_runtime.h"         // _PyRuntime
+#include "pycore_tuple.h"           // _Py_EMPTY_TUPLE
 
 
-#include <stdlib.h>               // free()
+#include <stdlib.h>                 // free()
 #include <string.h>
 
 #include <lzma.h>
@@ -83,7 +85,6 @@ typedef struct {
     PyTypeObject *lzma_compressor_type;
     PyTypeObject *lzma_decompressor_type;
     PyObject *error;
-    PyObject *empty_tuple;
 } _lzma_state;
 
 static inline _lzma_state*
@@ -266,7 +267,7 @@ parse_filter_spec_lzma(_lzma_state *state, PyObject *spec)
         return NULL;
     }
 
-    if (!PyArg_ParseTupleAndKeywords(state->empty_tuple, spec,
+    if (!PyArg_ParseTupleAndKeywords(_Py_EMPTY_TUPLE, spec,
                                      "|OOO&O&O&O&O&O&O&O&", optnames,
                                      &id, &preset_obj,
                                      uint32_converter, &options->dict_size,
@@ -294,7 +295,7 @@ parse_filter_spec_delta(_lzma_state *state, PyObject *spec)
     uint32_t dist = 1;
     lzma_options_delta *options;
 
-    if (!PyArg_ParseTupleAndKeywords(state->empty_tuple, spec, "|OO&", optnames,
+    if (!PyArg_ParseTupleAndKeywords(_Py_EMPTY_TUPLE, spec, "|OO&", optnames,
                                      &id, uint32_converter, &dist)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid filter specifier for delta filter");
@@ -318,7 +319,7 @@ parse_filter_spec_bcj(_lzma_state *state, PyObject *spec)
     uint32_t start_offset = 0;
     lzma_options_bcj *options;
 
-    if (!PyArg_ParseTupleAndKeywords(state->empty_tuple, spec, "|OO&", optnames,
+    if (!PyArg_ParseTupleAndKeywords(_Py_EMPTY_TUPLE, spec, "|OO&", optnames,
                                      &id, uint32_converter, &start_offset)) {
         PyErr_SetString(PyExc_ValueError,
                         "Invalid filter specifier for BCJ filter");
@@ -1527,11 +1528,6 @@ lzma_exec(PyObject *module)
 
     _lzma_state *state = get_lzma_state(module);
 
-    state->empty_tuple = PyTuple_New(0);
-    if (state->empty_tuple == NULL) {
-        return -1;
-    }
-
     ADD_INT_MACRO(module, FORMAT_AUTO);
     ADD_INT_MACRO(module, FORMAT_XZ);
     ADD_INT_MACRO(module, FORMAT_ALONE);
@@ -1615,7 +1611,6 @@ lzma_traverse(PyObject *module, visitproc visit, void *arg)
     Py_VISIT(state->lzma_compressor_type);
     Py_VISIT(state->lzma_decompressor_type);
     Py_VISIT(state->error);
-    Py_VISIT(state->empty_tuple);
     return 0;
 }
 
@@ -1626,7 +1621,6 @@ lzma_clear(PyObject *module)
     Py_CLEAR(state->lzma_compressor_type);
     Py_CLEAR(state->lzma_decompressor_type);
     Py_CLEAR(state->error);
-    Py_CLEAR(state->empty_tuple);
     return 0;
 }
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -1917,15 +1917,10 @@ product_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     if (kwds != NULL) {
         char *kwlist[] = {"repeat", 0};
-        PyObject *tmpargs = PyTuple_New(0);
-        if (tmpargs == NULL)
-            return NULL;
-        if (!PyArg_ParseTupleAndKeywords(tmpargs, kwds, "|n:product",
+        if (!PyArg_ParseTupleAndKeywords(_Py_EMPTY_TUPLE, kwds, "|n:product",
                                          kwlist, &repeat)) {
-            Py_DECREF(tmpargs);
             return NULL;
         }
-        Py_DECREF(tmpargs);
         if (repeat < 0) {
             PyErr_SetString(PyExc_ValueError,
                             "repeat argument cannot be negative");

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -879,17 +879,12 @@ static const uint8_t linetable[2] = {
 PyCodeObject *
 PyCode_NewEmpty(const char *filename, const char *funcname, int firstlineno)
 {
-    PyObject *nulltuple = NULL;
     PyObject *filename_ob = NULL;
     PyObject *funcname_ob = NULL;
     PyObject *code_ob = NULL;
     PyObject *linetable_ob = NULL;
     PyCodeObject *result = NULL;
 
-    nulltuple = PyTuple_New(0);
-    if (nulltuple == NULL) {
-        goto failed;
-    }
     funcname_ob = PyUnicode_FromString(funcname);
     if (funcname_ob == NULL) {
         goto failed;
@@ -915,9 +910,9 @@ PyCode_NewEmpty(const char *filename, const char *funcname, int firstlineno)
         .code = code_ob,
         .firstlineno = firstlineno,
         .linetable = linetable_ob,
-        .consts = nulltuple,
-        .names = nulltuple,
-        .localsplusnames = nulltuple,
+        .consts = _Py_EMPTY_TUPLE,
+        .names = _Py_EMPTY_TUPLE,
+        .localsplusnames = _Py_EMPTY_TUPLE,
         .localspluskinds = emptystring,
         .exceptiontable = emptystring,
         .stacksize = 1,
@@ -925,7 +920,6 @@ PyCode_NewEmpty(const char *filename, const char *funcname, int firstlineno)
     result = _PyCode_New(&con);
 
 failed:
-    Py_XDECREF(nulltuple);
     Py_XDECREF(funcname_ob);
     Py_XDECREF(filename_ob);
     Py_XDECREF(code_ob);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1561,7 +1561,6 @@ static int
 ImportError_init(PyImportErrorObject *self, PyObject *args, PyObject *kwds)
 {
     static char *kwlist[] = {"name", "path", "name_from", 0};
-    PyObject *empty_tuple;
     PyObject *msg = NULL;
     PyObject *name = NULL;
     PyObject *path = NULL;
@@ -1570,15 +1569,11 @@ ImportError_init(PyImportErrorObject *self, PyObject *args, PyObject *kwds)
     if (BaseException_init((PyBaseExceptionObject *)self, args, NULL) == -1)
         return -1;
 
-    empty_tuple = PyTuple_New(0);
-    if (!empty_tuple)
-        return -1;
-    if (!PyArg_ParseTupleAndKeywords(empty_tuple, kwds, "|$OOO:ImportError", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(_Py_EMPTY_TUPLE, kwds,
+                                     "|$OOO:ImportError", kwlist,
                                      &name, &path, &name_from)) {
-        Py_DECREF(empty_tuple);
         return -1;
     }
-    Py_DECREF(empty_tuple);
 
     Py_XSETREF(self->name, Py_XNewRef(name));
     Py_XSETREF(self->path, Py_XNewRef(path));
@@ -2240,16 +2235,11 @@ NameError_init(PyNameErrorObject *self, PyObject *args, PyObject *kwds)
         return -1;
     }
 
-    PyObject *empty_tuple = PyTuple_New(0);
-    if (!empty_tuple) {
-        return -1;
-    }
-    if (!PyArg_ParseTupleAndKeywords(empty_tuple, kwds, "|$O:NameError", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(_Py_EMPTY_TUPLE, kwds,
+                                     "|$O:NameError", kwlist,
                                      &name)) {
-        Py_DECREF(empty_tuple);
         return -1;
     }
-    Py_DECREF(empty_tuple);
 
     Py_XSETREF(self->name, Py_XNewRef(name));
 
@@ -2314,16 +2304,11 @@ AttributeError_init(PyAttributeErrorObject *self, PyObject *args, PyObject *kwds
         return -1;
     }
 
-    PyObject *empty_tuple = PyTuple_New(0);
-    if (!empty_tuple) {
-        return -1;
-    }
-    if (!PyArg_ParseTupleAndKeywords(empty_tuple, kwds, "|$OO:AttributeError", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(_Py_EMPTY_TUPLE, kwds,
+                                     "|$OO:AttributeError", kwlist,
                                      &name, &obj)) {
-        Py_DECREF(empty_tuple);
         return -1;
     }
-    Py_DECREF(empty_tuple);
 
     Py_XSETREF(self->name, Py_XNewRef(name));
     Py_XSETREF(self->obj, Py_XNewRef(obj));

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -61,7 +61,7 @@ tuple_alloc(Py_ssize_t size)
 static inline PyObject *
 tuple_get_empty(void)
 {
-    return (PyObject *)&_Py_SINGLETON(tuple_empty);
+    return _Py_EMPTY_TUPLE;
 }
 
 PyObject *
@@ -185,7 +185,7 @@ tupledealloc(PyTupleObject *op)
 {
     if (Py_SIZE(op) == 0) {
         /* The empty tuple is statically allocated. */
-        if (op == &_Py_SINGLETON(tuple_empty)) {
+        if (op == (PyTupleObject *)(_Py_EMPTY_TUPLE)) {
 #ifdef Py_DEBUG
             _Py_FatalRefcountError("deallocating the empty tuple singleton");
 #else
@@ -942,7 +942,7 @@ _PyTuple_Resize(PyObject **pv, Py_ssize_t newsize)
     }
     if (oldsize == 0) {
 #ifdef Py_DEBUG
-        assert(v == &_Py_SINGLETON(tuple_empty));
+        assert(v == (PyTupleObject *)(_Py_EMPTY_TUPLE));
 #endif
         /* The empty tuple is statically allocated so we never
            resize it in-place. */

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2886,14 +2886,9 @@ zip_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     int strict = 0;
 
     if (kwds) {
-        PyObject *empty = PyTuple_New(0);
-        if (empty == NULL) {
-            return NULL;
-        }
         static char *kwlist[] = {"strict", NULL};
-        int parsed = PyArg_ParseTupleAndKeywords(
-                empty, kwds, "|$p:zip", kwlist, &strict);
-        Py_DECREF(empty);
+        int parsed = PyArg_ParseTupleAndKeywords(_Py_EMPTY_TUPLE, kwds,
+                                                 "|$p:zip", kwlist, &strict);
         if (!parsed) {
             return NULL;
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1469,7 +1469,7 @@ initialize_locals(PyThreadState *tstate, PyFunctionObject *func,
     if (co->co_flags & CO_VARARGS) {
         PyObject *u = NULL;
         if (argcount == n) {
-            u = (PyObject *)&_Py_SINGLETON(tuple_empty);
+            u = _Py_EMPTY_TUPLE;
         }
         else {
             u = _PyTuple_FromStackRefSteal(args + n, argcount - n);

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2739,11 +2739,11 @@ static const PyBytesObject no_location = {
 
 const struct _PyCode8 _Py_InitCleanup = {
     _PyVarObject_HEAD_INIT(&PyCode_Type, 3),
-    .co_consts = (PyObject *)&_Py_SINGLETON(tuple_empty),
-    .co_names = (PyObject *)&_Py_SINGLETON(tuple_empty),
+    .co_consts = _Py_EMPTY_TUPLE,
+    .co_names = _Py_EMPTY_TUPLE,
     .co_exceptiontable = (PyObject *)&_Py_SINGLETON(bytes_empty),
     .co_flags = CO_OPTIMIZED | CO_NO_MONITORING_EVENTS,
-    .co_localsplusnames = (PyObject *)&_Py_SINGLETON(tuple_empty),
+    .co_localsplusnames = _Py_EMPTY_TUPLE,
     .co_localspluskinds = (PyObject *)&_Py_SINGLETON(bytes_empty),
     .co_filename = &_Py_ID(__init__),
     .co_name = &_Py_ID(__init__),


### PR DESCRIPTION
While writing this PR, I thought about the following:

- For callables that need an empty tuple, using the macro should be recommended. This will 1) reduce the number of lines (we don't need to check if the value is NULL for instance) 2) make it clear that we are using an empty tuple.

- We should replace calls of the form `return PyTuple_New(0)` to calls of the form `Py_GetConstant(...)` and `Py_GetConstantBorrowed` depending on the semantics. This is something that is important, both for contributors that read the code and for detecting the places where this should be done.

There are places where the compiler would not accept a non-static value (when you initialize structures for instance). In those places, AFAICT, we can only use the macro form and not a call. 

While there are many occurrences of constructing empty tuples, they don't have the same semantic meaning. I decided to only replace the following:

- explicit usage of `_Py_SINGLETON`.
- usage of an empty tuple when calling `PyArg_ParseTupleAndKeywords`. 
- usage of an empty tuple when constructing a structure.

There are other usages where you return an empty tuple, you call `PyObject_Call` or other functions, but since the diff would be much larger, I decided not to do it for those files. I also removed an empty tuple reference from the lzma's state since it's not needed at all and could make the module slightly faster to instantiate. 

While using `_Py_EMPTY_TUPLE` over `PyTuple_New(0)` could be slightly faster (or maybe not, I don't know), it removes the needs of redundant checks `if (arg == NULL) { ... }` since empty tuples are immortal. Currently, those kind of checks still exist, probably because they were not removed when we introduced immortal objects. There is a trade-off between changing everything and removing the checks or not changing all places and only keep the relevant ones changed. 

I'm willing to revert the commit for the changes with `PyArg_ParseTupleAndKeywords` and `PyCode_New` but I'd like to keep the one concerning the LZMA module.


<!-- gh-issue-number: gh-123660 -->
* Issue: gh-123660
<!-- /gh-issue-number -->
