### PR TITLE
`shutil.which()` docs reference os.environ as :data:

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -449,9 +449,10 @@ Directory and files operations
    *mode* is a permission mask passed to :func:`os.access`, by default
    determining if the file exists and is executable.
 
-   *path* is a "``PATH`` string" specifying the lookup directory list. When no
-   *path* is specified, the results of :func:`os.environ` are used, returning
-   either the "PATH" value or a fallback of :data:`os.defpath`.
+   *path* is a "``PATH`` string" specifying the directories to look in,
+   delimited by :data:`os.pathsep`. When no *path* is specified, the
+   :envvar:`PATH` environment variable is read from :data:`os.environ`,
+   falling back to :data:`os.defpath` if it is not set.
 
    On Windows, the current directory is prepended to the *path* if *mode* does
    not include ``os.X_OK``. When the *mode* does include ``os.X_OK``, the
@@ -460,9 +461,9 @@ Directory and files operations
    consulting the current working directory for executables: set the environment
    variable ``NoDefaultCurrentDirectoryInExePath``.
 
-   Also on Windows, the ``PATHEXT`` variable is used to resolve commands
-   that may not already include an extension. For example, if you call
-   ``shutil.which("python")``, :func:`which` will search ``PATHEXT``
+   Also on Windows, the :envvar:`PATHEXT` environment variable is used to
+   resolve commands that may not already include an extension. For example,
+   if you call ``shutil.which("python")``, :func:`which` will search ``PATHEXT``
    to know that it should look for ``python.exe`` within the *path*
    directories. For example, on Windows::
 


### PR DESCRIPTION
The [`shutil.which()` docs](https://docs.python.org/3/library/shutil.html#shutil.which) referenced `os.environ` using ``:func:`os.environ` ``, which renders as "os.environ()" &mdash; nonsensical, as the mapping is not callable. The correct notation is ``:data:`os.environ` ``.

![screenshot of os.environ()](https://github.com/user-attachments/assets/db1914dc-4af9-4ec8-9080-59376156e4e7)

I also made use of ``:envvar:`` when talking about PATH and PATHEXT, following the pattern in the venv docs.

I did not file an issue, nor create a blurb (the [previous PR here](https://github.com/python/cpython/pull/118175) didn't), as this change seems trivial. Happy to do so, though! I did reword the paragraph a bit, though most of the diff is caused by re-wrapping lines.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124494.org.readthedocs.build/en/124494/library/shutil.html

<!-- readthedocs-preview cpython-previews end -->