### PR TITLE
gh-125682: Python implementation of `json.loads()` accepts non-ascii digits

### DIFF
--- a/Lib/json/scanner.py
+++ b/Lib/json/scanner.py
@@ -9,7 +9,7 @@ except ImportError:
 __all__ = ['make_scanner']
 
 NUMBER_RE = re.compile(
-    r'(-?(?:0|[1-9]\d*))(\.\d+)?([eE][-+]?\d+)?',
+    r'(-?(?:0|[1-9][0-9]*))(\.[0-9]+)?([eE][-+]?[0-9]+)?',
     (re.VERBOSE | re.MULTILINE | re.DOTALL))
 
 def py_make_scanner(context):

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -17,6 +17,7 @@ class TestDecode:
         self.assertEqual(rval, 1.0)
 
     def test_nonascii_digits_rejected(self):
+        # JSON specifies only ascii digits, see gh-125687
         for num in ["1\uff10", "0.\uff10", "0e\uff10"]:
             with self.assertRaises(self.JSONDecodeError):
                 self.loads(num)

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -16,6 +16,11 @@ class TestDecode:
         self.assertIsInstance(rval, float)
         self.assertEqual(rval, 1.0)
 
+    def test_unicode_digits(self):
+        for num in ["1\uff10", "0.\uff10", "0e\uff10"]:
+            with self.assertRaises(self.JSONDecodeError):
+                self.loads(num)
+
     def test_bytes(self):
         self.assertEqual(self.loads(b"1"), 1)
 

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -16,7 +16,7 @@ class TestDecode:
         self.assertIsInstance(rval, float)
         self.assertEqual(rval, 1.0)
 
-    def test_unicode_digits(self):
+    def test_nonascii_digits_rejected(self):
         for num in ["1\uff10", "0.\uff10", "0e\uff10"]:
             with self.assertRaises(self.JSONDecodeError):
                 self.loads(num)

--- a/Misc/NEWS.d/next/Library/2024-10-18-09-51-29.gh-issue-125682.vsj4cU.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-18-09-51-29.gh-issue-125682.vsj4cU.rst
@@ -1,1 +1,1 @@
-Reject unicode digits for Python implementation of :func:`json.loads`.
+Reject non-ASCII digits in the Python implementation of :func:`json.loads`.

--- a/Misc/NEWS.d/next/Library/2024-10-18-09-51-29.gh-issue-125682.vsj4cU.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-18-09-51-29.gh-issue-125682.vsj4cU.rst
@@ -1,1 +1,2 @@
-Reject non-ASCII digits in the Python implementation of :func:`json.loads`.
+Reject non-ASCII digits in the Python implementation of :func:`json.loads`
+conforming to the json specification.

--- a/Misc/NEWS.d/next/Library/2024-10-18-09-51-29.gh-issue-125682.vsj4cU.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-18-09-51-29.gh-issue-125682.vsj4cU.rst
@@ -1,0 +1,1 @@
+Reject unicode digits for Python implementation of :func:`json.loads`.

--- a/Misc/NEWS.d/next/Library/2024-10-18-09-51-29.gh-issue-125682.vsj4cU.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-18-09-51-29.gh-issue-125682.vsj4cU.rst
@@ -1,2 +1,2 @@
 Reject non-ASCII digits in the Python implementation of :func:`json.loads`
-conforming to the json specification.
+conforming to the JSON specification.


### PR DESCRIPTION


<!-- gh-issue-number: gh-125682 -->
* Issue: gh-125682
<!-- /gh-issue-number -->
