### PR TITLE
gh-126074: Removes unnecessary DLLs from embeddable package

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-10-29-20-09-52.gh-issue-126074.83ZzZs.rst
+++ b/Misc/NEWS.d/next/Windows/2024-10-29-20-09-52.gh-issue-126074.83ZzZs.rst
@@ -1,0 +1,1 @@
+Removed unnecessary DLLs from Windows embeddable package

--- a/PC/layout/main.py
+++ b/PC/layout/main.py
@@ -31,11 +31,13 @@ from .support.props import *
 from .support.nuspec import *
 
 TEST_PYDS_ONLY = FileStemSet("xxlimited", "xxlimited_35", "_ctypes_test", "_test*")
+TEST_DLLS_ONLY = set()
 TEST_DIRS_ONLY = FileNameSet("test", "tests")
 
 IDLE_DIRS_ONLY = FileNameSet("idlelib")
 
-TCLTK_PYDS_ONLY = FileStemSet("tcl*", "tk*", "_tkinter", "zlib1")
+TCLTK_PYDS_ONLY = FileStemSet("_tkinter")
+TCLTK_DLLS_ONLY = FileStemSet("tcl*", "tk*", "zlib1")
 TCLTK_DIRS_ONLY = FileNameSet("tkinter", "turtledemo")
 TCLTK_FILES_ONLY = FileNameSet("turtle.py")
 
@@ -225,6 +227,10 @@ def get_layout(ns):
         if src.stem.endswith("_d") != bool(ns.debug) and src not in REQUIRED_DLLS:
             continue
         if src in EXCLUDE_FROM_DLLS:
+            continue
+        if src in TEST_DLLS_ONLY and not ns.include_tests:
+            continue
+        if src in TCLTK_DLLS_ONLY and not ns.include_tcltk:
             continue
         yield from in_build(src.name, dest=dest, no_lib=True)
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-126074 -->
* Issue: gh-126074
<!-- /gh-issue-number -->
