### PR TITLE
Fixed the spelling error in test_xmlrpc where test was misspelled

### DIFF
--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -649,7 +649,7 @@ def http_server(evt, numrequests, requestHandler=None, encoding=None):
         serv.register_introspection_functions()
         serv.register_multicall_functions()
         serv.register_function(pow)
-        serv.register_function(lambda x: x, 'têšt')
+        serv.register_function(lambda x: x, 'test')
         @serv.register_function
         def my_function():
             '''This is my function'''
@@ -846,7 +846,7 @@ class SimpleServerTestCase(BaseServerTestCase):
     def test_nonascii_methodname(self):
         try:
             p = xmlrpclib.ServerProxy(URL, encoding='ascii')
-            self.assertEqual(p.têšt(42), 42)
+            self.assertEqual(p.test(42), 42)
         except (xmlrpclib.ProtocolError, socket.error) as e:
             # ignore failures due to non-blocking socket unavailable errors.
             if not is_unavailable_exception(e):
@@ -864,7 +864,7 @@ class SimpleServerTestCase(BaseServerTestCase):
         self.assertEqual(response.reason, 'Not Found')
 
     def test_introspection1(self):
-        expected_methods = set(['pow', 'div', 'my_function', 'add', 'têšt',
+        expected_methods = set(['pow', 'div', 'my_function', 'add', 'test',
                                 'system.listMethods', 'system.methodHelp',
                                 'system.methodSignature', 'system.multicall',
                                 'Fixture'])


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

I changed `têšt` to `test` in `test_xmlrpc.py`, because I thought it wasn't an ASCII character.