### PR TITLE
gh-125716: Use A Global Mutex When Initializing Global State For The _interpqueues Module

### DIFF
--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -1350,6 +1350,7 @@ static void
 _channels_init(_channels *channels, PyThread_type_lock mutex)
 {
     assert(mutex != NULL);
+    assert(channels->mutex == NULL);
     channels->mutex = mutex;
     channels->head = NULL;
     channels->numopen = 0;
@@ -2823,7 +2824,6 @@ _globals_init(void)
         return 0;
     }
 
-    assert(_globals.channels.mutex == NULL);
     PyThread_type_lock mutex = PyThread_allocate_lock();
     if (mutex == NULL) {
         return ERR_CHANNELS_MUTEX_INIT;

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -28,6 +28,7 @@
 This module has the following process-global state:
 
 _globals (static struct globals):
+    mutex (PyMutex)
     module_count (int)
     channels (struct _channels):
         numopen (int64_t)

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -2836,6 +2836,7 @@ _globals_init(void)
         // Called for the first time.
         PyThread_type_lock mutex = PyThread_allocate_lock();
         if (mutex == NULL) {
+            _globals.module_count--;
             PyMutex_Unlock(&_globals.mutex);
             return ERR_CHANNELS_MUTEX_INIT;
         }

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -3482,7 +3482,8 @@ The 'interpreters' module provides a more convenient interface.");
 static int
 module_exec(PyObject *mod)
 {
-    if (_globals_init() != 0) {
+    int err = _globals_init();
+    if (handle_channel_error(err, mod, -1)) {
         return -1;
     }
 

--- a/Modules/_interpqueuesmodule.c
+++ b/Modules/_interpqueuesmodule.c
@@ -846,6 +846,7 @@ static void
 _queues_init(_queues *queues, PyThread_type_lock mutex)
 {
     assert(mutex != NULL);
+    assert(queues->mutex == NULL);
     queues->mutex = mutex;
     queues->head = NULL;
     queues->count = 0;
@@ -1410,7 +1411,6 @@ _globals_init(void)
         return 0;
     }
 
-    assert(_globals.queues.mutex == NULL);
     PyThread_type_lock mutex = PyThread_allocate_lock();
     if (mutex == NULL) {
         return ERR_QUEUES_ALLOC;

--- a/Modules/_interpqueuesmodule.c
+++ b/Modules/_interpqueuesmodule.c
@@ -1416,6 +1416,7 @@ _globals_init(void)
         // Called for the first time.
         PyThread_type_lock mutex = PyThread_allocate_lock();
         if (mutex == NULL) {
+            _globals.module_count--;
             PyMutex_Unlock(&_globals.mutex);
             return ERR_QUEUES_ALLOC;
         }

--- a/Modules/_interpqueuesmodule.c
+++ b/Modules/_interpqueuesmodule.c
@@ -1401,38 +1401,43 @@ _queueobj_shared(PyThreadState *tstate, PyObject *queueobj,
    the data that we need to share between interpreters, so it cannot
    hold PyObject values. */
 static struct globals {
-    uint8_t module_count;
+    PyMutex mutex;
+    int module_count;
     _queues queues;
 } _globals = {0};
 
 static int
 _globals_init(void)
 {
-    if (_Py_atomic_add_uint8(&_globals.module_count, 1) > 0) {
-        // Already initialized.
-        return 0;
+    PyMutex_Lock(&_globals.mutex);
+    assert(_globals.module_count >= 0);
+    _globals.module_count++;
+    if (_globals.module_count == 1) {
+        // Called for the first time.
+        PyThread_type_lock mutex = PyThread_allocate_lock();
+        if (mutex == NULL) {
+            PyMutex_Unlock(&_globals.mutex);
+            return ERR_QUEUES_ALLOC;
+        }
+        _queues_init(&_globals.queues, mutex);
     }
-
-    PyThread_type_lock mutex = PyThread_allocate_lock();
-    if (mutex == NULL) {
-        return ERR_QUEUES_ALLOC;
-    }
-    _queues_init(&_globals.queues, mutex);
+    PyMutex_Unlock(&_globals.mutex);
     return 0;
 }
 
 static void
 _globals_fini(void)
 {
-    if (_Py_atomic_add_uint8(&_globals.module_count, -1) > 1) {
-        return;
-    }
-
-    PyThread_type_lock mutex;
-    _queues_fini(&_globals.queues, &mutex);
-    if (mutex != NULL) {
+    PyMutex_Lock(&_globals.mutex);
+    assert(_globals.module_count > 0);
+    _globals.module_count--;
+    if (_globals.module_count == 0) {
+        PyThread_type_lock mutex;
+        _queues_fini(&_globals.queues, &mutex);
+        assert(mutex != NULL);
         PyThread_free_lock(mutex);
     }
+    PyMutex_Unlock(&_globals.mutex);
 }
 
 static _queues *

--- a/Modules/_interpqueuesmodule.c
+++ b/Modules/_interpqueuesmodule.c
@@ -1894,7 +1894,8 @@ The 'interpreters' module provides a more convenient interface.");
 static int
 module_exec(PyObject *mod)
 {
-    if (_globals_init() != 0) {
+    int err = _globals_init();
+    if (handle_queue_error(err, mod, -1)) {
         return -1;
     }
 

--- a/Modules/_interpqueuesmodule.c
+++ b/Modules/_interpqueuesmodule.c
@@ -1315,7 +1315,7 @@ _queueid_xid_new(int64_t qid)
 
     struct _queueid_xid *data = PyMem_RawMalloc(sizeof(struct _queueid_xid));
     if (data == NULL) {
-        _queues_incref(queues, qid);
+        _queues_decref(queues, qid);
         return NULL;
     }
     data->qid = qid;


### PR DESCRIPTION
This includes a drive-by cleanup in `_queues_init()` and `_queues_fini()`.

This change also applies to the _interpchannels module.

<!-- gh-issue-number: gh-125716 -->
* Issue: gh-125716
<!-- /gh-issue-number -->
