### PR TITLE
gh-124400: Use the normal command path for breakpoint commands

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -430,7 +430,7 @@ can be overridden by the local file.
    breakpoint—which could have its own command list, leading to ambiguities about
    which list to execute.
 
-   If the command list contains the ``silent`` command, or a command that
+   If the list of commands contains the ``silent`` command, or a command that
    resumes execution, then the breakpoint message containing information about
    the frame is not displayed.
 

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -430,14 +430,9 @@ can be overridden by the local file.
    breakpoint—which could have its own command list, leading to ambiguities about
    which list to execute.
 
-   If you have a command that resumes execution in the command list, the normal
-   frame information before you interact with pdb is not displayed.  If none of
-   the other commands print anything, you see no sign that the breakpoint was
-   reached.
-
-   If you don't have a command that resumes execution in the command list, you
-   can also use the ``silent`` command anywhere in the command list to suppress
-   the frame information.
+   If the command list contains the ``silent`` command, or a command that
+   resumes execution, then the breakpoint message containing information about
+   the frame is not displayed.
 
    .. versionchanged:: 3.14
       Frame information will not be displayed if a command that resumes execution

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -423,17 +423,25 @@ can be overridden by the local file.
 
    Specifying any command resuming execution
    (currently :pdbcmd:`continue`, :pdbcmd:`step`, :pdbcmd:`next`,
-   :pdbcmd:`return`, :pdbcmd:`jump`, :pdbcmd:`quit` and their abbreviations)
+   :pdbcmd:`return`, :pdbcmd:`until`, :pdbcmd:`jump`, :pdbcmd:`quit` and their abbreviations)
    terminates the command list (as if
    that command was immediately followed by end). This is because any time you
    resume execution (even with a simple next or step), you may encounter another
    breakpoint—which could have its own command list, leading to ambiguities about
    which list to execute.
 
-   If you use the ``silent`` command in the command list, the usual message about
-   stopping at a breakpoint is not printed.  This may be desirable for breakpoints
-   that are to print a specific message and then continue.  If none of the other
-   commands print anything, you see no sign that the breakpoint was reached.
+   If you have a command that resumes execution in the command list, the normal
+   frame information before you interact with pdb is not displayed.  If none of
+   the other commands print anything, you see no sign that the breakpoint was
+   reached.
+
+   If you don't have a command that resumes execution in the command list, you
+   can also use the ``silent`` command anywhere in the command list to suppress
+   the frame information.
+
+   .. versionchanged:: 3.14
+      Frame information will not be displayed if a command that resumes execution
+      is present in the command list.
 
 .. pdbcommand:: s(tep)
 

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -859,7 +859,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             return True  # end of cmd list
         cmdlist = self.commands[self.commands_bnum]
         if cmd == 'silent':
-            cmdlist.append('_pdbcmd_silent_frame_status')
+            cmdlist.append('_pdbcmd_silence_frame_status')
             return False  # continue to handle other cmd def in the cmd list
         if arg:
             cmdlist.append(cmd+' '+arg)
@@ -984,7 +984,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.print_stack_trace(0)
         self._show_display()
 
-    def _pdbcmd_silent_frame_status(self, arg):
+    def _pdbcmd_silence_frame_status(self, arg):
         if self.cmdqueue and self.cmdqueue[-1] == '_pdbcmd_print_frame_status':
             self.cmdqueue.pop()
 

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -349,10 +349,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 pass
 
         self.commands = {} # associates a command list to breakpoint numbers
-        self.commands_doprompt = {} # for each bp num, tells if the prompt
-                                    # must be disp. after execing the cmd list
-        self.commands_silent = {} # for each bp num, tells if the stack trace
-                                  # must be disp. after execing the cmd list
         self.commands_defining = False # True while in the process of defining
                                        # a command list
         self.commands_bnum = None # The breakpoint number for which we are
@@ -439,8 +435,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 or frame.f_lineno <= 0):
                 return
             self._wait_for_mainpyfile = False
-        if self.bp_commands(frame):
-            self.interaction(frame, None)
+        self.bp_commands(frame)
+        self.interaction(frame, None)
 
     user_opcode = user_line
 
@@ -455,18 +451,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                self.currentbp in self.commands:
             currentbp = self.currentbp
             self.currentbp = 0
-            lastcmd_back = self.lastcmd
-            self.setup(frame, None)
             for line in self.commands[currentbp]:
-                self.onecmd(line)
-            self.lastcmd = lastcmd_back
-            if not self.commands_silent[currentbp]:
-                self.print_stack_entry(self.stack[self.curindex])
-            if self.commands_doprompt[currentbp]:
-                self._cmdloop()
-            self.forget()
-            return
-        return 1
+                self.cmdqueue.append(line)
+            self.cmdqueue.append(f'_pdbcmd_restore_lastcmd {self.lastcmd}')
 
     def user_return(self, frame, return_value):
         """This function is called when a return trap is set here."""
@@ -865,15 +852,15 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         cmd, arg, line = self.parseline(line)
         if not cmd:
             return False
-        if cmd == 'silent':
-            self.commands_silent[self.commands_bnum] = True
-            return False  # continue to handle other cmd def in the cmd list
-        elif cmd == 'end':
+        if cmd == 'end':
             return True  # end of cmd list
         elif cmd == 'EOF':
             print('')
             return True  # end of cmd list
         cmdlist = self.commands[self.commands_bnum]
+        if cmd == 'silent':
+            cmdlist.append('_pdbcmd_silent_frame_status')
+            return False  # continue to handle other cmd def in the cmd list
         if arg:
             cmdlist.append(cmd+' '+arg)
         else:
@@ -885,7 +872,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             func = self.default
         # one of the resuming commands
         if func.__name__ in self.commands_resuming:
