### PR TITLE
gh-125063: Emit slices as constants in the bytecode compiler

### DIFF
--- a/Include/internal/pycore_magic_number.h
+++ b/Include/internal/pycore_magic_number.h
@@ -259,6 +259,7 @@ Known values:
     Python 3.14a1 3605 (Move ENTER_EXECUTOR to opcode 255)
     Python 3.14a1 3606 (Specialize CALL_KW)
     Python 3.14a1 3607 (Add pseudo instructions JUMP_IF_TRUE/FALSE)
+    Python 3.14a1 3608 (Add support for slices)
 
     Python 3.15 will start with 3650
 
@@ -271,7 +272,7 @@ PC/launcher.c must also be updated.
 
 */
 
-#define PYC_MAGIC_NUMBER 3607
+#define PYC_MAGIC_NUMBER 3608
 /* This is equivalent to converting PYC_MAGIC_NUMBER to 2 bytes
    (little-endian) and then appending b'\r\n'. */
 #define PYC_MAGIC_NUMBER_TOKEN \

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1373,6 +1373,14 @@ class TestSpecifics(unittest.TestCase):
                     actual += 1
             self.assertEqual(actual, expected)
 
+        def check_consts(func, typ, expected):
+            slice_consts = 0
+            consts = func.__code__.co_consts
+            for instr in dis.Bytecode(func):
+                if instr.opname == "LOAD_CONST" and isinstance(consts[instr.oparg], typ):
+                    slice_consts += 1
+            self.assertEqual(slice_consts, expected)
+
         def load():
             return x[a:b] + x [a:] + x[:b] + x[:]
 
@@ -1388,15 +1396,30 @@ class TestSpecifics(unittest.TestCase):
         def aug():
             x[a:b] += y
 
-        check_op_count(load, "BINARY_SLICE", 4)
+        def aug_const():
+            x[1:2] += y
+
+        def compound_const_slice():
+            x[1:2:3, 4:5:6] = y
+
+        check_op_count(load, "BINARY_SLICE", 3)
         check_op_count(load, "BUILD_SLICE", 0)
-        check_op_count(store, "STORE_SLICE", 4)
+        check_consts(load, slice, 1)
+        check_op_count(store, "STORE_SLICE", 3)
         check_op_count(store, "BUILD_SLICE", 0)
+        check_consts(store, slice, 1)
         check_op_count(long_slice, "BUILD_SLICE", 1)
         check_op_count(long_slice, "BINARY_SLICE", 0)
         check_op_count(aug, "BINARY_SLICE", 1)
         check_op_count(aug, "STORE_SLICE", 1)
         check_op_count(aug, "BUILD_SLICE", 0)
+        check_op_count(aug_const, "BINARY_SLICE", 0)
+        check_op_count(aug_const, "STORE_SLICE", 0)
+        check_consts(aug_const, slice, 1)
+        check_op_count(compound_const_slice, "BINARY_SLICE", 0)
+        check_op_count(compound_const_slice, "BUILD_SLICE", 0)
+        check_consts(compound_const_slice, slice, 0)
+        check_consts(compound_const_slice, tuple, 1)
 
     def test_compare_positions(self):
         for opname_prefix, op in [

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -2336,6 +2336,7 @@ _PyCode_ConstantKey(PyObject *op)
     if (op == Py_None || op == Py_Ellipsis
        || PyLong_CheckExact(op)
        || PyUnicode_CheckExact(op)
+       || PySlice_Check(op)
           /* code_richcompare() uses _PyCode_ConstantKey() internally */
        || PyCode_Check(op))
     {

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -343,7 +343,7 @@ Create a slice object.  This is used for extended slicing (e.g. a[0:10:2]).");
 static void
 slice_dealloc(PySliceObject *r)
 {
-    _PyObject_GC_UNTRACK(r);
+    PyObject_GC_UnTrack(r);
     Py_DECREF(r->step);
     Py_DECREF(r->start);
     Py_DECREF(r->stop);

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -5286,9 +5286,6 @@ codegen_slice_two_parts(compiler *c, expr_ty s)
     return 0;
 }
 
-/* Returns the number of the values emitted as part of the slice.
- * May be 0 if a constant slice was emitted.
- * -1 if there is an error. */
 static int
 codegen_slice(compiler *c, expr_ty s)
 {
@@ -5309,8 +5306,11 @@ codegen_slice(compiler *c, expr_ty s)
             step = s->v.Slice.step->v.Constant.value;
         }
         PyObject *slice = PySlice_New(start, stop, step);
+        if (slice == NULL) {
+            return ERROR;
+        }
         ADDOP_LOAD_CONST_NEW(c, LOC(s), slice);
-        return 0;
+        return SUCCESS;
     }
 
     RETURN_IF_ERROR(codegen_slice_two_parts(c, s));
@@ -5321,7 +5321,7 @@ codegen_slice(compiler *c, expr_ty s)
     }
 
     ADDOP_I(c, LOC(s), BUILD_SLICE, n);
