### PR TITLE
gh-101100: Fix Sphinx warnings in `library/unittest.mock.rst`

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -68,7 +68,7 @@ available, and then make assertions about how they have been used:
     3
     >>> thing.method.assert_called_with(3, 4, 5, key='value')
 
-:attr:`side_effect` allows you to perform side effects, including raising an
+:attr:`~Mock.side_effect` allows you to perform side effects, including raising an
 exception when a mock is called:
 
    >>> from unittest.mock import Mock
@@ -737,8 +737,8 @@ the *new_callable* argument to :func:`patch`.
 
     .. attribute:: __class__
 
-        Normally the :attr:`__class__` attribute of an object will return its type.
-        For a mock object with a :attr:`spec`, ``__class__`` returns the spec class
+        Normally the :attr:`!__class__` attribute of an object will return its type.
+        For a mock object with a :attr:`spec`, :attr:`!__class__` returns the spec class
         instead. This allows mock objects to pass :func:`isinstance` tests for the
         object they are replacing / masquerading as:
 
@@ -746,7 +746,7 @@ the *new_callable* argument to :func:`patch`.
             >>> isinstance(mock, int)
             True
 
-        :attr:`__class__` is assignable to, this allows a mock to pass an
+        :attr:`!__class__` is assignable to, this allows a mock to pass an
         :func:`isinstance` check without forcing you to use a spec:
 
             >>> mock = Mock()
@@ -1175,7 +1175,7 @@ Calls made to the object will be recorded in the attributes
 like :attr:`~Mock.call_args` and :attr:`~Mock.call_args_list`.
 
 If :attr:`~Mock.side_effect` is set then it will be called after the call has
-been recorded, so if :attr:`side_effect` raises an exception the call is still
+been recorded, so if :attr:`!side_effect` raises an exception the call is still
 recorded.
 
 The simplest way to make a mock raise an exception when called is to make
@@ -1196,8 +1196,8 @@ The simplest way to make a mock raise an exception when called is to make
         >>> m.mock_calls
         [call(1, 2, 3), call('two', 'three', 'four')]
 
-If :attr:`side_effect` is a function then whatever that function returns is what
-calls to the mock return. The :attr:`side_effect` function is called with the
+If :attr:`~Mock.side_effect` is a function then whatever that function returns is what
+calls to the mock return. The :attr:`!side_effect` function is called with the
 same arguments as the mock. This allows you to vary the return value of the
 call dynamically, based on the input:
 
@@ -1214,7 +1214,7 @@ call dynamically, based on the input:
 
 If you want the mock to still return the default return value (a new mock), or
 any set return value, then there are two ways of doing this. Either return
-:attr:`mock.return_value` from inside :attr:`side_effect`, or return :data:`DEFAULT`:
+:attr:`~Mock.return_value` from inside :attr:`~Mock.side_effect`, or return :data:`DEFAULT`:
 
         >>> m = MagicMock()
         >>> def side_effect(*args, **kwargs):
@@ -1231,8 +1231,8 @@ any set return value, then there are two ways of doing this. Either return
         >>> m()
         3
 
-To remove a :attr:`side_effect`, and return to the default behaviour, set the
-:attr:`side_effect` to ``None``:
+To remove a :attr:`~Mock.side_effect`, and return to the default behaviour, set the
+:attr:`!side_effect` to ``None``:
 
         >>> m = MagicMock(return_value=6)
         >>> def side_effect(*args, **kwargs):
@@ -1245,7 +1245,7 @@ To remove a :attr:`side_effect`, and return to the default behaviour, set the
         >>> m()
         6
 
-The :attr:`side_effect` can also be any iterable object. Repeated calls to the mock
+The :attr:`~Mock.side_effect` can also be any iterable object. Repeated calls to the mock
 will return values from the iterable (until the iterable is exhausted and
 a :exc:`StopIteration` is raised):
 
@@ -1455,7 +1455,7 @@ patch
           If you are patching builtins in a module then you don't
           need to pass ``create=True``, it will be added by default.
 
