### PR TITLE
Fix typo in library/functions.rst

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -686,7 +686,7 @@ are always available.  They are listed here in alphabetical order.
    The *closure* argument specifies a closure--a tuple of cellvars.
    It's only valid when the *object* is a code object containing
    :term:`free (closure) variables <closure variable>`.
-   The length of the tuple must exactly match the length of the code object'S
+   The length of the tuple must exactly match the length of the code object's
    :attr:`~codeobject.co_freevars` attribute.
 
    .. audit-event:: exec code_object exec


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125327.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->