### PR TITLE
gh-123899: Add timeout argument for notify_all/notify method in Condition class in threading/multiprocessing module

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -834,7 +834,7 @@ item to the buffer only needs to wake up one consumer thread.
 
       .. versionadded:: 3.2
 
-   .. method:: notify(n=1)
+   .. method:: notify(n=1, timeout=None)
 
       By default, wake up one thread waiting on this condition, if any.  If the
       calling thread has not acquired the lock when this method is called, a
@@ -852,7 +852,10 @@ item to the buffer only needs to wake up one consumer thread.
       call until it can reacquire the lock.  Since :meth:`notify` does not
       release the lock, its caller should.
 
-   .. method:: notify_all()
+      .. versionchanged:: 3.14
+         The *timeout* parameter is new.
+
+   .. method:: notify_all(timeout=None)
 
       Wake up all threads waiting on this condition.  This method acts like
       :meth:`notify`, but wakes up all waiting threads instead of one. If the
@@ -860,6 +863,9 @@ item to the buffer only needs to wake up one consumer thread.
       :exc:`RuntimeError` is raised.
 
       The method ``notifyAll`` is a deprecated alias for this method.
+
+      .. versionchanged:: 3.14
+         The *timeout* parameter is new.
 
 
 .. _semaphore-objects:

--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -274,7 +274,7 @@ class Condition(object):
             for i in range(count):
                 self._lock.acquire()
 
-    def notify(self, n=1):
+    def notify(self, n=1, timeout=None):
         assert self._lock._semlock._is_mine(), 'lock is not owned'
         assert not self._wait_semaphore.acquire(
             False), ('notify: Should not have been able to acquire '
@@ -282,26 +282,25 @@ class Condition(object):
 
         # to take account of timeouts since last notify*() we subtract
         # woken_count from sleeping_count and rezero woken_count
-        while self._woken_count.acquire(False):
-            res = self._sleeping_count.acquire(False)
+        while self._woken_count.acquire(False, timeout=timeout):
+            res = self._sleeping_count.acquire(False, timeout=timeout)
             assert res, ('notify: Bug in sleeping_count.acquire'
                          + '- res should not be False')
 
         sleepers = 0
-        while sleepers < n and self._sleeping_count.acquire(False):
+        while sleepers < n and self._sleeping_count.acquire(False, timeout=timeout):
             self._wait_semaphore.release()        # wake up one sleeper
             sleepers += 1
 
         if sleepers:
             for i in range(sleepers):
-                self._woken_count.acquire()       # wait for a sleeper to wake
-
+                self._woken_count.acquire(timeout=timeout)       # wait for a sleeper to wake
             # rezero wait_semaphore in case some timeouts just happened
-            while self._wait_semaphore.acquire(False):
+            while self._wait_semaphore.acquire(False, timeout=timeout):
                 pass
 
-    def notify_all(self):
-        self.notify(n=sys.maxsize)
+    def notify_all(self, timeout=None):
+        self.notify(n=sys.maxsize, timeout=timeout)
 
     def wait_for(self, predicate, timeout=None):
         result = predicate()

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -411,10 +411,7 @@ class Condition:
         while waiters and n > 0:
             waiter = waiters[0]
             try:
-                if timeout:
-                    waiter.release(timeout)
-                else:
-                    waiter.release()
+                waiter.release()
             except RuntimeError:
                 # gh-92530: The previous call of notify() released the lock,
                 # but was interrupted before removing it from the queue.

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -395,7 +395,7 @@ class Condition:
             result = predicate()
         return result
 
-    def notify(self, n=1):
+    def notify(self, n=1, timeout=None):
         """Wake up one or more threads waiting on this condition, if any.
 
         If the calling thread has not acquired the lock when this method is
@@ -411,7 +411,10 @@ class Condition:
         while waiters and n > 0:
             waiter = waiters[0]
             try:
-                waiter.release()
+                if timeout:
+                    waiter.release(timeout)
+                else:
+                    waiter.release()
             except RuntimeError:
                 # gh-92530: The previous call of notify() released the lock,
                 # but was interrupted before removing it from the queue.
@@ -425,14 +428,14 @@ class Condition:
             except ValueError:
                 pass
 
-    def notify_all(self):
+    def notify_all(self, timeout=None):
         """Wake up all threads waiting on this condition.
 
         If the calling thread has not acquired the lock when this method
         is called, a RuntimeError is raised.
 
         """
-        self.notify(len(self._waiters))
+        self.notify(len(self._waiters), timeout=timeout)
 
     def notifyAll(self):
         """Wake up all threads waiting on this condition.
@@ -723,7 +726,7 @@ class Barrier:
             try:
                 if index + 1 == self._parties:
                     # We release the barrier
-                    self._release()
+                    self._release(timeout=timeout)
                 else:
                     # We wait until someone releases us
                     self._wait(timeout)
@@ -746,13 +749,13 @@ class Barrier:
 
     # Optionally run the 'action' and release the threads waiting
     # in the barrier.
-    def _release(self):
+    def _release(self, timeout=None):
         try:
             if self._action:
                 self._action()
             # enter draining state
             self._state = 1
-            self._cond.notify_all()
+            self._cond.notify_all(timeout=timeout)
         except:
             #an exception during the _action handler.  Break and reraise
             self._break()

--- a/Misc/NEWS.d/next/Library/2024-10-16-19-58-13.gh-issue-123899.VfXZse.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-16-19-58-13.gh-issue-123899.VfXZse.rst
@@ -1,0 +1,2 @@
+Add timeout argument for notify_all/notify method in Condition class in
+threading/multiprocessing module


### PR DESCRIPTION
Fix #123899

<!-- gh-issue-number: gh-123899 -->
* Issue: gh-123899
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125578.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->