### PR TITLE
gh-99108: Disable HACL SIMD code on older versions of Android

### DIFF
--- a/configure
+++ b/configure
@@ -30646,7 +30646,10 @@ case "$ac_sys_system" in
 esac
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -msse -msse2 -msse3 -msse4.1 -msse4.2" >&5
+# The SIMD files use aligned_alloc, which is not available on older versions of
+# Android.
+if test "$ac_sys_system" != "Linux-android" || test "$ANDROID_API_LEVEL" -ge 28; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -msse -msse2 -msse3 -msse4.1 -msse4.2" >&5
 printf %s "checking whether C compiler accepts -msse -msse2 -msse3 -msse4.1 -msse4.2... " >&6; }
 if test ${ax_cv_check_cflags__Werror__msse__msse2__msse3__msse4_1__msse4_2+y}
 then :
@@ -30680,37 +30683,44 @@ printf "%s\n" "$ax_cv_check_cflags__Werror__msse__msse2__msse3__msse4_1__msse4_2
 if test "x$ax_cv_check_cflags__Werror__msse__msse2__msse3__msse4_1__msse4_2" = xyes
 then :
 
-  LIBHACL_SIMD128_FLAGS="-msse -msse2 -msse3 -msse4.1 -msse4.2"
+    LIBHACL_SIMD128_FLAGS="-msse -msse2 -msse3 -msse4.1 -msse4.2"
 
 
 printf "%s\n" "#define HACL_CAN_COMPILE_SIMD128 1" >>confdefs.h
 
 
-  # macOS universal2 builds *support* the -msse etc flags because they're
-  # available on x86_64. However, performance of the HACL SIMD128 implementation
-  # isn't great, so it's disabled on ARM64.
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for HACL* SIMD128 implementation" >&5
+    # macOS universal2 builds *support* the -msse etc flags because they're
+    # available on x86_64. However, performance of the HACL SIMD128 implementation
+    # isn't great, so it's disabled on ARM64.
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for HACL* SIMD128 implementation" >&5
 printf %s "checking for HACL* SIMD128 implementation... " >&6; }
-  if test "$UNIVERSAL_ARCHS" == "universal2"; then
-    LIBHACL_SIMD128_OBJS="Modules/_hacl/Hacl_Hash_Blake2s_Simd128_universal2.o"
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: universal2" >&5
+    if test "$UNIVERSAL_ARCHS" == "universal2"; then
+      LIBHACL_SIMD128_OBJS="Modules/_hacl/Hacl_Hash_Blake2s_Simd128_universal2.o"
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: universal2" >&5
 printf "%s\n" "universal2" >&6; }
-  else
-    LIBHACL_SIMD128_OBJS="Modules/_hacl/Hacl_Hash_Blake2s_Simd128.o"
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: standard" >&5
+    else
+      LIBHACL_SIMD128_OBJS="Modules/_hacl/Hacl_Hash_Blake2s_Simd128.o"
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: standard" >&5
 printf "%s\n" "standard" >&6; }
-  fi
+    fi
 
 
 else $as_nop
   :
 fi
 
+fi
 
 
 
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -mavx2" >&5
+# The SIMD files use aligned_alloc, which is not available on older versions of
+# Android.
+#
+# Although AVX support is not guaranteed on Android
+# (https://developer.android.com/ndk/guides/abis#86-64), this is safe because we do a
+# runtime CPUID check.
+if test "$ac_sys_system" != "Linux-android" || test "$ANDROID_API_LEVEL" -ge 28; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -mavx2" >&5
 printf %s "checking whether C compiler accepts -mavx2... " >&6; }
 if test ${ax_cv_check_cflags__Werror__mavx2+y}
 then :
@@ -30744,32 +30754,32 @@ printf "%s\n" "$ax_cv_check_cflags__Werror__mavx2" >&6; }
 if test "x$ax_cv_check_cflags__Werror__mavx2" = xyes
 then :
 
-  LIBHACL_SIMD256_FLAGS="-mavx2"
+    LIBHACL_SIMD256_FLAGS="-mavx2"
 
 printf "%s\n" "#define HACL_CAN_COMPILE_SIMD256 1" >>confdefs.h
 
 
