### PR TITLE
Doc: Simplify the definition of 'soft deprecated'

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1165,9 +1165,8 @@ Glossary
       The API remains documented and tested, but will not be
       enhanced further.
 
-      The main difference with a regular deprecation
-      is that the soft deprecation does not schedule the removal of the
-      API.
+      The main difference from a normal deprecation
+      is that soft deprecation does not plan on removing the API.
 
       Another difference is that the use a soft deprecated API does not issue a warning.
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1164,8 +1164,8 @@ Glossary
       safe for already existing code to use it.  The API remains
       documented and tested, but will not be enhanced further.
 
-      The main difference from a normal deprecation is that soft
-      deprecation does not plan on removing the API.
+      Soft deprecation, unlike normal deprecation, does not plan on removing the API and
+      will not emit warnings.
 
       Another difference is that soft deprecated APIs don't emit warnings.
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1160,14 +1160,12 @@ Glossary
       (subscript) notation uses :class:`slice` objects internally.
 
    soft deprecated
-      A soft deprecated API should not be used in new code, but it is
-      safe for already existing code to use it.  The API remains
-      documented and tested, but will not be enhanced further.
+      A soft deprecated API should not be used in new code, 
+      but it is safe for already existing code to use it.
+      The API remains documented and tested, but will not be enhanced further.
 
-      Soft deprecation, unlike normal deprecation, does not plan on removing the API and
-      will not emit warnings.
-
-      Another difference is that soft deprecated APIs don't emit warnings.
+      Soft deprecation, unlike normal deprecation, does not plan on removing the API 
+      and will not emit warnings.
 
       See `PEP 387: Soft Deprecation
       <https://peps.python.org/pep-0387/#soft-deprecation>`_.

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1167,7 +1167,7 @@ Glossary
 
       The main difference with a regular deprecation
       is that the soft deprecation does not schedule the removal of the
-      deprecated API.
+      API.
 
       Another difference is that the use a soft deprecated API does not issue a warning.
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1160,13 +1160,12 @@ Glossary
       (subscript) notation uses :class:`slice` objects internally.
 
    soft deprecated
-      A soft deprecated API should not
-      be used in new code, but it is safe for already existing code to use it.
-      The API remains documented and tested, but will not be
-      enhanced further.
+      A soft deprecated API should not be used in new code, but it is
+      safe for already existing code to use it.  The API remains
+      documented and tested, but will not be enhanced further.
 
-      The main difference from a normal deprecation
-      is that soft deprecation does not plan on removing the API.
+      The main difference from a normal deprecation is that soft
+      deprecation does not plan on removing the API.
 
       Another difference is that soft deprecated APIs don't emit warnings.
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1161,14 +1161,14 @@ Glossary
 
    soft deprecated
       A soft deprecated API should not
-      be used on new code, but it is safe for already existing code to use it.
+      be used in new code, but it is safe for already existing code to use it.
       The API remains documented and tested, but will not be
       enhanced further.
 
       The main difference from a normal deprecation
       is that soft deprecation does not plan on removing the API.
 
-      Another difference is that the use a soft deprecated API does not issue a warning.
+      Another difference is that soft deprecated APIs don't emit warnings.
 
       See `PEP 387: Soft Deprecation
       <https://peps.python.org/pep-0387/#soft-deprecation>`_.

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1160,11 +1160,11 @@ Glossary
       (subscript) notation uses :class:`slice` objects internally.
 
    soft deprecated
-      A soft deprecated API should not be used in new code, 
+      A soft deprecated API should not be used in new code,
       but it is safe for already existing code to use it.
       The API remains documented and tested, but will not be enhanced further.
 
-      Soft deprecation, unlike normal deprecation, does not plan on removing the API 
+      Soft deprecation, unlike normal deprecation, does not plan on removing the API
       and will not emit warnings.
 
       See `PEP 387: Soft Deprecation

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1160,16 +1160,16 @@ Glossary
       (subscript) notation uses :class:`slice` objects internally.
 
    soft deprecated
-      A soft deprecation can be used when using an API which should no longer
-      be used to write new code, but it remains safe to continue using it in
-      existing code. The API remains documented and tested, but will not be
-      developed further (no enhancement).
+      A soft deprecated API should not
+      be used on new code, but it is safe for already existing code to use it.
+      The API remains documented and tested, but will not be
+      enhanced further.
 
-      The main difference between a "soft" and a (regular) "hard" deprecation
-      is that the soft deprecation does not imply scheduling the removal of the
+      The main difference with a regular deprecation
+      is that the soft deprecation does not schedule the removal of the
       deprecated API.
 
-      Another difference is that a soft deprecation does not issue a warning.
+      Another difference is that the use a soft deprecated API does not issue a warning.
 
       See `PEP 387: Soft Deprecation
       <https://peps.python.org/pep-0387/#soft-deprecation>`_.


### PR DESCRIPTION
I found the definition of Soft deprecated somewhat complicated, and I wanted to give it a try.

The violation of line max width is intentional, as I was once told it's better for diff purposes, until merge.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--124988.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->