### PR TITLE
Bump Ruff to 0.6.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.10
+    rev: v0.6.7
     hooks:
       - id: ruff
         name: Run Ruff (lint) on Doc/

--- a/Doc/tools/extensions/c_annotations.py
+++ b/Doc/tools/extensions/c_annotations.py
@@ -124,10 +124,7 @@ def add_annotations(app: Sphinx, doctree: nodes.document) -> None:
             continue
         if not par[0].get("ids", None):
             continue
-        name = par[0]["ids"][0]
-        if name.startswith("c."):
-            name = name[2:]
-
+        name = par[0]["ids"][0].removeprefix("c.")
         objtype = par["objtype"]
 
         # Stable ABI annotation.

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -4345,7 +4345,9 @@ class MyIntWithNew2(MyIntWithNew):
 class SlotList(MyList):
     __slots__ = ["foo"]
 
-class SimpleNewObj(int):
+# Ruff "redefined while unused" false positive here due to `global` variables
+# being assigned (and then restored) from within test methods earlier in the file
+class SimpleNewObj(int):  # noqa: F811
     def __init__(self, *args, **kwargs):
         # raise an error, to make sure this isn't called
         raise TypeError("SimpleNewObj.__init__() didn't expect to get called")

--- a/Lib/test/test_bz2.py
+++ b/Lib/test/test_bz2.py
@@ -476,7 +476,6 @@ class BZ2FileTest(BaseTest):
         self.assertEqual(xlines, [b'Test'])
 
     def testContextProtocol(self):
-        f = None
         with BZ2File(self.filename, "wb") as f:
             f.write(b"xxx")
         f = BZ2File(self.filename, "rb")

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -444,12 +444,10 @@ class FileContextTestCase(unittest.TestCase):
     def testWithOpen(self):
         tfn = tempfile.mktemp()
         try:
-            f = None
             with open(tfn, "w", encoding="utf-8") as f:
                 self.assertFalse(f.closed)
                 f.write("Booh\n")
             self.assertTrue(f.closed)
-            f = None
             with self.assertRaises(ZeroDivisionError):
                 with open(tfn, "r", encoding="utf-8") as f:
                     self.assertFalse(f.closed)

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -639,11 +639,9 @@ class IOTest(unittest.TestCase):
 
     def test_with_open(self):
         for bufsize in (0, 100):
-            f = None
             with self.open(os_helper.TESTFN, "wb", bufsize) as f:
                 f.write(b"xxx")
             self.assertEqual(f.closed, True)
-            f = None
             try:
                 with self.open(os_helper.TESTFN, "wb", bufsize) as f:
                     1/0

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3177,7 +3177,8 @@ class Win32NtTests(unittest.TestCase):
     def test_getfinalpathname_handles(self):
         nt = import_helper.import_module('nt')
         ctypes = import_helper.import_module('ctypes')
-        import ctypes.wintypes
+        # Ruff false positive -- it thinks we're redefining `ctypes` here
+        import ctypes.wintypes  # noqa: F811
 
         kernel = ctypes.WinDLL('Kernel32.dll', use_last_error=True)
         kernel.GetCurrentProcess.restype = ctypes.wintypes.HANDLE

--- a/Lib/test/test_with.py
+++ b/Lib/test/test_with.py
@@ -171,7 +171,10 @@ class FailureTestCase(unittest.TestCase):
         def shouldThrow():
             ct = EnterThrows()
             self.foo = None
-            with ct as self.foo:
+            # Ruff complains that we're redefining `self.foo` here,
+            # but the whole point of the test is to check that `self.foo`
+            # is *not* redefined (because `__enter__` raises)
+            with ct as self.foo:  # ruff: noqa: F811
                 pass
         self.assertRaises(RuntimeError, shouldThrow)
         self.assertEqual(self.foo, None)
@@ -252,7 +255,6 @@ class NonexceptionalTestCase(unittest.TestCase, ContextmanagerAssertionMixin):
         self.assertAfterWithGeneratorInvariantsNoError(foo)
 
     def testInlineGeneratorBoundToExistingVariable(self):
-        foo = None
         with mock_contextmanager_generator() as foo:
             self.assertInWithGeneratorInvariants(foo)
         self.assertAfterWithGeneratorInvariantsNoError(foo)


### PR DESCRIPTION
This bump requires the addition of three `noqa: F811` comments. Two of these (the ones in `Lib/test/pickletester.py` and `Lib/test/test_with.py`) are somewhat unavoidable, as Ruff is working as intended. The `noqa` added in `Lib/test/test_os.py` indicates a bug in Ruff, however; I'll follow up on this and hopefully fix it.

As well as the `F811`-related changes, there's also a small simplification made to `Doc/tools/extensions/c_annotations.py`, to address a new `FURB188` diagnostic in that file.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124384.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->