### PR TITLE
[3.13] Backport idlelib typos

### DIFF
--- a/Lib/idlelib/config.py
+++ b/Lib/idlelib/config.py
@@ -600,7 +600,7 @@ class IdleConf:
         """
         # TODO: = dict(sorted([(v-event, keys), ...]))?
         keyBindings={
-            # vitual-event: list of key events.
+            # virtual-event: list of key events.
             '<<copy>>': ['<Control-c>', '<Control-C>'],
             '<<cut>>': ['<Control-x>', '<Control-X>'],
             '<<paste>>': ['<Control-v>', '<Control-V>'],

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -914,7 +914,7 @@ class EditorWindow:
     def ApplyKeybindings(self):
         """Apply the virtual, configurable keybindings.
 
-        Alse update hotkeys to current keyset.
+        Also update hotkeys to current keyset.
         """
         # Called from configdialog.activate_config_changes.
         self.mainmenu.default_keydefs = keydefs = idleConf.GetCurrentKeySet()

--- a/Lib/idlelib/extend.txt
+++ b/Lib/idlelib/extend.txt
@@ -52,7 +52,7 @@ should probably be refined in the future.)
 
 Extensions are not required to define menu entries for all the events they
 implement.  (They are also not required to create keybindings, but in that
-case there must be empty bindings in cofig-extensions.def)
+case there must be empty bindings in config-extensions.def)
 
 Here is a partial example from zzdummy.py:
 


### PR DESCRIPTION
See #123597.  The typo in Icon/README.txt was fixed in the unmerged 3.13 backport #123608 of the
PR that added the text with the typo.

(cherry picked from commit 1f4a49e)

Co-authored-by: abstractee

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
