### PR TITLE
[3.13] gh-124785: alternative interned string clear fix

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -123,6 +123,10 @@ struct _is {
     /* Has been fully initialized via pylifecycle.c. */
     int _ready;
     int finalizing;
+    /* Set if a subinterpreter imports basic single-phase extensions and
+     * therefore needs to leak interned strings (it's too tricky to safely
+     * free them). */
+    int leak_interned_strings;
 
     uintptr_t last_restart_version;
     struct pythreads {

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-26-18-21-06.gh-issue-116510.FacUWO.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-26-18-21-06.gh-issue-116510.FacUWO.rst
@@ -1,5 +1,0 @@
-Fix a crash caused by immortal interned strings being shared between
-sub-interpreters that use basic single-phase init.  In that case, the string
-can be used by an interpreter that outlives the interpreter that created and
-interned it.  For interpreters that share obmalloc state, also share the
-interned dict with the main interpreter.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-30-11-49-58.gh-issue-124785.sSKaJF.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-30-11-49-58.gh-issue-124785.sSKaJF.rst
@@ -1,0 +1,2 @@
+Use simpler fix for interned string cleanup.  This avoids the potential
+use-after-free crashes but doesn't break the trace-refs debug build.

--- a/Python/import.c
+++ b/Python/import.c
@@ -1897,6 +1897,11 @@ import_find_extension(PyThreadState *tstate,
         return NULL;
     }
 
+    /* Interned strings used by this module can be shared between
+     * subinterpreters, due to the PyDict_Update() call in basic single-phase
+     * module import case. */
+    tstate->interp->leak_interned_strings = 1;
+
     PyObject *mod = reload_singlephase_extension(tstate, cached, info);
     if (mod == NULL) {
         return NULL;


### PR DESCRIPTION
The gh-124646 fix has the issue that it breaks the trace-refs debug build.  This is a simpler fix that avoids the use-after-free crashes by just leaking immortal interned strings allocated by legacy sub-interpreters.

<!-- gh-issue-number: gh-124785 -->
* Issue: gh-124785
<!-- /gh-issue-number -->
