### PR TITLE
gh-125541: Make Ctrl-C interrupt `threading.Lock.acquire()` on Windows

### DIFF
--- a/Doc/library/_thread.rst
+++ b/Doc/library/_thread.rst
@@ -187,6 +187,9 @@ Lock objects have the following methods:
    .. versionchanged:: 3.2
       Lock acquires can now be interrupted by signals on POSIX.
 
+   .. versionchanged:: 3.14
+      Lock acquires can now be interrupted by signals on Windows.
+
 
 .. method:: lock.release()
 
@@ -218,12 +221,6 @@ In addition to these methods, lock objects can also be used via the
 
 * Calling :func:`sys.exit` or raising the :exc:`SystemExit` exception is
   equivalent to calling :func:`_thread.exit`.
-
-* It is platform-dependent whether the :meth:`~threading.Lock.acquire` method
-  on a lock can be interrupted (so that the :exc:`KeyboardInterrupt` exception
-  will happen immediately, rather than only after the lock has been acquired or
-  the operation has timed out). It can be interrupted on POSIX, but not on
-  Windows.
 
 * When the main thread exits, it is system defined whether the other threads
   survive.  On most systems, they are killed without executing

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -567,6 +567,9 @@ All methods are executed atomically.
          Lock acquisition can now be interrupted by signals on POSIX if the
          underlying threading implementation supports it.
 
+      .. versionchanged:: 3.14
+         Lock acquisition can now be interrupted by signals on Windows.
+
 
    .. method:: release()
 

--- a/Misc/NEWS.d/next/Library/2024-10-15-16-50-03.gh-issue-125541.FfhmWo.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-15-16-50-03.gh-issue-125541.FfhmWo.rst
@@ -1,0 +1,3 @@
+Pressing :kbd:`Ctrl-C` while blocked in :meth:`threading.Lock.acquire` now
+interrupts the function and raises a :exc:`KeyboardInterrupt` exception on
+Windows, similar to how it behaves on macOS and Linux.

--- a/Misc/NEWS.d/next/Library/2024-10-15-16-50-03.gh-issue-125541.FfhmWo.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-15-16-50-03.gh-issue-125541.FfhmWo.rst
@@ -1,3 +1,4 @@
-Pressing :kbd:`Ctrl-C` while blocked in :meth:`threading.Lock.acquire` now
-interrupts the function and raises a :exc:`KeyboardInterrupt` exception on
-Windows, similar to how it behaves on macOS and Linux.
+Pressing :kbd:`Ctrl-C` while blocked in :meth:`threading.Lock.acquire`,
+:meth:`threading.RLock.acquire`, and :meth:`threading.Thread.join` now
+interrupts the function call and raises a :exc:`KeyboardInterrupt` exception
+on Windows, similar to how those functions behave on macOS and Linux.

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -111,15 +111,27 @@ _PySemaphore_PlatformWait(_PySemaphore *sema, PyTime_t timeout)
             millis = (DWORD) div;
         }
     }
-    wait = WaitForSingleObjectEx(sema->platform_sem, millis, FALSE);
+
+    // NOTE: we wait on the sigint event even in non-main threads to match the
+    // behavior of the other platforms. Non-main threads will ignore the
+    // Py_PARK_INTR result.
+    HANDLE sigint_event = _PyOS_SigintEvent();
+    HANDLE handles[2] = { sema->platform_sem, sigint_event };
+    wait = WaitForMultipleObjectsEx(2, handles, FALSE, millis, FALSE);
     if (wait == WAIT_OBJECT_0) {
         res = Py_PARK_OK;
+    }
+    else if (wait == WAIT_OBJECT_0 + 1) {
+        ResetEvent(sigint_event);
+        res = Py_PARK_INTR;
     }
     else if (wait == WAIT_TIMEOUT) {
         res = Py_PARK_TIMEOUT;
     }
     else {
-        res = Py_PARK_INTR;
+        _Py_FatalErrorFormat(__func__,
+            "unexpected error from semaphore: %u (error: %u)",
+            wait, GetLastError());
     }
 #elif defined(_Py_USE_SEMAPHORES)
     int err;

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -118,7 +118,7 @@ _PySemaphore_PlatformWait(_PySemaphore *sema, PyTime_t timeout)
     HANDLE sigint_event = _PyOS_SigintEvent();
     HANDLE handles[2] = { sema->platform_sem, sigint_event };
     DWORD count = sigint_event != NULL ? 2 : 1;
-    wait = WaitForMultipleObjectsEx(count, handles, FALSE, millis, FALSE);
+    wait = WaitForMultipleObjects(count, handles, FALSE, millis);
     if (wait == WAIT_OBJECT_0) {
         res = Py_PARK_OK;
     }

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -117,7 +117,8 @@ _PySemaphore_PlatformWait(_PySemaphore *sema, PyTime_t timeout)
     // Py_PARK_INTR result.
     HANDLE sigint_event = _PyOS_SigintEvent();
     HANDLE handles[2] = { sema->platform_sem, sigint_event };
-    wait = WaitForMultipleObjectsEx(2, handles, FALSE, millis, FALSE);
+    DWORD count = sigint_event != NULL ? 2 : 1;
+    wait = WaitForMultipleObjectsEx(count, handles, FALSE, millis, FALSE);
     if (wait == WAIT_OBJECT_0) {
         res = Py_PARK_OK;
     }


### PR DESCRIPTION
<!-- gh-issue-number: gh-125541 -->
* Issue: gh-125541
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: 
https://cpython-previews--125546.org.readthedocs.build/en/125546/library/threading.html
https://cpython-previews--125546.org.readthedocs.build/en/125546/library/_thread.html

<!-- readthedocs-preview cpython-previews end -->