### PR TITLE
[3.12] GH-124321: Fix argparse negative number parsing to capture -.5(G…

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1405,7 +1405,7 @@ class _ActionsContainer(object):
         self._defaults = {}
 
         # determines whether an "option" looks like a negative number
-        self._negative_number_matcher = _re.compile(r'^-\d+$|^-\d*\.\d+$')
+        self._negative_number_matcher = _re.compile(r'^-(?:\d+(?:_\d+)*(?:\.\d+(?:_\d+)*)?|\.\d+(?:_\d+)*)$')
 
         # whether or not there are any optionals that look like negative
         # numbers -- uses a list so it can be shared and edited

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2092,6 +2092,49 @@ class TestActionExtend(ParserTestCase):
         ('--foo f1 --foo f2 f3 f4', NS(foo=['f1', 'f2', 'f3', 'f4'])),
     ]
 
+
+class TestNegativeNumber(ParserTestCase):
+    """Test parsing negative numbers"""
+
+    argument_signatures = [
+        Sig('--int', type=int),
+        Sig('--float', type=float),
+    ]
+    failures = [
+        '--float -_.45',
+        '--float -1__000.0',
+        '--int -1__000',
+    ]
+    successes = [
+        ('--int -1000 --float -1000.0', NS(int=-1000, float=-1000.0)),
+        ('--int -1_000 --float -1_000.0', NS(int=-1000, float=-1000.0)),
+        ('--int -1_000_000 --float -1_000_000.0', NS(int=-1000000, float=-1000000.0)),
+        ('--float -1_000.0', NS(int=None, float=-1000.0)),
+        ('--float -1_000_000.0_0', NS(int=None, float=-1000000.0)),
+        ('--float -.5', NS(int=None, float=-0.5)),
+        ('--float -.5_000', NS(int=None, float=-0.5)),
+    ]
+
+class TestInvalidAction(TestCase):
+    """Test invalid user defined Action"""
+
+    class ActionWithoutCall(argparse.Action):
+        pass
+
+    def test_invalid_type(self):
+        parser = argparse.ArgumentParser()
+
+        parser.add_argument('--foo', action=self.ActionWithoutCall)
+        self.assertRaises(NotImplementedError, parser.parse_args, ['--foo', 'bar'])
+
+    def test_modified_invalid_action(self):
+        parser = ErrorRaisingArgumentParser()
+        action = parser.add_argument('--foo')
+        # Someone got crazy and did this
+        action.type = 1
+        self.assertRaises(ArgumentParserError, parser.parse_args, ['--foo', 'bar'])
+
+
 # ================
 # Subparsers tests
 # ================

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2115,25 +2115,6 @@ class TestNegativeNumber(ParserTestCase):
         ('--float -.5_000', NS(int=None, float=-0.5)),
     ]
 
-class TestInvalidAction(TestCase):
-    """Test invalid user defined Action"""
-
-    class ActionWithoutCall(argparse.Action):
-        pass
-
-    def test_invalid_type(self):
-        parser = argparse.ArgumentParser()
-
-        parser.add_argument('--foo', action=self.ActionWithoutCall)
-        self.assertRaises(NotImplementedError, parser.parse_args, ['--foo', 'bar'])
-
-    def test_modified_invalid_action(self):
-        parser = ErrorRaisingArgumentParser()
-        action = parser.add_argument('--foo')
-        # Someone got crazy and did this
-        action.type = 1
-        self.assertRaises(ArgumentParserError, parser.parse_args, ['--foo', 'bar'])
-
 
 # ================
 # Subparsers tests

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2115,7 +2115,6 @@ class TestNegativeNumber(ParserTestCase):
         ('--float -.5_000', NS(int=None, float=-0.5)),
     ]
 
-
 # ================
 # Subparsers tests
 # ================


### PR DESCRIPTION
…H-124322)

(cherry picked from commit dc48312)

Co-authored-by: Savannah Ostrowski <savannahostrowski@gmail.com>
Co-authored-by: Adam Turner <9087854+AA-Turner@users.noreply.github.com><!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124321 -->
* Issue: gh-124321
<!-- /gh-issue-number -->
