### PR TITLE
gh-53834: Fix support of arguments with choices in argparse

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2485,7 +2485,6 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                 value = action.default
             if isinstance(value, str):
                 value = self._get_value(action, value)
-                self._check_value(action, value)
 
         # when nargs='*' on a positional, if there were no command-line
         # args, use the default if it is anything other than None
@@ -2493,11 +2492,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
               not action.option_strings):
             if action.default is not None:
                 value = action.default
-                self._check_value(action, value)
             else:
-                # since arg_strings is always [] at this point
-                # there is no need to use self._check_value(action, value)
-                value = arg_strings
+                value = []
 
         # single argument or optional argument produces a single value
         elif len(arg_strings) == 1 and action.nargs in [None, OPTIONAL]:

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -621,9 +621,9 @@ class TestOptionalsNargsOptional(ParserTestCase):
         Sig('-w', nargs='?'),
         Sig('-x', nargs='?', const=42),
         Sig('-y', nargs='?', default='spam'),
-        Sig('-z', nargs='?', type=int, const='42', default='84'),
+        Sig('-z', nargs='?', type=int, const='42', default='84', choices=[1, 2]),
     ]
-    failures = ['2']
+    failures = ['2', '-z a', '-z 42', '-z 84']
     successes = [
         ('', NS(w=None, x=None, y='spam', z=84)),
         ('-w', NS(w=None, x=None, y='spam', z=84)),
@@ -1001,8 +1001,8 @@ class TestPositionalsNargsZeroOrMore(ParserTestCase):
 class TestPositionalsNargsZeroOrMoreDefault(ParserTestCase):
     """Test a Positional that specifies unlimited nargs and a default"""
 
-    argument_signatures = [Sig('foo', nargs='*', default='bar')]
-    failures = ['-x']
+    argument_signatures = [Sig('foo', nargs='*', default='bar', choices=['a', 'b'])]
+    failures = ['-x', 'bar', 'a c']
     successes = [
         ('', NS(foo='bar')),
         ('a', NS(foo=['a'])),
@@ -1035,8 +1035,8 @@ class TestPositionalsNargsOptional(ParserTestCase):
 class TestPositionalsNargsOptionalDefault(ParserTestCase):
     """Tests an Optional Positional with a default value"""
 
-    argument_signatures = [Sig('foo', nargs='?', default=42)]
-    failures = ['-x', 'a b']
+    argument_signatures = [Sig('foo', nargs='?', default=42, choices=['a', 'b'])]
+    failures = ['-x', 'a b', '42']
     successes = [
         ('', NS(foo=42)),
         ('a', NS(foo='a')),
@@ -1049,9 +1049,9 @@ class TestPositionalsNargsOptionalConvertedDefault(ParserTestCase):
     """
 
     argument_signatures = [
-        Sig('foo', nargs='?', type=int, default='42'),
+        Sig('foo', nargs='?', type=int, default='42', choices=[1, 2]),
     ]
-    failures = ['-x', 'a b', '1 2']
+    failures = ['-x', 'a b', '1 2', '42']
     successes = [
         ('', NS(foo=42)),
         ('1', NS(foo=1)),

--- a/Misc/NEWS.d/next/Library/2024-09-25-10-25-57.gh-issue-53834.uyIckw.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-25-10-25-57.gh-issue-53834.uyIckw.rst
@@ -1,0 +1,4 @@
+Fix support of arguments with :ref:`choices` in :mod:`argparse`. Positional
+arguments with :ref:`nargs` equal to ``'?'`` or ``'*'`` no longer check
+:ref:`default` against ``choices``. Optional arguments with ``nargs`` equal
+to ``'?'`` no longer check :ref:`const` against ``choices``.


### PR DESCRIPTION
Positional arguments with nargs equal to '?' or '*' no longer check default against choices.
Optional arguments with nargs equal to '?' no longer check const against choices.


<!-- gh-issue-number: gh-53834 -->
* Issue: gh-53834
<!-- /gh-issue-number -->
