### PR TITLE
gh-117376: Fix off-by-ones in conversion functions

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -3924,7 +3924,7 @@ dummy_func(
             PyCFunctionFastWithKeywords cfunc =
                 (PyCFunctionFastWithKeywords)(void(*)(void))meth->ml_meth;
 
-            STACKREFS_TO_PYOBJECTS(args, nargs, args_o);
+            STACKREFS_TO_PYOBJECTS(args, total_args, args_o);
             if (CONVERSION_FAILED(args_o)) {
                 DECREF_INPUTS();
                 ERROR_IF(true, error);
@@ -4005,7 +4005,7 @@ dummy_func(
                 (PyCFunctionFast)(void(*)(void))meth->ml_meth;
             int nargs = total_args - 1;
 
-            STACKREFS_TO_PYOBJECTS(args, nargs, args_o);
+            STACKREFS_TO_PYOBJECTS(args, total_args, args_o);
             if (CONVERSION_FAILED(args_o)) {
                 DECREF_INPUTS();
                 ERROR_IF(true, error);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -4610,7 +4610,7 @@
             int nargs = total_args - 1;
             PyCFunctionFastWithKeywords cfunc =
             (PyCFunctionFastWithKeywords)(void(*)(void))meth->ml_meth;
-            STACKREFS_TO_PYOBJECTS(args, nargs, args_o);
+            STACKREFS_TO_PYOBJECTS(args, total_args, args_o);
             if (CONVERSION_FAILED(args_o)) {
                 PyStackRef_CLOSE(callable);
                 PyStackRef_CLOSE(self_or_null[0]);
@@ -4727,7 +4727,7 @@
             PyCFunctionFast cfunc =
             (PyCFunctionFast)(void(*)(void))meth->ml_meth;
             int nargs = total_args - 1;
-            STACKREFS_TO_PYOBJECTS(args, nargs, args_o);
+            STACKREFS_TO_PYOBJECTS(args, total_args, args_o);
             if (CONVERSION_FAILED(args_o)) {
                 PyStackRef_CLOSE(callable);
                 PyStackRef_CLOSE(self_or_null[0]);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2256,7 +2256,7 @@
                 PyCFunctionFast cfunc =
                 (PyCFunctionFast)(void(*)(void))meth->ml_meth;
                 int nargs = total_args - 1;
-                STACKREFS_TO_PYOBJECTS(args, nargs, args_o);
+                STACKREFS_TO_PYOBJECTS(args, total_args, args_o);
                 if (CONVERSION_FAILED(args_o)) {
                     PyStackRef_CLOSE(callable);
                     PyStackRef_CLOSE(self_or_null[0]);
@@ -2337,7 +2337,7 @@
                 int nargs = total_args - 1;
                 PyCFunctionFastWithKeywords cfunc =
                 (PyCFunctionFastWithKeywords)(void(*)(void))meth->ml_meth;
-                STACKREFS_TO_PYOBJECTS(args, nargs, args_o);
+                STACKREFS_TO_PYOBJECTS(args, total_args, args_o);
                 if (CONVERSION_FAILED(args_o)) {
                     PyStackRef_CLOSE(callable);
                     PyStackRef_CLOSE(self_or_null[0]);


### PR DESCRIPTION
This wasn't caught because the specializations are currently not tested in the free-threaded builds.

To test this, apply the following patch to main:
```diff
diff --git a/Python/ceval_macros.h b/Python/ceval_macros.h
index 9e1540674d4..7ca2400529d 100644
--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -441,28 +441,13 @@ do { \
 /* How much scratch space to give stackref to PyObject* conversion. */
 #define MAX_STACKREF_SCRATCH 10
 
-#ifdef Py_GIL_DISABLED
 #define STACKREFS_TO_PYOBJECTS(ARGS, ARG_COUNT, NAME) \
     /* +1 because vectorcall might use -1 to write self */ \
     PyObject *NAME##_temp[MAX_STACKREF_SCRATCH+1]; \
     PyObject **NAME = _PyObjectArray_FromStackRefArray(ARGS, ARG_COUNT, NAME##_temp + 1);
-#else
-#define STACKREFS_TO_PYOBJECTS(ARGS, ARG_COUNT, NAME) \
-    PyObject **NAME = (PyObject **)ARGS; \
-    assert(NAME != NULL);
-#endif
 
-#ifdef Py_GIL_DISABLED
 #define STACKREFS_TO_PYOBJECTS_CLEANUP(NAME) \
     /* +1 because we +1 previously */ \
-    _PyObjectArray_Free(NAME - 1, NAME##_temp);
-#else
-#define STACKREFS_TO_PYOBJECTS_CLEANUP(NAME) \
-    (void)(NAME);
-#endif
+    // _PyObjectArray_Free(NAME - 1, NAME##_temp);
 
-#ifdef Py_GIL_DISABLED
 #define CONVERSION_FAILED(NAME) ((NAME) == NULL)
-#else
-#define CONVERSION_FAILED(NAME) (0)
-#endif
```

Note that Python fails to build on main, but passes on this branch.

<!-- gh-issue-number: gh-117376 -->
* Issue: gh-117376
<!-- /gh-issue-number -->
