### PR TITLE
gh-116622: Kill Android Signal Catcher thread before running tests

### DIFF
--- a/Android/testbed/app/src/main/python/main.py
+++ b/Android/testbed/app/src/main/python/main.py
@@ -1,14 +1,7 @@
 import os
 import runpy
 import shlex
-import signal
 import sys
-
-# Some tests use SIGUSR1, but that's blocked by default in an Android app in
-# order to make it available to `sigwait` in the "Signal Catcher" thread. That
-# thread's functionality is only relevant to the JVM ("forcing GC (no HPROF) and
-# profile save"), so disabling it should not weaken the tests.
-signal.pthread_sigmask(signal.SIG_UNBLOCK, [signal.SIGUSR1])
 
 sys.argv[1:] = shlex.split(os.environ["PYTHON_ARGS"])
 


### PR DESCRIPTION
This is an alternative attempt to fix the problem described in #123981, by killing the Android Signal Catcher completely. But it ended up being quite large and complex, and depends on several internal details which Android might change in the future.

Also, when I tried to test the "SignalCatcher TID %d still exists" message by commenting out the first `tgkill` call, I found that about 80% of the time, the 0.1 second delay between installing the signal handler and sending the signal somehow caused the handler to be bypassed, and the signal to kill the process. I have no idea why that would happen, and that makes me feel even less confident about this approach.

As #123981 says, the original problem only occurs in a fairly rare combination of circumstances, has a clearly-identifiable log message, and some easy workarounds, so it isn't worth pursuing this.

<!-- gh-issue-number: gh-116622 -->
* Issue: gh-116622
<!-- /gh-issue-number -->
