### PR TITLE
gh-124308: Make standard library `TimeoutError`s unique rather than aliases

### DIFF
--- a/Doc/library/asyncio-exceptions.rst
+++ b/Doc/library/asyncio-exceptions.rst
@@ -13,12 +13,46 @@ Exceptions
 
 .. exception:: TimeoutError
 
-   A deprecated alias of :exc:`TimeoutError`,
+   A near-alias of :exc:`TimeoutError`,
    raised when the operation has exceeded the given deadline.
 
    .. versionchanged:: 3.11
 
       This class was made an alias of :exc:`TimeoutError`.
+
+    .. versionchanged:: 3.14
+
+      This class was made unique, but subclasses :exc:`TimeoutError`.
+
+
+.. exception:: CancelledError
+
+   The operation has been cancelled.
+
+   This exception can be caught to perform custom operations
+   when asyncio Tasks are cancelled.  In almost all situations the
+   exception must be re-raised.
+
+   .. versionchanged:: 3.8
+
+      :exc:`CancelledError` is now a subclass of :class:`BaseException` rather than :class:`Exception`.
+
+
+.. exception:: InvalidStateError
+
+   Invalid internal state of :class:`Task` or :class:`Future`.
+
+   Can be raised in situations like setting a result value for a
+   *Future* object that already has a result value set.
+
+
+.. exception:: SendfileNotAvailableError
+
+   The "sendfile" syscall is not available for the given
+   socket or file type.
+
+   A subclass of :exc:`RuntimeError`.
+
 
 
 .. exception:: CancelledError

--- a/Doc/library/asyncio-exceptions.rst
+++ b/Doc/library/asyncio-exceptions.rst
@@ -13,7 +13,7 @@ Exceptions
 
 .. exception:: TimeoutError
 
-   A near-alias of :exc:`TimeoutError`,
+   A deprecated alias of :exc:`TimeoutError`,
    raised when the operation has exceeded the given deadline.
 
    .. versionchanged:: 3.11
@@ -22,37 +22,7 @@ Exceptions
 
     .. versionchanged:: 3.14
 
-      This class was made unique, but subclasses :exc:`TimeoutError`.
-
-
-.. exception:: CancelledError
-
-   The operation has been cancelled.
-
-   This exception can be caught to perform custom operations
-   when asyncio Tasks are cancelled.  In almost all situations the
-   exception must be re-raised.
-
-   .. versionchanged:: 3.8
-
-      :exc:`CancelledError` is now a subclass of :class:`BaseException` rather than :class:`Exception`.
-
-
-.. exception:: InvalidStateError
-
-   Invalid internal state of :class:`Task` or :class:`Future`.
-
-   Can be raised in situations like setting a result value for a
-   *Future* object that already has a result value set.
-
-
-.. exception:: SendfileNotAvailableError
-
-   The "sendfile" syscall is not available for the given
-   socket or file type.
-
-   A subclass of :exc:`RuntimeError`.
-
+      This class was made a unique subclass of :exc:`TimeoutError`.
 
 
 .. exception:: CancelledError

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -549,7 +549,7 @@ Exception classes
 
       This class was made an alias of :exc:`TimeoutError`.
 
-    .. versionchanged:: 3.14
+   .. versionchanged:: 3.14
 
       This class was made a unique subclass of :exc:`TimeoutError`.
 

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -542,12 +542,16 @@ Exception classes
 
 .. exception:: TimeoutError
 
-   A deprecated alias of :exc:`TimeoutError`,
+   A near-alias of :exc:`TimeoutError`,
    raised when a future operation exceeds the given timeout.
 
    .. versionchanged:: 3.11
 
       This class was made an alias of :exc:`TimeoutError`.
+
+    .. versionchanged:: 3.14
+
+      This class was made unique, but subclasses :exc:`TimeoutError`.
 
 
 .. exception:: BrokenExecutor

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -551,7 +551,7 @@ Exception classes
 
     .. versionchanged:: 3.14
 
-      This class was made unique, but subclasses :exc:`TimeoutError`.
+      This class was made a unique subclass of :exc:`TimeoutError`.
 
 
 .. exception:: BrokenExecutor

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -726,6 +726,10 @@ The :mod:`multiprocessing` package mostly replicates the API of the
 
    Raised by methods with a timeout when the timeout expires.
 
