### PR TITLE
Pin the doctest workflow to Ubuntu 22.04

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -95,7 +95,7 @@ jobs:
   # Run "doctest" on HEAD as new syntax doesn't exist in the latest stable release
   doctest:
     name: 'Doctest'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This takes the simplest approach of pinning the runner-image to Ubuntu 22.04. Ubuntu-latest is [being switched](https://github.com/actions/runner-images/issues/10636) to 24.04, so we'll see intermitant failures.

We should aim to upgrade everything to 24.04, but that will take co-ordination with the autoconf work I believe (also see #122566).

A