### PR TITLE
gh-124722: Fix leak in `test_detach_materialized_dict_no_memory`

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -1,8 +1,7 @@
 "Test the functionality of Python classes implementing operators."
 
 import unittest
-from test.support import cpython_only
-from test.support import import_helper, script_helper
+from test.support import cpython_only, import_helper, script_helper
 
 testmeths = [
 

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -1,7 +1,8 @@
 "Test the functionality of Python classes implementing operators."
 
 import unittest
-import test.support
+from test.support import cpython_only
+from test.support import import_helper, script_helper
 
 testmeths = [
 
@@ -933,20 +934,36 @@ class TestInlineValues(unittest.TestCase):
         C.a = X()
         C.a = X()
 
+    @cpython_only
     def test_detach_materialized_dict_no_memory(self):
-        import _testcapi
-        class A:
-            def __init__(self):
-                self.a = 1
-                self.b = 2
-        a = A()
-        d = a.__dict__
-        with test.support.catch_unraisable_exception() as ex:
-            _testcapi.set_nomemory(0, 1)
-            del a
-            self.assertEqual(ex.unraisable.exc_type, MemoryError)
-        with self.assertRaises(KeyError):
-            d["a"]
+        # Skip test if _testcapi is not available:
+        import_helper.import_module('_testcapi')
+
+        code = """if 1:
+            import test.support
+            import _testcapi
+
+            class A:
+                def __init__(self):
+                    self.a = 1
+                    self.b = 2
+            a = A()
+            d = a.__dict__
+            with test.support.catch_unraisable_exception() as ex:
+                _testcapi.set_nomemory(0, 1)
+                del a
+                assert ex.unraisable.exc_type is MemoryError
+            try:
+                d["a"]
+            except KeyError:
+                pass
+            else:
+                assert False, "KeyError not raised"
+        """
+        rc, out, err = script_helper.assert_python_ok("-c", code)
+        self.assertEqual(rc, 0)
+        self.assertFalse(out, msg=out.decode('utf-8'))
+        self.assertFalse(err, msg=err.decode('utf-8'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The leak was in setting `_testcapi.set_nomemory(0, 1)`, in other places it is only used together with `assert_python_ok`

I also marked this test as `cpython_only` and I also skip it if `_testcapi` is not present.

Local run:

```
» ./python.exe -m test test_class -m test_detach_materialized_dict_no_memory -R 3:3
Using random seed: 365282797
0:00:00 load avg: 1.55 Run 1 test sequentially in a single process
0:00:00 load avg: 1.55 [1/1] test_class
beginning 6 repetitions. Showing number of leaks (. for 0 or less, X for 10 or more)
123:456
XX. ...

== Tests result: SUCCESS ==

1 test OK.

Total duration: 403 ms
Total tests: run=1 (filtered)
Total test files: run=1/1 (filtered)
Result: SUCCESS
```

<!-- gh-issue-number: gh-124722 -->
* Issue: gh-124722
<!-- /gh-issue-number -->
