### PR TITLE
gh-118658: Modify cert generation script to extract cert3.pem

### DIFF
--- a/Lib/test/certdata/cert3.pem
+++ b/Lib/test/certdata/cert3.pem
@@ -1,3 +1,90 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            cb:2d:80:99:5a:69:52:5c
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=XY, O=Python Software Foundation CA, CN=our-ca-server
+        Validity
+            Not Before: Aug 29 14:23:16 2018 GMT
+            Not After : Oct 28 14:23:16 2037 GMT
+        Subject: C=XY, L=Castle Anthrax, O=Python Software Foundation, CN=localhost
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (3072 bit)
+                Modulus:
+                    00:a0:2a:28:71:0b:ed:a0:ed:de:cc:25:f2:14:05:
+                    f1:56:8a:e3:30:c6:0d:16:85:dc:4f:c8:65:33:30:
+                    08:de:c5:b1:0e:1e:8d:28:8e:7b:71:3d:d1:fd:29:
+                    84:70:88:a4:4a:6f:d8:e7:9b:35:e9:d8:22:93:86:
+                    a0:58:24:87:ad:ab:fd:cb:61:9a:78:6e:f0:c9:fe:
+                    15:42:2f:d7:b8:8e:ab:b5:97:ec:1d:f4:39:2a:84:
+                    a6:7a:f5:be:82:d7:f7:75:d8:90:0a:bc:2e:53:21:
+                    3f:bf:6f:b1:20:95:85:3c:28:c3:71:d9:63:b9:2b:
+                    12:09:79:5a:57:eb:c8:e7:e3:d6:2d:53:38:34:85:
+                    3d:10:89:78:f8:7a:e8:1b:0e:4d:4b:d5:ff:7d:c6:
+                    0b:e4:1d:a5:56:55:0c:62:e8:c1:4d:58:72:6a:ff:
+                    15:d4:6f:c1:3f:85:df:d0:de:86:9d:37:50:57:31:
+                    69:7d:3f:8e:83:e1:1f:98:18:a4:10:75:91:64:c0:
+                    42:6c:6e:a8:a3:16:f5:96:6c:ea:1a:cf:b4:c5:c5:
+                    ff:27:d2:ae:b5:eb:cd:37:69:72:df:69:68:a4:7c:
+                    45:cb:9f:39:c4:bc:aa:3b:bf:21:22:be:d4:ff:cb:
+                    5e:0d:9b:e4:a2:47:79:d2:e8:4d:32:0e:df:20:99:
+                    e1:dd:68:77:2b:99:04:fe:c9:0e:b2:34:e6:03:09:
+                    c7:de:60:cf:ab:06:eb:ce:50:73:ee:76:33:32:d2:
+                    4f:0a:ff:42:0f:8c:3a:34:28:07:2d:28:f1:f4:51:
+                    56:f2:0c:13:0a:0d:d1:90:db:e2:e1:44:52:ec:19:
+                    71:e5:0f:d6:f4:e4:fc:61:a9:35:0b:7b:72:de:2b:
+                    a2:99:fa:2b:86:6d:6b:70:54:b6:8b:e5:2e:36:5a:
+                    20:80:61:73:52:84:4d:4a:a3:44:3b:c2:e8:00:8a:
+                    9a:57:09:ff:9a:58:fd:d6:c7:d6:53:ae:c7:e2:0c:
+                    16:c8:7e:76:39:9a:57:dd:1b:dd
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Alternative Name: 
+                DNS:localhost
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment
+            X509v3 Extended Key Usage: 
+                TLS Web Server Authentication, TLS Web Client Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Key Identifier: 
+                3F:B1:E9:4F:A0:BE:30:66:3E:0A:18:C8:0F:47:1A:4F:34:6A:0F:42
+            X509v3 Authority Key Identifier: 
+                keyid:F3:EC:94:8E:F2:8E:30:C4:8E:68:C2:BF:8E:6A:19:C0:C1:9F:76:65
+                DirName:/C=XY/O=Python Software Foundation CA/CN=our-ca-server
+                serial:CB:2D:80:99:5A:69:52:5B
+            Authority Information Access: 
+                CA Issuers - URI:http://testca.pythontest.net/testca/pycacert.cer
+                OCSP - URI:http://testca.pythontest.net/testca/ocsp/
+            X509v3 CRL Distribution Points: 
+                Full Name:
+                  URI:http://testca.pythontest.net/testca/revocation.crl
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        ca:34:ba:c5:d0:cf:27:31:32:d6:0d:27:30:b8:db:17:df:b7:
+        39:a7:bb:b1:3b:86:c4:31:fd:fb:ab:db:63:1a:cc:90:ab:b9:
+        4e:ab:34:49:0c:5e:8c:3e:70:a3:a7:6b:2f:a7:9a:25:7b:01:
+        5a:18:96:48:76:f8:36:78:74:fa:bc:7d:68:7f:e5:ca:a6:9d:
+        7b:dc:72:bd:a3:25:51:17:68:e8:e9:d7:02:86:2c:7d:16:7c:
+        b5:dc:44:b2:0a:e3:f7:c9:33:a3:51:36:83:bc:d4:70:cd:84:
+        91:9f:06:ba:2d:d2:05:0a:65:c3:d9:55:09:a8:b8:09:69:bb:
+        93:86:c2:b7:c2:90:74:7c:bf:f0:5d:bc:0e:63:13:8c:eb:fa:
+        0f:f1:fa:e5:12:70:4d:0c:eb:8c:2e:a2:42:42:00:04:0f:fc:
+        f9:1f:41:9c:63:78:f0:66:93:b2:8f:2e:e8:93:1c:50:cb:2d:
+        7f:b6:ba:57:6f:52:62:d7:39:0b:09:82:ab:a6:53:4d:cc:05:
+        3e:19:f0:d4:c0:ce:a9:ad:10:ce:b9:71:e4:8f:f2:5a:3c:65:
+        ba:dc:cb:e0:04:90:2b:a5:15:a6:7d:da:dc:a3:b5:b7:bc:a0:
+        de:30:4e:64:cb:17:0d:3a:a0:52:d2:67:3b:a2:3a:00:d5:39:
+        aa:61:75:52:9f:fe:9b:c0:e8:a0:69:af:a8:b3:a3:1d:0a:40:
+        52:04:e7:3d:c0:00:96:5f:2b:33:06:0c:30:f6:d3:18:72:ee:
+        38:d0:64:d3:00:86:37:ec:4f:e9:38:49:e6:01:ff:a2:9a:7c:
+        dc:6a:d3:cb:a8:ba:58:fb:c3:86:78:47:f1:06:a6:45:e7:53:
+        de:99:1d:81:e6:bc:63:74:46:7c:70:23:57:29:60:70:9a:cc:
+        6f:00:8e:c2:bf:6a:73:7d:6e:b0:62:e6:dc:13:1a:b9:fe:0f:
+        c2:d1:06:a1:79:62:7f:b6:30:a9:03:d0:47:57:25:db:48:10:
+        d1:cf:fb:7d:ac:3d
 -----BEGIN CERTIFICATE-----
 MIIF8TCCBFmgAwIBAgIJAMstgJlaaVJcMA0GCSqGSIb3DQEBCwUAME0xCzAJBgNV
 BAYTAlhZMSYwJAYDVQQKDB1QeXRob24gU29mdHdhcmUgRm91bmRhdGlvbiBDQTEW

--- a/Lib/test/certdata/make_ssl_certs.py
+++ b/Lib/test/certdata/make_ssl_certs.py
@@ -265,6 +265,8 @@ if __name__ == '__main__':
     with open('keycert3.pem', 'w') as f:
         f.write(key)
         f.write(cert)
+    with open('cert3.pem', 'w') as f:
+        f.write(cert)
 
     cert, key = make_cert_key(cmdlineargs, 'fakehostname', sign=True)
     with open('keycert4.pem', 'w') as f:


### PR DESCRIPTION
An alternative to #124598 that's simpler. The additional data in cert3.pem shouldn't affect the tests.

Edit: doesn't work since `PEM_cert_to_DER_cert` doesn't like PEM comments.

<!-- gh-issue-number: gh-118658 -->
* Issue: gh-118658
<!-- /gh-issue-number -->
