### PR TITLE
Docs: for for/else clarify that return or raise also skip the else

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -211,7 +211,7 @@ In a :keyword:`while` loop, it's executed after the loop's condition becomes fal
 
 In either kind of loop, the :keyword:`!else` clause is **not** executed if the
 loop was terminated by a :keyword:`break`.  Of course, other ways of ending the
-loop early, such as a :keyword:`return` or a raised exception will also skip
+loop early, such as a :keyword:`return` or a raised exception, will also skip
 execution of the :keyword:`else` clause.
 
 This is exemplified in the following :keyword:`!for` loop,

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -209,8 +209,10 @@ after the loop finishes its final iteration, that is, if no break occurred.
 
 In a :keyword:`while` loop, it's executed after the loop's condition becomes false.
 
-In either kind of loop, the :keyword:`!else` clause is **not** executed
-if the loop was terminated by a :keyword:`break`.
+In either kind of loop, the :keyword:`!else` clause is **not** executed if the
+loop was terminated by a :keyword:`break`.  Of course, other ways of ending the
+loop early, such as a :keyword:`return` or a raised exception will also skip
+execution of the :keyword:`else` clause.
 
 This is exemplified in the following :keyword:`!for` loop,
 which searches for prime numbers::


### PR DESCRIPTION
A clarification requested by @terryjreedy 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124591.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->