### PR TITLE
gh-97588: remove unused functions in _ctypes/cfield.c

### DIFF
--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -46,31 +46,9 @@ class _ctypes.CField "PyObject *" "PyObject"
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=602817ea3ffc709c]*/
 
 static inline
-Py_ssize_t round_down(Py_ssize_t numToRound, Py_ssize_t multiple)
-{
-    assert(numToRound >= 0);
-    assert(multiple >= 0);
-    if (multiple == 0)
-        return numToRound;
-    return (numToRound / multiple) * multiple;
-}
-
-static inline
-Py_ssize_t round_up(Py_ssize_t numToRound, Py_ssize_t multiple)
-{
-    assert(numToRound >= 0);
-    assert(multiple >= 0);
-    if (multiple == 0)
-        return numToRound;
-    return ((numToRound + multiple - 1) / multiple) * multiple;
-}
-
-static inline
 Py_ssize_t NUM_BITS(Py_ssize_t bitsize);
 static inline
 Py_ssize_t LOW_BIT(Py_ssize_t offset);
-static inline
-Py_ssize_t BUILD_SIZE(Py_ssize_t bitsize, Py_ssize_t offset);
 
 
 /*[clinic input]
@@ -403,20 +381,6 @@ Py_ssize_t LOW_BIT(Py_ssize_t offset) {
 static inline
 Py_ssize_t NUM_BITS(Py_ssize_t bitsize) {
     return bitsize >> 16;
-}
-
-static inline
-Py_ssize_t BUILD_SIZE(Py_ssize_t bitsize, Py_ssize_t offset) {
-    assert(0 <= offset);
-    assert(offset <= 0xFFFF);
-    // We don't support zero length bitfields.
-    // And GET_BITFIELD uses NUM_BITS(size)==0,
-    // to figure out whether we are handling a bitfield.
-    assert(0 < bitsize);
-    Py_ssize_t result = (bitsize << 16) + offset;
-    assert(bitsize == NUM_BITS(result));
-    assert(offset == LOW_BIT(result));
-    return result;
 }
 
 /* Doesn't work if NUM_BITS(size) == 0, but it never happens in SET() call. */


### PR DESCRIPTION
```
./Modules/_ctypes/cfield.c:49:12: warning: unused function 'round_down' [-Wunused-function]
Py_ssize_t round_down(Py_ssize_t numToRound, Py_ssize_t multiple)
           ^
./Modules/_ctypes/cfield.c:59:12: warning: unused function 'round_up' [-Wunused-function]
Py_ssize_t round_up(Py_ssize_t numToRound, Py_ssize_t multiple)
           ^
./Modules/_ctypes/cfield.c:409:12: warning: unused function 'BUILD_SIZE' [-Wunused-function]
Py_ssize_t BUILD_SIZE(Py_ssize_t bitsize, Py_ssize_t offset) {

```


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97588 -->
* Issue: gh-97588
<!-- /gh-issue-number -->
