### PR TITLE
gh-123672: Clarify the usage of `PyGILState*` for subinterpreters

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -920,10 +920,11 @@ Note that the ``PyGILState_*`` functions assume there is only one global
 interpreter (created automatically by :c:func:`Py_Initialize`).  Python
 supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
-``PyGILState_*`` API is unsupported.  If you call ``PyGILState_Ensure``
-in order to create a sub-interpreter, you must never try and interact
-with the GIL of other interpreters (including trying to release the GIL
-to return back to the previous interpreter).
+``PyGILState_*`` API is unsupported.  Similiarly, after creating a
+sub-interpreter via :c:func:`!PyGILState_Ensure`, interacting with
+the GIL of other interpreters (including, but not limited to trying
+to release the GIL to return back to the previous interpreter) is not
+supported.
 
 
 .. _fork-and-threads:

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -920,7 +920,7 @@ Note that the ``PyGILState_*`` functions assume there is only one global
 interpreter (created automatically by :c:func:`Py_Initialize`).  Python
 supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
-``PyGILState_*`` API is unsupported.  Similiarly, after creating a
+``PyGILState_*`` API is unsupported.  Similarly, after creating a
 sub-interpreter via :c:func:`!PyGILState_Ensure`, interacting with
 the GIL of other interpreters (including, but not limited to, trying
 to release the GIL to return back to the previous interpreter) is not

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -920,7 +920,9 @@ Note that the ``PyGILState_*`` functions assume there is only one global
 interpreter (created automatically by :c:func:`Py_Initialize`).  Python
 supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
-``PyGILState_*`` API is unsupported.
+``PyGILState_*`` API is unsupported.  If you call ``PyGILState_Ensure``
+in order to create a sub-interpreter, you must never try and interact
+with the GIL of other interpreters.
 
 
 .. _fork-and-threads:
@@ -1090,6 +1092,13 @@ with sub-interpreters:
 
    When the function returns, the current thread will hold the GIL and be able
    to call arbitrary Python code.  Failure is a fatal error.
+
+   If sub-interpreters are active, this function puts you in the global
+   interpreter (created by :c:func:`Py_Initialize`). If you create a sub-interpreter
+   right after you call this function, then the current thread is switched to that
+   sub-interpreter, and you no longer have the :c:type:`PyGILState_STATE` of the global
+   interpreter. In which case, you must call :c:func:`Py_EndInterpreter` instead of
+   :c:func:`PyGILState_Release`.
 
    .. note::
       Calling this function from a thread when the runtime is finalizing

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1096,10 +1096,10 @@ with sub-interpreters:
 
    If sub-interpreters are active, this function puts you in the global
    interpreter (created by :c:func:`Py_Initialize`). If you create a sub-interpreter
-   right after you call this function, then the current thread is switched to that
-   sub-interpreter, and you no longer have the :c:type:`PyGILState_STATE` of the global
-   interpreter. In which case, you must call :c:func:`Py_EndInterpreter` instead of
-   :c:func:`PyGILState_Release`.
+   right after you call this function, then the current thread's interpreter state is
+   switched to of that of the sub-interpreter, and you no longer have the
+   :c:type:`PyGILState_STATE` of the global interpreter. In which case, you must call
+   :c:func:`Py_EndInterpreter` instead of :c:func:`PyGILState_Release`.
 
    .. note::
       Calling this function from a thread when the runtime is finalizing

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -920,10 +920,9 @@ Note that the ``PyGILState_*`` functions assume there is only one global
 interpreter (created automatically by :c:func:`Py_Initialize`).  Python
 supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
-``PyGILState_*`` API is unsupported. With that being said, you still need
-to hold the :term:`GIL` in order to *create* a subinterpreter, even if using
-a per-interpreter GIL (see :pep:`684`). The need for :c:type:`PyGILState_STATE`
-doesn't go away when creating isolated subinterpreters!
+``PyGILState_*`` API is unsupported. On the other hand, *creating*
+sub-interpreters (whether they have a per-interprter GIL or not in
+the sense of :pep:`684`) still require to hold the :term:`GIL`.
 
 
 .. _fork-and-threads:

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1081,7 +1081,8 @@ with sub-interpreters:
    matched with a call to :c:func:`PyGILState_Release`, *except* when the
    thread creates a sub-interpreter with its own GIL (see
    :c:member:`PyInterpreterConfig.gil`).
