### PR TITLE
gh-124176: Add special support for dataclasses to `create_autospec`

### DIFF
--- a/Lib/test/test_unittest/testmock/testhelpers.py
+++ b/Lib/test/test_unittest/testmock/testhelpers.py
@@ -8,8 +8,10 @@ from unittest.mock import (
     Mock, ANY, _CallList, patch, PropertyMock, _callable
 )
 
+from dataclasses import dataclass, field, InitVar
 from datetime import datetime
 from functools import partial
+from typing import ClassVar
 
 class SomeClass(object):
     def one(self, a, b): pass
@@ -1034,10 +1036,7 @@ class SpecSignatureTest(unittest.TestCase):
         self.assertEqual(mock.mock_calls, [])
         self.assertEqual(rv.mock_calls, [])
 
-    def test_dataclass(self):
-        from dataclasses import dataclass, field, InitVar
-        from typing import ClassVar
-
+    def test_dataclass_post_init(self):
         @dataclass
         class WithPostInit:
             a: int = field(init=False)
@@ -1062,6 +1061,7 @@ class SpecSignatureTest(unittest.TestCase):
         with self.assertRaisesRegex(AttributeError, msg):
             mock.b
 
+    def test_dataclass_default(self):
         @dataclass
         class WithDefault:
             a: int
@@ -1075,6 +1075,7 @@ class SpecSignatureTest(unittest.TestCase):
                 self.assertIsInstance(mock.a, int)
                 self.assertIsInstance(mock.b, int)
 
+    def test_dataclass_with_method(self):
         @dataclass
         class WithMethod:
             a: int
@@ -1089,6 +1090,7 @@ class SpecSignatureTest(unittest.TestCase):
                 self.assertIsInstance(mock.a, int)
                 mock.b.assert_not_called()
 
+    def test_dataclass_with_non_fields(self):
         @dataclass
         class WithNonFields:
             a: ClassVar[int]

--- a/Lib/test/test_unittest/testmock/testhelpers.py
+++ b/Lib/test/test_unittest/testmock/testhelpers.py
@@ -1096,6 +1096,7 @@ class SpecSignatureTest(unittest.TestCase):
             a: ClassVar[int]
             b: InitVar[int]
 
+        msg = "Mock object has no attribute"
         for mock in [
             create_autospec(WithNonFields, instance=True),
             create_autospec(WithNonFields(1)),

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2757,8 +2757,6 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
     is_async_func = _is_async_func(spec)
 
     entries = [(entry, _missing) for entry in dir(spec)]
-    # Not using `is_dataclass` to avoid an import of dataclasses module
-    # for types that don't need that.
     if is_type and instance and is_dataclass(spec):
         dataclass_fields = fields(spec)
         entries.extend((f.name, f.type) for f in dataclass_fields)

--- a/Misc/NEWS.d/next/Library/2024-09-24-13-32-16.gh-issue-124176.6hmOPz.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-24-13-32-16.gh-issue-124176.6hmOPz.rst
@@ -1,0 +1,4 @@
+Add support for :func:`dataclasses.dataclass` in
+:func:`unittest.mock.create_autospec`. Now ``create_autospec`` will check
+for potential dataclasses and use :func:`dataclasses.fields` function to
+retrieve the spec information.


### PR DESCRIPTION
Now creating autospecs from dataclass types is easier. We inspect all fields and add them to `__dir__`, so mock's spec will know about future dataclass instance fields.



<!-- gh-issue-number: gh-124176 -->
* Issue: gh-124176
<!-- /gh-issue-number -->
