### PR TITLE
gh-125500: threading.py Timer context manager

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1342,6 +1342,12 @@ class Timer(Thread):
             self.function(*self.args, **self.kwargs)
         self.finished.set()
 
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cancel()
+
 
 # Special thread class to represent the main thread
 


### PR DESCRIPTION
Add support for context manager. Start on entry, cancel on exit

<!-- gh-issue-number: gh-125500 -->
* Issue: gh-125500
<!-- /gh-issue-number -->
