### PR TITLE
gh-123242: Note that type.__annotations__ may not exist

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1045,7 +1045,8 @@ Special attributes
 
           Accessing the :attr:`!__annotations__` attribute of a class
           object directly may yield incorrect results in the presence of
-          metaclasses. Use :func:`annotationlib.get_annotations` to
+          metaclasses. In addition, the attribute may not exist for
+          some classes. Use :func:`annotationlib.get_annotations` to
           retrieve class annotations safely.
 
        .. versionchanged:: 3.14


### PR DESCRIPTION
Closes #123242. The real criterion is that the attribute does not
exist on heap types, but I don't think we should discuss heap vs.
static types in the language reference.


<!-- gh-issue-number: gh-123242 -->
* Issue: gh-123242
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124557.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->