### PR TITLE
gh-90996: Fixed the issue that the xmlrpc module throws a ProtocolError which may leak the password

### DIFF
--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -1397,8 +1397,6 @@ class FailingServerTestCase(unittest.TestCase):
     def test_fail_no_info(self):
         # use the broken message class
         xmlrpc.server.SimpleXMLRPCRequestHandler.MessageClass = FailingMessageClass
-
-        
         try:
             p = xmlrpclib.ServerProxy(URL)
             p.pow(6,8)

--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -1397,6 +1397,7 @@ class FailingServerTestCase(unittest.TestCase):
     def test_fail_no_info(self):
         # use the broken message class
         xmlrpc.server.SimpleXMLRPCRequestHandler.MessageClass = FailingMessageClass
+
         
         try:
             p = xmlrpclib.ServerProxy(URL)

--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -1167,8 +1167,9 @@ class Transport:
         #Discard any response data and raise exception
         if resp.getheader("content-length", ""):
             resp.read()
+        uname = f'{host.split(':')[0]}@{host.split('@')[1]}'
         raise ProtocolError(
-            host + handler,
+            uname + handler,
             resp.status, resp.reason,
             dict(resp.getheaders())
             )

--- a/Misc/NEWS.d/next/Library/2024-09-13-20-48-05.gh-issue-90996.MPGcGC.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-13-20-48-05.gh-issue-90996.MPGcGC.rst
@@ -1,0 +1,3 @@
+fixed security issue where passwords might get leaked because of
+``ProtocolError`` thrown by the :meth:`xmlrpc.client.Transport.single_request`
+in the :mod:`xmlrpc.client`

--- a/Misc/NEWS.d/next/Library/2024-09-13-20-48-05.gh-issue-90996.MPGcGC.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-13-20-48-05.gh-issue-90996.MPGcGC.rst
@@ -1,3 +1,3 @@
 Fixed a security issue where a ``ProtocolError`` raised by
-:meth:`Transport.send_request`` in the :mod:`xmlrpc.client`
+:meth:`xmlrpc.client.Transport.send_request`` in the :mod:`xmlrpc.client`
 could lead to password leaks.

--- a/Misc/NEWS.d/next/Library/2024-09-13-20-48-05.gh-issue-90996.MPGcGC.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-13-20-48-05.gh-issue-90996.MPGcGC.rst
@@ -1,3 +1,3 @@
 Fixed a security issue where a ``ProtocolError`` raised by
-:meth:`xmlrpc.client.Transport.send_request`` in the :mod:`xmlrpc.client`
-could lead to password leaks.
+:meth:`xmlrpc.client.Transport.send_request`` in the :mod:`xmlrpc.client` could lead
+to password leaks.

--- a/Misc/NEWS.d/next/Library/2024-09-13-20-48-05.gh-issue-90996.MPGcGC.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-13-20-48-05.gh-issue-90996.MPGcGC.rst
@@ -1,2 +1,3 @@
-Fixed a security issue where passwords could leakdue to a
-``ProtocolError`` in :meth:`xmlrpc.client.Transport.send_request`
+Fixed a security issue where a ``ProtocolError`` raised by
+:meth:`Transport.send_request`` in the :mod:`xmlrpc.client`
+could lead to password leaks.

--- a/Misc/NEWS.d/next/Library/2024-09-13-20-48-05.gh-issue-90996.MPGcGC.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-13-20-48-05.gh-issue-90996.MPGcGC.rst
@@ -1,3 +1,2 @@
-fixed security issue where passwords might get leaked because of
-``ProtocolError`` thrown by the :meth:`xmlrpc.client.Transport.single_request`
-in the :mod:`xmlrpc.client`
+Fixed a security issue where passwords could leakdue to a
+``ProtocolError`` in :meth:`xmlrpc.client.Transport.send_request`


### PR DESCRIPTION
…ay cause password leakage

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Fixed the security issue mentioned in https://github.com/python/cpython/issues/90996, could be leaked password due to a `ProtocolError` thrown

<!-- gh-issue-number: gh-90996 -->
* Issue: gh-90996
<!-- /gh-issue-number -->
