### PR TITLE
gh-123961: Improve curses C API cleanup

### DIFF
--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -4859,7 +4859,7 @@ curses_capi_start_color_called(void)
 }
 
 static void *
-_curses_capi_new(_cursesmodule_state *state)
+curses_capi_new(_cursesmodule_state *state)
 {
     assert(state->window_type != NULL);
     void **capi = (void **)PyMem_Calloc(PyCurses_API_pointers, sizeof(void *));
@@ -4875,7 +4875,7 @@ _curses_capi_new(_cursesmodule_state *state)
 }
 
 static void
-_curses_capi_free(void *capi)
+curses_capi_free(void *capi)
 {
     assert(capi != NULL);
     void **capi_ptr = (void **)capi;
@@ -4887,17 +4887,17 @@ _curses_capi_free(void *capi)
 /* Module C API Capsule */
 
 static void
-_curses_capi_capsule_destructor(PyObject *op)
+curses_capi_capsule_destructor(PyObject *op)
 {
     void *capi = PyCapsule_GetPointer(op, PyCurses_CAPSULE_NAME);
-    _curses_capi_free(capi);
+    curses_capi_free(capi);
 }
 
 static PyObject *
-_curses_capi_capsule_new(void *capi)
+curses_capi_capsule_new(void *capi)
 {
     return PyCapsule_New(capi, PyCurses_CAPSULE_NAME,
-                         _curses_capi_capsule_destructor);
+                         curses_capi_capsule_destructor);
 }
 
 /* Module initialization */
@@ -4922,14 +4922,14 @@ cursesmodule_exec(PyObject *module)
     }
 
     /* Create the C API object */
-    void *capi = _curses_capi_new(state);
+    void *capi = curses_capi_new(state);
     if (capi == NULL) {
         return -1;
     }
     /* Add a capsule for the C API */
-    PyObject *capi_capsule = _curses_capi_capsule_new(capi);
+    PyObject *capi_capsule = curses_capi_capsule_new(capi);
     if (capi_capsule == NULL) {
-        _curses_capi_free(capi);
+        curses_capi_free(capi);
         return -1;
     }
     int rc = PyDict_SetItemString(module_dict, "_C_API", capi_capsule);

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -105,10 +105,8 @@ static const char PyCursesVersion[] = "2.2";
 #endif
 
 #include "Python.h"
-#include "pycore_capsule.h"     // _PyCapsule_SetTraverse()
-#include "pycore_long.h"        // _PyLong_GetZero()
-#include "pycore_object.h"      // _PyType_HasFeature()
-#include "pycore_structseq.h"   // _PyStructSequence_NewType()
+#include "pycore_long.h"          // _PyLong_GetZero()
+#include "pycore_structseq.h"     // _PyStructSequence_NewType()
 
 #ifdef __hpux
 #define STRICT_SYSV_CURSES

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -4893,9 +4893,8 @@ _curses_capi_capsule_destructor(PyObject *op)
 static PyObject *
 _curses_capi_capsule_new(void *capi)
 {
-    PyObject *capsule = PyCapsule_New(capi, PyCurses_CAPSULE_NAME,
-                                      _curses_capi_capsule_destructor);
-    return capsule;
+    return PyCapsule_New(capi, PyCurses_CAPSULE_NAME,
+                         _curses_capi_capsule_destructor);
 }
 
 /* Module initialization */
@@ -5138,14 +5137,9 @@ cursesmodule_exec(PyObject *module)
 
 static struct PyModuleDef _cursesmodule = {
     PyModuleDef_HEAD_INIT,
-    "_curses",
-    NULL,
-    -1,
-    PyCurses_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
+    .m_name = "_curses",
+    .m_size = -1,
+    .m_methods = PyCurses_methods,
 };
 
 PyMODINIT_FUNC

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -4840,17 +4840,20 @@ static PyMethodDef PyCurses_methods[] = {
 /* Function versions of the 3 functions for testing whether curses has been
    initialised or not. */
 
-static inline int curses_capi_setupterm_called(void)
+static inline int
+curses_capi_setupterm_called(void)
 {
     return _PyCursesCheckFunction(curses_setupterm_called, "setupterm");
 }
 
-static inline int curses_capi_initscr_called(void)
+static inline int
+curses_capi_initscr_called(void)
 {
     return _PyCursesCheckFunction(curses_initscr_called, "initscr");
 }
 
-static inline int curses_capi_start_color_called(void)
+static inline int
+curses_capi_start_color_called(void)
 {
     return _PyCursesCheckFunction(curses_start_color_called, "start_color");
 }

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -105,8 +105,10 @@ static const char PyCursesVersion[] = "2.2";
 #endif
 
 #include "Python.h"
-#include "pycore_long.h"          // _PyLong_GetZero()
-#include "pycore_structseq.h"     // _PyStructSequence_NewType()
+#include "pycore_capsule.h"     // _PyCapsule_SetTraverse()
+#include "pycore_long.h"        // _PyLong_GetZero()
+#include "pycore_object.h"      // _PyType_HasFeature()
+#include "pycore_structseq.h"   // _PyStructSequence_NewType()
 
 #ifdef __hpux
 #define STRICT_SYSV_CURSES
@@ -625,24 +627,6 @@ class component_converter(CConverter):
     converter = 'component_converter'
 [python start generated code]*/
 /*[python end generated code: output=da39a3ee5e6b4b0d input=38e9be01d33927fb]*/
-
-/* Function versions of the 3 functions for testing whether curses has been
-   initialised or not. */
-
-static int func_PyCursesSetupTermCalled(void)
-{
-    return _PyCursesCheckFunction(curses_setupterm_called, "setupterm");
-}
-
-static int func_PyCursesInitialised(void)
-{
-    return _PyCursesCheckFunction(curses_initscr_called, "initscr");
-}
-
-static int func_PyCursesInitialisedColor(void)
-{
-    return _PyCursesCheckFunction(curses_start_color_called, "start_color");
-}
 
 /*****************************************************************************
  The Window Object
@@ -4853,28 +4837,107 @@ static PyMethodDef PyCurses_methods[] = {
     {NULL,                  NULL}         /* sentinel */
 };
 
