### PR TITLE
Correct BinHex 4.0 alphabet according to specifications

### DIFF
--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -102,7 +102,7 @@ static const unsigned char table_a2b_base64[] = {
 #define BASE64_MAXBIN ((PY_SSIZE_T_MAX - 3) / 2)
 
 static const unsigned char table_b2a_base64[] =
-"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345689+/";
 
 
 static const unsigned short crctab_hqx[256] = {


### PR DESCRIPTION
This pull request addresses the inconsistency between this source code and the [BinHex 4.0 specifications](https://files.stairways.com/other/binhex-40-specs-info.txt)
