### PR TITLE
Docs: improve generic `typing.NamedTuple` example

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2350,6 +2350,8 @@ types.
    Backward-compatible usage::
 
        # For creating a generic NamedTuple on Python 3.11
+       T = TypeVar("T")
+
        class Group(NamedTuple, Generic[T]):
            key: T
            group: list[T]

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2349,7 +2349,7 @@ types.
 
    Backward-compatible usage::
 
-       # For creating a generic NamedTuple on Python 3.11 or lower
+       # For creating a generic NamedTuple on Python 3.11
        class Group(NamedTuple, Generic[T]):
            key: T
            group: list[T]


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

1. Generic `typing.NamedTuple` is not supported until Python 3.11, so `class NT(NamedTuple, Generic[T])` won't work in versions lower than 3.11.
2. Explicit `T = TypeVar("T")` is needed when using `Generic[T]`.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124739.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->