### PR TITLE
[3.13] gh-124402: Speed up test_free_threading and test_super (#124491)

### DIFF
--- a/Lib/test/test_free_threading/test_list.py
+++ b/Lib/test/test_free_threading/test_list.py
@@ -3,8 +3,11 @@ import unittest
 from threading import Thread
 from unittest import TestCase
 
-from test import support
 from test.support import threading_helper
+
+
+NTHREAD = 10
+OBJECT_COUNT = 5_000
 
 
 class C:
@@ -14,11 +17,8 @@ class C:
 
 @threading_helper.requires_working_threading()
 class TestList(TestCase):
-    @support.requires_resource('cpu')
     def test_racing_iter_append(self):
-
         l = []
-        OBJECT_COUNT = 10000
 
         def writer_func():
             for i in range(OBJECT_COUNT):
@@ -34,7 +34,7 @@ class TestList(TestCase):
 
         writer = Thread(target=writer_func)
         readers = []
-        for x in range(30):
+        for x in range(NTHREAD):
             reader = Thread(target=reader_func)
             readers.append(reader)
             reader.start()
@@ -44,39 +44,32 @@ class TestList(TestCase):
         for reader in readers:
             reader.join()
 
-    @support.requires_resource('cpu')
     def test_racing_iter_extend(self):
-        iters = [
-            lambda x: [x],
-        ]
-        for iter_case in iters:
-            with self.subTest(iter=iter_case):
-                l = []
-                OBJECT_COUNT = 10000
+        l = []
 
-                def writer_func():
-                    for i in range(OBJECT_COUNT):
-                        l.extend(iter_case(C(i + OBJECT_COUNT)))
+        def writer_func():
+            for i in range(OBJECT_COUNT):
+                l.extend([C(i + OBJECT_COUNT)])
 
-                def reader_func():
-                    while True:
-                        count = len(l)
-                        for i, x in enumerate(l):
-                            self.assertEqual(x.v, i + OBJECT_COUNT)
-                        if count == OBJECT_COUNT:
-                            break
+        def reader_func():
+            while True:
+                count = len(l)
+                for i, x in enumerate(l):
+                    self.assertEqual(x.v, i + OBJECT_COUNT)
+                if count == OBJECT_COUNT:
+                    break
 
-                writer = Thread(target=writer_func)
-                readers = []
-                for x in range(30):
-                    reader = Thread(target=reader_func)
-                    readers.append(reader)
-                    reader.start()
+        writer = Thread(target=writer_func)
+        readers = []
+        for x in range(NTHREAD):
+            reader = Thread(target=reader_func)
+            readers.append(reader)
+            reader.start()
 
-                writer.start()
-                writer.join()
-                for reader in readers:
-                    reader.join()
+        writer.start()
+        writer.join()
+        for reader in readers:
+            reader.join()
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_free_threading/test_type.py
+++ b/Lib/test/test_free_threading/test_type.py
@@ -6,7 +6,7 @@ from threading import Thread
 from unittest import TestCase
 
 from test import support
-from test.support import threading_helper, import_helper
+from test.support import threading_helper
 
 
 
@@ -97,8 +97,9 @@ class TestType(TestCase):
 
         self.run_one(writer_func, reader_func)
 
-    @support.requires_resource('cpu')
     def test___class___modification(self):
+        loops = 200
+
         class Foo:
             pass
 
@@ -108,7 +109,7 @@ class TestType(TestCase):
         thing = Foo()
         def work():
             foo = thing
-            for _ in range(5000):
+            for _ in range(loops):
                 foo.__class__ = Bar
                 type(foo)
                 foo.__class__ = Foo

--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -4,7 +4,6 @@ import textwrap
 import threading
 import unittest
 from unittest.mock import patch
-from test import support
 from test.support import import_helper, threading_helper
 
 
@@ -515,10 +514,6 @@ class TestSuper(unittest.TestCase):
         an audit hook.
         """
 
-        if support.Py_GIL_DISABLED:
-            # gh-124402: On a Free Threaded build, the test takes a few minutes
-            support.requires('cpu')
-
         class Foo:
             pass
 
@@ -528,7 +523,7 @@ class TestSuper(unittest.TestCase):
         thing = Foo()
         def work():
             foo = thing
-            for _ in range(5000):
+            for _ in range(200):
                 foo.__class__ = Bar
                 type(foo)
                 foo.__class__ = Foo


### PR DESCRIPTION
* Reduce the number of iterations and the number of threads so a whole test file takes less than a minute.
* Refactor test_racing_iter_extend() to remove two levels of indentation.
* test_monitoring() uses a sleep of 100 ms instead of 1 second.

(cherry picked from commit 0387c34f7c91428681ca8a4ba4e3d22b9acffde4)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124402 -->
* Issue: gh-124402
<!-- /gh-issue-number -->
