### PR TITLE
gh-125984: fix UAF on `fut->fut_{callback,context}0` due to an evil `loop.__getattribute__`

### DIFF
--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -32,6 +32,25 @@ def last_cb():
     pass
 
 
+class ReachableCode(Exception):
+    """Exception to raise to indicate that some code was reached.
+
+    Use this exception if using mocks is not a good alternative.
+    """
+
+
+class SimpleEvilEventLoop(asyncio.base_events.BaseEventLoop):
+    """Base class for UAF and other evil stuff requiring an evil event loop."""
+
+    def get_debug(self):  # to suppress tracebacks
+        return False
+
+    def __del__(self):
+        # Automatically close the evil event loop to avoid warnings.
+        if not self.is_closed() and not self.is_running():
+            self.close()
+
+
 class DuckFuture:
     # Class that does not inherit from Future but aims to be duck-type
     # compatible with it.
@@ -948,6 +967,7 @@ class BaseFutureDoneCallbackTests():
         fut.remove_done_callback(evil())
 
     def test_evil_call_soon_list_mutation(self):
+        # see: https://github.com/python/cpython/issues/125969
         called_on_fut_callback0 = False
 
         pad = lambda: ...
@@ -962,9 +982,8 @@ class BaseFutureDoneCallbackTests():
             else:
                 called_on_fut_callback0 = True
 
-        fake_event_loop = lambda: ...
+        fake_event_loop = SimpleEvilEventLoop()
         fake_event_loop.call_soon = evil_call_soon
-        fake_event_loop.get_debug = lambda: False  # suppress traceback
 
         with mock.patch.object(self, 'loop', fake_event_loop):
             fut = self._new_future()
@@ -979,6 +998,56 @@ class BaseFutureDoneCallbackTests():
             # When there are no more callbacks, the Python implementation
             # returns an empty list but the C implementation returns None.
             self.assertIn(fut._callbacks, (None, []))
+
+    def test_use_after_free_on_fut_callback_0_with_evil__getattribute__(self):
+        # see: https://github.com/python/cpython/issues/125984
+
+        class EvilEventLoop(SimpleEvilEventLoop):
+            def call_soon(self, callback, *args, context=None):
+                super().call_soon(callback, *args, context=context)
+                raise ReachableCode
+
+            def __getattribute__(self, name):
+                nonlocal fut_callback_0
+                if name == 'call_soon':
+                    fut.remove_done_callback(fut_callback_0)
+                    del fut_callback_0
+                return object.__getattribute__(self, name)
+
+        evil_loop = EvilEventLoop()
+        with mock.patch.object(self, 'loop', evil_loop):
+            fut = self._new_future()
+            self.assertIs(fut.get_loop(), evil_loop)
+
+            fut_callback_0 = lambda: ...
+            fut.add_done_callback(fut_callback_0)
+            self.assertRaises(ReachableCode, fut.set_result, "boom")
+
+    def test_use_after_free_on_fut_context_0_with_evil__getattribute__(self):
+        # see: https://github.com/python/cpython/issues/125984
+
+        class EvilEventLoop(SimpleEvilEventLoop):
+            def call_soon(self, callback, *args, context=None):
+                super().call_soon(callback, *args, context=context)
+                raise ReachableCode
+
+            def __getattribute__(self, name):
+                if name == 'call_soon':
+                    # resets the future's event loop
+                    fut.__init__(loop=SimpleEvilEventLoop())
+                return object.__getattribute__(self, name)
+
+        evil_loop = EvilEventLoop()
+        with mock.patch.object(self, 'loop', evil_loop):
+            fut = self._new_future()
+            self.assertIs(fut.get_loop(), evil_loop)
+
+            fut_callback_0 = mock.Mock()
+            fut_context_0 = mock.Mock()
+            fut.add_done_callback(fut_callback_0, context=fut_context_0)
+            del fut_context_0
+            del fut_callback_0
+            self.assertRaises(ReachableCode, fut.set_result, "boom")
 
 
 @unittest.skipUnless(hasattr(futures, '_CFuture'),

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -1003,8 +1003,8 @@ class BaseFutureDoneCallbackTests():
         # see: https://github.com/python/cpython/issues/125984
 
         class EvilEventLoop(SimpleEvilEventLoop):
-            def call_soon(self, callback, *args, context=None):
-                super().call_soon(callback, *args, context=context)
+            def call_soon(self, *args, **kwargs):
+                super().call_soon(*args, **kwargs)
                 raise ReachableCode
 
             def __getattribute__(self, name):
@@ -1027,8 +1027,8 @@ class BaseFutureDoneCallbackTests():
         # see: https://github.com/python/cpython/issues/125984
 
         class EvilEventLoop(SimpleEvilEventLoop):
-            def call_soon(self, callback, *args, context=None):
-                super().call_soon(callback, *args, context=context)
+            def call_soon(self, *args, **kwargs):
+                super().call_soon(*args, **kwargs)
                 raise ReachableCode
 
             def __getattribute__(self, name):

--- a/Misc/NEWS.d/next/Library/2024-10-26-12-50-48.gh-issue-125984.d4vp5_.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-26-12-50-48.gh-issue-125984.d4vp5_.rst
@@ -1,0 +1,3 @@
+Fix use-after-free crashes on :class:`asyncio.Future` objects for which the
+underlying event loop implements an evil :meth:`~object.__getattribute__`.
+Reported by Nico-Posada. Patch by Bénédikt Tran.


### PR DESCRIPTION
Minimal PoCs:

```py
import asyncio

class EvilLoop:
	def call_soon(self, *args, **kwargs):
		print(1)  # crashes just after printing

    def get_debug(self):
        return False

    def __getattribute__(self, name):
        global tracker
        if name == "call_soon":
            fut.remove_done_callback(tracker)
            del tracker
        return object.__getattribute__(self, name)

fut = asyncio.Future(loop=EvilLoop())
tracker = lambda: ...
fut.add_done_callback(tracker)
fut.set_result("boom")
```

and

```py
import asyncio

class EvilLoop:
	def call_soon(self, *args, **kwargs):
		raise Exception("unreachable")

    def get_debug(self):
        return False

    def __getattribute__(self, name):
        if name == "call_soon":
            x = lambda: ...
            x.get_debug = lambda: False
            fut.__init__(loop=x)
        return object.__getattribute__(self, name)

fut = asyncio.Future(loop=EvilLoop())
cb, ctx = lambda: ..., lambda: ...
fut.add_done_callback(cb, context=ctx)
del cb, ctx
fut.set_result("kaboom")
```

Note that depending on how the PoC is written, the crash may happen at interpreter shutdown instead. The above PoCs are a bit different from the original ones and from the ones in the tests though, but I've confirmed that without the ownership transfer, all PoCs crash.

cc @Nico-Posada

<!-- gh-issue-number: gh-125984 -->
* Issue: gh-125984
<!-- /gh-issue-number -->
