### PR TITLE
gh-124531: Fix strftime() with embedded null characters

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -2955,6 +2955,16 @@ class TestDateTime(TestDate):
         except UnicodeEncodeError:
             pass
 
+    def test_strftime_embedded_nul(self):
+        # gh-124531: The null character should not terminate the format string.
+        t = self.theclass(2004, 12, 31, 6, 22, 33, 47)
+        self.assertEqual(t.strftime('\0'), '\0')
+        self.assertEqual(t.strftime('\0'*1000), '\0'*1000)
+        s1 = t.strftime('%c')
+        s2 = t.strftime('%x')
+        self.assertEqual(t.strftime('\0%c\0%x'), f'\0{s1}\0{s2}')
+        self.assertEqual(t.strftime('\0%c\0%x\0'), f'\0{s1}\0{s2}\0')
+
     def test_extract(self):
         dt = self.theclass(2002, 3, 4, 18, 45, 3, 1234)
         self.assertEqual(dt.date(), date(2002, 3, 4))
@@ -3735,6 +3745,16 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
 
         # gh-85432: The parameter was named "fmt" in the pure-Python impl.
         t.strftime(format="%f")
+
+    def test_strftime_embedded_nul(self):
+        # gh-124531: The null character should not terminate the format string.
+        t = self.theclass(1, 2, 3, 4)
+        self.assertEqual(t.strftime('\0'), '\0')
+        self.assertEqual(t.strftime('\0'*1000), '\0'*1000)
+        s1 = t.strftime('%Z')
+        s2 = t.strftime('%X')
+        self.assertEqual(t.strftime('\0%Z\0%X'), f'\0{s1}\0{s2}')
+        self.assertEqual(t.strftime('\0%Z\0%X\0'), f'\0{s1}\0{s2}\0')
 
     def test_format(self):
         t = self.theclass(1, 2, 3, 4)

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -182,8 +182,16 @@ class TimeTestCase(unittest.TestCase):
                 self.fail('conversion specifier: %r failed.' % format)
 
         self.assertRaises(TypeError, time.strftime, b'%S', tt)
-        # embedded null character
-        self.assertRaises(ValueError, time.strftime, '%S\0', tt)
+
+    def test_strftime_embedded_nul(self):
+        # gh-124531: The null character should not terminate the format string.
+        tt = time.gmtime(self.t)
+        self.assertEqual(time.strftime('\0', tt), '\0')
+        self.assertEqual(time.strftime('\0'*1000, tt), '\0'*1000)
+        s1 = time.strftime('%c', tt)
+        s2 = time.strftime('%x', tt)
+        self.assertEqual(time.strftime('\0%c\0%x', tt), f'\0{s1}\0{s2}')
+        self.assertEqual(time.strftime('\0%c\0%x\0', tt), f'\0{s1}\0{s2}\0')
 
     def _bounds_checking(self, func):
         # Make sure that strftime() checks the bounds of the various parts

--- a/Misc/NEWS.d/next/Library/2024-10-05-16-42-33.gh-issue-124531.1ZDOwp.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-05-16-42-33.gh-issue-124531.1ZDOwp.rst
@@ -1,0 +1,4 @@
+Fix :func:`time.strftime`, the :meth:`~datetime.datetime.strftime` method of
+the :mod:`datetime` classes :class:`~datetime.datetime`,
+:class:`~datetime.date` and :class:`~datetime.time` and formatting of these
+classes with format strings containing embedded null characters.


### PR DESCRIPTION
* time.strftime() (raised ValueError)
* the strftime() method and formatting of the datetime classes datetime, date and time (truncated at the null character)


<!-- gh-issue-number: gh-124531 -->
* Issue: gh-124531
<!-- /gh-issue-number -->
