### PR TITLE
Simplify partial() rough equivalent code

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -347,8 +347,7 @@ The :mod:`functools` module defines the following functions:
 
       def partial(func, /, *args, **keywords):
           def newfunc(*more_args, **more_keywords):
-              keywords_union = {**keywords, **more_keywords}
-              return func(*args, *more_args, **keywords_union)
+              return func(*args, *more_args, **keywords | more_keywords)
           newfunc.func = func
           newfunc.args = args
           newfunc.keywords = keywords

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -347,7 +347,7 @@ The :mod:`functools` module defines the following functions:
 
       def partial(func, /, *args, **keywords):
           def newfunc(*more_args, **more_keywords):
-              return func(*args, *more_args, **keywords | more_keywords)
+              return func(*args, *more_args, **(keywords | more_keywords))
           newfunc.func = func
           newfunc.args = args
           newfunc.keywords = keywords


### PR DESCRIPTION
The or-operator is more concise and expressive than building a separate dictionary with generalized argument unpacking.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124941.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->