-    Patch can be used as a :class:`TestCase` class decorator. It works by
+    Patch can be used as a :class:`~unittest.TestCase` class decorator. It works by
     decorating each test method in the class. This reduces the boilerplate
     code when your test methods share a common patchings set. :func:`patch` finds
     tests by looking for method names that start with ``patch.TEST_PREFIX``.
@@ -1493,7 +1493,7 @@ If the class is instantiated multiple times you could use
 can set the *return_value* to be anything you want.
 
 To configure return values on methods of *instances* on the patched class
-you must do this on the :attr:`return_value`. For example::
+you must do this on the :attr:`~Mock.return_value`. For example::
 
     >>> class Class:
     ...     def method(self):
@@ -1815,13 +1815,13 @@ context manager is a dictionary where created mocks are keyed by name::
 patch methods: start and stop
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-All the patchers have :meth:`start` and :meth:`stop` methods. These make it simpler to do
+All the patchers have :meth:`!start` and :meth:`!stop` methods. These make it simpler to do
 patching in ``setUp`` methods or where you want to do multiple patches without
 nesting decorators or with statements.
 
 To use them call :func:`patch`, :func:`patch.object` or :func:`patch.dict` as
 normal and keep a reference to the returned ``patcher`` object. You can then
-call :meth:`start` to put the patch in place and :meth:`stop` to undo it.
+call :meth:`!start` to put the patch in place and :meth:`!stop` to undo it.
 
 If you are using :func:`patch` to create a mock for you then it will be returned by
 the call to ``patcher.start``. ::
@@ -1838,7 +1838,7 @@ the call to ``patcher.start``. ::
 
 
 A typical use case for this might be for doing multiple patches in the ``setUp``
-method of a :class:`TestCase`::
+method of a :class:`~unittest.TestCase`::
 
     >>> class MyTest(unittest.TestCase):
     ...     def setUp(self):
@@ -2511,7 +2511,7 @@ behaviour you can switch it off by setting the module level switch
 
 Alternatively you can just use ``vars(my_mock)`` (instance members) and
 ``dir(type(my_mock))`` (type members) to bypass the filtering irrespective of
-:const:`mock.FILTER_DIR`.
+:const:`FILTER_DIR`.
 
 
 mock_open
@@ -2526,7 +2526,7 @@ mock_open
    default) then a :class:`MagicMock` will be created for you, with the API limited
    to methods or attributes available on standard file handles.
 
-   *read_data* is a string for the :meth:`~io.IOBase.read`,
+   *read_data* is a string for the :meth:`~io.RawIOBase.read`,
    :meth:`~io.IOBase.readline`, and :meth:`~io.IOBase.readlines` methods
    of the file handle to return.  Calls to those methods will take data from
    *read_data* until it is depleted.  The mock of these methods is pretty
@@ -2538,7 +2538,7 @@ mock_open
 
    .. versionchanged:: 3.4
       Added :meth:`~io.IOBase.readline` and :meth:`~io.IOBase.readlines` support.
-      The mock of :meth:`~io.IOBase.read` changed to consume *read_data* rather
+      The mock of :meth:`~io.RawIOBase.read` changed to consume *read_data* rather
       than returning it on each call.
 
    .. versionchanged:: 3.5
@@ -2615,7 +2615,7 @@ unit tests. Testing everything in isolation is all fine and dandy, but if you
 don't test how your units are "wired together" there is still lots of room
 for bugs that tests might have caught.
 
-:mod:`mock` already provides a feature to help with this, called speccing. If you
+:mod:`unittest.mock` already provides a feature to help with this, called speccing. If you
 use a class or instance as the :attr:`spec` for a mock then you can only access
 attributes on the mock that exist on the real class:
 
@@ -2654,7 +2654,7 @@ Here's an example of it in use::
     >>> mock_request.Request
     <MagicMock name='request.Request' spec='Request' id='...'>
 
-You can see that :class:`request.Request` has a spec. :class:`request.Request` takes two
+You can see that :class:`!request.Request` has a spec. :class:`!request.Request` takes two
 arguments in the constructor (one of which is *self*). Here's what happens if
 we try to call it incorrectly::
 
