### PR TITLE
[3.13] gh-89683: add tests for `deepcopy` on frozen dataclasses (GH-123098)

### DIFF
--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -17,7 +17,8 @@ from unittest.mock import Mock
 from typing import ClassVar, Any, List, Union, Tuple, Dict, Generic, TypeVar, Optional, Protocol, DefaultDict
 from typing import get_type_hints
 from collections import deque, OrderedDict, namedtuple, defaultdict
-from functools import total_ordering
+from copy import deepcopy
+from functools import total_ordering, wraps
 
 import typing       # Needed for the string "typing.ClassVar[int]" to work as an annotation.
 import dataclasses  # Needed for the string "dataclasses.InitVar[int]" to work as an annotation.
@@ -3174,6 +3175,48 @@ class TestFrozen(unittest.TestCase):
         # If x is mutable, computing the hash is an error.
         with self.assertRaisesRegex(TypeError, 'unhashable type'):
             hash(C({}))
+
+    def test_frozen_deepcopy_without_slots(self):
+        # see: https://github.com/python/cpython/issues/89683
+        @dataclass(frozen=True, slots=False)
+        class C:
+            s: str
+
+        c = C('hello')
+        self.assertEqual(deepcopy(c), c)
+
+    def test_frozen_deepcopy_with_slots(self):
+        # see: https://github.com/python/cpython/issues/89683
+        with self.subTest('generated __slots__'):
+            @dataclass(frozen=True, slots=True)
+            class C:
+                s: str
+
+            c = C('hello')
+            self.assertEqual(deepcopy(c), c)
+
+        with self.subTest('user-defined __slots__ and no __{get,set}state__'):
+            @dataclass(frozen=True, slots=False)
+            class C:
+                __slots__ = ('s',)
+                s: str
+
+            # with user-defined slots, __getstate__ and __setstate__ are not
+            # automatically added, hence the error
+            err = r"^cannot\ assign\ to\ field\ 's'$"
+            self.assertRaisesRegex(FrozenInstanceError, err, deepcopy, C(''))
+
+        with self.subTest('user-defined __slots__ and __{get,set}state__'):
+            @dataclass(frozen=True, slots=False)
+            class C:
+                __slots__ = ('s',)
+                __getstate__ = dataclasses._dataclass_getstate
+                __setstate__ = dataclasses._dataclass_setstate
+
+                s: str
+
+            c = C('hello')
+            self.assertEqual(deepcopy(c), c)
 
 
 class TestSlots(unittest.TestCase):

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -18,7 +18,7 @@ from typing import ClassVar, Any, List, Union, Tuple, Dict, Generic, TypeVar, Op
 from typing import get_type_hints
 from collections import deque, OrderedDict, namedtuple, defaultdict
 from copy import deepcopy
-from functools import total_ordering, wraps
+from functools import total_ordering
 
 import typing       # Needed for the string "typing.ClassVar[int]" to work as an annotation.
 import dataclasses  # Needed for the string "dataclasses.InitVar[int]" to work as an annotation.


### PR DESCRIPTION
(cherry picked from commit 5e7eba09bcdafe361b491b3f8cf30d7dd2df0a78)

I needed do to a manual backport because `cherry_picker` is dissident on my side.

<!-- gh-issue-number: gh-89683 -->
* Issue: gh-89683
<!-- /gh-issue-number -->
