### PR TITLE
gh-125444: Fix illegal instruction for older Arm architectures

### DIFF
--- a/Include/internal/mimalloc/mimalloc/prim.h
+++ b/Include/internal/mimalloc/mimalloc/prim.h
@@ -151,9 +151,9 @@ static inline mi_threadid_t _mi_prim_thread_id(void) mi_attr_noexcept {
 // If you test on another platform and it works please send a PR :-)
 // see also https://akkadia.org/drepper/tls.pdf for more info on the TLS register.
 #elif defined(__GNUC__) && ( \
-           (defined(__GLIBC__)   && (defined(__x86_64__) || defined(__i386__) || defined(__arm__) || defined(__aarch64__))) \
+           (defined(__GLIBC__)   && (defined(__x86_64__) || defined(__i386__) || (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__))) \
         || (defined(__APPLE__)   && (defined(__x86_64__) || defined(__aarch64__))) \
-        || (defined(__BIONIC__)  && (defined(__x86_64__) || defined(__i386__) || defined(__arm__) || defined(__aarch64__))) \
+        || (defined(__BIONIC__)  && (defined(__x86_64__) || defined(__i386__) || (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__))) \
         || (defined(__FreeBSD__) && (defined(__x86_64__) || defined(__i386__) || defined(__aarch64__))) \
         || (defined(__OpenBSD__) && (defined(__x86_64__) || defined(__i386__) || defined(__aarch64__))) \
       )

--- a/Include/object.h
+++ b/Include/object.h
@@ -192,7 +192,7 @@ _Py_ThreadId(void)
     __asm__("movq %%gs:0, %0" : "=r" (tid));  // x86_64 macOSX uses GS
 #elif defined(__x86_64__)
    __asm__("movq %%fs:0, %0" : "=r" (tid));  // x86_64 Linux, BSD uses FS
-#elif defined(__arm__)
+#elif defined(__arm__) && __ARM_ARCH >= 7
     __asm__ ("mrc p15, 0, %0, c13, c0, 3\nbic %0, %0, #3" : "=r" (tid));
 #elif defined(__aarch64__) && defined(__APPLE__)
     __asm__ ("mrs %0, tpidrro_el0" : "=r" (tid));

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-10-16-12-12-39.gh-issue-125444.9tG2X6.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-10-16-12-12-39.gh-issue-125444.9tG2X6.rst
@@ -1,0 +1,1 @@
+Fix illegal instruction for older Arm architectures. Patch by Diego Russo, testing by Ross Burton.


### PR DESCRIPTION
On Arm v5 it is not possible to get the thread ID via c13 register hence the illegal instruction. The c13 register started to provide thread ID since Arm v6K architecture variant. Other variants of Arm v6 (T2, Z and base) don’t provide the thread ID via c13. For the sake of simplicity we group v5 and v6 together and consider that instructions for Arm v7 only.


<!-- gh-issue-number: gh-125444 -->
* Issue: gh-125444
<!-- /gh-issue-number -->
