### PR TITLE
[3.12] gh-101100: Add a table of class attributes to the "Custom classes" section of the data model docs (#124480)

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -720,7 +720,7 @@ Exception Classes
    This creates a class object derived from :exc:`Exception` (accessible in C as
    :c:data:`PyExc_Exception`).
 
-   The :attr:`!__module__` attribute of the new class is set to the first part (up
+   The :attr:`~type.__module__` attribute of the new class is set to the first part (up
    to the last dot) of the *name* argument, and the class name is set to the last
    part (after the last dot).  The *base* argument can be used to specify alternate
    base classes; it can either be only one class or a tuple of classes. The *dict*

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -253,14 +253,14 @@ Object Protocol
    The result will be ``1`` when at least one of the checks returns ``1``,
    otherwise it will be ``0``.
 
-   If *cls* has a :meth:`~class.__subclasscheck__` method, it will be called to
+   If *cls* has a :meth:`~type.__subclasscheck__` method, it will be called to
    determine the subclass status as described in :pep:`3119`.  Otherwise,
    *derived* is a subclass of *cls* if it is a direct or indirect subclass,
-   i.e. contained in ``cls.__mro__``.
+   i.e. contained in :attr:`cls.__mro__ <type.__mro__>`.
 
    Normally only class objects, i.e. instances of :class:`type` or a derived
    class, are considered classes.  However, objects can override this by having
-   a :attr:`~class.__bases__` attribute (which must be a tuple of base classes).
+   a :attr:`~type.__bases__` attribute (which must be a tuple of base classes).
 
 
 .. c:function:: int PyObject_IsInstance(PyObject *inst, PyObject *cls)
@@ -272,15 +272,15 @@ Object Protocol
    The result will be ``1`` when at least one of the checks returns ``1``,
    otherwise it will be ``0``.
 
-   If *cls* has a :meth:`~class.__instancecheck__` method, it will be called to
+   If *cls* has a :meth:`~type.__instancecheck__` method, it will be called to
    determine the subclass status as described in :pep:`3119`.  Otherwise, *inst*
    is an instance of *cls* if its class is a subclass of *cls*.
 
    An instance *inst* can override what is considered its class by having a
-   :attr:`~instance.__class__` attribute.
+   :attr:`~object.__class__` attribute.
 
    An object *cls* can override if it is considered a class, and what its base
-   classes are, by having a :attr:`~class.__bases__` attribute (which must be a tuple
+   classes are, by having a :attr:`~type.__bases__` attribute (which must be a tuple
    of base classes).
 
 

--- a/Doc/c-api/type.rst
+++ b/Doc/c-api/type.rst
@@ -53,7 +53,8 @@ Type Objects
 .. c:function:: PyObject* PyType_GetDict(PyTypeObject* type)
 
    Return the type object's internal namespace, which is otherwise only
-   exposed via a read-only proxy (``cls.__dict__``).  This is a
+   exposed via a read-only proxy (:attr:`cls.__dict__ <type.__dict__>`).
+   This is a
    replacement for accessing :c:member:`~PyTypeObject.tp_dict` directly.
    The returned dictionary must be treated as read-only.
 
@@ -140,7 +141,7 @@ Type Objects
    Return true if *a* is a subtype of *b*.
 
    This function only checks for actual subtypes, which means that
-   :meth:`~class.__subclasscheck__` is not called on *b*.  Call
+   :meth:`~type.__subclasscheck__` is not called on *b*.  Call
    :c:func:`PyObject_IsSubclass` to do the same check that :func:`issubclass`
    would do.
 
@@ -174,14 +175,15 @@ Type Objects
 
 .. c:function:: PyObject* PyType_GetName(PyTypeObject *type)
 
-   Return the type's name. Equivalent to getting the type's ``__name__`` attribute.
+   Return the type's name. Equivalent to getting the type's
+   :attr:`~type.__name__` attribute.
 
    .. versionadded:: 3.11
 
 .. c:function:: PyObject* PyType_GetQualName(PyTypeObject *type)
 
    Return the type's qualified name. Equivalent to getting the
-   type's ``__qualname__`` attribute.
+   type's :attr:`~type.__qualname__` attribute.
 
    .. versionadded:: 3.11
 

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -589,12 +589,12 @@ and :c:data:`PyType_Type` effectively act as defaults.)
 
    For :ref:`statically allocated type objects <static-types>`,
    the *tp_name* field should contain a dot.
-   Everything before the last dot is made accessible as the :attr:`__module__`
+   Everything before the last dot is made accessible as the :attr:`~type.__module__`
    attribute, and everything after the last dot is made accessible as the
-   :attr:`~definition.__name__` attribute.
+   :attr:`~type.__name__` attribute.
 
    If no dot is present, the entire :c:member:`~PyTypeObject.tp_name` field is made accessible as the
-   :attr:`~definition.__name__` attribute, and the :attr:`__module__` attribute is undefined
+   :attr:`~type.__name__` attribute, and the :attr:`~type.__module__` attribute is undefined
    (unless explicitly set in the dictionary, as explained above).  This means your
    type will be impossible to pickle.  Additionally, it will not be listed in
    module documentations created with pydoc.
@@ -1149,7 +1149,7 @@ and :c:data:`PyType_Type` effectively act as defaults.)
 
    .. c:macro:: Py_TPFLAGS_MANAGED_DICT
 
-      This bit indicates that instances of the class have a ``__dict__``
+      This bit indicates that instances of the class have a `~object.__dict__`
       attribute, and that the space for the dictionary is managed by the VM.
 
       If this flag is set, :c:macro:`Py_TPFLAGS_HAVE_GC` should also be set.
@@ -1350,8 +1350,8 @@ and :c:data:`PyType_Type` effectively act as defaults.)
 .. c:member:: const char* PyTypeObject.tp_doc
 
    An optional pointer to a NUL-terminated C string giving the docstring for this
-   type object.  This is exposed as the :attr:`__doc__` attribute on the type and
-   instances of the type.
+   type object.  This is exposed as the :attr:`~type.__doc__` attribute on the
+   type and instances of the type.
 
    **Inheritance:**
 
@@ -2028,7 +2028,7 @@ and :c:data:`PyType_Type` effectively act as defaults.)
    A collection of subclasses.  Internal use only.  May be an invalid pointer.
 
    To get a list of subclasses, call the Python method
