### PR TITLE
gh-123657: Fix crash and refleak in `decimal.getcontext()`

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-09-04-18-23-43.gh-issue-123657.Oks4So.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-04-18-23-43.gh-issue-123657.Oks4So.rst
@@ -1,0 +1,2 @@
+Fix crash and memory leak in :func:`decimal.getcontext`. It crashed when using
+a thread-local context by ``--with-decimal-contextvar=no``.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -76,7 +76,8 @@ typedef struct {
 #ifndef WITH_DECIMAL_CONTEXTVAR
     /* Key for thread state dictionary */
     PyObject *tls_context_key;
-    /* Invariant: NULL or the most recently accessed thread local context */
+    /* Invariant: NULL or a strong reference to the most recently accessed
+       thread local context object, not a borrowed reference. */
     struct PyDecContextObject *cached_context;
 #else
     PyObject *current_context_var;
@@ -1764,7 +1765,7 @@ PyDec_SetCurrentContext(PyObject *self, PyObject *v)
         Py_INCREF(v);
     }
 
-    state->cached_context = NULL;
+    Py_CLEAR(state->cached_context);
     if (PyDict_SetItem(dict, state->tls_context_key, v) < 0) {
         Py_DECREF(v);
         return NULL;

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -6117,6 +6117,16 @@ decimal_traverse(PyObject *module, visitproc visit, void *arg)
     Py_VISIT(state->Rational);
     Py_VISIT(state->SignalTuple);
 
+    if (state->signal_map != NULL) {
+        for (DecCondMap *cm = state->signal_map; cm->name != NULL; cm++) {
+            Py_VISIT(cm->ex);
+        }
+    }
+    if (state->cond_map != NULL) {
+        for (DecCondMap *cm = state->cond_map + 1; cm->name != NULL; cm++) {
+            Py_VISIT(cm->ex);
+        }
+    }
     return 0;
 }
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -78,7 +78,7 @@ typedef struct {
     PyObject *tls_context_key;
     /* Invariant: NULL or a strong reference to the most recently accessed
        thread local context. */
-    struct PyDecContextObject *cached_context;  /* Do not borrow */
+    struct PyDecContextObject *cached_context;  /* Not borrowed */
 #else
     PyObject *current_context_var;
 #endif

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -77,8 +77,8 @@ typedef struct {
     /* Key for thread state dictionary */
     PyObject *tls_context_key;
     /* Invariant: NULL or a strong reference to the most recently accessed
-       thread local context object, not a borrowed reference. */
-    struct PyDecContextObject *cached_context;
+       thread local context. */
+    struct PyDecContextObject *cached_context;  /* Do not borrow */
 #else
     PyObject *current_context_var;
 #endif

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1419,12 +1419,6 @@ context_dealloc(PyDecContextObject *self)
 {
     PyTypeObject *tp = Py_TYPE(self);
     PyObject_GC_UnTrack(self);
-#ifndef WITH_DECIMAL_CONTEXTVAR
-    decimal_state *state = get_module_state_by_def(Py_TYPE(self));
-    if (self == state->cached_context) {
-        state->cached_context = NULL;
-    }
-#endif
     (void)context_clear(self);
     tp->tp_free(self);
     Py_DECREF(tp);
@@ -1701,7 +1695,8 @@ current_context_from_dict(decimal_state *modstate)
 
     /* Cache the context of the current thread, assuming that it
      * will be accessed several times before a thread switch. */
-    modstate->cached_context = (PyDecContextObject *)tl_context;
+    Py_XSETREF(modstate->cached_context,
+               (PyDecContextObject *)Py_NewRef(tl_context));
     modstate->cached_context->tstate = tstate;
 
     /* Borrowed reference with refcount==1 */


### PR DESCRIPTION


<!-- gh-issue-number: gh-123657 -->
* Issue: gh-123657
<!-- /gh-issue-number -->
