### PR TITLE
gh-123968: Fix lower bound for `python -m random --float`

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -1013,7 +1013,7 @@ def _parse_args(arg_list: list[str] | None):
         help="print a random integer between 1 and N inclusive")
     group.add_argument(
         "-f", "--float", type=float, metavar="N",
-        help="print a random floating-point number between 1 and N inclusive")
+        help="print a random floating-point number between 0 and N inclusive")
     group.add_argument(
         "--test", type=int, const=10_000, nargs="?",
         help=argparse.SUPPRESS)
@@ -1038,7 +1038,7 @@ def main(arg_list: list[str] | None = None) -> int | str:
         return randint(1, args.integer)
 
     if args.float is not None:
-        return uniform(1, args.float)
+        return uniform(0, args.float)
 
     if args.test:
         _test(args.test)
@@ -1055,7 +1055,7 @@ def main(arg_list: list[str] | None = None) -> int | str:
             try:
                 # Is it a float?
                 val = float(val)
-                return uniform(1, val)
+                return uniform(0, val)
             except ValueError:
                 # Split in case of space-separated string: "a b c"
                 return choice(val.split())

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -1433,8 +1433,8 @@ class CommandLineTest(unittest.TestCase):
             ("'a a' 'b b' 'c c'", "b b"),
             ("--integer 5", 4),
             ("5", 4),
-            ("--float 2.5", 2.266632777287572),
-            ("2.5", 2.266632777287572),
+            ("--float 2.5", 2.1110546288126204),
+            ("2.5", 2.1110546288126204),
         ]:
             random.seed(0)
             self.assertEqual(random.main(shlex.split(command)), expected)

--- a/Misc/NEWS.d/next/Library/2024-09-11-19-12-23.gh-issue-123968.OwHON_.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-11-19-12-23.gh-issue-123968.OwHON_.rst
@@ -1,0 +1,1 @@
+Fix the command-line interface for the :mod:`random` module to select floats between 0 and N, not 1 and N.


### PR DESCRIPTION
`python -m random --float N` incorrectly used a range between 1 and N of length N - 1.  Fix it to use a range between 0 and N of length N, as originally specified in #118131, and as everyone will expect.

<!-- gh-issue-number: gh-123968 -->
* Issue: gh-123968
<!-- /gh-issue-number -->
