### PR TITLE
Misc improvements to the itertools docs

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -134,7 +134,7 @@ loops that truncate the stream.
     To compute a running minimum, set *function* to :func:`min`.
     For a running maximum, set *function* to :func:`max`.
     Or for a running product, set *function* to :func:`operator.mul`.
-    To build an `Amortization table
+    To build an `amortization table
     <https://www.ramseysolutions.com/real-estate/amortization-schedule>`_,
     accumulate the interest and apply payments:
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -1261,12 +1261,6 @@ The following recipes have a more mathematical flavor:
     [1, 2, 3, 4, 5, 6]
 
 
-    >>> list(repeatfunc(pow, 5, 2, 3))
-    [8, 8, 8, 8, 8]
-    >>> take(5, map(int, repeatfunc(random.random)))
-    [0, 0, 0, 0, 0]
-
-
     >>> list(ncycles('abc', 3))
     ['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c']
     >>> # Verify greedy consumption of input iterator
@@ -1551,6 +1545,10 @@ The following recipes have a more mathematical flavor:
     ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
 
 
+    >>> list(repeatfunc(pow, 5, 2, 3))
+    [8, 8, 8, 8, 8]
+    >>> take(5, map(int, repeatfunc(random.random)))
+    [0, 0, 0, 0, 0]
     >>> random.seed(85753098575309)
     >>> list(repeatfunc(random.random, 3))
     [0.16370491282496968, 0.45889608687313455, 0.3747076837820118]

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -972,15 +972,6 @@ and :term:`generators <generator>` which incur interpreter overhead.
            iterators = cycle(islice(iterators, num_active))
            yield from map(next, iterators)
 
-   def partition(predicate, iterable):
-       """Partition entries into false entries and true entries.
-
-       If *predicate* is slow, consider wrapping it with functools.lru_cache().
-       """
-       # partition(is_odd, range(10)) → 0 2 4 6 8   and  1 3 5 7 9
-       t1, t2 = tee(iterable)
-       return filterfalse(predicate, t1), filter(predicate, t2)
-
    def subslices(seq):
        "Return all contiguous non-empty subslices of a sequence."
        # subslices('ABCD') → A AB ABC ABCD B BC BCD C CD D
@@ -1603,26 +1594,6 @@ The following recipes have a more mathematical flavor:
     >>> ''.join(chain(*input_iterators))
     'dijkopqr'
 
-    >>> def is_odd(x):
-    ...     return x % 2 == 1
-
-    >>> evens, odds = partition(is_odd, range(10))
-    >>> list(evens)
-    [0, 2, 4, 6, 8]
-    >>> list(odds)
-    [1, 3, 5, 7, 9]
-    >>> # Verify that the input is consumed lazily
-    >>> input_iterator = iter(range(10))
-    >>> evens, odds = partition(is_odd, input_iterator)
-    >>> next(odds)
-    1
-    >>> next(odds)
-    3
-    >>> next(evens)
-    0
-    >>> list(input_iterator)
-    [4, 5, 6, 7, 8, 9]
-
     >>> list(subslices('ABCD'))
     ['A', 'AB', 'ABC', 'ABCD', 'B', 'BC', 'BCD', 'C', 'CD', 'D']
 
@@ -1767,6 +1738,17 @@ The following recipes have a more mathematical flavor:
 
        return true_iterator(), chain(transition, it)
 
+    def partition(predicate, iterable):
+        """Partition entries into false entries and true entries.
+
+        If *predicate* is slow, consider wrapping it with functools.lru_cache().
+        """
+        # partition(is_odd, range(10)) → 0 2 4 6 8   and  1 3 5 7 9
+        t1, t2 = tee(iterable)
+        return filterfalse(predicate, t1), filter(predicate, t2)
+
+
+
 .. doctest::
     :hide:
 
@@ -1802,3 +1784,23 @@ The following recipes have a more mathematical flavor:
     'ABC'
     >>> ''.join(remainder)
     'dEfGhI'
+
+    >>> def is_odd(x):
+    ...     return x % 2 == 1
+
+    >>> evens, odds = partition(is_odd, range(10))
+    >>> list(evens)
+    [0, 2, 4, 6, 8]
+    >>> list(odds)
+    [1, 3, 5, 7, 9]
+    >>> # Verify that the input is consumed lazily
+    >>> input_iterator = iter(range(10))
+    >>> evens, odds = partition(is_odd, input_iterator)
+    >>> next(odds)
+    1
+    >>> next(odds)
+    3
+    >>> next(evens)
+    0
+    >>> list(input_iterator)
+    [4, 5, 6, 7, 8, 9]

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -1189,14 +1189,18 @@ The following recipes have a more mathematical flavor:
     >>> list(it)
     ['d', 'e', 'f']
 
