### PR TITLE
gh-116510: Fix crash during sub-interpreter shutdown

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-26-17-55-34.gh-issue-116510.dhn8w8.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-26-17-55-34.gh-issue-116510.dhn8w8.rst
@@ -1,0 +1,3 @@
+Fix a bug that can cause a crash when sub-interpreters use "basic"
+single-phase extension modules.  Shared objects could refer to PyGC_Head
+nodes that had been freed as part of interpreter cleanup.


### PR DESCRIPTION
Fix a bug that can cause a crash when sub-interpreters use "basic" single-phase extension modules.  Shared objects could refer to PyGC_Head nodes that had been freed as part of interpreter shutdown.


<!-- gh-issue-number: gh-116510 -->
* Issue: gh-116510
<!-- /gh-issue-number -->
