### PR TITLE
[3.13] gh-123370: Fix the canvas not clearing after running turtledemo.clock (gh-123457)

### DIFF
--- a/Lib/turtledemo/clock.py
+++ b/Lib/turtledemo/clock.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-# -*- coding: cp1252 -*-
 """       turtle-example-suite:
 
-             tdemo_clock.py
+           turtledemo/clock.py
 
 Enhanced clock-program, showing date
 and time
@@ -12,6 +11,9 @@ and time
 """
 from turtle import *
 from datetime import datetime
+
+dtfont = "TkFixedFont", 14, "bold"
+current_day = None
 
 def jump(distanz, winkel=0):
     penup()
@@ -53,11 +55,23 @@ def clockface(radius):
             jump(-radius)
         rt(6)
 
+def display_date_time():
+    global current_day
+    writer.clear()
+    now = datetime.now()
+    current_day = now.day
+    writer.home()
+    writer.forward(distance=65)
+    writer.write(wochentag(now), align="center", font=dtfont)
+    writer.back(distance=150)
+    writer.write(datum(now), align="center", font=dtfont)
+    writer.forward(distance=85)
+
 def setup():
     global second_hand, minute_hand, hour_hand, writer
     mode("logo")
     make_hand_shape("second_hand", 125, 25)
-    make_hand_shape("minute_hand",  130, 25)
+    make_hand_shape("minute_hand",  115, 25)
     make_hand_shape("hour_hand", 90, 25)
     clockface(160)
     second_hand = Turtle()
@@ -75,10 +89,10 @@ def setup():
         hand.speed(0)
     ht()
     writer = Turtle()
-    #writer.mode("logo")
     writer.ht()
     writer.pu()
     writer.bk(85)
+    display_date_time()
 
 def wochentag(t):
     wochentag = ["Monday", "Tuesday", "Wednesday",
@@ -100,18 +114,11 @@ def tick():
     stunde = t.hour + minute/60.0
     try:
         tracer(False)  # Terminator can occur here
-        writer.clear()
-        writer.home()
-        writer.forward(65)
-        writer.write(wochentag(t),
-                     align="center", font=("Courier", 14, "bold"))
-        writer.back(150)
-        writer.write(datum(t),
-                     align="center", font=("Courier", 14, "bold"))
-        writer.forward(85)
         second_hand.setheading(6*sekunde)  # or here
         minute_hand.setheading(6*minute)
         hour_hand.setheading(30*stunde)
+        if t.day != current_day:
+            display_date_time()
         tracer(True)
         ontimer(tick, 100)
     except Terminator:

--- a/Misc/NEWS.d/next/Library/2024-08-28-19-27-35.gh-issue-123370.SPZ9Ux.rst
+++ b/Misc/NEWS.d/next/Library/2024-08-28-19-27-35.gh-issue-123370.SPZ9Ux.rst
@@ -1,0 +1,1 @@
+Fix the canvas not clearing after running turtledemo clock.


### PR DESCRIPTION
Rewriting the day and date every tick somehow prevented them from being removed either by clicking STOP or loading another example.  The solution is to rewrite them only when they change. (cherry picked from commit c124577ebe915a00de4033c0f7fa7c47621d79e0)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123370 -->
* Issue: gh-123370
<!-- /gh-issue-number -->
