### PR TITLE
gh-123418: Update Android build to use OpenSSL 3.0.15

### DIFF
--- a/Android/android.py
+++ b/Android/android.py
@@ -138,7 +138,7 @@ def make_build_python(context):
 
 def unpack_deps(host):
     deps_url = "https://github.com/beeware/cpython-android-source-deps/releases/download"
-    for name_ver in ["bzip2-1.0.8-1", "libffi-3.4.4-2", "openssl-3.0.13-1",
+    for name_ver in ["bzip2-1.0.8-1", "libffi-3.4.4-2", "openssl-3.0.15-0",
                      "sqlite-3.45.1-0", "xz-5.4.6-0"]:
         filename = f"{name_ver}-{host}.tar.gz"
         download(f"{deps_url}/{name_ver}/{filename}")

--- a/Misc/NEWS.d/next/Build/2024-09-04-12-01-43.gh-issue-123418.ynzspB.rst
+++ b/Misc/NEWS.d/next/Build/2024-09-04-12-01-43.gh-issue-123418.ynzspB.rst
@@ -1,0 +1,1 @@
+Updated Android build to use OpenSSL 3.0.15.


### PR DESCRIPTION
Note: this will require an update to https://github.com/beeware/cpython-android-source-deps to add an openssl 3.0.15-0 release before this will actually build.  (cc @freakboy3742, @mhsmith)


<!-- gh-issue-number: gh-123418 -->
* Issue: gh-123418
<!-- /gh-issue-number -->
