### PR TITLE
gh-124653: relax (again) detection of queue API for logging handlers 

### DIFF
--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -753,16 +753,17 @@ The ``queue`` and ``listener`` keys are optional.
 
 If the ``queue`` key is present, the corresponding value can be one of the following:
 
-* An object implementing the :class:`queue.Queue` public API. For instance,
-  this may be an actual instance of :class:`queue.Queue` or a subclass thereof,
-  or a proxy obtained by :meth:`multiprocessing.managers.SyncManager.Queue`.
+* An object implementing the :meth:`Queue.put_nowait <queue.Queue.put_nowait>`
+  and :meth:`Queue.get <queue.Queue.get>` public API. For instance, this may be
+  an actual instance of :class:`queue.Queue` or a subclass thereof, or a proxy
+  obtained by :meth:`multiprocessing.managers.SyncManager.Queue`.
 
   This is of course only possible if you are constructing or modifying
   the configuration dictionary in code.
 
 * A string that resolves to a callable which, when called with no arguments, returns
-  the :class:`queue.Queue` instance to use. That callable could be a
-  :class:`queue.Queue` subclass or a function which returns a suitable queue instance,
+  the queue instance to use. That callable could be a :class:`queue.Queue` subclass
+  or a function which returns a suitable queue instance,
   such as ``my.module.queue_factory()``.
 
 * A dict with a ``'()'`` key which is constructed in the usual way as discussed in

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -499,7 +499,7 @@ class BaseConfigurator(object):
 
 def _is_queue_like_object(obj):
     """Check that *obj* implements the Queue API."""
-    if isinstance(obj, queue.Queue):
+    if isinstance(obj, (queue.Queue, queue.SimpleQueue)):
         return True
     # defer importing multiprocessing as much as possible
     from multiprocessing.queues import Queue as MPQueue
@@ -516,13 +516,13 @@ def _is_queue_like_object(obj):
     # Ideally, we would have wanted to simply use strict type checking
     # instead of a protocol-based type checking since the latter does
     # not check the method signatures.
-    queue_interface = [
-        'empty', 'full', 'get', 'get_nowait',
-        'put', 'put_nowait', 'join', 'qsize',
-        'task_done',
-    ]
+    #
+    # Note that only 'put_nowait' and 'get' are required by the logging
+    # queue handler and queue listener (see gh-124653) and that other
+    # methods are either optional or unused.
+    minimal_queue_interface = ['put_nowait', 'get']
     return all(callable(getattr(obj, method, None))
-               for method in queue_interface)
+               for method in minimal_queue_interface)
 
 class DictConfigurator(BaseConfigurator):
     """

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3971,7 +3971,7 @@ class ConfigDictTest(BaseTest):
         q4 = CustomQueueFakeProtocol()
         q5 = MinimalQueueProtocol()
 
-        for qspec in (q1, q2, q3, q4):
+        for qspec in (q1, q2, q3, q4, q5):
             self.apply_config(
                 {
                     "version": 1,

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3973,8 +3973,8 @@ class ConfigDictTest(BaseTest):
             CustomQueueFakeProtocol(),
             MinimalQueueProtocol(),
             # multiprocessing.Queue() is a valid queue for the logging module
-            # multiprocessing.SimpleQueue() is NOT valid because it lacks the
-            # 'put_nowait' method which is needed by the logging queue handler.
+            # but multiprocessing.SimpleQueue() is NOT valid because it lacks
+            # the 'put_nowait' method needed by the logging queue handler.
             multiprocessing.Queue(),
         ]:
             with self.subTest(qspec=qspec):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3988,7 +3988,7 @@ class ConfigDictTest(BaseTest):
 
     @patch("multiprocessing.Manager")
     def test_config_queue_handler_invalid_config_does_not_create_multiprocessing_manager(self, manager):
-        # gh-120868, gh-121723, gh-124653
+        # gh-120868, gh-121723
 
         for qspec in [object(), CustomQueueWrongProtocol()]:
             with self.subTest(qspec=qspec), self.assertRaises(ValueError):

--- a/Misc/NEWS.d/next/Library/2024-10-02-15-05-45.gh-issue-124653.tqsTu9.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-02-15-05-45.gh-issue-124653.tqsTu9.rst
@@ -1,0 +1,2 @@
+Fix detection of the minimal Queue API needed by the :mod:`logging` module.
+Patch by Bénédikt Tran.


### PR DESCRIPTION
NOw we really have a minmal inteface, namely `put_nowait` and `get`. More than that is not needed for the default handlers and listeners. 

I think, we had a misunderstanding between what the docs told (namely a queue API) and what we expected at runtime. `SimpleQueue` is *not* the compatible with "queue.Queue" since it lacks some methods and neither is `multiprocessing.SimpleQueue` would never work since it does not even have the `put_nowait` method (so even before my PRs, this would just break at runtime due to a missing interface).

So it *is* correct to raise if the queue interface is `multiprocessing.SimpleQueue`.

<!-- gh-issue-number: gh-124653 -->
* Issue: gh-124653
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124897.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->