### PR TITLE
gh-125855: pstats.Stats: Allow sorting/filtering by caller/callee

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -196,7 +196,13 @@ is still sorted according to the last criteria) do::
 
    p.print_callers(.5, 'init')
 
-and you would get a list of callers for each of the listed functions.
+and you would get a list of all the callers for each of the listed functions.
+That may be a very long list, so if you want to sort or limit each function's
+list of callers, you might put::
+
+   p.print_callers(.5, 'init', callers_sort=SortKey.TIME, callers_filter=5)
+
+to get the top 5 callers by time of each ``init`` function in the top 50%.
 
 If you want more functionality, you're going to have to read the manual, or
 guess what the following functions do::
@@ -507,7 +513,8 @@ Analysis of the profiler data is done using the :class:`~pstats.Stats` class.
       and then proceed to only print the first 10% of them.
 
 
-   .. method:: print_callers(*restrictions)
+   .. method:: print_callers(*restrictions, callers_sort_key=(),
+      callers_filter=())
 
       This method for the :class:`Stats` class prints a list of all functions
       that called each function in the profiled database.  The ordering is
@@ -526,13 +533,23 @@ Analysis of the profiler data is done using the :class:`~pstats.Stats` class.
         cumulative times spent in the current function while it was invoked by
         this specific caller.
 
+      By default, all callers of a function are printed in lexicographic order.
+      To sort them differently, you can supply sort criteria in the keyword
+      argument ``callers_sort_key``. These use exactly the same format as in
+      :meth:`~pstats.Stats.sort_stats`, though you must supply them each time
+      you call this method. And to limit the number of callers printed per
+      function, you can supply restrictions in the keyword argument
+      ``callers_filter``, as you would in :meth:`~pstats.Stats.print_stats`.
 
-   .. method:: print_callees(*restrictions)
+
+   .. method:: print_callees(*restrictions, callees_sort_key=(),
+      callees_filter=())
 
       This method for the :class:`Stats` class prints a list of all function
       that were called by the indicated function.  Aside from this reversal of
-      direction of calls (re: called vs was called by), the arguments and
-      ordering are identical to the :meth:`~pstats.Stats.print_callers` method.
+      direction of calls (re: called vs was called by), and names of the
+      keyword arguments, the arguments and ordering are identical to the
+      :meth:`~pstats.Stats.print_callers` method.
 
 
    .. method:: get_stats_profile()

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -513,8 +513,7 @@ Analysis of the profiler data is done using the :class:`~pstats.Stats` class.
       and then proceed to only print the first 10% of them.
 
 
-   .. method:: print_callers(*restrictions, callers_sort_key=(),
-      callers_filter=())
+   .. method:: print_callers(*restrictions, callers_sort_key=(), callers_filter=())
 
       This method for the :class:`Stats` class prints a list of all functions
       that called each function in the profiled database.  The ordering is
@@ -542,8 +541,7 @@ Analysis of the profiler data is done using the :class:`~pstats.Stats` class.
       ``callers_filter``, as you would in :meth:`~pstats.Stats.print_stats`.
 
 
-   .. method:: print_callees(*restrictions, callees_sort_key=(),
-      callees_filter=())
+   .. method:: print_callees(*restrictions, callees_sort_key=(), callees_filter=())
 
       This method for the :class:`Stats` class prints a list of all function
       that were called by the indicated function.  Aside from this reversal of

--- a/Lib/pstats.py
+++ b/Lib/pstats.py
@@ -449,7 +449,8 @@ class Stats:
                 if isinstance(callees_sort_key, str):
                     callees_sort_key = (callees_sort_key,)
                 sort_tuple, sort_type = self.get_sort_tuple_and_type(*callees_sort_key)
-                print("   Callees ordered by: " + sort_type + "\n")
+                print(f"   Callees ordered by: {sort_type}", file=self.stream)
+                print(file=self.stream)
             if not isinstance(callees_filter, tuple):
                 callees_filter = (callees_filter,)
             self.print_call_heading(width, "called...")
@@ -472,7 +473,8 @@ class Stats:
                 if isinstance(callers_sort_key, str):
                     callers_sort_key = (callers_sort_key,)
                 sort_tuple, sort_type = self.get_sort_tuple_and_type(*callers_sort_key)
-                print("   Callers ordered by: " + sort_type + "\n")
+                print(f"   Callers ordered by: {sort_type}", file=self.stream)
+                print(file=self.stream)
             if not isinstance(callers_filter, tuple):
                 callers_filter = (callers_filter,)
             self.print_call_heading(width, "was called by...")
@@ -512,12 +514,11 @@ class Stats:
                     stats_list.append((cc, nc, tt, ct) + func +
                                       (func_std_string(func),))
                 else:
-                    if not calls_only:
-                        if "time" in sort_type:
-                            raise TypeError("Caller/callee stats for %s do not have time information. "
-                                            "Try using cProfile instead of profile if you wish to record time by caller/callee."
-                                            % func_std_string(func))
-                        calls_only = True
+                    if not calls_only and "time" in sort_type:
+                        raise TypeError("Caller/callee stats for %s do not have time information. "
+                                        "Try using cProfile instead of profile if you wish to record time by caller/callee."
+                                        % func_std_string(func))
+                    calls_only = True
                     stats_list.append((None, value, None, None) + func +
                                       (func_std_string(func),))
 

--- a/Misc/NEWS.d/next/Library/2024-10-22-19-36-47.gh-issue-125855.942kuz.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-22-19-36-47.gh-issue-125855.942kuz.rst
@@ -1,0 +1,1 @@
+Add new keyword arguments for sorting and filtering callers and callees to :func:`~pstats.Stats.print_callers` and :func:`~pstats.Stats.print_callees`. Contributed by Benjamin S Wolf.


### PR DESCRIPTION
This PR adds new keyword arguments `callers_sort_key` and `callers_filter` to `pstats.Stats.print_callers`, and similar to `pstats.Stats.print_callees`, and documents them in the profiling doc. The sorting and filtering are accomplished via use of similar code in `pstats.Stats`, now refactored to be shared, though unlike `sort_stats` the sorting is not sticky.

This produces something like:
```
>>> p.print_callers(r'\(has\)', callers_sort_key='time', callers_filter=5)
   Ordered by: internal time
   List reduced from 965 to 1 due to restriction <'\\(has\\)'>

   Callers ordered by: internal time

Function                 was called by...
                             ncalls  tottime  cumtime
BaseClasses.py:820(has)  <-    4926    0.002    0.002  worlds\overcooked2\Logic.py:6(has_requirements_for_level_access)
                               1148    0.000    0.001  worlds\overcooked2\Logic.py:291(can_reach_sky_shelf)
                               1119    0.000    0.000  worlds\overcooked2\Logic.py:278(can_reach_stonehenge_mountain)
                                728    0.000    0.000  worlds\overcooked2\Logic.py:257(can_reach_yellow_island)
                                220    0.000    0.000  worlds\overcooked2\Logic.py:310(can_reach_pink_island)
   List reduced from 7 to 5 due to restriction <5>
```


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125856.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-125855 -->
* Issue: gh-125855
<!-- /gh-issue-number -->
