### PR TITLE
gh-124785: re-work fix so tracerefs test passes

### DIFF
--- a/Include/internal/pycore_global_objects.h
+++ b/Include/internal/pycore_global_objects.h
@@ -65,6 +65,7 @@ struct _Py_static_objects {
 
 struct _Py_interp_cached_objects {
     PyObject *interned_strings;
+    PyObject *interned_strings_legacy;
 
     /* AST */
     PyObject *str_replace_inf;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -317,7 +317,7 @@ init_interned_dict(PyInterpreterState *interp)
             // allocate for main interpreter. We share obmalloc in this case
             // and we use a separate dict because it's cleaner to ensure these
             // objects don't show up in the main interpreter (which they could
-            // if uswe use interned_strings).  They will be shared by all
+            // if we use interned_strings).  They will be shared by all
             // subinterpreters that allow legacy single-phase init modules.
             interned = PyDict_New();
             if (interned == NULL) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -358,7 +358,6 @@ clear_interned_dict_legacy(PyInterpreterState *interp)
     Py_ssize_t pos = 0;
     PyObject *s, *ignored_value;
     while (PyDict_Next(interned, &pos, &s, &ignored_value)) {
-        assert(PyUnicode_IS_READY(s));
 #ifdef Py_TRACE_REFS
         _Py_AddToAllObjects(s);
 #endif
@@ -381,7 +380,7 @@ clear_interned_dict_legacy(PyInterpreterState *interp)
 #endif
             break;
         case SSTATE_NOT_INTERNED:
-            /* fall through */
+            _Py_FALLTHROUGH;
         default:
             Py_UNREACHABLE();
         }


### PR DESCRIPTION
The previous fix to this bug caused some trace-refs tests to fail.  Object references from the sub-interpreters were not being correctly accounted in the main interpreter.  Re-work the fix so that the interned strings for sub-interpreters go into their own dict, `interned_strings_legacy`.  That allows the main interpreter to clean them knowing that those specific strings have been allocated in sub-interpreters.


<!-- gh-issue-number: gh-124785 -->
* Issue: gh-124785
<!-- /gh-issue-number -->
