### PR TITLE
gh-124295: Skip translation tests when pygettext is missing

### DIFF
--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -27,6 +27,7 @@ from test.support import import_helper
 from test.support import os_helper
 from test.support import requires_subprocess
 from test.support import script_helper
+from test.test_tools import skip_if_missing
 from unittest import mock
 
 
@@ -7036,6 +7037,7 @@ class TestTranslations(unittest.TestCase):
 
     def test_translations(self):
         # Test messages extracted from the argparse module against a snapshot
+        skip_if_missing('i18n')
         res = generate_po_file(stdout_only=False)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(res.stderr, '')


### PR DESCRIPTION
https://github.com/python/cpython/pull/124803 broke some buildbots. pygettext may not always be present when python is intalled, so we simply skip the test if that's the case.

<!-- gh-issue-number: gh-124295 -->
* Issue: gh-124295
<!-- /gh-issue-number -->
