### PR TITLE
gh-123085: _compile_importlib: Avoid copying sources before compilation

### DIFF
--- a/Lib/test/test_importlib/resources/test_files.py
+++ b/Lib/test/test_importlib/resources/test_files.py
@@ -134,6 +134,9 @@ class ImplicitContextFiles:
     def _compile_importlib(self):
         """
         Make a compiled-only copy of the importlib resources package.
+
+        Currently only code is copied, as importlib resources doesn't itself
+        have any resources.
         """
         bin_site = self.fixtures.enter_context(os_helper.temp_dir())
         c_resources = pathlib.Path(bin_site, 'c_resources')

--- a/Lib/test/test_importlib/resources/test_files.py
+++ b/Lib/test/test_importlib/resources/test_files.py
@@ -142,19 +142,9 @@ class ImplicitContextFiles:
         c_resources = pathlib.Path(bin_site, 'c_resources')
         sources = pathlib.Path(resources.__file__).parent
 
-        for dirpath, dirnames, filenames in os.walk(sources):
-            try:
-                dirnames.remove('__pycache__')
-            except ValueError:
-                pass
-            source_dir_path = pathlib.Path(dirpath)
-            dir_relpath = pathlib.Path(source_dir_path).relative_to(sources)
-            c_dir_path = c_resources.joinpath(dir_relpath)
-            for filename in filenames:
-                if filename.endswith('.py'):
-                    source_path = source_dir_path / filename
-                    cfile = c_dir_path.joinpath(filename).with_suffix('.pyc')
-                    py_compile.compile(source_path, cfile)
+        for source_path in sources.glob('**/*.py'):
+            c_path = c_resources.joinpath(source_path.relative_to(sources)).with_suffix('.pyc')
+            py_compile.compile(source_path, c_path)
         self.fixtures.enter_context(import_helper.DirsOnSysPath(bin_site))
 
     def test_implicit_files_with_compiled_importlib(self):

--- a/Lib/test/test_importlib/resources/test_files.py
+++ b/Lib/test/test_importlib/resources/test_files.py
@@ -152,7 +152,6 @@ class ImplicitContextFiles:
                     source_path = source_dir_path / filename
                     cfile = c_dir_path.joinpath(filename).with_suffix('.pyc')
                     py_compile.compile(source_path, cfile)
-                    print(source_path, cfile)
         self.fixtures.enter_context(import_helper.DirsOnSysPath(bin_site))
 
     def test_implicit_files_with_compiled_importlib(self):


### PR DESCRIPTION
Make the test helper compile directly from the “installed” sources.
This should avoid doing some unnecessary work, as well as possible issues in copying too much/too little metadata to a different filesystem. Hopefully, it'll fix the buildbot failure.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123085 -->
* Issue: gh-123085
<!-- /gh-issue-number -->
