### PR TITLE
gh-125058: update `_thread` docs regarding interruptibility of `lock.acquire()`

### DIFF
--- a/Doc/library/_thread.rst
+++ b/Doc/library/_thread.rst
@@ -219,9 +219,10 @@ In addition to these methods, lock objects can also be used via the
 * Calling :func:`sys.exit` or raising the :exc:`SystemExit` exception is
   equivalent to calling :func:`_thread.exit`.
 
-* It is not possible to interrupt the :meth:`~threading.Lock.acquire` method on
-  a lock --- the :exc:`KeyboardInterrupt` exception will happen after the lock
-  has been acquired.
+* It is platform-dependent whether the :meth:`~threading.Lock.acquire` method
+  on a lock can be interrupted (so that the :exc:`KeyboardInterrupt` exception
+  will happen immediately, rather than only after the lock has been acquired or
+  the operation has timed out). E.g., it can be interrupted on POSIX.
 
 * When the main thread exits, it is system defined whether the other threads
   survive.  On most systems, they are killed without executing

--- a/Doc/library/_thread.rst
+++ b/Doc/library/_thread.rst
@@ -222,7 +222,8 @@ In addition to these methods, lock objects can also be used via the
 * It is platform-dependent whether the :meth:`~threading.Lock.acquire` method
   on a lock can be interrupted (so that the :exc:`KeyboardInterrupt` exception
   will happen immediately, rather than only after the lock has been acquired or
-  the operation has timed out). E.g., it can be interrupted on POSIX.
+  the operation has timed out). It can be interrupted on POSIX, but not on
+  Windows.
 
 * When the main thread exits, it is system defined whether the other threads
   survive.  On most systems, they are killed without executing


### PR DESCRIPTION
Document that it is platform-dependent (e.g., can be interrupted on POSIX).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125058 -->
* Issue: gh-125058
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125141.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->