### PR TITLE
gh-125889: Fix bounds check of hi argument in bisect_left|right functions

### DIFF
--- a/Lib/bisect.py
+++ b/Lib/bisect.py
@@ -33,7 +33,7 @@ def bisect_right(a, x, lo=0, hi=None, *, key=None):
 
     if lo < 0:
         raise ValueError('lo must be non-negative')
-    if hi is None:
+    if hi is None or hi < 0:
         hi = len(a)
     # Note, the comparison uses "<" to match the
     # __lt__() logic in list.sort() and in heapq.
@@ -86,7 +86,7 @@ def bisect_left(a, x, lo=0, hi=None, *, key=None):
 
     if lo < 0:
         raise ValueError('lo must be non-negative')
-    if hi is None:
+    if hi is None or hi < 0:
         hi = len(a)
     # Note, the comparison uses "<" to match the
     # __lt__() logic in list.sort() and in heapq.

--- a/Lib/test/test_bisect.py
+++ b/Lib/test/test_bisect.py
@@ -126,6 +126,20 @@ class TestBisect:
         self.assertRaises(ValueError, mod.insort_left, [1, 2, 3], 5, -1, 3)
         self.assertRaises(ValueError, mod.insort_right, [1, 2, 3], 5, -1, 3)
 
+    def test_negative_hi(self):
+        # Issue 125889
+        def assertNoRiases(f, *arg, **kwargs):
+            try:
+                f(*arg, **kwargs)
+            except Exception:
+                self.fail('Unable to work negative hi argument')
+        mod = self.module
+        # It can work negative values
+        assertNoRiases(mod.bisect_left, [1, 2, 3], 5, 3, -2)
+        assertNoRiases(mod.bisect_right, [1, 2, 3], 5, 3, -2)
+        assertNoRiases(mod.insort_left, [1, 2, 3], 5, 3, -2)
+        assertNoRiases(mod.insort_right, [1, 2, 3], 5, 3, -2)
+
     def test_large_range(self):
         # Issue 13496
         mod = self.module

--- a/Lib/test/test_bisect.py
+++ b/Lib/test/test_bisect.py
@@ -130,7 +130,11 @@ class TestBisect:
         # Issue 125889
         def assertNoRiases(f, *arg, **kwargs):
             try:
-                f(*arg, **kwargs)
+                res = f(*arg, **kwargs)
+                if f.__name__ in ('bisect_left', 'bisect_right'):
+                    self.assertEqual(res, 3)
+                else:
+                    self.assertIn(res, (3, None))
             except Exception:
                 self.fail('Unable to work negative hi argument')
         mod = self.module

--- a/Lib/test/test_bisect.py
+++ b/Lib/test/test_bisect.py
@@ -118,31 +118,18 @@ class TestBisect:
             self.assertEqual(func(data, elem), expected)
             self.assertEqual(func(UserList(data), elem), expected)
 
-    def test_negative_lo(self):
+    def test_negative_hi_lo(self):
         # Issue 3301
         mod = self.module
         self.assertRaises(ValueError, mod.bisect_left, [1, 2, 3], 5, -1, 3)
         self.assertRaises(ValueError, mod.bisect_right, [1, 2, 3], 5, -1, 3)
         self.assertRaises(ValueError, mod.insort_left, [1, 2, 3], 5, -1, 3)
         self.assertRaises(ValueError, mod.insort_right, [1, 2, 3], 5, -1, 3)
-
-    def test_negative_hi(self):
-        # Issue 125889
-        def assertNoRiases(f, *arg, **kwargs):
-            try:
-                res = f(*arg, **kwargs)
-                if f.__name__ in ('bisect_left', 'bisect_right'):
-                    self.assertEqual(res, 3)
-                else:
-                    self.assertIn(res, (3, None))
-            except Exception:
-                self.fail('Unable to work negative hi argument')
-        mod = self.module
-        # It can work negative values
-        assertNoRiases(mod.bisect_left, [1, 2, 3], 5, 3, -2)
-        assertNoRiases(mod.bisect_right, [1, 2, 3], 5, 3, -2)
-        assertNoRiases(mod.insort_left, [1, 2, 3], 5, 3, -2)
-        assertNoRiases(mod.insort_right, [1, 2, 3], 5, 3, -2)
+        # Test c implementation
+        self.assertRaises(ValueError, c_bisect.bisect_left, [1, 2, 3], 5, 3, -2)
+        self.assertRaises(ValueError, c_bisect.bisect_right, [1, 2, 3], 5, 3, -2)
+        self.assertRaises(ValueError, c_bisect.insort_left, [1, 2, 3], 5, 3, -2)
+        self.assertRaises(ValueError, c_bisect.insort_right, [1, 2, 3], 5, 3, -2)
 
     def test_large_range(self):
         # Issue 13496

