### PR TITLE
GH-118093: Don't lose confidence when tracing through 100% biased branches

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-09-30-16-39-37.gh-issue-118093.J2A3gz.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-09-30-16-39-37.gh-issue-118093.J2A3gz.rst
@@ -1,0 +1,2 @@
+Improve the experimental JIT compiler's ability to stay "on trace" when
+encountering highly-biased branches.

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -643,7 +643,6 @@ translate_bytecode_to_trace(
                 int bitcount = _Py_popcount32(counter);
                 int jump_likely = bitcount > 8;
                 /* If bitcount is 8 (half the jumps were taken), adjust confidence by 50%.
-                   If it's 16 or 0 (all or none were taken), adjust by 0%.
                    For values in between, adjust proportionally. */
                 if (jump_likely) {
                     confidence = confidence * bitcount / 16;

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -643,7 +643,7 @@ translate_bytecode_to_trace(
                 int bitcount = _Py_popcount32(counter);
                 int jump_likely = bitcount > 8;
                 /* If bitcount is 8 (half the jumps were taken), adjust confidence by 50%.
-                   If it's 16 or 0 (all or none were taken), adjust by ~6%
+                   If it's 16 or 0 (all or none were taken), adjust by 1/18th.
                    (since the future is still somewhat uncertain - see Laplace's
                    rule of succession, used here with 16 observations).
                    For values in between, adjust proportionally. */

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -643,14 +643,15 @@ translate_bytecode_to_trace(
                 int bitcount = _Py_popcount32(counter);
                 int jump_likely = bitcount > 8;
                 /* If bitcount is 8 (half the jumps were taken), adjust confidence by 50%.
-                   If it's 16 or 0 (all or none were taken), adjust by 10%
-                   (since the future is still somewhat uncertain).
+                   If it's 16 or 0 (all or none were taken), adjust by ~6%
+                   (since the future is still somewhat uncertain - see Laplace's
+                   rule of succession, used here with 16 observations).
                    For values in between, adjust proportionally. */
                 if (jump_likely) {
-                    confidence = confidence * (bitcount + 2) / 20;
+                    confidence = confidence * (bitcount + 1) / 18;
                 }
                 else {
-                    confidence = confidence * (18 - bitcount) / 20;
+                    confidence = confidence * (17 - bitcount) / 18;
                 }
                 uint32_t uopcode = BRANCH_TO_GUARD[opcode - POP_JUMP_IF_FALSE][jump_likely];
                 DPRINTF(2, "%d: %s(%d): counter=%04x, bitcount=%d, likely=%d, confidence=%d, uopcode=%s\n",

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -643,15 +643,13 @@ translate_bytecode_to_trace(
                 int bitcount = _Py_popcount32(counter);
                 int jump_likely = bitcount > 8;
                 /* If bitcount is 8 (half the jumps were taken), adjust confidence by 50%.
-                   If it's 16 or 0 (all or none were taken), adjust by 1/18th.
-                   (since the future is still somewhat uncertain - see Laplace's
-                   rule of succession, used here with 16 observations).
+                   If it's 16 or 0 (all or none were taken), adjust by 0%.
                    For values in between, adjust proportionally. */
                 if (jump_likely) {
-                    confidence = confidence * (bitcount + 1) / 18;
+                    confidence = confidence * bitcount / 16;
                 }
                 else {
-                    confidence = confidence * (17 - bitcount) / 18;
+                    confidence = confidence * (16 - bitcount) / 16;
                 }
                 uint32_t uopcode = BRANCH_TO_GUARD[opcode - POP_JUMP_IF_FALSE][jump_likely];
                 DPRINTF(2, "%d: %s(%d): counter=%04x, bitcount=%d, likely=%d, confidence=%d, uopcode=%s\n",


### PR DESCRIPTION
A 16/16 bias in one direction of a branch is a *very* strong indicator that we'll stay on trace in that direction. I don't think our current 10% confidence drop is helping us very much.

I originally tried a value closer to 6% (precisely, 1/18th), which follows from applying Laplace's rule of succession. But that still underperformed relative to this PR, which just takes the naive approach of not adjusting our confidence when encountering a highly-biased branch.

[~1% faster](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240912-3.14.0a0-d06074b-JIT/bm-20240912-linux-x86_64-brandtbucher-confidence-3.14.0a0-d06074b-vs-base.svg), with a ~2% increase in uops executed and a ~3% decrease in traces executed ([stats](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20240912-3.14.0a0-d06074b-JIT/bm-20240912-azure-x86_64-brandtbucher-confidence-3.14.0a0-d06074b-pystats-vs-base.md)).

<!-- gh-issue-number: gh-118093 -->
* Issue: gh-118093
<!-- /gh-issue-number -->
