### PR TITLE
gh-123843: Remove broken links to the Zope DateTimeWiki

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -1,8 +1,4 @@
-"""Concrete date/time and related types.
-
-See http://www.iana.org/time-zones/repository/tz-link.html for
-time zone and DST data sources.
-"""
+"""Pure Python implementation of the datetime module."""
 
 __all__ = ("date", "datetime", "time", "timedelta", "timezone", "tzinfo",
            "MINYEAR", "MAXYEAR", "UTC")

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1,9 +1,13 @@
+"""Concrete date/time and related types.
+
+See http://www.iana.org/time-zones/repository/tz-link.html for
+time zone and DST data sources.
+"""
+
 try:
     from _datetime import *
-    from _datetime import __doc__  # noqa: F401
 except ImportError:
     from _pydatetime import *
-    from _pydatetime import __doc__  # noqa: F401
 
 __all__ = ("date", "datetime", "time", "timedelta", "timezone", "tzinfo",
            "MINYEAR", "MAXYEAR", "UTC")

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1,6 +1,6 @@
-"""Concrete date/time and related types.
+"""Specific date/time and related types.
 
-See http://www.iana.org/time-zones/repository/tz-link.html for
+See https://data.iana.org/time-zones/tz-link.html for
 time zone and DST data sources.
 """
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1,7 +1,4 @@
-"""Test date/time type.
-
-See https://www.zope.dev/Members/fdrake/DateTimeWiki/TestCases
-"""
+"""Test the datetime module."""
 import bisect
 import copy
 import decimal

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1,6 +1,4 @@
-/*  C implementation for the date/time type documented at
- *  https://www.zope.dev/Members/fdrake/DateTimeWiki/FrontPage
- */
+/*  C implementation of the datetime module */
 
 /* bpo-35081: Defining this prevents including the C API capsule;
  * internal versions of the  Py*_Check macros which do not require
@@ -7418,7 +7416,7 @@ module_free(void *mod)
 static PyModuleDef datetimemodule = {
     .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "_datetime",
-    .m_doc = "Fast implementation of the datetime type.",
+    .m_doc = "Fast implementation of the datetime module.",
     .m_size = sizeof(datetime_state),
     .m_methods = module_methods,
     .m_slots = module_slots,


### PR DESCRIPTION
As an alternative to #123844.

cc: @otkd @Eclips4 

A

<!-- gh-issue-number: gh-123843 -->
* Issue: gh-123843
<!-- /gh-issue-number -->
