### PR TITLE
gh-123905: Update TOML description to include version number

### DIFF
--- a/Doc/library/tomllib.rst
+++ b/Doc/library/tomllib.rst
@@ -13,7 +13,7 @@
 
 --------------
 
-This module provides an interface for parsing TOML (Tom's Obvious Minimal
+This module provides an interface for parsing TOML 1.0.0 (Tom's Obvious Minimal
 Language, `https://toml.io <https://toml.io/en/>`_). This module does not
 support writing TOML.
 


### PR DESCRIPTION
There is some movement, currently blocked, that would update the TOML spec to 1.1.0; this would include breaking changes to what characters are allowed. Thus, it is worthwhile for the library page to be clear which version is implemented here.

Patch by @paulehoffman (#123825)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123906.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-123905 -->
* Issue: gh-123905
<!-- /gh-issue-number -->
