### PR TITLE
gh-124019: do not call codegen_annotations_in_scope if there are no annotations

### DIFF
--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -1003,25 +1003,21 @@ codegen_annotations(compiler *c, location loc,
     PySTEntryObject *ste;
     RETURN_IF_ERROR(_PySymtable_LookupOptional(SYMTABLE(c), args, &ste));
     assert(ste != NULL);
-    bool annotations_used = ste->ste_annotations_used;
 
-    int err = annotations_used ?
-        codegen_setup_annotations_scope(c, loc, (void *)args, ste->ste_name) : SUCCESS;
-    Py_DECREF(ste);
-    RETURN_IF_ERROR(err);
-
-    if (codegen_annotations_in_scope(c, loc, args, returns, &annotations_len) < 0) {
-        if (annotations_used) {
-            _PyCompile_ExitScope(c);
-        }
-        return ERROR;
-    }
-
-    if (annotations_used) {
+    if (ste->ste_annotations_used) {
+        int err = codegen_setup_annotations_scope(c, loc, (void *)args, ste->ste_name);
+        Py_DECREF(ste);
+        RETURN_IF_ERROR(err);
+        RETURN_IF_ERROR_IN_SCOPE(
+            c, codegen_annotations_in_scope(c, loc, args, returns, &annotations_len)
+        );
         RETURN_IF_ERROR(
             codegen_leave_annotations_scope(c, loc, annotations_len)
         );
         return MAKE_FUNCTION_ANNOTATE;
+    }
+    else {
+        Py_DECREF(ste);
     }
 
     return 0;


### PR DESCRIPTION

AFAICT there is no point in calling `codegen_annotations_in_scope` when `ste->ste_annotations_used` is false. Am I wrong?

Fixes #124019.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124019 -->
* Issue: gh-124019
<!-- /gh-issue-number -->
