### PR TITLE
gh-122544: Change base OS image in Azure pipeline to ubuntu-24.04.

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -5,7 +5,7 @@ jobs:
   displayName: Pre-build checks
 
   pool:
-    vmImage: ubuntu-22.04
+    vmImage: ubuntu-24.04
 
   steps:
   - template: ./prebuild-checks.yml


### PR DESCRIPTION
Change base OS image in Azure pipeline from ubuntu-22.04 to ubuntu-24.04
According to [Microsft-host agent](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml), `ubuntu-24.04` is now available.

Issue: #122544 

<!-- gh-issue-number: gh-122544 -->
* Issue: gh-122544
<!-- /gh-issue-number -->
