### PR TITLE
gh-92953: Improve nextpool/prevpool comment.

### DIFF
--- a/Include/internal/pycore_obmalloc.h
+++ b/Include/internal/pycore_obmalloc.h
@@ -255,8 +255,8 @@ struct pool_header {
     union { pymem_block *_padding;
             uint count; } ref;          /* number of allocated blocks    */
     pymem_block *freeblock;             /* pool's free list head         */
-    struct pool_header *nextpool;       /* next pool of this size class  */
-    struct pool_header *prevpool;       /* previous pool       ""        */
+    struct pool_header *nextpool;       /* see "Pool table" for meaning  */
+    struct pool_header *prevpool;       /* "                             */
     uint arenaindex;                    /* index into arenas of base adr */
     uint szidx;                         /* block size class index        */
     uint nextoffset;                    /* bytes to virgin block         */


### PR DESCRIPTION
The meaning of these links depends on which list the pool is part of. They are only the same size class if on the "usedpools" list.

<!-- gh-issue-number: gh-92953 -->
* Issue: gh-92953
<!-- /gh-issue-number -->
