### PR TITLE
gh-124378: Update test_ttk for Tcl/Tk 8.6.15

### DIFF
--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -963,8 +963,7 @@ class ScrollbarTest(AbstractWidgetTest, unittest.TestCase):
         return ttk.Scrollbar(self.root, **kwargs)
 
 
-@add_standard_options(PixelSizeTests if tk_version >= (8, 7) else IntegerSizeTests,
-                      StandardTtkOptionsTests)
+@add_standard_options(StandardTtkOptionsTests)
 class NotebookTest(AbstractWidgetTest, unittest.TestCase):
     OPTIONS = (
         'class', 'cursor', 'height', 'padding', 'style', 'takefocus', 'width',
@@ -982,6 +981,20 @@ class NotebookTest(AbstractWidgetTest, unittest.TestCase):
 
     def create(self, **kwargs):
         return ttk.Notebook(self.root, **kwargs)
+
+    def test_configure_height(self):
+        widget = self.create()
+        if get_tk_patchlevel(self.root) < (8, 6, 15):
+            self.checkIntegerParam(widget, 'height', 402, -402, 0)
+        else:
+            self.checkPixelsParam(widget, 'height', '10c', 402, -402, 0, conv=False)
+
+    def test_configure_width(self):
+        widget = self.create()
+        if get_tk_patchlevel(self.root) < (8, 6, 15):
+            self.checkIntegerParam(widget, 'width', 402, -402, 0)
+        else:
+            self.checkPixelsParam(widget, 'width', '10c', 402, -402, 0, conv=False)
 
     def test_tab_identifiers(self):
         self.nb.forget(0)

--- a/Misc/NEWS.d/next/Tests/2024-09-25-12-39-34.gh-issue-124378.Ywwgia.rst
+++ b/Misc/NEWS.d/next/Tests/2024-09-25-12-39-34.gh-issue-124378.Ywwgia.rst
@@ -1,0 +1,1 @@
+Updated ``test_ttk`` to pass with Tcl/Tk 8.6.15.


### PR DESCRIPTION
This is split out from @culler's GH-124156 as a minimal fix for Tcl/Tk 8.6.15 support to unblock GH-124449.


<!-- gh-issue-number: gh-124378 -->
* Issue: gh-124378
<!-- /gh-issue-number -->
