### PR TITLE
gh-125522 : add explicit exception types to bare excepts in tests

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -543,7 +543,7 @@ class CmdLineTest(unittest.TestCase):
         script = textwrap.dedent("""\
             try:
                 raise ValueError
-            except:
+            except ValueError:
                 raise NameError from None
             """)
         with os_helper.temp_dir() as script_dir:

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -1185,7 +1185,7 @@ class CoroutineTest(unittest.TestCase):
         async def g():
             try:
                 raise KeyError
-            except:
+            except KeyError:
                 return await f()
 
         _, result = run_async(g())

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -126,7 +126,7 @@ class AutoFileTests:
         # it must also return None if an exception was given
         try:
             1/0
-        except:
+        except ZeroDivisionError:
             self.assertEqual(self.f.__exit__(*sys.exc_info()), None)
 
     def testReadWhenWriting(self):

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -609,7 +609,7 @@ class ListComprehensionTest(unittest.TestCase):
             result = snapshot = None
             try:
                 result = [{func}(value) for value in value]
-            except:
+            except ValueError:
                 snapshot = value
                 raise
         """
@@ -643,7 +643,7 @@ class ListComprehensionTest(unittest.TestCase):
             value = [1, None]
             try:
                 [v for v in value].sort()
-            except:
+            except TypeError:
                 pass
         """
         self._check_in_scopes(code, {"value": [1, None]})

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4877,7 +4877,7 @@ class ExceptionTest(BaseTest):
         r.addHandler(h)
         try:
             raise RuntimeError('deliberate mistake')
-        except:
+        except RuntimeError:
             logging.exception('failed', stack_info=True)
         r.removeHandler(h)
         h.close()

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1081,7 +1081,7 @@ def test_convenience_variables():
     ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
     ...     try:
     ...         raise Exception('test')
-    ...     except:
+    ...     except Exception:
     ...         pass
     ...     return 1
 
@@ -1153,7 +1153,7 @@ def test_convenience_variables():
     Exception('test')
     (Pdb) next
     > <doctest test.test_pdb.test_convenience_variables[0]>(5)util_function()
-    -> except:
+    -> except Exception:
     (Pdb) $_exception
     *** KeyError: '_exception'
     (Pdb) return

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -766,7 +766,7 @@ class TestMarkingVariablesAsUnKnown(BytecodeTestCase):
         def f():
             try:
                 1 / 0
-            except:
+            except ZeroDivisionError:
                 print(a, b, c, d, e, f, g)
             a = b = c = d = e = f = g = 1
         self.assertInBytecode(f, 'LOAD_FAST_CHECK')

--- a/Lib/test/test_raise.py
+++ b/Lib/test/test_raise.py
@@ -48,7 +48,7 @@ class TestRaise(unittest.TestCase):
         def reraise():
             try:
                 raise TypeError("foo")
-            except:
+            except TypeError:
                 try:
                     raise KeyError("caught")
                 except KeyError:
@@ -60,7 +60,7 @@ class TestRaise(unittest.TestCase):
         def reraise():
             try:
                 raise TypeError("foo")
-            except:
+            except TypeError:
                 try:
                     raise KeyError("caught")
                 finally:
@@ -73,7 +73,7 @@ class TestRaise(unittest.TestCase):
         def reraise():
             try:
                 raise TypeError("foo")
-            except:
+            except TypeError:
                 nested_reraise()
         self.assertRaises(TypeError, reraise)
 
@@ -81,7 +81,7 @@ class TestRaise(unittest.TestCase):
         try:
             try:
                 raise TypeError("foo")
-            except:
+            except TypeError:
                 raise ValueError() from None
         except ValueError as e:
             self.assertIsInstance(e.__context__, TypeError)
@@ -91,7 +91,7 @@ class TestRaise(unittest.TestCase):
         def reraise():
             try:
                 raise TypeError("foo")
-            except:
+            except TypeError:
                 with Context():
                     pass
                 raise
@@ -101,7 +101,7 @@ class TestRaise(unittest.TestCase):
         def reraise():
             try:
                 raise TypeError("foo")
-            except:
+            except TypeError:
                 with Context():
                     raise KeyError("caught")
                 raise
@@ -111,7 +111,7 @@ class TestRaise(unittest.TestCase):
         def reraise():
             try:
                 raise TypeError("foo")
-            except:
+            except TypeError:
                 yield 1
                 raise
         g = reraise()
@@ -314,7 +314,7 @@ class TestContext(unittest.TestCase):
         try:
             try:
                 raise context
-            except:
+            except IndexError:
                 raise OSError()
         except OSError as e:
             self.assertIs(e.__context__, context)
@@ -326,7 +326,7 @@ class TestContext(unittest.TestCase):
         try:
             try:
                 raise context
-            except:
+            except IndexError:
                 raise OSError()
         except OSError as e:
             self.assertIsNot(e.__context__, context)
@@ -339,7 +339,7 @@ class TestContext(unittest.TestCase):
         try:
             try:
                 raise context
-            except:
+            except IndexError:
                 raise OSError
         except OSError as e:
             self.assertIsNot(e.__context__, context)
@@ -351,7 +351,7 @@ class TestContext(unittest.TestCase):
         try:
             try:
                 1/0
-            except:
+            except ZeroDivisionError:
                 raise OSError
         except OSError as e:
             self.assertIsInstance(e.__context__, ZeroDivisionError)
