### PR TITLE
gh-125008: Fix `tokenize.untokenize` roundtrip for `\n{{`

### DIFF
--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -1934,6 +1934,11 @@ class TestRoundtrip(TestCase):
         self.check_roundtrip(r"rf'\\t{{foo}}'")
         self.check_roundtrip(r"rf'\\\t{{foo}}'")
         self.check_roundtrip(r"rf'\\\\t{{foo}}'")
+
+        self.check_roundtrip(r"rf'\{{foo}}'")
+        self.check_roundtrip(r"f'\\{{foo}}'")
+        self.check_roundtrip(r"rf'\\\{{foo}}'")
+        self.check_roundtrip(r"f'\\\\{{foo}}'")
         cases = [
     """
 if 1:

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -1919,6 +1919,16 @@ class TestRoundtrip(TestCase):
         self.check_roundtrip(r"f'\\\\N{{'")
         self.check_roundtrip(r"f'\\\\\\N{{'")
         self.check_roundtrip(r"f'\\\\\\\\N{{'")
+
+        self.check_roundtrip(r"f'\n{{foo}}'")
+        self.check_roundtrip(r"f'\\n{{foo}}'")
+        self.check_roundtrip(r"f'\\\n{{foo}}'")
+        self.check_roundtrip(r"f'\\\\n{{foo}}'")
+
+        self.check_roundtrip(r"f'\t{{foo}}'")
+        self.check_roundtrip(r"f'\\t{{foo}}'")
+        self.check_roundtrip(r"f'\\\t{{foo}}'")
+        self.check_roundtrip(r"f'\\\\t{{foo}}'")
         cases = [
     """
 if 1:

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -1929,6 +1929,11 @@ class TestRoundtrip(TestCase):
         self.check_roundtrip(r"f'\\t{{foo}}'")
         self.check_roundtrip(r"f'\\\t{{foo}}'")
         self.check_roundtrip(r"f'\\\\t{{foo}}'")
+
+        self.check_roundtrip(r"rf'\t{{foo}}'")
+        self.check_roundtrip(r"rf'\\t{{foo}}'")
+        self.check_roundtrip(r"rf'\\\t{{foo}}'")
+        self.check_roundtrip(r"rf'\\\\t{{foo}}'")
         cases = [
     """
 if 1:

--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -200,7 +200,7 @@ class Untokenizer:
                         characters[-2::-1]
                     )
                 )
-                if n_backslashes % 2 == 0:
+                if n_backslashes % 2 == 0 or characters[-1] != "N":
                     characters.append(character)
                 else:
                     consume_until_next_bracket = True

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-10-05-23-53-06.gh-issue-125008.ETANpd.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-10-05-23-53-06.gh-issue-125008.ETANpd.rst
@@ -1,0 +1,2 @@
+Fix :func:`tokenize.untokenize` producing invalid syntax for
+double braces preceded by certain escape characters.


### PR DESCRIPTION
I'm not sure if this is the best way to fix this issue so I'm open to alternatives :)

<!-- gh-issue-number: gh-125008 -->
* Issue: gh-125008
<!-- /gh-issue-number -->
