### PR TITLE
gh-126178: NFC Separate Emscripten and WASI standard lib disables in configure

### DIFF
--- a/configure
+++ b/configure
@@ -29175,7 +29175,7 @@ case $ac_sys_system in #(
 
     py_cv_module__scproxy=n/a
  ;; #(
-  Emscripten|WASI) :
+  Emscripten) :
 
 
 
@@ -29197,9 +29197,6 @@ case $ac_sys_system in #(
     py_cv_module_syslog=n/a
     py_cv_module_=n/a
 
-    case $ac_sys_system/$ac_sys_emscripten_target in #(
-  Emscripten/browser*) :
-
 
 
     py_cv_module_fcntl=n/a
@@ -29207,10 +29204,28 @@ case $ac_sys_system in #(
     py_cv_module_termios=n/a
     py_cv_module_=n/a
 
-       ;; #(
-  Emscripten/node*) :
-     ;; #(
-  WASI/*) :
+   ;; #(
+  WASI) :
+
+
+
+    py_cv_module__curses=n/a
+    py_cv_module__curses_panel=n/a
+    py_cv_module__dbm=n/a
+    py_cv_module__gdbm=n/a
+    py_cv_module__multiprocessing=n/a
+    py_cv_module__posixshmem=n/a
+    py_cv_module__posixsubprocess=n/a
+    py_cv_module__scproxy=n/a
+    py_cv_module__tkinter=n/a
+    py_cv_module__interpreters=n/a
+    py_cv_module__interpchannels=n/a
+    py_cv_module__interpqueues=n/a
+    py_cv_module_grp=n/a
+    py_cv_module_pwd=n/a
+    py_cv_module_resource=n/a
+    py_cv_module_syslog=n/a
+    py_cv_module_=n/a
 
 
 
@@ -29226,11 +29241,6 @@ case $ac_sys_system in #(
     py_cv_module_xxlimited_35=n/a
     py_cv_module_=n/a
 
-
-     ;; #(
-  *) :
-     ;;
-esac
    ;; #(
   *) :
 

--- a/configure.ac
+++ b/configure.ac
@@ -7619,12 +7619,11 @@ AS_CASE([$ac_sys_system],
   [CYGWIN*], [PY_STDLIB_MOD_SET_NA([_scproxy])],
   [QNX*], [PY_STDLIB_MOD_SET_NA([_scproxy])],
   [FreeBSD*], [PY_STDLIB_MOD_SET_NA([_scproxy])],
-  [Emscripten|WASI], [
+  [Emscripten], [
     dnl subprocess and multiprocessing are not supported (no fork syscall).
     dnl curses and tkinter user interface are not available.
     dnl dbm and gdbm aren't available, too.
-    dnl Emscripten and WASI provide only stubs for pwd, grp APIs.
-    dnl resource functions (get/setrusage) are stubs, too.
+    dnl pwd, grp APIs, and resource functions (get/setrusage) are stubs.
     PY_STDLIB_MOD_SET_NA(
       [_curses],
       [_curses_panel],
@@ -7643,33 +7642,50 @@ AS_CASE([$ac_sys_system],
       [resource],
       [syslog],
     )
-    AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
-      [Emscripten/browser*], [
-        dnl These modules are not particularly useful in browsers.
-        PY_STDLIB_MOD_SET_NA(
-          [fcntl],
-          [readline],
-          [termios],
-        )
-      ],
-      [Emscripten/node*], [],
-      [WASI/*], [
-        dnl WASI SDK 15.0 does not support file locking, mmap, and more.
-        dnl Test modules that must be compiled as shared libraries are not supported
-        dnl (see Modules/Setup.stdlib.in).
-        PY_STDLIB_MOD_SET_NA(
-          [_ctypes_test],
-          [_testexternalinspection],
-          [_testimportmultiple],
-          [_testmultiphase],
-          [_testsinglephase],
-          [fcntl],
-          [mmap],
-          [termios],
-          [xxlimited],
-          [xxlimited_35],
-        )
-      ]
+    dnl fcntl, readline, and termios are not particularly useful in browsers.
+    PY_STDLIB_MOD_SET_NA(
+      [fcntl],
+      [readline],
+      [termios],
+    )
+  ],
+  [WASI], [
+    dnl subprocess and multiprocessing are not supported (no fork syscall).
+    dnl curses and tkinter user interface are not available.
+    dnl dbm and gdbm aren't available, too.
+    dnl pwd, grp APIs, and resource functions (get/setrusage) are stubs.
+    PY_STDLIB_MOD_SET_NA(
+      [_curses],
+      [_curses_panel],
+      [_dbm],
+      [_gdbm],
+      [_multiprocessing],
+      [_posixshmem],
+      [_posixsubprocess],
+      [_scproxy],
+      [_tkinter],
+      [_interpreters],
+      [_interpchannels],
+      [_interpqueues],
+      [grp],
+      [pwd],
+      [resource],
+      [syslog],
+    )
+    dnl WASI SDK 15.0 does not support file locking, mmap, and more.
+    dnl Test modules that must be compiled as shared libraries are not supported
+    dnl (see Modules/Setup.stdlib.in).
+    PY_STDLIB_MOD_SET_NA(
+      [_ctypes_test],
+      [_testexternalinspection],
+      [_testimportmultiple],
+      [_testmultiphase],
+      [_testsinglephase],
+      [fcntl],
+      [mmap],
+      [termios],
+      [xxlimited],
+      [xxlimited_35],
     )
   ],
   [PY_STDLIB_MOD_SET_NA([_scproxy])]


### PR DESCRIPTION
@brettcannon If I am interpreting correctly this was one of your desiderata?
cc @freakboy3742 

I think it should be skip-news.

<!-- gh-issue-number: gh-126178 -->
* Issue: gh-126178
<!-- /gh-issue-number -->
