### PR TITLE
Experiment: Determine necessity of save_cwd() in PR #116131

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -871,10 +871,10 @@ module.
 
 The current working directory -- denoted by an empty string -- is handled
 slightly differently from other entries on :data:`sys.path`. First, if the
-current working directory is found to not exist, no value is stored in
-:data:`sys.path_importer_cache`. Second, the value for the current working
-directory is looked up fresh for each module lookup. Third, the path used for
-:data:`sys.path_importer_cache` and returned by
+current working directory cannot be determined or is found not to exist, no
+value is stored in :data:`sys.path_importer_cache`. Second, the value for the
+current working directory is looked up fresh for each module lookup. Third,
+the path used for :data:`sys.path_importer_cache` and returned by
 :meth:`importlib.machinery.PathFinder.find_spec` will be the actual current
 working directory and not the empty string.
 

--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1234,7 +1234,7 @@ class PathFinder:
         if path == '':
             try:
                 path = _os.getcwd()
-            except FileNotFoundError:
+            except (FileNotFoundError, PermissionError):
                 # Don't cache the failure as the cwd can easily change to
                 # a valid directory later on.
                 return None

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -296,11 +296,11 @@ def skip_unless_working_chmod(test):
 
 @contextlib.contextmanager
 def save_mode(path, *, quiet=False):
-    """Context manager that restores the mode (permissions) of path on exit.
+    """Context manager that restores the mode (permissions) of *path* on exit.
 
     Arguments:
 
-      path: Path of the file to restore mode of.
+      path: Path of the file to restore the mode of.
 
       quiet: if False (the default), the context manager raises an exception
         on error.  Otherwise, it issues only a warning and keeps the current

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -536,37 +536,8 @@ def temp_dir(path=None, quiet=False):
 
 
 @contextlib.contextmanager
-def save_cwd(*, quiet=False):
-    """Return a context manager that restores the current working directory on
-    exit.
-
-    Prefer change_cwd() if you can. For most use cases it is cleaner.
-
-    Arguments:
-
-      quiet: if False (the default), the context manager raises an exception
-        on error.  Otherwise, it issues only a warning and keeps the current
-        working directory the same.
-
-    """
-    saved_dir = os.getcwd()
-    try:
-        yield
-    finally:
-        try:
-            os.chdir(saved_dir)
-        except OSError as exc:
-            if not quiet:
-                raise
-            warnings.warn(f'tests may fail, unable to restore the current '
-                          f'working directory to {saved_dir!r}: {exc}',
-                          RuntimeWarning, stacklevel=3)
-
-
-@contextlib.contextmanager
 def change_cwd(path, quiet=False):
-    """Return a context manager that changes the current working directory on
-    entry, and restores it on exit.
+    """Return a context manager that changes the current working directory.
 
     Arguments:
 

--- a/Lib/test/test_importlib/import_/test_path.py
+++ b/Lib/test/test_importlib/import_/test_path.py
@@ -1,3 +1,4 @@
+from test.support import os_helper
 from test.test_importlib import util
 
 importlib = util.import_importlib('importlib')
@@ -151,6 +152,29 @@ class FinderTests:
 
         with util.import_state(path=['']):
             # Do not want FileNotFoundError raised.
+            self.assertIsNone(self.machinery.PathFinder.find_spec('whatever'))
+
+    @os_helper.skip_unless_working_chmod
+    def test_permission_error_cwd(self):
+        # gh-115911: Test that an unreadable CWD does not break imports, in
+        # particular during early stages of interpreter startup.
+        with (
+            os_helper.temp_dir() as new_dir,
+            os_helper.save_mode(new_dir),
+            os_helper.save_cwd(),
+            util.import_state(path=['']),
+        ):
+            # chdir() & chmod() are done here (inside the with block) because
+            # the order of setup and teardown operations must be precise. See
+            # https://github.com/python/cpython/pull/116131#discussion_r1739649390
+            os.chdir(new_dir)
+            try:
+                os.chmod(new_dir, 0o000)
+            except OSError:
+                self.skipTest("platform does not allow "
+                              "changing mode of the cwd")
+
+            # Do not want PermissionError raised.
             self.assertIsNone(self.machinery.PathFinder.find_spec('whatever'))
 
     def test_invalidate_caches_finders(self):

--- a/Lib/test/test_importlib/import_/test_path.py
+++ b/Lib/test/test_importlib/import_/test_path.py
@@ -164,7 +164,7 @@ class FinderTests:
             os_helper.save_cwd(),
             util.import_state(path=['']),
         ):
-            # chdir() & chmod() are done here (inside the with block) because
+            # chdir() & chmod() are done here (inside the 'with' block) because
             # the order of setup and teardown operations must be precise. See
             # https://github.com/python/cpython/pull/116131#discussion_r1739649390
             os.chdir(new_dir)

--- a/Lib/test/test_importlib/import_/test_path.py
+++ b/Lib/test/test_importlib/import_/test_path.py
@@ -161,13 +161,12 @@ class FinderTests:
         with (
             os_helper.temp_dir() as new_dir,
             os_helper.save_mode(new_dir),
-            os_helper.save_cwd(),
+            os_helper.change_cwd(new_dir),
             util.import_state(path=['']),
         ):
-            # chdir() & chmod() are done here (inside the 'with' block) because
-            # the order of setup and teardown operations must be precise. See
+            # chmod() is done here (inside the 'with' block) because the order
+            # of teardown operations cannot be the reverse of setup order. See
             # https://github.com/python/cpython/pull/116131#discussion_r1739649390
-            os.chdir(new_dir)
             try:
                 os.chmod(new_dir, 0o000)
             except OSError:

--- a/Misc/NEWS.d/next/Core and Builtins/2024-02-29-16-55-52.gh-issue-115911.Vnkue_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-02-29-16-55-52.gh-issue-115911.Vnkue_.rst
@@ -1,0 +1,3 @@
+If the current working directory cannot be determined due to permissions,
+then import will no longer raise :exc:`PermissionError`. Patch by Alex
+Willmer.


### PR DESCRIPTION
During review of #116131 the necessity of introducing `test.support.os_helper.save_cwd()` and `test.support.os_helper.save_mode()` has been rightfully queried. I have verified `save_mode()` is necessary, as described in https://github.com/python/cpython/pull/116131#discussion_r1739649390.

This PR is intended to run a variation of PR #116131 without `save_cwd()` through the CPython CI. If this variation passes, then `save_cwd()` is unnecessary. If a failure of `test.test_import_lib.import_.test_permission_error_cwd()` is introduced, then it will inform the reviews, and serve as a reference for updating comments/docstrings.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124091.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->