### PR TITLE
GH-124547: Clear instance dictionary if memory error occurs during object dealloc

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -1,6 +1,7 @@
 "Test the functionality of Python classes implementing operators."
 
 import unittest
+import test.support
 
 testmeths = [
 
@@ -932,6 +933,20 @@ class TestInlineValues(unittest.TestCase):
         C.a = X()
         C.a = X()
 
+    def test_detach_materialized_dict_no_memory(self):
+        import _testcapi
+        class A:
+            def __init__(self):
+                self.a = 1
+                self.b = 2
+        a = A()
+        d = a.__dict__
+        with test.support.catch_unraisable_exception() as ex:
+            _testcapi.set_nomemory(0, 1)
+            del a
+            self.assertEqual(ex.unraisable.exc_type, MemoryError)
+        with self.assertRaises(KeyError):
+            d["a"]
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-26-12-19-13.gh-issue-124547.P_SHfU.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-26-12-19-13.gh-issue-124547.P_SHfU.rst
@@ -1,0 +1,3 @@
+When deallocating an object with inline values whose ``__dict__`` is still
+live: if memory allocation for the inline values fails, clear the
+dictionary. Prevents an interpreter crash.


### PR DESCRIPTION
If a memory error occurs when copying values into the dict during object deallocation: clear the dict, so that the dict is at least a valid object.


<!-- gh-issue-number: gh-124547 -->
* Issue: gh-124547
<!-- /gh-issue-number -->
