### PR TITLE
GH-124549: Add a note that when over-specifying datetime format, only the last directive gets used.

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2761,6 +2761,14 @@ Notes:
       :exc:`DeprecationWarning`. In 3.15 or later we may change this into
       an error or change the default year to a leap year. See :gh:`70647`.
 
+(11)
+   When parsing a string using :meth:`~.datetime.strptime`, if more than one
+   directives of the same time unit were used, only the last directive gets parsed
+   and applied to the datetime object. For example, if the format string contains
+   both ``%Y`` and ``%y``, like ``%Y%y``, only the last directive on the string (``%y``)
+   gets used on the resulting datetime object.
+
+
 .. rubric:: Footnotes
 
 .. [#] If, that is, we ignore the effects of Relativity


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125009.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-124549 -->
* Issue: gh-124549
<!-- /gh-issue-number -->
