### PR TITLE
gh-124498: Fix `TypeAliasType` not to be generic, when `type_params=()`

### DIFF
--- a/Lib/test/test_type_aliases.py
+++ b/Lib/test/test_type_aliases.py
@@ -211,6 +211,19 @@ class TypeAliasConstructorTest(unittest.TestCase):
         self.assertEqual(TA.__value__, list[T])
         self.assertEqual(TA.__type_params__, (T,))
         self.assertEqual(TA.__module__, __name__)
+        self.assertIs(TA[int].__class__, types.GenericAlias)
+
+    def test_not_generic(self):
+        TA = TypeAliasType("TA", list[int], type_params=())
+        self.assertEqual(TA.__name__, "TA")
+        self.assertEqual(TA.__value__, list[int])
+        self.assertEqual(TA.__type_params__, ())
+        self.assertEqual(TA.__module__, __name__)
+        with self.assertRaisesRegex(
+            TypeError,
+            "Only generic type aliases are subscriptable",
+        ):
+            TA[int]
 
     def test_keywords(self):
         TA = TypeAliasType(name="TA", value=int)

--- a/Lib/test/test_type_aliases.py
+++ b/Lib/test/test_type_aliases.py
@@ -211,7 +211,7 @@ class TypeAliasConstructorTest(unittest.TestCase):
         self.assertEqual(TA.__value__, list[T])
         self.assertEqual(TA.__type_params__, (T,))
         self.assertEqual(TA.__module__, __name__)
-        self.assertIs(TA[int].__class__, types.GenericAlias)
+        self.assertIs(type(TA[int]), types.GenericAlias)
 
     def test_not_generic(self):
         TA = TypeAliasType("TA", list[int], type_params=())

--- a/Misc/NEWS.d/next/Library/2024-09-25-12-14-58.gh-issue-124498.Ozxs55.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-25-12-14-58.gh-issue-124498.Ozxs55.rst
@@ -1,0 +1,2 @@
+Fix :class:`typing.TypeAliasType` not to be generic, when ``type_params`` is
+an empty tuple.

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -1957,7 +1957,8 @@ typealias_reduce_impl(typealiasobject *self)
 static PyObject *
 typealias_subscript(PyObject *self, PyObject *args)
 {
-    if (((typealiasobject *)self)->type_params == NULL) {
+    typealiasobject *ta = ((typealiasobject *)self);
+    if (ta->type_params == NULL || PyTuple_GET_SIZE(ta->type_params) == 0) {
         PyErr_SetString(PyExc_TypeError,
                         "Only generic type aliases are subscriptable");
         return NULL;

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -1914,7 +1914,16 @@ typealias_alloc(PyObject *name, PyObject *type_params, PyObject *compute_value,
         return NULL;
     }
     ta->name = Py_NewRef(name);
-    ta->type_params = Py_IsNone(type_params) ? NULL : Py_XNewRef(type_params);
+    if (
+        type_params == NULL
+        || Py_IsNone(type_params)
+        || (PyTuple_Check(type_params) && PyTuple_GET_SIZE(type_params) == 0)
+    ) {
+        ta->type_params = NULL;
+    }
+    else {
+        ta->type_params = Py_NewRef(type_params);
+    }
     ta->compute_value = Py_XNewRef(compute_value);
     ta->value = Py_XNewRef(value);
     ta->module = Py_XNewRef(module);
@@ -1957,8 +1966,7 @@ typealias_reduce_impl(typealiasobject *self)
 static PyObject *
 typealias_subscript(PyObject *self, PyObject *args)
 {
-    typealiasobject *ta = ((typealiasobject *)self);
-    if (ta->type_params == NULL || PyTuple_GET_SIZE(ta->type_params) == 0) {
+    if (((typealiasobject *)self)->type_params == NULL) {
         PyErr_SetString(PyExc_TypeError,
                         "Only generic type aliases are subscriptable");
         return NULL;


### PR DESCRIPTION


<!-- gh-issue-number: gh-124498 -->
* Issue: gh-124498
<!-- /gh-issue-number -->
