### PR TITLE
gh-90984: clarify math.rst preamble sentence about return types

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -22,8 +22,8 @@ instead of a complex result allows earlier detection of the unexpected complex
 number used as a parameter, so that the programmer can determine how and why it
 was generated in the first place.
 
-The following functions are provided by this module.  Except when explicitly
-noted otherwise, all return values are floats.
+The following functions are provided by this module.  Return values for module
+functions are either floats, or determined from acceptable types of arguments.
 
 
 Number-theoretic and representation functions

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -22,8 +22,9 @@ instead of a complex result allows earlier detection of the unexpected complex
 number used as a parameter, so that the programmer can determine how and why it
 was generated in the first place.
 
-The following functions are provided by this module.  Return values for module
-functions are either floats, or determined from acceptable types of arguments.
+The following functions are provided by this module.  Except when explicitly
+noted otherwise, return values for module functions are either floats or
+determined from acceptable types of arguments.
 
 
 Number-theoretic and representation functions


### PR DESCRIPTION
Most functions in the module return floats, some might be clearly (for the reader) identified as returning integers (e.g. comb(), non-integer inputs rejected) and few (e.g. prod() and sumprod()) return something, that depends on types in the input.

New preamble should cover all three cases.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-90984 -->
* Issue: gh-90984
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124297.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->