### PR TITLE
gh-90102: Fix pyio return value

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1806,7 +1806,7 @@ class FileIO(RawIOBase):
         """
         if (self._stat_atopen is not None
             and not stat.S_ISCHR(self._stat_atopen.st_mode)):
-            return True
+            return False
         return os.isatty(self._fd)
 
     @property


### PR DESCRIPTION
Spotted by @ngnpope (https://github.com/python/cpython/pull/124922/files#r1791363776).

`isatty` returns False to indicate the file is not a TTY. The C implementation of _io does that (`Py_RETURN_FALSE`) but I got the bool backwards in the _pyio implementaiton.

cc: @vstinner 

<!-- gh-issue-number: gh-90102 -->
* Issue: gh-90102
<!-- /gh-issue-number -->
