### PR TITLE
gh-124212 fix invalid variable name in test_venv.py

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -504,6 +504,21 @@ class BasicTest(BaseTest):
         )
         self.assertEqual(out.strip(), '0')
 
+    @unittest.skipUnless(os.name == 'nt' and can_symlink(),
+                         'symlinks on Windows')
+    def test_failed_symlink(self):
+        """
+        Test handling of failed symlinks on Windows.
+        """
+        rmtree(self.env_dir)
+        env_dir = os.path.join(os.path.realpath(self.env_dir), 'venv')
+        with patch('os.symlink') as mock_symlink:
+            mock_symlink.side_effect = OSError()
+            builder = venv.EnvBuilder(clear=True, symlinks=True)
+            _, err = self.run_with_capture(builder.create, env_dir)
+            filepath_regex = r"'.+\/[^\/]+'"
+            self.assertRegex(err, rf"Unable to symlink {filepath_regex} to {filepath_regex}",)
+
     @requireVenvCreate
     def test_multiprocessing(self):
         """

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -516,8 +516,8 @@ class BasicTest(BaseTest):
             mock_symlink.side_effect = OSError()
             builder = venv.EnvBuilder(clear=True, symlinks=True)
             _, err = self.run_with_capture(builder.create, env_dir)
-            filepath_regex = r"'.+\/[^\/]+'"
-            self.assertRegex(err, rf"Unable to symlink {filepath_regex} to {filepath_regex}",)
+            filepath_regex = r"'[A-Z]:\\\\(?:[^\\\\]+\\\\)*[^\\\\]+'"
+            self.assertRegex(err, rf"Unable to symlink {filepath_regex} to {filepath_regex}")
 
     @requireVenvCreate
     def test_multiprocessing(self):

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -393,7 +393,7 @@ class EnvBuilder:
                         os.symlink(src, dest)
                         to_unlink.append(dest)
                     except OSError:
-                        logger.warning('Unable to symlink %r to %r', src, dst)
+                        logger.warning('Unable to symlink %r to %r', src, dest)
                         do_copies = True
                         for f in to_unlink:
                             try:

--- a/Misc/NEWS.d/next/Library/2024-09-18-17-45-52.gh-issue-124212.n6kIby.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-18-17-45-52.gh-issue-124212.n6kIby.rst
@@ -1,1 +1,1 @@
-Fix invalid variable in ``venv`` handling of failed symlink on Windows
+Fix invalid variable in :mod:`venv` handling of failed symlink on Windows

--- a/Misc/NEWS.d/next/Library/2024-09-18-17-45-52.gh-issue-124212.n6kIby.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-18-17-45-52.gh-issue-124212.n6kIby.rst
@@ -1,0 +1,1 @@
+Fix invalid variable in ``venv`` handling of failed symlink on Windows


### PR DESCRIPTION
Fix an invalid variable name from `dst` to `dest`. Add a test covering that code path

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124212 -->
* Issue: gh-124212
<!-- /gh-issue-number -->
