### PR TITLE
gh-125789: fix side-effects in `asyncio` callback scheduling methods 

### DIFF
--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -234,10 +234,11 @@ class Future:
 
         Returns the number of callbacks removed.
         """
+        count = len(self._callbacks)
         filtered_callbacks = [(f, ctx)
                               for (f, ctx) in self._callbacks
                               if f != fn]
-        removed_count = len(self._callbacks) - len(filtered_callbacks)
+        removed_count = count - len(filtered_callbacks)
         if removed_count:
             self._callbacks[:] = filtered_callbacks
         return removed_count

--- a/Misc/NEWS.d/next/Library/2024-10-22-12-47-46.gh-issue-125789.Hk885p.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-12-47-46.gh-issue-125789.Hk885p.rst
@@ -1,0 +1,3 @@
+Mitigate interpreter's crashes and state corruption due to side-effects in
+:meth:`asyncio.Future.remove_done_callback` or others callback scheduling
+methods. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2024-10-22-12-47-46.gh-issue-125789.Hk885p.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-12-47-46.gh-issue-125789.Hk885p.rst
@@ -1,3 +1,3 @@
-Mitigate interpreter's crashes and state corruption due to side-effects in
-:meth:`asyncio.Future.remove_done_callback` or others callback scheduling
+Mitigate interpreter crashes and state corruption due to side-effects in
+:meth:`asyncio.Future.remove_done_callback` or other callback scheduling
 methods. Patch by Bénédikt Tran.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -448,7 +448,7 @@ future_schedule_callbacks(asyncio_state *state, FutureObj *fut)
          i++) {
         PyObject *cb_tup = PyList_GET_ITEM(fut->fut_callbacks, i);
         if (!PyTuple_CheckExact(cb_tup) || PyTuple_GET_SIZE(cb_tup) != 2) {
-            PyErr_SetString(PyExc_RuntimeError, "corrupted callback tuple?");
+            PyErr_SetString(PyExc_RuntimeError, "corrupted callback tuple");
             return -1;
         }
         PyObject *cb = PyTuple_GET_ITEM(cb_tup, 0);

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -1071,8 +1071,10 @@ _asyncio_Future_remove_done_callback_impl(FutureObj *self, PyTypeObject *cls,
             PyErr_SetString(PyExc_RuntimeError, "corrupted future state");
             return NULL;
         }
+        Py_INCREF(cb_tup);
         PyObject *cb = PyTuple_GET_ITEM(cb_tup, 0);
         int cmp = PyObject_RichCompareBool(cb, fn, Py_EQ);
+        Py_DECREF(cb_tup);
         if (cmp == -1) {
             return NULL;
         }

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -457,7 +457,7 @@ future_schedule_callbacks(asyncio_state *state, FutureObj *fut)
             break; // done
         }
         PyObject *cb_tup = PyList_GET_ITEM(fut->fut_callbacks, i);
-        if (!PyTuple_CheckExact(cb_tup) || PyTuple_GET_SIZE(cb_tup) < 2) {
+        if (!PyTuple_CheckExact(cb_tup) || PyTuple_GET_SIZE(cb_tup) != 2) {
             PyErr_SetString(PyExc_RuntimeError, "corrupted callback tuple");
             return -1;
         }
@@ -1073,7 +1073,7 @@ _asyncio_Future_remove_done_callback_impl(FutureObj *self, PyTypeObject *cls,
         // Beware: An evil PyObject_RichCompareBool could change fut_callbacks
         // or its items (see https://github.com/python/cpython/issues/97592 or
         // https://github.com/python/cpython/issues/125789 for details).
-        if (!PyTuple_CheckExact(cb_tup) || PyTuple_GET_SIZE(cb_tup) < 1) {
+        if (!PyTuple_CheckExact(cb_tup) || PyTuple_GET_SIZE(cb_tup) != 2) {
             PyErr_SetString(PyExc_RuntimeError, "corrupted callback tuple");
             return NULL;
         }
@@ -1110,7 +1110,7 @@ _asyncio_Future_remove_done_callback_impl(FutureObj *self, PyTypeObject *cls,
             break; // done
         }
         PyObject *cb_tup = PyList_GET_ITEM(self->fut_callbacks, i);
-        if (!PyTuple_CheckExact(cb_tup) || PyTuple_GET_SIZE(cb_tup) < 1) {
+        if (!PyTuple_CheckExact(cb_tup) || PyTuple_GET_SIZE(cb_tup) != 2) {
             PyErr_SetString(PyExc_RuntimeError, "corrupted callback tuple");
             goto fail;
         }


### PR DESCRIPTION
This is a proposal for fixing the side-effects that could arise from `Py_EQ`. Similar to the patch where I fixed `OrderedDict.__eq__`, I did not modify the pure Python implementation but I can do it (I don't think we want to align both implementations; we just don't want the interpreter to crash and I don't think we can make it crash using the pure Python implementation only).

<!-- gh-issue-number: gh-125789 -->
* Issue: gh-125789
<!-- /gh-issue-number -->