### PR TITLE
gh-126105: Fix crash in `ast` module, when `._fields` is deleted

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -94,11 +94,11 @@ class AST_Tests(unittest.TestCase):
 
         del ast.AST._fields
 
-        msg = 'AST has no fields'
+        msg = "type object 'ast.AST' has no attribute '_fields'"
         # Both examples used to crash:
-        with self.assertRaisesRegex(TypeError, msg):
+        with self.assertRaisesRegex(AttributeError, msg):
             ast.AST(arg1=123)
-        with self.assertRaisesRegex(TypeError, msg):
+        with self.assertRaisesRegex(AttributeError, msg):
             ast.AST()
 
     def test_AST_garbage_collection(self):

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -84,6 +84,23 @@ class AST_Tests(unittest.TestCase):
             # "ast.AST constructor takes 0 positional arguments"
             ast.AST(2)
 
+    def test_AST_fields_NULL_check(self):
+        # See: https://github.com/python/cpython/issues/126105
+        old_value = ast.AST._fields
+
+        def cleanup():
+            ast.AST._fields = old_value
+        self.addCleanup(cleanup)
+
+        del ast.AST._fields
+
+        msg = 'AST has no fields'
+        # Both examples used to crash:
+        with self.assertRaisesRegex(TypeError, msg):
+            ast.AST(arg1=123)
+        with self.assertRaisesRegex(TypeError, msg):
+            ast.AST()
+
     def test_AST_garbage_collection(self):
         class X:
             pass

--- a/Misc/NEWS.d/next/Library/2024-10-29-11-45-44.gh-issue-126105.cOL-R6.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-29-11-45-44.gh-issue-126105.cOL-R6.rst
@@ -1,1 +1,1 @@
-Fix a crash in :mod:`ast` when ``_fields`` attribute is deleted.
+Fix a crash in :mod:`ast` when the :attr:`ast.AST._fields` attribute is deleted.

--- a/Misc/NEWS.d/next/Library/2024-10-29-11-45-44.gh-issue-126105.cOL-R6.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-29-11-45-44.gh-issue-126105.cOL-R6.rst
@@ -1,0 +1,1 @@
+Fix a crash in :mod:`ast` when ``_fields`` attribute is deleted.

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -887,16 +887,18 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     if (PyObject_GetOptionalAttr((PyObject*)Py_TYPE(self), state->_fields, &fields) < 0) {
         goto cleanup;
     }
-    if (fields) {
-        numfields = PySequence_Size(fields);
-        if (numfields == -1) {
-            goto cleanup;
-        }
-        remaining_fields = PySet_New(fields);
+    if (fields == NULL) {
+        PyErr_Format(PyExc_TypeError,
+                     "%.400s has no fields",
+                     _PyType_Name(Py_TYPE(self)));
+        goto cleanup;
     }
-    else {
-        remaining_fields = PySet_New(NULL);
+
+    numfields = PySequence_Size(fields);
+    if (numfields == -1) {
+        goto cleanup;
     }
+    remaining_fields = PySet_New(fields);
     if (remaining_fields == NULL) {
         goto cleanup;
     }

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -884,13 +884,9 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t i, numfields = 0;
     int res = -1;
     PyObject *key, *value, *fields, *attributes = NULL, *remaining_fields = NULL;
-    if (PyObject_GetOptionalAttr((PyObject*)Py_TYPE(self), state->_fields, &fields) < 0) {
-        goto cleanup;
-    }
+
+    fields = PyObject_GetAttr((PyObject*)Py_TYPE(self), state->_fields);
     if (fields == NULL) {
-        PyErr_Format(PyExc_TypeError,
-                     "%.400s has no fields",
-                     _PyType_Name(Py_TYPE(self)));
         goto cleanup;
     }
 

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -5083,13 +5083,9 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t i, numfields = 0;
     int res = -1;
     PyObject *key, *value, *fields, *attributes = NULL, *remaining_fields = NULL;
-    if (PyObject_GetOptionalAttr((PyObject*)Py_TYPE(self), state->_fields, &fields) < 0) {
-        goto cleanup;
-    }
+
+    fields = PyObject_GetAttr((PyObject*)Py_TYPE(self), state->_fields);
     if (fields == NULL) {
-        PyErr_Format(PyExc_TypeError,
-                     "%.400s has no fields",
-                     _PyType_Name(Py_TYPE(self)));
         goto cleanup;
     }
 

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -5086,16 +5086,18 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     if (PyObject_GetOptionalAttr((PyObject*)Py_TYPE(self), state->_fields, &fields) < 0) {
         goto cleanup;
     }
-    if (fields) {
-        numfields = PySequence_Size(fields);
-        if (numfields == -1) {
-            goto cleanup;
-        }
-        remaining_fields = PySet_New(fields);
+    if (fields == NULL) {
+        PyErr_Format(PyExc_TypeError,
+                     "%.400s has no fields",
+                     _PyType_Name(Py_TYPE(self)));
+        goto cleanup;
     }
-    else {
-        remaining_fields = PySet_New(NULL);
+
+    numfields = PySequence_Size(fields);
+    if (numfields == -1) {
+        goto cleanup;
     }
+    remaining_fields = PySet_New(fields);
     if (remaining_fields == NULL) {
         goto cleanup;
     }


### PR DESCRIPTION
This PR changes the logic a bit, but it looks like a correct thing to me.
Previously we were handling `NULL` of `fields` case for `remaining_fields` https://github.com/python/cpython/blob/9b14083497f50213f908c1359eeaf47c97161347/Python/Python-ast.c#L5089-L5098

But, we didn't really handle the `fields` itself.
Further calls assume that `fields` cannot be `NULL`.

The other way of fixing this is to add a default for `fields` like:

```c
    if (fields == NULL) {
        fields = PyList_New(0);
        if (fields == NULL) {
            goto cleanup;
        }
    }
```

In this case `ast.AST(arg=1)` with no `_fields` will produce:

```
DeprecationWarning: ast.AST.__init__ got an unexpected keyword argument 'arg'. Support for arbitrary keyword arguments is deprecated and will be removed in Python 3.15.
```

It does not seem correct to me, because `_fields` is a part of our API. Since `AST` objects are mostly internal, there are no real cases of missing `_fields`.

<!-- gh-issue-number: gh-126105 -->
* Issue: gh-126105
<!-- /gh-issue-number -->