+    .. versionchanged:: 3.14
+
+        This class now subclasses :exc:`TimeoutError`
+
 Pipes and Queues
 ^^^^^^^^^^^^^^^^
 

--- a/Lib/asyncio/exceptions.py
+++ b/Lib/asyncio/exceptions.py
@@ -11,13 +11,8 @@ class CancelledError(BaseException):
     """The Future or Task was cancelled."""
 
 
-# GH-124308, BPO-32413: Originally, asyncio.TimeoutError was it's
-# own unique exception. This was a bit of a gotcha because catching TimeoutError
-# didn't catch asyncio.TimeoutError. So, it was turned into an alias
-# of TimeoutError directly. Unfortunately, this made it effectively
-# impossible to differentiate between asyncio.TimeoutError or a TimeoutError
-# raised by a third party, so this is now a unique exception again (that inherits
-# from TimeoutError to address the first problem).
+# GH-124308, BPO-32413: Catching TimeoutError should catch asyncio.TimeoutError, but
+# not vice versa.
 class TimeoutError(TimeoutError):
     """Operation timed out."""
 

--- a/Lib/asyncio/exceptions.py
+++ b/Lib/asyncio/exceptions.py
@@ -11,7 +11,15 @@ class CancelledError(BaseException):
     """The Future or Task was cancelled."""
 
 
-TimeoutError = TimeoutError  # make local alias for the standard exception
+# GH-124308, BPO-32413: Originally, asyncio.TimeoutError was it's
+# own unique exception. This was a bit of a gotcha because catching TimeoutError
+# didn't catch asyncio.TimeoutError. So, it was turned into an alias
+# of TimeoutError directly. Unfortunately, this made it effectively
+# impossible to differentiate between asyncio.TimeoutError or a TimeoutError
+# raised by a third party, so this is now a unique exception again (that inherits
+# from TimeoutError to address the first problem).
+class TimeoutError(TimeoutError):
+    """Operation timed out."""
 
 
 class InvalidStateError(Exception):

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -486,7 +486,7 @@ async def wait_for(fut, timeout):
         try:
             return fut.result()
         except exceptions.CancelledError as exc:
-            raise TimeoutError from exc
+            raise exceptions.TimeoutError from exc
 
     async with timeouts.timeout(timeout):
         return await fut

--- a/Lib/asyncio/timeouts.py
+++ b/Lib/asyncio/timeouts.py
@@ -113,7 +113,7 @@ class Timeout:
                 # Since there are no new cancel requests, we're
                 # handling this.
                 if issubclass(exc_type, exceptions.CancelledError):
-                    raise TimeoutError from exc_val
+                    raise exceptions.TimeoutError from exc_val
                 elif exc_val is not None:
                     self._insert_timeout_error(exc_val)
                     if isinstance(exc_val, ExceptionGroup):
@@ -135,7 +135,7 @@ class Timeout:
     def _insert_timeout_error(exc_val: BaseException) -> None:
         while exc_val.__context__ is not None:
             if isinstance(exc_val.__context__, exceptions.CancelledError):
-                te = TimeoutError()
+                te = exceptions.TimeoutError()
                 te.__context__ = te.__cause__ = exc_val.__context__
                 exc_val.__context__ = te
                 break

--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -42,7 +42,7 @@ class CancelledError(Error):
     """The Future was cancelled."""
     pass
 
-# Intentional, see GH-124308
+# See GH-124308
 class TimeoutError(TimeoutError):
     pass
 

--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -42,7 +42,8 @@ class CancelledError(Error):
     """The Future was cancelled."""
     pass
 
-# See GH-124308
+# GH-124308, BPO-42413: Catching TimeoutError should catch futures.TimeoutError, but
+# not vice versa.
 class TimeoutError(TimeoutError):
     pass
 

--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -42,7 +42,9 @@ class CancelledError(Error):
     """The Future was cancelled."""
     pass
 
-TimeoutError = TimeoutError  # make local alias for the standard exception
+# Intentional, see GH-124308
+class TimeoutError(TimeoutError):
+    pass
 
 class InvalidStateError(Error):
     """The operation is not allowed in this state."""

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -17,7 +17,7 @@ class ProcessError(Exception):
 class BufferTooShort(ProcessError):
     pass
 
