### PR TITLE
gh-124656: Added info that only one profiler can be used

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -47,7 +47,7 @@ profiling interface:
 .. note::
 
    Only one profiler can be active at any given time.
-   Attemting to enable a profiler while another one is already in use will 
+   Attemting to enable a profiler while another one is already in use will
    result in a :exc:`ValueError`.
 
 

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -44,6 +44,12 @@ profiling interface:
    but not for C-level functions, and so the C code would seem faster than any
    Python one.
 
+.. note::
+
+   Only one profiler can be active at any given time.
+   Attemting to enable a profiler while another one is already in use will 
+   result in a :exc:`ValueError`.
+
 
 .. _profile-instant:
 


### PR DESCRIPTION
Added info that only one profiler can be used

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124656 -->
* Issue: gh-124656
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124671.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->