--- a/Misc/NEWS.d/next/Library/2024-10-24-15-21-03.gh-issue-125889.P9MXpN.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-24-15-21-03.gh-issue-125889.P9MXpN.rst
@@ -1,2 +1,1 @@
-Modify the check of the ``hi`` argument in ``internal_bisect_left`` and ``internal_bisect_right``
-so that when ``hi`` is negative, it's calculated based on the list length.
+Allow negative values ​​for ``hi`` argument of ``bisect_left/right`` and ``insort_left/right``.

--- a/Misc/NEWS.d/next/Library/2024-10-24-15-21-03.gh-issue-125889.P9MXpN.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-24-15-21-03.gh-issue-125889.P9MXpN.rst
@@ -1,0 +1,3 @@
+Modify the check of ``hi`` argument in ``internal_bisect_left`` and
+``internal_bisect_right`` so that negative numbers are not allowed
+to be passed.

--- a/Misc/NEWS.d/next/Library/2024-10-24-15-21-03.gh-issue-125889.P9MXpN.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-24-15-21-03.gh-issue-125889.P9MXpN.rst
@@ -1,3 +1,2 @@
-Modify the check of ``hi`` argument in ``internal_bisect_left`` and
-``internal_bisect_right`` so that negative numbers are not allowed
-to be passed.
+Modify the check of the ``hi`` argument in ``internal_bisect_left`` and ``internal_bisect_right``
+so that when ``hi`` is negative, it's calculated based on the list length.

--- a/Modules/_bisectmodule.c
+++ b/Modules/_bisectmodule.c
@@ -61,10 +61,14 @@ internal_bisect_right(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t 
         PyErr_SetString(PyExc_ValueError, "lo must be non-negative");
         return -1;
     }
-    if (hi < 0) {
+    if (hi == -1) {
         hi = PySequence_Size(list);
         if (hi < 0)
             return -1;
+    }
+    if (hi < 0) {
+        PyErr_SetString(PyExc_ValueError, "hi must be non-negative");
+        return -1;
     }
     ssizeargfunc sq_item = get_sq_item(list);
     if (sq_item == NULL) {
@@ -245,10 +249,14 @@ internal_bisect_left(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t h
         PyErr_SetString(PyExc_ValueError, "lo must be non-negative");
         return -1;
     }
-    if (hi < 0) {
+    if (hi == -1) {
         hi = PySequence_Size(list);
         if (hi < 0)
             return -1;
+    }
+    if (hi < 0) {
+        PyErr_SetString(PyExc_ValueError, "hi must be non-negative");
+        return -1;
     }
     ssizeargfunc sq_item = get_sq_item(list);
     if (sq_item == NULL) {

--- a/Modules/_bisectmodule.c
+++ b/Modules/_bisectmodule.c
@@ -61,7 +61,7 @@ internal_bisect_right(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t 
         PyErr_SetString(PyExc_ValueError, "lo must be non-negative");
         return -1;
     }
-    if (hi == -1) {
+    if (hi < 0) {
         hi = PySequence_Size(list);
         if (hi < 0)
             return -1;
@@ -245,7 +245,7 @@ internal_bisect_left(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t h
         PyErr_SetString(PyExc_ValueError, "lo must be non-negative");
         return -1;
     }
-    if (hi == -1) {
+    if (hi < 0) {
         hi = PySequence_Size(list);
         if (hi < 0)
             return -1;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125889 -->
* Issue: gh-125889
<!-- /gh-issue-number -->
