### PR TITLE
chore: decimal module macro cleanup

### DIFF
--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -1717,11 +1717,13 @@ current_context(decimal_state *modstate)
 }
 
 /* ctxobj := borrowed reference to the current context */
-#define CURRENT_CONTEXT(state, ctxobj) \
-    ctxobj = current_context(state); \
-    if (ctxobj == NULL) {       \
-        return NULL;            \
-    }
+#define CURRENT_CONTEXT(STATE, CTXOBJ)      \
+    do {                                    \
+        CTXOBJ = current_context(STATE);    \
+        if (CTXOBJ == NULL) {               \
+            return NULL;                    \
+        }                                   \
+    } while (0)
 
 /* Return a new reference to the current context */
 static PyObject *
@@ -1810,12 +1812,14 @@ current_context(decimal_state *state)
 }
 
 /* ctxobj := borrowed reference to the current context */
-#define CURRENT_CONTEXT(state, ctxobj) \
-    ctxobj = current_context(state);   \
-    if (ctxobj == NULL) {       \
-        return NULL;            \
-    }                           \
-    Py_DECREF(ctxobj);
+#define CURRENT_CONTEXT(STATE, CTXOBJ)      \
+    do {                                    \
+        CTXOBJ = current_context(STATE);    \
+        if (CTXOBJ == NULL) {               \
+            return NULL;                    \
+        }                                   \
+        Py_DECREF(CTXOBJ);                  \
+    } while (0)
 
 /* Return a new reference to the current context */
 static PyObject *

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -161,12 +161,6 @@ find_state_left_or_right(PyObject *left, PyObject *right)
 
 #define BOUNDS_CHECK(x, MIN, MAX) x = (x < MIN || MAX < x) ? MAX : x
 
-#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
-  #define UNUSED __attribute__((unused))
-#else
-  #define UNUSED
-#endif
-
 /* _Py_DEC_MINALLOC >= MPD_MINALLOC */
 #define _Py_DEC_MINALLOC 4
 
@@ -362,7 +356,7 @@ runtime_error_ptr(const char *mesg)
     return runtime_error_ptr("internal error in " funcname)
 
 static void
-dec_traphandler(mpd_context_t *ctx UNUSED) /* GCOV_NOT_REACHED */
+dec_traphandler(mpd_context_t *Py_UNUSED(ctx)) /* GCOV_NOT_REACHED */
 { /* GCOV_NOT_REACHED */
     return; /* GCOV_NOT_REACHED */
 }
@@ -624,7 +618,8 @@ getround(decimal_state *state, PyObject *v)
 static const char *INVALID_SIGNALDICT_ERROR_MSG = "invalid signal dict";
 
 static int
-signaldict_init(PyObject *self, PyObject *args UNUSED, PyObject *kwds UNUSED)
+signaldict_init(PyObject *self,
+                PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwds))
 {
     SdFlagAddr(self) = NULL;
     return 0;
@@ -782,7 +777,7 @@ signaldict_richcompare(PyObject *v, PyObject *w, int op)
 }
 
 static PyObject *
