### PR TITLE
gh-123913: Fix `NULL` handling in `_curses_initscr_impl` of `_cursesmodule`

### DIFF
--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3266,7 +3266,6 @@ _curses_initscr_impl(PyObject *module)
 /*[clinic end generated code: output=619fb68443810b7b input=514f4bce1821f6b5]*/
 {
     WINDOW *win;
-    PyCursesWindowObject *winobj;
 
     if (initialised) {
         wrefresh(stdscr);
@@ -3362,9 +3361,12 @@ _curses_initscr_impl(PyObject *module)
     SetDictInt("LINES", LINES);
     SetDictInt("COLS", COLS);
 
-    winobj = (PyCursesWindowObject *)PyCursesWindow_New(win, NULL);
-    screen_encoding = winobj->encoding;
-    return (PyObject *)winobj;
+    PyObject *winobj = PyCursesWindow_New(win, NULL);
+    if (winobj == NULL) {
+        return NULL;
+    }
+    screen_encoding = ((PyCursesWindowObject *) winobj)->encoding;
+    return winobj;
 }
 
 /*[clinic input]


### PR DESCRIPTION
Thanks to @n-bes for the help with this bug.

<!-- gh-issue-number: gh-123913 -->
* Issue: gh-123913
<!-- /gh-issue-number -->
