### PR TITLE
docs: restore an anchor to for/else

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -196,6 +196,7 @@ iteration of the loop::
     Found an odd number 9
 
 .. _tut-for-else:
+.. _break-and-continue-statements-and-else-clauses-on-loops:
 
 :keyword:`!else` Clauses on Loops
 =================================


### PR DESCRIPTION
Keep this shortlink working: https://bit.ly/for_else

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126154.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->