### PR TITLE
gh-126035: add missing whitespace to `*Py_EnterRecursiveCall` messages

### DIFF
--- a/Modules/_bisectmodule.c
+++ b/Modules/_bisectmodule.c
@@ -70,7 +70,7 @@ internal_bisect_right(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t 
     if (sq_item == NULL) {
         return -1;
     }
-    if (Py_EnterRecursiveCall("in _bisect.bisect_right")) {
+    if (Py_EnterRecursiveCall(" in _bisect.bisect_right")) {
         return -1;
     }
     PyTypeObject *tp = Py_TYPE(item);
@@ -254,7 +254,7 @@ internal_bisect_left(PyObject *list, PyObject *item, Py_ssize_t lo, Py_ssize_t h
     if (sq_item == NULL) {
         return -1;
     }
-    if (Py_EnterRecursiveCall("in _bisect.bisect_left")) {
+    if (Py_EnterRecursiveCall(" in _bisect.bisect_left")) {
         return -1;
     }
     PyTypeObject *tp = Py_TYPE(item);

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2425,7 +2425,7 @@ PyCSimpleType_from_param_impl(PyObject *type, PyTypeObject *cls,
         return NULL;
     }
     if (as_parameter) {
-        if (_Py_EnterRecursiveCall("while processing _as_parameter_")) {
+        if (_Py_EnterRecursiveCall(" while processing _as_parameter_")) {
             Py_DECREF(as_parameter);
             Py_XDECREF(exc);
             return NULL;


### PR DESCRIPTION
I don't know how to test it easily though so if anyone knows, feel free to help me! (or we can just observe that all other occurrences are prefixing the message with a whitespace and be done).

<!-- gh-issue-number: gh-126035 -->
* Issue: gh-126035
<!-- /gh-issue-number -->
