### PR TITLE
gh-125593: Use colors to highlight error locations in tracebacks from exception group

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4659,12 +4659,13 @@ class TestColorizedTraceback(unittest.TestCase):
         boldm = _colorize.ANSIColors.BOLD_MAGENTA
         reset = _colorize.ANSIColors.RESET
         lno_foo = foo.__code__.co_firstlineno
-        actual = "".join(exc.format(colorize=True))
+        actual = "".join(exc.format(colorize=True)).splitlines()
         expected = [f"  + Exception Group Traceback (most recent call last):",
                    f'  |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+9}{reset}, in {magenta}test_colorized_traceback_from_exception_group{reset}',
                    f'  |     {red}foo{reset}{boldr}(){reset}',
                    f'  |     {red}~~~{reset}{boldr}^^{reset}',
                    f"  |     e = ExceptionGroup('test', [ZeroDivisionError('division by zero')])",
+                   f"  |     foo = {foo}",
                    f'  |     self = <{__name__}.TestColorizedTraceback testMethod=test_colorized_traceback_from_exception_group>',
                    f'  |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+6}{reset}, in {magenta}foo{reset}',
                    f'  |     raise ExceptionGroup("test", exceptions)',
@@ -4678,11 +4679,7 @@ class TestColorizedTraceback(unittest.TestCase):
                    f"    |     exceptions = [ZeroDivisionError('division by zero')]",
                    f'    | {boldm}ZeroDivisionError{reset}: {magenta}division by zero{reset}',
                    f'    +------------------------------------']
-        string_with_address = r'  |     foo = <function TestColorizedTraceback.test_colorized_traceback_from_exception_group.<locals>.foo at 0x[0-9a-fA-F]+>'
-        for line in expected:
-            self.assertIn(line, actual)
-        self.assertRegex(actual, string_with_address)
-
+        self.assertEqual(actual, expected)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4666,7 +4666,7 @@ class TestColorizedTraceback(unittest.TestCase):
                    f'  |     {red}~~~{reset}{boldr}^^{reset}',
                    f"  |     e = ExceptionGroup('test', [ZeroDivisionError('division by zero')])",
                    f'  |     foo = <function TestColorizedTraceback.test_colorized_traceback_from_exception_group.<locals>.foo at {hex(id(foo))}>',
-                   f'  |     self = <__main__.TestColorizedTraceback testMethod=test_colorized_traceback_from_exception_group>',
+                   f'  |     self = <{__name__}.TestColorizedTraceback testMethod=test_colorized_traceback_from_exception_group>',
                    f'  |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+6}{reset}, in {magenta}foo{reset}',
                    f'  |     raise ExceptionGroup("test", exceptions)',
                    f"  |     exceptions = [ZeroDivisionError('division by zero')]",

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4659,13 +4659,12 @@ class TestColorizedTraceback(unittest.TestCase):
         boldm = _colorize.ANSIColors.BOLD_MAGENTA
         reset = _colorize.ANSIColors.RESET
         lno_foo = foo.__code__.co_firstlineno
-        actual = "".join(exc.format(colorize=True)).splitlines()
+        actual = "".join(exc.format(colorize=True))
         expected = [f"  + Exception Group Traceback (most recent call last):",
                    f'  |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+9}{reset}, in {magenta}test_colorized_traceback_from_exception_group{reset}',
                    f'  |     {red}foo{reset}{boldr}(){reset}',
                    f'  |     {red}~~~{reset}{boldr}^^{reset}',
                    f"  |     e = ExceptionGroup('test', [ZeroDivisionError('division by zero')])",
-                   f'  |     foo = <function TestColorizedTraceback.test_colorized_traceback_from_exception_group.<locals>.foo at {hex(id(foo))}>',
                    f'  |     self = <{__name__}.TestColorizedTraceback testMethod=test_colorized_traceback_from_exception_group>',
                    f'  |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+6}{reset}, in {magenta}foo{reset}',
                    f'  |     raise ExceptionGroup("test", exceptions)',
@@ -4679,7 +4678,10 @@ class TestColorizedTraceback(unittest.TestCase):
                    f"    |     exceptions = [ZeroDivisionError('division by zero')]",
                    f'    | {boldm}ZeroDivisionError{reset}: {magenta}division by zero{reset}',
                    f'    +------------------------------------']
-        self.assertEqual(actual, expected)
+        string_with_address = r'  |     foo = <function TestColorizedTraceback.test_colorized_traceback_from_exception_group.<locals>.foo at 0x[0-9a-fA-F]+>'
+        for line in expected:
+            self.assertIn(line, actual)
+        self.assertRegex(actual, string_with_address)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4660,30 +4660,27 @@ class TestColorizedTraceback(unittest.TestCase):
         boldm = _colorize.ANSIColors.BOLD_MAGENTA
         reset = _colorize.ANSIColors.RESET
         lno_foo = foo.__code__.co_firstlineno
