### PR TITLE
GH-118093: Fix off-by-one errors in tier-up thresholds

### DIFF
--- a/Include/internal/pycore_backoff.h
+++ b/Include/internal/pycore_backoff.h
@@ -108,7 +108,7 @@ backoff_counter_triggers(_Py_BackoffCounter counter)
 /* Initial JUMP_BACKWARD counter.
  * This determines when we create a trace for a loop.
 * Backoff sequence 16, 32, 64, 128, 256, 512, 1024, 2048, 4096. */
-#define JUMP_BACKWARD_INITIAL_VALUE 16
+#define JUMP_BACKWARD_INITIAL_VALUE 15
 #define JUMP_BACKWARD_INITIAL_BACKOFF 4
 static inline _Py_BackoffCounter
 initial_jump_backoff_counter(void)
@@ -122,7 +122,7 @@ initial_jump_backoff_counter(void)
  * otherwise when a side exit warms up we may construct
  * a new trace before the Tier 1 code has properly re-specialized.
  * Backoff sequence 64, 128, 256, 512, 1024, 2048, 4096. */
-#define SIDE_EXIT_INITIAL_VALUE 64
+#define SIDE_EXIT_INITIAL_VALUE 63
 #define SIDE_EXIT_INITIAL_BACKOFF 6
 
 static inline _Py_BackoffCounter


### PR DESCRIPTION
Instead of warming up loops at 16 hits and side-exits at 64 hits, we're currently warming them up at 17 hits and 65 hits, respectively. This is just a simple change to fix the thresholds.

No change in [stats](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240912-3.14.0a0-e099186-JIT/bm-20240912-azure-x86_64-brandtbucher-off_by_one-3.14.0a0-e099186-pystats-vs-base.md), [perf](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240912-3.14.0a0-e099186-JIT/bm-20240912-linux-x86_64-brandtbucher-off_by_one-3.14.0a0-e099186-vs-base.svg) is 0.7% faster and [memory](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240912-3.14.0a0-e099186-JIT/bm-20240912-linux-x86_64-brandtbucher-off_by_one-3.14.0a0-e099186-vs-base-mem.svg) is 0.5% lower, but that's *probably* just noise.

<!-- gh-issue-number: gh-118093 -->
* Issue: gh-118093
<!-- /gh-issue-number -->
