### PR TITLE
gh-125260: gzip: let compress mtime default to 0

### DIFF
--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -184,7 +184,7 @@ The module defines the following items:
       attribute instead.
 
 
-.. function:: compress(data, compresslevel=9, *, mtime=None)
+.. function:: compress(data, compresslevel=9, *, mtime=0)
 
    Compress the *data*, returning a :class:`bytes` object containing
    the compressed data.  *compresslevel* and *mtime* have the same meaning as in
@@ -203,6 +203,8 @@ The module defines the following items:
    .. versionchanged:: 3.13
       The gzip header OS byte is guaranteed to be set to 255 when this function
       is used as was the case in 3.10 and earlier.
+   .. versionchanged:: 3.14
+      The *mtime* parameter now defaults to 0 for reproducible output.
 
 .. function:: decompress(data)
 

--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -188,7 +188,8 @@ The module defines the following items:
 
    Compress the *data*, returning a :class:`bytes` object containing
    the compressed data.  *compresslevel* and *mtime* have the same meaning as in
-   the :class:`GzipFile` constructor above.
+   the :class:`GzipFile` constructor above,
+   but *mtime* defaults to 0 for reproducible output.
 
    .. versionadded:: 3.2
    .. versionchanged:: 3.8
@@ -205,6 +206,8 @@ The module defines the following items:
       is used as was the case in 3.10 and earlier.
    .. versionchanged:: 3.14
       The *mtime* parameter now defaults to 0 for reproducible output.
+      For the previous behaviour of using the current time,
+      pass ``None`` to *mtime*.
 
 .. function:: decompress(data)
 

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -580,7 +580,7 @@ class _GzipReader(_compression.DecompressReader):
         self._new_member = True
 
 
-def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=None):
+def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=0):
     """Compress data in one shot and return the compressed string.
 
     compresslevel sets the compression level in range of 0-9.

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -584,8 +584,8 @@ def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=0):
     """Compress data in one shot and return the compressed string.
 
     compresslevel sets the compression level in range of 0-9.
-    mtime can be used to set the modification time. The modification time is
-    set to the current time by default.
+    mtime can be used to set the modification time.
+    The modification time is set to 0 by default, for reproducibility.
     """
     # Wbits=31 automatically includes a gzip header and trailer.
     gzip_data = zlib.compress(data, level=compresslevel, wbits=31)

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -713,14 +713,18 @@ class TestGzip(BaseTest):
                         f.read(1) # to set mtime attribute
                         self.assertEqual(f.mtime, mtime)
 
+    def test_compress_mtime_default(self):
+        # test for gh-125260
+        datac = gzip.compress(data1, mtime=0)
+        datac2 = gzip.compress(data1)
+        self.assertEqual(datac, datac2)
+        datac3 = gzip.compress(data1, mtime=None)
+        self.assertNotEqual(datac, datac3)
+
     def test_compress_correct_level(self):
         for mtime in (0, 42):
             with self.subTest(mtime=mtime):
                 nocompress = gzip.compress(data1, compresslevel=0, mtime=mtime)
-                if mtime == 0:
-                    # test for gh-125260
-                    nocompressnomtime = gzip.compress(data1, compresslevel=0)
-                    self.assertEqual(nocompress, nocompressnomtime)
                 yescompress = gzip.compress(data1, compresslevel=1, mtime=mtime)
                 self.assertIn(data1, nocompress)
                 self.assertNotIn(data1, yescompress)

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -717,6 +717,10 @@ class TestGzip(BaseTest):
         for mtime in (0, 42):
             with self.subTest(mtime=mtime):
                 nocompress = gzip.compress(data1, compresslevel=0, mtime=mtime)
+                if mtime == 0:
+                    # test for gh-125260
+                    nocompressnomtime = gzip.compress(data1, compresslevel=0)
+                    self.assertEqual(nocompress, nocompressnomtime)
                 yescompress = gzip.compress(data1, compresslevel=1, mtime=mtime)
                 self.assertIn(data1, nocompress)
                 self.assertNotIn(data1, yescompress)

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -720,6 +720,9 @@ class TestGzip(BaseTest):
         self.assertEqual(datac, datac2)
         datac3 = gzip.compress(data1, mtime=None)
         self.assertNotEqual(datac, datac3)
+        with gzip.GzipFile(fileobj=io.BytesIO(datac3), mode="rb") as f:
+            f.read(1) # to set mtime attribute
+            self.assertGreater(f.mtime, 1)
 
     def test_compress_correct_level(self):
         for mtime in (0, 42):

--- a/Misc/NEWS.d/next/Library/2024-10-11-04-04-38.gh-issue-125260.PeZ0Mb.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-11-04-04-38.gh-issue-125260.PeZ0Mb.rst
@@ -1,1 +1,2 @@
 The :func:`gzip.compress` *mtime* parameter now defaults to 0 for reproducible output.
+Patch by Bernhard M. Wiedemann and Adam Turner.

--- a/Misc/NEWS.d/next/Library/2024-10-11-04-04-38.gh-issue-125260.PeZ0Mb.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-11-04-04-38.gh-issue-125260.PeZ0Mb.rst
@@ -1,0 +1,1 @@
+The :func:`gzip.compress` *mtime* parameter now defaults to 0 for reproducible output.


### PR DESCRIPTION
this follows GNU gzip, which defaults to
store 0 as mtime for compressing stdin, where no file mtime is involved

This makes gzip.compress(str) output deterministic by default and greatly helps reproducible builds.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125260 -->
* Issue: gh-125260
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125261.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->