### PR TITLE
gh-124213: Skip tests failing with ``--suppress-sync=true`` when inside systemd-nspawn container

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2876,7 +2876,6 @@ class BrokenIter:
         return self
 
 
-
 def in_systemd_nspawn_sync_suppressed() -> bool:
     """
     Test whether the test suite is runing in systemd-nspawn
@@ -2896,10 +2895,9 @@ def in_systemd_nspawn_sync_suppressed() -> bool:
     except FileNotFoundError:
         return False
 
-    import errno
-
     # If systemd-nspawn is used, O_SYNC flag will immediately
     # trigger EINVAL.  Otherwise, ENOENT will be given instead.
+    import errno
     try:
         with os.open(__file__, os.O_RDONLY | os.O_SYNC):
             pass

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -17,6 +17,7 @@ import time
 import types
 import unittest
 import warnings
+from pathlib import Path
 
 
 __all__ = [
@@ -61,6 +62,7 @@ __all__ = [
     "without_optimizer",
     "force_not_colorized",
     "BrokenIter",
+    "in_systemd_nspawn",
     ]
 
 
@@ -2873,3 +2875,11 @@ class BrokenIter:
         if self.iter_raises:
             1/0
         return self
+
+
+def in_systemd_nspawn() -> bool:
+    try:
+        return (Path("/run/systemd/container").read_bytes().rstrip() ==
+                b"systemd-nspawn")
+    except FileNotFoundError:
+        return False

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -17,7 +17,6 @@ import time
 import types
 import unittest
 import warnings
-from pathlib import Path
 
 
 __all__ = [
@@ -2878,8 +2877,18 @@ class BrokenIter:
 
 
 def in_systemd_nspawn() -> bool:
+    """
+    Test whether the test suite is running inside of systemd-nspawn container
+
+    Return True if the test suite is being run inside a systemd-nspawn
+    container, False otherwise.  This can be used to skip tests that are
+    known to be reliable inside this kind of virtualization, for example
+    tests that are relying on fsync() not being stubbed out
+    (as ``systemd-nspawn --suppress-sync=true` does).
+    """
+
     try:
-        return (Path("/run/systemd/container").read_bytes().rstrip() ==
-                b"systemd-nspawn")
+        with open("/run/systemd/container", "rb") as fp:
+            return fp.read().rstrip() == b"systemd-nspawn"
     except FileNotFoundError:
         return False

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2890,12 +2890,11 @@ def in_systemd_nspawn() -> bool:
 
 def in_systemd_nspawn_sync_suppressed() -> bool:
     """
-    Test whether the test suite is runing in systemd-nspawn with ``--suppress-sync=true``
+    Test whether the test suite is runing in systemd-nspawn
+    with ``--suppress-sync=true``.
 
-    Return True if the test suite is being run inside a systemd-nspawn
-    container and ``--suppress-sync=true`` option is detected to be used,
-    False otherwise.  This can be used to skip tests that rely
-    on ``fsync()`` calls and similar not being intercepted.
+    This can be used to skip tests that rely on ``fsync()`` calls
+    and similar not being intercepted.
     """
 
     if hasattr(os, "O_SYNC") and in_systemd_nspawn():
@@ -2904,7 +2903,7 @@ def in_systemd_nspawn_sync_suppressed() -> bool:
         # If systemd-nspawn is used, O_SYNC flag will immediately trigger
         # EINVAL.  Otherwise, ENOENT will be given instead.
         try:
-            with os.open("", os.O_RDONLY | os.O_SYNC):
+            with os.open(__file__, os.O_RDONLY | os.O_SYNC):
                 pass
         except OSError as err:
             if err.errno == errno.EINVAL:

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -840,7 +840,7 @@ class MmapTests(unittest.TestCase):
         mm.write(b'python')
         result = mm.flush()
         self.assertIsNone(result)
-        if (sys.platform.startswith(('linux', 'android')) 
+        if (sys.platform.startswith(('linux', 'android'))
             and not in_systemd_nspawn_sync_suppressed()):
             # 'offset' must be a multiple of mmap.PAGESIZE on Linux.
             # See bpo-34754 for details.

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1,6 +1,6 @@
 from test.support import (
     requires, _2G, _4G, gc_collect, cpython_only, is_emscripten, is_apple,
-    in_systemd_nspawn,
+    in_systemd_nspawn_sync_suppressed,
 )
 from test.support.import_helper import import_module
 from test.support.os_helper import TESTFN, unlink
@@ -840,7 +840,7 @@ class MmapTests(unittest.TestCase):
         mm.write(b'python')
         result = mm.flush()
         self.assertIsNone(result)
-        if sys.platform.startswith(('linux', 'android')) and not in_systemd_nspawn():
+        if sys.platform.startswith(('linux', 'android')) and not in_systemd_nspawn_sync_suppressed():
             # 'offset' must be a multiple of mmap.PAGESIZE on Linux.
             # See bpo-34754 for details.
             self.assertRaises(OSError, mm.flush, 1, len(b'python'))

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -840,7 +840,8 @@ class MmapTests(unittest.TestCase):
         mm.write(b'python')
         result = mm.flush()
         self.assertIsNone(result)
-        if sys.platform.startswith(('linux', 'android')) and not in_systemd_nspawn_sync_suppressed():
+        if (sys.platform.startswith(('linux', 'android')) 
+            and not in_systemd_nspawn_sync_suppressed()):
             # 'offset' must be a multiple of mmap.PAGESIZE on Linux.
             # See bpo-34754 for details.
             self.assertRaises(OSError, mm.flush, 1, len(b'python'))

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1,5 +1,6 @@
 from test.support import (
     requires, _2G, _4G, gc_collect, cpython_only, is_emscripten, is_apple,
+    in_systemd_nspawn,
 )
 from test.support.import_helper import import_module
 from test.support.os_helper import TESTFN, unlink
@@ -839,7 +840,7 @@ class MmapTests(unittest.TestCase):
         mm.write(b'python')
         result = mm.flush()
         self.assertIsNone(result)
-        if sys.platform.startswith(('linux', 'android')):
+        if sys.platform.startswith(('linux', 'android')) and not in_systemd_nspawn():
             # 'offset' must be a multiple of mmap.PAGESIZE on Linux.
             # See bpo-34754 for details.
             self.assertRaises(OSError, mm.flush, 1, len(b'python'))

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2355,7 +2355,7 @@ class TestInvalidFD(unittest.TestCase):
     singles_fildes = {"fchdir"}
     # systemd-nspawn --suppress-sync=true does not verify fd passed
     # fdatasync() and fsync(), and always returns success
-    if not support.in_systemd_nspawn():
+    if not support.in_systemd_nspawn_sync_suppressed():
         singles += ["fdatasync", "fsync"]
         singles_fildes |= {"fdatasync", "fsync"}
     #singles.append("close")

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2351,9 +2351,13 @@ class Win32ErrorTests(unittest.TestCase):
 
 @unittest.skipIf(support.is_wasi, "Cannot create invalid FD on WASI.")
 class TestInvalidFD(unittest.TestCase):
-    singles = ["fchdir", "dup", "fdatasync", "fstat",
-               "fstatvfs", "fsync", "tcgetpgrp", "ttyname"]
-    singles_fildes = {"fchdir", "fdatasync", "fsync"}
+    singles = ["fchdir", "dup", "fstat", "fstatvfs", "tcgetpgrp", "ttyname"]
+    singles_fildes = {"fchdir"}
+    # systemd-nspawn --suppress-sync=true does not verify fd passed
+    # fdatasync() and fsync(), and always returns success
+    if not support.in_systemd_nspawn():
+        singles += ["fdatasync", "fsync"]
+        singles_fildes |= {"fdatasync", "fsync"}
     #singles.append("close")
     #We omit close because it doesn't raise an exception on some platforms
     def get_single(f):

--- a/Misc/NEWS.d/next/Tests/2024-09-18-18-39-21.gh-issue-124213.AQq_xg.rst
+++ b/Misc/NEWS.d/next/Tests/2024-09-18-18-39-21.gh-issue-124213.AQq_xg.rst
@@ -1,3 +1,3 @@
 Detect whether the test suite is running inside a systemd-nspawn container
-with ``--suppress-sync=true`` option, and skip the `test_os`` and ``test_mmap``
-tests that are failing in this scenario.
+with ``--suppress-sync=true`` option, and skip the ``test_os``
+and ``test_mmap`` tests that are failing in this scenario.

--- a/Misc/NEWS.d/next/Tests/2024-09-18-18-39-21.gh-issue-124213.AQq_xg.rst
+++ b/Misc/NEWS.d/next/Tests/2024-09-18-18-39-21.gh-issue-124213.AQq_xg.rst
@@ -1,2 +1,3 @@
-Skip tests failing with ``--suppress-sync=true`` when running inside
-systemd-nspawn container.
+Skip ``test_os`` and ``test_mmap`` tests that are failing
+with ``--suppress-sync=true`` when running inside a systemd-nspawn
+container.

--- a/Misc/NEWS.d/next/Tests/2024-09-18-18-39-21.gh-issue-124213.AQq_xg.rst
+++ b/Misc/NEWS.d/next/Tests/2024-09-18-18-39-21.gh-issue-124213.AQq_xg.rst
@@ -1,3 +1,3 @@
-Skip ``test_os`` and ``test_mmap`` tests that are failing
-with ``--suppress-sync=true`` when running inside a systemd-nspawn
-container.
+Detect whether the test suite is running inside a systemd-nspawn container
+with ``--suppress-sync=true`` option, and skip the `test_os`` and ``test_mmap``
+tests that are failing in this scenario.

--- a/Misc/NEWS.d/next/Tests/2024-09-18-18-39-21.gh-issue-124213.AQq_xg.rst
+++ b/Misc/NEWS.d/next/Tests/2024-09-18-18-39-21.gh-issue-124213.AQq_xg.rst
@@ -1,0 +1,2 @@
+Skip tests failing with ``--suppress-sync=true`` when running inside
+systemd-nspawn container.


### PR DESCRIPTION
Add a helper functon that checks whether the test suite is running inside a systemd-nspawn container, and skip the few tests failing with `--suppress-sync=true` in that case.  The tests are failing because `--suppress-sync=true` stubs out `fsync()`, `fdatasync()` and `msync()` calls, and therefore they always return success without checking for invalid arguments.

Technically, this means that the tests are also skipped when running inside systemd-nspawn container without `--suppress-sync=true`. However, to the best of my knowledge the only way to detect this option is to actually reproduce one of the unexpectedly-succeeding syscalls, and since this is precisely what we're testing for, the skip-test and the actual test would be doing the same thing.

<!-- gh-issue-number: gh-124213 -->
* Issue: gh-124213
<!-- /gh-issue-number -->
