### PR TITLE
gh-125096: Don't import _pyrepl in site if PYTHON_BASIC_REPL

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -491,12 +491,21 @@ def register_readline():
     This can be overridden in the sitecustomize or usercustomize module,
     or in a PYTHONSTARTUP file.
     """
+    if not sys.flags.ignore_environment:
+        PYTHON_BASIC_REPL = os.getenv("PYTHON_BASIC_REPL")
+    else:
+        PYTHON_BASIC_REPL = False
+
     import atexit
     try:
         import readline
         import rlcompleter  # noqa: F401
-        import _pyrepl.readline
-        import _pyrepl.unix_console
+        if PYTHON_BASIC_REPL:
+            CAN_USE_PYREPL = False
+        else:
+            import _pyrepl.readline
+            import _pyrepl.unix_console
+            from _pyrepl.main import CAN_USE_PYREPL
     except ImportError:
         return
 
@@ -517,7 +526,6 @@ def register_readline():
         pass
 
     if readline.get_current_history_length() == 0:
-        from _pyrepl.main import CAN_USE_PYREPL
         # If no history was loaded, default to .python_history,
         # or PYTHON_HISTORY.
         # The guard is necessary to avoid doubling history size at
@@ -525,13 +533,17 @@ def register_readline():
         # through a PYTHONSTARTUP hook, see:
         # http://bugs.python.org/issue5845#msg198636
         history = gethistoryfile()
-        if os.getenv("PYTHON_BASIC_REPL") or not CAN_USE_PYREPL:
-            readline_module = readline
-        else:
+
+        if CAN_USE_PYREPL:
             readline_module = _pyrepl.readline
+            exceptions = (OSError, *_pyrepl.unix_console._error)
+        else:
+            readline_module = readline
+            exceptions = OSError
+
         try:
             readline_module.read_history_file(history)
-        except (OSError,* _pyrepl.unix_console._error):
+        except exceptions:
             pass
 
         def write_history():

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1204,6 +1204,18 @@ class TestMain(ReplTestCase):
         self.assertNotIn("Exception", output)
         self.assertNotIn("Traceback", output)
 
+        # The site module must not load _pyrepl if PYTHON_BASIC_REPL is set
+        commands = ("import sys\n"
+                    "print('_pyrepl' in sys.modules)\n"
+                    "exit()\n")
+        env["PYTHON_BASIC_REPL"] = "1"
+        output, exit_code = self.run_repl(commands, env=env)
+        self.assertEqual(exit_code, 0)
+        self.assertIn("False", output)
+        self.assertNotIn("True", output)
+        self.assertNotIn("Exception", output)
+        self.assertNotIn("Traceback", output)
+
     @force_not_colorized
     def test_bad_sys_excepthook_doesnt_crash_pyrepl(self):
         env = os.environ.copy()

--- a/Misc/NEWS.d/next/Library/2024-10-08-13-28-22.gh-issue-125096.Vz0W5g.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-08-13-28-22.gh-issue-125096.Vz0W5g.rst
@@ -1,0 +1,5 @@
+If the :envvar:`PYTHON_BASIC_REPL` environment variable is set, the
+:mod:`site` module no longer imports the :mod:`!_pyrepl` module. Moreover,
+the :mod:`site` module now respects :option:`-E` and :option:`-I` command
+line options: ignore :envvar:`PYTHON_BASIC_REPL` in this case. Patch by
+Victor Stinner.


### PR DESCRIPTION
If the PYTHON_BASIC_REPL environment variable is set, the site module no longer imports the _pyrepl module.

Moreover, the site module now respects -E and -I command line options: ignore PYTHON_BASIC_REPL in this case.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125096 -->
* Issue: gh-125096
<!-- /gh-issue-number -->
