### PR TITLE
gh-125783: Add more tests to prevent regressions with the combination of ctypes and metaclasses.

### DIFF
--- a/Lib/test/test_ctypes/test_c_simple_type_meta.py
+++ b/Lib/test/test_ctypes/test_c_simple_type_meta.py
@@ -87,6 +87,9 @@ class PyCSimpleTypeAsMetaclassTest(unittest.TestCase):
         self.assertTrue(issubclass(POINTER(Sub), Sub))
 
     def test_creating_pointer_in_dunder_init_1(self):
+        # Test for modern metaclass initialization that does not
+        # require recursion avoidance.
+
         class ct_meta(type):
             def __init__(self, name, bases, namespace):
                 if bases == (object,):
@@ -117,6 +120,8 @@ class PyCSimpleTypeAsMetaclassTest(unittest.TestCase):
         self.assertTrue(issubclass(POINTER(Sub), POINTER(CtBase)))
 
     def test_creating_pointer_in_dunder_init_2(self):
+        # A simpler variant of the above.
+
         class ct_meta(type):
             def __init__(self, name, bases, namespace):
                 p = p_meta(f"POINTER({self.__name__})", (self, c_void_p), {})

--- a/Lib/test/test_ctypes/test_c_simple_type_meta.py
+++ b/Lib/test/test_ctypes/test_c_simple_type_meta.py
@@ -85,3 +85,54 @@ class PyCSimpleTypeAsMetaclassTest(unittest.TestCase):
 
         self.assertIsInstance(POINTER(Sub), p_meta)
         self.assertTrue(issubclass(POINTER(Sub), Sub))
+
+    def test_creating_pointer_in_dunder_init_1(self):
+        class ct_meta(type):
+            def __init__(self, name, bases, namespace):
+                if bases == (object,):
+                    ptr_bases = (self, PtrBase)
+                else:
+                    ptr_bases = (self, POINTER(bases[0]))
+                p = p_meta(f"POINTER({self.__name__})", ptr_bases, {})
+                ctypes._pointer_type_cache[self] = p
+
+        class p_meta(PyCSimpleType, ct_meta):
+            pass
+
+        class PtrBase(c_void_p, metaclass=p_meta):
+            pass
+
+        class CtBase(object, metaclass=ct_meta):
+            pass
+
+        class Sub(CtBase):
+            pass
+
+        class Sub2(Sub):
+            pass
+
+        self.assertIsInstance(POINTER(Sub2), p_meta)
+        self.assertTrue(issubclass(POINTER(Sub2), Sub2))
+        self.assertTrue(issubclass(POINTER(Sub2), POINTER(Sub)))
+        self.assertTrue(issubclass(POINTER(Sub), POINTER(CtBase)))
+
+    def test_creating_pointer_in_dunder_init_2(self):
+        class ct_meta(type):
+            def __init__(self, name, bases, namespace):
+                p = p_meta(f"POINTER({self.__name__})", (self, c_void_p), {})
+                ctypes._pointer_type_cache[self] = p
+
+        class p_meta(PyCSimpleType, ct_meta):
+            pass
+
+        class Core(object):
+            pass
+
+        class CtBase(Core, metaclass=ct_meta):
+            pass
+
+        class Sub(CtBase):
+            pass
+
+        self.assertIsInstance(POINTER(Sub), p_meta)
+        self.assertTrue(issubclass(POINTER(Sub), Sub))

--- a/Lib/test/test_ctypes/test_c_simple_type_meta.py
+++ b/Lib/test/test_ctypes/test_c_simple_type_meta.py
@@ -132,7 +132,7 @@ class PyCSimpleTypeAsMetaclassTest(unittest.TestCase):
                 # Avoid recursion.
                 # (See test_creating_pointer_in_dunder_new_2)
                 if isinstance(self, p_meta):
-                    return self
+                    return
                 p = p_meta(f"POINTER({self.__name__})", (self, c_void_p), {})
                 ctypes._pointer_type_cache[self] = p
 


### PR DESCRIPTION
In #125881, tests were added for generating pointer types in `__new__` of metaclasses.
This time, I've added tests for generating pointer types in `__init__` of metaclasses.

This is internal-only, so I don’t think it needs a NEWS entry.
I would like to backport this to 3.13 as well.
Please see also https://github.com/python/cpython/issues/125783#issuecomment-2439488942.

<!-- gh-issue-number: gh-125783 -->
* Issue: gh-125783
<!-- /gh-issue-number -->
