### PR TITLE
gh-101100: Add a table of class attributes to the "Custom classes" section of the data model docs

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -733,7 +733,7 @@ Exception Classes
    This creates a class object derived from :exc:`Exception` (accessible in C as
    :c:data:`PyExc_Exception`).
 
-   The :attr:`~class.__module__` attribute of the new class is set to the first part (up
+   The :attr:`~type.__module__` attribute of the new class is set to the first part (up
    to the last dot) of the *name* argument, and the class name is set to the last
    part (after the last dot).  The *base* argument can be used to specify alternate
    base classes; it can either be only one class or a tuple of classes. The *dict*

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -733,7 +733,7 @@ Exception Classes
    This creates a class object derived from :exc:`Exception` (accessible in C as
    :c:data:`PyExc_Exception`).
 
-   The :attr:`!__module__` attribute of the new class is set to the first part (up
+   The :attr:`~class.__module__` attribute of the new class is set to the first part (up
    to the last dot) of the *name* argument, and the class name is set to the last
    part (after the last dot).  The *base* argument can be used to specify alternate
    base classes; it can either be only one class or a tuple of classes. The *dict*

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -370,7 +370,7 @@ Object Protocol
    If *cls* has a :meth:`~class.__subclasscheck__` method, it will be called to
    determine the subclass status as described in :pep:`3119`.  Otherwise,
    *derived* is a subclass of *cls* if it is a direct or indirect subclass,
-   i.e. contained in ``cls.__mro__``.
+   i.e. contained in :attr:`cls.__mro__ <class.__mro__>`.
 
    Normally only class objects, i.e. instances of :class:`type` or a derived
    class, are considered classes.  However, objects can override this by having

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -367,14 +367,14 @@ Object Protocol
    The result will be ``1`` when at least one of the checks returns ``1``,
    otherwise it will be ``0``.
 
-   If *cls* has a :meth:`~class.__subclasscheck__` method, it will be called to
+   If *cls* has a :meth:`~type.__subclasscheck__` method, it will be called to
    determine the subclass status as described in :pep:`3119`.  Otherwise,
    *derived* is a subclass of *cls* if it is a direct or indirect subclass,
-   i.e. contained in :attr:`cls.__mro__ <class.__mro__>`.
+   i.e. contained in :attr:`cls.__mro__ <type.__mro__>`.
 
    Normally only class objects, i.e. instances of :class:`type` or a derived
    class, are considered classes.  However, objects can override this by having
-   a :attr:`~class.__bases__` attribute (which must be a tuple of base classes).
+   a :attr:`~type.__bases__` attribute (which must be a tuple of base classes).
 
 
 .. c:function:: int PyObject_IsInstance(PyObject *inst, PyObject *cls)
@@ -386,7 +386,7 @@ Object Protocol
    The result will be ``1`` when at least one of the checks returns ``1``,
    otherwise it will be ``0``.
 
-   If *cls* has a :meth:`~class.__instancecheck__` method, it will be called to
+   If *cls* has a :meth:`~type.__instancecheck__` method, it will be called to
    determine the subclass status as described in :pep:`3119`.  Otherwise, *inst*
    is an instance of *cls* if its class is a subclass of *cls*.
 
@@ -394,7 +394,7 @@ Object Protocol
    :attr:`~object.__class__` attribute.
 
    An object *cls* can override if it is considered a class, and what its base
-   classes are, by having a :attr:`~class.__bases__` attribute (which must be a tuple
+   classes are, by having a :attr:`~type.__bases__` attribute (which must be a tuple
    of base classes).
 
 

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -391,7 +391,7 @@ Object Protocol
    is an instance of *cls* if its class is a subclass of *cls*.
 
    An instance *inst* can override what is considered its class by having a
-   :attr:`~instance.__class__` attribute.
+   :attr:`~object.__class__` attribute.
 
    An object *cls* can override if it is considered a class, and what its base
    classes are, by having a :attr:`~class.__bases__` attribute (which must be a tuple

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -53,7 +53,8 @@ Type Objects
 .. c:function:: PyObject* PyType_GetDict(PyTypeObject* type)
 
    Return the type object's internal namespace, which is otherwise only
-   exposed via a read-only proxy (``cls.__dict__``).  This is a
+   exposed via a read-only proxy (:attr:`cls.__dict__ <class.__dict__>`).
+   This is a
    replacement for accessing :c:member:`~PyTypeObject.tp_dict` directly.
    The returned dictionary must be treated as read-only.
 
@@ -174,29 +175,32 @@ Type Objects
 
 .. c:function:: PyObject* PyType_GetName(PyTypeObject *type)
 
-   Return the type's name. Equivalent to getting the type's ``__name__`` attribute.
+   Return the type's name. Equivalent to getting the type's
+   :attr:`~class.__name__` attribute.
 
    .. versionadded:: 3.11
 
 .. c:function:: PyObject* PyType_GetQualName(PyTypeObject *type)
 
    Return the type's qualified name. Equivalent to getting the
-   type's ``__qualname__`` attribute.
+   type's :attr:`~class.__qualname__` attribute.
 
    .. versionadded:: 3.11
 
 .. c:function:: PyObject* PyType_GetFullyQualifiedName(PyTypeObject *type)
 
    Return the type's fully qualified name. Equivalent to
-   ``f"{type.__module__}.{type.__qualname__}"``, or ``type.__qualname__`` if
-   ``type.__module__`` is not a string or is equal to ``"builtins"``.
+   ``f"{type.__module__}.{type.__qualname__}"``, or
+   :attr:`type.__qualname__ <class.__qualname__>` if
+   :attr:`type.__module__ <class.__module__>` is not a string or is equal to
+   ``"builtins"``.
 
    .. versionadded:: 3.13
 
 .. c:function:: PyObject* PyType_GetModuleName(PyTypeObject *type)
 
-   Return the type's module name. Equivalent to getting the ``type.__module__``
-   attribute.
+   Return the type's module name. Equivalent to getting the
+   :attr:`type.__module__ <class.__module__>` attribute.
 
    .. versionadded:: 3.13
 

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -53,7 +53,7 @@ Type Objects
 .. c:function:: PyObject* PyType_GetDict(PyTypeObject* type)
 
    Return the type object's internal namespace, which is otherwise only
-   exposed via a read-only proxy (:attr:`cls.__dict__ <class.__dict__>`).
+   exposed via a read-only proxy (:attr:`cls.__dict__ <type.__dict__>`).
    This is a
    replacement for accessing :c:member:`~PyTypeObject.tp_dict` directly.
    The returned dictionary must be treated as read-only.
@@ -141,7 +141,7 @@ Type Objects
    Return true if *a* is a subtype of *b*.
 
    This function only checks for actual subtypes, which means that
-   :meth:`~class.__subclasscheck__` is not called on *b*.  Call
+   :meth:`~type.__subclasscheck__` is not called on *b*.  Call
    :c:func:`PyObject_IsSubclass` to do the same check that :func:`issubclass`
    would do.
 
@@ -176,31 +176,29 @@ Type Objects
 .. c:function:: PyObject* PyType_GetName(PyTypeObject *type)
 
    Return the type's name. Equivalent to getting the type's
-   :attr:`~class.__name__` attribute.
+   :attr:`~type.__name__` attribute.
 
    .. versionadded:: 3.11
 
 .. c:function:: PyObject* PyType_GetQualName(PyTypeObject *type)
 
    Return the type's qualified name. Equivalent to getting the
-   type's :attr:`~class.__qualname__` attribute.
+   type's :attr:`~type.__qualname__` attribute.
 
    .. versionadded:: 3.11
 
 .. c:function:: PyObject* PyType_GetFullyQualifiedName(PyTypeObject *type)
 
    Return the type's fully qualified name. Equivalent to
-   ``f"{type.__module__}.{type.__qualname__}"``, or
-   :attr:`type.__qualname__ <class.__qualname__>` if
-   :attr:`type.__module__ <class.__module__>` is not a string or is equal to
-   ``"builtins"``.
+   ``f"{type.__module__}.{type.__qualname__}"``, or :attr:`type.__qualname__`
+   if :attr:`type.__module__` is not a string or is equal to ``"builtins"``.
 
    .. versionadded:: 3.13
 
 .. c:function:: PyObject* PyType_GetModuleName(PyTypeObject *type)
 
    Return the type's module name. Equivalent to getting the
-   :attr:`type.__module__ <class.__module__>` attribute.
+   :attr:`type.__module__` attribute.
 
    .. versionadded:: 3.13
 

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -567,12 +567,12 @@ and :c:data:`PyType_Type` effectively act as defaults.)
 
    For :ref:`statically allocated type objects <static-types>`,
    the *tp_name* field should contain a dot.
-   Everything before the last dot is made accessible as the :attr:`__module__`
+   Everything before the last dot is made accessible as the :attr:`~class.__module__`
    attribute, and everything after the last dot is made accessible as the
-   :attr:`~definition.__name__` attribute.
+   :attr:`~class.__name__` attribute.
 
    If no dot is present, the entire :c:member:`~PyTypeObject.tp_name` field is made accessible as the
-   :attr:`~definition.__name__` attribute, and the :attr:`__module__` attribute is undefined
+   :attr:`~class.__name__` attribute, and the :attr:`~class.__module__` attribute is undefined
    (unless explicitly set in the dictionary, as explained above).  This means your
    type will be impossible to pickle.  Additionally, it will not be listed in
    module documentations created with pydoc.
@@ -1131,7 +1131,7 @@ and :c:data:`PyType_Type` effectively act as defaults.)
 
    .. c:macro:: Py_TPFLAGS_MANAGED_DICT
 
-      This bit indicates that instances of the class have a ``__dict__``
+      This bit indicates that instances of the class have a `~object.__dict__`
       attribute, and that the space for the dictionary is managed by the VM.
 
       If this flag is set, :c:macro:`Py_TPFLAGS_HAVE_GC` should also be set.
@@ -1335,8 +1335,8 @@ and :c:data:`PyType_Type` effectively act as defaults.)
 .. c:member:: const char* PyTypeObject.tp_doc
 
    An optional pointer to a NUL-terminated C string giving the docstring for this
-   type object.  This is exposed as the :attr:`__doc__` attribute on the type and
-   instances of the type.
+   type object.  This is exposed as the :attr:`~class.__doc__` attribute on the
+   type and instances of the type.
 
    **Inheritance:**
 

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -572,7 +572,7 @@ and :c:data:`PyType_Type` effectively act as defaults.)
    :attr:`~type.__name__` attribute.
 
    If no dot is present, the entire :c:member:`~PyTypeObject.tp_name` field is made accessible as the
