### PR TITLE
Fix typo in tutorial/controlflow.rst

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -832,7 +832,7 @@ parameters as there is a ``/`` in the function definition::
      File "<stdin>", line 1, in <module>
    TypeError: pos_only_arg() got some positional-only arguments passed as keyword arguments: 'arg'
 
-The third function ``kwd_only_args`` only allows keyword arguments as indicated
+The third function ``kwd_only_arg`` only allows keyword arguments as indicated
 by a ``*`` in the function definition::
 
    >>> kwd_only_arg(3)


### PR DESCRIPTION
The example (below and above the changed text) actually uses kwd_only_arg (without 's'). See https://docs.python.org/3/tutorial/controlflow.html#function-examples

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125338.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->