### PR TITLE
gh-87063: Add `closed` attribute to multiprocessing.Process

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -673,6 +673,15 @@ The :mod:`multiprocessing` package mostly replicates the API of the
 
       .. versionadded:: 3.7
 
+   .. method:: is_closed()
+
+      Return whether the process is closed.
+
+      Roughly, a process object is considered closed when :meth:`close`
+      is called on it.
+
+      .. versionadded:: 3.14
+
    .. method:: close()
 
       Close the :class:`Process` object, releasing all resources associated

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -673,15 +673,6 @@ The :mod:`multiprocessing` package mostly replicates the API of the
 
       .. versionadded:: 3.7
 
-   .. method:: closed()
-
-      Return whether the process is closed.
-
-      Roughly, a process object is considered closed when :meth:`close`
-      is called on it.
-
-      .. versionadded:: 3.14
-
    .. method:: close()
 
       Close the :class:`Process` object, releasing all resources associated
@@ -714,6 +705,12 @@ The :mod:`multiprocessing` package mostly replicates the API of the
        <...Process ... stopped exitcode=-SIGTERM> False
        >>> p.exitcode == -signal.SIGTERM
        True
+
+   .. attribute:: closed
+
+      Boolean indicating whether the process has been closed via :meth:`close`.
+
+      .. versionadded:: 3.14
 
 .. exception:: ProcessError
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -673,7 +673,7 @@ The :mod:`multiprocessing` package mostly replicates the API of the
 
       .. versionadded:: 3.7
 
-   .. method:: is_closed()
+   .. method:: closed()
 
       Return whether the process is closed.
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -171,6 +171,14 @@ See the :ref:`JSON command-line interface <json-commandline>` documentation.
 (Contributed by Trey Hunner in :gh:`122873`.)
 
 
+multiprocessing
+---------------
+
+* Add the :attr:`~multiprocessing.Process.closed` property to
+  :class:`multiprocessing.Process` objects to determine whether
+  they have been closed or not.
+
+
 operator
 --------
 
@@ -220,14 +228,6 @@ pickle
 
 * Set the default protocol version on the :mod:`pickle` module to 5.
   For more details, please see :ref:`pickle protocols <pickle-protocols>`.
-
-
-multiprocessing
----------------
-
-* Add attribute :attr:`!closed` to :class:`multiprocessing.Process`,
-  It is used to check whether the process is closed.
-  (Contributed by James Roy in :gh:`87063`.)
 
 
 symtable

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -177,6 +177,7 @@ multiprocessing
 * Add the :attr:`~multiprocessing.Process.closed` property to
   :class:`multiprocessing.Process` objects to determine whether
   they have been closed or not.
+  (Contributed by James Roy in :gh:`87063`.)
 
 
 operator

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -222,6 +222,14 @@ pickle
   For more details, please see :ref:`pickle protocols <pickle-protocols>`.
 
 
+multiprocessing
+---------------
+
+* Add attribute :attr:`!closed` to :class:`multiprocessing.Process`,
+  It is used to check whether the process is closed.
+  (Contributed by James Roy in :gh:`87063`.)
+
+
 symtable
 --------
 

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -169,6 +169,12 @@ class BaseProcess(object):
             _children.discard(self)
             return False
 
+    def is_closed(self):
+        '''
+        Return whether process is closed
+        '''
+        return self._closed
+
     def close(self):
         '''
         Close the Process object.

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -170,7 +170,7 @@ class BaseProcess(object):
             return False
 
     @property
-    def is_closed(self):
+    def closed(self):
         '''
         Return whether process is closed
         '''

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -169,6 +169,7 @@ class BaseProcess(object):
             _children.discard(self)
             return False
 
+    @property
     def is_closed(self):
         '''
         Return whether process is closed

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -649,21 +649,6 @@ class _TestProcess(BaseTestCase):
             q.get()
         sys.exit(rc)
 
-    def test_is_close(self):
-        if self.TYPE == "threads":
-            self.skipTest('test not appropriate for {}'.format(self.TYPE))
-        def _test_task():
-            pass
-        p = self.Process(target=_test_task)
-        self.assertFalse(p.closed)
-        p.close()
-        self.assertTrue(p.closed)
-
-        wr = weakref.ref(p)
-        del p
-        gc.collect()
-        self.assertIs(wr(), None)
-
     def test_close(self):
         if self.TYPE == "threads":
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
@@ -687,7 +672,9 @@ class _TestProcess(BaseTestCase):
             p.join()
         with self.assertRaises(ValueError):
             p.terminate()
+        self.assertFalse(p.closed)
         p.close()
+        self.assertTrue(p.closed)
 
         wr = weakref.ref(p)
         del p

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -659,20 +659,22 @@ class _TestProcess(BaseTestCase):
         self.assertEqual(p.is_alive(), True)
         # Child is still alive, cannot close
         with self.assertRaises(ValueError):
+            self.assertFalse(p.closed)
             p.close()
+            self.assertTrue(p.closed)
 
         q.put(None)
         p.join()
         self.assertEqual(p.is_alive(), False)
         self.assertEqual(p.exitcode, 0)
         p.close()
+        self.assertTrue(p.closed)
         with self.assertRaises(ValueError):
             p.is_alive()
         with self.assertRaises(ValueError):
             p.join()
         with self.assertRaises(ValueError):
             p.terminate()
-        self.assertFalse(p.closed)
         p.close()
         self.assertTrue(p.closed)
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -655,9 +655,9 @@ class _TestProcess(BaseTestCase):
         def _test_task():
             pass
         p = self.Process(target=_test_task)
