### PR TITLE
[3.12] gh-125318: Perform sanity check in `find_ttinfo` to mitigate out-of-bounds read

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-10-22-10-27-33.gh-issue-125824._oesZh.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-10-27-33.gh-issue-125824._oesZh.rst
@@ -1,0 +1,1 @@
+Add sanity check in :mod:`zoneinfo` to mitigate out-of-bounds read.

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -2205,7 +2205,15 @@ find_ttinfo(zoneinfo_state *state, PyZoneInfo_ZoneInfo *self, PyObject *dt)
     }
 
     unsigned char fold = PyDateTime_DATE_GET_FOLD(dt);
-    assert(fold < 2);
+
+    // gh-125318: out-of-bounds sanity check on non-PyDateTime types
+    if (fold >= 2) {
+        PyErr_Format(PyExc_MemoryError,
+                     "find_ttinfo: sanity check failed, fold = %d, expected "
+                     "only 0 or 1", fold);
+        return NULL;
+    }
+
     int64_t *local_transitions = self->trans_list_wall[fold];
     size_t num_trans = self->num_transitions;
 


### PR DESCRIPTION
User custom temporal data types that partially fulfill the datetime contract, e.g. `hour`, `minute`, `second` and `toordinal()`, could bypass the type checking in `find_ttinfo`. Accessing internal fields `PyDateTime_GET_*` on non-datetime types causes undefined behaviors and out-of-bounds read.

<!-- gh-issue-number: gh-125318 -->
* Issue: gh-125318
<!-- /gh-issue-number -->
