### PR TITLE
gh-125864: Propagate `pickle.loads()` failures in `InterpreterPoolExecutor`

### DIFF
--- a/Lib/concurrent/futures/interpreter.py
+++ b/Lib/concurrent/futures/interpreter.py
@@ -107,7 +107,8 @@ class WorkerContext(_thread.WorkerContext):
 
     @classmethod
     def _call_pickled(cls, pickled, resultsid):
-        fn, args, kwargs = pickle.loads(pickled)
+        with cls._capture_exc(resultsid):
+            fn, args, kwargs = pickle.loads(pickled)
         cls._call(fn, args, kwargs, resultsid)
 
     def __init__(self, initdata, shared=None):

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -56,7 +56,7 @@ class InterpretersMixin(InterpreterPoolMixin):
         return r, w
 
 
-class Shenanigans:
+class PickleShenanigans:
     """Succeeds with pickle.dumps(), but fails with pickle.loads()"""
     def __init__(self, value):
         if value == 1:
@@ -293,7 +293,7 @@ class InterpreterPoolExecutorTest(
         # GH-125864: Pickle errors happen before the script tries to execute, so the
         # queue used to wait infinitely.
 
-        fut = self.executor.submit(Shenanigans(0))
+        fut = self.executor.submit(PickleShenanigans(0))
         with self.assertRaisesRegex(RuntimeError, "gotcha"):
             fut.result()
 

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -369,7 +369,6 @@ class AsyncioTest(InterpretersMixin, testasyncio_utils.TestCase):
         self.assertNotEqual(interpid, unexpected)
 
 
-
 def setUpModule():
     setup_module()
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-125864 -->
* Issue: gh-125864
<!-- /gh-issue-number -->
