### PR TITLE
Added `AnyLogger` type (`Logger | LoggerAdapter` type)

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -26,11 +26,12 @@ To use, simply 'import logging' and log away!
 import sys, os, time, io, re, traceback, warnings, weakref, collections.abc
 
 from types import GenericAlias
+from typing import TypeAlias
 from string import Template
 from string import Formatter as StrFormatter
 
 
-__all__ = ['BASIC_FORMAT', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',
+__all__ = ['BASIC_FORMAT', 'AnyLogger', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',
            'FATAL', 'FileHandler', 'Filter', 'Formatter', 'Handler', 'INFO',
            'LogRecord', 'Logger', 'LoggerAdapter', 'NOTSET', 'NullHandler',
            'StreamHandler', 'WARN', 'WARNING', 'addLevelName', 'basicConfig',
@@ -1991,6 +1992,8 @@ class LoggerAdapter(object):
         return '<%s %s (%s)>' % (self.__class__.__name__, logger.name, level)
 
     __class_getitem__ = classmethod(GenericAlias)
+
+AnyLogger: TypeAlias = Logger | LoggerAdapter
 
 root = RootLogger(WARNING)
 Logger.root = root


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

According to the [docs](https://docs.python.org/3.13/library/logging.html#logging.LoggerAdapter), `LoggerAdapter` should look mostly like `Logger`. So it would be really nice to have a type that can be used for both `Logger` and `LoggerAdapter`.

Instead of this:

```python
def my_func(logger: Logger | LoggerAdapter):
    ...
```

I would have this:

```python
def my_func(logger: AnyLogger):
    ...
```

This is my first PR in the python community, please help me learn if I made a mistake :)