### PR TITLE
gh-124932: Distinguish build prefix from host prefix in cross builds

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -141,6 +141,13 @@ prefix=		@prefix@
 # Install prefix for architecture-dependent files
 exec_prefix=	@exec_prefix@
 
+# For cross compilation, we distinguish between "prefix" (where we install the
+# files) and "host_prefix" (where getpath.c expects to find the files at
+# runtime)
+host_prefix= 	@host_prefix@
+host_exec_prefix= 	@host_exec_prefix@
+
+
 # Install prefix for data files
 datarootdir=    @datarootdir@
 
@@ -1740,8 +1747,8 @@ Modules/getbuildinfo.o: $(PARSER_OBJS) \
 
 Modules/getpath.o: $(srcdir)/Modules/getpath.c Python/frozen_modules/getpath.h Makefile $(PYTHON_HEADERS)
 	$(CC) -c $(PY_CORE_CFLAGS) -DPYTHONPATH='"$(PYTHONPATH)"' \
-		-DPREFIX='"$(prefix)"' \
-		-DEXEC_PREFIX='"$(exec_prefix)"' \
+		-DPREFIX='"$(host_prefix)"' \
+		-DEXEC_PREFIX='"$(host_exec_prefix)"' \
 		-DVERSION='"$(VERSION)"' \
 		-DVPATH='"$(VPATH)"' \
 		-DPLATLIBDIR='"$(PLATLIBDIR)"' \

--- a/Misc/NEWS.d/next/Build/2024-10-25-17-20-50.gh-issue-124932.F-aNuS.rst
+++ b/Misc/NEWS.d/next/Build/2024-10-25-17-20-50.gh-issue-124932.F-aNuS.rst
@@ -1,0 +1,4 @@
+For cross builds, there is now support for having a different install
+``prefix`` than the ``host_prefix`` used by ``getpath.py``. This is set to ``/`` by
+default for Emscripten, on other platforms the default behavior is the same
+as before.

--- a/configure
+++ b/configure
@@ -1003,6 +1003,8 @@ LIPO_INTEL64_FLAGS
 LIPO_32BIT_FLAGS
 ARCH_RUN_32BIT
 UNIVERSALSDK
+host_exec_prefix
+host_prefix
 MACHDEP
 PKG_CONFIG_LIBDIR
 PKG_CONFIG_PATH
@@ -4104,6 +4106,29 @@ printf "%s\n" "#define Py_SUNOS_VERSION $SUNOS_VERSION" >>confdefs.h
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: \"$MACHDEP\"" >&5
 printf "%s\n" "\"$MACHDEP\"" >&6; }
+
+
+if test -z "$host_prefix"; then
+  case $ac_sys_system in #(
+  Emscripten) :
+    host_prefix=/ ;; #(
+  *) :
+    host_prefix='${prefix}'
+   ;;
+esac
+fi
+
+
+if test -z "$host_exec_prefix"; then
+  case $ac_sys_system in #(
+  Emscripten) :
+    host_exec_prefix=$host_prefix ;; #(
+  *) :
+    host_exec_prefix='${exec_prefix}'
+   ;;
+esac
+fi
+
 
 # On cross-compile builds, configure will look for a host-specific compiler by
 # prepending the user-provided host triple to the required binary name.

--- a/configure.ac
+++ b/configure.ac
@@ -379,6 +379,25 @@ then
 fi
 AC_MSG_RESULT(["$MACHDEP"])
 
+dnl For cross compilation, we distinguish between "prefix" (where we install the
+dnl files) and "host_prefix" (where we expect to find the files at runtime)
+
+if test -z "$host_prefix"; then
+  AS_CASE([$ac_sys_system],
+    [Emscripten], [host_prefix=/],
+    [host_prefix='${prefix}']
+  )
+fi
+AC_SUBST([host_prefix])
+
+if test -z "$host_exec_prefix"; then
+  AS_CASE([$ac_sys_system],
+    [Emscripten], [host_exec_prefix=$host_prefix],
+    [host_exec_prefix='${exec_prefix}']
+  )
+fi
+AC_SUBST([host_exec_prefix])
+
 # On cross-compile builds, configure will look for a host-specific compiler by
 # prepending the user-provided host triple to the required binary name.
 #


### PR DESCRIPTION
In Emscripten and wasi builds, and presumably for other cross builds, the build file system and the host file system look different. For instance, we may want to install into `cross-build/$TARGET/lib` and then mount that as `/lib` in the host file system. `wasi.py` has to mess around with setting `PYTHONPATH` because `prefix` is set to a path from the build machine. It would simplify this if we distinguish between:

* `prefix` -- the path in the build file system where we want to install the files
* `host_prefix` -- the path in the host file system where getpath.c will look for the files

And similarly for `exec_prefix` and `host_exec_prefix`.

<!-- gh-issue-number: gh-124932 -->
* Issue: gh-124932
<!-- /gh-issue-number -->
