### PR TITLE
gh-125615: Replace "without ... nor" with "with neither ... nor"

### DIFF
--- a/Doc/tutorial/appendix.rst
+++ b/Doc/tutorial/appendix.rst
@@ -20,7 +20,7 @@ This one supports color, multiline editing, history browsing, and
 paste mode.  To disable color, see :ref:`using-on-controlling-color` for
 details.  Function keys provide some additional functionality.
 :kbd:`F1` enters the interactive help browser :mod:`pydoc`.
-:kbd:`F2` allows for browsing command-line history without output nor the
+:kbd:`F2` allows for browsing command-line history with neither output nor the
 :term:`>>>` and :term:`...` prompts. :kbd:`F3` enters "paste mode", which
 makes pasting larger blocks of code easier. Press :kbd:`F3` to return to
 the regular prompt.


### PR DESCRIPTION
"without ... nor" is incorrect grammar. This PR replaces it with the correct "with neither ... nor" - an alternative would be "without ... or" but for clarity, neither-nor is chosen.

Resolves #125615

<!-- gh-issue-number: gh-125615 -->
* Issue: gh-125615
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125617.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->