### PR TITLE
gh-124254: Detect freethreaded MSI component when doing an upgrade on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-09-20-11-18-50.gh-issue-124254.iPin-L.rst
+++ b/Misc/NEWS.d/next/Windows/2024-09-20-11-18-50.gh-issue-124254.iPin-L.rst
@@ -1,0 +1,1 @@
+Ensures experimental free-threaded binaries remain installed when updating.

--- a/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
+++ b/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
@@ -213,6 +213,7 @@ static struct { LPCWSTR regName; LPCWSTR variableName; } OPTIONAL_FEATURES[] = {
     { L"Shortcuts", L"Shortcuts" },
     // Include_launcher and AssociateFiles are handled separately and so do
     // not need to be included in this list.
+    { L"freethreaded", L"Include_freethreaded" },
     { nullptr, nullptr }
 };
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-124254 -->
* Issue: gh-124254
<!-- /gh-issue-number -->