-   :attr:`~type.__name__` attribute, and the :attr:`~class.__module__` attribute is undefined
+   :attr:`~type.__name__` attribute, and the :attr:`~type.__module__` attribute is undefined
    (unless explicitly set in the dictionary, as explained above).  This means your
    type will be impossible to pickle.  Additionally, it will not be listed in
    module documentations created with pydoc.

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -567,12 +567,12 @@ and :c:data:`PyType_Type` effectively act as defaults.)
 
    For :ref:`statically allocated type objects <static-types>`,
    the *tp_name* field should contain a dot.
-   Everything before the last dot is made accessible as the :attr:`~class.__module__`
+   Everything before the last dot is made accessible as the :attr:`~type.__module__`
    attribute, and everything after the last dot is made accessible as the
-   :attr:`~class.__name__` attribute.
+   :attr:`~type.__name__` attribute.
 
    If no dot is present, the entire :c:member:`~PyTypeObject.tp_name` field is made accessible as the
-   :attr:`~class.__name__` attribute, and the :attr:`~class.__module__` attribute is undefined
+   :attr:`~type.__name__` attribute, and the :attr:`~class.__module__` attribute is undefined
    (unless explicitly set in the dictionary, as explained above).  This means your
    type will be impossible to pickle.  Additionally, it will not be listed in
    module documentations created with pydoc.
@@ -1335,7 +1335,7 @@ and :c:data:`PyType_Type` effectively act as defaults.)
 .. c:member:: const char* PyTypeObject.tp_doc
 
    An optional pointer to a NUL-terminated C string giving the docstring for this
-   type object.  This is exposed as the :attr:`~class.__doc__` attribute on the
+   type object.  This is exposed as the :attr:`~type.__doc__` attribute on the
    type and instances of the type.
 
    **Inheritance:**
@@ -2036,7 +2036,7 @@ and :c:data:`PyType_Type` effectively act as defaults.)
    A collection of subclasses.  Internal use only.  May be an invalid pointer.
 
    To get a list of subclasses, call the Python method
-   :py:meth:`~class.__subclasses__`.
+   :py:meth:`~type.__subclasses__`.
 
    .. versionchanged:: 3.12
 

--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -296,7 +296,7 @@ An interesting advantage of using the :c:member:`~PyTypeObject.tp_members` table
 descriptors that are used at runtime is that any attribute defined this way can
 have an associated doc string simply by providing the text in the table.  An
 application can use the introspection API to retrieve the descriptor from the
-class object, and get the doc string using its :attr:`!__doc__` attribute.
+class object, and get the doc string using its :attr:`~class.__doc__` attribute.
 
 As with the :c:member:`~PyTypeObject.tp_methods` table, a sentinel entry with a :c:member:`~PyMethodDef.ml_name` value
 of ``NULL`` is required.

--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -296,7 +296,7 @@ An interesting advantage of using the :c:member:`~PyTypeObject.tp_members` table
 descriptors that are used at runtime is that any attribute defined this way can
 have an associated doc string simply by providing the text in the table.  An
 application can use the introspection API to retrieve the descriptor from the
-class object, and get the doc string using its :attr:`~class.__doc__` attribute.
+class object, and get the doc string using its :attr:`~type.__doc__` attribute.
 
 As with the :c:member:`~PyTypeObject.tp_methods` table, a sentinel entry with a :c:member:`~PyMethodDef.ml_name` value
 of ``NULL`` is required.

--- a/Doc/extending/newtypes_tutorial.rst
+++ b/Doc/extending/newtypes_tutorial.rst
@@ -144,7 +144,7 @@ only used for variable-sized objects and should otherwise be zero.
    If you want your type to be subclassable from Python, and your type has the same
    :c:member:`~PyTypeObject.tp_basicsize` as its base type, you may have problems with multiple
    inheritance.  A Python subclass of your type will have to list your type first
-   in its :attr:`~class.__bases__`, or else it will not be able to call your type's
+   in its :attr:`~type.__bases__`, or else it will not be able to call your type's
    :meth:`~object.__new__` method without getting an error.  You can avoid this problem by
    ensuring that your type has a larger value for :c:member:`~PyTypeObject.tp_basicsize` than its
    base type does.  Most of the time, this will be true anyway, because either your

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1614,7 +1614,7 @@ method too, and it must do so carefully.  The basic implementation of
        ...
 
 Most :meth:`!__setattr__` implementations must modify
-:meth:`self.__dict__ <object.__dict__>` to store
+:attr:`self.__dict__ <object.__dict__>` to store
 local state for self without causing an infinite recursion.
 
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -347,7 +347,7 @@ Glossary
    docstring
       A string literal which appears as the first expression in a class,
       function or module.  While ignored when the suite is executed, it is
-      recognized by the compiler and put into the :attr:`!__doc__` attribute
+      recognized by the compiler and put into the :attr:`~definition.__doc__` attribute
       of the enclosing class, function or module.  Since it is available via
       introspection, it is the canonical place for documentation of the
       object.

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1241,7 +1241,7 @@ Glossary
    type
       The type of a Python object determines what kind of object it is; every
       object has a type.  An object's type is accessible as its
-      :attr:`~instance.__class__` attribute or can be retrieved with
+      :attr:`~object.__class__` attribute or can be retrieved with
       ``type(obj)``.
 
    type alias

--- a/Doc/howto/annotations.rst
+++ b/Doc/howto/annotations.rst
@@ -107,7 +107,7 @@ Your code will have to have a separate code path if the object
 you're examining is a class (``isinstance(o, type)``).
 In that case, best practice relies on an implementation detail
 of Python 3.9 and before: if a class has annotations defined,
-they are stored in the class's :attr:`~class.__dict__` dictionary.  Since
+they are stored in the class's :attr:`~type.__dict__` dictionary.  Since
 the class may or may not have annotations defined, best practice
 is to call the :meth:`~dict.get` method on the class dict.
 
@@ -126,7 +126,7 @@ the type of ``ann`` using :func:`isinstance` before further
 examination.
 
 Note that some exotic or malformed type objects may not have
-a :attr:`~class.__dict__` attribute, so for extra safety you may also wish
+a :attr:`~type.__dict__` attribute, so for extra safety you may also wish
 to use :func:`getattr` to access :attr:`!__dict__`.
 
 
@@ -247,5 +247,5 @@ on the class, you may observe unexpected behavior; see
 quirks by using :func:`annotationlib.get_annotations` on Python 3.14+ or
 :func:`inspect.get_annotations` on Python 3.10+. On earlier versions of
 Python, you can avoid these bugs by accessing the annotations from the
-class's :attr:`~class.__dict__`
+class's :attr:`~type.__dict__`
 (e.g., ``cls.__dict__.get('__annotations__', None)``).

--- a/Doc/howto/annotations.rst
+++ b/Doc/howto/annotations.rst
@@ -107,9 +107,9 @@ Your code will have to have a separate code path if the object
 you're examining is a class (``isinstance(o, type)``).
 In that case, best practice relies on an implementation detail
 of Python 3.9 and before: if a class has annotations defined,
-they are stored in the class's ``__dict__`` dictionary.  Since
+they are stored in the class's :attr:`~class.__dict__` dictionary.  Since
 the class may or may not have annotations defined, best practice
-is to call the ``get`` method on the class dict.
+is to call the :meth:`~dict.get` method on the class dict.
 
 To put it all together, here is some sample code that safely
 accesses the ``__annotations__`` attribute on an arbitrary
@@ -126,8 +126,8 @@ the type of ``ann`` using :func:`isinstance` before further
 examination.
 
 Note that some exotic or malformed type objects may not have
-a ``__dict__`` attribute, so for extra safety you may also wish
-to use :func:`getattr` to access ``__dict__``.
+a :attr:`~class.__dict__` attribute, so for extra safety you may also wish
+to use :func:`getattr` to access :attr:`!__dict__`.
 
 
 Manually Un-Stringizing Stringized Annotations
@@ -247,4 +247,5 @@ on the class, you may observe unexpected behavior; see
 quirks by using :func:`annotationlib.get_annotations` on Python 3.14+ or
 :func:`inspect.get_annotations` on Python 3.10+. On earlier versions of
 Python, you can avoid these bugs by accessing the annotations from the
-class's ``__dict__`` (e.g., ``cls.__dict__.get('__annotations__', None)``).
+class's :attr:`~class.__dict__`
+(e.g., ``cls.__dict__.get('__annotations__', None)``).

--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -562,8 +562,8 @@ attribute access.
 
 The expression ``obj.x`` looks up the attribute ``x`` in the chain of
 namespaces for ``obj``.  If the search finds a descriptor outside of the
-instance ``__dict__``, its :meth:`__get__` method is invoked according to the
-precedence rules listed below.
+instance :attr:`~object.__dict__`, its :meth:`~object.__get__` method is
+invoked according to the precedence rules listed below.
 
 The details of invocation depend on whether ``obj`` is an object, class, or
 instance of super.

--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -608,7 +608,7 @@ The solution is to specify the module name explicitly as follows::
     the source, pickling will be disabled.
 
 The new pickle protocol 4 also, in some circumstances, relies on
-:attr:`~class.__qualname__` being set to the location where pickle will be able
+:attr:`~type.__qualname__` being set to the location where pickle will be able
 to find the class.  For example, if the class was made available in class
 SomeData in the global scope::
 

--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -608,7 +608,7 @@ The solution is to specify the module name explicitly as follows::
     the source, pickling will be disabled.
 
 The new pickle protocol 4 also, in some circumstances, relies on
-:attr:`~definition.__qualname__` being set to the location where pickle will be able
+:attr:`~class.__qualname__` being set to the location where pickle will be able
 to find the class.  For example, if the class was made available in class
 SomeData in the global scope::
 

--- a/Doc/howto/mro.rst
+++ b/Doc/howto/mro.rst
@@ -335,7 +335,7 @@ E is more specialized than C, even if it is in a higher level.
 
 A lazy programmer can obtain the MRO directly from Python 2.2, since in
 this case it coincides with the Python 2.3 linearization.  It is enough
