### PR TITLE
gh-124405: Fix `NameError` in `openpty`

### DIFF
--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -39,8 +39,8 @@ def openpty():
     except ImportError:
          return master_fd, slave_fd
     try:
-        ioctl(result, I_PUSH, "ptem")
-        ioctl(result, I_PUSH, "ldterm")
+        ioctl(slave_fd, I_PUSH, "ptem")
+        ioctl(slave_fd, I_PUSH, "ldterm")
     except OSError:
         pass
     return master_fd, slave_fd


### PR DESCRIPTION
@ambv how can I test this change? This looks very platform specific, but it seems that you have a reproducer :)

<!-- gh-issue-number: gh-124405 -->
* Issue: gh-124405
<!-- /gh-issue-number -->