-  # macOS universal2 builds *support* the -mavx2 compiler flag because it's
-  # available on x86_64; but the HACL SIMD256 build then fails because the
-  # implementation requires symbols that aren't available on ARM64. Use a
-  # wrapped implementation if we're building for universal2.
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for HACL* SIMD256 implementation" >&5
+    # macOS universal2 builds *support* the -mavx2 compiler flag because it's
+    # available on x86_64; but the HACL SIMD256 build then fails because the
+    # implementation requires symbols that aren't available on ARM64. Use a
+    # wrapped implementation if we're building for universal2.
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for HACL* SIMD256 implementation" >&5
 printf %s "checking for HACL* SIMD256 implementation... " >&6; }
-  if test "$UNIVERSAL_ARCHS" == "universal2"; then
-    LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256_universal2.o"
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: universal2" >&5
+    if test "$UNIVERSAL_ARCHS" == "universal2"; then
+      LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256_universal2.o"
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: universal2" >&5
 printf "%s\n" "universal2" >&6; }
-  else
-    LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256.o"
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: standard" >&5
+    else
+      LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256.o"
+      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: standard" >&5
 printf "%s\n" "standard" >&6; }
-  fi
+    fi
 
 else $as_nop
   :
 fi
 
-
+fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -7810,47 +7810,57 @@ case "$ac_sys_system" in
 esac
 AC_SUBST([LIBHACL_CFLAGS])
 
-dnl This can be extended here to detect e.g. Power8, which HACL* should also support.
-AX_CHECK_COMPILE_FLAG([-msse -msse2 -msse3 -msse4.1 -msse4.2],[
-  [LIBHACL_SIMD128_FLAGS="-msse -msse2 -msse3 -msse4.1 -msse4.2"]
+# The SIMD files use aligned_alloc, which is not available on older versions of
+# Android.
+if test "$ac_sys_system" != "Linux-android" || test "$ANDROID_API_LEVEL" -ge 28; then
+  dnl This can be extended here to detect e.g. Power8, which HACL* should also support.
+  AX_CHECK_COMPILE_FLAG([-msse -msse2 -msse3 -msse4.1 -msse4.2],[
+    [LIBHACL_SIMD128_FLAGS="-msse -msse2 -msse3 -msse4.1 -msse4.2"]
 
-  AC_DEFINE([HACL_CAN_COMPILE_SIMD128], [1], [HACL* library can compile SIMD128 implementations])
+    AC_DEFINE([HACL_CAN_COMPILE_SIMD128], [1], [HACL* library can compile SIMD128 implementations])
 
-  # macOS universal2 builds *support* the -msse etc flags because they're
-  # available on x86_64. However, performance of the HACL SIMD128 implementation
-  # isn't great, so it's disabled on ARM64.
-  AC_MSG_CHECKING([for HACL* SIMD128 implementation])
-  if test "$UNIVERSAL_ARCHS" == "universal2"; then
-    [LIBHACL_SIMD128_OBJS="Modules/_hacl/Hacl_Hash_Blake2s_Simd128_universal2.o"]
-    AC_MSG_RESULT([universal2])
-  else
-    [LIBHACL_SIMD128_OBJS="Modules/_hacl/Hacl_Hash_Blake2s_Simd128.o"]
-    AC_MSG_RESULT([standard])
-  fi
+    # macOS universal2 builds *support* the -msse etc flags because they're
+    # available on x86_64. However, performance of the HACL SIMD128 implementation
+    # isn't great, so it's disabled on ARM64.
+    AC_MSG_CHECKING([for HACL* SIMD128 implementation])
+    if test "$UNIVERSAL_ARCHS" == "universal2"; then
+      [LIBHACL_SIMD128_OBJS="Modules/_hacl/Hacl_Hash_Blake2s_Simd128_universal2.o"]
+      AC_MSG_RESULT([universal2])
+    else
+      [LIBHACL_SIMD128_OBJS="Modules/_hacl/Hacl_Hash_Blake2s_Simd128.o"]
+      AC_MSG_RESULT([standard])
+    fi
 
-], [], [-Werror])
-
+  ], [], [-Werror])
+fi
 AC_SUBST([LIBHACL_SIMD128_FLAGS])
 AC_SUBST([LIBHACL_SIMD128_OBJS])
 