-            self.commands_doprompt[self.commands_bnum] = False
             return True
         return False
 
@@ -998,6 +984,13 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.print_stack_trace(0)
         self._show_display()
 
+    def _pdbcmd_silent_frame_status(self, arg):
+        if self.cmdqueue and self.cmdqueue[-1] == '_pdbcmd_print_frame_status':
+            self.cmdqueue.pop()
+
+    def _pdbcmd_restore_lastcmd(self, arg):
+        self.lastcmd = arg
+
     # Command definitions, called by cmdloop()
     # The argument is the remaining string on the command line
     # Return true to exit from the command loop
@@ -1056,14 +1049,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.commands_bnum = bnum
         # Save old definitions for the case of a keyboard interrupt.
         if bnum in self.commands:
-            old_command_defs = (self.commands[bnum],
-                                self.commands_doprompt[bnum],
-                                self.commands_silent[bnum])
+            old_commands = self.commands[bnum]
         else:
-            old_command_defs = None
+            old_commands = None
         self.commands[bnum] = []
-        self.commands_doprompt[bnum] = True
-        self.commands_silent[bnum] = False
 
         prompt_back = self.prompt
         self.prompt = '(com) '
@@ -1072,14 +1061,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             self.cmdloop()
         except KeyboardInterrupt:
             # Restore old definitions.
-            if old_command_defs:
-                self.commands[bnum] = old_command_defs[0]
-                self.commands_doprompt[bnum] = old_command_defs[1]
-                self.commands_silent[bnum] = old_command_defs[2]
+            if old_commands:
+                self.commands[bnum] = old_commands
             else:
                 del self.commands[bnum]
-                del self.commands_doprompt[bnum]
-                del self.commands_silent[bnum]
             self.error('command definition aborted, old commands restored')
         finally:
             self.commands_defining = False
@@ -2091,7 +2076,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     # List of all the commands making the program resume execution.
     commands_resuming = ['do_continue', 'do_step', 'do_next', 'do_return',
-                         'do_quit', 'do_jump']
+                         'do_until', 'do_quit', 'do_jump']
 
     # Print a traceback starting at the top stack frame.
     # The most recently entered frame is printed last;

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -363,6 +363,54 @@ def test_pdb_breakpoint_commands():
     4
     """
 
+def test_pdb_commands():
+    """Test the commands command of pdb.
+
+    >>> def test_function():
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     print(1)
+    ...     print(2)
+    ...     print(3)
+
+    >>> reset_Breakpoint()
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'b 3',
+    ...     'commands',
+    ...     'silent',      # suppress the frame status output
+    ...     'p "hello"',
+    ...     'end',
+    ...     'b 4',
+    ...     'commands',
+    ...     'until 5',     # no output, should stop at line 5
+    ...     'continue',    # hit breakpoint at line 3
+    ...     '',            # repeat continue, hit breakpoint at line 4 then `until` to line 5
+    ...     '',
+    ... ]):
+    ...    test_function()
+    > <doctest test.test_pdb.test_pdb_commands[0]>(2)test_function()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) b 3
+    Breakpoint 1 at <doctest test.test_pdb.test_pdb_commands[0]>:3
+    (Pdb) commands
+    (com) silent
+    (com) p "hello"
+    (com) end
+    (Pdb) b 4
+    Breakpoint 2 at <doctest test.test_pdb.test_pdb_commands[0]>:4
+    (Pdb) commands
+    (com) until 5
+    (Pdb) continue
+    'hello'
+    (Pdb)
+    1
+    2
+    > <doctest test.test_pdb.test_pdb_commands[0]>(5)test_function()
+    -> print(3)
+    (Pdb)
+    3
+    """
+
 def test_pdb_breakpoint_with_filename():
     """Breakpoints with filename:lineno
 

--- a/Misc/NEWS.d/next/Library/2024-09-24-00-01-24.gh-issue-124400.0XCgfe.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-24-00-01-24.gh-issue-124400.0XCgfe.rst
@@ -1,0 +1,1 @@
+``until`` in ``commands`` executes correctly now in :mod:`pdb`. Breakpoint commands will not print the frame information if there's a command that resumes execution in the command list.

--- a/Misc/NEWS.d/next/Library/2024-09-24-00-01-24.gh-issue-124400.0XCgfe.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-24-00-01-24.gh-issue-124400.0XCgfe.rst
@@ -1,1 +1,1 @@
-``until`` in ``commands`` executes correctly now in :mod:`pdb`. Breakpoint commands will not print the frame information if there's a command that resumes execution in the command list.
+Fixed :mod:`pdb` bug where ``until`` has no effect when it appears in a ``commands`` sequence. Also avoid printing the frame information at a breakpoint if it has a command list containing a command that resumes execution.

--- a/Misc/NEWS.d/next/Library/2024-09-24-00-01-24.gh-issue-124400.0XCgfe.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-24-00-01-24.gh-issue-124400.0XCgfe.rst
@@ -1,1 +1,1 @@
-Fixed :mod:`pdb` bug where ``until`` has no effect when it appears in a ``commands`` sequence. Also avoid printing the frame information at a breakpoint if it has a command list containing a command that resumes execution.
+Fixed a :mod:`pdb` bug where ``until`` has no effect when it appears in a ``commands`` sequence. Also avoid printing the frame information at a breakpoint that has a command list containing a command that resumes execution.


### PR DESCRIPTION
Cleaned up the code for `commands` command so breakpoint commands will go through the normal parsing and executing path.

Also a bug (#68328) is fixed for `until` in commands. A small behavior of `silent` is changed which matches the current behavior of `.pdbrc` (no interaction, no frame info).

@iritkatriel sorry there are too many PRs, blame the sprint!

<!-- gh-issue-number: gh-124400 -->
* Issue: gh-124400
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124401.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->