### PR TITLE
gh-94521: IDLE: Auto-select and copy/cut current line if no selection on copy/cut

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -583,6 +583,13 @@ email
 * Remove the *isdst* parameter from :func:`email.utils.localtime`.
   (Contributed by Hugo van Kemenade in :gh:`118798`.)
 
+idlelib and IDLE
+----------------
+
+* While doing copy/cut a empty selection, the current line will be selected
+  and copied/cut automatically.
+  (Contributed by Jiahao Li in :gh:`94521`.)
+
 importlib
 ---------
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -587,7 +587,7 @@ idlelib and IDLE
 ----------------
 
 * If no selection is made during copy/cut, the current line will
-  copied/cut automatically.
+  copy/cut automatically.
   (Contributed by Jiahao Li in :gh:`94521`.)
 
 importlib

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -319,6 +319,14 @@ http
   (Contributed by Yorik Hansen in :gh:`123430`.)
 
 
+idlelib and IDLE
+----------------
+
+* If no selection is made during copy/cut, the current line will
+  copy/cut automatically.
+  (Contributed by Jiahao Li in :gh:`94521`.)
+
+
 inspect
 -------
 
@@ -582,13 +590,6 @@ email
 
 * Remove the *isdst* parameter from :func:`email.utils.localtime`.
   (Contributed by Hugo van Kemenade in :gh:`118798`.)
-
-idlelib and IDLE
-----------------
-
-* If no selection is made during copy/cut, the current line will
-  copy/cut automatically.
-  (Contributed by Jiahao Li in :gh:`94521`.)
 
 importlib
 ---------

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -586,8 +586,8 @@ email
 idlelib and IDLE
 ----------------
 
-* While doing copy/cut a empty selection, the current line will be selected
-  and copied/cut automatically.
+* If no selection is made during copy/cut, the current line will
+  copied/cut automatically.
   (Contributed by Jiahao Li in :gh:`94521`.)
 
 importlib

--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -1,6 +1,15 @@
+What's New in IDLE 3.14.0
+(since 3.13.0)
+Released on 2025-10-xx
+=========================
+
+
+gh-94521: While doing copy/cut a empty selection, the current line will
+be selected and copied/cut automatically.
+
 What's New in IDLE 3.13.0
 (since 3.12.0)
-Released on 2024-10-xx
+Released on 2024-10-07
 =========================
 
 

--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -5,7 +5,7 @@ Released on 2025-10-xx
 
 
 gh-94521: If no selection is made during copy/cut, the current line
-will copied/cut automatically.
+will copy/cut automatically.
 
 What's New in IDLE 3.13.0
 (since 3.12.0)

--- a/Lib/idlelib/News3.txt
+++ b/Lib/idlelib/News3.txt
@@ -4,8 +4,8 @@ Released on 2025-10-xx
 =========================
 
 
-gh-94521: While doing copy/cut a empty selection, the current line will
-be selected and copied/cut automatically.
+gh-94521: If no selection is made during copy/cut, the current line
+will copied/cut automatically.
 
 What's New in IDLE 3.13.0
 (since 3.12.0)

--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -7,6 +7,7 @@ import tokenize
 
 from tkinter import filedialog
 from tkinter import messagebox
+from tkinter import TclError
 from tkinter.simpledialog import askstring  # loadfile encoding.
 
 from idlelib.config import idleConf
@@ -33,6 +34,8 @@ class IOBinding:
                                             self.save_a_copy)
         self.fileencoding = 'utf-8'
         self.__id_print = self.text.bind("<<print-window>>", self.print_window)
+        self.__id_copy = self.text.bind("<<copy>>", self.copy)
+        self.__id_cut = self.text.bind("<<cut>>", self.cut)
 
     def close(self):
         # Undo command bindings
@@ -41,6 +44,8 @@ class IOBinding:
         self.text.unbind("<<save-window-as-file>>",self.__id_saveas)
         self.text.unbind("<<save-copy-of-window-as-file>>", self.__id_savecopy)
         self.text.unbind("<<print-window>>", self.__id_print)
+        self.text.unbind("<<copy>>", self.__id_copy)
+        self.text.unbind("<<cut>>", self.__id_cut)
         # Break cycles
         self.editwin = None
         self.text = None
@@ -346,6 +351,20 @@ class IOBinding:
             messagebox.showinfo("Print status", message, parent=self.text)
         if tempfilename:
             os.unlink(tempfilename)
+        return "break"
+
+    def copy(self, event):
+        if not self.text.tag_ranges("sel"):
+            self.text.tag_add("sel", "insert linestart", "insert+1l linestart")
+            self.text.mark_set("insert", "insert linestart")
+        self.text.event_generate("<<Copy>>")
+        return "break"
+
+    def cut(self, event):
+        if not self.text.tag_ranges("sel"):
+            self.text.tag_add("sel", "insert linestart", "insert+1l linestart")
+            self.text.mark_set("insert", "insert linestart")
+        self.text.event_generate("<<Cut>>")
         return "break"
 
     opendialog = None

--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -7,7 +7,6 @@ import tokenize
 
 from tkinter import filedialog
 from tkinter import messagebox
-from tkinter import TclError
 from tkinter.simpledialog import askstring  # loadfile encoding.
 
 from idlelib.config import idleConf

--- a/Misc/NEWS.d/next/IDLE/2024-10-27-20-17-54.gh-issue-94521.XEFTrz.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-10-27-20-17-54.gh-issue-94521.XEFTrz.rst
@@ -1,2 +1,2 @@
-If no selection is made during copy/cut, the current line will copied/cut
+If no selection is made during copy/cut, the current line will copy/cut
 automatically.

--- a/Misc/NEWS.d/next/IDLE/2024-10-27-20-17-54.gh-issue-94521.XEFTrz.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-10-27-20-17-54.gh-issue-94521.XEFTrz.rst
@@ -1,2 +1,2 @@
-While doing copy/cut a empty selection, the current line will be selected
-and copied/cut automatically.
+If no selection is made during copy/cut, the current line will copied/cut
+automatically.

--- a/Misc/NEWS.d/next/IDLE/2024-10-27-20-17-54.gh-issue-94521.XEFTrz.rst
+++ b/Misc/NEWS.d/next/IDLE/2024-10-27-20-17-54.gh-issue-94521.XEFTrz.rst
@@ -1,0 +1,2 @@
+While doing copy/cut a empty selection, the current line will be selected
+and copied/cut automatically.


### PR DESCRIPTION
In now IDLE, unselected text copy and paste will only add a space (no sense I think). After my test,  this feature also available in VScode, should be common, and will improve the using experience

Feature preview video:

https://github.com/user-attachments/assets/e0f7b9d1-a30c-434b-b006-ea01bbea90a6



<!-- gh-issue-number: gh-94521 -->
* Issue: gh-94521
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126034.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->