### PR TITLE
gh-96859: Optimize argparse actions 'append', 'append_const' and 'extend'

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1016,7 +1016,8 @@ class _AppendAction(Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest, None)
-        items = _copy_items(items)
+        if items is self.default:
+            items = _copy_items(items)
         items.append(values)
         setattr(namespace, self.dest, items)
 
@@ -1045,7 +1046,8 @@ class _AppendConstAction(Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest, None)
-        items = _copy_items(items)
+        if items is self.default:
+            items = _copy_items(items)
         items.append(self.const)
         setattr(namespace, self.dest, items)
 
@@ -1238,7 +1240,8 @@ class _SubParsersAction(Action):
 class _ExtendAction(_AppendAction):
     def __call__(self, parser, namespace, values, option_string=None):
         items = getattr(namespace, self.dest, None)
-        items = _copy_items(items)
+        if items is self.default:
+            items = _copy_items(items)
         items.extend(values)
         setattr(namespace, self.dest, items)
 

--- a/Misc/NEWS.d/next/Library/2024-10-02-21-34-08.gh-issue-124745.efyaxu.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-02-21-34-08.gh-issue-124745.efyaxu.rst
@@ -1,0 +1,4 @@
+Optimize :mod:`argparse` actions 'append', 'append_const' and 'extend' for
+the case when the option is specified many times.
+The targed list no longer copied every time the action is taken, only
+the default value is copied the first time the action is taken.

--- a/Misc/NEWS.d/next/Library/2024-10-02-21-34-08.gh-issue-96859.efyaxu.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-02-21-34-08.gh-issue-96859.efyaxu.rst
@@ -1,4 +1,4 @@
 Optimize :mod:`argparse` actions 'append', 'append_const' and 'extend' for
 the case when the option is specified many times.
-The targed list no longer copied every time the action is taken, only
+The targed list is no longer copied every time the action is taken, only
 the default value is copied the first time the action is taken.

--- a/Misc/NEWS.d/next/Library/2024-10-02-21-34-08.gh-issue-96859.efyaxu.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-02-21-34-08.gh-issue-96859.efyaxu.rst
@@ -1,4 +1,4 @@
 Optimize :mod:`argparse` actions 'append', 'append_const' and 'extend' for
 the case when the option is specified many times.
-The targed list is no longer copied every time the action is taken, only
+The target list is no longer copied every time the action is taken, only
 the default value is copied the first time the action is taken.


### PR DESCRIPTION
Previously, the target list was copied every time the action was taken. Now only the default value is copied the first time the action is taken.


<!-- gh-issue-number: gh-96859 -->
* Issue: gh-96859
<!-- /gh-issue-number -->
