### PR TITLE
[3.10] gh-125529: Avoid f-strings in the metagrammar

### DIFF
--- a/Tools/peg_generator/pegen/grammar_parser.py
+++ b/Tools/peg_generator/pegen/grammar_parser.py
@@ -420,7 +420,7 @@ class GeneratedParser(Parser):
             and
             (item := self.item())
         ):
-            return NamedItem ( name . string , item , f"{type.string}*" )
+            return NamedItem ( name . string , item , type . string + "*" )
         self.reset(mark)
         if cut: return None
         cut = False

--- a/Tools/peg_generator/pegen/metagrammar.gram
+++ b/Tools/peg_generator/pegen/metagrammar.gram
@@ -84,7 +84,7 @@ items[NamedItemList]:
     | named_item { [named_item] }
 
 named_item[NamedItem]:
-    | NAME '[' type=NAME '*' ']' '=' ~ item {NamedItem(name.string, item, f"{type.string}*")}
+    | NAME '[' type=NAME '*' ']' '=' ~ item {NamedItem(name.string, item, type.string+"*")}
     | NAME '[' type=NAME ']' '=' ~ item {NamedItem(name.string, item, type.string)}
     | NAME '=' ~ item {NamedItem(name.string, item)}
     | item {NamedItem(None, item)}


### PR DESCRIPTION
Grammar actions need to be valid Python tokens and the accepted tokens need to be listed in the actions mini-grammar).

In Python 3.12+ (PEP 701), f-strings are no longer STRING tokens, so pegen fails to regenerate the metaparser on this Python version, as in:

   PYTHON_FOR_REGEN=python3.12 make regen-pegen-metaparser

Use `+` and plain strings rather than f-strings.

Note that 3.9 and 3.11+ don't use f-strings in the metagrammar

---

This affects our PR CI fail in the *Check if generated files are up to date* step, like here: https://github.com/python/cpython/actions/runs/11274132145/job/31352641619?pr=125255

I see several ways we could solve this:
- Remove this step from our CI
- Change our CI to require Python 3.11
- Merge this patch

I believe this patch is best:
- The failing check is relevant: There are a few parties that build 3.10 using a current Python -- and I expect it to become more common as 3.12+ becomes the “system Python” even on conservative platforms.
- Low chance of impactful breakage: OTOH, not *that* many people run `pegen`, and ones that do are likely equipped handle any failures.

But of course, it's entirely the RM's call. @pablogsal?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125529 -->
* Issue: gh-125529
<!-- /gh-issue-number -->
