### PR TITLE
Fix incorrect indentation in importlib.metadata.rst

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -229,10 +229,10 @@ Distribution metadata
 .. class:: PackageMetadata
 
    A concrete implementation of the
-    `PackageMetadata protocol <https://importlib-metadata.readthedocs.io/en/latest/api.html#importlib_metadata.PackageMetadata>`_.
+   `PackageMetadata protocol <https://importlib-metadata.readthedocs.io/en/latest/api.html#importlib_metadata.PackageMetadata>`_.
 
-    In addition to providing the defined protocol methods and attributes, subscripting
-    the instance is equivalent to calling the :meth:`!get` method.
+   In addition to providing the defined protocol methods and attributes, subscripting
+   the instance is equivalent to calling the :meth:`!get` method.
 
 Every `Distribution Package <https://packaging.python.org/en/latest/glossary/#term-Distribution-Package>`_
 includes some metadata, which you can extract using the :func:`!metadata` function::


### PR DESCRIPTION
This code was breaking lines and splitting translation strings

How it was:

![image](https://github.com/user-attachments/assets/d87f8c96-7675-4156-9842-dec926363a62)

After this fix:

![image](https://github.com/user-attachments/assets/3821bfcc-d07f-405a-b75e-89c6cc80e226)



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126189.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->