### PR TITLE
CI: Bump Python to 3.13 and mypy to 1.12 in mypy workflow

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: Tools/requirements-dev.txt
       - run: pip install -r Tools/requirements-dev.txt

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: Tools/requirements-dev.txt
       - run: pip install -r Tools/requirements-dev.txt

--- a/Tools/clinic/libclinic/converter.py
+++ b/Tools/clinic/libclinic/converter.py
@@ -545,9 +545,7 @@ def add_legacy_c_converter(
         if not kwargs:
             added_f = f
         else:
-            # type ignore due to a mypy regression :(
-            # https://github.com/python/mypy/issues/17646
-            added_f = functools.partial(f, **kwargs)  # type: ignore[misc]
+            added_f = functools.partial(f, **kwargs)
         if format_unit:
             legacy_converters[format_unit] = added_f
         return f

--- a/Tools/requirements-dev.txt
+++ b/Tools/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements file for external linters and checks we run on
 # Tools/clinic, Tools/cases_generator/, and Tools/peg_generator/ in CI
-mypy==1.11.2
+mypy==1.12
 
 # needed for peg_generator:
 types-psutil==6.0.0.20240901


### PR DESCRIPTION
I think that we're ready to bump python to 3.12 in mypy workflow, from what I can see at https://github.com/python/mypy/issues/15277, mypy almost supports 3.12 except for https://github.com/python/mypy/issues/15313.