### PR TITLE
gh-126018: Avoid aborting due to unnecessary assert in `sys.audit`

### DIFF
--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -567,6 +567,15 @@ def test_winapi_createnamedpipe(pipe_name):
     _winapi.CreateNamedPipe(pipe_name, _winapi.PIPE_ACCESS_DUPLEX, 8, 2, 0, 0, 0, 0)
 
 
+def test_assert_unicode():
+    import sys
+    sys.addaudithook(lambda *args: None)
+    try:
+        sys.audit(9)
+    except:
+        pass
+
+
 if __name__ == "__main__":
     from test.support import suppress_msvcrt_asserts
 

--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -572,7 +572,7 @@ def test_assert_unicode():
     sys.addaudithook(lambda *args: None)
     try:
         sys.audit(9)
-    except:
+    except TypeError:
         pass
 
 

--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -574,6 +574,8 @@ def test_assert_unicode():
         sys.audit(9)
     except TypeError:
         pass
+    else:
+        raise RuntimeError("Expected sys.audit(9) to fail.")
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -308,6 +308,7 @@ class AuditTest(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_assert_unicode(self):
+        # See gh-126018
         returncode, _, stderr = self.run_python("test_assert_unicode")
         if returncode:
             self.fail(stderr)

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -307,5 +307,11 @@ class AuditTest(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
+    def test_assert_unicode(self):
+        returncode, events, stderr = self.run_python("test_assert_unicode")
+        if returncode:
+            self.fail(stderr)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -308,7 +308,7 @@ class AuditTest(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_assert_unicode(self):
-        returncode, events, stderr = self.run_python("test_assert_unicode")
+        returncode, _, stderr = self.run_python("test_assert_unicode")
         if returncode:
             self.fail(stderr)
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-10-26-23-50-03.gh-issue-126018.Hq-qcM.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-10-26-23-50-03.gh-issue-126018.Hq-qcM.rst
@@ -1,1 +1,2 @@
-Fix a crash in :func:`sys.audit` when passing a non-string as first argument.
+Fix a crash in :func:`sys.audit` when passing a non-string as first argument
+and Python was compiled in debug mode.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-10-26-23-50-03.gh-issue-126018.Hq-qcM.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-10-26-23-50-03.gh-issue-126018.Hq-qcM.rst
@@ -1,0 +1,1 @@
+Fix a crash in :func:`sys.audit` when passing a non-string as first argument.

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -519,7 +519,6 @@ sys_audit(PyObject *self, PyObject *const *args, Py_ssize_t argc)
     }
 
     assert(args[0] != NULL);
-    assert(PyUnicode_Check(args[0]));
 
     if (!should_audit(tstate->interp)) {
         Py_RETURN_NONE;


### PR DESCRIPTION
This PR removes an assert in `sysmodule.c` that caused the interpreter to abort when `sys.audit` received a non-string as first argument.

Without this assert, the code that runs the hooks will raise an exception instead.

<!-- gh-issue-number: gh-126018 -->
* Issue: gh-126018
<!-- /gh-issue-number -->
