### PR TITLE
gh-124842: Fix test.support.import_helper.make_legacy_pyc()

### DIFF
--- a/Lib/test/support/import_helper.py
+++ b/Lib/test/support/import_helper.py
@@ -58,8 +58,8 @@ def make_legacy_pyc(source):
     :return: The file system path to the legacy pyc file.
     """
     pyc_file = importlib.util.cache_from_source(source)
-    up_one = os.path.dirname(os.path.abspath(source))
-    legacy_pyc = os.path.join(up_one, source + 'c')
+    assert source.endswith('.py')
+    legacy_pyc = source + 'c'
     shutil.move(pyc_file, legacy_pyc)
     return legacy_pyc
 


### PR DESCRIPTION
For source file "path/to/file.py" it created file with incorrect path "/absolute/path/to/path/to/file.pyc" instead of "path/to/file.pyc".


<!-- gh-issue-number: gh-124842 -->
* Issue: gh-124842
<!-- /gh-issue-number -->
