### PR TITLE
gh-125600: Only show stale code warning on source code display commands

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -493,8 +493,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             except KeyboardInterrupt:
                 self.message('--KeyboardInterrupt--')
 
-    def _update_file_mtime(self):
-        """update the file mtime table with the current frame's file if it
+    def _init_file_mtime(self):
+        """initialize the file mtime table with the current frame's file if it
         hasn't been seen yet."""
         filename = self.curframe.f_code.co_filename
         if filename not in self._file_mtime_table:
@@ -504,8 +504,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 pass
 
     def _validate_file_mtime(self):
-        """Check if the source file of the current frame has been modified since
-        the last time we saw it. If so, give a warning."""
+        """Check if the source file of the current frame has been modified.
+        If so, give a warning and reset the modify time to current."""
         try:
             filename = self.curframe.f_code.co_filename
             mtime = os.path.getmtime(filename)
@@ -845,7 +845,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         a breakpoint command list definition.
         """
         if not self.commands_defining:
-            self._update_file_mtime()
+            self._init_file_mtime()
             if line.startswith('_pdbcmd'):
                 command, arg, line = self.parseline(line)
                 if hasattr(self, command):

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -494,11 +494,12 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 self.message('--KeyboardInterrupt--')
 
     def _update_file_mtime(self):
-        """update the file mtime table with the current frame's file"""
+        """update the file mtime table with the current frame's file if it
+        hasn't been seen yet."""
         try:
             filename = self.curframe.f_code.co_filename
-            mtime = os.path.getmtime(filename)
-            self._file_mtime_table.setdefault(filename, mtime)
+            if filename not in self._file_mtime_table:
+                self._file_mtime_table[filename] = os.path.getmtime(filename)
         except Exception:
             return
 

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -496,12 +496,12 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     def _update_file_mtime(self):
         """update the file mtime table with the current frame's file if it
         hasn't been seen yet."""
-        try:
-            filename = self.curframe.f_code.co_filename
-            if filename not in self._file_mtime_table:
+        filename = self.curframe.f_code.co_filename
+        if filename not in self._file_mtime_table:
+            try:
                 self._file_mtime_table[filename] = os.path.getmtime(filename)
-        except Exception:
-            return
+            except Exception:
+                pass
 
     def _validate_file_mtime(self):
         """Check if the source file of the current frame has been modified since

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -497,7 +497,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     def _save_initial_file_mtime(self, frame):
         """save the mtime of the all the files in the frame stack in the file mtime table
-        if it hasn't been saved yet."""
+        if they haven't been saved yet."""
         while frame:
             filename = frame.f_code.co_filename
             if filename not in self._file_mtime_table:

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -496,7 +496,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                 self.message('--KeyboardInterrupt--')
 
     def _save_initial_file_mtime(self, frame):
-        """save the mtile of the all the files in the frame stack in the file mtime table
+        """save the mtime of the all the files in the frame stack in the file mtime table
         if it hasn't been saved yet."""
         while frame:
             filename = frame.f_code.co_filename

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3662,6 +3662,25 @@ def bœr():
         self.assertIn("WARNING:", stdout)
         self.assertIn("was edited", stdout)
 
+    def test_file_modified_and_immediately_restarted(self):
+        script = """
+            print("hello")
+        """
+
+        # the time.sleep is needed for low-resolution filesystems like HFS+
+        commands = """
+            filename = $_frame.f_code.co_filename
+            f = open(filename, "w")
+            f.write("print('goodbye')")
+            import time; time.sleep(1)
+            f.close()
+            restart
+        """
+
+        stdout, stderr = self.run_pdb_script(script, commands)
+        self.assertNotIn("WARNING:", stdout)
+        self.assertNotIn("was edited", stdout)
+
     def test_file_modified_after_execution_with_multiple_instances(self):
         # the time.sleep is needed for low-resolution filesystems like HFS+
         script = """

--- a/Misc/NEWS.d/next/Library/2024-10-16-15-55-50.gh-issue-125600.yMsJx0.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-16-15-55-50.gh-issue-125600.yMsJx0.rst
@@ -1,0 +1,1 @@
+Only show stale code warning in :mod:`pdb` when we display source code.


### PR DESCRIPTION
Now we only show this warning on `l`, `ll` and any command that triggers a stack print.

<!-- gh-issue-number: gh-125600 -->
* Issue: gh-125600
<!-- /gh-issue-number -->
