### PR TITLE
Remove unused variable in `MagicMixin._mock_set_magics`

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2166,8 +2166,6 @@ class MagicMixin(Base):
 
         if getattr(self, "_mock_methods", None) is not None:
             these_magics = orig_magics.intersection(self._mock_methods)
-
-            remove_magics = set()
             remove_magics = orig_magics - these_magics
 
             for entry in remove_magics:


### PR DESCRIPTION
I am going to enable automerge for this, because the change is trivial.