### PR TITLE
[3.12] gh-101100: Make __subclasses__ doctest stable (GH-124577)

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1048,8 +1048,10 @@ have the following two methods available:
 
    .. doctest::
 
-      >>> int.__subclasses__()
-      [<class 'bool'>, <enum 'IntEnum'>, <flag 'IntFlag'>, <class 're._constants._NamedIntConstant'>]
+      >>> class A: pass
+      >>> class B(A): pass
+      >>> A.__subclasses__()
+      [<class 'B'>]
 
 Class instances
 ---------------


### PR DESCRIPTION
Using a standard library class makes this test difficult to maintain as other tests and other parts of the stdlib may create subclasses, which may still be alive when this test runs depending on GC timing. (cherry picked from commit 08a467b537b3d9b499d060697e79b3950374ab0f)


<!-- gh-issue-number: gh-101100 -->
* Issue: gh-101100
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124580.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->