### PR TITLE
gh-124984: Fix `ssl` thread safety

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2844,7 +2844,10 @@ class ThreadedTests(unittest.TestCase):
                 for thread in threads:
                     with self.subTest(thread=thread):
                         thread.join()
-                self.assertIsNone(cm.exc_value)
+                if cm.exc_value is not None:
+                    # Some threads can skip their test
+                    if not isinstance(cm.exc_value, unittest.SkipTest):
+                        raise cm.exc_value
         finally:
             USE_SAME_TEST_CONTEXT = False
 

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2818,38 +2818,40 @@ class ThreadedTests(unittest.TestCase):
         # See GH-124984
         threads = []
 
+        global USE_SAME_TEST_CONTEXT
         USE_SAME_TEST_CONTEXT = True
-        for func in (
-            self.test_echo,
-            self.test_alpn_protocols,
-            self.test_getpeercert,
-            self.test_crl_check,
-            self.test_ecc_cert,
-            self.test_dual_rsa_ecc,
-            self.test_check_hostname_idn,
-            self.test_wrong_cert_tls12,
-            self.test_wrong_cert_tls13,
-            self.test_rude_shutdown,
-            self.test_ssl_cert_verify_error,
-            self.test_starttls,
-            self.test_socketserver,
-            self.test_recv_send,
-            self.test_recv_zero,
-            self.test_nonblocking_send
-        ):
-            for num in range(10):
-                with self.subTest(func=func, num=num):
-                    threads.append(Thread(target=func))
+        try:
+            for func in (
+                self.test_echo,
+                self.test_alpn_protocols,
+                self.test_getpeercert,
+                self.test_crl_check,
+                self.test_ecc_cert,
+                self.test_dual_rsa_ecc,
+                self.test_check_hostname_idn,
+                self.test_wrong_cert_tls12,
+                self.test_wrong_cert_tls13,
+                self.test_rude_shutdown,
+                self.test_ssl_cert_verify_error,
+                self.test_starttls,
+                self.test_socketserver,
+                self.test_recv_send,
+                self.test_recv_zero,
+                self.test_nonblocking_send
+            ):
+                for num in range(10):
+                    with self.subTest(func=func, num=num):
+                        threads.append(Thread(target=func))
 
-        for thread in threads:
-            with self.subTest(thread=thread):
-                thread.start()
+            for thread in threads:
+                with self.subTest(thread=thread):
+                    thread.start()
 
-        for thread in threads:
-            with self.subTest(thread=thread):
-                thread.join()
-
-        USE_SAME_TEST_CONTEXT = False
+            for thread in threads:
+                with self.subTest(thread=thread):
+                    thread.join()
+        finally:
+            USE_SAME_TEST_CONTEXT = False
 
     def test_getpeercert(self):
         if support.verbose:

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2809,7 +2809,20 @@ class ThreadedTests(unittest.TestCase):
         for func in (
             self.test_echo,
             self.test_alpn_protocols,
-            self.test_getpeercert
+            self.test_getpeercert,
+            self.test_crl_check,
+            self.test_ecc_cert,
+            self.test_dual_rsa_ecc,
+            self.test_check_hostname_idn,
+            self.test_wrong_cert_tls12,
+            self.test_wrong_cert_tls13,
+            self.test_rude_shutdown,
+            self.test_ssl_cert_verify_error,
+            self.test_starttls,
+            self.test_socketserver,
+            self.test_recv_send,
+            self.test_recv_zero,
+            self.test_nonblocking_send
         ):
             for num in range(10):
                 with self.subTest(func=func, num=num):

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2829,13 +2829,6 @@ class ThreadedTests(unittest.TestCase):
                 self.test_check_hostname_idn,
                 self.test_wrong_cert_tls12,
                 self.test_wrong_cert_tls13,
-                self.test_rude_shutdown,
-                self.test_ssl_cert_verify_error,
-                self.test_starttls,
-                self.test_socketserver,
-                self.test_recv_send,
-                self.test_recv_zero,
-                self.test_nonblocking_send
             ):
                 for num in range(5):
                     with self.subTest(func=func, num=num):

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2830,6 +2830,8 @@ class ThreadedTests(unittest.TestCase):
                 self.test_wrong_cert_tls12,
                 self.test_wrong_cert_tls13,
             ):
+                # Be careful with the number of threads here.
+                # Too many can result in failing tests.
                 for num in range(5):
                     with self.subTest(func=func, num=num):
                         threads.append(Thread(target=func))

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2826,8 +2826,6 @@ class ThreadedTests(unittest.TestCase):
                 self.test_alpn_protocols,
                 self.test_getpeercert,
                 self.test_crl_check,
-                self.test_ecc_cert,
-                self.test_dual_rsa_ecc,
                 self.test_check_hostname_idn,
                 self.test_wrong_cert_tls12,
                 self.test_wrong_cert_tls13,
@@ -2839,7 +2837,7 @@ class ThreadedTests(unittest.TestCase):
                 self.test_recv_zero,
                 self.test_nonblocking_send
             ):
-                for num in range(10):
+                for num in range(5):
                     with self.subTest(func=func, num=num):
                         threads.append(Thread(target=func))
 

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2801,7 +2801,7 @@ class ThreadedTests(unittest.TestCase):
                 'Cannot create a client socket with a PROTOCOL_TLS_SERVER context',
                 str(e.exception))
 
-    @unittest.skipUnless(support.Py_GIL_DISABLED, "test is only useful is GIL is disabled")
+    @unittest.skipUnless(support.Py_GIL_DISABLED, "test is only useful if the GIL is disabled")
     def test_ssl_in_multiple_threads(self):
         # See GH-124984
         threads = []

--- a/Misc/NEWS.d/next/Library/2024-10-04-22-43-48.gh-issue-124984.xjMv9b.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-04-22-43-48.gh-issue-124984.xjMv9b.rst
@@ -1,0 +1,1 @@
+Fixed thread safety in :mod:`ssl`.

--- a/Misc/NEWS.d/next/Library/2024-10-04-22-43-48.gh-issue-124984.xjMv9b.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-04-22-43-48.gh-issue-124984.xjMv9b.rst
@@ -1,1 +1,1 @@
-Fixed thread safety in :mod:`ssl`.
+Fixed thread safety in :mod:`ssl` in the free-threaded build. OpenSSL operations are now protected by a per-object lock.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3688,19 +3688,33 @@ set_options(PySSLContext *self, PyObject *arg, void *c)
     return 0;
 }
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLContext._host_flags
+[clinic start generated code]*/
+
 static PyObject *
-get_host_flags(PySSLContext *self, void *c)
+_ssl__SSLContext__host_flags_get_impl(PySSLContext *self)
+/*[clinic end generated code: output=0f9db6654ce32582 input=8e3c49499eefd0e5]*/
 {
     return PyLong_FromUnsignedLong(self->hostflags);
 }
 
+/*[clinic input]
+@critical_section
+@setter
+_ssl._SSLContext._host_flags
+[clinic start generated code]*/
+
 static int
