### PR TITLE
gh-109975: nntplib is not on PyPI so propose pynntp

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1621,7 +1621,7 @@ and are now removed:
 * :mod:`!msilib`
 * :mod:`!nis`
 * :mod:`!nntplib`:
-  Use the :pypi:`nntplib` library from PyPI instead.
+  Use the :pypi:`pynntp` library from PyPI instead.
 * :mod:`!ossaudiodev`:
   For audio playback, use the :pypi:`pygame` library from PyPI instead.
 * :mod:`!pipes`:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
[`PEP 594: Remove “dead batteries” from the standard library`](https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-pep594) section of `What’s New In Python 3.13` suggests downloading `nntplib` from PyPI but it is not there!  https://pypi.org/project/nntplib as discussed in greenbender/pynntp#8

This pull request suggests [`pynntp`](https://pypi.org/project/pynntp) instead based on that library's new testing and modernization efforts.
* https://github.com/greenbender/pynntp/releases

@greenbender, @mcepl, @Julien-Elie Your reviews, please.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124830.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->
