### PR TITLE
Prefer "similar" over "equivalent" in tutorial

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -19,13 +19,13 @@ objects:
 .. method:: list.append(x)
    :noindex:
 
-   Add an item to the end of the list.  Equivalent to ``a[len(a):] = [x]``.
+   Add an item to the end of the list.  Similar to ``a[len(a):] = [x]``.
 
 
 .. method:: list.extend(iterable)
    :noindex:
 
-   Extend the list by appending all the items from the iterable.  Equivalent to
+   Extend the list by appending all the items from the iterable.  Similar to
    ``a[len(a):] = iterable``.
 
 
@@ -56,7 +56,7 @@ objects:
 .. method:: list.clear()
    :noindex:
 
-   Remove all items from the list.  Equivalent to ``del a[:]``.
+   Remove all items from the list.  Similar to ``del a[:]``.
 
 
 .. method:: list.index(x[, start[, end]])
@@ -93,7 +93,7 @@ objects:
 .. method:: list.copy()
    :noindex:
 
-   Return a shallow copy of the list.  Equivalent to ``a[:]``.
+   Return a shallow copy of the list.  Similar to ``a[:]``.
 
 
 An example that uses most of the list methods::


### PR DESCRIPTION
In the datastructures tutorial doc, some operations are described as "equivalent to" others.
This has led to some user-confusion -- at least [here in the Discourse forums](https://discuss.python.org/t/67012) -- about cases in which the operations differ.

This change doesn't systematically eliminate the word "equivalent" from the tutorial.
It just substitutes "similar to" in several cases in which "equivalent to" could mislead users into expecting exact equivalence.

---

Some thread participants in Discourse seem to want more changes to this doc.
I'm not against further changes, but in my view this change of wording is trivial and can be made as a first step.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125343.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->