### PR TITLE
[3.9] gh-89452: GHA: Set --with-dbmliborder to avoid issues with homebrew's gdbm 1.24 (GH-125112)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,9 @@ jobs:
             --with-pydebug \
             --with-openssl="$(brew --prefix openssl@3.0)" \
             --with-tcltk-libs="$(pkg-config --libs tk)" \
-            --with-tcltk-includes="$(pkg-config --cflags tk)"
+            --with-tcltk-includes="$(pkg-config --cflags tk)" \
+            --with-dbmliborder=gdbm:ndbm
+        # (--with-dbmliborder needed for homebrew's gdbm 1.24: see gh-89452)
     - name: Build CPython
       run: make -j4
     - name: Display build info


### PR DESCRIPTION
Per https://github.com/python/cpython/issues/89452GH-issuecomment-1116329316, the issue is fixed in configure for 3.11+, and

> For older Python versions, the workaround is to build with:
>
>     ./configure --with-dbmliborder=gdbm:ndbm

We need this workaround in GitHub Actions, otherwise the tests fail.

(cherry picked from commit 850189a64e7f0b920fe48cb12a5da3e648435680)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-89452 -->
* Issue: gh-89452
<!-- /gh-issue-number -->
