### PR TITLE
GH-103219: Fix optional args incorrectly being processed as required args

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2130,7 +2130,9 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         required_actions = []
         for action in self._actions:
             if action not in seen_actions:
-                if action.required:
+                if (action.required and
+                    action.default is None and
+                    action.nargs not in (ZERO_OR_MORE, OPTIONAL)):
                     required_actions.append(_get_action_name(action))
                 else:
                     # Convert action default now instead of doing it before

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -6091,6 +6091,13 @@ class TestExitOnError(TestCase):
                                'the following arguments are required: bar, baz',
                                self.parser.parse_args, [])
 
+    def test_required_and_nargs(self):
+        self.parser.add_argument('bar')
+        self.parser.add_argument('baz', nargs='*')
+        self.assertRaisesRegex(argparse.ArgumentError,
+                               'the following arguments are required: bar',
+                               self.parser.parse_args, [])
+
     def test_required_mutually_exclusive_args(self):
         group = self.parser.add_mutually_exclusive_group(required=True)
         group.add_argument('--bar')

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -6091,7 +6091,7 @@ class TestExitOnError(TestCase):
                                'the following arguments are required: bar, baz',
                                self.parser.parse_args, [])
 
-    def test_required_and_nargs(self):
+    def test_required_and_optional(self):
         self.parser.add_argument('bar')
         self.parser.add_argument('baz', nargs='*')
         self.assertRaisesRegex(argparse.ArgumentError,

--- a/Misc/NEWS.d/next/Library/2024-09-11-03-21-56.gh-issue-103219.F5atBD.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-11-03-21-56.gh-issue-103219.F5atBD.rst
@@ -1,0 +1,1 @@
+Fixes a bug in argparse where optional args are incorrectly processed as required args


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This PR addresses a pretty old bug where optional args were incorrectly marked as required and adds a corresponding test case. We now more thoroughly check to see that an arg is 1) required, 2) has no default value, and 3) `nargs` is not set to `*` or `?` before adding it to the list of required args.

It looks like this bug at least dates back to 3.9, but since those releases are just for security fixes at this point, I've marked this for backport to 3.12 and 3.13.


<!-- gh-issue-number: gh-103219 -->
* Issue: gh-103219
<!-- /gh-issue-number -->
