### PR TITLE
gh-125542: Deprecate `prefix_chars` in `ArgumentParser.add_argument_group`

### DIFF
--- a/Doc/deprecations/pending-removal-in-future.rst
+++ b/Doc/deprecations/pending-removal-in-future.rst
@@ -4,8 +4,13 @@ Pending removal in future versions
 The following APIs will be removed in the future,
 although there is currently no date scheduled for their removal.
 
-* :mod:`argparse`: Nesting argument groups and nesting mutually exclusive
-  groups are deprecated.
+* :mod:`argparse`:
+
+  * Nesting argument groups and nesting mutually exclusive
+    groups are deprecated.
+  * Passing the undocumented keyword argument *prefix_chars* to
+    :meth:`~argparse.ArgumentParser.add_argument_group` is now
+    deprecated.
 
 * :mod:`array`'s ``'u'`` format code (:gh:`57281`)
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1868,7 +1868,7 @@ Argument groups
     The function exists on the API by accident through inheritance and
     will be removed in the future.
 
-   .. versionchanged:: 3.14
+   .. deprecated:: 3.14
     Passing prefix_chars_ to :meth:`add_argument_group`
     is now deprecated.
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1868,6 +1868,10 @@ Argument groups
     The function exists on the API by accident through inheritance and
     will be removed in the future.
 
+   .. versionchanged:: 3.14
+   Passing the prefix_chars_ parameter to :meth:`ArgumentParser.add_argument_group`
+   is now deprecated.
+
 
 Mutual exclusion
 ^^^^^^^^^^^^^^^^

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1869,8 +1869,8 @@ Argument groups
     will be removed in the future.
 
    .. versionchanged:: 3.14
-   Passing the prefix_chars_ parameter to :meth:`ArgumentParser.add_argument_group`
-   is now deprecated.
+    Passing the prefix_chars_ parameter to :meth:`add_argument_group`
+    is now deprecated.
 
 
 Mutual exclusion

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1869,7 +1869,7 @@ Argument groups
     will be removed in the future.
 
    .. versionchanged:: 3.14
-    Passing the prefix_chars_ parameter to :meth:`add_argument_group`
+    Passing prefix_chars_ to :meth:`add_argument_group`
     is now deprecated.
 
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -423,7 +423,7 @@ Deprecated
 * :mod:`argparse`:
   Passing the prefix_chars_ parameter to :meth:`ArgumentParser.add_argument_group`
   is now deprecated.
-  (Contributed by Savannah Ostrowski in :gh:`xxxx`.)
+  (Contributed by Savannah Ostrowski in :gh:`125563`.)
 
 * :mod:`asyncio`:
   :func:`!asyncio.iscoroutinefunction` is deprecated

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -421,8 +421,9 @@ Deprecated
 ==========
 
 * :mod:`argparse`:
-  Passing *prefix_chars* to :func:`argparse.add_argument_group`
-  is now deprecated.
+  Passing the undocumented keyword argument *prefix_chars* to
+  :meth:`~argparse.ArgumentParser.add_argument_group` is now
+  deprecated.
   (Contributed by Savannah Ostrowski in :gh:`125563`.)
 
 * :mod:`asyncio`:

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -421,7 +421,7 @@ Deprecated
 ==========
 
 * :mod:`argparse`:
-  Passing the prefix_chars_ parameter to :meth:`ArgumentParser.add_argument_group`
+  Passing the prefix_chars_ parameter to :meth:`add_argument_group`
   is now deprecated.
   (Contributed by Savannah Ostrowski in :gh:`125563`.)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -420,6 +420,11 @@ asyncio
 Deprecated
 ==========
 
+* :mod:`argparse`:
+  Passing the prefix_chars_ parameter to :meth:`ArgumentParser.add_argument_group`
+  is now deprecated.
+  (Contributed by Savannah Ostrowski in :gh:`xxxx`.)
+
 * :mod:`asyncio`:
   :func:`!asyncio.iscoroutinefunction` is deprecated
   and will be removed in Python 3.16,

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -421,7 +421,7 @@ Deprecated
 ==========
 
 * :mod:`argparse`:
-  Passing the prefix_chars_ parameter to :meth:`add_argument_group`
+  Passing *prefix_chars* to :meth:`argparse.add_argument_group`
   is now deprecated.
   (Contributed by Savannah Ostrowski in :gh:`125563`.)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -421,7 +421,7 @@ Deprecated
 ==========
 
 * :mod:`argparse`:
-  Passing *prefix_chars* to :meth:`argparse.add_argument_group`
+  Passing *prefix_chars* to :func:`argparse.add_argument_group`
   is now deprecated.
   (Contributed by Savannah Ostrowski in :gh:`125563`.)
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1666,7 +1666,7 @@ class _ArgumentGroup(_ActionsContainer):
             import warnings
             depr_msg = (
                 "The use of the undocumented 'prefix_chars' parameter in "
-                "ArgumentParser.add_argument_group is deprecated."
+                "ArgumentParser.add_argument_group() is deprecated."
             )
             warnings.warn(depr_msg, DeprecationWarning, stacklevel=3)
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1662,6 +1662,15 @@ class _ActionsContainer(object):
 class _ArgumentGroup(_ActionsContainer):
 
     def __init__(self, container, title=None, description=None, **kwargs):
+
+        if 'prefix_chars' in kwargs:
+            import warnings
+            depr_msg = (
+                "The use of the undocumented 'prefix_chars' parameter in "
+                "ArgumentParser.add_argument_group is deprecated."
+            )
+            warnings.warn(depr_msg, DeprecationWarning, stacklevel=3)
+
         # add any missing keyword arguments by checking the container
         update = kwargs.setdefault
         update('conflict_handler', container.conflict_handler)

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1662,7 +1662,6 @@ class _ActionsContainer(object):
 class _ArgumentGroup(_ActionsContainer):
 
     def __init__(self, container, title=None, description=None, **kwargs):
