### PR TITLE
gh-125783: Add tests to prevent regressions with the combination of `ctypes` and metaclasses.

### DIFF
--- a/Lib/test/test_ctypes/test_c_simple_type_meta.py
+++ b/Lib/test/test_ctypes/test_c_simple_type_meta.py
@@ -1,0 +1,49 @@
+import unittest
+import ctypes
+from ctypes import POINTER, c_void_p
+
+from ._support import PyCSimpleType
+
+
+class PyCSimpleTypeAsMetaclassTest(unittest.TestCase):
+    def tearDown(self):
+        # to not leak references, we must clean _pointer_type_cache
+        ctypes._reset_cache()
+
+    def test_early_return_in_dunder_new_1(self):
+        # Such an implementation is used in `IUnknown` of `comtypes`.
+
+        class _ct_meta(type):
+            def __new__(cls, name, bases, namespace):
+                self = super().__new__(cls, name, bases, namespace)
+                if bases == (c_void_p,):
+                    return self
+                if issubclass(self, _PtrBase):
+                    return self
+                if bases == (object,):
+                    _ptr_bases = (self, _PtrBase)
+                else:
+                    _ptr_bases = (self, POINTER(bases[0]))
+                p = _p_meta(f"POINTER({self.__name__})", _ptr_bases, {})
+                ctypes._pointer_type_cache[self] = p
+                return self
+
+        class _p_meta(PyCSimpleType, _ct_meta):
+            pass
+
+        class _PtrBase(c_void_p, metaclass=_p_meta):
+            pass
+
+        class _CtBase(object, metaclass=_ct_meta):
+            pass
+
+        class _Sub(_CtBase):
+            pass
+
+        class _Sub2(_Sub):
+            pass
+
+        self.assertIsInstance(POINTER(_Sub2), _p_meta)
+        self.assertTrue(issubclass(POINTER(_Sub2), _Sub2))
+        self.assertTrue(issubclass(POINTER(_Sub2), POINTER(_Sub)))
+        self.assertTrue(issubclass(POINTER(_Sub), POINTER(_CtBase)))

--- a/Lib/test/test_ctypes/test_c_simple_type_meta.py
+++ b/Lib/test/test_ctypes/test_c_simple_type_meta.py
@@ -59,7 +59,8 @@ class PyCSimpleTypeAsMetaclassTest(unittest.TestCase):
         self.assertTrue(issubclass(POINTER(Sub), POINTER(CtBase)))
 
     def test_creating_pointer_in_dunder_new_2(self):
-        # A simpler variant of the above, used in `CoClass` of `comtypes`.
+        # A simpler variant of the above, used in `CoClass` of the `comtypes`
+        # project.
 
         class ct_meta(type):
             def __new__(cls, name, bases, namespace):


### PR DESCRIPTION
I would like to backport this to 3.12 and 3.13 as well.

<!-- gh-issue-number: gh-125783 -->
* Issue: gh-125783
<!-- /gh-issue-number -->
