### PR TITLE
Doc: Fix pluralization in os.process_cpu_count() documentation

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -5579,7 +5579,7 @@ Miscellaneous System Information
    If :option:`-X cpu_count <-X>` is given or :envvar:`PYTHON_CPU_COUNT` is set,
    :func:`process_cpu_count` returns the overridden value *n*.
 
-   See also the :func:`sched_getaffinity` functions.
+   See also the :func:`sched_getaffinity` function.
 
    .. versionadded:: 3.13
 


### PR DESCRIPTION
Remove the misplaced pluralization of "functions" in the sentence "See also the `sched_getaffinity()` functions."

Ref: https://docs.python.org/3/library/os.html#os.process_cpu_count


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125678.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->