### PR TITLE
gh-124064: Fix -Wconversion warnings in pycore_{long,object}.h

### DIFF
--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -140,9 +140,9 @@ static inline void _PyObject_GC_SET_SHARED_INLINE(PyObject *op) {
 
 /* Bit flags for _gc_prev */
 /* Bit 0 is set when tp_finalize is called */
-#define _PyGC_PREV_MASK_FINALIZED  1
+#define _PyGC_PREV_MASK_FINALIZED  ((uintptr_t)1)
 /* Bit 1 is set when the object is in generation which is GCed currently. */
-#define _PyGC_PREV_MASK_COLLECTING 2
+#define _PyGC_PREV_MASK_COLLECTING ((uintptr_t)2)
 
 /* Bit 0 in _gc_next is the old space bit.
  * It is set as follows:
@@ -227,7 +227,7 @@ static inline void _PyGC_CLEAR_FINALIZED(PyObject *op) {
     _PyObject_CLEAR_GC_BITS(op, _PyGC_BITS_FINALIZED);
 #else
     PyGC_Head *gc = _Py_AS_GC(op);
-    gc->_gc_prev &= ~(uintptr_t)_PyGC_PREV_MASK_FINALIZED;
+    gc->_gc_prev &= ~_PyGC_PREV_MASK_FINALIZED;
 #endif
 }
 

--- a/Include/internal/pycore_long.h
+++ b/Include/internal/pycore_long.h
@@ -228,7 +228,7 @@ static inline Py_ssize_t
 _PyLong_DigitCount(const PyLongObject *op)
 {
     assert(PyLong_Check(op));
-    return op->long_value.lv_tag >> NON_SIZE_BITS;
+    return (Py_ssize_t)(op->long_value.lv_tag >> NON_SIZE_BITS);
 }
 
 /* Equivalent to _PyLong_DigitCount(op) * _PyLong_NonCompactSign(op) */
@@ -263,7 +263,8 @@ _PyLong_SameSign(const PyLongObject *a, const PyLongObject *b)
     return (a->long_value.lv_tag & SIGN_MASK) == (b->long_value.lv_tag & SIGN_MASK);
 }
 
-#define TAG_FROM_SIGN_AND_SIZE(sign, size) ((1 - (sign)) | ((size) << NON_SIZE_BITS))
+#define TAG_FROM_SIGN_AND_SIZE(sign, size) \
+    ((uintptr_t)(1 - (sign)) | ((uintptr_t)(size) << NON_SIZE_BITS))
 
 static inline void
 _PyLong_SetSignAndDigitCount(PyLongObject *op, int sign, Py_ssize_t size)
@@ -271,7 +272,7 @@ _PyLong_SetSignAndDigitCount(PyLongObject *op, int sign, Py_ssize_t size)
     assert(size >= 0);
     assert(-1 <= sign && sign <= 1);
     assert(sign != 0 || size == 0);
-    op->long_value.lv_tag = TAG_FROM_SIGN_AND_SIZE(sign, (size_t)size);
+    op->long_value.lv_tag = TAG_FROM_SIGN_AND_SIZE(sign, size);
 }
 
 static inline void
@@ -281,7 +282,7 @@ _PyLong_SetDigitCount(PyLongObject *op, Py_ssize_t size)
     op->long_value.lv_tag = (((size_t)size) << NON_SIZE_BITS) | (op->long_value.lv_tag & SIGN_MASK);
 }
 
