### PR TITLE
gh-125159: Speed up `posixpath.realpath()` in the common case

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -428,13 +428,14 @@ def _realpath(filename, strict=False, sep=sep, curdir=curdir, pardir=pardir,
 
     while rest:
         name = rest.pop()
-        if name is None:
-            # resolved symlink target
-            seen[rest.pop()] = path
-            continue
         if not name or name == curdir:
-            # current dir
-            continue
+            if name is None:
+                # resolved symlink target
+                seen[rest.pop()] = path
+                continue
+            else:
+                # current dir
+                continue
         if name == pardir:
             # parent dir
             path = path[:path.rindex(sep)] or sep

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -429,13 +429,11 @@ def _realpath(filename, strict=False, sep=sep, curdir=curdir, pardir=pardir,
     while rest:
         name = rest.pop()
         if not name or name == curdir:
+            # current dir
             if name is None:
                 # resolved symlink target
                 seen[rest.pop()] = path
-                continue
-            else:
-                # current dir
-                continue
+            continue
         if name == pardir:
             # parent dir
             path = path[:path.rindex(sep)] or sep

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-10-08-21-29-30.gh-issue-125159.jmi9FB.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-10-08-21-29-30.gh-issue-125159.jmi9FB.rst
@@ -1,0 +1,1 @@
+Speed up :func:`os.path.realpath` on Unix.


### PR DESCRIPTION
Originally proposed in #120146.

### Benchmark

<details><summary>Show script</summary>

```sh
# patch-1.sh
mkdir -p "tmp/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/\
a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/\
a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/\
a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/\
a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/\
a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/\
a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/\
a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a"

echo 200 .
main/python.exe    -m timeit -s "import os; path = './' * 200"   "os.path.realpath(path)"
patch-1/python.exe -m timeit -s "import os; path = './' * 200"   "os.path.realpath(path)"

echo 200 ..
main/python.exe    -m timeit -s "import os; path = '../' * 200"   "os.path.realpath(path)"
patch-1/python.exe -m timeit -s "import os; path = '../' * 200"   "os.path.realpath(path)"

echo 200 dirs
main/python.exe    -m timeit -s "import os; path = os.getcwd() + '/tmp' + '/a' * 200" "os.path.realpath(path)"
patch-1/python.exe -m timeit -s "import os; path = os.getcwd() + '/tmp' + '/a' * 200" "os.path.realpath(path)"
```

</details>

<details><summary>200 . - no difference</summary>

```none
10000 loops, best of 5: 26.9 usec per loop
10000 loops, best of 5: 26.7 usec per loop
```

</details>

<details><summary>200 .. - 1.02x faster </summary>

```none
5000 loops, best of 5: 50.3 usec per loop
5000 loops, best of 5: 49.2 usec per loop
```

</details>

<details><summary>200 dirs - no difference</summary>

```none
100 loops, best of 5: 2.19 msec per loop
100 loops, best of 5: 2.16 msec per loop
```

</details>

```shell
$ python -m timeit -s "name = '.'" "pass" "if name is None: pass"
50000000 loops, best of 5: 9.03 nsec per loop
$ python -m timeit -s "name = '.'" "pass"
50000000 loops, best of 5: 6.08 nsec per loop
```

<!-- gh-issue-number: gh-125159 -->
* Issue: gh-125159
<!-- /gh-issue-number -->
