### PR TITLE
gh-125729: Makes the presence of the :mod:`turtle` module dependent on the Tcl/Tk installer option. 

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-10-31-09-46-53.gh-issue-125729.KdKVLa.rst
+++ b/Misc/NEWS.d/next/Windows/2024-10-31-09-46-53.gh-issue-125729.KdKVLa.rst
@@ -1,1 +1,1 @@
-Mention the turtle module in Tcl/Tk installation option in Windows installer. Exclude turtle.py from stdlib if this option is not set.
+Makes the presence of the :mod:`turtle` module dependent on the Tcl/Tk installer option. Previously, the module was always installed but would be unusable without Tcl/Tk.

--- a/Misc/NEWS.d/next/Windows/2024-10-31-09-46-53.gh-issue-125729.KdKVLa.rst
+++ b/Misc/NEWS.d/next/Windows/2024-10-31-09-46-53.gh-issue-125729.KdKVLa.rst
@@ -1,0 +1,1 @@
+Add turtle.py into Tcl/Tk installation option

--- a/Misc/NEWS.d/next/Windows/2024-10-31-09-46-53.gh-issue-125729.KdKVLa.rst
+++ b/Misc/NEWS.d/next/Windows/2024-10-31-09-46-53.gh-issue-125729.KdKVLa.rst
@@ -1,1 +1,1 @@
-Add turtle.py into Tcl/Tk installation option
+Mention the turtle module in Tcl/Tk installation option in Windows installer. Exclude turtle.py from stdlib if this option is not set.

--- a/Tools/msi/bundle/Default.wxl
+++ b/Tools/msi/bundle/Default.wxl
@@ -70,8 +70,8 @@ Select Customize to review current options.</String>
   <String Id="Include_docHelpLabel">Installs the Python documentation files.</String>
   <String Id="Include_pipLabel">&amp;pip</String>
   <String Id="Include_pipHelpLabel">Installs pip, which can download and install other Python packages.</String>
-  <String Id="Include_tcltkLabel">tcl/tk and &amp;IDLE</String>
-  <String Id="Include_tcltkHelpLabel">Installs tkinter and the IDLE development environment.</String>
+  <String Id="Include_tcltkLabel">tcl/tk, turtle and &amp;IDLE</String>
+  <String Id="Include_tcltkHelpLabel">Installs tkinter, turtle and the IDLE development environment.</String>
   <String Id="Include_testLabel">Python &amp;test suite</String>
   <String Id="Include_testHelpLabel">Installs the standard library test suite.</String>
   <String Id="Include_launcherLabel">py &amp;launcher</String>

--- a/Tools/msi/bundle/Default.wxl
+++ b/Tools/msi/bundle/Default.wxl
@@ -70,7 +70,7 @@ Select Customize to review current options.</String>
   <String Id="Include_docHelpLabel">Installs the Python documentation files.</String>
   <String Id="Include_pipLabel">&amp;pip</String>
   <String Id="Include_pipHelpLabel">Installs pip, which can download and install other Python packages.</String>
-  <String Id="Include_tcltkLabel">tcl/tk, turtle and &amp;IDLE</String>
+  <String Id="Include_tcltkLabel">Tcl/Tk, turtle and &amp;IDLE</String>
   <String Id="Include_tcltkHelpLabel">Installs tkinter, turtle and the IDLE development environment.</String>
   <String Id="Include_testLabel">Python &amp;test suite</String>
   <String Id="Include_testHelpLabel">Installs the standard library test suite.</String>

--- a/Tools/msi/lib/lib.wixproj
+++ b/Tools/msi/lib/lib.wixproj
@@ -15,10 +15,11 @@
         <EmbeddedResource Include="*.wxl" />
     </ItemGroup>
     <ItemGroup>
-        <ExcludeFolders Include="Lib\test;Lib\tests;Lib\tkinter;Lib\idlelib;Lib\turtledemo;Lib\turtle.py" />
+        <ExcludeFolders Include="Lib\test;Lib\tests;Lib\tkinter;Lib\idlelib;Lib\turtledemo" />
         <InstallFiles Include="$(PySourcePath)Lib\**\*"
                       Exclude="$(PySourcePath)Lib\**\*.pyc;
                                $(PySourcePath)Lib\**\*.pyo;
+                               $(PySourcePath)Lib\turtle.py;
                                $(PySourcePath)Lib\site-packages\README;
                                @(ExcludeFolders->'$(PySourcePath)%(Identity)\*');
                                @(ExcludeFolders->'$(PySourcePath)%(Identity)\**\*')">

--- a/Tools/msi/lib/lib.wixproj
+++ b/Tools/msi/lib/lib.wixproj
@@ -15,7 +15,7 @@
         <EmbeddedResource Include="*.wxl" />
     </ItemGroup>
     <ItemGroup>
-        <ExcludeFolders Include="Lib\test;Lib\tests;Lib\tkinter;Lib\idlelib;Lib\turtledemo" />
+        <ExcludeFolders Include="Lib\test;Lib\tests;Lib\tkinter;Lib\idlelib;Lib\turtledemo;Lib\turtle.py" />
         <InstallFiles Include="$(PySourcePath)Lib\**\*"
                       Exclude="$(PySourcePath)Lib\**\*.pyc;
                                $(PySourcePath)Lib\**\*.pyo;

--- a/Tools/msi/tcltk/tcltk.wixproj
+++ b/Tools/msi/tcltk/tcltk.wixproj
@@ -28,7 +28,7 @@
             <Group>tcltk_lib</Group>
         </InstallFiles>
 
-        <InstallFiles Include="$(PySourcePath)Lib\tkinter\**\*;$(PySourcePath)Lib\idlelib\**\*;$(PySourcePath)Lib\turtledemo\**\*"
+        <InstallFiles Include="$(PySourcePath)Lib\tkinter\**\*;$(PySourcePath)Lib\idlelib\**\*;$(PySourcePath)Lib\turtledemo\**\*;$(PySourcePath)Lib\turtle.py"
                       Exclude="$(PySourcePath)Lib\**\*.pyc;$(PySourcePath)Lib\**\*.pyo">
             <SourceBase>$(PySourcePath)</SourceBase>
             <Source>!(bindpath.src)</Source>


### PR DESCRIPTION
Deal with the issue https://github.com/python/cpython/issues/125729

<!-- gh-issue-number: gh-125729 -->
* Issue: gh-125729
<!-- /gh-issue-number -->
