### PR TITLE
gh-125234: Make PyInitConfig_Free(NULL) a no-op

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -1617,6 +1617,8 @@ Create Config
 
    Free memory of the initialization configuration *config*.
 
+   If *config* is ``NULL``, no operation is performed.
+
 
 Error Handling
 --------------

--- a/Misc/NEWS.d/next/C_API/2024-10-10-15-22-40.gh-issue-125234.Y4TVgT.rst
+++ b/Misc/NEWS.d/next/C_API/2024-10-10-15-22-40.gh-issue-125234.Y4TVgT.rst
@@ -1,0 +1,1 @@
+:c:func:`PyInitConfig_Free` has no behavior when the `config` is NULL.

--- a/Misc/NEWS.d/next/C_API/2024-10-10-15-22-40.gh-issue-125234.Y4TVgT.rst
+++ b/Misc/NEWS.d/next/C_API/2024-10-10-15-22-40.gh-issue-125234.Y4TVgT.rst
@@ -1,1 +1,1 @@
-:c:func:`PyInitConfig_Free` has no behavior when the `config` is NULL.
+:c:func:`PyInitConfig_Free` has no behavior when the ``config`` is NULL.

--- a/Misc/NEWS.d/next/C_API/2024-10-10-15-22-40.gh-issue-125234.Y4TVgT.rst
+++ b/Misc/NEWS.d/next/C_API/2024-10-10-15-22-40.gh-issue-125234.Y4TVgT.rst
@@ -1,1 +1,0 @@
-:c:func:`PyInitConfig_Free` has no behavior when the ``config`` is NULL.

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1849,6 +1849,7 @@ static int test_initconfig_api(void)
         goto error;
     }
     PyInitConfig_Free(config);
+    PyInitConfig_Free(NULL);
 
     dump_config();
     Py_Finalize();

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -3452,7 +3452,6 @@ PyInitConfig_Create(void)
 void
 PyInitConfig_Free(PyInitConfig *config)
 {
-    /* PyInitConfig_Free(NULL) has no effect */
     if (config == NULL) {
         return;
     }

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -3452,7 +3452,7 @@ PyInitConfig_Create(void)
 void
 PyInitConfig_Free(PyInitConfig *config)
 {
-    if (!config) {
+    if (config == NULL) {
         return;
     }
     free(config->err_msg);

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -3452,6 +3452,9 @@ PyInitConfig_Create(void)
 void
 PyInitConfig_Free(PyInitConfig *config)
 {
+    if (!config) {
+        return;
+    }
     free(config->err_msg);
     free(config);
 }

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -3452,6 +3452,7 @@ PyInitConfig_Create(void)
 void
 PyInitConfig_Free(PyInitConfig *config)
 {
+    /* PyInitConfig_Free(NULL) has no effect */
     if (config == NULL) {
         return;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Modified `PyInitConfig_Free`,  to release the memory occupied when the config argument isn't NULL.
```
PyInitConfig *config = NULL;
// some code
if (error_occurred) {
    goto Error;
}
config = PyInitConfig_Create();
if (config == NULL) {
    goto Error;
}
// some other code
if (error_occurred) {
    goto Error;
}
// more code
Error:
// release resources
PyInitConfig_Free(config);
// release resources
```
(I hope my understanding is correct).
<!-- gh-issue-number: gh-125234 -->
* Issue: gh-125234
<!-- /gh-issue-number -->