@@ -2670,8 +2670,8 @@ specced mocks)::
     >>> req
     <NonCallableMagicMock name='request.Request()' spec='Request' id='...'>
 
-:class:`Request` objects are not callable, so the return value of instantiating our
-mocked out :class:`request.Request` is a non-callable mock. With the spec in place
+:class:`!Request` objects are not callable, so the return value of instantiating our
+mocked out :class:`!request.Request` is a non-callable mock. With the spec in place
 any typos in our asserts will raise the correct error::
 
     >>> req.add_header('spam', 'eggs')
@@ -2823,8 +2823,8 @@ Sealing mocks
     .. versionadded:: 3.7
 
 
-Order of precedence of :attr:`side_effect`, :attr:`return_value` and *wraps*
-----------------------------------------------------------------------------
+Order of precedence of :attr:`!side_effect`, :attr:`!return_value` and *wraps*
+------------------------------------------------------------------------------
 
 The order of their precedence is:
 

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -738,7 +738,7 @@ the *new_callable* argument to :func:`patch`.
     .. attribute:: __class__
 
         Normally the :attr:`!__class__` attribute of an object will return its type.
-        For a mock object with a :attr:`spec`, :attr:`!__class__` returns the spec class
+        For a mock object with a :attr:`!spec`, :attr:`!__class__` returns the spec class
         instead. This allows mock objects to pass :func:`isinstance` tests for the
         object they are replacing / masquerading as:
 
@@ -760,8 +760,8 @@ the *new_callable* argument to :func:`patch`.
     meaning of :class:`Mock`, with the exception of *return_value* and *side_effect*
     which have no meaning on a non-callable mock.
 
-Mock objects that use a class or an instance as a :attr:`spec` or
-:attr:`spec_set` are able to pass :func:`isinstance` tests:
+Mock objects that use a class or an instance as a :attr:`!spec` or
+:attr:`!spec_set` are able to pass :func:`isinstance` tests:
 
     >>> mock = Mock(spec=SomeClass)
     >>> isinstance(mock, SomeClass)
@@ -1286,7 +1286,7 @@ objects of any type.
 
 You may want a mock object to return ``False`` to a :func:`hasattr` call, or raise an
 :exc:`AttributeError` when an attribute is fetched. You can do this by providing
-an object as a :attr:`spec` for a mock, but that isn't always convenient.
+an object as a :attr:`!spec` for a mock, but that isn't always convenient.
 
 You "block" attributes by deleting them. Once deleted, accessing an attribute
 will raise an :exc:`AttributeError`.
@@ -2590,7 +2590,7 @@ And for reading files::
 Autospeccing
 ~~~~~~~~~~~~
 
-Autospeccing is based on the existing :attr:`spec` feature of mock. It limits the
+Autospeccing is based on the existing :attr:`!spec` feature of mock. It limits the
 api of mocks to the api of an original object (the spec), but it is recursive
 (implemented lazily) so that attributes of mocks only have the same api as
 the attributes of the spec. In addition mocked functions / methods have the
@@ -2616,7 +2616,7 @@ don't test how your units are "wired together" there is still lots of room
 for bugs that tests might have caught.
 
 :mod:`unittest.mock` already provides a feature to help with this, called speccing. If you
-use a class or instance as the :attr:`spec` for a mock then you can only access
+use a class or instance as the :attr:`!spec` for a mock then you can only access
 attributes on the mock that exist on the real class:
 
     >>> from urllib import request


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fix 26 warnings in `library/unittest.mock.rst`:

Before:

