### PR TITLE
gh-123942: add missing test for docstring-handling code in ast_opt.c

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -871,30 +871,6 @@ class TestSpecifics(unittest.TestCase):
             list(dis.get_instructions(unused_code_at_end))[-1].opname)
 
     @support.cpython_only
-    def test_docstring_omitted(self):
-        # See gh-115347
-        src = textwrap.dedent("""
-            def f():
-                "docstring1"
-                def h():
-                    "docstring2"
-                    return 42
-
-                class C:
-                    "docstring3"
-                    pass
-
-                return h
-        """)
-        for opt in [-1, 0, 1, 2]:
-            with self.subTest(opt=opt):
-                code = compile(src, "<test>", "exec", optimize=opt)
-                output = io.StringIO()
-                with contextlib.redirect_stdout(output):
-                    dis.dis(code)
-                self.assertNotIn('NOP' , output.getvalue())
-
-    @support.cpython_only
     def test_docstring(self):
         src = textwrap.dedent("""
             def with_docstring():
@@ -920,6 +896,29 @@ class TestSpecifics(unittest.TestCase):
                 self.assertIsNone(ns['with_fstring'].__doc__)
                 self.assertIsNone(ns['with_const_expression'].__doc__)
 
+    @support.cpython_only
+    def test_docstring_omitted(self):
+        # See gh-115347
+        src = textwrap.dedent("""
+            def f():
+                "docstring1"
+                def h():
+                    "docstring2"
+                    return 42
+
+                class C:
+                    "docstring3"
+                    pass
+
+                return h
+        """)
+        for opt in [-1, 0, 1, 2]:
+            with self.subTest(opt=opt):
+                code = compile(src, "<test>", "exec", optimize=opt)
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    dis.dis(code)
+                self.assertNotIn('NOP' , output.getvalue())
 
     def test_dont_merge_constants(self):
         # Issue #25843: compile() must not merge constants which are equal

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -883,7 +883,7 @@ class TestSpecifics(unittest.TestCase):
                 "also" + " not docstring"
             """)
 
-        for opt in [-1, 0, 1, 2]:
+        for opt in [0, 1, 2]:
             with self.subTest(opt=opt):
                 code = compile(src, "<test>", "exec", optimize=opt)
                 ns = {}

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -337,6 +337,22 @@ class TestSpecifics(unittest.TestCase):
         l = lambda: "foo"
         self.assertIsNone(l.__doc__)
 
+    def test_docstring(self):
+        def with_docstring():
+            "docstring"
+
+        self.assertEqual(with_docstring.__doc__, "docstring")
+
+        def with_fstring():
+            f"not docstring"
+
+        self.assertIsNone(with_fstring.__doc__)
+
+        def with_const_expression():
+            "also" + " not docstring"
+
+        self.assertIsNone(with_const_expression.__doc__)
+
     def test_encoding(self):
         code = b'# -*- coding: badencoding -*-\npass\n'
         self.assertRaises(SyntaxError, compile, code, 'tmp', 'exec')


### PR DESCRIPTION
Fixes #123942.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123942 -->
* Issue: gh-123942
<!-- /gh-issue-number -->
