### PR TITLE
[3.12] gh-102988: Adjust version numbers in versionadded directives

### DIFF
--- a/Doc/library/email.utils.rst
+++ b/Doc/library/email.utils.rst
@@ -67,7 +67,7 @@ of the new API.
 
    If *strict* is true, use a strict parser which rejects malformed inputs.
 
-   .. versionchanged:: 3.13
+   .. versionchanged:: 3.12.6
       Add *strict* optional parameter and reject malformed inputs by default.
 
 
@@ -105,7 +105,7 @@ of the new API.
       resent_ccs = msg.get_all('resent-cc', [])
       all_recipients = getaddresses(tos + ccs + resent_tos + resent_ccs)
 
-   .. versionchanged:: 3.13
+   .. versionchanged:: 3.12.6
       Add *strict* optional parameter and reject malformed inputs by default.
 
 


### PR DESCRIPTION
I left these out in GH-123766. Sorry for the noise.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102988 -->
* Issue: gh-102988
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123771.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->