### PR TITLE
gh-100141: Allow pdb to deal with empty file

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -429,8 +429,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def user_line(self, frame):
         """This function is called when we stop or break at this line."""
         if self._wait_for_mainpyfile:
-            if (self.mainpyfile != self.canonic(frame.f_code.co_filename)
-                or frame.f_lineno <= 0):
+            if (self.mainpyfile != self.canonic(frame.f_code.co_filename)):
                 return
             self._wait_for_mainpyfile = False
         self.bp_commands(frame)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3951,9 +3951,12 @@ def bœr():
     def test_empty_file(self):
         script = ''
         commands = 'q\n'
-        # Anything reasonable is acceptable here, as long as it does not halt
-        _, _ = self.run_pdb_script(script, commands)
-        _, _ = self.run_pdb_module(script, commands)
+        # We check that pdb stopped at line 0, but anything reasonable
+        # is acceptable here, as long as it does not halt
+        stdout, _ = self.run_pdb_script(script, commands)
+        self.assertIn('main.py(0)', stdout)
+        stdout, _ = self.run_pdb_module(script, commands)
+        self.assertIn('__main__.py(0)', stdout)
 
     def test_non_utf8_encoding(self):
         script_dir = os.path.join(os.path.dirname(__file__), 'encoded_modules')

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3948,6 +3948,13 @@ def bœr():
         # verify that pdb found the source of the "frozen" function
         self.assertIn('x = "Sentinel string for gh-93696"', stdout, "Sentinel statement not found")
 
+    def test_empty_file(self):
+        script = ''
+        commands = 'q\n'
+        # Anything reasonable is acceptable here, as long as it does not halt
+        _, _ = self.run_pdb_script(script, commands)
+        _, _ = self.run_pdb_module(script, commands)
+
     def test_non_utf8_encoding(self):
         script_dir = os.path.join(os.path.dirname(__file__), 'encoded_modules')
         for filename in os.listdir(script_dir):

--- a/Misc/NEWS.d/next/Library/2024-10-14-02-27-03.gh-issue-100141.NuAcwa.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-14-02-27-03.gh-issue-100141.NuAcwa.rst
@@ -1,0 +1,1 @@
+Fixed the bug where :mod:`pdb` will be stuck in an infinite loop when debugging an empty file.


### PR DESCRIPTION
`f_lineno == 0` is possible and pdb should just stop. The original fix is from #106467, I added the regression test.

Co-authored-by: SonOfLilit

<!-- gh-issue-number: gh-100141 -->
* Issue: gh-100141
<!-- /gh-issue-number -->
