### PR TITLE
gh-125666: Avoid PyREPL exiting when a null byte is in input

### DIFF
--- a/Lib/code.py
+++ b/Lib/code.py
@@ -136,7 +136,8 @@ class InteractiveInterpreter:
         # Set the line of text that the exception refers to
         lines = source.splitlines()
         if (source and typ is SyntaxError
-                and not value.text and len(lines) >= value.lineno):
+                and not value.text and value.lineno is not None
+                and len(lines) >= value.lineno):
             value.text = lines[value.lineno - 1]
         sys.last_exc = sys.last_value = value
         if sys.excepthook is sys.__excepthook__:

--- a/Lib/test/test_pyrepl/test_interact.py
+++ b/Lib/test/test_pyrepl/test_interact.py
@@ -121,9 +121,8 @@ SyntaxError: duplicate argument 'x' in function definition"""
         console = InteractiveColoredConsole()
         source = "\x00\n"
         f = io.StringIO()
-        with contextlib.redirect_stdout(f):
-            with contextlib.redirect_stderr(f):
-                result = console.runsource(source)
+        with contextlib.redirect_stdout(f), contextlib.redirect_stderr(f):
+            result = console.runsource(source)
         self.assertFalse(result)
         self.assertIn("source code string cannot contain null bytes", f.getvalue())
 

--- a/Lib/test/test_pyrepl/test_interact.py
+++ b/Lib/test/test_pyrepl/test_interact.py
@@ -122,8 +122,10 @@ SyntaxError: duplicate argument 'x' in function definition"""
         source = "\x00\n"
         f = io.StringIO()
         with contextlib.redirect_stdout(f):
-            result = console.runsource(source)
+            with contextlib.redirect_stderr(f):
+                result = console.runsource(source)
         self.assertFalse(result)
+        self.assertIn("source code string cannot contain null bytes", f.getvalue())
 
     def test_no_active_future(self):
         console = InteractiveColoredConsole()

--- a/Lib/test/test_pyrepl/test_interact.py
+++ b/Lib/test/test_pyrepl/test_interact.py
@@ -117,6 +117,14 @@ SyntaxError: duplicate argument 'x' in function definition"""
             console.runsource(source)
             mock_showsyntaxerror.assert_called_once()
 
+    def test_runsource_survives_null_bytes(self):
+        console = InteractiveColoredConsole()
+        source = "\x00\n"
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            result = console.runsource(source)
+        self.assertFalse(result)
+
     def test_no_active_future(self):
         console = InteractiveColoredConsole()
         source = dedent("""\

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1313,6 +1313,11 @@ class TestMain(ReplTestCase):
                         self.assertIn("in x3", output)
                         self.assertIn("in <module>", output)
 
+    def test_null_byte(self):
+        output, exit_code = self.run_repl("\x00\nexit()\n")
+        self.assertEqual(exit_code, 0)
+        self.assertNotIn("TypeError", output)
+
     def test_readline_history_file(self):
         # skip, if readline module is not available
         readline = import_module('readline')

--- a/Misc/NEWS.d/next/Library/2024-10-19-16-06-52.gh-issue-125666.jGfdCP.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-19-16-06-52.gh-issue-125666.jGfdCP.rst
@@ -1,0 +1,1 @@
+Avoid the exiting the interpreter if a null byte is given as input in the new REPL.


### PR DESCRIPTION
This PR adds a guard against `SyntaxError.lineno` being `None` in `code.InteractiveInterpreter._showtraceback`, which should avoid `PyREPL` exiting the interpreter when a null byte is present in the input.

Not sure both new tests are necessary, happy to remove one or the other if it's better.

<!-- gh-issue-number: gh-125666 -->
* Issue: gh-125666
<!-- /gh-issue-number -->
