### PR TITLE
gh-124682: Disable test that is prone to intermittent failure on iOS.

### DIFF
--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -548,13 +548,14 @@ class TestSupport(unittest.TestCase):
             with self.subTest(opts=opts):
                 self.check_options(opts, 'optim_args_from_interpreter_flags')
 
+    @unittest.skipIf(support.is_apple_mobile, "Unstable on Apple Mobile")
     @unittest.skipIf(support.is_emscripten, "Unstable in Emscripten")
     @unittest.skipIf(support.is_wasi, "Unavailable on WASI")
     def test_fd_count(self):
-        # We cannot test the absolute value of fd_count(): on old Linux
-        # kernel or glibc versions, os.urandom() keeps a FD open on
-        # /dev/urandom device and Python has 4 FD opens instead of 3.
-        # Test is unstable on Emscripten. The platform starts and stops
+        # We cannot test the absolute value of fd_count(): on old Linux kernel
+        # or glibc versions, os.urandom() keeps a FD open on /dev/urandom
+        # device and Python has 4 FD opens instead of 3. Test is unstable on
+        # Emscripten and Apple Mobile platforms; these platforms start and stop
         # background threads that use pipes and epoll fds.
         start = os_helper.fd_count()
         fd = os.open(__file__, os.O_RDONLY)


### PR DESCRIPTION
`test_support.test_fd_count` is prone to intermittent failure (3 times in over 1400 runs) because an iOS app has other threads running that can modify file handles. The test is already skipped on Emscripten and WASI for similar reasons.

<!-- gh-issue-number: gh-124682 -->
* Issue: gh-124682
<!-- /gh-issue-number -->
