### PR TITLE
gh-126083: Fix a reference leak in `asyncio.Task` when reinitializing with new non-`None` context

### DIFF
--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2702,13 +2702,9 @@ class BaseTaskTests:
         task = asyncio.Task.__new__(asyncio.Task)
 
         for _ in range(5):
-            try:
+            with self.assertRaisesRegex(RuntimeError, 'break'):
                 task.__init__(coro, loop=loop, context=obj, name=Break())
-            except Exception as e:
-                # exception should only come from Break.__str__ as it's used to
-                # avoid having to do too much setup for this test
-                self.assertIs(type(e), RuntimeError)
-                self.assertEqual(e.args[0], "break")
+
         coro.close()
         del task
 

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2688,6 +2688,25 @@ class BaseTaskTests:
         finally:
             loop.close()
 
+    def test_proper_refcounts(self):
+        class Break:
+            def __str__(self):
+                raise Exception("break")
+        
+        obj = object()
+        initial_refcount = sys.getrefcount(obj)
+
+        coro = coroutine_function()
+        task = asyncio.Task.__new__(asyncio.Task)
+
+        for _ in range(10000):
+            try:
+                task.__init__(coro, context=obj, name=Break())
+            except: pass
+        del task
+
+        self.assertEqual(sys.getrefcount(obj), initial_refcount)
+
 
 def add_subclass_tests(cls):
     BaseTask = cls.Task

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2693,7 +2693,7 @@ class BaseTaskTests:
         class Break:
             def __str__(self):
                 raise RuntimeError("break")
-        
+
         obj = object()
         initial_refcount = sys.getrefcount(obj)
 

--- a/Misc/NEWS.d/next/Library/2024-10-28-22-35-22.gh-issue-126083.TuI--n.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-28-22-35-22.gh-issue-126083.TuI--n.rst
@@ -1,2 +1,1 @@
-Fixed a reference leak that would happen in asyncio tasks when you would
-reinitialize your task object with a non-None context.
+Fixed a reference leak in :class:`asyncio.Task` objects when reinitializing the same object with a non-``None`` context. Patch by Nico Posada.

--- a/Misc/NEWS.d/next/Library/2024-10-28-22-35-22.gh-issue-126083.TuI--n.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-28-22-35-22.gh-issue-126083.TuI--n.rst
@@ -1,0 +1,2 @@
+Fixed a reference leak that would happen in asyncio tasks when you would
+reinitialize your task object with a non-None context.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2120,7 +2120,7 @@ _asyncio_Task___init___impl(TaskObj *self, PyObject *coro, PyObject *loop,
             return -1;
         }
     } else {
-        self->task_context = Py_NewRef(context);
+        Py_XSETREF(self->task_context, Py_NewRef(context));
     }
 
     Py_CLEAR(self->task_fut_waiter);


### PR DESCRIPTION
Fix for ref leak described in https://github.com/python/cpython/issues/126083.

This is my first CPython PR so feedback is appreciated :)

<!-- gh-issue-number: gh-126083 -->
* Issue: gh-126083
<!-- /gh-issue-number -->
