### PR TITLE
GH-109975: Copyedit 3.13 What's New: Copyedit C API deprecations pending removal

### DIFF
--- a/Doc/deprecations/c-api-pending-removal-in-3.14.rst
+++ b/Doc/deprecations/c-api-pending-removal-in-3.14.rst
@@ -9,38 +9,64 @@ Pending Removal in Python 3.14
 
 * Functions to configure Python's initialization, deprecated in Python 3.11:
 
-  * ``PySys_SetArgvEx()``: set :c:member:`PyConfig.argv` instead.
-  * ``PySys_SetArgv()``: set :c:member:`PyConfig.argv` instead.
-  * ``Py_SetProgramName()``: set :c:member:`PyConfig.program_name` instead.
-  * ``Py_SetPythonHome()``: set :c:member:`PyConfig.home` instead.
+  * :c:func:`!PySys_SetArgvEx()`:
+    Set :c:member:`PyConfig.argv` instead.
+  * :c:func:`!PySys_SetArgv()`:
+    Set :c:member:`PyConfig.argv` instead.
+  * :c:func:`!Py_SetProgramName()`:
+    Set :c:member:`PyConfig.program_name` instead.
+  * :c:func:`!Py_SetPythonHome()`:
+    Set :c:member:`PyConfig.home` instead.
 
   The :c:func:`Py_InitializeFromConfig` API should be used with
   :c:type:`PyConfig` instead.
 
 * Global configuration variables:
 
-  * :c:var:`Py_DebugFlag`: use :c:member:`PyConfig.parser_debug` instead.
-  * :c:var:`Py_VerboseFlag`: use :c:member:`PyConfig.verbose` instead.
-  * :c:var:`Py_QuietFlag`: use :c:member:`PyConfig.quiet` instead.
-  * :c:var:`Py_InteractiveFlag`: use :c:member:`PyConfig.interactive` instead.
-  * :c:var:`Py_InspectFlag`: use :c:member:`PyConfig.inspect` instead.
-  * :c:var:`Py_OptimizeFlag`: use :c:member:`PyConfig.optimization_level` instead.
-  * :c:var:`Py_NoSiteFlag`: use :c:member:`PyConfig.site_import` instead.
-  * :c:var:`Py_BytesWarningFlag`: use :c:member:`PyConfig.bytes_warning` instead.
-  * :c:var:`Py_FrozenFlag`: use :c:member:`PyConfig.pathconfig_warnings` instead.
-  * :c:var:`Py_IgnoreEnvironmentFlag`: use :c:member:`PyConfig.use_environment` instead.
-  * :c:var:`Py_DontWriteBytecodeFlag`: use :c:member:`PyConfig.write_bytecode` instead.
-  * :c:var:`Py_NoUserSiteDirectory`: use :c:member:`PyConfig.user_site_directory` instead.
-  * :c:var:`Py_UnbufferedStdioFlag`: use :c:member:`PyConfig.buffered_stdio` instead.
-  * :c:var:`Py_HashRandomizationFlag`: use :c:member:`PyConfig.use_hash_seed`
+  * :c:var:`Py_DebugFlag`:
+    Use :c:member:`PyConfig.parser_debug` instead.
+  * :c:var:`Py_VerboseFlag`:
+    Use :c:member:`PyConfig.verbose` instead.
+  * :c:var:`Py_QuietFlag`:
+    Use :c:member:`PyConfig.quiet` instead.
+  * :c:var:`Py_InteractiveFlag`:
+    Use :c:member:`PyConfig.interactive` instead.
+  * :c:var:`Py_InspectFlag`:
+    Use :c:member:`PyConfig.inspect` instead.
+  * :c:var:`Py_OptimizeFlag`:
+    Use :c:member:`PyConfig.optimization_level` instead.
+  * :c:var:`Py_NoSiteFlag`:
+    Use :c:member:`PyConfig.site_import` instead.
+  * :c:var:`Py_BytesWarningFlag`:
+    Use :c:member:`PyConfig.bytes_warning` instead.
+  * :c:var:`Py_FrozenFlag`:
+    Use :c:member:`PyConfig.pathconfig_warnings` instead.
+  * :c:var:`Py_IgnoreEnvironmentFlag`:
+    Use :c:member:`PyConfig.use_environment` instead.
+  * :c:var:`Py_DontWriteBytecodeFlag`:
+    Use :c:member:`PyConfig.write_bytecode` instead.
+  * :c:var:`Py_NoUserSiteDirectory`:
+    Use :c:member:`PyConfig.user_site_directory` instead.
+  * :c:var:`Py_UnbufferedStdioFlag`:
+    Use :c:member:`PyConfig.buffered_stdio` instead.
+  * :c:var:`Py_HashRandomizationFlag`:
+    Use :c:member:`PyConfig.use_hash_seed`
     and :c:member:`PyConfig.hash_seed` instead.
