### PR TITLE
gh-125651: Fix UUID hex parsing with underscores

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -279,7 +279,6 @@ class BaseTestUUID:
         badvalue(lambda: self.uuid.UUID('abc'))
         badvalue(lambda: self.uuid.UUID('123_4567812345678123456781234567'))
         badvalue(lambda: self.uuid.UUID('123_4567812345678123456781_23456'))
-        badvalue(lambda: self.uuid.UUID('123_4567812345678123456781_23456'))
         badvalue(lambda: self.uuid.UUID('1234567812345678123456781234567'))
         badvalue(lambda: self.uuid.UUID('123456781234567812345678123456789'))
         badvalue(lambda: self.uuid.UUID('123456781234567812345678z2345678'))

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -277,11 +277,17 @@ class BaseTestUUID:
         # Badly formed hex strings.
         badvalue(lambda: self.uuid.UUID(''))
         badvalue(lambda: self.uuid.UUID('abc'))
-        badvalue(lambda: self.uuid.UUID("123_4567812345678123456781234567"))
-        badvalue(lambda: self.uuid.UUID("123_4567812345678123456781_23456"))
+        badvalue(lambda: self.uuid.UUID('123_4567812345678123456781234567'))
+        badvalue(lambda: self.uuid.UUID('123_4567812345678123456781_23456'))
+        badvalue(lambda: self.uuid.UUID('123_4567812345678123456781_23456'))
         badvalue(lambda: self.uuid.UUID('1234567812345678123456781234567'))
         badvalue(lambda: self.uuid.UUID('123456781234567812345678123456789'))
         badvalue(lambda: self.uuid.UUID('123456781234567812345678z2345678'))
+        badvalue(lambda: self.uuid.UUID('0x123456781234567812345678z23456'))
+        badvalue(lambda: self.uuid.UUID('0X123456781234567812345678z23456'))
+        badvalue(lambda: self.uuid.UUID('+123456781234567812345678z234567'))
+        badvalue(lambda: self.uuid.UUID(' 123456781234567812345678z23456 '))
+        badvalue(lambda: self.uuid.UUID('  123456781234567812345678z2345  '))
 
         # Badly formed bytes.
         badvalue(lambda: self.uuid.UUID(bytes='abc'))

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -277,6 +277,8 @@ class BaseTestUUID:
         # Badly formed hex strings.
         badvalue(lambda: self.uuid.UUID(''))
         badvalue(lambda: self.uuid.UUID('abc'))
+        badvalue(lambda: self.uuid.UUID("123_4567812345678123456781234567"))
+        badvalue(lambda: self.uuid.UUID("123_4567812345678123456781_23456"))
         badvalue(lambda: self.uuid.UUID('1234567812345678123456781234567'))
         badvalue(lambda: self.uuid.UUID('123456781234567812345678123456789'))
         badvalue(lambda: self.uuid.UUID('123456781234567812345678z2345678'))

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -287,6 +287,7 @@ class BaseTestUUID:
         badvalue(lambda: self.uuid.UUID('+123456781234567812345678z234567'))
         badvalue(lambda: self.uuid.UUID(' 123456781234567812345678z23456 '))
         badvalue(lambda: self.uuid.UUID('  123456781234567812345678z2345  '))
+        badvalue(lambda: self.uuid.UUID('\uff10123456781234567812345678z234567'))
 
         # Badly formed bytes.
         badvalue(lambda: self.uuid.UUID(bytes='abc'))

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -57,7 +57,6 @@ Typical usage:
 """
 
 import os
-import re
 import sys
 import time
 
@@ -84,6 +83,7 @@ if _AIX:
     _MAC_DELIM = b'.'
     _MAC_OMITS_LEADING_ZEROES = True
 
+_HEX_TT = str.maketrans('', '', 'abcdefABCDEF0123456789')
 RESERVED_NCS, RFC_4122, RESERVED_MICROSOFT, RESERVED_FUTURE = [
     'reserved for NCS compatibility', 'specified in RFC 4122',
     'reserved for Microsoft compatibility', 'reserved for future definition']
@@ -216,7 +216,8 @@ class UUID:
         elif hex is not None:
             hex = hex.replace('urn:', '').replace('uuid:', '')
             hex = hex.strip('{}').replace('-', '')
-            if not re.fullmatch(r'[0-9A-Fa-f]{32}', hex):
+            # ensure that only 32 hex characters pass through
+            if len(hex) != 32 or hex.translate(_HEX_TT):
                 raise ValueError('badly formed hexadecimal UUID string')
             int = int_(hex, 16)
         elif bytes_le is not None:

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -214,7 +214,7 @@ class UUID:
             pass
         elif hex is not None:
             hex = hex.replace('urn:', '').replace('uuid:', '')
-            hex = hex.strip('{}').replace('-', '')
+            hex = hex.strip("{}").replace("-", "").replace("_", "")
             if len(hex) != 32:
                 raise ValueError('badly formed hexadecimal UUID string')
             int = int_(hex, 16)

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -57,6 +57,7 @@ Typical usage:
 """
 
 import os
+import re
 import sys
 import time
 
@@ -214,8 +215,8 @@ class UUID:
             pass
         elif hex is not None:
             hex = hex.replace('urn:', '').replace('uuid:', '')
-            hex = hex.strip("{}").replace("-", "").replace("_", "")
-            if len(hex) != 32:
+            hex = hex.strip('{}').replace('-', '')
+            if not re.fullmatch(r'[0-9A-Fa-f]{32}', hex):
                 raise ValueError('badly formed hexadecimal UUID string')
             int = int_(hex, 16)
         elif bytes_le is not None:

--- a/Misc/NEWS.d/next/Library/2024-10-18-09-45-34.gh-issue-125651.M0wSAS.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-18-09-45-34.gh-issue-125651.M0wSAS.rst
@@ -1,0 +1,1 @@
+Fix parsing of HEX encoded UUID string

--- a/Misc/NEWS.d/next/Library/2024-10-18-09-45-34.gh-issue-125651.M0wSAS.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-18-09-45-34.gh-issue-125651.M0wSAS.rst
@@ -1,1 +1,1 @@
-Fix parsing of HEX encoded UUID string
+Fix HEX parsing of :class:`uuid.UUID`.


### PR DESCRIPTION
Adds sanitization from "digit grouping separators" in UUID parser to comply with [RFC](https://datatracker.ietf.org/doc/html/rfc4122.html).


<!-- gh-issue-number: gh-125651 -->
* Issue: gh-125651
<!-- /gh-issue-number -->
