### PR TITLE
gh-125590: Allow FrameLocalsProxy to delete and pop keys from extra locals

### DIFF
--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -423,7 +423,7 @@ class TestFrameLocals(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             d.pop('non_exist')
-        
+
         del d['m']
         self.assertEqual(d.pop('n'), 1)
 

--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -399,22 +399,22 @@ class TestFrameLocals(unittest.TestCase):
         d = sys._getframe().f_locals
 
         # This needs to be tested before f_extra_locals is created
-        with self.assertRaises(KeyError):
+        with self.assertRaisesRegex(KeyError, 'non_exist'):
             del d['non_exist']
 
         with self.assertRaises(KeyError):
             d.pop('non_exist')
 
-        with self.assertRaises(KeyError):
+        with self.assertRaisesRegex(RuntimeError, 'local variables'):
             del d['x']
 
         with self.assertRaises(AttributeError):
             d.clear()
 
-        with self.assertRaises(KeyError):
+        with self.assertRaises(RuntimeError):
             d.pop('x')
 
-        with self.assertRaises(KeyError):
+        with self.assertRaises(RuntimeError):
             d.pop('x', None)
 
         # 'm', 'n' is stored in f_extra_locals

--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -397,14 +397,40 @@ class TestFrameLocals(unittest.TestCase):
     def test_delete(self):
         x = 1
         d = sys._getframe().f_locals
-        with self.assertRaises(TypeError):
+
+        # This needs to be tested before f_extra_locals is created
+        with self.assertRaises(KeyError):
+            del d['non_exist']
+
+        with self.assertRaises(KeyError):
+            d.pop('non_exist')
+
+        with self.assertRaises(KeyError):
             del d['x']
 
         with self.assertRaises(AttributeError):
             d.clear()
 
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(KeyError):
             d.pop('x')
+
+        with self.assertRaises(KeyError):
+            d.pop('x', None)
+
+        # 'm', 'n' is stored in f_extra_locals
+        d['m'] = 1
+        d['n'] = 1
+
+        with self.assertRaises(KeyError):
+            d.pop('non_exist')
+        
+        del d['m']
+        self.assertEqual(d.pop('n'), 1)
+
+        self.assertNotIn('m', d)
+        self.assertNotIn('n', d)
+
+        self.assertEqual(d.pop('n', 2), 2)
 
     @support.cpython_only
     def test_sizeof(self):

--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -405,16 +405,16 @@ class TestFrameLocals(unittest.TestCase):
         with self.assertRaises(KeyError):
             d.pop('non_exist')
 
-        with self.assertRaisesRegex(RuntimeError, 'local variables'):
+        with self.assertRaisesRegex(ValueError, 'local variables'):
             del d['x']
 
         with self.assertRaises(AttributeError):
             d.clear()
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             d.pop('x')
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             d.pop('x', None)
 
         # 'm', 'n' is stored in f_extra_locals

--- a/Misc/NEWS.d/next/Library/2024-10-16-20-32-40.gh-issue-125590.stHzOP.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-16-20-32-40.gh-issue-125590.stHzOP.rst
@@ -1,0 +1,1 @@
+Allow ``FrameLocalsProxy`` to delete and pop if the key is not a fast variable.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -5,6 +5,7 @@
 #include "pycore_code.h"          // CO_FAST_LOCAL, etc.
 #include "pycore_function.h"      // _PyFunction_FromConstructor()
 #include "pycore_moduleobject.h"  // _PyModule_GetDict()
+#include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 #include "pycore_object.h"        // _PyObject_GC_UNTRACK()
 #include "pycore_opcode_metadata.h" // _PyOpcode_Deopt, _PyOpcode_Caches
 
@@ -164,7 +165,7 @@ framelocalsproxy_setitem(PyObject *self, PyObject *key, PyObject *value)
     }
     if (i >= 0) {
         if (value == NULL) {
-            PyErr_SetString(PyExc_KeyError, "cannot remove local variables from FrameLocalsProxy");
+            PyErr_SetString(PyExc_RuntimeError, "cannot remove local variables from FrameLocalsProxy");
             return -1;
         }
 
@@ -203,7 +204,7 @@ framelocalsproxy_setitem(PyObject *self, PyObject *key, PyObject *value)
 
     if (extra == NULL) {
         if (value == NULL) {
-            PyErr_Format(PyExc_KeyError, "'%R'", key);
+            _PyErr_SetKeyError(key);
             return -1;
         }
         extra = PyDict_New();
@@ -687,8 +688,7 @@ framelocalsproxy_setdefault(PyObject* self, PyObject *const *args, Py_ssize_t na
 static PyObject*
 framelocalsproxy_pop(PyObject* self, PyObject *const *args, Py_ssize_t nargs)
 {
-    if (nargs < 1 || nargs > 2) {
-        PyErr_SetString(PyExc_TypeError, "pop expected 1 or 2 arguments");
+    if (!_PyArg_CheckPositional("pop", nargs, 1, 2)) {
         return NULL;
     }
 
@@ -707,17 +707,17 @@ framelocalsproxy_pop(PyObject* self, PyObject *const *args, Py_ssize_t nargs)
     }
 
     if (i >= 0) {
-        PyErr_SetString(PyExc_KeyError, "cannot remove local variables from FrameLocalsProxy");
+        PyErr_SetString(PyExc_RuntimeError, "cannot remove local variables from FrameLocalsProxy");
         return NULL;
     }
 
-    PyObject* result = NULL;
+    PyObject *result = NULL;
 
     if (frame->f_extra_locals == NULL) {
         if (default_value != NULL) {
             return Py_XNewRef(default_value);
         } else {
-            PyErr_Format(PyExc_KeyError, "'%R'", key);
+            _PyErr_SetKeyError(key);
             return NULL;
         }
     }
@@ -730,7 +730,7 @@ framelocalsproxy_pop(PyObject* self, PyObject *const *args, Py_ssize_t nargs)
         if (default_value != NULL) {
             return Py_XNewRef(default_value);
         } else {
-            PyErr_Format(PyExc_KeyError, "'%R'", key);
+            _PyErr_SetKeyError(key);
             return NULL;
         }
     }

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -165,7 +165,7 @@ framelocalsproxy_setitem(PyObject *self, PyObject *key, PyObject *value)
     }
     if (i >= 0) {
         if (value == NULL) {
-            PyErr_SetString(PyExc_RuntimeError, "cannot remove local variables from FrameLocalsProxy");
+            PyErr_SetString(PyExc_ValueError, "cannot remove local variables from FrameLocalsProxy");
             return -1;
         }
 
@@ -707,7 +707,7 @@ framelocalsproxy_pop(PyObject* self, PyObject *const *args, Py_ssize_t nargs)
     }
 
     if (i >= 0) {
-        PyErr_SetString(PyExc_RuntimeError, "cannot remove local variables from FrameLocalsProxy");
+        PyErr_SetString(PyExc_ValueError, "cannot remove local variables from FrameLocalsProxy");
         return NULL;
     }
 


### PR DESCRIPTION
It's okay for us to pop/delete the keys that were added to `f_locals` manually, just ban the real fast variables.
@ncoghlan not sure if there's any documentation that needs to be changed.

There are two types of exceptions that could be raised:
* `RuntimeError` when users trying to remove a local variable
* `KeyError` when users trying to remove a key that does not exist

<!-- gh-issue-number: gh-125590 -->
* Issue: gh-125590
<!-- /gh-issue-number -->
