### PR TITLE
gh-123961: move `PyCursesError` in `_cursesmodule.c` to a global state variable

### DIFF
--- a/Include/py_curses.h
+++ b/Include/py_curses.h
@@ -81,8 +81,6 @@ typedef struct {
     char *encoding;
 } PyCursesWindowObject;
 
-#define PyCursesWindow_Check(v) Py_IS_TYPE((v), &PyCursesWindow_Type)
-
 #define PyCurses_CAPSULE_NAME "_curses._C_API"
 
 
@@ -98,6 +96,8 @@ static void **PyCurses_API;
 #define PyCursesSetupTermCalled  {if (! ((int (*)(void))PyCurses_API[1]) () ) return NULL;}
 #define PyCursesInitialised      {if (! ((int (*)(void))PyCurses_API[2]) () ) return NULL;}
 #define PyCursesInitialisedColor {if (! ((int (*)(void))PyCurses_API[3]) () ) return NULL;}
+
+#define PyCursesWindow_Check(v)     Py_IS_TYPE((v), &PyCursesWindow_Type)
 
 #define import_curses() \
     PyCurses_API = (void **)PyCapsule_Import(PyCurses_CAPSULE_NAME, 1);

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -4797,6 +4797,7 @@ curses_destructor(PyObject *op)
 static int
 _cursesmodule_exec(PyObject *module)
 {
+    _cursesmodule_state *st = get_cursesmodule_state(module);
     /* Initialize object type */
     if (PyType_Ready(&PyCursesWindow_Type) < 0) {
         return -1;
@@ -4837,12 +4838,11 @@ _cursesmodule_exec(PyObject *module)
     }
 
     /* For exception curses.error */
-    PyCursesError = PyErr_NewException("_curses.error", NULL, NULL);
-    if (PyCursesError == NULL) {
+    st->PyCursesError = PyErr_NewException("_curses.error", NULL, NULL);
+    if (st->PyCursesError == NULL) {
         return -1;
     }
-    rc = PyDict_SetItemString(module_dict, "error", PyCursesError);
-    Py_DECREF(PyCursesError);
+    rc = PyDict_SetItemString(module_dict, "error", st->PyCursesError);
     if (rc < 0) {
         return -1;
     }

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -638,50 +638,70 @@ PyTypeObject PyCursesWindow_Type;
 #define Window_NoArgNoReturnFunction(X)                         \
     static PyObject *PyCursesWindow_ ## X                       \
     (PyCursesWindowObject *self, PyObject *Py_UNUSED(ignored))  \
-    { return PyCursesCheckERR(X(self->win), # X); }
+    {                                                           \
+        int rtn = X(self->win);                                 \
+        return PyCursesCheckERR_FromSelf(self, rtn, # X);       \
+    }
 
-#define Window_NoArgTrueFalseFunction(X)                                \
-    static PyObject * PyCursesWindow_ ## X                              \
-    (PyCursesWindowObject *self, PyObject *Py_UNUSED(ignored))          \
-    {                                                                   \
-        return PyBool_FromLong(X(self->win)); }
+#define Window_NoArgTrueFalseFunction(X)                        \
+    static PyObject * PyCursesWindow_ ## X                      \
+    (PyCursesWindowObject *self, PyObject *Py_UNUSED(ignored))  \
+    {                                                           \
+        return PyBool_FromLong(X(self->win));                   \
+    }
 
 #define Window_NoArgNoReturnVoidFunction(X)                     \
     static PyObject * PyCursesWindow_ ## X                      \
     (PyCursesWindowObject *self, PyObject *Py_UNUSED(ignored))  \
     {                                                           \
-        X(self->win); Py_RETURN_NONE; }
+        X(self->win);                                           \
+        Py_RETURN_NONE;                                         \
+    }
 
-#define Window_NoArg2TupleReturnFunction(X, TYPE, ERGSTR)               \
-    static PyObject * PyCursesWindow_ ## X                              \
-    (PyCursesWindowObject *self, PyObject *Py_UNUSED(ignored))          \
-    {                                                                   \
-        TYPE arg1, arg2;                                                \
-        X(self->win,arg1,arg2); return Py_BuildValue(ERGSTR, arg1, arg2); }
+#define Window_NoArg2TupleReturnFunction(X, TYPE, ERGSTR)       \
+    static PyObject * PyCursesWindow_ ## X                      \
+    (PyCursesWindowObject *self, PyObject *Py_UNUSED(ignored))  \
+    {                                                           \
+        TYPE arg1, arg2;                                        \
+        X(self->win,arg1,arg2);                                 \
+        return Py_BuildValue(ERGSTR, arg1, arg2);               \
+    }
 
-#define Window_OneArgNoReturnVoidFunction(X, TYPE, PARSESTR)            \
-    static PyObject * PyCursesWindow_ ## X                              \
-    (PyCursesWindowObject *self, PyObject *args)                        \
-    {                                                                   \
-        TYPE arg1;                                                      \
-        if (!PyArg_ParseTuple(args, PARSESTR, &arg1)) return NULL;      \
-        X(self->win,arg1); Py_RETURN_NONE; }
+#define Window_OneArgNoReturnVoidFunction(X, TYPE, PARSESTR)    \
+    static PyObject * PyCursesWindow_ ## X                      \
+    (PyCursesWindowObject *self, PyObject *args)                \
+    {                                                           \
+        TYPE arg1;                                              \
+        if (!PyArg_ParseTuple(args, PARSESTR, &arg1)) {         \
+            return NULL;                                        \
+        }                                                       \
+        X(self->win,arg1);                                      \
+        Py_RETURN_NONE;                                         \
+    }
 
-#define Window_OneArgNoReturnFunction(X, TYPE, PARSESTR)                \
-    static PyObject * PyCursesWindow_ ## X                              \
-    (PyCursesWindowObject *self, PyObject *args)                        \
-    {                                                                   \
-        TYPE arg1;                                                      \
-        if (!PyArg_ParseTuple(args,PARSESTR, &arg1)) return NULL;       \
-        return PyCursesCheckERR(X(self->win, arg1), # X); }
+#define Window_OneArgNoReturnFunction(X, TYPE, PARSESTR)    \
+    static PyObject * PyCursesWindow_ ## X                  \
+    (PyCursesWindowObject *self, PyObject *args)            \
+    {                                                       \
+        TYPE arg1;                                          \
+        if (!PyArg_ParseTuple(args, PARSESTR, &arg1)) {     \
+            return NULL;                                    \
+        }                                                   \
+        int rtn = X(self->win, arg1);                       \
+        return PyCursesCheckERR_FromSelf(self, rtn, # X);   \
+    }
 
-#define Window_TwoArgNoReturnFunction(X, TYPE, PARSESTR)                \
-    static PyObject * PyCursesWindow_ ## X                              \
-    (PyCursesWindowObject *self, PyObject *args)                        \
-    {                                                                   \
-        TYPE arg1, arg2;                                                \
-        if (!PyArg_ParseTuple(args,PARSESTR, &arg1, &arg2)) return NULL; \
-        return PyCursesCheckERR(X(self->win, arg1, arg2), # X); }
+#define Window_TwoArgNoReturnFunction(X, TYPE, PARSESTR)        \
+    static PyObject * PyCursesWindow_ ## X                      \
+    (PyCursesWindowObject *self, PyObject *args)                \
+    {                                                           \
+        TYPE arg1, arg2;                                        \
+        if (!PyArg_ParseTuple(args, PARSESTR, &arg1, &arg2)) {  \
+            return NULL;                                        \
+        }                                                       \
+        int rtn = X(self->win, arg1, arg2);                     \
+        return PyCursesCheckERR_FromSelf(self, rtn, # X);       \
+    }
 
 /* ------------- WINDOW routines --------------- */
 

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -159,32 +159,11 @@ typedef chtype attr_t;           /* No attr_t type is available */
 #define _CURSES_PAIR_CONTENT_FUNC       pair_content
 #endif  /* _NCURSES_EXTENDED_COLOR_FUNCS */
 
-typedef struct _cursesmodule_state {
-    PyObject *PyCursesError;
-    PyTypeObject *PyCursesWindow_Type;
-} _cursesmodule_state;
-
-static inline _cursesmodule_state *
-get_cursesmodule_state(PyObject *module)
-{
-    void *state = PyModule_GetState(module);
-    assert(state != NULL);
-    return (_cursesmodule_state *)state;
-}
-
-static inline _cursesmodule_state *
-get_cursesmodule_state_by_cls(PyTypeObject *cls)
-{
-    void *state = PyType_GetModuleState(cls);
-    assert(state != NULL);
-    return (_cursesmodule_state *)state;
-}
-
 /*[clinic input]
 module _curses
-class _curses.window "PyCursesWindowObject *" "clinic_state()->PyCursesWindow_Type"
+class _curses.window "PyCursesWindowObject *" "&PyCursesWindow_Type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=83369be6e20ef0da]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=43265c372c2887d6]*/
 
 /* Tells whether setupterm() has been called to initialise terminfo.  */
 static int curses_setupterm_called = FALSE;
@@ -2151,8 +2130,7 @@ _curses_window_noutrefresh_impl(PyCursesWindowObject *self)
 /*[clinic input]
 _curses.window.overlay
 
-    destwin: object(type="PyCursesWindowObject *",\
-                    subclass_of="clinic_state()->PyCursesWindow_Type")
+    destwin: object(type="PyCursesWindowObject *", subclass_of="&PyCursesWindow_Type")
 
     [
     sminrow: int
@@ -2181,7 +2159,7 @@ _curses_window_overlay_impl(PyCursesWindowObject *self,
                             PyCursesWindowObject *destwin, int group_right_1,
                             int sminrow, int smincol, int dminrow,
                             int dmincol, int dmaxrow, int dmaxcol)
-/*[clinic end generated code: output=82bb2c4cb443ca58 input=a1fa2bb9dd91ab1d]*/
+/*[clinic end generated code: output=82bb2c4cb443ca58 input=7edd23ad22cc1984]*/
 {
     int rtn;
 
@@ -2199,8 +2177,7 @@ _curses_window_overlay_impl(PyCursesWindowObject *self,
 /*[clinic input]
 _curses.window.overwrite
 
-    destwin: object(type="PyCursesWindowObject *",\
-                    subclass_of="clinic_state()->PyCursesWindow_Type")
+    destwin: object(type="PyCursesWindowObject *", subclass_of="&PyCursesWindow_Type")
 
     [
     sminrow: int
@@ -2230,7 +2207,7 @@ _curses_window_overwrite_impl(PyCursesWindowObject *self,
                               int group_right_1, int sminrow, int smincol,
                               int dminrow, int dmincol, int dmaxrow,
                               int dmaxcol)
-/*[clinic end generated code: output=12ae007d1681be28 input=c5b2388e80206a47]*/
+/*[clinic end generated code: output=12ae007d1681be28 input=ea5de1b35cd948e0]*/
 {
     int rtn;
 
@@ -2578,9 +2555,7 @@ PyCursesWindow_set_encoding(PyCursesWindowObject *self, PyObject *value, void *P
     return 0;
 }
 
-#define clinic_state() (get_cursesmodule_state_by_cls(Py_TYPE(self)))
 #include "clinic/_cursesmodule.c.h"
-#undef clinic_state
 
 static PyMethodDef PyCursesWindow_Methods[] = {
     _CURSES_WINDOW_ADDCH_METHODDEF
@@ -4753,7 +4728,7 @@ _curses_has_extended_color_support_impl(PyObject *module)
 
 /* List of functions defined in the module */
 
-static PyMethodDef _cursesmodule_methods[] = {
+static PyMethodDef PyCurses_methods[] = {
     _CURSES_BAUDRATE_METHODDEF
     _CURSES_BEEP_METHODDEF
     _CURSES_CAN_CHANGE_COLOR_METHODDEF
@@ -4838,7 +4813,20 @@ static PyMethodDef _cursesmodule_methods[] = {
     {NULL,                  NULL}         /* sentinel */
 };
 
-/* Module initialization and cleanup functions. */
+/* Initialization function for the module */
+
+
+static struct PyModuleDef _cursesmodule = {
+    PyModuleDef_HEAD_INIT,
+    "_curses",
+    NULL,
+    -1,
+    PyCurses_methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
 
 static void
 _curses_capi_destructor(PyObject *op)
@@ -4849,7 +4837,7 @@ _curses_capi_destructor(PyObject *op)
 }
 
 static int
-_cursesmodule_exec(PyObject *module)
+cursesmodule_exec(PyObject *module)
 {
     _cursesmodule_state *st = get_cursesmodule_state(module);
     /* Initialize object type */
@@ -5087,49 +5075,6 @@ _cursesmodule_exec(PyObject *module)
     return 0;
 }
 
-static int
-_cursesmodule_traverse(PyObject *mod, visitproc visit, void *arg)
-{
-    _cursesmodule_state *st = get_cursesmodule_state(mod);
-    Py_VISIT(st->PyCursesError);
-    Py_VISIT(st->PyCursesWindow_Type);
-    return 0;
-}
-
-static int
-_cursesmodule_clear(PyObject *mod)
-{
-    _cursesmodule_state *st = get_cursesmodule_state(mod);
-    Py_CLEAR(st->PyCursesError);
-    Py_CLEAR(st->PyCursesWindow_Type);
-    return 0;
-}
-
-static void
-_cursesmodule_free(void *mod)
-{
-    (void)_cursesmodule_clear((PyObject *)mod);
-}
-
-static PyModuleDef_Slot _cursesmodule_slots[] = {
-    {Py_mod_exec, _cursesmodule_exec},
-    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
-    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-    {0, NULL}
-};
-
-static struct PyModuleDef _cursesmodule = {
-    PyModuleDef_HEAD_INIT,
-    .m_name = "_curses",
-    .m_doc = NULL,
-    .m_size = sizeof(_cursesmodule_state),
-    .m_methods = _cursesmodule_methods,
-    .m_slots = _cursesmodule_slots,
-    .m_traverse = _cursesmodule_traverse,
-    .m_clear = _cursesmodule_clear,
-    .m_free = _cursesmodule_free
-};
-
 PyMODINIT_FUNC
 PyInit__curses(void)
 {
@@ -5144,7 +5089,7 @@ PyInit__curses(void)
     }
 #endif
     // populate the module
-    if (_cursesmodule_exec(mod) < 0) {
+    if (cursesmodule_exec(mod) < 0) {
         goto error;
     }
     return mod;

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -5133,5 +5133,23 @@ static struct PyModuleDef _cursesmodule = {
 PyMODINIT_FUNC
 PyInit__curses(void)
 {
-    return PyModuleDef_Init(&_cursesmodule);
+    // create the module
+    PyObject *mod = PyModule_Create(&_cursesmodule);
+    if (mod == NULL) {
+        goto error;
+    }
+#ifdef Py_GIL_DISABLED
+    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED) < 0) {
+        goto error;
+    }
+#endif
+    // populate the module
+    if (_cursesmodule_exec(mod) < 0) {
+        goto error;
+    }
+    return mod;
+
+error:
+    Py_XDECREF(mod);
+    return NULL;
 }

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -264,8 +264,7 @@ PyCursesCheckERR(PyObject *module, int code, const char *fname)
         _cursesmodule_state *st = get_cursesmodule_state(module);
         if (fname == NULL) {
             PyErr_SetString(st->PyCursesError, catchall_ERR);
-        }
-        else {
+        } else {
             PyErr_Format(st->PyCursesError, "%s() returned ERR", fname);
         }
         return NULL;
@@ -776,9 +775,7 @@ PyCursesWindow_New(_cursesmodule_state *st, WINDOW *win, const char *encoding)
 
     PyTypeObject *type = st->PyCursesWindow_Type;
     wo = (PyCursesWindowObject *)type->tp_alloc(type, 0);
-    if (wo == NULL) {
-        return NULL;
-    }
+    if (wo == NULL) return NULL;
     wo->win = win;
     wo->encoding = _PyMem_Strdup(encoding);
     if (wo->encoding == NULL) {

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -875,7 +875,7 @@ _curses_window_addch_impl(PyCursesWindowObject *self, int group_left_1,
     else {
         return NULL;
     }
-    return PyCursesCheckERR(rtn, funcname);
+    return PyCursesCheckERR_FromSelf(self, rtn, funcname);
 }
 
 /*[clinic input]
@@ -955,7 +955,7 @@ _curses_window_addstr_impl(PyCursesWindowObject *self, int group_left_1,
     }
     if (use_attr)
         (void)wattrset(self->win,attr_old);
-    return PyCursesCheckERR(rtn, funcname);
+    return PyCursesCheckERR_FromSelf(self, rtn, funcname);
 }
 
 /*[clinic input]
@@ -1038,7 +1038,7 @@ _curses_window_addnstr_impl(PyCursesWindowObject *self, int group_left_1,
     }
     if (use_attr)
         (void)wattrset(self->win,attr_old);
-    return PyCursesCheckERR(rtn, funcname);
+    return PyCursesCheckERR_FromSelf(self, rtn, funcname);
 }
 
 /*[clinic input]
@@ -1062,7 +1062,7 @@ _curses_window_bkgd_impl(PyCursesWindowObject *self, PyObject *ch, long attr)
     if (!PyCurses_ConvertToChtype(self, ch, &bkgd))
         return NULL;
 
-    return PyCursesCheckERR(wbkgd(self->win, bkgd | attr), "bkgd");
+    return PyCursesCheckERR_FromSelf(self, wbkgd(self->win, bkgd | attr), "bkgd");
 }
 
 /*[clinic input]
@@ -1078,7 +1078,7 @@ static PyObject *
 _curses_window_attroff_impl(PyCursesWindowObject *self, long attr)
 /*[clinic end generated code: output=8a2fcd4df682fc64 input=786beedf06a7befe]*/
 {
-    return PyCursesCheckERR(wattroff(self->win, (attr_t)attr), "attroff");
+    return PyCursesCheckERR_FromSelf(self, wattroff(self->win, (attr_t)attr), "attroff");
 }
 
 /*[clinic input]
@@ -1094,7 +1094,7 @@ static PyObject *
 _curses_window_attron_impl(PyCursesWindowObject *self, long attr)
 /*[clinic end generated code: output=7afea43b237fa870 input=5a88fba7b1524f32]*/
 {
-    return PyCursesCheckERR(wattron(self->win, (attr_t)attr), "attron");
+    return PyCursesCheckERR_FromSelf(self, wattron(self->win, (attr_t)attr), "attron");
 }
 
 /*[clinic input]
@@ -1110,7 +1110,7 @@ static PyObject *
 _curses_window_attrset_impl(PyCursesWindowObject *self, long attr)
 /*[clinic end generated code: output=84e379bff20c0433 input=42e400c0d0154ab5]*/
 {
-    return PyCursesCheckERR(wattrset(self->win, (attr_t)attr), "attrset");
+    return PyCursesCheckERR_FromSelf(self, wattrset(self->win, (attr_t)attr), "attrset");
 }
 
 /*[clinic input]
@@ -1136,7 +1136,7 @@ _curses_window_bkgdset_impl(PyCursesWindowObject *self, PyObject *ch,
         return NULL;
 
     wbkgdset(self->win, bkgd | attr);
-    return PyCursesCheckERR(0, "bkgdset");
+    return PyCursesCheckERR_FromSelf(self, 0, "bkgdset");
 }
 
 /*[clinic input]
@@ -1336,7 +1336,7 @@ PyCursesWindow_ChgAt(PyCursesWindowObject *self, PyObject *args)
         rtn = wchgat(self->win,num,attr,color,NULL);
         touchline(self->win,y,1);
     }
-    return PyCursesCheckERR(rtn, "chgat");
+    return PyCursesCheckERR_FromSelf(self, rtn, "chgat");
 }
 #endif
 
@@ -1360,10 +1360,10 @@ _curses_window_delch_impl(PyCursesWindowObject *self, int group_right_1,
 /*[clinic end generated code: output=22e77bb9fa11b461 input=d2f79e630a4fc6d0]*/
 {
     if (!group_right_1) {
-        return PyCursesCheckERR(wdelch(self->win), "wdelch");
+        return PyCursesCheckERR_FromSelf(self, wdelch(self->win), "wdelch");
     }
     else {
-        return PyCursesCheckERR(py_mvwdelch(self->win, y, x), "mvwdelch");
+        return PyCursesCheckERR_FromSelf(self, py_mvwdelch(self->win, y, x), "mvwdelch");
     }
 }
 
@@ -1431,13 +1431,15 @@ _curses_window_echochar_impl(PyCursesWindowObject *self, PyObject *ch,
 
 #ifdef py_is_pad
     if (py_is_pad(self->win)) {
-        return PyCursesCheckERR(pechochar(self->win, ch_ | (attr_t)attr),
-                                "echochar");
+        return PyCursesCheckERR_FromSelf(self,
+                                         pechochar(self->win, ch_ | (attr_t)attr),
+                                         "echochar");
     }
     else
 #endif
-        return PyCursesCheckERR(wechochar(self->win, ch_ | (attr_t)attr),
-                                "echochar");
+        return PyCursesCheckERR_FromSelf(self,
+                                         wechochar(self->win, ch_ | (attr_t)attr),
+                                         "echochar");
 }
 
 #ifdef NCURSES_MOUSE_VERSION
@@ -1731,10 +1733,10 @@ _curses_window_hline_impl(PyCursesWindowObject *self, int group_left_1,
         return NULL;
     if (group_left_1) {
         if (wmove(self->win, y, x) == ERR) {
-            return PyCursesCheckERR(ERR, "wmove");
+            return PyCursesCheckERR_FromSelf(self, ERR, "wmove");
         }
     }
-    return PyCursesCheckERR(whline(self->win, ch_ | (attr_t)attr, n), "hline");
+    return PyCursesCheckERR_FromSelf(self, whline(self->win, ch_ | (attr_t)attr, n), "hline");
 }
 
 /*[clinic input]
@@ -1781,7 +1783,7 @@ _curses_window_insch_impl(PyCursesWindowObject *self, int group_left_1,
         rtn = mvwinsch(self->win, y, x, ch_ | (attr_t)attr);
     }
 
-    return PyCursesCheckERR(rtn, "insch");
+    return PyCursesCheckERR_FromSelf(self, rtn, "insch");
 }
 
 /*[clinic input]
@@ -1958,7 +1960,7 @@ _curses_window_insstr_impl(PyCursesWindowObject *self, int group_left_1,
     }
     if (use_attr)
         (void)wattrset(self->win,attr_old);
-    return PyCursesCheckERR(rtn, funcname);
+    return PyCursesCheckERR_FromSelf(self, rtn, funcname);
 }
 
 /*[clinic input]
@@ -2043,7 +2045,7 @@ _curses_window_insnstr_impl(PyCursesWindowObject *self, int group_left_1,
     }
     if (use_attr)
         (void)wattrset(self->win,attr_old);
-    return PyCursesCheckERR(rtn, funcname);
+    return PyCursesCheckERR_FromSelf(self, rtn, funcname);
 }
 
 /*[clinic input]
@@ -2129,7 +2131,7 @@ _curses_window_noutrefresh_impl(PyCursesWindowObject *self)
         rtn = pnoutrefresh(self->win, pminrow, pmincol,
                            sminrow, smincol, smaxrow, smaxcol);
         Py_END_ALLOW_THREADS
-        return PyCursesCheckERR(rtn, "pnoutrefresh");
+        return PyCursesCheckERR_FromSelf(self, rtn, "pnoutrefresh");
     }
     if (group_right_1) {
         PyErr_SetString(PyExc_TypeError,
@@ -2140,7 +2142,7 @@ _curses_window_noutrefresh_impl(PyCursesWindowObject *self)
     Py_BEGIN_ALLOW_THREADS
     rtn = wnoutrefresh(self->win);
     Py_END_ALLOW_THREADS
-    return PyCursesCheckERR(rtn, "wnoutrefresh");
+    return PyCursesCheckERR_FromSelf(self, rtn, "wnoutrefresh");
 }
 
 /*[clinic input]
@@ -2183,11 +2185,11 @@ _curses_window_overlay_impl(PyCursesWindowObject *self,
     if (group_right_1) {
         rtn = copywin(self->win, destwin->win, sminrow, smincol,
                       dminrow, dmincol, dmaxrow, dmaxcol, TRUE);
-        return PyCursesCheckERR(rtn, "copywin");
+        return PyCursesCheckERR_FromSelf(self, rtn, "copywin");
     }
     else {
         rtn = overlay(self->win, destwin->win);
-        return PyCursesCheckERR(rtn, "overlay");
+        return PyCursesCheckERR_FromSelf(self, rtn, "overlay");
     }
 }
 
@@ -2232,11 +2234,11 @@ _curses_window_overwrite_impl(PyCursesWindowObject *self,
     if (group_right_1) {
         rtn = copywin(self->win, destwin->win, sminrow, smincol,
                       dminrow, dmincol, dmaxrow, dmaxcol, FALSE);
-        return PyCursesCheckERR(rtn, "copywin");
+        return PyCursesCheckERR_FromSelf(self, rtn, "copywin");
     }
     else {
         rtn = overwrite(self->win, destwin->win);
-        return PyCursesCheckERR(rtn, "overwrite");
+        return PyCursesCheckERR_FromSelf(self, rtn, "overwrite");
     }
 }
 
@@ -2265,7 +2267,7 @@ _curses_window_putwin(PyCursesWindowObject *self, PyObject *file)
         return PyErr_SetFromErrno(PyExc_OSError);
     if (_Py_set_inheritable(fileno(fp), 0, NULL) < 0)
         goto exit;
-    res = PyCursesCheckERR(putwin(self->win, fp), "putwin");
+    res = PyCursesCheckERR_FromSelf(self, putwin(self->win, fp), "putwin");
     if (res == NULL)
         goto exit;
     fseek(fp, 0, 0);
@@ -2304,7 +2306,7 @@ static PyObject *
 _curses_window_redrawln_impl(PyCursesWindowObject *self, int beg, int num)
 /*[clinic end generated code: output=ea216e334f9ce1b4 input=152155e258a77a7a]*/
 {
-    return PyCursesCheckERR(wredrawln(self->win,beg,num), "redrawln");
+    return PyCursesCheckERR_FromSelf(self, wredrawln(self->win,beg,num), "redrawln");
 }
 
 /*[clinic input]
@@ -2354,7 +2356,7 @@ _curses_window_refresh_impl(PyCursesWindowObject *self, int group_right_1,
         rtn = prefresh(self->win, pminrow, pmincol,
                        sminrow, smincol, smaxrow, smaxcol);
         Py_END_ALLOW_THREADS
-        return PyCursesCheckERR(rtn, "prefresh");
+        return PyCursesCheckERR_FromSelf(self, rtn, "prefresh");
     }
 #endif
     if (group_right_1) {
@@ -2365,7 +2367,7 @@ _curses_window_refresh_impl(PyCursesWindowObject *self, int group_right_1,
     Py_BEGIN_ALLOW_THREADS
     rtn = wrefresh(self->win);
     Py_END_ALLOW_THREADS
-    return PyCursesCheckERR(rtn, "prefresh");
+    return PyCursesCheckERR_FromSelf(self, rtn, "prefresh");
 }
 
 /*[clinic input]
@@ -2387,7 +2389,7 @@ _curses_window_setscrreg_impl(PyCursesWindowObject *self, int top,
                               int bottom)
 /*[clinic end generated code: output=486ab5db218d2b1a input=1b517b986838bf0e]*/
 {
-    return PyCursesCheckERR(wsetscrreg(self->win, top, bottom), "wsetscrreg");
+    return PyCursesCheckERR_FromSelf(self, wsetscrreg(self->win, top, bottom), "wsetscrreg");
 }
 
 /*[clinic input]
@@ -2455,10 +2457,10 @@ _curses_window_scroll_impl(PyCursesWindowObject *self, int group_right_1,
 /*[clinic end generated code: output=4541a8a11852d360 input=c969ca0cfabbdbec]*/
 {
     if (!group_right_1) {
-        return PyCursesCheckERR(scroll(self->win), "scroll");
+        return PyCursesCheckERR_FromSelf(self, scroll(self->win), "scroll");
     }
     else {
-        return PyCursesCheckERR(wscrl(self->win, lines), "scroll");
+        return PyCursesCheckERR_FromSelf(self, wscrl(self->win, lines), "scroll");
     }
 }
 
@@ -2484,10 +2486,10 @@ _curses_window_touchline_impl(PyCursesWindowObject *self, int start,
 /*[clinic end generated code: output=65d05b3f7438c61d input=a98aa4f79b6be845]*/
 {
     if (!group_right_1) {
-        return PyCursesCheckERR(touchline(self->win, start, count), "touchline");
+        return PyCursesCheckERR_FromSelf(self, touchline(self->win, start, count), "touchline");
     }
     else {
-        return PyCursesCheckERR(wtouchln(self->win, start, count, changed), "touchline");
+        return PyCursesCheckERR_FromSelf(self, wtouchln(self->win, start, count, changed), "touchline");
     }
 }
 
@@ -2527,9 +2529,9 @@ _curses_window_vline_impl(PyCursesWindowObject *self, int group_left_1,
         return NULL;
     if (group_left_1) {
         if (wmove(self->win, y, x) == ERR)
-            return PyCursesCheckERR(ERR, "wmove");
+            return PyCursesCheckERR_FromSelf(self, ERR, "wmove");
     }
-    return PyCursesCheckERR(wvline(self->win, ch_ | (attr_t)attr, n), "vline");
+    return PyCursesCheckERR_FromSelf(self, wvline(self->win, ch_ | (attr_t)attr, n), "vline");
 }
 
 static PyObject *

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1396,7 +1396,8 @@ _curses_window_derwin_impl(PyCursesWindowObject *self, int group_left_1,
     win = derwin(self->win,nlines,ncols,begin_y,begin_x);
 
     if (win == NULL) {
-        PyErr_SetString(curses_global_state.error, catchall_NULL);
+        _cursesmodule_state *st = get_cursesmodule_state_by_win(self);
+        PyErr_SetString(st->error, catchall_NULL);
         return NULL;
     }
 
@@ -1547,8 +1548,10 @@ _curses_window_getkey_impl(PyCursesWindowObject *self, int group_right_1,
     if (rtn == ERR) {
         /* getch() returns ERR in nodelay mode */
         PyErr_CheckSignals();
-        if (!PyErr_Occurred())
-            PyErr_SetString(curses_global_state.error, "no input");
+        if (!PyErr_Occurred()) {
+            _cursesmodule_state *st = get_cursesmodule_state_by_win(self);
+            PyErr_SetString(st->error, "no input");
+        }
         return NULL;
     } else if (rtn <= 255) {
 #ifdef NCURSES_VERSION_MAJOR
@@ -1606,7 +1609,8 @@ _curses_window_get_wch_impl(PyCursesWindowObject *self, int group_right_1,
             return NULL;
 
         /* get_wch() returns ERR in nodelay mode */
-        PyErr_SetString(curses_global_state.error, "no input");
+        _cursesmodule_state *st = get_cursesmodule_state_by_win(self);
+        PyErr_SetString(st->error, "no input");
         return NULL;
     }
     if (ct == KEY_CODE_YES)
@@ -2119,7 +2123,8 @@ _curses_window_noutrefresh_impl(PyCursesWindowObject *self)
 #ifdef py_is_pad
     if (py_is_pad(self->win)) {
         if (!group_right_1) {
-            PyErr_SetString(curses_global_state.error,
+            _cursesmodule_state *st = get_cursesmodule_state_by_win(self);
+            PyErr_SetString(st->error,
                             "noutrefresh() called for a pad "
                             "requires 6 arguments");
             return NULL;
@@ -2343,7 +2348,8 @@ _curses_window_refresh_impl(PyCursesWindowObject *self, int group_right_1,
 #ifdef py_is_pad
     if (py_is_pad(self->win)) {
         if (!group_right_1) {
-            PyErr_SetString(curses_global_state.error,
+            _cursesmodule_state *st = get_cursesmodule_state_by_win(self);
+            PyErr_SetString(st->error,
                             "refresh() for a pad requires 6 arguments");
             return NULL;
         }
@@ -2425,7 +2431,8 @@ _curses_window_subwin_impl(PyCursesWindowObject *self, int group_left_1,
         win = subwin(self->win, nlines, ncols, begin_y, begin_x);
 
     if (win == NULL) {
-        PyErr_SetString(curses_global_state.error, catchall_NULL);
+        _cursesmodule_state *st = get_cursesmodule_state_by_win(self);
+        PyErr_SetString(st->error, catchall_NULL);
         return NULL;
     }
 

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2675,12 +2675,12 @@ PyTypeObject PyCursesWindow_Type = {
 
 #define NoArgNoReturnFunctionBody(X) \
 { \
-  PyCursesInitialised; \
+  PyCursesStatefulInitialised(module); \
   return PyCursesCheckERR(X(), # X); }
 
 #define NoArgOrFlagNoReturnFunctionBody(X, flag) \
 { \
-    PyCursesInitialised; \
+    PyCursesStatefulInitialised(module); \
     if (flag) \
         return PyCursesCheckERR(X(), # X); \
     else \
@@ -2689,23 +2689,23 @@ PyTypeObject PyCursesWindow_Type = {
 
 #define NoArgReturnIntFunctionBody(X) \
 { \
- PyCursesInitialised; \
+ PyCursesStatefulInitialised(module); \
  return PyLong_FromLong((long) X()); }
 
 
 #define NoArgReturnStringFunctionBody(X) \
 { \
-  PyCursesInitialised; \
+  PyCursesStatefulInitialised(module); \
   return PyBytes_FromString(X()); }
 
 #define NoArgTrueFalseFunctionBody(X) \
 { \
-  PyCursesInitialised; \
+  PyCursesStatefulInitialised(module); \
   return PyBool_FromLong(X()); }
 
 #define NoArgNoReturnVoidFunctionBody(X) \
 { \
-  PyCursesInitialised; \
+  PyCursesStatefulInitialised(module); \
   X(); \
   Py_RETURN_NONE; }
 
@@ -2803,8 +2803,8 @@ _curses_color_content_impl(PyObject *module, int color_number)
 {
     _CURSES_COLOR_VAL_TYPE r,g,b;
 
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     if (_COLOR_CONTENT_FUNC(color_number, &r, &g, &b) == ERR) {
         _cursesmodule_state *st = get_cursesmodule_state(module);
@@ -2833,8 +2833,8 @@ static PyObject *
 _curses_color_pair_impl(PyObject *module, int pair_number)
 /*[clinic end generated code: output=60718abb10ce9feb input=6034e9146f343802]*/
 {
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     return  PyLong_FromLong(COLOR_PAIR(pair_number));
 }
@@ -2860,7 +2860,7 @@ _curses_curs_set_impl(PyObject *module, int visibility)
 {
     int erg;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     erg = curs_set(visibility);
     if (erg == ERR) return PyCursesCheckERR(erg, "curs_set");
@@ -2912,7 +2912,7 @@ static PyObject *
 _curses_delay_output_impl(PyObject *module, int ms)
 /*[clinic end generated code: output=b6613a67f17fa4f4 input=5316457f5f59196c]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(delay_output(ms), "delay_output");
 }
@@ -2968,7 +2968,7 @@ _curses_erasechar_impl(PyObject *module)
 {
     char ch;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     ch = erasechar();
 
@@ -3018,7 +3018,7 @@ _curses_getsyx_impl(PyObject *module)
     int x = 0;
     int y = 0;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     getsyx(y, x);
 
@@ -3043,7 +3043,7 @@ _curses_getmouse_impl(PyObject *module)
     int rtn;
     MEVENT event;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     rtn = getmouse( &event );
     if (rtn == ERR) {
@@ -3079,7 +3079,7 @@ _curses_ungetmouse_impl(PyObject *module, short id, int x, int y, int z,
 {
     MEVENT event;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     event.id = id;
     event.x = x;
@@ -3112,7 +3112,7 @@ _curses_getwin(PyObject *module, PyObject *file)
     WINDOW *win;
     PyObject *res = NULL;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     fp = tmpfile();
     if (fp == NULL)
@@ -3169,7 +3169,7 @@ static PyObject *
 _curses_halfdelay_impl(PyObject *module, unsigned char tenths)
 /*[clinic end generated code: output=e92cdf0ef33c0663 input=e42dce7259c15100]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(halfdelay(tenths), "halfdelay");
 }
@@ -3222,7 +3222,7 @@ static PyObject *
 _curses_has_key_impl(PyObject *module, int key)
 /*[clinic end generated code: output=19ad48319414d0b1 input=78bd44acf1a4997c]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyBool_FromLong(has_key(key));
 }
@@ -3253,8 +3253,8 @@ _curses_init_color_impl(PyObject *module, int color_number, short r, short g,
                         short b)
 /*[clinic end generated code: output=d7ed71b2d818cdf2 input=ae2b8bea0f152c80]*/
 {
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     return PyCursesCheckERR(_CURSES_INIT_COLOR_FUNC(color_number, r, g, b),
                             Py_STRINGIFY(_CURSES_INIT_COLOR_FUNC));
@@ -3281,8 +3281,8 @@ static PyObject *
 _curses_init_pair_impl(PyObject *module, int pair_number, int fg, int bg)
 /*[clinic end generated code: output=a0bba03d2bbc3ee6 input=54b421b44c12c389]*/
 {
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     if (_CURSES_INIT_PAIR_FUNC(pair_number, fg, bg) == ERR) {
         if (pair_number >= COLOR_PAIRS) {
@@ -3580,7 +3580,7 @@ static PyObject *
 _curses_intrflush_impl(PyObject *module, int flag)
 /*[clinic end generated code: output=c1986df35e999a0f input=c65fe2ef973fe40a]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(intrflush(NULL, flag), "intrflush");
 }
@@ -3613,7 +3613,7 @@ static PyObject *
 _curses_is_term_resized_impl(PyObject *module, int nlines, int ncols)
 /*[clinic end generated code: output=aafe04afe50f1288 input=ca9c0bd0fb8ab444]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyBool_FromLong(is_term_resized(nlines, ncols));
 }
@@ -3635,7 +3635,7 @@ _curses_keyname_impl(PyObject *module, int key)
 {
     const char *knp;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (key < 0) {
         PyErr_SetString(PyExc_ValueError, "invalid key number");
@@ -3693,7 +3693,7 @@ static PyObject *
 _curses_meta_impl(PyObject *module, int yes)
 /*[clinic end generated code: output=22f5abda46a605d8 input=cfe7da79f51d0e30]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(meta(stdscr, yes), "meta");
 }
@@ -3717,7 +3717,7 @@ static PyObject *
 _curses_mouseinterval_impl(PyObject *module, int interval)
 /*[clinic end generated code: output=c4f5ff04354634c5 input=75aaa3f0db10ac4e]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(mouseinterval(interval), "mouseinterval");
 }
@@ -3742,7 +3742,7 @@ _curses_mousemask_impl(PyObject *module, unsigned long newmask)
 {
     mmask_t oldmask, availmask;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
     availmask = mousemask((mmask_t)newmask, &oldmask);
     return Py_BuildValue("(kk)",
                          (unsigned long)availmask, (unsigned long)oldmask);
@@ -3763,7 +3763,7 @@ static int
 _curses_napms_impl(PyObject *module, int ms)
 /*[clinic end generated code: output=5f292a6a724491bd input=c6d6e01f2f1df9f7]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return napms(ms);
 }
@@ -3787,7 +3787,7 @@ _curses_newpad_impl(PyObject *module, int nlines, int ncols)
 {
     WINDOW *win;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     win = newpad(nlines, ncols);
 
@@ -3828,7 +3828,7 @@ _curses_newwin_impl(PyObject *module, int nlines, int ncols,
 {
     WINDOW *win;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     win = newwin(nlines,ncols,begin_y,begin_x);
     if (win == NULL) {
@@ -3941,8 +3941,8 @@ _curses_pair_content_impl(PyObject *module, int pair_number)
 {
     _CURSES_COLOR_NUM_TYPE f, b;
 
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     if (_CURSES_PAIR_CONTENT_FUNC(pair_number, &f, &b) == ERR) {
         if (pair_number >= COLOR_PAIRS) {
@@ -3976,8 +3976,8 @@ static PyObject *
 _curses_pair_number_impl(PyObject *module, int attr)
 /*[clinic end generated code: output=85bce7d65c0aa3f4 input=d478548e33f5e61a]*/
 {
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     return PyLong_FromLong(PAIR_NUMBER(attr));
 }
@@ -4017,7 +4017,7 @@ static PyObject *
 _curses_qiflush_impl(PyObject *module, int flag)
 /*[clinic end generated code: output=9167e862f760ea30 input=6ec8b3e2b717ec40]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (flag) {
         qiflush();
@@ -4172,7 +4172,7 @@ _curses_resizeterm_impl(PyObject *module, int nlines, int ncols)
 {
     PyObject *result;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     result = PyCursesCheckERR(resizeterm(nlines, ncols), "resizeterm");
     if (!result)
@@ -4211,7 +4211,7 @@ _curses_resize_term_impl(PyObject *module, int nlines, int ncols)
 {
     PyObject *result;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     result = PyCursesCheckERR(resize_term(nlines, ncols), "resize_term");
     if (!result)
@@ -4254,7 +4254,7 @@ static PyObject *
 _curses_setsyx_impl(PyObject *module, int y, int x)
 /*[clinic end generated code: output=23dcf753511a2464 input=fa7f2b208e10a557]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     setsyx(y,x);
 
@@ -4279,7 +4279,7 @@ static PyObject *
 _curses_start_color_impl(PyObject *module)
 /*[clinic end generated code: output=8b772b41d8090ede input=0ca0ecb2b77e1a12]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (start_color() == ERR) {
         _cursesmodule_state *st = get_cursesmodule_state(module);
@@ -4352,7 +4352,7 @@ static PyObject *
 _curses_tigetflag_impl(PyObject *module, const char *capname)
 /*[clinic end generated code: output=8853c0e55542195b input=b0787af9e3e9a6ce]*/
 {
-    PyCursesSetupTermCalled;
+    PyCursesStatefulSetupTermCalled(module);
 
     return PyLong_FromLong( (long) tigetflag( (char *)capname ) );
 }
@@ -4374,7 +4374,7 @@ static PyObject *
 _curses_tigetnum_impl(PyObject *module, const char *capname)
 /*[clinic end generated code: output=46f8b0a1b5dff42f input=5cdf2f410b109720]*/
 {
-    PyCursesSetupTermCalled;
+    PyCursesStatefulSetupTermCalled(module);
 
     return PyLong_FromLong( (long) tigetnum( (char *)capname ) );
 }
@@ -4396,7 +4396,7 @@ static PyObject *
 _curses_tigetstr_impl(PyObject *module, const char *capname)
 /*[clinic end generated code: output=f22b576ad60248f3 input=36644df25c73c0a7]*/
 {
-    PyCursesSetupTermCalled;
+    PyCursesStatefulSetupTermCalled(module);
 
     capname = tigetstr( (char *)capname );
     if (capname == NULL || capname == (char*) -1) {
@@ -4431,7 +4431,7 @@ _curses_tparm_impl(PyObject *module, const char *str, int i1, int i2, int i3,
 {
     char* result = NULL;
 
-    PyCursesSetupTermCalled;
+    PyCursesStatefulSetupTermCalled(module);
 
     result = tparm((char *)str,i1,i2,i3,i4,i5,i6,i7,i8,i9);
     if (!result) {
@@ -4460,7 +4460,7 @@ static PyObject *
 _curses_typeahead_impl(PyObject *module, int fd)
 /*[clinic end generated code: output=084bb649d7066583 input=f2968d8e1805051b]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(typeahead( fd ), "typeahead");
 }
@@ -4484,7 +4484,7 @@ _curses_unctrl(PyObject *module, PyObject *ch)
 {
     chtype ch_;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (!PyCurses_ConvertToChtype(NULL, ch, &ch_))
         return NULL;
@@ -4507,7 +4507,7 @@ _curses_ungetch(PyObject *module, PyObject *ch)
 {
     chtype ch_;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (!PyCurses_ConvertToChtype(NULL, ch, &ch_))
         return NULL;
@@ -4578,7 +4578,7 @@ _curses_unget_wch(PyObject *module, PyObject *ch)
 {
     wchar_t wch;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (!PyCurses_ConvertToWchar_t(ch, &wch))
         return NULL;
@@ -4630,8 +4630,8 @@ _curses_use_default_colors_impl(PyObject *module)
 {
     int code;
 
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     code = use_default_colors();
     if (code != ERR) {

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -4796,7 +4796,7 @@ static struct PyModuleDef _cursesmodule = {
 };
 
 static void
-_curses_capi_destructor(PyObject *op)
+curses_destructor(PyObject *op)
 {
     void *ptr = PyCapsule_GetPointer(op, PyCurses_CAPSULE_NAME);
     Py_DECREF(*(void **)ptr);
@@ -4835,7 +4835,7 @@ cursesmodule_exec(PyObject *module)
 
     /* Add a capsule for the C API */
     PyObject *c_api_object = PyCapsule_New(PyCurses_API, PyCurses_CAPSULE_NAME,
-                                           _curses_capi_destructor);
+                                           curses_destructor);
     if (c_api_object == NULL) {
         Py_DECREF(PyCurses_API[0]);
         PyMem_Free(PyCurses_API);

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1405,7 +1405,8 @@ _curses_window_derwin_impl(PyCursesWindowObject *self, int group_left_1,
         return NULL;
     }
 
-    return (PyObject *)PyCursesWindow_New(win, NULL);
+    _cursesmodule_state *st = get_cursesmodule_state_by_cls(Py_TYPE(self));
+    return (PyObject *)PyCursesWindow_New(st, win, NULL);
 }
 
 /*[clinic input]
@@ -2442,7 +2443,8 @@ _curses_window_subwin_impl(PyCursesWindowObject *self, int group_left_1,
         return NULL;
     }
 
-    return (PyObject *)PyCursesWindow_New(win, self->encoding);
+    _cursesmodule_state *st = get_cursesmodule_state_by_cls(Py_TYPE(self));
+    return (PyObject *)PyCursesWindow_New(st, win, self->encoding);
 }
 
 /*[clinic input]
@@ -3177,7 +3179,8 @@ _curses_getwin(PyObject *module, PyObject *file)
         PyErr_SetString(st->PyCursesError, catchall_NULL);
         goto error;
     }
-    res = PyCursesWindow_New(win, NULL);
+    _cursesmodule_state *st = get_cursesmodule_state(module);
+    res = PyCursesWindow_New(st, win, NULL);
 
 error:
     fclose(fp);
@@ -3349,7 +3352,8 @@ _curses_initscr_impl(PyObject *module)
 
     if (curses_initscr_called) {
         wrefresh(stdscr);
-        return (PyObject *)PyCursesWindow_New(stdscr, NULL);
+        _cursesmodule_state *st = get_cursesmodule_state(module);
+        return (PyObject *)PyCursesWindow_New(st, stdscr, NULL);
     }
 
     win = initscr();
@@ -3452,7 +3456,8 @@ _curses_initscr_impl(PyObject *module)
     SetDictInt("COLS", COLS);
 #undef SetDictInt
 
-    PyCursesWindowObject *winobj = (PyCursesWindowObject *)PyCursesWindow_New(win, NULL);
+    _cursesmodule_state *st = get_cursesmodule_state(module);
+    PyCursesWindowObject *winobj = (PyCursesWindowObject *)PyCursesWindow_New(st, win, NULL);
     if (winobj == NULL) {
         return NULL;
     }
@@ -3829,7 +3834,8 @@ _curses_newpad_impl(PyObject *module, int nlines, int ncols)
         return NULL;
     }
 
-    return (PyObject *)PyCursesWindow_New(win, NULL);
+    _cursesmodule_state *st = get_cursesmodule_state(module);
+    return (PyObject *)PyCursesWindow_New(st, win, NULL);
 }
 
 /*[clinic input]
@@ -3869,7 +3875,8 @@ _curses_newwin_impl(PyObject *module, int nlines, int ncols,
         return NULL;
     }
 
-    return (PyObject *)PyCursesWindow_New(win, NULL);
+    _cursesmodule_state *st = get_cursesmodule_state(module);
+    return (PyObject *)PyCursesWindow_New(st, win, NULL);
 }
 
 /*[clinic input]

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -235,21 +235,21 @@ _PyCursesStatefulCheckFunction(PyObject *module, int called, const char *funcnam
     return 0;
 }
 
-#define PyCursesStatefulSetupTermCalled(MODULE)                     \
-    do {                                                            \
-        if (_PyCursesStatefulCheckFunction(MODULE,                  \
-                                           curses_setupterm_called, \
-                                           "setupterm"))            \
-        {                                                           \
-            return 0;                                               \
-        }                                                           \
+#define PyCursesStatefulSetupTermCalled(MODULE)                         \
+    do {                                                                \
+        if (!_PyCursesStatefulCheckFunction(MODULE,                     \
+                                            curses_setupterm_called,    \
+                                            "setupterm"))               \
+        {                                                               \
+            return 0;                                                   \
+        }                                                               \
     } while (0)
 
 #define PyCursesStatefulInitialised(MODULE)                         \
     do {                                                            \
-        if (_PyCursesStatefulCheckFunction(MODULE,                  \
-                                           curses_initscr_called,   \
-                                           "initscr"))              \
+        if (!_PyCursesStatefulCheckFunction(MODULE,                 \
+                                            curses_initscr_called,  \
+                                            "initscr"))             \
         {                                                           \
             return 0;                                               \
         }                                                           \
@@ -257,9 +257,9 @@ _PyCursesStatefulCheckFunction(PyObject *module, int called, const char *funcnam
 
 #define PyCursesStatefulInitialisedColor(MODULE)                        \
     do {                                                                \
-        if (_PyCursesStatefulCheckFunction(MODULE,                      \
-                                           curses_start_color_called,   \
-                                           "start_color"))              \
+        if (!_PyCursesStatefulCheckFunction(MODULE,                     \
+                                            curses_start_color_called,  \
+                                            "start_color"))             \
         {                                                               \
             return 0;                                                   \
         }                                                               \

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -588,19 +588,19 @@ class component_converter(CConverter):
 
 static int func_PyCursesSetupTermCalled(void)
 {
-    PyCursesSetupTermCalled;
+    _PyCursesCheckFunction(curses_setupterm_called, "setupterm");
     return 1;
 }
 
 static int func_PyCursesInitialised(void)
 {
-    PyCursesInitialised;
+    _PyCursesCheckFunction(curses_initscr_called, "initscr");
     return 1;
 }
 
 static int func_PyCursesInitialisedColor(void)
 {
-    PyCursesInitialisedColor;
+    _PyCursesCheckFunction(curses_start_color_called, "start_color");;
     return 1;
 }
 

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -186,10 +186,6 @@ class _curses.window "PyCursesWindowObject *" "clinic_state()->PyCursesWindow_Ty
 [clinic start generated code]*/
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=83369be6e20ef0da]*/
 
-/* Definition of exception curses.error */
-
-static PyObject *PyCursesError;
-
 /* Tells whether setupterm() has been called to initialise terminfo.  */
 static int curses_setupterm_called = FALSE;
 
@@ -201,33 +197,54 @@ static int curses_start_color_called = FALSE;
 
 static const char *curses_screen_encoding = NULL;
 
-/* Utility Macros */
-#define PyCursesSetupTermCalled                                         \
+/*
+ * Macro to check that FUNC_NAME has been called by testing
+ * the CALLED boolean. If an error occurs, a PyCursesError
+ * is raised.
+ *
+ * Since these macros can be called in functions that do not
+ * have a direct access to the module's state, the exception
+ * type is imported on demand as well.
+ */
+#define _PyCursesCheckFunction(CALLED, FUNC_NAME)                       \
     do {                                                                \
-        if (curses_setupterm_called != TRUE) {                          \
-            PyErr_SetString(PyCursesError,                              \
-                            "must call (at least) setupterm() first");  \
+        if ((CALLED) != TRUE) {                                         \
+            PyObject *exc = _PyImport_GetModuleAttrString("_curses",    \
+                                                          "error");     \
+            if (exc == NULL) {                                          \
+                return 0;                                               \
+            }                                                           \
+            PyErr_SetString(exc, "must call " # FUNC_NAME "() first");  \
+            Py_DECREF(exc);                                             \
             return 0;                                                   \
         }                                                               \
     } while (0)
 
-#define PyCursesInitialised                                 \
-    do {                                                    \
-        if (curses_initscr_called != TRUE) {                \
-            PyErr_SetString(PyCursesError,                  \
-                            "must call initscr() first");   \
-            return 0;                                       \
-        }                                                   \
+/*
+ * Macro to check that FUNC_NAME has been called by testing
+ * the CALLED boolean. If an error occurs, a PyCursesError
+ * is raised. The exception type is obtained from the module
+ * state.
+ */
+#define _PyCursesStatefulCheckFunction(CALLED, FUNC_NAME, MODULE)       \
+    do {                                                                \
+        if ((CALLED) != TRUE) {                                         \
+            _cursesmodule_state *st = get_cursesmodule_state((MODULE)); \
+            PyErr_SetString(st->PyCursesError,                          \
+                            "must call " # FUNC_NAME "() first");       \
+            return 0;                                                   \
+        }                                                               \
     } while (0)
 
-#define PyCursesInitialisedColor                                \
-    do {                                                        \
-        if (curses_start_color_called != TRUE) {                \
-            PyErr_SetString(PyCursesError,                      \
-                            "must call start_color() first");   \
-            return 0;                                           \
-        }                                                       \
-    } while (0)
+#define PyCursesStatefulSetupTermCalled(MODULE)               \
+    _PyCursesStatefulCheckFunction(curses_setupterm_called,   \
+                                  "setupterm", (MODULE))
+#define PyCursesStatefulInitialised(MODULE)                   \
+    _PyCursesStatefulCheckFunction(curses_initscr_called,     \
+                                  "initscr", (MODULE))
+#define PyCursesStatefulInitialisedColor(MODULE)              \
+    _PyCursesStatefulCheckFunction(curses_start_color_called, \
+                                  "start_color", (MODULE))
 
 /* Utility Functions */
 

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -4787,7 +4787,7 @@ static PyMethodDef _cursesmodule_methods[] = {
 /* Module initialization and cleanup functions. */
 
 static void
-curses_destructor(PyObject *op)
+_curses_capi_destructor(PyObject *op)
 {
     void *ptr = PyCapsule_GetPointer(op, PyCurses_CAPSULE_NAME);
     Py_DECREF(*(void **)ptr);
@@ -4825,7 +4825,7 @@ _cursesmodule_exec(PyObject *module)
 
     /* Add a capsule for the C API */
     PyObject *c_api_object = PyCapsule_New(PyCurses_API, PyCurses_CAPSULE_NAME,
-                                           curses_destructor);
+                                           _curses_capi_destructor);
     if (c_api_object == NULL) {
         Py_DECREF(PyCurses_API[0]);
         PyMem_Free(PyCurses_API);

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -5137,23 +5137,5 @@ static struct PyModuleDef _cursesmodule = {
 PyMODINIT_FUNC
 PyInit__curses(void)
 {
-    // create the module
-    PyObject *mod = PyModule_Create(&_cursesmodule);
-    if (mod == NULL) {
-        goto error;
-    }
-#ifdef Py_GIL_DISABLED
-    if (PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED) < 0) {
-        goto error;
-    }
-#endif
-    // populate the module
-    if (_cursesmodule_exec(mod) < 0) {
-        goto error;
-    }
-    return mod;
-
-error:
-    Py_XDECREF(mod);
-    return NULL;
+    return PyModuleDef_Init(&_cursesmodule);
 }

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1345,7 +1345,7 @@ _curses_window_derwin_impl(PyCursesWindowObject *self, int group_left_1,
         return NULL;
     }
 
-    return PyCursesWindow_New(win, NULL);
+    return (PyObject *)PyCursesWindow_New(win, NULL);
 }
 
 /*[clinic input]
@@ -2371,7 +2371,7 @@ _curses_window_subwin_impl(PyCursesWindowObject *self, int group_left_1,
         return NULL;
     }
 
-    return PyCursesWindow_New(win, self->encoding);
+    return (PyObject *)PyCursesWindow_New(win, self->encoding);
 }
 
 /*[clinic input]
@@ -3295,7 +3295,7 @@ _curses_initscr_impl(PyObject *module)
 
     if (curses_initscr_called) {
         wrefresh(stdscr);
-        return PyCursesWindow_New(stdscr, NULL);
+        return (PyObject *)PyCursesWindow_New(stdscr, NULL);
     }
 
     win = initscr();
@@ -3775,7 +3775,7 @@ _curses_newpad_impl(PyObject *module, int nlines, int ncols)
         return NULL;
     }
 
-    return PyCursesWindow_New(win, NULL);
+    return (PyObject *)PyCursesWindow_New(win, NULL);
 }
 
 /*[clinic input]
@@ -3815,7 +3815,7 @@ _curses_newwin_impl(PyObject *module, int nlines, int ncols,
         return NULL;
     }
 
-    return PyCursesWindow_New(win, NULL);
+    return (PyObject *)PyCursesWindow_New(win, NULL);
 }
 
 /*[clinic input]

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -259,8 +259,7 @@ PyCursesCheckERR(PyObject *module, int code, const char *fname)
 {
     if (code != ERR) {
         Py_RETURN_NONE;
-    }
-    else {
+    } else {
         _cursesmodule_state *st = get_cursesmodule_state(module);
         if (fname == NULL) {
             PyErr_SetString(st->PyCursesError, catchall_ERR);

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -272,6 +272,13 @@ PyCursesCheckERR(PyObject *module, int code, const char *fname)
     }
 }
 
+static inline PyObject *
+PyCursesCheckERR_FromSelf(PyCursesWindowObject *self, int code, const char *fname)
+{
+    PyObject *module = PyType_GetModule(Py_TYPE(self));
+    return PyCursesCheckERR(module, code, fname);
+}
+
 /* Convert an object to a byte (an integer of type chtype):
 
    - int

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2812,8 +2812,8 @@ _curses_color_content_impl(PyObject *module, int color_number)
 {
     _CURSES_COLOR_VAL_TYPE r,g,b;
 
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     if (_COLOR_CONTENT_FUNC(color_number, &r, &g, &b) == ERR) {
         PyErr_Format(PyCursesError, "%s() returned ERR",
@@ -2841,8 +2841,8 @@ static PyObject *
 _curses_color_pair_impl(PyObject *module, int pair_number)
 /*[clinic end generated code: output=60718abb10ce9feb input=6034e9146f343802]*/
 {
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     return  PyLong_FromLong(COLOR_PAIR(pair_number));
 }
@@ -2868,7 +2868,7 @@ _curses_curs_set_impl(PyObject *module, int visibility)
 {
     int erg;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     erg = curs_set(visibility);
     if (erg == ERR) return PyCursesCheckERR(erg, "curs_set");
@@ -2920,7 +2920,7 @@ static PyObject *
 _curses_delay_output_impl(PyObject *module, int ms)
 /*[clinic end generated code: output=b6613a67f17fa4f4 input=5316457f5f59196c]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(delay_output(ms), "delay_output");
 }
@@ -2976,7 +2976,7 @@ _curses_erasechar_impl(PyObject *module)
 {
     char ch;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     ch = erasechar();
 
@@ -3026,7 +3026,7 @@ _curses_getsyx_impl(PyObject *module)
     int x = 0;
     int y = 0;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     getsyx(y, x);
 
@@ -3051,7 +3051,7 @@ _curses_getmouse_impl(PyObject *module)
     int rtn;
     MEVENT event;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     rtn = getmouse( &event );
     if (rtn == ERR) {
@@ -3086,7 +3086,7 @@ _curses_ungetmouse_impl(PyObject *module, short id, int x, int y, int z,
 {
     MEVENT event;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     event.id = id;
     event.x = x;
@@ -3119,7 +3119,7 @@ _curses_getwin(PyObject *module, PyObject *file)
     WINDOW *win;
     PyObject *res = NULL;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     fp = tmpfile();
     if (fp == NULL)
@@ -3175,7 +3175,7 @@ static PyObject *
 _curses_halfdelay_impl(PyObject *module, unsigned char tenths)
 /*[clinic end generated code: output=e92cdf0ef33c0663 input=e42dce7259c15100]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(halfdelay(tenths), "halfdelay");
 }
@@ -3228,7 +3228,7 @@ static PyObject *
 _curses_has_key_impl(PyObject *module, int key)
 /*[clinic end generated code: output=19ad48319414d0b1 input=78bd44acf1a4997c]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyBool_FromLong(has_key(key));
 }
@@ -3259,8 +3259,8 @@ _curses_init_color_impl(PyObject *module, int color_number, short r, short g,
                         short b)
 /*[clinic end generated code: output=d7ed71b2d818cdf2 input=ae2b8bea0f152c80]*/
 {
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     return PyCursesCheckERR(_CURSES_INIT_COLOR_FUNC(color_number, r, g, b),
                             Py_STRINGIFY(_CURSES_INIT_COLOR_FUNC));
@@ -3287,8 +3287,8 @@ static PyObject *
 _curses_init_pair_impl(PyObject *module, int pair_number, int fg, int bg)
 /*[clinic end generated code: output=a0bba03d2bbc3ee6 input=54b421b44c12c389]*/
 {
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     if (_CURSES_INIT_PAIR_FUNC(pair_number, fg, bg) == ERR) {
         if (pair_number >= COLOR_PAIRS) {
@@ -3584,7 +3584,7 @@ static PyObject *
 _curses_intrflush_impl(PyObject *module, int flag)
 /*[clinic end generated code: output=c1986df35e999a0f input=c65fe2ef973fe40a]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(intrflush(NULL, flag), "intrflush");
 }
@@ -3617,7 +3617,7 @@ static PyObject *
 _curses_is_term_resized_impl(PyObject *module, int nlines, int ncols)
 /*[clinic end generated code: output=aafe04afe50f1288 input=ca9c0bd0fb8ab444]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyBool_FromLong(is_term_resized(nlines, ncols));
 }
@@ -3639,7 +3639,7 @@ _curses_keyname_impl(PyObject *module, int key)
 {
     const char *knp;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (key < 0) {
         PyErr_SetString(PyExc_ValueError, "invalid key number");
@@ -3697,7 +3697,7 @@ static PyObject *
 _curses_meta_impl(PyObject *module, int yes)
 /*[clinic end generated code: output=22f5abda46a605d8 input=cfe7da79f51d0e30]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(meta(stdscr, yes), "meta");
 }
@@ -3721,7 +3721,7 @@ static PyObject *
 _curses_mouseinterval_impl(PyObject *module, int interval)
 /*[clinic end generated code: output=c4f5ff04354634c5 input=75aaa3f0db10ac4e]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(mouseinterval(interval), "mouseinterval");
 }
@@ -3746,7 +3746,7 @@ _curses_mousemask_impl(PyObject *module, unsigned long newmask)
 {
     mmask_t oldmask, availmask;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
     availmask = mousemask((mmask_t)newmask, &oldmask);
     return Py_BuildValue("(kk)",
                          (unsigned long)availmask, (unsigned long)oldmask);
@@ -3767,7 +3767,7 @@ static int
 _curses_napms_impl(PyObject *module, int ms)
 /*[clinic end generated code: output=5f292a6a724491bd input=c6d6e01f2f1df9f7]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return napms(ms);
 }
@@ -3791,7 +3791,7 @@ _curses_newpad_impl(PyObject *module, int nlines, int ncols)
 {
     WINDOW *win;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     win = newpad(nlines, ncols);
 
@@ -3831,7 +3831,7 @@ _curses_newwin_impl(PyObject *module, int nlines, int ncols,
 {
     WINDOW *win;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     win = newwin(nlines,ncols,begin_y,begin_x);
     if (win == NULL) {
@@ -3943,8 +3943,8 @@ _curses_pair_content_impl(PyObject *module, int pair_number)
 {
     _CURSES_COLOR_NUM_TYPE f, b;
 
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     if (_CURSES_PAIR_CONTENT_FUNC(pair_number, &f, &b) == ERR) {
         if (pair_number >= COLOR_PAIRS) {
@@ -3977,8 +3977,8 @@ static PyObject *
 _curses_pair_number_impl(PyObject *module, int attr)
 /*[clinic end generated code: output=85bce7d65c0aa3f4 input=d478548e33f5e61a]*/
 {
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     return PyLong_FromLong(PAIR_NUMBER(attr));
 }
@@ -4018,7 +4018,7 @@ static PyObject *
 _curses_qiflush_impl(PyObject *module, int flag)
 /*[clinic end generated code: output=9167e862f760ea30 input=6ec8b3e2b717ec40]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (flag) {
         qiflush();
@@ -4173,7 +4173,7 @@ _curses_resizeterm_impl(PyObject *module, int nlines, int ncols)
 {
     PyObject *result;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     result = PyCursesCheckERR(resizeterm(nlines, ncols), "resizeterm");
     if (!result)
@@ -4212,7 +4212,7 @@ _curses_resize_term_impl(PyObject *module, int nlines, int ncols)
 {
     PyObject *result;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     result = PyCursesCheckERR(resize_term(nlines, ncols), "resize_term");
     if (!result)
@@ -4255,7 +4255,7 @@ static PyObject *
 _curses_setsyx_impl(PyObject *module, int y, int x)
 /*[clinic end generated code: output=23dcf753511a2464 input=fa7f2b208e10a557]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     setsyx(y,x);
 
@@ -4280,7 +4280,7 @@ static PyObject *
 _curses_start_color_impl(PyObject *module)
 /*[clinic end generated code: output=8b772b41d8090ede input=0ca0ecb2b77e1a12]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (start_color() == ERR) {
         PyErr_SetString(PyCursesError, "start_color() returned ERR");
@@ -4352,7 +4352,7 @@ static PyObject *
 _curses_tigetflag_impl(PyObject *module, const char *capname)
 /*[clinic end generated code: output=8853c0e55542195b input=b0787af9e3e9a6ce]*/
 {
-    PyCursesSetupTermCalled;
+    PyCursesStatefulSetupTermCalled(module);
 
     return PyLong_FromLong( (long) tigetflag( (char *)capname ) );
 }
@@ -4374,7 +4374,7 @@ static PyObject *
 _curses_tigetnum_impl(PyObject *module, const char *capname)
 /*[clinic end generated code: output=46f8b0a1b5dff42f input=5cdf2f410b109720]*/
 {
-    PyCursesSetupTermCalled;
+    PyCursesStatefulSetupTermCalled(module);
 
     return PyLong_FromLong( (long) tigetnum( (char *)capname ) );
 }
@@ -4396,7 +4396,7 @@ static PyObject *
 _curses_tigetstr_impl(PyObject *module, const char *capname)
 /*[clinic end generated code: output=f22b576ad60248f3 input=36644df25c73c0a7]*/
 {
-    PyCursesSetupTermCalled;
+    PyCursesStatefulSetupTermCalled(module);
 
     capname = tigetstr( (char *)capname );
     if (capname == NULL || capname == (char*) -1) {
@@ -4431,7 +4431,7 @@ _curses_tparm_impl(PyObject *module, const char *str, int i1, int i2, int i3,
 {
     char* result = NULL;
 
-    PyCursesSetupTermCalled;
+    PyCursesStatefulSetupTermCalled(module);
 
     result = tparm((char *)str,i1,i2,i3,i4,i5,i6,i7,i8,i9);
     if (!result) {
@@ -4459,7 +4459,7 @@ static PyObject *
 _curses_typeahead_impl(PyObject *module, int fd)
 /*[clinic end generated code: output=084bb649d7066583 input=f2968d8e1805051b]*/
 {
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     return PyCursesCheckERR(typeahead( fd ), "typeahead");
 }
@@ -4483,7 +4483,7 @@ _curses_unctrl(PyObject *module, PyObject *ch)
 {
     chtype ch_;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (!PyCurses_ConvertToChtype(NULL, ch, &ch_))
         return NULL;
@@ -4506,7 +4506,7 @@ _curses_ungetch(PyObject *module, PyObject *ch)
 {
     chtype ch_;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (!PyCurses_ConvertToChtype(NULL, ch, &ch_))
         return NULL;
@@ -4577,7 +4577,7 @@ _curses_unget_wch(PyObject *module, PyObject *ch)
 {
     wchar_t wch;
 
-    PyCursesInitialised;
+    PyCursesStatefulInitialised(module);
 
     if (!PyCurses_ConvertToWchar_t(ch, &wch))
         return NULL;
@@ -4629,8 +4629,8 @@ _curses_use_default_colors_impl(PyObject *module)
 {
     int code;
 
-    PyCursesInitialised;
-    PyCursesInitialisedColor;
+    PyCursesStatefulInitialised(module);
+    PyCursesStatefulInitialisedColor(module);
 
     code = use_default_colors();
     if (code != ERR) {

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2905,7 +2905,7 @@ _curses_curs_set_impl(PyObject *module, int visibility)
     PyCursesStatefulInitialised(module);
 
     erg = curs_set(visibility);
-    if (erg == ERR) return PyCursesCheckERR(erg, "curs_set");
+    if (erg == ERR) return PyCursesCheckERR(module, erg, "curs_set");
 
     return PyLong_FromLong((long) erg);
 }
@@ -2956,7 +2956,7 @@ _curses_delay_output_impl(PyObject *module, int ms)
 {
     PyCursesStatefulInitialised(module);
 
-    return PyCursesCheckERR(delay_output(ms), "delay_output");
+    return PyCursesCheckERR(module, delay_output(ms), "delay_output");
 }
 
 /*[clinic input]
@@ -3127,7 +3127,7 @@ _curses_ungetmouse_impl(PyObject *module, short id, int x, int y, int z,
     event.y = y;
     event.z = z;
     event.bstate = bstate;
-    return PyCursesCheckERR(ungetmouse(&event), "ungetmouse");
+    return PyCursesCheckERR(module, ungetmouse(&event), "ungetmouse");
 }
 #endif
 
@@ -3211,7 +3211,7 @@ _curses_halfdelay_impl(PyObject *module, unsigned char tenths)
 {
     PyCursesStatefulInitialised(module);
 
-    return PyCursesCheckERR(halfdelay(tenths), "halfdelay");
+    return PyCursesCheckERR(module, halfdelay(tenths), "halfdelay");
 }
 
 /*[clinic input]
@@ -3296,7 +3296,8 @@ _curses_init_color_impl(PyObject *module, int color_number, short r, short g,
     PyCursesStatefulInitialised(module);
     PyCursesStatefulInitialisedColor(module);
 
-    return PyCursesCheckERR(_CURSES_INIT_COLOR_FUNC(color_number, r, g, b),
+    return PyCursesCheckERR(module,
+                            _CURSES_INIT_COLOR_FUNC(color_number, r, g, b),
                             Py_STRINGIFY(_CURSES_INIT_COLOR_FUNC));
 }
 
@@ -3563,7 +3564,7 @@ _curses_set_escdelay_impl(PyObject *module, int ms)
         return NULL;
     }
 
-    return PyCursesCheckERR(set_escdelay(ms), "set_escdelay");
+    return PyCursesCheckERR(module, set_escdelay(ms), "set_escdelay");
 }
 
 /*[clinic input]
@@ -3602,7 +3603,7 @@ _curses_set_tabsize_impl(PyObject *module, int size)
         return NULL;
     }
 
-    return PyCursesCheckERR(set_tabsize(size), "set_tabsize");
+    return PyCursesCheckERR(module, set_tabsize(size), "set_tabsize");
 }
 #endif
 
@@ -3620,7 +3621,7 @@ _curses_intrflush_impl(PyObject *module, int flag)
 {
     PyCursesStatefulInitialised(module);
 
-    return PyCursesCheckERR(intrflush(NULL, flag), "intrflush");
+    return PyCursesCheckERR(module, intrflush(NULL, flag), "intrflush");
 }
 
 /*[clinic input]
@@ -3733,7 +3734,7 @@ _curses_meta_impl(PyObject *module, int yes)
 {
     PyCursesStatefulInitialised(module);
 
-    return PyCursesCheckERR(meta(stdscr, yes), "meta");
+    return PyCursesCheckERR(module, meta(stdscr, yes), "meta");
 }
 
 #ifdef NCURSES_MOUSE_VERSION
@@ -3757,7 +3758,7 @@ _curses_mouseinterval_impl(PyObject *module, int interval)
 {
     PyCursesStatefulInitialised(module);
 
-    return PyCursesCheckERR(mouseinterval(interval), "mouseinterval");
+    return PyCursesCheckERR(module, mouseinterval(interval), "mouseinterval");
 }
 
 /*[clinic input]
@@ -4032,7 +4033,7 @@ static PyObject *
 _curses_putp_impl(PyObject *module, const char *string)
 /*[clinic end generated code: output=e98081d1b8eb5816 input=1601faa828b44cb3]*/
 {
-    return PyCursesCheckERR(putp(string), "putp");
+    return PyCursesCheckERR(module, putp(string), "putp");
 }
 
 /*[clinic input]
@@ -4209,7 +4210,7 @@ _curses_resizeterm_impl(PyObject *module, int nlines, int ncols)
 
     PyCursesStatefulInitialised(module);
 
-    result = PyCursesCheckERR(resizeterm(nlines, ncols), "resizeterm");
+    result = PyCursesCheckERR(module, resizeterm(nlines, ncols), "resizeterm");
     if (!result)
         return NULL;
     if (!update_lines_cols(module)) {
@@ -4248,7 +4249,7 @@ _curses_resize_term_impl(PyObject *module, int nlines, int ncols)
 
     PyCursesStatefulInitialised(module);
 
-    result = PyCursesCheckERR(resize_term(nlines, ncols), "resize_term");
+    result = PyCursesCheckERR(module, resize_term(nlines, ncols), "resize_term");
     if (!result)
         return NULL;
     if (!update_lines_cols(module)) {
@@ -4495,7 +4496,7 @@ _curses_typeahead_impl(PyObject *module, int fd)
 {
     PyCursesStatefulInitialised(module);
 
-    return PyCursesCheckERR(typeahead( fd ), "typeahead");
+    return PyCursesCheckERR(module, typeahead( fd ), "typeahead");
 }
 #endif
 
@@ -4545,7 +4546,7 @@ _curses_ungetch(PyObject *module, PyObject *ch)
     if (!PyCurses_ConvertToChtype(NULL, ch, &ch_))
         return NULL;
 
-    return PyCursesCheckERR(ungetch(ch_), "ungetch");
+    return PyCursesCheckERR(module, ungetch(ch_), "ungetch");
 }
 
 #ifdef HAVE_NCURSESW
@@ -4615,7 +4616,7 @@ _curses_unget_wch(PyObject *module, PyObject *ch)
 
     if (!PyCurses_ConvertToWchar_t(ch, &wch))
         return NULL;
-    return PyCursesCheckERR(unget_wch(wch), "unget_wch");
+    return PyCursesCheckERR(module, unget_wch(wch), "unget_wch");
 }
 #endif
 

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -174,12 +174,6 @@ get_cursesmodule_state(PyObject *Py_UNUSED(module))
 }
 
 static inline _cursesmodule_state *
-get_cursesmodule_state_by_cls(PyObject *Py_UNUSED(cls))
-{
-    return &curses_global_state;
-}
-
-static inline _cursesmodule_state *
 get_cursesmodule_state_by_win(PyCursesWindowObject *Py_UNUSED(win))
 {
     return &curses_global_state;

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -255,15 +255,18 @@ static const char *curses_screen_encoding = NULL;
  */
 
 static PyObject *
-PyCursesCheckERR(int code, const char *fname)
+PyCursesCheckERR(PyObject *module, int code, const char *fname)
 {
     if (code != ERR) {
         Py_RETURN_NONE;
-    } else {
+    }
+    else {
+        _cursesmodule_state *st = get_cursesmodule_state(module);
         if (fname == NULL) {
-            PyErr_SetString(PyCursesError, catchall_ERR);
-        } else {
-            PyErr_Format(PyCursesError, "%s() returned ERR", fname);
+            PyErr_SetString(st->PyCursesError, catchall_ERR);
+        }
+        else {
+            PyErr_Format(st->PyCursesError, "%s() returned ERR", fname);
         }
         return NULL;
     }

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1373,11 +1373,13 @@ _curses_window_echochar_impl(PyCursesWindowObject *self, PyObject *ch,
 
 #ifdef py_is_pad
     if (py_is_pad(self->win)) {
-        return PyCursesCheckERR(pechochar(self->win, ch_ | (attr_t)attr), "echochar");
+        return PyCursesCheckERR(pechochar(self->win, ch_ | (attr_t)attr),
+                                "echochar");
     }
     else
 #endif
-        return PyCursesCheckERR(wechochar(self->win, ch_ | (attr_t)attr), "echochar");
+        return PyCursesCheckERR(wechochar(self->win, ch_ | (attr_t)attr),
+                                "echochar");
 }
 
 #ifdef NCURSES_MOUSE_VERSION
@@ -1488,9 +1490,8 @@ _curses_window_getkey_impl(PyCursesWindowObject *self, int group_right_1,
     if (rtn == ERR) {
         /* getch() returns ERR in nodelay mode */
         PyErr_CheckSignals();
-        if (!PyErr_Occurred()) {
+        if (!PyErr_Occurred())
             PyErr_SetString(curses_global_state.PyCursesError, "no input");
-        }
         return NULL;
     } else if (rtn <= 255) {
 #ifdef NCURSES_VERSION_MAJOR
@@ -2649,43 +2650,41 @@ PyTypeObject PyCursesWindow_Type = {
    PARSESTR - format string for argument parsing
    */
 
-#define NoArgNoReturnFunctionBody(X)            \
-{                                               \
-    PyCursesInitialised;        \
-    return PyCursesCheckERR(X(), # X);  \
+#define NoArgNoReturnFunctionBody(X) \
+{ \
+  PyCursesInitialised; \
+  return PyCursesCheckERR(X(), # X); }
+
+#define NoArgOrFlagNoReturnFunctionBody(X, flag) \
+{ \
+    PyCursesInitialised; \
+    if (flag) \
+        return PyCursesCheckERR(X(), # X); \
+    else \
+        return PyCursesCheckERR(no ## X(), # X); \
 }
 
-#define NoArgOrFlagNoReturnFunctionBody(X, flag)    \
-{                                                   \
-    PyCursesInitialised;            \
-    int rtn = (flag) ? X() : no ## X();             \
-    return PyCursesCheckERR(rtn, # X);      \
-}
+#define NoArgReturnIntFunctionBody(X) \
+{ \
+ PyCursesInitialised; \
+ return PyLong_FromLong((long) X()); }
 
-#define NoArgReturnIntFunctionBody(X)       \
-{                                           \
-    PyCursesInitialised;    \
-    return PyLong_FromLong((long) X());     \
-}
 
-#define NoArgReturnStringFunctionBody(X)    \
-{                                           \
-    PyCursesInitialised;    \
-    return PyBytes_FromString(X());         \
-}
+#define NoArgReturnStringFunctionBody(X) \
+{ \
+  PyCursesInitialised; \
+  return PyBytes_FromString(X()); }
 
-#define NoArgTrueFalseFunctionBody(X)       \
-{                                           \
-    PyCursesInitialised;    \
-    return PyBool_FromLong(X());            \
-}
+#define NoArgTrueFalseFunctionBody(X) \
+{ \
+  PyCursesInitialised; \
+  return PyBool_FromLong(X()); }
 
-#define NoArgNoReturnVoidFunctionBody(X)    \
-{                                           \
-    PyCursesInitialised;    \
-    X();                                    \
-    Py_RETURN_NONE;                         \
-}
+#define NoArgNoReturnVoidFunctionBody(X) \
+{ \
+  PyCursesInitialised; \
+  X(); \
+  Py_RETURN_NONE; }
 
 /*********************************************************************
  Global Functions

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2704,7 +2704,7 @@ PyTypeObject PyCursesWindow_Type = {
     PyCursesWindow_getsets,     /* tp_getset */
 };
 
-/* Function Prototype Macros - They are ugly but very, very useful. ;-)
+/* Function Body Macros - They are ugly but very, very useful. ;-)
 
    X - function name
    TYPE - parameter Type
@@ -2712,41 +2712,43 @@ PyTypeObject PyCursesWindow_Type = {
    PARSESTR - format string for argument parsing
    */
 
-#define NoArgNoReturnFunctionBody(X) \
-{ \
-  PyCursesInitialised; \
-  return PyCursesCheckERR(X(), # X); }
-
-#define NoArgOrFlagNoReturnFunctionBody(X, flag) \
-{ \
-    PyCursesInitialised; \
-    if (flag) \
-        return PyCursesCheckERR(X(), # X); \
-    else \
-        return PyCursesCheckERR(no ## X(), # X); \
+#define NoArgNoReturnFunctionBody(X)            \
+{                                               \
+    PyCursesStatefulInitialised(module);        \
+    return PyCursesCheckERR(module, X(), # X);  \
 }
 
-#define NoArgReturnIntFunctionBody(X) \
-{ \
- PyCursesInitialised; \
- return PyLong_FromLong((long) X()); }
+#define NoArgOrFlagNoReturnFunctionBody(X, flag)    \
+{                                                   \
+    PyCursesStatefulInitialised(module);            \
+    int rtn = (flag) ? X() : no ## X();             \
+    return PyCursesCheckERR(module, rtn, # X);      \
+}
 
+#define NoArgReturnIntFunctionBody(X)       \
+{                                           \
+    PyCursesStatefulInitialised(module);    \
+    return PyLong_FromLong((long) X());     \
+}
 
-#define NoArgReturnStringFunctionBody(X) \
-{ \
-  PyCursesInitialised; \
-  return PyBytes_FromString(X()); }
+#define NoArgReturnStringFunctionBody(X)    \
+{                                           \
+    PyCursesStatefulInitialised(module);    \
+    return PyBytes_FromString(X());         \
+}
 
-#define NoArgTrueFalseFunctionBody(X) \
-{ \
-  PyCursesInitialised; \
-  return PyBool_FromLong(X()); }
+#define NoArgTrueFalseFunctionBody(X)       \
+{                                           \
+    PyCursesStatefulInitialised(module);    \
+    return PyBool_FromLong(X());            \
+}
 
-#define NoArgNoReturnVoidFunctionBody(X) \
-{ \
-  PyCursesInitialised; \
-  X(); \
-  Py_RETURN_NONE; }
+#define NoArgNoReturnVoidFunctionBody(X)    \
+{                                           \
+    PyCursesStatefulInitialised(module);    \
+    X();                                    \
+    Py_RETURN_NONE;                         \
+}
 
 /*********************************************************************
  Global Functions

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1406,7 +1406,7 @@ _curses_window_derwin_impl(PyCursesWindowObject *self, int group_left_1,
     }
 
     _cursesmodule_state *st = get_cursesmodule_state_by_cls(Py_TYPE(self));
-    return (PyObject *)PyCursesWindow_New(st, win, NULL);
+    return PyCursesWindow_New(st, win, NULL);
 }
 
 /*[clinic input]
@@ -2444,7 +2444,7 @@ _curses_window_subwin_impl(PyCursesWindowObject *self, int group_left_1,
     }
 
     _cursesmodule_state *st = get_cursesmodule_state_by_cls(Py_TYPE(self));
-    return (PyObject *)PyCursesWindow_New(st, win, self->encoding);
+    return PyCursesWindow_New(st, win, self->encoding);
 }
 
 /*[clinic input]
@@ -3353,7 +3353,7 @@ _curses_initscr_impl(PyObject *module)
     if (curses_initscr_called) {
         wrefresh(stdscr);
         _cursesmodule_state *st = get_cursesmodule_state(module);
-        return (PyObject *)PyCursesWindow_New(st, stdscr, NULL);
+        return PyCursesWindow_New(st, stdscr, NULL);
     }
 
     win = initscr();
@@ -3835,7 +3835,7 @@ _curses_newpad_impl(PyObject *module, int nlines, int ncols)
     }
 
     _cursesmodule_state *st = get_cursesmodule_state(module);
-    return (PyObject *)PyCursesWindow_New(st, win, NULL);
+    return PyCursesWindow_New(st, win, NULL);
 }
 
 /*[clinic input]
@@ -3876,7 +3876,7 @@ _curses_newwin_impl(PyObject *module, int nlines, int ncols,
     }
 
     _cursesmodule_state *st = get_cursesmodule_state(module);
-    return (PyObject *)PyCursesWindow_New(st, win, NULL);
+    return PyCursesWindow_New(st, win, NULL);
 }
 
 /*[clinic input]

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -593,19 +593,19 @@ class component_converter(CConverter):
 
 static int func_PyCursesSetupTermCalled(void)
 {
-    PyCursesSetupTermCalled;
+    _PyCursesCheckFunction(curses_setupterm_called, "setupterm");
     return 1;
 }
 
 static int func_PyCursesInitialised(void)
 {
-    PyCursesInitialised;
+    _PyCursesCheckFunction(curses_initscr_called, "initscr");
     return 1;
 }
 
 static int func_PyCursesInitialisedColor(void)
 {
-    PyCursesInitialisedColor;
+    _PyCursesCheckFunction(curses_start_color_called, "start_color");
     return 1;
 }
 

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -1389,12 +1389,12 @@ _curses_window_overlay(PyCursesWindowObject *self, PyObject *args)
 
     switch (PyTuple_GET_SIZE(args)) {
         case 1:
-            if (!PyArg_ParseTuple(args, "O!:overlay", &PyCursesWindow_Type, &destwin)) {
+            if (!PyArg_ParseTuple(args, "O!:overlay", clinic_state()->PyCursesWindow_Type, &destwin)) {
                 goto exit;
             }
             break;
         case 7:
-            if (!PyArg_ParseTuple(args, "O!iiiiii:overlay", &PyCursesWindow_Type, &destwin, &sminrow, &smincol, &dminrow, &dmincol, &dmaxrow, &dmaxcol)) {
+            if (!PyArg_ParseTuple(args, "O!iiiiii:overlay", clinic_state()->PyCursesWindow_Type, &destwin, &sminrow, &smincol, &dminrow, &dmincol, &dmaxrow, &dmaxcol)) {
                 goto exit;
             }
             group_right_1 = 1;
@@ -1448,12 +1448,12 @@ _curses_window_overwrite(PyCursesWindowObject *self, PyObject *args)
 
     switch (PyTuple_GET_SIZE(args)) {
         case 1:
-            if (!PyArg_ParseTuple(args, "O!:overwrite", &PyCursesWindow_Type, &destwin)) {
+            if (!PyArg_ParseTuple(args, "O!:overwrite", clinic_state()->PyCursesWindow_Type, &destwin)) {
                 goto exit;
             }
             break;
         case 7:
-            if (!PyArg_ParseTuple(args, "O!iiiiii:overwrite", &PyCursesWindow_Type, &destwin, &sminrow, &smincol, &dminrow, &dmincol, &dmaxrow, &dmaxcol)) {
+            if (!PyArg_ParseTuple(args, "O!iiiiii:overwrite", clinic_state()->PyCursesWindow_Type, &destwin, &sminrow, &smincol, &dminrow, &dmincol, &dmaxrow, &dmaxcol)) {
                 goto exit;
             }
             group_right_1 = 1;
@@ -4318,4 +4318,4 @@ _curses_has_extended_color_support(PyObject *module, PyObject *Py_UNUSED(ignored
 #ifndef _CURSES_USE_DEFAULT_COLORS_METHODDEF
     #define _CURSES_USE_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_USE_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=96887782374f070a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8463fe82c8906325 input=a9049054013a1b77]*/

--- a/Modules/clinic/_cursesmodule.c.h
+++ b/Modules/clinic/_cursesmodule.c.h
@@ -1389,12 +1389,12 @@ _curses_window_overlay(PyCursesWindowObject *self, PyObject *args)
 
     switch (PyTuple_GET_SIZE(args)) {
         case 1:
-            if (!PyArg_ParseTuple(args, "O!:overlay", clinic_state()->PyCursesWindow_Type, &destwin)) {
+            if (!PyArg_ParseTuple(args, "O!:overlay", &PyCursesWindow_Type, &destwin)) {
                 goto exit;
             }
             break;
         case 7:
-            if (!PyArg_ParseTuple(args, "O!iiiiii:overlay", clinic_state()->PyCursesWindow_Type, &destwin, &sminrow, &smincol, &dminrow, &dmincol, &dmaxrow, &dmaxcol)) {
+            if (!PyArg_ParseTuple(args, "O!iiiiii:overlay", &PyCursesWindow_Type, &destwin, &sminrow, &smincol, &dminrow, &dmincol, &dmaxrow, &dmaxcol)) {
                 goto exit;
             }
             group_right_1 = 1;
@@ -1448,12 +1448,12 @@ _curses_window_overwrite(PyCursesWindowObject *self, PyObject *args)
 
     switch (PyTuple_GET_SIZE(args)) {
         case 1:
-            if (!PyArg_ParseTuple(args, "O!:overwrite", clinic_state()->PyCursesWindow_Type, &destwin)) {
+            if (!PyArg_ParseTuple(args, "O!:overwrite", &PyCursesWindow_Type, &destwin)) {
                 goto exit;
             }
             break;
         case 7:
-            if (!PyArg_ParseTuple(args, "O!iiiiii:overwrite", clinic_state()->PyCursesWindow_Type, &destwin, &sminrow, &smincol, &dminrow, &dmincol, &dmaxrow, &dmaxcol)) {
+            if (!PyArg_ParseTuple(args, "O!iiiiii:overwrite", &PyCursesWindow_Type, &destwin, &sminrow, &smincol, &dminrow, &dmincol, &dmaxrow, &dmaxcol)) {
                 goto exit;
             }
             group_right_1 = 1;
@@ -4318,4 +4318,4 @@ _curses_has_extended_color_support(PyObject *module, PyObject *Py_UNUSED(ignored
 #ifndef _CURSES_USE_DEFAULT_COLORS_METHODDEF
     #define _CURSES_USE_DEFAULT_COLORS_METHODDEF
 #endif /* !defined(_CURSES_USE_DEFAULT_COLORS_METHODDEF) */
-/*[clinic end generated code: output=8463fe82c8906325 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=96887782374f070a input=a9049054013a1b77]*/

--- a/Tools/c-analyzer/cpython/globals-to-fix.tsv
+++ b/Tools/c-analyzer/cpython/globals-to-fix.tsv
@@ -423,6 +423,7 @@ Modules/readline.c	-	libedit_history_start	-
 
 Modules/_ctypes/cfield.c	-	formattable	-
 Modules/_ctypes/malloc_closure.c	-	free_list	-
+Modules/_cursesmodule.c	-	curses_global_state	-
 Modules/_curses_panel.c	-	lop	-
 Modules/_ssl/debughelpers.c	_PySSL_keylog_callback	lock	-
 Modules/_tkinter.c	-	quitMainLoop	-


### PR DESCRIPTION
UPDATE: managed to make it smaller.

---

<details>
<summary>Previous discussion (now resolved)</summary>

Ideally, I wanted to make multiple PRs for the curses module but simply adding a module state with the minimal logic would not be helpful at all. So I decided to do the following in one go:

- Add a module's state that holds the curses exception type and the curses window object type.
- Make the window object type a heap type.
- Use multi-phase initialization for the module.

The reason I couldn't find a way to split those changes is due to the exposed C API. The C API uses parameter-less functions and thus does not have access to the module's state. More precisely, we need to access the exception type in three different contexts without relying on a global variable (the purpose is to remove the global variables):

- In a parameter-less function: we need to re-import the curses module.
- In a window object's method: if we use a static type, we still can't access the module's state so it does not makes sense to me to make a change where I would first import the exception and in the next PR I would access it directly from the module's state.
- In a module's method: we can avoid using the state since the exception is stored in the module's dict, but again, this does not make sense to keep a temporary workaround for a few days.

---

There **is** a way to split the PR into two, namely by getting `PyCursesError` via an import. Informally, we would consider the module's dict as the state (which we must do for parameter-less functions) though I honestly think it's not worth that effort for window and module's methods.

Alternatively, we could first make the module a multi-phase initialization module, without any state and keep the global variables. However, I'm not sure that's a good idea. Note that I cleanly separated the commits so that I can pick them up if needed. 

Finally, I did not apply any cosmetic changes even though I was very tempted. The only cosmetic change I did was for the macros so that they readability is improved and if I'm anyway editing the lines. If a cosmetic change slipped through, please tell me.
</details>

<!-- gh-issue-number: gh-123961 -->
* Issue: gh-123961
<!-- /gh-issue-number -->
