### PR TITLE
Remove unused `_allowed_types` from `typing.py`

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -29,7 +29,7 @@ import functools
 import operator
 import sys
 import types
-from types import WrapperDescriptorType, MethodWrapperType, MethodDescriptorType, GenericAlias
+from types import GenericAlias
 
 from _typing import (
     _idfunc,

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2352,11 +2352,6 @@ def assert_type(val, typ, /):
     return val
 
 
-_allowed_types = (types.FunctionType, types.BuiltinFunctionType,
-                  types.MethodType, types.ModuleType,
-                  WrapperDescriptorType, MethodWrapperType, MethodDescriptorType)
-
-
 def get_type_hints(obj, globalns=None, localns=None, include_extras=False,
                    *, format=annotationlib.Format.VALUE):
     """Return type hints for an object.


### PR DESCRIPTION
This object was used here: https://github.com/python/cpython/blob/b2a7d718e3b70922f46208c22750c33145dccb75/Lib/typing.py#L2292

But, since `annotationlib` change, it is no longer needed.