### PR TITLE
[3.13] gh-124969: Fix locale.nl_langinfo(locale.ALT_DIGITS) (GH-124974)

### DIFF
--- a/Doc/library/locale.rst
+++ b/Doc/library/locale.rst
@@ -158,7 +158,8 @@ The :mod:`locale` module defines the following exception and functions:
 
 .. function:: nl_langinfo(option)
 
-   Return some locale-specific information as a string.  This function is not
+   Return some locale-specific information as a string (or a tuple for
+   ``ALT_DIGITS``).  This function is not
    available on all systems, and the set of possible options might also vary
    across platforms.  The possible argument values are numbers, for which
    symbolic constants are available in the locale module.
@@ -311,8 +312,7 @@ The :mod:`locale` module defines the following exception and functions:
 
    .. data:: ALT_DIGITS
 
-      Get a representation of up to 100 values used to represent the values
-      0 to 99.
+      Get a tuple of up to 100 strings used to represent the values 0 to 99.
 
 
 .. function:: getdefaultlocale([envvars])

--- a/Misc/NEWS.d/next/Library/2024-10-08-12-09-09.gh-issue-124969._VBQLq.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-08-12-09-09.gh-issue-124969._VBQLq.rst
@@ -1,0 +1,3 @@
+Fix ``locale.nl_langinfo(locale.ALT_DIGITS)``. Now it returns a tuple of up
+to 100 strings (an empty tuple on most locales). Previously it returned the
+first item of that tuple or an empty string.

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -608,7 +608,34 @@ _locale_nl_langinfo_impl(PyObject *module, int item)
                instead of an empty string for nl_langinfo(ERA).  */
             const char *result = nl_langinfo(item);
             result = result != NULL ? result : "";
-            return PyUnicode_DecodeLocale(result, NULL);
+            PyObject *pyresult;
+#ifdef ALT_DIGITS
+            if (item == ALT_DIGITS) {
+                /* The result is a sequence of up to 100 NUL-separated strings. */
+                const char *s = result;
+                int count = 0;
+                for (; count < 100 && *s; count++) {
+                    s += strlen(s) + 1;
+                }
+                pyresult = PyTuple_New(count);
+                if (pyresult != NULL) {
+                    for (int i = 0; i < count; i++) {
+                        PyObject *unicode = PyUnicode_DecodeLocale(result, NULL);
+                        if (unicode == NULL) {
+                            Py_CLEAR(pyresult);
+                            break;
+                        }
+                        PyTuple_SET_ITEM(pyresult, i, unicode);
+                        result += strlen(result) + 1;
+                    }
+                }
+            }
+            else
+#endif
+            {
+                pyresult = PyUnicode_DecodeLocale(result, NULL);
+            }
+            return pyresult;
         }
     PyErr_SetString(PyExc_ValueError, "unsupported langinfo constant");
     return NULL;


### PR DESCRIPTION
Now it returns a tuple of up to 100 strings (an empty tuple on most locales). Previously it returned the first item of that tuple or an empty string. (cherry picked from commit 21c04e1a972bd1b6285e0ea41fa107d635bbe43a)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124969 -->
* Issue: gh-124969
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125232.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->