### PR TITLE
gh-125904: Fix MRO summary description in tutorial

### DIFF
--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -638,7 +638,7 @@ multiple base classes looks like this::
        <statement-N>
 
 For most purposes, in the simplest cases, you can think of the search for
-attributes inherited from a parent class as depth-first, left-to-right, not
+attributes inherited from a parent class as breadth-first, left-to-right, not
 searching twice in the same class where there is an overlap in the hierarchy.
 Thus, if an attribute is not found in :class:`!DerivedClassName`, it is searched
 for in :class:`!Base1`, then (recursively) in the base classes of :class:`!Base1`,


### PR DESCRIPTION
The tutorial classes chapter multiple inheritance section described MRO as depth first.  That was the case for the old classic classes in Python2.

<!-- gh-issue-number: gh-125904 -->
* Issue: gh-125904
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--125906.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->