### PR TITLE
Doc: Fix archive filenames for standard builds

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -305,13 +305,15 @@ serve:
 
 # for development releases: always build
 .PHONY: autobuild-dev
+autobuild-dev: DISTVERSION = $(shell $(PYTHON) tools/extensions/patchlevel.py --short)
 autobuild-dev:
-	$(MAKE) dist-no-html SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1'
+	$(MAKE) dist-no-html SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1' DISTVERSION=$(DISTVERSION)
 
 # for HTML-only rebuilds
 .PHONY: autobuild-dev-html
+autobuild-dev-html: DISTVERSION = $(shell $(PYTHON) tools/extensions/patchlevel.py --short)
 autobuild-dev-html:
-	$(MAKE) dist-html SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1'
+	$(MAKE) dist-html SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1' DISTVERSION=$(DISTVERSION)
 
 # for stable releases: only build if not in pre-release stage (alpha, beta)
 # release candidate downloads are okay, since the stable tree can be in that stage

--- a/Doc/tools/extensions/patchlevel.py
+++ b/Doc/tools/extensions/patchlevel.py
@@ -74,4 +74,8 @@ def get_version_info():
 
 
 if __name__ == "__main__":
-    print(format_version_info(get_header_version_info())[0])
+    short_ver, full_ver = format_version_info(get_header_version_info())
+    if sys.argv[1:2] == ["--short"]:
+        print(short_ver)
+    else:
+        print(full_ver)


### PR DESCRIPTION
The recent commit 6318ffcba21f8fc155f5558237ab03aa45f0e174 (PR #124534) meant all created archive files (`.zip` and `.tar.bz2`) used the short `{major}.{minor}` version. This PR updates the logic so that only the daily rebuilds use the short version, with all other builds using the full release version.

Local test (daily rebuild):

```bash
$ make autobuild-dev-html
make dist-html SPHINXOPTS=' -A daily=1' DISTVERSION=3.14
make[1]: Entering directory '/mnt/s/Development/cpython/Doc'
# archive the HTML
Building HTML...
mkdir -p dist
rm -rf build/html
find dist -name 'python-3.14-docs-html*' -exec rm -rf {} \;
make html
make[2]: Entering directory '/mnt/s/Development/cpython/Doc'
[... snip ...]
Build finished. The HTML pages are in build/html.
make[2]: Leaving directory '/mnt/s/Development/cpython/Doc'
cp -pPR build/html dist/python-3.14-docs-html
tar -C dist -cf dist/python-3.14-docs-html.tar python-3.14-docs-html
bzip2 -9 -k dist/python-3.14-docs-html.tar
(cd dist; zip -q -r -9 python-3.14-docs-html.zip python-3.14-docs-html)
rm -r dist/python-3.14-docs-html
rm dist/python-3.14-docs-html.tar
Build finished and archived!
make[1]: Leaving directory '/mnt/s/Development/cpython/Doc'
```

Local test (standard build):

```bash
$ make dist-html
# archive the HTML
Building HTML...
mkdir -p dist
rm -rf build/html
find dist -name 'python-3.14.0a0-docs-html*' -exec rm -rf {} \;
make html
make[1]: Entering directory '/mnt/s/Development/cpython/Doc'
[... snip ...]
Build finished. The HTML pages are in build/html.
make[1]: Leaving directory '/mnt/s/Development/cpython/Doc'
cp -pPR build/html dist/python-3.14.0a0-docs-html
tar -C dist -cf dist/python-3.14.0a0-docs-html.tar python-3.14.0a0-docs-html
bzip2 -9 -k dist/python-3.14.0a0-docs-html.tar
(cd dist; zip -q -r -9 python-3.14.0a0-docs-html.zip python-3.14.0a0-docs-html)
rm -r dist/python-3.14.0a0-docs-html
rm dist/python-3.14.0a0-docs-html.tar
Build finished and archived!
```

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124826.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->