### PR TITLE
Doc/glossary.rst: fix `-X gil` option usage

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -617,7 +617,7 @@ Glossary
 
       As of Python 3.13, the GIL can be disabled using the :option:`--disable-gil`
       build configuration. After building Python with this option, code must be
-      run with :option:`-X gil 0 <-X>` or after setting the :envvar:`PYTHON_GIL=0 <PYTHON_GIL>`
+      run with :option:`-X gil=0 <-X>` or after setting the :envvar:`PYTHON_GIL=0 <PYTHON_GIL>`
       environment variable. This feature enables improved performance for
       multi-threaded applications and makes it easier to use multi-core CPUs
       efficiently. For more details, see :pep:`703`.


### PR DESCRIPTION
Currently, the "global interpreter lock" entry in the glossary mentions that `-X gil 0` can be used to disable the GIL. However, this is invalid; the correct usage should be `-X gil=0` [^1].

```console
$ python -X gil 0 -c 'print("hello, world")'
Fatal Python error: config_read_gil: PYTHON_GIL / -X gil must be "0" or "1"
Python runtime state: preinitialized

$ python -X gil=0 -c 'print("hello, world")'
hello, world
```

[^1]: https://docs.python.org/3.13/using/cmdline.html#cmdoption-X

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125366.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->