### PR TITLE
gh-66449: remove duplicate configparser section in 3.13 whatsnew

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -786,14 +786,6 @@ compileall
   (Contributed by Victor Stinner in :gh:`109649`.)
 
 
-configparser
-------------
-
-* The :class:`configparser.ConfigParser` now accepts unnamed sections
-  before named ones if configured to do so.
-  (Contributed by Pedro Sousa Lacerda in :gh:`66449`.)
-
-
 concurrent.futures
 ------------------
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123874.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-66449 -->
* Issue: gh-66449
<!-- /gh-issue-number -->
