### PR TITLE
gh-112088: aclocal version is updated to 1.16.5 in docs

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -29,7 +29,7 @@ Features and minimum versions required to build CPython:
 
 * Tcl/Tk 8.5.12 for the :mod:`tkinter` module.
 
-* Autoconf 2.71 and aclocal 1.16.4 are required to regenerate the
+* Autoconf 2.71 and aclocal 1.16.5 are required to regenerate the
   :file:`configure` script.
 
 .. versionchanged:: 3.1
@@ -57,6 +57,9 @@ Features and minimum versions required to build CPython:
 
 .. versionchanged:: 3.13
    Autoconf 2.71, aclocal 1.16.4 and SQLite 3.15.2 are now required.
+
+.. versionchanged:: 3.13
+   Require aclocal 1.16.5.
 
 See also :pep:`7` "Style Guide for C Code" and :pep:`11` "CPython platform
 support".

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -56,10 +56,7 @@ Features and minimum versions required to build CPython:
    Tcl/Tk version 8.5.12 is now required for the :mod:`tkinter` module.
 
 .. versionchanged:: 3.13
-   Autoconf 2.71, aclocal 1.16.4 and SQLite 3.15.2 are now required.
-
-.. versionchanged:: 3.13
-   Require aclocal 1.16.5.
+   Autoconf 2.71, aclocal 1.16.5 and SQLite 3.15.2 are now required.
 
 See also :pep:`7` "Style Guide for C Code" and :pep:`11` "CPython platform
 support".

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2497,7 +2497,7 @@ Build Changes
 
 * Autoconf 2.71 and aclocal 1.16.5 are now required to regenerate
   the :file:`configure` script.
-  (Contributed by Victor Stinner in :gh:`112090`.)
+  (Contributed by Christian Heimes in :gh:`89886` and by Victor Stinner in :gh:`112090`.)
 
 * SQLite 3.15.2 or newer is required to build
   the :mod:`sqlite3` extension module.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -2495,9 +2495,9 @@ Build Changes
 * Building CPython now requires a compiler with support for the C11 atomic
   library, GCC built-in atomic functions, or MSVC interlocked intrinsics.
 
-* Autoconf 2.71 and aclocal 1.16.4 are now required to regenerate
+* Autoconf 2.71 and aclocal 1.16.5 are now required to regenerate
   the :file:`configure` script.
-  (Contributed by Christian Heimes in :gh:`89886`.)
+  (Contributed by Victor Stinner in :gh:`112090`.)
 
 * SQLite 3.15.2 or newer is required to build
   the :mod:`sqlite3` extension module.


### PR DESCRIPTION
cc @vstinner 

<!-- gh-issue-number: gh-112088 -->
* Issue: gh-112088
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125457.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->