### PR TITLE
GH-103484: Fix permanently redirects reported by linkcheck

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -556,6 +556,8 @@ linkcheck_allowed_redirects = {
     r'https://www.sqlite.org': 'https://www.sqlite.org/index.html',
     r'https://mitpress.mit.edu/sicp$': 'https://mitpress.mit.edu/9780262510875/structure-and-interpretation-of-computer-programs/',
     r'https://www.python.org/psf/': 'https://www.python.org/psf-landing/',
+    # pypi.org project name normalization (upper to lowercase, underscore to hyphen)
+    r'https://pypi.org/project/[A-Za-z\d_\-\.]+/': r'https://pypi.org/project/[a-z\d\-\.]+/',
 }
 
 linkcheck_anchors_ignore = [

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -552,7 +552,7 @@ linkcheck_allowed_redirects = {
     # pypi.org project name normalization (upper to lowercase, underscore to hyphen)
     r'https://pypi.org/project/[A-Za-z\d_\-\.]+/': r'https://pypi.org/project/[a-z\d\-\.]+/',
     # Discourse title name expansion (text changes when title is edited)
-    r'https://discuss\.python\.org/t/\d+': r'https://discuss\.python\.org/t/.*/\d+'
+    r'https://discuss\.python\.org/t/\d+': r'https://discuss\.python\.org/t/.*/\d+',
     # Other redirects
     r'https://www.boost.org/libs/.+': r'https://www.boost.org/doc/libs/\d_\d+_\d/.+',
     r'https://support.microsoft.com/en-us/help/\d+': 'https://support.microsoft.com/en-us/topic/.+',

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -549,6 +549,10 @@ linkcheck_allowed_redirects = {
     # Language redirects
     r'https://toml.io': 'https://toml.io/en/',
     r'https://www.redhat.com': 'https://www.redhat.com/en',
+    # pypi.org project name normalization (upper to lowercase, underscore to hyphen)
+    r'https://pypi.org/project/[A-Za-z\d_\-\.]+/': r'https://pypi.org/project/[a-z\d\-\.]+/',
+    # Discourse title name expansion (text changes when title is edited)
+    r'https://discuss\.python\.org/t/\d+': r'https://discuss\.python\.org/t/.*/\d+'
     # Other redirects
     r'https://www.boost.org/libs/.+': r'https://www.boost.org/doc/libs/\d_\d+_\d/.+',
     r'https://support.microsoft.com/en-us/help/\d+': 'https://support.microsoft.com/en-us/topic/.+',
@@ -556,8 +560,6 @@ linkcheck_allowed_redirects = {
     r'https://www.sqlite.org': 'https://www.sqlite.org/index.html',
     r'https://mitpress.mit.edu/sicp$': 'https://mitpress.mit.edu/9780262510875/structure-and-interpretation-of-computer-programs/',
     r'https://www.python.org/psf/': 'https://www.python.org/psf-landing/',
-    # pypi.org project name normalization (upper to lowercase, underscore to hyphen)
-    r'https://pypi.org/project/[A-Za-z\d_\-\.]+/': r'https://pypi.org/project/[a-z\d\-\.]+/',
 }
 
 linkcheck_anchors_ignore = [

--- a/Doc/faq/design.rst
+++ b/Doc/faq/design.rst
@@ -328,7 +328,7 @@ Can Python be compiled to machine code, C or some other language?
 -----------------------------------------------------------------
 
 `Cython <https://cython.org/>`_ compiles a modified version of Python with
-optional annotations into C extensions.  `Nuitka <https://www.nuitka.net/>`_ is
+optional annotations into C extensions.  `Nuitka <https://nuitka.net/>`_ is
 an up-and-coming compiler of Python into C++ code, aiming to support the full
 Python language.
 
@@ -345,7 +345,7 @@ to perform a garbage collection, obtain debugging statistics, and tune the
 collector's parameters.
 
 Other implementations (such as `Jython <https://www.jython.org>`_ or
-`PyPy <https://www.pypy.org>`_), however, can rely on a different mechanism
+`PyPy <https://pypy.org>`_), however, can rely on a different mechanism
 such as a full-blown garbage collector.  This difference can cause some
 subtle porting problems if your Python code depends on the behavior of the
 reference counting implementation.

--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -655,7 +655,7 @@ on the hash function used in digital signatures.
     by the signer.
 
     (`NIST SP-800-106 "Randomized Hashing for Digital Signatures"
-    <https://csrc.nist.gov/publications/detail/sp/800-106/archive/2009-02-25>`_)
+    <https://csrc.nist.gov/pubs/sp/800/106/final>`_)
 
 In BLAKE2 the salt is processed as a one-time input to the hash function during
 initialization, rather than as an input to each compression function.
@@ -809,8 +809,8 @@ Domain Dedication 1.0 Universal:
 .. _NIST-SP-800-132: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf
 .. _stackexchange pbkdf2 iterations question: https://security.stackexchange.com/questions/3959/recommended-of-iterations-when-using-pbkdf2-sha256/
 .. _Attacks on cryptographic hash algorithms: https://en.wikipedia.org/wiki/Cryptographic_hash_function#Attacks_on_cryptographic_hash_algorithms
-.. _the FIPS 180-4 standard: https://csrc.nist.gov/publications/detail/fips/180/4/final
-.. _the FIPS 202 standard: https://csrc.nist.gov/publications/detail/fips/202/final
+.. _the FIPS 180-4 standard: https://csrc.nist.gov/pubs/fips/180-4/upd1/final
+.. _the FIPS 202 standard: https://csrc.nist.gov/pubs/fips/202/final
 .. _HACL\* project: https://github.com/hacl-star/hacl-star
 
 
@@ -827,7 +827,7 @@ Domain Dedication 1.0 Universal:
    https://nvlpubs.nist.gov/nistpubs/fips/nist.fips.180-4.pdf
       The FIPS 180-4 publication on Secure Hash Algorithms.
 
-   https://csrc.nist.gov/publications/detail/fips/202/final
+   https://csrc.nist.gov/pubs/fips/202/final
       The FIPS 202 publication on the SHA-3 Standard.
 
    https://www.blake2.net/

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -137,7 +137,7 @@ The following classes are provided:
       The Netscape protocol with the bugs fixed.  Uses :mailheader:`Set-Cookie2` in
       place of :mailheader:`Set-Cookie`.  Not widely used.
 
-   http://kristol.org/cookie/errata.html
+   https://kristol.org/cookie/errata.html
       Unfinished errata to :rfc:`2965`.
 
    :rfc:`2964` - Use of HTTP State Management

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -13,7 +13,7 @@
 
 `JSON (JavaScript Object Notation) <https://json.org>`_, specified by
 :rfc:`7159` (which obsoletes :rfc:`4627`) and by
-`ECMA-404 <https://www.ecma-international.org/publications-and-standards/standards/ecma-404/>`_,
+`ECMA-404 <https://ecma-international.org/publications-and-standards/standards/ecma-404/>`_,
 is a lightweight data interchange format inspired by
 `JavaScript <https://en.wikipedia.org/wiki/JavaScript>`_ object literal syntax
 (although it is not a strict subset of JavaScript [#rfc-errata]_ ).
@@ -559,7 +559,7 @@ Standard Compliance and Interoperability
 ----------------------------------------
 
 The JSON format is specified by :rfc:`7159` and by
-`ECMA-404 <https://www.ecma-international.org/publications-and-standards/standards/ecma-404/>`_.
+`ECMA-404 <https://ecma-international.org/publications-and-standards/standards/ecma-404/>`_.
 This section details this module's level of compliance with the RFC.
 For simplicity, :class:`JSONEncoder` and :class:`JSONDecoder` subclasses, and
 parameters other than those explicitly mentioned, are not considered.

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4511,7 +4511,7 @@ written in Python, such as a mail server's external command delivery program.
       already more likely to experience deadlocks running such code.
 
       See `this discussion on fork being incompatible with threads
-      <https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555>`_
+      <https://discuss.python.org/t/33555>`_
       for technical details of why we're surfacing this longstanding
       platform compatibility problem to developers.
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -4511,7 +4511,7 @@ written in Python, such as a mail server's external command delivery program.
       already more likely to experience deadlocks running such code.
 
       See `this discussion on fork being incompatible with threads
-      <https://discuss.python.org/t/33555>`_
+      <https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555>`_
       for technical details of why we're surfacing this longstanding
       platform compatibility problem to developers.
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1566,7 +1566,7 @@ to speed up repeated connections from the same clients.
    The *capath* string, if present, is
    the path to a directory containing several CA certificates in PEM format,
    following an `OpenSSL specific layout
-   <https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html>`_.
+   <https://docs.openssl.org/master/man3/SSL_CTX_load_verify_locations/>`_.
 
    The *cadata* object, if present, is either an ASCII string of one or more
    PEM-encoded certificates or a :term:`bytes-like object` of DER-encoded
@@ -1641,7 +1641,7 @@ to speed up repeated connections from the same clients.
 
    Set the available ciphers for sockets created with this context.
    It should be a string in the `OpenSSL cipher list format
-   <https://www.openssl.org/docs/manmaster/man1/ciphers.html>`_.
+   <https://docs.openssl.org/master/man1/ciphers/>`_.
    If no cipher can be selected (because compile-time options or other
    configuration forbids use of all the specified ciphers), an
    :class:`SSLError` will be raised.
@@ -1874,7 +1874,7 @@ to speed up repeated connections from the same clients.
 .. method:: SSLContext.session_stats()
 
    Get statistics about the SSL sessions created or managed by this context.
-   A dictionary is returned which maps the names of each `piece of information <https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_sess_number.html>`_ to their
+   A dictionary is returned which maps the names of each `piece of information <https://docs.openssl.org/1.1.1/man3/SSL_CTX_sess_number/>`_ to their
    numeric values.  For example, here is the total number of hits and misses
    in the session cache since the context was created::
 
@@ -2017,7 +2017,7 @@ to speed up repeated connections from the same clients.
 .. attribute:: SSLContext.security_level
 
    An integer representing the `security level
-   <https://www.openssl.org/docs/manmaster/man3/SSL_CTX_get_security_level.html>`_
+   <https://docs.openssl.org/master/man3/SSL_CTX_get_security_level/>`_
    for the context. This attribute is read-only.
 
    .. versionadded:: 3.10

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -58,7 +58,7 @@ details that are unchanged.
    * `Modern Tkinter for Busy Python Developers <https://tkdocs.com/book.html>`_
       By Mark Roseman. (ISBN 978-1999149567)
 
-   * `Python GUI programming with Tkinter <https://www.packtpub.com/product/python-gui-programming-with-tkinter/9781788835886>`_
+   * `Python GUI programming with Tkinter <https://www.packtpub.com/en-us/product/python-gui-programming-with-tkinter-9781788835886>`_
       By Alan D. Moore. (ISBN 978-1788835886)
 
    * `Programming Python <https://learning-python.com/about-pp4e.html>`_

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2709,7 +2709,7 @@ Functions and decorators
 
    .. seealso::
       `Unreachable Code and Exhaustiveness Checking
-      <https://typing.readthedocs.io/en/latest/source/unreachable.html>`__ has more
+      <https://typing.readthedocs.io/en/latest/guides/unreachable.html>`__ has more
       information about exhaustiveness checking with static typing.
 
    .. versionadded:: 3.11

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -165,7 +165,7 @@ between conformable Python objects and XML on the wire.
       A good description of XML-RPC operation and client software in several languages.
       Contains pretty much everything an XML-RPC client developer needs to know.
 
-   `XML-RPC Introspection <https://xmlrpc-c.sourceforge.net/introspection.html>`_
+   `XML-RPC Introspection <https://xmlrpc-c.sourceforge.io/introspection.html>`_
       Describes the XML-RPC protocol extension for introspection.
 
    `XML-RPC Specification <http://xmlrpc.scripting.com/spec.html>`_

--- a/Doc/reference/introduction.rst
+++ b/Doc/reference/introduction.rst
@@ -74,7 +74,7 @@ PyPy
    and a Just in Time compiler. One of the goals of the project is to encourage
    experimentation with the language itself by making it easier to modify the
    interpreter (since it is written in Python).  Additional information is
-   available on `the PyPy project's home page <https://www.pypy.org/>`_.
+   available on `the PyPy project's home page <https://pypy.org/>`_.
 
 Each of these implementations varies in some way from the language as documented
 in this manual, or introduces specific information beyond what's covered in the

--- a/Doc/using/mac.rst
+++ b/Doc/using/mac.rst
@@ -155,7 +155,7 @@ https://www.activestate.com; it can also be built from source.
 A number of alternative macOS GUI toolkits are available:
 
 * `PySide <https://www.qt.io/qt-for-python>`__: Official Python bindings to the
-  `Qt GUI toolkit <https://qt.io>`__.
+  `Qt GUI toolkit <https://www.qt.io>`__.
 
 * `PyQt <https://riverbankcomputing.com/software/pyqt/intro>`__: Alternative
   Python bindings to Qt.

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -608,7 +608,7 @@ key features:
     Popular scientific modules (such as numpy, scipy and pandas) and the
     ``conda`` package manager.
 
-`Enthought Deployment Manager <https://www.enthought.com/edm/>`_
+`Enthought Deployment Manager <https://assets.enthought.com/downloads/edm/>`_
     "The Next Generation Python Environment and Package Manager".
 
     Previously Enthought provided Canopy, but it `reached end of life in 2016
@@ -1305,7 +1305,7 @@ shipped with PyWin32.  It is an embeddable IDE with a built-in debugger.
 
 .. seealso::
 
-   `Win32 How Do I...? <http://timgolden.me.uk/python/win32_how_do_i.html>`_
+   `Win32 How Do I...? <https://timgolden.me.uk/python/win32_how_do_i.html>`_
       by Tim Golden
 
    `Python and COM <https://www.boddie.org.uk/python/COM.html>`_

--- a/Doc/whatsnew/2.4.rst
+++ b/Doc/whatsnew/2.4.rst
@@ -684,7 +684,7 @@ includes a quick-start tutorial and a reference.
       Written by Facundo Batista and implemented by Facundo Batista, Eric Price,
       Raymond Hettinger, Aahz, and Tim Peters.
 
-   `http://www.lahey.com/float.htm <https://web.archive.org/web/20230604072523/http://www.lahey.com/float.htm>`
+   `http://www.lahey.com/float.htm <https://web.archive.org/web/20230604072523/http://www.lahey.com/float.htm>`__
       The article uses Fortran code to illustrate many of the problems that
       floating-point inaccuracy can cause.
 

--- a/Doc/whatsnew/2.4.rst
+++ b/Doc/whatsnew/2.4.rst
@@ -684,11 +684,11 @@ includes a quick-start tutorial and a reference.
       Written by Facundo Batista and implemented by Facundo Batista, Eric Price,
       Raymond Hettinger, Aahz, and Tim Peters.
 
-   http://www.lahey.com/float.htm
+   `http://www.lahey.com/float.htm <https://web.archive.org/web/20230604072523/http://www.lahey.com/float.htm>`
       The article uses Fortran code to illustrate many of the problems that
       floating-point inaccuracy can cause.
 
-   http://speleotrove.com/decimal/
+   https://speleotrove.com/decimal/
       A description of a decimal-based representation.  This representation is being
       proposed as a standard, and underlies the new Python decimal type.  Much of this
       material was written by Mike Cowlishaw, designer of the Rexx language.

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -1548,7 +1548,7 @@ changes, or look through the Subversion logs for all the details.
   *ciphers* argument that's a string listing the encryption algorithms
   to be allowed; the format of the string is described
   `in the OpenSSL documentation
-  <https://www.openssl.org/docs/man1.0.2/man1/ciphers.html>`__.
+  <https://docs.openssl.org/1.0.2/man1/ciphers/>`__.
   (Added by Antoine Pitrou; :issue:`8322`.)
 
   Another change makes the extension load all of OpenSSL's ciphers and

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1254,7 +1254,7 @@ Deprecated
     We added the warning to raise awareness as issues encountered by code doing
     this are becoming more frequent. See the :func:`os.fork` documentation for
     more details along with `this discussion on fork being incompatible with threads
-    <https://discuss.python.org/t/33555>`_ for *why* we're now surfacing this
+    <https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555>`_ for *why* we're now surfacing this
     longstanding platform compatibility problem to developers.
 
   When this warning appears due to usage of :mod:`multiprocessing` or

--- a/Misc/NEWS.d/3.10.0a7.rst
+++ b/Misc/NEWS.d/3.10.0a7.rst
@@ -715,7 +715,7 @@ this situation.  Also ensures that the :func:`tempfile.gettempdir()` and
 Expose ``X509_V_FLAG_ALLOW_PROXY_CERTS`` as
 :const:`~ssl.VERIFY_ALLOW_PROXY_CERTS` to allow proxy certificate validation
 as explained in
-https://www.openssl.org/docs/man1.1.1/man7/proxy-certificates.html.
+https://docs.openssl.org/1.1.1/man7/proxy-certificates/.
 
 ..
 

--- a/Misc/NEWS.d/3.12.0a6.rst
+++ b/Misc/NEWS.d/3.12.0a6.rst
@@ -17,7 +17,7 @@ from the HACL* project.
 Updated the OpenSSL version used in Windows and macOS binary release builds
 to 1.1.1t to address :cve:`2023-0286`, :cve:`2022-4303`, and :cve:`2022-4303` per
 `the OpenSSL 2023-02-07 security advisory
-<https://www.openssl.org/news/secadv/20230207.txt>`_.
+<https://openssl-library.org/news/secadv/20230207.txt>`_.
 
 ..
 


### PR DESCRIPTION
This is another patch required to fix the current state of `make linkcheck` in Python Docs. This pull request fixes occurrences of "redirected permanently" as reported by `make linkcheck`.

Please backport to 3.13 and 3.12 branches.

See below the linkcheck occurrences this PR handles:

### Add or remove 'www'

- faq/design.rst:330: [redirected permanently] https://www.nuitka.net/ to https://nuitka.net/
- faq/design.rst:347: [redirected permanently] https://www.pypy.org to https://pypy.org/
- library/json.rst:14: [redirected permanently] https://www.ecma-international.org/publications-and-standards/standards/ecma-404/ to https://ecma-international.org/publications-and-standards/standards/ecma-404/
- reference/introduction.rst:72: [redirected permanently] https://www.pypy.org/ to https://pypy.org/
- using/mac.rst:157: [redirected permanently] https://qt.io to https://www.qt.io/

### http to https

- library/http.cookiejar.rst:140: [redirected permanently] http://kristol.org/cookie/errata.html to https://kristol.org/cookie/errata.html
- using/windows.rst:1308: [redirected permanently] http://timgolden.me.uk/python/win32_how_do_i.html to https://timgolden.me.uk/python/win32_how_do_i.html
- whatsnew/2.4.rst:691: [redirected permanently] http://speleotrove.com/decimal/ to https://speleotrove.com/decimal/

### URL path change

- library/hashlib.rst:23: [redirected permanently] https://csrc.nist.gov/publications/detail/fips/180/4/final to https://csrc.nist.gov/pubs/fips/180-4/upd1/final
- library/hashlib.rst:23: [redirected permanently] https://csrc.nist.gov/publications/detail/fips/202/final to https://csrc.nist.gov/pubs/fips/202/final
- library/hashlib.rst:657: [redirected permanently] https://csrc.nist.gov/publications/detail/sp/800-106/archive/2009-02-25 to https://csrc.nist.gov/pubs/sp/800/106/final
- library/tkinter.rst:61: [redirected permanently] https://www.packtpub.com/product/python-gui-programming-with-tkinter/9781788835886 to https://www.packtpub.com/en-us/product/python-gui-programming-with-tkinter-9781788835886
- library/typing.rst:2711: [redirected permanently] https://typing.readthedocs.io/en/latest/source/unreachable.html to https://typing.readthedocs.io/en/latest/guides/unreachable.html
- using/windows.rst:611: [redirected permanently] https://www.enthought.com/edm/ to https://assets.enthought.com/downloads/edm/

### Domain name change

- library/xmlrpc.client.rst:168: [redirected permanently] https://xmlrpc-c.sourceforge.net/introspection.html to https://xmlrpc-c.sourceforge.io/introspection.html
- whatsnew/changelog.rst:8710: [redirected permanently] https://www.openssl.org/news/secadv/20230207.txt to https://openssl-library.org/news/secadv/20230207.txt

### www.openssl.org/docs to docs.openssl.org

- library/ssl.rst:1566: [redirected permanently] https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html to https://docs.openssl.org/master/man3/SSL_CTX_load_verify_locations/
- library/ssl.rst:1642: [redirected permanently] https://www.openssl.org/docs/manmaster/man1/ciphers.html to https://docs.openssl.org/master/man1/ciphers/
- library/ssl.rst:1876: [redirected permanently] https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_sess_number.html to https://docs.openssl.org/1.1.1/man3/SSL_CTX_sess_number/
- library/ssl.rst:2019: [redirected permanently] https://www.openssl.org/docs/manmaster/man3/SSL_CTX_get_security_level.html to https://docs.openssl.org/master/man3/SSL_CTX_get_security_level/
- whatsnew/2.7.rst:1547: [redirected permanently] https://www.openssl.org/docs/man1.0.2/man1/ciphers.html to https://docs.openssl.org/1.0.2/man1/ciphers/
- whatsnew/changelog.rst:19200: [redirected permanently] https://www.openssl.org/docs/man1.1.1/man7/proxy-certificates.html to https://docs.openssl.org/1.1.1/man7/proxy-certificates/

### pypi.org package URL normalization 

- howto/curses.rst:38: [redirected permanently] https://pypi.org/project/Urwid/ to https://pypi.org/project/urwid/
- library/datetime.rst:40: [redirected permanently] https://pypi.org/project/DateType/ to https://pypi.org/project/datetype/
- library/importlib.metadata.rst:182: [redirected permanently] https://pypi.org/project/backports.entry_points_selectable/ to https://pypi.org/project/backports.entry-points-selectable/
- library/typing.rst:42: [redirected permanently] https://pypi.org/project/typing_extensions/ to https://pypi.org/project/typing-extensions/
- using/windows.rst:1288: [redirected permanently] https://pypi.org/project/PyWin32/ to https://pypi.org/project/pywin32/
- whatsnew/3.11.rst:2045: [redirected permanently] https://pypi.org/project/Pynche/ to https://pypi.org/project/pynche/
- whatsnew/3.13.rst:1315: [redirected permanently] https://pypi.org/project/crypt_r/ to https://pypi.org/project/crypt-r/

### Expanding discuss.python.org URL 

- library/os.rst:4513: [redirected permanently] https://discuss.python.org/t/33555 to https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555

### Website unavailable (remove or use wayback machine)

- whatsnew/2.4.rst:687: [redirected permanently] http://www.lahey.com/float.htm to https://sierraweb.com

### Changes done by the bots (separated for avoid confusion)


<!-- gh-issue-number: gh-103484 -->
* Issue: gh-103484
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124144.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->