### PR TITLE
gh-124344: Make `_PyObject_IS_GC()` use underscored `PyType_IS_GC()`

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -727,12 +727,15 @@ _PyObject_GET_WEAKREFS_LISTPTR_FROM_OFFSET(PyObject *op)
     return (PyWeakReference **)((char *)op + offset);
 }
 
+// Fast inlined version of PyType_IS_GC()
+#define _PyType_IS_GC(t) _PyType_HasFeature((t), Py_TPFLAGS_HAVE_GC)
+
 // Fast inlined version of PyObject_IS_GC()
 static inline int
 _PyObject_IS_GC(PyObject *obj)
 {
     PyTypeObject *type = Py_TYPE(obj);
-    return (PyType_IS_GC(type)
+    return (_PyType_IS_GC(type)
             && (type->tp_is_gc == NULL || type->tp_is_gc(obj)));
 }
 
@@ -749,9 +752,6 @@ _PyObject_HashFast(PyObject *op)
     }
     return PyObject_Hash(op);
 }
-
-// Fast inlined version of PyType_IS_GC()
-#define _PyType_IS_GC(t) _PyType_HasFeature((t), Py_TPFLAGS_HAVE_GC)
 
 static inline size_t
 _PyType_PreHeaderSize(PyTypeObject *tp)


### PR DESCRIPTION


<!-- gh-issue-number: gh-124344 -->
* Issue: gh-124344
<!-- /gh-issue-number -->
