### PR TITLE
gh-124879: simplify `colorsys.rgb_to_hsv`

### DIFF
--- a/Lib/colorsys.py
+++ b/Lib/colorsys.py
@@ -130,15 +130,12 @@ def rgb_to_hsv(r, g, b):
     if minc == maxc:
         return 0.0, 0.0, v
     s = rangec / maxc
-    rc = (maxc-r) / rangec
-    gc = (maxc-g) / rangec
-    bc = (maxc-b) / rangec
     if r == maxc:
-        h = bc-gc
+        h = (g-b) / rangec
     elif g == maxc:
-        h = 2.0+rc-bc
+        h = 2.0 + (b-r) / rangec
     else:
-        h = 4.0+gc-rc
+        h = 4.0 + (r-g) / rangec
     h = (h/6.0) % 1.0
     return h, s, v
 

--- a/Misc/NEWS.d/next/Library/2024-10-02-16-47-45.gh-issue-124879.9m2Wmx.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-02-16-47-45.gh-issue-124879.9m2Wmx.rst
@@ -1,0 +1,1 @@
+`colorsys.rgb_to_hsv` has been slightly optimized.

--- a/Misc/NEWS.d/next/Library/2024-10-02-16-47-45.gh-issue-124879.9m2Wmx.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-02-16-47-45.gh-issue-124879.9m2Wmx.rst
@@ -1,1 +1,1 @@
-`colorsys.rgb_to_hsv` has been slightly optimized.
+Optimized :func:`colorsys.rgb_to_hsv` to reduce the number of operations.


### PR DESCRIPTION
By inlining some variables, the number of operations performed can be reduced. Example:
with
```python
gc = (maxc-g) / rangec
bc = (maxc-b) / rangec
```
then
```python
h = bc-gc
h = (maxc-b)/rangec - (maxc-g)/rangec
h = ((maxc-b) - (maxc-g)) / rangec
h = (maxc - b - maxc + g) / rangec
h = (g-b) / rangec
```

<!-- gh-issue-number: gh-124879 -->
* Issue: gh-124879
<!-- /gh-issue-number -->
