### PR TITLE
[3.13] gh-124448: Update Windows builds to use Tcl/Tk 8.6.15

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-09-24-19-04-56.gh-issue-124448.srVT3d.rst
+++ b/Misc/NEWS.d/next/Windows/2024-09-24-19-04-56.gh-issue-124448.srVT3d.rst
@@ -1,0 +1,1 @@
+Updated bundled Tcl/Tk to 8.6.15.

--- a/Misc/externals.spdx.json
+++ b/Misc/externals.spdx.json
@@ -112,42 +112,42 @@
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "ad7623a44e1b6e42df47ba8f16b2b0435ac605650b5054077c4355a30473074c"
+          "checksumValue": "4c23f0dd3efcbe6f3a22c503a68d147617bb30c4f5290f1eb3eaacf0b460440b"
         }
       ],
-      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/tcl-core-8.6.14.0.tar.gz",
+      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/tcl-core-8.6.15.0.tar.gz",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:tcl_tk:tcl_tk:8.6.14.0:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:tcl_tk:tcl_tk:8.6.15.0:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
       "licenseConcluded": "NOASSERTION",
       "name": "tcl-core",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "8.6.14.0"
+      "versionInfo": "8.6.15.0"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-tk",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "e8d5cbe97952037962518b69aba85e324d80aa189054c163ab0ee764a448e802"
+          "checksumValue": "0ae56d39bca92865f338529557a1e56d110594184b6dc5a91339c5675751e264"
         }
       ],
-      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/tk-8.6.14.0.tar.gz",
+      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/tk-8.6.15.0.tar.gz",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:tcl_tk:tcl_tk:8.6.14.0:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:tcl_tk:tcl_tk:8.6.15.0:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
       "licenseConcluded": "NOASSERTION",
       "name": "tk",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "8.6.14.0"
+      "versionInfo": "8.6.15.0"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-xz",

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -56,8 +56,8 @@ if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.4.4
 if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-3.0.15
 set libraries=%libraries%                                       mpdecimal-4.0.0
 set libraries=%libraries%                                       sqlite-3.45.3.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.14.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.14.0
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.15.0
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.15.0
 set libraries=%libraries%                                       xz-5.2.5
 set libraries=%libraries%                                       zlib-1.3.1
 
@@ -78,7 +78,7 @@ echo.Fetching external binaries...
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.4.4
 if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-3.0.15
-if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.14.0
+if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.15.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 
 for %%b in (%binaries%) do (

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -195,7 +195,7 @@ _sqlite3
     Homepage:
         https://www.sqlite.org/
 _tkinter
-    Wraps version 8.6.6 of the Tk windowing system, which is downloaded
+    Wraps version 8.6.15 of the Tk windowing system, which is downloaded
     from our binaries repository at
     https://github.com/python/cpython-bin-deps.
 

--- a/PCbuild/tcltk.props
+++ b/PCbuild/tcltk.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="pyproject.props" Condition="$(__PyProject_Props_Imported) != 'true'" />
   <PropertyGroup>
-    <TclVersion Condition="$(TclVersion) == ''">8.6.14.0</TclVersion>
+    <TclVersion Condition="$(TclVersion) == ''">8.6.15.0</TclVersion>
     <TkVersion Condition="$(TkVersion) == ''">$(TclVersion)</TkVersion>
     <TclMajorVersion>$([System.Version]::Parse($(TclVersion)).Major)</TclMajorVersion>
     <TclMinorVersion>$([System.Version]::Parse($(TclVersion)).Minor)</TclMinorVersion>


### PR DESCRIPTION
(cherry picked from commit 9d8f2d8e08336695fdade5846da4bbcc3eb5f152)

<!-- gh-issue-number: gh-124448 -->
* Issue: gh-124448
<!-- /gh-issue-number -->
