### PR TITLE
gh-124538: Fix crash when using `gc.get_referents` on an untracked capsule object

### DIFF
--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1050,7 +1050,7 @@ class GCTests(unittest.TestCase):
 
     @cpython_only
     def test_get_referents_on_capsule(self):
-        # See GH-124538
+        # gh-124538: Calling gc.get_referents() on an untracked capsule must not crash.
         import _datetime
         import _socket
         untracked_capsule = _datetime.datetime_CAPI

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1048,6 +1048,24 @@ class GCTests(unittest.TestCase):
         callback.assert_not_called()
         gc.enable()
 
+    @cpython_only
+    def test_get_referents_on_capsule(self):
+        # See GH-124538
+        import _datetime
+        import _socket
+        untracked_capsule = _datetime.datetime_CAPI
+        tracked_capsule = _socket.CAPI
+
+        # For whoever sees this in the future: if this is failing
+        # after making datetime's capsule tracked, that's fine -- this isn't something
+        # users are relying on. Just find a different capsule that is untracked.
+        self.assertFalse(gc.is_tracked(untracked_capsule))
+        self.assertTrue(gc.is_tracked(tracked_capsule))
+
+        self.assertEqual(len(gc.get_referents(untracked_capsule)), 0)
+        gc.get_referents(tracked_capsule)
+
+
 
 class IncrementalGCTests(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2024-09-25-18-34-48.gh-issue-124538.nXZk4R.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-25-18-34-48.gh-issue-124538.nXZk4R.rst
@@ -1,0 +1,1 @@
+Fixed crash when using :func:`gc.get_referents` on a capsule object.

--- a/Objects/capsule.c
+++ b/Objects/capsule.c
@@ -317,10 +317,14 @@ static int
 capsule_traverse(PyCapsule *capsule, visitproc visit, void *arg)
 {
     // Capsule object is only tracked by the GC
-    // if _PyCapsule_SetTraverse() is called
-    assert(capsule->traverse_func != NULL);
+    // if _PyCapsule_SetTraverse() is called, but
+    // this can still be manually triggered by gc.get_referents()
 
-    return capsule->traverse_func((PyObject*)capsule, visit, arg);
+    if (capsule->traverse_func != NULL) {
+        return capsule->traverse_func((PyObject*)capsule, visit, arg);
+    }
+
+    return 0;
 }
 
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-124538 -->
* Issue: gh-124538
<!-- /gh-issue-number -->
