### PR TITLE
gh-123983: Redefine PyThread_ident_t as a size_t, and also use it.

### DIFF
--- a/Include/internal/pycore_lock.h
+++ b/Include/internal/pycore_lock.h
@@ -13,6 +13,8 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+#include "pycore_pythread.h" // for PyThread_ident_t
+
 //_Py_UNLOCKED is defined as 0 and _Py_LOCKED as 1 in Include/cpython/lock.h
 #define _Py_HAS_PARKED  2
 #define _Py_ONCE_INITIALIZED 4
@@ -154,7 +156,7 @@ _PyOnceFlag_CallOnce(_PyOnceFlag *flag, _Py_once_fn_t *fn, void *arg)
 // A recursive mutex. The mutex should zero-initialized.
 typedef struct {
     PyMutex mutex;
-    unsigned long long thread;  // i.e., PyThread_get_thread_ident_ex()
+    PyThread_ident_t thread;  // i.e., PyThread_get_thread_ident_ex()
     size_t level;
 } _PyRecursiveMutex;
 

--- a/Include/internal/pycore_pythread.h
+++ b/Include/internal/pycore_pythread.h
@@ -116,7 +116,7 @@ PyAPI_FUNC(PyLockStatus) PyThread_acquire_lock_timed_with_retries(
     PyThread_type_lock,
     PY_TIMEOUT_T microseconds);
 
-typedef unsigned long long PyThread_ident_t;
+typedef size_t PyThread_ident_t;
 typedef Py_uintptr_t PyThread_handle_t;
 
 #define PY_FORMAT_THREAD_IDENT_T "llu"

--- a/Python/lock.c
+++ b/Python/lock.c
@@ -355,7 +355,8 @@ _PyOnceFlag_CallOnceSlow(_PyOnceFlag *flag, _Py_once_fn_t *fn, void *arg)
 static int
 recursive_mutex_is_owned_by(_PyRecursiveMutex *m, PyThread_ident_t tid)
 {
-    return _Py_atomic_load_ullong_relaxed(&m->thread) == tid;
+  return tid == (PyThread_ident_t) _Py_atomic_load_ssize_relaxed(
+      (const Py_ssize_t *) &m->thread);
 }
 
 int
@@ -373,7 +374,7 @@ _PyRecursiveMutex_Lock(_PyRecursiveMutex *m)
         return;
     }
     PyMutex_Lock(&m->mutex);
-    _Py_atomic_store_ullong_relaxed(&m->thread, thread);
+    _Py_atomic_store_ssize_relaxed((Py_ssize_t*) &m->thread, thread);
     assert(m->level == 0);
 }
 
@@ -390,7 +391,7 @@ _PyRecursiveMutex_Unlock(_PyRecursiveMutex *m)
         return;
     }
     assert(m->level == 0);
-    _Py_atomic_store_ullong_relaxed(&m->thread, 0);
+    _Py_atomic_store_ssize_relaxed((Py_ssize_t *) &m->thread, 0);
     PyMutex_Unlock(&m->mutex);
 }
 


### PR DESCRIPTION
This PR fixes #123983 by using the PyThread_ident_t type in the struct _PyRecursiveMutex and also redefines that type as size_t rather than unsigned long long.  See the  #123983 for an explanation of why size_t is more robust.
 

<!-- gh-issue-number: gh-123983 -->
* Issue: gh-123983
<!-- /gh-issue-number -->
