### PR TITLE
gh-123748: Disable HACL SIMD256 on universal builds.

### DIFF
--- a/Misc/NEWS.d/next/macOS/2024-09-11-08-00-19.gh-issue-123748.TOM9vt.rst
+++ b/Misc/NEWS.d/next/macOS/2024-09-11-08-00-19.gh-issue-123748.TOM9vt.rst
@@ -1,0 +1,1 @@
+HACL* Blake2 SIMD256 has been disabled for universal2 builds on macOS.

--- a/configure
+++ b/configure
@@ -30568,11 +30568,16 @@ printf "%s\n" "$ax_cv_check_cflags__Werror__mavx2" >&6; }
 if test "x$ax_cv_check_cflags__Werror__mavx2" = xyes
 then :
 
-  LIBHACL_SIMD256_FLAGS="-mavx2"
-  LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256.o"
+  # macOS universal2 builds *support* the -mavx2 compiler flag because it's
+  # available on x86_64; but the HACL SIMD256 build then fails because the
+  # implementation requires symbols that aren't available on ARM64.
+  if test "$UNIVERSAL_ARCHS" != "universal2"; then
+    LIBHACL_SIMD256_FLAGS="-mavx2"
+    LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256.o"
 
 printf "%s\n" "#define HACL_CAN_COMPILE_SIMD256 1" >>confdefs.h
 
+  fi
 
 else $as_nop
   :

--- a/configure.ac
+++ b/configure.ac
@@ -7813,9 +7813,14 @@ AC_SUBST([LIBHACL_SIMD128_FLAGS])
 AC_SUBST([LIBHACL_SIMD128_OBJS])
 
 AX_CHECK_COMPILE_FLAG([-mavx2],[
-  [LIBHACL_SIMD256_FLAGS="-mavx2"]
-  [LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256.o"]
-  AC_DEFINE([HACL_CAN_COMPILE_SIMD256], [1], [HACL* library can compile SIMD256 implementations])
+  # macOS universal2 builds *support* the -mavx2 compiler flag because it's
+  # available on x86_64; but the HACL SIMD256 build then fails because the
+  # implementation requires symbols that aren't available on ARM64.
+  if test "$UNIVERSAL_ARCHS" != "universal2"; then
+    [LIBHACL_SIMD256_FLAGS="-mavx2"]
+    [LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256.o"]
+    AC_DEFINE([HACL_CAN_COMPILE_SIMD256], [1], [HACL* library can compile SIMD256 implementations])
+  fi
 ], [], [-Werror])
 
 AC_SUBST([LIBHACL_SIMD256_FLAGS])


### PR DESCRIPTION
The native HACL implementation added in #119316 compiles fine on single architecture x86_64 and ARM64 macOS builds, but failed when compiled on universal2 builds. This is because the autoconf detection is based on the existence of the `-mavx2` compiler flag; this flag is *legal* in universal builds (because the x86_64 compilation path supports the flag), but this then requires symbols that *aren't* available on ARM64 builds. A standalone ARM64 build disables this feature.

This PR modifies the autoconf check so that if `-mavx2` support is detected *and* the build is universal2, the autoconf feature isn't enabled.


<!-- gh-issue-number: gh-123748 -->
* Issue: gh-123748
<!-- /gh-issue-number -->
