### PR TITLE
gh-119333: PyContext watchers notify get interp from tstate

### DIFF
--- a/Include/cpython/context.h
+++ b/Include/cpython/context.h
@@ -33,10 +33,10 @@ typedef enum {
 } PyContextEvent;
 
 /*
- * A Callback to clue in non-python contexts impls about a
- * change in the active python context.
+ * A Callback to signal non-python contexts impls when a context
+ * object undergoes a PyContext_Enter or PyContext_Exit
  *
- * The callback is invoked with the event and a reference to =
+ * The callback is invoked with the event and a reference to
  * the context after its entered and before its exited.
  *
  * if the callback returns with an exception set, it must return -1. Otherwise

--- a/Include/cpython/context.h
+++ b/Include/cpython/context.h
@@ -33,8 +33,7 @@ typedef enum {
 } PyContextEvent;
 
 /*
- * A Callback to signal non-python contexts impls when a context
- * object undergoes a PyContext_Enter or PyContext_Exit
+ * Callback to be invoked when a context object is entered or exited.
  *
  * The callback is invoked with the event and a reference to
  * the context after its entered and before its exited.

--- a/Python/context.c
+++ b/Python/context.c
@@ -115,7 +115,9 @@ context_event_name(PyContextEvent event) {
 static void notify_context_watchers(PyContextEvent event, PyContext *ctx)
 {
     assert(Py_REFCNT(ctx) > 0);
-    PyInterpreterState *interp = _PyInterpreterState_GET();
+    PyThreadState *ts = _PyThreadState_GET();
+    assert(ts != NULL);
+    PyInterpreterState *interp = ts->interp;
     assert(interp->_initialized);
     uint8_t bits = interp->active_context_watchers;
     int i = 0;

--- a/Python/context.c
+++ b/Python/context.c
@@ -112,11 +112,9 @@ context_event_name(PyContextEvent event) {
     Py_UNREACHABLE();
 }
 
-static void notify_context_watchers(PyContextEvent event, PyContext *ctx)
+static void notify_context_watchers(PyContextEvent event, PyContext *ctx, PyThreadState *ts)
 {
     assert(Py_REFCNT(ctx) > 0);
-    PyThreadState *ts = _PyThreadState_GET();
-    assert(ts != NULL);
     PyInterpreterState *interp = ts->interp;
     assert(interp->_initialized);
     uint8_t bits = interp->active_context_watchers;
@@ -194,7 +192,7 @@ _PyContext_Enter(PyThreadState *ts, PyObject *octx)
     ts->context = Py_NewRef(ctx);
     ts->context_ver++;
 
-    notify_context_watchers(Py_CONTEXT_EVENT_ENTER, ctx);
+    notify_context_watchers(Py_CONTEXT_EVENT_ENTER, ctx, ts);
     return 0;
 }
 
@@ -228,7 +226,7 @@ _PyContext_Exit(PyThreadState *ts, PyObject *octx)
         return -1;
     }
 
-    notify_context_watchers(Py_CONTEXT_EVENT_EXIT, ctx);
+    notify_context_watchers(Py_CONTEXT_EVENT_EXIT, ctx, ts);
     Py_SETREF(ts->context, (PyObject *)ctx->ctx_prev);
     ts->context_ver++;
 


### PR DESCRIPTION
This fixes a suggestion from #119335 that we should be getting the *interp from tstate instead.  
Also attempting to clean up comments as suggested. 


<!-- gh-issue-number: gh-119333 -->
* Issue: gh-119333
<!-- /gh-issue-number -->
