### PR TITLE
gh-120754: Fix memory leak in FileIO.__init__()

### DIFF
--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -457,6 +457,7 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
 #endif
     }
 
+    PyMem_Free(self->stat_atopen);
     self->stat_atopen = PyMem_New(struct _Py_stat_struct, 1);
     if (self->stat_atopen == NULL) {
         PyErr_NoMemory();


### PR DESCRIPTION
Free 'self->stat_atopen' before assigning it, since io.FileIO.__init__() can be called multiple times manually (especially by test_io).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120754 -->
* Issue: gh-120754
<!-- /gh-issue-number -->
