### PR TITLE
gh-125942: Android: set stdout to `errors="backslashreplace"`

### DIFF
--- a/Lib/_android_support.py
+++ b/Lib/_android_support.py
@@ -31,16 +31,19 @@ def init_streams(android_log_write, stdout_prio, stderr_prio):
     logcat = Logcat(android_log_write)
 
     sys.stdout = TextLogStream(
-        stdout_prio, "python.stdout", sys.stdout.fileno(),
-        errors=sys.stdout.errors)
+        stdout_prio, "python.stdout", sys.stdout.fileno())
     sys.stderr = TextLogStream(
-        stderr_prio, "python.stderr", sys.stderr.fileno(),
-        errors=sys.stderr.errors)
+        stderr_prio, "python.stderr", sys.stderr.fileno())
 
 
 class TextLogStream(io.TextIOWrapper):
     def __init__(self, prio, tag, fileno=None, **kwargs):
+        # The default is surrogateescape for stdout and backslashreplace for
+        # stderr, but in the context of an Android log, readability is more
+        # important than reversibility.
         kwargs.setdefault("encoding", "UTF-8")
+        kwargs.setdefault("errors", "backslashreplace")
+
         super().__init__(BinaryLogStream(prio, tag, fileno), **kwargs)
         self._lock = RLock()
         self._pending_bytes = []

--- a/Lib/test/test_android.py
+++ b/Lib/test/test_android.py
@@ -123,12 +123,9 @@ class TestAndroidOutput(unittest.TestCase):
                 self.assertIs(stream.readable(), False)
                 self.assertEqual(stream.fileno(), fileno)
                 self.assertEqual("UTF-8", stream.encoding)
+                self.assertEqual("backslashreplace", stream.errors)
                 self.assertIs(stream.line_buffering, True)
                 self.assertIs(stream.write_through, False)
-
-                # stderr is backslashreplace by default; stdout is configured
-                # that way by libregrtest.main.
-                self.assertEqual("backslashreplace", stream.errors)
 
                 def write(s, lines=None, *, write_len=None):
                     if write_len is None:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-10-24-22-43-03.gh-issue-125942.3UQht1.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-10-24-22-43-03.gh-issue-125942.3UQht1.rst
@@ -1,0 +1,2 @@
+On Android, the ``errors`` setting of :any:`sys.stdout` was changed from
+``surrogateescape`` to ``backslashreplace``.


### PR DESCRIPTION

<!-- gh-issue-number: gh-125942 -->
* Closes gh-125942
<!-- /gh-issue-number -->