```console
❯ make -C Doc html SPHINXOPTS="-n -W --keep-going" SOURCES="library/unittest.mock.rst" 2>&1 | grep WARNING | tee >(wc -l)
library/unittest.mock.rst:71: WARNING: py:attr reference target not found: side_effect [ref.attr]
library/unittest.mock.rst:740: WARNING: py:attr reference target not found: spec [ref.attr]
library/unittest.mock.rst:763: WARNING: py:attr reference target not found: spec [ref.attr]
library/unittest.mock.rst:763: WARNING: py:attr reference target not found: spec_set [ref.attr]
library/unittest.mock.rst:1177: WARNING: py:attr reference target not found: side_effect [ref.attr]
library/unittest.mock.rst:1199: WARNING: py:attr reference target not found: side_effect [ref.attr]
library/unittest.mock.rst:1199: WARNING: py:attr reference target not found: side_effect [ref.attr]
library/unittest.mock.rst:1215: WARNING: py:attr reference target not found: mock.return_value [ref.attr]
library/unittest.mock.rst:1215: WARNING: py:attr reference target not found: side_effect [ref.attr]
library/unittest.mock.rst:1234: WARNING: py:attr reference target not found: side_effect [ref.attr]
library/unittest.mock.rst:1234: WARNING: py:attr reference target not found: side_effect [ref.attr]
library/unittest.mock.rst:1248: WARNING: py:attr reference target not found: side_effect [ref.attr]
library/unittest.mock.rst:1287: WARNING: py:attr reference target not found: spec [ref.attr]
library/unittest.mock.rst:1458: WARNING: py:class reference target not found: TestCase [ref.class]
library/unittest.mock.rst:1495: WARNING: py:attr reference target not found: return_value [ref.attr]
library/unittest.mock.rst:1818: WARNING: py:meth reference target not found: start [ref.meth]
library/unittest.mock.rst:1818: WARNING: py:meth reference target not found: stop [ref.meth]
library/unittest.mock.rst:1822: WARNING: py:meth reference target not found: start [ref.meth]
library/unittest.mock.rst:1822: WARNING: py:meth reference target not found: stop [ref.meth]
library/unittest.mock.rst:1840: WARNING: py:class reference target not found: TestCase [ref.class]
library/unittest.mock.rst:2204: WARNING: py:meth reference target not found: MagicMock.__iter__ [ref.meth]
library/unittest.mock.rst:2512: WARNING: py:const reference target not found: mock.FILTER_DIR [ref.const]
library/unittest.mock.rst:2529: WARNING: py:meth reference target not found: io.IOBase.read [ref.meth]
library/unittest.mock.rst:2540: WARNING: py:meth reference target not found: io.IOBase.read [ref.meth]
library/unittest.mock.rst:2593: WARNING: py:attr reference target not found: spec [ref.attr]
library/unittest.mock.rst:2618: WARNING: py:mod reference target not found: mock [ref.mod]
library/unittest.mock.rst:2618: WARNING: py:attr reference target not found: spec [ref.attr]
library/unittest.mock.rst:2657: WARNING: py:class reference target not found: request.Request [ref.class]
library/unittest.mock.rst:2657: WARNING: py:class reference target not found: request.Request [ref.class]
library/unittest.mock.rst:2673: WARNING: py:class reference target not found: Request [ref.class]
library/unittest.mock.rst:2673: WARNING: py:class reference target not found: request.Request [ref.class]
library/unittest.mock.rst:2826: WARNING: py:attr reference target not found: side_effect [ref.attr]
library/unittest.mock.rst:2826: WARNING: py:attr reference target not found: return_value [ref.attr]
      33
```

After:

```console
❯ make -C Doc html SPHINXOPTS="-n -W --keep-going" SOURCES="library/unittest.mock.rst" 2>&1 | grep WARNING | tee >(wc -l)
library/unittest.mock.rst:740: WARNING: py:attr reference target not found: spec [ref.attr]
library/unittest.mock.rst:763: WARNING: py:attr reference target not found: spec [ref.attr]
library/unittest.mock.rst:763: WARNING: py:attr reference target not found: spec_set [ref.attr]
library/unittest.mock.rst:1287: WARNING: py:attr reference target not found: spec [ref.attr]
library/unittest.mock.rst:2204: WARNING: py:meth reference target not found: MagicMock.__iter__ [ref.meth]
library/unittest.mock.rst:2593: WARNING: py:attr reference target not found: spec [ref.attr]
library/unittest.mock.rst:2618: WARNING: py:attr reference target not found: spec [ref.attr]
       7
```



<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124106.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->