-/* Initialization function for the module */
+/* Module C API */
 
+/* Function versions of the 3 functions for testing whether curses has been
+   initialised or not. */
 
-static struct PyModuleDef _cursesmodule = {
-    PyModuleDef_HEAD_INIT,
-    "_curses",
-    NULL,
-    -1,
-    PyCurses_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
+static inline int curses_capi_setupterm_called(void)
+{
+    return _PyCursesCheckFunction(curses_setupterm_called, "setupterm");
+}
+
+static inline int curses_capi_initscr_called(void)
+{
+    return _PyCursesCheckFunction(curses_initscr_called, "initscr");
+}
+
+static inline int curses_capi_start_color_called(void)
+{
+    return _PyCursesCheckFunction(curses_start_color_called, "start_color");
+}
+
+static void *
+_curses_capi_new(_cursesmodule_state *state)
+{
+    assert(state->window_type != NULL);
+    void **capi = (void **)PyMem_Calloc(PyCurses_API_pointers, sizeof(void *));
+    if (capi == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    capi[0] = (void *)Py_NewRef(state->window_type);
+    capi[1] = curses_capi_setupterm_called;
+    capi[2] = curses_capi_initscr_called;
+    capi[3] = curses_capi_start_color_called;
+    return (void *)capi;
+}
 
 static void
-curses_destructor(PyObject *op)
+_curses_capi_free(void *capi)
 {
-    void *ptr = PyCapsule_GetPointer(op, PyCurses_CAPSULE_NAME);
-    Py_DECREF(*(void **)ptr);
-    PyMem_Free(ptr);
+    assert(capi != NULL);
+    void **capi_ptr = (void **)capi;
+    assert(capi_ptr[0] != NULL);
+    Py_DECREF(capi_ptr[0]); // decref curses window type
+    PyMem_Free(capi_ptr);
 }
+
+/* Module C API Capsule */
+
+static void
+_curses_capi_capsule_destructor(PyObject *op)
+{
+    void *capi = PyCapsule_GetPointer(op, PyCurses_CAPSULE_NAME);
+    _curses_capi_free(capi);
+}
+
+static int
+_curses_capi_capsule_traverse(PyObject *op, visitproc visit, void *arg)
+{
+    void *capi = PyCapsule_GetPointer(op, PyCurses_CAPSULE_NAME);
+    assert(capi != NULL);
+    void *window_type = *(void **)(capi);
+    assert(window_type != NULL);
+    if (_PyType_HasFeature(_PyType_CAST(window_type), Py_TPFLAGS_HEAPTYPE)) {
+        Py_VISIT(window_type);
+    }
+    return 0;
+}
+
+static int
+_curses_capi_capsule_clear(PyObject *op) {
+    void *capi = PyCapsule_GetPointer(op, PyCurses_CAPSULE_NAME);
+    assert(capi != NULL);
+    void *window_type = *(void **)(capi);
+    if (_PyType_HasFeature(_PyType_CAST(window_type), Py_TPFLAGS_HEAPTYPE)) {
+        Py_CLEAR(window_type);
+    }
+    return 0;
+}
+
+static PyObject *
+_curses_capi_capsule_new(void *capi)
+{
+    PyObject *capsule = PyCapsule_New(capi, PyCurses_CAPSULE_NAME,
+                                      _curses_capi_capsule_destructor);
+    if (capsule == NULL) {
+        return NULL;
+    }
+    void *window_type = *(void **)(capi);
+    if (_PyType_HasFeature(_PyType_CAST(window_type), Py_TPFLAGS_HEAPTYPE)) {
+        if (_PyCapsule_SetTraverse(capsule,
+                                   _curses_capi_capsule_traverse,
+                                   _curses_capi_capsule_clear) < 0)
+        {
+            Py_DECREF(capsule);
+            return NULL;
+        }
+    }
+    return capsule;
+}
+
+/* Module initialization */
 
 static int
 cursesmodule_exec(PyObject *module)
@@ -4895,27 +4958,19 @@ cursesmodule_exec(PyObject *module)
         return -1;
     }
 
-    void **PyCurses_API = PyMem_Calloc(PyCurses_API_pointers, sizeof(void *));
-    if (PyCurses_API == NULL) {
-        PyErr_NoMemory();
+    /* Create the C API object */
+    void *capi = _curses_capi_new(state);
+    if (capi == NULL) {
         return -1;
     }
-    /* Initialize the C API pointer array */
-    PyCurses_API[0] = (void *)Py_NewRef(&PyCursesWindow_Type);
-    PyCurses_API[1] = (void *)func_PyCursesSetupTermCalled;
-    PyCurses_API[2] = (void *)func_PyCursesInitialised;
-    PyCurses_API[3] = (void *)func_PyCursesInitialisedColor;
-
     /* Add a capsule for the C API */
-    PyObject *c_api_object = PyCapsule_New(PyCurses_API, PyCurses_CAPSULE_NAME,
-                                           curses_destructor);
-    if (c_api_object == NULL) {
-        Py_DECREF(PyCurses_API[0]);
-        PyMem_Free(PyCurses_API);
+    PyObject *capi_capsule = _curses_capi_capsule_new(capi);
+    if (capi_capsule == NULL) {
+        _curses_capi_free(capi);
         return -1;
     }
-    int rc = PyDict_SetItemString(module_dict, "_C_API", c_api_object);
-    Py_DECREF(c_api_object);
+    int rc = PyDict_SetItemString(module_dict, "_C_API", capi_capsule);
+    Py_DECREF(capi_capsule);
     if (rc < 0) {
         return -1;
     }
@@ -5117,6 +5172,20 @@ cursesmodule_exec(PyObject *module)
 #undef SetDictInt
     return 0;
 }
+
+/* Initialization function for the module */
+
+static struct PyModuleDef _cursesmodule = {
+    PyModuleDef_HEAD_INIT,
+    "_curses",
+    NULL,
+    -1,
+    PyCurses_methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
 
 PyMODINIT_FUNC
 PyInit__curses(void)

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -4892,48 +4892,11 @@ _curses_capi_capsule_destructor(PyObject *op)
     _curses_capi_free(capi);
 }
 
-static int
-_curses_capi_capsule_traverse(PyObject *op, visitproc visit, void *arg)
-{
-    void *capi = PyCapsule_GetPointer(op, PyCurses_CAPSULE_NAME);
-    assert(capi != NULL);
-    void *window_type = *(void **)(capi);
-    assert(window_type != NULL);
-    if (_PyType_HasFeature(_PyType_CAST(window_type), Py_TPFLAGS_HEAPTYPE)) {
-        Py_VISIT(window_type);
-    }
-    return 0;
-}
-
-static int
-_curses_capi_capsule_clear(PyObject *op) {
-    void *capi = PyCapsule_GetPointer(op, PyCurses_CAPSULE_NAME);
-    assert(capi != NULL);
-    void *window_type = *(void **)(capi);
-    if (_PyType_HasFeature(_PyType_CAST(window_type), Py_TPFLAGS_HEAPTYPE)) {
-        Py_CLEAR(window_type);
-    }
-    return 0;
-}
-
 static PyObject *
 _curses_capi_capsule_new(void *capi)
 {
     PyObject *capsule = PyCapsule_New(capi, PyCurses_CAPSULE_NAME,
                                       _curses_capi_capsule_destructor);
-    if (capsule == NULL) {
-        return NULL;
-    }
-    void *window_type = *(void **)(capi);
-    if (_PyType_HasFeature(_PyType_CAST(window_type), Py_TPFLAGS_HEAPTYPE)) {
-        if (_PyCapsule_SetTraverse(capsule,
-                                   _curses_capi_capsule_traverse,
-                                   _curses_capi_capsule_clear) < 0)
-        {
-            Py_DECREF(capsule);
-            return NULL;
-        }
-    }
     return capsule;
 }
 


### PR DESCRIPTION
This PR moves some functions closer to where they are needed and adds the traversal and clear functions in prepartion to make the window type a heap type.

> [!NOTE]
> I always hated dealing with void pointers so I'm grateful if you carefully check that I didn't introduce some decaying calls or weird stuff. In addition, please check that the names were carefully refactored (the functions look all the same and it's very simple to make typos!).

<!-- gh-issue-number: gh-123961 -->
* Issue: gh-123961
<!-- /gh-issue-number -->
