### PR TITLE
gh-125435: Add total_seconds() method to datetime.time

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -1392,6 +1392,7 @@ class time:
     utcoffset()
     tzname()
     dst()
+    total_seconds()
 
     Properties (readonly):
     hour, minute, second, microsecond, tzinfo, fold
@@ -1473,6 +1474,11 @@ class time:
     def fold(self):
         return self._fold
 
+    def total_seconds(self):
+        """Total seconds in the time."""
+        return ((self.hour * 3600 + self.minute * 60 + self.second) * 10**6 +
+                self.microsecond) / 10**6
+    
     # Standard conversions, __hash__ (and helpers)
 
     # Comparisons of time objects with other.

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -1478,7 +1478,7 @@ class time:
         """Total seconds in the time."""
         return ((self.hour * 3600 + self.minute * 60 + self.second) * 10**6 +
                 self.microsecond) / 10**6
-    
+
     # Standard conversions, __hash__ (and helpers)
 
     # Comparisons of time objects with other.

--- a/Misc/NEWS.d/next/Library/2024-10-14-08-20-18.gh-issue-125435.0bB-44.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-14-08-20-18.gh-issue-125435.0bB-44.rst
@@ -1,0 +1,1 @@
+Add :meth:`datetime.time.total_seconds` method


### PR DESCRIPTION
A method similar to datetime.timedelta.total_seconds()
Returns total seconds of time object

<!-- gh-issue-number: gh-125435 -->
* Issue: gh-125435
<!-- /gh-issue-number -->