-signaldict_copy(PyObject *self, PyObject *args UNUSED)
+signaldict_copy(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     if (SdFlagAddr(self) == NULL) {
         return value_error_ptr(INVALID_SIGNALDICT_ERROR_MSG);
@@ -829,18 +824,18 @@ static PyType_Spec signaldict_spec = {
 /*                         Context Object, Part 1                             */
 /******************************************************************************/
 
-#define Dec_CONTEXT_GET_SSIZE(mem) \
-static PyObject *                                       \
-context_get##mem(PyObject *self, void *closure UNUSED)  \
-{                                                       \
-    return PyLong_FromSsize_t(mpd_get##mem(CTX(self))); \
+#define Dec_CONTEXT_GET_SSIZE(mem)                          \
+static PyObject *                                           \
+context_get##mem(PyObject *self, void *Py_UNUSED(closure))  \
+{                                                           \
+    return PyLong_FromSsize_t(mpd_get##mem(CTX(self)));     \
 }
 
-#define Dec_CONTEXT_GET_ULONG(mem) \
-static PyObject *                                            \
-context_get##mem(PyObject *self, void *closure UNUSED)       \
-{                                                            \
-    return PyLong_FromUnsignedLong(mpd_get##mem(CTX(self))); \
+#define Dec_CONTEXT_GET_ULONG(mem)                              \
+static PyObject *                                               \
+context_get##mem(PyObject *self, void *Py_UNUSED(closure))      \
+{                                                               \
+    return PyLong_FromUnsignedLong(mpd_get##mem(CTX(self)));    \
 }
 
 Dec_CONTEXT_GET_SSIZE(prec)
@@ -854,7 +849,7 @@ Dec_CONTEXT_GET_ULONG(status)
 #endif
 
 static PyObject *
-context_getround(PyObject *self, void *closure UNUSED)
+context_getround(PyObject *self, void *Py_UNUSED(closure))
 {
     int i = mpd_getround(CTX(self));
     decimal_state *state = get_module_state_by_def(Py_TYPE(self));
@@ -863,33 +858,33 @@ context_getround(PyObject *self, void *closure UNUSED)
 }
 
 static PyObject *
-context_getcapitals(PyObject *self, void *closure UNUSED)
+context_getcapitals(PyObject *self, void *Py_UNUSED(closure))
 {
     return PyLong_FromLong(CtxCaps(self));
 }
 
 #ifdef EXTRA_FUNCTIONALITY
 static PyObject *
-context_getallcr(PyObject *self, void *closure UNUSED)
+context_getallcr(PyObject *self, void *Py_UNUSED(closure))
 {
     return PyLong_FromLong(mpd_getcr(CTX(self)));
 }
 #endif
 
 static PyObject *
-context_getetiny(PyObject *self, PyObject *dummy UNUSED)
+context_getetiny(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     return PyLong_FromSsize_t(mpd_etiny(CTX(self)));
 }
 
 static PyObject *
-context_getetop(PyObject *self, PyObject *dummy UNUSED)
+context_getetop(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     return PyLong_FromSsize_t(mpd_etop(CTX(self)));
 }
 
 static int
-context_setprec(PyObject *self, PyObject *value, void *closure UNUSED)
+context_setprec(PyObject *self, PyObject *value, void *Py_UNUSED(closure))
 {
     mpd_context_t *ctx;
     mpd_ssize_t x;
@@ -909,7 +904,7 @@ context_setprec(PyObject *self, PyObject *value, void *closure UNUSED)
 }
 
 static int
-context_setemin(PyObject *self, PyObject *value, void *closure UNUSED)
+context_setemin(PyObject *self, PyObject *value, void *Py_UNUSED(closure))
 {
     mpd_context_t *ctx;
     mpd_ssize_t x;
@@ -929,7 +924,7 @@ context_setemin(PyObject *self, PyObject *value, void *closure UNUSED)
 }
 
 static int
-context_setemax(PyObject *self, PyObject *value, void *closure UNUSED)
+context_setemax(PyObject *self, PyObject *value, void *Py_UNUSED(closure))
 {
     mpd_context_t *ctx;
     mpd_ssize_t x;
@@ -1011,7 +1006,7 @@ context_unsafe_setemax(PyObject *self, PyObject *value)
 #endif
 
 static int
-context_setround(PyObject *self, PyObject *value, void *closure UNUSED)
+context_setround(PyObject *self, PyObject *value, void *Py_UNUSED(closure))
 {
     mpd_context_t *ctx;
     int x;
@@ -1031,7 +1026,7 @@ context_setround(PyObject *self, PyObject *value, void *closure UNUSED)
 }
 
 static int
-context_setcapitals(PyObject *self, PyObject *value, void *closure UNUSED)
+context_setcapitals(PyObject *self, PyObject *value, void *Py_UNUSED(closure))
 {
     mpd_ssize_t x;
 
@@ -1051,7 +1046,7 @@ context_setcapitals(PyObject *self, PyObject *value, void *closure UNUSED)
 
 #ifdef EXTRA_FUNCTIONALITY
 static int
-context_settraps(PyObject *self, PyObject *value, void *closure UNUSED)
+context_settraps(PyObject *self, PyObject *value, void *Py_UNUSED(closure))
 {
     mpd_context_t *ctx;
     uint32_t flags;
@@ -1116,7 +1111,7 @@ context_settraps_dict(PyObject *self, PyObject *value)
 
 #ifdef EXTRA_FUNCTIONALITY
 static int
-context_setstatus(PyObject *self, PyObject *value, void *closure UNUSED)
+context_setstatus(PyObject *self, PyObject *value, void *Py_UNUSED(closure))
 {
     mpd_context_t *ctx;
     uint32_t flags;
@@ -1181,7 +1176,7 @@ context_setstatus_dict(PyObject *self, PyObject *value)
 }
 
 static int
-context_setclamp(PyObject *self, PyObject *value, void *closure UNUSED)
+context_setclamp(PyObject *self, PyObject *value, void *Py_UNUSED(closure))
 {
     mpd_context_t *ctx;
     mpd_ssize_t x;
@@ -1202,7 +1197,7 @@ context_setclamp(PyObject *self, PyObject *value, void *closure UNUSED)
 
 #ifdef EXTRA_FUNCTIONALITY
 static int
-context_setallcr(PyObject *self, PyObject *value, void *closure UNUSED)
+context_setallcr(PyObject *self, PyObject *value, void *Py_UNUSED(closure))
 {
     mpd_context_t *ctx;
     mpd_ssize_t x;
@@ -1324,14 +1319,14 @@ context_setattrs(PyObject *self, PyObject *prec, PyObject *rounding,
 }
 
 static PyObject *
-context_clear_traps(PyObject *self, PyObject *dummy UNUSED)
+context_clear_traps(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     CTX(self)->traps = 0;
     Py_RETURN_NONE;
 }
 
 static PyObject *
-context_clear_flags(PyObject *self, PyObject *dummy UNUSED)
+context_clear_flags(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     CTX(self)->status = 0;
     Py_RETURN_NONE;
@@ -1347,7 +1342,8 @@ static mpd_context_t dflt_ctx = {
 };
 
 static PyObject *
-context_new(PyTypeObject *type, PyObject *args UNUSED, PyObject *kwds UNUSED)
+context_new(PyTypeObject *type,
+            PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwds))
 {
     PyDecContextObject *self = NULL;
     mpd_context_t *ctx;
@@ -1554,7 +1550,7 @@ error:
 #endif
 
 static PyObject *
-context_copy(PyObject *self, PyObject *args UNUSED)
+context_copy(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *copy;
 
@@ -1572,7 +1568,7 @@ context_copy(PyObject *self, PyObject *args UNUSED)
 }
 
 static PyObject *
-context_reduce(PyObject *self, PyObject *args UNUSED)
+context_reduce(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *flags;
     PyObject *traps;
@@ -1727,7 +1723,7 @@ current_context(decimal_state *modstate)
 
 /* Return a new reference to the current context */
 static PyObject *
-PyDec_GetCurrentContext(PyObject *self, PyObject *args UNUSED)
+PyDec_GetCurrentContext(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *context;
     decimal_state *state = get_module_state(self);
@@ -1823,7 +1819,7 @@ current_context(decimal_state *state)
 
 /* Return a new reference to the current context */
 static PyObject *
-PyDec_GetCurrentContext(PyObject *self, PyObject *args UNUSED)
+PyDec_GetCurrentContext(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     decimal_state *state = get_module_state(self);
     return current_context(state);
@@ -1960,7 +1956,8 @@ ctxmanager_dealloc(PyDecContextManagerObject *self)
 }
 
 static PyObject *
-ctxmanager_set_local(PyDecContextManagerObject *self, PyObject *args UNUSED)
+ctxmanager_set_local(PyDecContextManagerObject *self,
+                     PyObject *Py_UNUSED(dummy))
 {
     PyObject *ret;
 
@@ -1975,7 +1972,7 @@ ctxmanager_set_local(PyDecContextManagerObject *self, PyObject *args UNUSED)
 
 static PyObject *
 ctxmanager_restore_global(PyDecContextManagerObject *self,
-                          PyObject *args UNUSED)
+                          PyObject *Py_UNUSED(args))
 {
     PyObject *ret;
 
@@ -3638,7 +3635,7 @@ dec_as_long(PyObject *dec, PyObject *context, int round)
 
 /* Convert a Decimal to its exact integer ratio representation. */
 static PyObject *
-dec_as_integer_ratio(PyObject *self, PyObject *args UNUSED)
+dec_as_integer_ratio(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *numerator = NULL;
     PyObject *denominator = NULL;
@@ -3906,7 +3903,7 @@ PyDec_Round(PyObject *dec, PyObject *args)
 
 /* Return the DecimalTuple representation of a PyDecObject. */
 static PyObject *
-PyDec_AsTuple(PyObject *dec, PyObject *dummy UNUSED)
+PyDec_AsTuple(PyObject *dec, PyObject *Py_UNUSED(dummy))
 {
     PyObject *result = NULL;
     PyObject *sign = NULL;
@@ -4062,7 +4059,7 @@ nm_##MPDFUNC(PyObject *self, PyObject *other)                    \
 /* Boolean function without a context arg. */
 #define Dec_BoolFunc(MPDFUNC) \
 static PyObject *                                           \
-dec_##MPDFUNC(PyObject *self, PyObject *dummy UNUSED)       \
+dec_##MPDFUNC(PyObject *self, PyObject *Py_UNUSED(dummy))   \
 {                                                           \
     return MPDFUNC(MPD(self)) ? incr_true() : incr_false(); \
 }
@@ -4391,7 +4388,7 @@ Dec_BoolFuncVA(mpd_issubnormal)
 
 /* Unary functions, no context arg */
 static PyObject *
-dec_mpd_adjexp(PyObject *self, PyObject *dummy UNUSED)
+dec_mpd_adjexp(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     mpd_ssize_t retval;
 
@@ -4406,19 +4403,19 @@ dec_mpd_adjexp(PyObject *self, PyObject *dummy UNUSED)
 }
 
 static PyObject *
-dec_canonical(PyObject *self, PyObject *dummy UNUSED)
+dec_canonical(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     return Py_NewRef(self);
 }
 
 static PyObject *
-dec_conjugate(PyObject *self, PyObject *dummy UNUSED)
+dec_conjugate(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     return Py_NewRef(self);
 }
 
 static PyObject *
-dec_mpd_radix(PyObject *self, PyObject *dummy UNUSED)
+dec_mpd_radix(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *result;
 
@@ -4433,7 +4430,7 @@ dec_mpd_radix(PyObject *self, PyObject *dummy UNUSED)
 }
 
 static PyObject *
-dec_mpd_qcopy_abs(PyObject *self, PyObject *dummy UNUSED)
+dec_mpd_qcopy_abs(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *result;
     uint32_t status = 0;
@@ -4454,7 +4451,7 @@ dec_mpd_qcopy_abs(PyObject *self, PyObject *dummy UNUSED)
 }
 
 static PyObject *
-dec_mpd_qcopy_negate(PyObject *self, PyObject *dummy UNUSED)
+dec_mpd_qcopy_negate(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *result;
     uint32_t status = 0;
@@ -4708,7 +4705,7 @@ dec_richcompare(PyObject *v, PyObject *w, int op)
 
 /* __ceil__ */
 static PyObject *
-dec_ceil(PyObject *self, PyObject *dummy UNUSED)
+dec_ceil(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *context;
 
@@ -4719,7 +4716,7 @@ dec_ceil(PyObject *self, PyObject *dummy UNUSED)
 
 /* __complex__ */
 static PyObject *
-dec_complex(PyObject *self, PyObject *dummy UNUSED)
+dec_complex(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *f;
     double x;
@@ -4738,16 +4735,16 @@ dec_complex(PyObject *self, PyObject *dummy UNUSED)
     return PyComplex_FromDoubles(x, 0);
 }
 
-/* __copy__ and __deepcopy__ */
+/* __copy__ (METH_NOARGS) and __deepcopy__ (METH_O) */
 static PyObject *
-dec_copy(PyObject *self, PyObject *dummy UNUSED)
+dec_copy(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     return Py_NewRef(self);
 }
 
 /* __floor__ */
 static PyObject *
-dec_floor(PyObject *self, PyObject *dummy UNUSED)
+dec_floor(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *context;
 
@@ -4884,7 +4881,7 @@ dec_hash(PyDecObject *self)
 
 /* __reduce__ */
 static PyObject *
-dec_reduce(PyObject *self, PyObject *dummy UNUSED)
+dec_reduce(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *result, *str;
 
@@ -4901,7 +4898,7 @@ dec_reduce(PyObject *self, PyObject *dummy UNUSED)
 
 /* __sizeof__ */
 static PyObject *
-dec_sizeof(PyObject *v, PyObject *dummy UNUSED)
+dec_sizeof(PyObject *v, PyObject *Py_UNUSED(dummy))
 {
     size_t res = _PyObject_SIZE(Py_TYPE(v));
     if (mpd_isdynamic_data(MPD(v))) {
@@ -4912,7 +4909,7 @@ dec_sizeof(PyObject *v, PyObject *dummy UNUSED)
 
 /* __trunc__ */
 static PyObject *
-dec_trunc(PyObject *self, PyObject *dummy UNUSED)
+dec_trunc(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     PyObject *context;
 
@@ -4923,13 +4920,13 @@ dec_trunc(PyObject *self, PyObject *dummy UNUSED)
 
 /* real and imag */
 static PyObject *
-dec_real(PyObject *self, void *closure UNUSED)
+dec_real(PyObject *self, void *Py_UNUSED(closure))
 {
     return Py_NewRef(self);
 }
 
 static PyObject *
-dec_imag(PyObject *self UNUSED, void *closure UNUSED)
+dec_imag(PyObject *self, void *Py_UNUSED(closure))
 {
     PyObject *result;
 

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -788,7 +788,7 @@ signaldict_copy(PyObject *self, PyObject *Py_UNUSED(dummy))
 
 
 static PyMethodDef signaldict_methods[] = {
-    { "copy", (PyCFunction)signaldict_copy, METH_NOARGS, NULL},
+    { "copy", signaldict_copy, METH_NOARGS, NULL},
     {NULL, NULL}
 };
 
@@ -5718,9 +5718,9 @@ static PyMethodDef context_methods [] =
 #endif
 
   /* Miscellaneous */
-  { "__copy__", (PyCFunction)context_copy, METH_NOARGS, NULL },
+  { "__copy__", context_copy, METH_NOARGS, NULL },
   { "__reduce__", context_reduce, METH_NOARGS, NULL },
-  { "copy", (PyCFunction)context_copy, METH_NOARGS, doc_ctx_copy },
+  { "copy", context_copy, METH_NOARGS, doc_ctx_copy },
   { "create_decimal", ctx_create_decimal, METH_VARARGS, doc_ctx_create_decimal },
   { "create_decimal_from_float", ctx_from_float, METH_O, doc_ctx_create_decimal_from_float },
 
@@ -5753,11 +5753,11 @@ static PyType_Spec context_spec = {
 
 static PyMethodDef _decimal_methods [] =
 {
-  { "getcontext", (PyCFunction)PyDec_GetCurrentContext, METH_NOARGS, doc_getcontext},
-  { "setcontext", (PyCFunction)PyDec_SetCurrentContext, METH_O, doc_setcontext},
+  { "getcontext", PyDec_GetCurrentContext, METH_NOARGS, doc_getcontext},
+  { "setcontext", PyDec_SetCurrentContext, METH_O, doc_setcontext},
   { "localcontext", _PyCFunction_CAST(ctxmanager_new), METH_VARARGS|METH_KEYWORDS, doc_localcontext},
 #ifdef EXTRA_FUNCTIONALITY
-  { "IEEEContext", (PyCFunction)ieee_context, METH_O, doc_ieee_context},
+  { "IEEEContext", ieee_context, METH_O, doc_ieee_context},
 #endif
   { NULL, NULL, 1, NULL }
 };


### PR DESCRIPTION
When I looked at the refleaks in the decimal module, I observed that some macros are not protected against dangling else and that `UNUSED` does not match `Py_UNUSED`. 

I didn't want to make two different PRs (though I can cherry-pick the commits since they are easy separated); nevertheless, I think the `do-while` protection should be included (I've already done this kind of PRs in the past).

There are some casts are redundant and one argument that was marked as unused but that was not! Some methods used 'args' but were using the `METH_NOARGS` (so it could be confusing to users!) flag. There is one exception being `dec_copy` which both uses a `METH_NOARGS` and `METH_O` flag for `__copy__` and `__deepcopy__` respectively. I left it as `dummy` but added a small comment.