### PR TITLE
gh-124213: Fix incorrect context manager use in in_systemd_nspawn_sync_suppressed()

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2907,10 +2907,11 @@ def in_systemd_nspawn_sync_suppressed() -> bool:
     # trigger EINVAL.  Otherwise, ENOENT will be given instead.
     import errno
     try:
-        with os.open(__file__, os.O_RDONLY | os.O_SYNC):
-            pass
+        fd = os.open(__file__, os.O_RDONLY | os.O_SYNC)
     except OSError as err:
         if err.errno == errno.EINVAL:
             return True
+    else:
+        os.close(fd)
 
     return False


### PR DESCRIPTION
Fix the incorrect use of `os.open()` result as a context manager, while it is actually a numeric file descriptor.

I have missed the problem, because in the original version the `os.open()` call would always fail, and I failed to test the final version in all possible scenarios properly.

CC @vstinner 

<!-- gh-issue-number: gh-124213 -->
* Issue: gh-124213
<!-- /gh-issue-number -->
