### PR TITLE
gh-123915: Ensure that AMD64 and ARM64 builds use different directories

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-09-10-19-23-00.gh-issue-123915.yZMEDO.rst
+++ b/Misc/NEWS.d/next/Windows/2024-09-10-19-23-00.gh-issue-123915.yZMEDO.rst
@@ -1,0 +1,1 @@
+Ensure that ``Tools\msi\buildrelease.bat`` uses different directories for AMD64 and ARM64 builds.

--- a/Tools/msi/buildrelease.bat
+++ b/Tools/msi/buildrelease.bat
@@ -127,7 +127,7 @@ if "%1" EQU "x86" (
     set OUTDIR_PLAT=amd64
     set OBJDIR_PLAT=x64
 ) else if "%1" EQU "ARM64" (
-    set BUILD=%Py_OutDir%amd64\
+    set BUILD=%Py_OutDir%arm64\
     set PGO=%~2
     set BUILD_PLAT=ARM64
     set OUTDIR_PLAT=arm64


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This fixes #123915 and ensures that when `buildrelease.bat` is used, AMD64 and ARM64 builds happen in different directories.

<!-- gh-issue-number: gh-123915 -->
* Issue: gh-123915
<!-- /gh-issue-number -->
