### PR TITLE
gh-125398: Convert paths in venv activate script when using Git Bash under Windows

### DIFF
--- a/Lib/venv/scripts/common/activate
+++ b/Lib/venv/scripts/common/activate
@@ -38,8 +38,8 @@ deactivate nondestructive
 
 # on Windows, a path can contain colons and backslashes and has to be converted:
 case "$(uname)" in
-    CYGWIN*|MSYS*)
-        # transform D:\path\to\venv to /d/path/to/venv on MSYS
+    CYGWIN*|MSYS*|MINGW*)
+        # transform D:\path\to\venv to /d/path/to/venv on MSYS and MINGW
         # and to /cygdrive/d/path/to/venv on Cygwin
         VIRTUAL_ENV=$(cygpath "__VENV_DIR__")
         export VIRTUAL_ENV

--- a/Misc/NEWS.d/next/Library/2024-10-13-15-04-58.gh-issue-125398.UW7Ndv.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-13-15-04-58.gh-issue-125398.UW7Ndv.rst
@@ -1,1 +1,1 @@
-Fix the conversion of the VIRTUAL_ENV path in the activate script in :mod:`venv` when running in Git Bash for Windows.
+Fix the conversion of the ``VIRTUAL_ENV`` path in the activate script in :mod:`venv` when running in Git Bash for Windows.

--- a/Misc/NEWS.d/next/Library/2024-10-13-15-04-58.gh-issue-125398.UW7Ndv.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-13-15-04-58.gh-issue-125398.UW7Ndv.rst
@@ -1,1 +1,1 @@
-Fix the conversion of the :envvar:`VIRTUAL_ENV` path in the activate script in :mod:`venv` when running in Git Bash for Windows.
+Fix the conversion of the :envvar:`!VIRTUAL_ENV` path in the activate script in :mod:`venv` when running in Git Bash for Windows.

--- a/Misc/NEWS.d/next/Library/2024-10-13-15-04-58.gh-issue-125398.UW7Ndv.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-13-15-04-58.gh-issue-125398.UW7Ndv.rst
@@ -1,1 +1,1 @@
-Fix the conversion of the ``VIRTUAL_ENV`` path in the activate script in :mod:`venv` when running in Git Bash for Windows.
+Fix the conversion of the :envvar:`VIRTUAL_ENV` path in the activate script in :mod:`venv` when running in Git Bash for Windows.

--- a/Misc/NEWS.d/next/Library/2024-10-13-15-04-58.gh-issue-125398.UW7Ndv.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-13-15-04-58.gh-issue-125398.UW7Ndv.rst
@@ -1,0 +1,1 @@
+Fix the conversion of the VIRTUAL_ENV path in the activate script in :mod:`venv` when running in Git Bash for Windows.


### PR DESCRIPTION
With https://github.com/python/cpython/pull/112508 the check to convert paths when running on Windows was changed from using the non-posix environment variable `$OSTYPE` to using `uname` instead.

However this missed the fact that when running under Git Bash on Windows, uname reports `MINGW*` (`$OSTYPE` is still `msys`).

This results in `$PATH` being set to something like `D:\a\github-actions-shells\github-actions-shells\venv/Scripts:…`, instead of `/d/a/github-actions-shells/github-actions-shells/venv/Scripts`.

Notably, the Git Bash is the bash shell that’s used for GitHub Actions Windows runners, and ships with VSCode.

Fixes https://github.com/python/cpython/issues/125398

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125398 -->
* Issue: gh-125398
<!-- /gh-issue-number -->
