### PR TITLE
Solved a little bug hopefully

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -776,8 +776,13 @@ class SMTP:
                 raise RuntimeError("No SSL support included in this Python")
             if context is None:
                 context = ssl._create_stdlib_context()
+            if self._host[-1] is ".":
+                context_host = self._host[:-1]
+            else:
+                context_host = self._host
             self.sock = context.wrap_socket(self.sock,
-                                            server_hostname=self._host)
+                                            server_hostname=context_host)
+            
             self.file = None
             # RFC 3207:
             # The client MUST discard any knowledge obtained from


### PR DESCRIPTION
When you are trying to connect to a domain with the dot at the end (ex: `mta5.am0.yahoodns.net.` instead of  `mta5.am0.yahoodns.net`)  the smtp connection works just fine but starttls() will raise an handshake execption.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
