### PR TITLE
gh-124872: Move PyThreadState to first argument for consistency

### DIFF
--- a/Python/context.c
+++ b/Python/context.c
@@ -112,7 +112,8 @@ context_event_name(PyContextEvent event) {
     Py_UNREACHABLE();
 }
 
-static void notify_context_watchers(PyContextEvent event, PyContext *ctx, PyThreadState *ts)
+static void
+notify_context_watchers(PyThreadState *ts, PyContextEvent event, PyContext *ctx)
 {
     assert(Py_REFCNT(ctx) > 0);
     PyInterpreterState *interp = ts->interp;
@@ -192,7 +193,7 @@ _PyContext_Enter(PyThreadState *ts, PyObject *octx)
     ts->context = Py_NewRef(ctx);
     ts->context_ver++;
 
-    notify_context_watchers(Py_CONTEXT_EVENT_ENTER, ctx, ts);
+    notify_context_watchers(ts, Py_CONTEXT_EVENT_ENTER, ctx);
     return 0;
 }
 
@@ -226,7 +227,7 @@ _PyContext_Exit(PyThreadState *ts, PyObject *octx)
         return -1;
     }
 
-    notify_context_watchers(Py_CONTEXT_EVENT_EXIT, ctx, ts);
+    notify_context_watchers(ts, Py_CONTEXT_EVENT_EXIT, ctx);
     Py_SETREF(ts->context, (PyObject *)ctx->ctx_prev);
     ts->context_ver++;
 


### PR DESCRIPTION
This is a trivial readability tweak, I don't think a NEWS blurb is warranted; the [existing blurb](https://github.com/python/cpython/blob/dd0ee201da34d1d4a631d77b420728f9233f53f9/Misc/NEWS.d/next/C%20API/2024-05-21-18-28-44.gh-issue-119333.OTsYVX.rst) should suffice.

<!-- gh-issue-number: gh-119333 -->
* Issue: gh-119333
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-124872 -->
* Issue: gh-124872
<!-- /gh-issue-number -->
