### PR TITLE
gh-124160: Pass main_tstate to update_global_state_for_extension()

### DIFF
--- a/Misc/NEWS.d/next/C_API/2024-09-18-18-40-30.gh-issue-124160.Zy-VKi.rst
+++ b/Misc/NEWS.d/next/C_API/2024-09-18-18-40-30.gh-issue-124160.Zy-VKi.rst
@@ -1,0 +1,2 @@
+Fix crash when importing modules containing state and single-phase
+initialization in a subinterpreter.

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -95,6 +95,14 @@ static void _testembed_Py_Initialize(void)
 }
 
 
+static int test_import_in_subinterpreters(void)
+{
+    _testembed_Py_InitializeFromConfig();
+    PyThreadState_Swap(Py_NewInterpreter());
+    return PyRun_SimpleString("import readline"); // gh-124160
+}
+
+
 /*****************************************************
  * Test repeated initialisation and subinterpreters
  *****************************************************/
@@ -2398,6 +2406,7 @@ static struct TestCase TestCases[] = {
     {"test_repeated_init_exec", test_repeated_init_exec},
     {"test_repeated_simple_init", test_repeated_simple_init},
     {"test_forced_io_encoding", test_forced_io_encoding},
+    {"test_import_in_subinterpreters", test_import_in_subinterpreters},
     {"test_repeated_init_and_subinterpreters", test_repeated_init_and_subinterpreters},
     {"test_repeated_init_and_inittab", test_repeated_init_and_inittab},
     {"test_pre_initialization_api", test_pre_initialization_api},

--- a/Python/import.c
+++ b/Python/import.c
@@ -2045,7 +2045,7 @@ import_run_extension(PyThreadState *tstate, PyModInitFunction p0,
                 singlephase.m_init = p0;
             }
             cached = update_global_state_for_extension(
-                    tstate, info->path, info->name, def, &singlephase);
+                    main_tstate, info->path, info->name, def, &singlephase);
             if (cached == NULL) {
                 assert(PyErr_Occurred());
                 goto main_finally;


### PR DESCRIPTION
Otherwise it'll always return NULL if tstate != main_tstate due to _Py_IsMainInterpreter() check inside it.

Also, add a regression test that makes sure that `readline` is importable in case that triggered the crash before.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124160 -->
* Issue: gh-124160
<!-- /gh-issue-number -->
