### PR TITLE
gh-125118: don't copy arbitrary values to _Bool in the struct module

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -540,6 +540,9 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
 
         for c in [b'\x01', b'\x7f', b'\xff', b'\x0f', b'\xf0']:
             self.assertTrue(struct.unpack('>?', c)[0])
+            self.assertTrue(struct.unpack('<?', c)[0])
+            self.assertTrue(struct.unpack('=?', c)[0])
+            self.assertTrue(struct.unpack('@?', c)[0])
 
     def test_count_overflow(self):
         hugecount = '{}b'.format(sys.maxsize+1)

--- a/Misc/NEWS.d/next/Library/2024-10-09-07-09-00.gh-issue-125118.J9rQ1S.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-09-07-09-00.gh-issue-125118.J9rQ1S.rst
@@ -1,0 +1,1 @@
+Don't copy arbitrary values to :c:expr:`_Bool` in the :mod:`struct` module.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -497,7 +497,7 @@ nu_ulonglong(_structmodulestate *state, const char *p, const formatdef *f)
 static PyObject *
 nu_bool(_structmodulestate *state, const char *p, const formatdef *f)
 {
-    const _Bool bool_false = false;
+    const _Bool bool_false = 0;
     return PyBool_FromLong(memcmp(p, &bool_false, sizeof(_Bool)));
 }
 

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -497,7 +497,8 @@ nu_ulonglong(_structmodulestate *state, const char *p, const formatdef *f)
 static PyObject *
 nu_bool(_structmodulestate *state, const char *p, const formatdef *f)
 {
-    return PyBool_FromLong((*p) != 0);
+    const _Bool f = false;
+    return PyBool_FromLong(memcmp(p, &f, sizeof(_Bool));
 }
 
 

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -497,9 +497,7 @@ nu_ulonglong(_structmodulestate *state, const char *p, const formatdef *f)
 static PyObject *
 nu_bool(_structmodulestate *state, const char *p, const formatdef *f)
 {
-    _Bool x;
-    memcpy(&x, p, sizeof x);
-    return PyBool_FromLong(x != 0);
+    return PyBool_FromLong((*p) != 0);
 }
 
 

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -497,8 +497,8 @@ nu_ulonglong(_structmodulestate *state, const char *p, const formatdef *f)
 static PyObject *
 nu_bool(_structmodulestate *state, const char *p, const formatdef *f)
 {
-    const _Bool f = false;
-    return PyBool_FromLong(memcmp(p, &f, sizeof(_Bool));
+    const _Bool _false = false;
+    return PyBool_FromLong(memcmp(p, &_false, sizeof(_Bool));
 }
 
 

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -497,8 +497,8 @@ nu_ulonglong(_structmodulestate *state, const char *p, const formatdef *f)
 static PyObject *
 nu_bool(_structmodulestate *state, const char *p, const formatdef *f)
 {
-    const _Bool _false = false;
-    return PyBool_FromLong(memcmp(p, &_false, sizeof(_Bool)));
+    const _Bool bool_false = false;
+    return PyBool_FromLong(memcmp(p, &bool_false, sizeof(_Bool)));
 }
 
 

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -498,7 +498,7 @@ static PyObject *
 nu_bool(_structmodulestate *state, const char *p, const formatdef *f)
 {
     const _Bool _false = false;
-    return PyBool_FromLong(memcmp(p, &_false, sizeof(_Bool));
+    return PyBool_FromLong(memcmp(p, &_false, sizeof(_Bool)));
 }
 
 


### PR DESCRIPTION
memcopy'ing arbitrary values to _Bool variable triggers undefined behaviour, e.g.:
```c
/* a.c */
#include <stdbool.h>
#include <stdio.h>
#include <string.h>
int main(void)
{
    _Bool x;
    char y = 2;
    memcpy(&x, &y, 1);
    printf("%d\n", x != 0);
    return 0;
}
```
```
$ gcc-12 a.c -Wall && ./a.out
2
$ clang-15 a.c -Wall && ./a.out
0
$ gcc-12 a.c -Wall -fsanitize=undefined && ./a.out
a.c:9:5: runtime error: load of value 2, which is not a valid value for type '_Bool'
0
$ clang-15 a.c -Wall -fsanitize=undefined && ./a.out
a.c:9:20: runtime error: load of value 2, which is not a valid value for type '_Bool'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior a.c:9:20 in
0
```

Cridits to Alex Gaynor.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125118 -->
* Issue: gh-125118
<!-- /gh-issue-number -->
