### PR TITLE
gh-124022: Fix bug where class docstring is removed in interactive mode

### DIFF
--- a/Include/internal/pycore_compile.h
+++ b/Include/internal/pycore_compile.h
@@ -172,7 +172,8 @@ int _PyCompile_AddDeferredAnnotaion(struct _PyCompiler *c, stmt_ty s);
 int _PyCodegen_AddReturnAtEnd(struct _PyCompiler *c, int addNone);
 int _PyCodegen_EnterAnonymousScope(struct _PyCompiler* c, mod_ty mod);
 int _PyCodegen_Expression(struct _PyCompiler *c, expr_ty e);
-int _PyCodegen_Body(struct _PyCompiler *c, _Py_SourceLocation loc, asdl_stmt_seq *stmts);
+int _PyCodegen_Body(struct _PyCompiler *c, _Py_SourceLocation loc, asdl_stmt_seq *stmts,
+                    bool is_interactive);
 
 /* Utility for a number of growing arrays used in the compiler */
 int _PyCompile_EnsureArrayLargeEnough(

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -935,13 +935,13 @@ class TestSpecifics(unittest.TestCase):
                 return h
         """)
         for opt in [-1, 0, 1, 2]:
-            for mode in ["exec",  "single"]:
+            for mode in ["exec", "single"]:
                 with self.subTest(opt=opt, mode=mode):
                     code = compile(src, "<test>", mode, optimize=opt)
                     output = io.StringIO()
                     with contextlib.redirect_stdout(output):
                         dis.dis(code)
-                    self.assertNotIn('NOP' , output.getvalue())
+                    self.assertNotIn('NOP', output.getvalue())
 
     def test_dont_merge_constants(self):
         # Issue #25843: compile() must not merge constants which are equal

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -904,19 +904,25 @@ class TestSpecifics(unittest.TestCase):
 
     @support.cpython_only
     def test_docstring_interactive_mode(self):
-        src = textwrap.dedent("""
-            def with_docstring():
+        srcs = [
+            """def with_docstring():
                 "docstring"
-        """)
+            """,
+            """class with_docstring:
+                "docstring"
+            """,
+        ]
+
         for opt in [0, 1, 2]:
-            with self.subTest(opt=opt):
-                code = compile(src, "<test>", "single", optimize=opt)
-                ns = {}
-                exec(code, ns)
-                if opt < 2:
-                    self.assertEqual(ns['with_docstring'].__doc__, "docstring")
-                else:
-                    self.assertIsNone(ns['with_docstring'].__doc__)
+            for src in srcs:
+                with self.subTest(opt=opt, src=src):
+                    code = compile(textwrap.dedent(src), "<test>", "single", optimize=opt)
+                    ns = {}
+                    exec(code, ns)
+                    if opt < 2:
+                        self.assertEqual(ns['with_docstring'].__doc__, "docstring")
+                    else:
+                        self.assertIsNone(ns['with_docstring'].__doc__)
 
     @support.cpython_only
     def test_docstring_omitted(self):

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -903,6 +903,22 @@ class TestSpecifics(unittest.TestCase):
                 self.assertIsNone(ns['with_const_expression'].__doc__)
 
     @support.cpython_only
+    def test_docstring_interactive_mode(self):
+        src = textwrap.dedent("""
+            def with_docstring():
+                "docstring"
+        """)
+        for opt in [0, 1, 2]:
+            with self.subTest(opt=opt):
+                code = compile(src, "<test>", "single", optimize=opt)
+                ns = {}
+                exec(code, ns)
+                if opt < 2:
+                    self.assertEqual(ns['with_docstring'].__doc__, "docstring")
+                else:
+                    self.assertIsNone(ns['with_docstring'].__doc__)
+
+    @support.cpython_only
     def test_docstring_omitted(self):
         # See gh-115347
         src = textwrap.dedent("""
@@ -919,30 +935,13 @@ class TestSpecifics(unittest.TestCase):
                 return h
         """)
         for opt in [-1, 0, 1, 2]:
-            with self.subTest(opt=opt):
-                code = compile(src, "<test>", "exec", optimize=opt)
-                output = io.StringIO()
-                with contextlib.redirect_stdout(output):
-                    dis.dis(code)
-                self.assertNotIn('NOP' , output.getvalue())
-
-    @support.cpython_only
-    def test_docstring_removed_no_NOP_interactive_mode(self):
-        # See gh-124022
-        src = textwrap.dedent("""
-            class C:
-                "docstring"
-                x = 42
-        """)
-        for opt in [-1, 0, 1, 2]:
-            with self.subTest(opt=opt):
-                code = compile(src, "<test>", "single", optimize=opt)
-                # make sure the bytecode doesn't have any instruction
-                # on line 3, where the docstring is, but we have
-                # instructions for the assignment in line 4.
-                lines = [line for (_, _, line) in code.co_consts[0].co_lines()]
-                self.assertNotIn(3, lines)
-                self.assertIn(4, lines)
+            for mode in ["exec",  "single"]:
+                with self.subTest(opt=opt, mode=mode):
+                    code = compile(src, "<test>", mode, optimize=opt)
+                    output = io.StringIO()
+                    with contextlib.redirect_stdout(output):
+                        dis.dis(code)
+                    self.assertNotIn('NOP' , output.getvalue())
 
     def test_dont_merge_constants(self):
         # Issue #25843: compile() must not merge constants which are equal

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-12-21-53-26.gh-issue-124022.fQzUiW.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-12-21-53-26.gh-issue-124022.fQzUiW.rst
@@ -1,1 +1,1 @@
-Fix bug where docstring it removed from classes in interactive mode.
+Fix bug where docstring is removed from classes in interactive mode.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-12-21-53-26.gh-issue-124022.fQzUiW.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-12-21-53-26.gh-issue-124022.fQzUiW.rst
@@ -1,0 +1,1 @@
+Fix bug where a class that has a docstring, which is compiled in interactive mode, generates bytecode that contains a NOP with the line of the docstring.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-12-21-53-26.gh-issue-124022.fQzUiW.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-12-21-53-26.gh-issue-124022.fQzUiW.rst
@@ -1,1 +1,1 @@
-Fix bug where a class that has a docstring, which is compiled in interactive mode, generates bytecode that contains a NOP with the line of the docstring.
+Fix bug where docstring it removed from classes in interactive mode.

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -758,10 +758,10 @@ _PyCodegen_Body(compiler *c, location loc, asdl_stmt_seq *stmts)
         return SUCCESS;
     }
     Py_ssize_t first_instr = 0;
-    if (!IS_INTERACTIVE(c)) {
-        PyObject *docstring = _PyAST_GetDocString(stmts);
-        if (docstring) {
-            first_instr = 1;
+    PyObject *docstring = _PyAST_GetDocString(stmts);
+    if (docstring) {
+        first_instr = 1;
+        if (!IS_INTERACTIVE(c)) {
             /* set docstring */
             assert(OPTIMIZATION_LEVEL(c) < 2);
             PyObject *cleandoc = _PyCompile_CleanDoc(docstring);

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -758,7 +758,7 @@ _PyCodegen_Body(compiler *c, location loc, asdl_stmt_seq *stmts, bool is_interac
         return SUCCESS;
     }
     Py_ssize_t first_instr = 0;
-    if (!is_interactive) {      /* A string literal typed on the REPL prompt is not a docstring */
+    if (!is_interactive) { /* A string literal on REPL prompt is not a docstring */
         PyObject *docstring = _PyAST_GetDocString(stmts);
         if (docstring) {
             first_instr = 1;

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -761,20 +761,18 @@ _PyCodegen_Body(compiler *c, location loc, asdl_stmt_seq *stmts)
     PyObject *docstring = _PyAST_GetDocString(stmts);
     if (docstring) {
         first_instr = 1;
-        if (!IS_INTERACTIVE(c)) {
-            /* set docstring */
-            assert(OPTIMIZATION_LEVEL(c) < 2);
-            PyObject *cleandoc = _PyCompile_CleanDoc(docstring);
-            if (cleandoc == NULL) {
-                return ERROR;
-            }
-            stmt_ty st = (stmt_ty)asdl_seq_GET(stmts, 0);
-            assert(st->kind == Expr_kind);
-            location loc = LOC(st->v.Expr.value);
-            ADDOP_LOAD_CONST(c, loc, cleandoc);
-            Py_DECREF(cleandoc);
-            RETURN_IF_ERROR(codegen_nameop(c, NO_LOCATION, &_Py_ID(__doc__), Store));
+        /* set docstring */
+        assert(OPTIMIZATION_LEVEL(c) < 2);
+        PyObject *cleandoc = _PyCompile_CleanDoc(docstring);
+        if (cleandoc == NULL) {
+            return ERROR;
         }
+        stmt_ty st = (stmt_ty)asdl_seq_GET(stmts, 0);
+        assert(st->kind == Expr_kind);
+        location loc = LOC(st->v.Expr.value);
+        ADDOP_LOAD_CONST(c, loc, cleandoc);
+        Py_DECREF(cleandoc);
+        RETURN_IF_ERROR(codegen_nameop(c, NO_LOCATION, &_Py_ID(__doc__), Store));
     }
     for (Py_ssize_t i = first_instr; i < asdl_seq_LEN(stmts); i++) {
         VISIT(c, stmt, (stmt_ty)asdl_seq_GET(stmts, i));

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -758,10 +758,7 @@ _PyCodegen_Body(compiler *c, location loc, asdl_stmt_seq *stmts, bool is_interac
         return SUCCESS;
     }
     Py_ssize_t first_instr = 0;
-    // If this is a top-level interactive statement, we don't want to
-    // extract a docstring, because then writing a string literal in the REPL
-    // would get interpreted as a docstring.
-    if (!is_interactive) {
+    if (!is_interactive) {      /* A string literal typed on the REPL prompt is not a docstring */
         PyObject *docstring = _PyAST_GetDocString(stmts);
         if (docstring) {
             first_instr = 1;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -790,13 +790,13 @@ compiler_codegen(compiler *c, mod_ty mod)
     switch (mod->kind) {
     case Module_kind: {
         asdl_stmt_seq *stmts = mod->v.Module.body;
-        RETURN_IF_ERROR(_PyCodegen_Body(c, start_location(stmts), stmts));
+        RETURN_IF_ERROR(_PyCodegen_Body(c, start_location(stmts), stmts, false));
         break;
     }
     case Interactive_kind: {
         c->c_interactive = 1;
         asdl_stmt_seq *stmts = mod->v.Interactive.body;
-        RETURN_IF_ERROR(_PyCodegen_Body(c, start_location(stmts), stmts));
+        RETURN_IF_ERROR(_PyCodegen_Body(c, start_location(stmts), stmts, true));
         break;
     }
     case Expression_kind: {


### PR DESCRIPTION
Fixes #124022.

Class docstring is removed in interactive mode, but since the `first_instr` is not bumped to 1, this ends up being a `NOP` with the line number of the docstring.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124022 -->
* Issue: gh-124022
<!-- /gh-issue-number -->
