### PR TITLE
gh-118915: Add/fix docs entries for some new 3.13 C API

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -1004,6 +1004,7 @@ the variables:
    single: PyExc_OverflowError (C var)
    single: PyExc_PermissionError (C var)
    single: PyExc_ProcessLookupError (C var)
+   single: PyExc_PythonFinalizationError (C var)
    single: PyExc_RecursionError (C var)
    single: PyExc_ReferenceError (C var)
    single: PyExc_RuntimeError (C var)
@@ -1095,6 +1096,8 @@ the variables:
 | :c:data:`PyExc_PermissionError`         | :exc:`PermissionError`          |          |
 +-----------------------------------------+---------------------------------+----------+
 | :c:data:`PyExc_ProcessLookupError`      | :exc:`ProcessLookupError`       |          |
++-----------------------------------------+---------------------------------+----------+
+| :c:data:`PyExc_PythonFinalizationError` | :exc:`PythonFinalizationError`  |          |
 +-----------------------------------------+---------------------------------+----------+
 | :c:data:`PyExc_RecursionError`          | :exc:`RecursionError`           |          |
 +-----------------------------------------+---------------------------------+----------+

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -509,6 +509,8 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    Currently, ``-1`` corresponds to
    ``Py_ASNATIVEBYTES_NATIVE_ENDIAN | Py_ASNATIVEBYTES_UNSIGNED_BUFFER``.
 
+   .. c:namespace:: NULL
+
    ============================================= ======
    Flag                                          Value
    ============================================= ======

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -421,6 +421,8 @@ The available slot types are:
 
    Specifies one of the following values:
 
+   .. c:namespace:: NULL
+
    .. c:macro:: Py_MOD_GIL_USED
 
       The module depends on the presence of the global interpreter lock (GIL),

--- a/Doc/c-api/monitoring.rst
+++ b/Doc/c-api/monitoring.rst
@@ -133,7 +133,7 @@ Managing the Monitoring State
 Monitoring states can be managed with the help of monitoring scopes. A scope
 would typically correspond to a python function.
 
-.. :c:function:: int PyMonitoring_EnterScope(PyMonitoringState *state_array, uint64_t *version, const uint8_t *event_types, Py_ssize_t length)
+.. c:function:: int PyMonitoring_EnterScope(PyMonitoringState *state_array, uint64_t *version, const uint8_t *event_types, Py_ssize_t length)
 
    Enter a monitored scope. ``event_types`` is an array of the event IDs for
    events that may be fired from the scope. For example, the ID of a ``PY_START``
@@ -158,7 +158,35 @@ would typically correspond to a python function.
    execution is paused, such as when emulating a generator, the scope needs to
    be exited and re-entered.
 
+   The macros for *event_types* are:
 
-.. :c:function:: int PyMonitoring_ExitScope(void)
+   .. c:namespace:: NULL
+
+   .. The table is here to make the docs searchable, and to allow automatic
+      links to the identifiers.
+
+   ================================================== =====================================
+   Macro                                              Event
+   ================================================== =====================================
+   .. c:macro:: PY_MONITORING_EVENT_BRANCH            :monitoring-event:`BRANCH`
+   .. c:macro:: PY_MONITORING_EVENT_CALL              :monitoring-event:`CALL`
+   .. c:macro:: PY_MONITORING_EVENT_C_RAISE           :monitoring-event:`C_RAISE`
+   .. c:macro:: PY_MONITORING_EVENT_C_RETURN          :monitoring-event:`C_RETURN`
+   .. c:macro:: PY_MONITORING_EVENT_EXCEPTION_HANDLED :monitoring-event:`EXCEPTION_HANDLED`
+   .. c:macro:: PY_MONITORING_EVENT_INSTRUCTION       :monitoring-event:`INSTRUCTION`
+   .. c:macro:: PY_MONITORING_EVENT_JUMP              :monitoring-event:`JUMP`
+   .. c:macro:: PY_MONITORING_EVENT_LINE              :monitoring-event:`LINE`
+   .. c:macro:: PY_MONITORING_EVENT_PY_RESUME         :monitoring-event:`PY_RESUME`
+   .. c:macro:: PY_MONITORING_EVENT_PY_RETURN         :monitoring-event:`PY_RETURN`
+   .. c:macro:: PY_MONITORING_EVENT_PY_START          :monitoring-event:`PY_START`
+   .. c:macro:: PY_MONITORING_EVENT_PY_THROW          :monitoring-event:`PY_THROW`
+   .. c:macro:: PY_MONITORING_EVENT_PY_UNWIND         :monitoring-event:`PY_UNWIND`
+   .. c:macro:: PY_MONITORING_EVENT_PY_YIELD          :monitoring-event:`PY_YIELD`
+   .. c:macro:: PY_MONITORING_EVENT_RAISE             :monitoring-event:`RAISE`
+   .. c:macro:: PY_MONITORING_EVENT_RERAISE           :monitoring-event:`RERAISE`
+   .. c:macro:: PY_MONITORING_EVENT_STOP_ITERATION    :monitoring-event:`STOP_ITERATION`
+   ================================================== =====================================
+
+.. c:function:: int PyMonitoring_ExitScope(void)
 
    Exit the last scope that was entered with ``PyMonitoring_EnterScope``.

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -244,6 +244,7 @@ nitpick_ignore += [
     ('c:data', 'PyExc_OverflowError'),
     ('c:data', 'PyExc_PermissionError'),
     ('c:data', 'PyExc_ProcessLookupError'),
+    ('c:data', 'PyExc_PythonFinalizationError'),
     ('c:data', 'PyExc_RecursionError'),
     ('c:data', 'PyExc_ReferenceError'),
     ('c:data', 'PyExc_RuntimeError'),

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -132,6 +132,8 @@ nitpick_ignore = [
     ('c:func', 'vsnprintf'),
     # Standard C types
     ('c:type', 'FILE'),
+    ('c:type', 'int8_t'),
+    ('c:type', 'int16_t'),
     ('c:type', 'int32_t'),
     ('c:type', 'int64_t'),
     ('c:type', 'intmax_t'),
@@ -141,6 +143,8 @@ nitpick_ignore = [
     ('c:type', 'size_t'),
     ('c:type', 'ssize_t'),
     ('c:type', 'time_t'),
+    ('c:type', 'uint8_t'),
+    ('c:type', 'uint16_t'),
     ('c:type', 'uint32_t'),
     ('c:type', 'uint64_t'),
     ('c:type', 'uintmax_t'),


### PR DESCRIPTION
- Add an entry for `PyExc_PythonFinalizationError`
- Add formal entries for `PY_MONITORING_EVENT_*`, making them searchable and linkable with Intersphinx.
- Use the "NULL namespace" for several macros that are documented below the functions that use them. This fixes their names in search results, and fixes linking using Intersphinx inventories.
- Fix ReST definition syntax for `PyMonitoring_*Scope` (these were comments before!)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118915 -->
* Issue: gh-118915
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124134.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->