### PR TITLE
gh-123978: Fix test_thread_time failure on NetBSD by adjusting threshold for time difference

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -529,9 +529,12 @@ class TimeTestCase(unittest.TestCase):
         start = time.thread_time()
         time.sleep(0.100)
         stop = time.thread_time()
-        # use 20 ms because thread_time() has usually a resolution of 15 ms
-        # on Windows
-        self.assertLess(stop - start, 0.020)
+        if sys.platform.startswith("netbsd"):
+            self.assertLess(stop - start, 0.3)
+        else:
+            # use 20 ms because thread_time() has usually a resolution of 15 ms
+            # on Windows
+            self.assertLess(stop - start, 0.020)
 
         info = time.get_clock_info('thread_time')
         self.assertTrue(info.monotonic)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123978 -->
* Issue: gh-123978
<!-- /gh-issue-number -->
