### PR TITLE
[3.12]: gh-103484: Relink _xxsubinterpretersmodule.c in whatsnew/3.12.rst

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -359,7 +359,7 @@ create an interpreter with its own GIL:
    /* The new interpreter is now active in the current thread. */
 
 For further examples how to use the C-API for sub-interpreters with a
-per-interpreter GIL, see ``Modules/_xxsubinterpretersmodule.c``.
+per-interpreter GIL, see :source:`Modules/_xxsubinterpretersmodule.c`.
 
 (Contributed by Eric Snow in :gh:`104210`, etc.)
 


### PR DESCRIPTION
The backport PR https://github.com/python/cpython/pull/124180 replaced a linking role `:source:` with literal text in the 3.12 branch, when it should apply only to 3.13 and newer branches. [Modules/_xxsubinterpretersmodule.c](https://github.com/python/cpython/blob/3.12/Modules/_xxsubinterpretersmodule.c) does exist in 3.12 branch and it was only renamed afterwards via https://github.com/python/cpython/pull/117791.

<!-- gh-issue-number: gh-103484 -->
* Issue: gh-103484
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124183.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->