### PR TITLE
gh-126055:  Add omitted command (in docs [os.walk]) for code to fulfill `shutil.rmtree` algorithm

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3676,6 +3676,8 @@ features:
           for name in dirs:
               os.rmdir(os.path.join(root, name))
 
+      os.rmdir(top)
+
    .. audit-event:: os.walk top,topdown,onerror,followlinks os.walk
 
    .. versionchanged:: 3.5

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3675,7 +3675,6 @@ features:
               os.remove(os.path.join(root, name))
           for name in dirs:
               os.rmdir(os.path.join(root, name))
-
       os.rmdir(top)
 
    .. audit-event:: os.walk top,topdown,onerror,followlinks os.walk


### PR DESCRIPTION
In `./Doc/library/os.rst`, the section documenting `os.walk()` gives a code example at the bottom that says it is "a simple implementation of shutil.rmtree()". However it is incomplete. Reason: shutil.rmtree() also removes the passed directory whereas the code shown will not. This PR adds the last missing command to complete the algorithm and make the statement correct.

Resolves #126055


<!-- gh-issue-number: gh-126055 -->
* Issue: gh-126055
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126067.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->