### PR TITLE
gh-123934: Fix `MagicMock` not to reset magic method return values

### DIFF
--- a/Lib/test/test_unittest/testmock/testmagicmethods.py
+++ b/Lib/test/test_unittest/testmock/testmagicmethods.py
@@ -352,6 +352,17 @@ class TestMockingMagicMethods(unittest.TestCase):
                     self.assertIs(type(mm.__hash__()), int)
                     mm.__hash__.assert_called_once()
 
+    def test_magic_mock_resets_manual_mocks(self):
+        mm = MagicMock()
+        mm.__iter__ = MagicMock(return_value=iter([1]))
+        mm.custom = MagicMock(return_value=2)
+        self.assertEqual(list(iter(mm)), [1])
+        self.assertEqual(mm.custom(), 2)
+
+        mm.reset_mock(return_value=True)
+        self.assertEqual(list(iter(mm)), [])
+        self.assertIsInstance(mm.custom(), MagicMock)
+
     def test_magic_methods_and_spec(self):
         class Iterable(object):
             def __iter__(self): pass

--- a/Lib/test/test_unittest/testmock/testmagicmethods.py
+++ b/Lib/test/test_unittest/testmock/testmagicmethods.py
@@ -331,6 +331,26 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(os.fspath(mock), expected_path)
         mock.__fspath__.assert_called_once()
 
+    def test_magic_mock_does_not_reset_magic_returns(self):
+        # https://github.com/python/cpython/issues/123934
+        for reset in (True, False):
+            with self.subTest(reset=reset):
+                mm = MagicMock()
+                self.assertIs(type(mm.__str__()), str)
+                mm.__str__.assert_called_once()
+
+                self.assertIs(type(mm.__hash__()), int)
+                mm.__hash__.assert_called_once()
+
+                for _ in range(3):
+                    # Repeat reset several times to be sure:
+                    mm.reset_mock(return_value=reset)
+
+                    self.assertIs(type(mm.__str__()), str)
+                    mm.__str__.assert_called_once()
+
+                    self.assertIs(type(mm.__hash__()), int)
+                    mm.__hash__.assert_called_once()
 
     def test_magic_methods_and_spec(self):
         class Iterable(object):

--- a/Lib/test/test_unittest/testmock/testmagicmethods.py
+++ b/Lib/test/test_unittest/testmock/testmagicmethods.py
@@ -363,6 +363,14 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(list(iter(mm)), [])
         self.assertIsInstance(mm.custom(), MagicMock)
 
+    def test_magic_mock_resets_manual_mocks_empty_iter(self):
+        mm = MagicMock()
+        mm.__iter__.return_value = []
+        self.assertEqual(list(iter(mm)), [])
+
+        mm.reset_mock(return_value=True)
+        self.assertEqual(list(iter(mm)), [])
+
     def test_magic_methods_and_spec(self):
         class Iterable(object):
             def __iter__(self): pass

--- a/Misc/NEWS.d/next/Library/2024-09-13-10-34-19.gh-issue-123934.yMe7mL.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-13-10-34-19.gh-issue-123934.yMe7mL.rst
@@ -1,0 +1,2 @@
+Fix :class:`unittest.mock.MagicMock` reseting magic methods return values
+after ``.reset_mock(return_value=True)`` was called.


### PR DESCRIPTION
Refs https://github.com/python/cpython/pull/17409/files

<!-- gh-issue-number: gh-123934 -->
* Issue: gh-123934
<!-- /gh-issue-number -->
