### PR TITLE
gh-125884: Support breakpoint on functions with annotations

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -142,8 +142,8 @@ def find_function(funcname, filename):
                 except SyntaxError:
                     continue
                 # We should always be able to find the code object here
-                funccode = next(const for const in code.co_consts if
-                                isinstance(const, CodeType) and const.co_name == funcname)
+                funccode = next(c for c in code.co_consts if
+                                isinstance(c, CodeType) and c.co_name == funcname)
                 lineno_offset = find_first_executable_line(funccode)
                 return funcname, filename, funcstart + lineno_offset - 1
     return None

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -139,14 +139,11 @@ def find_function(funcname, filename):
             if funcdef:
                 try:
                     code = compile(funcdef, filename, 'exec')
-                    for const in code.co_consts:
-                        if isinstance(const, CodeType) and const.co_name == funcname:
-                            funccode = const
-                            break
-                    else:
-                        continue
                 except SyntaxError:
                     continue
+                # We should always be able to find the code object here
+                funccode = next(const for const in code.co_consts if
+                                isinstance(const, CodeType) and const.co_name == funcname)
                 lineno_offset = find_first_executable_line(funccode)
                 return funcname, filename, funcstart + lineno_offset - 1
     return None

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -118,7 +118,7 @@ def find_first_executable_line(code):
     return code.co_firstlineno
 
 def find_function(funcname, filename):
-    cre = re.compile(r'def\s+%s\s*[(]' % re.escape(funcname))
+    cre = re.compile(r'def\s+%s(\s*\[.+\])?\s*[(]' % re.escape(funcname))
     try:
         fp = tokenize.open(filename)
     except OSError:
@@ -138,7 +138,13 @@ def find_function(funcname, filename):
 
             if funcdef:
                 try:
-                    funccode = compile(funcdef, filename, 'exec').co_consts[0]
+                    code = compile(funcdef, filename, 'exec')
+                    for const in code.co_consts:
+                        if isinstance(const, CodeType) and const.co_name == funcname:
+                            funccode = const
+                            break
+                    else:
+                        continue
                 except SyntaxError:
                     continue
                 lineno_offset = find_first_executable_line(funccode)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -363,6 +363,42 @@ def test_pdb_breakpoint_commands():
     4
     """
 
+def test_pdb_breakpoint_on_annotated_function_def():
+    """Test breakpoints on function definitions with annotation.
+
+    >>> def foo[T]():
+    ...     return 0
+
+    >>> def bar() -> int:
+    ...     return 0
+
+    >>> def foobar[T]() -> int:
+    ...     return 0
+
+    >>> reset_Breakpoint()
+
+    >>> def test_function():
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     pass
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'break foo',
+    ...     'break bar',
+    ...     'break foobar',
+    ...     'continue',
+    ... ]):
+    ...    test_function()
+    > <doctest test.test_pdb.test_pdb_breakpoint_on_annotated_function_def[4]>(2)test_function()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) break foo
+    Breakpoint 1 at <doctest test.test_pdb.test_pdb_breakpoint_on_annotated_function_def[0]>:2
+    (Pdb) break bar
+    Breakpoint 2 at <doctest test.test_pdb.test_pdb_breakpoint_on_annotated_function_def[1]>:2
+    (Pdb) break foobar
+    Breakpoint 3 at <doctest test.test_pdb.test_pdb_breakpoint_on_annotated_function_def[2]>:2
+    (Pdb) continue
+    """
+
 def test_pdb_commands():
     """Test the commands command of pdb.
 

--- a/Misc/NEWS.d/next/Library/2024-10-23-17-45-40.gh-issue-125884.41E_PD.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-23-17-45-40.gh-issue-125884.41E_PD.rst
@@ -1,0 +1,1 @@
+Fixed the bug for :mod:`pdb` where it can't set breakpoints on functions with certain annotations.


### PR DESCRIPTION
close #125885 as well.

Two things are fixed:

1. The regex for a function definition is improved to include generics
2. We do not rely on the function code object being the first const in the compiled code object. We search for it.

<!-- gh-issue-number: gh-125884 -->
* Issue: gh-125884
<!-- /gh-issue-number -->
