### PR TITLE
gh-91818: Use default program name in the CLI of many modules

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1743,7 +1743,7 @@ def unparse(ast_obj):
 def main():
     import argparse
 
-    parser = argparse.ArgumentParser(prog='python -m ast')
+    parser = argparse.ArgumentParser()
     parser.add_argument('infile', nargs='?', default='-',
                         help='the file to parse; defaults to stdin')
     parser.add_argument('-m', '--mode', default='exec',

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -205,7 +205,7 @@ def _uninstall_helper(*, verbosity=0):
 
 def _main(argv=None):
     import argparse
-    parser = argparse.ArgumentParser(prog="python -m ensurepip")
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         "--version",
         action="version",

--- a/Lib/ensurepip/_uninstall.py
+++ b/Lib/ensurepip/_uninstall.py
@@ -6,7 +6,7 @@ import sys
 
 
 def _main(argv=None):
-    parser = argparse.ArgumentParser(prog="python -m ensurepip._uninstall")
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         "--version",
         action="version",

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -9,10 +9,9 @@ import sys
 
 
 def main():
-    prog = 'python -m json'
     description = ('A simple command line interface for json module '
                    'to validate and pretty-print JSON objects.')
-    parser = argparse.ArgumentParser(prog=prog, description=description)
+    parser = argparse.ArgumentParser(description=description)
     parser.add_argument('infile', nargs='?',
                         help='a JSON file to be validated or pretty-printed',
                         default='-')

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2423,8 +2423,7 @@ To let the script run up to a given line X in the debugged file, use
 def main():
     import argparse
 
-    parser = argparse.ArgumentParser(prog="pdb",
-                                     usage="%(prog)s [-h] [-c command] (-m module | pyfile) [args ...]",
+    parser = argparse.ArgumentParser(usage="%(prog)s [-h] [-c command] (-m module | pyfile) [args ...]",
                                      description=_usage,
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
                                      allow_abbrev=False)

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -65,7 +65,6 @@ class SqliteInteractiveConsole(InteractiveConsole):
 def main(*args):
     parser = ArgumentParser(
         description="Python sqlite3 CLI",
-        prog="python -m sqlite3",
     )
     parser.add_argument(
         "filename", type=str, default=":memory:", nargs="?",

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -34,7 +34,9 @@ class CommandLineInterface(unittest.TestCase):
 
     def test_cli_help(self):
         out = self.expect_success("-h")
-        self.assertIn("usage: python -m sqlite3", out)
+        self.assertIn("usage: ", out)
+        self.assertIn(" [-h] [-v] [filename] [sql]", out)
+        self.assertIn("Python sqlite3 CLI", out)
 
     def test_cli_version(self):
         out = self.expect_success("-v")

--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -510,7 +510,7 @@ def main():
         sys.exit(1)
 
     # Parse the arguments and options
-    parser = argparse.ArgumentParser(prog='python -m tokenize')
+    parser = argparse.ArgumentParser()
     parser.add_argument(dest='filename', nargs='?',
                         metavar='filename.py',
                         help='the file to tokenize; defaults to stdin')

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -572,8 +572,7 @@ def create(env_dir, system_site_packages=False, clear=False,
 def main(args=None):
     import argparse
 
-    parser = argparse.ArgumentParser(prog=__name__,
-                                     description='Creates virtual Python '
+    parser = argparse.ArgumentParser(description='Creates virtual Python '
                                                  'environments in one or '
                                                  'more target '
                                                  'directories.',

--- a/Misc/NEWS.d/next/Library/2024-10-01-23-29-09.gh-issue-91818.Kz8cPI.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-01-23-29-09.gh-issue-91818.Kz8cPI.rst
@@ -1,0 +1,4 @@
+The CLI of many modules (:mod:`ast`, :mod:`ensurepip`, :mod:`json`,
+:mod:`pdb`, :mod:`sqlite3`, :mod:`tokenize`, :mod:`venv`) now uses the
+actual executable name instead of simply "python" to display in the usage
+message.


### PR DESCRIPTION
As argparse now detects by default when the code was run as a module.

This leads to using the actual executable name instead of simply "python" to display in the usage message ("usage: python -m ...").


<!-- gh-issue-number: gh-91818 -->
* Issue: gh-91818
<!-- /gh-issue-number -->