-   :py:meth:`~class.__subclasses__`.
+   :py:meth:`~type.__subclasses__`.
 
    .. versionchanged:: 3.12
 

--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -296,7 +296,7 @@ An interesting advantage of using the :c:member:`~PyTypeObject.tp_members` table
 descriptors that are used at runtime is that any attribute defined this way can
 have an associated doc string simply by providing the text in the table.  An
 application can use the introspection API to retrieve the descriptor from the
-class object, and get the doc string using its :attr:`!__doc__` attribute.
+class object, and get the doc string using its :attr:`~type.__doc__` attribute.
 
 As with the :c:member:`~PyTypeObject.tp_methods` table, a sentinel entry with a :c:member:`~PyMethodDef.ml_name` value
 of ``NULL`` is required.

--- a/Doc/extending/newtypes_tutorial.rst
+++ b/Doc/extending/newtypes_tutorial.rst
@@ -144,7 +144,7 @@ only used for variable-sized objects and should otherwise be zero.
    If you want your type to be subclassable from Python, and your type has the same
    :c:member:`~PyTypeObject.tp_basicsize` as its base type, you may have problems with multiple
    inheritance.  A Python subclass of your type will have to list your type first
-   in its :attr:`~class.__bases__`, or else it will not be able to call your type's
+   in its :attr:`~type.__bases__`, or else it will not be able to call your type's
    :meth:`~object.__new__` method without getting an error.  You can avoid this problem by
    ensuring that your type has a larger value for :c:member:`~PyTypeObject.tp_basicsize` than its
    base type does.  Most of the time, this will be true anyway, because either your

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1614,7 +1614,7 @@ method too, and it must do so carefully.  The basic implementation of
        ...
 
 Most :meth:`!__setattr__` implementations must modify
-:meth:`self.__dict__ <object.__dict__>` to store
+:attr:`self.__dict__ <object.__dict__>` to store
 local state for self without causing an infinite recursion.
 
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -350,7 +350,7 @@ Glossary
    docstring
       A string literal which appears as the first expression in a class,
       function or module.  While ignored when the suite is executed, it is
-      recognized by the compiler and put into the :attr:`!__doc__` attribute
+      recognized by the compiler and put into the :attr:`~definition.__doc__` attribute
       of the enclosing class, function or module.  Since it is available via
       introspection, it is the canonical place for documentation of the
       object.
@@ -1201,7 +1201,7 @@ Glossary
    type
       The type of a Python object determines what kind of object it is; every
       object has a type.  An object's type is accessible as its
-      :attr:`~instance.__class__` attribute or can be retrieved with
+      :attr:`~object.__class__` attribute or can be retrieved with
       ``type(obj)``.
 
    type alias

--- a/Doc/howto/annotations.rst
+++ b/Doc/howto/annotations.rst
@@ -102,9 +102,9 @@ Your code will have to have a separate code path if the object
 you're examining is a class (``isinstance(o, type)``).
 In that case, best practice relies on an implementation detail
 of Python 3.9 and before: if a class has annotations defined,
-they are stored in the class's ``__dict__`` dictionary.  Since
+they are stored in the class's :attr:`~type.__dict__` dictionary.  Since
 the class may or may not have annotations defined, best practice
-is to call the ``get`` method on the class dict.
+is to call the :meth:`~dict.get` method on the class dict.
 
 To put it all together, here is some sample code that safely
 accesses the ``__annotations__`` attribute on an arbitrary
@@ -121,8 +121,8 @@ the type of ``ann`` using :func:`isinstance` before further
 examination.
 
 Note that some exotic or malformed type objects may not have
-a ``__dict__`` attribute, so for extra safety you may also wish
-to use :func:`getattr` to access ``__dict__``.
+a :attr:`~type.__dict__` attribute, so for extra safety you may also wish
+to use :func:`getattr` to access :attr:`!__dict__`.
 
 
 Manually Un-Stringizing Stringized Annotations

--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -559,8 +559,8 @@ attribute access.
 
 The expression ``obj.x`` looks up the attribute ``x`` in the chain of
 namespaces for ``obj``.  If the search finds a descriptor outside of the
-instance ``__dict__``, its :meth:`__get__` method is invoked according to the
-precedence rules listed below.
+instance :attr:`~object.__dict__`, its :meth:`~object.__get__` method is
+invoked according to the precedence rules listed below.
 
 The details of invocation depend on whether ``obj`` is an object, class, or
 instance of super.

--- a/Doc/howto/enum.rst
+++ b/Doc/howto/enum.rst
@@ -589,7 +589,7 @@ The solution is to specify the module name explicitly as follows::
     the source, pickling will be disabled.
 
 The new pickle protocol 4 also, in some circumstances, relies on
-:attr:`~definition.__qualname__` being set to the location where pickle will be able
+:attr:`~type.__qualname__` being set to the location where pickle will be able
 to find the class.  For example, if the class was made available in class
 SomeData in the global scope::
 

--- a/Doc/howto/mro.rst
+++ b/Doc/howto/mro.rst
@@ -335,7 +335,7 @@ E is more specialized than C, even if it is in a higher level.
 
 A lazy programmer can obtain the MRO directly from Python 2.2, since in
 this case it coincides with the Python 2.3 linearization.  It is enough
-to invoke the .mro() method of class A:
+to invoke the :meth:`~type.mro` method of class A:
 
   >>> A.mro()  # doctest: +NORMALIZE_WHITESPACE
   [<class 'A'>, <class 'B'>, <class 'E'>,

--- a/Doc/library/abc.rst
+++ b/Doc/library/abc.rst
@@ -99,7 +99,7 @@ a helper class :class:`ABC` to alternatively define ABCs through inheritance:
       that you can customize the behavior of :func:`issubclass` further without the
       need to call :meth:`register` on every class you want to consider a
       subclass of the ABC.  (This class method is called from the
-      :meth:`~class.__subclasscheck__` method of the ABC.)
+      :meth:`~type.__subclasscheck__` method of the ABC.)
 
       This method should return ``True``, ``False`` or :data:`NotImplemented`.  If
       it returns ``True``, the *subclass* is considered a subclass of this ABC.
