### PR TITLE
gh-124642: Dictionaries aren't marking objects as weakref'd

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-27-17-18-53.gh-issue-124642.OCjhBJ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-27-17-18-53.gh-issue-124642.OCjhBJ.rst
@@ -1,0 +1,1 @@
+Fixed scalability issue in free-threaded builds for lock-free reads from dictionaries in multi-threaded scenarios

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1488,7 +1488,7 @@ read_failed:
     *value_addr = value;
     if (value != NULL) {
         assert(ix >= 0);
-        Py_INCREF(value);
+        _Py_NewRefWithLock(value);
     }
     Py_END_CRITICAL_SECTION();
     return ix;

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -7015,7 +7015,7 @@ _PyObject_TryGetInstanceAttribute(PyObject *obj, PyObject *name, PyObject **attr
             // Still no dict, we can read from the values
             assert(values->valid);
             value = values->values[ix];
-            *attr = Py_XNewRef(value);
+            *attr = _Py_XNewRefWithLock(value);
             success = true;
         }
 
@@ -7035,7 +7035,7 @@ _PyObject_TryGetInstanceAttribute(PyObject *obj, PyObject *name, PyObject **attr
 
     if (dict->ma_values == values && FT_ATOMIC_LOAD_UINT8(values->valid)) {
         value = _Py_atomic_load_ptr_relaxed(&values->values[ix]);
-        *attr = Py_XNewRef(value);
+        *attr = _Py_XNewRefWithLock(value);
         success = true;
     } else {
         // Caller needs to lookup from the dictionary


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124642 -->
* Issue: gh-124642
<!-- /gh-issue-number -->
