### PR TITLE
gh-119311: Add missing magic number (3571) for 3.13.0b1

### DIFF
--- a/Include/internal/pycore_magic_number.h
+++ b/Include/internal/pycore_magic_number.h
@@ -251,6 +251,7 @@ Known values:
     Python 3.13a1 3568 (Change semantics of END_FOR)
     Python 3.13a5 3569 (Specialize CONTAINS_OP)
     Python 3.13a6 3570 (Add __firstlineno__ class attribute)
+    Python 3.13b1 3571 (Fix miscompilation of private names in generic classes)
     Python 3.14a1 3600 (Add LOAD_COMMON_CONSTANT)
     Python 3.14a1 3601 (Fix miscompilation of private names in generic classes)
     Python 3.14a1 3602 (Add LOAD_SPECIAL. Remove BEFORE_WITH and BEFORE_ASYNC_WITH)


### PR DESCRIPTION
It was added after branching in https://github.com/python/cpython/commit/6394a72e99b342d980297ec437ecafea92a044c4#diff-efefe383b3a81d16150c280db0b64eed7569254299418f64cc0d749f8e16f3a4R475

<!-- gh-issue-number: gh-119311 -->
* Issue: gh-119311
<!-- /gh-issue-number -->
