### PR TITLE
gh-86009: Fix solaris detection in `_USE_CP_SENDFILE` check

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -48,7 +48,7 @@ COPY_BUFSIZE = 1024 * 1024 if _WINDOWS else 64 * 1024
 # This should never be removed, see rationale in:
 # https://bugs.python.org/issue43743#msg393429
 _USE_CP_SENDFILE = (hasattr(os, "sendfile")
-                    and sys.platform.startswith(("linux", "android", "solaris")))
+                    and sys.platform.startswith(("linux", "android", "sunos")))
 _HAS_FCOPYFILE = posix and hasattr(posix, "_fcopyfile")  # macOS
 
 # CMD defaults in Windows 10


### PR DESCRIPTION
I am sorry, when rebasing my changes two days ago (PR #23893), I accidentally used 'solaris' rather than 'sunos' string in `sys.platform.startswith` check for `_USE_CP_SENDFILE`.

This simple PR fixes it (and this is re-tested with our internal buildbots).

<!-- gh-issue-number: gh-86009 -->
* Issue: gh-86009
<!-- /gh-issue-number -->
