### PR TITLE
Fix console prompt syntax in What's New in Python 3.8

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -428,9 +428,9 @@ Other Language Changes
   normal assignment syntax::
 
     >>> def parse(family):
-            lastname, *members = family.split()
-            return lastname.upper(), *members
-
+    ...     lastname, *members = family.split()
+    ...     return lastname.upper(), *members
+    ...
     >>> parse('simpsons homer marge bart lisa maggie')
     ('SIMPSONS', 'homer', 'marge', 'bart', 'lisa', 'maggie')
 


### PR DESCRIPTION

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: [`whatsnew/3.8.html `](https://cpython-previews--124968.org.readthedocs.build/en/124968/whatsnew/3.8.html)

<!-- readthedocs-preview cpython-previews end -->