### PR TITLE
[3.12] gh-118633: Add warning regarding the unsafe usage of eval and exec (GH-118437)

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -588,6 +588,11 @@ are always available.  They are listed here in alphabetical order.
    :returns: The result of the evaluated expression.
    :raises: Syntax errors are reported as exceptions.
 
+   .. warning::
+
+      This function executes arbitrary code. Calling it with
+      user-supplied input may lead to security vulnerabilities.
+
    The *expression* argument is parsed and evaluated as a Python expression
    (technically speaking, a condition list) using the *globals* and *locals*
    dictionaries as global and local namespace.  If the *globals* dictionary is
@@ -633,6 +638,11 @@ are always available.  They are listed here in alphabetical order.
 .. index:: pair: built-in function; exec
 
 .. function:: exec(object, globals=None, locals=None, /, *, closure=None)
+
+   .. warning::
+
+      This function executes arbitrary code. Calling it with
+      user-supplied input may lead to security vulnerabilities.
 
    This function supports dynamic execution of Python code. *object* must be
    either a string or a code object.  If it is a string, the string is parsed as


### PR DESCRIPTION
* Add warning regarding the unsafe usage of eval

* Add warning regarding the unsafe usage of exec

* Move warning under parameters table

* Use suggested shorter text

Co-authored-by: Jelle Zijlstra <jelle.zijlstra@gmail.com>

* Use suggested shorter text

Co-authored-by: Jelle Zijlstra <jelle.zijlstra@gmail.com>

* Improve wording as suggested

---------

(cherry picked from commit https://github.com/python/cpython/commit/00e5ec0d35193c1665e5c0cfe5ef82eed270d0f4)

Co-authored-by: Daniel Ruf <daniel@daniel-ruf.de>
Co-authored-by: Kirill Podoprigora <kirill.bast9@mail.ru>
Co-authored-by: Jelle Zijlstra <jelle.zijlstra@gmail.com>

<!-- gh-issue-number: gh-118633 -->
* Issue: gh-118633
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126162.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->