-
-        print(f"{lno_foo=}")
         
-        actual = "".join(exc.format(colorize=True))
-        expected = f'  + Exception Group Traceback (most recent call last):    ' \
-                   f'  |   File {magenta}"{__file__}"{reset}, line {lno_foo+10}, in {magenta}test_colorized_traceback_from_exception_group{reset}    ' \
-                   f'  |     {red}foo{reset}{boldr}(){reset}  ' \
-                   f'  |     {red}~~~{reset}{boldr}^^{reset}  ' \
-                   f"  |     e = ExceptionGroup('test', [ZeroDivisionError('division by zero')])  " \
-                   f'  |     foo = <function TestColorizedTraceback.test_colorized_traceback_from_exception_group.<locals>.foo at {hex(id(foo))}>  ' \
-                   f'  |     self = <__main__.TestColorizedTraceback testMethod=test_colorized_traceback_from_exception_group>' \
-                   f'  |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+6}{reset}, in {magenta}foo{reset}  ' \
-                   f'  |     raise ExceptionGroup("test", exceptions)  ' \
-                   f"  |     exceptions = [ZeroDivisionError('division by zero')]  " \
-                   f'  | {boldm}ExceptionGroup{reset}: {magenta}test (1 sub-exception){reset}  ' \
-                   f'  +-+---------------- 1 ----------------  ' \
-                   f'    | Traceback (most recent call last):  ' \
-                   f'    |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+3}{reset}, in {magenta}foo{reset}  ' \
-                   f'    |     {red}1{reset} {boldr}/{reset} {red}0{reset}  ' \
-                   f'    |     {red}~~{reset}{boldr}^{reset}{red}~~{reset}  ' \
-                   f"    |     exceptions = [ZeroDivisionError('division by zero')]  " \
-                   f'    | {boldm}ZeroDivisionError{reset}: {magenta}division by zero{reset}  ' \
-                   f'    +------------------------------------'
-         
+        actual = "".join(exc.format(colorize=True)).splitlines()
+        expected = [f"  + Exception Group Traceback (most recent call last):",
+                   f'  |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+9}{reset}, in {magenta}test_colorized_traceback_from_exception_group{reset}',
+                   f'  |     {red}foo{reset}{boldr}(){reset}',
+                   f'  |     {red}~~~{reset}{boldr}^^{reset}',
+                   f"  |     e = ExceptionGroup('test', [ZeroDivisionError('division by zero')])",
+                   f'  |     foo = <function TestColorizedTraceback.test_colorized_traceback_from_exception_group.<locals>.foo at {hex(id(foo))}>',
+                   f'  |     self = <__main__.TestColorizedTraceback testMethod=test_colorized_traceback_from_exception_group>',
+                   f'  |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+6}{reset}, in {magenta}foo{reset}',
+                   f'  |     raise ExceptionGroup("test", exceptions)',
+                   f"  |     exceptions = [ZeroDivisionError('division by zero')]",
+                   f'  | {boldm}ExceptionGroup{reset}: {magenta}test (1 sub-exception){reset}',
+                   f'  +-+---------------- 1 ----------------',
+                   f'    | Traceback (most recent call last):',
+                   f'    |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+3}{reset}, in {magenta}foo{reset}',
+                   f'    |     {red}1 {reset}{boldr}/{reset}{red} 0{reset}',
+                   f'    |     {red}~~{reset}{boldr}^{reset}{red}~~{reset}',
+                   f"    |     exceptions = [ZeroDivisionError('division by zero')]",
+                   f'    | {boldm}ZeroDivisionError{reset}: {magenta}division by zero{reset}',
+                   f'    +------------------------------------']
         self.assertEqual(actual, expected)
 
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4638,25 +4638,53 @@ class TestColorizedTraceback(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_colorized_traceback_from_exception_group(self):
-        try:
+        self.maxDiff = None
+        def foo():
             exceptions = []
             try:
                 1 / 0
             except ZeroDivisionError as inner_exc:
                 exceptions.append(inner_exc)
             raise ExceptionGroup("test", exceptions)
+
+        try:
+            foo()
         except Exception as e:
             exc = traceback.TracebackException.from_exception(
                 e, capture_locals=True
             )
 
-        actual = "".join(exc.format(colorize=True))
         red = _colorize.ANSIColors.RED
         boldr = _colorize.ANSIColors.BOLD_RED
+        magenta = _colorize.ANSIColors.MAGENTA
+        boldm = _colorize.ANSIColors.BOLD_MAGENTA
         reset = _colorize.ANSIColors.RESET
+        lno_foo = foo.__code__.co_firstlineno
 
-        self.assertIn(f"{red}1 {reset+boldr}/{reset+red} 0{reset}", actual)
-        self.assertIn(f"{red}~~{reset+boldr}^{reset+red}~~{reset}", actual)
+        print(f"{lno_foo=}")
+        
+        actual = "".join(exc.format(colorize=True))
+        expected = f'  + Exception Group Traceback (most recent call last):    ' \
+                   f'  |   File {magenta}"{__file__}"{reset}, line {lno_foo+10}, in {magenta}test_colorized_traceback_from_exception_group{reset}    ' \
+                   f'  |     {red}foo{reset}{boldr}(){reset}  ' \
+                   f'  |     {red}~~~{reset}{boldr}^^{reset}  ' \
+                   f"  |     e = ExceptionGroup('test', [ZeroDivisionError('division by zero')])  " \
+                   f'  |     foo = <function TestColorizedTraceback.test_colorized_traceback_from_exception_group.<locals>.foo at {hex(id(foo))}>  ' \
+                   f'  |     self = <__main__.TestColorizedTraceback testMethod=test_colorized_traceback_from_exception_group>' \
+                   f'  |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+6}{reset}, in {magenta}foo{reset}  ' \
+                   f'  |     raise ExceptionGroup("test", exceptions)  ' \
+                   f"  |     exceptions = [ZeroDivisionError('division by zero')]  " \
+                   f'  | {boldm}ExceptionGroup{reset}: {magenta}test (1 sub-exception){reset}  ' \
+                   f'  +-+---------------- 1 ----------------  ' \
+                   f'    | Traceback (most recent call last):  ' \
+                   f'    |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+3}{reset}, in {magenta}foo{reset}  ' \
+                   f'    |     {red}1{reset} {boldr}/{reset} {red}0{reset}  ' \
+                   f'    |     {red}~~{reset}{boldr}^{reset}{red}~~{reset}  ' \
+                   f"    |     exceptions = [ZeroDivisionError('division by zero')]  " \
+                   f'    | {boldm}ZeroDivisionError{reset}: {magenta}division by zero{reset}  ' \
+                   f'    +------------------------------------'
+         
+        self.assertEqual(actual, expected)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4638,7 +4638,6 @@ class TestColorizedTraceback(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_colorized_traceback_from_exception_group(self):
-        self.maxDiff = None
         def foo():
             exceptions = []
             try:
@@ -4660,7 +4659,6 @@ class TestColorizedTraceback(unittest.TestCase):
         boldm = _colorize.ANSIColors.BOLD_MAGENTA
         reset = _colorize.ANSIColors.RESET
         lno_foo = foo.__code__.co_firstlineno
-        
         actual = "".join(exc.format(colorize=True)).splitlines()
         expected = [f"  + Exception Group Traceback (most recent call last):",
                    f'  |   File {magenta}"{__file__}"{reset}, line {magenta}{lno_foo+9}{reset}, in {magenta}test_colorized_traceback_from_exception_group{reset}',

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4637,6 +4637,27 @@ class TestColorizedTraceback(unittest.TestCase):
             f'{boldm}ZeroDivisionError{reset}: {magenta}division by zero{reset}']
         self.assertEqual(actual, expected)
 
+    def test_colorized_traceback_from_exception_group(self):
+        try:
+            exceptions = []
+            try:
+                1 / 0
+            except ZeroDivisionError as inner_exc:
+                exceptions.append(inner_exc)
+            raise ExceptionGroup("test", exceptions)
+        except Exception as e:
+            exc = traceback.TracebackException.from_exception(
+                e, capture_locals=True
+            )
+
+        actual = "".join(exc.format(colorize=True))
+        red = _colorize.ANSIColors.RED
+        boldr = _colorize.ANSIColors.BOLD_RED
+        reset = _colorize.ANSIColors.RESET
+
+        self.assertIn(f"{red}1 {reset+boldr}/{reset+red} 0{reset}", actual)
+        self.assertIn(f"{red}~~{reset+boldr}^{reset+red}~~{reset}", actual)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1428,7 +1428,7 @@ class TracebackException:
                            f'+---------------- {title} ----------------\n')
                     _ctx.exception_group_depth += 1
                     if not truncated:
-                        yield from exc.exceptions[i].format(chain=chain, _ctx=_ctx)
+                        yield from exc.exceptions[i].format(chain=chain, _ctx=_ctx, colorize=colorize)
                     else:
                         remaining = num_excs - self.max_group_width
                         plural = 's' if remaining > 1 else ''

--- a/Misc/NEWS.d/next/Core and Builtins/2024-10-18-10-11-43.gh-issue-125593.Q97m3A.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-10-18-10-11-43.gh-issue-125593.Q97m3A.rst
@@ -1,0 +1,1 @@
+Use color to highlight error locations in traceback from exception group


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125593 -->
* Issue: gh-125593
<!-- /gh-issue-number -->
