### PR TITLE
Doc: Change config to expand toc object entries

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -94,7 +94,7 @@ needs_sphinx = '7.2.6'
 
 # Create table of contents entries for domain objects (e.g. functions, classes,
 # attributes, etc.). Default is True.
-toc_object_entries = False
+toc_object_entries = True
 
 # Ignore any .rst files in the includes/ directory;
 # they're embedded in pages but not rendered individually.
@@ -332,7 +332,7 @@ gettext_additional_targets = [
 html_theme = 'python_docs_theme'
 html_theme_path = ['tools']
 html_theme_options = {
-    'collapsiblesidebar': True,
+    'collapsiblesidebar': False,
     'issues_url': '/bugs.html',
     'license_url': '/license.html',
     'root_include_title': False,  # We use the version switcher instead.

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -332,7 +332,7 @@ gettext_additional_targets = [
 html_theme = 'python_docs_theme'
 html_theme_path = ['tools']
 html_theme_options = {
-    'collapsiblesidebar': False,
+    'collapsiblesidebar': True,
     'issues_url': '/bugs.html',
     'license_url': '/license.html',
     'root_include_title': False,  # We use the version switcher instead.


### PR DESCRIPTION
Expand the toctree entries for the sidebar. Pages with lots of methods/functions would benefit from easier click-through navigation.

Prompted to experiment due to the Discourse discussion: https://discuss.python.org/t/summary-tables-as-an-api-overview/68474

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125754.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->