### PR TITLE
gh-84545: Clarify the 'extend' action documentation in argparse

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -741,6 +741,21 @@ how the command-line arguments should be handled. The supplied actions are:
     >>> parser.parse_args('--str --int'.split())
     Namespace(types=[<class 'str'>, <class 'int'>])
 
+* ``'extend'`` - This stores a list, and appends each item from the multi-value
+  argument list to the list.
+  The ``'extend'`` action is typically used with the nargs_ keyword argument
+  value ``'+'`` or ``'*'``;
+  note that when nargs_ is ``None`` (by default) or ``'?'``, separate
+  characters of the argument string will be appended to the list.
+  Example usage::
+
+    >>> parser = argparse.ArgumentParser()
+    >>> parser.add_argument("--foo", action="extend", nargs="+", type=str)
+    >>> parser.parse_args(["--foo", "f1", "--foo", "f2", "f3", "f4"])
+    Namespace(foo=['f1', 'f2', 'f3', 'f4'])
+
+  .. versionadded:: 3.8
+
 * ``'count'`` - This counts the number of times a keyword argument occurs. For
   example, this is useful for increasing verbosity levels::
 
@@ -765,17 +780,6 @@ how the command-line arguments should be handled. The supplied actions are:
     >>> parser.add_argument('--version', action='version', version='%(prog)s 2.0')
     >>> parser.parse_args(['--version'])
     PROG 2.0
-
-* ``'extend'`` - This stores a list, and extends each argument value to the
-  list.
-  Example usage::
-
-    >>> parser = argparse.ArgumentParser()
-    >>> parser.add_argument("--foo", action="extend", nargs="+", type=str)
-    >>> parser.parse_args(["--foo", "f1", "--foo", "f2", "f3", "f4"])
-    Namespace(foo=['f1', 'f2', 'f3', 'f4'])
-
-  .. versionadded:: 3.8
 
 Only actions that consume command-line arguments (e.g. ``'store'``,
 ``'append'`` or ``'extend'``) can be used with positional arguments.

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -741,12 +741,12 @@ how the command-line arguments should be handled. The supplied actions are:
     >>> parser.parse_args('--str --int'.split())
     Namespace(types=[<class 'str'>, <class 'int'>])
 
-* ``'extend'`` - This stores a list, and appends each item from the multi-value
-  argument list to the list.
+* ``'extend'`` - This stores a list and appends each item from the multi-value
+  argument list to it.
   The ``'extend'`` action is typically used with the nargs_ keyword argument
-  value ``'+'`` or ``'*'``;
-  note that when nargs_ is ``None`` (by default) or ``'?'``, separate
-  characters of the argument string will be appended to the list.
+  value ``'+'`` or ``'*'``.
+  Note that when nargs_ is ``None`` (the default) or ``'?'``, each
+  character of the argument string will be appended to the list.
   Example usage::
 
     >>> parser = argparse.ArgumentParser()


### PR DESCRIPTION


<!-- gh-issue-number: gh-84545 -->
* Issue: gh-84545
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125870.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->