### PR TITLE
gh-125584: Require network resource in test_urllib2.HandlerTests.test_ftp_error

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -794,6 +794,7 @@ class HandlerTests(unittest.TestCase):
             self.assertEqual(headers.get("Content-type"), mimetype)
             self.assertEqual(int(headers["Content-length"]), len(data))
 
+    @support.requires_resource("network")
     def test_ftp_error(self):
         class ErrorFTPHandler(urllib.request.FTPHandler):
             def __init__(self, exception):


### PR DESCRIPTION


<!-- gh-issue-number: gh-125584 -->
* Issue: gh-125584
<!-- /gh-issue-number -->
