### PR TITLE
Minor edits to the descriptor guide

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -389,7 +389,9 @@ Here are three practical data validation utilities:
 
         def validate(self, value):
             if value not in self.options:
-                raise ValueError(f'Expected {value!r} to be one of {self.options!r}')
+                raise ValueError(
+                    f'Expected {value!r} to be one of {self.options!r}'
+                )
 
     class Number(Validator):
 

--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -471,6 +471,7 @@ The descriptors prevent invalid instances from being created:
     Traceback (most recent call last):
         ...
     ValueError: Expected -5 to be at least 0
+
     >>> Component('WIDGET', 'metal', 'V')    # Blocked: 'V' isn't a number
     Traceback (most recent call last):
         ...

--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -1004,7 +1004,6 @@ here is a pure Python equivalent that implements most of the core functionality:
             if doc is None and fget is not None:
                 doc = fget.__doc__
             self.__doc__ = doc
-            self.__name__ = ''
 
         def __set_name__(self, owner, name):
             self.__name__ = name

--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -1303,8 +1303,8 @@ mean, median, and other descriptive statistics that depend on the data. However,
 there may be useful functions which are conceptually related but do not depend
 on the data.  For instance, ``erf(x)`` is handy conversion routine that comes up
 in statistical work but does not directly depend on a particular dataset.
-It can be called either from an object or the class:  ``s.erf(1.5) --> .9332`` or
-``Sample.erf(1.5) --> .9332``.
+It can be called either from an object or the class:  ``s.erf(1.5) --> 0.9332``
+or ``Sample.erf(1.5) --> 0.9332``.
 
 Since static methods return the underlying function with no changes, the
 example calls are unexciting:


### PR DESCRIPTION
* Wrap long line
* Add blank line for readability
* Property has no `__name__` on initialization
* Floats are more legible with a leading zero

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123928.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->