### PR TITLE
gh-88110: clear concurrent.futures.thread._threads_queues after fork to avoid joining parent process' threads

### DIFF
--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -41,6 +41,7 @@ if hasattr(os, 'register_at_fork'):
     os.register_at_fork(before=_global_shutdown_lock.acquire,
                         after_in_child=_global_shutdown_lock._at_fork_reinit,
                         after_in_parent=_global_shutdown_lock.release)
+    os.register_at_fork(after_in_child=_threads_queues.clear)
 
 
 class WorkerContext:

--- a/Lib/test/test_concurrent_futures/test_thread_pool.py
+++ b/Lib/test/test_concurrent_futures/test_thread_pool.py
@@ -80,10 +80,8 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
 
         with futures.ThreadPoolExecutor(1) as pool:
             process_exitcode = pool.submit(fork_process_and_return_exitcode).result()
-        
+
         self.assertEqual(process_exitcode, 0)
-
-
 
     def test_executor_map_current_future_cancel(self):
         stop_event = threading.Event()

--- a/Lib/test/test_concurrent_futures/test_thread_pool.py
+++ b/Lib/test/test_concurrent_futures/test_thread_pool.py
@@ -4,7 +4,6 @@ import multiprocessing.process
 import multiprocessing.util
 import os
 import threading
-import warnings
 import unittest
 from concurrent import futures
 from test import support
@@ -68,15 +67,15 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
                     workers.submit(tuple)
 
     @support.requires_fork()
-    @unittest.skipUnless(hasattr(os, "register_at_fork"), "need os.register_at_fork")
-    @support.requires_resource("cpu")
+    @unittest.skipUnless(hasattr(os, 'register_at_fork'), 'need os.register_at_fork')
+    @support.requires_resource('cpu')
     def test_process_fork_from_a_threadpool(self):
         # bpo-43944: clear concurrent.futures.thread._threads_queues after fork,
         # otherwise child process will try to join parent thread
         def fork_process_and_return_exitcode():
             # Ignore the warning about fork with threads.
-            with warnings.catch_warnings(category=DeprecationWarning, action="ignore"):
-                p = mp.get_context("fork").Process(target=lambda: 1)
+            with self.assertWarnsRegex(DeprecationWarning, msg="use of fork() may lead to deadlocks in child"):
+                p = mp.get_context('fork').Process(target=lambda: 1)
                 p.start()
             p.join()
             return p.exitcode

--- a/Lib/test/test_concurrent_futures/test_thread_pool.py
+++ b/Lib/test/test_concurrent_futures/test_thread_pool.py
@@ -4,6 +4,7 @@ import multiprocessing.process
 import multiprocessing.util
 import os
 import threading
+import warnings
 import unittest
 from concurrent import futures
 from test import support
@@ -67,20 +68,22 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
                     workers.submit(tuple)
 
     @support.requires_fork()
-    @unittest.skipUnless(hasattr(os, 'register_at_fork'), 'need os.register_at_fork')
-    @support.requires_resource('cpu')
+    @unittest.skipUnless(hasattr(os, "register_at_fork"), "need os.register_at_fork")
+    @support.requires_resource("cpu")
     def test_process_fork_from_a_threadpool(self):
         # bpo-43944: clear concurrent.futures.thread._threads_queues after fork,
         # otherwise child process will try to join parent thread
         def fork_process_and_return_exitcode():
-            p = mp.get_context('fork').Process(target=lambda: 1)
-            p.start()
+            # Ignore the warning about fork with threads.
+            with warnings.catch_warnings(category=DeprecationWarning, action="ignore"):
+                p = mp.get_context("fork").Process(target=lambda: 1)
+                p.start()
             p.join()
             return p.exitcode
-
+    
         with futures.ThreadPoolExecutor(1) as pool:
             process_exitcode = pool.submit(fork_process_and_return_exitcode).result()
-
+    
         self.assertEqual(process_exitcode, 0)
 
     def test_executor_map_current_future_cancel(self):

--- a/Lib/test/test_concurrent_futures/test_thread_pool.py
+++ b/Lib/test/test_concurrent_futures/test_thread_pool.py
@@ -66,6 +66,25 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
                 with futures.ProcessPoolExecutor(1, mp_context=mp.get_context('fork')) as workers:
                     workers.submit(tuple)
 
