### PR TITLE
gh-125449: Remove `PyUnicode_READY` function in `unicodeobject.h`

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -87,16 +87,6 @@ access to internal read-only data of Unicode objects:
    subtype.  This function always succeeds.
 
 
-.. c:function:: int PyUnicode_READY(PyObject *unicode)
-
-   Returns ``0``. This API is kept only for backward compatibility.
-
-   .. versionadded:: 3.3
-
-   .. deprecated:: 3.10
-      This API does nothing since Python 3.12.
-
-
 .. c:function:: Py_ssize_t PyUnicode_GET_LENGTH(PyObject *unicode)
 
    Return the length of the Unicode string, in code points.  *unicode* has to be a

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -2765,9 +2765,6 @@ PyUnicode_WriteChar:PyObject*:unicode:0:
 PyUnicode_WriteChar:Py_ssize_t:index::
 PyUnicode_WriteChar:Py_UCS4:character::
 
-PyUnicode_READY:int:::
-PyUnicode_READY:PyObject*:o:0:
-
 PyUnicode_Substring:PyObject*::+1:
 PyUnicode_Substring:PyObject*:str:0:
 PyUnicode_Substring:Py_ssize_t:start::

--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -388,13 +388,6 @@ PyAPI_FUNC(PyObject*) PyUnicode_New(
     Py_UCS4 maxchar             /* maximum code point value in the string */
     );
 
-/* For backward compatibility */
-static inline int PyUnicode_READY(PyObject* Py_UNUSED(op))
-{
-    return 0;
-}
-#define PyUnicode_READY(op) PyUnicode_READY(_PyObject_CAST(op))
-
 /* Copy character from one unicode object into another, this function performs
    character conversion when necessary and falls back to memcpy() if possible.
 

--- a/Misc/NEWS.d/next/C_API/2024-10-14-20-29-52.gh-issue-125449.eoS-Ru.rst
+++ b/Misc/NEWS.d/next/C_API/2024-10-14-20-29-52.gh-issue-125449.eoS-Ru.rst
@@ -1,0 +1,1 @@
+Remove :c:func:`PyUnicode_READY` in ``unicodeobjecct.h``.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125449 -->
* Issue: gh-125449
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125450.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->