### PR TITLE
Improve accuracy of kde() invcdf estimates

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -889,8 +889,11 @@ def quartic_kernel():
     return pdf, cdf, invcdf, support
 
 def _triweight_invcdf_estimate(p):
+    # A handrolled piecewise approximation. There is no magic here.
     sign, p = (1.0, p) if p <= 1/2 else (-1.0, 1.0 - p)
     x = (2.0 * p) ** 0.3400218741872791 - 1.0
+    if 0.00001 < p < 0.499:
+        x -= 0.033 * sin(1.07 * tau * (p - 0.035))
     return x * sign
 
 @register('triweight')

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -870,9 +870,12 @@ def _newton_raphson(f_inv_estimate, f, f_prime, tolerance=1e-12):
     return f_inv
 
 def _quartic_invcdf_estimate(p):
+    # A handrolled piecewise approximation. There is no magic here.
     sign, p = (1.0, p) if p <= 1/2 else (-1.0, 1.0 - p)
+    if p < 0.0106:
+        return ((2.0 * p) ** 0.3838 - 1.0) * sign
     x = (2.0 * p) ** 0.4258865685331 - 1.0
-    if p >= 0.004 < 0.499:
+    if p < 0.499:
         x += 0.026818732 * sin(7.101753784 * p + 2.73230839482953)
     return x * sign
 


### PR DESCRIPTION
KDE's quartic kernel and triweight kernels employ the Newton-Raphson method to compute their inverse-cdf functions.   For a starting point, they need a reasonably good estimate of the inverse function.  This PR improves those estimates giving both a lower maximum error and lower mean absolute deviation.

Measurement tooling:

```
from math import sumprod, sin

def cdf(t):
    return sumprod((3/16, -5/8, 15/16, 1/2), (t**5, t**3, t, 1.0))

def invcdf_exact(p):
    'Use bisection to locate best inverse and then run forward'
    xlo = -1.0;            xhi = 1.0
    plo = 0.0;             phi = 1.0

    if p == plo: return (p, xlo)
    if p == phi: return (p, xhi)

    for i in range(55):
        xmid = (xlo + xhi) / 2
        pmid = cdf(xmid)
        if p < pmid:
            phi = pmid
            xhi = xmid
        else:
            plo = pmid
            xlo = xmid
    x = (xlo + xhi) / 2
    p = cdf(x)
    return p, x

def frange(lo, hi, n):
    width = (hi - lo) / n
    return [lo + width * i for i in range(n+1)]

def max_error(invcdf_estimated):
    err = 0.0
    for p in frange(0.0, 1.0, 2**20):
        p, xtgt = invcdf_exact(p)
        xhat = invcdf_estimated(p)
        delta = abs(xhat - xtgt)
        err = max(err, delta)
    return err

def baseline_invcdf_est(p):
     sign, p = (1.0, p) if p <= 1/2 else (-1.0, 1.0 - p)
     x = (2.0 * p) ** 0.4258865685331 - 1.0
     if p > 0.004 < 0.499:
         x += 0.026818732 * sin(7.101753784 * p + 2.73230839482953)
     return x * sign

def new_invcdf_est(p):
    sign, p = (1.0, p) if p <= 1/2 else (-1.0, 1.0 - p)
    if p < 0.0106:
        return ((2.0 * p) ** 0.3838 - 1.0) * sign
    x = (2.0 * p) ** 0.4258865685331 - 1.0
    if p < 0.499:
        x += 0.026818732 * sin(7.101753784 * p + 2.73230839482953)
    return x * sign

if __name__ == '__main__':

    for invcdf_est in baseline_invcdf_est, new_invcdf_est:
        name = invcdf_est.__name__
        error = max_error(invcdf_est)
        print(f'{error=:.6f} {name}')

```