### PR TITLE
Update to 3.13 the output of exceptions raised

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -45,14 +45,20 @@ programs, however, and result in error messages as shown here::
    >>> 10 * (1/0)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
+       10 * (1/0)
+             ~^~
    ZeroDivisionError: division by zero
    >>> 4 + spam*3
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
+       4 + spam*3
+           ^^^^
    NameError: name 'spam' is not defined
    >>> '2' + 2
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
+       '2' + 2
+       ~~~~^~~
    TypeError: can only concatenate str (not "int") to str
 
 The last line of the error message indicates what happened. Exceptions come in
@@ -252,6 +258,7 @@ exception to occur. For example::
    >>> raise NameError('HiThere')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
+       raise NameError('HiThere')
    NameError: HiThere
 
 The sole argument to :keyword:`raise` indicates the exception to be raised.
@@ -275,6 +282,7 @@ re-raise the exception::
    An exception flew by!
    Traceback (most recent call last):
      File "<stdin>", line 2, in <module>
+       raise NameError('HiThere')
    NameError: HiThere
 
 
@@ -294,12 +302,15 @@ message::
     ...
     Traceback (most recent call last):
       File "<stdin>", line 2, in <module>
+        open("database.sqlite")
+        ~~~~^^^^^^^^^^^^^^^^^^^
     FileNotFoundError: [Errno 2] No such file or directory: 'database.sqlite'
     <BLANKLINE>
     During handling of the above exception, another exception occurred:
     <BLANKLINE>
     Traceback (most recent call last):
       File "<stdin>", line 4, in <module>
+        raise RuntimeError("unable to handle error")
     RuntimeError: unable to handle error
 
 To indicate that an exception is a direct consequence of another, the
@@ -320,6 +331,8 @@ This can be useful when you are transforming exceptions. For example::
     ...
     Traceback (most recent call last):
       File "<stdin>", line 2, in <module>
+        func()
+        ~~~~^^
       File "<stdin>", line 2, in func
     ConnectionError
     <BLANKLINE>
@@ -327,6 +340,7 @@ This can be useful when you are transforming exceptions. For example::
     <BLANKLINE>
     Traceback (most recent call last):
       File "<stdin>", line 4, in <module>
+        raise RuntimeError('Failed to open database') from exc
     RuntimeError: Failed to open database
 
 It also allows disabling automatic exception chaining using the ``from None``
@@ -339,6 +353,7 @@ idiom::
     ...
     Traceback (most recent call last):
       File "<stdin>", line 4, in <module>
+        raise RuntimeError from None
     RuntimeError
 
 For more information about chaining mechanics, see :ref:`bltin-exceptions`.
@@ -381,6 +396,7 @@ example::
    Goodbye, world!
    Traceback (most recent call last):
      File "<stdin>", line 2, in <module>
+       raise KeyboardInterrupt
    KeyboardInterrupt
 
 If a :keyword:`finally` clause is present, the :keyword:`!finally`
@@ -448,7 +464,11 @@ A more complicated example::
    executing finally clause
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
+       divide("2", "0")
+       ~~~~~~^^^^^^^^^^
      File "<stdin>", line 3, in divide
+       result = x / y
+                ~~^~~
    TypeError: unsupported operand type(s) for /: 'str' and 'str'
 
 As you can see, the :keyword:`finally` clause is executed in any event.  The
@@ -511,8 +531,11 @@ caught like any other exception. ::
    >>> f()
      + Exception Group Traceback (most recent call last):
      |   File "<stdin>", line 1, in <module>
+     |     f()
+     |     ~^^
      |   File "<stdin>", line 3, in f
-     | ExceptionGroup: there were problems
+     |     raise ExceptionGroup('there were problems', excs)
+     | ExceptionGroup: there were problems (2 sub-exceptions)
      +-+---------------- 1 ----------------
        | OSError: error 1
        +---------------- 2 ----------------
@@ -560,10 +583,15 @@ other clauses and eventually to be reraised. ::
    There were SystemErrors
      + Exception Group Traceback (most recent call last):
      |   File "<stdin>", line 2, in <module>
+     |     f()
+     |     ~^^
      |   File "<stdin>", line 2, in f
-     | ExceptionGroup: group1
+     |     raise ExceptionGroup(
+     |     ...<12 lines>...
+     |     )
+     | ExceptionGroup: group1 (1 sub-exception)
      +-+---------------- 1 ----------------
-       | ExceptionGroup: group2
+       | ExceptionGroup: group2 (1 sub-exception)
        +-+---------------- 1 ----------------
          | RecursionError: 4
          +------------------------------------
@@ -607,6 +635,7 @@ includes all notes, in the order they were added, after the exception. ::
    ...
    Traceback (most recent call last):
      File "<stdin>", line 2, in <module>
+       raise TypeError('bad type')
    TypeError: bad type
    Add some information
    Add some more information
@@ -630,23 +659,33 @@ exception in the group has a note indicating when this error has occurred. ::
    >>> raise ExceptionGroup('We have some problems', excs)
      + Exception Group Traceback (most recent call last):
      |   File "<stdin>", line 1, in <module>
+     |     raise ExceptionGroup('We have some problems', excs)
      | ExceptionGroup: We have some problems (3 sub-exceptions)
      +-+---------------- 1 ----------------
        | Traceback (most recent call last):
        |   File "<stdin>", line 3, in <module>
+       |     f()
+       |     ~^^
        |   File "<stdin>", line 2, in f
+       |     raise OSError('operation failed')
        | OSError: operation failed
        | Happened in Iteration 1
        +---------------- 2 ----------------
        | Traceback (most recent call last):
        |   File "<stdin>", line 3, in <module>
+       |     f()
+       |     ~^^
        |   File "<stdin>", line 2, in f
+       |     raise OSError('operation failed')
        | OSError: operation failed
        | Happened in Iteration 2
        +---------------- 3 ----------------
        | Traceback (most recent call last):
        |   File "<stdin>", line 3, in <module>
+       |     f()
+       |     ~^^
        |   File "<stdin>", line 2, in f
+       |     raise OSError('operation failed')
        | OSError: operation failed
        | Happened in Iteration 3
        +------------------------------------


### PR DESCRIPTION
I compared the current documented output of the exceptions running python 3.13, and found these differences in comparison with previous python versions.

Please backport to 3.13 (this doesn't apply to 3.12!)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123888.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->