### PR TITLE
gh-124402: Require cpu resource in test_super slow method

### DIFF
--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -4,6 +4,7 @@ import textwrap
 import threading
 import unittest
 from unittest.mock import patch
+from test import support
 from test.support import import_helper, threading_helper
 
 
@@ -513,6 +514,11 @@ class TestSuper(unittest.TestCase):
         This should be the case anyways as our test suite sets
         an audit hook.
         """
+
+        if support.Py_GIL_DISABLED:
+            # gh-124402: On a Free Threaded build, the test takes a few minutes
+            support.requires('cpu')
+
         class Foo:
             pass
 


### PR DESCRIPTION
test___class___modification_multithreaded() now requires the 'cpu' test resource on a Free Threaded build.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124402 -->
* Issue: gh-124402
<!-- /gh-issue-number -->
