### PR TITLE
[3.12] gh-116510: Fix a crash due to shared immortal interned strings.

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-25-12-37-58.gh-issue-116510.WeBAx1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-25-12-37-58.gh-issue-116510.WeBAx1.rst
@@ -1,0 +1,5 @@
+Fix a crash caused by immortal interned strings being shared between
+sub-interpreters that use basic single-phase init.  In that case, the string
+can be used by an interpreter that outlives the interpeter that created and
+interned it.  For interpreters that share obmalloc state, also share the
+interned dict with the main interpreter.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -266,6 +266,23 @@ hashtable_unicode_compare(const void *key1, const void *key2)
     }
 }
 
+/* Return true if this interpreter should share the main interpreter's
+   intern_dict.  That's important for interpreters which load basic
+   single-phase init extension modules (m_size == -1).  There could be interned
+   immortal strings that are shared between interpreters, due to the
+   PyDict_Update(mdict, m_copy) call in import_find_extension().
+
+   It's not safe to deallocate those strings until all interpreters that
+   potentially use them are freed.  By storing them in the main interpreter, we
+   ensure they get freed after all other interpreters are freed.
+*/
+static bool
+has_shared_intern_dict(PyInterpreterState *interp)
+{
+    PyInterpreterState *main_interp = _PyInterpreterState_Main();
+    return interp != main_interp  && interp->feature_flags & Py_RTFLAGS_USE_MAIN_OBMALLOC;
+}
+
 static int
 init_interned_dict(PyInterpreterState *interp)
 {
@@ -284,9 +301,16 @@ init_interned_dict(PyInterpreterState *interp)
         }
     }
     assert(get_interned_dict(interp) == NULL);
-    PyObject *interned = interned = PyDict_New();
-    if (interned == NULL) {
-        return -1;
+    PyObject *interned;
+    if (has_shared_intern_dict(interp)) {
+        interned = get_interned_dict(_PyInterpreterState_Main());
+        Py_INCREF(interned);
+    }
+    else {
+        interned = PyDict_New();
+        if (interned == NULL) {
+            return -1;
+        }
     }
     _Py_INTERP_CACHED_OBJECT(interp, interned_strings) = interned;
     return 0;
@@ -295,6 +319,9 @@ init_interned_dict(PyInterpreterState *interp)
 static void
 clear_interned_dict(PyInterpreterState *interp)
 {
+    if (has_shared_intern_dict(interp)) {
+        return; // the dict doesn't belong to this interpreter
+    }
     PyObject *interned = get_interned_dict(interp);
     if (interned != NULL) {
         PyDict_Clear(interned);
@@ -14855,6 +14882,9 @@ PyUnicode_InternFromString(const char *cp)
 void
 _PyUnicode_ClearInterned(PyInterpreterState *interp)
 {
+    if (has_shared_intern_dict(interp)) {
+        return; // the dict doesn't belong to this interpreter
+    }
     PyObject *interned = get_interned_dict(interp);
     if (interned == NULL) {
         return;
@@ -15364,8 +15394,10 @@ _PyUnicode_Fini(PyInterpreterState *interp)
 {
     struct _Py_unicode_state *state = &interp->unicode;
 
-    // _PyUnicode_ClearInterned() must be called before _PyUnicode_Fini()
-    assert(get_interned_dict(interp) == NULL);
+    if (!has_shared_intern_dict(interp)) {
+        // _PyUnicode_ClearInterned() must be called before _PyUnicode_Fini()
+        assert(get_interned_dict(interp) == NULL);
+    }
 
     _PyUnicode_FiniEncodings(&state->fs_codec);
 


### PR DESCRIPTION
Fix a crash caused by immortal interned strings being shared between sub-interpreters that use basic single-phase init.  In that case, the string can be used by an interpreter that outlives the interpeter that created and
interned it.  For interpreters that share obmalloc state, also share the interned dict with the main interpreter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116510 -->
* Issue: gh-116510
<!-- /gh-issue-number -->
