### PR TITLE
gh-124872: Change PyContext_WatchCallback to take PyObject

### DIFF
--- a/Doc/c-api/contextvars.rst
+++ b/Doc/c-api/contextvars.rst
@@ -136,7 +136,7 @@ Context object management functions:
 
    .. versionadded:: 3.14
 
-.. c:type:: int (*PyContext_WatchCallback)(PyContextEvent event, PyContext* ctx)
+.. c:type:: int (*PyContext_WatchCallback)(PyContextEvent event, PyObject *obj)
 
    Context object watcher callback function.  The object passed to the callback
    is event-specific; see :c:type:`PyContextEvent` for details.

--- a/Include/cpython/context.h
+++ b/Include/cpython/context.h
@@ -52,7 +52,7 @@ typedef enum {
  * if the callback returns with an exception set, it must return -1. Otherwise
  * it should return 0
  */
-typedef int (*PyContext_WatchCallback)(PyContextEvent, PyContext *);
+typedef int (*PyContext_WatchCallback)(PyContextEvent, PyObject *);
 
 /*
  * Register a per-interpreter callback that will be invoked for context object

--- a/Modules/_testcapi/watchers.c
+++ b/Modules/_testcapi/watchers.c
@@ -630,7 +630,7 @@ static int num_context_object_enter_events[NUM_CONTEXT_WATCHERS] = {0, 0};
 static int num_context_object_exit_events[NUM_CONTEXT_WATCHERS] = {0, 0};
 
 static int
-handle_context_watcher_event(int which_watcher, PyContextEvent event, PyContext *ctx) {
+handle_context_watcher_event(int which_watcher, PyContextEvent event, PyObject *ctx) {
     if (event == Py_CONTEXT_EVENT_ENTER) {
         num_context_object_enter_events[which_watcher]++;
     }
@@ -644,22 +644,22 @@ handle_context_watcher_event(int which_watcher, PyContextEvent event, PyContext 
 }
 
 static int
-first_context_watcher_callback(PyContextEvent event, PyContext *ctx) {
+first_context_watcher_callback(PyContextEvent event, PyObject *ctx) {
     return handle_context_watcher_event(0, event, ctx);
 }
 
 static int
-second_context_watcher_callback(PyContextEvent event, PyContext *ctx) {
+second_context_watcher_callback(PyContextEvent event, PyObject *ctx) {
     return handle_context_watcher_event(1, event, ctx);
 }
 
 static int
-noop_context_event_handler(PyContextEvent event, PyContext *ctx) {
+noop_context_event_handler(PyContextEvent event, PyObject *ctx) {
     return 0;
 }
 
 static int
-error_context_event_handler(PyContextEvent event, PyContext *ctx) {
+error_context_event_handler(PyContextEvent event, PyObject *ctx) {
     PyErr_SetString(PyExc_RuntimeError, "boom!");
     return -1;
 }

--- a/Python/context.c
+++ b/Python/context.c
@@ -113,7 +113,7 @@ context_event_name(PyContextEvent event) {
 }
 
 static void
-notify_context_watchers(PyThreadState *ts, PyContextEvent event, PyContext *ctx)
+notify_context_watchers(PyThreadState *ts, PyContextEvent event, PyObject *ctx)
 {
     assert(Py_REFCNT(ctx) > 0);
     PyInterpreterState *interp = ts->interp;
@@ -193,7 +193,7 @@ _PyContext_Enter(PyThreadState *ts, PyObject *octx)
     ts->context = Py_NewRef(ctx);
     ts->context_ver++;
 
-    notify_context_watchers(ts, Py_CONTEXT_EVENT_ENTER, ctx);
+    notify_context_watchers(ts, Py_CONTEXT_EVENT_ENTER, octx);
     return 0;
 }
 
@@ -227,7 +227,7 @@ _PyContext_Exit(PyThreadState *ts, PyObject *octx)
         return -1;
     }
 
-    notify_context_watchers(ts, Py_CONTEXT_EVENT_EXIT, ctx);
+    notify_context_watchers(ts, Py_CONTEXT_EVENT_EXIT, octx);
     Py_SETREF(ts->context, (PyObject *)ctx->ctx_prev);
     ts->context_ver++;
 


### PR DESCRIPTION
The PyContext struct is not intended to be public, and users of the API don't need anything more specific than PyObject.  Also see gh-78943.

I don't think a NEWS blurb is needed because this amends a feature that is new to v3.14 so the [existing blurb](https://github.com/python/cpython/blob/dd0ee201da34d1d4a631d77b420728f9233f53f9/Misc/NEWS.d/next/C%20API/2024-05-21-18-28-44.gh-issue-119333.OTsYVX.rst) should suffice.

cc @fried

<!-- gh-issue-number: gh-119333 -->
* Issue: gh-119333
<!-- /gh-issue-number -->
<!-- gh-issue-number: gh-124872 -->
* Issue: gh-124872
<!-- /gh-issue-number -->

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124737.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

