### PR TITLE
Revert "gh-123974: Fix time.get_clock_info() on NetBSD (#123975)"

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1509,19 +1509,15 @@ _PyTime_GetThreadTimeWithInfo(PyTime_t *tp, _Py_clock_info_t *info)
         return -1;
     }
     if (info) {
+        struct timespec res;
         info->implementation = function;
         info->monotonic = 1;
         info->adjustable = 0;
-    #if defined(__NetBSD__)
-        info->resolution = 1e-9;
-    #else
-        struct timespec res;
         if (clock_getres(clk_id, &res)) {
             PyErr_SetFromErrno(PyExc_OSError);
             return -1;
         }
         info->resolution = res.tv_sec + res.tv_nsec * 1e-9;
-    #endif
     }
 
     if (_PyTime_FromTimespec(tp, &ts) < 0) {


### PR DESCRIPTION
This reverts commit b1d6f8a2ee04215c64aa8752cc515b7e98a08d28.

We should remove `time.thread_time()` on NetBSD instead.

<!-- gh-issue-number: gh-123974 -->
* Issue: gh-123974
<!-- /gh-issue-number -->
