### PR TITLE
[3.12] Doc: Simplify the definition of 'soft deprecated' (GH-124988)

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1134,6 +1134,17 @@ Glossary
       when several are given, such as in ``variable_name[1:3:5]``.  The bracket
       (subscript) notation uses :class:`slice` objects internally.
 
+   soft deprecated
+      A soft deprecated API should not be used in new code,
+      but it is safe for already existing code to use it.
+      The API remains documented and tested, but will not be enhanced further.
+
+      Soft deprecation, unlike normal deprecation, does not plan on removing the API
+      and will not emit warnings.
+
+      See `PEP 387: Soft Deprecation
+      <https://peps.python.org/pep-0387/#soft-deprecation>`_.
+
    special method
       .. index:: pair: special; method
 


### PR DESCRIPTION
(cherry picked from commit feca4cf64e9742b9c002d5533ced47e68b34a880)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125030.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->