-    return n;
+    return SUCCESS;
 }
 
 

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1544,6 +1544,7 @@ r_object(RFILE *p)
 
     case TYPE_SLICE:
     {
+        int idx = r_ref_reserve(flag, p);
         PyObject *stop = NULL;
         PyObject *step = NULL;
         PyObject *start = r_object(p);
@@ -1559,6 +1560,8 @@ r_object(RFILE *p)
             goto cleanup;
         }
         retval = PySlice_New(start, stop, step);
+        if (idx)
+            r_ref_insert(retval, idx, flag, p);
     cleanup:
         Py_XDECREF(start);
         Py_XDECREF(stop);

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1560,8 +1560,7 @@ r_object(RFILE *p)
             goto cleanup;
         }
         retval = PySlice_New(start, stop, step);
-        if (idx)
-            r_ref_insert(retval, idx, flag, p);
+        r_ref_insert(retval, idx, flag, p);
     cleanup:
         Py_XDECREF(start);
         Py_XDECREF(stop);

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -76,6 +76,7 @@ module marshal
 #define TYPE_UNKNOWN            '?'
 #define TYPE_SET                '<'
 #define TYPE_FROZENSET          '>'
+#define TYPE_SLICE              ':'
 #define FLAG_REF                '\x80' /* with a type, add obj to index */
 
 #define TYPE_ASCII              'a'
@@ -612,6 +613,13 @@ w_complex_object(PyObject *v, char flag, WFILE *p)
         W_TYPE(TYPE_STRING, p);
         w_pstring(view.buf, view.len, p);
         PyBuffer_Release(&view);
+    }
+    else if (PySlice_Check(v)) {
+        PySliceObject *slice = (PySliceObject *)v;
+        W_TYPE(TYPE_SLICE, p);
+        w_object(slice->start, p);
+        w_object(slice->stop, p);
+        w_object(slice->step, p);
     }
     else {
         W_TYPE(TYPE_UNKNOWN, p);
@@ -1533,6 +1541,30 @@ r_object(RFILE *p)
         }
         retval = Py_NewRef(v);
         break;
+
+    case TYPE_SLICE:
+    {
+        PyObject *stop = NULL;
+        PyObject *step = NULL;
+        PyObject *start = r_object(p);
+        if (start == NULL) {
+            goto cleanup;
+        }
+        stop = r_object(p);
+        if (stop == NULL) {
+            goto cleanup;
+        }
+        step = r_object(p);
+        if (step == NULL) {
+            goto cleanup;
+        }
+        retval = PySlice_New(start, stop, step);
+    cleanup:
+        Py_XDECREF(start);
+        Py_XDECREF(stop);
+        Py_XDECREF(step);
+        break;
+    }
 
     default:
         /* Bogus data got written, which isn't ideal.

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1544,7 +1544,7 @@ r_object(RFILE *p)
 
     case TYPE_SLICE:
     {
-        int idx = r_ref_reserve(flag, p);
+        Py_ssize_t idx = r_ref_reserve(flag, p);
         PyObject *stop = NULL;
         PyObject *step = NULL;
         PyObject *start = r_object(p);


### PR DESCRIPTION
This emits slices as constants in the compiler (when the slices only contain constant members).

I measured a 10% speedup on the [cavity_flow benchmark](https://github.com/spcl/npbench/blob/main/npbench/benchmarks/cavity_flow/cavity_flow_numpy.py) in npbench, which not surprisingly uses a lot of slices, but this kind of code is fairly idiomatic for Numpy.  (EDIT: The benchmark as a [standalone script](https://gist.github.com/mdboom/0cce1f5b76fa710f25dcb0adc772b346))

This does measure as are 1% slower on [pyperformance](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20241007-3.14.0a0-8738ae5/bm-20241007-linux-x86_64-mdboom-marshal_slice-3.14.0a0-8738ae5-vs-base.svg), but that seems largely due to `unpack_sequence`.  I'm going to rerun on more platforms, and also collect stats, since I would expect a measurable reduction in instructions executed.

<!-- gh-issue-number: gh-125063 -->
* Issue: gh-125063
<!-- /gh-issue-number -->
