### PR TITLE
GH-103484: Fix broken links reported by linkcheck

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -218,7 +218,7 @@ The :mod:`functools` module defines the following functions:
    cache.  See :ref:`faq-cache-method-calls`
 
    An `LRU (least recently used) cache
-   <https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)>`_
+   <https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_Recently_Used_(LRU)>`_
    works best when the most recent calls are the best predictors of upcoming
    calls (for example, the most popular articles on a news server tend to
    change each day).  The cache's size limit assures that the cache does not

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -2759,7 +2759,7 @@ enabled when negotiating a SSL session is possible through the
 :meth:`SSLContext.set_ciphers` method.  Starting from Python 3.2.3, the
 ssl module disables certain weak ciphers by default, but you may want
 to further restrict the cipher choice. Be sure to read OpenSSL's documentation
-about the `cipher list format <https://www.openssl.org/docs/man1.1.1/man1/ciphers.html#CIPHER-LIST-FORMAT>`_.
+about the `cipher list format <https://docs.openssl.org/1.1.1/man1/ciphers/#cipher-list-format>`_.
 If you want to check which ciphers are enabled by a given cipher list, use
 :meth:`SSLContext.get_ciphers` or the ``openssl ciphers`` command on your
 system.

--- a/Doc/whatsnew/2.4.rst
+++ b/Doc/whatsnew/2.4.rst
@@ -757,7 +757,7 @@ API that perform ASCII-only conversions, ignoring the locale setting:
   :c:expr:`double` to an ASCII string.
 
 The code for these functions came from the GLib library
-(https://developer-old.gnome.org/glib/2.26/), whose developers kindly
+(`https://developer-old.gnome.org/glib/2.26/ <http://web.archive.org/web/20210306104320/https://developer.gnome.org/glib/2.26/>`__), whose developers kindly
 relicensed the relevant functions and donated them to the Python Software
 Foundation.  The :mod:`locale` module  can now change the numeric locale,
 letting extensions such as GTK+  produce the correct results.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -359,7 +359,7 @@ create an interpreter with its own GIL:
    /* The new interpreter is now active in the current thread. */
 
 For further examples how to use the C-API for sub-interpreters with a
-per-interpreter GIL, see :source:`Modules/_interpretersmodule.c`.
+per-interpreter GIL, see ``Modules/_xxsubinterpretersmodule.c``.
 
 (Contributed by Eric Snow in :gh:`104210`, etc.)
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -359,7 +359,7 @@ create an interpreter with its own GIL:
    /* The new interpreter is now active in the current thread. */
 
 For further examples how to use the C-API for sub-interpreters with a
-per-interpreter GIL, see :source:`Modules/_xxsubinterpretersmodule.c`.
+per-interpreter GIL, see :source:`Modules/_interpretersmodule.c`.
 
 (Contributed by Eric Snow in :gh:`104210`, etc.)
 

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -1650,7 +1650,7 @@ for secure (encrypted, authenticated) internet connections:
 * The :func:`ssl.wrap_socket() <ssl.SSLContext.wrap_socket>` constructor function now takes a *ciphers*
   argument.  The *ciphers* string lists the allowed encryption algorithms using
   the format described in the `OpenSSL documentation
-  <https://www.openssl.org/docs/man1.0.2/man1/ciphers.html#CIPHER-LIST-FORMAT>`__.
+  <https://docs.openssl.org/1.0.2/man1/ciphers/#cipher-list-format>`__.
 
 * When linked against recent versions of OpenSSL, the :mod:`ssl` module now
   supports the Server Name Indication extension to the TLS protocol, allowing

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -1963,7 +1963,7 @@ Other Improvements
   <https://devguide.python.org/coverage/#measuring-coverage-of-c-code-with-gcov-and-lcov>`_
   will build python, run the test suite, and generate an HTML coverage report
   for the C codebase using ``gcov`` and `lcov
-  <https://ltp.sourceforge.net/coverage/lcov.php>`_.
+  <https://github.com/linux-test-project/lcov>`_.
 
 * The ``-R`` option to the :ref:`python regression test suite <regrtest>` now
   also checks for memory allocation leaks, using


### PR DESCRIPTION
This is another patch required to fix the current state of `make linkcheck` in Python Docs. This pull request fixes occurrences of "broken" as reported by `make linkcheck`.

Please backport to 3.13 and 3.12 branches. 3.12 will have one conflict, which can be solved by undoing the change to whatsnew/3.12.rst.

See below the linkcheck occurrences this PR handles:

- library/functools.rst:220: [broken] https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU): Anchor 'Least_recently_used_%28LRU%29' not found
- library/ssl.rst:2757: [broken] https://www.openssl.org/docs/man1.1.1/man1/ciphers.html#CIPHER-LIST-FORMAT: Anchor 'CIPHER-LIST-FORMAT' not found
- whatsnew/2.4.rst:759: [broken] https://developer-old.gnome.org/glib/2.26/: HTTPSConnectionPool(host='developer-old.gnome.org', port=443): Max retries exceeded with url: /glib/2.26/ (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7fe9dddce6c0>: Failed to resolve 'developer-old.gnome.org' ([Errno -2] Name or service not known)"))
- whatsnew/3.12.rst:361: [broken] https://github.com/python/cpython/tree/main/Modules/_xxsubinterpretersmodule.c: 404 Client Error: Not Found for url: https://github.com/python/cpython/tree/main/Modules/_xxsubinterpretersmodule.c
- whatsnew/3.2.rst:1650: [broken] https://www.openssl.org/docs/man1.0.2/man1/ciphers.html#CIPHER-LIST-FORMAT: Anchor 'CIPHER-LIST-FORMAT' not found
- whatsnew/3.4.rst:1962: [broken] https://ltp.sourceforge.net/coverage/lcov.php: 404 Client Error: Not Found for url: https://ltp.sourceforge.net/coverage/lcov.php

----

<!-- gh-issue-number: gh-103484 -->
* Issue: gh-103484
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124169.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->