### PR TITLE
gh-124609: Fix _Py_ThreadId for Windows builds using MinGW

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -55,6 +55,10 @@
 #  include <intrin.h>             // __readgsqword()
 #endif
 
+#if defined(Py_GIL_DISABLED) && defined(__MINGW32__)
+#  include <intrin.h>             // __readgsqword()
+#endif
+
 // Include Python header files
 #include "pyport.h"
 #include "pymacro.h"

--- a/Include/object.h
+++ b/Include/object.h
@@ -180,6 +180,12 @@ _Py_ThreadId(void)
     tid = __readfsdword(24);
 #elif defined(_MSC_VER) && defined(_M_ARM64)
     tid = __getReg(18);
+#elif defined(__MINGW32__) && defined(_M_X64)
+    tid = __readgsqword(48);
+#elif defined(__MINGW32__) && defined(_M_IX86)
+    tid = __readfsdword(24);
+#elif defined(__MINGW32__) && defined(_M_ARM64)
+    tid = __getReg(18);
 #elif defined(__i386__)
     __asm__("movl %%gs:0, %0" : "=r" (tid));  // 32-bit always uses GS
 #elif defined(__MACH__) && defined(__x86_64__)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1552,6 +1552,7 @@ Lisa Roach
 Carl Robben
 Ben Roberts
 Mark Roberts
+Tony Roberts
 Andy Robinson
 Izan "TizzySaurus" Robinson
 Jim Robinson

--- a/Misc/NEWS.d/next/Windows/2024-09-27-13-40-25.gh-issue-124609.WaKk8G.rst
+++ b/Misc/NEWS.d/next/Windows/2024-09-27-13-40-25.gh-issue-124609.WaKk8G.rst
@@ -1,1 +1,1 @@
-Fix _Py_ThreadId for Windows builds using MinGW.
+Fix ``_Py_ThreadId`` for Windows builds using MinGW. Patch by Tony Roberts.

--- a/Misc/NEWS.d/next/Windows/2024-09-27-13-40-25.gh-issue-124609.WaKk8G.rst
+++ b/Misc/NEWS.d/next/Windows/2024-09-27-13-40-25.gh-issue-124609.WaKk8G.rst
@@ -1,0 +1,1 @@
+Fix _Py_ThreadId for Windows builds using MinGW.


### PR DESCRIPTION
Fixes #124609

<!-- gh-issue-number: gh-124609 -->
* Issue: gh-124609
<!-- /gh-issue-number -->
