### PR TITLE
gh-91279: ZipFile.writestr now respect SOURCE_DATE_EPOCH

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -670,6 +670,12 @@ zipinfo
 
   (Contributed by Bénédikt Tran in :gh:`123424`.)
 
+* :meth:`zipfile.ZipFile.writestr` now respect ``SOURCE_DATE_EPOCH`` that
+  distributions can set centrally and have build tools consume this in order
+  to produce reproducible output.
+
+  (Contributed by Jiahao Li in :gh:`91279`.)
+
 .. Add improved modules above alphabetically, not here at the end.
 
 Optimizations

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -19,7 +19,7 @@ from tempfile import TemporaryFile
 from random import randint, random, randbytes
 
 from test import archiver_tests
-from test.support import script_helper
+from test.support import script_helper, os_helper
 from test.support import (
     findfile, requires_zlib, requires_bz2, requires_lzma,
     captured_stdout, captured_stderr, requires_subprocess
@@ -1780,6 +1780,35 @@ class OtherTests(unittest.TestCase):
                 zinfo = zipfile.ZipInfo(data)
                 zinfo.flag_bits |= zipfile._MASK_USE_DATA_DESCRIPTOR  # Include an extended local header.
                 orig_zip.writestr(zinfo, data)
+
+    def test_write_with_source_date_epoch(self):
+        with os_helper.EnvironmentVarGuard() as env:
+            # Set the SOURCE_DATE_EPOCH environment variable to a specific timestamp
+            env['SOURCE_DATE_EPOCH'] = "1727440508"
+
+            with zipfile.ZipFile(TESTFN, "w") as zf:
+                zf.writestr("test_source_date_epoch.txt", "Testing SOURCE_DATE_EPOCH")
+
+            with zipfile.ZipFile(TESTFN, "r") as zf:
+                zip_info = zf.getinfo("test_source_date_epoch.txt")
+                get_time = time.gmtime(int(os.environ['SOURCE_DATE_EPOCH']))[:6]
+                # Compare each element of the date_time tuple
+                # Allow for a 1-second difference
+                for z_time, g_time in zip(zip_info.date_time, get_time):
+                    self.assertAlmostEqual(z_time, g_time, delta=1)
+
+    def test_write_without_source_date_epoch(self):
+        if 'SOURCE_DATE_EPOCH' in os.environ:
+            del os.environ['SOURCE_DATE_EPOCH']
+
+        with zipfile.ZipFile(TESTFN, "w") as zf:
+            zf.writestr("test_no_source_date_epoch.txt", "Testing without SOURCE_DATE_EPOCH")
+
+        with zipfile.ZipFile(TESTFN, "r") as zf:
+            zip_info = zf.getinfo("test_no_source_date_epoch.txt")
+            current_time = time.gmtime()[:6]
+            for z_time, c_time in zip(zip_info.date_time, current_time):
+                self.assertAlmostEqual(z_time, c_time, delta=1)
 
     def test_close(self):
         """Check that the zipfile is closed after the 'with' block."""

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -1784,14 +1784,14 @@ class OtherTests(unittest.TestCase):
     def test_write_with_source_date_epoch(self):
         with os_helper.EnvironmentVarGuard() as env:
             # Set the SOURCE_DATE_EPOCH environment variable to a specific timestamp
-            env['SOURCE_DATE_EPOCH'] = "1727440508"
+            env['SOURCE_DATE_EPOCH'] = "1735715999"
 
             with zipfile.ZipFile(TESTFN, "w") as zf:
                 zf.writestr("test_source_date_epoch.txt", "Testing SOURCE_DATE_EPOCH")
 
             with zipfile.ZipFile(TESTFN, "r") as zf:
                 zip_info = zf.getinfo("test_source_date_epoch.txt")
-                get_time = time.gmtime(int(os.environ['SOURCE_DATE_EPOCH']))[:6]
+                get_time = time.localtime(int(os.environ['SOURCE_DATE_EPOCH']))[:6]
                 # Compare each element of the date_time tuple
                 # Allow for a 1-second difference
                 for z_time, g_time in zip(zip_info.date_time, get_time):
@@ -1806,7 +1806,7 @@ class OtherTests(unittest.TestCase):
 
         with zipfile.ZipFile(TESTFN, "r") as zf:
             zip_info = zf.getinfo("test_no_source_date_epoch.txt")
-            current_time = time.gmtime()[:6]
+            current_time = time.localtime()[:6]
             for z_time, c_time in zip(zip_info.date_time, current_time):
                 self.assertAlmostEqual(z_time, c_time, delta=1)
 

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -614,7 +614,11 @@ class ZipInfo:
 
         Return self.
         """
-        self.date_time = time.localtime(time.time())[:6]
+        # gh-91279: Set the SOURCE_DATE_EPOCH to a specific timestamp
+        self.epoch = os.environ.get('SOURCE_DATE_EPOCH')
+        self.get_time = int(self.epoch) if self.epoch else time.time()
+        self.date_time = time.gmtime(self.get_time)[:6]
+
         self.compress_type = archive.compression
         self.compress_level = archive.compresslevel
         if self.filename.endswith('/'):  # pragma: no cover

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -615,9 +615,9 @@ class ZipInfo:
         Return self.
         """
         # gh-91279: Set the SOURCE_DATE_EPOCH to a specific timestamp
-        self.epoch = os.environ.get('SOURCE_DATE_EPOCH')
-        self.get_time = int(self.epoch) if self.epoch else time.time()
-        self.date_time = time.gmtime(self.get_time)[:6]
+        epoch = os.environ.get('SOURCE_DATE_EPOCH')
+        get_time = int(epoch) if epoch else time.time()
+        self.date_time = time.gmtime(get_time)[:6]
 
         self.compress_type = archive.compression
         self.compress_level = archive.compresslevel

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -617,7 +617,7 @@ class ZipInfo:
         # gh-91279: Set the SOURCE_DATE_EPOCH to a specific timestamp
         epoch = os.environ.get('SOURCE_DATE_EPOCH')
         get_time = int(epoch) if epoch else time.time()
-        self.date_time = time.gmtime(get_time)[:6]
+        self.date_time = time.localtime(get_time)[:6]
 
         self.compress_type = archive.compression
         self.compress_level = archive.compresslevel

--- a/Misc/NEWS.d/next/Library/2024-12-30-19-53-14.gh-issue-91279.EeOJk1.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-30-19-53-14.gh-issue-91279.EeOJk1.rst
@@ -1,0 +1,3 @@
+:meth:`zipfile.ZipFile.writestr` now respect ``SOURCE_DATE_EPOCH`` that
+distributions can set centrally and have build tools consume this in order
+to produce reproducible output.


### PR DESCRIPTION
No `SOURCE_DATE_EPOCH` environment variable makes pip installing a package generate non-reproducible build artifacts.

`SOURCE_DATE_EPOCH` is a [standardised environment variable](https://reproducible-builds.org/specs/source-date-epoch/) that distributions can set centrally and have build tools consume this in order to produce reproducible output. In practice, specifies the last modification of something, usually the source code, measured in the number seconds since the Unix epoch, ie. .`SOURCE_DATE_EPOCHJanuary 1st 1970, 00:00:00 UTC`

See https://reproducible-builds.org/docs/source-date-epoch/
details in issue: https://github.com/python/cpython/issues/91279

<!-- gh-issue-number: gh-91279 -->
* Issue: gh-91279
<!-- /gh-issue-number -->
