### PR TITLE
gh-116622: Switch test_stress_delivery_simultaneous from SIGUSR1 to SIGUSR2

### DIFF
--- a/Android/testbed/app/src/main/python/main.py
+++ b/Android/testbed/app/src/main/python/main.py
@@ -5,18 +5,21 @@ import signal
 import sys
 
 # Some tests use SIGUSR1, but that's blocked by default in an Android app in
-# order to make it available to `sigwait` in the Signal Catcher thread. That
-# thread's functionality is only useful for debugging the JVM, so disabling it
-# should not weaken the tests.
+# order to make it available to `sigwait` in the Signal Catcher thread.
+# (https://cs.android.com/android/platform/superproject/+/android14-qpr3-release:art/runtime/signal_catcher.cc).
+# That thread's functionality is only useful for debugging the JVM, so disabling
+# it should not weaken the tests.
 #
-# Simply unblocking SIGUSR1 is enough to fix most tests that use it. But in
-# tests that generate multiple different signals in quick succession, it's
-# possible for SIGUSR1 to arrive while the main thread is busy running the
-# C-level handler for a different signal, in which case the SIGUSR1 may be sent
-# to the Signal Catcher thread instead. When this happens, there will be a log
+# There's no safe way of stopping the thread completely (#123982), but simply
+# unblocking SIGUSR1 is enough to fix most tests.
+#
+# However, in tests that generate multiple different signals in quick
+# succession, it's possible for SIGUSR1 to arrive while the main thread is busy
+# running the C-level handler for a different signal. In that case, the SIGUSR1
+# may be sent to the Signal Catcher thread instead, which will generate a log
 # message containing the text "reacting to signal".
 #
-# In such cases, the tests may need to be changed. Possible workarounds include:
+# Such tests may need to be changed in one of the following ways:
 #   * Use a signal other than SIGUSR1 (e.g. test_stress_delivery_simultaneous in
 #     test_signal.py).
 #   * Send the signal to a specific thread rather than the whole process (e.g.

--- a/Android/testbed/app/src/main/python/main.py
+++ b/Android/testbed/app/src/main/python/main.py
@@ -5,9 +5,22 @@ import signal
 import sys
 
 # Some tests use SIGUSR1, but that's blocked by default in an Android app in
-# order to make it available to `sigwait` in the "Signal Catcher" thread. That
-# thread's functionality is only relevant to the JVM ("forcing GC (no HPROF) and
-# profile save"), so disabling it should not weaken the tests.
+# order to make it available to `sigwait` in the Signal Catcher thread. That
+# thread's functionality is only useful for debugging the JVM, so disabling it
+# should not weaken the tests.
+#
+# Simply unblocking SIGUSR1 is enough to fix most tests that use it. But in
+# tests that generate multiple different signals in quick succession, it's
+# possible for SIGUSR1 to arrive while the main thread is busy running the
+# C-level handler for a different signal, in which case the SIGUSR1 may be sent
+# to the Signal Catcher thread instead. When this happens, there will be a log
+# message containing the text "reacting to signal".
+#
+# In such cases, the tests may need to be changed. Possible workarounds include:
+#   * Use a signal other than SIGUSR1 (e.g. test_stress_delivery_simultaneous in
+#     test_signal.py).
+#   * Send the signal to a specific thread rather than the whole process (e.g.
+#     test_signals in test_threadsignals.py.
 signal.pthread_sigmask(signal.SIG_UNBLOCK, [signal.SIGUSR1])
 
 sys.argv[1:] = shlex.split(os.environ["PYTHON_ARGS"])

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -1325,15 +1325,18 @@ class StressTest(unittest.TestCase):
         def handler(signum, frame):
             sigs.append(signum)
 
-        self.setsig(signal.SIGUSR1, handler)
+        # On Android, SIGUSR1 is unreliable when used in close proximity to
+        # another signal – see Android/testbed/app/src/main/python/main.py.
+        # So we use a different signal.
+        self.setsig(signal.SIGUSR2, handler)
         self.setsig(signal.SIGALRM, handler)  # for ITIMER_REAL
 
         expected_sigs = 0
         while expected_sigs < N:
             # Hopefully the SIGALRM will be received somewhere during
-            # initial processing of SIGUSR1.
+            # initial processing of SIGUSR2.
             signal.setitimer(signal.ITIMER_REAL, 1e-6 + random.random() * 1e-5)
-            os.kill(os.getpid(), signal.SIGUSR1)
+            os.kill(os.getpid(), signal.SIGUSR2)
 
             expected_sigs += 2
             # Wait for handlers to run to avoid signal coalescing


### PR DESCRIPTION
On Android, test_stress_delivery_simultaneous was failing intermittently:

```
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/test/test_signal.py", line 1340, in test_stress_delivery_simultaneous
    for _ in support.sleeping_retry(support.SHORT_TIMEOUT):
             ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/test/support/__init__.py", line 2509, in sleeping_retry
    for _ in busy_retry(timeout, err_msg, error=error):
             ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/user/0/org.python.testbed/files/python/lib/python3.14/test/support/__init__.py", line 2479, in busy_retry
    raise AssertionError(msg)
AssertionError: timeout (30.4 seconds)
```

When it fails, it also produces this log message:
```
Thread[6,tid=29634,WaitingInMainSignalCatcherLoop,Thread*=0xb400007e782136f0,peer=0x12cc0578,"Signal Catcher"]: reacting to signal 10
```

The root cause was the same as #116423 – SIGUSR1 being consumed by a pre-existing thread that we have no control over. I looked into killing that thread, but I couldn't find a safe way of doing it (#123982). So the simplest solution is to use a different signal instead.

It looks like this problem only happens when two different signals are sent so close together that one signal arrives while the other signal's C-level handler is still running. The other tests that use SIGUSR1 don't do this, so they don't need to be changed.

<!-- gh-issue-number: gh-116622 -->
* Issue: gh-116622
<!-- /gh-issue-number -->
