### PR TITLE
gh-101100: Make __subclasses__ doctest stable

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1112,7 +1112,7 @@ have the following two methods available:
       >>> class A: pass
       >>> class B(A): pass
       >>> A.__subclasses__()
-      [<class '__main__.B'>]
+      [<class 'B'>]
 
 Class instances
 ---------------

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1109,8 +1109,10 @@ have the following two methods available:
 
    .. doctest::
 
-      >>> int.__subclasses__()
-      [<class 'bool'>, <enum 'IntEnum'>, <flag 'IntFlag'>, <class 're._constants._NamedIntConstant'>, <class 're._ZeroSentinel'>]
+      >>> class A: pass
+      >>> class B(A): pass
+      >>> A.__subclasses__()
+      [<class '__main__.B'>]
 
 Class instances
 ---------------


### PR DESCRIPTION
Using a standard library class makes this test difficult to maintain
as other tests and other parts of the stdlib may create subclasses,
which may still be alive when this test runs depending on GC timing.


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124577.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->