### PR TITLE
gh-116850: Fix argparse for namespaces with not directly writable dict

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1224,7 +1224,8 @@ class _SubParsersAction(Action):
             setattr(namespace, key, value)
 
         if arg_strings:
-            vars(namespace).setdefault(_UNRECOGNIZED_ARGS_ATTR, [])
+            if not hasattr(namespace, _UNRECOGNIZED_ARGS_ATTR):
+                setattr(namespace, _UNRECOGNIZED_ARGS_ATTR, [])
             getattr(namespace, _UNRECOGNIZED_ARGS_ATTR).extend(arg_strings)
 
 class _ExtendAction(_AppendAction):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2312,6 +2312,18 @@ class TestAddSubparsers(TestCase):
             (NS(foo=False, bar=0.5, w=7, x='b'), ['-W', '-X', 'Y', 'Z']),
         )
 
+    def test_parse_known_args_to_class_namespace(self):
+        class C:
+            pass
+        self.assertEqual(
+            self.parser.parse_known_args('0.5 1 b -w 7 -p'.split(), namespace=C),
+            (C, ['-p']),
+        )
+        self.assertIs(C.foo, False)
+        self.assertEqual(C.bar, 0.5)
+        self.assertEqual(C.w, 7)
+        self.assertEqual(C.x, 'b')
+
     def test_parse_known_args_with_single_dash_option(self):
         parser = ErrorRaisingArgumentParser()
         parser.add_argument('-k', '--known', action='count', default=0)

--- a/Misc/NEWS.d/next/Library/2024-09-27-15-16-04.gh-issue-116850.dBkR0-.rst
+++ b/Misc/NEWS.d/next/Library/2024-09-27-15-16-04.gh-issue-116850.dBkR0-.rst
@@ -1,0 +1,2 @@
+Fix :mod:`argparse` for namespaces with not directly writable dict (e.g.
+classes).


### PR DESCRIPTION
It now always uses setattr() instead of setting the dict item to modify the namespace. This allows to use a class as a namespace.


<!-- gh-issue-number: gh-116850 -->
* Issue: gh-116850
<!-- /gh-issue-number -->
