### PR TITLE
Fix a typo in tutorial exception output

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -464,7 +464,7 @@ A more complicated example::
    executing finally clause
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
-       divide("2", "0")
+       divide("2", "1")
        ~~~~~~^^^^^^^^^^
      File "<stdin>", line 3, in divide
        result = x / y


### PR DESCRIPTION
This fixes a small typo on [Errors](https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions) page of the tutorial.

The output of the method call does not currently match its arguments:

```
   >>> divide("2", "1")
   executing finally clause
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
       divide("2", "0")
```



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126001.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->