### PR TITLE
gh-124513: Check args in framelocalsproxy_new()

### DIFF
--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -512,6 +512,8 @@ class TestFrameLocals(unittest.TestCase):
             FrameLocalsProxy()     # no arguments
         with self.assertRaises(TypeError):
             FrameLocalsProxy(123)  # wrong type
+        with self.assertRaises(TypeError):
+            FrameLocalsProxy(frame=sys._getframe())  # no keyword arguments
 
 
 class FrameLocalsProxyMappingTests(mapping_tests.TestHashMappingProtocol):

--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -494,6 +494,23 @@ class TestFrameLocals(unittest.TestCase):
                 with self.assertRaises(TypeError):
                     proxy[obj] = 0
 
+    def test_constructor(self):
+        FrameLocalsProxy = type([sys._getframe().f_locals
+                                 for x in range(1)][0])
+        self.assertEqual(FrameLocalsProxy.__name__, 'FrameLocalsProxy')
+
+        def make_frame():
+            x = 1
+            y = 2
+            return sys._getframe()
+
+        proxy = FrameLocalsProxy(make_frame())
+        self.assertEqual(proxy, {'x': 1, 'y': 2})
+
+        # constructor expects 1 argument (frame)
+        with self.assertRaises(TypeError):
+            FrameLocalsProxy()
+
 
 class FrameLocalsProxyMappingTests(mapping_tests.TestHashMappingProtocol):
     """Test that FrameLocalsProxy behaves like a Mapping (with exceptions)"""

--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -507,9 +507,11 @@ class TestFrameLocals(unittest.TestCase):
         proxy = FrameLocalsProxy(make_frame())
         self.assertEqual(proxy, {'x': 1, 'y': 2})
 
-        # constructor expects 1 argument (frame)
+        # constructor expects 1 frame argument
         with self.assertRaises(TypeError):
-            FrameLocalsProxy()
+            FrameLocalsProxy()     # no arguments
+        with self.assertRaises(TypeError):
+            FrameLocalsProxy(123)  # wrong type
 
 
 class FrameLocalsProxyMappingTests(mapping_tests.TestHashMappingProtocol):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-25-14-45-56.gh-issue-124513.ywiXtr.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-25-14-45-56.gh-issue-124513.ywiXtr.rst
@@ -1,0 +1,2 @@
+Fix a crash in FrameLocalsProxy constructor: check the number of arguments.
+Patch by Victor Stinner.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -310,6 +310,13 @@ framelocalsproxy_dealloc(PyObject *self)
 static PyObject *
 framelocalsproxy_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
+    if (PyTuple_GET_SIZE(args) != 1) {
+        PyErr_Format(PyExc_TypeError,
+                     "FrameLocalsProxy expected 1 argument, got %zd",
+                     PyTuple_GET_SIZE(args));
+        return NULL;
+    }
+
     PyFrameLocalsProxyObject *self = (PyFrameLocalsProxyObject *)type->tp_alloc(type, 0);
     if (self == NULL) {
         return NULL;

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -324,6 +324,12 @@ framelocalsproxy_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     }
     PyFrameObject *frame = (PyFrameObject*)item;
 
+    if (kwds != NULL && PyDict_Size(kwds) != 0) {
+        PyErr_SetString(PyExc_TypeError,
+                        "FrameLocalsProxy takes no keyword arguments");
+        return 0;
+    }
+
     PyFrameLocalsProxyObject *self = (PyFrameLocalsProxyObject *)type->tp_alloc(type, 0);
     if (self == NULL) {
         return NULL;

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -316,14 +316,18 @@ framelocalsproxy_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
                      PyTuple_GET_SIZE(args));
         return NULL;
     }
+    PyObject *item = PyTuple_GET_ITEM(args, 0);
+
+    if (!PyFrame_Check(item)) {
+        PyErr_Format(PyExc_TypeError, "expect frame, not %T", item);
+        return NULL;
+    }
+    PyFrameObject *frame = (PyFrameObject*)item;
 
     PyFrameLocalsProxyObject *self = (PyFrameLocalsProxyObject *)type->tp_alloc(type, 0);
     if (self == NULL) {
         return NULL;
     }
-
-    PyFrameObject *frame = (PyFrameObject*)PyTuple_GET_ITEM(args, 0);
-    assert(PyFrame_Check(frame));
 
     ((PyFrameLocalsProxyObject*)self)->frame = (PyFrameObject*)Py_NewRef(frame);
 


### PR DESCRIPTION
Fix a crash in FrameLocalsProxy constructor: check the number of arguments.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124513 -->
* Issue: gh-124513
<!-- /gh-issue-number -->
