### PR TITLE
gh-124130: Notes on empty string corner case of category `\B`

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -572,6 +572,12 @@ character ``'$'``.
    Word boundaries are determined by the current locale
    if the :py:const:`~re.LOCALE` flag is used.
 
+   .. note::
+
+      Note that ``\B`` does not match an empty string, which differs from
+      RE implementations in other programming languages such as Perl.
+      This behavior is kept for compatibility reasons.
+
 .. index:: single: \d; in regular expressions
 
 ``\d``


### PR DESCRIPTION


<!-- gh-issue-number: gh-124130 -->
* Issue: gh-124130
<!-- /gh-issue-number -->
