### PR TITLE
gh-125245: Fix race condition when importing `collections.abc`

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -29,6 +29,9 @@ __all__ = [
 import _collections_abc
 import sys as _sys
 
+_sys.modules['collections.abc'] = _collections_abc
+abc = _collections_abc
+
 from itertools import chain as _chain
 from itertools import repeat as _repeat
 from itertools import starmap as _starmap

--- a/Lib/collections/abc.py
+++ b/Lib/collections/abc.py
@@ -1,3 +1,0 @@
-import _collections_abc
-import sys
-sys.modules[__name__] = _collections_abc

--- a/Misc/NEWS.d/next/Library/2024-10-11-00-40-13.gh-issue-125245.8vReM-.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-11-00-40-13.gh-issue-125245.8vReM-.rst
@@ -1,0 +1,2 @@
+Fix race condition when importing :mod:`collections.abc`, which could
+incorrectly return an empty module.


### PR DESCRIPTION
If multiple threads concurrently imported `collections.abc`, some of the threads might incorrectly see the "shim" `Lib/collections/abc.py` module instead of the correct `Lib/_collections_abc.py` module.  This was observed in the free threading build, but could, in theory, occur in the default GIL-enabled build as well.

<!-- gh-issue-number: gh-125245 -->
* Issue: gh-125245
<!-- /gh-issue-number -->
