### PR TITLE
gh-124309: Fix the AssertionError when using the happy_eyeballs_delay argument in open_connection

### DIFF
--- a/Lib/asyncio/staggered.py
+++ b/Lib/asyncio/staggered.py
@@ -116,7 +116,7 @@ async def staggered_race(coro_fns, delay, *, loop=None):
                 if i != this_index:
                     t.cancel()
 
-    first_task = loop.create_task(run_one_coro(None))
+    first_task = loop.create_task(run_one_coro(locks.Event()))
     running_tasks.append(first_task)
     try:
         # Wait for a growing list of tasks to all finish: poor man's version of


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
I'm looking for a better solution for this, if anyone finds one I can close this PR.

<!-- gh-issue-number: gh-124309 -->
* Issue: gh-124309
<!-- /gh-issue-number -->
