### PR TITLE
Doc: Fix default ``latex_elements['papersize']``

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -413,8 +413,8 @@ latex_elements = {
 \let\endVerbatim=\endOriginalVerbatim
 \setcounter{tocdepth}{2}
 ''',
-    # The paper size ('letter' or 'a4').
-    'papersize': 'a4',
+    # The paper size ('letterpaper' or 'a4paper').
+    'papersize': 'a4paper',
     # The font size ('10pt', '11pt' or '12pt').
     'pointsize': '10pt',
 }


### PR DESCRIPTION
https://www.sphinx-doc.org/en/master/latex.html#the-latex-elements-configuration-setting

It should be 'letterpaper' or 'a4paper' not 'letter' or 'a4' (not to be confused with PAPER env variable).

The issue was reported at https://github.com/python/docsbuild-scripts/issues/187#issuecomment-2372304829.
```
$ grep -A1 'LaTeX Warning' library.log
LaTeX Warning: Unused global option(s):
    [a4].
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124525.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->