### PR TITLE
gh-126049: Updated Parser/Token.c to unnest switch statements

### DIFF
--- a/Include/internal/pycore_token.h
+++ b/Include/internal/pycore_token.h
@@ -96,36 +96,6 @@ extern "C" {
 #define GENERATE_2CHAR_CODE(x, y) ((int)((x) << 8 | (y)))
 #define GENERATE_3CHAR_CODE(x, y, z) ((int)((x) << 16 | (y) << 8 | (z)))
 
-
-// The code is a 16-bit integer with the first character in the high byte and the second character in the low byte.
-#define NOTEQUAL_CODE GENERATE_2CHAR_CODE('!', '=')
-#define PERCENTEQUAL_CODE GENERATE_2CHAR_CODE('%', '=')
-#define AMPEREQUAL_CODE GENERATE_2CHAR_CODE('&', '=')
-#define DOUBLESTAR_CODE GENERATE_2CHAR_CODE('*', '*')
-#define STAREQUAL_CODE GENERATE_2CHAR_CODE('*', '=')
-#define PLUSEQUAL_CODE GENERATE_2CHAR_CODE('+', '=')
-#define MINEQUAL_CODE GENERATE_2CHAR_CODE('-', '=')
-#define RARROW_CODE GENERATE_2CHAR_CODE('-', '>')
-#define DOUBLESLASH_CODE GENERATE_2CHAR_CODE('/', '/')
-#define SLASHEQUAL_CODE GENERATE_2CHAR_CODE('/', '=')
-#define COLONEQUAL_CODE GENERATE_2CHAR_CODE(':', '=')
-#define LEFTSHIFT_CODE GENERATE_2CHAR_CODE('<', '<')
-#define LESSEQUAL_CODE GENERATE_2CHAR_CODE('<', '=')
-#define NOTEQUAL_2_CODE GENERATE_2CHAR_CODE('<', '>')
-#define EQEQUAL_CODE GENERATE_2CHAR_CODE('=', '=')
-#define GREATEREQUAL_CODE GENERATE_2CHAR_CODE('>', '=')
-#define RIGHTSHIFT_CODE GENERATE_2CHAR_CODE('>', '>')
-#define ATEQUAL_CODE GENERATE_2CHAR_CODE('@', '=')
-#define CIRCUMFLEXEQUAL_CODE GENERATE_2CHAR_CODE('^', '=')
-#define VBAREQUAL_CODE GENERATE_2CHAR_CODE('|', '=')
-
-// The code is a 24-bit integer with the first character in the high byte, the second character in the middle byte, and the third character in the low byte.
-#define DOUBLESTAREQUAL_CODE GENERATE_3CHAR_CODE('*', '*', '=')
-#define ELLIPSIS_CODE GENERATE_3CHAR_CODE('.', '.', '.')
-#define DOUBLESLASHEQUAL_CODE GENERATE_3CHAR_CODE('/', '/', '=')
-#define LEFTSHIFTEQUAL_CODE GENERATE_3CHAR_CODE('<', '<', '=')
-#define RIGHTSHIFTEQUAL_CODE GENERATE_3CHAR_CODE('>', '>', '=')
-
 // Export these 4 symbols for 'test_peg_generator'
 PyAPI_DATA(const char * const) _PyParser_TokenNames[]; /* Token names */
 PyAPI_FUNC(int) _PyToken_OneChar(int);

--- a/Include/internal/pycore_token.h
+++ b/Include/internal/pycore_token.h
@@ -93,8 +93,8 @@ extern "C" {
 #define ISSTRINGLIT(x)          ((x) == STRING           || \
                                  (x) == FSTRING_MIDDLE)
 
-#define GENERATE_2CHAR_CODE(x, y) ((int)((x) << 8 | (y)))
-#define GENERATE_3CHAR_CODE(x, y, z) ((int)((x) << 16 | (y) << 8 | (z)))
+#define GENERATE_2CHAR_CODE(x, y) ((int)((x) << 8 | (y))) // Generate a 16-bit integer from 2 8-bit characters
+#define GENERATE_3CHAR_CODE(x, y, z) ((int)((x) << 16 | (y) << 8 | (z))) // Generate a 24-bit integer from 3 8-bit characters
 
 // Export these 4 symbols for 'test_peg_generator'
 PyAPI_DATA(const char * const) _PyParser_TokenNames[]; /* Token names */

--- a/Include/internal/pycore_token.h
+++ b/Include/internal/pycore_token.h
@@ -93,6 +93,38 @@ extern "C" {
 #define ISSTRINGLIT(x)          ((x) == STRING           || \
                                  (x) == FSTRING_MIDDLE)
 
+#define GENERATE_2CHAR_CODE(x, y) ((int)((x) << 8 | (y)))
+#define GENERATE_3CHAR_CODE(x, y, z) ((int)((x) << 16 | (y) << 8 | (z)))
+
+
+// The code is a 16-bit integer with the first character in the high byte and the second character in the low byte.
+#define NOTEQUAL_CODE GENERATE_2CHAR_CODE('!', '=')
+#define PERCENTEQUAL_CODE GENERATE_2CHAR_CODE('%', '=')
+#define AMPEREQUAL_CODE GENERATE_2CHAR_CODE('&', '=')
+#define DOUBLESTAR_CODE GENERATE_2CHAR_CODE('*', '*')
+#define STAREQUAL_CODE GENERATE_2CHAR_CODE('*', '=')
+#define PLUSEQUAL_CODE GENERATE_2CHAR_CODE('+', '=')
+#define MINEQUAL_CODE GENERATE_2CHAR_CODE('-', '=')
+#define RARROW_CODE GENERATE_2CHAR_CODE('-', '>')
+#define DOUBLESLASH_CODE GENERATE_2CHAR_CODE('/', '/')
+#define SLASHEQUAL_CODE GENERATE_2CHAR_CODE('/', '=')
+#define COLONEQUAL_CODE GENERATE_2CHAR_CODE(':', '=')
+#define LEFTSHIFT_CODE GENERATE_2CHAR_CODE('<', '<')
+#define LESSEQUAL_CODE GENERATE_2CHAR_CODE('<', '=')
+#define NOTEQUAL_2_CODE GENERATE_2CHAR_CODE('<', '>')
+#define EQEQUAL_CODE GENERATE_2CHAR_CODE('=', '=')
+#define GREATEREQUAL_CODE GENERATE_2CHAR_CODE('>', '=')
+#define RIGHTSHIFT_CODE GENERATE_2CHAR_CODE('>', '>')
+#define ATEQUAL_CODE GENERATE_2CHAR_CODE('@', '=')
+#define CIRCUMFLEXEQUAL_CODE GENERATE_2CHAR_CODE('^', '=')
+#define VBAREQUAL_CODE GENERATE_2CHAR_CODE('|', '=')
+
+// The code is a 24-bit integer with the first character in the high byte, the second character in the middle byte, and the third character in the low byte.
+#define DOUBLESTAREQUAL_CODE GENERATE_3CHAR_CODE('*', '*', '=')
+#define ELLIPSIS_CODE GENERATE_3CHAR_CODE('.', '.', '.')
+#define DOUBLESLASHEQUAL_CODE GENERATE_3CHAR_CODE('/', '/', '=')
+#define LEFTSHIFTEQUAL_CODE GENERATE_3CHAR_CODE('<', '<', '=')
+#define RIGHTSHIFTEQUAL_CODE GENERATE_3CHAR_CODE('>', '>', '=')
 
 // Export these 4 symbols for 'test_peg_generator'
 PyAPI_DATA(const char * const) _PyParser_TokenNames[]; /* Token names */

--- a/Parser/token.c
+++ b/Parser/token.c
@@ -109,30 +109,36 @@ _PyToken_OneChar(int c1)
     return OP;
 }
 
