### PR TITLE
Remove the turtle screen during doctests

### DIFF
--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -17,6 +17,7 @@
 .. testcleanup::
 
    import os
+   Screen().bye()
    os.remove("my_drawing.ps")
 
 --------------


### PR DESCRIPTION
Followup to #125288.

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125293.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->