### PR TITLE
gh-123919: Fix null handling in `_freeze_module.c`

### DIFF
--- a/Programs/_freeze_module.c
+++ b/Programs/_freeze_module.c
@@ -110,6 +110,9 @@ static PyObject *
 compile_and_marshal(const char *name, const char *text)
 {
     char *filename = (char *) malloc(strlen(name) + 10);
+    if (filename == NULL) {
+        return PyErr_NoMemory();
+    }
     sprintf(filename, "<frozen %s>", name);
     PyObject *code = Py_CompileStringExFlags(text, filename,
                                              Py_file_input, NULL, 0);
@@ -133,6 +136,9 @@ get_varname(const char *name, const char *prefix)
 {
     size_t n = strlen(prefix);
     char *varname = (char *) malloc(strlen(name) + n + 1);
+    if (varname == NULL) {
+        return NULL;
+    }
     (void)strcpy(varname, prefix);
     for (size_t i = 0; name[i] != '\0'; i++) {
         if (name[i] == '.') {
@@ -178,6 +184,11 @@ write_frozen(const char *outpath, const char *inpath, const char *name,
 
     fprintf(outfile, "%s\n", header);
     char *arrayname = get_varname(name, "_Py_M__");
+    if (arrayname == NULL) {
+        fprintf(stderr, "memory error: could not allocate varname\n");
+        fclose(outfile);
+        return -1;
+    }
     write_code(outfile, marshalled, arrayname);
     free(arrayname);
 


### PR DESCRIPTION
Thanks to @n-bes for the help with finding this issue: https://github.com/n-bes/build-cpython/blob/master/data/amd64-sast/errors.csv#L120

<!-- gh-issue-number: gh-123919 -->
* Issue: gh-123919
<!-- /gh-issue-number -->
