### PR TITLE
gh-124194: Fix wrong issue number in What's New in Python 3.8

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1755,7 +1755,7 @@ The following features and APIs have been removed from Python 3.8:
 *  Starting with Python 3.3, importing ABCs from :mod:`collections` was
    deprecated, and importing should be done from :mod:`collections.abc`. Being
    able to import from collections was marked for removal in 3.8, but has been
-   delayed to 3.9. (See :issue:`36953`.)
+   delayed to 3.9. (See :gh:`81134`.)
 
 * The :mod:`macpath` module, deprecated in Python 3.7, has been removed.
   (Contributed by Victor Stinner in :issue:`35471`.)

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -1755,7 +1755,7 @@ The following features and APIs have been removed from Python 3.8:
 *  Starting with Python 3.3, importing ABCs from :mod:`collections` was
    deprecated, and importing should be done from :mod:`collections.abc`. Being
    able to import from collections was marked for removal in 3.8, but has been
-   delayed to 3.9. (See :issue:`36952`.)
+   delayed to 3.9. (See :issue:`36953`.)
 
 * The :mod:`macpath` module, deprecated in Python 3.7, has been removed.
   (Contributed by Victor Stinner in :issue:`35471`.)


### PR DESCRIPTION
<!-- gh-issue-number: gh-124194 -->
* Issue: gh-124194
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124195.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->