### PR TITLE
Doc: Use ``major.minor`` for documentation distribution archive filenames

### DIFF
--- a/Doc/tools/extensions/patchlevel.py
+++ b/Doc/tools/extensions/patchlevel.py
@@ -74,4 +74,4 @@ def get_version_info():
 
 
 if __name__ == "__main__":
-    print(format_version_info(get_header_version_info())[1])
+    print(format_version_info(get_header_version_info())[0])

--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -1,13 +1,15 @@
 {% extends "layout.html" %}
 {% set title = _('Download') %}
 {% if daily is defined %}
-  {% set dlbase = pathto('archives', 1) %}
+  {% set dl_base = pathto('archives', resource=True) %}
+  {% set dl_version = version %}
 {% else %}
   {#
     The link below returns HTTP 404 until the first related alpha release.
     This is expected; use daily documentation builds for CPython development.
   #}
-  {% set dlbase = 'https://www.python.org/ftp/python/doc/' + release %}
+  {% set dl_base = 'https://www.python.org/ftp/python/doc/' + release %}
+  {% set dl_version = release %}
 {% endif %}
 
 {% block body %}
@@ -26,27 +28,27 @@ Python in one of various formats, follow one of links in this table.{% endtrans 
   </tr>
   <tr>
     <td>{% trans %}PDF{% endtrans %}</td>
-    <td>{% trans download_size="17" %}<a href="{{ dlbase }}/python-{{ release }}-docs-pdf-a4.zip">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
-    <td>{% trans download_size="17" %}<a href="{{ dlbase }}/python-{{ release }}-docs-pdf-a4.tar.bz2">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
+    <td>{% trans download_size="17" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-pdf-a4.zip">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
+    <td>{% trans download_size="17" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-pdf-a4.tar.bz2">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
   </tr>
   <tr>
     <td>{% trans %}HTML{% endtrans %}</td>
-    <td>{% trans download_size="13" %}<a href="{{ dlbase }}/python-{{ release }}-docs-html.zip">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
-    <td>{% trans download_size="8" %}<a href="{{ dlbase }}/python-{{ release }}-docs-html.tar.bz2">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
+    <td>{% trans download_size="13" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-html.zip">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
+    <td>{% trans download_size="8" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-html.tar.bz2">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
   </tr>
   <tr>
     <td>{% trans %}Plain text{% endtrans %}</td>
-    <td>{% trans download_size="4" %}<a href="{{ dlbase }}/python-{{ release }}-docs-text.zip">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
-    <td>{% trans download_size="3" %}<a href="{{ dlbase }}/python-{{ release }}-docs-text.tar.bz2">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
+    <td>{% trans download_size="4" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-text.zip">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
+    <td>{% trans download_size="3" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-text.tar.bz2">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
   </tr>
   <tr>
     <td>{% trans %}Texinfo{% endtrans %}</td>
-    <td>{% trans download_size="9" %}<a href="{{ dlbase }}/python-{{ release }}-docs-texinfo.zip">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
-    <td>{% trans download_size="7" %}<a href="{{ dlbase }}/python-{{ release }}-docs-texinfo.tar.bz2">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
+    <td>{% trans download_size="9" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-texinfo.zip">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
+    <td>{% trans download_size="7" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs-texinfo.tar.bz2">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
  </tr>
  <tr>
     <td>{% trans %}EPUB{% endtrans %}</td>
-    <td>{% trans download_size="6" %}<a href="{{ dlbase }}/python-{{ release }}-docs.epub">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
+    <td>{% trans download_size="6" %}<a href="{{ dl_base }}/python-{{ dl_version }}-docs.epub">Download</a> (ca. {{ download_size }} MiB){% endtrans %}</td>
     <td></td>
   </tr>
 </table>


### PR DESCRIPTION
Per https://github.com/python/docs-community/issues/131, this adjusts the documentation archive filenames to only include "major.minor". 

Ned outlines a key motivating point:

> "``python-3.12.5-docs-pdf-a4.zip`` neither reflects the state of the documentation at the time of the 3.12.5 release nor necessarily the final state of the 3.12 docs prior to the 3.12.6 release; it's just what existed in the 3.12 git branch the last time the cron started building (and successfully finished) before the 3.12.6 release was merged into the 3.12 branch."

By just using `x.y` we are honest that the download reflects the state of the website rather than any one release -- for that, use https://docs.python.org/release/.

This patch changes `patchlevel.py` to return the `major.minor` version rather than the full release version. This is picked up in the Makefile as `$(DISTVERSION)` and interpolated into the filenames.

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124489.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->