### PR TITLE
gh-121459: Add missing return to _PyDict_LoadGlobalStackRef

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1550,7 +1550,12 @@ _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject *key, Py_hash_t h
 {
     PyObject *val;
     Py_ssize_t ix = _Py_dict_lookup(mp, key, hash, &val);
-	*value_addr = val == NULL ? PyStackRef_NULL : PyStackRef_FromPyObjectNew(val);
+    if (val == NULL) {
+        *value_addr = PyStackRef_NULL;
+    }
+    else {
+        *value_addr = PyStackRef_FromPyObjectNew(val);
+    }
     return ix;
 }
 
@@ -2483,7 +2488,7 @@ _PyDict_LoadGlobalStackRef(PyDictObject *globals, PyDictObject *builtins, PyObje
     /* namespace 1: globals */
     ix = _Py_dict_lookup_threadsafe_stackref(globals, key, hash, res);
     if (ix == DKIX_ERROR) {
-        *res = PyStackRef_NULL;
+        return;
     }
     if (ix != DKIX_EMPTY && !PyStackRef_IsNull(*res)) {
         return;


### PR DESCRIPTION
We need to return immediately if there's an error during dictionary lookup.

Also avoid the conditional-if operator. The Windows 10 buildbot seems to miscompile that for unknown reasons.

<!-- gh-issue-number: gh-121459 -->
* Issue: gh-121459
<!-- /gh-issue-number -->
