### PR TITLE
[3.13] gh-124746: remove assertion on exits having line numbers

### DIFF
--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -518,21 +518,6 @@ no_redundant_jumps(cfg_builder *g) {
     return true;
 }
 
-static bool
-all_exits_have_lineno(basicblock *entryblock) {
-    for (basicblock *b = entryblock; b != NULL; b = b->b_next) {
-        for (int i = 0; i < b->b_iused; i++) {
-            cfg_instr *instr = &b->b_instr[i];
-            if (instr->i_opcode == RETURN_VALUE) {
-                if (instr->i_loc.lineno < 0) {
-                    assert(0);
-                    return false;
-                }
-            }
-        }
-    }
-    return true;
-}
 #endif
 
 /***** CFG preprocessing (jump targets and exceptions) *****/
@@ -2500,7 +2485,6 @@ _PyCfg_OptimizeCodeUnit(cfg_builder *g, PyObject *consts, PyObject *const_cache,
     RETURN_IF_ERROR(insert_superinstructions(g));
 
     RETURN_IF_ERROR(push_cold_blocks_to_end(g));
-    assert(all_exits_have_lineno(g->g_entryblock));
     RETURN_IF_ERROR(resolve_line_numbers(g, firstlineno));
     return SUCCESS;
 }


### PR DESCRIPTION
This is a new assertion, which is still finding edge cases. I am leaving it in 3.14 but at this stage these things should not block a 3.13 release, so removing the assertion in 3.13.



<!-- gh-issue-number: gh-124746 -->
* Issue: gh-124746
<!-- /gh-issue-number -->
