### PR TITLE
gh-83923: Added `os.getdtablesize` function to os module

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2229,6 +2229,13 @@ features:
 
    Return a string representing the current working directory.
 
+.. function:: getdtablesize()
+
+   Return the maximum number of files a process can have open.
+
+   .. warning::
+
+      This function currently only supports unix-like system.
 
 .. function:: getcwdb()
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2233,9 +2233,9 @@ features:
 
    Return the maximum number of files a process can have open.
 
-   .. warning::
-
-      This function currently only supports unix-like system.
+   .. versionadded:: 3.14
+      
+   .. availability:: Unix.
 
 .. function:: getcwdb()
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2234,7 +2234,7 @@ features:
    Return the maximum number of files a process can have open.
 
    .. versionadded:: 3.14
-      
+
    .. availability:: Unix.
 
 .. function:: getcwdb()

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -123,6 +123,7 @@ class MiscTests(unittest.TestCase):
             else:
                 self.fail('No NotImplementedError is thrown')
         else:
+            size = os.getdtablesize()
             self.assertIsInstance(size, int)
 
     def test_getcwd_long_path(self):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -113,7 +113,7 @@ class MiscTests(unittest.TestCase):
         cwd = os.getcwd()
         self.assertIsInstance(cwd, str)
 
-    @unittest.skipUnless(hasattr(os, 'getdtablesize'), 'need os.getdtablesize()')  
+    @unittest.skipUnless(hasattr(os, 'getdtablesize'), 'need os.getdtablesize()')
     def test_getdtablesize(self):
         size = os.getdtablesize()
         self.assertIsInstance(size, int)

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -113,18 +113,11 @@ class MiscTests(unittest.TestCase):
         cwd = os.getcwd()
         self.assertIsInstance(cwd, str)
 
+    @unittest.skipUnless(hasattr(os, 'getdtablesize'), 'need os.getdtablesize()')  
     def test_getdtablesize(self):
-        curr_system = platform.system()
-        if curr_system == 'Windows':
-            try:
-                size = os.getdtablesize()
-            except NotImplementedError as e:
-                self.assertIsInstance(e, NotImplementedError)
-            else:
-                self.fail('No NotImplementedError is thrown')
-        else:
-            size = os.getdtablesize()
-            self.assertIsInstance(size, int)
+        size = os.getdtablesize()
+        self.assertIsInstance(size, int)
+        self.assertGreaterEqual(size, 0)
 
     def test_getcwd_long_path(self):
         # bpo-37412: On Linux, PATH_MAX is usually around 4096 bytes. On

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -113,6 +113,18 @@ class MiscTests(unittest.TestCase):
         cwd = os.getcwd()
         self.assertIsInstance(cwd, str)
 
+    def test_getdtablesize(self):
+        curr_system = platform.system()
+        if curr_system == 'Windows':
+            try:
+                size = os.getdtablesize()
+            except NotImplementedError as e:
+                self.assertIsInstance(e, NotImplementedError)
+            else:
+                self.fail('No NotImplementedError is thrown')
+        else:
+            self.assertIsInstance(size, int)
+
     def test_getcwd_long_path(self):
         # bpo-37412: On Linux, PATH_MAX is usually around 4096 bytes. On
         # Windows, MAX_PATH is defined as 260 characters, but Windows supports

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -117,7 +117,7 @@ class MiscTests(unittest.TestCase):
     def test_getdtablesize(self):
         size = os.getdtablesize()
         self.assertIsInstance(size, int)
-        self.assertGreaterEqual(size, 0)
+        self.assertGreaterEqual(size, 1)
 
     def test_getcwd_long_path(self):
         # bpo-37412: On Linux, PATH_MAX is usually around 4096 bytes. On

--- a/Misc/NEWS.d/next/Library/2024-09-24-14-15-34.gh-issue-83923.YunOLX.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-24-14-15-34.gh-issue-83923.YunOLX.rst
@@ -1,0 +1,2 @@
+Added :func:`getdtablesize` to :mod:`os` (supported only on unix-like
+systems)

--- a/Misc/NEWS.d/next/Library/2024-09-24-14-15-34.gh-issue-83923.YunOLX.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-24-14-15-34.gh-issue-83923.YunOLX.rst
@@ -1,2 +1,2 @@
-Added :func:`getdtablesize` to :mod:`os` (supported only on unix-like
+Added :func:`os.getdtablesize` to :mod:`os` (supported only on unix-like
 systems)

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1419,6 +1419,24 @@ os_getcwdb(PyObject *module, PyObject *Py_UNUSED(ignored))
     return os_getcwdb_impl(module);
 }
 
