### PR TITLE
GH-101599: Update docs to remove redundant option in argparse tutorial

### DIFF
--- a/Doc/howto/argparse.rst
+++ b/Doc/howto/argparse.rst
@@ -444,7 +444,7 @@ And the output:
 
    options:
      -h, --help            show this help message and exit
-     -v {0,1,2}, --verbosity {0,1,2}
+     -v, --verbosity {0,1,2}
                            increase output verbosity
 
 Note that the change also reflects both in the error message as well as the


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This PR updates docs to reflect updates made in #103372. I discovered this as a duplicate while closing out on #77570. I've also skimmed through the argparse docs and tutorial for other instances where this may need to be updated. This appears to be the only instance that needed to be updated.

<!-- gh-issue-number: gh-101599 -->
* Issue: gh-101599
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124025.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->