### PR TITLE
GH-124108: Skip test_strcoll_with_diacritic and test_strxfrm_with_diacritic on NetBSD due to lack of UTF-8 LC_COLLATE support

### DIFF
--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -356,7 +356,7 @@ class TestEnUSCollation(BaseLocalizedTest, TestCollation):
         "musl libc issue on Emscripten/WASI, bpo-46390"
     )
     @unittest.skipIf(sys.platform.startswith("netbsd"),
-                     "GH-124108: NetBSD doesn't support UTF-8 for LC_COLLATE")
+                     "gh-124108: NetBSD doesn't support UTF-8 for LC_COLLATE")
     def test_strcoll_with_diacritic(self):
         self.assertLess(locale.strcoll('à', 'b'), 0)
 
@@ -367,7 +367,7 @@ class TestEnUSCollation(BaseLocalizedTest, TestCollation):
         "musl libc issue on Emscripten/WASI, bpo-46390"
     )
     @unittest.skipIf(sys.platform.startswith("netbsd"),
-                     "GH-124108: NetBSD doesn't support UTF-8 for LC_COLLATE")
+                     "gh-124108: NetBSD doesn't support UTF-8 for LC_COLLATE")
     def test_strxfrm_with_diacritic(self):
         self.assertLess(locale.strxfrm('à'), locale.strxfrm('b'))
 

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -355,6 +355,8 @@ class TestEnUSCollation(BaseLocalizedTest, TestCollation):
         is_emscripten or is_wasi,
         "musl libc issue on Emscripten/WASI, bpo-46390"
     )
+    @unittest.skipIf(sys.platform.startswith("netbsd"),
+                     "GH-124108: NetBSD doesn't support UTF-8 for LC_COLLATE")
     def test_strcoll_with_diacritic(self):
         self.assertLess(locale.strcoll('à', 'b'), 0)
 
@@ -364,6 +366,8 @@ class TestEnUSCollation(BaseLocalizedTest, TestCollation):
         is_emscripten or is_wasi,
         "musl libc issue on Emscripten/WASI, bpo-46390"
     )
+    @unittest.skipIf(sys.platform.startswith("netbsd"),
+                     "GH-124108: NetBSD doesn't support UTF-8 for LC_COLLATE")
     def test_strxfrm_with_diacritic(self):
         self.assertLess(locale.strxfrm('à'), locale.strxfrm('b'))
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124108 -->
* Issue: gh-124108
<!-- /gh-issue-number -->
