### PR TITLE
gh-123418: Update macOS installer to use OpenSSL 3.0.15

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -246,9 +246,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 3.0.13",
-              url="https://www.openssl.org/source/openssl-3.0.13.tar.gz",
-              checksum='88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313',
+              name="OpenSSL 3.0.15",
+              url="https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz",
+              checksum='23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2024-09-04-11-55-29.gh-issue-123418.8P4bmN.rst
+++ b/Misc/NEWS.d/next/macOS/2024-09-04-11-55-29.gh-issue-123418.8P4bmN.rst
@@ -1,0 +1,1 @@
+Updated macOS installer build to use OpenSSL 3.0.15.


### PR DESCRIPTION
Note: OpenSSL seems to have switched to using GitHub for artifact storage; the canonical download links on (the new) https://openssl-library.org/source/index.html now point there, and the old location does not contain the latest releases.  The base URL in build-installer.py is updated accordingly.


<!-- gh-issue-number: gh-123418 -->
* Issue: gh-123418
<!-- /gh-issue-number -->
