### PR TITLE
gh-82419: Improve site docs to clarify user site-packages disabling

### DIFF
--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -195,8 +195,8 @@ Module contents
    Note that :func:`getusersitepackages` and :func:`getuserbase`
    don't take this variable into account. The check for :data:`ENABLE_USER_SITE` and
    modification of ``sys.path`` occur later.  To disable user site-packages,
-   users are encouraged to create :mod:`sitecustomize` or :mod:`usercustomize`,
-   rather than try to edit :file:`site.py`.
+   administrators or users are encouraged to create :mod:`sitecustomize`
+   or :mod:`usercustomize` rather than try to edit :file:`site.py`.
 
 
 .. data:: USER_SITE

--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -190,7 +190,13 @@ Module contents
    was disabled by user request (with :option:`-s` or
    :envvar:`PYTHONNOUSERSITE`).  ``None`` means it was disabled for security
    reasons (mismatch between user or group id and effective id) or by an
-   administrator.
+   administrator. Note that :func:`getusersitepackages` and :func:`getuserbase`
+   don't take this variable into account. The check for :data:`ENABLE_USER_SITE` and
+   modification of ``sys.path`` occurs later.  To disable user site-packages,
+   users are encouraged to create :mod:`sitecustomize` or :mod:`usercustomize`,
+   rather than try to edit :file:`Lib/site.py`. Changing :file:`Lib/site.py`
+   won't work unless recompile Python, but administrators should still be able
+   to set :data:`ENABLE_USER_SITE` in a :mod:`sitecustomize` module.
 
 
 .. data:: USER_SITE

--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -190,13 +190,13 @@ Module contents
    was disabled by user request (with :option:`-s` or
    :envvar:`PYTHONNOUSERSITE`).  ``None`` means it was disabled for security
    reasons (mismatch between user or group id and effective id) or by an
-   administrator. Note that :func:`getusersitepackages` and :func:`getuserbase`
+   administrator.
+
+   Note that :func:`getusersitepackages` and :func:`getuserbase`
    don't take this variable into account. The check for :data:`ENABLE_USER_SITE` and
-   modification of ``sys.path`` occurs later.  To disable user site-packages,
+   modification of ``sys.path`` occur later.  To disable user site-packages,
    users are encouraged to create :mod:`sitecustomize` or :mod:`usercustomize`,
-   rather than try to edit :file:`Lib/site.py`. Changing :file:`Lib/site.py`
-   won't work unless recompile Python, but administrators should still be able
-   to set :data:`ENABLE_USER_SITE` in a :mod:`sitecustomize` module.
+   rather than try to edit :file:`site.py`.
 
 
 .. data:: USER_SITE


### PR DESCRIPTION
Based on the discussion here: https://github.com/python/cpython/issues/82419 and advises from the @tiran and @encukou , I further clarified the relationship between ENABLE_USER_SITE and the functions `getusersitepackages()` and `getuserbase()` in the document. I also added a method to configure the output of these two functions.



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-82419 -->
* Issue: gh-82419
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125083.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->