### PR TITLE
gh-124871: fix 'visited' tracking in compiler's reachability analysis

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -479,6 +479,19 @@ class TestSpecifics(unittest.TestCase):
                     x = 2
                """), '<eval>', 'exec')
 
+    def test_try_except_in_while_with_chained_condition_compiles(self):
+        # see gh-124871
+        compile(textwrap.dedent("""
+            name_1, name_2, name_3 = 1, 2, 3
+            while name_3 <= name_2 > name_1:
+                try:
+                    raise
+                except:
+                    pass
+                finally:
+                    pass
+            """), '<eval>', 'exec')
+
     def test_compile_invalid_namedexpr(self):
         # gh-109351
         m = ast.Module(

--- a/Misc/NEWS.d/next/Core and Builtins/2024-10-03-22-26-39.gh-issue-124871.tAMF47.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-10-03-22-26-39.gh-issue-124871.tAMF47.rst
@@ -1,0 +1,2 @@
+Fix compiler bug (in some versions of 3.13) where an assertion fails during reachability
+analysis.

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1001,13 +1001,14 @@ remove_unreachable(basicblock *entryblock) {
     basicblock **sp = stack;
     entryblock->b_predecessors = 1;
     *sp++ = entryblock;
+    entryblock->b_visited = 1;
     while (sp > stack) {
         basicblock *b = *(--sp);
-        b->b_visited = 1;
         if (b->b_next && BB_HAS_FALLTHROUGH(b)) {
             if (!b->b_next->b_visited) {
                 assert(b->b_next->b_predecessors == 0);
                 *sp++ = b->b_next;
+                b->b_next->b_visited = 1;
             }
             b->b_next->b_predecessors++;
         }
@@ -1017,8 +1018,8 @@ remove_unreachable(basicblock *entryblock) {
             if (is_jump(instr) || is_block_push(instr)) {
                 target = instr->i_target;
                 if (!target->b_visited) {
-                    assert(target->b_predecessors == 0 || target == b->b_next);
                     *sp++ = target;
+                    target->b_visited = 1;
                 }
                 target->b_predecessors++;
             }


### PR DESCRIPTION
This fixes reachability analysis to mark blocks as visited once they are inserted to the queue (as is done in other traversals), and then we can remove an assertion that failed for the code in the issue.

Fixes #124871.

<!-- gh-issue-number: gh-124871 -->
* Issue: gh-124871
<!-- /gh-issue-number -->
