### PR TITLE
[3.12] gh-123242: Note that type.__annotations__ may not exist (GH-124557)

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1009,6 +1009,14 @@ Special attributes
        collected during class body execution. For best practices on working
        with :attr:`!__annotations__`, please see :ref:`annotations-howto`.
 
+       .. caution::
+
+          Accessing the :attr:`!__annotations__` attribute of a class
+          object directly may yield incorrect results in the presence of
+          metaclasses. In addition, the attribute may not exist for
+          some classes. Use :func:`inspect.get_annotations` to
+          retrieve class annotations safely.
+
    * - .. attribute:: type.__type_params__
      - A :class:`tuple` containing the :ref:`type parameters <type-params>` of
        a :ref:`generic class <generic-classes>`.


### PR DESCRIPTION
Closes GH-123242. The real criterion is that the attribute does not exist on heap types, but I don't think we should discuss heap vs. static types in the language reference.
(cherry picked from commit 99b23c64de301c9e77add6b0d8e60118ef807840)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124562.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->