### PR TITLE
Fix invisible character typo

### DIFF
--- a/Lib/zipfile/_path/__init__.py
+++ b/Lib/zipfile/_path/__init__.py
@@ -280,7 +280,7 @@ class Path:
     >>> str(path.parent)
     'mem'
 
-    If the zipfile has no filename, such ﻿attributes are not
+    If the zipfile has no filename, such attributes are not
     valid and accessing them will raise an Exception.
 
     >>> zf.filename = None


### PR DESCRIPTION
Remove accidental addition of zero-width character (U+FEFF) in #118622, reported by @jaraco:
- https://github.com/python/cpython/commit/c3f4a6b52418d9b9f091f864cb6340d0d5fc6966#commitcomment-146456562

The character can be found by:
```sh
❯ rg '\ufeff'
Lib/zipfile/_path/__init__.py
283:    If the zipfile has no filename, such attributes are not
```
The character has been removed and can no longer be found in the cpython repository.

Additionally, @jaraco has requested a new feature in `ruff` to detect invisible characters in the future (https://github.com/astral-sh/ruff/issues/13297). Since cpython uses `ruff` for linting, this feature will prevent similar issues from occurring in the future.