### PR TITLE
gh-124385: Document and soft-deprecate PyLong_AS_LONG

### DIFF
--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -159,7 +159,6 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    .. versionadded:: 3.13
 
 
-.. XXX alias PyLong_AS_LONG (for now)
 .. c:function:: long PyLong_AsLong(PyObject *obj)
 
    .. index::
@@ -181,6 +180,13 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    .. versionchanged:: 3.10
       This function will no longer use :meth:`~object.__int__`.
 
+   .. c:namespace:: NULL
+
+   .. c:function:: long PyLong_AS_LONG(PyObject *obj)
+
+      A :term:`soft deprecated` alias.
+      Exactly equivalent to the preferred ``PyLong_AsLong``. In particular,
+      it can fail with :exc:`OverflowError` or another exception.
 
 .. c:function:: int PyLong_AsInt(PyObject *obj)
 

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -188,6 +188,9 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
       Exactly equivalent to the preferred ``PyLong_AsLong``. In particular,
       it can fail with :exc:`OverflowError` or another exception.
 
+      .. deprecated:: 3.14
+         The function is soft deprecated.      
+
 .. c:function:: int PyLong_AsInt(PyObject *obj)
 
    Similar to :c:func:`PyLong_AsLong`, but store the result in a C

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -189,7 +189,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
       it can fail with :exc:`OverflowError` or another exception.
 
       .. deprecated:: 3.14
-         The function is soft deprecated.      
+         The function is soft deprecated.
 
 .. c:function:: int PyLong_AsInt(PyObject *obj)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124385 -->
* Issue: gh-124385
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124386.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->