### PR TITLE
gh-116114: Replace deprecated `Py_OptimizeFlag` in `makefreeze.py`

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2024-10-14-14-12-26.gh-issue-116114.xbAl-0.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2024-10-14-14-12-26.gh-issue-116114.xbAl-0.rst
@@ -1,0 +1,2 @@
+Replace :c:var:`Py_OptimizeFlag` in ``makefreeze.py`` with
+:c:member:`PyConfig.optimization_level`.

--- a/Tools/freeze/makefreeze.py
+++ b/Tools/freeze/makefreeze.py
@@ -21,7 +21,11 @@ main(int argc, char **argv)
 {
         extern int Py_FrozenMain(int, char **);
 """ + ((not __debug__ and """
-        Py_OptimizeFlag++;
+        PyConfig *config;
+        PyConfig_InitPythonConfig(config);
+        config->optimization_level++;
+        Py_InitializeFromConfig(config);
+        PyConfig_Clear(config);
 """) or "")  + """
         PyImport_FrozenModules = _PyImport_FrozenModules;
         return Py_FrozenMain(argc, argv);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
In https://github.com/python/cpython/blob/main/Doc/deprecations/c-api-pending-removal-in-3.14.rst that Py_OptimizeFlag should be replaced by **PyConfig.optimization_level** in 3.14. However, `makefreeze.py` still uses **Py_OptimizeFlag**


<!-- gh-issue-number: gh-116114 -->
* Issue: gh-116114
<!-- /gh-issue-number -->
