### PR TITLE
[3.12] Fix `c-api/file.rst` indexes (GH-114608)

### DIFF
--- a/Doc/c-api/file.rst
+++ b/Doc/c-api/file.rst
@@ -65,9 +65,10 @@ the :mod:`io` APIs instead.
    Overrides the normal behavior of :func:`io.open_code` to pass its parameter
    through the provided handler.
 
-   The handler is a function of type:
+   The *handler* is a function of type:
 
-   .. c:type:: Py_OpenCodeHookFunction
+   .. c:namespace:: NULL
+   .. c:type:: PyObject * (*Py_OpenCodeHookFunction)(PyObject *, void *)
 
       Equivalent of :c:expr:`PyObject *(\*)(PyObject *path,
       void *userData)`, where *path* is guaranteed to be


### PR DESCRIPTION
(cherry picked from commit 23fb9f0777b054526b3b32f58e60b2a03132bf45)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124786.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->