-        self.assertFalse(p.is_closed)
+        self.assertFalse(p.closed)
         p.close()
-        self.assertTrue(p.is_closed)
+        self.assertTrue(p.closed)
 
         wr = weakref.ref(p)
         del p

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -652,8 +652,9 @@ class _TestProcess(BaseTestCase):
     def test_is_close(self):
         if self.TYPE == "threads":
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
-        q = self.Queue()
-        p = self.Process(target=self._test_close, kwargs={'q': q})
+        def _test_task():
+            pass
+        p = self.Process(target=_test_task)
         self.assertFalse(p.is_closed())
         p.close()
         self.assertTrue(p.is_closed())
@@ -662,7 +663,6 @@ class _TestProcess(BaseTestCase):
         del p
         gc.collect()
         self.assertIs(wr(), None)
-        close_queue(q)
 
     def test_close(self):
         if self.TYPE == "threads":

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -655,9 +655,9 @@ class _TestProcess(BaseTestCase):
         def _test_task():
             pass
         p = self.Process(target=_test_task)
-        self.assertFalse(p.is_closed())
+        self.assertFalse(p.is_closed)
         p.close()
-        self.assertTrue(p.is_closed())
+        self.assertTrue(p.is_closed)
 
         wr = weakref.ref(p)
         del p

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -649,6 +649,21 @@ class _TestProcess(BaseTestCase):
             q.get()
         sys.exit(rc)
 
+    def test_is_close(self):
+        if self.TYPE == "threads":
+            self.skipTest('test not appropriate for {}'.format(self.TYPE))
+        q = self.Queue()
+        p = self.Process(target=self._test_close, kwargs={'q': q})
+        self.assertFalse(p.is_closed())
+        p.close()
+        self.assertTrue(p.is_closed())
+
+        wr = weakref.ref(p)
+        del p
+        gc.collect()
+        self.assertIs(wr(), None)
+        close_queue(q)
+
     def test_close(self):
         if self.TYPE == "threads":
             self.skipTest('test not appropriate for {}'.format(self.TYPE))

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -657,16 +657,16 @@ class _TestProcess(BaseTestCase):
         p.daemon = True
         p.start()
         self.assertEqual(p.is_alive(), True)
+        self.assertFalse(p.closed)
         # Child is still alive, cannot close
         with self.assertRaises(ValueError):
-            self.assertFalse(p.closed)
             p.close()
-            self.assertTrue(p.closed)
 
         q.put(None)
         p.join()
         self.assertEqual(p.is_alive(), False)
         self.assertEqual(p.exitcode, 0)
+        self.assertFalse(p.closed)
         p.close()
         self.assertTrue(p.closed)
         with self.assertRaises(ValueError):

--- a/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
@@ -1,2 +1,3 @@
-Allow to determine whether a :class:`multiprocessing.Process` has been closed
-via the :attr:`~multiprocessing.Process.closed` attribute.
+Add attribute :attr:`!closed` to :class:`multiprocessing.Process`,
+It is used to check whether the process is closed.
+(Contributed by James Roy in :gh:`87063`.)

--- a/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
@@ -1,3 +1,2 @@
-Add attribute :attr:`!closed` to :class:`multiprocessing.Process`,
-It is used to check whether the process is closed.
-(Contributed by James Roy in :gh:`87063`.)
+Allow to determine whether a :class:`multiprocessing.Process` has been closed
+via the :attr:`!closed` attribute.

--- a/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
@@ -1,0 +1,2 @@
+Add the :meth:`.is_closed()` in the :class:`multiprocessing.Process` to
+determine whether the process is closed.

--- a/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
@@ -1,2 +1,2 @@
-Add the ``closed()`` in the :class:`multiprocessing.Process` to
-determine whether the process is closed.
+Allow to determine whether a :class:`multiprocessing.Process` has been closed
+via the :attr:`~multiprocessing.Process.closed` attribute.

--- a/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
@@ -1,2 +1,2 @@
 Allow to determine whether a :class:`multiprocessing.Process` has been closed
-via the :attr:`!closed` attribute.
+via the :attr:`~multiprocessing.Process.closed` property.

--- a/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
@@ -1,2 +1,3 @@
-Allow to determine whether a :class:`multiprocessing.Process` has been closed
-via the :attr:`~multiprocessing.Process.closed` property.
+Add the :attr:`~multiprocessing.Process.closed` property to
+:class:`multiprocessing.Process` objects to determine whether
+they have been closed or not.

--- a/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
@@ -1,2 +1,2 @@
-Add the :meth:`.is_closed()` in the :class:`multiprocessing.Process` to
+Add the ``is_closed()`` in the :class:`multiprocessing.Process` to
 determine whether the process is closed.

--- a/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-19-52-15.gh-issue-87063.fR-wJa.rst
@@ -1,2 +1,2 @@
-Add the ``is_closed()`` in the :class:`multiprocessing.Process` to
+Add the ``closed()`` in the :class:`multiprocessing.Process` to
 determine whether the process is closed.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-87063 -->
* Issue: gh-87063
<!-- /gh-issue-number -->

for example:
```
import multiprocessing


def f():
    print('hello')
    print('world')

if __name__ == "__main__":
    p = multiprocessing.Process(target=f)
    p.start()
    p.join()

    # In a more context, it's closed
    p.close()
    
    # Currnet context
    # It's thrown a ValueError
    if p.exitcode == 0:
        pass

    # Changed
    if not p.is_closed():
        print(p.exitcode)
```
