### PR TITLE
gh-125315: Avoid crashing in _wmimodule due to slow WMI calls on some Windows machines

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-10-29-19-48-03.gh-issue-125315.jdB9qN.rst
+++ b/Misc/NEWS.d/next/Windows/2024-10-29-19-48-03.gh-issue-125315.jdB9qN.rst
@@ -1,0 +1,2 @@
+Avoid crashing in :mod:`platform` due to slow WMI calls on some Windows
+machines.


### PR DESCRIPTION


<!-- gh-issue-number: gh-125315 -->
* Issue: gh-125315
<!-- /gh-issue-number -->
