### PR TITLE
Fix "The Matrix" movie release year in `typing.rst`

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1316,7 +1316,7 @@ These can be used as types in annotations. They all support subscription using
          year: int
 
       def mutate_movie(m: Movie) -> None:
-         m["year"] = 1992  # allowed
+         m["year"] = 1999  # allowed
          m["title"] = "The Matrix"  # typechecker error
 
    There is no runtime checking for this property.


### PR DESCRIPTION
I am really sorry for doing this, but this really bothered me while reading the docs.

The Matrix was released in 1999, not 1992. Link: https://en.wikipedia.org/wiki/The_Matrix

Feel free to ignore this PR.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--123965.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->