### PR TITLE
functools: Give up on lazy-importing types

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -16,14 +16,11 @@ __all__ = ['update_wrapper', 'wraps', 'WRAPPER_ASSIGNMENTS', 'WRAPPER_UPDATES',
 
 from abc import get_cache_token
 from collections import namedtuple
-# import types, weakref  # Deferred to single_dispatch()
+# import weakref  # Deferred to single_dispatch()
 from operator import itemgetter
 from reprlib import recursive_repr
-from types import MethodType
+from types import GenericAlias, MethodType, MappingProxyType, UnionType
 from _thread import RLock
-
-# Avoid importing types, so we can speedup import time
-GenericAlias = type(list[int])
 
 ################################################################################
 ### update_wrapper() and wraps() decorator
@@ -900,7 +897,7 @@ def singledispatch(func):
     # There are many programs that use functools without singledispatch, so we
     # trade-off making singledispatch marginally slower for the benefit of
     # making start-up of such applications slightly faster.
-    import types, weakref
+    import weakref
 
     registry = {}
     dispatch_cache = weakref.WeakKeyDictionary()
@@ -931,7 +928,7 @@ def singledispatch(func):
 
     def _is_union_type(cls):
         from typing import get_origin, Union
-        return get_origin(cls) in {Union, types.UnionType}
+        return get_origin(cls) in {Union, UnionType}
 
     def _is_valid_dispatch_type(cls):
         if isinstance(cls, type):
@@ -1008,7 +1005,7 @@ def singledispatch(func):
     registry[object] = func
     wrapper.register = register
     wrapper.dispatch = dispatch
-    wrapper.registry = types.MappingProxyType(registry)
+    wrapper.registry = MappingProxyType(registry)
     wrapper._clear_cache = dispatch_cache.clear
     update_wrapper(wrapper, func)
     return wrapper


### PR DESCRIPTION
PR #121089 added an eager import for `types.MethodType`, but
still left the existing hacks for lazily importing from types.

We could also create MethodType internally in functools.py (e.g.,
by using `type(Placeholder.__repr__)`, but it feels not worth it at
this point, so instead I unlazified all the usages of types in the
module.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
