### PR TITLE
Fix typo in InternalDocs/string_interning.md

### DIFF
--- a/InternalDocs/string_interning.md
+++ b/InternalDocs/string_interning.md
@@ -72,7 +72,7 @@ We currently also immortalize strings contained in code objects and similar,
 specifically in the compiler and in `marshal`.
 These are “close enough” to immortal: even in use cases like hot reloading
 or `eval`-ing user input, the number of distinct identifiers and string
-constants expected to stay low.
+constants is expected to stay low.
 
 
 ## Internal API


### PR DESCRIPTION
Jelle found this typo in a backport PR: https://github.com/python/cpython/pull/123065#discussion_r1774110525

I don't think it's worth backporting on its own.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
