### PR TITLE
gh-125873: Improve error message when PYTHONHOME is invalid

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-10-27-22-23-57.gh-issue-125873.BG97KU.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-10-27-22-23-57.gh-issue-125873.BG97KU.rst
@@ -1,1 +1,1 @@
-Improved error message when ``PYTHONHOME`` is invalid.
+Improved error message when an environment variable is misonfigured.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-10-27-22-23-57.gh-issue-125873.BG97KU.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-10-27-22-23-57.gh-issue-125873.BG97KU.rst
@@ -1,1 +1,1 @@
-Improved error message when an environment variable is misonfigured.
+Improved error message when an environment variable is misconfigured.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-10-27-22-23-57.gh-issue-125873.BG97KU.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-10-27-22-23-57.gh-issue-125873.BG97KU.rst
@@ -1,0 +1,1 @@
+Improved error message when ``PYTHONHOME`` is invalid.

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -1526,7 +1526,7 @@ _PyCodec_InitRegistry(PyInterpreterState *interp)
     // search functions, so this is done after everything else is initialized.
     PyObject *mod = PyImport_ImportModule("encodings");
     if (mod == NULL) {
-        return PyStatus_Error("Failed to import encodings module");
+        return PyStatus_Error("Failed to import encodings module. Are you sure PYTHONHOME is correct?");
     }
     Py_DECREF(mod);
 

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -1526,7 +1526,7 @@ _PyCodec_InitRegistry(PyInterpreterState *interp)
     // search functions, so this is done after everything else is initialized.
     PyObject *mod = PyImport_ImportModule("encodings");
     if (mod == NULL) {
-        return PyStatus_Error("Failed to import encodings module. Are you sure PYTHONHOME is correct?");
+        return PyStatus_Error("Failed to import encodings module. Your environment probably has misconfigured variables!");
     }
     Py_DECREF(mod);
 

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -1526,7 +1526,9 @@ _PyCodec_InitRegistry(PyInterpreterState *interp)
     // search functions, so this is done after everything else is initialized.
     PyObject *mod = PyImport_ImportModule("encodings");
     if (mod == NULL) {
-        return PyStatus_Error("Failed to import encodings module. Your environment probably has misconfigured variables! Please refer to `--help-env`");
+        return PyStatus_Error("Failed to import encodings module. "
+                              "Your environment probably has misconfigured variables! "
+                              "Please check PYTHONHOME otherwise refer to `--help-env`");
     }
     Py_DECREF(mod);
 

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -1526,7 +1526,7 @@ _PyCodec_InitRegistry(PyInterpreterState *interp)
     // search functions, so this is done after everything else is initialized.
     PyObject *mod = PyImport_ImportModule("encodings");
     if (mod == NULL) {
-        return PyStatus_Error("Failed to import encodings module. Your environment probably has misconfigured variables!");
+        return PyStatus_Error("Failed to import encodings module. Your environment probably has misconfigured variables! Please refer to `--help-env`");
     }
     Py_DECREF(mod);
 


### PR DESCRIPTION
* Issue: gh-125873

## Summary

Improves the error message shown when the `encodings` module fails to import due to a misconfigured `PYTHONHOME` environment variable.

**Before:** `Failed to import encodings module`  
**After:** `Failed to import encodings module. Your environment probably has misconfigured variables! Please check PYTHONHOME otherwise refer to --help-env`

The new message gives users an actionable next step instead of a bare failure notice, which was particularly unhelpful since this error almost always means `PYTHONHOME` is set to an invalid path.

A NEWS entry is included under `Core_and_Builtins`.