### PR TITLE
[3.9] gh-112275: Fix HEAD_LOCK deadlock in child process after fork (GH-112336)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-04-18-20-11.gh-issue-112275.W_iMiB.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-04-18-20-11.gh-issue-112275.W_iMiB.rst
@@ -1,0 +1,3 @@
+A deadlock involving ``pystate.c``'s ``HEAD_LOCK`` in ``posixmodule.c``
+at fork is now fixed. Patch by ChuBoning based on previous Python 3.12
+fix by Victor Stinner.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -589,10 +589,10 @@ PyOS_AfterFork_Child(void)
 {
     _PyRuntimeState *runtime = &_PyRuntime;
     _PyGILState_Reinit(runtime);
+    _PyRuntimeState_ReInitThreads(runtime);
     _PyEval_ReInitThreads(runtime);
     _PyImport_ReInitLock();
     _PySignal_AfterFork();
-    _PyRuntimeState_ReInitThreads(runtime);
     _PyInterpreterState_DeleteExceptMain(runtime);
 
     run_at_forkers(_PyInterpreterState_GET()->after_forkers_child, 0);


### PR DESCRIPTION
HEAD_LOCK is called from _PyEval_ReInitThreads->_PyThreadState_DeleteExcept before _PyRuntimeState_ReInitThreads reinit runtime->interpreters.mutex which might be locked before fork.

(cherry picked from commit 522799a05e3e820339718151ac055af6d864d463)


<!-- gh-issue-number: gh-112275 -->
* Issue: gh-112275
<!-- /gh-issue-number -->
