### PR TITLE
gh-125286: Share the Main Refchain With Legacy Interpreters

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -920,6 +920,35 @@ always available.
       It is not guaranteed to exist in all implementations of Python.
 
 
+.. function:: getobjects(limit[, type])
+
+   This function only exists if CPython was built using the
+   specialized configure option :option:`--with-trace-refs`.
+   It is intended only for debugging garbage-collection issues.
+
+   Return a list of up to *limit* dynamically allocated Python objects.
+   If *type* is given, only objects of that exact type (not subtypes)
+   are included.
+
+   Objects from the list are not safe to use.
+   Specifically, the result will include objects from all interpreters that
+   share their object allocator state (that is, ones created with
+   :c:member:`PyInterpreterConfig.use_main_obmalloc` set to 0
+   or using :c:func:`Py_NewInterpreter`, and the
+   :ref:`main interpreter <sub-interpreter-support>`).
+   Mixing objects from different interpreters may lead to crashes
+   or other unexpected behavior.
+
+   .. impl-detail::
+
+      This function should be used for specialized purposes only.
+      It is not guaranteed to exist in all implementations of Python.
+
+   .. versionchanged:: next
+
+      The result may include objects from other interpreters.
+
+
 .. function:: getprofile()
 
    .. index::

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -933,7 +933,7 @@ always available.
    Objects from the list are not safe to use.
    Specifically, the result will include objects from all interpreters that
    share their object allocator state (that is, ones created with
-   :c:member:`PyInterpreterConfig.use_main_obmalloc` set to 0
+   :c:member:`PyInterpreterConfig.use_main_obmalloc` set to 1
    or using :c:func:`Py_NewInterpreter`, and the
    :ref:`main interpreter <sub-interpreter-support>`).
    Mixing objects from different interpreters may lead to crashes

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -702,7 +702,7 @@ Debug options
    Effects:
 
    * Define the ``Py_TRACE_REFS`` macro.
-   * Add :func:`!sys.getobjects` function.
+   * Add :func:`sys.getobjects` function.
    * Add :envvar:`PYTHONDUMPREFS` environment variable.
 
    The :envvar:`PYTHONDUMPREFS` environment variable can be used to dump

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -407,6 +407,15 @@ symtable
 
   (Contributed by Bénédikt Tran in :gh:`120029`.)
 
+
+sys
+---
+
+* The previously undocumented special function :func:`sys.getobjects`,
+  which only exists in specialized builds of Python, may now return objects
+  from other interpreters that the one it's called in.
+
+
 unicodedata
 -----------
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -413,7 +413,7 @@ sys
 
 * The previously undocumented special function :func:`sys.getobjects`,
   which only exists in specialized builds of Python, may now return objects