-#define NOTEQUAL_CODE (int)('!' << 8 | '=')
-#define PERCENTEQUAL_CODE (int)('%' << 8 | '=')
-#define AMPEREQUAL_CODE (int)('&' << 8 | '=')
-#define DOUBLESTAR_CODE (int)('*' << 8 | '*')
-#define STAREQUAL_CODE (int)('*' << 8 | '=')
-#define PLUSEQUAL_CODE (int)('+' << 8 | '=')
-#define MINEQUAL_CODE (int)('-' << 8 | '=')
-#define RARROW_CODE (int)('-' << 8 | '>')
-#define DOUBLESLASH_CODE (int)('/' << 8 | '/')
-#define SLASHEQUAL_CODE (int)('/' << 8 | '=')
-#define COLONEQUAL_CODE (int)(':' << 8 | '=')
-#define LEFTSHIFT_CODE (int)('<' << 8 | '<')
-#define LESSEQUAL_CODE (int)('<' << 8 | '=')
-#define EQEQUAL_CODE (int)('=' << 8 | '=')
-#define GREATEREQUAL_CODE (int)('>' << 8 | '=')
-#define RIGHTSHIFT_CODE (int)('>' << 8 | '>')
-#define ATEQUAL_CODE (int)('@' << 8 | '=')
-#define CIRCUMFLEXEQUAL_CODE (int)('^' << 8 | '=')
-#define VBAREQUAL_CODE (int)('|' << 8 | '=')
+// Return the token corresponding to two tokens
+// The code is a 16-bit integer with the first character in the high byte and the second character in the low byte.
+#define NOTEQUAL_CODE (int)('!' << 8 | '=') // !=
+#define PERCENTEQUAL_CODE (int)('%' << 8 | '=') // %=
+#define AMPEREQUAL_CODE (int)('&' << 8 | '=') // &=
+#define DOUBLESTAR_CODE (int)('*' << 8 | '*') // **
+#define STAREQUAL_CODE (int)('*' << 8 | '=') // *=
+#define PLUSEQUAL_CODE (int)('+' << 8 | '=') // +=
+#define MINEQUAL_CODE (int)('-' << 8 | '=') // -=
+#define RARROW_CODE (int)('-' << 8 | '>') // ->
+#define DOUBLESLASH_CODE (int)('/' << 8 | '/') // //
+#define SLASHEQUAL_CODE (int)('/' << 8 | '=') // /=
+#define COLONEQUAL_CODE (int)(':' << 8 | '=') // :=
+#define LEFTSHIFT_CODE (int)('<' << 8 | '<') // <<
+#define LESSEQUAL_CODE (int)('<' << 8 | '=') // <=
+#define EQEQUAL_CODE (int)('=' << 8 | '=') // ==
+#define GREATEREQUAL_CODE (int)('>' << 8 | '=') // >=
+#define RIGHTSHIFT_CODE (int)('>' << 8 | '>') // >>
+#define ATEQUAL_CODE (int)('@' << 8 | '=') // @=
+#define CIRCUMFLEXEQUAL_CODE (int)('^' << 8 | '=') // ^=
+#define VBAREQUAL_CODE (int)('|' << 8 | '=') // |=
 
 int
 _PyToken_TwoChars(int c1, int c2)
 {
-    switch (c1 << 8 | c2) {
+    if(c1 > 255 || c2 > 255) { // handle to see if tokens are out of range
+        return OP;
+    }
+
+    switch (c1 << 8 | c2) { // Combine the two tokens into a 16-bit integer
     case NOTEQUAL_CODE: return NOTEQUAL;
     case PERCENTEQUAL_CODE: return PERCENTEQUAL;
     case AMPEREQUAL_CODE: return AMPEREQUAL;
@@ -156,17 +162,23 @@ _PyToken_TwoChars(int c1, int c2)
     return OP;
 }
 
-#define DOUBLESTAREQUAL_CODE (int)('*' << 16 | '*' << 8 | '=')
-#define ELLIPSIS_CODE (int)('.' << 16 | '.' << 8 | '.')
-#define DOUBLESLASHEQUAL_CODE (int)('/' << 16 | '/' << 8 | '=')
-#define LEFTSHIFTEQUAL_CODE (int)('<' << 16 | '<' << 8 | '=')
-#define RIGHTSHIFTEQUAL_CODE (int)('>' << 16 | '>' << 8 | '=')
+// Return the token corresponding to three tokens
+// The code is a 24-bit integer with the first character in the high byte, the second character in the middle byte, and the third character in the low byte.
+#define DOUBLESTAREQUAL_CODE (int)('*' << 16 | '*' << 8 | '=') // **=
+#define ELLIPSIS_CODE (int)('.' << 16 | '.' << 8 | '.') // ...
+#define DOUBLESLASHEQUAL_CODE (int)('/' << 16 | '/' << 8 | '=') // //=
+#define LEFTSHIFTEQUAL_CODE (int)('<' << 16 | '<' << 8 | '=') // <<=
+#define RIGHTSHIFTEQUAL_CODE (int)('>' << 16 | '>' << 8 | '=') // >>=
 
 
 int
 _PyToken_ThreeChars(int c1, int c2, int c3)
 {
-    switch (c1 << 16 | c2 << 8 | c3) {
+    if(c1 > 255 || c2 > 255 || c3 > 255) { // handle to see if tokens are out of range
+        return OP;
+    }
+
+    switch (c1 << 16 | c2 << 8 | c3) { // Combine the three tokens into a 24-bit integer
         case DOUBLESTAREQUAL_CODE: return DOUBLESTAREQUAL;
         case ELLIPSIS_CODE: return ELLIPSIS;
         case DOUBLESLASHEQUAL_CODE: return DOUBLESLASHEQUAL;

--- a/Parser/token.c
+++ b/Parser/token.c
@@ -109,13 +109,11 @@ _PyToken_OneChar(int c1)
     return OP;
 }
 
-
 int
 _PyToken_TwoChars(int c1, int c2)
 {
-    switch (GENERATE_2CHAR_CODE(c1, c2)) { // Combine the two tokens into a 16-bit integer
-        case GENERATE_2CHAR_CODE('!', '='): 
-        case GENERATE_2CHAR_CODE('<', '>'): return NOTEQUAL;
+    switch (GENERATE_2CHAR_CODE(c1, c2)) {
+        case GENERATE_2CHAR_CODE('!', '='): return NOTEQUAL;
         case GENERATE_2CHAR_CODE('%', '='): return PERCENTEQUAL;
         case GENERATE_2CHAR_CODE('&', '='): return AMPEREQUAL;
         case GENERATE_2CHAR_CODE('*', '*'): return DOUBLESTAR;
@@ -128,6 +126,7 @@ _PyToken_TwoChars(int c1, int c2)
         case GENERATE_2CHAR_CODE(':', '='): return COLONEQUAL;
         case GENERATE_2CHAR_CODE('<', '<'): return LEFTSHIFT;
         case GENERATE_2CHAR_CODE('<', '='): return LESSEQUAL;
+        case GENERATE_2CHAR_CODE('<', '>'): return NOTEQUAL;
         case GENERATE_2CHAR_CODE('=', '='): return EQEQUAL;
         case GENERATE_2CHAR_CODE('>', '='): return GREATEREQUAL;
         case GENERATE_2CHAR_CODE('>', '>'): return RIGHTSHIFT;
@@ -138,13 +137,10 @@ _PyToken_TwoChars(int c1, int c2)
     return OP;
 }
 
-
-
-
 int
 _PyToken_ThreeChars(int c1, int c2, int c3)
 {
-    switch (GENERATE_3CHAR_CODE(c1, c2, c3)) { // Combine the three tokens into a 24-bit integer
+    switch (GENERATE_3CHAR_CODE(c1, c2, c3)) {
         case GENERATE_3CHAR_CODE('*', '*', '='): return DOUBLESTAREQUAL;
         case GENERATE_3CHAR_CODE('.', '.', '.'): return ELLIPSIS;
         case GENERATE_3CHAR_CODE('/', '/', '='): return DOUBLESLASHEQUAL;

--- a/Parser/token.c
+++ b/Parser/token.c
@@ -81,30 +81,30 @@ int
 _PyToken_OneChar(int c1)
 {
     switch (c1) {
-    case '!': return EXCLAMATION;
-    case '%': return PERCENT;
-    case '&': return AMPER;
-    case '(': return LPAR;
-    case ')': return RPAR;
-    case '*': return STAR;
-    case '+': return PLUS;
-    case ',': return COMMA;
-    case '-': return MINUS;
-    case '.': return DOT;
-    case '/': return SLASH;
-    case ':': return COLON;
-    case ';': return SEMI;
-    case '<': return LESS;
-    case '=': return EQUAL;
-    case '>': return GREATER;
-    case '@': return AT;
-    case '[': return LSQB;
-    case ']': return RSQB;
-    case '^': return CIRCUMFLEX;
-    case '{': return LBRACE;
-    case '|': return VBAR;
-    case '}': return RBRACE;
-    case '~': return TILDE;
+        case '!': return EXCLAMATION;
+        case '%': return PERCENT;
+        case '&': return AMPER;
+        case '(': return LPAR;
+        case ')': return RPAR;
+        case '*': return STAR;
+        case '+': return PLUS;
+        case ',': return COMMA;
+        case '-': return MINUS;
+        case '.': return DOT;
+        case '/': return SLASH;
+        case ':': return COLON;
+        case ';': return SEMI;
+        case '<': return LESS;
+        case '=': return EQUAL;
+        case '>': return GREATER;
+        case '@': return AT;
+        case '[': return LSQB;
+        case ']': return RSQB;
+        case '^': return CIRCUMFLEX;
+        case '{': return LBRACE;
+        case '|': return VBAR;
+        case '}': return RBRACE;
+        case '~': return TILDE;
     }
     return OP;
 }

--- a/Parser/token.c
+++ b/Parser/token.c
@@ -109,75 +109,47 @@ _PyToken_OneChar(int c1)
     return OP;
 }
 
-// Return the token corresponding to two tokens
-// The code is a 16-bit integer with the first character in the high byte and the second character in the low byte.
-#define NOTEQUAL_CODE (int)('!' << 8 | '=') // !=
-#define PERCENTEQUAL_CODE (int)('%' << 8 | '=') // %=
-#define AMPEREQUAL_CODE (int)('&' << 8 | '=') // &=
-#define DOUBLESTAR_CODE (int)('*' << 8 | '*') // **
-#define STAREQUAL_CODE (int)('*' << 8 | '=') // *=
-#define PLUSEQUAL_CODE (int)('+' << 8 | '=') // +=
-#define MINEQUAL_CODE (int)('-' << 8 | '=') // -=
-#define RARROW_CODE (int)('-' << 8 | '>') // ->
-#define DOUBLESLASH_CODE (int)('/' << 8 | '/') // //
-#define SLASHEQUAL_CODE (int)('/' << 8 | '=') // /=
-#define COLONEQUAL_CODE (int)(':' << 8 | '=') // :=
-#define LEFTSHIFT_CODE (int)('<' << 8 | '<') // <<
-#define LESSEQUAL_CODE (int)('<' << 8 | '=') // <=
-#define NOTEQUAL_OTHER_CODE (int)('<' << 8 | '>') // <>
-#define EQEQUAL_CODE (int)('=' << 8 | '=') // ==
-#define GREATEREQUAL_CODE (int)('>' << 8 | '=') // >=
-#define RIGHTSHIFT_CODE (int)('>' << 8 | '>') // >>
-#define ATEQUAL_CODE (int)('@' << 8 | '=') // @=
-#define CIRCUMFLEXEQUAL_CODE (int)('^' << 8 | '=') // ^=
-#define VBAREQUAL_CODE (int)('|' << 8 | '=') // |=
 
 int
 _PyToken_TwoChars(int c1, int c2)
 {
-    switch (c1 << 8 | c2) { // Combine the two tokens into a 16-bit integer
-        case NOTEQUAL_CODE: 
-        case NOTEQUAL_OTHER_CODE: return NOTEQUAL;
-        case PERCENTEQUAL_CODE: return PERCENTEQUAL;
-        case AMPEREQUAL_CODE: return AMPEREQUAL;
-        case DOUBLESTAR_CODE: return DOUBLESTAR;
-        case STAREQUAL_CODE: return STAREQUAL;
-        case PLUSEQUAL_CODE: return PLUSEQUAL;
-        case MINEQUAL_CODE: return MINEQUAL;
-        case RARROW_CODE: return RARROW;
-        case DOUBLESLASH_CODE: return DOUBLESLASH;
-        case SLASHEQUAL_CODE: return SLASHEQUAL;
-        case COLONEQUAL_CODE: return COLONEQUAL;
-        case LEFTSHIFT_CODE: return LEFTSHIFT;
-        case LESSEQUAL_CODE: return LESSEQUAL;
-        case EQEQUAL_CODE: return EQEQUAL;
-        case GREATEREQUAL_CODE: return GREATEREQUAL;
-        case RIGHTSHIFT_CODE: return RIGHTSHIFT;
-        case ATEQUAL_CODE: return ATEQUAL;
-        case CIRCUMFLEXEQUAL_CODE: return CIRCUMFLEXEQUAL;
-        case VBAREQUAL_CODE: return VBAREQUAL;
+    switch (GENERATE_2CHAR_CODE(c1, c2)) { // Combine the two tokens into a 16-bit integer
+        case GENERATE_2CHAR_CODE('!', '='): 
+        case GENERATE_2CHAR_CODE('<', '>'): return NOTEQUAL;
+        case GENERATE_2CHAR_CODE('%', '='): return PERCENTEQUAL;
+        case GENERATE_2CHAR_CODE('&', '='): return AMPEREQUAL;
+        case GENERATE_2CHAR_CODE('*', '*'): return DOUBLESTAR;
+        case GENERATE_2CHAR_CODE('*', '='): return STAREQUAL;
+        case GENERATE_2CHAR_CODE('+', '='): return PLUSEQUAL;
+        case GENERATE_2CHAR_CODE('-', '='): return MINEQUAL;
+        case GENERATE_2CHAR_CODE('-', '>'): return RARROW;
+        case GENERATE_2CHAR_CODE('/', '/'): return DOUBLESLASH;
+        case GENERATE_2CHAR_CODE('/', '='): return SLASHEQUAL;
+        case GENERATE_2CHAR_CODE(':', '='): return COLONEQUAL;
+        case GENERATE_2CHAR_CODE('<', '<'): return LEFTSHIFT;
+        case GENERATE_2CHAR_CODE('<', '='): return LESSEQUAL;
+        case GENERATE_2CHAR_CODE('=', '='): return EQEQUAL;
+        case GENERATE_2CHAR_CODE('>', '='): return GREATEREQUAL;
+        case GENERATE_2CHAR_CODE('>', '>'): return RIGHTSHIFT;
+        case GENERATE_2CHAR_CODE('@', '='): return ATEQUAL;
+        case GENERATE_2CHAR_CODE('^', '='): return CIRCUMFLEXEQUAL;
+        case GENERATE_2CHAR_CODE('|', '='): return VBAREQUAL;
     }
     return OP;
 }
 
-// Return the token corresponding to three tokens
-// The code is a 24-bit integer with the first character in the high byte, the second character in the middle byte, and the third character in the low byte.
-#define DOUBLESTAREQUAL_CODE (int)('*' << 16 | '*' << 8 | '=') // **=
-#define ELLIPSIS_CODE (int)('.' << 16 | '.' << 8 | '.') // ...
-#define DOUBLESLASHEQUAL_CODE (int)('/' << 16 | '/' << 8 | '=') // //=
-#define LEFTSHIFTEQUAL_CODE (int)('<' << 16 | '<' << 8 | '=') // <<=
-#define RIGHTSHIFTEQUAL_CODE (int)('>' << 16 | '>' << 8 | '=') // >>=
+
 
 
 int
 _PyToken_ThreeChars(int c1, int c2, int c3)
 {
-    switch (c1 << 16 | c2 << 8 | c3) { // Combine the three tokens into a 24-bit integer
-        case DOUBLESTAREQUAL_CODE: return DOUBLESTAREQUAL;
-        case ELLIPSIS_CODE: return ELLIPSIS;
-        case DOUBLESLASHEQUAL_CODE: return DOUBLESLASHEQUAL;
-        case LEFTSHIFTEQUAL_CODE: return LEFTSHIFTEQUAL;
-        case RIGHTSHIFTEQUAL_CODE: return RIGHTSHIFTEQUAL;
+    switch (GENERATE_3CHAR_CODE(c1, c2, c3)) { // Combine the three tokens into a 24-bit integer
+        case GENERATE_3CHAR_CODE('*', '*', '='): return DOUBLESTAREQUAL;
+        case GENERATE_3CHAR_CODE('.', '.', '.'): return ELLIPSIS;
+        case GENERATE_3CHAR_CODE('/', '/', '='): return DOUBLESLASHEQUAL;
+        case GENERATE_3CHAR_CODE('<', '<', '='): return LEFTSHIFTEQUAL;
+        case GENERATE_3CHAR_CODE('>', '>', '='): return RIGHTSHIFTEQUAL;
     }
     return OP;
 }

--- a/Parser/token.c
+++ b/Parser/token.c
@@ -124,6 +124,7 @@ _PyToken_OneChar(int c1)
 #define COLONEQUAL_CODE (int)(':' << 8 | '=') // :=
 #define LEFTSHIFT_CODE (int)('<' << 8 | '<') // <<
 #define LESSEQUAL_CODE (int)('<' << 8 | '=') // <=
+#define NOTEQUAL_OTHER_CODE (int)('<' << 8 | '>') // <>
 #define EQEQUAL_CODE (int)('=' << 8 | '=') // ==
 #define GREATEREQUAL_CODE (int)('>' << 8 | '=') // >=
 #define RIGHTSHIFT_CODE (int)('>' << 8 | '>') // >>
@@ -134,30 +135,27 @@ _PyToken_OneChar(int c1)
 int
 _PyToken_TwoChars(int c1, int c2)
 {
-    if(c1 > 255 || c2 > 255) { // handle to see if tokens are out of range
-        return OP;
-    }
-
     switch (c1 << 8 | c2) { // Combine the two tokens into a 16-bit integer
-    case NOTEQUAL_CODE: return NOTEQUAL;
-    case PERCENTEQUAL_CODE: return PERCENTEQUAL;
-    case AMPEREQUAL_CODE: return AMPEREQUAL;
-    case DOUBLESTAR_CODE: return DOUBLESTAR;
-    case STAREQUAL_CODE: return STAREQUAL;
-    case PLUSEQUAL_CODE: return PLUSEQUAL;
-    case MINEQUAL_CODE: return MINEQUAL;
-    case RARROW_CODE: return RARROW;
-    case DOUBLESLASH_CODE: return DOUBLESLASH;
-    case SLASHEQUAL_CODE: return SLASHEQUAL;
-    case COLONEQUAL_CODE: return COLONEQUAL;
-    case LEFTSHIFT_CODE: return LEFTSHIFT;
-    case LESSEQUAL_CODE: return LESSEQUAL;
-    case EQEQUAL_CODE: return EQEQUAL;
-    case GREATEREQUAL_CODE: return GREATEREQUAL;
-    case RIGHTSHIFT_CODE: return RIGHTSHIFT;
-    case ATEQUAL_CODE: return ATEQUAL;
-    case CIRCUMFLEXEQUAL_CODE: return CIRCUMFLEXEQUAL;
-    case VBAREQUAL_CODE: return VBAREQUAL;
+        case NOTEQUAL_CODE: 
+        case NOTEQUAL_OTHER_CODE: return NOTEQUAL;
+        case PERCENTEQUAL_CODE: return PERCENTEQUAL;
+        case AMPEREQUAL_CODE: return AMPEREQUAL;
+        case DOUBLESTAR_CODE: return DOUBLESTAR;
+        case STAREQUAL_CODE: return STAREQUAL;
+        case PLUSEQUAL_CODE: return PLUSEQUAL;
+        case MINEQUAL_CODE: return MINEQUAL;
+        case RARROW_CODE: return RARROW;
+        case DOUBLESLASH_CODE: return DOUBLESLASH;
+        case SLASHEQUAL_CODE: return SLASHEQUAL;
+        case COLONEQUAL_CODE: return COLONEQUAL;
+        case LEFTSHIFT_CODE: return LEFTSHIFT;
+        case LESSEQUAL_CODE: return LESSEQUAL;
+        case EQEQUAL_CODE: return EQEQUAL;
+        case GREATEREQUAL_CODE: return GREATEREQUAL;
+        case RIGHTSHIFT_CODE: return RIGHTSHIFT;
+        case ATEQUAL_CODE: return ATEQUAL;
+        case CIRCUMFLEXEQUAL_CODE: return CIRCUMFLEXEQUAL;
+        case VBAREQUAL_CODE: return VBAREQUAL;
     }
     return OP;
 }
@@ -174,10 +172,6 @@ _PyToken_TwoChars(int c1, int c2)
 int
 _PyToken_ThreeChars(int c1, int c2, int c3)
 {
-    if(c1 > 255 || c2 > 255 || c3 > 255) { // handle to see if tokens are out of range
-        return OP;
-    }
-
     switch (c1 << 16 | c2 << 8 | c3) { // Combine the three tokens into a 24-bit integer
         case DOUBLESTAREQUAL_CODE: return DOUBLESTAREQUAL;
         case ELLIPSIS_CODE: return ELLIPSIS;

--- a/Parser/token.c
+++ b/Parser/token.c
@@ -109,139 +109,69 @@ _PyToken_OneChar(int c1)
     return OP;
 }
 
+#define NOTEQUAL_CODE (int)('!' << 8 | '=')
+#define PERCENTEQUAL_CODE (int)('%' << 8 | '=')
+#define AMPEREQUAL_CODE (int)('&' << 8 | '=')
+#define DOUBLESTAR_CODE (int)('*' << 8 | '*')
+#define STAREQUAL_CODE (int)('*' << 8 | '=')
+#define PLUSEQUAL_CODE (int)('+' << 8 | '=')
+#define MINEQUAL_CODE (int)('-' << 8 | '=')
+#define RARROW_CODE (int)('-' << 8 | '>')
+#define DOUBLESLASH_CODE (int)('/' << 8 | '/')
+#define SLASHEQUAL_CODE (int)('/' << 8 | '=')
+#define COLONEQUAL_CODE (int)(':' << 8 | '=')
+#define LEFTSHIFT_CODE (int)('<' << 8 | '<')
+#define LESSEQUAL_CODE (int)('<' << 8 | '=')
+#define EQEQUAL_CODE (int)('=' << 8 | '=')
+#define GREATEREQUAL_CODE (int)('>' << 8 | '=')
+#define RIGHTSHIFT_CODE (int)('>' << 8 | '>')
+#define ATEQUAL_CODE (int)('@' << 8 | '=')
+#define CIRCUMFLEXEQUAL_CODE (int)('^' << 8 | '=')
+#define VBAREQUAL_CODE (int)('|' << 8 | '=')
+
 int
 _PyToken_TwoChars(int c1, int c2)
 {
-    switch (c1) {
-    case '!':
-        switch (c2) {
-        case '=': return NOTEQUAL;
-        }
-        break;
-    case '%':
-        switch (c2) {
-        case '=': return PERCENTEQUAL;
-        }
-        break;
-    case '&':
-        switch (c2) {
-        case '=': return AMPEREQUAL;
-        }
-        break;
-    case '*':
-        switch (c2) {
-        case '*': return DOUBLESTAR;
-        case '=': return STAREQUAL;
-        }
-        break;
-    case '+':
-        switch (c2) {
-        case '=': return PLUSEQUAL;
-        }
-        break;
-    case '-':
-        switch (c2) {
-        case '=': return MINEQUAL;
-        case '>': return RARROW;
-        }
-        break;
-    case '/':
-        switch (c2) {
-        case '/': return DOUBLESLASH;
-        case '=': return SLASHEQUAL;
-        }
-        break;
-    case ':':
-        switch (c2) {
-        case '=': return COLONEQUAL;
-        }
-        break;
-    case '<':
-        switch (c2) {
-        case '<': return LEFTSHIFT;
-        case '=': return LESSEQUAL;
-        case '>': return NOTEQUAL;
-        }
-        break;
-    case '=':
-        switch (c2) {
-        case '=': return EQEQUAL;
-        }
-        break;
-    case '>':
-        switch (c2) {
-        case '=': return GREATEREQUAL;
-        case '>': return RIGHTSHIFT;
-        }
-        break;
-    case '@':
-        switch (c2) {
-        case '=': return ATEQUAL;
-        }
-        break;
-    case '^':
-        switch (c2) {
-        case '=': return CIRCUMFLEXEQUAL;
-        }
-        break;
-    case '|':
-        switch (c2) {
-        case '=': return VBAREQUAL;
-        }
-        break;
+    switch (c1 << 8 | c2) {
+    case NOTEQUAL_CODE: return NOTEQUAL;
+    case PERCENTEQUAL_CODE: return PERCENTEQUAL;
+    case AMPEREQUAL_CODE: return AMPEREQUAL;
+    case DOUBLESTAR_CODE: return DOUBLESTAR;
+    case STAREQUAL_CODE: return STAREQUAL;
+    case PLUSEQUAL_CODE: return PLUSEQUAL;
+    case MINEQUAL_CODE: return MINEQUAL;
+    case RARROW_CODE: return RARROW;
+    case DOUBLESLASH_CODE: return DOUBLESLASH;
+    case SLASHEQUAL_CODE: return SLASHEQUAL;
+    case COLONEQUAL_CODE: return COLONEQUAL;
+    case LEFTSHIFT_CODE: return LEFTSHIFT;
+    case LESSEQUAL_CODE: return LESSEQUAL;
+    case EQEQUAL_CODE: return EQEQUAL;
+    case GREATEREQUAL_CODE: return GREATEREQUAL;
+    case RIGHTSHIFT_CODE: return RIGHTSHIFT;
+    case ATEQUAL_CODE: return ATEQUAL;
+    case CIRCUMFLEXEQUAL_CODE: return CIRCUMFLEXEQUAL;
+    case VBAREQUAL_CODE: return VBAREQUAL;
     }
     return OP;
 }
 
+#define DOUBLESTAREQUAL_CODE (int)('*' << 16 | '*' << 8 | '=')
+#define ELLIPSIS_CODE (int)('.' << 16 | '.' << 8 | '.')
+#define DOUBLESLASHEQUAL_CODE (int)('/' << 16 | '/' << 8 | '=')
+#define LEFTSHIFTEQUAL_CODE (int)('<' << 16 | '<' << 8 | '=')
+#define RIGHTSHIFTEQUAL_CODE (int)('>' << 16 | '>' << 8 | '=')
+
+
 int
 _PyToken_ThreeChars(int c1, int c2, int c3)
 {
-    switch (c1) {
-    case '*':
-        switch (c2) {
-        case '*':
-            switch (c3) {
-            case '=': return DOUBLESTAREQUAL;
-            }
-            break;
-        }
-        break;
-    case '.':
-        switch (c2) {
-        case '.':
-            switch (c3) {
-            case '.': return ELLIPSIS;
-            }
-            break;
-        }
-        break;
-    case '/':
-        switch (c2) {
-        case '/':
-            switch (c3) {
-            case '=': return DOUBLESLASHEQUAL;
-            }
-            break;
-        }
-        break;
-    case '<':
-        switch (c2) {
-        case '<':
-            switch (c3) {
-            case '=': return LEFTSHIFTEQUAL;
-            }
-            break;
-        }
-        break;
-    case '>':
-        switch (c2) {
-        case '>':
-            switch (c3) {
-            case '=': return RIGHTSHIFTEQUAL;
-            }
-            break;
-        }
-        break;
+    switch (c1 << 16 | c2 << 8 | c3) {
+        case DOUBLESTAREQUAL_CODE: return DOUBLESTAREQUAL;
+        case ELLIPSIS_CODE: return ELLIPSIS;
+        case DOUBLESLASHEQUAL_CODE: return DOUBLESLASHEQUAL;
+        case LEFTSHIFTEQUAL_CODE: return LEFTSHIFTEQUAL;
+        case RIGHTSHIFTEQUAL_CODE: return RIGHTSHIFTEQUAL;
     }
     return OP;
 }


### PR DESCRIPTION
This PR updates Parser/Token.c, Include/internal/pycore_token.h, and Tools/build/generate_token.py to unnnest the switch statements in `_PyToken_TwoChars` and `_PyToken_TwoChars`


<!-- gh-issue-number: gh-126049 -->
* Issue: gh-126049
<!-- /gh-issue-number -->
