### PR TITLE
gh-124927: Fix conversion issue between coordinates and position in REPL

### DIFF
--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -62,7 +62,7 @@ def disp_str(buffer: str) -> tuple[str, list[int]]:
         elif unicodedata.category(c).startswith("C"):
             c = r"\u%04x" % ord(c)
             s.append(c)
-            b.extend([0] * (len(c) - 1))
+            b.append(len(c) - 1)
         else:
             s.append(c)
             b.append(str_width(c))
@@ -577,6 +577,7 @@ class Reader:
         cur_x = self.screeninfo[i][0]
         while cur_x < x:
             if self.screeninfo[i][1][j] == 0:
+                j += 1
                 continue
             cur_x += self.screeninfo[i][1][j]
             j += 1

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -577,7 +577,7 @@ class Reader:
         cur_x = self.screeninfo[i][0]
         while cur_x < x:
             if self.screeninfo[i][1][j] == 0:
-                j += 1  # prevent infinite loop
+                j += 1  # prevent potential future infinite loop
                 continue
             cur_x += self.screeninfo[i][1][j]
             j += 1

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -62,7 +62,7 @@ def disp_str(buffer: str) -> tuple[str, list[int]]:
         elif unicodedata.category(c).startswith("C"):
             c = r"\u%04x" % ord(c)
             s.append(c)
-            b.append(len(c) - 1)
+            b.append(len(c))
         else:
             s.append(c)
             b.append(str_width(c))
@@ -577,7 +577,7 @@ class Reader:
         cur_x = self.screeninfo[i][0]
         while cur_x < x:
             if self.screeninfo[i][1][j] == 0:
-                j += 1
+                j += 1  # prevent infinite loop
                 continue
             cur_x += self.screeninfo[i][1][j]
             j += 1

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -313,18 +313,17 @@ class TestReader(TestCase):
 
         self.assert_screen_equals(reader, f"{code}a")
 
-    def test_setpos_from_xy_for_non_printing_char(self):
-        code = "# non \u200c printing character"
-        events = code_to_events(code)
-
-        reader, _ = handle_all_events(events)
-        reader.setpos_from_xy(8, 0)
-
-        self.assertEqual(reader.pos, 7)
-
     def test_pos2xy_with_no_columns(self):
         console = prepare_console([])
         reader = prepare_reader(console)
         # Simulate a resize to 0 columns
         reader.screeninfo = []
         self.assertEqual(reader.pos2xy(), (0, 0))
+
+    def test_setpos_from_xy_for_non_printing_char(self):
+        code = "# non \u200c printing character"
+        events = code_to_events(code)
+
+        reader, _ = handle_all_events(events)
+        reader.setpos_from_xy(8, 0)
+        self.assertEqual(reader.pos, 7)

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -313,6 +313,15 @@ class TestReader(TestCase):
 
         self.assert_screen_equals(reader, f"{code}a")
 
+    def test_setpos_from_xy_for_non_printing_char(self):
+        code = "# non \u200c printing character"
+        events = code_to_events(code)
+
+        reader, _ = handle_all_events(events)
+        reader.setpos_from_xy(8, 0)
+
+        self.assertEqual(reader.pos, 7)
+
     def test_pos2xy_with_no_columns(self):
         console = prepare_console([])
         reader = prepare_reader(console)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -279,6 +279,7 @@ Laurent De Buyst
 Zach Byrne
 Vedran Čačić
 Nicolas Cadou
+Zhikai Cai
 Jp Calderone
 Ben Caller
 Arnaud Calmettes

--- a/Misc/NEWS.d/next/Library/2024-10-05-13-25-07.gh-issue-124927.uzNA32.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-05-13-25-07.gh-issue-124927.uzNA32.rst
@@ -1,1 +1,1 @@
-Non-printing characters are now properly handled.
+Non-printing characters are now properly handled in the new REPL.

--- a/Misc/NEWS.d/next/Library/2024-10-05-13-25-07.gh-issue-124927.uzNA32.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-05-13-25-07.gh-issue-124927.uzNA32.rst
@@ -1,0 +1,1 @@
+Non-printing characters are now properly handled.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


When encountering non printing characters, there will be 0 in self.screeninfo. Resulting in the setpos_from_xy function getting stuck in a dead loop when pressing the up/down keys, and pos2xy returns an incorrect value when the left/right keys.

<!-- gh-issue-number: gh-124927 -->
* Issue: gh-124927
<!-- /gh-issue-number -->
