### PR TITLE
GH-109975: Announce final release in What's New in Python 3.13

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -59,7 +59,7 @@ Summary -- Release highlights
 .. This section singles out the most important changes in Python 3.12.
    Brevity is key.
 
-Python 3.12 is the latest stable release of the Python programming language,
+Python 3.12 is a stable release of the Python programming language,
 with a mix of changes to the language and the standard library.
 The library changes focus on cleaning up deprecated APIs, usability, and correctness.
 Of note, the :mod:`!distutils` package has been removed from the standard library.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -46,7 +46,7 @@
    when researching a change.
 
 This article explains the new features in Python 3.13, compared to 3.12.
-Python 3.13 will be released on October 7, 2024.
+Python 3.13 was released on October 7, 2024.
 For full details, see the :ref:`changelog <changelog>`.
 
 .. seealso::
@@ -60,7 +60,7 @@ Summary -- Release Highlights
 .. This section singles out the most important changes in Python 3.13.
    Brevity is key.
 
-Python 3.13 will be the latest stable release of the Python programming
+Python 3.13 is the latest stable release of the Python programming
 language, with a mix of changes to the language, the implementation
 and the standard library.
 The biggest changes include a new `interactive interpreter


### PR DESCRIPTION
Thomas -- this should be the final *What's New in Python 3.13* PR ahead of 3.13.0 final -- please close if you'll address it yourself, but as with last year I thought it was worth opening a PR as the commit needs to go into both 3.14 and 3.13.

I've also updated the text for *What's New in Python 3.12* as it will no longer be the latest stable release.

A

<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125007.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->