### PR TITLE
gh-124832: Add a note to indicate that `datetime.now` may return the same instant

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -934,6 +934,10 @@ Other constructors, all class methods:
 
    This function is preferred over :meth:`today` and :meth:`utcnow`.
 
+   .. warning::
+
+      It's possible that subsequent ``datetime.now()`` return the same instant,
+      depending on the precision of the underlying functions.
 
 .. classmethod:: datetime.utcnow()
 

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -934,7 +934,7 @@ Other constructors, all class methods:
 
    This function is preferred over :meth:`today` and :meth:`utcnow`.
 
-   .. warning::
+   .. note::
 
       It's possible that subsequent ``datetime.now()`` return the same instant,
       depending on the precision of the underlying functions.

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -937,7 +937,7 @@ Other constructors, all class methods:
    .. note::
 
       It's possible that subsequent ``datetime.now()`` return the same instant,
-      depending on the precision of the underlying functions.
+      depending on the precision of the underlying clock.
 
 .. classmethod:: datetime.utcnow()
 

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -936,8 +936,8 @@ Other constructors, all class methods:
 
    .. note::
 
-      It's possible that subsequent ``datetime.now()`` return the same instant,
-      depending on the precision of the underlying clock.
+      Subsequent calls to :meth:`!datetime.now` may return the same
+      instant depending on the precision of the underlying clock.
 
 .. classmethod:: datetime.utcnow()
 


### PR DESCRIPTION
Made the implied behavior more clear

<!-- gh-issue-number: gh-124832 -->
* Issue: gh-124832
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124834.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->