### PR TITLE
gh-120762: make_ssl_certs: Don't set extensions for the temporary CSR

### DIFF
--- a/Lib/test/certdata/make_ssl_certs.py
+++ b/Lib/test/certdata/make_ssl_certs.py
@@ -139,7 +139,6 @@ def make_cert_key(cmdlineargs, hostname, sign=False, extra_san='',
             f.write(req)
         args = ['req', '-new', '-nodes', '-days', cmdlineargs.days,
                 '-newkey', key, '-keyout', key_file,
-                '-extensions', ext,
                 '-config', req_file]
         if sign:
             with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -148,7 +147,7 @@ def make_cert_key(cmdlineargs, hostname, sign=False, extra_san='',
             args += ['-out', reqfile ]
 
         else:
-            args += ['-x509', '-out', cert_file ]
+            args += ['-extensions', ext, '-x509', '-out', cert_file ]
         check_call(['openssl'] + args)
 
         if sign:


### PR DESCRIPTION
`openssl req` fails with openssl 3.2.2 because the config line

    authorityKeyIdentifier = keyid:always,issuer:always

is not supported for certificate signing requests (since the issuing certificate authority is not known).

David von Oheimb, the OpenSSL dev that made the change, commented in: https://github.com/openssl/openssl/issues/22966#issuecomment-1858396738 :

> This problem did not show up in older OpenSSL versions because of a bug:
> the `req` app ignored the `-extensions` option unless `-x505` is given,
> which I fixed in https://github.com/openssl/openssl/pull/16865.

(I assume `-x505` is a typo for `-x509`.)

In our `make_cert_key` function:

If `sign` is true:
- We don't pass `-x509` to `req`, so in this case it should be safe to omit the `-extensions` argument. (Old OpenSSL ignores it, new OpenSSL fails on it.)
- The extensions are passed to the `ca` call later in the function. There they take effect, and `authorityKeyIdentifier` is valid.

If `sign` is false, this commit has no effect except rearranging the CLI arguments.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-120762 -->
* Issue: gh-120762
<!-- /gh-issue-number -->
