### PR TITLE
gh-123596: Add missing tracebacklimit attribute to sys module

### DIFF
--- a/Include/internal/pycore_traceback.h
+++ b/Include/internal/pycore_traceback.h
@@ -8,6 +8,9 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+/* Maximum number of error tracebacks to print */
+#define PyTraceBack_LIMIT 1000
+
 // Export for '_ctypes' shared extension
 PyAPI_FUNC(int) _Py_DisplaySourceLine(PyObject *, PyObject *, int, int, int *, PyObject **);
 

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1189,7 +1189,7 @@ class SysModuleTest(unittest.TestCase):
         ]
         self.assertTrue(hasattr(sys, "tracebacklimit"),
                         'tracebacklimit attribute does not exist')
-        self.assertEqual(getattr(sys, 'tracebacklimit', 1_000), 1_000)
+        self.assertEqual(sys.tracebacklimit, 1_000)
         check(10, traceback)
         check(3, traceback)
         check(2, traceback[:1] + traceback[4:])

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1187,6 +1187,9 @@ class SysModuleTest(unittest.TestCase):
             b'    ~~^~~',
             b'ZeroDivisionError: division by zero'
         ]
+        self.assertTrue(hasattr(sys, "tracebacklimit"),
+                        'tracebacklimit attribute does not exist')
+        self.assertEqual(getattr(sys, 'tracebacklimit', 1_000), 1_000)
         check(10, traceback)
         check(3, traceback)
         check(2, traceback[:1] + traceback[4:])

--- a/Misc/NEWS.d/next/Library/2024-10-20-11-45-50.gh-issue-123596.HONVYS.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-20-11-45-50.gh-issue-123596.HONVYS.rst
@@ -1,0 +1,1 @@
+Fix non-existent :attr:`sys.tracebacklimit` in :mod:`sys`. Patch by RUANG.

--- a/Misc/NEWS.d/next/Library/2024-10-20-11-45-50.gh-issue-123596.HONVYS.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-20-11-45-50.gh-issue-123596.HONVYS.rst
@@ -1,1 +1,1 @@
-Fix non-existent :attr:`sys.tracebacklimit` in :mod:`sys`. Patch by RUANG.
+Fix missing :attr:`sys.tracebacklimit` in :mod:`sys`. Patch by RUANG.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -35,6 +35,7 @@ Data members:
 #include "pycore_structseq.h"     // _PyStructSequence_InitBuiltinWithFlags()
 #include "pycore_sysmodule.h"     // export _PySys_GetSizeOf()
 #include "pycore_tuple.h"         // _PyTuple_FromArray()
+#include "pycore_traceback.h"     // PyTraceBack_LIMIT
 
 #include "pydtrace.h"             // PyDTrace_AUDIT()
 #include "osdefs.h"               // DELIM
@@ -3665,6 +3666,8 @@ _PySys_UpdateConfig(PyThreadState *tstate)
     if (config->module_search_paths_set) {
         COPY_LIST("path", config->module_search_paths);
     }
+
+    SET_SYS("tracebacklimit", PyLong_FromLong(PyTraceBack_LIMIT));
 
     COPY_WSTR("executable", config->executable);
     COPY_WSTR("_base_executable", config->base_executable);

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -704,8 +704,6 @@ error:
     return -1;
 }
 
-#define PyTraceBack_LIMIT 1000
-
 int
 _PyTraceBack_Print(PyObject *v, const char *header, PyObject *f)
 {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

test code:
```
import sys

def f():
    f()

sys.setrecursionlimit(2000)
f()
```
In fact, in https://github.com/python/cpython/blob/322f14eeff9e3b5853eaac3233f7580ca0214cf8/Python/sysmodule.c#L3647
the `sys.tracebacklimit` attribute isn't set. 
However, in https://github.com/python/cpython/blob/c3ed775899eedd47d37f8f1840345b108920e400/Python/traceback.c#L722
it tries to get the attribute and performs the same behavior in
https://github.com/python/cpython/blob/c3ed775899eedd47d37f8f1840345b108920e400/Lib/traceback.py#L458
Therefore, the number of tracebacks is inaccurate.

<!-- gh-issue-number: gh-123596 -->
* Issue: gh-123596
<!-- /gh-issue-number -->