-to invoke the :meth:`~class.mro` method of class A:
+to invoke the :meth:`~type.mro` method of class A:
 
   >>> A.mro()  # doctest: +NORMALIZE_WHITESPACE
   [<class 'A'>, <class 'B'>, <class 'E'>,

--- a/Doc/howto/mro.rst
+++ b/Doc/howto/mro.rst
@@ -335,7 +335,7 @@ E is more specialized than C, even if it is in a higher level.
 
 A lazy programmer can obtain the MRO directly from Python 2.2, since in
 this case it coincides with the Python 2.3 linearization.  It is enough
-to invoke the .mro() method of class A:
+to invoke the :meth:`~class.mro` method of class A:
 
   >>> A.mro()  # doctest: +NORMALIZE_WHITESPACE
   [<class 'A'>, <class 'B'>, <class 'E'>,

--- a/Doc/library/abc.rst
+++ b/Doc/library/abc.rst
@@ -99,7 +99,7 @@ a helper class :class:`ABC` to alternatively define ABCs through inheritance:
       that you can customize the behavior of :func:`issubclass` further without the
       need to call :meth:`register` on every class you want to consider a
       subclass of the ABC.  (This class method is called from the
-      :meth:`~class.__subclasscheck__` method of the ABC.)
+      :meth:`~type.__subclasscheck__` method of the ABC.)
 
       This method should return ``True``, ``False`` or :data:`NotImplemented`.  If
       it returns ``True``, the *subclass* is considered a subclass of this ABC.
@@ -149,7 +149,7 @@ a helper class :class:`ABC` to alternatively define ABCs through inheritance:
    The :meth:`__subclasshook__` class method defined here says that any class
    that has an :meth:`~iterator.__iter__` method in its
    :attr:`~object.__dict__` (or in that of one of its base classes, accessed
-   via the :attr:`~class.__mro__` list) is considered a ``MyIterable`` too.
+   via the :attr:`~type.__mro__` list) is considered a ``MyIterable`` too.
 
    Finally, the last line makes ``Foo`` a virtual subclass of ``MyIterable``,
    even though it does not define an :meth:`~iterator.__iter__` method (it uses

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -874,7 +874,7 @@ they add the ability to access fields by name instead of position index.
     ``(1, 2)``, then ``x`` will be a required argument, ``y`` will default to
     ``1``, and ``z`` will default to ``2``.
 
-    If *module* is defined, the :attr:`~class.__module__` attribute of the
+    If *module* is defined, the :attr:`~type.__module__` attribute of the
     named tuple is set to that value.
 
     Named tuple instances do not have per-instance dictionaries, so they are

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -874,8 +874,8 @@ they add the ability to access fields by name instead of position index.
     ``(1, 2)``, then ``x`` will be a required argument, ``y`` will default to
     ``1``, and ``z`` will default to ``2``.
 
-    If *module* is defined, the ``__module__`` attribute of the named tuple is
-    set to that value.
+    If *module* is defined, the :attr:`~class.__module__` attribute of the
+    named tuple is set to that value.
 
     Named tuple instances do not have per-instance dictionaries, so they are
     lightweight and require no more memory than regular tuples.

--- a/Doc/library/email.contentmanager.rst
+++ b/Doc/library/email.contentmanager.rst
@@ -58,11 +58,11 @@
       * the type itself (``typ``)
       * the type's fully qualified name (``typ.__module__ + '.' +
         typ.__qualname__``).
-      * the type's :attr:`qualname <class.__qualname__>` (``typ.__qualname__``)
-      * the type's :attr:`name <class.__name__>` (``typ.__name__``).
+      * the type's :attr:`qualname <type.__qualname__>` (``typ.__qualname__``)
+      * the type's :attr:`name <type.__name__>` (``typ.__name__``).
 
       If none of the above match, repeat all of the checks above for each of
-      the types in the :term:`MRO` (:attr:`typ.__mro__ <class.__mro__>`).
+      the types in the :term:`MRO` (:attr:`typ.__mro__ <type.__mro__>`).
       Finally, if no other key
       yields a handler, check for a handler for the key ``None``.  If there is
       no handler for ``None``, raise a :exc:`KeyError` for the fully

--- a/Doc/library/email.contentmanager.rst
+++ b/Doc/library/email.contentmanager.rst
@@ -58,11 +58,12 @@
       * the type itself (``typ``)
       * the type's fully qualified name (``typ.__module__ + '.' +
         typ.__qualname__``).
-      * the type's qualname (``typ.__qualname__``)
-      * the type's name (``typ.__name__``).
+      * the type's :attr:`qualname <class.__qualname__>` (``typ.__qualname__``)
+      * the type's :attr:`name <class.__name__>` (``typ.__name__``).
 
       If none of the above match, repeat all of the checks above for each of
-      the types in the :term:`MRO` (``typ.__mro__``).  Finally, if no other key
+      the types in the :term:`MRO` (:attr:`typ.__mro__ <class.__mro__>`).
+      Finally, if no other key
       yields a handler, check for a handler for the key ``None``.  If there is
       no handler for ``None``, raise a :exc:`KeyError` for the fully
       qualified name of the type.

--- a/Doc/library/email.headerregistry.rst
+++ b/Doc/library/email.headerregistry.rst
@@ -317,7 +317,7 @@ variant, :attr:`~.BaseHeader.max_count` is set to 1.
     class.  When *use_default_map* is ``True`` (the default), the standard
     mapping of header names to classes is copied in to the registry during
     initialization.  *base_class* is always the last class in the generated
-    class's :class:`~class.__bases__` list.
+    class's :class:`~type.__bases__` list.
 
     The default mappings are:
 

--- a/Doc/library/email.headerregistry.rst
+++ b/Doc/library/email.headerregistry.rst
@@ -317,7 +317,7 @@ variant, :attr:`~.BaseHeader.max_count` is set to 1.
     class.  When *use_default_map* is ``True`` (the default), the standard
     mapping of header names to classes is copied in to the registry during
     initialization.  *base_class* is always the last class in the generated
-    class's ``__bases__`` list.
+    class's :class:`~class.__bases__` list.
 
     The default mappings are:
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1965,11 +1965,11 @@ are always available.  They are listed here in alphabetical order.
    to be searched.  The search starts from the class right after the
    *type*.
 
-   For example, if :attr:`~class.__mro__` of *object_or_type* is
+   For example, if :attr:`~type.__mro__` of *object_or_type* is
    ``D -> B -> C -> A -> object`` and the value of *type* is ``B``,
    then :func:`super` searches ``C -> A -> object``.
 
-   The :attr:`~class.__mro__` attribute of the class corresponding to
+   The :attr:`~type.__mro__` attribute of the class corresponding to
    *object_or_type* lists the method resolution search order used by both
    :func:`getattr` and :func:`super`.  The attribute is dynamic and can change
    whenever the inheritance hierarchy is updated.
@@ -2055,20 +2055,22 @@ are always available.  They are listed here in alphabetical order.
 
    With three arguments, return a new type object.  This is essentially a
    dynamic form of the :keyword:`class` statement. The *name* string is
-   the class name and becomes the :attr:`~class.__name__` attribute.
+   the class name and becomes the :attr:`~type.__name__` attribute.
    The *bases* tuple contains the base classes and becomes the
-   :attr:`~class.__bases__` attribute; if empty, :class:`object`, the
+   :attr:`~type.__bases__` attribute; if empty, :class:`object`, the
    ultimate base of all classes, is added.  The *dict* dictionary contains
    attribute and method definitions for the class body; it may be copied
-   or wrapped before becoming the :attr:`~class.__dict__` attribute.
-   The following two statements create identical :class:`type` objects:
+   or wrapped before becoming the :attr:`~type.__dict__` attribute.
+   The following two statements create identical :class:`!type` objects:
 
       >>> class X:
       ...     a = 1
       ...
       >>> X = type('X', (), dict(a=1))
 
-   See also :ref:`bltin-type-objects`.
+   See also:
+   * :ref:`Documentation on attributes and methods on classes <class-attrs-and-methods>`.
+   * :ref:`bltin-type-objects`
 
    Keyword arguments provided to the three argument form are passed to the
    appropriate metaclass machinery (usually :meth:`~object.__init_subclass__`)
@@ -2078,7 +2080,7 @@ are always available.  They are listed here in alphabetical order.
    See also :ref:`class-customization`.
 
    .. versionchanged:: 3.6
-      Subclasses of :class:`type` which don't override ``type.__new__`` may no
+      Subclasses of :class:`!type` which don't override ``type.__new__`` may no
       longer use the one-argument form to get the type of an object.
 
 .. function:: vars()

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -2069,6 +2069,7 @@ are always available.  They are listed here in alphabetical order.
       >>> X = type('X', (), dict(a=1))
 
    See also:
+
    * :ref:`Documentation on attributes and methods on classes <class-attrs-and-methods>`.
    * :ref:`bltin-type-objects`
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -283,9 +283,11 @@ are always available.  They are listed here in alphabetical order.
       :func:`property`.
 
    .. versionchanged:: 3.10
-      Class methods now inherit the method attributes (``__module__``,
-      ``__name__``, ``__qualname__``, ``__doc__`` and ``__annotations__``) and
-      have a new ``__wrapped__`` attribute.
+      Class methods now inherit the method attributes
+      (:attr:`~function.__module__`, :attr:`~function.__name__`,
+      :attr:`~function.__qualname__`, :attr:`~function.__doc__` and
+      :attr:`~function.__annotations__`) and have a new ``__wrapped__``
+      attribute.
 
    .. deprecated-removed:: 3.11 3.13
       Class methods can no longer wrap other :term:`descriptors <descriptor>` such as
@@ -1286,8 +1288,9 @@ are always available.  They are listed here in alphabetical order.
 
    .. note::
 
-      :class:`object` does *not* have a :attr:`~object.__dict__`, so you can't
-      assign arbitrary attributes to an instance of the :class:`object` class.
+      :class:`object` instances do *not* have :attr:`~object.__dict__`
+      attributes, so you can't assign arbitrary attributes to an instance of
+      :class:`object`.
 
 
 .. function:: oct(x)
@@ -1907,10 +1910,11 @@ are always available.  They are listed here in alphabetical order.
    For more information on static methods, see :ref:`types`.
 
    .. versionchanged:: 3.10
-      Static methods now inherit the method attributes (``__module__``,
-      ``__name__``, ``__qualname__``, ``__doc__`` and ``__annotations__``),
-      have a new ``__wrapped__`` attribute, and are now callable as regular
-      functions.
+      Static methods now inherit the method attributes
+      (:attr:`~function.__module__`, :attr:`~function.__name__`,
+      :attr:`~function.__qualname__`, :attr:`~function.__doc__` and
+      :attr:`~function.__annotations__`), have a new ``__wrapped__`` attribute,
+      and are now callable as regular functions.
 
 
 .. index::
@@ -2049,15 +2053,14 @@ are always available.  They are listed here in alphabetical order.
    The :func:`isinstance` built-in function is recommended for testing the type
    of an object, because it takes subclasses into account.
 
