### PR TITLE
gh-126195: Use pthread_jit_write_protect_np on macOS

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-10-30-18-16-10.gh-issue-126195.6ezBpr.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-10-30-18-16-10.gh-issue-126195.6ezBpr.rst
@@ -1,1 +1,1 @@
-Improve JIT performance by 1.4% on macOS Apple Silicon. Patch by Diego Russo.
+Improve JIT performance by 1.4% on macOS Apple Silicon by using platform-specific memory protection APIs. Patch by Diego Russo.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-10-30-18-16-10.gh-issue-126195.6ezBpr.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-10-30-18-16-10.gh-issue-126195.6ezBpr.rst
@@ -1,0 +1,1 @@
+Improve JIT performance by 1.4% on macOS Apple Silicon. Patch by Diego Russo.

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -540,11 +540,10 @@ _PyJIT_Compile(_PyExecutorObject *executor, const _PyUOpInstruction trace[], siz
     data += group->data_size;
     assert(code == memory + code_size);
     assert(data == memory + code_size + data_size);
-    int status = mark_executable(memory, total_size);
 #ifdef MAP_JIT
     pthread_jit_write_protect_np(1);
 #endif
-    if (status) {
+    if (mark_executable(memory, total_size)) {
         jit_free(memory, total_size);
         return -1;
     }

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -109,9 +109,9 @@ mark_executable(unsigned char *memory, size_t size)
 #else
     int failed = 0;
     __builtin___clear_cache((char *)memory, (char *)memory + size);
-# ifndef MAP_JIT
+#ifndef MAP_JIT
     failed = mprotect(memory, size, PROT_EXEC | PROT_READ);
-# endif
+#endif
 #endif
     if (failed) {
         jit_error("unable to protect executable memory");


### PR DESCRIPTION
Replace mprotect with pthread_jit_write_protect_np on MacOS Apple Silicon.
Improve JIT performance by ~1.4% on this platform.

<!-- gh-issue-number: gh-126195 -->
* Issue: gh-126195
<!-- /gh-issue-number -->
