### PR TITLE
gh-111495: improve test coverage of codecs C API

### DIFF
--- a/Lib/test/test_capi/test_codecs.py
+++ b/Lib/test/test_capi/test_codecs.py
@@ -878,8 +878,8 @@ class CAPICodecErrors(unittest.TestCase):
 
     @classmethod
     def _exception_may_crash(cls, exc):
-        """Indicate whether a Unicode exception may crash the interpreter
-        when used by a built-in codecs error handler.
+        """Indicate whether a Unicode exception might currently crash
+        the interpreter when used by a built-in codecs error handler.
 
         Until gh-123378 is fixed, we skip the tests for these exceptions.
 

--- a/Lib/test/test_capi/test_codecs.py
+++ b/Lib/test/test_capi/test_codecs.py
@@ -7,7 +7,6 @@ import unittest
 import unittest.mock as mock
 import _testcapi
 from test.support import import_helper
-from test.support.script_helper import assert_python_failure
 
 _testlimitedcapi = import_helper.import_module('_testlimitedcapi')
 

--- a/Lib/test/test_capi/test_codecs.py
+++ b/Lib/test/test_capi/test_codecs.py
@@ -881,6 +881,8 @@ class CAPICodecErrors(unittest.TestCase):
         """Indicate whether a Unicode exception may crash the interpreter
         when used by a built-in codecs error handler.
 
+        Until gh-123378 is fixed, we skip the tests for these exceptions.
+
         This should only be used by "do_test_codec_errors_handler".
         """
         message, start, end = exc.object, exc.start, exc.end


### PR DESCRIPTION
I found out that not all handlers were tested and that there was a way to check which exceptions are currently crashing. Note that I *must* determine whether the exception will make the handler crash directly in the Python code because if I access the attributes, I'll be using a buggy version (see https://github.com/python/cpython/issues/123378).

I'd like to first update the tests and then fix the handlers one by one. As I said in https://github.com/python/cpython/issues/123378#issuecomment-2429127588 and https://github.com/python/cpython/issues/123378#issuecomment-2439924914, just fixing the getters is not sufficient. I haven't sufficiently in the handlers themselves, but one assertion makes the replace errors handler crash so it wouldn't help just fixing the getters.

We really need to decide how to handle the start and end values of unicode errors in general but let's discuss it on https://github.com/python/cpython/issues/123378.

<!-- gh-issue-number: gh-111495 -->
* Issue: gh-111495
<!-- /gh-issue-number -->
