### PR TITLE
GH-109975: Copyedit 3.13 What's New: Build Changes

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2504,31 +2504,10 @@ Deprecated C APIs
 Build Changes
 =============
 
-* The :file:`configure` option :option:`--with-system-libmpdec` now defaults
-  to ``yes``. The bundled copy of ``libmpdecimal`` will be removed in Python
-  3.15.
-
-* Autoconf 2.71 and aclocal 1.16.4 are now required to regenerate
-  the :file:`configure` script.
-  (Contributed by Christian Heimes in :gh:`89886`.)
-
-* SQLite 3.15.2 or newer is required to build the :mod:`sqlite3` extension module.
-  (Contributed by Erlend Aasland in :gh:`105875`.)
-
-* Python built with :file:`configure` :option:`--with-trace-refs` (tracing
-  references) is now ABI compatible with the Python release build and
-  :ref:`debug build <debug-build>`.
-  (Contributed by Victor Stinner in :gh:`108634`.)
-
-* Building CPython now requires a compiler with support for the C11 atomic
-  library, GCC built-in atomic functions, or MSVC interlocked intrinsics.
-
-* The ``errno``, ``fcntl``, ``grp``, ``md5``, ``pwd``, ``resource``,
-  ``termios``, ``winsound``,
-  ``_ctypes_test``, ``_multiprocessing.posixshmem``, ``_scproxy``, ``_stat``,
-  ``_statistics``, ``_testconsole``, ``_testimportmultiple`` and ``_uuid``
-  C extensions are now built with the :ref:`limited C API <limited-c-api>`.
-  (Contributed by Victor Stinner in :gh:`85283`.)
+* ``arm64-apple-ios`` and ``arm64-apple-ios-simulator`` are both
+  now :pep:`11` tier 3 platforms.
+  (:ref:`PEP 739 <whatsnew313-platform-support>` written
+  and implementation contributed by Russell Keith-Magee in :gh:`114099`.)
 
 * ``wasm32-wasi`` is now a :pep:`11` tier 2 platform.
   (Contributed by Brett Cannon in :gh:`115192`.)
@@ -2536,14 +2515,44 @@ Build Changes
 * ``wasm32-emscripten`` is no longer a :pep:`11` supported platform.
   (Contributed by Brett Cannon in :gh:`115192`.)
 
-* Python now bundles the `mimalloc library <https://github.com/microsoft/mimalloc>`__.
-  It is licensed under the MIT license; see :ref:`mimalloc license <mimalloc-license>`.
+* Building CPython now requires a compiler with support for the C11 atomic
+  library, GCC built-in atomic functions, or MSVC interlocked intrinsics.
+
+* Autoconf 2.71 and aclocal 1.16.4 are now required to regenerate
+  the :file:`configure` script.
+  (Contributed by Christian Heimes in :gh:`89886`.)
+
+* SQLite 3.15.2 or newer is required to build
+  the :mod:`sqlite3` extension module.
+  (Contributed by Erlend Aasland in :gh:`105875`.)
+
+* CPython now bundles the `mimalloc library`_ by default.
+  It is licensed under the MIT license;
+  see :ref:`mimalloc license <mimalloc-license>`.
   The bundled mimalloc has custom changes, see :gh:`113141` for details.
   (Contributed by Dino Viehland in :gh:`109914`.)
+
+  .. _mimalloc library: https://github.com/microsoft/mimalloc/
+
+* The :file:`configure` option :option:`--with-system-libmpdec`
+  now defaults to ``yes``.
+  The bundled copy of ``libmpdecimal`` will be removed in Python 3.15.
+
+* Python built with :file:`configure` :option:`--with-trace-refs`
+  (tracing references) is now ABI compatible with the Python release build
+  and :ref:`debug build <debug-build>`.
+  (Contributed by Victor Stinner in :gh:`108634`.)
 
 * On POSIX systems, the pkg-config (``.pc``) filenames now include the ABI
   flags.  For example, the free-threaded build generates ``python-3.13t.pc``
   and the debug build generates ``python-3.13d.pc``.
+
+* The ``errno``, ``fcntl``, ``grp``, ``md5``, ``pwd``, ``resource``,
+  ``termios``, ``winsound``,
+  ``_ctypes_test``, ``_multiprocessing.posixshmem``, ``_scproxy``, ``_stat``,
+  ``_statistics``, ``_testconsole``, ``_testimportmultiple`` and ``_uuid``
+  C extensions are now built with the :ref:`limited C API <limited-c-api>`.
+  (Contributed by Victor Stinner in :gh:`85283`.)
 
 
 Porting to Python 3.13

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2506,7 +2506,7 @@ Build Changes
 
 * ``arm64-apple-ios`` and ``arm64-apple-ios-simulator`` are both
   now :pep:`11` tier 3 platforms.
-  (:ref:`PEP 739 <whatsnew313-platform-support>` written
+  (:ref:`PEP 730 <whatsnew313-platform-support>` written
   and implementation contributed by Russell Keith-Magee in :gh:`114099`.)
 
 * ``wasm32-wasi`` is now a :pep:`11` tier 2 platform.


### PR DESCRIPTION
A copy-editing pass for *Build Changes*.

* List PEP 11 platform changes first
* Note iOS in the newly-supported platforms
* Group compiler and tool requirements / changes
* Group `configure` changes

A

<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124343.org.readthedocs.build/en/124343/whatsnew/3.13.html#build-changes

<!-- readthedocs-preview cpython-previews end -->