### PR TITLE
gh-123700: Update OpenSSL versions in multissltests and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        openssl_ver: [1.1.1w, 3.0.15, 3.1.7, 3.2.3]
+        openssl_ver: [3.0.15, 3.1.7, 3.2.3, 3.3.2]
     env:
       OPENSSL_VER: ${{ matrix.openssl_ver }}
       MULTISSL_DIR: ${{ github.workspace }}/multissl

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -43,13 +43,14 @@ import tarfile
 log = logging.getLogger("multissl")
 
 OPENSSL_OLD_VERSIONS = [
+    "1.1.1w",
 ]
 
 OPENSSL_RECENT_VERSIONS = [
-    "1.1.1w",
     "3.0.15",
     "3.1.7",
     "3.2.3",
+    "3.3.2",
 ]
 
 LIBRESSL_OLD_VERSIONS = [


### PR DESCRIPTION
Remove EOL 1.1.1w from CI and move it to the 'old' set in multissltests,
add latest 3.3.2 to both CI and multissltests.


<!-- gh-issue-number: gh-123700 -->
* Issue: gh-123700
<!-- /gh-issue-number -->
