### PR TITLE
gh-123407: Allow translation of doctest blocks content

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -312,6 +312,7 @@ root_doc = 'contents'
 gettext_additional_targets = [
     'index',
     'literal-block',
+    'doctest-block',
 ]
 
 # Options for HTML output


### PR DESCRIPTION
Refs #123407. Doctest blocks are the second type of blocks present in Python documentation, that need a separate configuration value. Example: https://github.com/python/cpython/blob/e09442089eb86d88d4b5a96e56f713cb31173ae9/Doc/tutorial/introduction.rst?plain=1#L150-L155

Disclaimer: changing the Sphinx config [doesn't seem to make expected difference](https://github.com/sphinx-doc/sphinx/issues/12871).

<!-- gh-issue-number: gh-123407 -->
* Issue: gh-123407
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123852.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->