### PR TITLE
gh-124835: `tomllib.loads`: Raise TypeError not AttributeError. Improve message

### DIFF
--- a/Lib/test/test_tomllib/test_error.py
+++ b/Lib/test/test_tomllib/test_error.py
@@ -39,6 +39,15 @@ class TestError(unittest.TestCase):
             tomllib.loads("v = '\n'")
         self.assertTrue(" '\\n' " in str(exc_info.exception))
 
+    def test_type_error(self):
+        with self.assertRaises(TypeError) as exc_info:
+            tomllib.loads(b"v = 1")  # type: ignore[arg-type]
+        self.assertEqual(str(exc_info.exception), "Expected str object, not 'bytes'")
+
+        with self.assertRaises(TypeError) as exc_info:
+            tomllib.loads(False)  # type: ignore[arg-type]
+        self.assertEqual(str(exc_info.exception), "Expected str object, not 'bool'")
+
     def test_module_name(self):
         self.assertEqual(tomllib.TOMLDecodeError().__module__, tomllib.__name__)
 

--- a/Lib/tomllib/_parser.py
+++ b/Lib/tomllib/_parser.py
@@ -72,7 +72,7 @@ def loads(s: str, /, *, parse_float: ParseFloat = float) -> dict[str, Any]:  # n
     # The spec allows converting "\r\n" to "\n", even in string
     # literals. Let's do so to simplify parsing.
     try:
-        src = __s.replace("\r\n", "\n")
+        src = s.replace("\r\n", "\n")
     except (AttributeError, TypeError):
         raise TypeError(
             f"Expected str object, not '{type(__s).__qualname__}'"

--- a/Lib/tomllib/_parser.py
+++ b/Lib/tomllib/_parser.py
@@ -71,7 +71,12 @@ def loads(s: str, /, *, parse_float: ParseFloat = float) -> dict[str, Any]:  # n
 
     # The spec allows converting "\r\n" to "\n", even in string
     # literals. Let's do so to simplify parsing.
-    src = s.replace("\r\n", "\n")
+    try:
+        src = __s.replace("\r\n", "\n")
+    except (AttributeError, TypeError):
+        raise TypeError(
+            f"Expected str object, not '{type(__s).__qualname__}'"
+        ) from None
     pos = 0
     out = Output(NestedDict(), Flags())
     header: Key = ()

--- a/Lib/tomllib/_parser.py
+++ b/Lib/tomllib/_parser.py
@@ -75,7 +75,7 @@ def loads(s: str, /, *, parse_float: ParseFloat = float) -> dict[str, Any]:  # n
         src = s.replace("\r\n", "\n")
     except (AttributeError, TypeError):
         raise TypeError(
-            f"Expected str object, not '{type(__s).__qualname__}'"
+            f"Expected str object, not '{type(s).__qualname__}'"
         ) from None
     pos = 0
     out = Output(NestedDict(), Flags())

--- a/Misc/NEWS.d/next/Library/2024-10-01-12-43-42.gh-issue-124835.SVyp3K.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-01-12-43-42.gh-issue-124835.SVyp3K.rst
@@ -1,0 +1,3 @@
+Make :func:`tomllib.loads` raise :exc:`TypeError` not :exc:`AttributeError`
+on bad input types that do not have the ``replace`` attribute. Improve error
+message when :class:`bytes` is received.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This PR makes `tomllib.loads(b"")` throw
```
TypeError: Expected str object, not 'bool'
```
instead of 
```
TypeError: a bytes-like object is required, not 'str'
```

Given an input type that doesn't have the `replace` attribute, it makes `tomllib.loads` raise the same new TypeError, instead of an AttributeError. Should this be a separate PR though?

The corresponding Tomli PR is https://github.com/hukkin/tomli/pull/229
The issue report is https://github.com/hukkin/tomli/issues/223
Pinging @encukou as requested here https://github.com/hukkin/tomli/issues/223#issuecomment-1852195187

<!-- gh-issue-number: gh-124835 -->
* Issue: gh-124835
<!-- /gh-issue-number -->
