### PR TITLE
gh-123935: Fix typo in `_get_slots` in `dataclasses.py`

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1208,7 +1208,7 @@ def _get_slots(cls):
             slots = []
             if getattr(cls, '__weakrefoffset__', -1) != 0:
                 slots.append('__weakref__')
-            if getattr(cls, '__dictrefoffset__', -1) != 0:
+            if getattr(cls, '__dictoffset__', -1) != 0:
                 slots.append('__dict__')
             yield from slots
         case str(slot):

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -3665,6 +3665,23 @@ class TestSlots(unittest.TestCase):
         A()
 
     @support.cpython_only
+    def test_dataclass_slot_dict_ctype(self):
+        # https://github.com/python/cpython/issues/123935
+        from test.support import import_helper
+        # Skips test if `_testcapi` is not present:
+        _testcapi = import_helper.import_module('_testcapi')
+
+        @dataclass(slots=True)
+        class A(_testcapi.HeapCTypeWithDict):
+            __dict__: dict = {}
+        self.assertEqual(A.__slots__, ())
+
+        @dataclass(slots=True)
+        class A(_testcapi.HeapCTypeWithWeakref):
+            __dict__: dict = {}
+        self.assertEqual(A.__slots__, ('__dict__',))
+
+    @support.cpython_only
     def test_slots_with_wrong_init_subclass(self):
         # TODO: This test is for a kinda-buggy behavior.
         # Ideally, it should be fixed and `__init_subclass__`

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -3672,14 +3672,16 @@ class TestSlots(unittest.TestCase):
         _testcapi = import_helper.import_module('_testcapi')
 
         @dataclass(slots=True)
-        class A(_testcapi.HeapCTypeWithDict):
+        class HasDictOffset(_testcapi.HeapCTypeWithDict):
             __dict__: dict = {}
-        self.assertEqual(A.__slots__, ())
+        self.assertNotEqual(_testcapi.HeapCTypeWithDict.__dictoffset__, 0)
+        self.assertEqual(HasDictOffset.__slots__, ())
 
         @dataclass(slots=True)
-        class A(_testcapi.HeapCTypeWithWeakref):
+        class DoesNotHaveDictOffset(_testcapi.HeapCTypeWithWeakref):
             __dict__: dict = {}
-        self.assertEqual(A.__slots__, ('__dict__',))
+        self.assertEqual(_testcapi.HeapCTypeWithWeakref.__dictoffset__, 0)
+        self.assertEqual(DoesNotHaveDictOffset.__slots__, ('__dict__',))
 
     @support.cpython_only
     def test_slots_with_wrong_init_subclass(self):

--- a/Misc/NEWS.d/next/Library/2024-09-11-13-33-19.gh-issue-123935.fRZ_56.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-11-13-33-19.gh-issue-123935.fRZ_56.rst
@@ -1,0 +1,2 @@
+Fix parent slots detection for dataclasses that inherit from classes with
+``__dictoffset__``.


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/118099

Local tests to better understand the problem / test. With this change:

```python
from _testcapi import HeapCTypeWithDict, HeapCTypeWithWeakref
from dataclasses import _get_slots

assert list(_get_slots(HeapCTypeWithWeakref)) == ['__weakref__']
assert list(_get_slots(HeapCTypeWithDict)) == ['__dict__']
```

Without this change:

```python
assert list(_get_slots(HeapCTypeWithWeakref)) == ['__weakref__', '__dict__']
```

But, since there's no public api to set `__dict__` slot similar to `weakref_slot`, I had to use `__dict__` as a field name. This is very ugly, I fully understand that. If prefered, I can remove the test completely.

<!-- gh-issue-number: gh-123935 -->
* Issue: gh-123935
<!-- /gh-issue-number -->
