### PR TITLE
gh-86673: Loosen test_ttk.test_identify() requirements

### DIFF
--- a/Lib/test/test_ttk/test_widgets.py
+++ b/Lib/test/test_ttk/test_widgets.py
@@ -336,7 +336,8 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
         'show', 'state', 'style', 'takefocus', 'textvariable',
         'validate', 'validatecommand', 'width', 'xscrollcommand',
     )
-    IDENTIFY_AS = 'Entry.field' if sys.platform == 'darwin' else 'textarea'
+    # bpo-27313: macOS Tk/Tcl may or may not report 'Entry.field'.
+    IDENTIFY_AS = {'Entry.field', 'textarea'}
 
     def setUp(self):
         super().setUp()
@@ -373,8 +374,7 @@ class EntryTest(AbstractWidgetTest, unittest.TestCase):
         self.entry.pack()
         self.entry.update()
 
-        # bpo-27313: macOS Cocoa widget differs from X, allow either
-        self.assertEqual(self.entry.identify(5, 5), self.IDENTIFY_AS)
+        self.assertIn(self.entry.identify(5, 5), self.IDENTIFY_AS)
         self.assertEqual(self.entry.identify(-1, -1), "")
 
         self.assertRaises(tkinter.TclError, self.entry.identify, None, 5)
@@ -461,7 +461,7 @@ class ComboboxTest(EntryTest, unittest.TestCase):
         'validate', 'validatecommand', 'values',
         'width', 'xscrollcommand',
     )
-    IDENTIFY_AS = 'Combobox.button' if sys.platform == 'darwin' else 'textarea'
+    IDENTIFY_AS = {'Combobox.button', 'textarea'}
 
     def setUp(self):
         super().setUp()
@@ -1204,7 +1204,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         'takefocus', 'textvariable', 'to', 'validate', 'validatecommand',
         'values', 'width', 'wrap', 'xscrollcommand',
     )
-    IDENTIFY_AS = 'Spinbox.field' if sys.platform == 'darwin' else 'textarea'
+    IDENTIFY_AS = {'Spinbox.field', 'textarea'}
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
In aeca373b3 (PR gh-12011, issue gh-71500), test_identify() was changed to expect different results on Darwin. Ned's fix was later adjusted by e52f9bee802aa7a7fbd405dcc43bc2d1bea884d9. This workaround is only needed for some variants of Tk/Tcl on macOS, so we now allow both the workaround and the generic results for these tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-86673 -->
* Issue: gh-86673
<!-- /gh-issue-number -->
