### PR TITLE
gh-124294: str.format() raises misleading error when using negative indices

### DIFF
--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -1389,8 +1389,9 @@ class StrTest(string_tests.StringLikeTest,
         self.assertRaises(TypeError, "{}".format, n)
 
         # String index for sequences
-        self.assertRaises(TypeError, "{[s]}".format, "abc")
-        self.assertRaises(TypeError, "{[-1]}".format, "abc")
+        index_msg = 'Index must be a sequence of digits'
+        self.assertRaisesRegex(TypeError, index_msg, "{[s]}".format, "abc")
+        self.assertRaisesRegex(TypeError, index_msg, "{[-1]}".format, "abc")
 
     def test_format_map(self):
         self.assertEqual(''.format_map({}), '')

--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -1388,6 +1388,10 @@ class StrTest(string_tests.StringLikeTest,
         self.assertEqual("{!s}".format(n), 'N(data)')
         self.assertRaises(TypeError, "{}".format, n)
 
+        # String index for sequences
+        self.assertRaises(TypeError, "{[s]}".format, "abc")
+        self.assertRaises(TypeError, "{[-1]}".format, "abc")
+
     def test_format_map(self):
         self.assertEqual(''.format_map({}), '')
         self.assertEqual('a'.format_map({}), 'a')

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-24-11-12-09.gh-issue-124294.jBPOm1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-24-11-12-09.gh-issue-124294.jBPOm1.rst
@@ -1,0 +1,2 @@
+More informative error message in :func:`str.format` when passing negative
+integer or string index to sequence.

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -464,11 +464,14 @@ get_field_object(SubString *input, PyObject *args, PyObject *kwargs,
             /* getitem lookup "[]" */
             if (index == -1) {
                 if (PySequence_Check(obj)) {
+                    /* string index can't be passed to sequence */
                     PyObject *str = SubString_new_object(&name);
-                    /* TypeError is for backward compatibility */
-                    PyErr_Format(PyExc_TypeError,
-                         "Sequence index must consist of digits, \"%S\" is not allowed",
-                         str);
+                    if (str != NULL)
+                        PyErr_Format(PyExc_TypeError,
+                             "Index must be a sequence of digits, string %R "
+                             "is not allowed",
+                             str);
+                    Py_XDECREF(str);
                     goto error;
                 }
                 tmp = getitem_str(obj, &name);

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -462,8 +462,17 @@ get_field_object(SubString *input, PyObject *args, PyObject *kwargs,
             tmp = getattr(obj, &name);
         else
             /* getitem lookup "[]" */
-            if (index == -1)
+            if (index == -1) {
+                if (PySequence_Check(obj)) {
+                    PyObject *str = SubString_new_object(&name);
+                    /* TypeError is for backward compatibility */
+                    PyErr_Format(PyExc_TypeError,
+                         "Sequence index must consist of digits, \"%S\" is not allowed",
+                         str);
+                    goto error;
+                }
                 tmp = getitem_str(obj, &name);
+            }
             else
                 if (PySequence_Check(obj))
                     tmp = getitem_sequence(obj, index);

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -466,11 +466,12 @@ get_field_object(SubString *input, PyObject *args, PyObject *kwargs,
                 if (PySequence_Check(obj)) {
                     /* string index can't be passed to sequence */
                     PyObject *str = SubString_new_object(&name);
-                    if (str != NULL)
+                    if (str) {
                         PyErr_Format(PyExc_TypeError,
                              "Index must be a sequence of digits, string %R "
                              "is not allowed",
                              str);
+                    }
                     Py_XDECREF(str);
                     goto error;
                 }


### PR DESCRIPTION
Fixes #124294.

TypeError is raised instead of ValueError for backward compatibility with current behaviour.
Detailed error message includes invalid string index value to avoid ambiguity.
Without these details, user might be confused by error pointing to the wrong place.

```doctest
>>> '{x[-1]}'.format(x=[0,1,2])
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    '{x[-1]}'.format(x=[0,1,2])
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^
TypeError: Index must be a sequence of digits, string '-1' is not allowed
```

<!-- gh-issue-number: gh-124294 -->
* Issue: gh-124294
<!-- /gh-issue-number -->
