### PR TITLE
Fixup indentation for docs on `ModuleSpec` attributes

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1166,10 +1166,9 @@ find and load modules.
 .. class:: ModuleSpec(name, loader, *, origin=None, loader_state=None, is_package=None)
 
    A specification for a module's import-system-related state.  This is
-   typically exposed as the module's :attr:`__spec__` attribute.  In the
-   descriptions below, the names in parentheses give the corresponding
-   attribute available directly on the module object,
-   e.g. ``module.__spec__.origin == module.__file__``.  Note, however, that
+   typically exposed as the module's :attr:`__spec__` attribute.  Many
+   of these attributes are also available directly on a module: e.g.,
+   ``module.__spec__.origin == module.__file__``.  Note, however, that
    while the *values* are usually equivalent, they can differ since there is
    no synchronization between the two objects.  For example, it is possible to update
    the module's :attr:`__file__` at runtime and this will not be automatically
@@ -1179,66 +1178,60 @@ find and load modules.
 
    .. attribute:: name
 
-   (:attr:`__name__`)
-
-   The module's fully qualified name.
-   The :term:`finder` should always set this attribute to a non-empty string.
+      The module's fully qualified name
+      (see :attr:`__name__ attributes on modules <__name__>`).
+      The :term:`finder` should always set this attribute to a non-empty string.
 
    .. attribute:: loader
 
-   (:attr:`__loader__`)
-
-   The :term:`loader` used to load the module.
-   The :term:`finder` should always set this attribute.
+      The :term:`loader` used to load the module
+      (see :attr:`__loader__ attributes on modules <__loader__>`).
+      The :term:`finder` should always set this attribute.
 
    .. attribute:: origin
 
-   (:attr:`__file__`)
-
-   The location the :term:`loader` should use to load the module.
-   For example, for modules loaded from a .py file this is the filename.
-   The :term:`finder` should always set this attribute to a meaningful value
-   for the :term:`loader` to use.  In the uncommon case that there is not one
-   (like for namespace packages), it should be set to ``None``.
+      The location the :term:`loader` should use to load the module
+      (see :attr:`__file__ attributes on modules <__file__>`).
+      For example, for modules loaded from a .py file this is the filename.
+      The :term:`finder` should always set this attribute to a meaningful value
+      for the :term:`loader` to use.  In the uncommon case that there is not one
+      (like for namespace packages), it should be set to ``None``.
 
    .. attribute:: submodule_search_locations
 
-   (:attr:`__path__`)
-
-   The list of locations where the package's submodules will be found.
-   Most of the time this is a single directory.
-   The :term:`finder` should set this attribute to a list, even an empty one, to indicate
-   to the import system that the module is a package.  It should be set to ``None`` for
-   non-package modules.  It is set automatically later to a special object for
-   namespace packages.
+      The list of locations where the package's submodules will be found
+      (see :attr:`__path__ attributes on modules <__path__>`).
+      Most of the time this is a single directory.
+      The :term:`finder` should set this attribute to a list, even an empty one, to indicate
+      to the import system that the module is a package.  It should be set to ``None`` for
+      non-package modules.  It is set automatically later to a special object for
+      namespace packages.
 
    .. attribute:: loader_state
 
-   The :term:`finder` may set this attribute to an object containing additional,
-   module-specific data to use when loading the module.  Otherwise it should be
-   set to ``None``.
+      The :term:`finder` may set this attribute to an object containing additional,
+      module-specific data to use when loading the module.  Otherwise it should be
+      set to ``None``.
 
    .. attribute:: cached
 
-   (:attr:`__cached__`)
-
-   The filename of a compiled version of the module's code.
-   The :term:`finder` should always set this attribute but it may be ``None``
-   for modules that do not need compiled code stored.
+      The filename of a compiled version of the module's code
+      (see :attr:`__cached__ attributes on modules <__cached__>`).
+      The :term:`finder` should always set this attribute but it may be ``None``
+      for modules that do not need compiled code stored.
 
    .. attribute:: parent
 
-   (:attr:`__package__`)
-
-   (Read-only) The fully qualified name of the package the module is in (or the
-   empty string for a top-level module).
-   If the module is a package then this is the same as :attr:`name`.
+      (Read-only) The fully qualified name of the package the module is in (or the
+      empty string for a top-level module).
+      See :attr:`__package__ attributes on modules <__package__>`.
+      If the module is a package then this is the same as :attr:`name`.
 
    .. attribute:: has_location
 
-   ``True`` if the spec's :attr:`origin` refers to a loadable location,
-   ``False`` otherwise.  This value impacts how :attr:`origin` is interpreted
-   and how the module's :attr:`__file__` is populated.
+      ``True`` if the spec's :attr:`origin` refers to a loadable location,
+      ``False`` otherwise.  This value impacts how :attr:`origin` is interpreted
+      and how the module's :attr:`__file__` is populated.
 
 
 .. class:: AppleFrameworkLoader(name, path)

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1167,7 +1167,7 @@ find and load modules.
 
    A specification for a module's import-system-related state.  This is
    typically exposed as the module's :attr:`__spec__` attribute.  Many
-   of these attributes are also available directly on a module: e.g.,
+   of these attributes are also available directly on a module: for example,
    ``module.__spec__.origin == module.__file__``.  Note, however, that
    while the *values* are usually equivalent, they can differ since there is
    no synchronization between the two objects.  For example, it is possible to update
@@ -1179,19 +1179,19 @@ find and load modules.
    .. attribute:: name
 
       The module's fully qualified name
-      (see :attr:`__name__ attributes on modules <__name__>`).
+      (see :attr:`__name__` attributes on modules).
       The :term:`finder` should always set this attribute to a non-empty string.
 
    .. attribute:: loader
 
       The :term:`loader` used to load the module
-      (see :attr:`__loader__ attributes on modules <__loader__>`).
+      (see :attr:`__loader__` attributes on modules).
       The :term:`finder` should always set this attribute.
 
    .. attribute:: origin
 
       The location the :term:`loader` should use to load the module
-      (see :attr:`__file__ attributes on modules <__file__>`).
+      (see :attr:`__file__` attributes on modules).
       For example, for modules loaded from a .py file this is the filename.
       The :term:`finder` should always set this attribute to a meaningful value
       for the :term:`loader` to use.  In the uncommon case that there is not one
@@ -1200,7 +1200,7 @@ find and load modules.
    .. attribute:: submodule_search_locations
 
       The list of locations where the package's submodules will be found
-      (see :attr:`__path__ attributes on modules <__path__>`).
+      (see :attr:`__path__` attributes on modules).
       Most of the time this is a single directory.
       The :term:`finder` should set this attribute to a list, even an empty one, to indicate
       to the import system that the module is a package.  It should be set to ``None`` for
@@ -1216,7 +1216,7 @@ find and load modules.
    .. attribute:: cached
 
       The filename of a compiled version of the module's code
-      (see :attr:`__cached__ attributes on modules <__cached__>`).
+      (see :attr:`__cached__` attributes on modules).
       The :term:`finder` should always set this attribute but it may be ``None``
       for modules that do not need compiled code stored.
 
@@ -1224,7 +1224,7 @@ find and load modules.
 
       (Read-only) The fully qualified name of the package the module is in (or the
       empty string for a top-level module).
-      See :attr:`__package__ attributes on modules <__package__>`.
+      See :attr:`__package__` attributes on modules.
       If the module is a package then this is the same as :attr:`name`.
 
    .. attribute:: has_location


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124681.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->