### PR TITLE
Highlight `datetime.timedelta.seconds` vs `.total_seconds()` in docs.

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -295,11 +295,11 @@ Instance attributes (read-only):
 
    Between 0 and 86,399 inclusive.
 
-   .. warning::
+   .. caution::
 
       It is a somewhat common bug for code to unintentionally use this attribute
-      when it actually intended to get a :meth:`~timedelta.total_seconds` value
-      instead:
+      when it is actually intended to get a :meth:`~timedelta.total_seconds`
+      value instead:
 
       .. doctest::
 

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -299,7 +299,16 @@ Instance attributes (read-only):
 
       It is a somewhat common bug for code to unintentionally use this attribute
       when it actually intended to get a :meth:`~timedelta.total_seconds` value
-      instead.
+      instead:
+
+      .. doctest::
+
+         >>> from datetime import timedelta
+         >>> duration = timedelta(seconds=11235813)
+         >>> duration.days, duration.seconds
+         (130, 3813)
+         >>> duration.total_seconds()
+         11235813.0
 
 .. attribute:: timedelta.microseconds
 
@@ -356,7 +365,7 @@ Supported operations:
 |                                | same value. (2)                               |
 +--------------------------------+-----------------------------------------------+
 | ``-t1``                        | Equivalent to ``timedelta(-t1.days,           |
-|                                | -t1.seconds*, -t1.microseconds)``,            |
+|                                | -t1.seconds, -t1.microseconds)``,             |
 |                                | and to ``t1 * -1``. (1)(4)                    |
 +--------------------------------+-----------------------------------------------+
 | ``abs(t)``                     | Equivalent to ``+t`` when ``t.days >= 0``,    |

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -295,6 +295,11 @@ Instance attributes (read-only):
 
    Between 0 and 86,399 inclusive.
 
+   .. warning::
+
+      It is a somewhat common bug for code to unintentionally use this attribute
+      when it actually intended to get a :meth:`~timedelta.total_seconds` value
+      instead.
 
 .. attribute:: timedelta.microseconds
 


### PR DESCRIPTION
This comes out of a discovery a colleague made:

> Should we create a linter rule for code that looks at `timedelta.seconds` when they mean `timedelta.total_seconds()`, and if so, what would that look like? A quick grep suggests we have this bug in a number of places in our code.

which prompted an investigation by @Zac-HD:

> of N occurences of .seconds >N-6 of them are this bug on timedeltas, and the rest are attributes of classes we define and can thus change.

meaning basically 100% of uses of `datetime.timedelta.seconds` should've been using `.total_seconds()`...

If you _know_ that you will never be encountering a timedelta longer than 1 day there is no difference between the two (which is why code often gets away with this...), but how often does code guarantee that and would fail in a surprising manner when >=1 day deltas _are_ encountered as a result of the mistake?

Documenting the caveat seems useful to guide people away from this mistake.

Linter ecosystem checks to highlight this deemed useful but are outside of our purview.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124811.org.readthedocs.build/

https://cpython-previews--124811.org.readthedocs.build/en/124811/library/datetime.html#datetime.timedelta.seconds

<!-- readthedocs-preview cpython-previews end -->