### PR TITLE
`immutable` -> `hashable` in the Glossary

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1131,7 +1131,7 @@ Glossary
       :class:`tuple`, and :class:`bytes`. Note that :class:`dict` also
       supports :meth:`~object.__getitem__` and :meth:`!__len__`, but is considered a
       mapping rather than a sequence because the lookups use arbitrary
-      :term:`immutable` keys rather than integers.
+      :term:`hashable` keys rather than integers.
 
       The :class:`collections.abc.Sequence` abstract base class
       defines a much richer interface that goes beyond just


### PR DESCRIPTION
Dicts accept hashable keys, which is not the same as immutable. For example, user-defined functions are mutable and hashable (so are instances of user-defined classes by default, unless they redefine `__eq__` or set `__hash__ = None`).

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124350.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->