+    @support.requires_fork()
+    @unittest.skipUnless(hasattr(os, 'register_at_fork'), 'need os.register_at_fork')
+    @support.requires_resource('cpu')
+    def test_process_fork_from_a_threadpool(self):
+        # bpo-43944: clear concurrent.futures.thread._threads_queues after fork,
+        # otherwise child process will try to join parent thread
+        def fork_process_and_return_exitcode():
+            p = mp.get_context('fork').Process(target=lambda: 1)
+            p.start()
+            p.join()
+            return p.exitcode
+
+        with futures.ThreadPoolExecutor(1) as pool:
+            process_exitcode = pool.submit(fork_process_and_return_exitcode).result()
+        
+        self.assertEqual(process_exitcode, 0)
+
+
+
     def test_executor_map_current_future_cancel(self):
         stop_event = threading.Event()
         log = []

--- a/Lib/test/test_concurrent_futures/test_thread_pool.py
+++ b/Lib/test/test_concurrent_futures/test_thread_pool.py
@@ -68,13 +68,13 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
 
     @support.requires_fork()
     @unittest.skipUnless(hasattr(os, 'register_at_fork'), 'need os.register_at_fork')
-    @support.requires_resource('cpu')
     def test_process_fork_from_a_threadpool(self):
         # bpo-43944: clear concurrent.futures.thread._threads_queues after fork,
         # otherwise child process will try to join parent thread
         def fork_process_and_return_exitcode():
             # Ignore the warning about fork with threads.
-            with self.assertWarnsRegex(DeprecationWarning, msg="use of fork() may lead to deadlocks in child"):
+            with self.assertWarnsRegex(DeprecationWarning,
+                                       r"use of fork\(\) may lead to deadlocks in the child"):
                 p = mp.get_context('fork').Process(target=lambda: 1)
                 p.start()
             p.join()

--- a/Lib/test/test_concurrent_futures/test_thread_pool.py
+++ b/Lib/test/test_concurrent_futures/test_thread_pool.py
@@ -80,10 +80,10 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
                 p.start()
             p.join()
             return p.exitcode
-    
+
         with futures.ThreadPoolExecutor(1) as pool:
             process_exitcode = pool.submit(fork_process_and_return_exitcode).result()
-    
+
         self.assertEqual(process_exitcode, 0)
 
     def test_executor_map_current_future_cancel(self):

--- a/Misc/NEWS.d/next/Library/2023-02-15-23-54-42.gh-issue-88110.KU6erv.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-15-23-54-42.gh-issue-88110.KU6erv.rst
@@ -1,0 +1,2 @@
+Fix multiprocessing.Process exiting with code 1 even on successful run when
+threads are used in the same application too.

--- a/Misc/NEWS.d/next/Library/2023-02-15-23-54-42.gh-issue-88110.KU6erv.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-15-23-54-42.gh-issue-88110.KU6erv.rst
@@ -1,2 +1,2 @@
-Fix multiprocessing.Process exiting with code 1 even on successful run when
+Fix :class:`multiprocessing.Process` exiting with code 1 even on successful run when
 threads are used in the same application too.

--- a/Misc/NEWS.d/next/Library/2023-02-15-23-54-42.gh-issue-88110.KU6erv.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-15-23-54-42.gh-issue-88110.KU6erv.rst
@@ -1,2 +1,2 @@
-Fixed :class:`multiprocessing.Process` exiting with code 1 even on success when
-it was used from a :class:`concurrent.futures.ThreadPoolExecutor` task.
+Fixed :class:`multiprocessing.Process` reporting a ``.exitcode`` of 1 even on success when
+using the ``"fork"`` start method while using a :class:`concurrent.futures.ThreadPoolExecutor`.

--- a/Misc/NEWS.d/next/Library/2023-02-15-23-54-42.gh-issue-88110.KU6erv.rst
+++ b/Misc/NEWS.d/next/Library/2023-02-15-23-54-42.gh-issue-88110.KU6erv.rst
@@ -1,2 +1,2 @@
-Fix :class:`multiprocessing.Process` exiting with code 1 even on successful run when
-threads are used in the same application too.
+Fixed :class:`multiprocessing.Process` exiting with code 1 even on success when
+it was used from a :class:`concurrent.futures.ThreadPoolExecutor` task.


### PR DESCRIPTION
I've added a test to marmarek@ PR: https://github.com/python/cpython/pull/101940

`_threads_queues`  are copied as-is into the fork memory, but there are no threads in the child process, so child process crashes when calling `t.join()` in  `_python_exit`.

I'm facing this issue for the second time during last two years, so I hope it can be fixed :)

<!-- gh-issue-number: gh-88110 -->
* Issue: gh-88110
<!-- /gh-issue-number -->
