### PR TITLE
gh-124043: Disallow mixing `--with-trace-refs` and `--disable-gil`

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-09-13-17-48-37.gh-issue-124043.Bruxpq.rst
+++ b/Misc/NEWS.d/next/Build/2024-09-13-17-48-37.gh-issue-124043.Bruxpq.rst
@@ -1,0 +1,2 @@
+Building using ``--with-trace-refs`` is (temporarily) disallowed when the
+GIL is disabled.

--- a/Misc/NEWS.d/next/Build/2024-09-13-17-48-37.gh-issue-124043.Bruxpq.rst
+++ b/Misc/NEWS.d/next/Build/2024-09-13-17-48-37.gh-issue-124043.Bruxpq.rst
@@ -1,2 +1,2 @@
-Building using ``--with-trace-refs`` is (temporarily) disallowed when the
+Building using :option:`--with-trace-refs` is (temporarily) disallowed when the
 GIL is disabled.

--- a/configure
+++ b/configure
@@ -8234,6 +8234,10 @@ printf "%s\n" "#define Py_TRACE_REFS 1" >>confdefs.h
 
 fi
 
+if test "$disable_gil" = "yes" -o "$with_trace_refs" = "yes";
+then
+  as_fn_error $? "--disable-gil cannot be used with --with-trace-refs" "$LINENO" 5
+fi
 
 # Check for --enable-pystats
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --enable-pystats" >&5

--- a/configure
+++ b/configure
@@ -8234,7 +8234,7 @@ printf "%s\n" "#define Py_TRACE_REFS 1" >>confdefs.h
 
 fi
 
-if test "$disable_gil" = "yes" -o "$with_trace_refs" = "yes";
+if test "$disable_gil" = "yes" -a "$with_trace_refs" = "yes";
 then
   as_fn_error $? "--disable-gil cannot be used with --with-trace-refs" "$LINENO" 5
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1777,6 +1777,10 @@ then
             [Define if you want to enable tracing references for debugging purpose])
 fi
 
+if test "$disable_gil" = "yes" -o "$with_trace_refs" = "yes";
+then
+  AC_MSG_ERROR([--disable-gil cannot be used with --with-trace-refs])
+fi
 
 # Check for --enable-pystats
 AC_MSG_CHECKING([for --enable-pystats])

--- a/configure.ac
+++ b/configure.ac
@@ -1777,7 +1777,7 @@ then
             [Define if you want to enable tracing references for debugging purpose])
 fi
 
-if test "$disable_gil" = "yes" -o "$with_trace_refs" = "yes";
+if test "$disable_gil" = "yes" -a "$with_trace_refs" = "yes";
 then
   AC_MSG_ERROR([--disable-gil cannot be used with --with-trace-refs])
 fi


### PR DESCRIPTION
cc @colesbury

<!-- gh-issue-number: gh-124043 -->
* Issue: gh-124043
<!-- /gh-issue-number -->