@@ -362,7 +362,7 @@ class TestContext(unittest.TestCase):
         try:
             try:
                 1/0
-            except:
+            except ZeroDivisionError:
                 xyzzy
         except NameError as e:
             self.assertIsInstance(e.__context__, ZeroDivisionError)
@@ -459,7 +459,7 @@ class TestContext(unittest.TestCase):
             try:
                 try:
                     raise ValueError
-                except:
+                except ValueError:
                     del g
                     raise KeyError
             except Exception as e:
@@ -475,7 +475,7 @@ class TestContext(unittest.TestCase):
             def __del__(self):
                 try:
                     1/0
-                except:
+                except ZeroDivisionError:
                     raise
 
         def f():

--- a/Lib/test/test_sys_setprofile.py
+++ b/Lib/test/test_sys_setprofile.py
@@ -124,7 +124,7 @@ class ProfileHookTestCase(TestCaseBase):
     def test_caught_exception(self):
         def f(p):
             try: 1/0
-            except: pass
+            except ZeroDivisionError: pass
         f_ident = ident(f)
         self.check_events(f, [(1, 'call', f_ident),
                               (1, 'return', f_ident),
@@ -133,7 +133,7 @@ class ProfileHookTestCase(TestCaseBase):
     def test_caught_nested_exception(self):
         def f(p):
             try: 1/0
-            except: pass
+            except ZeroDivisionError: pass
         f_ident = ident(f)
         self.check_events(f, [(1, 'call', f_ident),
                               (1, 'return', f_ident),
@@ -156,9 +156,9 @@ class ProfileHookTestCase(TestCaseBase):
         def g(p):
             try:
                 f(p)
-            except:
+            except ZeroDivisionError:
                 try: f(p)
-                except: pass
+                except ZeroDivisionError: pass
         f_ident = ident(f)
         g_ident = ident(g)
         self.check_events(g, [(1, 'call', g_ident),
@@ -187,7 +187,7 @@ class ProfileHookTestCase(TestCaseBase):
     def test_raise_twice(self):
         def f(p):
             try: 1/0
-            except: 1/0
+            except ZeroDivisionError: 1/0
         f_ident = ident(f)
         self.check_events(f, [(1, 'call', f_ident),
                               (1, 'return', f_ident),
@@ -196,7 +196,7 @@ class ProfileHookTestCase(TestCaseBase):
     def test_raise_reraise(self):
         def f(p):
             try: 1/0
-            except: raise
+            except ZeroDivisionError: raise
         f_ident = ident(f)
         self.check_events(f, [(1, 'call', f_ident),
                               (1, 'return', f_ident),
@@ -320,7 +320,7 @@ class ProfileSimulatorTestCase(TestCaseBase):
     def test_caught_exception(self):
         def f(p):
             try: 1/0
-            except: pass
+            except ZeroDivisionError: pass
         f_ident = ident(f)
         self.check_events(f, [(1, 'call', f_ident),
                               (1, 'return', f_ident),

--- a/Lib/test/test_unittest/test_result.py
+++ b/Lib/test/test_unittest/test_result.py
@@ -186,7 +186,7 @@ class Test_TestResult(unittest.TestCase):
         test = Foo('test_1')
         try:
             test.fail("foo")
-        except:
+        except AssertionError:
             exc_info_tuple = sys.exc_info()
 
         result = unittest.TestResult()
@@ -214,7 +214,7 @@ class Test_TestResult(unittest.TestCase):
         def get_exc_info():
             try:
                 test.fail("foo")
-            except:
+            except AssertionError:
                 return sys.exc_info()
 
         exc_info_tuple = get_exc_info()
@@ -241,9 +241,9 @@ class Test_TestResult(unittest.TestCase):
             try:
                 try:
                     test.fail("foo")
-                except:
+                except AssertionError:
                     raise ValueError(42)
-            except:
+            except ValueError:
                 return sys.exc_info()
 
         exc_info_tuple = get_exc_info()
@@ -271,7 +271,7 @@ class Test_TestResult(unittest.TestCase):
                 loop.__cause__ = loop
                 loop.__context__ = loop
                 raise loop
-            except:
+            except Exception:
                 return sys.exc_info()
 
         exc_info_tuple = get_exc_info()
@@ -300,7 +300,7 @@ class Test_TestResult(unittest.TestCase):
                     ex1.__cause__ = ex2
                     ex2.__context__ = ex1
                 raise C
-            except:
+            except Exception:
                 return sys.exc_info()
 
         exc_info_tuple = get_exc_info()
@@ -345,7 +345,7 @@ class Test_TestResult(unittest.TestCase):
         test = Foo('test_1')
         try:
             raise TypeError()
-        except:
+        except TypeError:
             exc_info_tuple = sys.exc_info()
 
         result = unittest.TestResult()

--- a/Lib/test/test_with.py
+++ b/Lib/test/test_with.py
@@ -719,7 +719,7 @@ class NestedWith(unittest.TestCase):
         try:
             with self.Dummy() as a, self.InitRaises():
                 pass
-        except:
+        except RuntimeError:
             pass
         self.assertTrue(a.enter_called)
         self.assertTrue(a.exit_called)


### PR DESCRIPTION

Add explicit exception type in tests where it's obvious what it should be.

<!-- gh-issue-number: gh-125522 -->
* Issue: gh-125522
<!-- /gh-issue-number -->