-set_host_flags(PySSLContext *self, PyObject *arg, void *c)
+_ssl__SSLContext__host_flags_set_impl(PySSLContext *self, PyObject *value)
+/*[clinic end generated code: output=1ed6f4027aaf2e3e input=28caf1fb9c32f6cb]*/
 {
     X509_VERIFY_PARAM *param;
     unsigned int new_flags = 0;
 
-    if (!PyArg_Parse(arg, "I", &new_flags))
+    if (!PyArg_Parse(value, "I", &new_flags))
         return -1;
 
     param = SSL_CTX_get0_param(self->ctx);
@@ -4997,8 +5011,7 @@ _ssl__SSLContext_set_psk_server_callback_impl(PySSLContext *self,
 
 static PyGetSetDef context_getsetlist[] = {
     _SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF
-    {"_host_flags", (getter) get_host_flags,
-                    (setter) set_host_flags, NULL},
+    _SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF
     {"minimum_version", (getter) get_minimum_version,
                         (setter) set_minimum_version, NULL},
     {"maximum_version", (getter) get_maximum_version,

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2163,7 +2163,6 @@ _ssl__SSLSocket_version_impl(PySSLSocket *self)
         Py_RETURN_NONE;
     }
 
-    PySSL_LOCK(self);
     version = SSL_get_version(self->ssl);
     PySSL_UNLOCK(self);
     if (!strcmp(version, "unknown"))

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2232,13 +2232,11 @@ _ssl__SSLSocket_server_hostname_get_impl(PySSLSocket *self)
 @critical_section
 @getter
 _ssl._SSLSocket.owner
-
-The Python-level owner of this object. Passed as "self" in servername callback.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_owner_get_impl(PySSLSocket *self)
-/*[clinic end generated code: output=1f278cb930382927 input=57fd0d5f2644757a]*/
+/*[clinic end generated code: output=1f278cb930382927 input=bc2861ff3cf1402e]*/
 {
     if (self->owner == NULL) {
         Py_RETURN_NONE;
@@ -2852,13 +2850,11 @@ _ssl__SSLSocket_verify_client_post_handshake_impl(PySSLSocket *self)
 @critical_section
 @getter
 _ssl._SSLSocket.session
-
-Get / set SSLSession.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_session_get_impl(PySSLSocket *self)
-/*[clinic end generated code: output=a5cd5755b35da670 input=be77165ad3547c3d]*/
+/*[clinic end generated code: output=a5cd5755b35da670 input=b9792df9255a9f63]*/
 {
     /* get_session can return sessions from a server-side connection,
      * it does not check for handshake done or client socket. */

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5515,15 +5515,20 @@ _ssl_SSLSession_time_get_impl(PySSLSession *self)
 #endif
 }
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl.SSLSession.timeout
+[clinic start generated code]*/
+
 static PyObject *
-PySSLSession_get_timeout(PySSLSession *self, void *closure) {
+_ssl_SSLSession_timeout_get_impl(PySSLSession *self)
+/*[clinic end generated code: output=82339c148ab2f7d1 input=ae5e84a9d85df60d]*/
+{
     long timeout = SSL_SESSION_get_timeout(self->session);
     PyObject *res = PyLong_FromLong(timeout);
     return res;
 }
-
-PyDoc_STRVAR(PySSLSession_get_timeout_doc,
-"Session timeout (delta in seconds).");
 
 /*[clinic input]
 @critical_section
@@ -5578,8 +5583,7 @@ static PyGetSetDef PySSLSession_getsetlist[] = {
     _SSL_SSLSESSION_SESSION_ID_GETSETDEF
     _SSL_SSLSESSION_TICKET_LIFETIME_HINT_GETSETDEF
     _SSL_SSLSESSION_TIME_GETSETDEF
-    {"timeout", (getter) PySSLSession_get_timeout, NULL,
-              PySSLSession_get_timeout_doc},
+    _SSL_SSLSESSION_TIMEOUT_GETSETDEF
     {NULL},            /* sentinel */
 };
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -890,7 +890,6 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
 #undef SID_CTX
     }
 
-    PySSL_LOCK(self);
     /* bpo43522 and OpenSSL < 1.1.1l: copy hostflags manually */
 #if OPENSSL_VERSION < 0x101010cf
     X509_VERIFY_PARAM *ssl_params = SSL_get0_param(self->ssl);
@@ -927,7 +926,6 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
         }
     }
 #endif
-    PySSL_UNLOCK(self);
 
     if (server_hostname != NULL) {
         if (_ssl_configure_hostname(self, server_hostname) < 0) {
@@ -939,19 +937,15 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
      * to non-blocking mode (blocking is the default)
      */
     if (sock && sock->sock_timeout >= 0) {
-        PySSL_LOCK(self);
         BIO_set_nbio(SSL_get_rbio(self->ssl), 1);
         BIO_set_nbio(SSL_get_wbio(self->ssl), 1);
-        PySSL_UNLOCK(self);
     }
 
     PySSL_BEGIN_ALLOW_THREADS
-    PySSL_LOCK(self);
     if (socket_type == PY_SSL_CLIENT)
         SSL_set_connect_state(self->ssl);
     else
         SSL_set_accept_state(self->ssl);
-    PySSL_UNLOCK(self);
     PySSL_END_ALLOW_THREADS
 
     self->socket_type = socket_type;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4755,6 +4755,7 @@ X509_STORE_get1_objects(X509_STORE *store)
     ret = sk_X509_OBJECT_deep_copy(X509_STORE_get0_objects(store),
                                    x509_object_dup, X509_OBJECT_free);
     X509_STORE_unlock(store);
+    return ret;
 }
 #endif
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5576,10 +5576,6 @@ _ssl_SSLSession_has_ticket_get_impl(PySSLSession *self)
     return res ? Py_True : Py_False;
 }
 
-PyDoc_STRVAR(PySSLSession_get_has_ticket_doc,
-"Does the session contain a ticket?");
-
-
 static PyGetSetDef PySSLSession_getsetlist[] = {
     _SSL_SSLSESSION_HAS_TICKET_GETSETDEF
     _SSL_SSLSESSION_ID_GETSETDEF

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3815,14 +3815,16 @@ set_check_hostname(PySSLContext *self, PyObject *arg, void *c)
     if (!PyArg_Parse(arg, "p", &check_hostname))
         return -1;
     PySSL_LOCK(self);
+    int verify_mode = check_hostname ? SSL_CTX_get_verify_mode(self->ctx) : 0;
+    PySSL_UNLOCK(self);
     if (check_hostname &&
-            SSL_CTX_get_verify_mode(self->ctx) == SSL_VERIFY_NONE) {
+            verify_mode == SSL_VERIFY_NONE) {
         /* check_hostname = True sets verify_mode = CERT_REQUIRED */
         if (_set_verify_mode(self, PY_SSL_CERT_REQUIRED) == -1) {
-            PySSL_UNLOCK(self);
             return -1;
         }
     }
+    PySSL_LOCK(self);
     self->check_hostname = check_hostname;
     PySSL_UNLOCK(self);
     return 0;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -945,12 +945,13 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
 /* SSL object methods */
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.do_handshake
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_do_handshake_impl(PySSLSocket *self)
-/*[clinic end generated code: output=6c0898a8936548f6 input=d2d737de3df018c8]*/
+/*[clinic end generated code: output=6c0898a8936548f6 input=65619a7a4bea3176]*/
 {
     int ret;
     _PySSLError err;
@@ -984,10 +985,6 @@ _ssl__SSLSocket_do_handshake_impl(PySSLSocket *self)
     /* XXX If SSL_do_handshake() returns 0, it's also a failure. */
     do {
         PySSL_BEGIN_ALLOW_THREADS
-        // XXX This isn't thread safe anymore, but locking this can cause a
-        // deadlock if a callback is active (see bpo-43577). I guess this
-        // isn't a huge problem because people shouldn't be calling
-        // do_handshake() across multiple threads anyway.
         ret = SSL_do_handshake(self->ssl);
         err = _PySSL_errno(ret < 1, self->ssl, ret);
         PySSL_END_ALLOW_THREADS
@@ -1824,6 +1821,7 @@ _ssl__test_decode_cert_impl(PyObject *module, PyObject *path)
 
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.getpeercert
     der as binary_mode: bool = False
     /
@@ -1841,7 +1839,7 @@ return the certificate even if it wasn't validated.
 
 static PyObject *
 _ssl__SSLSocket_getpeercert_impl(PySSLSocket *self, int binary_mode)
-/*[clinic end generated code: output=1f0ab66dfb693c88 input=c0fbe802e57629b7]*/
+/*[clinic end generated code: output=1f0ab66dfb693c88 input=e35af55fa5f9bab8]*/
 {
     int verification;
     X509 *peer_cert;
@@ -1871,13 +1869,14 @@ _ssl__SSLSocket_getpeercert_impl(PySSLSocket *self, int binary_mode)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.get_verified_chain
 
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_get_verified_chain_impl(PySSLSocket *self)
-/*[clinic end generated code: output=802421163cdc3110 input=5fb0714f77e2bd51]*/
+/*[clinic end generated code: output=802421163cdc3110 input=83035fe238ec057b]*/
 {
     /* borrowed reference */
     STACK_OF(X509) *chain = SSL_get0_verified_chain(self->ssl);
@@ -1888,13 +1887,14 @@ _ssl__SSLSocket_get_verified_chain_impl(PySSLSocket *self)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.get_unverified_chain
 
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_get_unverified_chain_impl(PySSLSocket *self)
-/*[clinic end generated code: output=5acdae414e13f913 input=78c33c360c635cb5]*/
+/*[clinic end generated code: output=5acdae414e13f913 input=079f8ff5c205cb3b]*/
 {
     PyObject *retval;
     /* borrowed reference */
@@ -2024,12 +2024,13 @@ cipher_to_dict(const SSL_CIPHER *cipher)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.shared_ciphers
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_shared_ciphers_impl(PySSLSocket *self)
-/*[clinic end generated code: output=3d174ead2e42c4fd input=0bfe149da8fe6306]*/
+/*[clinic end generated code: output=3d174ead2e42c4fd input=869645271e3bc6d0]*/
 {
     STACK_OF(SSL_CIPHER) *server_ciphers;
     STACK_OF(SSL_CIPHER) *client_ciphers;
@@ -2073,12 +2074,13 @@ _ssl__SSLSocket_shared_ciphers_impl(PySSLSocket *self)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.cipher
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_cipher_impl(PySSLSocket *self)
-/*[clinic end generated code: output=376417c16d0e5815 input=548fb0e27243796d]*/
+/*[clinic end generated code: output=376417c16d0e5815 input=39e180269a36f486]*/
 {
     const SSL_CIPHER *current;
 
@@ -2091,12 +2093,13 @@ _ssl__SSLSocket_cipher_impl(PySSLSocket *self)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.version
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_version_impl(PySSLSocket *self)
-/*[clinic end generated code: output=178aed33193b2cdb input=900186a503436fd6]*/
+/*[clinic end generated code: output=178aed33193b2cdb input=2732bc3f7f597d09]*/
 {
     const char *version;
 
@@ -2113,12 +2116,13 @@ _ssl__SSLSocket_version_impl(PySSLSocket *self)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.selected_alpn_protocol
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_selected_alpn_protocol_impl(PySSLSocket *self)
-/*[clinic end generated code: output=ec33688b303d250f input=442de30e35bc2913]*/
+/*[clinic end generated code: output=ec33688b303d250f input=f0b53506c9acdf8c]*/
 {
     const unsigned char *out;
     unsigned int outlen;
@@ -2347,6 +2351,7 @@ PySSL_select(PySocketSockObject *s, int writing, PyTime_t timeout)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.write
     b: Py_buffer
     /
@@ -2358,7 +2363,7 @@ Returns the number of bytes written.
 
 static PyObject *
 _ssl__SSLSocket_write_impl(PySSLSocket *self, Py_buffer *b)
-/*[clinic end generated code: output=aa7a6be5527358d8 input=77262d994fe5100a]*/
+/*[clinic end generated code: output=aa7a6be5527358d8 input=967b5feeae641a26]*/
 {
     size_t count = 0;
     int retval;
@@ -2456,6 +2461,7 @@ error:
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.pending
 
 Returns the number of already decrypted bytes available for read, pending on the connection.
@@ -2463,7 +2469,7 @@ Returns the number of already decrypted bytes available for read, pending on the
 
 static PyObject *
 _ssl__SSLSocket_pending_impl(PySSLSocket *self)
-/*[clinic end generated code: output=983d9fecdc308a83 input=2b77487d6dfd597f]*/
+/*[clinic end generated code: output=983d9fecdc308a83 input=32ab982a254e8866]*/
 {
     int count = 0;
     _PySSLError err;
@@ -2481,6 +2487,7 @@ _ssl__SSLSocket_pending_impl(PySSLSocket *self)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.read
     size as len: Py_ssize_t
     [
@@ -2494,7 +2501,7 @@ Read up to size bytes from the SSL socket.
 static PyObject *
 _ssl__SSLSocket_read_impl(PySSLSocket *self, Py_ssize_t len,
                           int group_right_1, Py_buffer *buffer)
-/*[clinic end generated code: output=49b16e6406023734 input=ec48bf622be1c4a1]*/
+/*[clinic end generated code: output=49b16e6406023734 input=80ed30436df01a71]*/
 {
     PyObject *dest = NULL;
     char *mem;
@@ -2623,6 +2630,7 @@ error:
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.shutdown
 
 Does the SSL shutdown handshake with the remote end.
@@ -2630,7 +2638,7 @@ Does the SSL shutdown handshake with the remote end.
 
 static PyObject *
 _ssl__SSLSocket_shutdown_impl(PySSLSocket *self)
-/*[clinic end generated code: output=ca1aa7ed9d25ca42 input=11d39e69b0a2bf4a]*/
+/*[clinic end generated code: output=ca1aa7ed9d25ca42 input=98d9635cd4e16514]*/
 {
     _PySSLError err;
     int sockstate, nonblocking, ret;
@@ -2742,6 +2750,7 @@ error:
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.get_channel_binding
    cb_type: str = "tls-unique"
 
@@ -2755,7 +2764,7 @@ Only 'tls-unique' channel binding data from RFC 5929 is supported.
 static PyObject *
 _ssl__SSLSocket_get_channel_binding_impl(PySSLSocket *self,
                                          const char *cb_type)
-/*[clinic end generated code: output=34bac9acb6a61d31 input=08b7e43b99c17d41]*/
+/*[clinic end generated code: output=34bac9acb6a61d31 input=e008004fc08744db]*/
 {
     char buf[PySSL_CB_MAXLEN];
     size_t len;
@@ -2787,6 +2796,7 @@ _ssl__SSLSocket_get_channel_binding_impl(PySSLSocket *self,
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLSocket.verify_client_post_handshake
 
 Initiate TLS 1.3 post-handshake authentication
@@ -2794,7 +2804,7 @@ Initiate TLS 1.3 post-handshake authentication
 
 static PyObject *
 _ssl__SSLSocket_verify_client_post_handshake_impl(PySSLSocket *self)
-/*[clinic end generated code: output=532147f3b1341425 input=6bfa874810a3d889]*/
+/*[clinic end generated code: output=532147f3b1341425 input=42b5bb1f0981eda1]*/
 {
 #if defined(PySSL_HAVE_POST_HS_AUTH)
     int err = SSL_verify_client_post_handshake(self->ssl);
@@ -2968,6 +2978,7 @@ _set_verify_mode(PySSLContext *self, enum py_ssl_cert_requirements n)
 }
 
 /*[clinic input]
+@critical_section
 @classmethod
 _ssl._SSLContext.__new__
     protocol as proto_version: int
@@ -2976,7 +2987,7 @@ _ssl._SSLContext.__new__
 
 static PyObject *
 _ssl__SSLContext_impl(PyTypeObject *type, int proto_version)
-/*[clinic end generated code: output=2cf0d7a0741b6bd1 input=8d58a805b95fc534]*/
+/*[clinic end generated code: output=2cf0d7a0741b6bd1 input=6fc79e62ae9d143c]*/
 {
     PySSLContext *self;
     uint64_t options;
@@ -3216,6 +3227,7 @@ context_dealloc(PySSLContext *self)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.set_ciphers
     cipherlist: str
     /
@@ -3223,7 +3235,7 @@ _ssl._SSLContext.set_ciphers
 
 static PyObject *
 _ssl__SSLContext_set_ciphers_impl(PySSLContext *self, const char *cipherlist)
-/*[clinic end generated code: output=3a3162f3557c0f3f input=a7ac931b9f3ca7fc]*/
+/*[clinic end generated code: output=3a3162f3557c0f3f input=40b583cded5c6ff9]*/
 {
     int ret = SSL_CTX_set_cipher_list(self->ctx, cipherlist);
     if (ret == 0) {
@@ -3239,12 +3251,13 @@ _ssl__SSLContext_set_ciphers_impl(PySSLContext *self, const char *cipherlist)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.get_ciphers
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLContext_get_ciphers_impl(PySSLContext *self)
-/*[clinic end generated code: output=a56e4d68a406dfc4 input=a2aadc9af89b79c5]*/
+/*[clinic end generated code: output=a56e4d68a406dfc4 input=d7fff51631a260ae]*/
 {
     SSL *ssl = NULL;
     STACK_OF(SSL_CIPHER) *sk = NULL;
@@ -3319,6 +3332,7 @@ _selectALPN_cb(SSL *s,
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext._set_alpn_protocols
     protos: Py_buffer
     /
@@ -3327,7 +3341,7 @@ _ssl._SSLContext._set_alpn_protocols
 static PyObject *
 _ssl__SSLContext__set_alpn_protocols_impl(PySSLContext *self,
                                           Py_buffer *protos)
-/*[clinic end generated code: output=87599a7f76651a9b input=9bba964595d519be]*/
+/*[clinic end generated code: output=87599a7f76651a9b input=b5096b186e49287d]*/
 {
     if ((size_t)protos->len > UINT_MAX) {
         PyErr_Format(PyExc_OverflowError,
@@ -3822,6 +3836,7 @@ error:
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.load_cert_chain
     certfile: object
     keyfile: object = None
@@ -3832,7 +3847,7 @@ _ssl._SSLContext.load_cert_chain
 static PyObject *
 _ssl__SSLContext_load_cert_chain_impl(PySSLContext *self, PyObject *certfile,
                                       PyObject *keyfile, PyObject *password)
-/*[clinic end generated code: output=9480bc1c380e2095 input=30bc7e967ea01a58]*/
+/*[clinic end generated code: output=9480bc1c380e2095 input=6c7c5e8b73e4264b]*/
 {
     PyObject *certfile_bytes = NULL, *keyfile_bytes = NULL;
     pem_password_cb *orig_passwd_cb = SSL_CTX_get_default_passwd_cb(self->ctx);
@@ -4026,6 +4041,7 @@ _add_ca_certs(PySSLContext *self, const void *data, Py_ssize_t len,
 
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.load_verify_locations
     cafile: object = None
     capath: object = None
@@ -4038,7 +4054,7 @@ _ssl__SSLContext_load_verify_locations_impl(PySSLContext *self,
                                             PyObject *cafile,
                                             PyObject *capath,
                                             PyObject *cadata)
-/*[clinic end generated code: output=454c7e41230ca551 input=42ecfe258233e194]*/
+/*[clinic end generated code: output=454c7e41230ca551 input=b178852b41618414]*/
 {
     PyObject *cafile_bytes = NULL, *capath_bytes = NULL;
     const char *cafile_buf = NULL, *capath_buf = NULL;
@@ -4154,6 +4170,7 @@ _ssl__SSLContext_load_verify_locations_impl(PySSLContext *self,
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.load_dh_params
     path as filepath: object
     /
@@ -4161,8 +4178,8 @@ _ssl._SSLContext.load_dh_params
 [clinic start generated code]*/
 
 static PyObject *
-_ssl__SSLContext_load_dh_params(PySSLContext *self, PyObject *filepath)
-/*[clinic end generated code: output=1c8e57a38e055af0 input=c8871f3c796ae1d6]*/
+_ssl__SSLContext_load_dh_params_impl(PySSLContext *self, PyObject *filepath)
+/*[clinic end generated code: output=dd74b3c524dd2723 input=832769a0734b8c4d]*/
 {
     FILE *f;
     DH *dh;
@@ -4195,6 +4212,7 @@ _ssl__SSLContext_load_dh_params(PySSLContext *self, PyObject *filepath)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext._wrap_socket
     sock: object(subclass_of="get_state_ctx(self)->Sock_Type")
     server_side: bool
@@ -4209,7 +4227,7 @@ static PyObject *
 _ssl__SSLContext__wrap_socket_impl(PySSLContext *self, PyObject *sock,
                                    int server_side, PyObject *hostname_obj,
                                    PyObject *owner, PyObject *session)
-/*[clinic end generated code: output=f103f238633940b4 input=700ca8fedff53994]*/
+/*[clinic end generated code: output=f103f238633940b4 input=eceadcee4434a06f]*/
 {
     char *hostname = NULL;
     PyObject *res;
@@ -4231,6 +4249,7 @@ _ssl__SSLContext__wrap_socket_impl(PySSLContext *self, PyObject *sock,
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext._wrap_bio
     incoming: object(subclass_of="get_state_ctx(self)->PySSLMemoryBIO_Type", type="PySSLMemoryBIO *")
     outgoing: object(subclass_of="get_state_ctx(self)->PySSLMemoryBIO_Type", type="PySSLMemoryBIO *")
@@ -4247,7 +4266,7 @@ _ssl__SSLContext__wrap_bio_impl(PySSLContext *self, PySSLMemoryBIO *incoming,
                                 PySSLMemoryBIO *outgoing, int server_side,
                                 PyObject *hostname_obj, PyObject *owner,
                                 PyObject *session)
-/*[clinic end generated code: output=5c5d6d9b41f99332 input=a9205d097fd45a82]*/
+/*[clinic end generated code: output=5c5d6d9b41f99332 input=58277fc962a60182]*/
 {
     char *hostname = NULL;
     PyObject *res;
@@ -4268,12 +4287,13 @@ _ssl__SSLContext__wrap_bio_impl(PySSLContext *self, PySSLMemoryBIO *incoming,
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.session_stats
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLContext_session_stats_impl(PySSLContext *self)
-/*[clinic end generated code: output=0d96411c42893bfb input=7e0a81fb11102c8b]*/
+/*[clinic end generated code: output=0d96411c42893bfb input=db62af53004127a4]*/
 {
     int r;
     PyObject *value, *stats = PyDict_New();
@@ -4312,12 +4332,13 @@ error:
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.set_default_verify_paths
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLContext_set_default_verify_paths_impl(PySSLContext *self)
-/*[clinic end generated code: output=0bee74e6e09deaaa input=35f3408021463d74]*/
+/*[clinic end generated code: output=0bee74e6e09deaaa input=939a88e78f634119]*/
 {
     int rc;
     Py_BEGIN_ALLOW_THREADS
@@ -4331,6 +4352,7 @@ _ssl__SSLContext_set_default_verify_paths_impl(PySSLContext *self)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.set_ecdh_curve
     name: object
     /
@@ -4338,8 +4360,8 @@ _ssl._SSLContext.set_ecdh_curve
 [clinic start generated code]*/
 
 static PyObject *
-_ssl__SSLContext_set_ecdh_curve(PySSLContext *self, PyObject *name)
-/*[clinic end generated code: output=23022c196e40d7d2 input=c2bafb6f6e34726b]*/
+_ssl__SSLContext_set_ecdh_curve_impl(PySSLContext *self, PyObject *name)
+/*[clinic end generated code: output=01081151ce0ecc45 input=039df032e666870e]*/
 {
     PyObject *name_bytes;
     int nid;
@@ -4561,6 +4583,7 @@ with the SSLSocket, the server name as a string, and the SSLContext object.\n\
 See RFC 6066 for details of the SNI extension.");
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.cert_store_stats
 
 Returns quantities of loaded X.509 certificates.
@@ -4574,7 +4597,7 @@ been used at least once.
 
 static PyObject *
 _ssl__SSLContext_cert_store_stats_impl(PySSLContext *self)
-/*[clinic end generated code: output=5f356f4d9cca874d input=eb40dd0f6d0e40cf]*/
+/*[clinic end generated code: output=5f356f4d9cca874d input=d13c6e3f2b48539b]*/
 {
     X509_STORE *store;
     STACK_OF(X509_OBJECT) *objs;
@@ -4611,6 +4634,7 @@ _ssl__SSLContext_cert_store_stats_impl(PySSLContext *self)
 }
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.get_ca_certs
     binary_form: bool = False
 
@@ -4625,7 +4649,7 @@ been used at least once.
 
 static PyObject *
 _ssl__SSLContext_get_ca_certs_impl(PySSLContext *self, int binary_form)
-/*[clinic end generated code: output=0d58f148f37e2938 input=6887b5a09b7f9076]*/
+/*[clinic end generated code: output=0d58f148f37e2938 input=eb0592909c9ad6e7]*/
 {
     X509_STORE *store;
     STACK_OF(X509_OBJECT) *objs;
@@ -4751,6 +4775,7 @@ error:
 #endif
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.set_psk_client_callback
     callback: object
 
@@ -4759,7 +4784,7 @@ _ssl._SSLContext.set_psk_client_callback
 static PyObject *
 _ssl__SSLContext_set_psk_client_callback_impl(PySSLContext *self,
                                               PyObject *callback)
-/*[clinic end generated code: output=0aba86f6ed75119e input=7627bae0e5ee7635]*/
+/*[clinic end generated code: output=0aba86f6ed75119e input=1e436eea625cfc35]*/
 {
 #ifndef OPENSSL_NO_PSK
     if (self->protocol == PY_SSL_VERSION_TLS_SERVER) {
@@ -4859,6 +4884,7 @@ error:
 #endif
 
 /*[clinic input]
+@critical_section
 _ssl._SSLContext.set_psk_server_callback
     callback: object
     identity_hint: str(accept={str, NoneType}) = None
@@ -4869,7 +4895,7 @@ static PyObject *
 _ssl__SSLContext_set_psk_server_callback_impl(PySSLContext *self,
                                               PyObject *callback,
                                               const char *identity_hint)
-/*[clinic end generated code: output=1f4d6a4e09a92b03 input=65d4b6022aa85ea3]*/
+/*[clinic end generated code: output=1f4d6a4e09a92b03 input=5f79d932458284a7]*/
 {
 #ifndef OPENSSL_NO_PSK
     if (self->protocol == PY_SSL_VERSION_TLS_CLIENT) {
@@ -4995,6 +5021,7 @@ static PyType_Spec PySSLContext_spec = {
  */
 
 /*[clinic input]
+@critical_section
 @classmethod
 _ssl.MemoryBIO.__new__
 
@@ -5002,7 +5029,7 @@ _ssl.MemoryBIO.__new__
 
 static PyObject *
 _ssl_MemoryBIO_impl(PyTypeObject *type)
-/*[clinic end generated code: output=8820a58db78330ac input=26d22e4909ecb1b5]*/
+/*[clinic end generated code: output=8820a58db78330ac input=87f146cf30af454e]*/
 {
     BIO *bio;
     PySSLMemoryBIO *self;
@@ -5068,6 +5095,7 @@ PyDoc_STRVAR(PySSL_memory_bio_eof_doc,
 "Whether the memory BIO is at EOF.");
 
 /*[clinic input]
+@critical_section
 _ssl.MemoryBIO.read
     size as len: int = -1
     /
@@ -5082,7 +5110,7 @@ distinguish between the two.
 
 static PyObject *
 _ssl_MemoryBIO_read_impl(PySSLMemoryBIO *self, int len)
-/*[clinic end generated code: output=a657aa1e79cd01b3 input=574d7be06a902366]*/
+/*[clinic end generated code: output=a657aa1e79cd01b3 input=21046f2d7dac3a90]*/
 {
     int avail, nbytes;
     PyObject *result;
@@ -5112,6 +5140,7 @@ _ssl_MemoryBIO_read_impl(PySSLMemoryBIO *self, int len)
 }
 
 /*[clinic input]
+@critical_section
 _ssl.MemoryBIO.write
     b: Py_buffer
     /
@@ -5123,7 +5152,7 @@ Returns the number of bytes written.
 
 static PyObject *
 _ssl_MemoryBIO_write_impl(PySSLMemoryBIO *self, Py_buffer *b)
-/*[clinic end generated code: output=156ec59110d75935 input=e45757b3e17c4808]*/
+/*[clinic end generated code: output=156ec59110d75935 input=107da3f5fba26b37]*/
 {
     int nbytes;
 
@@ -5153,6 +5182,7 @@ _ssl_MemoryBIO_write_impl(PySSLMemoryBIO *self, Py_buffer *b)
 }
 
 /*[clinic input]
+@critical_section
 _ssl.MemoryBIO.write_eof
 
 Write an EOF marker to the memory BIO.
@@ -5162,7 +5192,7 @@ When all data has been read, the "eof" property will be True.
 
 static PyObject *
 _ssl_MemoryBIO_write_eof_impl(PySSLMemoryBIO *self)
-/*[clinic end generated code: output=d4106276ccd1ed34 input=56a945f1d29e8bd6]*/
+/*[clinic end generated code: output=d4106276ccd1ed34 input=1e914231b1c5900a]*/
 {
     self->eof_written = 1;
     /* After an EOF is written, a zero return from read() should be a real EOF
@@ -5300,10 +5330,10 @@ PySSLSession_clear(PySSLSession *self)
 static PyObject *
 PySSLSession_get_time(PySSLSession *self, void *closure) {
 #if OPENSSL_VERSION_NUMBER >= 0x30300000L
-    int time = SSL_SESSION_get_time(self->session);
-    PyObject *res = PyLong_FromLong(time);
+    return _PyLong_FromTime_t(SSL_SESSION_get_time_ex(self->session));
+#else
+    return PyLong_FromLong(SSL_SESSION_get_time(self->session));
 #endif
-    return res;
 }
 
 PyDoc_STRVAR(PySSLSession_get_time_doc,
@@ -5388,6 +5418,7 @@ static PyType_Spec PySSLSession_spec = {
 
 /* helper routines for seeding the SSL PRNG */
 /*[clinic input]
+@critical_section
 _ssl.RAND_add
     string as view: Py_buffer(accept={str, buffer})
     entropy: double
@@ -5401,7 +5432,7 @@ string.  See RFC 4086.
 
 static PyObject *
 _ssl_RAND_add_impl(PyObject *module, Py_buffer *view, double entropy)
-/*[clinic end generated code: output=e6dd48df9c9024e9 input=5c33017422828f5c]*/
+/*[clinic end generated code: output=e6dd48df9c9024e9 input=313cb73b34db31d5]*/
 {
     const char *buf;
     Py_ssize_t len, written;
@@ -5457,6 +5488,7 @@ PySSL_RAND(PyObject *module, int len, int pseudo)
 }
 
 /*[clinic input]
+@critical_section
 _ssl.RAND_bytes
     n: int
     /
@@ -5466,13 +5498,14 @@ Generate n cryptographically strong pseudo-random bytes.
 
 static PyObject *
 _ssl_RAND_bytes_impl(PyObject *module, int n)
-/*[clinic end generated code: output=977da635e4838bc7 input=678ddf2872dfebfc]*/
+/*[clinic end generated code: output=977da635e4838bc7 input=2e78ce1e86336776]*/
 {
     return PySSL_RAND(module, n, 0);
 }
 
 
 /*[clinic input]
+@critical_section
 _ssl.RAND_status
 
 Returns True if the OpenSSL PRNG has been seeded with enough data and False if not.
@@ -5483,12 +5516,13 @@ using the ssl() function.
 
 static PyObject *
 _ssl_RAND_status_impl(PyObject *module)
-/*[clinic end generated code: output=7e0aaa2d39fdc1ad input=d5ae5aea52f36e01]*/
+/*[clinic end generated code: output=7e0aaa2d39fdc1ad input=636fb5659ea2e727]*/
 {
     return PyBool_FromLong(RAND_status());
 }
 
 /*[clinic input]
+@critical_section
 _ssl.get_default_verify_paths
 
 Return search paths and environment vars that are used by SSLContext's set_default_verify_paths() to load default CAs.
@@ -5498,7 +5532,7 @@ The values are 'cert_file_env', 'cert_file', 'cert_dir_env', 'cert_dir'.
 
 static PyObject *
 _ssl_get_default_verify_paths_impl(PyObject *module)
-/*[clinic end generated code: output=e5b62a466271928b input=5210c953d98c3eb5]*/
+/*[clinic end generated code: output=e5b62a466271928b input=c6ae00bc04eb2b6e]*/
 {
     PyObject *ofile_env = NULL;
     PyObject *ofile = NULL;
@@ -5547,6 +5581,7 @@ asn1obj2py(_sslmodulestate *state, ASN1_OBJECT *obj)
 }
 
 /*[clinic input]
+@critical_section
 _ssl.txt2obj
     txt: str
     name: bool = False
@@ -5559,7 +5594,7 @@ long name are also matched.
 
 static PyObject *
 _ssl_txt2obj_impl(PyObject *module, const char *txt, int name)
-/*[clinic end generated code: output=c38e3991347079c1 input=1c1e7d0aa7c48602]*/
+/*[clinic end generated code: output=c38e3991347079c1 input=c99b134d70173c5e]*/
 {
     PyObject *result = NULL;
     ASN1_OBJECT *obj;
@@ -5575,6 +5610,7 @@ _ssl_txt2obj_impl(PyObject *module, const char *txt, int name)
 }
 
 /*[clinic input]
+@critical_section
 _ssl.nid2obj
     nid: int
     /
@@ -5584,7 +5620,7 @@ Lookup NID, short name, long name and OID of an ASN1_OBJECT by NID.
 
 static PyObject *
 _ssl_nid2obj_impl(PyObject *module, int nid)
-/*[clinic end generated code: output=4a98ab691cd4f84a input=51787a3bee7d8f98]*/
+/*[clinic end generated code: output=4a98ab691cd4f84a input=1b1170506fa83a53]*/
 {
     PyObject *result = NULL;
     ASN1_OBJECT *obj;
@@ -5736,6 +5772,7 @@ ssl_collect_certificates(const char *store_name)
 }
 
 /*[clinic input]
+@critical_section
 _ssl.enum_certificates
     store_name: str
 
@@ -5750,7 +5787,7 @@ a set of OIDs or the boolean True.
 
 static PyObject *
 _ssl_enum_certificates_impl(PyObject *module, const char *store_name)
-/*[clinic end generated code: output=5134dc8bb3a3c893 input=915f60d70461ea4e]*/
+/*[clinic end generated code: output=5134dc8bb3a3c893 input=263c22e6c6988cf3]*/
 {
     HCERTSTORE hCollectionStore = NULL;
     PCCERT_CONTEXT pCertCtx = NULL;
@@ -5835,6 +5872,7 @@ _ssl_enum_certificates_impl(PyObject *module, const char *store_name)
 }
 
 /*[clinic input]
+@critical_section
 _ssl.enum_crls
     store_name: str
 
@@ -5848,7 +5886,7 @@ X509_ASN_ENCODING or PKCS_7_ASN_ENCODING.
 
 static PyObject *
 _ssl_enum_crls_impl(PyObject *module, const char *store_name)
-/*[clinic end generated code: output=bce467f60ccd03b6 input=a1f1d7629f1c5d3d]*/
+/*[clinic end generated code: output=bce467f60ccd03b6 input=51a1b1059e55ce43]*/
 {
     HCERTSTORE hCollectionStore = NULL;
     PCCRL_CONTEXT pCrlCtx = NULL;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3849,8 +3849,16 @@ set_post_handshake_auth(PySSLContext *self, PyObject *arg, void *c) {
 }
 #endif
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLContext.protocol
+[clinic start generated code]*/
+
 static PyObject *
-get_protocol(PySSLContext *self, void *c) {
+_ssl__SSLContext_protocol_get_impl(PySSLContext *self)
+/*[clinic end generated code: output=a9a48febc16cee22 input=c9f5fa1a2bd4b8a8]*/
+{
     return PyLong_FromLong(self->protocol);
 }
 
@@ -5094,8 +5102,7 @@ static PyGetSetDef context_getsetlist[] = {
                             NULL,
 #endif
                             NULL},
-    {"protocol", (getter) get_protocol,
-                 NULL, NULL},
+    _SSL__SSLCONTEXT_PROTOCOL_GETSETDEF
     {"verify_flags", (getter) get_verify_flags,
                      (setter) set_verify_flags, NULL},
     {"verify_mode", (getter) get_verify_mode,

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3151,7 +3151,10 @@ _ssl__SSLContext_impl(PyTypeObject *type, int proto_version)
         return NULL;
     }
 
-    // This is the constructor, no need to lock it.
+    // This is the constructor, no need to lock it, because
+    // no other thread can be touching this object yet.
+    // (Technically, we can't even lock if we wanted to, as the
+    // lock hasn't been initialized yet.)
     PySSL_BEGIN_ALLOW_THREADS
     ctx = SSL_CTX_new(method);
     PySSL_END_ALLOW_THREADS

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5522,15 +5522,19 @@ PyDoc_STRVAR(PySSLSession_get_timeout_doc,
 "Session timeout (delta in seconds).");
 
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl.SSLSession.ticket_lifetime_hint
+[clinic start generated code]*/
+
 static PyObject *
-PySSLSession_get_ticket_lifetime_hint(PySSLSession *self, void *closure) {
+_ssl_SSLSession_ticket_lifetime_hint_get_impl(PySSLSession *self)
+/*[clinic end generated code: output=c8b6db498136c275 input=d0e06942ddd8d07f]*/
+{
     unsigned long hint = SSL_SESSION_get_ticket_lifetime_hint(self->session);
     return PyLong_FromUnsignedLong(hint);
 }
-
-PyDoc_STRVAR(PySSLSession_get_ticket_lifetime_hint_doc,
-"Ticket life time hint.");
-
 
 /*[clinic input]
 @critical_section
@@ -5568,10 +5572,8 @@ PyDoc_STRVAR(PySSLSession_get_has_ticket_doc,
 
 static PyGetSetDef PySSLSession_getsetlist[] = {
     _SSL_SSLSESSION_HAS_TICKET_GETSETDEF
-    {"id",   (getter) PySSLSession_get_session_id, NULL,
-              PySSLSession_get_session_id_doc},
-    {"ticket_lifetime_hint", (getter) PySSLSession_get_ticket_lifetime_hint,
-              NULL, PySSLSession_get_ticket_lifetime_hint_doc},
+    _SSL_SSLSESSION_SESSION_ID_GETSETDEF
+    _SSL_SSLSESSION_TICKET_LIFETIME_HINT_GETSETDEF
     {"time", (getter) PySSLSession_get_time, NULL,
               PySSLSession_get_time_doc},
     {"timeout", (getter) PySSLSession_get_timeout, NULL,

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3416,14 +3416,15 @@ _ssl__SSLContext__set_alpn_protocols_impl(PySSLContext *self,
         return NULL;
     }
 
+    PySSL_LOCK(self);
     PyMem_Free(self->alpn_protocols);
     self->alpn_protocols = PyMem_Malloc(protos->len);
-    if (!self->alpn_protocols)
+    if (!self->alpn_protocols) {
+        PySSL_UNLOCK(self);
         return PyErr_NoMemory();
+    }
     memcpy(self->alpn_protocols, protos->buf, protos->len);
     self->alpn_protocols_len = (unsigned int)protos->len;
-
-    PySSL_LOCK(self);
     if (SSL_CTX_set_alpn_protos(self->ctx, self->alpn_protocols, self->alpn_protocols_len)) {
         PySSL_UNLOCK(self);
         return PyErr_NoMemory();

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -637,7 +637,7 @@ PySSL_SetError(PySSLSocket *sslsock, const char *filename, int lineno)
     _sslmodulestate *state = get_state_sock(sslsock);
     type = state->PySSLErrorObject;
 
-    // XXX Are ERR functions thread-safe?
+    // ERR functions are thread local, no need to lock them.
     e = ERR_peek_last_error();
 
     if (sslsock->ssl != NULL) {

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -52,8 +52,8 @@
 #define PySSL_END_ALLOW_THREADS PySSL_END_ALLOW_THREADS_S(_save); }
 
 #ifdef Py_GIL_DISABLED
-#define PySSL_LOCK(obj) PyMutex_Lock(obj->lock)
-#define PySSL_UNLOCK(obj) PyMutex_Unlock(obj->lock)
+#define PySSL_LOCK(obj) PyMutex_Lock(&(obj)->lock)
+#define PySSL_UNLOCK(obj) PyMutex_Unlock(&(obj)->lock)
 #else
 #define PySSL_LOCK(obj)
 #define PySSL_UNLOCK(obj)
@@ -2196,7 +2196,7 @@ _ssl__SSLSocket_compression_impl(PySSLSocket *self)
         Py_RETURN_NONE;
     PySSL_LOCK(self);
     comp_method = SSL_get_current_compression(self->ssl);
-    PySSL_UNLOCK(self)
+    PySSL_UNLOCK(self);
     if (comp_method == NULL || COMP_get_type(comp_method) == NID_undef)
         Py_RETURN_NONE;
     short_name = OBJ_nid2sn(COMP_get_type(comp_method));
@@ -5431,14 +5431,14 @@ PySSLSession_richcompare(PyObject *left, PyObject *right, int op)
     } else {
         const unsigned char *left_id, *right_id;
         unsigned int left_len, right_len;
-        PySSL_LOCK(left);
+        PySSL_LOCK((PySSLSession *)left);
         left_id = SSL_SESSION_get_id(((PySSLSession *)left)->session,
                                      &left_len);
-        PySSL_UNLOCK(left);
-        PySSL_LOCK(right);
+        PySSL_UNLOCK((PySSLSession *)left);
+        PySSL_LOCK((PySSLSession *)right);
         right_id = SSL_SESSION_get_id(((PySSLSession *)right)->session,
                                       &right_len);
-        PySSL_UNLOCK(right);
+        PySSL_UNLOCK((PySSLSession *)right);
         if (left_len == right_len) {
             result = memcmp(left_id, right_id, left_len);
         } else {

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5498,18 +5498,22 @@ PySSLSession_clear(PySSLSession *self)
 }
 
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl.SSLSession.time
+[clinic start generated code]*/
+
 static PyObject *
-PySSLSession_get_time(PySSLSession *self, void *closure) {
+_ssl_SSLSession_time_get_impl(PySSLSession *self)
+/*[clinic end generated code: output=4b887b9299de9be4 input=8d1e4afd09103279]*/
+{
 #if OPENSSL_VERSION_NUMBER >= 0x30300000L
     return _PyLong_FromTime_t(SSL_SESSION_get_time_ex(self->session));
 #else
     return PyLong_FromLong(SSL_SESSION_get_time(self->session));
 #endif
 }
-
-PyDoc_STRVAR(PySSLSession_get_time_doc,
-"Session creation time (seconds since epoch).");
-
 
 static PyObject *
 PySSLSession_get_timeout(PySSLSession *self, void *closure) {
@@ -5520,7 +5524,6 @@ PySSLSession_get_timeout(PySSLSession *self, void *closure) {
 
 PyDoc_STRVAR(PySSLSession_get_timeout_doc,
 "Session timeout (delta in seconds).");
-
 
 /*[clinic input]
 @critical_section
@@ -5574,8 +5577,7 @@ static PyGetSetDef PySSLSession_getsetlist[] = {
     _SSL_SSLSESSION_HAS_TICKET_GETSETDEF
     _SSL_SSLSESSION_SESSION_ID_GETSETDEF
     _SSL_SSLSESSION_TICKET_LIFETIME_HINT_GETSETDEF
-    {"time", (getter) PySSLSession_get_time, NULL,
-              PySSLSession_get_time_doc},
+    _SSL_SSLSESSION_TIME_GETSETDEF
     {"timeout", (getter) PySSLSession_get_timeout, NULL,
               PySSLSession_get_timeout_doc},
     {NULL},            /* sentinel */

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5532,17 +5532,21 @@ PyDoc_STRVAR(PySSLSession_get_ticket_lifetime_hint_doc,
 "Ticket life time hint.");
 
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl.SSLSession.session_id
+[clinic start generated code]*/
+
 static PyObject *
-PySSLSession_get_session_id(PySSLSession *self, void *closure) {
+_ssl_SSLSession_session_id_get_impl(PySSLSession *self)
+/*[clinic end generated code: output=3882d1e7a7f8bab3 input=3a867b83fdff3183]*/
+{
     const unsigned char *id;
     unsigned int len;
     id = SSL_SESSION_get_id(self->session, &len);
     return PyBytes_FromStringAndSize((const char *)id, len);
 }
-
-PyDoc_STRVAR(PySSLSession_get_session_id_doc,
-"Session id");
-
 
 /*[clinic input]
 @critical_section

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3406,8 +3406,15 @@ _ssl__SSLContext__set_alpn_protocols_impl(PySSLContext *self,
     Py_RETURN_NONE;
 }
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLContext.verify_mode
+[clinic start generated code]*/
+
 static PyObject *
-get_verify_mode(PySSLContext *self, void *c)
+_ssl__SSLContext_verify_mode_get_impl(PySSLContext *self)
+/*[clinic end generated code: output=3e788736cc7229bc input=7e3c7f4454121d0a]*/
 {
     /* ignore SSL_VERIFY_CLIENT_ONCE and SSL_VERIFY_POST_HANDSHAKE */
     int mask = (SSL_VERIFY_NONE | SSL_VERIFY_PEER |
@@ -3426,11 +3433,18 @@ get_verify_mode(PySSLContext *self, void *c)
     return NULL;
 }
 
+/*[clinic input]
+@critical_section
+@setter
+_ssl._SSLContext.verify_mode
+[clinic start generated code]*/
+
 static int
-set_verify_mode(PySSLContext *self, PyObject *arg, void *c)
+_ssl__SSLContext_verify_mode_set_impl(PySSLContext *self, PyObject *value)
+/*[clinic end generated code: output=d698e16c58db3118 input=3ee60057c3a22378]*/
 {
     int n;
-    if (!PyArg_Parse(arg, "i", &n))
+    if (!PyArg_Parse(value, "i", &n))
         return -1;
     if (n == PY_SSL_CERT_NONE && self->check_hostname) {
         PyErr_SetString(PyExc_ValueError,
@@ -5118,8 +5132,7 @@ static PyGetSetDef context_getsetlist[] = {
                             NULL},
     _SSL__SSLCONTEXT_PROTOCOL_GETSETDEF
     _SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF
-    {"verify_mode", (getter) get_verify_mode,
-                    (setter) set_verify_mode, NULL},
+    _SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF
     {"security_level", (getter) get_security_level,
                        NULL, PySSLContext_security_level_doc},
     {NULL},            /* sentinel */

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3628,19 +3628,37 @@ _ssl__SSLContext_maximum_version_set_impl(PySSLContext *self,
     return set_min_max_proto_version(self, value, 1);
 }
 
-#if defined(TLS1_3_VERSION) && !defined(OPENSSL_NO_TLS1_3)
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLContext.num_tickets
+[clinic start generated code]*/
+
 static PyObject *
-get_num_tickets(PySSLContext *self, void *c)
+_ssl__SSLContext_num_tickets_get_impl(PySSLContext *self)
+/*[clinic end generated code: output=3d06d016318846c9 input=1dee26d75163c073]*/
 {
+    // Clinic seems to be misbehaving when the comment is wrapped with in directive
+#if defined(TLS1_3_VERSION) && !defined(OPENSSL_NO_TLS1_3)
     PyObject *res = PyLong_FromSize_t(SSL_CTX_get_num_tickets(self->ctx));
     return res;
+#else
+    return 0;
+#endif
 }
 
+/*[clinic input]
+@critical_section
+@setter
+_ssl._SSLContext.num_tickets
+[clinic start generated code]*/
+
 static int
-set_num_tickets(PySSLContext *self, PyObject *arg, void *c)
+_ssl__SSLContext_num_tickets_set_impl(PySSLContext *self, PyObject *value)
+/*[clinic end generated code: output=ced81b46f3beab09 input=6ef8067ac55607e7]*/
 {
     long num;
-    if (!PyArg_Parse(arg, "l", &num))
+    if (!PyArg_Parse(value, "l", &num))
         return -1;
     if (num < 0) {
         PyErr_SetString(PyExc_ValueError, "value must be non-negative");
@@ -3657,10 +3675,6 @@ set_num_tickets(PySSLContext *self, PyObject *arg, void *c)
     }
     return 0;
 }
-
-PyDoc_STRVAR(PySSLContext_num_tickets_doc,
-"Control the number of TLSv1.3 session tickets");
-#endif /* defined(TLS1_3_VERSION) */
 
 static PyObject *
 get_security_level(PySSLContext *self, void *c)
@@ -5056,8 +5070,7 @@ static PyGetSetDef context_getsetlist[] = {
                       (setter) _PySSLContext_set_msg_callback, NULL},
     _SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF
 #if defined(TLS1_3_VERSION) && !defined(OPENSSL_NO_TLS1_3)
-    {"num_tickets", (getter) get_num_tickets,
-                    (setter) set_num_tickets, PySSLContext_num_tickets_doc},
+    _SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF
 #endif
     {"options", (getter) get_options,
                 (setter) set_options, NULL},

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2327,10 +2327,8 @@ PySSL_dealloc(PySSLSocket *self)
         //
         // See elaborate explanation at
         // https://github.com/python/cpython/pull/123249#discussion_r1766164530
-        PySSL_LOCK(self);
         SSL_set_shutdown(self->ssl, SSL_SENT_SHUTDOWN | SSL_get_shutdown(self->ssl));
         SSL_free(self->ssl);
-        PySSL_UNLOCK(self);
     }
     Py_XDECREF(self->Socket);
     Py_XDECREF(self->ctx);

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -52,11 +52,11 @@
 #define PySSL_END_ALLOW_THREADS PySSL_END_ALLOW_THREADS_S(_save); }
 
 #ifdef Py_GIL_DISABLED
-#define PySSL_LOCK(obj) PyMutex_Lock(&(obj)->lock)
-#define PySSL_UNLOCK(obj) PyMutex_Unlock(&(obj)->lock)
+#  define PySSL_LOCK(OBJ) 	PyMutex_Lock(&(OBJ)->lock)
+#  define PySSL_UNLOCK(OBJ)	PyMutex_Unlock(&(OBJ)->lock)
 #else
-#define PySSL_LOCK(obj)
-#define PySSL_UNLOCK(obj)
+#  define PySSL_LOCK(OBJ)
+#  define PySSL_UNLOCK(OBJ)
 #endif
 
 #if defined(HAVE_POLL_H)

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5239,25 +5239,33 @@ memory_bio_dealloc(PySSLMemoryBIO *self)
     Py_DECREF(tp);
 }
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl.MemoryBIO.pending
+[clinic start generated code]*/
+
 static PyObject *
-memory_bio_get_pending(PySSLMemoryBIO *self, void *c)
+_ssl_MemoryBIO_pending_get_impl(PySSLMemoryBIO *self)
+/*[clinic end generated code: output=19236a32a51ac8ff input=c0b6d14eba107f6a]*/
 {
     size_t res = BIO_ctrl_pending(self->bio);
     return PyLong_FromSize_t(res);
 }
 
-PyDoc_STRVAR(PySSL_memory_bio_pending_doc,
-"The number of bytes pending in the memory BIO.");
+/*[clinic input]
+@critical_section
+@getter
+_ssl.MemoryBIO.eof
+[clinic start generated code]*/
 
 static PyObject *
-memory_bio_get_eof(PySSLMemoryBIO *self, void *c)
+_ssl_MemoryBIO_eof_get_impl(PySSLMemoryBIO *self)
+/*[clinic end generated code: output=c255a9ea16e31b92 input=0f5c6be69752e04c]*/
 {
     size_t pending = BIO_ctrl_pending(self->bio);
     return PyBool_FromLong((pending == 0) && self->eof_written);
 }
-
-PyDoc_STRVAR(PySSL_memory_bio_eof_doc,
-"Whether the memory BIO is at EOF.");
 
 /*[clinic input]
 @critical_section
@@ -5369,10 +5377,8 @@ _ssl_MemoryBIO_write_eof_impl(PySSLMemoryBIO *self)
 }
 
 static PyGetSetDef memory_bio_getsetlist[] = {
-    {"pending", (getter) memory_bio_get_pending, NULL,
-                PySSL_memory_bio_pending_doc},
-    {"eof", (getter) memory_bio_get_eof, NULL,
-            PySSL_memory_bio_eof_doc},
+    _SSL_MEMORYBIO_PENDING_GETSETDEF
+    _SSL_MEMORYBIO_EOF_GETSETDEF
     {NULL},            /* sentinel */
 };
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5544,8 +5544,16 @@ PyDoc_STRVAR(PySSLSession_get_session_id_doc,
 "Session id");
 
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl.SSLSession.has_ticket
+[clinic start generated code]*/
+
 static PyObject *
-PySSLSession_get_has_ticket(PySSLSession *self, void *closure) {
+_ssl_SSLSession_has_ticket_get_impl(PySSLSession *self)
+/*[clinic end generated code: output=aa3ccfc40b10b96d input=1a48ae8955fa9601]*/
+{
     int res = SSL_SESSION_has_ticket(self->session);
     return res ? Py_True : Py_False;
 }
@@ -5555,8 +5563,7 @@ PyDoc_STRVAR(PySSLSession_get_has_ticket_doc,
 
 
 static PyGetSetDef PySSLSession_getsetlist[] = {
-    {"has_ticket", (getter) PySSLSession_get_has_ticket, NULL,
-              PySSLSession_get_has_ticket_doc},
+    _SSL_SSLSESSION_HAS_TICKET_GETSETDEF
     {"id",   (getter) PySSLSession_get_session_id, NULL,
               PySSLSession_get_session_id_doc},
     {"ticket_lifetime_hint", (getter) PySSLSession_get_ticket_lifetime_hint,

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4595,8 +4595,15 @@ error:
     return ret;
 }
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLContext.sni_callback
+[clinic start generated code]*/
+
 static PyObject *
-get_sni_callback(PySSLContext *self, void *c)
+_ssl__SSLContext_sni_callback_get_impl(PySSLContext *self)
+/*[clinic end generated code: output=961e6575cdfaf036 input=22dd28c31fdc4318]*/
 {
     PyObject *cb = self->set_sni_cb;
     if (cb == NULL) {
@@ -4605,8 +4612,15 @@ get_sni_callback(PySSLContext *self, void *c)
     return Py_NewRef(cb);
 }
 
+/*[clinic input]
+@critical_section
+@setter
+_ssl._SSLContext.sni_callback
+[clinic start generated code]*/
+
 static int
-set_sni_callback(PySSLContext *self, PyObject *arg, void *c)
+_ssl__SSLContext_sni_callback_set_impl(PySSLContext *self, PyObject *value)
+/*[clinic end generated code: output=b32736c6b891f61a input=c3c4ff33540b3c85]*/
 {
     if (self->protocol == PY_SSL_VERSION_TLS_CLIENT) {
         PyErr_SetString(PyExc_ValueError,
@@ -4614,17 +4628,17 @@ set_sni_callback(PySSLContext *self, PyObject *arg, void *c)
         return -1;
     }
     Py_CLEAR(self->set_sni_cb);
-    if (arg == Py_None) {
+    if (value == Py_None) {
         SSL_CTX_set_tlsext_servername_callback(self->ctx, NULL);
     }
     else {
-        if (!PyCallable_Check(arg)) {
+        if (!PyCallable_Check(value)) {
             SSL_CTX_set_tlsext_servername_callback(self->ctx, NULL);
             PyErr_SetString(PyExc_TypeError,
                             "not a callable object");
             return -1;
         }
-        self->set_sni_cb = Py_NewRef(arg);
+        self->set_sni_cb = Py_NewRef(value);
         SSL_CTX_set_tlsext_servername_callback(self->ctx, _servername_callback);
         SSL_CTX_set_tlsext_servername_arg(self->ctx, self);
     }
@@ -4671,16 +4685,8 @@ X509_STORE_get1_objects(X509_STORE *store)
     ret = sk_X509_OBJECT_deep_copy(X509_STORE_get0_objects(store),
                                    x509_object_dup, X509_OBJECT_free);
     X509_STORE_unlock(store);
-    return ret;
 }
 #endif
-
-PyDoc_STRVAR(PySSLContext_sni_callback_doc,
-"Set a callback that will be called when a server name is provided by the SSL/TLS client in the SNI extension.\n\
-\n\
-If the argument is None then the callback is disabled. The method is called\n\
-with the SSLSocket, the server name as a string, and the SSLContext object.\n\
-See RFC 6066 for details of the SNI extension.");
 
 /*[clinic input]
 @critical_section
@@ -5048,8 +5054,7 @@ static PyGetSetDef context_getsetlist[] = {
                         (setter) _PySSLContext_set_keylog_filename, NULL},
     {"_msg_callback", (getter) _PySSLContext_get_msg_callback,
                       (setter) _PySSLContext_set_msg_callback, NULL},
-    {"sni_callback", (getter) get_sni_callback,
-                     (setter) set_sni_callback, PySSLContext_sni_callback_doc},
+    _SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF
 #if defined(TLS1_3_VERSION) && !defined(OPENSSL_NO_TLS1_3)
     {"num_tickets", (getter) get_num_tickets,
                     (setter) set_num_tickets, PySSLContext_num_tickets_doc},

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2198,16 +2198,23 @@ PySSL_get_server_side(PySSLSocket *self, void *c)
 PyDoc_STRVAR(PySSL_get_server_side_doc,
 "Whether this is a server-side socket.");
 
+
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLSocket.server_hostname
+
+The currently set server hostname (for SNI).
+[clinic start generated code]*/
+
 static PyObject *
-PySSL_get_server_hostname(PySSLSocket *self, void *c)
+_ssl__SSLSocket_server_hostname_get_impl(PySSLSocket *self)
+/*[clinic end generated code: output=1f40ea5a076de8e7 input=55d12a1dc6634b08]*/
 {
     if (self->server_hostname == NULL)
         Py_RETURN_NONE;
     return Py_NewRef(self->server_hostname);
 }
-
-PyDoc_STRVAR(PySSL_get_server_hostname_doc,
-"The currently set server hostname (for SNI).");
 
 /*[clinic input]
 @critical_section
@@ -2927,8 +2934,7 @@ static PyGetSetDef ssl_getsetlist[] = {
                 (setter) PySSL_set_context, PySSL_set_context_doc},
     {"server_side", (getter) PySSL_get_server_side, NULL,
                     PySSL_get_server_side_doc},
-    {"server_hostname", (getter) PySSL_get_server_hostname, NULL,
-                        PySSL_get_server_hostname_doc},
+    _SSL__SSLSOCKET_SERVER_HOSTNAME_GETSETDEF
     _SSL__SSLSOCKET_OWNER_GETSETDEF
     _SSL__SSLSOCKET_SESSION_GETSETDEF
     _SSL__SSLSOCKET_SESSION_REUSED_GETSETDEF

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4689,8 +4689,8 @@ set_sni_callback(PySSLContext *self, PyObject *arg, void *c)
                             "not a callable object");
             return -1;
         }
-        self->set_sni_cb = Py_NewRef(arg);
         PySSL_LOCK(self);
+        self->set_sni_cb = Py_NewRef(arg);
         SSL_CTX_set_tlsext_servername_callback(self->ctx, _servername_callback);
         SSL_CTX_set_tlsext_servername_arg(self->ctx, self);
         PySSL_UNLOCK(self);
@@ -4990,8 +4990,8 @@ _ssl__SSLContext_set_psk_client_callback_impl(PySSLContext *self,
     Py_XDECREF(self->psk_client_callback);
     Py_XINCREF(callback);
 
-    self->psk_client_callback = callback;
     PySSL_LOCK(self);
+    self->psk_client_callback = callback;
     SSL_CTX_set_psk_client_callback(self->ctx, ssl_callback);
     PySSL_UNLOCK(self);
 
@@ -5111,8 +5111,8 @@ _ssl__SSLContext_set_psk_server_callback_impl(PySSLContext *self,
     Py_XDECREF(self->psk_server_callback);
     Py_XINCREF(callback);
 
-    self->psk_server_callback = callback;
     PySSL_LOCK(self);
+    self->psk_server_callback = callback;
     SSL_CTX_set_psk_server_callback(self->ctx, ssl_callback);
     PySSL_UNLOCK(self);
 
@@ -5387,10 +5387,10 @@ static PyObject *
 _ssl_MemoryBIO_write_eof_impl(PySSLMemoryBIO *self)
 /*[clinic end generated code: output=d4106276ccd1ed34 input=56a945f1d29e8bd6]*/
 {
+    PySSL_LOCK(self);
     self->eof_written = 1;
     /* After an EOF is written, a zero return from read() should be a real EOF
      * i.e. it should not be retried. Clear the SHOULD_RETRY flag. */
-    PySSL_LOCK(self);
     BIO_clear_retry_flags(self->bio);
     BIO_set_mem_eof_return(self->bio, 0);
     PySSL_UNLOCK(self);

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3709,17 +3709,31 @@ set_host_flags(PySSLContext *self, PyObject *arg, void *c)
     return 0;
 }
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLContext.check_hostname
+[clinic start generated code]*/
+
 static PyObject *
-get_check_hostname(PySSLContext *self, void *c)
+_ssl__SSLContext_check_hostname_get_impl(PySSLContext *self)
+/*[clinic end generated code: output=e046d6eeefc76063 input=1b8341e705f9ecf5]*/
 {
     return PyBool_FromLong(self->check_hostname);
 }
 
+/*[clinic input]
+@critical_section
+@setter
+_ssl._SSLContext.check_hostname
+[clinic start generated code]*/
+
 static int
-set_check_hostname(PySSLContext *self, PyObject *arg, void *c)
+_ssl__SSLContext_check_hostname_set_impl(PySSLContext *self, PyObject *value)
+/*[clinic end generated code: output=0e767b4784e7dc3f input=e6a771cb5919f74d]*/
 {
     int check_hostname;
-    if (!PyArg_Parse(arg, "p", &check_hostname))
+    if (!PyArg_Parse(value, "p", &check_hostname))
         return -1;
     int verify_mode = check_hostname ? SSL_CTX_get_verify_mode(self->ctx) : 0;
     if (check_hostname &&
@@ -4982,8 +4996,7 @@ _ssl__SSLContext_set_psk_server_callback_impl(PySSLContext *self,
 
 
 static PyGetSetDef context_getsetlist[] = {
-    {"check_hostname", (getter) get_check_hostname,
-                       (setter) set_check_hostname, NULL},
+    _SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF
     {"_host_flags", (getter) get_host_flags,
                     (setter) set_host_flags, NULL},
     {"minimum_version", (getter) get_minimum_version,

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -869,7 +869,9 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
     self->server_hostname = NULL;
     self->err = err;
     self->exc = NULL;
+#ifdef Py_GIL_DISABLED
     self->lock = (PyMutex) { 0 };
+#endif
 
     /* Make sure the SSL error state is initialized */
     ERR_clear_error();
@@ -2923,7 +2925,9 @@ PySSL_get_session(PySSLSocket *self, void *closure) {
     assert(self->ctx);
     pysess->ctx = (PySSLContext*)Py_NewRef(self->ctx);
     pysess->session = session;
-    self->lock = (PyMutex) { 0 };
+#ifdef Py_GIL_DISABLED
+    pysess->lock = (PyMutex) { 0 };
+#endif
     PyObject_GC_Track(pysess);
     return (PyObject *)pysess;
 }
@@ -3174,6 +3178,9 @@ _ssl__SSLContext_impl(PyTypeObject *type, int proto_version)
 #ifndef OPENSSL_NO_PSK
     self->psk_client_callback = NULL;
     self->psk_server_callback = NULL;
+#endif
+#ifdef Py_GIL_DISABLED
+    self->lock = (PyMutex) { 0 };
 #endif
 
     /* Don't check host name by default */
@@ -5233,7 +5240,9 @@ _ssl_MemoryBIO_impl(PyTypeObject *type)
     }
     self->bio = bio;
     self->eof_written = 0;
+#ifdef Py_GIL_DISABLED
     self->lock = (PyMutex) { 0 };
+#endif
 
     return (PyObject *) self;
 }

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3597,8 +3597,15 @@ _ssl__SSLContext_minimum_version_set_impl(PySSLContext *self,
     return set_min_max_proto_version(self, value, 0);
 }
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLContext.maximum_version
+[clinic start generated code]*/
+
 static PyObject *
-get_maximum_version(PySSLContext *self, void *c)
+_ssl__SSLContext_maximum_version_get_impl(PySSLContext *self)
+/*[clinic end generated code: output=889249475112826a input=2b9e4c2d45f16b14]*/
 {
     int v = SSL_CTX_get_max_proto_version(self->ctx);
     if (v == 0) {
@@ -3607,10 +3614,18 @@ get_maximum_version(PySSLContext *self, void *c)
     return PyLong_FromLong(v);
 }
 
+/*[clinic input]
+@critical_section
+@setter
+_ssl._SSLContext.maximum_version
+[clinic start generated code]*/
+
 static int
-set_maximum_version(PySSLContext *self, PyObject *arg, void *c)
+_ssl__SSLContext_maximum_version_set_impl(PySSLContext *self,
+                                          PyObject *value)
+/*[clinic end generated code: output=4c0eed3042ca20d5 input=fe27e9fbbeb73c89]*/
 {
-    return set_min_max_proto_version(self, arg, 1);
+    return set_min_max_proto_version(self, value, 1);
 }
 
 #if defined(TLS1_3_VERSION) && !defined(OPENSSL_NO_TLS1_3)
@@ -5028,8 +5043,7 @@ static PyGetSetDef context_getsetlist[] = {
     _SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF
     _SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF
     _SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF
-    {"maximum_version", (getter) get_maximum_version,
-                        (setter) set_maximum_version, NULL},
+    _SSL__SSLCONTEXT_MAXIMUM_VERSION_GETSETDEF
     {"keylog_filename", (getter) _PySSLContext_get_keylog_filename,
                         (setter) _PySSLContext_set_keylog_filename, NULL},
     {"_msg_callback", (getter) _PySSLContext_get_msg_callback,

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5547,12 +5547,13 @@ _ssl_SSLSession_ticket_lifetime_hint_get_impl(PySSLSession *self)
 /*[clinic input]
 @critical_section
 @getter
-_ssl.SSLSession.session_id
+_ssl.SSLSession.id
 [clinic start generated code]*/
 
 static PyObject *
-_ssl_SSLSession_session_id_get_impl(PySSLSession *self)
-/*[clinic end generated code: output=3882d1e7a7f8bab3 input=3a867b83fdff3183]*/
+_ssl_SSLSession_id_get_impl(PySSLSession *self)
+/*[clinic end generated code: output=c532fb96b10c5adf input=e7322372cf6325dd]*/
+
 {
     const unsigned char *id;
     unsigned int len;
@@ -5580,7 +5581,7 @@ PyDoc_STRVAR(PySSLSession_get_has_ticket_doc,
 
 static PyGetSetDef PySSLSession_getsetlist[] = {
     _SSL_SSLSESSION_HAS_TICKET_GETSETDEF
-    _SSL_SSLSESSION_SESSION_ID_GETSETDEF
+    _SSL_SSLSESSION_ID_GETSETDEF
     _SSL_SSLSESSION_TICKET_LIFETIME_HINT_GETSETDEF
     _SSL_SSLSESSION_TIME_GETSETDEF
     _SSL_SSLSESSION_TIMEOUT_GETSETDEF

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1020,9 +1020,11 @@ _ssl__SSLSocket_do_handshake_impl(PySSLSocket *self)
     /* XXX If SSL_do_handshake() returns 0, it's also a failure. */
     do {
         PySSL_BEGIN_ALLOW_THREADS
-        PySSL_LOCK(self);
+        // XXX This isn't thread safe anymore, but locking this can cause a
+        // deadlock if a callback is active (see bpo-43577). I guess this
+        // isn't a huge problem because people shouldn't be calling
+        // do_handshake() across multiple threads anyway.
         ret = SSL_do_handshake(self->ssl);
-        PySSL_UNLOCK(self);
         err = _PySSL_errno(ret < 1, self->ssl, ret);
         PySSL_END_ALLOW_THREADS
         self->err = err;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2157,13 +2157,29 @@ _ssl__SSLSocket_compression_impl(PySSLSocket *self)
 #endif
 }
 
-static PySSLContext *PySSL_get_context(PySSLSocket *self, void *closure) {
-    return (PySSLContext*)Py_NewRef(self->ctx);
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLSocket.context
+[clinic start generated code]*/
+
+static PyObject *
+_ssl__SSLSocket_context_get_impl(PySSLSocket *self)
+/*[clinic end generated code: output=d23e82f72f32e3d7 input=25aa82e4d9fa344a]*/
+{
+    return Py_NewRef(self->ctx);
 }
 
-static int PySSL_set_context(PySSLSocket *self, PyObject *value,
-                                   void *closure) {
+/*[clinic input]
+@critical_section
+@setter
+_ssl._SSLSocket.context
+[clinic start generated code]*/
 
+static int
+_ssl__SSLSocket_context_set_impl(PySSLSocket *self, PyObject *value)
+/*[clinic end generated code: output=6b0a6cc5cf33d9fe input=48ece77724fd9dd4]*/
+{
     if (PyObject_TypeCheck(value, self->ctx->state->PySSLContext_Type)) {
         Py_SETREF(self->ctx, (PySSLContext *)Py_NewRef(value));
         SSL_set_SSL_CTX(self->ssl, self->ctx->ctx);
@@ -2180,24 +2196,20 @@ static int PySSL_set_context(PySSLSocket *self, PyObject *value,
     return 0;
 }
 
-PyDoc_STRVAR(PySSL_set_context_doc,
-"_setter_context(ctx)\n\
-\
-This changes the context associated with the SSLSocket. This is typically\n\
-used from within a callback function set by the sni_callback\n\
-on the SSLContext to change the certificate information associated with the\n\
-SSLSocket before the cryptographic exchange handshake messages\n");
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLSocket.server_side
 
+Whether this is a server-side socket.
+[clinic start generated code]*/
 
 static PyObject *
-PySSL_get_server_side(PySSLSocket *self, void *c)
+_ssl__SSLSocket_server_side_get_impl(PySSLSocket *self)
+/*[clinic end generated code: output=ae51e372489148e3 input=b09b320510bc7cae]*/
 {
     return PyBool_FromLong(self->socket_type == PY_SSL_SERVER);
 }
-
-PyDoc_STRVAR(PySSL_get_server_side_doc,
-"Whether this is a server-side socket.");
-
 
 /*[clinic input]
 @critical_section
@@ -2930,10 +2942,8 @@ _ssl__SSLSocket_session_reused_get_impl(PySSLSocket *self)
 }
 
 static PyGetSetDef ssl_getsetlist[] = {
-    {"context", (getter) PySSL_get_context,
-                (setter) PySSL_set_context, PySSL_set_context_doc},
-    {"server_side", (getter) PySSL_get_server_side, NULL,
-                    PySSL_get_server_side_doc},
+    _SSL__SSLSOCKET_CONTEXT_GETSETDEF
+    _SSL__SSLSOCKET_SERVER_SIDE_GETSETDEF
     _SSL__SSLSOCKET_SERVER_HOSTNAME_GETSETDEF
     _SSL__SSLSOCKET_OWNER_GETSETDEF
     _SSL__SSLSOCKET_SESSION_GETSETDEF

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3441,8 +3441,15 @@ set_verify_mode(PySSLContext *self, PyObject *arg, void *c)
     return _set_verify_mode(self, n);
 }
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLContext.verify_flags
+[clinic start generated code]*/
+
 static PyObject *
-get_verify_flags(PySSLContext *self, void *c)
+_ssl__SSLContext_verify_flags_get_impl(PySSLContext *self)
+/*[clinic end generated code: output=fbbf8ba28ad6e56e input=c1ec36d610b3f391]*/
 {
     X509_VERIFY_PARAM *param;
     unsigned long flags;
@@ -3452,13 +3459,20 @@ get_verify_flags(PySSLContext *self, void *c)
     return PyLong_FromUnsignedLong(flags);
 }
 
+/*[clinic input]
+@critical_section
+@setter
+_ssl._SSLContext.verify_flags
+[clinic start generated code]*/
+
 static int
-set_verify_flags(PySSLContext *self, PyObject *arg, void *c)
+_ssl__SSLContext_verify_flags_set_impl(PySSLContext *self, PyObject *value)
+/*[clinic end generated code: output=a3e3b2a0ce6c2e99 input=b2a0c42583d4f34e]*/
 {
     X509_VERIFY_PARAM *param;
     unsigned long new_flags, flags, set, clear;
 
-    if (!PyArg_Parse(arg, "k", &new_flags))
+    if (!PyArg_Parse(value, "k", &new_flags))
         return -1;
     param = SSL_CTX_get0_param(self->ctx);
     flags = X509_VERIFY_PARAM_get_flags(param);
@@ -5103,8 +5117,7 @@ static PyGetSetDef context_getsetlist[] = {
 #endif
                             NULL},
     _SSL__SSLCONTEXT_PROTOCOL_GETSETDEF
-    {"verify_flags", (getter) get_verify_flags,
-                     (setter) set_verify_flags, NULL},
+    _SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF
     {"verify_mode", (getter) get_verify_mode,
                     (setter) set_verify_mode, NULL},
     {"security_level", (getter) get_security_level,

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2884,8 +2884,17 @@ PyDoc_STRVAR(PySSL_set_session_doc,
 \
 Get / set SSLSession.");
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLSocket.session_reused
+
+Was the client session reused during handshake?
+[clinic start generated code]*/
+
 static PyObject *
-PySSL_get_session_reused(PySSLSocket *self, void *closure) {
+_ssl__SSLSocket_session_reused_get_impl(PySSLSocket *self) {
+/*[clinic end generated code: output=c8916909bcb80893 input=cec8bfec73a4461e]*/
     int res = SSL_session_reused(self->ssl);
     return res ? Py_True : Py_False;
 }
@@ -2904,8 +2913,7 @@ static PyGetSetDef ssl_getsetlist[] = {
               PySSL_get_owner_doc},
     {"session", (getter) PySSL_get_session,
                 (setter) PySSL_set_session, PySSL_set_session_doc},
-    {"session_reused", (getter) PySSL_get_session_reused, NULL,
-              PySSL_get_session_reused_doc},
+    _SSL__SSLSOCKET_SESSION_REUSED_GETSETDEF
     {NULL},            /* sentinel */
 };
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3684,16 +3684,30 @@ get_security_level(PySSLContext *self, void *c)
 }
 PyDoc_STRVAR(PySSLContext_security_level_doc, "The current security level");
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLContext.options
+[clinic start generated code]*/
+
 static PyObject *
-get_options(PySSLContext *self, void *c)
+_ssl__SSLContext_options_get_impl(PySSLContext *self)
+/*[clinic end generated code: output=3dfa6a74837f525b input=f5a2805c7cda6f25]*/
 {
     uint64_t options = SSL_CTX_get_options(self->ctx);
     Py_BUILD_ASSERT(sizeof(unsigned long long) >= sizeof(options));
     return PyLong_FromUnsignedLongLong(options);
 }
 
+/*[clinic input]
+@critical_section
+@setter
+_ssl._SSLContext.options
+[clinic start generated code]*/
+
 static int
-set_options(PySSLContext *self, PyObject *arg, void *c)
+_ssl__SSLContext_options_set_impl(PySSLContext *self, PyObject *value)
+/*[clinic end generated code: output=92ca34731ece5dbb input=2b94bf789e9ae5dd]*/
 {
     PyObject *new_opts_obj;
     unsigned long long new_opts_arg;
@@ -3703,7 +3717,7 @@ set_options(PySSLContext *self, PyObject *arg, void *c)
         SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_2 | SSL_OP_NO_TLSv1_3
     );
 
-    if (!PyArg_Parse(arg, "O!", &PyLong_Type, &new_opts_obj)) {
+    if (!PyArg_Parse(value, "O!", &PyLong_Type, &new_opts_obj)) {
         return -1;
     }
     new_opts_arg = PyLong_AsUnsignedLongLong(new_opts_obj);
@@ -5072,8 +5086,7 @@ static PyGetSetDef context_getsetlist[] = {
 #if defined(TLS1_3_VERSION) && !defined(OPENSSL_NO_TLS1_3)
     _SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF
 #endif
-    {"options", (getter) get_options,
-                (setter) set_options, NULL},
+    _SSL__SSLCONTEXT_OPTIONS_GETSETDEF
     {"post_handshake_auth", (getter) get_post_handshake_auth,
 #if defined(PySSL_HAVE_POST_HS_AUTH)
                             (setter) set_post_handshake_auth,

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3704,13 +3704,19 @@ _ssl__SSLContext_num_tickets_set_impl(PySSLContext *self, PyObject *value)
     return 0;
 }
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLContext.security_level
+[clinic start generated code]*/
+
 static PyObject *
-get_security_level(PySSLContext *self, void *c)
+_ssl__SSLContext_security_level_get_impl(PySSLContext *self)
+/*[clinic end generated code: output=56ece09e6a9572d0 input=a0416598e07c3183]*/
 {
     PyObject *res = PyLong_FromLong(SSL_CTX_get_security_level(self->ctx));
     return res;
 }
-PyDoc_STRVAR(PySSLContext_security_level_doc, "The current security level");
 
 /*[clinic input]
 @critical_section
@@ -5133,8 +5139,7 @@ static PyGetSetDef context_getsetlist[] = {
     _SSL__SSLCONTEXT_PROTOCOL_GETSETDEF
     _SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF
     _SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF
-    {"security_level", (getter) get_security_level,
-                       NULL, PySSLContext_security_level_doc},
+    _SSL__SSLCONTEXT_SECURITY_LEVEL_GETSETDEF
     {NULL},            /* sentinel */
 };
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3566,8 +3566,15 @@ set_min_max_proto_version(PySSLContext *self, PyObject *arg, int what)
     return 0;
 }
 
+/*[clinic input]
+@critical_section
+@getter
+_ssl._SSLContext.minimum_version
+[clinic start generated code]*/
+
 static PyObject *
-get_minimum_version(PySSLContext *self, void *c)
+_ssl__SSLContext_minimum_version_get_impl(PySSLContext *self)
+/*[clinic end generated code: output=27fa8382276635ed input=6832821e7e974d40]*/
 {
     int v = SSL_CTX_get_min_proto_version(self->ctx);
     if (v == 0) {
@@ -3576,10 +3583,18 @@ get_minimum_version(PySSLContext *self, void *c)
     return PyLong_FromLong(v);
 }
 
+/*[clinic input]
+@critical_section
+@setter
+_ssl._SSLContext.minimum_version
+[clinic start generated code]*/
+
 static int
-set_minimum_version(PySSLContext *self, PyObject *arg, void *c)
+_ssl__SSLContext_minimum_version_set_impl(PySSLContext *self,
+                                          PyObject *value)
+/*[clinic end generated code: output=482e82f7372afb78 input=2c64724901a514b3]*/
 {
-    return set_min_max_proto_version(self, arg, 0);
+    return set_min_max_proto_version(self, value, 0);
 }
 
 static PyObject *
@@ -5012,8 +5027,7 @@ _ssl__SSLContext_set_psk_server_callback_impl(PySSLContext *self,
 static PyGetSetDef context_getsetlist[] = {
     _SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF
     _SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF
-    {"minimum_version", (getter) get_minimum_version,
-                        (setter) set_minimum_version, NULL},
+    _SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF
     {"maximum_version", (getter) get_maximum_version,
                         (setter) set_maximum_version, NULL},
     {"keylog_filename", (getter) _PySSLContext_get_keylog_filename,

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2161,7 +2161,6 @@ _ssl__SSLSocket_version_impl(PySSLSocket *self)
         /* handshake not finished */
         Py_RETURN_NONE;
     }
-
     version = SSL_get_version(self->ssl);
     PySSL_UNLOCK(self);
     if (!strcmp(version, "unknown"))

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -990,6 +990,60 @@ _ssl__SSLContext_maximum_version_set(PySSLContext *self, PyObject *value, void *
     return return_value;
 }
 
+#if defined(_ssl__SSLContext_num_tickets_HAS_DOCSTR)
+#  define _ssl__SSLContext_num_tickets_DOCSTR _ssl__SSLContext_num_tickets__doc__
+#else
+#  define _ssl__SSLContext_num_tickets_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF
+#  define _SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF {"num_tickets", (getter)_ssl__SSLContext_num_tickets_get, (setter)_ssl__SSLContext_num_tickets_set, _ssl__SSLContext_num_tickets_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF {"num_tickets", (getter)_ssl__SSLContext_num_tickets_get, NULL, _ssl__SSLContext_num_tickets_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLContext_num_tickets_get_impl(PySSLContext *self);
+
+static PyObject *
+_ssl__SSLContext_num_tickets_get(PySSLContext *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_num_tickets_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLCONTEXT_NUM_TICKETS_HAS_DOCSTR)
+#  define _ssl__SSLContext_num_tickets_DOCSTR _ssl__SSLContext_num_tickets__doc__
+#else
+#  define _ssl__SSLContext_num_tickets_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF
+#  define _SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF {"num_tickets", (getter)_ssl__SSLContext_num_tickets_get, (setter)_ssl__SSLContext_num_tickets_set, _ssl__SSLContext_num_tickets_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF {"num_tickets", NULL, (setter)_ssl__SSLContext_num_tickets_set, NULL},
+#endif
+
+static int
+_ssl__SSLContext_num_tickets_set_impl(PySSLContext *self, PyObject *value);
+
+static int
+_ssl__SSLContext_num_tickets_set(PySSLContext *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_num_tickets_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl__SSLContext__host_flags_HAS_DOCSTR)
 #  define _ssl__SSLContext__host_flags_DOCSTR _ssl__SSLContext__host_flags__doc__
 #else
@@ -2377,4 +2431,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=4fc34fbd4ebf95c7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9d61586e3ca7fcfd input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -1152,6 +1152,33 @@ _ssl__SSLContext_num_tickets_set(PySSLContext *self, PyObject *value, void *Py_U
     return return_value;
 }
 
+#if defined(_ssl__SSLContext_security_level_HAS_DOCSTR)
+#  define _ssl__SSLContext_security_level_DOCSTR _ssl__SSLContext_security_level__doc__
+#else
+#  define _ssl__SSLContext_security_level_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_SECURITY_LEVEL_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_SECURITY_LEVEL_GETSETDEF
+#  define _SSL__SSLCONTEXT_SECURITY_LEVEL_GETSETDEF {"security_level", (getter)_ssl__SSLContext_security_level_get, (setter)_ssl__SSLContext_security_level_set, _ssl__SSLContext_security_level_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_SECURITY_LEVEL_GETSETDEF {"security_level", (getter)_ssl__SSLContext_security_level_get, NULL, _ssl__SSLContext_security_level_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLContext_security_level_get_impl(PySSLContext *self);
+
+static PyObject *
+_ssl__SSLContext_security_level_get(PySSLContext *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_security_level_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl__SSLContext_options_HAS_DOCSTR)
 #  define _ssl__SSLContext_options_DOCSTR _ssl__SSLContext_options__doc__
 #else
@@ -2620,4 +2647,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=f2adf3bcedabfea3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5921bfbc09f4d44f input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -493,6 +493,64 @@ _ssl__SSLSocket_verify_client_post_handshake(PySSLSocket *self, PyObject *Py_UNU
     return return_value;
 }
 
+PyDoc_STRVAR(_ssl__SSLSocket_session__doc__,
+"Get / set SSLSession.");
+#define _ssl__SSLSocket_session_HAS_DOCSTR
+
+#if defined(_ssl__SSLSocket_session_HAS_DOCSTR)
+#  define _ssl__SSLSocket_session_DOCSTR _ssl__SSLSocket_session__doc__
+#else
+#  define _ssl__SSLSocket_session_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLSOCKET_SESSION_GETSETDEF)
+#  undef _SSL__SSLSOCKET_SESSION_GETSETDEF
+#  define _SSL__SSLSOCKET_SESSION_GETSETDEF {"session", (getter)_ssl__SSLSocket_session_get, (setter)_ssl__SSLSocket_session_set, _ssl__SSLSocket_session_DOCSTR},
+#else
+#  define _SSL__SSLSOCKET_SESSION_GETSETDEF {"session", (getter)_ssl__SSLSocket_session_get, NULL, _ssl__SSLSocket_session_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLSocket_session_get_impl(PySSLSocket *self);
+
+static PyObject *
+_ssl__SSLSocket_session_get(PySSLSocket *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_session_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLSOCKET_SESSION_HAS_DOCSTR)
+#  define _ssl__SSLSocket_session_DOCSTR _ssl__SSLSocket_session__doc__
+#else
+#  define _ssl__SSLSocket_session_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLSOCKET_SESSION_GETSETDEF)
+#  undef _SSL__SSLSOCKET_SESSION_GETSETDEF
+#  define _SSL__SSLSOCKET_SESSION_GETSETDEF {"session", (getter)_ssl__SSLSocket_session_get, (setter)_ssl__SSLSocket_session_set, _ssl__SSLSocket_session_DOCSTR},
+#else
+#  define _SSL__SSLSOCKET_SESSION_GETSETDEF {"session", NULL, (setter)_ssl__SSLSocket_session_set, NULL},
+#endif
+
+static int
+_ssl__SSLSocket_session_set_impl(PySSLSocket *self, PyObject *value);
+
+static int
+_ssl__SSLSocket_session_set(PySSLSocket *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_session_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl__SSLSocket_session_reused__doc__,
 "Was the client session reused during handshake?");
 #define _ssl__SSLSocket_session_reused_HAS_DOCSTR
@@ -1873,4 +1931,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=79aaaf0e264304c7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4e7e2b7a652aa50a input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -6,6 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
+#include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
 #include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(_ssl__SSLSocket_do_handshake__doc__,
@@ -22,7 +23,13 @@ _ssl__SSLSocket_do_handshake_impl(PySSLSocket *self);
 static PyObject *
 _ssl__SSLSocket_do_handshake(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLSocket_do_handshake_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_do_handshake_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__test_decode_cert__doc__,
@@ -88,7 +95,9 @@ _ssl__SSLSocket_getpeercert(PySSLSocket *self, PyObject *const *args, Py_ssize_t
         goto exit;
     }
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLSocket_getpeercert_impl(self, binary_mode);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -108,7 +117,13 @@ _ssl__SSLSocket_get_verified_chain_impl(PySSLSocket *self);
 static PyObject *
 _ssl__SSLSocket_get_verified_chain(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLSocket_get_verified_chain_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_get_verified_chain_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLSocket_get_unverified_chain__doc__,
@@ -125,7 +140,13 @@ _ssl__SSLSocket_get_unverified_chain_impl(PySSLSocket *self);
 static PyObject *
 _ssl__SSLSocket_get_unverified_chain(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLSocket_get_unverified_chain_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_get_unverified_chain_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLSocket_shared_ciphers__doc__,
@@ -142,7 +163,13 @@ _ssl__SSLSocket_shared_ciphers_impl(PySSLSocket *self);
 static PyObject *
 _ssl__SSLSocket_shared_ciphers(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLSocket_shared_ciphers_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_shared_ciphers_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLSocket_cipher__doc__,
@@ -159,7 +186,13 @@ _ssl__SSLSocket_cipher_impl(PySSLSocket *self);
 static PyObject *
 _ssl__SSLSocket_cipher(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLSocket_cipher_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_cipher_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLSocket_version__doc__,
@@ -176,7 +209,13 @@ _ssl__SSLSocket_version_impl(PySSLSocket *self);
 static PyObject *
 _ssl__SSLSocket_version(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLSocket_version_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_version_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLSocket_selected_alpn_protocol__doc__,
@@ -193,7 +232,13 @@ _ssl__SSLSocket_selected_alpn_protocol_impl(PySSLSocket *self);
 static PyObject *
 _ssl__SSLSocket_selected_alpn_protocol(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLSocket_selected_alpn_protocol_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_selected_alpn_protocol_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLSocket_compression__doc__,
@@ -236,7 +281,9 @@ _ssl__SSLSocket_write(PySSLSocket *self, PyObject *arg)
     if (PyObject_GetBuffer(arg, &b, PyBUF_SIMPLE) != 0) {
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLSocket_write_impl(self, &b);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     /* Cleanup for b */
@@ -262,7 +309,13 @@ _ssl__SSLSocket_pending_impl(PySSLSocket *self);
 static PyObject *
 _ssl__SSLSocket_pending(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLSocket_pending_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_pending_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLSocket_read__doc__,
@@ -300,7 +353,9 @@ _ssl__SSLSocket_read(PySSLSocket *self, PyObject *args)
             PyErr_SetString(PyExc_TypeError, "_ssl._SSLSocket.read requires 1 to 2 arguments");
             goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLSocket_read_impl(self, len, group_right_1, &buffer);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     /* Cleanup for buffer */
@@ -326,7 +381,13 @@ _ssl__SSLSocket_shutdown_impl(PySSLSocket *self);
 static PyObject *
 _ssl__SSLSocket_shutdown(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLSocket_shutdown_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_shutdown_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLSocket_get_channel_binding__doc__,
@@ -400,7 +461,9 @@ _ssl__SSLSocket_get_channel_binding(PySSLSocket *self, PyObject *const *args, Py
         goto exit;
     }
 skip_optional_pos:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLSocket_get_channel_binding_impl(self, cb_type);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -421,7 +484,13 @@ _ssl__SSLSocket_verify_client_post_handshake_impl(PySSLSocket *self);
 static PyObject *
 _ssl__SSLSocket_verify_client_post_handshake(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLSocket_verify_client_post_handshake_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_verify_client_post_handshake_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 static PyObject *
@@ -445,7 +514,9 @@ _ssl__SSLContext(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     if (proto_version == -1 && PyErr_Occurred()) {
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(type);
     return_value = _ssl__SSLContext_impl(type, proto_version);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -481,7 +552,9 @@ _ssl__SSLContext_set_ciphers(PySSLContext *self, PyObject *arg)
         PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLContext_set_ciphers_impl(self, cipherlist);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -501,7 +574,13 @@ _ssl__SSLContext_get_ciphers_impl(PySSLContext *self);
 static PyObject *
 _ssl__SSLContext_get_ciphers(PySSLContext *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLContext_get_ciphers_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_get_ciphers_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLContext__set_alpn_protocols__doc__,
@@ -525,7 +604,9 @@ _ssl__SSLContext__set_alpn_protocols(PySSLContext *self, PyObject *arg)
     if (PyObject_GetBuffer(arg, &protos, PyBUF_SIMPLE) != 0) {
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLContext__set_alpn_protocols_impl(self, &protos);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     /* Cleanup for protos */
@@ -599,7 +680,9 @@ _ssl__SSLContext_load_cert_chain(PySSLContext *self, PyObject *const *args, Py_s
     }
     password = args[2];
 skip_optional_pos:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLContext_load_cert_chain_impl(self, certfile, keyfile, password);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -675,7 +758,9 @@ _ssl__SSLContext_load_verify_locations(PySSLContext *self, PyObject *const *args
     }
     cadata = args[2];
 skip_optional_pos:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLContext_load_verify_locations_impl(self, cafile, capath, cadata);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -688,6 +773,21 @@ PyDoc_STRVAR(_ssl__SSLContext_load_dh_params__doc__,
 
 #define _SSL__SSLCONTEXT_LOAD_DH_PARAMS_METHODDEF    \
     {"load_dh_params", (PyCFunction)_ssl__SSLContext_load_dh_params, METH_O, _ssl__SSLContext_load_dh_params__doc__},
+
+static PyObject *
+_ssl__SSLContext_load_dh_params_impl(PySSLContext *self, PyObject *filepath);
+
+static PyObject *
+_ssl__SSLContext_load_dh_params(PySSLContext *self, PyObject *filepath)
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_load_dh_params_impl(self, filepath);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
 
 PyDoc_STRVAR(_ssl__SSLContext__wrap_socket__doc__,
 "_wrap_socket($self, /, sock, server_side, server_hostname=None, *,\n"
@@ -774,7 +874,9 @@ skip_optional_pos:
     }
     session = args[4];
 skip_optional_kwonly:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLContext__wrap_socket_impl(self, sock, server_side, hostname_obj, owner, session);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -872,7 +974,9 @@ skip_optional_pos:
     }
     session = args[5];
 skip_optional_kwonly:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLContext__wrap_bio_impl(self, incoming, outgoing, server_side, hostname_obj, owner, session);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -892,7 +996,13 @@ _ssl__SSLContext_session_stats_impl(PySSLContext *self);
 static PyObject *
 _ssl__SSLContext_session_stats(PySSLContext *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLContext_session_stats_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_session_stats_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLContext_set_default_verify_paths__doc__,
@@ -909,7 +1019,13 @@ _ssl__SSLContext_set_default_verify_paths_impl(PySSLContext *self);
 static PyObject *
 _ssl__SSLContext_set_default_verify_paths(PySSLContext *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLContext_set_default_verify_paths_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_set_default_verify_paths_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLContext_set_ecdh_curve__doc__,
@@ -919,6 +1035,21 @@ PyDoc_STRVAR(_ssl__SSLContext_set_ecdh_curve__doc__,
 
 #define _SSL__SSLCONTEXT_SET_ECDH_CURVE_METHODDEF    \
     {"set_ecdh_curve", (PyCFunction)_ssl__SSLContext_set_ecdh_curve, METH_O, _ssl__SSLContext_set_ecdh_curve__doc__},
+
+static PyObject *
+_ssl__SSLContext_set_ecdh_curve_impl(PySSLContext *self, PyObject *name);
+
+static PyObject *
+_ssl__SSLContext_set_ecdh_curve(PySSLContext *self, PyObject *name)
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_set_ecdh_curve_impl(self, name);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
 
 PyDoc_STRVAR(_ssl__SSLContext_cert_store_stats__doc__,
 "cert_store_stats($self, /)\n"
@@ -941,7 +1072,13 @@ _ssl__SSLContext_cert_store_stats_impl(PySSLContext *self);
 static PyObject *
 _ssl__SSLContext_cert_store_stats(PySSLContext *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl__SSLContext_cert_store_stats_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_cert_store_stats_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl__SSLContext_get_ca_certs__doc__,
@@ -1007,7 +1144,9 @@ _ssl__SSLContext_get_ca_certs(PySSLContext *self, PyObject *const *args, Py_ssiz
         goto exit;
     }
 skip_optional_pos:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLContext_get_ca_certs_impl(self, binary_form);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -1062,7 +1201,9 @@ _ssl__SSLContext_set_psk_client_callback(PySSLContext *self, PyObject *const *ar
         goto exit;
     }
     callback = args[0];
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLContext_set_psk_client_callback_impl(self, callback);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -1142,7 +1283,9 @@ _ssl__SSLContext_set_psk_server_callback(PySSLContext *self, PyObject *const *ar
         goto exit;
     }
 skip_optional_pos:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLContext_set_psk_server_callback_impl(self, callback, identity_hint);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -1165,7 +1308,9 @@ _ssl_MemoryBIO(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         !_PyArg_NoKeywords("MemoryBIO", kwargs)) {
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(type);
     return_value = _ssl_MemoryBIO_impl(type);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -1205,7 +1350,9 @@ _ssl_MemoryBIO_read(PySSLMemoryBIO *self, PyObject *const *args, Py_ssize_t narg
         goto exit;
     }
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl_MemoryBIO_read_impl(self, len);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -1234,7 +1381,9 @@ _ssl_MemoryBIO_write(PySSLMemoryBIO *self, PyObject *arg)
     if (PyObject_GetBuffer(arg, &b, PyBUF_SIMPLE) != 0) {
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl_MemoryBIO_write_impl(self, &b);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     /* Cleanup for b */
@@ -1262,7 +1411,13 @@ _ssl_MemoryBIO_write_eof_impl(PySSLMemoryBIO *self);
 static PyObject *
 _ssl_MemoryBIO_write_eof(PySSLMemoryBIO *self, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl_MemoryBIO_write_eof_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl_MemoryBIO_write_eof_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl_RAND_add__doc__,
@@ -1315,7 +1470,9 @@ _ssl_RAND_add(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
             goto exit;
         }
     }
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = _ssl_RAND_add_impl(module, &view, entropy);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     /* Cleanup for view */
@@ -1348,7 +1505,9 @@ _ssl_RAND_bytes(PyObject *module, PyObject *arg)
     if (n == -1 && PyErr_Occurred()) {
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = _ssl_RAND_bytes_impl(module, n);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -1372,7 +1531,13 @@ _ssl_RAND_status_impl(PyObject *module);
 static PyObject *
 _ssl_RAND_status(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl_RAND_status_impl(module);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = _ssl_RAND_status_impl(module);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl_get_default_verify_paths__doc__,
@@ -1392,7 +1557,13 @@ _ssl_get_default_verify_paths_impl(PyObject *module);
 static PyObject *
 _ssl_get_default_verify_paths(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
-    return _ssl_get_default_verify_paths_impl(module);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = _ssl_get_default_verify_paths_impl(module);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(_ssl_txt2obj__doc__,
@@ -1469,7 +1640,9 @@ _ssl_txt2obj(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
         goto exit;
     }
 skip_optional_pos:
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = _ssl_txt2obj_impl(module, txt, name);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -1497,7 +1670,9 @@ _ssl_nid2obj(PyObject *module, PyObject *arg)
     if (nid == -1 && PyErr_Occurred()) {
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = _ssl_nid2obj_impl(module, nid);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -1572,7 +1747,9 @@ _ssl_enum_certificates(PyObject *module, PyObject *const *args, Py_ssize_t nargs
         PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = _ssl_enum_certificates_impl(module, store_name);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -1648,7 +1825,9 @@ _ssl_enum_crls(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObje
         PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = _ssl_enum_crls_impl(module, store_name);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -1663,4 +1842,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=28a22f2b09d631cb input=a9049054013a1b77]*/
+/*[clinic end generated code: output=930f7b2ce6d07704 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -258,6 +258,91 @@ _ssl__SSLSocket_compression(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
     return _ssl__SSLSocket_compression_impl(self);
 }
 
+#if defined(_ssl__SSLSocket_context_HAS_DOCSTR)
+#  define _ssl__SSLSocket_context_DOCSTR _ssl__SSLSocket_context__doc__
+#else
+#  define _ssl__SSLSocket_context_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLSOCKET_CONTEXT_GETSETDEF)
+#  undef _SSL__SSLSOCKET_CONTEXT_GETSETDEF
+#  define _SSL__SSLSOCKET_CONTEXT_GETSETDEF {"context", (getter)_ssl__SSLSocket_context_get, (setter)_ssl__SSLSocket_context_set, _ssl__SSLSocket_context_DOCSTR},
+#else
+#  define _SSL__SSLSOCKET_CONTEXT_GETSETDEF {"context", (getter)_ssl__SSLSocket_context_get, NULL, _ssl__SSLSocket_context_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLSocket_context_get_impl(PySSLSocket *self);
+
+static PyObject *
+_ssl__SSLSocket_context_get(PySSLSocket *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_context_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLSOCKET_CONTEXT_HAS_DOCSTR)
+#  define _ssl__SSLSocket_context_DOCSTR _ssl__SSLSocket_context__doc__
+#else
+#  define _ssl__SSLSocket_context_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLSOCKET_CONTEXT_GETSETDEF)
+#  undef _SSL__SSLSOCKET_CONTEXT_GETSETDEF
+#  define _SSL__SSLSOCKET_CONTEXT_GETSETDEF {"context", (getter)_ssl__SSLSocket_context_get, (setter)_ssl__SSLSocket_context_set, _ssl__SSLSocket_context_DOCSTR},
+#else
+#  define _SSL__SSLSOCKET_CONTEXT_GETSETDEF {"context", NULL, (setter)_ssl__SSLSocket_context_set, NULL},
+#endif
+
+static int
+_ssl__SSLSocket_context_set_impl(PySSLSocket *self, PyObject *value);
+
+static int
+_ssl__SSLSocket_context_set(PySSLSocket *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_context_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+PyDoc_STRVAR(_ssl__SSLSocket_server_side__doc__,
+"Whether this is a server-side socket.");
+#define _ssl__SSLSocket_server_side_HAS_DOCSTR
+
+#if defined(_ssl__SSLSocket_server_side_HAS_DOCSTR)
+#  define _ssl__SSLSocket_server_side_DOCSTR _ssl__SSLSocket_server_side__doc__
+#else
+#  define _ssl__SSLSocket_server_side_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLSOCKET_SERVER_SIDE_GETSETDEF)
+#  undef _SSL__SSLSOCKET_SERVER_SIDE_GETSETDEF
+#  define _SSL__SSLSOCKET_SERVER_SIDE_GETSETDEF {"server_side", (getter)_ssl__SSLSocket_server_side_get, (setter)_ssl__SSLSocket_server_side_set, _ssl__SSLSocket_server_side_DOCSTR},
+#else
+#  define _SSL__SSLSOCKET_SERVER_SIDE_GETSETDEF {"server_side", (getter)_ssl__SSLSocket_server_side_get, NULL, _ssl__SSLSocket_server_side_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLSocket_server_side_get_impl(PySSLSocket *self);
+
+static PyObject *
+_ssl__SSLSocket_server_side_get(PySSLSocket *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_server_side_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl__SSLSocket_server_hostname__doc__,
 "The currently set server hostname (for SNI).");
 #define _ssl__SSLSocket_server_hostname_HAS_DOCSTR
@@ -2020,4 +2105,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=236e1d55e76c93ca input=a9049054013a1b77]*/
+/*[clinic end generated code: output=92017ea0e2f2fcba input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -880,6 +880,60 @@ exit:
     return return_value;
 }
 
+#if defined(_ssl__SSLContext_verify_flags_HAS_DOCSTR)
+#  define _ssl__SSLContext_verify_flags_DOCSTR _ssl__SSLContext_verify_flags__doc__
+#else
+#  define _ssl__SSLContext_verify_flags_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF
+#  define _SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF {"verify_flags", (getter)_ssl__SSLContext_verify_flags_get, (setter)_ssl__SSLContext_verify_flags_set, _ssl__SSLContext_verify_flags_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF {"verify_flags", (getter)_ssl__SSLContext_verify_flags_get, NULL, _ssl__SSLContext_verify_flags_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLContext_verify_flags_get_impl(PySSLContext *self);
+
+static PyObject *
+_ssl__SSLContext_verify_flags_get(PySSLContext *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_verify_flags_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLCONTEXT_VERIFY_FLAGS_HAS_DOCSTR)
+#  define _ssl__SSLContext_verify_flags_DOCSTR _ssl__SSLContext_verify_flags__doc__
+#else
+#  define _ssl__SSLContext_verify_flags_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF
+#  define _SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF {"verify_flags", (getter)_ssl__SSLContext_verify_flags_get, (setter)_ssl__SSLContext_verify_flags_set, _ssl__SSLContext_verify_flags_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF {"verify_flags", NULL, (setter)_ssl__SSLContext_verify_flags_set, NULL},
+#endif
+
+static int
+_ssl__SSLContext_verify_flags_set_impl(PySSLContext *self, PyObject *value);
+
+static int
+_ssl__SSLContext_verify_flags_set(PySSLContext *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_verify_flags_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl__SSLContext_minimum_version_HAS_DOCSTR)
 #  define _ssl__SSLContext_minimum_version_DOCSTR _ssl__SSLContext_minimum_version__doc__
 #else
@@ -2512,4 +2566,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=26e79b114b8c43df input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6d9009cbbac4cf2f input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -880,6 +880,60 @@ exit:
     return return_value;
 }
 
+#if defined(_ssl__SSLContext_verify_mode_HAS_DOCSTR)
+#  define _ssl__SSLContext_verify_mode_DOCSTR _ssl__SSLContext_verify_mode__doc__
+#else
+#  define _ssl__SSLContext_verify_mode_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF
+#  define _SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF {"verify_mode", (getter)_ssl__SSLContext_verify_mode_get, (setter)_ssl__SSLContext_verify_mode_set, _ssl__SSLContext_verify_mode_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF {"verify_mode", (getter)_ssl__SSLContext_verify_mode_get, NULL, _ssl__SSLContext_verify_mode_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLContext_verify_mode_get_impl(PySSLContext *self);
+
+static PyObject *
+_ssl__SSLContext_verify_mode_get(PySSLContext *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_verify_mode_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLCONTEXT_VERIFY_MODE_HAS_DOCSTR)
+#  define _ssl__SSLContext_verify_mode_DOCSTR _ssl__SSLContext_verify_mode__doc__
+#else
+#  define _ssl__SSLContext_verify_mode_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF
+#  define _SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF {"verify_mode", (getter)_ssl__SSLContext_verify_mode_get, (setter)_ssl__SSLContext_verify_mode_set, _ssl__SSLContext_verify_mode_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF {"verify_mode", NULL, (setter)_ssl__SSLContext_verify_mode_set, NULL},
+#endif
+
+static int
+_ssl__SSLContext_verify_mode_set_impl(PySSLContext *self, PyObject *value);
+
+static int
+_ssl__SSLContext_verify_mode_set(PySSLContext *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_verify_mode_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl__SSLContext_verify_flags_HAS_DOCSTR)
 #  define _ssl__SSLContext_verify_flags_DOCSTR _ssl__SSLContext_verify_flags__doc__
 #else
@@ -2566,4 +2620,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=6d9009cbbac4cf2f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f2adf3bcedabfea3 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -1532,6 +1532,60 @@ _ssl__SSLContext_set_ecdh_curve(PySSLContext *self, PyObject *name)
     return return_value;
 }
 
+#if defined(_ssl__SSLContext_sni_callback_HAS_DOCSTR)
+#  define _ssl__SSLContext_sni_callback_DOCSTR _ssl__SSLContext_sni_callback__doc__
+#else
+#  define _ssl__SSLContext_sni_callback_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF
+#  define _SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF {"sni_callback", (getter)_ssl__SSLContext_sni_callback_get, (setter)_ssl__SSLContext_sni_callback_set, _ssl__SSLContext_sni_callback_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF {"sni_callback", (getter)_ssl__SSLContext_sni_callback_get, NULL, _ssl__SSLContext_sni_callback_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLContext_sni_callback_get_impl(PySSLContext *self);
+
+static PyObject *
+_ssl__SSLContext_sni_callback_get(PySSLContext *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_sni_callback_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLCONTEXT_SNI_CALLBACK_HAS_DOCSTR)
+#  define _ssl__SSLContext_sni_callback_DOCSTR _ssl__SSLContext_sni_callback__doc__
+#else
+#  define _ssl__SSLContext_sni_callback_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF
+#  define _SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF {"sni_callback", (getter)_ssl__SSLContext_sni_callback_get, (setter)_ssl__SSLContext_sni_callback_set, _ssl__SSLContext_sni_callback_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF {"sni_callback", NULL, (setter)_ssl__SSLContext_sni_callback_set, NULL},
+#endif
+
+static int
+_ssl__SSLContext_sni_callback_set_impl(PySSLContext *self, PyObject *value);
+
+static int
+_ssl__SSLContext_sni_callback_set(PySSLContext *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_sni_callback_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl__SSLContext_cert_store_stats__doc__,
 "cert_store_stats($self, /)\n"
 "--\n"
@@ -2323,4 +2377,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=2cdc16c38db51f7c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4fc34fbd4ebf95c7 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -2360,28 +2360,28 @@ _ssl_SSLSession_ticket_lifetime_hint_get(PySSLSession *self, void *Py_UNUSED(con
     return return_value;
 }
 
-#if defined(_ssl_SSLSession_session_id_HAS_DOCSTR)
-#  define _ssl_SSLSession_session_id_DOCSTR _ssl_SSLSession_session_id__doc__
+#if defined(_ssl_SSLSession_id_HAS_DOCSTR)
+#  define _ssl_SSLSession_id_DOCSTR _ssl_SSLSession_id__doc__
 #else
-#  define _ssl_SSLSession_session_id_DOCSTR NULL
+#  define _ssl_SSLSession_id_DOCSTR NULL
 #endif
-#if defined(_SSL_SSLSESSION_SESSION_ID_GETSETDEF)
-#  undef _SSL_SSLSESSION_SESSION_ID_GETSETDEF
-#  define _SSL_SSLSESSION_SESSION_ID_GETSETDEF {"session_id", (getter)_ssl_SSLSession_session_id_get, (setter)_ssl_SSLSession_session_id_set, _ssl_SSLSession_session_id_DOCSTR},
+#if defined(_SSL_SSLSESSION_ID_GETSETDEF)
+#  undef _SSL_SSLSESSION_ID_GETSETDEF
+#  define _SSL_SSLSESSION_ID_GETSETDEF {"id", (getter)_ssl_SSLSession_id_get, (setter)_ssl_SSLSession_id_set, _ssl_SSLSession_id_DOCSTR},
 #else
-#  define _SSL_SSLSESSION_SESSION_ID_GETSETDEF {"session_id", (getter)_ssl_SSLSession_session_id_get, NULL, _ssl_SSLSession_session_id_DOCSTR},
+#  define _SSL_SSLSESSION_ID_GETSETDEF {"id", (getter)_ssl_SSLSession_id_get, NULL, _ssl_SSLSession_id_DOCSTR},
 #endif
 
 static PyObject *
-_ssl_SSLSession_session_id_get_impl(PySSLSession *self);
+_ssl_SSLSession_id_get_impl(PySSLSession *self);
 
 static PyObject *
-_ssl_SSLSession_session_id_get(PySSLSession *self, void *Py_UNUSED(context))
+_ssl_SSLSession_id_get(PySSLSession *self, void *Py_UNUSED(context))
 {
     PyObject *return_value = NULL;
 
     Py_BEGIN_CRITICAL_SECTION(self);
-    return_value = _ssl_SSLSession_session_id_get_impl(self);
+    return_value = _ssl_SSLSession_id_get_impl(self);
     Py_END_CRITICAL_SECTION();
 
     return return_value;
@@ -2836,4 +2836,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=139101c7caeefcae input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b4d8f9eb33016974 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -2279,6 +2279,33 @@ _ssl_MemoryBIO_write_eof(PySSLMemoryBIO *self, PyObject *Py_UNUSED(ignored))
     return return_value;
 }
 
+#if defined(_ssl_SSLSession_ticket_lifetime_hint_HAS_DOCSTR)
+#  define _ssl_SSLSession_ticket_lifetime_hint_DOCSTR _ssl_SSLSession_ticket_lifetime_hint__doc__
+#else
+#  define _ssl_SSLSession_ticket_lifetime_hint_DOCSTR NULL
+#endif
+#if defined(_SSL_SSLSESSION_TICKET_LIFETIME_HINT_GETSETDEF)
+#  undef _SSL_SSLSESSION_TICKET_LIFETIME_HINT_GETSETDEF
+#  define _SSL_SSLSESSION_TICKET_LIFETIME_HINT_GETSETDEF {"ticket_lifetime_hint", (getter)_ssl_SSLSession_ticket_lifetime_hint_get, (setter)_ssl_SSLSession_ticket_lifetime_hint_set, _ssl_SSLSession_ticket_lifetime_hint_DOCSTR},
+#else
+#  define _SSL_SSLSESSION_TICKET_LIFETIME_HINT_GETSETDEF {"ticket_lifetime_hint", (getter)_ssl_SSLSession_ticket_lifetime_hint_get, NULL, _ssl_SSLSession_ticket_lifetime_hint_DOCSTR},
+#endif
+
+static PyObject *
+_ssl_SSLSession_ticket_lifetime_hint_get_impl(PySSLSession *self);
+
+static PyObject *
+_ssl_SSLSession_ticket_lifetime_hint_get(PySSLSession *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl_SSLSession_ticket_lifetime_hint_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl_SSLSession_session_id_HAS_DOCSTR)
 #  define _ssl_SSLSession_session_id_DOCSTR _ssl_SSLSession_session_id__doc__
 #else
@@ -2755,4 +2782,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=9cc4a80ccece933a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f09b15ce11130fd6 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -2279,6 +2279,33 @@ _ssl_MemoryBIO_write_eof(PySSLMemoryBIO *self, PyObject *Py_UNUSED(ignored))
     return return_value;
 }
 
+#if defined(_ssl_SSLSession_has_ticket_HAS_DOCSTR)
+#  define _ssl_SSLSession_has_ticket_DOCSTR _ssl_SSLSession_has_ticket__doc__
+#else
+#  define _ssl_SSLSession_has_ticket_DOCSTR NULL
+#endif
+#if defined(_SSL_SSLSESSION_HAS_TICKET_GETSETDEF)
+#  undef _SSL_SSLSESSION_HAS_TICKET_GETSETDEF
+#  define _SSL_SSLSESSION_HAS_TICKET_GETSETDEF {"has_ticket", (getter)_ssl_SSLSession_has_ticket_get, (setter)_ssl_SSLSession_has_ticket_set, _ssl_SSLSession_has_ticket_DOCSTR},
+#else
+#  define _SSL_SSLSESSION_HAS_TICKET_GETSETDEF {"has_ticket", (getter)_ssl_SSLSession_has_ticket_get, NULL, _ssl_SSLSession_has_ticket_DOCSTR},
+#endif
+
+static PyObject *
+_ssl_SSLSession_has_ticket_get_impl(PySSLSession *self);
+
+static PyObject *
+_ssl_SSLSession_has_ticket_get(PySSLSession *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl_SSLSession_has_ticket_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl_RAND_add__doc__,
 "RAND_add($module, string, entropy, /)\n"
 "--\n"
@@ -2701,4 +2728,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=a006967d9642ce21 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3e62ae8f7ba3d7f9 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -374,10 +374,6 @@ _ssl__SSLSocket_server_hostname_get(PySSLSocket *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-PyDoc_STRVAR(_ssl__SSLSocket_owner__doc__,
-"The Python-level owner of this object. Passed as \"self\" in servername callback.");
-#define _ssl__SSLSocket_owner_HAS_DOCSTR
-
 #if defined(_ssl__SSLSocket_owner_HAS_DOCSTR)
 #  define _ssl__SSLSocket_owner_DOCSTR _ssl__SSLSocket_owner__doc__
 #else
@@ -666,10 +662,6 @@ _ssl__SSLSocket_verify_client_post_handshake(PySSLSocket *self, PyObject *Py_UNU
 
     return return_value;
 }
-
-PyDoc_STRVAR(_ssl__SSLSocket_session__doc__,
-"Get / set SSLSession.");
-#define _ssl__SSLSocket_session_HAS_DOCSTR
 
 #if defined(_ssl__SSLSocket_session_HAS_DOCSTR)
 #  define _ssl__SSLSocket_session_DOCSTR _ssl__SSLSocket_session__doc__
@@ -2836,4 +2828,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=b4d8f9eb33016974 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c1489122072a9f5e input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -2121,6 +2121,60 @@ exit:
     return return_value;
 }
 
+#if defined(_ssl_MemoryBIO_pending_HAS_DOCSTR)
+#  define _ssl_MemoryBIO_pending_DOCSTR _ssl_MemoryBIO_pending__doc__
+#else
+#  define _ssl_MemoryBIO_pending_DOCSTR NULL
+#endif
+#if defined(_SSL_MEMORYBIO_PENDING_GETSETDEF)
+#  undef _SSL_MEMORYBIO_PENDING_GETSETDEF
+#  define _SSL_MEMORYBIO_PENDING_GETSETDEF {"pending", (getter)_ssl_MemoryBIO_pending_get, (setter)_ssl_MemoryBIO_pending_set, _ssl_MemoryBIO_pending_DOCSTR},
+#else
+#  define _SSL_MEMORYBIO_PENDING_GETSETDEF {"pending", (getter)_ssl_MemoryBIO_pending_get, NULL, _ssl_MemoryBIO_pending_DOCSTR},
+#endif
+
+static PyObject *
+_ssl_MemoryBIO_pending_get_impl(PySSLMemoryBIO *self);
+
+static PyObject *
+_ssl_MemoryBIO_pending_get(PySSLMemoryBIO *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl_MemoryBIO_pending_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_ssl_MemoryBIO_eof_HAS_DOCSTR)
+#  define _ssl_MemoryBIO_eof_DOCSTR _ssl_MemoryBIO_eof__doc__
+#else
+#  define _ssl_MemoryBIO_eof_DOCSTR NULL
+#endif
+#if defined(_SSL_MEMORYBIO_EOF_GETSETDEF)
+#  undef _SSL_MEMORYBIO_EOF_GETSETDEF
+#  define _SSL_MEMORYBIO_EOF_GETSETDEF {"eof", (getter)_ssl_MemoryBIO_eof_get, (setter)_ssl_MemoryBIO_eof_set, _ssl_MemoryBIO_eof_DOCSTR},
+#else
+#  define _SSL_MEMORYBIO_EOF_GETSETDEF {"eof", (getter)_ssl_MemoryBIO_eof_get, NULL, _ssl_MemoryBIO_eof_DOCSTR},
+#endif
+
+static PyObject *
+_ssl_MemoryBIO_eof_get_impl(PySSLMemoryBIO *self);
+
+static PyObject *
+_ssl_MemoryBIO_eof_get(PySSLMemoryBIO *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl_MemoryBIO_eof_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl_MemoryBIO_read__doc__,
 "read($self, size=-1, /)\n"
 "--\n"
@@ -2647,4 +2701,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=5921bfbc09f4d44f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a006967d9642ce21 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -493,6 +493,37 @@ _ssl__SSLSocket_verify_client_post_handshake(PySSLSocket *self, PyObject *Py_UNU
     return return_value;
 }
 
+PyDoc_STRVAR(_ssl__SSLSocket_session_reused__doc__,
+"Was the client session reused during handshake?");
+#define _ssl__SSLSocket_session_reused_HAS_DOCSTR
+
+#if defined(_ssl__SSLSocket_session_reused_HAS_DOCSTR)
+#  define _ssl__SSLSocket_session_reused_DOCSTR _ssl__SSLSocket_session_reused__doc__
+#else
+#  define _ssl__SSLSocket_session_reused_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLSOCKET_SESSION_REUSED_GETSETDEF)
+#  undef _SSL__SSLSOCKET_SESSION_REUSED_GETSETDEF
+#  define _SSL__SSLSOCKET_SESSION_REUSED_GETSETDEF {"session_reused", (getter)_ssl__SSLSocket_session_reused_get, (setter)_ssl__SSLSocket_session_reused_set, _ssl__SSLSocket_session_reused_DOCSTR},
+#else
+#  define _SSL__SSLSOCKET_SESSION_REUSED_GETSETDEF {"session_reused", (getter)_ssl__SSLSocket_session_reused_get, NULL, _ssl__SSLSocket_session_reused_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLSocket_session_reused_get_impl(PySSLSocket *self);
+
+static PyObject *
+_ssl__SSLSocket_session_reused_get(PySSLSocket *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_session_reused_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 static PyObject *
 _ssl__SSLContext_impl(PyTypeObject *type, int proto_version);
 
@@ -1842,4 +1873,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=930f7b2ce6d07704 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=79aaaf0e264304c7 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -2279,6 +2279,33 @@ _ssl_MemoryBIO_write_eof(PySSLMemoryBIO *self, PyObject *Py_UNUSED(ignored))
     return return_value;
 }
 
+#if defined(_ssl_SSLSession_session_id_HAS_DOCSTR)
+#  define _ssl_SSLSession_session_id_DOCSTR _ssl_SSLSession_session_id__doc__
+#else
+#  define _ssl_SSLSession_session_id_DOCSTR NULL
+#endif
+#if defined(_SSL_SSLSESSION_SESSION_ID_GETSETDEF)
+#  undef _SSL_SSLSESSION_SESSION_ID_GETSETDEF
+#  define _SSL_SSLSESSION_SESSION_ID_GETSETDEF {"session_id", (getter)_ssl_SSLSession_session_id_get, (setter)_ssl_SSLSession_session_id_set, _ssl_SSLSession_session_id_DOCSTR},
+#else
+#  define _SSL_SSLSESSION_SESSION_ID_GETSETDEF {"session_id", (getter)_ssl_SSLSession_session_id_get, NULL, _ssl_SSLSession_session_id_DOCSTR},
+#endif
+
+static PyObject *
+_ssl_SSLSession_session_id_get_impl(PySSLSession *self);
+
+static PyObject *
+_ssl_SSLSession_session_id_get(PySSLSession *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl_SSLSession_session_id_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl_SSLSession_has_ticket_HAS_DOCSTR)
 #  define _ssl_SSLSession_has_ticket_DOCSTR _ssl_SSLSession_has_ticket__doc__
 #else
@@ -2728,4 +2755,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=3e62ae8f7ba3d7f9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9cc4a80ccece933a input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -258,6 +258,64 @@ _ssl__SSLSocket_compression(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
     return _ssl__SSLSocket_compression_impl(self);
 }
 
+PyDoc_STRVAR(_ssl__SSLSocket_owner__doc__,
+"The Python-level owner of this object. Passed as \"self\" in servername callback.");
+#define _ssl__SSLSocket_owner_HAS_DOCSTR
+
+#if defined(_ssl__SSLSocket_owner_HAS_DOCSTR)
+#  define _ssl__SSLSocket_owner_DOCSTR _ssl__SSLSocket_owner__doc__
+#else
+#  define _ssl__SSLSocket_owner_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLSOCKET_OWNER_GETSETDEF)
+#  undef _SSL__SSLSOCKET_OWNER_GETSETDEF
+#  define _SSL__SSLSOCKET_OWNER_GETSETDEF {"owner", (getter)_ssl__SSLSocket_owner_get, (setter)_ssl__SSLSocket_owner_set, _ssl__SSLSocket_owner_DOCSTR},
+#else
+#  define _SSL__SSLSOCKET_OWNER_GETSETDEF {"owner", (getter)_ssl__SSLSocket_owner_get, NULL, _ssl__SSLSocket_owner_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLSocket_owner_get_impl(PySSLSocket *self);
+
+static PyObject *
+_ssl__SSLSocket_owner_get(PySSLSocket *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_owner_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLSOCKET_OWNER_HAS_DOCSTR)
+#  define _ssl__SSLSocket_owner_DOCSTR _ssl__SSLSocket_owner__doc__
+#else
+#  define _ssl__SSLSocket_owner_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLSOCKET_OWNER_GETSETDEF)
+#  undef _SSL__SSLSOCKET_OWNER_GETSETDEF
+#  define _SSL__SSLSOCKET_OWNER_GETSETDEF {"owner", (getter)_ssl__SSLSocket_owner_get, (setter)_ssl__SSLSocket_owner_set, _ssl__SSLSocket_owner_DOCSTR},
+#else
+#  define _SSL__SSLSOCKET_OWNER_GETSETDEF {"owner", NULL, (setter)_ssl__SSLSocket_owner_set, NULL},
+#endif
+
+static int
+_ssl__SSLSocket_owner_set_impl(PySSLSocket *self, PyObject *value);
+
+static int
+_ssl__SSLSocket_owner_set(PySSLSocket *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_owner_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl__SSLSocket_write__doc__,
 "write($self, b, /)\n"
 "--\n"
@@ -1931,4 +1989,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=4e7e2b7a652aa50a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=21899c86029bc674 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -880,6 +880,60 @@ exit:
     return return_value;
 }
 
+#if defined(_ssl__SSLContext__host_flags_HAS_DOCSTR)
+#  define _ssl__SSLContext__host_flags_DOCSTR _ssl__SSLContext__host_flags__doc__
+#else
+#  define _ssl__SSLContext__host_flags_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF)
+#  undef _SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF
+#  define _SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF {"_host_flags", (getter)_ssl__SSLContext__host_flags_get, (setter)_ssl__SSLContext__host_flags_set, _ssl__SSLContext__host_flags_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF {"_host_flags", (getter)_ssl__SSLContext__host_flags_get, NULL, _ssl__SSLContext__host_flags_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLContext__host_flags_get_impl(PySSLContext *self);
+
+static PyObject *
+_ssl__SSLContext__host_flags_get(PySSLContext *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext__host_flags_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLCONTEXT__HOST_FLAGS_HAS_DOCSTR)
+#  define _ssl__SSLContext__host_flags_DOCSTR _ssl__SSLContext__host_flags__doc__
+#else
+#  define _ssl__SSLContext__host_flags_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF)
+#  undef _SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF
+#  define _SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF {"_host_flags", (getter)_ssl__SSLContext__host_flags_get, (setter)_ssl__SSLContext__host_flags_set, _ssl__SSLContext__host_flags_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF {"_host_flags", NULL, (setter)_ssl__SSLContext__host_flags_set, NULL},
+#endif
+
+static int
+_ssl__SSLContext__host_flags_set_impl(PySSLContext *self, PyObject *value);
+
+static int
+_ssl__SSLContext__host_flags_set(PySSLContext *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext__host_flags_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl__SSLContext_check_hostname_HAS_DOCSTR)
 #  define _ssl__SSLContext_check_hostname_DOCSTR _ssl__SSLContext_check_hostname__doc__
 #else
@@ -2159,4 +2213,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=fdfe4b2244ae2a54 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=caca896be11b53a6 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -1206,6 +1206,33 @@ _ssl__SSLContext_check_hostname_set(PySSLContext *self, PyObject *value, void *P
     return return_value;
 }
 
+#if defined(_ssl__SSLContext_protocol_HAS_DOCSTR)
+#  define _ssl__SSLContext_protocol_DOCSTR _ssl__SSLContext_protocol__doc__
+#else
+#  define _ssl__SSLContext_protocol_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_PROTOCOL_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_PROTOCOL_GETSETDEF
+#  define _SSL__SSLCONTEXT_PROTOCOL_GETSETDEF {"protocol", (getter)_ssl__SSLContext_protocol_get, (setter)_ssl__SSLContext_protocol_set, _ssl__SSLContext_protocol_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_PROTOCOL_GETSETDEF {"protocol", (getter)_ssl__SSLContext_protocol_get, NULL, _ssl__SSLContext_protocol_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLContext_protocol_get_impl(PySSLContext *self);
+
+static PyObject *
+_ssl__SSLContext_protocol_get(PySSLContext *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_protocol_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl__SSLContext_load_cert_chain__doc__,
 "load_cert_chain($self, /, certfile, keyfile=None, password=None)\n"
 "--\n"
@@ -2485,4 +2512,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=4f8d4d84a6974ef2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=26e79b114b8c43df input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -880,6 +880,60 @@ exit:
     return return_value;
 }
 
+#if defined(_ssl__SSLContext_check_hostname_HAS_DOCSTR)
+#  define _ssl__SSLContext_check_hostname_DOCSTR _ssl__SSLContext_check_hostname__doc__
+#else
+#  define _ssl__SSLContext_check_hostname_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF
+#  define _SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF {"check_hostname", (getter)_ssl__SSLContext_check_hostname_get, (setter)_ssl__SSLContext_check_hostname_set, _ssl__SSLContext_check_hostname_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF {"check_hostname", (getter)_ssl__SSLContext_check_hostname_get, NULL, _ssl__SSLContext_check_hostname_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLContext_check_hostname_get_impl(PySSLContext *self);
+
+static PyObject *
+_ssl__SSLContext_check_hostname_get(PySSLContext *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_check_hostname_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLCONTEXT_CHECK_HOSTNAME_HAS_DOCSTR)
+#  define _ssl__SSLContext_check_hostname_DOCSTR _ssl__SSLContext_check_hostname__doc__
+#else
+#  define _ssl__SSLContext_check_hostname_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF
+#  define _SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF {"check_hostname", (getter)_ssl__SSLContext_check_hostname_get, (setter)_ssl__SSLContext_check_hostname_set, _ssl__SSLContext_check_hostname_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF {"check_hostname", NULL, (setter)_ssl__SSLContext_check_hostname_set, NULL},
+#endif
+
+static int
+_ssl__SSLContext_check_hostname_set_impl(PySSLContext *self, PyObject *value);
+
+static int
+_ssl__SSLContext_check_hostname_set(PySSLContext *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_check_hostname_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl__SSLContext_load_cert_chain__doc__,
 "load_cert_chain($self, /, certfile, keyfile=None, password=None)\n"
 "--\n"
@@ -2105,4 +2159,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=92017ea0e2f2fcba input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fdfe4b2244ae2a54 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -1044,6 +1044,60 @@ _ssl__SSLContext_num_tickets_set(PySSLContext *self, PyObject *value, void *Py_U
     return return_value;
 }
 
+#if defined(_ssl__SSLContext_options_HAS_DOCSTR)
+#  define _ssl__SSLContext_options_DOCSTR _ssl__SSLContext_options__doc__
+#else
+#  define _ssl__SSLContext_options_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_OPTIONS_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_OPTIONS_GETSETDEF
+#  define _SSL__SSLCONTEXT_OPTIONS_GETSETDEF {"options", (getter)_ssl__SSLContext_options_get, (setter)_ssl__SSLContext_options_set, _ssl__SSLContext_options_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_OPTIONS_GETSETDEF {"options", (getter)_ssl__SSLContext_options_get, NULL, _ssl__SSLContext_options_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLContext_options_get_impl(PySSLContext *self);
+
+static PyObject *
+_ssl__SSLContext_options_get(PySSLContext *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_options_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLCONTEXT_OPTIONS_HAS_DOCSTR)
+#  define _ssl__SSLContext_options_DOCSTR _ssl__SSLContext_options__doc__
+#else
+#  define _ssl__SSLContext_options_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_OPTIONS_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_OPTIONS_GETSETDEF
+#  define _SSL__SSLCONTEXT_OPTIONS_GETSETDEF {"options", (getter)_ssl__SSLContext_options_get, (setter)_ssl__SSLContext_options_set, _ssl__SSLContext_options_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_OPTIONS_GETSETDEF {"options", NULL, (setter)_ssl__SSLContext_options_set, NULL},
+#endif
+
+static int
+_ssl__SSLContext_options_set_impl(PySSLContext *self, PyObject *value);
+
+static int
+_ssl__SSLContext_options_set(PySSLContext *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_options_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl__SSLContext__host_flags_HAS_DOCSTR)
 #  define _ssl__SSLContext__host_flags_DOCSTR _ssl__SSLContext__host_flags__doc__
 #else
@@ -2431,4 +2485,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=9d61586e3ca7fcfd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4f8d4d84a6974ef2 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -2306,6 +2306,33 @@ _ssl_SSLSession_time_get(PySSLSession *self, void *Py_UNUSED(context))
     return return_value;
 }
 
+#if defined(_ssl_SSLSession_timeout_HAS_DOCSTR)
+#  define _ssl_SSLSession_timeout_DOCSTR _ssl_SSLSession_timeout__doc__
+#else
+#  define _ssl_SSLSession_timeout_DOCSTR NULL
+#endif
+#if defined(_SSL_SSLSESSION_TIMEOUT_GETSETDEF)
+#  undef _SSL_SSLSESSION_TIMEOUT_GETSETDEF
+#  define _SSL_SSLSESSION_TIMEOUT_GETSETDEF {"timeout", (getter)_ssl_SSLSession_timeout_get, (setter)_ssl_SSLSession_timeout_set, _ssl_SSLSession_timeout_DOCSTR},
+#else
+#  define _SSL_SSLSESSION_TIMEOUT_GETSETDEF {"timeout", (getter)_ssl_SSLSession_timeout_get, NULL, _ssl_SSLSession_timeout_DOCSTR},
+#endif
+
+static PyObject *
+_ssl_SSLSession_timeout_get_impl(PySSLSession *self);
+
+static PyObject *
+_ssl_SSLSession_timeout_get(PySSLSession *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl_SSLSession_timeout_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl_SSLSession_ticket_lifetime_hint_HAS_DOCSTR)
 #  define _ssl_SSLSession_ticket_lifetime_hint_DOCSTR _ssl_SSLSession_ticket_lifetime_hint__doc__
 #else
@@ -2809,4 +2836,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=6a8338feec145d07 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=139101c7caeefcae input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -880,6 +880,61 @@ exit:
     return return_value;
 }
 
+#if defined(_ssl__SSLContext_minimum_version_HAS_DOCSTR)
+#  define _ssl__SSLContext_minimum_version_DOCSTR _ssl__SSLContext_minimum_version__doc__
+#else
+#  define _ssl__SSLContext_minimum_version_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF
+#  define _SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF {"minimum_version", (getter)_ssl__SSLContext_minimum_version_get, (setter)_ssl__SSLContext_minimum_version_set, _ssl__SSLContext_minimum_version_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF {"minimum_version", (getter)_ssl__SSLContext_minimum_version_get, NULL, _ssl__SSLContext_minimum_version_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLContext_minimum_version_get_impl(PySSLContext *self);
+
+static PyObject *
+_ssl__SSLContext_minimum_version_get(PySSLContext *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_minimum_version_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLCONTEXT_MINIMUM_VERSION_HAS_DOCSTR)
+#  define _ssl__SSLContext_minimum_version_DOCSTR _ssl__SSLContext_minimum_version__doc__
+#else
+#  define _ssl__SSLContext_minimum_version_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF
+#  define _SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF {"minimum_version", (getter)_ssl__SSLContext_minimum_version_get, (setter)_ssl__SSLContext_minimum_version_set, _ssl__SSLContext_minimum_version_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF {"minimum_version", NULL, (setter)_ssl__SSLContext_minimum_version_set, NULL},
+#endif
+
+static int
+_ssl__SSLContext_minimum_version_set_impl(PySSLContext *self,
+                                          PyObject *value);
+
+static int
+_ssl__SSLContext_minimum_version_set(PySSLContext *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_minimum_version_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl__SSLContext__host_flags_HAS_DOCSTR)
 #  define _ssl__SSLContext__host_flags_DOCSTR _ssl__SSLContext__host_flags__doc__
 #else
@@ -2213,4 +2268,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=caca896be11b53a6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1bdcf2ac943863a1 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -258,6 +258,37 @@ _ssl__SSLSocket_compression(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
     return _ssl__SSLSocket_compression_impl(self);
 }
 
+PyDoc_STRVAR(_ssl__SSLSocket_server_hostname__doc__,
+"The currently set server hostname (for SNI).");
+#define _ssl__SSLSocket_server_hostname_HAS_DOCSTR
+
+#if defined(_ssl__SSLSocket_server_hostname_HAS_DOCSTR)
+#  define _ssl__SSLSocket_server_hostname_DOCSTR _ssl__SSLSocket_server_hostname__doc__
+#else
+#  define _ssl__SSLSocket_server_hostname_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLSOCKET_SERVER_HOSTNAME_GETSETDEF)
+#  undef _SSL__SSLSOCKET_SERVER_HOSTNAME_GETSETDEF
+#  define _SSL__SSLSOCKET_SERVER_HOSTNAME_GETSETDEF {"server_hostname", (getter)_ssl__SSLSocket_server_hostname_get, (setter)_ssl__SSLSocket_server_hostname_set, _ssl__SSLSocket_server_hostname_DOCSTR},
+#else
+#  define _SSL__SSLSOCKET_SERVER_HOSTNAME_GETSETDEF {"server_hostname", (getter)_ssl__SSLSocket_server_hostname_get, NULL, _ssl__SSLSocket_server_hostname_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLSocket_server_hostname_get_impl(PySSLSocket *self);
+
+static PyObject *
+_ssl__SSLSocket_server_hostname_get(PySSLSocket *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_server_hostname_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl__SSLSocket_owner__doc__,
 "The Python-level owner of this object. Passed as \"self\" in servername callback.");
 #define _ssl__SSLSocket_owner_HAS_DOCSTR
@@ -1989,4 +2020,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=21899c86029bc674 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=236e1d55e76c93ca input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -2279,6 +2279,33 @@ _ssl_MemoryBIO_write_eof(PySSLMemoryBIO *self, PyObject *Py_UNUSED(ignored))
     return return_value;
 }
 
+#if defined(_ssl_SSLSession_time_HAS_DOCSTR)
+#  define _ssl_SSLSession_time_DOCSTR _ssl_SSLSession_time__doc__
+#else
+#  define _ssl_SSLSession_time_DOCSTR NULL
+#endif
+#if defined(_SSL_SSLSESSION_TIME_GETSETDEF)
+#  undef _SSL_SSLSESSION_TIME_GETSETDEF
+#  define _SSL_SSLSESSION_TIME_GETSETDEF {"time", (getter)_ssl_SSLSession_time_get, (setter)_ssl_SSLSession_time_set, _ssl_SSLSession_time_DOCSTR},
+#else
+#  define _SSL_SSLSESSION_TIME_GETSETDEF {"time", (getter)_ssl_SSLSession_time_get, NULL, _ssl_SSLSession_time_DOCSTR},
+#endif
+
+static PyObject *
+_ssl_SSLSession_time_get_impl(PySSLSession *self);
+
+static PyObject *
+_ssl_SSLSession_time_get(PySSLSession *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl_SSLSession_time_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl_SSLSession_ticket_lifetime_hint_HAS_DOCSTR)
 #  define _ssl_SSLSession_ticket_lifetime_hint_DOCSTR _ssl_SSLSession_ticket_lifetime_hint__doc__
 #else
@@ -2782,4 +2809,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=f09b15ce11130fd6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6a8338feec145d07 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -935,6 +935,61 @@ _ssl__SSLContext_minimum_version_set(PySSLContext *self, PyObject *value, void *
     return return_value;
 }
 
+#if defined(_ssl__SSLContext_maximum_version_HAS_DOCSTR)
+#  define _ssl__SSLContext_maximum_version_DOCSTR _ssl__SSLContext_maximum_version__doc__
+#else
+#  define _ssl__SSLContext_maximum_version_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_MAXIMUM_VERSION_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_MAXIMUM_VERSION_GETSETDEF
+#  define _SSL__SSLCONTEXT_MAXIMUM_VERSION_GETSETDEF {"maximum_version", (getter)_ssl__SSLContext_maximum_version_get, (setter)_ssl__SSLContext_maximum_version_set, _ssl__SSLContext_maximum_version_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_MAXIMUM_VERSION_GETSETDEF {"maximum_version", (getter)_ssl__SSLContext_maximum_version_get, NULL, _ssl__SSLContext_maximum_version_DOCSTR},
+#endif
+
+static PyObject *
+_ssl__SSLContext_maximum_version_get_impl(PySSLContext *self);
+
+static PyObject *
+_ssl__SSLContext_maximum_version_get(PySSLContext *self, void *Py_UNUSED(context))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_maximum_version_get_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+#if defined(_SSL__SSLCONTEXT_MAXIMUM_VERSION_HAS_DOCSTR)
+#  define _ssl__SSLContext_maximum_version_DOCSTR _ssl__SSLContext_maximum_version__doc__
+#else
+#  define _ssl__SSLContext_maximum_version_DOCSTR NULL
+#endif
+#if defined(_SSL__SSLCONTEXT_MAXIMUM_VERSION_GETSETDEF)
+#  undef _SSL__SSLCONTEXT_MAXIMUM_VERSION_GETSETDEF
+#  define _SSL__SSLCONTEXT_MAXIMUM_VERSION_GETSETDEF {"maximum_version", (getter)_ssl__SSLContext_maximum_version_get, (setter)_ssl__SSLContext_maximum_version_set, _ssl__SSLContext_maximum_version_DOCSTR},
+#else
+#  define _SSL__SSLCONTEXT_MAXIMUM_VERSION_GETSETDEF {"maximum_version", NULL, (setter)_ssl__SSLContext_maximum_version_set, NULL},
+#endif
+
+static int
+_ssl__SSLContext_maximum_version_set_impl(PySSLContext *self,
+                                          PyObject *value);
+
+static int
+_ssl__SSLContext_maximum_version_set(PySSLContext *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_maximum_version_set_impl(self, value);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 #if defined(_ssl__SSLContext__host_flags_HAS_DOCSTR)
 #  define _ssl__SSLContext__host_flags_DOCSTR _ssl__SSLContext__host_flags__doc__
 #else
@@ -2268,4 +2323,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=1bdcf2ac943863a1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2cdc16c38db51f7c input=a9049054013a1b77]*/


### PR DESCRIPTION
As it turns out, OpenSSL doesn't like being called in multiple threads. This adds a per-socket (and per-context and per-session) lock for all OpenSSL calls.

<!-- gh-issue-number: gh-124984 -->
* Issue: gh-124984
<!-- /gh-issue-number -->