-
    With three arguments, return a new type object.  This is essentially a
    dynamic form of the :keyword:`class` statement. The *name* string is
-   the class name and becomes the :attr:`~definition.__name__` attribute.
+   the class name and becomes the :attr:`~class.__name__` attribute.
    The *bases* tuple contains the base classes and becomes the
    :attr:`~class.__bases__` attribute; if empty, :class:`object`, the
    ultimate base of all classes, is added.  The *dict* dictionary contains
    attribute and method definitions for the class body; it may be copied
-   or wrapped before becoming the :attr:`~object.__dict__` attribute.
+   or wrapped before becoming the :attr:`~class.__dict__` attribute.
    The following two statements create identical :class:`type` objects:
 
       >>> class X:
@@ -2082,11 +2085,11 @@ are always available.  They are listed here in alphabetical order.
               vars(object)
 
    Return the :attr:`~object.__dict__` attribute for a module, class, instance,
-   or any other object with a :attr:`~object.__dict__` attribute.
+   or any other object with a :attr:`!__dict__` attribute.
 
    Objects such as modules and instances have an updateable :attr:`~object.__dict__`
    attribute; however, other objects may have write restrictions on their
-   :attr:`~object.__dict__` attributes (for example, classes use a
+   :attr:`!__dict__` attributes (for example, classes use a
    :class:`types.MappingProxyType` to prevent direct dictionary updates).
 
    Without an argument, :func:`vars` acts like :func:`locals`.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -2048,7 +2048,7 @@ are always available.  They are listed here in alphabetical order.
 
    With one argument, return the type of an *object*.  The return value is a
    type object and generally the same object as returned by
-   :attr:`object.__class__ <instance.__class__>`.
+   :attr:`object.__class__`.
 
    The :func:`isinstance` built-in function is recommended for testing the type
    of an object, because it takes subclasses into account.

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -646,10 +646,11 @@ The :mod:`functools` module defines the following functions:
    attributes of the wrapper function are updated with the corresponding attributes
    from the original function. The default values for these arguments are the
    module level constants ``WRAPPER_ASSIGNMENTS`` (which assigns to the wrapper
-   function's ``__module__``, ``__name__``, ``__qualname__``, ``__annotations__``,
-   ``__type_params__``, and ``__doc__``, the documentation string)
-   and ``WRAPPER_UPDATES`` (which
-   updates the wrapper function's ``__dict__``, i.e. the instance dictionary).
+   function's :attr:`~function.__module__`, :attr:`~function.__name__`,
+   :attr:`~function.__qualname__`, :attr:`~function.__annotations__`,
+   :attr:`~function.__type_params__`, and :attr:`~function.__doc__`, the
+   documentation string) and ``WRAPPER_UPDATES`` (which updates the wrapper
+   function's :attr:`~function.__dict__`, i.e. the instance dictionary).
 
    To allow access to the original function for introspection and other purposes
    (e.g. bypassing a caching decorator such as :func:`lru_cache`), this function
@@ -670,7 +671,7 @@ The :mod:`functools` module defines the following functions:
 
    .. versionchanged:: 3.2
       The ``__wrapped__`` attribute is now automatically added.
-      The ``__annotations__`` attribute is now copied by default.
+      The :attr:`~function.__annotations__` attribute is now copied by default.
       Missing attributes no longer trigger an :exc:`AttributeError`.
 
    .. versionchanged:: 3.4
@@ -679,7 +680,7 @@ The :mod:`functools` module defines the following functions:
       (see :issue:`17482`)
 
    .. versionchanged:: 3.12
-      The ``__type_params__`` attribute is now copied by default.
+      The :attr:`~function.__type_params__` attribute is now copied by default.
 
 
 .. decorator:: wraps(wrapped, assigned=WRAPPER_ASSIGNMENTS, updated=WRAPPER_UPDATES)
@@ -743,7 +744,8 @@ have three read-only attributes:
 
 :class:`partial` objects are like :class:`function` objects in that they are
 callable, weak referenceable, and can have attributes.  There are some important
-differences.  For instance, the :attr:`~definition.__name__` and :attr:`__doc__` attributes
+differences.  For instance, the :attr:`~function.__name__` and
+:attr:`function.__doc__` attributes
 are not created automatically.  Also, :class:`partial` objects defined in
 classes behave like static methods and do not transform into bound methods
 during instance attribute look-up.

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -742,10 +742,10 @@ have three read-only attributes:
    The keyword arguments that will be supplied when the :class:`partial` object is
    called.
 
-:class:`partial` objects are like :class:`function` objects in that they are
-callable, weak referenceable, and can have attributes.  There are some important
-differences.  For instance, the :attr:`~function.__name__` and
-:attr:`function.__doc__` attributes
+:class:`partial` objects are like :ref:`function objects <user-defined-funcs>`
+in that they are callable, weak referenceable, and can have attributes.
+There are some important differences.  For instance, the
+:attr:`~function.__name__` and :attr:`function.__doc__` attributes
 are not created automatically.  Also, :class:`partial` objects defined in
 classes behave like static methods and do not transform into bound methods
 during instance attribute look-up.

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -545,7 +545,7 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
    has a :meth:`~object.__get__` method, but not a :meth:`~object.__set__`
    method or a :meth:`~object.__delete__` method.  Beyond that, the set of
    attributes varies.  A :attr:`~definition.__name__` attribute is usually
-   sensible, and :attr:`!__doc__` often is.
+   sensible, and :attr:`~definition.__doc__` often is.
 
    Methods implemented via descriptors that also pass one of the other tests
    return ``False`` from the :func:`ismethoddescriptor` test, simply because the

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -304,7 +304,8 @@ in a module, ``__name__`` is the module's name in the Python package namespace.
       parameter mirrors the equivalent one in the :mod:`warnings` module.
 
       The fourth keyword argument is *extra* which can be used to pass a
-      dictionary which is used to populate the __dict__ of the :class:`LogRecord`
+      dictionary which is used to populate the :attr:`~object.__dict__` of the
+      :class:`LogRecord`
       created for the logging event with user-defined attributes. These custom
       attributes can then be used as you like. For example, they could be
       incorporated into logged messages. For example::

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -953,7 +953,7 @@ a given class::
    unpickled_class = pickle.loads(f.getvalue())
 
    assert isinstance(unpickled_class, type)
-   assert unpickled_type.__name__ == "MyClass"
+   assert unpickled_class.__name__ == "MyClass"
    assert unpickled_class.my_attribute == 1
 
 

--- a/Doc/library/pickle.rst
+++ b/Doc/library/pickle.rst
@@ -953,7 +953,7 @@ a given class::
    unpickled_class = pickle.loads(f.getvalue())
 
    assert isinstance(unpickled_class, type)
-   assert unpickled_class.__name__ == "MyClass"
+   assert unpickled_type.__name__ == "MyClass"
    assert unpickled_class.my_attribute == 1
 
 

--- a/Doc/library/pydoc.rst
+++ b/Doc/library/pydoc.rst
@@ -21,7 +21,7 @@ modules.  The documentation can be presented as pages of text on the console,
 served to a web browser, or saved to HTML files.
 
 For modules, classes, functions and methods, the displayed documentation is
-derived from the docstring (i.e. the :attr:`!__doc__` attribute) of the object,
+derived from the docstring (i.e. the :attr:`~definition.__doc__` attribute) of the object,
 and recursively of its documentable members.  If there is no docstring,
 :mod:`!pydoc` tries to obtain a description from the block of comment lines just
 above the definition of the class, function or method in the source file, or at

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5521,22 +5521,6 @@ types, where they are relevant.  Some of these are not reported by the
 :func:`dir` built-in function.
 
 
-.. attribute:: object.__dict__
-
-   A dictionary or other mapping object used to store an object's (writable)
-   attributes.
-
-
-.. attribute:: instance.__class__
-
-   The class to which a class instance belongs.
-
-
-.. attribute:: class.__bases__
-
-   The tuple of base classes of a class object.
-
-
 .. attribute:: definition.__name__
 
    The name of the class, function, method, descriptor, or
@@ -5551,43 +5535,24 @@ types, where they are relevant.  Some of these are not reported by the
    .. versionadded:: 3.3
 
 
+.. attribute:: definition.__module__
+
+   The name of the module in which a class or function was defined.
+
+
+.. attribute:: definition.__doc__
+
+   The documentation string of a class or function, or ``None`` if undefined.
+
+
 .. attribute:: definition.__type_params__
 
    The :ref:`type parameters <type-params>` of generic classes, functions,
-   and :ref:`type aliases <type-aliases>`.
+   and :ref:`type aliases <type-aliases>`. For classes and functions that
+   are not generic, this will be an empty tuple.
 
    .. versionadded:: 3.12
 
-
-.. attribute:: class.__mro__
-
-   This attribute is a tuple of classes that are considered when looking for
-   base classes during method resolution.
-
-
-.. method:: class.mro()
-
-   This method can be overridden by a metaclass to customize the method
-   resolution order for its instances.  It is called at class instantiation, and
-   its result is stored in :attr:`~class.__mro__`.
-
-
-.. method:: class.__subclasses__
-
-   Each class keeps a list of weak references to its immediate subclasses.  This
-   method returns a list of all those references still alive.  The list is in
-   definition order.  Example::
-
-      >>> int.__subclasses__()
-      [<class 'bool'>, <enum 'IntEnum'>, <flag 'IntFlag'>, <class 're._constants._NamedIntConstant'>]
-
-
-.. attribute:: class.__static_attributes__
-
-      A tuple containing names of attributes of this class which are accessed
-      through ``self.X`` from any function in its body.
-
-      .. versionadded:: 3.13
 
 .. _int_max_str_digits:
 

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -946,7 +946,7 @@ The :mod:`test.support` module defines the following functions:
    other modules, possibly a C backend (like ``csv`` and its ``_csv``).
 
    The *extra* argument can be a set of names that wouldn't otherwise be automatically
-   detected as "public", like objects without a proper ``__module__``
+   detected as "public", like objects without a proper :attr:`~definition.__module__`
    attribute. If provided, it will be added to the automatically detected ones.
 
    The *not_exported* argument can be a set of names that must not be treated

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -91,8 +91,8 @@ Dynamic Type Creation
 
     For classes that have an ``__orig_bases__`` attribute, this
     function returns the value of ``cls.__orig_bases__``.
-    For classes without the ``__orig_bases__`` attribute, ``cls.__bases__`` is
-    returned.
+    For classes without the ``__orig_bases__`` attribute,
+    :attr:`cls.__bases__ <class.__bases__>` is returned.
 
     Examples::
 
@@ -392,7 +392,7 @@ Standard names are defined for the following types:
 
    In addition, when a class is defined with a :attr:`~object.__slots__` attribute, then for
    each slot, an instance of :class:`!MemberDescriptorType` will be added as an attribute
-   on the class. This allows the slot to appear in the class's :attr:`~object.__dict__`.
+   on the class. This allows the slot to appear in the class's :attr:`~class.__dict__`.
 
    .. impl-detail::
 

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -92,7 +92,7 @@ Dynamic Type Creation
     For classes that have an ``__orig_bases__`` attribute, this
     function returns the value of ``cls.__orig_bases__``.
     For classes without the ``__orig_bases__`` attribute,
-    :attr:`cls.__bases__ <class.__bases__>` is returned.
+    :attr:`cls.__bases__ <type.__bases__>` is returned.
 
     Examples::
 
@@ -392,7 +392,7 @@ Standard names are defined for the following types:
 
    In addition, when a class is defined with a :attr:`~object.__slots__` attribute, then for
    each slot, an instance of :class:`!MemberDescriptorType` will be added as an attribute
-   on the class. This allows the slot to appear in the class's :attr:`~class.__dict__`.
+   on the class. This allows the slot to appear in the class's :attr:`~type.__dict__`.
 
    .. impl-detail::
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3252,7 +3252,8 @@ Introspection helpers
      empty dictionary is returned.
    * If *obj* is a class ``C``, the function returns a dictionary that merges
      annotations from ``C``'s base classes with those on ``C`` directly. This
-     is done by traversing ``C.__mro__`` and iteratively combining
+     is done by traversing :attr:`C.__mro__ <class.__mro__>` and iteratively
+     combining
      ``__annotations__`` dictionaries. Annotations on classes appearing
      earlier in the :term:`method resolution order` always take precedence over
      annotations on classes appearing later in the method resolution order.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3252,7 +3252,7 @@ Introspection helpers
      empty dictionary is returned.
    * If *obj* is a class ``C``, the function returns a dictionary that merges
      annotations from ``C``'s base classes with those on ``C`` directly. This
-     is done by traversing :attr:`C.__mro__ <class.__mro__>` and iteratively
+     is done by traversing :attr:`C.__mro__ <type.__mro__>` and iteratively
      combining
      ``__annotations__`` dictionaries. Annotations on classes appearing
      earlier in the :term:`method resolution order` always take precedence over

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -239,7 +239,7 @@ the *new_callable* argument to :func:`patch`.
       Accessing any attribute not in this list will raise an :exc:`AttributeError`.
 
       If *spec* is an object (rather than a list of strings) then
-      :attr:`~instance.__class__` returns the class of the spec object. This
+      :attr:`~object.__class__` returns the class of the spec object. This
       allows mocks to pass :func:`isinstance` tests.
 
     * *spec_set*: A stricter variant of *spec*. If used, attempting to *set*

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1416,7 +1416,7 @@ dictionary.  The class name is bound to this class object in the original local
 namespace.
 
 The order in which attributes are defined in the class body is preserved
-in the new class's ``__dict__``.  Note that this is reliable only right
+in the new class's :attr:`~class.__dict__`.  Note that this is reliable only right
 after the class is created and only for classes that were defined using
 the definition syntax.
 
@@ -1447,8 +1447,8 @@ decorators.  The result is then bound to the class name.
 A list of :ref:`type parameters <type-params>` may be given in square brackets
 immediately after the class's name.
 This indicates to static type checkers that the class is generic. At runtime,
-the type parameters can be retrieved from the class's ``__type_params__``
-attribute. See :ref:`generic-classes` for more.
+the type parameters can be retrieved from the class's
+:attr:`~class.__type_params__` attribute. See :ref:`generic-classes` for more.
 
 .. versionchanged:: 3.12
    Type parameter lists are new in Python 3.12.
@@ -1661,8 +1661,8 @@ with more precision. The scope of type parameters is modeled with a special
 function (technically, an :ref:`annotation scope <annotation-scopes>`) that
 wraps the creation of the generic object.
 
-Generic functions, classes, and type aliases have a :attr:`!__type_params__`
-attribute listing their type parameters.
+Generic functions, classes, and type aliases have a
+:attr:`~definition.__type_params__` attribute listing their type parameters.
 
 Type parameters come in three kinds:
 
@@ -1924,5 +1924,5 @@ all annotations are instead stored as strings::
    therefore the function's :term:`docstring`.
 
 .. [#] A string literal appearing as the first statement in the class body is
-   transformed into the namespace's ``__doc__`` item and therefore the class's
-   :term:`docstring`.
+   transformed into the namespace's :attr:`~class.__doc__` item and therefore
+   the class's :term:`docstring`.

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1416,7 +1416,7 @@ dictionary.  The class name is bound to this class object in the original local
 namespace.
 
 The order in which attributes are defined in the class body is preserved
-in the new class's :attr:`~class.__dict__`.  Note that this is reliable only right
+in the new class's :attr:`~type.__dict__`.  Note that this is reliable only right
 after the class is created and only for classes that were defined using
 the definition syntax.
 
@@ -1448,7 +1448,7 @@ A list of :ref:`type parameters <type-params>` may be given in square brackets
 immediately after the class's name.
 This indicates to static type checkers that the class is generic. At runtime,
 the type parameters can be retrieved from the class's
-:attr:`~class.__type_params__` attribute. See :ref:`generic-classes` for more.
+:attr:`~type.__type_params__` attribute. See :ref:`generic-classes` for more.
 
 .. versionchanged:: 3.12
    Type parameter lists are new in Python 3.12.
@@ -1924,5 +1924,5 @@ all annotations are instead stored as strings::
    therefore the function's :term:`docstring`.
 
 .. [#] A string literal appearing as the first statement in the class body is
-   transformed into the namespace's :attr:`~class.__doc__` item and therefore
+   transformed into the namespace's :attr:`~type.__doc__` item and therefore
    the class's :term:`docstring`.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -941,6 +941,8 @@ namespace as a dictionary object.
    or keep the module around while using its dictionary directly.
 
 
+.. _class-attrs-and-methods:
+
 Custom classes
 --------------
 
@@ -1004,32 +1006,32 @@ Special attributes
    * - Attribute
      - Meaning
 
-   * - .. attribute:: class.__name__
+   * - .. attribute:: type.__name__
      - The class's name.
        See also: :attr:`__name__ attributes <definition.__name__>`.
 
-   * - .. attribute:: class.__qualname__
+   * - .. attribute:: type.__qualname__
      - The class's :term:`qualified name`.
        See also: :attr:`__qualname__ attributes <definition.__qualname__>`.
 
-   * - .. attribute:: class.__module__
+   * - .. attribute:: type.__module__
      - The name of the module in which the class was defined.
 
-   * - .. attribute:: class.__dict__
+   * - .. attribute:: type.__dict__
      - A :class:`mapping proxy <types.MappingProxyType>`
        providing a read-only view of the class's namespace.
        See also: :attr:`__dict__ attributes <object.__dict__>`.
 
-   * - .. attribute:: class.__bases__
+   * - .. attribute:: type.__bases__
      - A :class:`tuple` containing the class's bases.
        In most cases, for a class defined as ``class X(A, B, C)``,
        ``X.__bases__`` will be exactly equal to ``(A, B, C)``.
 
-   * - .. attribute:: class.__doc__
+   * - .. attribute:: type.__doc__
      - The class's documentation string, or ``None`` if undefined.
        Not inherited by subclasses.
 
-   * - .. attribute:: class.__annotations__
+   * - .. attribute:: type.__annotations__
      - A dictionary containing
        :term:`variable annotations <variable annotation>`
        collected during class body execution. See also:
@@ -1049,7 +1051,7 @@ Special attributes
           Annotations are now :ref:`lazily evaluated <lazy-evaluation>`.
           See :pep:`649`.
 
-   * - .. method:: class.__annotate__
+   * - .. method:: type.__annotate__
      - The :term:`annotate function` for this class, or ``None``
        if the class has no annotations.
        See also: :attr:`__annotate__ attributes <object.__annotate__>`.
@@ -1063,24 +1065,24 @@ Special attributes
 
        .. versionadded:: 3.14
 
-   * - .. attribute:: class.__type_params__
+   * - .. attribute:: type.__type_params__
      - A :class:`tuple` containing the :ref:`type parameters <type-params>` of
        a :ref:`generic class <generic-classes>`.
 
        .. versionadded:: 3.12
 
-   * - .. attribute:: class.__static_attributes__
+   * - .. attribute:: type.__static_attributes__
      - A :class:`tuple` containing names of attributes of this class which are
        assigned through ``self.X`` from any function in its body.
 
        .. versionadded:: 3.13
 
-   * - .. attribute:: class.__firstlineno__
+   * - .. attribute:: type.__firstlineno__
      - The line number of the first line of the class definition, including decorators.
 
        .. versionadded:: 3.13
 
-   * - .. attribute:: class.__mro__
+   * - .. attribute:: type.__mro__
      - The :class:`tuple` of classes that are considered when looking for
        base classes during method resolution.
 
@@ -1091,13 +1093,13 @@ Special methods
 In addition to the special attributes described above, all Python classes also
 have the following two methods available:
 
-.. method:: class.mro
+.. method:: type.mro
 
    This method can be overridden by a metaclass to customize the method
    resolution order for its instances.  It is called at class instantiation,
-   and its result is stored in :attr:`~class.__mro__`.
+   and its result is stored in :attr:`~type.__mro__`.
 
-.. method:: class.__subclasses__
+.. method:: type.__subclasses__
 
    Each class keeps a list of weak references to its immediate subclasses. This
    method returns a list of all those references still alive. The list is in
@@ -2595,7 +2597,7 @@ Preparing the class namespace
 
 Once the appropriate metaclass has been identified, then the class namespace
 is prepared. If the metaclass has a ``__prepare__`` attribute, it is called
-as ``namespace = metaclass.__prepare__(name, bases, **kwds)`` (where the
+as ``namespace = metatype.__prepare__(name, bases, **kwds)`` (where the
 additional keyword arguments, if any, come from the class definition). The
 ``__prepare__`` method should be implemented as a
 :func:`classmethod <classmethod>`. The
@@ -2678,7 +2680,7 @@ in the local namespace as the defined class.
 When a new class is created by ``type.__new__``, the object provided as the
 namespace parameter is copied to a new ordered mapping and the original
 object is discarded. The new copy is wrapped in a read-only proxy, which
-becomes the :attr:`~class.__dict__` attribute of the class object.
+becomes the :attr:`~type.__dict__` attribute of the class object.
 
 .. seealso::
 
@@ -2706,14 +2708,14 @@ order to allow the addition of Abstract Base Classes (ABCs) as "virtual base
 classes" to any class or type (including built-in types), including other
 ABCs.
 
-.. method:: class.__instancecheck__(self, instance)
+.. method:: type.__instancecheck__(self, instance)
 
    Return true if *instance* should be considered a (direct or indirect)
    instance of *class*. If defined, called to implement ``isinstance(instance,
    class)``.
 
 
-.. method:: class.__subclasscheck__(self, subclass)
+.. method:: type.__subclasscheck__(self, subclass)
 
    Return true if *subclass* should be considered a (direct or indirect)
    subclass of *class*.  If defined, called to implement ``issubclass(subclass,
@@ -2729,8 +2731,8 @@ case the instance is itself a class.
 
    :pep:`3119` - Introducing Abstract Base Classes
       Includes the specification for customizing :func:`isinstance` and
-      :func:`issubclass` behavior through :meth:`~class.__instancecheck__` and
-      :meth:`~class.__subclasscheck__`, with motivation for this functionality
+      :func:`issubclass` behavior through :meth:`~type.__instancecheck__` and
+      :meth:`~type.__subclasscheck__`, with motivation for this functionality
       in the context of adding Abstract Base Classes (see the :mod:`abc`
       module) to the language.
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2597,7 +2597,7 @@ Preparing the class namespace
 
 Once the appropriate metaclass has been identified, then the class namespace
 is prepared. If the metaclass has a ``__prepare__`` attribute, it is called
-as ``namespace = metatype.__prepare__(name, bases, **kwds)`` (where the
+as ``namespace = metaclass.__prepare__(name, bases, **kwds)`` (where the
 additional keyword arguments, if any, come from the class definition). The
 ``__prepare__`` method should be implemented as a
 :func:`classmethod <classmethod>`. The

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -595,7 +595,6 @@ Most of these attributes check the type of the assigned value:
 
    * - .. attribute:: function.__doc__
      - The function's documentation string, or ``None`` if unavailable.
-       Not inherited by subclasses.
 
    * - .. attribute:: function.__name__
      - The function's name.
@@ -984,6 +983,9 @@ of a base class.
 
 A class object can be called (see above) to yield a class instance (see below).
 
+Special attributes
+^^^^^^^^^^^^^^^^^^
+
 .. index::
    single: __name__ (class attribute)
    single: __module__ (class attribute)
@@ -996,66 +998,115 @@ A class object can be called (see above) to yield a class instance (see below).
    single: __static_attributes__ (class attribute)
    single: __firstlineno__ (class attribute)
 
-Special attributes:
+.. list-table::
+   :header-rows: 1
 
-   :attr:`~definition.__name__`
-      The class name.
+   * - Attribute
+     - Meaning
 
-   :attr:`__module__`
-      The name of the module in which the class was defined.
+   * - .. attribute:: class.__name__
+     - The class's name.
+       See also: :attr:`__name__ attributes <definition.__name__>`.
 
-   :attr:`~object.__dict__`
-      The dictionary containing the class's namespace.
+   * - .. attribute:: class.__qualname__
+     - The class's :term:`qualified name`.
+       See also: :attr:`__qualname__ attributes <definition.__qualname__>`.
 
-   :attr:`~class.__bases__`
-      A tuple containing the base classes, in the order of
-      their occurrence in the base class list.
+   * - .. attribute:: class.__module__
+     - The name of the module in which the class was defined.
 
-   :attr:`__doc__`
-      The class's documentation string, or ``None`` if undefined.
+   * - .. attribute:: class.__dict__
+     - A :class:`mapping proxy <types.MappingProxyType>`
+       providing a read-only view of the class's namespace.
+       See also: :attr:`__dict__ attributes <object.__dict__>`.
 
-   :attr:`~object.__annotations__`
-      A dictionary containing
-      :term:`variable annotations <variable annotation>`
-      collected during class body execution.  For best practices on
-      working with :attr:`~object.__annotations__`, please see
-      :mod:`annotationlib`.
+   * - .. attribute:: class.__bases__
+     - A :class:`tuple` containing the class's bases.
+       In most cases, for a class defined as ``class X(A, B, C)``,
+       ``X.__bases__`` will be exactly equal to ``(A, B, C)``.
 
-      .. warning::
+   * - .. attribute:: class.__doc__
+     - The class's documentation string, or ``None`` if undefined.
+       Not inherited by subclasses.
 
-         Accessing the :attr:`~object.__annotations__` attribute of a class
-         object directly may yield incorrect results in the presence of
-         metaclasses. Use :func:`annotationlib.get_annotations` to
-         retrieve class annotations safely.
+   * - .. attribute:: class.__annotations__
+     - A dictionary containing
+       :term:`variable annotations <variable annotation>`
+       collected during class body execution. See also:
+       :attr:`__annotations__ attributes <object.__annotations__>`.
 
-      .. versionchanged:: 3.14
-         Annotations are now :ref:`lazily evaluated <lazy-evaluation>`.
-         See :pep:`649`.
+       For best practices on working with :attr:`~object.__annotations__`,
+       please see :mod:`annotationlib`.
 
-   :attr:`~object.__annotate__`
-      The :term:`annotate function` for this class, or ``None``
-      if the class has no annotations. See :attr:`object.__annotate__`.
+       .. warning::
 
-      .. warning::
+          Accessing the :attr:`!__annotations__` attribute of a class
+          object directly may yield incorrect results in the presence of
+          metaclasses. Use :func:`annotationlib.get_annotations` to
+          retrieve class annotations safely.
 
-         Accessing the :attr:`~object.__annotate__` attribute of a class
-         object directly may yield incorrect results in the presence of
-         metaclasses. Use :func:`annotationlib.get_annotate_function` to
-         retrieve the annotate function safely.
+       .. versionchanged:: 3.14
+          Annotations are now :ref:`lazily evaluated <lazy-evaluation>`.
+          See :pep:`649`.
 
-      .. versionadded:: 3.14
+   * - .. method:: class.__annotate__
+     - The :term:`annotate function` for this class, or ``None``
+       if the class has no annotations.
+       See also: :attr:`__annotate__ attributes <object.__annotate__>`.
 
-   :attr:`__type_params__`
-      A tuple containing the :ref:`type parameters <type-params>` of
-      a :ref:`generic class <generic-classes>`.
+       .. warning::
 
-   :attr:`~class.__static_attributes__`
-      A tuple containing names of attributes of this class which are assigned
-      through ``self.X`` from any function in its body.
+          Accessing the :attr:`!__annotate__` attribute of a class
+          object directly may yield incorrect results in the presence of
+          metaclasses. Use :func:`annotationlib.get_annotate_function` to
+          retrieve the annotate function safely.
 
-   :attr:`__firstlineno__`
-      The line number of the first line of the class definition, including decorators.
+       .. versionadded:: 3.14
 
+   * - .. attribute:: class.__type_params__
+     - A :class:`tuple` containing the :ref:`type parameters <type-params>` of
+       a :ref:`generic class <generic-classes>`.
+
+       .. versionadded:: 3.12
+
+   * - .. attribute:: class.__static_attributes__
+     - A :class:`tuple` containing names of attributes of this class which are
+       assigned through ``self.X`` from any function in its body.
+
+       .. versionadded:: 3.13
+
+   * - .. attribute:: class.__firstlineno__
+     - The line number of the first line of the class definition, including decorators.
+
+       .. versionadded:: 3.13
+
+   * - .. attribute:: class.__mro__
+     - The :class:`tuple` of classes that are considered when looking for
+       base classes during method resolution.
+
+
+Special methods
+^^^^^^^^^^^^^^^
+
+In addition to the special attributes described above, all Python classes also
+have the following two methods available:
+
+.. method:: class.mro
+
+   This method can be overridden by a metaclass to customize the method
+   resolution order for its instances.  It is called at class instantiation,
+   and its result is stored in :attr:`~class.__mro__`.
+
+.. method:: class.__subclasses__
+
+   Each class keeps a list of weak references to its immediate subclasses. This
+   method returns a list of all those references still alive. The list is in
+   definition order. Example:
+
+   .. doctest::
+
+      >>> int.__subclasses__()
+      [<class 'bool'>, <enum 'IntEnum'>, <flag 'IntFlag'>, <class 're._constants._NamedIntConstant'>]
 
 Class instances
 ---------------
@@ -1095,12 +1146,22 @@ dictionary directly.
 Class instances can pretend to be numbers, sequences, or mappings if they have
 methods with certain special names.  See section :ref:`specialnames`.
 
+Special attributes
+^^^^^^^^^^^^^^^^^^
+
 .. index::
    single: __dict__ (instance attribute)
    single: __class__ (instance attribute)
 
-Special attributes: :attr:`~object.__dict__` is the attribute dictionary;
-:attr:`~instance.__class__` is the instance's class.
+.. attribute:: object.__class__
+
+   The class to which a class instance belongs.
+
+.. attribute:: object.__dict__
+
+   A dictionary or other mapping object used to store an object's (writable)
+   attributes. Not all instances have a :attr:`!__dict__` attribute; see the
+   section on :ref:`slots` for more details.
 
 
 I/O objects (also known as file objects)
@@ -2330,9 +2391,9 @@ Notes on using *__slots__*:
 
 * The action of a *__slots__* declaration is not limited to the class
   where it is defined.  *__slots__* declared in parents are available in
-  child classes. However, child subclasses will get a :attr:`~object.__dict__` and
-  *__weakref__* unless they also define *__slots__* (which should only
-  contain names of any *additional* slots).
+  child classes. However, instances of a child subclass will get a
+  :attr:`~object.__dict__` and *__weakref__* unless the subclass also defines
+  *__slots__* (which should only contain names of any *additional* slots).
 
 * If a class defines a slot also defined in a base class, the instance variable
   defined by the base class slot is inaccessible (except by retrieving its
@@ -2617,7 +2678,7 @@ in the local namespace as the defined class.
 When a new class is created by ``type.__new__``, the object provided as the
 namespace parameter is copied to a new ordered mapping and the original
 object is discarded. The new copy is wrapped in a read-only proxy, which
-becomes the :attr:`~object.__dict__` attribute of the class object.
+becomes the :attr:`~class.__dict__` attribute of the class object.
 
 .. seealso::
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1040,7 +1040,7 @@ Special attributes
        For best practices on working with :attr:`~object.__annotations__`,
        please see :mod:`annotationlib`.
 
-       .. warning::
+       .. caution::
 
           Accessing the :attr:`!__annotations__` attribute of a class
           object directly may yield incorrect results in the presence of
@@ -1056,7 +1056,7 @@ Special attributes
        if the class has no annotations.
        See also: :attr:`__annotate__ attributes <object.__annotate__>`.
 
-       .. warning::
+       .. caution::
 
           Accessing the :attr:`!__annotate__` attribute of a class
           object directly may yield incorrect results in the presence of

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1106,7 +1106,7 @@ have the following two methods available:
    .. doctest::
 
       >>> int.__subclasses__()
-      [<class 'bool'>, <enum 'IntEnum'>, <flag 'IntFlag'>, <class 're._constants._NamedIntConstant'>]
+      [<class 'bool'>, <enum 'IntEnum'>, <flag 'IntFlag'>, <class 're._constants._NamedIntConstant'>, <class 're._ZeroSentinel'>]
 
 Class instances
 ---------------
@@ -2412,7 +2412,7 @@ Notes on using *__slots__*:
   to provide per-attribute docstrings that will be recognised by
   :func:`inspect.getdoc` and displayed in the output of :func:`help`.
 
-* :attr:`~instance.__class__` assignment works only if both classes have the
+* :attr:`~object.__class__` assignment works only if both classes have the
   same *__slots__*.
 
 * :ref:`Multiple inheritance <tut-multiple>` with multiple slotted parent

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -226,8 +226,8 @@ Annotation scopes differ from function scopes in the following ways:
   statements in inner scopes. This includes only type parameters, as no other
   syntactic elements that can appear within annotation scopes can introduce new names.
 * While annotation scopes have an internal name, that name is not reflected in the
-  :term:`__qualname__ <qualified name>` of objects defined within the scope.
-  Instead, the :attr:`!__qualname__`
+  :term:`qualified name` of objects defined within the scope.
+  Instead, the :attr:`~definition.__qualname__`
   of such objects is as if the object were defined in the enclosing scope.
 
 .. versionadded:: 3.12

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -104,8 +104,8 @@ identifier is used but only the following private identifiers are mangled:
 - Any name used as the name of a variable that is assigned or read or any
   name of an attribute being accessed.
 
-  The ``__name__`` attribute of nested functions, classes, and type aliases
-  is however not mangled.
+  The :attr:`~definition.__name__` attribute of nested functions, classes, and
+  type aliases is however not mangled.
 
 - The name of imported modules, e.g., ``__spam`` in ``import __spam``.
   If the module is part of a package (i.e., its name contains a dot),

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -276,7 +276,7 @@ definition looked like this::
 then ``MyClass.i`` and ``MyClass.f`` are valid attribute references, returning
 an integer and a function object, respectively. Class attributes can also be
 assigned to, so you can change the value of ``MyClass.i`` by assignment.
-:attr:`~class.__doc__` is also a valid attribute, returning the docstring
+:attr:`~type.__doc__` is also a valid attribute, returning the docstring
 belonging to the class: ``"A simple example class"``.
 
 Class *instantiation* uses function notation.  Just pretend that the class

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -276,8 +276,8 @@ definition looked like this::
 then ``MyClass.i`` and ``MyClass.f`` are valid attribute references, returning
 an integer and a function object, respectively. Class attributes can also be
 assigned to, so you can change the value of ``MyClass.i`` by assignment.
-:attr:`!__doc__` is also a valid attribute, returning the docstring belonging to
-the class: ``"A simple example class"``.
+:attr:`~class.__doc__` is also a valid attribute, returning the docstring
+belonging to the class: ``"A simple example class"``.
 
 Class *instantiation* uses function notation.  Just pretend that the class
 object is a parameterless function that returns a new instance of the class.
@@ -932,6 +932,6 @@ Examples::
 
 .. [#] Except for one thing.  Module objects have a secret read-only attribute called
    :attr:`~object.__dict__` which returns the dictionary used to implement the module's
-   namespace; the name :attr:`~object.__dict__` is an attribute but not a global name.
+   namespace; the name ``__dict__`` is an attribute but not a global name.
    Obviously, using this violates the abstraction of namespace implementation, and
    should be restricted to things like post-mortem debuggers.

--- a/Doc/whatsnew/2.1.rst
+++ b/Doc/whatsnew/2.1.rst
@@ -443,8 +443,8 @@ Python syntax::
    f.grammar = "A ::= B (C D)*"
 
 The dictionary containing attributes can be accessed as the function's
-:attr:`~object.__dict__`. Unlike the :attr:`~object.__dict__` attribute of class instances, in
-functions you can actually assign a new dictionary to :attr:`~object.__dict__`, though
+:attr:`~function.__dict__`. Unlike the :attr:`~class.__dict__` attribute of class instances, in
+functions you can actually assign a new dictionary to :attr:`~function.__dict__`, though
 the new value is restricted to a regular Python dictionary; you *can't* be
 tricky and set it to a :class:`!UserDict` instance, or any other random object
 that behaves like a mapping.

--- a/Doc/whatsnew/2.1.rst
+++ b/Doc/whatsnew/2.1.rst
@@ -443,7 +443,7 @@ Python syntax::
    f.grammar = "A ::= B (C D)*"
 
 The dictionary containing attributes can be accessed as the function's
-:attr:`~function.__dict__`. Unlike the :attr:`~class.__dict__` attribute of class instances, in
+:attr:`~function.__dict__`. Unlike the :attr:`~type.__dict__` attribute of class instances, in
 functions you can actually assign a new dictionary to :attr:`~function.__dict__`, though
 the new value is restricted to a regular Python dictionary; you *can't* be
 tricky and set it to a :class:`!UserDict` instance, or any other random object

--- a/Doc/whatsnew/2.2.rst
+++ b/Doc/whatsnew/2.2.rst
@@ -173,12 +173,12 @@ attributes of their own:
 
 * :attr:`~definition.__doc__` is the attribute's docstring.
 
-* :meth:`~object.__get__` is a method that retrieves the attribute value from
+* ``__get__(object)`` is a method that retrieves the attribute value from
   *object*.
 
-* :meth:`~object.__set__` sets the attribute on *object* to *value*.
+* ``__set__(object, value)`` sets the attribute on *object* to *value*.
 
-* :meth:`~object.__delete__` deletes the *value*  attribute of *object*.
+* ``__delete__(object, value)`` deletes the *value*  attribute of *object*.
 
 For example, when you write ``obj.x``, the steps that Python actually performs
 are::

--- a/Doc/whatsnew/2.2.rst
+++ b/Doc/whatsnew/2.2.rst
@@ -171,14 +171,14 @@ attributes of their own:
 
 * :attr:`~definition.__name__` is the attribute's name.
 
-* :attr:`!__doc__` is the attribute's docstring.
+* :attr:`~definition.__doc__` is the attribute's docstring.
 
-* ``__get__(object)`` is a method that retrieves the attribute value from
+* :meth:`~object.__get__` is a method that retrieves the attribute value from
   *object*.
 
-* ``__set__(object, value)`` sets the attribute on *object* to *value*.
+* :meth:`~object.__set__` sets the attribute on *object* to *value*.
 
-* ``__delete__(object, value)`` deletes the *value*  attribute of *object*.
+* :meth:`~object.__delete__` deletes the *value*  attribute of *object*.
 
 For example, when you write ``obj.x``, the steps that Python actually performs
 are::
@@ -186,7 +186,8 @@ are::
    descriptor = obj.__class__.x
    descriptor.__get__(obj)
 
-For methods, :meth:`!descriptor.__get__` returns a temporary object that's
+For methods, :meth:`descriptor.__get__ <object.__get__>` returns a temporary
+object that's
 callable, and wraps up the instance and the method to be called on it. This is
 also why static methods and class methods are now possible; they have
 descriptors that wrap up just the method, or the method and the class.  As a

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -1113,7 +1113,7 @@ Here are all of the changes that Python 2.3 makes to the core Python language.
      <type '_socket.socket'>
 
 * One of the noted incompatibilities between old- and new-style classes has been
-  removed: you can now assign to the :attr:`~class.__name__` and :attr:`~class.__bases__`
+  removed: you can now assign to the :attr:`~type.__name__` and :attr:`~class.__bases__`
   attributes of new-style classes.  There are some restrictions on what can be
   assigned to :attr:`!__bases__` along the lines of those relating to assigning to
   an instance's :attr:`~object.__class__` attribute.
@@ -1925,8 +1925,8 @@ Changes to Python's build process and to the C API include:
   dependence on a system version or local installation of Expat.
 
 * If you dynamically allocate type objects in your extension, you should be
-  aware of a change in the rules relating to the :attr:`~class.__module__` and
-  :attr:`~class.__name__` attributes.  In summary, you will want to ensure the type's
+  aware of a change in the rules relating to the :attr:`~type.__module__` and
+  :attr:`~type.__name__` attributes.  In summary, you will want to ensure the type's
   dictionary contains a ``'__module__'`` key; making the module name the part of
   the type name leading up to the final period will no longer have the desired
   effect.  For more detail, read the API reference documentation or the  source.

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -1113,9 +1113,9 @@ Here are all of the changes that Python 2.3 makes to the core Python language.
      <type '_socket.socket'>
 
 * One of the noted incompatibilities between old- and new-style classes has been
-  removed: you can now assign to the :attr:`~definition.__name__` and :attr:`~class.__bases__`
+  removed: you can now assign to the :attr:`~class.__name__` and :attr:`~class.__bases__`
   attributes of new-style classes.  There are some restrictions on what can be
-  assigned to :attr:`~class.__bases__` along the lines of those relating to assigning to
+  assigned to :attr:`!__bases__` along the lines of those relating to assigning to
   an instance's :attr:`~instance.__class__` attribute.
 
 .. ======================================================================
@@ -1925,8 +1925,8 @@ Changes to Python's build process and to the C API include:
   dependence on a system version or local installation of Expat.
 
 * If you dynamically allocate type objects in your extension, you should be
-  aware of a change in the rules relating to the :attr:`!__module__` and
-  :attr:`~definition.__name__` attributes.  In summary, you will want to ensure the type's
+  aware of a change in the rules relating to the :attr:`~class.__module__` and
+  :attr:`~class.__name__` attributes.  In summary, you will want to ensure the type's
   dictionary contains a ``'__module__'`` key; making the module name the part of
   the type name leading up to the final period will no longer have the desired
   effect.  For more detail, read the API reference documentation or the  source.

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -1116,7 +1116,7 @@ Here are all of the changes that Python 2.3 makes to the core Python language.
   removed: you can now assign to the :attr:`~class.__name__` and :attr:`~class.__bases__`
   attributes of new-style classes.  There are some restrictions on what can be
   assigned to :attr:`!__bases__` along the lines of those relating to assigning to
-  an instance's :attr:`~instance.__class__` attribute.
+  an instance's :attr:`~object.__class__` attribute.
 
 .. ======================================================================
 

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -1113,7 +1113,7 @@ Here are all of the changes that Python 2.3 makes to the core Python language.
      <type '_socket.socket'>
 
 * One of the noted incompatibilities between old- and new-style classes has been
-  removed: you can now assign to the :attr:`~type.__name__` and :attr:`~class.__bases__`
+  removed: you can now assign to the :attr:`~type.__name__` and :attr:`~type.__bases__`
   attributes of new-style classes.  There are some restrictions on what can be
   assigned to :attr:`!__bases__` along the lines of those relating to assigning to
   an instance's :attr:`~object.__class__` attribute.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -2006,7 +2006,7 @@ Porting to Python 3.12
   internal-only field directly.
 
   To get a list of subclasses, call the Python method
-  :py:meth:`~class.__subclasses__` (using :c:func:`PyObject_CallMethod`,
+  :py:meth:`~type.__subclasses__` (using :c:func:`PyObject_CallMethod`,
   for example).
 
 * Add support of more formatting options (left aligning, octals, uppercase

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1887,7 +1887,7 @@ New Features
 
   The :c:macro:`Py_TPFLAGS_MANAGED_DICT` and :c:macro:`Py_TPFLAGS_MANAGED_WEAKREF`
   flags have been added. This allows extensions classes to support object
-  ``__dict__`` and weakrefs with less bookkeeping,
+  :attr:`~object.__dict__` and weakrefs with less bookkeeping,
   using less memory and with faster access.
 
 * API for performing calls using
@@ -2025,7 +2025,7 @@ Porting to Python 3.12
   :c:func:`PyUnicode_FromFormatV`.
   (Contributed by Philip Georgi in :gh:`95504`.)
 
-* Extension classes wanting to add a ``__dict__`` or weak reference slot
+* Extension classes wanting to add a :attr:`~object.__dict__` or weak reference slot
   should use :c:macro:`Py_TPFLAGS_MANAGED_DICT` and
   :c:macro:`Py_TPFLAGS_MANAGED_WEAKREF` instead of ``tp_dictoffset`` and
   ``tp_weaklistoffset``, respectively.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -121,9 +121,9 @@ Interpreter improvements:
 
 Python data model improvements:
 
-* :attr:`~class.__static_attributes__` stores the names of attributes accessed
+* :attr:`~type.__static_attributes__` stores the names of attributes accessed
   through ``self.X`` in any function in a class body.
-* :attr:`~class.__firstlineno__` records the first line number of a class
+* :attr:`~type.__firstlineno__` records the first line number of a class
   definition.
 
 Significant improvements in the standard library:
@@ -589,7 +589,7 @@ Other Language Changes
   (Contributed by Levi Sabah, Zackery Spytz and Hugo van Kemenade
   in :gh:`73965`.)
 
-* Classes have a new :attr:`~class.__static_attributes__` attribute.
+* Classes have a new :attr:`~type.__static_attributes__` attribute.
   This is populated by the compiler with a tuple of the class's attribute names
   which are assigned through ``self.<name>`` from any function in its body.
   (Contributed by Irit Katriel in :gh:`115775`.)
@@ -2192,13 +2192,13 @@ New Features
 
 * Add the :c:func:`PyType_GetFullyQualifiedName` function
   to get the type's fully qualified name.
-  The module name is prepended if :attr:`type.__module__ <class.__module__>` is
+  The module name is prepended if :attr:`type.__module__` is
   a string and is not equal to either ``'builtins'`` or ``'__main__'``.
   (Contributed by Victor Stinner in :gh:`111696`.)
 
 * Add the :c:func:`PyType_GetModuleName` function
   to get the type's module name. This is equivalent to getting the
-  :attr:`type.__module__ <class.__module__>` attribute.
+  :attr:`type.__module__` attribute.
   (Contributed by Eric Snow and Victor Stinner in :gh:`111696`.)
 
 * Add the :c:func:`PyUnicode_EqualToUTF8AndSize`

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -123,7 +123,8 @@ Python data model improvements:
 
 * :attr:`~class.__static_attributes__` stores the names of attributes accessed
   through ``self.X`` in any function in a class body.
-* :attr:`!__firstlineno__` records the first line number of a class definition.
+* :attr:`~class.__firstlineno__` records the first line number of a class
+  definition.
 
 Significant improvements in the standard library:
 
@@ -2191,13 +2192,13 @@ New Features
 
 * Add the :c:func:`PyType_GetFullyQualifiedName` function
   to get the type's fully qualified name.
-  The module name is prepended if ``type.__module__`` is a string
-  and is not equal to either ``'builtins'`` or ``'__main__'``.
+  The module name is prepended if :attr:`type.__module__ <class.__module__>` is
+  a string and is not equal to either ``'builtins'`` or ``'__main__'``.
   (Contributed by Victor Stinner in :gh:`111696`.)
 
 * Add the :c:func:`PyType_GetModuleName` function
-  to get the type's module name.
-  This is equivalent to getting the ``type.__module__`` attribute.
+  to get the type's module name. This is equivalent to getting the
+  :attr:`type.__module__ <class.__module__>` attribute.
   (Contributed by Eric Snow and Victor Stinner in :gh:`111696`.)
 
 * Add the :c:func:`PyUnicode_EqualToUTF8AndSize`

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -549,9 +549,11 @@ separation of binary and text data).
 PEP 3155: Qualified name for classes and functions
 ==================================================
 
-Functions and class objects have a new ``__qualname__`` attribute representing
+Functions and class objects have a new :attr:`~definition.__qualname__`
+attribute representing
 the "path" from the module top-level to their definition.  For global functions
-and classes, this is the same as ``__name__``.  For other functions and classes,
+and classes, this is the same as :attr:`~definition.__name__`.
+For other functions and classes,
 it provides better information about where they were actually defined, and
 how they might be accessible from the global scope.
 

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -2526,9 +2526,9 @@ Changes in the C API
   to format the :func:`repr` of the object.
   (Contributed by Serhiy Storchaka in :issue:`22453`.)
 
-* Because the lack of the :attr:`__module__` attribute breaks pickling and
+* Because the lack of the :attr:`~class.__module__` attribute breaks pickling and
   introspection, a deprecation warning is now raised for builtin types without
-  the :attr:`__module__` attribute.  This would be an AttributeError in
+  the :attr:`~class.__module__` attribute.  This will be an :exc:`AttributeError` in
   the future.
   (Contributed by Serhiy Storchaka in :issue:`20204`.)
 

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -2526,9 +2526,9 @@ Changes in the C API
   to format the :func:`repr` of the object.
   (Contributed by Serhiy Storchaka in :issue:`22453`.)
 
-* Because the lack of the :attr:`~class.__module__` attribute breaks pickling and
+* Because the lack of the :attr:`~type.__module__` attribute breaks pickling and
   introspection, a deprecation warning is now raised for builtin types without
-  the :attr:`~class.__module__` attribute.  This will be an :exc:`AttributeError` in
+  the :attr:`~type.__module__` attribute.  This will be an :exc:`AttributeError` in
   the future.
   (Contributed by Serhiy Storchaka in :issue:`20204`.)
 

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -549,7 +549,7 @@ PEP 520: Preserving Class Attribute Definition Order
 
 Attributes in a class definition body have a natural ordering: the same
 order in which the names appear in the source.  This order is now
-preserved in the new class's :attr:`~object.__dict__` attribute.
+preserved in the new class's :attr:`~class.__dict__` attribute.
 
 Also, the effective default class *execution* namespace (returned from
 :ref:`type.__prepare__() <prepare>`) is now an insertion-order-preserving
@@ -934,7 +934,7 @@ asynchronous generators.
 
 The :func:`~collections.namedtuple` function now accepts an optional
 keyword argument *module*, which, when specified, is used for
-the ``__module__`` attribute of the returned named tuple class.
+the :attr:`~class.__module__` attribute of the returned named tuple class.
 (Contributed by Raymond Hettinger in :issue:`17941`.)
 
 The *verbose* and *rename* arguments for

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -549,7 +549,7 @@ PEP 520: Preserving Class Attribute Definition Order
 
 Attributes in a class definition body have a natural ordering: the same
 order in which the names appear in the source.  This order is now
-preserved in the new class's :attr:`~class.__dict__` attribute.
+preserved in the new class's :attr:`~type.__dict__` attribute.
 
 Also, the effective default class *execution* namespace (returned from
 :ref:`type.__prepare__() <prepare>`) is now an insertion-order-preserving
@@ -934,7 +934,7 @@ asynchronous generators.
 
 The :func:`~collections.namedtuple` function now accepts an optional
 keyword argument *module*, which, when specified, is used for
-the :attr:`~class.__module__` attribute of the returned named tuple class.
+the :attr:`~type.__module__` attribute of the returned named tuple class.
 (Contributed by Raymond Hettinger in :issue:`17941`.)
 
 The *verbose* and *rename* arguments for

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -637,7 +637,8 @@ pydoc
 -----
 
 The documentation string is now shown not only for class, function,
-method etc, but for any object that has its own ``__doc__`` attribute.
+method etc, but for any object that has its own :attr:`~definition.__doc__`
+attribute.
 (Contributed by Serhiy Storchaka in :issue:`40257`.)
 
 random

--- a/Misc/NEWS.d/next/Core and Builtins/2024-07-30-11-41-35.gh-issue-122445.Rq0bjS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-07-30-11-41-35.gh-issue-122445.Rq0bjS.rst
@@ -1,1 +1,1 @@
-Add only fields which are modified via self.* to :attr:`~class.__static_attributes__`.
+Add only fields which are modified via self.* to :attr:`~type.__static_attributes__`.


### PR DESCRIPTION
- Convert the attribute references in the "Custom classes" section to a list table
- Refer to the attributes as `type.__*__` rather than `class.__*__`; this reflects the reality at runtime
- Make sure all attribute references for custom classes are referenceable from other files
- Add references for attributes that were not previously documented (such as `__qualname__`), and move some references from `library/stdtypes.rst` to the datamodel docs so that references for all class attributes can be found in a single location
- Update and improve references to class attributes from other files so that they properly link to the canonical entries in the table
- Fix 21 or so Sphinx nitpicks in the process

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124480.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->