### PR TITLE
gh-123165: improve docs signature for `dis.disassemble`

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -312,7 +312,8 @@ operation is being performed, so the intermediate analysis object isn't useful:
    .. versionchanged:: 3.14
       Added the *show_positions* parameter.
 
-.. function:: disassemble(code, lasti=-1, *, file=None, show_caches=False, adaptive=False)
+.. function:: disassemble(code, lasti=-1, *, file=None, show_caches=False,\
+                          adaptive=False, show_offsets=False, show_positions=False)
               disco(code, lasti=-1, *, file=None, show_caches=False, adaptive=False,\
                     show_offsets=False, show_positions=False)
 


### PR DESCRIPTION
I forgot to update the signature for `dis.disassemble` (which is the principal function, while `disco` is just an alias).

<!-- gh-issue-number: gh-123165 -->
* Issue: gh-123165
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123808.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->