-  from other interpreters that the one it's called in.
+  from other interpreters than the one it's called in.
 
 
 unicodedata

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -399,7 +399,6 @@ extern int _PyInterpreterState_HasFeature(PyInterpreterState *interp,
 
 PyAPI_FUNC(PyStatus) _PyInterpreterState_New(
     PyThreadState *tstate,
-    const PyInterpreterConfig *config,
     PyInterpreterState **pinterp);
 
 

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -399,6 +399,7 @@ extern int _PyInterpreterState_HasFeature(PyInterpreterState *interp,
 
 PyAPI_FUNC(PyStatus) _PyInterpreterState_New(
     PyThreadState *tstate,
+    const PyInterpreterConfig *config,
     PyInterpreterState **pinterp);
 
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -215,9 +215,6 @@ refchain_fini(PyInterpreterState *interp)
 bool
 _PyRefchain_IsTraced(PyInterpreterState *interp, PyObject *obj)
 {
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
     return (_Py_hashtable_get(REFCHAIN(interp), obj) == REFCHAIN_VALUE);
 }
 
@@ -225,9 +222,6 @@ _PyRefchain_IsTraced(PyInterpreterState *interp, PyObject *obj)
 static void
 _PyRefchain_Trace(PyInterpreterState *interp, PyObject *obj)
 {
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
     if (_Py_hashtable_set(REFCHAIN(interp), obj, REFCHAIN_VALUE) < 0) {
         // Use a fatal error because _Py_NewReference() cannot report
         // the error to the caller.
@@ -239,9 +233,6 @@ _PyRefchain_Trace(PyInterpreterState *interp, PyObject *obj)
 static void
 _PyRefchain_Remove(PyInterpreterState *interp, PyObject *obj)
 {
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
     void *value = _Py_hashtable_steal(REFCHAIN(interp), obj);
 #ifndef NDEBUG
     assert(value == REFCHAIN_VALUE);
@@ -2587,9 +2578,6 @@ _Py_PrintReferences(PyInterpreterState *interp, FILE *fp)
         interp = _PyInterpreterState_Main();
     }
     fprintf(fp, "Remaining objects:\n");
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
     _Py_hashtable_foreach(REFCHAIN(interp), _Py_PrintReference, fp);
 }
 
@@ -2618,9 +2606,6 @@ void
 _Py_PrintReferenceAddresses(PyInterpreterState *interp, FILE *fp)
 {
     fprintf(fp, "Remaining object addresses:\n");
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
     _Py_hashtable_foreach(REFCHAIN(interp), _Py_PrintReferenceAddress, fp);
 }
 
@@ -2700,9 +2685,6 @@ _Py_GetObjects(PyObject *self, PyObject *args)
         .limit = limit,
     };
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
     int res = _Py_hashtable_foreach(REFCHAIN(interp), _Py_GetObject, &data);
     if (res == _PY_GETOBJECTS_ERROR) {
         Py_DECREF(list);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -209,15 +209,61 @@ refchain_fini(PyInterpreterState *interp)
     if (has_own_refchain(interp)) {
         _Py_hashtable_destroy(REFCHAIN(interp));
     }
+    // This extra branch can be removed once we start setting
+    // interp->feature_flags *before* refchain_init() gets called.
+    else if (REFCHAIN(interp) != REFCHAIN(_PyInterpreterState_Main())) {
+        _Py_hashtable_destroy(REFCHAIN(interp));
+    }
     REFCHAIN(interp) = NULL;
+}
+
+/* Currently refchain_init() is called during interpreter initialization,
+   via _PyObject_InitState(), before interp->feature_flags is set,
+   so an interpreter may have its own refchain even though it shouldn't.
+   Until that gets fixed, we patch it all up wherever apprpriate.
+  maybe_fix_refchain() and move_refchain_item() can be dropped
+  once we sort out the init order problem. */
+
+static int
+copy_refchain_item(_Py_hashtable_t *ht,
+                   const void *key, const void *value,
+                   void *user_data)
+{
+    if (value != REFCHAIN_VALUE) {
+        assert(value == NULL);
+        return 0;
+    }
+    _Py_hashtable_t *new_chain = (_Py_hashtable_t *)user_data;
+    if (_Py_hashtable_set(new_chain, key, REFCHAIN_VALUE) < 0) {
+        Py_FatalError("_Py_hashtable_set() memory allocation failed");
+    }
+    return 0;
+}
+
+static void
+maybe_fix_refchain(PyInterpreterState *interp)
+{
+    if (has_own_refchain(interp)) {
+        // It's okay or we haven't set the feature flags correctly yet.
+        return;
+    }
+
+    _Py_hashtable_t *cur_chain = REFCHAIN(interp);
+    _Py_hashtable_t *main_chain = REFCHAIN(_PyInterpreterState_Main());
+    if (cur_chain == main_chain) {
+        // It was already fixed.
+        return;
+    }
+    REFCHAIN(interp) = main_chain;
+
+    (void)_Py_hashtable_foreach(cur_chain, copy_refchain_item, main_chain);
+    _Py_hashtable_destroy(cur_chain);
 }
 
 bool
 _PyRefchain_IsTraced(PyInterpreterState *interp, PyObject *obj)
 {
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
+    maybe_fix_refchain(interp);
     return (_Py_hashtable_get(REFCHAIN(interp), obj) == REFCHAIN_VALUE);
 }
 
@@ -225,9 +271,7 @@ _PyRefchain_IsTraced(PyInterpreterState *interp, PyObject *obj)
 static void
 _PyRefchain_Trace(PyInterpreterState *interp, PyObject *obj)
 {
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
+    maybe_fix_refchain(interp);
     if (_Py_hashtable_set(REFCHAIN(interp), obj, REFCHAIN_VALUE) < 0) {
         // Use a fatal error because _Py_NewReference() cannot report
         // the error to the caller.
@@ -239,9 +283,7 @@ _PyRefchain_Trace(PyInterpreterState *interp, PyObject *obj)
 static void
 _PyRefchain_Remove(PyInterpreterState *interp, PyObject *obj)
 {
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
+    maybe_fix_refchain(interp);
     void *value = _Py_hashtable_steal(REFCHAIN(interp), obj);
 #ifndef NDEBUG
     assert(value == REFCHAIN_VALUE);
@@ -2587,9 +2629,7 @@ _Py_PrintReferences(PyInterpreterState *interp, FILE *fp)
         interp = _PyInterpreterState_Main();
     }
     fprintf(fp, "Remaining objects:\n");
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
+    maybe_fix_refchain(interp);
     _Py_hashtable_foreach(REFCHAIN(interp), _Py_PrintReference, fp);
 }
 
@@ -2618,9 +2658,7 @@ void
 _Py_PrintReferenceAddresses(PyInterpreterState *interp, FILE *fp)
 {
     fprintf(fp, "Remaining object addresses:\n");
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
+    maybe_fix_refchain(interp);
     _Py_hashtable_foreach(REFCHAIN(interp), _Py_PrintReferenceAddress, fp);
 }
 
@@ -2700,9 +2738,7 @@ _Py_GetObjects(PyObject *self, PyObject *args)
         .limit = limit,
     };
     PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
+    maybe_fix_refchain(interp);
     int res = _Py_hashtable_foreach(REFCHAIN(interp), _Py_GetObject, &data);
     if (res == _PY_GETOBJECTS_ERROR) {
         Py_DECREF(list);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -207,7 +207,7 @@ refchain_init(PyInterpreterState *interp)
 static void
 refchain_fini(PyInterpreterState *interp)
 {
-    if (has_own_refchain(interp)) {
+    if (has_own_refchain(interp) && REFCHAIN(interp) != NULL) {
         _Py_hashtable_destroy(REFCHAIN(interp));
     }
     REFCHAIN(interp) = NULL;

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2541,38 +2541,6 @@ _Py_ResurrectReference(PyObject *op)
 
 
 #ifdef Py_TRACE_REFS
-/* Make sure the ref is associated with the right interpreter.
- * This only needs special attention for heap-allocated objects
- * that have been immortalized, and only when the object might
- * outlive the interpreter where it was created.  That means the
- * object was necessarily created using a global allocator
- * (i.e. from the main interpreter).  Thus in that specific case
- * we move the object over to the main interpreter's refchain.
- *
- * This was added for the sake of the immortal interned strings,
- * where legacy subinterpreters share the main interpreter's
- * interned dict (and allocator), and therefore the strings can
- * outlive the subinterpreter.
- *
- * It may make sense to fold this into _Py_SetImmortalUntracked(),
- * but that requires further investigation.  In the meantime, it is
- * up to the caller to know if this is needed.  There should be
- * very few cases.
- */
-void
-_Py_NormalizeImmortalReference(PyObject *op)
-{
-    assert(_Py_IsImmortal(op));
-    PyInterpreterState *interp = _PyInterpreterState_GET();
-    if (!_PyRefchain_IsTraced(interp, op)) {
-        return;
-    }
-    if (!has_own_refchain(interp)) {
-        interp = _PyInterpreterState_Main();
-    }
-    assert(_PyRefchain_IsTraced(interp, op));
-}
-
 void
 _Py_ForgetReference(PyObject *op)
 {

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -215,6 +215,9 @@ refchain_fini(PyInterpreterState *interp)
 bool
 _PyRefchain_IsTraced(PyInterpreterState *interp, PyObject *obj)
 {
+    if (!has_own_refchain(interp)) {
+        interp = _PyInterpreterState_Main();
+    }
     return (_Py_hashtable_get(REFCHAIN(interp), obj) == REFCHAIN_VALUE);
 }
 
@@ -222,6 +225,9 @@ _PyRefchain_IsTraced(PyInterpreterState *interp, PyObject *obj)
 static void
 _PyRefchain_Trace(PyInterpreterState *interp, PyObject *obj)
 {
+    if (!has_own_refchain(interp)) {
+        interp = _PyInterpreterState_Main();
+    }
     if (_Py_hashtable_set(REFCHAIN(interp), obj, REFCHAIN_VALUE) < 0) {
         // Use a fatal error because _Py_NewReference() cannot report
         // the error to the caller.
@@ -233,6 +239,9 @@ _PyRefchain_Trace(PyInterpreterState *interp, PyObject *obj)
 static void
 _PyRefchain_Remove(PyInterpreterState *interp, PyObject *obj)
 {
+    if (!has_own_refchain(interp)) {
+        interp = _PyInterpreterState_Main();
+    }
     void *value = _Py_hashtable_steal(REFCHAIN(interp), obj);
 #ifndef NDEBUG
     assert(value == REFCHAIN_VALUE);
@@ -2578,6 +2587,9 @@ _Py_PrintReferences(PyInterpreterState *interp, FILE *fp)
         interp = _PyInterpreterState_Main();
     }
     fprintf(fp, "Remaining objects:\n");
+    if (!has_own_refchain(interp)) {
+        interp = _PyInterpreterState_Main();
+    }
     _Py_hashtable_foreach(REFCHAIN(interp), _Py_PrintReference, fp);
 }
 
@@ -2606,6 +2618,9 @@ void
 _Py_PrintReferenceAddresses(PyInterpreterState *interp, FILE *fp)
 {
     fprintf(fp, "Remaining object addresses:\n");
+    if (!has_own_refchain(interp)) {
+        interp = _PyInterpreterState_Main();
+    }
     _Py_hashtable_foreach(REFCHAIN(interp), _Py_PrintReferenceAddress, fp);
 }
 
@@ -2685,6 +2700,9 @@ _Py_GetObjects(PyObject *self, PyObject *args)
         .limit = limit,
     };
     PyInterpreterState *interp = _PyInterpreterState_GET();
+    if (!has_own_refchain(interp)) {
+        interp = _PyInterpreterState_Main();
+    }
     int res = _Py_hashtable_foreach(REFCHAIN(interp), _Py_GetObject, &data);
     if (res == _PY_GETOBJECTS_ERROR) {
         Py_DECREF(list);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -175,7 +175,8 @@ static inline int
 has_own_refchain(PyInterpreterState *interp)
 {
     if (interp->feature_flags & Py_RTFLAGS_USE_MAIN_OBMALLOC) {
-        return _Py_IsMainInterpreter(interp);
+        return (_Py_IsMainInterpreter(interp)
+            || _PyInterpreterState_Main() == NULL);
     }
     return 1;
 }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15444,10 +15444,6 @@ _PyUnicode_InternStatic(PyInterpreterState *interp, PyObject **p)
     assert(*p);
 }
 
-#ifdef Py_TRACE_REFS
-extern void _Py_NormalizeImmortalReference(PyObject *);
-#endif
-
 static void
 immortalize_interned(PyObject *s)
 {
@@ -15463,10 +15459,6 @@ immortalize_interned(PyObject *s)
 #endif
     _PyUnicode_STATE(s).interned = SSTATE_INTERNED_IMMORTAL;
     _Py_SetImmortal(s);
-#ifdef Py_TRACE_REFS
-    /* Make sure the ref is associated with the right interpreter. */
-    _Py_NormalizeImmortalReference(s);
-#endif
 }
 
 static /* non-null */ PyObject*

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -674,6 +674,13 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
         return status;
     }
 
+    // This could be done in init_interpreter() (in pystate.c) if it
+    // didn't depend on interp->feature_flags being set already.
+    status = _PyObject_InitState(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     // initialize the interp->obmalloc state.  This must be done after
     // the settings are loaded (so that feature_flags are set) but before
     // any calls are made to obmalloc functions.
@@ -2295,6 +2302,13 @@ new_interpreter(PyThreadState **tstate_p,
     status = init_interp_settings(interp, config);
     if (_PyStatus_EXCEPTION(status)) {
         goto error;
+    }
+
+    // This could be done in init_interpreter() (in pystate.c) if it
+    // didn't depend on interp->feature_flags being set already.
+    status = _PyObject_InitState(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
     }
 
     // initialize the interp->obmalloc state.  This must be done after

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -674,6 +674,16 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
         return status;
     }
 
+    // Ideally we would call this in _PyInterpreterState_New(), but it
+    // requires interp->feature_flags to be correctly set already.
+    // That mwans we'd have to compute the feature flags before
+    // creating the interpreter and passing them in there, which we
+    // should probably be doing anyway.
+    status = _PyObject_InitState(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     // initialize the interp->obmalloc state.  This must be done after
     // the settings are loaded (so that feature_flags are set) but before
     // any calls are made to obmalloc functions.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -674,16 +674,6 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
         return status;
     }
 
-    // Ideally we would call this in _PyInterpreterState_New(), but it
-    // requires interp->feature_flags to be correctly set already.
-    // That mwans we'd have to compute the feature flags before
-    // creating the interpreter and passing them in there, which we
-    // should probably be doing anyway.
-    status = _PyObject_InitState(interp);
-    if (_PyStatus_EXCEPTION(status)) {
-        return status;
-    }
-
     // initialize the interp->obmalloc state.  This must be done after
     // the settings are loaded (so that feature_flags are set) but before
     // any calls are made to obmalloc functions.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -551,62 +551,6 @@ pycore_init_runtime(_PyRuntimeState *runtime,
 }
 
 
-static PyStatus
-init_interp_settings(PyInterpreterState *interp,
-                     const PyInterpreterConfig *config)
-{
-    assert(interp->feature_flags == 0);
-
-    if (config->use_main_obmalloc) {
-        interp->feature_flags |= Py_RTFLAGS_USE_MAIN_OBMALLOC;
-    }
-    else if (!config->check_multi_interp_extensions) {
-        /* The reason: PyModuleDef.m_base.m_copy leaks objects between
-           interpreters. */
-        return _PyStatus_ERR("per-interpreter obmalloc does not support "
-                             "single-phase init extension modules");
-    }
-#ifdef Py_GIL_DISABLED
-    if (!_Py_IsMainInterpreter(interp) &&
-        !config->check_multi_interp_extensions)
-    {
-        return _PyStatus_ERR("The free-threaded build does not support "
-                             "single-phase init extension modules in "
-                             "subinterpreters");
-    }
-#endif
-
-    if (config->allow_fork) {
-        interp->feature_flags |= Py_RTFLAGS_FORK;
-    }
-    if (config->allow_exec) {
-        interp->feature_flags |= Py_RTFLAGS_EXEC;
-    }
-    // Note that fork+exec is always allowed.
-
-    if (config->allow_threads) {
-        interp->feature_flags |= Py_RTFLAGS_THREADS;
-    }
-    if (config->allow_daemon_threads) {
-        interp->feature_flags |= Py_RTFLAGS_DAEMON_THREADS;
-    }
-
-    if (config->check_multi_interp_extensions) {
-        interp->feature_flags |= Py_RTFLAGS_MULTI_INTERP_EXTENSIONS;
-    }
-
-    switch (config->gil) {
-    case PyInterpreterConfig_DEFAULT_GIL: break;
-    case PyInterpreterConfig_SHARED_GIL: break;
-    case PyInterpreterConfig_OWN_GIL: break;
-    default:
-        return _PyStatus_ERR("invalid interpreter config 'gil' value");
-    }
-
-    return _PyStatus_OK();
-}
-
-
 static void
 init_interp_create_gil(PyThreadState *tstate, int gil)
 {
@@ -643,8 +587,15 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
                           PyThreadState **tstate_p)
 {
     PyStatus status;
+
+    PyInterpreterConfig config = _PyInterpreterConfig_LEGACY_INIT;
+    // The main interpreter always has its own GIL and supports single-phase
+    // init extensions.
+    config.gil = PyInterpreterConfig_OWN_GIL;
+    config.check_multi_interp_extensions = 0;
+
     PyInterpreterState *interp;
-    status = _PyInterpreterState_New(NULL, &interp);
+    status = _PyInterpreterState_New(NULL, &config, &interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
@@ -660,16 +611,6 @@ pycore_create_interpreter(_PyRuntimeState *runtime,
 
     /* Auto-thread-state API */
     status = _PyGILState_Init(interp);
-    if (_PyStatus_EXCEPTION(status)) {
-        return status;
-    }
-
-    PyInterpreterConfig config = _PyInterpreterConfig_LEGACY_INIT;
-    // The main interpreter always has its own GIL and supports single-phase
-    // init extensions.
-    config.gil = PyInterpreterConfig_OWN_GIL;
-    config.check_multi_interp_extensions = 0;
-    status = init_interp_settings(interp, &config);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
@@ -2253,17 +2194,18 @@ new_interpreter(PyThreadState **tstate_p,
        interpreters: disable PyGILState_Check(). */
     runtime->gilstate.check_enabled = 0;
 
-    PyInterpreterState *interp = PyInterpreterState_New();
-    if (interp == NULL) {
-        *tstate_p = NULL;
-        return _PyStatus_OK();
-    }
-    _PyInterpreterState_SetWhence(interp, whence);
-    interp->_ready = 1;
 
     // XXX Might new_interpreter() have been called without the GIL held?
     PyThreadState *save_tstate = _PyThreadState_GET();
     PyThreadState *tstate = NULL;
+
+    PyInterpreterState *interp;
+    status = _PyInterpreterState_New(save_tstate, config, &interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+    _PyInterpreterState_SetWhence(interp, whence);
+    interp->_ready = 1;
 
     /* From this point until the init_interp_create_gil() call,
        we must not do anything that requires that the GIL be held
@@ -2287,12 +2229,6 @@ new_interpreter(PyThreadState **tstate_p,
 
     /* This does not require that the GIL be held. */
     status = _PyConfig_Copy(&interp->config, src_config);
-    if (_PyStatus_EXCEPTION(status)) {
-        goto error;
-    }
-
-    /* This does not require that the GIL be held. */
-    status = init_interp_settings(interp, config);
     if (_PyStatus_EXCEPTION(status)) {
         goto error;
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -629,6 +629,9 @@ init_interpreter(PyInterpreterState *interp,
     assert(next != NULL || (interp == runtime->interpreters.main));
     interp->next = next;
 
+    // This relies on interp->feature_flags being set already,
+    // but currently we don't set that by this point.
+    // That's something to fix.
     PyStatus status = _PyObject_InitState(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -629,13 +629,8 @@ init_interpreter(PyInterpreterState *interp,
     assert(next != NULL || (interp == runtime->interpreters.main));
     interp->next = next;
 
-    // This relies on interp->feature_flags being set already,
-    // but currently we don't set that by this point.
-    // That's something to fix.
-    PyStatus status = _PyObject_InitState(interp);
-    if (_PyStatus_EXCEPTION(status)) {
-        return status;
-    }
+    // We would call _PyObject_InitState() at this point
+    // if interp->feature_flags were alredy set.
 
     _PyEval_InitState(interp);
     _PyGC_InitState(&interp->gc);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -629,10 +629,9 @@ init_interpreter(PyInterpreterState *interp,
     assert(next != NULL || (interp == runtime->interpreters.main));
     interp->next = next;
 
-    PyStatus status = _PyObject_InitState(interp);
-    if (_PyStatus_EXCEPTION(status)) {
-        return status;
-    }
+    // We would call _PyObject_InitState() here, but it needs the
+    // interp->feature_flags to be correctly set already, which we don't
+    // currently do.
 
     _PyEval_InitState(interp);
     _PyGC_InitState(&interp->gc);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -629,9 +629,10 @@ init_interpreter(PyInterpreterState *interp,
     assert(next != NULL || (interp == runtime->interpreters.main));
     interp->next = next;
 
-    // We would call _PyObject_InitState() here, but it needs the
-    // interp->feature_flags to be correctly set already, which we don't
-    // currently do.
+    PyStatus status = _PyObject_InitState(interp);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
 
     _PyEval_InitState(interp);
     _PyGC_InitState(&interp->gc);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -581,9 +581,66 @@ free_interpreter(PyInterpreterState *interp)
         PyMem_RawFree(interp);
     }
 }
+
+static PyStatus
+init_interp_settings(PyInterpreterState *interp,
+                     const PyInterpreterConfig *config)
+{
+    assert(interp->feature_flags == 0);
+
+    if (config->use_main_obmalloc) {
+        interp->feature_flags |= Py_RTFLAGS_USE_MAIN_OBMALLOC;
+    }
+    else if (!config->check_multi_interp_extensions) {
+        /* The reason: PyModuleDef.m_base.m_copy leaks objects between
+           interpreters. */
+        return _PyStatus_ERR("per-interpreter obmalloc does not support "
+                             "single-phase init extension modules");
+    }
+#ifdef Py_GIL_DISABLED
+    if (!_Py_IsMainInterpreter(interp) &&
+        !config->check_multi_interp_extensions)
+    {
+        return _PyStatus_ERR("The free-threaded build does not support "
+                             "single-phase init extension modules in "
+                             "subinterpreters");
+    }
+#endif
+
+    if (config->allow_fork) {
+        interp->feature_flags |= Py_RTFLAGS_FORK;
+    }
+    if (config->allow_exec) {
+        interp->feature_flags |= Py_RTFLAGS_EXEC;
+    }
+    // Note that fork+exec is always allowed.
+
+    if (config->allow_threads) {
+        interp->feature_flags |= Py_RTFLAGS_THREADS;
+    }
+    if (config->allow_daemon_threads) {
+        interp->feature_flags |= Py_RTFLAGS_DAEMON_THREADS;
+    }
+
+    if (config->check_multi_interp_extensions) {
+        interp->feature_flags |= Py_RTFLAGS_MULTI_INTERP_EXTENSIONS;
+    }
+
+    switch (config->gil) {
+    case PyInterpreterConfig_DEFAULT_GIL: break;
+    case PyInterpreterConfig_SHARED_GIL: break;
+    case PyInterpreterConfig_OWN_GIL: break;
+    default:
+        return _PyStatus_ERR("invalid interpreter config 'gil' value");
+    }
+
+    return _PyStatus_OK();
+}
+
 #ifndef NDEBUG
 static inline int check_interpreter_whence(long);
 #endif
+
 /* Get the interpreter state to a minimal consistent state.
    Further init happens in pylifecycle.c before it can be used.
    All fields not initialized here are expected to be zeroed out,
@@ -607,7 +664,8 @@ static PyStatus
 init_interpreter(PyInterpreterState *interp,
                  _PyRuntimeState *runtime, int64_t id,
                  PyInterpreterState *next,
-                 long whence)
+                 long whence,
+                 const PyInterpreterConfig *config)
 {
     if (interp->_initialized) {
         return _PyStatus_ERR("interpreter already initialized");
@@ -629,10 +687,15 @@ init_interpreter(PyInterpreterState *interp,
     assert(next != NULL || (interp == runtime->interpreters.main));
     interp->next = next;
 
+    PyStatus status = init_interp_settings(interp, config);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
+    }
+
     // This relies on interp->feature_flags being set already,
     // but currently we don't set that by this point.
     // That's something to fix.
-    PyStatus status = _PyObject_InitState(interp);
+    status = _PyObject_InitState(interp);
     if (_PyStatus_EXCEPTION(status)) {
         return status;
     }
@@ -673,7 +736,9 @@ init_interpreter(PyInterpreterState *interp,
 
 
 PyStatus
-_PyInterpreterState_New(PyThreadState *tstate, PyInterpreterState **pinterp)
+_PyInterpreterState_New(PyThreadState *tstate,
+                        const PyInterpreterConfig *config,
+                        PyInterpreterState **pinterp)
 {
     *pinterp = NULL;
 
@@ -735,7 +800,7 @@ _PyInterpreterState_New(PyThreadState *tstate, PyInterpreterState **pinterp)
 
     long whence = _PyInterpreterState_WHENCE_UNKNOWN;
     status = init_interpreter(interp, runtime,
-                              id, old_head, whence);
+                              id, old_head, whence, config);
     if (_PyStatus_EXCEPTION(status)) {
         goto error;
     }
@@ -762,8 +827,10 @@ PyInterpreterState_New(void)
     // tstate can be NULL
     PyThreadState *tstate = current_fast_get();
 
+    const PyInterpreterConfig config = _PyInterpreterConfig_LEGACY_INIT;
+
     PyInterpreterState *interp;
-    PyStatus status = _PyInterpreterState_New(tstate, &interp);
+    PyStatus status = _PyInterpreterState_New(tstate, &config, &interp);
     if (_PyStatus_EXCEPTION(status)) {
         Py_ExitStatusException(status);
     }


### PR DESCRIPTION
They used to be shared, before 3.12.  Returning to sharing them resolves a failure on `Py_TRACE_REFS` builds.

<!-- gh-issue-number: gh-125286 -->
* Issue: gh-125286
<!-- /gh-issue-number -->
