### PR TITLE
gh-123290: fix a decref usage in `_cursesmodule.c`

### DIFF
--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -4036,7 +4036,7 @@ update_lines_cols(PyObject *private_module)
 
 error:
     Py_XDECREF(o);
-    Py_DECREF(exposed_module);
+    Py_XDECREF(exposed_module);
     return 0;
 }
 


### PR DESCRIPTION
Using `Py_DECREF` on an object that could be NULL (my bad).

<!-- gh-issue-number: gh-123290 -->
* Issue: gh-123290
<!-- /gh-issue-number -->