-  * :c:var:`Py_IsolatedFlag`: use :c:member:`PyConfig.isolated` instead.
-  * :c:var:`Py_LegacyWindowsFSEncodingFlag`: use :c:member:`PyPreConfig.legacy_windows_fs_encoding` instead.
-  * :c:var:`Py_LegacyWindowsStdioFlag`: use :c:member:`PyConfig.legacy_windows_stdio` instead.
-  * :c:var:`!Py_FileSystemDefaultEncoding`: use :c:member:`PyConfig.filesystem_encoding` instead.
-  * :c:var:`!Py_HasFileSystemDefaultEncoding`: use :c:member:`PyConfig.filesystem_encoding` instead.
-  * :c:var:`!Py_FileSystemDefaultEncodeErrors`: use :c:member:`PyConfig.filesystem_errors` instead.
-  * :c:var:`!Py_UTF8Mode`: use :c:member:`PyPreConfig.utf8_mode` instead. (see :c:func:`Py_PreInitialize`)
+  * :c:var:`Py_IsolatedFlag`:
+    Use :c:member:`PyConfig.isolated` instead.
+  * :c:var:`Py_LegacyWindowsFSEncodingFlag`:
+    Use :c:member:`PyPreConfig.legacy_windows_fs_encoding` instead.
+  * :c:var:`Py_LegacyWindowsStdioFlag`:
+    Use :c:member:`PyConfig.legacy_windows_stdio` instead.
+  * :c:var:`!Py_FileSystemDefaultEncoding`:
+    Use :c:member:`PyConfig.filesystem_encoding` instead.
+  * :c:var:`!Py_HasFileSystemDefaultEncoding`:
+    Use :c:member:`PyConfig.filesystem_encoding` instead.
+  * :c:var:`!Py_FileSystemDefaultEncodeErrors`:
+    Use :c:member:`PyConfig.filesystem_errors` instead.
+  * :c:var:`!Py_UTF8Mode`:
+    Use :c:member:`PyPreConfig.utf8_mode` instead.
+    (see :c:func:`Py_PreInitialize`)
 
   The :c:func:`Py_InitializeFromConfig` API should be used with
   :c:type:`PyConfig` instead.

--- a/Doc/deprecations/c-api-pending-removal-in-3.15.rst
+++ b/Doc/deprecations/c-api-pending-removal-in-3.15.rst
@@ -2,19 +2,26 @@ Pending Removal in Python 3.15
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * The bundled copy of ``libmpdecimal``.
-* :c:func:`PyImport_ImportModuleNoBlock`: use :c:func:`PyImport_ImportModule` instead.
-* :c:func:`PyWeakref_GET_OBJECT`: use :c:func:`PyWeakref_GetRef` instead.
-* :c:func:`PyWeakref_GetObject`: use :c:func:`PyWeakref_GetRef` instead.
-* :c:type:`!Py_UNICODE_WIDE` type: use :c:type:`wchar_t` instead.
-* :c:type:`Py_UNICODE` type: use :c:type:`wchar_t` instead.
+* The :c:func:`PyImport_ImportModuleNoBlock`:
+  Use :c:func:`PyImport_ImportModule` instead.
+* :c:func:`PyWeakref_GetObject` and :c:func:`PyWeakref_GET_OBJECT`:
+  Use :c:func:`PyWeakref_GetRef` instead.
+* :c:type:`Py_UNICODE` type and the :c:macro:`!Py_UNICODE_WIDE` macro:
+  Use :c:type:`wchar_t` instead.
 * Python initialization functions:
 
