### PR TITLE
[3.13] GH-124321: Fix argparse negative number parsing to capture -.5(GH-124322)

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1388,7 +1388,7 @@ class _ActionsContainer(object):
         self._defaults = {}
 
         # determines whether an "option" looks like a negative number
-        self._negative_number_matcher = _re.compile(r'^-\d+$|^-\d*\.\d+$')
+        self._negative_number_matcher = _re.compile(r'^-(?:\d+(?:_\d+)*(?:\.\d+(?:_\d+)*)?|\.\d+(?:_\d+)*)$')
 
         # whether or not there are any optionals that look like negative
         # numbers -- uses a list so it can be shared and edited

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2136,6 +2136,28 @@ class TestActionExtend(ParserTestCase):
     ]
 
 
+class TestNegativeNumber(ParserTestCase):
+    """Test parsing negative numbers"""
+
+    argument_signatures = [
+        Sig('--int', type=int),
+        Sig('--float', type=float),
+    ]
+    failures = [
+        '--float -_.45',
+        '--float -1__000.0',
+        '--int -1__000',
+    ]
+    successes = [
+        ('--int -1000 --float -1000.0', NS(int=-1000, float=-1000.0)),
+        ('--int -1_000 --float -1_000.0', NS(int=-1000, float=-1000.0)),
+        ('--int -1_000_000 --float -1_000_000.0', NS(int=-1000000, float=-1000000.0)),
+        ('--float -1_000.0', NS(int=None, float=-1000.0)),
+        ('--float -1_000_000.0_0', NS(int=None, float=-1000000.0)),
+        ('--float -.5', NS(int=None, float=-0.5)),
+        ('--float -.5_000', NS(int=None, float=-0.5)),
+    ]
+
 class TestInvalidAction(TestCase):
     """Test invalid user defined Action"""
 


### PR DESCRIPTION
Co-authored-by: Adam Turner <9087854+AA-Turner@users.noreply.github.com>
(cherry picked from commit dc48312)
