### PR TITLE
gh-119180: No longer set `__annotations__` in `__main__`

### DIFF
--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -849,7 +849,6 @@ class RunStringTests(TestBase):
         ns.pop('__loader__')
         self.assertEqual(ns, {
             '__name__': '__main__',
-            '__annotations__': {},
             '__doc__': None,
             '__package__': None,
             '__spec__': None,

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1080,7 +1080,7 @@ class TestMain(ReplTestCase):
 
     @force_not_colorized
     def test_exposed_globals_in_repl(self):
-        pre = "['__annotations__', '__builtins__'"
+        pre = "['__builtins__'"
         post = "'__loader__', '__name__', '__package__', '__spec__']"
         output, exit_code = self.run_repl(["sorted(dir())", "exit()"])
         if "can't use pyrepl" in output:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-26-13-25-01.gh-issue-119180.k_JCX0.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-26-13-25-01.gh-issue-119180.k_JCX0.rst
@@ -1,0 +1,2 @@
+The ``__main__`` module no longer always contains an ``__annotations__``
+dictionary in its global namespace.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2503,18 +2503,12 @@ finalize_subinterpreters(void)
 static PyStatus
 add_main_module(PyInterpreterState *interp)
 {
-    PyObject *m, *d, *ann_dict;
+    PyObject *m, *d;
     m = PyImport_AddModuleObject(&_Py_ID(__main__));
     if (m == NULL)
         return _PyStatus_ERR("can't create __main__ module");
 
     d = PyModule_GetDict(m);
-    ann_dict = PyDict_New();
-    if ((ann_dict == NULL) ||
-        (PyDict_SetItemString(d, "__annotations__", ann_dict) < 0)) {
-        return _PyStatus_ERR("Failed to initialize __main__.__annotations__");
-    }
-    Py_DECREF(ann_dict);
 
     int has_builtins = PyDict_ContainsString(d, "__builtins__");
     if (has_builtins < 0) {


### PR DESCRIPTION
This was apparently added during the PEP-526 implementation. I think we no longer need it, but let's see what the test suite says.

<!-- gh-issue-number: gh-119180 -->
* Issue: gh-119180
<!-- /gh-issue-number -->
