### PR TITLE
gh-119180: Rename parameter to __annotate__ functions

### DIFF
--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -557,7 +557,6 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_STR(defaults));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_STR(dot_locals));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_STR(empty));
-    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_STR(format));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_STR(generic_base));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_STR(json_decoder));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_STR(kwdefaults));

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -43,7 +43,6 @@ struct _Py_global_strings {
         STRUCT_FOR_STR(defaults, ".defaults")
         STRUCT_FOR_STR(dot_locals, ".<locals>")
         STRUCT_FOR_STR(empty, "")
-        STRUCT_FOR_STR(format, ".format")
         STRUCT_FOR_STR(generic_base, ".generic_base")
         STRUCT_FOR_STR(json_decoder, "json.decoder")
         STRUCT_FOR_STR(kwdefaults, ".kwdefaults")

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -552,7 +552,6 @@ extern "C" {
     INIT_STR(defaults, ".defaults"), \
     INIT_STR(dot_locals, ".<locals>"), \
     INIT_STR(empty, ""), \
-    INIT_STR(format, ".format"), \
     INIT_STR(generic_base, ".generic_base"), \
     INIT_STR(json_decoder, "json.decoder"), \
     INIT_STR(kwdefaults, ".kwdefaults"), \

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -2912,10 +2912,6 @@ _PyUnicode_InitStaticStrings(PyInterpreterState *interp) {
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));
     assert(PyUnicode_GET_LENGTH(string) != 1);
-    string = &_Py_STR(format);
-    _PyUnicode_InternStatic(interp, &string);
-    assert(_PyUnicode_CheckConsistency(string, 1));
-    assert(PyUnicode_GET_LENGTH(string) != 1);
     string = &_Py_STR(generic_base);
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));

--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -79,7 +79,7 @@ CLASSES
     class B(builtins.object)
      |  Methods defined here:
      |
-     |  __annotate__(...)
+     |  __annotate__(__format__, /)
      |
      |  ----------------------------------------------------------------------
      |  Data descriptors defined here:
@@ -180,7 +180,7 @@ class A(builtins.object)
 
 class B(builtins.object)
     Methods defined here:
-        __annotate__(...)
+        __annotate__(__format__, /)
     ----------------------------------------------------------------------
     Data descriptors defined here:
         __dict__

--- a/Lib/test/test_type_annotations.py
+++ b/Lib/test/test_type_annotations.py
@@ -271,7 +271,7 @@ class AnnotateTests(unittest.TestCase):
         def f(x: int): pass
         anno = f.__annotate__
         self.assertIsInstance(anno, types.FunctionType)
-        self.assertEqual(f.__name__, "__annotate__")
+        self.assertEqual(anno.__name__, "__annotate__")
 
         expected_sig = inspect.Signature(
             [inspect.Parameter("__format__", inspect.Parameter.POSITIONAL_ONLY)]

--- a/Lib/test/test_type_annotations.py
+++ b/Lib/test/test_type_annotations.py
@@ -1,4 +1,5 @@
 import annotationlib
+import inspect
 import textwrap
 import types
 import unittest
@@ -265,6 +266,17 @@ class AnnotateTests(unittest.TestCase):
         # Setting f.__annotations__ also clears __annotate__
         f.__annotations__ = {"z": 43}
         self.assertIs(f.__annotate__, None)
+
+    def test_annotate_function_signature(self):
+        def f(x: int): pass
+        anno = f.__annotate__
+        self.assertIsInstance(anno, types.FunctionType)
+        self.assertEqual(f.__name__, "__annotate__")
+
+        expected_sig = inspect.Signature(
+            [inspect.Parameter("__format__", inspect.Parameter.POSITIONAL_ONLY)]
+        )
+        self.assertEqual(inspect.signature(anno), expected_sig)
 
 
 class DeferredEvaluationTests(unittest.TestCase):

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -655,8 +655,7 @@ codegen_setup_annotations_scope(compiler *c, location loc,
         codegen_enter_scope(c, name, COMPILE_SCOPE_ANNOTATIONS,
                             key, loc.lineno, NULL, &umd));
 
-    // if .format != 1: raise NotImplementedError
-    _Py_DECLARE_STR(format, ".format");
+    // if __format__ != 1: raise NotImplementedError
     ADDOP_I(c, loc, LOAD_FAST, 0);
     ADDOP_LOAD_CONST(c, loc, _PyLong_GetOne());
     ADDOP_I(c, loc, COMPARE_OP, (Py_NE << 5) | compare_masks[Py_NE]);

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1427,12 +1427,11 @@ symtable_enter_block(struct symtable *st, identifier name, _Py_block_ty block,
     int result = symtable_enter_existing_block(st, ste);
     Py_DECREF(ste);
     if (block == AnnotationBlock || block == TypeVariableBlock || block == TypeAliasBlock) {
-        _Py_DECLARE_STR(format, ".format");
         // We need to insert code that reads this "parameter" to the function.
-        if (!symtable_add_def(st, &_Py_STR(format), DEF_PARAM, loc)) {
+        if (!symtable_add_def(st, &_Py_ID(__format__), DEF_PARAM, loc)) {
             return 0;
         }
-        if (!symtable_add_def(st, &_Py_STR(format), USE, loc)) {
+        if (!symtable_add_def(st, &_Py_ID(__format__), USE, loc)) {
             return 0;
         }
     }


### PR DESCRIPTION
Larry Hastings pointed out that using an illegal parameter name makes
it impossible to use inspect.signature() on annotate functions.

Cross-ref python/peps#3993.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119180 -->
* Issue: gh-119180
<!-- /gh-issue-number -->