+
     >>> list(prepend(1, [2, 3, 4]))
     [1, 2, 3, 4]
+
 
     >>> list(enumerate('abc'))
     [(0, 'a'), (1, 'b'), (2, 'c')]
 
+
     >>> list(islice(tabulate(lambda x: 2*x), 4))
     [0, 2, 4, 6]
+
 
     >>> list(tail(3, 'ABCDEFG'))
     ['E', 'F', 'G']
@@ -1205,6 +1209,7 @@ The following recipes have a more mathematical flavor:
     >>> output_iterator = tail(3, input_iterator)
     >>> list(input_iterator)
     []
+
 
     >>> it = iter(range(10))
     >>> consume(it, 3)
@@ -1216,6 +1221,7 @@ The following recipes have a more mathematical flavor:
     >>> next(it, 'Done')
     'Done'
 
+
     >>> nth('abcde', 3)
     'd'
     >>> nth('abcde', 9) is None
@@ -1226,6 +1232,7 @@ The following recipes have a more mathematical flavor:
     'c'
     >>> list(it)
     ['d', 'e']
+
 
     >>> [all_equal(s) for s in ('', 'A', 'AAAA', 'AAAB', 'AAABA')]
     [True, True, True, False, False]
@@ -1240,24 +1247,25 @@ The following recipes have a more mathematical flavor:
     >>> ''.join(it)
     'bbccc'
 
+
     >>> quantify(range(99), lambda x: x%2==0)
     50
-
     >>> quantify([True, False, False, True, True])
     3
-
     >>> quantify(range(12), predicate=lambda x: x%2==1)
     6
+
 
     >>> a = [[1, 2, 3], [4, 5, 6]]
     >>> list(flatten(a))
     [1, 2, 3, 4, 5, 6]
 
+
     >>> list(repeatfunc(pow, 5, 2, 3))
     [8, 8, 8, 8, 8]
-
     >>> take(5, map(int, repeatfunc(random.random)))
     [0, 0, 0, 0, 0]
+
 
     >>> list(ncycles('abc', 3))
     ['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c']
@@ -1267,8 +1275,10 @@ The following recipes have a more mathematical flavor:
     >>> list(input_iterator)
     []
 
+
     >>> sum_of_squares([10, 20, 30])
     1400
+
 
     >>> list(reshape([(0, 1), (2, 3), (4, 5)], 3))
     [(0, 1, 2), (3, 4, 5)]
@@ -1290,6 +1300,7 @@ The following recipes have a more mathematical flavor:
     >>> list(reshape(M, 12))
     [(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)]
 
+
     >>> list(transpose([(1, 2, 3), (11, 22, 33)]))
     [(1, 11), (2, 22), (3, 33)]
     >>> # Verify that the inputs are consumed lazily
@@ -1301,10 +1312,12 @@ The following recipes have a more mathematical flavor:
     >>> list(zip(input1, input2))
     [(2, 22), (3, 33)]
 
+
     >>> list(matmul([(7, 5), (3, 5)], [[2, 5], [7, 9]]))
     [(49, 80), (41, 60)]
     >>> list(matmul([[2, 5], [7, 9], [3, 4]], [[7, 11, 5, 4, 9], [3, 5, 2, 6, 3]]))
     [(29, 47, 20, 38, 33), (76, 122, 53, 82, 90), (33, 53, 23, 36, 39)]
+
 
     >>> list(convolve([1, -1, -20], [1, -3])) == [1, -4, -17, 60]
     True
@@ -1327,6 +1340,7 @@ The following recipes have a more mathematical flavor:
     40
     >>> list(signal_iterator)
     [30, 40, 50]
+
 
     >>> from fractions import Fraction
     >>> from decimal import Decimal
@@ -1359,6 +1373,7 @@ The following recipes have a more mathematical flavor:
     >>> polynomial_eval([11, 2], 7) == 11 * 7 + 2
     True
 
+
     >>> polynomial_from_roots([5, -4, 3])
     [1, -4, -17, 60]
     >>> factored = lambda x: (x - 5) * (x + 4) * (x - 3)
