### PR TITLE
gh-122392: Fix the wrong size of the Path Browser vertical spacing for IDLE (#122392)

### DIFF
--- a/Lib/idlelib/tree.py
+++ b/Lib/idlelib/tree.py
@@ -91,6 +91,7 @@ class TreeNode:
         self.selected = False
         self.children = []
         self.x = self.y = None
+        self.dy = 0
         self.iconimages = {} # cache of PhotoImage instances for icons
 
     def destroy(self):
@@ -199,12 +200,11 @@ class TreeNode:
 
     def draw(self, x, y):
         # XXX This hard-codes too many geometry constants!
-        dy = 20
         self.x, self.y = x, y
         self.drawicon()
         self.drawtext()
         if self.state != 'expanded':
-            return y + dy
+            return y + self.dy
         # draw children
         if not self.children:
             sublist = self.item._GetSubList()
@@ -215,7 +215,7 @@ class TreeNode:
                 child = self.__class__(self.canvas, self, item)
                 self.children.append(child)
         cx = x+20
-        cy = y + dy
+        cy = y + self.dy
         cylast = 0
         for child in self.children:
             cylast = cy
@@ -289,6 +289,11 @@ class TreeNode:
             self.label.bind("<Button-4>", lambda e: wheel_event(e, self.canvas))
             self.label.bind("<Button-5>", lambda e: wheel_event(e, self.canvas))
         self.text_id = id
+        if self.dy == 0:
+            # The first row doesn't matter what the dy is, just measure its
+            # size to get the value of the subsequent dy
+            coords = self.canvas.bbox(id)
+            self.dy = coords[3] - coords[1]
 
     def select_or_edit(self, event=None):
         if self.selected and self.item.IsEditable():

--- a/Lib/idlelib/tree.py
+++ b/Lib/idlelib/tree.py
@@ -83,6 +83,8 @@ def wheel_event(event, widget=None):
 
 class TreeNode:
 
+    dy = 0
+
     def __init__(self, canvas, parent, item):
         self.canvas = canvas
         self.parent = parent
@@ -91,7 +93,6 @@ class TreeNode:
         self.selected = False
         self.children = []
         self.x = self.y = None
-        self.dy = 0
         self.iconimages = {} # cache of PhotoImage instances for icons
 
     def destroy(self):
@@ -204,18 +205,18 @@ class TreeNode:
         self.drawicon()
         self.drawtext()
         if self.state != 'expanded':
-            return y + self.dy
+            return y + TreeNode.dy
         # draw children
         if not self.children:
             sublist = self.item._GetSubList()
             if not sublist:
                 # _IsExpandable() was mistaken; that's allowed
-                return y + self.dy
+                return y + TreeNode.dy - 3
             for item in sublist:
                 child = self.__class__(self.canvas, self, item)
                 self.children.append(child)
         cx = x+20
-        cy = y + self.dy
+        cy = y + TreeNode.dy
         cylast = 0
         for child in self.children:
             cylast = cy
@@ -289,11 +290,11 @@ class TreeNode:
             self.label.bind("<Button-4>", lambda e: wheel_event(e, self.canvas))
             self.label.bind("<Button-5>", lambda e: wheel_event(e, self.canvas))
         self.text_id = id
-        if self.dy == 0:
+        if TreeNode.dy == 0:
             # The first row doesn't matter what the dy is, just measure its
             # size to get the value of the subsequent dy
             coords = self.canvas.bbox(id)
-            self.dy = coords[3] - coords[1]
+            TreeNode.dy = max(20, coords[3] - coords[1] - 3)
 
     def select_or_edit(self, event=None):
         if self.selected and self.item.IsEditable():

--- a/Lib/idlelib/tree.py
+++ b/Lib/idlelib/tree.py
@@ -210,7 +210,7 @@ class TreeNode:
             sublist = self.item._GetSubList()
             if not sublist:
                 # _IsExpandable() was mistaken; that's allowed
-                return y+17
+                return y + self.dy
             for item in sublist:
                 child = self.__class__(self.canvas, self, item)
                 self.children.append(child)

--- a/Lib/idlelib/tree.py
+++ b/Lib/idlelib/tree.py
@@ -211,7 +211,7 @@ class TreeNode:
             sublist = self.item._GetSubList()
             if not sublist:
                 # _IsExpandable() was mistaken; that's allowed
-                return y + TreeNode.dy - 3
+                return y + TreeNode.dy
             for item in sublist:
                 child = self.__class__(self.canvas, self, item)
                 self.children.append(child)

--- a/Misc/NEWS.d/next/IDLE/2024-10-04-15-34-34.gh-issue-122392.V8K3w2.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-10-04-15-34-34.gh-issue-122392.V8K3w2.rst
@@ -1,2 +1,2 @@
-Increase currently inadequate vertical spacing for the IDLE browsers (path, 
+Increase currently inadequate vertical spacing for the IDLE browsers (path,
 module, and stack) on high-resolution monitors.

--- a/Misc/NEWS.d/next/IDLE/2024-10-04-15-34-34.gh-issue-122392.V8K3w2.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-10-04-15-34-34.gh-issue-122392.V8K3w2.rst
@@ -1,0 +1,1 @@
+Fixed the wrong vertical spacing of the Path Browser of IDLE.

--- a/Misc/NEWS.d/next/IDLE/2024-10-04-15-34-34.gh-issue-122392.V8K3w2.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-10-04-15-34-34.gh-issue-122392.V8K3w2.rst
@@ -1,1 +1,2 @@
-Fixed the wrong vertical spacing of the Path Browser of IDLE.
+Increase currently inadequate vertical spacing for the IDLE browsers (path, 
+module, and stack) on high-resolution monitors.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The Path Browser vertical interval size was originally set to `20`, but this caused display issues (such as overlapping) on some devices. Actually, we should calculate the size, and giving a fixed value will not solve the problem in all cases.

But no matter what the value is, the elements in the first row will not use it, so we can get the size of this value through the elements in the first row after the first row is drawn, and assign the value to the corresponding variable for the subsequent elements to use.

After testing, this solution worked very well on my device (Windows10 22H2 1920x1080).

<!-- gh-issue-number: gh-122392 -->
* Issue: gh-122392
<!-- /gh-issue-number -->
