### PR TITLE
Align functools.reduce() docstring with PEP-257

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -240,7 +240,7 @@ def reduce(function, sequence, initial=_initial_missing):
 
     Apply a function of two arguments cumulatively to an iterable, from left to right.
 
-    This efficiently reduces the iterable to a single value.  If initial is present,
+    This effectively reduces the iterable to a single value.  If initial is present,
     it is placed before the items of the iterable in the calculation, and serves as
     a default when the iterable is empty.
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -238,7 +238,7 @@ def reduce(function, sequence, initial=_initial_missing):
     """
     reduce(function, iterable[, initial], /) -> value
 
-    Apply a function of two arguments cumulatively to an iterable, from left to right.
+    Apply a function of two arguments cumulatively to the items of an iterable, from left to right.
 
     This effectively reduces the iterable to a single value.  If initial is present,
     it is placed before the items of the iterable in the calculation, and serves as

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -238,12 +238,14 @@ def reduce(function, sequence, initial=_initial_missing):
     """
     reduce(function, iterable[, initial], /) -> value
 
-    Apply a function of two arguments cumulatively to the items of a sequence
-    or iterable, from left to right, so as to reduce the iterable to a single
-    value.  For example, reduce(lambda x, y: x+y, [1, 2, 3, 4, 5]) calculates
-    ((((1+2)+3)+4)+5).  If initial is present, it is placed before the items
-    of the iterable in the calculation, and serves as a default when the
-    iterable is empty.
+    Apply a function of two arguments cumulatively to an iterable, from left to right.
+
+    This efficiently reduces the iterable to a single value.  If initial is present,
+    it is placed before the items of the iterable in the calculation, and serves as
+    a default when the iterable is empty.
+
+    For example, reduce(lambda x, y: x+y, [1, 2, 3, 4, 5])
+    calculates ((((1 + 2) + 3) + 4) + 5).
     """
 
     it = iter(sequence)

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1011,7 +1011,7 @@ PyDoc_STRVAR(functools_reduce_doc,
 \n\
 Apply a function of two arguments cumulatively to an iterable, from left to right.\n\
 \n\
-This efficiently reduces the iterable to a single value.  If initial is present,\n\
+This effectively reduces the iterable to a single value.  If initial is present,\n\
 it is placed before the items of the iterable in the calculation, and serves as\n\
 a default when the iterable is empty.\n\
 \n\

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1009,7 +1009,7 @@ Fail:
 PyDoc_STRVAR(functools_reduce_doc,
 "reduce(function, iterable[, initial], /) -> value\n\
 \n\
-Apply a function of two arguments cumulatively to an iterable, from left to right.\n\
+Apply a function of two arguments cumulatively to the items of an iterable, from left to right.\n\
 \n\
 This effectively reduces the iterable to a single value.  If initial is present,\n\
 it is placed before the items of the iterable in the calculation, and serves as\n\

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1009,12 +1009,14 @@ Fail:
 PyDoc_STRVAR(functools_reduce_doc,
 "reduce(function, iterable[, initial], /) -> value\n\
 \n\
-Apply a function of two arguments cumulatively to the items of a sequence\n\
-or iterable, from left to right, so as to reduce the iterable to a single\n\
-value.  For example, reduce(lambda x, y: x+y, [1, 2, 3, 4, 5]) calculates\n\
-((((1+2)+3)+4)+5).  If initial is present, it is placed before the items\n\
-of the iterable in the calculation, and serves as a default when the\n\
-iterable is empty.");
+Apply a function of two arguments cumulatively to an iterable, from left to right.\n\
+\n\
+This efficiently reduces the iterable to a single value.  If initial is present,\n\
+it is placed before the items of the iterable in the calculation, and serves as\n\
+a default when the iterable is empty.\n\
+\n\
+For example, reduce(lambda x, y: x+y, [1, 2, 3, 4, 5])\n\
+calculates ((((1 + 2) + 3) + 4) + 5).");
 
 /* lru_cache object **********************************************************/
 


### PR DESCRIPTION
PEP 257 says that "Multi-line docstrings consist of a summary line just like a one-line docstring, followed by a blank line, followed by a more elaborate description."  This is also a requirement from the Argument Clinic.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