@@ -149,7 +149,7 @@ a helper class :class:`ABC` to alternatively define ABCs through inheritance:
    The :meth:`__subclasshook__` class method defined here says that any class
    that has an :meth:`~iterator.__iter__` method in its
    :attr:`~object.__dict__` (or in that of one of its base classes, accessed
-   via the :attr:`~class.__mro__` list) is considered a ``MyIterable`` too.
+   via the :attr:`~type.__mro__` list) is considered a ``MyIterable`` too.
 
    Finally, the last line makes ``Foo`` a virtual subclass of ``MyIterable``,
    even though it does not define an :meth:`~iterator.__iter__` method (it uses

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -874,8 +874,8 @@ they add the ability to access fields by name instead of position index.
     ``(1, 2)``, then ``x`` will be a required argument, ``y`` will default to
     ``1``, and ``z`` will default to ``2``.
 
-    If *module* is defined, the ``__module__`` attribute of the named tuple is
-    set to that value.
+    If *module* is defined, the :attr:`~type.__module__` attribute of the
+    named tuple is set to that value.
 
     Named tuple instances do not have per-instance dictionaries, so they are
     lightweight and require no more memory than regular tuples.

--- a/Doc/library/email.contentmanager.rst
+++ b/Doc/library/email.contentmanager.rst
@@ -58,11 +58,12 @@
       * the type itself (``typ``)
       * the type's fully qualified name (``typ.__module__ + '.' +
         typ.__qualname__``).
-      * the type's qualname (``typ.__qualname__``)
-      * the type's name (``typ.__name__``).
+      * the type's :attr:`qualname <type.__qualname__>` (``typ.__qualname__``)
+      * the type's :attr:`name <type.__name__>` (``typ.__name__``).
 
       If none of the above match, repeat all of the checks above for each of
-      the types in the :term:`MRO` (``typ.__mro__``).  Finally, if no other key
+      the types in the :term:`MRO` (:attr:`typ.__mro__ <type.__mro__>`).
+      Finally, if no other key
       yields a handler, check for a handler for the key ``None``.  If there is
       no handler for ``None``, raise a :exc:`KeyError` for the fully
       qualified name of the type.

--- a/Doc/library/email.headerregistry.rst
+++ b/Doc/library/email.headerregistry.rst
@@ -317,7 +317,7 @@ variant, :attr:`~.BaseHeader.max_count` is set to 1.
     class.  When *use_default_map* is ``True`` (the default), the standard
     mapping of header names to classes is copied in to the registry during
     initialization.  *base_class* is always the last class in the generated
-    class's ``__bases__`` list.
+    class's :class:`~type.__bases__` list.
 
     The default mappings are:
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -283,9 +283,11 @@ are always available.  They are listed here in alphabetical order.
       :func:`property`.
 
    .. versionchanged:: 3.10
-      Class methods now inherit the method attributes (``__module__``,
-      ``__name__``, ``__qualname__``, ``__doc__`` and ``__annotations__``) and
-      have a new ``__wrapped__`` attribute.
+      Class methods now inherit the method attributes
+      (:attr:`~function.__module__`, :attr:`~function.__name__`,
+      :attr:`~function.__qualname__`, :attr:`~function.__doc__` and
+      :attr:`~function.__annotations__`) and have a new ``__wrapped__``
+      attribute.
 
    .. versionchanged:: 3.11
       Class methods can no longer wrap other :term:`descriptors <descriptor>` such as
@@ -1217,8 +1219,9 @@ are always available.  They are listed here in alphabetical order.
 
    .. note::
 
-      :class:`object` does *not* have a :attr:`~object.__dict__`, so you can't
-      assign arbitrary attributes to an instance of the :class:`object` class.
+      :class:`object` instances do *not* have :attr:`~object.__dict__`
+      attributes, so you can't assign arbitrary attributes to an instance of
+      :class:`object`.
 
 
 .. function:: oct(x)
@@ -1831,10 +1834,11 @@ are always available.  They are listed here in alphabetical order.
    For more information on static methods, see :ref:`types`.
 
    .. versionchanged:: 3.10
-      Static methods now inherit the method attributes (``__module__``,
-      ``__name__``, ``__qualname__``, ``__doc__`` and ``__annotations__``),
-      have a new ``__wrapped__`` attribute, and are now callable as regular
-      functions.
+      Static methods now inherit the method attributes
+      (:attr:`~function.__module__`, :attr:`~function.__name__`,
+      :attr:`~function.__qualname__`, :attr:`~function.__doc__` and
+      :attr:`~function.__annotations__`), have a new ``__wrapped__`` attribute,
+      and are now callable as regular functions.
 
 
 .. index::
@@ -1881,11 +1885,11 @@ are always available.  They are listed here in alphabetical order.
    to be searched.  The search starts from the class right after the
    *type*.
 
-   For example, if :attr:`~class.__mro__` of *object_or_type* is
+   For example, if :attr:`~type.__mro__` of *object_or_type* is
    ``D -> B -> C -> A -> object`` and the value of *type* is ``B``,
    then :func:`super` searches ``C -> A -> object``.
 
-   The :attr:`~class.__mro__` attribute of the class corresponding to
+   The :attr:`~type.__mro__` attribute of the class corresponding to
    *object_or_type* lists the method resolution search order used by both
    :func:`getattr` and :func:`super`.  The attribute is dynamic and can change
    whenever the inheritance hierarchy is updated.
@@ -1957,28 +1961,30 @@ are always available.  They are listed here in alphabetical order.
 
    With one argument, return the type of an *object*.  The return value is a
    type object and generally the same object as returned by
-   :attr:`object.__class__ <instance.__class__>`.
+   :attr:`object.__class__`.
 
    The :func:`isinstance` built-in function is recommended for testing the type
    of an object, because it takes subclasses into account.
 
-
    With three arguments, return a new type object.  This is essentially a
    dynamic form of the :keyword:`class` statement. The *name* string is
-   the class name and becomes the :attr:`~definition.__name__` attribute.
+   the class name and becomes the :attr:`~type.__name__` attribute.
    The *bases* tuple contains the base classes and becomes the
-   :attr:`~class.__bases__` attribute; if empty, :class:`object`, the
+   :attr:`~type.__bases__` attribute; if empty, :class:`object`, the
    ultimate base of all classes, is added.  The *dict* dictionary contains
    attribute and method definitions for the class body; it may be copied
