### PR TITLE
GH-124567: Reduce overhead of cycle GC.

### DIFF
--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -351,6 +351,7 @@ struct _gc_runtime_state {
         <0: suppressed; don't immortalize objects */
     int immortalize;
 #endif
+    Py_ssize_t prior_heap_size;
 };
 
 #ifdef Py_GIL_DISABLED

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -328,7 +328,8 @@ struct _gc_runtime_state {
     Py_ssize_t heap_size;
     Py_ssize_t work_to_do;
     /* Which of the old spaces is the visited space */
-    int visited_space;
+    uint8_t visited_space;
+    uint8_t scan_reachable;
 
 #ifdef Py_GIL_DISABLED
     /* This is the number of objects that survived the last full

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1115,6 +1115,7 @@ class IncrementalGCTests(unittest.TestCase):
             olds.append(newhead)
             if len(olds) == 20:
                 live = _testinternalcapi.get_heap_size()
+                print(i, live, baseline_live)
                 self.assertLess(live, baseline_live*2)
                 del olds[:]
         if not enabled:

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1108,13 +1108,14 @@ class IncrementalGCTests(unittest.TestCase):
         olds = []
         gc.collect()
         baseline_live = _testinternalcapi.get_heap_size()
-        for i in range(20_000):
+        iterations = 200_000 if support.is_resource_enabled('cpu') else 20_000
+        for i in range(iterations):
             newhead = make_ll(20)
             newhead.surprise = head
             olds.append(newhead)
             if len(olds) == 20:
                 live = _testinternalcapi.get_heap_size()
-                self.assertLess(live-baseline_live, 25000)
+                self.assertLess(live, baseline_live*2)
                 del olds[:]
         if not enabled:
             gc.disable()

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -2048,6 +2048,11 @@ identify_type_slot_wrappers(PyObject *self, PyObject *Py_UNUSED(ignored))
     return _PyType_GetSlotWrapperNames();
 }
 
+static PyObject *
+get_heap_size(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return PyLong_FromSsize_t(PyInterpreterState_Get()->gc.heap_size);
+}
 
 static PyMethodDef module_functions[] = {
     {"get_configs", get_configs, METH_NOARGS},
@@ -2145,6 +2150,7 @@ static PyMethodDef module_functions[] = {
     GH_119213_GETARGS_METHODDEF
     {"get_static_builtin_types", get_static_builtin_types, METH_NOARGS},
     {"identify_type_slot_wrappers", identify_type_slot_wrappers, METH_NOARGS},
+    {"get_heap_size", get_heap_size,  METH_NOARGS, NULL},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1287,8 +1287,8 @@ gc_list_set_space(PyGC_Head *list, int space)
  */
 
 /* Multiply by 5, so that the default incremental threshold of 10
- * scans objects at half the rate as the young generation */
-#define SCAN_RATE_MULTIPLIER 20
+ * scans objects at the same rate as the young generation */
+#define SCAN_RATE_MULTIPLIER 10
 
 static void
 add_stats(GCState *gcstate, int gen, struct gc_collection_stats *stats)
@@ -1461,7 +1461,7 @@ gc_collect_increment(PyThreadState *tstate, struct gc_collection_stats *stats)
     gc_list_validate_space(&survivors, gcstate->visited_space);
     gc_list_merge(&survivors, visited);
     assert(gc_list_is_empty(&increment));
-    Py_ssize_t delta = gcstate->heap_size - gcstate->prior_heap_size;
+    Py_ssize_t delta = (gcstate->heap_size - gcstate->prior_heap_size)*2;
     delta += gcstate->young.threshold * SCAN_RATE_MULTIPLIER / scale_factor;
     if (delta > 0) {
         gcstate->work_to_do += delta;


### PR DESCRIPTION
This PR makes the following changes to cycle GC, to reduce the overhead observed in #124567:

* Does not form the transitive closure of the young generation before collecting it. Avoids scanning too much of the heap that is likely reachable.
* Performs an amount of work proportional to the young collection in the incremental collection, avoiding n**2 performance on large heaps (this was a regression w.r.t. 3.12)
* At the start of each full scan, mark all objects reachable from `sys.modules`, so they are not scanned this scan.
* Computes the delta in heap size during incremental collection, and accelerates incremental collection if the heap is growing
* Adds a `_testinternalcapi.get_heap_size()` function for more precise testing of the GC

Before merging, I need to:
* Get performance numbers and stats for this version
* Likewise for an alternative version that does form the transitive closure of the young generation, but only does so after marking reachable objects.
I still need benchmarks and stats for this before merging.


<!-- gh-issue-number: gh-124567 -->
* Issue: gh-124567
<!-- /gh-issue-number -->
