### PR TITLE
GH-109975: Copyedit 3.13 What's New: Remove references to the incremental GC

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -498,30 +498,6 @@ are not tier 3 supported platforms, but will have best-effort support.
 .. seealso:: :pep:`730`, :pep:`738`
 
 
-.. _whatsnew313-incremental-gc:
-
-Incremental garbage collection
-------------------------------
-
-The cycle garbage collector is now incremental.
-This means that maximum pause times are reduced
-by an order of magnitude or more for larger heaps.
-
-There are now only two generations: young and old.
-When :func:`gc.collect` is not called directly, the
-GC is invoked a little less frequently. When invoked, it
-collects the young generation and an increment of the
-old generation, instead of collecting one or more generations.
-
-The behavior of :func:`!gc.collect` changes slightly:
-
-* ``gc.collect(1)``: Performs an increment of garbage collection,
-  rather than collecting generation 1.
-* Other calls to :func:`!gc.collect` are unchanged.
-
-(Contributed by Mark Shannon in :gh:`108362`.)
-
-
 Other Language Changes
 ======================
 
@@ -916,36 +892,6 @@ fractions
   :ref:`format specification mini-language <formatspec>` rules
   for fill, alignment, sign handling, minimum width, and grouping.
   (Contributed by Mark Dickinson in :gh:`111320`.)
-
-
-gc
---
-
-The cyclic garbage collector is now incremental,
-which changes the meaning of the results of
-:meth:`~gc.get_threshold` and :meth:`~gc.set_threshold`
-as well as :meth:`~gc.get_count` and :meth:`~gc.get_stats`.
-
-* For backwards compatibility, :meth:`~gc.get_threshold` continues to return
-  a three-item tuple.
-  The first value is the threshold for young collections, as before;
-  the second value determines the rate at which the old collection is scanned
-  (the default is 10, and higher values mean that the old collection
-  is scanned more slowly).
-  The third value is meaningless and is always zero.
-
-* :meth:`~gc.set_threshold` ignores any items after the second.
-
-* :meth:`~gc.get_count` and :meth:`~gc.get_stats` continue to return
-  the same format of results.
-  The only difference is that instead of the results referring to
-  the young, aging and old generations,
-  the results refer to the young generation
-  and the aging and collecting spaces of the old generation.
-
-In summary, code that attempted to manipulate the behavior of the cycle GC
-may not work exactly as intended, but it is very unlikely to be harmful.
-All other code will work just fine.
 
 
 glob
@@ -1511,11 +1457,6 @@ zipimport
 
 Optimizations
 =============
-
-* The new :ref:`incremental garbage collector <whatsnew313-incremental-gc>`
-  means that maximum pause times are reduced
-  by an order of magnitude or more for larger heaps.
-  (Contributed by Mark Shannon in :gh:`108362`.)
 
 * Several standard library modules have had
   their import times significantly improved.
@@ -2628,13 +2569,6 @@ Changes in the Python API
   The behavior will change in future Python versions.
   Wrap it in :func:`staticmethod` if you want to preserve the old behavior.
   (Contributed by Serhiy Storchaka in :gh:`121027`.)
-
-* The :ref:`garbage collector is now incremental <whatsnew313-incremental-gc>`,
-  which means that the behavior of :func:`gc.collect` changes slightly:
-
-  * ``gc.collect(1)``: Performs an increment of garbage collection,
-    rather than collecting generation 1.
-  * Other calls to :func:`!gc.collect` are unchanged.
 
 * An :exc:`OSError` is now raised by :func:`getpass.getuser`
   for any failure to retrieve a username,


### PR DESCRIPTION
The incremental GC was reverted in Python 3.13 (#124770), but *What's New* in 3.14 (`/dev/`) still references it. This synchronises the two branches.

A

<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124947.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->