### PR TITLE
GH-125012: Make `PurePath` emit `FutureWarning` when converting separators

### DIFF
--- a/Lib/pathlib/_local.py
+++ b/Lib/pathlib/_local.py
@@ -119,11 +119,23 @@ class PurePath(PurePathBase):
         paths = []
         for arg in args:
             if isinstance(arg, PurePath):
-                if arg.parser is not self.parser:
+                if arg.parser is self.parser:
+                    paths.extend(arg._raw_paths)
+                elif arg.parser is ntpath:
                     # GH-103631: Convert separators for backwards compatibility.
+                    # GH-125012: This emits FutureWarning as of Python 3.14.
+                    import warnings
+                    msg = ("pathlib.PurePosixPath(pathlib.PureWindowsPath(...)): "
+                           "converting backward slashes to forward slashes. "
+                           "This will cease in a future Python release. Use "
+                           "PurePosixPath(PureWindowsPath(...).as_posix()) to "
+                           "explicitly convert Windows separators to POSIX "
+                           "separators when 'casting' a Windows-flavoured "
+                           "path object to a POSIX-flavoured path object.")
+                    warnings.warn(msg, FutureWarning, stacklevel=2)
                     paths.append(arg.as_posix())
                 else:
-                    paths.extend(arg._raw_paths)
+                    paths.append(str(arg))
             else:
                 try:
                     path = os.fspath(arg)

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -388,7 +388,8 @@ class PurePathTest(test_pathlib_abc.DummyPurePathTest):
     def test_parse_windows_path(self):
         P = self.cls
         p = P('c:', 'a', 'b')
-        pp = P(pathlib.PureWindowsPath('c:\\a\\b'))
+        with self.assertWarns(FutureWarning):
+            pp = P(pathlib.PureWindowsPath('c:\\a\\b'))
         self.assertEqual(p, pp)
 
     windows_equivalences = {

--- a/Misc/NEWS.d/next/Library/2024-10-23-01-26-04.gh-issue-125012.uy3tPa.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-23-01-26-04.gh-issue-125012.uy3tPa.rst
@@ -1,0 +1,6 @@
+``pathlib.PurePosixPath(pathlib.PureWindowsPath(...))`` now emits a
+:exc:`FutureWarning` indicating that implicit conversion of backward slashes
+to forward slashes will cease in a future Python release. Use
+``PurePosixPath(PureWindowsPath(...).as_posix())`` to explicitly convert
+Windows path separators to POSIX path separators when converting between
+path flavours.


### PR DESCRIPTION
Make `PurePosixPath(PureWindowsPath(...))` emit a `FutureWarning` indicating that implicit conversion of backward slashes to forward slashes will cease in a future Python release. This feature isn't documented, and it wasn't tested until I accidentally broke it a couple of releases ago!


<!-- gh-issue-number: gh-125012 -->
* Issue: gh-125012
<!-- /gh-issue-number -->
