### PR TITLE
GH-124742: Add the `PYTHON_GC_THRESHOLD` environment variable.

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -978,10 +978,10 @@ conflict.
 
 .. envvar:: PYTHON_GC_THRESHOLD
 
-   Set the `threshold0` value for the garbage collector.  This is the same
-   as calling `gc.set_threshold(n)` where `n` is value of the variable.  Using
-   an empty value or the value "default" will cause the default threshold to be
-   used.
+   Set the ``threshold0`` value for the garbage collector.  This is the same as
+   calling ``gc.set_threshold(n)`` where ``n`` is value of the variable. Using
+   an empty value or the value ``default`` will cause the default threshold to
+   be used.
 
    .. versionadded:: 3.13
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -976,6 +976,16 @@ conflict.
    .. versionadded:: 3.4
 
 
+.. envvar:: PYTHON_GC_THRESHOLD
+
+   Set the `threshold0` value for the garbage collector.  This is the same
+   as calling `gc.set_threshold(n)` where `n` is value of the variable.  Using
+   an empty value or the value "default" will cause the default threshold to be
+   used.
+
+   .. versionadded:: 3.13
+
+
 .. envvar:: PYTHONMALLOC
 
    Set the Python memory allocators and/or install debug hooks.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-28-20-01-40.gh-issue-124742.7kJx88.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-28-20-01-40.gh-issue-124742.7kJx88.rst
@@ -1,0 +1,4 @@
+Add the `PYTHON_GC_THRESHOLD` environment variable.  This can be used to set
+the `threshold0` value for the garbage collector, similar to calling
+`gc.set_threshold()`.  If the value is empty or "default", the default
+threshold value is used.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-28-20-01-40.gh-issue-124742.7kJx88.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-28-20-01-40.gh-issue-124742.7kJx88.rst
@@ -1,4 +1,4 @@
-Add the `PYTHON_GC_THRESHOLD` environment variable.  This can be used to set
-the `threshold0` value for the garbage collector, similar to calling
-`gc.set_threshold()`.  If the value is empty or "default", the default
+Add the :envvar:`PYTHON_GC_THRESHOLD` environment variable.  This can be used
+to set the ``threshold0`` value for the garbage collector, similar to calling
+``gc.set_threshold()``.  If the value is empty or ``default``, the default
 threshold value is used.

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -838,11 +838,30 @@ _PyGC_InitState(GCState *gcstate)
     gcstate->young.threshold = 2000;
 }
 
+static void
+gc_set_threshold_from_env(PyInterpreterState *interp)
+{
+    const PyConfig *config = _PyInterpreterState_GetConfig(interp);
+    const char *env = _Py_GetEnv(config->use_environment,
+                                 "PYTHON_GC_THRESHOLD");
+    if (env == NULL || strcmp(env, "default") == 0) {
+        return;
+    }
+    int threshold = -1;
+    if (_Py_str_to_int(env, &threshold) < 0) {
+        return; // parse failed, silently ignore
+    }
+    if (threshold > 0) {
+        interp->gc.young.threshold = threshold;
+    }
+}
 
 PyStatus
 _PyGC_Init(PyInterpreterState *interp)
 {
     GCState *gcstate = &interp->gc;
+
+    gc_set_threshold_from_env(interp);
 
     gcstate->garbage = PyList_New(0);
     if (gcstate->garbage == NULL) {

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -342,6 +342,8 @@ static const char usage_envvars[] =
 "                  on Python memory allocators.  Use PYTHONMALLOC=debug to\n"
 "                  install debug hooks.\n"
 "PYTHONMALLOCSTATS: print memory allocator statistics\n"
+"PYTHON_GC_THRESHOLD: set threshold0 for the garbage collector.  This\n"
+"                  threshold can also be set by gc.set_threshold().\n"
 "PYTHONCOERCECLOCALE: if this variable is set to 0, it disables the locale\n"
 "                  coercion behavior.  Use PYTHONCOERCECLOCALE=warn to request\n"
 "                  display of locale coercion and locale compatibility warnings\n"


### PR DESCRIPTION

<!-- gh-issue-number: gh-124742 -->
* Issue: gh-124742
<!-- /gh-issue-number -->

Some comments of the approach taken here:

- I want to keep this change as simple as possible and as robust as possible, in case it is deemed safe enough to merge into 3.13.  Getting it into 3.13 could increase the amount of useful feedback from real apps, improving our decision making for the 3.14 release.  It is quite likely we change things related to this threshold.
- In the 'main' branch, I plan to make a corresponding `-X` option for it and to put it into the `config` structure, so it can be set for embedding scenarios
- This is a low level "tuning knob" and I think a high level knob would actually be more useful (e.g. `PYTHON_GC_STRATEGY`) as proposed on the Ideas forum.  However, for 3.13 it seems safest to do the simplest possible thing and that's exposing the `threshold0` setting to be set by an env var.
- I didn't raise an error if the env var value is invalid.  For the 'main' branch version, I would put that error in, so that an invalid setting doesn't pass silently.



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124743.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->