### PR TITLE
gh-123681: handle c99-specific specifiers for strftime when cross-compiling

### DIFF
--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1,3 +1,4 @@
+/* edited to trigger JIT checks */
 #ifdef _Py_TIER2
 
 #include "Python.h"

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1,4 +1,3 @@
-/* edited to trigger JIT checks */
 #ifdef _Py_TIER2
 
 #include "Python.h"

--- a/configure
+++ b/configure
@@ -26205,7 +26205,7 @@ else $as_nop
 
 if test "$cross_compiling" = yes
 then :
-  ac_cv_strftime_c99_support=no
+  ac_cv_strftime_c99_support=yes
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */

--- a/configure.ac
+++ b/configure.ac
@@ -6724,7 +6724,7 @@ int main(void)
 ]])],
 [ac_cv_strftime_c99_support=yes],
 [ac_cv_strftime_c99_support=no],
-[ac_cv_strftime_c99_support=no])])
+[ac_cv_strftime_c99_support=yes])])
 if test "$ac_cv_strftime_c99_support" = yes
 then
   AC_DEFINE([Py_STRFTIME_C99_SUPPORT], [1],


### PR DESCRIPTION


<!-- gh-issue-number: gh-123681 -->
* Issue: gh-123681
<!-- /gh-issue-number -->