-   In that case, the call to :c:func:`PyGILState_Release` should be replaced with :c:func:`Py_EndInterpreter`.
+   In that case, :c:func:`PyGILState_Release` should be used instead of
+   :c:func:`Py_EndInterpreter` to release that interpreter's GIL.
 
    In general, other thread-related APIs may be used between :c:func:`PyGILState_Ensure` and
    :c:func:`PyGILState_Release` calls as long as the thread state is restored to

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -920,9 +920,7 @@ Note that the ``PyGILState_*`` functions assume there is only one global
 interpreter (created automatically by :c:func:`Py_Initialize`).  Python
 supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
-``PyGILState_*`` API is unsupported. On the other hand, *creating*
-sub-interpreters (whether they have a per-interpreter GIL or not, in
-the sense of :pep:`684`) still require to hold the GIL.
+``PyGILState_*`` API is unsupported.
 
 
 .. _fork-and-threads:

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -922,7 +922,7 @@ supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
 ``PyGILState_*`` API is unsupported.  Similarly, after creating a
 sub-interpreter via :c:func:`!PyGILState_Ensure`, interacting with
-the GIL of other interpreters (including, but not limited to, trying
+the GIL of other interpreters (such as trying
 to release the GIL to return back to the previous interpreter) is not
 supported.
 
@@ -1078,11 +1078,7 @@ with sub-interpreters:
    Ensure that the current thread is ready to call the Python C API regardless
    of the current state of Python, or of the global interpreter lock. This may
    be called as many times as desired by a thread as long as each call is
-   matched with a call to :c:func:`PyGILState_Release`, *except* when the
-   thread creates a sub-interpreter with its own GIL (see
-   :c:member:`PyInterpreterConfig.gil`).
-   In that case, :c:func:`Py_EndInterpreter` should be used instead to
-   release that interpreter's GIL.
+   matched with a call to :c:func:`PyGILState_Release`
 
    In general, other thread-related APIs may be used between :c:func:`PyGILState_Ensure` and
    :c:func:`PyGILState_Release` calls as long as the thread state is restored to

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -922,7 +922,8 @@ supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
 ``PyGILState_*`` API is unsupported.  If you call ``PyGILState_Ensure``
 in order to create a sub-interpreter, you must never try and interact
-with the GIL of other interpreters.
+with the GIL of other interpreters (including trying to release the GIL
+to return back to the previous interpreter).
 
 
 .. _fork-and-threads:

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -921,8 +921,8 @@ interpreter (created automatically by :c:func:`Py_Initialize`).  Python
 supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
 ``PyGILState_*`` API is unsupported. On the other hand, *creating*
-sub-interpreters (whether they have a per-interprter GIL or not in
-the sense of :pep:`684`) still require to hold the :term:`GIL`.
+sub-interpreters (whether they have a per-interpreter :term:`GIL` or not in
+the sense of :pep:`684`) still require to hold the GIL.
 
 
 .. _fork-and-threads:

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -922,7 +922,7 @@ supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
 ``PyGILState_*`` API is unsupported.  Similiarly, after creating a
 sub-interpreter via :c:func:`!PyGILState_Ensure`, interacting with
-the GIL of other interpreters (including, but not limited to trying
+the GIL of other interpreters (including, but not limited to, trying
 to release the GIL to return back to the previous interpreter) is not
 supported.
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1098,7 +1098,7 @@ with sub-interpreters:
    If sub-interpreters are active, this function puts you in the global
    interpreter (created by :c:func:`Py_Initialize`). If you create a sub-interpreter
    right after you call this function, then the current thread's interpreter state is
-   switched to of that of the sub-interpreter, and you no longer have the
+   switched to that of the sub-interpreter, and you no longer have the
    :c:type:`PyGILState_STATE` of the global interpreter. In which case, you must call
    :c:func:`Py_EndInterpreter` instead of :c:func:`PyGILState_Release`.
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1098,7 +1098,8 @@ with sub-interpreters:
    When the function returns, the current thread will hold the GIL and be able
    to call arbitrary Python code.  Failure is a fatal error.
 
-   If no interpreter state has been initialized for the thread, then this function returns the state of the global interpreter (created by :c:func:`Py_Initialize`).
+   If no interpreter state has been initialized for the thread, then this function returns
+   the state of the global interpreter (created by :c:func:`Py_Initialize`).
 
    .. note::
       Calling this function from a thread when the runtime is finalizing

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1079,7 +1079,8 @@ with sub-interpreters:
    of the current state of Python, or of the global interpreter lock. This may
    be called as many times as desired by a thread as long as each call is
    matched with a call to :c:func:`PyGILState_Release`, *except* when the
-   thread creates a sub-interpreter with it's own :term:`GIL` (see :c:member:`PyInterpreterConfig.gil`).
+   thread creates a sub-interpreter with its own GIL (see
+   :c:member:`PyInterpreterConfig.gil`).
    In that case, the call to :c:func:`PyGILState_Release` should be replaced with :c:func:`Py_EndInterpreter`.
 
    In general, other thread-related APIs may be used between :c:func:`PyGILState_Ensure` and

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -921,7 +921,7 @@ interpreter (created automatically by :c:func:`Py_Initialize`).  Python
 supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
 ``PyGILState_*`` API is unsupported. On the other hand, *creating*
-sub-interpreters (whether they have a per-interpreter :term:`GIL` or not in
+sub-interpreters (whether they have a per-interpreter GIL or not, in
 the sense of :pep:`684`) still require to hold the GIL.
 
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1081,8 +1081,8 @@ with sub-interpreters:
    matched with a call to :c:func:`PyGILState_Release`, *except* when the
    thread creates a sub-interpreter with its own GIL (see
    :c:member:`PyInterpreterConfig.gil`).
-   In that case, :c:func:`PyGILState_Release` should be used instead of
-   :c:func:`Py_EndInterpreter` to release that interpreter's GIL.
+   In that case, :c:func:`Py_EndInterpreter` should be used instead to
+   release that interpreter's GIL.
 
    In general, other thread-related APIs may be used between :c:func:`PyGILState_Ensure` and
    :c:func:`PyGILState_Release` calls as long as the thread state is restored to

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -922,7 +922,7 @@ supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
 ``PyGILState_*`` API is unsupported. With that being said, you still need
 to hold the :term:`GIL` in order to _create_ a subinterpreter, even if using
-a per-interpreter GIL (see :pep:`684`). The need for :c:expr:`PyGILState_STATE`
+a per-interpreter GIL (see :pep:`684`). The need for :c:type:`PyGILState_STATE`
 doesn't go away when creating isolated subinterpreters!
 
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -920,9 +920,10 @@ Note that the ``PyGILState_*`` functions assume there is only one global
 interpreter (created automatically by :c:func:`Py_Initialize`).  Python
 supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
-``PyGILState_*`` API is unsupported.  With that being said, you still need
-to hold the :term:`GIL` in order to _create_ a subinterpreter, even if
-using a per-interpreter GIL (see :pep:`684`).
+``PyGILState_*`` API is unsupported. With that being said, you still need
+to hold the :term:`GIL` in order to _create_ a subinterpreter, even if using
+a per-interpreter GIL (see :pep:`684`). The need for :c:expr:`PyGILState_STATE`
+doesn't go away when creating isolated subinterpreters!
 
 
 .. _fork-and-threads:

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -919,8 +919,10 @@ from a C thread is::
 Note that the ``PyGILState_*`` functions assume there is only one global
 interpreter (created automatically by :c:func:`Py_Initialize`).  Python
 supports the creation of additional interpreters (using
-:c:func:`Py_NewInterpreter`), but mixing multiple interpreters and the
-``PyGILState_*`` API is unsupported.
+:c:func:`Py_NewInterpreter`), but switching between interpreters via the
+``PyGILState_*`` API is unsupported.  With that being said, you still need
+to hold the :term:`GIL` in order to _create_ a subinterpreter, even if
+using a per-interpreter GIL (see :pep:`684`).
 
 
 .. _fork-and-threads:

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -921,7 +921,7 @@ interpreter (created automatically by :c:func:`Py_Initialize`).  Python
 supports the creation of additional interpreters (using
 :c:func:`Py_NewInterpreter`), but switching between interpreters via the
 ``PyGILState_*`` API is unsupported. With that being said, you still need
-to hold the :term:`GIL` in order to _create_ a subinterpreter, even if using
+to hold the :term:`GIL` in order to *create* a subinterpreter, even if using
 a per-interpreter GIL (see :pep:`684`). The need for :c:type:`PyGILState_STATE`
 doesn't go away when creating isolated subinterpreters!
 


### PR DESCRIPTION
@encukou, this needs `skip news`, and backport to both 3.12 and 3.13.

<!-- gh-issue-number: gh-123672 -->
* Issue: gh-123672
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123728.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->