### PR TITLE
gh-123905: Update TOML description to include version number

### DIFF
--- a/Doc/library/tomllib.rst
+++ b/Doc/library/tomllib.rst
@@ -13,7 +13,7 @@
 
 --------------
 
-This module provides an interface for parsing TOML (Tom's Obvious Minimal
+This module provides an interface for parsing TOML 1.0.0 (Tom's Obvious Minimal
 Language, `https://toml.io <https://toml.io/en/>`_). This module does not
 support writing TOML.
 


### PR DESCRIPTION
There is some movement, currently blocked, that would update the TOML spec to 1.1.0; this would include breaking changes to what characters are allowed. Thus, it is worthwhile for the library page to be clear which version is implemented here.

<!--
Where: gh-NNNNN refers to the GitHub issue number.

PEH: The "update this file" functionality in GitHub didn't create an issue for this change.
-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123825.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-123905 -->
* Issue: gh-123905
<!-- /gh-issue-number -->
