### PR TITLE
gh-107954, PEP 741: Adjust Python initialization config

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1766,7 +1766,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'use_hash_seed': True,
         }
         config_dev_mode(preconfig, config)
-        config['faulthandler'] = 0
         self.check_all_configs("test_initconfig_api", config, preconfig,
                                api=API_ISOLATED)
 

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -1031,7 +1031,6 @@ PyConfig_InitIsolatedConfig(PyConfig *config)
     config->dev_mode = 0;
     config->install_signal_handlers = 0;
     config->use_hash_seed = 0;
-    config->faulthandler = 0;
     config->tracemalloc = 0;
     config->perf_profiling = 0;
     config->int_max_str_digits = _PY_LONG_DEFAULT_MAX_STR_DIGITS;
@@ -3753,7 +3752,7 @@ PyInitConfig_SetInt(PyInitConfig *config, const char *name, int64_t value)
         return -1;
     }
 
-    if (strcmp(name, "hash_seed")) {
+    if (strcmp(name, "hash_seed") == 0) {
         config->config.use_hash_seed = 1;
     }
 
@@ -3863,7 +3862,14 @@ PyInitConfig_SetStrList(PyInitConfig *config, const char *name,
         return -1;
     }
     PyWideStringList *list = raw_member;
-    return _PyWideStringList_FromUTF8(config, list, length, items);
+    if (_PyWideStringList_FromUTF8(config, list, length, items) < 0) {
+        return -1;
+    }
+
+    if (strcmp(name, "module_search_paths") == 0) {
+        config->config.module_search_paths_set = 1;
+    }
+    return 0;
 }
 
 


### PR DESCRIPTION
Setting dev_mode to 1 in an isolated configuration now enables also faulthandler.

Moreover, setting "module_search_paths" option with PyInitConfig_SetStrList() now sets "module_search_paths_set" to 1.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-107954 -->
* Issue: gh-107954
<!-- /gh-issue-number -->
