### PR TITLE
gh-126106: Fix `NULL` possible dereference in `Modules/_ssl.c`

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-10-29-10-58-52.gh-issue-126106.rlF798.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-29-10-58-52.gh-issue-126106.rlF798.rst
@@ -1,0 +1,1 @@
+Fixes ``NULL`` possible dereference in ``Modules/_ssl.c``.

--- a/Misc/NEWS.d/next/Library/2024-10-29-10-58-52.gh-issue-126106.rlF798.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-29-10-58-52.gh-issue-126106.rlF798.rst
@@ -1,1 +1,1 @@
-Fixes ``NULL`` possible dereference in ``Modules/_ssl.c``.
+Fixes a possible ``NULL`` pointer dereference in :mod:`ssl`.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5424,13 +5424,13 @@ PySSLSession_dealloc(PySSLSession *self)
 static PyObject *
 PySSLSession_richcompare(PyObject *left, PyObject *right, int op)
 {
-    int result;
-    PyTypeObject *sesstype = ((PySSLSession*)left)->ctx->state->PySSLSession_Type;
-
     if (left == NULL || right == NULL) {
         PyErr_BadInternalCall();
         return NULL;
     }
+
+    int result;
+    PyTypeObject *sesstype = ((PySSLSession*)left)->ctx->state->PySSLSession_Type;
 
     if (!Py_IS_TYPE(left, sesstype) || !Py_IS_TYPE(right, sesstype)) {
         Py_RETURN_NOTIMPLEMENTED;


### PR DESCRIPTION
Thanks to @federicovalenso for finding this.

<!-- gh-issue-number: gh-126106 -->
* Issue: gh-126106
<!-- /gh-issue-number -->
