### PR TITLE
gh-124487: Updated the documentation, now the minimum version installation is Win10

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -23,8 +23,9 @@ available for application-local distributions.
 
 As specified in :pep:`11`, a Python release only supports a Windows platform
 while Microsoft considers the platform under extended support. This means that
-Python |version| supports Windows 8.1 and newer. If you require Windows 7
-support, please install Python 3.8.
+Python |version| supports Windows 10 and newer. If you require Windows 7
+support, please install Python 3.8. If you require Windows 8.1 support,
+please install Python 3.12.
 
 There are a number of different installers available for Windows, each with
 certain benefits and downsides.

--- a/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
+++ b/Tools/msi/bundle/bootstrap/PythonBootstrapperApplication.cpp
@@ -3100,7 +3100,7 @@ private:
             } else {
                 BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Detected Windows Server 2003 or earlier");
             }
-            BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Windows Server 2012 or later is required to continue installation");
+            BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Windows Server 2016 or later is required to continue installation");
         } else {
             if (IsWindows10OrGreater()) {
                 BalLog(BOOTSTRAPPER_LOG_LEVEL_STANDARD, "Target OS is Windows 10 or later");
@@ -3116,7 +3116,7 @@ private:
             } else { 
                 BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Detected Windows XP or earlier");
             }
-            BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Windows 8.1 or later is required to continue installation");
+            BalLog(BOOTSTRAPPER_LOG_LEVEL_ERROR, "Windows 10 or later is required to continue installation");
         }
 
         LocGetString(_wixLoc, L"#(loc.FailureOldOS)", &pLocString);

--- a/Tools/msi/purge.py
+++ b/Tools/msi/purge.py
@@ -51,14 +51,6 @@ FILES = [
     "test_pdb.msi",
     "tools.msi",
     "ucrt.msi",
-    "Windows6.0-KB2999226-x64.msu",
-    "Windows6.0-KB2999226-x86.msu",
-    "Windows6.1-KB2999226-x64.msu",
-    "Windows6.1-KB2999226-x86.msu",
-    "Windows8.1-KB2999226-x64.msu",
-    "Windows8.1-KB2999226-x86.msu",
-    "Windows8-RT-KB2999226-x64.msu",
-    "Windows8-RT-KB2999226-x86.msu",
 ]
 PATHS = [
     "python-{}.exe".format(m.group(0)),


### PR DESCRIPTION
https://github.com/python/cpython/commit/fac5e7aa171f8547fcb56f090e718c15ffd79d0b stopped supporting win8.1

So I removed outdated Windows Updates. Since we stopped supporting Windows 7 and 8.1, these patches are no longer needed. The minimum version is now Windows 10.
Another part: https://github.com/python/cpython-bin-deps/pull/5

MSI  installer will now be smaller

Note: need backport to 3.13, skip news

<!-- gh-issue-number: gh-124487 -->
* Issue: gh-124487
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124822.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->