-   or wrapped before becoming the :attr:`~object.__dict__` attribute.
-   The following two statements create identical :class:`type` objects:
+   or wrapped before becoming the :attr:`~type.__dict__` attribute.
+   The following two statements create identical :class:`!type` objects:
 
       >>> class X:
       ...     a = 1
       ...
       >>> X = type('X', (), dict(a=1))
 
-   See also :ref:`bltin-type-objects`.
+   See also:
+
+   * :ref:`Documentation on attributes and methods on classes <class-attrs-and-methods>`.
+   * :ref:`bltin-type-objects`
 
    Keyword arguments provided to the three argument form are passed to the
    appropriate metaclass machinery (usually :meth:`~object.__init_subclass__`)
@@ -1988,18 +1994,18 @@ are always available.  They are listed here in alphabetical order.
    See also :ref:`class-customization`.
 
    .. versionchanged:: 3.6
-      Subclasses of :class:`type` which don't override ``type.__new__`` may no
+      Subclasses of :class:`!type` which don't override ``type.__new__`` may no
       longer use the one-argument form to get the type of an object.
 
 .. function:: vars()
               vars(object)
 
    Return the :attr:`~object.__dict__` attribute for a module, class, instance,
-   or any other object with a :attr:`~object.__dict__` attribute.
+   or any other object with a :attr:`!__dict__` attribute.
 
    Objects such as modules and instances have an updateable :attr:`~object.__dict__`
    attribute; however, other objects may have write restrictions on their
