### PR TITLE
gh-125217: Turn off optimization around_PyEval_EvalFrameDefault to avoid MSVC crash

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -41,7 +41,6 @@ jobs:
           ./python -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
   jit:
     name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
-    needs: interpreter
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     strategy:
@@ -163,7 +162,6 @@ jobs:
 
   jit-with-disabled-gil:
     name: Free-Threaded (Debug)
-    needs: interpreter
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -761,6 +761,16 @@ _PyObjectArray_Free(PyObject **array, PyObject **scratch)
  * so consume 3 units of C stack */
 #define PY_EVAL_C_STACK_UNITS 2
 
+#if defined(_MSC_VER) && defined(_Py_USING_PGO) && defined(Py_JIT)
+/* _PyEval_EvalFrameDefault is too large to optimize for speed with
+   PGO on MSVC when the JIT is enabled. Disable that optimization
+   around this function only. If this is fixed upstream, we should
+   gate this on the version of MSVC.
+ */
+#  pragma optimize("t", off)
+/* This setting is reversed below following _PyEval_EvalFrameDefault */
+#endif
+
 PyObject* _Py_HOT_FUNCTION
 _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int throwflag)
 {
@@ -1135,6 +1145,10 @@ goto_to_tier1:
 #endif // _Py_TIER2
 
 }
+
+#if defined(_MSC_VER) && defined(_Py_USING_PGO) && defined(Py_JIT)
+#  pragma optimize("", on)
+#endif
 
 #if defined(__GNUC__)
 #  pragma GCC diagnostic pop

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -462,6 +462,7 @@ combine_symbol_mask(const symbol_mask src, symbol_mask dest)
 }
 
 
+
 // Compiles executor in-place. Don't forget to call _PyJIT_Free later!
 int
 _PyJIT_Compile(_PyExecutorObject *executor, const _PyUOpInstruction trace[], size_t length)

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -461,6 +461,7 @@ combine_symbol_mask(const symbol_mask src, symbol_mask dest)
     }
 }
 
+
 // Compiles executor in-place. Don't forget to call _PyJIT_Free later!
 int
 _PyJIT_Compile(_PyExecutorObject *executor, const _PyUOpInstruction trace[], size_t length)


### PR DESCRIPTION


<!-- gh-issue-number: gh-125217 -->
* Issue: gh-125217
<!-- /gh-issue-number -->
