### PR TITLE
gh-125115: Pass unknown pdb command line args to script instead of fail

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -82,6 +82,7 @@ import signal
 import inspect
 import textwrap
 import tokenize
+import itertools
 import traceback
 import linecache
 import _colorize
@@ -2458,12 +2459,7 @@ def main():
         # If a script is being debugged, then pdb expects the script name as the first argument.
         # Anything before the script is considered an argument to pdb itself, which would
         # be invalid because it's not parsed by argparse.
-        invalid_args = []
-        for arg in args:
-            if not arg.startswith('-'):
-                break
-            invalid_args.append(arg)
-
+        invalid_args = list(itertools.takewhile(lambda a: a.startswith('-'), args))
         if invalid_args:
             parser.error(f"unrecognized arguments: {' '.join(invalid_args)}")
             sys.exit(2)

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -2452,10 +2452,10 @@ def main():
         #      "python -m pdb --spam -m foo" means passing "--spam" to "pdb" and is invalid
         idx = sys.argv.index('-m')
         args_to_pdb = sys.argv[1:idx]
-        # This will automatically raise an error if there are invalid arguments
+        # This will raise an error if there are invalid arguments
         parser.parse_args(args_to_pdb)
     else:
-        # If a script is being debugged, then pdb expects a script as the first argument.
+        # If a script is being debugged, then pdb expects the script name as the first argument.
         # Anything before the script is considered an argument to pdb itself, which would
         # be invalid because it's not parsed by argparse.
         invalid_args = []

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3052,6 +3052,7 @@ class PdbTestCase(unittest.TestCase):
     def run_pdb_script(self, script, commands,
                        expected_returncode=0,
                        extra_env=None,
+                       script_args=None,
                        pdbrc=None,
                        remove_home=False):
         """Run 'script' lines with pdb and the pdb 'commands'."""
@@ -3069,7 +3070,9 @@ class PdbTestCase(unittest.TestCase):
         if remove_home:
             homesave = os.environ.pop('HOME', None)
         try:
-            stdout, stderr = self._run_pdb([filename], commands, expected_returncode, extra_env)
+            if script_args is None:
+                script_args = []
+            stdout, stderr = self._run_pdb([filename] + script_args, commands, expected_returncode, extra_env)
         finally:
             if homesave is not None:
                 os.environ['HOME'] = homesave
@@ -3507,6 +3510,19 @@ def bœr():
 
         stdout, _ = self._run_pdb(["-m", "calendar", "1"], commands)
         self.assertIn("December", stdout)
+
+    def test_run_script_with_args(self):
+        script = """
+            import sys
+            print(sys.argv[1:])
+        """
+        commands = """
+            continue
+            quit
+        """
+
+        stdout, stderr = self.run_pdb_script(script, commands, script_args=["--bar", "foo"])
+        self.assertIn("['--bar', 'foo']", stdout)
 
     def test_breakpoint(self):
         script = """

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3511,6 +3511,9 @@ def bœr():
         stdout, _ = self._run_pdb(["-m", "calendar", "1"], commands)
         self.assertIn("December", stdout)
 
+        stdout, _ = self._run_pdb(["-m", "calendar", "--type", "text"], commands)
+        self.assertIn("December", stdout)
+
     def test_run_script_with_args(self):
         script = """
             import sys

--- a/Misc/NEWS.d/next/Library/2024-10-14-02-07-44.gh-issue-125115.IOf3ON.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-14-02-07-44.gh-issue-125115.IOf3ON.rst
@@ -1,0 +1,1 @@
+Fixed a bug in :mod:`pdb` where arguments starting with `-` can't be passed to the debugged script.

--- a/Misc/NEWS.d/next/Library/2024-10-14-02-07-44.gh-issue-125115.IOf3ON.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-14-02-07-44.gh-issue-125115.IOf3ON.rst
@@ -1,1 +1,1 @@
-Fixed a bug in :mod:`pdb` where arguments starting with `-` can't be passed to the debugged script.
+Fixed a bug in :mod:`pdb` where arguments starting with ``-`` can't be passed to the debugged script.


### PR DESCRIPTION
Moving to `argparse` created a bug where an argument starting with `-` to the script being debugged will be parsed, which frustrated `argparse`. We should just parse known args and pass the rest to the script.

<!-- gh-issue-number: gh-125115 -->
* Issue: gh-125115
<!-- /gh-issue-number -->
