### PR TITLE
gh-121404: typo fix in compile.c: MATADATA -> METADATA

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1534,7 +1534,7 @@ _PyCompile_CodeGen(PyObject *ast, PyObject *filename, PyCompilerFlags *pflags,
 
     _PyCompile_CodeUnitMetadata *umd = &c->u->u_metadata;
 
-#define SET_MATADATA_INT(key, value) do { \
+#define SET_METADATA_INT(key, value) do { \
         PyObject *v = PyLong_FromLong((long)value); \
         if (v == NULL) goto finally; \
         int res = PyDict_SetItemString(metadata, key, v); \
@@ -1542,10 +1542,10 @@ _PyCompile_CodeGen(PyObject *ast, PyObject *filename, PyCompilerFlags *pflags,
         if (res < 0) goto finally; \
     } while (0);
 
-    SET_MATADATA_INT("argcount", umd->u_argcount);
-    SET_MATADATA_INT("posonlyargcount", umd->u_posonlyargcount);
-    SET_MATADATA_INT("kwonlyargcount", umd->u_kwonlyargcount);
-#undef SET_MATADATA_INT
+    SET_METADATA_INT("argcount", umd->u_argcount);
+    SET_METADATA_INT("posonlyargcount", umd->u_posonlyargcount);
+    SET_METADATA_INT("kwonlyargcount", umd->u_kwonlyargcount);
+#undef SET_METADATA_INT
 
     int addNone = mod->kind != Expression_kind;
     if (_PyCodegen_AddReturnAtEnd(c, addNone) < 0) {


### PR DESCRIPTION
Tiny typo fix.
I've linked this PR to the refactoring issue.

<!-- gh-issue-number: gh-121404 -->
* Issue: gh-121404
<!-- /gh-issue-number -->
