### PR TITLE
Doc: Use the Snowball project's PyStemmer library

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -111,6 +111,8 @@ jobs:
       run: ./configure --with-pydebug
     - name: 'Build CPython'
       run: make -j4
+    - name: 'Remove PyStemmer from requirements.txt'
+      run: sed -i '/PyStemmer.*/d' Doc/requirements.txt
     - name: 'Install build dependencies'
       run: make -C Doc/ PYTHON=../python venv
     # Use "xvfb-run" since some doctest tests open GUI windows

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -111,8 +111,6 @@ jobs:
       run: ./configure --with-pydebug
     - name: 'Build CPython'
       run: make -j4
-    - name: 'Remove PyStemmer from requirements.txt'
-      run: sed -i '/PyStemmer.*/d' Doc/requirements.txt
     - name: 'Install build dependencies'
       run: make -C Doc/ PYTHON=../python venv
     # Use "xvfb-run" since some doctest tests open GUI windows

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -173,11 +173,11 @@ venv:
 		echo "Creating venv in $(VENVDIR)"; \
 		if $(UV) --version >/dev/null 2>&1; then \
 			$(UV) venv $(VENVDIR); \
-			VIRTUAL_ENV=$(VENVDIR) $(UV) pip install -r $(REQUIREMENTS) --only-binary PyStemmer; \
+			VIRTUAL_ENV=$(VENVDIR) $(UV) pip install -r $(REQUIREMENTS); \
 		else \
 			$(PYTHON) -m venv $(VENVDIR); \
 			$(VENVDIR)/bin/python3 -m pip install --upgrade pip; \
-			$(VENVDIR)/bin/python3 -m pip install -r $(REQUIREMENTS) --only-binary PyStemmer; \
+			$(VENVDIR)/bin/python3 -m pip install -r $(REQUIREMENTS); \
 		fi; \
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -173,11 +173,11 @@ venv:
 		echo "Creating venv in $(VENVDIR)"; \
 		if $(UV) --version >/dev/null 2>&1; then \
 			$(UV) venv $(VENVDIR); \
-			VIRTUAL_ENV=$(VENVDIR) $(UV) pip install -r $(REQUIREMENTS); \
+			VIRTUAL_ENV=$(VENVDIR) $(UV) pip install -r $(REQUIREMENTS) --only-binary PyStemmer; \
 		else \
 			$(PYTHON) -m venv $(VENVDIR); \
 			$(VENVDIR)/bin/python3 -m pip install --upgrade pip; \
-			$(VENVDIR)/bin/python3 -m pip install -r $(REQUIREMENTS); \
+			$(VENVDIR)/bin/python3 -m pip install -r $(REQUIREMENTS) --only-binary PyStemmer; \
 		fi; \
 		echo "The venv has been created in the $(VENVDIR) directory"; \
 	fi

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -10,8 +10,10 @@ sphinx~=8.0.0
 
 blurb
 
+# Optional packages, used if installed
 sphinxext-opengraph~=0.9.0
 sphinx-notfound-page~=1.0.0
+PyStemmer~=2.2.0
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.


### PR DESCRIPTION
PyStemmer exposes bindings to libstemmer_c,
the core Snowball library written in C.
This can improve performance of word stemming.

Sphinx will use PyStemmer if installed, but it isn't a requirement -- downstream redistributors can remove the package, for example.

A

xref:

* https://github.com/snowballstem/pystemmer/
* https://pypi.org/project/PyStemmer/
* https://snowballstem.org/
* https://github.com/snowballstem/snowball

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125264.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->