### PR TITLE
gh-125296: Fix strange fragment identifier for `name or flags` in argparse docs

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -568,7 +568,7 @@ The add_argument() method
                            [help], [metavar], [dest], [deprecated])
 
    Define how a single command-line argument should be parsed.  Each parameter
-   has its own more detailed description below, but in short they are:
+   has its own more detailed description below, but in short they are (see `name or flags`_):
 
    * `name or flags`_ - Either a name or a list of option strings, e.g. ``foo``
      or ``-f, --foo``.
@@ -602,7 +602,7 @@ The add_argument() method
 The following sections describe how each of these are used.
 
 
-.. _name_or_flags:
+.. _`name or flags`:
 
 name or flags
 ^^^^^^^^^^^^^

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -568,7 +568,7 @@ The add_argument() method
                            [help], [metavar], [dest], [deprecated])
 
    Define how a single command-line argument should be parsed.  Each parameter
-   has its own more detailed description below, but in short they are (see `name or flags`_):
+   has its own more detailed description below, but in short they are:
 
    * `name or flags`_ - Either a name or a list of option strings, e.g. ``foo``
      or ``-f, --foo``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125296 -->
* Issue: gh-125296
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125297.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->