### PR TITLE
gh-89819: Add `argument_default` and `conflict_handler` to `add_argument_group` docs

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1808,9 +1808,8 @@ FileType objects
 Argument groups
 ^^^^^^^^^^^^^^^
 
-.. method:: ArgumentParser.add_argument_group(title, description, \
-                                              [*argument_default], \
-                                              [*conflict_handler])
+.. method:: ArgumentParser.add_argument_group(title=None, description=None, *, \
+                                              [argument_default], [conflict_handler])
 
    By default, :class:`ArgumentParser` groups command-line arguments into
    "positional arguments" and "options" when displaying help
@@ -1855,12 +1854,11 @@ Argument groups
 
        --bar BAR  bar help
 
-   The optional parameters *argument_default* and *conflict_handler* allow
-   for finer-grained control of the behavior of the argument group. Both
-   of these parameters behave similarly to *argument_default* and
-   *conflict_handler* parameters of :meth:`~ArgumentParser.add_argument`.
-   However, when passes into :meth:`add_argument_group`, these parameters apply
-   to all arguments added to the group.
+   The optional keyword-only parameters argument_default_ and conflict_handler_ allow
+   for finer-grained control of the behavior of the argument group. These
+   parameters have the same meaning as in the :class:`~ArgumentParser` constructor,
+   but apply specifically to the argument group rather than the entire parser.
+
 
    Note that any arguments not in your user-defined groups will end up back
    in the usual "positional arguments" and "optional arguments" sections.

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1854,11 +1854,10 @@ Argument groups
 
        --bar BAR  bar help
 
-   The optional keyword-only parameters argument_default_ and conflict_handler_ allow
-   for finer-grained control of the behavior of the argument group. These
+   The optional, keyword-only parameters argument_default_ and conflict_handler_ 
+   allow for finer-grained control of the behavior of the argument group. These 
    parameters have the same meaning as in the :class:`~ArgumentParser` constructor,
    but apply specifically to the argument group rather than the entire parser.
-
 
    Note that any arguments not in your user-defined groups will end up back
    in the usual "positional arguments" and "optional arguments" sections.

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1854,9 +1854,9 @@ Argument groups
 
        --bar BAR  bar help
 
-   The optional, keyword-only parameters argument_default_ and conflict_handler_ 
-   allow for finer-grained control of the behavior of the argument group. These 
-   parameters have the same meaning as in the :class:`~ArgumentParser` constructor,
+   The optional, keyword-only parameters argument_default_ and conflict_handler_
+   allow for finer-grained control of the behavior of the argument group. These
+   parameters have the same meaning as in the :class:`ArgumentParser` constructor,
    but apply specifically to the argument group rather than the entire parser.
 
    Note that any arguments not in your user-defined groups will end up back

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1808,8 +1808,9 @@ FileType objects
 Argument groups
 ^^^^^^^^^^^^^^^
 
-.. method:: ArgumentParser.add_argument_group(title=None, description=None, \
-                                              [argument_default], [conflict_handler])
+.. method:: ArgumentParser.add_argument_group(title, description, \
+                                              [*argument_default], \
+                                              [*conflict_handler])
 
    By default, :class:`ArgumentParser` groups command-line arguments into
    "positional arguments" and "options" when displaying help

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1808,7 +1808,9 @@ FileType objects
 Argument groups
 ^^^^^^^^^^^^^^^
 
-.. method:: ArgumentParser.add_argument_group(title=None, description=None)
+.. method:: ArgumentParser.add_argument_group(title=None, description=None, \
+                                              argument_default=None, \
+                                              conflict_handler='error')
 
    By default, :class:`ArgumentParser` groups command-line arguments into
    "positional arguments" and "options" when displaying help

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1809,8 +1809,7 @@ Argument groups
 ^^^^^^^^^^^^^^^
 
 .. method:: ArgumentParser.add_argument_group(title=None, description=None, \
-                                              argument_default=None, \
-                                              conflict_handler='error')
+                                              [argument_default], [conflict_handler])
 
    By default, :class:`ArgumentParser` groups command-line arguments into
    "positional arguments" and "options" when displaying help
@@ -1854,6 +1853,13 @@ Argument groups
        group2 description
 
        --bar BAR  bar help
+
+   The optional parameters *argument_default* and *conflict_handler* allow
+   for finer-grained control of the behavior of the argument group. Both
+   of these parameters behave similarly to *argument_default* and
+   *conflict_handler* parameters of :meth:`~ArgumentParser.add_argument`.
+   However, when passes into :meth:`add_argument_group`, these parameters apply
+   to all arguments added to the group.
 
    Note that any arguments not in your user-defined groups will end up back
    in the usual "positional arguments" and "optional arguments" sections.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-89819 -->
* Issue: gh-89819
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125379.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->