### PR TITLE
gh-116750: Add clear_tool_id function to unregister events and callbacks

### DIFF
--- a/Doc/library/sys.monitoring.rst
+++ b/Doc/library/sys.monitoring.rst
@@ -50,16 +50,14 @@ Registering and using tools
    *tool_id* must be in the range 0 to 5 inclusive.
    Raises a :exc:`ValueError` if *tool_id* is in use.
 
+.. function:: clear_tool_id(tool_id: int, /) -> None
+
+   Unregister all events and callback functions associated with *tool_id*.
+
 .. function:: free_tool_id(tool_id: int, /) -> None
 
    Should be called once a tool no longer requires *tool_id*.
-
-.. note::
-
-   :func:`free_tool_id` will not disable global or local events associated
-   with *tool_id*, nor will it unregister any callback functions. This
-   function is only intended to be used to notify the VM that the
-   particular *tool_id* is no longer in use.
+   Will call :func:`clear_tool_id` before releasing *tool_id*.
 
 .. function:: get_tool(tool_id: int, /) -> str | None
 

--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -8,8 +8,8 @@
 extern "C" {
 #endif
 
-/* Total tool ids available for external use */
-#define  _PY_MONITORING_EXTENAL_TOOL_IDS 6
+/* Total tool ids available */
+#define  _PY_MONITORING_TOOL_IDS 8
 /* Count of all local monitoring events */
 #define  _PY_MONITORING_LOCAL_EVENTS 10
 /* Count of all "real" monitoring events (not derived from other events) */
@@ -60,7 +60,7 @@ typedef struct {
     /* The tools that are to be notified for events for the matching code unit */
     uint8_t *tools;
     /* The version of tools when they instrument the code */
-    uintptr_t tool_versions[_PY_MONITORING_EXTENAL_TOOL_IDS];
+    uintptr_t tool_versions[_PY_MONITORING_TOOL_IDS];
     /* Information to support line events */
     _PyCoLineInstrumentationData *lines;
     /* The tools that are to be notified for line events for the matching code unit */

--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -8,8 +8,8 @@
 extern "C" {
 #endif
 
-/* Total tool ids available */
-#define  _PY_MONITORING_TOOL_IDS 8
+/* Total tool ids available for external use */
+#define  _PY_MONITORING_EXTENAL_TOOL_IDS 6
 /* Count of all local monitoring events */
 #define  _PY_MONITORING_LOCAL_EVENTS 10
 /* Count of all "real" monitoring events (not derived from other events) */
@@ -60,7 +60,7 @@ typedef struct {
     /* The tools that are to be notified for events for the matching code unit */
     uint8_t *tools;
     /* The version of tools when they instrument the code */
-    uintptr_t tool_versions[_PY_MONITORING_TOOL_IDS];
+    uintptr_t tool_versions[_PY_MONITORING_EXTENAL_TOOL_IDS];
     /* Information to support line events */
     _PyCoLineInstrumentationData *lines;
     /* The tools that are to be notified for line events for the matching code unit */

--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -20,7 +20,6 @@ extern "C" {
 /* Tables of which tools are active for each monitored event. */
 typedef struct _Py_LocalMonitors {
     uint8_t tools[_PY_MONITORING_LOCAL_EVENTS];
-    uintptr_t tool_versions[_PY_MONITORING_TOOL_IDS];
 } _Py_LocalMonitors;
 
 typedef struct _Py_GlobalMonitors {
@@ -60,6 +59,8 @@ typedef struct {
     _Py_LocalMonitors active_monitors;
     /* The tools that are to be notified for events for the matching code unit */
     uint8_t *tools;
+    /* The version of tools when they instrument the code */
+    uintptr_t tool_versions[_PY_MONITORING_TOOL_IDS];
     /* Information to support line events */
     _PyCoLineInstrumentationData *lines;
     /* The tools that are to be notified for line events for the matching code unit */

--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -8,6 +8,8 @@
 extern "C" {
 #endif
 
+/* Total tool ids available */
+#define  _PY_MONITORING_TOOL_IDS 8
 /* Count of all local monitoring events */
 #define  _PY_MONITORING_LOCAL_EVENTS 10
 /* Count of all "real" monitoring events (not derived from other events) */
@@ -18,6 +20,7 @@ extern "C" {
 /* Tables of which tools are active for each monitored event. */
 typedef struct _Py_LocalMonitors {
     uint8_t tools[_PY_MONITORING_LOCAL_EVENTS];
+    uintptr_t tool_versions[_PY_MONITORING_TOOL_IDS];
 } _Py_LocalMonitors;
 
 typedef struct _Py_GlobalMonitors {

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -272,6 +272,7 @@ struct _is {
     Py_ssize_t sys_tracing_threads; /* Count of threads with c_tracefunc set */
     PyObject *monitoring_callables[PY_MONITORING_TOOL_IDS][_PY_MONITORING_EVENTS];
     PyObject *monitoring_tool_names[PY_MONITORING_TOOL_IDS];
+    uintptr_t monitoring_tool_versions[PY_MONITORING_TOOL_IDS];
 
     struct _Py_interp_cached_objects cached_objects;
     struct _Py_interp_static_objects static_objects;

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -272,7 +272,8 @@ struct _is {
     Py_ssize_t sys_tracing_threads; /* Count of threads with c_tracefunc set */
     PyObject *monitoring_callables[PY_MONITORING_TOOL_IDS][_PY_MONITORING_EVENTS];
     PyObject *monitoring_tool_names[PY_MONITORING_TOOL_IDS];
-    uintptr_t monitoring_tool_versions[PY_MONITORING_TOOL_IDS];
+    // Only external available tool ids need versioning.
+    uintptr_t monitoring_tool_versions[PY_MONITORING_SYS_PROFILE_ID];
 
     struct _Py_interp_cached_objects cached_objects;
     struct _Py_interp_static_objects static_objects;

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -272,8 +272,7 @@ struct _is {
     Py_ssize_t sys_tracing_threads; /* Count of threads with c_tracefunc set */
     PyObject *monitoring_callables[PY_MONITORING_TOOL_IDS][_PY_MONITORING_EVENTS];
     PyObject *monitoring_tool_names[PY_MONITORING_TOOL_IDS];
-    // Only external available tool ids need versioning.
-    uintptr_t monitoring_tool_versions[PY_MONITORING_SYS_PROFILE_ID];
+    uintptr_t monitoring_tool_versions[PY_MONITORING_TOOL_IDS];
 
     struct _Py_interp_cached_objects cached_objects;
     struct _Py_interp_static_objects static_objects;

--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -46,6 +46,9 @@ def nth_line(func, offset):
 
 class MonitoringBasicTest(unittest.TestCase):
 
+    def tearDown(self):
+        sys.monitoring.free_tool_id(TEST_TOOL)
+
     def test_has_objects(self):
         m = sys.monitoring
         m.events
@@ -99,6 +102,20 @@ class MonitoringBasicTest(unittest.TestCase):
         callback = sys.monitoring.register_callback(TEST_TOOL, E.LINE, None)
         self.assertIs(callback, None)
 
+        sys.monitoring.free_tool_id(TEST_TOOL)
+
+        events = []
+        sys.monitoring.use_tool_id(TEST_TOOL, "MonitoringTest.Tool")
+        sys.monitoring.register_callback(TEST_TOOL, E.LINE, lambda *args: events.append(args))
+        sys.monitoring.set_local_events(TEST_TOOL, f.__code__, E.LINE)
+        f()
+        sys.monitoring.free_tool_id(TEST_TOOL)
+        sys.monitoring.use_tool_id(TEST_TOOL, "MonitoringTest.Tool")
+        f()
+        # the first f() should trigger a LINE event, and even if we use the
+        # tool id immediately after freeing it, the second f() should not
+        # trigger any event
+        self.assertEqual(len(events), 1)
         sys.monitoring.free_tool_id(TEST_TOOL)
 
 

--- a/Misc/NEWS.d/next/Library/2024-09-26-00-35-24.gh-issue-116750.X1aMHI.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-26-00-35-24.gh-issue-116750.X1aMHI.rst
@@ -1,0 +1,1 @@
+Provide :func:`sys.monitoring.clear_tool_id` to unregister all events and callbacks set by the tool.

--- a/Python/clinic/instrumentation.c.h
+++ b/Python/clinic/instrumentation.c.h
@@ -36,6 +36,33 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(monitoring_clear_tool_id__doc__,
+"clear_tool_id($module, tool_id, /)\n"
+"--\n"
+"\n");
+
+#define MONITORING_CLEAR_TOOL_ID_METHODDEF    \
+    {"clear_tool_id", (PyCFunction)monitoring_clear_tool_id, METH_O, monitoring_clear_tool_id__doc__},
+
+static PyObject *
+monitoring_clear_tool_id_impl(PyObject *module, int tool_id);
+
+static PyObject *
+monitoring_clear_tool_id(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    int tool_id;
+
+    tool_id = PyLong_AsInt(arg);
+    if (tool_id == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = monitoring_clear_tool_id_impl(module, tool_id);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(monitoring_free_tool_id__doc__,
 "free_tool_id($module, tool_id, /)\n"
 "--\n"
@@ -304,4 +331,4 @@ monitoring__all_events(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return monitoring__all_events_impl(module);
 }
-/*[clinic end generated code: output=14ffc0884a6de50a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8f81876c6aba9be8 input=a9049054013a1b77]*/

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -2071,7 +2071,14 @@ int _PyMonitoring_ClearToolId(int tool_id)
         _PyEval_StartTheWorld(interp);
         return -1;
     }
+
+    // monitoring_tool_versions[tool_id] is set to latest global version here to
+    //   1. invalidate local events on all existing code objects
+    //   2. be ready for the next use_tool_id call so we can only do this in one place
     interp->monitoring_tool_versions[tool_id] = version;
+
+    // Set the new global version so all the code objects can refresh the
+    // instrumentation.
     set_global_version(_PyThreadState_GET(), version);
     int res = instrument_all_executing_code_objects(interp);
     _PyEval_StartTheWorld(interp);

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1662,7 +1662,7 @@ update_instrumentation_data(PyCodeObject *code, PyInterpreterState *interp)
     }
     // If the local monitors are out of date, clear them up
     _Py_LocalMonitors *local_monitors = &code->_co_monitoring->local_monitors;
-    for (int i = 0; i < PY_MONITORING_TOOL_IDS; i++) {
+    for (int i = 0; i < PY_MONITORING_SYS_PROFILE_ID; i++) {
         if (code->_co_monitoring->tool_versions[i] != interp->monitoring_tool_versions[i]) {
             for (int j = 0; j < _PY_MONITORING_LOCAL_EVENTS; j++) {
                 local_monitors->tools[j] &= ~(1 << i);

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -2074,7 +2074,7 @@ int _PyMonitoring_ClearToolId(int tool_id)
 
     // monitoring_tool_versions[tool_id] is set to latest global version here to
     //   1. invalidate local events on all existing code objects
-    //   2. be ready for the next use_tool_id call so we can only do this in one place
+    //   2. be ready for the next call to set local events
     interp->monitoring_tool_versions[tool_id] = version;
 
     // Set the new global version so all the code objects can refresh the

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1662,7 +1662,7 @@ update_instrumentation_data(PyCodeObject *code, PyInterpreterState *interp)
     }
     // If the local monitors are out of date, clear them up
     _Py_LocalMonitors *local_monitors = &code->_co_monitoring->local_monitors;
-    for (int i = 0; i < PY_MONITORING_SYS_PROFILE_ID; i++) {
+    for (int i = 0; i < PY_MONITORING_TOOL_IDS; i++) {
         if (code->_co_monitoring->tool_versions[i] != interp->monitoring_tool_versions[i]) {
             for (int j = 0; j < _PY_MONITORING_LOCAL_EVENTS; j++) {
                 local_monitors->tools[j] &= ~(1 << i);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -654,6 +654,7 @@ init_interpreter(PyInterpreterState *interp,
             interp->monitoring_callables[t][e] = NULL;
 
         }
+        interp->monitoring_tool_versions[t] = 0;
     }
     interp->sys_profile_initialized = false;
     interp->sys_trace_initialized = false;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -654,6 +654,8 @@ init_interpreter(PyInterpreterState *interp,
             interp->monitoring_callables[t][e] = NULL;
 
         }
+    }
+    for (int t = 0; t < PY_MONITORING_SYS_PROFILE_ID; t++) {
         interp->monitoring_tool_versions[t] = 0;
     }
     interp->sys_profile_initialized = false;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -654,8 +654,6 @@ init_interpreter(PyInterpreterState *interp,
             interp->monitoring_callables[t][e] = NULL;
 
         }
-    }
-    for (int t = 0; t < PY_MONITORING_SYS_PROFILE_ID; t++) {
         interp->monitoring_tool_versions[t] = 0;
     }
     interp->sys_profile_initialized = false;


### PR DESCRIPTION
Provide a mechanism to unregister everything of a tool, including local events. The life would be so much easier for debuggers.

<!-- gh-issue-number: gh-116750 -->
* Issue: gh-116750
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124568.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->