### PR TITLE
gh-96859: [argparse] Avoid copying lists on every append and extend action

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -138,7 +138,7 @@ class _AttributeHolder(object):
 def _copy_items(items):
     if items is None:
         return []
-    # The copy module is used only in the 'append' and 'append_const'
+    # The copy module is used only in the 'append', 'append_const', and 'extend'
     # actions, and it is needed only when the default value isn't a list.
     # Delay its import for speeding up the common case.
     if type(items) is list:
@@ -974,7 +974,13 @@ class _StoreFalseAction(_StoreConstAction):
             deprecated=deprecated)
 
 
-class _AppendAction(Action):
+class _CloningAction(Action):
+
+    def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+
+class _AppendAction(_CloningAction):
 
     def __init__(self,
                  option_strings,
@@ -1009,12 +1015,11 @@ class _AppendAction(Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest, None)
-        items = _copy_items(items)
         items.append(values)
         setattr(namespace, self.dest, items)
 
 
-class _AppendConstAction(Action):
+class _AppendConstAction(_CloningAction):
 
     def __init__(self,
                  option_strings,
@@ -1038,7 +1043,6 @@ class _AppendConstAction(Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest, None)
-        items = _copy_items(items)
         items.append(self.const)
         setattr(namespace, self.dest, items)
 
@@ -1230,7 +1234,6 @@ class _SubParsersAction(Action):
 class _ExtendAction(_AppendAction):
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest, None)
-        items = _copy_items(items)
         items.extend(values)
         setattr(namespace, self.dest, items)
 
@@ -1941,6 +1944,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         # converts arg strings to the appropriate and then takes the action
         seen_actions = set()
         seen_non_default_actions = set()
+        cloned = set()
         warned = set()
 
         def take_action(action, argument_strings, option_string=None):
@@ -1960,6 +1964,15 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
             # take the action if we didn't receive a SUPPRESS value
             # (e.g. from a default)
             if argument_values is not SUPPRESS:
+                # copy the destination attribute in case the action modifies it
+                # in-place.
+                if isinstance(action, _CloningAction) and action not in cloned:
+                    # only copy on the first action call.
+                    cloned.add(action)
+
+                    items = getattr(namespace, action.dest, None)
+                    setattr(namespace, action.dest, _copy_items(items))
+
                 action(self, namespace, argument_values, option_string)
 
         # function to convert arg_strings into an optional action


### PR DESCRIPTION
Currently the append, append_const, and extend actions make a copy of the target list every time the action is called. It becomes rather slow with very long option lists. This commit updates parse_known_args() to only copy on the first action call.

Using the repro script from [the issue description](https://github.com/python/cpython/issues/96859) I could see the following results before and after this change.

Before:

```
➜  cpython git:(c00964ecd5) ✗ ./repro.py                                      
     256 iterations: 0:00:00.002216 s
     512 iterations: 0:00:00.003734 s
    1024 iterations: 0:00:00.009686 s
    2048 iterations: 0:00:00.018806 s
    4096 iterations: 0:00:00.048392 s
    8192 iterations: 0:00:00.130792 s
   16384 iterations: 0:00:00.399441 s
   32768 iterations: 0:00:01.341005 s
   65536 iterations: 0:00:05.148916 s
  131072 iterations: 0:00:20.325517 s
```

After:

```
➜  cpython git:(gh-96859_take3) ✗ ./repro.py                   
     256 iterations: 0:00:00.002016 s
     512 iterations: 0:00:00.003760 s
    1024 iterations: 0:00:00.006729 s
    2048 iterations: 0:00:00.013103 s
    4096 iterations: 0:00:00.026316 s
    8192 iterations: 0:00:00.053061 s
   16384 iterations: 0:00:00.099570 s
   32768 iterations: 0:00:00.191617 s
   65536 iterations: 0:00:00.403077 s
  131072 iterations: 0:00:00.781361 s
```


<!-- gh-issue-number: gh-96859 -->
* Issue: gh-96859
<!-- /gh-issue-number -->
