### PR TITLE
gh-121277: Raise nice error on `next` as second argument to deprecated-removed

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -288,6 +288,9 @@ class DeprecatedRemoved(VersionChange):
         version_deprecated = expand_version_arg(self.arguments[0],
                                                 self.config.release)
         version_removed = self.arguments.pop(1)
+        if version_removed == 'next':
+            raise ValueError(
+                'deprecated-removed:: second argument cannot be `next`')
         self.arguments[0] = version_deprecated, version_removed
 
         # Set the label based on if we have reached the removal version


### PR DESCRIPTION
Using `next` as the second argument doesn't make sense, but users should get a nicer message than `ValueError: invalid literal for int()` -- especially since Sphinx hides the traceback by default.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121277 -->
* Issue: gh-121277
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124623.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->