### PR TITLE
gh-123797: Check for runtime availability of `ptsname_r` on macos

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -2140,6 +2140,13 @@ class TestPosixWeaklinking(unittest.TestCase):
             with self.assertRaisesRegex(NotImplementedError, "dir_fd unavailable"):
                 os.stat("file", dir_fd=0)
 
+    def test_ptsname_r(self):
+        self._verify_available("HAVE_PTSNAME_R")
+        if self.mac_ver >= (10, 13, 4):
+            self.assertIn("HAVE_PTSNAME_R", posix._have_functions)
+        else:
+            self.assertNotIn("HAVE_PTSNAME_R", posix._have_functions)
+
     def test_access(self):
         self._verify_available("HAVE_FACCESSAT")
         if self.mac_ver >= (10, 10):

--- a/Misc/NEWS.d/next/macOS/2024-09-07-12-14-54.gh-issue-123797.yFDeug.rst
+++ b/Misc/NEWS.d/next/macOS/2024-09-07-12-14-54.gh-issue-123797.yFDeug.rst
@@ -1,0 +1,1 @@
+Check for runtime availability of ``ptsname_r`` function on macos.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -125,6 +125,7 @@
 #  define HAVE_PWRITEV_RUNTIME __builtin_available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *)
 #  define HAVE_MKFIFOAT_RUNTIME __builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 #  define HAVE_MKNODAT_RUNTIME __builtin_available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
+#  define HAVE_PTSNAME_R_RUNTIME __builtin_available(macOS 10.13.4, iOS 11.3, tvOS 11.3, watchOS 4.3, *)
 
 #  define HAVE_POSIX_SPAWN_SETSID_RUNTIME __builtin_available(macOS 10.15, *)
 
@@ -206,6 +207,10 @@
 #    define HAVE_MKNODAT_RUNTIME (mknodat != NULL)
 #  endif
 
+#  ifdef HAVE_PTSNAME_R
+#    define HAVE_PTSNAME_R_RUNTIME (ptsname_r != NULL)
+#  endif
+
 #endif
 
 #ifdef HAVE_FUTIMESAT
@@ -231,6 +236,7 @@
 #  define HAVE_PWRITEV_RUNTIME 1
 #  define HAVE_MKFIFOAT_RUNTIME 1
 #  define HAVE_MKNODAT_RUNTIME 1
+#  define HAVE_PTSNAME_R_RUNTIME 1
 #endif
 
 
@@ -8656,7 +8662,12 @@ os_ptsname_impl(PyObject *module, int fd)
     int ret;
     char name[MAXPATHLEN+1];
 
-    ret = ptsname_r(fd, name, sizeof(name));
+    if (HAVE_PTSNAME_R_RUNTIME) {
+        ret = ptsname_r(fd, name, sizeof(name));
+    }
+    else {
+        ret = -1;
+    }
     if (ret != 0) {
         errno = ret;
         return posix_error();
@@ -17751,6 +17762,9 @@ PROBE(probe_futimens, HAVE_FUTIMENS_RUNTIME)
 PROBE(probe_utimensat, HAVE_UTIMENSAT_RUNTIME)
 #endif
 
+#ifdef HAVE_PTSNAME_R
+PROBE(probe_ptsname_r, HAVE_PTSNAME_R_RUNTIME)
+#endif
 
 
 
@@ -17889,6 +17903,10 @@ static const struct have_function {
 
 #ifdef HAVE_UTIMENSAT
     { "HAVE_UTIMENSAT", probe_utimensat },
+#endif
+
+#ifdef HAVE_PTSNAME_R
+    { "HAVE_PTSNAME_R", probe_ptsname_r },
 #endif
 
 #ifdef MS_WINDOWS

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8678,14 +8678,8 @@ os_ptsname_impl(PyObject *module, int fd)
         ret = ptsname_r(fd, name, sizeof(name));
     }
     else {
-#if defined(HAVE_PTSNAME)
         // fallback to `ptsname` if `ptsname_r` is not available in runtime.
         return from_ptsname(fd);
-#else
-        // unknown error:
-        // both ptsname_r and ptsname are not available for some reason.
-        ret = -1;
-#endif /* HAVE_PTSNAME */
     }
     if (ret != 0) {
         errno = ret;


### PR DESCRIPTION
I took the version info from https://github.com/xybp888/iOS-SDKs/blob/d7f1be9f5b79cffcfb547bbd930f92ec0fc35038/iPhoneOS13.0.sdk/usr/include/stdlib.h#L224

<!-- gh-issue-number: gh-123797 -->
* Issue: gh-123797
<!-- /gh-issue-number -->
