### PR TITLE
gh-125084: Resolve paths in generator common code

### DIFF
--- a/Tools/cases_generator/generators_common.py
+++ b/Tools/cases_generator/generators_common.py
@@ -44,12 +44,12 @@ class TokenIterator:
         return self.look_ahead
 
 ROOT = Path(__file__).parent.parent.parent
-DEFAULT_INPUT = (ROOT / "Python/bytecodes.c").absolute().as_posix()
+DEFAULT_INPUT = (ROOT / "Python/bytecodes.c").resolve().as_posix()
 
 
 def root_relative_path(filename: str) -> str:
     try:
-        return Path(filename).absolute().relative_to(ROOT).as_posix()
+        return Path(filename).resolve().relative_to(ROOT).as_posix()
     except ValueError:
         # Not relative to root, just return original path.
         return filename

--- a/Tools/cases_generator/generators_common.py
+++ b/Tools/cases_generator/generators_common.py
@@ -43,8 +43,8 @@ class TokenIterator:
                 break
         return self.look_ahead
 
-ROOT = Path(__file__).parent.parent.parent
-DEFAULT_INPUT = (ROOT / "Python/bytecodes.c").resolve().as_posix()
+ROOT = Path(__file__).parent.parent.parent.resolve()
+DEFAULT_INPUT = (ROOT / "Python/bytecodes.c").as_posix()
 
 
 def root_relative_path(filename: str) -> str:


### PR DESCRIPTION
In out of tree builds, the paths can contain `../` which needs to be resolved for the relative path calculation to work.

Tested by running `make regen-all` which in my dev setup (see: https://github.com/python/cpython/issues/125084 for layout) used to generate multiple path changes, now generates identical paths to the committed files.

Can this get the no-news label? (Minor internal dev tooling change)

<!-- gh-issue-number: gh-125084 -->
* Issue: gh-125084
<!-- /gh-issue-number -->
