### PR TITLE
gh-112301: Use literal format strings in unicode_fromformat_arg

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -2859,17 +2859,16 @@ unicode_fromformat_arg(_PyUnicodeWriter *writer,
                 case 'x': len = SPRINT(SIZE_SPEC, "x", UNSIGNED_TYPE); break; \
                 case 'X': len = SPRINT(SIZE_SPEC, "X", UNSIGNED_TYPE); break; \
                 default:  len = SPRINT(SIZE_SPEC, "d", SIGNED_TYPE); break;   \
-            }                                                                 \
-            break;
+            }
 
         // Outer switch to handle all the sizes/types
         switch (sizemod) {
-            case F_LONG:     DO_SPRINTS("l", long, unsigned long)
-            case F_LONGLONG: DO_SPRINTS("ll", long long, unsigned long long)
-            case F_SIZE:     DO_SPRINTS("z", Py_ssize_t, size_t)
-            case F_PTRDIFF:  DO_SPRINTS("t", ptrdiff_t, ptrdiff_t)
-            case F_INTMAX:   DO_SPRINTS("j", intmax_t, uintmax_t)
-            default:         DO_SPRINTS("", int, unsigned int)
+            case F_LONG:     DO_SPRINTS("l", long, unsigned long); break;
+            case F_LONGLONG: DO_SPRINTS("ll", long long, unsigned long long); break;
+            case F_SIZE:     DO_SPRINTS("z", Py_ssize_t, size_t); break;
+            case F_PTRDIFF:  DO_SPRINTS("t", ptrdiff_t, ptrdiff_t); break;
+            case F_INTMAX:   DO_SPRINTS("j", intmax_t, uintmax_t); break;
+            default:         DO_SPRINTS("", int, unsigned int); break;
         }
         #undef SPRINT
         #undef DO_SPRINTS


### PR DESCRIPTION
This switches sprintf format strings in unicode_fromformat_arg to compile-time literals, avoiding `-Wformat-nonliteral` warnings and maybe even allowing optimizing the `sprintf` calls.

The macros aren't too readable so I'm generous with comments.

(Another option would be code generation, see the first commit.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112301 -->
* Issue: gh-112301
<!-- /gh-issue-number -->
