### PR TITLE
Update Sphinx Lint and fix unnecessary parentheses in `:func:`s

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.4.10
     hooks:
       - id: ruff
         name: Run Ruff (lint) on Doc/
@@ -20,7 +20,7 @@ repos:
         files: ^Doc/
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
         name: Run Black on Tools/jit/
@@ -28,7 +28,7 @@ repos:
         language_version: python3.12
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -42,7 +42,7 @@ repos:
         types_or: [c, inc, python, rst]
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
-    rev: v0.9.1
+    rev: v1.0.0
     hooks:
       - id: sphinx-lint
         args: [--enable=default-role]

--- a/Doc/library/annotationlib.rst
+++ b/Doc/library/annotationlib.rst
@@ -315,7 +315,7 @@ Functions
 
    * If eval_str is true, :func:`eval` is called on values of type
      :class:`!str`. (Note that :func:`!get_annotations` doesn't catch
-     exceptions; if :func:`eval()` raises an exception, it will unwind
+     exceptions; if :func:`eval` raises an exception, it will unwind
      the stack past the :func:`!get_annotations` call.)
    * If *eval_str* is false (the default), values of type :class:`!str` are
      unchanged.

--- a/Misc/NEWS.d/next/Library/2024-08-23-22-01-30.gh-issue-76960.vsANPu.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-23-22-01-30.gh-issue-76960.vsANPu.rst
@@ -1,5 +1,5 @@
 Fix :func:`urllib.parse.urljoin` and :func:`urllib.parse.urldefrag` for URIs
-containing empty components. For example, :func:`!urljoin()` with relative
+containing empty components. For example, :func:`!urljoin` with relative
 reference "?" now sets empty query and removes fragment.
 Preserve empty components (authority, params, query, fragment) in :func:`!urljoin`.
 Preserve empty components (authority, params, query) in :func:`!urldefrag`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

We've just released Sphinx Lint 1.0.0:

* https://github.com/sphinx-contrib/sphinx-lint/releases/tag/v1.0.0

The main addition is a check for unnecessary parentheses in `:func:`s, and it finds two occurences in `main`:

```
Doc/library/annotationlib.rst:318: Unnecessary parentheses in ':func:`eval()`' (unnecessary-parentheses)
Misc/NEWS.d/next/Library/2024-08-23-22-01-30.gh-issue-76960.vsANPu.rst:2: Unnecessary parentheses in ':func:`!urljoin()`' (unnecessary-parentheses)
```

This PR updates pre-commit and fixes these.

Also update the other pre-commit hooks, except I only updated Ruff to v0.4.10, because v0.6.4 reports some F811 warnings, some of which I think are intentional:

<details>
<summary>Details</summary>

```
Run Ruff (lint) on Lib/test/.............................................Failed
- hook id: ruff
- exit code: 1

Lib/test/pickletester.py:4348:7: F811 Redefinition of unused `SimpleNewObj` from line 3164
     |
4346 |     __slots__ = ["foo"]
4347 |
4348 | class SimpleNewObj(int):
     |       ^^^^^^^^^^^^ F811
4349 |     def __init__(self, *args, **kwargs):
4350 |         # raise an error, to make sure this isn't called
     |
     = help: Remove definition: `SimpleNewObj`

Lib/test/test_bz2.py:480:46: F811 Redefinition of unused `f` from line 479
    |
478 |     def testContextProtocol(self):
479 |         f = None
480 |         with BZ2File(self.filename, "wb") as f:
    |                                              ^ F811
481 |             f.write(b"xxx")
482 |         f = BZ2File(self.filename, "rb")
    |
    = help: Remove definition: `f`

Lib/test/test_contextlib.py:448:54: F811 Redefinition of unused `f` from line 447
    |
446 |         try:
447 |             f = None
448 |             with open(tfn, "w", encoding="utf-8") as f:
    |                                                      ^ F811
449 |                 self.assertFalse(f.closed)
450 |                 f.write("Booh\n")
    |
    = help: Remove definition: `f`

Lib/test/test_io.py:643:64: F811 Redefinition of unused `f` from line 642
    |
641 |         for bufsize in (0, 100):
642 |             f = None
643 |             with self.open(os_helper.TESTFN, "wb", bufsize) as f:
    |                                                                ^ F811
644 |                 f.write(b"xxx")
645 |             self.assertEqual(f.closed, True)
    |
    = help: Remove definition: `f`

Lib/test/test_os.py:3176:16: F811 Redefinition of unused `ctypes` from line 3175
     |
3174 |         nt = import_helper.import_module('nt')
3175 |         ctypes = import_helper.import_module('ctypes')
3176 |         import ctypes.wintypes
     |                ^^^^^^^^^^^^^^^ F811
3177 |
3178 |         kernel = ctypes.WinDLL('Kernel32.dll', use_last_error=True)
     |
     = help: Remove definition: `ctypes`

Lib/test/test_with.py:256:49: F811 Redefinition of unused `foo` from line 255
    |
254 |     def testInlineGeneratorBoundToExistingVariable(self):
255 |         foo = None
256 |         with mock_contextmanager_generator() as foo:
    |                                                 ^^^ F811
257 |             self.assertInWithGeneratorInvariants(foo)
258 |         self.assertAfterWithGeneratorInvariantsNoError(foo)
    |
    = help: Remove definition: `foo`

Found 6 errors.
```

</details>

We can address those later (perhaps at the sprint).


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123960.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->