### PR TITLE
gh-123017: Add Android to the list of platforms where `strftime` doesn't support negative years

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -654,8 +654,7 @@ class _TestStrftimeYear:
             self.test_year('%04d', func=year4d)
 
     def skip_if_not_supported(y):
-        msg = "strftime() is limited to [1; 9999] with Visual Studio"
-        # Check that it doesn't crash for year > 9999
+        msg = f"strftime() does not support year {y} on this platform"
         try:
             time.strftime('%Y', (y,) + (0,) * 8)
         except ValueError:

--- a/Misc/NEWS.d/next/Library/2024-09-24-21-15-27.gh-issue-123017.dSAr2f.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-24-21-15-27.gh-issue-123017.dSAr2f.rst
@@ -1,0 +1,2 @@
+Due to unreliable results on some devices, :func:`time.strftime` no longer
+accepts negative years on Android.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -813,7 +813,12 @@ time_strftime(PyObject *module, PyObject *args)
         return NULL;
     }
 
-#if defined(_MSC_VER) || (defined(__sun) && defined(__SVR4)) || defined(_AIX) || defined(__VXWORKS__)
+// Some platforms only support a limited range of years.
+//
+// Android works with negative years on the emulator, but fails on some
+// physical devices (#123017).
+#if defined(_MSC_VER) || (defined(__sun) && defined(__SVR4)) || defined(_AIX) \
+    || defined(__VXWORKS__) || defined(__ANDROID__)
     if (buf.tm_year + 1900 < 1 || 9999 < buf.tm_year + 1900) {
         PyErr_SetString(PyExc_ValueError,
                         "strftime() requires year in [1; 9999]");


### PR DESCRIPTION

<!-- gh-issue-number: gh-123017 -->
* Fixes gh-123017
<!-- /gh-issue-number -->
