### PR TITLE
gh-126014: Ignore `__pycache__`-only folders in makefile tests

### DIFF
--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -53,7 +53,7 @@ class TestMakefile(unittest.TestCase):
                 continue
             # Skip dirs with hidden-only files:
             if files and all(
-                filename.startswith('.') or filename in {'__pycache__'}
+                filename.startswith('.') or filename == '__pycache__'
                 for filename in files
             ):
                 continue

--- a/Lib/test/test_tools/test_makefile.py
+++ b/Lib/test/test_tools/test_makefile.py
@@ -52,7 +52,10 @@ class TestMakefile(unittest.TestCase):
             if not dirs and not files:
                 continue
             # Skip dirs with hidden-only files:
-            if files and all(filename.startswith('.') for filename in files):
+            if files and all(
+                filename.startswith('.') or filename in {'__pycache__'}
+                for filename in files
+            ):
                 continue
 
             relpath = os.path.relpath(dirpath, support.STDLIB_DIR)


### PR DESCRIPTION


<!-- gh-issue-number: gh-126014 -->
* Issue: gh-126014
<!-- /gh-issue-number -->
