### PR TITLE
Doc: Use critical sections for custom types

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -2230,7 +2230,8 @@ Critical sections are appropriate for protecting custom types defined by your
 C-API extensions. They should generally not be used with built-in types like
 :c:struct:`PyDictObject` or :c:struct:`PyListObject` because their public APIs
 already use critical sections internally, with the :ref:`notable
-exception<PyDict_Next>` of :c:func:`PyDict_Next`.
+exception<PyDict_Next>` of :c:func:`PyDict_Next`, which requires external
+locking.
 
 The functions and structs used by the macros are exposed for cases
 where C macros are not available. They should only be used as in the

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -2229,8 +2229,8 @@ their behavior is similar to the :term:`GIL`.
 Critical sections are appropriate for protecting custom types defined by your
 C-API extensions. They should generally not be used with built-in types like
 :c:struct:`PyDictObject` or :c:struct:`PyListObject` because their public APIs
-already use critical sections internally, with the notable exception of
-:c:func:`PyDict_Next`.
+already use critical sections internally, with the :ref:`notable
+exception<PyDict_Next>` of :c:func:`PyDict_Next`.
 
 The functions and structs used by the macros are exposed for cases
 where C macros are not available. They should only be used as in the

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -2226,6 +2226,12 @@ is resumed, and its locks reacquired.  This means the critical section API
 provides weaker guarantees than traditional locks -- they are useful because
 their behavior is similar to the :term:`GIL`.
 
+Critical sections are appropriate for protecting custom types defined by your
+C-API extensions. They should generally not be used with built-in types like
+:c:struct:`PyDictObject` or :c:struct:`PyListObject` because their public APIs
+already use critical sections internally, with the notable exception of
+:c:func:`PyDict_Next`.
+
 The functions and structs used by the macros are exposed for cases
 where C macros are not available. They should only be used as in the
 given macro expansions. Note that the sizes and contents of the structures may


### PR DESCRIPTION
You should generally not use critical sections with built-in types because they already use critical sections internally.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124802.org.readthedocs.build/en/124802/c-api/init.html#python-critical-section-api

<!-- readthedocs-preview cpython-previews end -->