@@ -1366,8 +1381,10 @@ The following recipes have a more mathematical flavor:
     >>> all(factored(x) == expanded(x) for x in range(-10, 11))
     True
 
+
     >>> polynomial_derivative([1, -4, -17, 60])
     [3, -8, -17]
+
 
     >>> list(iter_index('AABCADEAF', 'A'))
     [0, 1, 4, 7]
@@ -1426,11 +1443,13 @@ The following recipes have a more mathematical flavor:
     >>> ''.join(input_iterator)
     'DEAF'
 
+
     >>> # Verify that the target value can be a sequence.
     >>> seq = [[10, 20], [30, 40], 30, 40, [30, 40], 50]
     >>> target = [30, 40]
     >>> list(iter_index(seq, target))
     [1, 4]
+
 
     >>> # Verify faithfulness to type specific index() method behaviors.
     >>> # For example, bytes and str perform continuous-subsequence searches
@@ -1460,6 +1479,7 @@ The following recipes have a more mathematical flavor:
     >>> carmichael = {561, 1105, 1729, 2465, 2821, 6601, 8911}  # https://oeis.org/A002997
     >>> set(sieve(10_000)).isdisjoint(carmichael)
     True
+
 
     >>> list(factor(99))                    # Code example 1
     [3, 3, 11]
@@ -1506,6 +1526,7 @@ The following recipes have a more mathematical flavor:
     >>> all(list(factor(n)) == sorted(factor(n)) for n in range(2_000))
     True
 