-  * :c:func:`PySys_ResetWarnOptions`: clear :data:`sys.warnoptions` and
-    :data:`!warnings.filters` instead.
-  * :c:func:`Py_GetExecPrefix`: get :data:`sys.exec_prefix` instead.
-  * :c:func:`Py_GetPath`: get :data:`sys.path` instead.
-  * :c:func:`Py_GetPrefix`: get :data:`sys.prefix` instead.
-  * :c:func:`Py_GetProgramFullPath`: get :data:`sys.executable` instead.
-  * :c:func:`Py_GetProgramName`: get :data:`sys.executable` instead.
-  * :c:func:`Py_GetPythonHome`: get :c:member:`PyConfig.home` or
-    the :envvar:`PYTHONHOME` environment variable instead.
+  * :c:func:`PySys_ResetWarnOptions`:
+    Clear :data:`sys.warnoptions` and :data:`!warnings.filters` instead.
+  * :c:func:`Py_GetExecPrefix`:
+    Get :data:`sys.exec_prefix` instead.
+  * :c:func:`Py_GetPath`:
+    Get :data:`sys.path` instead.
+  * :c:func:`Py_GetPrefix`:
+    Get :data:`sys.prefix` instead.
+  * :c:func:`Py_GetProgramFullPath`:
+    Get :data:`sys.executable` instead.
+  * :c:func:`Py_GetProgramName`:
+    Get :data:`sys.executable` instead.
+  * :c:func:`Py_GetPythonHome`:
+    Get :c:member:`PyConfig.home`
+    or the :envvar:`PYTHONHOME` environment variable instead.

--- a/Doc/deprecations/c-api-pending-removal-in-future.rst
+++ b/Doc/deprecations/c-api-pending-removal-in-future.rst
@@ -4,28 +4,48 @@ Pending Removal in Future Versions
 The following APIs are deprecated and will be removed,
 although there is currently no date scheduled for their removal.
 
