### PR TITLE
gh-119180: Disallow instantiation of ConstEvaluator objects

### DIFF
--- a/Lib/test/test_type_params.py
+++ b/Lib/test/test_type_params.py
@@ -1452,3 +1452,14 @@ class TestEvaluateFunctions(unittest.TestCase):
                 self.assertEqual(annotationlib.call_evaluate_function(case.evaluate_constraints, annotationlib.Format.VALUE), (int, str))
                 self.assertEqual(annotationlib.call_evaluate_function(case.evaluate_constraints, annotationlib.Format.FORWARDREF), (int, str))
                 self.assertEqual(annotationlib.call_evaluate_function(case.evaluate_constraints, annotationlib.Format.SOURCE), '(int, str)')
+
+    def test_const_evaluator(self):
+        T = TypeVar("T", bound=int)
+        self.assertEqual(repr(T.evaluate_bound), "<constevaluator <class 'int'>>")
+
+        ConstEvaluator = type(T.evaluate_bound)
+
+        with self.assertRaisesRegex(TypeError, r"cannot create '_typing\._ConstEvaluator' instances"):
+            ConstEvaluator()
+        with self.assertRaisesRegex(TypeError, r"cannot set 'attribute' attribute of immutable type '_typing\._ConstEvaluator'"):
+            ConstEvaluator.attribute = 1

--- a/Lib/test/test_type_params.py
+++ b/Lib/test/test_type_params.py
@@ -1460,6 +1460,6 @@ class TestEvaluateFunctions(unittest.TestCase):
         ConstEvaluator = type(T.evaluate_bound)
 
         with self.assertRaisesRegex(TypeError, r"cannot create '_typing\._ConstEvaluator' instances"):
-            ConstEvaluator()
+            ConstEvaluator()  # This used to segfault.
         with self.assertRaisesRegex(TypeError, r"cannot set 'attribute' attribute of immutable type '_typing\._ConstEvaluator'"):
             ConstEvaluator.attribute = 1

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -242,7 +242,8 @@ static PyType_Slot constevaluator_slots[] = {
 PyType_Spec constevaluator_spec = {
     .name = "_typing._ConstEvaluator",
     .basicsize = sizeof(constevaluatorobject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_IMMUTABLETYPE,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_IMMUTABLETYPE
+        | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .slots = constevaluator_slots,
 };
 

--- a/Objects/typevarobject.c
+++ b/Objects/typevarobject.c
@@ -151,7 +151,7 @@ constevaluator_clear(PyObject *self)
 }
 
 static PyObject *
-constevaluator_repr(PyObject *self, PyObject *repr)
+constevaluator_repr(PyObject *self)
 {
     PyObject *value = ((constevaluatorobject *)self)->value;
     return PyUnicode_FromFormat("<constevaluator %R>", value);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119180 -->
* Issue: gh-119180
<!-- /gh-issue-number -->
