### PR TITLE
[3.12] GH-125069: Fix inconsistent joining in `WindowsPath(PosixPath(...))` (GH-125156)

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -359,9 +359,9 @@ class PurePath(object):
         paths = []
         for arg in args:
             if isinstance(arg, PurePath):
-                if arg._flavour is ntpath and self._flavour is posixpath:
+                if arg._flavour is not self._flavour:
                     # GH-103631: Convert separators for backwards compatibility.
-                    paths.extend(path.replace('\\', '/') for path in arg._raw_paths)
+                    paths.append(arg.as_posix())
                 else:
                     paths.extend(arg._raw_paths)
             else:

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -831,6 +831,14 @@ class PureWindowsPathTest(_BasePurePathTest, unittest.TestCase):
             ],
     })
 
+    def test_constructor_nested_foreign_flavour(self):
+        # See GH-125069.
+        p1 = pathlib.PurePosixPath('b/c:\\d')
+        p2 = pathlib.PurePosixPath('b/', 'c:\\d')
+        self.assertEqual(p1, p2)
+        self.assertEqual(self.cls(p1), self.cls('b/c:/d'))
+        self.assertEqual(self.cls(p2), self.cls('b/c:/d'))
+
     def test_drive_root_parts(self):
         check = self._check_drive_root_parts
         # First part is anchored.

--- a/Misc/NEWS.d/next/Library/2024-10-08-21-17-16.gh-issue-125069.0RP0Mx.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-08-21-17-16.gh-issue-125069.0RP0Mx.rst
@@ -1,0 +1,4 @@
+Fix an issue where providing a :class:`pathlib.PurePath` object as an
+initializer argument to a second :class:`~pathlib.PurePath` object with a
+different :attr:`~pathlib.PurePath.parser` resulted in arguments to the
+former object's initializer being joined by the latter object's parser.

--- a/Misc/NEWS.d/next/Library/2024-10-08-21-17-16.gh-issue-125069.0RP0Mx.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-08-21-17-16.gh-issue-125069.0RP0Mx.rst
@@ -1,4 +1,4 @@
 Fix an issue where providing a :class:`pathlib.PurePath` object as an
 initializer argument to a second :class:`~pathlib.PurePath` object with a
-different :attr:`~pathlib.PurePath.parser` resulted in arguments to the
-former object's initializer being joined by the latter object's parser.
+different flavour resulted in arguments to the former object's initializer
+ being joined by the latter object's flavour.


### PR DESCRIPTION
`PurePath.__init__()` incorrectly uses the `_raw_paths` of a given `PurePath` object with a different flavour, even though the procedure to join path segments can differ between flavours.

This change makes the `_raw_paths`-enabled deferred joining apply _only_ when the path flavours match.

(cherry picked from commit cb8e5995d89d9b90e83cf43310ec50e177484e70)


<!-- gh-issue-number: gh-125069 -->
* Issue: gh-125069
<!-- /gh-issue-number -->