+
     >>> totient(0)  # https://www.wolframalpha.com/input?i=totient+0
     0
     >>> first_totients = [1, 1, 2, 2, 4, 2, 6, 4, 6, 4, 10, 4, 12, 6, 8, 8, 16, 6,
@@ -1525,8 +1546,10 @@ The following recipes have a more mathematical flavor:
     >>> totient(6 ** 20) == 1 * 2**19 * 2 * 3**19    # repeated primes
     True
 
+
     >>> list(flatten([('a', 'b'), (), ('c', 'd', 'e'), ('f',), ('g', 'h', 'i')]))
     ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
+
 
     >>> random.seed(85753098575309)
     >>> list(repeatfunc(random.random, 3))
@@ -1536,8 +1559,10 @@ The following recipes have a more mathematical flavor:
     >>> list(repeatfunc(pow, 3, 2, 5))
     [32, 32, 32]
 
+
     >>> list(grouper('abcdefg', 3, fillvalue='x'))
     [('a', 'b', 'c'), ('d', 'e', 'f'), ('g', 'x', 'x')]
+
 
     >>> it = grouper('abcdefg', 3, incomplete='strict')
     >>> next(it)
@@ -1551,6 +1576,7 @@ The following recipes have a more mathematical flavor:
 
     >>> list(grouper('abcdefg', n=3, incomplete='ignore'))
     [('a', 'b', 'c'), ('d', 'e', 'f')]
+
 
     >>> list(sliding_window('ABCDEFG', 1))
     [('A',), ('B',), ('C',), ('D',), ('E',), ('F',), ('G',)]
@@ -1581,6 +1607,7 @@ The following recipes have a more mathematical flavor:
     ...
     'zero or negative n not supported'
 
+
     >>> list(roundrobin('abc', 'd', 'ef'))
     ['a', 'd', 'e', 'b', 'f', 'c']
     >>> ranges = [range(5, 1000), range(4, 3000), range(0), range(3, 2000), range(2, 5000), range(1, 3500)]
@@ -1594,17 +1621,18 @@ The following recipes have a more mathematical flavor:
     >>> ''.join(chain(*input_iterators))
     'dijkopqr'
 
+
     >>> list(subslices('ABCD'))
     ['A', 'AB', 'ABC', 'ABCD', 'B', 'BC', 'BCD', 'C', 'CD', 'D']
 
+
     >>> list(powerset([1,2,3]))
     [(), (1,), (2,), (3,), (1, 2), (1, 3), (2, 3), (1, 2, 3)]
-
     >>> all(len(list(powerset(range(n)))) == 2**n for n in range(18))
     True
-
     >>> list(powerset('abcde')) == sorted(sorted(set(powerset('abcde'))), key=len)
     True
+
 
     >>> list(unique_everseen('AAAABBBCCDAABBB'))
     ['A', 'B', 'C', 'D']
@@ -1620,6 +1648,7 @@ The following recipes have a more mathematical flavor:
     >>> ''.join(input_iterator)
     'AAABBBCCDAABBB'
 
+
     >>> list(unique_justseen('AAAABBBCCDAABBB'))
     ['A', 'B', 'C', 'D', 'A', 'B']
     >>> list(unique_justseen('ABBCcAD', str.casefold))
@@ -1634,12 +1663,14 @@ The following recipes have a more mathematical flavor:
     >>> ''.join(input_iterator)
     'AAABBBCCDAABBB'
 
+
     >>> list(unique([[1, 2], [3, 4], [1, 2]]))
     [[1, 2], [3, 4]]
     >>> list(unique('ABBcCAD', str.casefold))
     ['A', 'B', 'c', 'D']
     >>> list(unique('ABBcCAD', str.casefold, reverse=True))
     ['D', 'c', 'B', 'A']
+
 
     >>> d = dict(a=1, b=2, c=3)
     >>> it = iter_except(d.popitem, KeyError)
@@ -1657,6 +1688,7 @@ The following recipes have a more mathematical flavor:
     ('a', 1)
     >>> next(it, 'empty')
     'empty'
+
 
     >>> first_true('ABC0DEF1', '9', str.isdigit)
     '0'
@@ -1755,14 +1787,18 @@ The following recipes have a more mathematical flavor:
     >>> dotproduct([1,2,3], [4,5,6])
     32
 
+
     >>> sumprod([1,2,3], [4,5,6])
     32
+
 
     >>> list(islice(pad_none('abc'), 0, 6))
     ['a', 'b', 'c', None, None, None]
 
+
     >>> list(triplewise('ABCDEFG'))
     [('A', 'B', 'C'), ('B', 'C', 'D'), ('C', 'D', 'E'), ('D', 'E', 'F'), ('E', 'F', 'G')]
+
 
     >>> population = 'ABCDEFGH'
     >>> for r in range(len(population) + 1):
@@ -1771,12 +1807,13 @@ The following recipes have a more mathematical flavor:
     ...         assert nth_combination(population, r, i) == seq[i]
     ...     for i in range(-len(seq), 0):
     ...         assert nth_combination(population, r, i) == seq[i]
-
+    ...
     >>> iterable = 'abcde'
     >>> r = 3
     >>> combos = list(combinations(iterable, r))
     >>> all(nth_combination(iterable, r, i) == comb for i, comb in enumerate(combos))
     True
+
 
     >>> it = iter('ABCdEfGhI')
     >>> all_upper, remainder = before_and_after(str.isupper, it)
@@ -1785,9 +1822,10 @@ The following recipes have a more mathematical flavor:
     >>> ''.join(remainder)
     'dEfGhI'
 
+
     >>> def is_odd(x):
     ...     return x % 2 == 1
-
+    ...
     >>> evens, odds = partition(is_odd, range(10))
     >>> list(evens)
     [0, 2, 4, 6, 8]

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -736,6 +736,26 @@ loops that truncate the stream.
    allows nested :func:`tee` calls to share the same underlying data
    chain and to have a single update step rather than a chain of calls.
 
+   The flattening property makes tee iterators efficiently peekable:
+
+   .. testcode::
+
+      def lookahead(tee_iterator):
+           "Return the next value without moving the input forward"
+           [forked_iterator] = tee(tee_iterator, 1)
+           return next(forked_iterator)
+
+   .. doctest::
+
+      >>> iterator = iter('abcdef')
+      >>> [iterator] = tee(iterator, 1)   # Make the input peekable
+      >>> next(iterator)                  # Move the iterator forward
+      'a'
+      >>> lookahead(iterator)             # Check next value
+      'b'
+      >>> next(iterator)                  # Continue moving forward
+      'b'
+
    ``tee`` iterators are not threadsafe. A :exc:`RuntimeError` may be
    raised when simultaneously using iterators returned by the same :func:`tee`
    call, even if the original *iterable* is threadsafe.


### PR DESCRIPTION
Visible changes:
* Add example of using a tee-of-a-tee to preview a data stream.
* Retire the `partitions()` recipe which did not follow the documented advice: "In general, if one iterator uses most or all of the data before another iterator starts, it is faster to use *list()* instead of *tee()*."

Non-visible changes:
* Add more generous whitespacing in the internal doctests.
* Move the two groups of `repeatfunc()` tests to one place.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125147.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->