### PR TITLE
gh-124694: In test_interpreter_pool, Restore the Asyncio Event Loop Policy During Cleanup

### DIFF
--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -290,6 +290,9 @@ class AsyncioTest(InterpretersMixin, testasyncio_utils.TestCase):
         self.executor = self.executor_type()
         self.addCleanup(lambda: self.executor.shutdown())
 
+        if support.maybe_get_event_loop_policy() is None:
+            self.addCleanup(lambda: asyncio.set_event_loop_policy(None))
+
     def tearDown(self):
         if not self.loop.is_closed():
             testasyncio_utils.run_briefly(self.loop)

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -284,12 +284,16 @@ class AsyncioTest(InterpretersMixin, testasyncio_utils.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        # Most uses of asyncio will implicitly call set_event_loop_policy()
+        # with the default policy if a policy hasn't been set already.
+        # If that happens in a test, likw here, we'll end up with a failure
+        # when --fail-env-changed is used.  That's why the other tests that
+        # use asyncio are careful to set the policy back to None and why
+        # we're careful to do so here.  We also validate that no other
+        # tests left a policy in place, just in case.
         policy = support.maybe_get_event_loop_policy()
         assert policy is None, policy
-
-    @classmethod
-    def tearDownClass(cls):
-        asyncio.set_event_loop_policy(None)
+        cls.addClassCleanup(lambda: asyncio.set_event_loop_policy(None))
 
     def setUp(self):
         super().setUp()

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -282,6 +282,15 @@ class InterpreterPoolExecutorTest(
 
 class AsyncioTest(InterpretersMixin, testasyncio_utils.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        policy = support.maybe_get_event_loop_policy()
+        assert policy is None, policy
+
+    @classmethod
+    def tearDownClass(cls):
+        asyncio.set_event_loop_policy(None)
+
     def setUp(self):
         super().setUp()
         self.loop = asyncio.new_event_loop()
@@ -289,9 +298,6 @@ class AsyncioTest(InterpretersMixin, testasyncio_utils.TestCase):
 
         self.executor = self.executor_type()
         self.addCleanup(lambda: self.executor.shutdown())
-
-        if support.maybe_get_event_loop_policy() is None:
-            self.addCleanup(lambda: asyncio.set_event_loop_policy(None))
 
     def tearDown(self):
         if not self.loop.is_closed():

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -286,7 +286,7 @@ class AsyncioTest(InterpretersMixin, testasyncio_utils.TestCase):
     def setUpClass(cls):
         # Most uses of asyncio will implicitly call set_event_loop_policy()
         # with the default policy if a policy hasn't been set already.
-        # If that happens in a test, likw here, we'll end up with a failure
+        # If that happens in a test, like here, we'll end up with a failure
         # when --fail-env-changed is used.  That's why the other tests that
         # use asyncio are careful to set the policy back to None and why
         # we're careful to do so here.  We also validate that no other


### PR DESCRIPTION
This resolves a failure on the android buildbot.

<!-- gh-issue-number: gh-124694 -->
* Issue: gh-124694
<!-- /gh-issue-number -->
