### PR TITLE
test_cext, test_cppext: enable /W4 warnings on Windows

### DIFF
--- a/Lib/test/test_cext/extension.c
+++ b/Lib/test/test_cext/extension.c
@@ -37,7 +37,13 @@ static PyMethodDef _testcext_methods[] = {
 
 
 static int
-_testcext_exec(PyObject *module)
+_testcext_exec(
+#ifdef __STDC_VERSION__
+    PyObject *module
+#else
+    PyObject *Py_UNUSED(module)
+#endif
+    )
 {
 #ifdef __STDC_VERSION__
     if (PyModule_AddIntMacro(module, __STDC_VERSION__) < 0) {
@@ -53,7 +59,7 @@ _testcext_exec(PyObject *module)
 }
 
 static PyModuleDef_Slot _testcext_slots[] = {
-    {Py_mod_exec, _testcext_exec},
+    {Py_mod_exec, (void*)_testcext_exec},
     {0, NULL}
 };
 

--- a/Lib/test/test_cext/setup.py
+++ b/Lib/test/test_cext/setup.py
@@ -31,6 +31,8 @@ if not support.MS_WINDOWS:
 else:
     # MSVC compiler flags
     CFLAGS = [
+        # Display warnings level 1 to 4
+        '/W4',
         # Treat all compiler warnings as compiler errors
         '/WX',
     ]

--- a/Lib/test/test_cppext/setup.py
+++ b/Lib/test/test_cppext/setup.py
@@ -22,6 +22,8 @@ if not support.MS_WINDOWS:
 else:
     # MSVC compiler flags
     CPPFLAGS = [
+        # Display warnings level 1 to 4
+        '/W4',
         # Treat all compiler warnings as compiler errors
         '/WX',
     ]


### PR DESCRIPTION
Add an explicit cast to (void*) and add Py_UNUSED() to fix some warnings in extension.c.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
