### PR TITLE
gh-124628: Pyrepl inputs on Windows shouldn't always be blocking reads

### DIFF
--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -371,14 +371,18 @@ class WindowsConsole(Console):
 
         return info.srWindow.Bottom  # type: ignore[no-any-return]
 
-    def _read_input(self) -> INPUT_RECORD | None:
+    def _read_input(self, block: bool = True) -> INPUT_RECORD | None:
+        if not block:
+            events = DWORD()
+            if not GetNumberOfConsoleInputEvents(InHandle, events):
+                raise WinError(GetLastError())
+            if not events.value:
+                return None
+
         rec = INPUT_RECORD()
         read = DWORD()
         if not ReadConsoleInput(InHandle, rec, 1, read):
             raise WinError(GetLastError())
-
-        if read.value == 0:
-            return None
 
         return rec
 
@@ -390,10 +394,8 @@ class WindowsConsole(Console):
             return self.event_queue.pop()
 
         while True:
-            rec = self._read_input()
+            rec = self._read_input(block)
             if rec is None:
-                if block:
-                    continue
                 return None
 
             if rec.EventType == WINDOW_BUFFER_SIZE_EVENT:
@@ -590,6 +592,10 @@ if sys.platform == "win32":
     ReadConsoleInput.argtypes = [HANDLE, POINTER(INPUT_RECORD), DWORD, POINTER(DWORD)]
     ReadConsoleInput.restype = BOOL
 
+    GetNumberOfConsoleInputEvents = _KERNEL32.GetNumberOfConsoleInputEvents
+    GetNumberOfConsoleInputEvents.argtypes = [HANDLE, POINTER(DWORD)]
+    GetNumberOfConsoleInputEvents.restype = BOOL
+
     FlushConsoleInputBuffer = _KERNEL32.FlushConsoleInputBuffer
     FlushConsoleInputBuffer.argtypes = [HANDLE]
     FlushConsoleInputBuffer.restype = BOOL
@@ -606,6 +612,7 @@ else:
     ScrollConsoleScreenBuffer = _win_only
     SetConsoleMode = _win_only
     ReadConsoleInput = _win_only
+    GetNumberOfConsoleInputEvents = _win_only
     FlushConsoleInputBuffer = _win_only
     OutHandle = 0
     InHandle = 0

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -464,8 +464,8 @@ class WindowsConsole(Console):
 
     def forgetinput(self) -> None:
         """Forget all pending, but not yet processed input."""
-        while self._read_input() is not None:
-            pass
+        if not FlushConsoleInputBuffer(InHandle):
+            raise WinError(GetLastError())
 
     def getpending(self) -> Event:
         """Return the characters that have been typed but not yet
@@ -590,6 +590,10 @@ if sys.platform == "win32":
     ReadConsoleInput.argtypes = [HANDLE, POINTER(INPUT_RECORD), DWORD, POINTER(DWORD)]
     ReadConsoleInput.restype = BOOL
 
+    FlushConsoleInputBuffer = _KERNEL32.FlushConsoleInputBuffer
+    FlushConsoleInputBuffer.argtypes = [HANDLE]
+    FlushConsoleInputBuffer.restype = BOOL
+
     OutHandle = GetStdHandle(STD_OUTPUT_HANDLE)
     InHandle = GetStdHandle(STD_INPUT_HANDLE)
 else:
@@ -602,5 +606,6 @@ else:
     ScrollConsoleScreenBuffer = _win_only
     SetConsoleMode = _win_only
     ReadConsoleInput = _win_only
+    FlushConsoleInputBuffer = _win_only
     OutHandle = 0
     InHandle = 0


### PR DESCRIPTION
`ReadConsoleInput` is documented to always return at least 1 input. This causes a couple of hangs in the Windows version of pyrepl:
1) When flushing the input after Ctrl-C in search we'll do a read, and this won't return until another Ctrl-C which crashes the interpreter. Windows provides an API for flushing the input buffer which we should use.
2) When passing `block=False` we also still block. We can use the API to check if there are any inputs available, and if not, then just not block.

<!-- gh-issue-number: gh-124628 -->
* Issue: gh-124628
<!-- /gh-issue-number -->