+PyDoc_STRVAR(os_getdtablesize__doc__,
+"getdtablesize($module, /)\n"
+"--\n"
+"\n"
+"Return the maximum number of files a process can have open.");
+
+#define OS_GETDTABLESIZE_METHODDEF      \
+    {"getdtablesize", (PyCFunction)os_getdtablesize, METH_NOARGS, os_getdtablesize__doc__},
+
+static PyObject *
+os_getdtablesize_impl(PyObject *module);
+
+static PyObject *
+os_getdtablesize(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return os_getdtablesize_impl(module);
+}
+
 #if defined(HAVE_LINK)
 
 PyDoc_STRVAR(os_link__doc__,

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4228,7 +4228,7 @@ Return the maximum number of files a process can have open.
 static PyObject *
 os_getdtablesize_impl(PyObject *module)
 {
-    PyObject *size;
+    int size;
 
     size = getdtablesize();
     return PyLong_FromLong(size);

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4218,6 +4218,7 @@ os_getcwdb_impl(PyObject *module)
     return posix_getcwd(1);
 }
 
+
 /*[clinic input]
 os.getdtablesize
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4218,6 +4218,33 @@ os_getcwdb_impl(PyObject *module)
     return posix_getcwd(1);
 }
 
+/*[clinic input]
+os.getdtablesize
+
+Return the maximum number of files a process can have open.
+[clinic start generated code]*/
+
+static PyObject *
+os_getdtablesize_impl(PyObject *module)
+{
+    PyObject *max_fptable_size;
+    int size;
+
+#ifdef MS_WINDOWS
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "this function is not supported on windows");
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+#else   /* !Unix-like */
+    size = getdtablesize();
+#endif   /* !MS_WINDOWS */
+    max_fptable_size = PyLong_FromLong(size);
+    if (max_fptable_size == NULL)
+        return NULL;
+
+    return max_fptable_size;
+}
 
 #if ((!defined(HAVE_LINK)) && defined(MS_WINDOWS))
 #define HAVE_LINK 1
@@ -16843,6 +16870,7 @@ static PyMethodDef posix_methods[] = {
     OS_CTERMID_METHODDEF
     OS_GETCWD_METHODDEF
     OS_GETCWDB_METHODDEF
+    OS_GETDTABLESIZE_METHODDEF
     OS_LINK_METHODDEF
     OS_LISTDIR_METHODDEF
     OS_LISTDRIVES_METHODDEF

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4218,7 +4218,7 @@ os_getcwdb_impl(PyObject *module)
     return posix_getcwd(1);
 }
 
-
+#ifndef MS_WINDOWS
 /*[clinic input]
 os.getdtablesize
 
@@ -4228,24 +4228,12 @@ Return the maximum number of files a process can have open.
 static PyObject *
 os_getdtablesize_impl(PyObject *module)
 {
-    PyObject *max_fptable_size;
-    int size;
+    PyObject *size;
 
-#ifdef MS_WINDOWS
-    PyErr_SetString(PyExc_NotImplementedError,
-                    "this function is not supported on windows");
-    if (PyErr_Occurred()) {
-        return NULL;
-    }
-#else   /* !Unix-like */
     size = getdtablesize();
-#endif   /* !MS_WINDOWS */
-    max_fptable_size = PyLong_FromLong(size);
-    if (max_fptable_size == NULL)
-        return NULL;
-
-    return max_fptable_size;
+    return PyLong_FromLong(size);
 }
+#endif  /* !MS_WINDOWS */
 
 #if ((!defined(HAVE_LINK)) && defined(MS_WINDOWS))
 #define HAVE_LINK 1

--- a/configure
+++ b/configure
@@ -18406,6 +18406,12 @@ then :
   printf "%s\n" "#define HAVE__GETPTY 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "getdtablesize" "ac_cv_func_getdtablesize"
+if test "x$ac_cv_func_getdtablesize" = xyes
+then :
+  printf "%s\n" "#define HAVE_GETDTABLESIZE 1" >>confdefs.h
+
+fi
 ac_fn_c_check_func "$LINENO" "getpwent" "ac_cv_func_getpwent"
 if test "x$ac_cv_func_getpwent" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -5149,7 +5149,7 @@ AC_CHECK_FUNCS([ \
   fork fork1 fpathconf fstatat ftime ftruncate futimens futimes futimesat \
   gai_strerror getegid geteuid getgid getgrent getgrgid getgrgid_r \
   getgrnam_r getgrouplist gethostname getitimer getloadavg getlogin \
-  getpeername getpgid getpid getppid getpriority _getpty \
+  getpeername getpgid getpid getppid getpriority _getpty getdtablesize \
   getpwent getpwnam_r getpwuid getpwuid_r getresgid getresuid getrusage getsid getspent \
   getspnam getuid getwd grantpt if_nameindex initgroups kill killpg lchown linkat \
   lockf lstat lutimes madvise mbrtowc memrchr mkdirat mkfifo mkfifoat \

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -471,6 +471,9 @@
 /* Define this if you have flockfile(), getc_unlocked(), and funlockfile() */
 #undef HAVE_GETC_UNLOCKED
 
+/* Define to 1 if you have the `getdtablesize' function. */
+#undef HAVE_GETDTABLESIZE
+
 /* Define to 1 if you have the `getegid' function. */
 #undef HAVE_GETEGID
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-83923 -->
* Issue: gh-83923
<!-- /gh-issue-number -->

What's confusing me now is that it seems there's no equivalent to `getdtablesize` on Windows. If it's allowed, I could write an API to provide an estimated value for the Windows system.

And I'm a bit confused about the `clinic` tag. This is my first time submitting changes to the C-API. Could you point out any mistakes I might have made? Thanks!!