### PR TITLE
gh-123856: Fix PyREPL failure when a keyboard interrupt is triggered after using a history search

### DIFF
--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -51,10 +51,9 @@ def check() -> str:
         _get_reader()
     except _error as e:
         import os  # temporary debugging measure to understand the Address sanitizer environment failure
-        term = ""
-        if term := os.environ.get("TERM"):
-            term = f"TERM={term}"
-        return (str(e) or repr(e) or "unknown error") + f"; {term}" if term else ""
+        if term := os.environ.get("TERM", ""):
+            term = f"; TERM={term}"
+        return str(str(e) or repr(e) or "unknown error") + term
     return ""
 
 

--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -50,7 +50,11 @@ def check() -> str:
     try:
         _get_reader()
     except _error as e:
-        return str(e) or repr(e) or "unknown error"
+        import os  # temporary debugging measure to understand the Address sanitizer environment failure
+        term = ""
+        if term := os.environ.get("TERM"):
+            term = f"TERM={term}"
+        return (str(e) or repr(e) or "unknown error") + "; {term}" if term else ""
     return ""
 
 

--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -159,7 +159,7 @@ def run_multiline_interactive_console(
             input_n += 1
         except KeyboardInterrupt:
             r = _get_reader()
-            if r.last_command and 'isearch' in r.last_command.__name__:
+            if r.input_trans is r.isearch_trans:
                 r.isearch_direction = ''
                 r.console.forgetinput()
                 r.pop_input_trans()

--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -54,7 +54,7 @@ def check() -> str:
         term = ""
         if term := os.environ.get("TERM"):
             term = f"TERM={term}"
-        return (str(e) or repr(e) or "unknown error") + "; {term}" if term else ""
+        return (str(e) or repr(e) or "unknown error") + f"; {term}" if term else ""
     return ""
 
 

--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -160,9 +160,7 @@ def run_multiline_interactive_console(
         except KeyboardInterrupt:
             r = _get_reader()
             if r.input_trans is r.isearch_trans:
-                r.isearch_direction = ''
-                r.console.forgetinput()
-                r.pop_input_trans()
+                r.do_cmd(("isearch-end", [""]))
             r.pos = len(r.get_unicode())
             r.dirty = True
             r.refresh()

--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import _sitebuiltins
 import linecache
 import functools
+import os
 import sys
 import code
 
@@ -50,7 +51,6 @@ def check() -> str:
     try:
         _get_reader()
     except _error as e:
-        import os  # temporary debugging measure to understand the Address sanitizer environment failure
         if term := os.environ.get("TERM", ""):
             term = f"; TERM={term}"
         return str(str(e) or repr(e) or "unknown error") + term

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1054,6 +1054,7 @@ class TestPasteEvent(TestCase):
         output = multiline_input(reader)
         self.assertEqual(output, input_code)
 
+
 @skipUnless(pty, "requires pty")
 class TestDumbTerminal(ReplTestCase):
     def test_dumb_terminal_exits_cleanly(self):
@@ -1065,8 +1066,9 @@ class TestDumbTerminal(ReplTestCase):
         self.assertNotIn("Exception", output)
         self.assertNotIn("Traceback", output)
 
+
 @skipUnless(pty, "requires pty")
-@skipIf(os.environ.get("TERM") == "dumb", "can't use pyrepl in dumb terminal")
+@skipIf((os.environ.get("TERM") or "dumb") == "dumb", "can't use pyrepl in dumb terminal")
 class TestMain(ReplTestCase):
     def setUp(self):
         # Cleanup from PYTHON* variables to isolate from local

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -8,7 +8,6 @@ import select
 import subprocess
 import sys
 import tempfile
-import termios
 from unittest import TestCase, skipUnless
 from unittest.mock import patch
 from test.support import force_not_colorized
@@ -1248,10 +1247,15 @@ class TestMain(TestCase):
         if cmdline_args is not None:
             cmd.extend(cmdline_args)
 
-        term_attr = termios.tcgetattr(slave_fd)
-        term_attr[6][termios.VREPRINT] = 0  # pass through CTRL-R
-        term_attr[6][termios.VINTR] = 0  # pass through CTRL-C
-        termios.tcsetattr(slave_fd, termios.TCSANOW, term_attr)
+        try:
+            import termios
+        except ModuleNotFoundError:
+            pass
+        else:
+            term_attr = termios.tcgetattr(slave_fd)
+            term_attr[6][termios.VREPRINT] = 0  # pass through CTRL-R
+            term_attr[6][termios.VINTR] = 0  # pass through CTRL-C
+            termios.tcsetattr(slave_fd, termios.TCSANOW, term_attr)
 
         process = subprocess.Popen(
             cmd,

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-23-15-23-14.gh-issue-123856.yrgJ9m.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-23-15-23-14.gh-issue-123856.yrgJ9m.rst
@@ -1,0 +1,2 @@
+Fix PyREPL failure when a keyboard interrupt is triggered after using a
+history search


### PR DESCRIPTION
The original check in `Lib/_pyrepl/simple_interact.py` for handling the manual clean up when a `KeyboardInterrupt` is received would result in duplicate calls to clean up the search translator  in some scenarios. When the search translator is allowed to exit cleanly without a `KeyboardInterrupt`, it calls its clean-up function (`isearch_end`) on its own. If a `KeyboardInterrupt` was triggered immediately after, the most recent command was still `isearch`, which would trigger a similar clean-up routine incorrectly. This now ensures that the clean-up is only executed once.

I've also added tests – we had to make modifications to the way the full version of the REPL is run – this now allows the necessary control characters to pass through. Additional overrides for other control characters may be required here as the test suite is bolstered.

<!-- gh-issue-number: gh-123856 -->
* Issue: gh-123856
<!-- /gh-issue-number -->