-* :c:macro:`Py_TPFLAGS_HAVE_FINALIZE`: unneeded since Python 3.8.
-* :c:func:`PyErr_Fetch`: use :c:func:`PyErr_GetRaisedException` instead.
-* :c:func:`PyErr_NormalizeException`: use :c:func:`PyErr_GetRaisedException` instead.
-* :c:func:`PyErr_Restore`: use :c:func:`PyErr_SetRaisedException` instead.
-* :c:func:`PyModule_GetFilename`: use :c:func:`PyModule_GetFilenameObject` instead.
-* :c:func:`PyOS_AfterFork`: use :c:func:`PyOS_AfterFork_Child` instead.
-* :c:func:`PySlice_GetIndicesEx`: use :c:func:`PySlice_Unpack` and :c:func:`PySlice_AdjustIndices` instead.
-* :c:func:`!PyUnicode_AsDecodedObject`: use :c:func:`PyCodec_Decode` instead.
-* :c:func:`!PyUnicode_AsDecodedUnicode`: use :c:func:`PyCodec_Decode` instead.
-* :c:func:`!PyUnicode_AsEncodedObject`: use :c:func:`PyCodec_Encode` instead.
-* :c:func:`!PyUnicode_AsEncodedUnicode`: use :c:func:`PyCodec_Encode` instead.
-* :c:func:`PyUnicode_READY`: unneeded since Python 3.12
-* :c:func:`!PyErr_Display`: use :c:func:`PyErr_DisplayException` instead.
-* :c:func:`!_PyErr_ChainExceptions`: use ``_PyErr_ChainExceptions1`` instead.
+* :c:macro:`Py_TPFLAGS_HAVE_FINALIZE`:
+  Unneeded since Python 3.8.
+* :c:func:`PyErr_Fetch`:
+  Use :c:func:`PyErr_GetRaisedException` instead.
+* :c:func:`PyErr_NormalizeException`:
+  Use :c:func:`PyErr_GetRaisedException` instead.
+* :c:func:`PyErr_Restore`:
+  Use :c:func:`PyErr_SetRaisedException` instead.
+* :c:func:`PyModule_GetFilename`:
+  Use :c:func:`PyModule_GetFilenameObject` instead.
+* :c:func:`PyOS_AfterFork`:
+  Use :c:func:`PyOS_AfterFork_Child` instead.
+* :c:func:`PySlice_GetIndicesEx`:
+  Use :c:func:`PySlice_Unpack` and :c:func:`PySlice_AdjustIndices` instead.
+* :c:func:`!PyUnicode_AsDecodedObject`:
+  Use :c:func:`PyCodec_Decode` instead.
+* :c:func:`!PyUnicode_AsDecodedUnicode`:
+  Use :c:func:`PyCodec_Decode` instead.
+* :c:func:`!PyUnicode_AsEncodedObject`:
+  Use :c:func:`PyCodec_Encode` instead.
+* :c:func:`!PyUnicode_AsEncodedUnicode`:
+  Use :c:func:`PyCodec_Encode` instead.
+* :c:func:`PyUnicode_READY`:
+  Unneeded since Python 3.12
+* :c:func:`!PyErr_Display`:
+  Use :c:func:`PyErr_DisplayException` instead.
+* :c:func:`!_PyErr_ChainExceptions`:
+  Use :c:func:`!_PyErr_ChainExceptions1` instead.
 * :c:member:`!PyBytesObject.ob_shash` member:
   call :c:func:`PyObject_Hash` instead.
 * :c:member:`!PyDictObject.ma_version_tag` member.
 * Thread Local Storage (TLS) API:
 
-  * :c:func:`PyThread_create_key`: use :c:func:`PyThread_tss_alloc` instead.
-  * :c:func:`PyThread_delete_key`: use :c:func:`PyThread_tss_free` instead.
-  * :c:func:`PyThread_set_key_value`: use :c:func:`PyThread_tss_set` instead.
-  * :c:func:`PyThread_get_key_value`: use :c:func:`PyThread_tss_get` instead.
-  * :c:func:`PyThread_delete_key_value`: use :c:func:`PyThread_tss_delete` instead.
-  * :c:func:`PyThread_ReInitTLS`: unneeded since Python 3.7.
+  * :c:func:`PyThread_create_key`:
+    Use :c:func:`PyThread_tss_alloc` instead.
+  * :c:func:`PyThread_delete_key`:
+    Use :c:func:`PyThread_tss_free` instead.
+  * :c:func:`PyThread_set_key_value`:
+    Use :c:func:`PyThread_tss_set` instead.
+  * :c:func:`PyThread_get_key_value`:
+    Use :c:func:`PyThread_tss_get` instead.
+  * :c:func:`PyThread_delete_key_value`:
+    Use :c:func:`PyThread_tss_delete` instead.
+  * :c:func:`PyThread_ReInitTLS`:
+    Unneeded since Python 3.7.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2476,7 +2476,8 @@ Deprecated C APIs
   or :c:func:`PyModule_AddObjectRef`.
   (Contributed by Serhiy Storchaka in :gh:`86493`.)
 
-* Deprecate the old ``Py_UNICODE`` and ``PY_UNICODE_TYPE`` types.
+* Deprecate the old ``Py_UNICODE`` and ``PY_UNICODE_TYPE`` types
+  and the :c:macro:`!Py_UNICODE_WIDE` define.
   Use the :c:type:`wchar_t` type directly instead.
   Since Python 3.3, ``Py_UNICODE`` and ``PY_UNICODE_TYPE``
   are just aliases to :c:type:`!wchar_t`.


### PR DESCRIPTION
A quick pass over the C API pending removal documents. The only consequential change is noting the deprecation of `Py_UNICODE_WIDE` in *What's New* (cc @vstinner).

A

<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124336.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->