### PR TITLE
[3.13] gh-124402: Require cpu resource in test_free_threading (#124438)

### DIFF
--- a/Lib/test/test_free_threading/test_list.py
+++ b/Lib/test/test_free_threading/test_list.py
@@ -3,6 +3,7 @@ import unittest
 from threading import Thread
 from unittest import TestCase
 
+from test import support
 from test.support import threading_helper
 
 
@@ -13,6 +14,7 @@ class C:
 
 @threading_helper.requires_working_threading()
 class TestList(TestCase):
+    @support.requires_resource('cpu')
     def test_racing_iter_append(self):
 
         l = []
@@ -42,6 +44,7 @@ class TestList(TestCase):
         for reader in readers:
             reader.join()
 
+    @support.requires_resource('cpu')
     def test_racing_iter_extend(self):
         iters = [
             lambda x: [x],

--- a/Lib/test/test_free_threading/test_monitoring.py
+++ b/Lib/test/test_free_threading/test_monitoring.py
@@ -7,6 +7,7 @@ import unittest
 import weakref
 
 from sys import monitoring
+from test import support
 from test.support import threading_helper
 from threading import Thread, _PyRLock
 from unittest import TestCase
@@ -43,6 +44,7 @@ class InstrumentationMultiThreadedMixin:
         """Runs once after the test is done"""
         pass
 
+    @support.requires_resource('cpu')
     def test_instrumentation(self):
         # Setup a bunch of functions which will need instrumentation...
         funcs = []
@@ -218,6 +220,7 @@ class MonitoringMisc(MonitoringTestMixin, TestCase):
         for ref in self.refs:
             self.assertEqual(ref(), None)
 
+    @support.requires_resource('cpu')
     def test_set_local_trace_opcodes(self):
         def trace(frame, event, arg):
             frame.f_trace_opcodes = True

--- a/Lib/test/test_free_threading/test_type.py
+++ b/Lib/test/test_free_threading/test_type.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from threading import Thread
 from unittest import TestCase
 
+from test import support
 from test.support import threading_helper, import_helper
 
 
@@ -96,6 +97,7 @@ class TestType(TestCase):
 
         self.run_one(writer_func, reader_func)
 
+    @support.requires_resource('cpu')
     def test___class___modification(self):
         class Foo:
             pass


### PR DESCRIPTION
Require the 'cpu' test resource on slow test_free_threading tests.

(cherry picked from commit 38a5beb12a64461a06b84fab285944ecb66de04c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124402 -->
* Issue: gh-124402
<!-- /gh-issue-number -->