-#define NON_SIZE_MASK ~((1 << NON_SIZE_BITS) - 1)
+#define NON_SIZE_MASK ~(uintptr_t)((1 << NON_SIZE_BITS) - 1)
 
 static inline void
 _PyLong_FlipSign(PyLongObject *op) {

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -442,7 +442,7 @@ static inline void _PyObject_GC_TRACK(
     _PyGCHead_SET_NEXT(last, gc);
     _PyGCHead_SET_PREV(gc, last);
     /* Young objects will be moved into the visited space during GC, so set the bit here */
-    gc->_gc_next = ((uintptr_t)generation0) | interp->gc.visited_space;
+    gc->_gc_next = ((uintptr_t)generation0) | (uintptr_t)interp->gc.visited_space;
     generation0->_gc_prev = (uintptr_t)gc;
 #endif
 }
@@ -758,9 +758,9 @@ _PyType_PreHeaderSize(PyTypeObject *tp)
 {
     return (
 #ifndef Py_GIL_DISABLED
-        _PyType_IS_GC(tp) * sizeof(PyGC_Head) +
+        (size_t)_PyType_IS_GC(tp) * sizeof(PyGC_Head) +
 #endif
-        _PyType_HasFeature(tp, Py_TPFLAGS_PREHEADER) * 2 * sizeof(PyObject *)
+        (size_t)_PyType_HasFeature(tp, Py_TPFLAGS_PREHEADER) * 2 * sizeof(PyObject *)
     );
 }
 
@@ -821,7 +821,7 @@ static inline PyDictValues *
 _PyObject_InlineValues(PyObject *obj)
 {
     PyTypeObject *tp = Py_TYPE(obj);
-    assert(tp->tp_basicsize > 0 && tp->tp_basicsize % sizeof(PyObject *) == 0);
+    assert(tp->tp_basicsize > 0 && (size_t)tp->tp_basicsize % sizeof(PyObject *) == 0);
     assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
     assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
     return (PyDictValues *)((char *)obj + tp->tp_basicsize);

--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -56,8 +56,8 @@ typedef union _PyStackRef {
 
 #define Py_TAG_DEFERRED (1)
 
-#define Py_TAG_PTR      (0)
-#define Py_TAG_BITS     (1)
+#define Py_TAG_PTR      ((uintptr_t)0)
+#define Py_TAG_BITS     ((uintptr_t)1)
 
 #ifdef Py_GIL_DISABLED
     static const _PyStackRef PyStackRef_NULL = { .bits = 0 | Py_TAG_DEFERRED};
@@ -98,7 +98,7 @@ typedef union _PyStackRef {
 static inline PyObject *
 PyStackRef_AsPyObjectBorrow(_PyStackRef stackref)
 {
-    PyObject *cleared = ((PyObject *)((stackref).bits & (~(uintptr_t)Py_TAG_BITS)));
+    PyObject *cleared = ((PyObject *)((stackref).bits & (~Py_TAG_BITS)));
     return cleared;
 }
 #else

--- a/Tools/build/.warningignore_macos
+++ b/Tools/build/.warningignore_macos
@@ -65,7 +65,7 @@ Modules/_testcapi/vectorcall.c 3
 Modules/_testcapi/watchers.c 3
 Modules/_testcapimodule.c 3
 Modules/_testclinic.c 14
-Modules/_testexternalinspection.c 8
+Modules/_testexternalinspection.c 7
 Modules/_testinternalcapi.c 8
 Modules/_testinternalcapi/pytime.c 8
 Modules/_testinternalcapi/test_critical_sections.c 1
@@ -199,7 +199,7 @@ Python/fileutils.c 7
 Python/flowgraph.c 8
 Python/formatter_unicode.c 7
 Python/frame.c 4
-Python/gc.c 8
+Python/gc.c 7
 Python/generated_cases.c.h 35
 Python/getargs.c 11
 Python/import.c 5

--- a/Tools/build/.warningignore_macos
+++ b/Tools/build/.warningignore_macos
@@ -6,8 +6,6 @@
 Include/internal/mimalloc/mimalloc/internal.h 4
 Include/internal/pycore_backoff.h 1
 Include/internal/pycore_dict.h 2
-Include/internal/pycore_long.h 2
-Include/internal/pycore_object.h 4
 Modules/_asynciomodule.c 3
 Modules/_bisectmodule.c 2
 Modules/_bz2module.c 5

--- a/Tools/build/.warningignore_ubuntu
+++ b/Tools/build/.warningignore_ubuntu
@@ -94,7 +94,7 @@ Modules/_testcapi/watchers.c 3
 Modules/_testcapimodule.c 1
 Modules/_testclinic.c 14
 Modules/_testclinic.c 14
-Modules/_testexternalinspection.c 7
+Modules/_testexternalinspection.c 6
 Modules/_testinternalcapi.c 10
 Modules/_testinternalcapi/test_critical_sections.c 1
 Modules/_testinternalcapi/test_lock.c 4
@@ -222,9 +222,7 @@ Python/fileutils.c 11
 Python/flowgraph.c 7
 Python/formatter_unicode.c 6
 Python/frame.c 3
-Python/gc.c 9
-Python/gc.c 9
-Python/generated_cases.c.h 27
+Python/gc.c 8
 Python/generated_cases.c.h 27
 Python/getargs.c 7
 Python/hashtable.c 1

--- a/Tools/build/.warningignore_ubuntu
+++ b/Tools/build/.warningignore_ubuntu
@@ -20,8 +20,6 @@ Include/internal/pycore_backoff.h 3
 Include/internal/pycore_blocks_output_buffer.h 1
 Include/internal/pycore_dict.h 2
 Include/internal/pycore_interp.h 1
-Include/internal/pycore_long.h 3
-Include/internal/pycore_object.h 4
 Include/internal/pycore_obmalloc.h 1
 Include/internal/pycore_pymath.h 1
 Include/internal/pycore_runtime_init.h 1


### PR DESCRIPTION
Change also the fix for pycore_gc.h and pycore_stackref.h: declare constants as uintptr_t rather than casting constants.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124064 -->
* Issue: gh-124064
<!-- /gh-issue-number -->
