### PR TITLE
Add some doctest cleanups for `turtle` and `configparser`

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -54,6 +54,7 @@ can be customized by end users easily.
 
    import os
    os.remove("example.ini")
+   os.remove("override.ini")
 
 
 Quick Start

--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -11,8 +11,14 @@
 
 .. testsetup:: default
 
+   import turtle as turtle_module
    from turtle import *
    turtle = Turtle()
+
+.. testcleanup::
+
+   import os
+   os.remove("my_drawing.ps")
 
 --------------
 

--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -11,7 +11,6 @@
 
 .. testsetup:: default
 
-   import turtle as turtle_module
    from turtle import *
    turtle = Turtle()
 


### PR DESCRIPTION
These doctests write files to your file system, leaving your working tree in a dirty state

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125288.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->