### PR TITLE
gh-109975: Add links to py-free-threading.github.io

### DIFF
--- a/Doc/howto/free-threading-extensions.rst
+++ b/Doc/howto/free-threading-extensions.rst
@@ -273,6 +273,6 @@ manually define ``Py_GIL_DISABLED=1`` when building extensions from source.
 
 .. seealso::
 
-   https://py-free-threading.github.io/porting/
-
+   `Porting Extension Modules to Support Free-Threading
+   <https://py-free-threading.github.io/porting/>`_:
    A community-maintained porting guide for extension authors.

--- a/Doc/howto/free-threading-extensions.rst
+++ b/Doc/howto/free-threading-extensions.rst
@@ -270,3 +270,9 @@ Windows
 
 Due to a limitation of the official Windows installer, you will need to
 manually define ``Py_GIL_DISABLED=1`` when building extensions from source.
+
+.. seealso::
+
+   https://py-free-threading.github.io/porting/
+
+   A community-maintained porting guide for extension authors.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -359,6 +359,9 @@ free-threaded build.
    :pep:`703` "Making the Global Interpreter Lock Optional in CPython"
    contains rationale and information surrounding this work.
 
+   A community-maintained guide for extension authors:
+   https://py-free-threading.github.io
+
 
 .. _whatsnew313-jit-compiler:
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -359,8 +359,9 @@ free-threaded build.
    :pep:`703` "Making the Global Interpreter Lock Optional in CPython"
    contains rationale and information surrounding this work.
 
-   A community-maintained guide for extension authors:
-   https://py-free-threading.github.io
+   See also the `Porting Extension Modules to Support Free-Threading
+   <https://py-free-threading.github.io/porting/>`_:
+   A community-maintained porting guide for extension authors.
 
 
 .. _whatsnew313-jit-compiler:

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -359,9 +359,9 @@ free-threaded build.
    :pep:`703` "Making the Global Interpreter Lock Optional in CPython"
    contains rationale and information surrounding this work.
 
-   See also the `Porting Extension Modules to Support Free-Threading
-   <https://py-free-threading.github.io/porting/>`_:
-   A community-maintained porting guide for extension authors.
+   `Porting Extension Modules to Support Free-Threading
+   <https://py-free-threading.github.io/porting/>`_: A community-maintained
+   porting guide for extension authors.
 
 
 .. _whatsnew313-jit-compiler:


### PR DESCRIPTION
@ncoghlan suggested adding links like this on discord after @oscarbenjamin found the porting guides useful [here](https://discuss.python.org/t/free-threading-trove-classifier/62406/15).


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123776.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->
