### PR TITLE
gh-125447: Remove `Py_TPFLAGS_HAVE_FINALIZE` macro

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -1200,20 +1200,6 @@ and :c:data:`PyType_Type` effectively act as defaults.)
       set appropriately, or the code that interacts with such types
       will behave differently depending on what kind of check is used.
 
-
-   .. c:macro:: Py_TPFLAGS_HAVE_FINALIZE
-
-      This bit is set when the :c:member:`~PyTypeObject.tp_finalize` slot is present in the
-      type structure.
-
-      .. versionadded:: 3.4
-
-      .. deprecated:: 3.8
-         This flag isn't necessary anymore, as the interpreter assumes the
-         :c:member:`~PyTypeObject.tp_finalize` slot is always present in the
-         type structure.
-
-
    .. c:macro:: Py_TPFLAGS_HAVE_VECTORCALL
 
       This bit is set when the class implements
@@ -2125,12 +2111,6 @@ and :c:data:`PyType_Type` effectively act as defaults.)
    This field is inherited by subtypes.
 
    .. versionadded:: 3.4
-
-   .. versionchanged:: 3.8
-
-      Before version 3.8 it was necessary to set the
-      :c:macro:`Py_TPFLAGS_HAVE_FINALIZE` flags bit in order for this field to be
-      used.  This is no longer required.
 
    .. seealso:: "Safe object finalization" (:pep:`442`)
 

--- a/Include/object.h
+++ b/Include/object.h
@@ -595,7 +595,6 @@ given type object has a specified feature.
  * Note that older extensions using the stable ABI set these flags,
  * so the bits must not be repurposed.
  */
-#define Py_TPFLAGS_HAVE_FINALIZE (1UL << 0)
 #define Py_TPFLAGS_HAVE_VERSION_TAG   (1UL << 18)
 
 

--- a/Misc/NEWS.d/next/C_API/2024-10-14-19-48-07.gh-issue-125448._fDzec.rst
+++ b/Misc/NEWS.d/next/C_API/2024-10-14-19-48-07.gh-issue-125448._fDzec.rst
@@ -1,0 +1,1 @@
+Remove :c:macro:`Py_TPFLAGS_HAVE_FINALIZE` macro.

--- a/Modules/_testcapi/heaptype.c
+++ b/Modules/_testcapi/heaptype.c
@@ -710,7 +710,7 @@ static PyType_Spec HeapCTypeSubclassWithFinalizer_spec = {
     "_testcapi.HeapCTypeSubclassWithFinalizer",
     sizeof(HeapCTypeSubclassObject),
     0,
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_FINALIZE,
+    Py_TPFLAGS_DEFAULT,
     HeapCTypeSubclassWithFinalizer_slots
 };
 

--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -289,7 +289,7 @@ static PyType_Spec StateAccessType_spec = {
     "_testimportexec.StateAccessType",
     sizeof(StateAccessTypeObject),
     0,
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_FINALIZE | Py_TPFLAGS_BASETYPE,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     StateAccessType_Type_slots
 };
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -16325,8 +16325,7 @@ static PyType_Spec ScandirIteratorType_spec = {
     0,
     // bpo-40549: Py_TPFLAGS_BASETYPE should not be used, since
     // PyType_GetModule(Py_TYPE(self)) doesn't work on a subclass instance.
-    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_FINALIZE
-        | Py_TPFLAGS_DISALLOW_INSTANTIATION),
+    (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION),
     ScandirIteratorType_slots
 };
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
According to [typeobj.rst](https://github.com/python/cpython/blob/main/Doc/c-api/typeobj.rst)
```
      .. deprecated:: 3.8
         This flag isn't necessary anymore, as the interpreter assumes the
         :c:member:`~PyTypeObject.tp_finalize` slot is always present in the
         type structure.
```

<!-- gh-issue-number: gh-125447 -->
* Issue: gh-125447
<!-- /gh-issue-number -->
