### PR TITLE
dataclasses: Avoid using private class

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -690,11 +690,8 @@ def _frozen_get_del_attr(cls, fields, func_builder):
 
 
 def _is_classvar(a_type, typing):
-    # This test uses a typing internal class, but it's the best way to
-    # test if this is a ClassVar.
     return (a_type is typing.ClassVar
-            or (type(a_type) is typing._GenericAlias
-                and a_type.__origin__ is typing.ClassVar))
+            or (typing.get_origin(a_type) is typing.ClassVar))
 
 
 def _is_initvar(a_type, dataclasses):


### PR DESCRIPTION
typing.get_origin() does what we need here, without reaching into
typing internals. This shouldn't change any behavior (so I am going
to skip news), but it sets a good example for other users introspecting
typing objects.

