### PR TITLE
gh-112938: IDLE - Fix uninteruptable hang when Shell gets rapid continuous output.

### DIFF
--- a/Lib/idlelib/idle_test/test_outwin.py
+++ b/Lib/idlelib/idle_test/test_outwin.py
@@ -1,6 +1,7 @@
 "Test outwin, coverage 76%."
 
 from idlelib import outwin
+import sys
 import unittest
 from test.support import requires
 from tkinter import Tk, Text
@@ -18,6 +19,10 @@ class OutputWindowTest(unittest.TestCase):
         root.withdraw()
         w = cls.window = outwin.OutputWindow(None, None, None, root)
         cls.text = w.text = Text(root)
+        if sys.platform == 'darwin':  # Issue 112938
+            cls.text.update = cls.text.update_idletasks
+            # Without this, test write, writelines, and goto... fail.
+            # The reasons and why macOS-specific are unclear.
 
     @classmethod
     def tearDownClass(cls):

--- a/Lib/idlelib/outwin.py
+++ b/Lib/idlelib/outwin.py
@@ -112,7 +112,7 @@ class OutputWindow(EditorWindow):
         assert isinstance(s, str)
         self.text.insert(mark, s, tags)
         self.text.see(mark)
-        self.text.update_idletasks()
+        self.text.update()
         return len(s)
 
     def writelines(self, lines):

--- a/Misc/NEWS.d/next/IDLE/2024-09-21-23-12-18.gh-issue-112938.OeiDru.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-09-21-23-12-18.gh-issue-112938.OeiDru.rst
@@ -1,0 +1,1 @@
+Fix uninteruptable hang when Shell gets rapid continuous output.


### PR DESCRIPTION
https://github.com/python/cpython/issues/88496 replaced text.update with text.update_idletasks in colorizer.py and outwin.py to fix test failures on macOS.  While theoretically correct, the result was Shell freezing when receiving continuous short strings to print.  Test: `while 1: 1`.

The guess is that there is no idle time in which to do the screen update.  Reverting the change in one of the files,
outwin, fixes the issue.  Colorizer runs ever 1/20 second and seems to work fine.

When running test-outwin on macOS, alias 'update' to 'update_idletasks on the text used for testing.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-112938 -->
* Issue: gh-112938
<!-- /gh-issue-number -->