-
         if 'prefix_chars' in kwargs:
             import warnings
             depr_msg = (

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2816,6 +2816,37 @@ class TestPositionalsGroups(TestCase):
         result = parser.parse_args('1 2 3 4'.split())
         self.assertEqual(expected, result)
 
+class TestGroupConstructor(TestCase):
+    def test_group_prefix_chars(self):
+        parser = ErrorRaisingArgumentParser()
+
+        msg = (
+            "The use of the undocumented 'prefix_chars' parameter in "
+            "ArgumentParser.add_argument_group is deprecated."
+        )
+        with self.assertWarnsRegex(DeprecationWarning, msg):
+            parser.add_argument_group(prefix_chars='-+')
+
+    def test_group_prefix_chars_default(self):
+        # "default" isn't quite the right word here, but it's the same as
+        # the parser's default prefix so it's a good test
+        parser = ErrorRaisingArgumentParser()
+
+        msg = (
+            "The use of the undocumented 'prefix_chars' parameter in "
+            "ArgumentParser.add_argument_group is deprecated."
+        )
+
+        # The parser uses a default of '-' if prefix_chars is not set
+        with self.assertWarnsRegex(DeprecationWarning, msg):
+            parser.add_argument_group(prefix_chars='-')
+
+    def test_group_without_prefix_chars(self):
+        parser = ErrorRaisingArgumentParser()
+        group = parser.add_argument_group()
+        group.add_argument('--foo')
+        self.assertEqual(parser.parse_args(['--foo', 'bar']), NS(foo='bar'))
+
 # ===================
 # Parent parser tests
 # ===================

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2837,7 +2837,6 @@ class TestGroupConstructor(TestCase):
             "ArgumentParser.add_argument_group is deprecated."
         )
 
-        # The parser uses a default of '-' if prefix_chars is not set
         with self.assertWarnsRegex(DeprecationWarning, msg):
             parser.add_argument_group(prefix_chars='-')
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2819,32 +2819,27 @@ class TestPositionalsGroups(TestCase):
 class TestGroupConstructor(TestCase):
     def test_group_prefix_chars(self):
         parser = ErrorRaisingArgumentParser()
-
         msg = (
             "The use of the undocumented 'prefix_chars' parameter in "
-            "ArgumentParser.add_argument_group is deprecated."
+            "ArgumentParser.add_argument_group() is deprecated."
         )
-        with self.assertWarnsRegex(DeprecationWarning, msg):
+        with self.assertWarns(DeprecationWarning) as cm:
             parser.add_argument_group(prefix_chars='-+')
+        self.assertEqual(msg, str(cm.warning))
+        self.assertEqual(cm.filename, __file__)
 
     def test_group_prefix_chars_default(self):
         # "default" isn't quite the right word here, but it's the same as
         # the parser's default prefix so it's a good test
         parser = ErrorRaisingArgumentParser()
-
         msg = (
             "The use of the undocumented 'prefix_chars' parameter in "
-            "ArgumentParser.add_argument_group is deprecated."
+            "ArgumentParser.add_argument_group() is deprecated."
         )
-
-        with self.assertWarnsRegex(DeprecationWarning, msg):
+        with self.assertWarns(DeprecationWarning) as cm:
             parser.add_argument_group(prefix_chars='-')
-
-    def test_group_without_prefix_chars(self):
-        parser = ErrorRaisingArgumentParser()
-        group = parser.add_argument_group()
-        group.add_argument('--foo')
-        self.assertEqual(parser.parse_args(['--foo', 'bar']), NS(foo='bar'))
+        self.assertEqual(msg, str(cm.warning))
+        self.assertEqual(cm.filename, __file__)
 
 # ===================
 # Parent parser tests

--- a/Misc/NEWS.d/next/Library/2024-10-16-04-50-53.gh-issue-125542.vZJ-Ns.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-16-04-50-53.gh-issue-125542.vZJ-Ns.rst
@@ -1,0 +1,1 @@
+Deprecate passing prefix_chars_ parameter to :meth:`ArgumentParser.add_argument_group`.

--- a/Misc/NEWS.d/next/Library/2024-10-16-04-50-53.gh-issue-125542.vZJ-Ns.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-16-04-50-53.gh-issue-125542.vZJ-Ns.rst
@@ -1,2 +1,2 @@
-Deprecate passing keyword-only :ref:`prefix_chars` argument to
+Deprecate passing keyword-only ``prefix_chars`` argument to
 :meth:`argparse.ArgumentParser.add_argument_group`.

--- a/Misc/NEWS.d/next/Library/2024-10-16-04-50-53.gh-issue-125542.vZJ-Ns.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-16-04-50-53.gh-issue-125542.vZJ-Ns.rst
@@ -1,1 +1,2 @@
-Deprecate passing prefix_chars_ parameter to :meth:`ArgumentParser.add_argument_group`.
+Deprecate passing keyword-only :ref:`prefix_chars` argument to
+:meth:`argparse.ArgumentParser.add_argument_group`.

--- a/Misc/NEWS.d/next/Library/2024-10-16-04-50-53.gh-issue-125542.vZJ-Ns.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-16-04-50-53.gh-issue-125542.vZJ-Ns.rst
@@ -1,2 +1,2 @@
-Deprecate passing keyword-only ``prefix_chars`` argument to
+Deprecate passing keyword-only *prefix_chars* argument to
 :meth:`argparse.ArgumentParser.add_argument_group`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125563.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-125542 -->
* Issue: gh-125542
<!-- /gh-issue-number -->