-class TimeoutError(ProcessError):
+class TimeoutError(ProcessError, TimeoutError):
     pass
 
 class AuthenticationError(ProcessError):

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2605,6 +2605,15 @@ class _TestPool(BaseTestCase):
             get = TimingWrapper(res.get)
             self.assertRaises(multiprocessing.TimeoutError, get, timeout=TIMEOUT2)
             self.assertTimingAlmostEqual(get.elapsed, TIMEOUT2)
+
+            # BPO-42413: Catching TimeoutError should catch multiprocessing.TimeoutError
+            with self.assertRaises(TimeoutError):
+                raise multiprocessing.TimeoutError
+
+            # GH-124308: Catching multiprocessing.TimeoutError should not catch TimeoutError
+            with self.assertRaises(TimeoutError):
+                with suppress(multiprocessing.TimeoutError):
+                    raise TimeoutError
         finally:
             if event is not None:
                 event.set()

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -25,6 +25,7 @@ import operator
 import pickle
 import weakref
 import warnings
+import contextlib
 import test.support
 import test.support.script_helper
 from test import support
@@ -2612,7 +2613,7 @@ class _TestPool(BaseTestCase):
 
             # GH-124308: Catching multiprocessing.TimeoutError should not catch TimeoutError
             with self.assertRaises(TimeoutError):
-                with suppress(multiprocessing.TimeoutError):
+                with contextlib.suppress(multiprocessing.TimeoutError):
                     raise TimeoutError
         finally:
             if event is not None:

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3502,7 +3502,7 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
         when a timeout is raised."""
         callback = lambda: self.target(timeout=0)
         future = self.loop.run_in_executor(None, callback)
-        with self.assertRaises(asyncio.TimeoutError):
+        with self.assertRaises(TimeoutError):
             self.loop.run_until_complete(future)
         test_utils.run_briefly(self.loop)
         # Check that there's no pending task (add has been cancelled)

--- a/Lib/test/test_asyncio/test_timeouts.py
+++ b/Lib/test/test_asyncio/test_timeouts.py
@@ -406,6 +406,15 @@ class TimeoutTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(e3.__cause__)
         self.assertIs(e2.__context__, e3)
 
+    async def test_timeouterror_is_unique(self):
+        # See GH-124308
+        with self.assertRaises(asyncio.TimeoutError) as err:
+            async with asyncio.timeout(0.01):
+                pass
+
+        # See BPO-42413
+        self.assertIsTrue(issubclass(err, TimeoutError))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_concurrent_futures/test_future.py
+++ b/Lib/test/test_concurrent_futures/test_future.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 
 from test import support
 
-from .util import (
+from test.test_concurrent_futures.util import (
     PENDING_FUTURE, RUNNING_FUTURE, CANCELLED_FUTURE,
     CANCELLED_AND_NOTIFIED_FUTURE, EXCEPTION_FUTURE, SUCCESSFUL_FUTURE,
     BaseTestCase, create_future, setup_module)

--- a/Lib/test/test_concurrent_futures/test_future.py
+++ b/Lib/test/test_concurrent_futures/test_future.py
@@ -198,12 +198,11 @@ class FutureTests(BaseTestCase):
         self.assertEqual(SUCCESSFUL_FUTURE.result(timeout=0), 42)
 
         # BPO-42413: Catching TimeoutError should catch futures.TimeoutError
-        with self.assertRaises(TimeoutError) as err:
-            self.assertRaises(futures.TimeoutError,
-                              PENDING_FUTURE.result, timeout=0)
+        with self.assertRaises(TimeoutError):
+            raise futures.TimeoutError
 
         with self.assertRaises(TimeoutError):
-            # GH-124308: Catching futures.TimeoutError should not allow TimeoutError
+            # GH-124308: Catching futures.TimeoutError should not catch TimeoutError
             with suppress(futures.TimeoutError):
                 raise TimeoutError
 

--- a/Misc/NEWS.d/next/Library/2024-09-22-16-05-21.gh-issue-124308.EPJqAB.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-22-16-05-21.gh-issue-124308.EPJqAB.rst
@@ -1,0 +1,2 @@
+Prevent :exc:`TimeoutError` from being caught when catching
+:exc:`asyncio.TimeoutError` or :exc:`concurrent.futures.TimeoutError`.


### PR DESCRIPTION
cc @ArtsiomAntropau

<!-- gh-issue-number: gh-124308 -->
* Issue: gh-124308
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124320.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->