-AX_CHECK_COMPILE_FLAG([-mavx2],[
-  [LIBHACL_SIMD256_FLAGS="-mavx2"]
-  AC_DEFINE([HACL_CAN_COMPILE_SIMD256], [1], [HACL* library can compile SIMD256 implementations])
+# The SIMD files use aligned_alloc, which is not available on older versions of
+# Android.
+#
+# Although AVX support is not guaranteed on Android
+# (https://developer.android.com/ndk/guides/abis#86-64), this is safe because we do a
+# runtime CPUID check.
+if test "$ac_sys_system" != "Linux-android" || test "$ANDROID_API_LEVEL" -ge 28; then
+  AX_CHECK_COMPILE_FLAG([-mavx2],[
+    [LIBHACL_SIMD256_FLAGS="-mavx2"]
+    AC_DEFINE([HACL_CAN_COMPILE_SIMD256], [1], [HACL* library can compile SIMD256 implementations])
 
-  # macOS universal2 builds *support* the -mavx2 compiler flag because it's
-  # available on x86_64; but the HACL SIMD256 build then fails because the
-  # implementation requires symbols that aren't available on ARM64. Use a
-  # wrapped implementation if we're building for universal2.
-  AC_MSG_CHECKING([for HACL* SIMD256 implementation])
-  if test "$UNIVERSAL_ARCHS" == "universal2"; then
-    [LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256_universal2.o"]
-    AC_MSG_RESULT([universal2])
-  else
-    [LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256.o"]
-    AC_MSG_RESULT([standard])
-  fi
-], [], [-Werror])
-
+    # macOS universal2 builds *support* the -mavx2 compiler flag because it's
+    # available on x86_64; but the HACL SIMD256 build then fails because the
+    # implementation requires symbols that aren't available on ARM64. Use a
+    # wrapped implementation if we're building for universal2.
+    AC_MSG_CHECKING([for HACL* SIMD256 implementation])
+    if test "$UNIVERSAL_ARCHS" == "universal2"; then
+      [LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256_universal2.o"]
+      AC_MSG_RESULT([universal2])
+    else
+      [LIBHACL_SIMD256_OBJS="Modules/_hacl/Hacl_Hash_Blake2b_Simd256.o"]
+      AC_MSG_RESULT([standard])
+    fi
+  ], [], [-Werror])
+fi
 AC_SUBST([LIBHACL_SIMD256_FLAGS])
 AC_SUBST([LIBHACL_SIMD256_OBJS])
 


### PR DESCRIPTION
The build is currently failing on Android x86-64:
```
/home/buildbot/android-sdk/ndk/26.2.11394342/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang -c -I../../../Modules/_hacl -I../../../Modules/_hacl/include -D_BSD_SOURCE -D_DEFAULT_SOURCE -fno-strict-overflow
 -Wsign-compare -Wunreachable-code -DNDEBUG -g -O3 -Wall -I/home/buildbot/git/python/cpython/cross-build/x86_64-linux-android/prefix/include  -I/home/buildbot/git/python/cpython/cross-build/x86_64-linux-android/prefix/include  -s
td=c11 -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wstrict-prototypes -Werror=implicit-function-declaration -fvisibility=hidden  -I../../../Include/internal -I../../../Include/internal/mimalloc -IObjects -IIncl
ude -IPython -I. -I../../../Include   -fPIC -fPIC -DLINUX_NO_EXPLICIT_BZERO -msse -msse2 -msse3 -msse4.1 -msse4.2 -DHACL_CAN_COMPILE_VEC128 -o Modules/_hacl/Hacl_Hash_Blake2s_Simd128.o ../../../Modules/_hacl/Hacl_Hash_Blake2s_Sim
d128.c
../../../Modules/_hacl/Hacl_Hash_Blake2s_Simd128.c:589:40: error: call to undeclared library function 'aligned_alloc' with type 'void *(unsigned long, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    (Lib_IntVector_Intrinsics_vec128 *)KRML_ALIGNED_MALLOC(16,
                                       ^
../../../Modules/_hacl/include/krml/internal/target.h:133:39: note: expanded from macro 'KRML_ALIGNED_MALLOC'
#    define KRML_ALIGNED_MALLOC(X, Y) aligned_alloc(X, Y)
```

This is because `aligned_alloc` was only added to Android in API level 28, while we're building against level 21. So this PR disables the SIMD code completely when building against older Android versions.

<!-- gh-issue-number: gh-99108 -->
* Issue: gh-99108
<!-- /gh-issue-number -->
