### PR TITLE
gh-123777: Allow `__orig_class__` to be accessed in `__init__`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5621,6 +5621,14 @@ class GenericTests(BaseTestCase):
                     with self.assertRaises(TypeError):
                         a[int]
 
+    def test_orig_class_init(self):
+        # See gh-123777
+        T = TypeVar("T")
+        class OrigClassInit(Generic[T]):
+            def __init__(self):
+                self.attr = self.__orig_class__
+        self.assertEqual(OrigClassInit[int]().attr, OrigClassInit[int])
+
 
 class ClassVarTests(BaseTestCase):
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -30,6 +30,7 @@ import operator
 import sys
 import types
 from types import WrapperDescriptorType, MethodWrapperType, MethodDescriptorType, GenericAlias
+import inspect
 
 from _typing import (
     _idfunc,
@@ -1291,7 +1292,7 @@ class _BaseGenericAlias(_Final, _root=True):
             raise TypeError(f"Type {self._name} cannot be instantiated; "
                             f"use {self.__origin__.__name__}() instead")
         clas = self.__origin__
-        is_python_type = clas.__new__ is type.__new__
+        is_python_type = inspect.isfunction(clas.__new__)
 
         if is_python_type:
             # GH-123777: Some types try and access __orig_class__ in their __init__

--- a/Misc/NEWS.d/next/Library/2024-09-09-16-21-12.gh-issue-123777.sdyP3n.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-09-16-21-12.gh-issue-123777.sdyP3n.rst
@@ -1,0 +1,2 @@
+Allowed the ``__orig_class__`` attribute to be used in the ``__init__`` of
+pure-Python types.


### PR DESCRIPTION


<!-- gh-issue-number: gh-123777 -->
* Issue: gh-123777
<!-- /gh-issue-number -->
