### PR TITLE
GH-124985: Document that `pathlib.Path.copy()` uses copy-on-write.

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1563,6 +1563,11 @@ Copying, moving and deleting
    This argument has no effect when copying files on Windows (where
    metadata is always preserved).
 
+   .. note::
+      Where supported by the operating system and file system, this method
+      performs a lightweight copy, where data blocks are only copied when
+      modified. This is known as copy-on-write.
+
    .. versionadded:: 3.14
 
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-124985 -->
* Issue: gh-124985
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125861.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->