### PR TITLE
Sentence revision in pdb.rst

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -182,7 +182,7 @@ slightly different way:
 .. function:: post_mortem(traceback=None)
 
    Enter post-mortem debugging of the given *traceback* object.  If no
-   *traceback* is given, it uses the one of the exception that is currently
+   *traceback* is given, it uses one of the exceptions that is currently
    being handled (an exception must be being handled if the default is to be
    used).
 


### PR DESCRIPTION
Fix unclear phrasing in exception traceback documentation for PDB.

Description:

Revised the sentence from:

    "If no traceback is given, it uses the one of the exception that is currently being handled."

to:

    "If no traceback is given, it uses one of the exceptions that is currently being handled."

The original phrasing was grammatically awkward and unclear due to the use of "the one of the exception", which incorrectly implied a specific, pre-identified exception. The revision eliminates this ambiguity by changing it to "one of the exceptions", which makes it clear that the traceback is selected from multiple possible exceptions being handled.

This improves readability and accuracy, ensuring the documentation is easier to understand.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125630.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->