### PR TITLE
gh-116622: Make test_unzip_zipfile recognize Android error message format

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1910,7 +1910,7 @@ class TestArchives(BaseTest, unittest.TestCase):
             except subprocess.CalledProcessError as exc:
                 details = exc.output.decode(errors="replace")
                 if any(message in details for message in [
-                    'unrecognized option: t',  # Info-ZIP
+                    'unrecognized option: t',  # BusyBox
                     'invalid option -- t',  # Android
                 ]):
                     self.skipTest("unzip doesn't support -t")

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -13,6 +13,7 @@ import functools
 import pathlib
 import subprocess
 import random
+import re
 import string
 import contextlib
 import io
@@ -1909,7 +1910,7 @@ class TestArchives(BaseTest, unittest.TestCase):
                 subprocess.check_output(zip_cmd, stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as exc:
                 details = exc.output.decode(errors="replace")
-                if 'unrecognized option: t' in details:
+                if re.search(r'(unrecognized|invalid) option(:| --) t', details):
                     self.skipTest("unzip doesn't support -t")
                 msg = "{}\n\n**Unzip Output**\n{}"
                 self.fail(msg.format(exc, details))

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -13,7 +13,6 @@ import functools
 import pathlib
 import subprocess
 import random
-import re
 import string
 import contextlib
 import io
@@ -1910,7 +1909,10 @@ class TestArchives(BaseTest, unittest.TestCase):
                 subprocess.check_output(zip_cmd, stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as exc:
                 details = exc.output.decode(errors="replace")
-                if re.search(r'(unrecognized|invalid) option(:| --) t', details):
+                if any(message in details for message in [
+                    'unrecognized option: t',  # Info-ZIP
+                    'invalid option -- t',  # Android
+                ]):
                     self.skipTest("unzip doesn't support -t")
                 msg = "{}\n\n**Unzip Output**\n{}"
                 self.fail(msg.format(exc, details))


### PR DESCRIPTION
The test expects the format `unrecognized option: t`, but the Android message is `invalid option -- t`.

This only failed in a fairly narrow range of Android versions including API level 30. Older versions didn't include an unzip command at all, and newer versions included a version that supports the `-t` option.

<!-- gh-issue-number: gh-116622 -->
* Issue: gh-116622
<!-- /gh-issue-number -->
