### PR TITLE
gh-124083: Skip test_strsignal on NetBSD due to TypeError

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -124,6 +124,8 @@ class PosixTests(unittest.TestCase):
         self.assertEqual(0, argument.repr_count)
 
     def test_strsignal(self):
+        if sys.platform.startswith("netbsd"):
+            self.skipTest("strsignal is not supported on this platform")
         self.assertIn("Interrupt", signal.strsignal(signal.SIGINT))
         self.assertIn("Terminated", signal.strsignal(signal.SIGTERM))
         self.assertIn("Hangup", signal.strsignal(signal.SIGHUP))

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -123,9 +123,9 @@ class PosixTests(unittest.TestCase):
         self.assertEqual(signal.getsignal(signal.SIGHUP), hup)
         self.assertEqual(0, argument.repr_count)
 
+    @unittest.skipIf(sys.platform.startswith("netbsd"),
+                     "gh-124083: strsignal is not supported on NetBSD")
     def test_strsignal(self):
-        if sys.platform.startswith("netbsd"):
-            self.skipTest("strsignal is not supported on this platform")
         self.assertIn("Interrupt", signal.strsignal(signal.SIGINT))
         self.assertIn("Terminated", signal.strsignal(signal.SIGTERM))
         self.assertIn("Hangup", signal.strsignal(signal.SIGHUP))


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124083 -->
* Issue: gh-124083
<!-- /gh-issue-number -->