-   :attr:`~object.__dict__` attributes (for example, classes use a
+   :attr:`!__dict__` attributes (for example, classes use a
    :class:`types.MappingProxyType` to prevent direct dictionary updates).
 
    Without an argument, :func:`vars` acts like :func:`locals`.  Note, the

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -644,10 +644,11 @@ The :mod:`functools` module defines the following functions:
    attributes of the wrapper function are updated with the corresponding attributes
    from the original function. The default values for these arguments are the
    module level constants ``WRAPPER_ASSIGNMENTS`` (which assigns to the wrapper
-   function's ``__module__``, ``__name__``, ``__qualname__``, ``__annotations__``,
-   ``__type_params__``, and ``__doc__``, the documentation string)
-   and ``WRAPPER_UPDATES`` (which
-   updates the wrapper function's ``__dict__``, i.e. the instance dictionary).
+   function's :attr:`~function.__module__`, :attr:`~function.__name__`,
+   :attr:`~function.__qualname__`, :attr:`~function.__annotations__`,
+   :attr:`~function.__type_params__`, and :attr:`~function.__doc__`, the
+   documentation string) and ``WRAPPER_UPDATES`` (which updates the wrapper
+   function's :attr:`~function.__dict__`, i.e. the instance dictionary).
 
    To allow access to the original function for introspection and other purposes
    (e.g. bypassing a caching decorator such as :func:`lru_cache`), this function
@@ -668,7 +669,7 @@ The :mod:`functools` module defines the following functions:
 
    .. versionchanged:: 3.2
       The ``__wrapped__`` attribute is now automatically added.
-      The ``__annotations__`` attribute is now copied by default.
+      The :attr:`~function.__annotations__` attribute is now copied by default.
       Missing attributes no longer trigger an :exc:`AttributeError`.
 
    .. versionchanged:: 3.4
@@ -677,7 +678,7 @@ The :mod:`functools` module defines the following functions:
       (see :issue:`17482`)
 
    .. versionchanged:: 3.12
-      The ``__type_params__`` attribute is now copied by default.
+      The :attr:`~function.__type_params__` attribute is now copied by default.
 
 
 .. decorator:: wraps(wrapped, assigned=WRAPPER_ASSIGNMENTS, updated=WRAPPER_UPDATES)
@@ -739,9 +740,10 @@ have three read-only attributes:
    The keyword arguments that will be supplied when the :class:`partial` object is
    called.
 
-:class:`partial` objects are like :class:`function` objects in that they are
-callable, weak referenceable, and can have attributes.  There are some important
-differences.  For instance, the :attr:`~definition.__name__` and :attr:`__doc__` attributes
+:class:`partial` objects are like :ref:`function objects <user-defined-funcs>`
+in that they are callable, weak referenceable, and can have attributes.
+There are some important differences.  For instance, the
+:attr:`~function.__name__` and :attr:`function.__doc__` attributes
 are not created automatically.  Also, :class:`partial` objects defined in
 classes behave like static methods and do not transform into bound methods
 during instance attribute look-up.

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -510,7 +510,7 @@ attributes (see :ref:`import-mod-attrs` for module attributes):
    has a :meth:`~object.__get__` method but not a :meth:`~object.__set__`
    method, but beyond that the set of attributes varies.  A
    :attr:`~definition.__name__` attribute is usually
-   sensible, and :attr:`!__doc__` often is.
+   sensible, and :attr:`~definition.__doc__` often is.
 
    Methods implemented via descriptors that also pass one of the other tests
    return ``False`` from the :func:`ismethoddescriptor` test, simply because the

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -304,7 +304,8 @@ in a module, ``__name__`` is the module's name in the Python package namespace.
       parameter mirrors the equivalent one in the :mod:`warnings` module.
 
       The fourth keyword argument is *extra* which can be used to pass a
-      dictionary which is used to populate the __dict__ of the :class:`LogRecord`
+      dictionary which is used to populate the :attr:`~object.__dict__` of the
+      :class:`LogRecord`
       created for the logging event with user-defined attributes. These custom
       attributes can then be used as you like. For example, they could be
       incorporated into logged messages. For example::

--- a/Doc/library/pydoc.rst
+++ b/Doc/library/pydoc.rst
@@ -21,7 +21,7 @@ modules.  The documentation can be presented as pages of text on the console,
 served to a web browser, or saved to HTML files.
 
 For modules, classes, functions and methods, the displayed documentation is
-derived from the docstring (i.e. the :attr:`!__doc__` attribute) of the object,
+derived from the docstring (i.e. the :attr:`~definition.__doc__` attribute) of the object,
 and recursively of its documentable members.  If there is no docstring,
 :mod:`!pydoc` tries to obtain a description from the block of comment lines just
 above the definition of the class, function or method in the source file, or at

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -5477,22 +5477,6 @@ types, where they are relevant.  Some of these are not reported by the
 :func:`dir` built-in function.
 
 
-.. attribute:: object.__dict__
-
-   A dictionary or other mapping object used to store an object's (writable)
-   attributes.
-
-
-.. attribute:: instance.__class__
-
-   The class to which a class instance belongs.
-
-
-.. attribute:: class.__bases__
-
-   The tuple of base classes of a class object.
-
-
 .. attribute:: definition.__name__
 
    The name of the class, function, method, descriptor, or
@@ -5507,35 +5491,23 @@ types, where they are relevant.  Some of these are not reported by the
    .. versionadded:: 3.3
 
 
+.. attribute:: definition.__module__
+
+   The name of the module in which a class or function was defined.
+
+
+.. attribute:: definition.__doc__
+
+   The documentation string of a class or function, or ``None`` if undefined.
+
+
 .. attribute:: definition.__type_params__
 
    The :ref:`type parameters <type-params>` of generic classes, functions,
-   and :ref:`type aliases <type-aliases>`.
+   and :ref:`type aliases <type-aliases>`. For classes and functions that
+   are not generic, this will be an empty tuple.
 
    .. versionadded:: 3.12
-
-
-.. attribute:: class.__mro__
-
-   This attribute is a tuple of classes that are considered when looking for
-   base classes during method resolution.
-
-
-.. method:: class.mro()
-
-   This method can be overridden by a metaclass to customize the method
-   resolution order for its instances.  It is called at class instantiation, and
-   its result is stored in :attr:`~class.__mro__`.
-
-
-.. method:: class.__subclasses__
-
-   Each class keeps a list of weak references to its immediate subclasses.  This
-   method returns a list of all those references still alive.  The list is in
-   definition order.  Example::
-
-      >>> int.__subclasses__()
-      [<class 'bool'>, <enum 'IntEnum'>, <flag 'IntFlag'>, <class 're._constants._NamedIntConstant'>]
 
 
 .. _int_max_str_digits:

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -940,7 +940,7 @@ The :mod:`test.support` module defines the following functions:
    other modules, possibly a C backend (like ``csv`` and its ``_csv``).
 
    The *extra* argument can be a set of names that wouldn't otherwise be automatically
-   detected as "public", like objects without a proper ``__module__``
+   detected as "public", like objects without a proper :attr:`~definition.__module__`
    attribute. If provided, it will be added to the automatically detected ones.
 
    The *not_exported* argument can be a set of names that must not be treated

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -91,8 +91,8 @@ Dynamic Type Creation
 
     For classes that have an ``__orig_bases__`` attribute, this
     function returns the value of ``cls.__orig_bases__``.
-    For classes without the ``__orig_bases__`` attribute, ``cls.__bases__`` is
-    returned.
+    For classes without the ``__orig_bases__`` attribute,
+    :attr:`cls.__bases__ <type.__bases__>` is returned.
 
     Examples::
 
@@ -392,7 +392,7 @@ Standard names are defined for the following types:
 
    In addition, when a class is defined with a :attr:`~object.__slots__` attribute, then for
    each slot, an instance of :class:`!MemberDescriptorType` will be added as an attribute
-   on the class. This allows the slot to appear in the class's :attr:`~object.__dict__`.
+   on the class. This allows the slot to appear in the class's :attr:`~type.__dict__`.
 
    .. impl-detail::
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2981,7 +2981,8 @@ Introspection helpers
      empty dictionary is returned.
    * If *obj* is a class ``C``, the function returns a dictionary that merges
      annotations from ``C``'s base classes with those on ``C`` directly. This
-     is done by traversing ``C.__mro__`` and iteratively combining
+     is done by traversing :attr:`C.__mro__ <type.__mro__>` and iteratively
+     combining
      ``__annotations__`` dictionaries. Annotations on classes appearing
      earlier in the :term:`method resolution order` always take precedence over
      annotations on classes appearing later in the method resolution order.

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -237,7 +237,7 @@ the *new_callable* argument to :func:`patch`.
       Accessing any attribute not in this list will raise an :exc:`AttributeError`.
 
       If *spec* is an object (rather than a list of strings) then
-      :attr:`~instance.__class__` returns the class of the spec object. This
+      :attr:`~object.__class__` returns the class of the spec object. This
       allows mocks to pass :func:`isinstance` tests.
 
     * *spec_set*: A stricter variant of *spec*. If used, attempting to *set*

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -1422,7 +1422,7 @@ dictionary.  The class name is bound to this class object in the original local
 namespace.
 
 The order in which attributes are defined in the class body is preserved
-in the new class's ``__dict__``.  Note that this is reliable only right
+in the new class's :attr:`~type.__dict__`.  Note that this is reliable only right
 after the class is created and only for classes that were defined using
 the definition syntax.
 
@@ -1453,8 +1453,8 @@ decorators.  The result is then bound to the class name.
 A list of :ref:`type parameters <type-params>` may be given in square brackets
 immediately after the class's name.
 This indicates to static type checkers that the class is generic. At runtime,
-the type parameters can be retrieved from the class's ``__type_params__``
-attribute. See :ref:`generic-classes` for more.
+the type parameters can be retrieved from the class's
+:attr:`~type.__type_params__` attribute. See :ref:`generic-classes` for more.
 
 .. versionchanged:: 3.12
    Type parameter lists are new in Python 3.12.
@@ -1664,8 +1664,8 @@ with more precision. The scope of type parameters is modeled with a special
 function (technically, an :ref:`annotation scope <annotation-scopes>`) that
 wraps the creation of the generic object.
 
-Generic functions, classes, and type aliases have a :attr:`!__type_params__`
-attribute listing their type parameters.
+Generic functions, classes, and type aliases have a
+:attr:`~definition.__type_params__` attribute listing their type parameters.
 
 Type parameters come in three kinds:
 
@@ -1877,5 +1877,5 @@ like ``TYPE_PARAMS_OF_ListOrSet`` are not actually bound at runtime.
    therefore the function's :term:`docstring`.
 
 .. [#] A string literal appearing as the first statement in the class body is
-   transformed into the namespace's ``__doc__`` item and therefore the class's
-   :term:`docstring`.
+   transformed into the namespace's :attr:`~type.__doc__` item and therefore
+   the class's :term:`docstring`.

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1041,7 +1041,7 @@ have the following two methods available:
    .. doctest::
 
       >>> int.__subclasses__()
-      [<class 'bool'>, <enum 'IntEnum'>, <flag 'IntFlag'>, <class 're._constants._NamedIntConstant'>, <class 're._ZeroSentinel'>]
+      [<class 'bool'>, <enum 'IntEnum'>, <flag 'IntFlag'>, <class 're._constants._NamedIntConstant'>]
 
 Class instances
 ---------------

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -591,7 +591,6 @@ Most of these attributes check the type of the assigned value:
 
    * - .. attribute:: function.__doc__
      - The function's documentation string, or ``None`` if unavailable.
-       Not inherited by subclasses.
 
    * - .. attribute:: function.__name__
      - The function's name.
@@ -917,6 +916,8 @@ namespace as a dictionary object.
    or keep the module around while using its dictionary directly.
 
 
+.. _class-attrs-and-methods:
+
 Custom classes
 --------------
 
@@ -959,6 +960,9 @@ of a base class.
 
 A class object can be called (see above) to yield a class instance (see below).
 
+Special attributes
+^^^^^^^^^^^^^^^^^^
+
 .. index::
    single: __name__ (class attribute)
    single: __module__ (class attribute)
@@ -968,35 +972,75 @@ A class object can be called (see above) to yield a class instance (see below).
    single: __annotations__ (class attribute)
    single: __type_params__ (class attribute)
 
-Special attributes:
+.. list-table::
+   :header-rows: 1
 
-   :attr:`~definition.__name__`
-      The class name.
+   * - Attribute
+     - Meaning
 
-   :attr:`__module__`
-      The name of the module in which the class was defined.
+   * - .. attribute:: type.__name__
+     - The class's name.
+       See also: :attr:`__name__ attributes <definition.__name__>`.
 
-   :attr:`~object.__dict__`
-      The dictionary containing the class's namespace.
+   * - .. attribute:: type.__qualname__
+     - The class's :term:`qualified name`.
+       See also: :attr:`__qualname__ attributes <definition.__qualname__>`.
 
-   :attr:`~class.__bases__`
-      A tuple containing the base classes, in the order of
-      their occurrence in the base class list.
+   * - .. attribute:: type.__module__
+     - The name of the module in which the class was defined.
 
-   :attr:`__doc__`
-      The class's documentation string, or ``None`` if undefined.
+   * - .. attribute:: type.__dict__
+     - A :class:`mapping proxy <types.MappingProxyType>`
+       providing a read-only view of the class's namespace.
+       See also: :attr:`__dict__ attributes <object.__dict__>`.
 
-   :attr:`__annotations__`
-      A dictionary containing
-      :term:`variable annotations <variable annotation>`
-      collected during class body execution.  For best practices on
-      working with :attr:`__annotations__`, please see
-      :ref:`annotations-howto`.
+   * - .. attribute:: type.__bases__
+     - A :class:`tuple` containing the class's bases.
+       In most cases, for a class defined as ``class X(A, B, C)``,
+       ``X.__bases__`` will be exactly equal to ``(A, B, C)``.
 
-   :attr:`__type_params__`
-      A tuple containing the :ref:`type parameters <type-params>` of
-      a :ref:`generic class <generic-classes>`.
+   * - .. attribute:: type.__doc__
+     - The class's documentation string, or ``None`` if undefined.
+       Not inherited by subclasses.
 
+   * - .. attribute:: type.__annotations__
+     - A dictionary containing
+       :term:`variable annotations <variable annotation>`
+       collected during class body execution. See also:
+       :attr:`__annotations__ attributes <object.__annotations__>`.
+
+       For best practices on working with :attr:`~object.__annotations__`,
+       please see :ref:`annotations-howto`.
+
+   * - .. attribute:: type.__type_params__
+     - A :class:`tuple` containing the :ref:`type parameters <type-params>` of
+       a :ref:`generic class <generic-classes>`.
+
+       .. versionadded:: 3.12
+
+
+Special methods
+^^^^^^^^^^^^^^^
+
+In addition to the special attributes described above, all Python classes also
+have the following two methods available:
+
+.. method:: type.mro
+
+   This method can be overridden by a metaclass to customize the method
+   resolution order for its instances.  It is called at class instantiation,
+   and its result is stored in :attr:`~type.__mro__`.
+
+.. method:: type.__subclasses__
+
+   Each class keeps a list of weak references to its immediate subclasses. This
+   method returns a list of all those references still alive. The list is in
+   definition order. Example:
+
+   .. doctest::
+
+      >>> int.__subclasses__()
+      [<class 'bool'>, <enum 'IntEnum'>, <flag 'IntFlag'>, <class 're._constants._NamedIntConstant'>, <class 're._ZeroSentinel'>]
 
 Class instances
 ---------------
@@ -1036,12 +1080,22 @@ dictionary directly.
 Class instances can pretend to be numbers, sequences, or mappings if they have
 methods with certain special names.  See section :ref:`specialnames`.
 
+Special attributes
+^^^^^^^^^^^^^^^^^^
+
 .. index::
    single: __dict__ (instance attribute)
    single: __class__ (instance attribute)
 
-Special attributes: :attr:`~object.__dict__` is the attribute dictionary;
-:attr:`~instance.__class__` is the instance's class.
+.. attribute:: object.__class__
+
+   The class to which a class instance belongs.
+
+.. attribute:: object.__dict__
+
+   A dictionary or other mapping object used to store an object's (writable)
+   attributes. Not all instances have a :attr:`!__dict__` attribute; see the
+   section on :ref:`slots` for more details.
 
 
 I/O objects (also known as file objects)
@@ -2259,9 +2313,9 @@ Notes on using *__slots__*:
 
 * The action of a *__slots__* declaration is not limited to the class
   where it is defined.  *__slots__* declared in parents are available in
-  child classes. However, child subclasses will get a :attr:`~object.__dict__` and
-  *__weakref__* unless they also define *__slots__* (which should only
-  contain names of any *additional* slots).
+  child classes. However, instances of a child subclass will get a
+  :attr:`~object.__dict__` and *__weakref__* unless the subclass also defines
+  *__slots__* (which should only contain names of any *additional* slots).
 
 * If a class defines a slot also defined in a base class, the instance variable
   defined by the base class slot is inaccessible (except by retrieving its
@@ -2280,7 +2334,7 @@ Notes on using *__slots__*:
   to provide per-attribute docstrings that will be recognised by
   :func:`inspect.getdoc` and displayed in the output of :func:`help`.
 
-* :attr:`~instance.__class__` assignment works only if both classes have the
+* :attr:`~object.__class__` assignment works only if both classes have the
   same *__slots__*.
 
 * :ref:`Multiple inheritance <tut-multiple>` with multiple slotted parent
@@ -2546,7 +2600,7 @@ in the local namespace as the defined class.
 When a new class is created by ``type.__new__``, the object provided as the
 namespace parameter is copied to a new ordered mapping and the original
 object is discarded. The new copy is wrapped in a read-only proxy, which
-becomes the :attr:`~object.__dict__` attribute of the class object.
+becomes the :attr:`~type.__dict__` attribute of the class object.
 
 .. seealso::
 
@@ -2574,14 +2628,14 @@ order to allow the addition of Abstract Base Classes (ABCs) as "virtual base
 classes" to any class or type (including built-in types), including other
 ABCs.
 
-.. method:: class.__instancecheck__(self, instance)
+.. method:: type.__instancecheck__(self, instance)
 
    Return true if *instance* should be considered a (direct or indirect)
    instance of *class*. If defined, called to implement ``isinstance(instance,
    class)``.
 
 
-.. method:: class.__subclasscheck__(self, subclass)
+.. method:: type.__subclasscheck__(self, subclass)
 
    Return true if *subclass* should be considered a (direct or indirect)
    subclass of *class*.  If defined, called to implement ``issubclass(subclass,
@@ -2597,8 +2651,8 @@ case the instance is itself a class.
 
    :pep:`3119` - Introducing Abstract Base Classes
       Includes the specification for customizing :func:`isinstance` and
-      :func:`issubclass` behavior through :meth:`~class.__instancecheck__` and
-      :meth:`~class.__subclasscheck__`, with motivation for this functionality
+      :func:`issubclass` behavior through :meth:`~type.__instancecheck__` and
+      :meth:`~type.__subclasscheck__`, with motivation for this functionality
       in the context of adding Abstract Base Classes (see the :mod:`abc`
       module) to the language.
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1006,17 +1006,18 @@ Special attributes
    * - .. attribute:: type.__annotations__
      - A dictionary containing
        :term:`variable annotations <variable annotation>`
-       collected during class body execution. See also:
-       :attr:`__annotations__ attributes <object.__annotations__>`.
-
-       For best practices on working with :attr:`~object.__annotations__`,
-       please see :ref:`annotations-howto`.
+       collected during class body execution. For best practices on working
+       with :attr:`!__annotations__`, please see :ref:`annotations-howto`.
 
    * - .. attribute:: type.__type_params__
      - A :class:`tuple` containing the :ref:`type parameters <type-params>` of
        a :ref:`generic class <generic-classes>`.
 
        .. versionadded:: 3.12
+
+   * - .. attribute:: type.__mro__
+     - The :class:`tuple` of classes that are considered when looking for
+       base classes during method resolution.
 
 
 Special methods

--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -225,8 +225,8 @@ Annotation scopes differ from function scopes in the following ways:
   statements in inner scopes. This includes only type parameters, as no other
   syntactic elements that can appear within annotation scopes can introduce new names.
 * While annotation scopes have an internal name, that name is not reflected in the
-  :term:`__qualname__ <qualified name>` of objects defined within the scope.
-  Instead, the :attr:`!__qualname__`
+  :term:`qualified name` of objects defined within the scope.
+  Instead, the :attr:`~definition.__qualname__`
   of such objects is as if the object were defined in the enclosing scope.
 
 .. versionadded:: 3.12

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -104,8 +104,8 @@ identifier is used but only the following private identifiers are mangled:
 - Any name used as the name of a variable that is assigned or read or any
   name of an attribute being accessed.
 
-  The ``__name__`` attribute of nested functions, classes, and type aliases
-  is however not mangled.
+  The :attr:`~definition.__name__` attribute of nested functions, classes, and
+  type aliases is however not mangled.
 
 - The name of imported modules, e.g., ``__spam`` in ``import __spam``.
   If the module is part of a package (i.e., its name contains a dot),

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -276,8 +276,8 @@ definition looked like this::
 then ``MyClass.i`` and ``MyClass.f`` are valid attribute references, returning
 an integer and a function object, respectively. Class attributes can also be
 assigned to, so you can change the value of ``MyClass.i`` by assignment.
-:attr:`!__doc__` is also a valid attribute, returning the docstring belonging to
-the class: ``"A simple example class"``.
+:attr:`~type.__doc__` is also a valid attribute, returning the docstring
+belonging to the class: ``"A simple example class"``.
 
 Class *instantiation* uses function notation.  Just pretend that the class
 object is a parameterless function that returns a new instance of the class.
@@ -932,6 +932,6 @@ Examples::
 
 .. [#] Except for one thing.  Module objects have a secret read-only attribute called
    :attr:`~object.__dict__` which returns the dictionary used to implement the module's
-   namespace; the name :attr:`~object.__dict__` is an attribute but not a global name.
+   namespace; the name ``__dict__`` is an attribute but not a global name.
    Obviously, using this violates the abstraction of namespace implementation, and
    should be restricted to things like post-mortem debuggers.

--- a/Doc/whatsnew/2.1.rst
+++ b/Doc/whatsnew/2.1.rst
@@ -443,8 +443,8 @@ Python syntax::
    f.grammar = "A ::= B (C D)*"
 
 The dictionary containing attributes can be accessed as the function's
-:attr:`~object.__dict__`. Unlike the :attr:`~object.__dict__` attribute of class instances, in
-functions you can actually assign a new dictionary to :attr:`~object.__dict__`, though
+:attr:`~function.__dict__`. Unlike the :attr:`~type.__dict__` attribute of class instances, in
+functions you can actually assign a new dictionary to :attr:`~function.__dict__`, though
 the new value is restricted to a regular Python dictionary; you *can't* be
 tricky and set it to a :class:`!UserDict` instance, or any other random object
 that behaves like a mapping.

--- a/Doc/whatsnew/2.2.rst
+++ b/Doc/whatsnew/2.2.rst
@@ -171,7 +171,7 @@ attributes of their own:
 
 * :attr:`~definition.__name__` is the attribute's name.
 
-* :attr:`!__doc__` is the attribute's docstring.
+* :attr:`~definition.__doc__` is the attribute's docstring.
 
 * ``__get__(object)`` is a method that retrieves the attribute value from
   *object*.
@@ -186,7 +186,8 @@ are::
    descriptor = obj.__class__.x
    descriptor.__get__(obj)
 
-For methods, :meth:`!descriptor.__get__` returns a temporary object that's
+For methods, :meth:`descriptor.__get__ <object.__get__>` returns a temporary
+object that's
 callable, and wraps up the instance and the method to be called on it. This is
 also why static methods and class methods are now possible; they have
 descriptors that wrap up just the method, or the method and the class.  As a

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -1113,10 +1113,10 @@ Here are all of the changes that Python 2.3 makes to the core Python language.
      <type '_socket.socket'>
 
 * One of the noted incompatibilities between old- and new-style classes has been
-  removed: you can now assign to the :attr:`~definition.__name__` and :attr:`~class.__bases__`
+  removed: you can now assign to the :attr:`~type.__name__` and :attr:`~type.__bases__`
   attributes of new-style classes.  There are some restrictions on what can be
-  assigned to :attr:`~class.__bases__` along the lines of those relating to assigning to
-  an instance's :attr:`~instance.__class__` attribute.
+  assigned to :attr:`!__bases__` along the lines of those relating to assigning to
+  an instance's :attr:`~object.__class__` attribute.
 
 .. ======================================================================
 
@@ -1925,8 +1925,8 @@ Changes to Python's build process and to the C API include:
   dependence on a system version or local installation of Expat.
 
 * If you dynamically allocate type objects in your extension, you should be
-  aware of a change in the rules relating to the :attr:`!__module__` and
-  :attr:`~definition.__name__` attributes.  In summary, you will want to ensure the type's
+  aware of a change in the rules relating to the :attr:`~type.__module__` and
+  :attr:`~type.__name__` attributes.  In summary, you will want to ensure the type's
   dictionary contains a ``'__module__'`` key; making the module name the part of
   the type name leading up to the final period will no longer have the desired
   effect.  For more detail, read the API reference documentation or the  source.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1898,7 +1898,7 @@ New Features
 
   The :c:macro:`Py_TPFLAGS_MANAGED_DICT` and :c:macro:`Py_TPFLAGS_MANAGED_WEAKREF`
   flags have been added. This allows extensions classes to support object
-  ``__dict__`` and weakrefs with less bookkeeping,
+  :attr:`~object.__dict__` and weakrefs with less bookkeeping,
   using less memory and with faster access.
 
 * API for performing calls using
@@ -2017,7 +2017,7 @@ Porting to Python 3.12
   internal-only field directly.
 
   To get a list of subclasses, call the Python method
-  :py:meth:`~class.__subclasses__` (using :c:func:`PyObject_CallMethod`,
+  :py:meth:`~type.__subclasses__` (using :c:func:`PyObject_CallMethod`,
   for example).
 
 * Add support of more formatting options (left aligning, octals, uppercase
@@ -2036,7 +2036,7 @@ Porting to Python 3.12
   :c:func:`PyUnicode_FromFormatV`.
   (Contributed by Philip Georgi in :gh:`95504`.)
 
-* Extension classes wanting to add a ``__dict__`` or weak reference slot
+* Extension classes wanting to add a :attr:`~object.__dict__` or weak reference slot
   should use :c:macro:`Py_TPFLAGS_MANAGED_DICT` and
   :c:macro:`Py_TPFLAGS_MANAGED_WEAKREF` instead of ``tp_dictoffset`` and
   ``tp_weaklistoffset``, respectively.

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -549,9 +549,11 @@ separation of binary and text data).
 PEP 3155: Qualified name for classes and functions
 ==================================================
 
-Functions and class objects have a new ``__qualname__`` attribute representing
+Functions and class objects have a new :attr:`~definition.__qualname__`
+attribute representing
 the "path" from the module top-level to their definition.  For global functions
-and classes, this is the same as ``__name__``.  For other functions and classes,
+and classes, this is the same as :attr:`~definition.__name__`.
+For other functions and classes,
 it provides better information about where they were actually defined, and
 how they might be accessible from the global scope.
 

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -2526,9 +2526,9 @@ Changes in the C API
   to format the :func:`repr` of the object.
   (Contributed by Serhiy Storchaka in :issue:`22453`.)
 
-* Because the lack of the :attr:`__module__` attribute breaks pickling and
+* Because the lack of the :attr:`~type.__module__` attribute breaks pickling and
   introspection, a deprecation warning is now raised for builtin types without
-  the :attr:`__module__` attribute.  This would be an AttributeError in
+  the :attr:`~type.__module__` attribute.  This will be an :exc:`AttributeError` in
   the future.
   (Contributed by Serhiy Storchaka in :issue:`20204`.)
 

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -549,7 +549,7 @@ PEP 520: Preserving Class Attribute Definition Order
 
 Attributes in a class definition body have a natural ordering: the same
 order in which the names appear in the source.  This order is now
-preserved in the new class's :attr:`~object.__dict__` attribute.
+preserved in the new class's :attr:`~type.__dict__` attribute.
 
 Also, the effective default class *execution* namespace (returned from
 :ref:`type.__prepare__() <prepare>`) is now an insertion-order-preserving
@@ -934,7 +934,7 @@ asynchronous generators.
 
 The :func:`~collections.namedtuple` function now accepts an optional
 keyword argument *module*, which, when specified, is used for
-the ``__module__`` attribute of the returned named tuple class.
+the :attr:`~type.__module__` attribute of the returned named tuple class.
 (Contributed by Raymond Hettinger in :issue:`17941`.)
 
 The *verbose* and *rename* arguments for

--- a/Doc/whatsnew/3.9.rst
+++ b/Doc/whatsnew/3.9.rst
@@ -637,7 +637,8 @@ pydoc
 -----
 
 The documentation string is now shown not only for class, function,
-method etc, but for any object that has its own ``__doc__`` attribute.
+method etc, but for any object that has its own :attr:`~definition.__doc__`
+attribute.
 (Contributed by Serhiy Storchaka in :issue:`40257`.)
 
 random


### PR DESCRIPTION
(cherry-picked from commit 0d9d56c4e4246495f506f7fb319548fb105b535b)

<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124558.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->