### PR TITLE
gh-126022: Docs: fix URL redirect for Zope Corporation

### DIFF
--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -21,8 +21,8 @@ Virginia where he released several versions of the software.
 
 In May 2000, Guido and the Python core development team moved to BeOpen.com to
 form the BeOpen PythonLabs team.  In October of the same year, the PythonLabs
-team moved to Digital Creations (now Zope Corporation; see
-https://www.zope.org/).  In 2001, the Python Software Foundation (PSF, see
+team moved to Digital Creations (now Zope Corporation; see https://zope.dev).
+In 2001, the Python Software Foundation (PSF, see
 https://www.python.org/psf/) was formed, a non-profit organization created
 specifically to own Python-related Intellectual Property.  Zope Corporation is a
 sponsoring member of the PSF.


### PR DESCRIPTION
Zope corporation's website is currently zope.dev

this pull requests updates the URL from zope.org to zope.dev

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126011.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-126022 -->
* Issue: gh-126022
<!-- /gh-issue-number -->
