### PR TITLE
[3.13] gh-125072: Add label for assignment expressions; update tracked section for assignment expression topic (GH-125074)

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1809,6 +1809,8 @@ returns a boolean value regardless of the type of its argument
    single: named expression
    pair: assignment; expression
 
+.. _assignment-expressions:
+
 Assignment expressions
 ======================
 

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -334,8 +334,8 @@ class MiscNews(SphinxDirective):
 # Support for building "topic help" for pydoc
 
 pydoc_topic_labels = [
-    'assert', 'assignment', 'async', 'atom-identifiers', 'atom-literals',
-    'attribute-access', 'attribute-references', 'augassign', 'await',
+    'assert', 'assignment', 'assignment-expressions', 'async',  'atom-identifiers',
+    'atom-literals', 'attribute-access', 'attribute-references', 'augassign', 'await',
     'binary', 'bitwise', 'bltin-code-objects', 'bltin-ellipsis-object',
     'bltin-null-object', 'bltin-type-objects', 'booleans',
     'break', 'callable-types', 'calls', 'class', 'comparisons', 'compound',


### PR DESCRIPTION
(cherry picked from commit 447a15190d6d766004b77619ba43e44256e348e2)


<!-- gh-issue-number: gh-125072 -->
* Issue: gh-125072
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125077.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->