### PR TITLE
GH-126205: Fix conversion of UNC paths to file URIs

### DIFF
--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -55,16 +55,11 @@ def pathname2url(p):
     if p[:4] == '\\\\?\\':
         p = p[4:]
         if p[:4].upper() == 'UNC\\':
-            p = '\\' + p[4:]
+            p = '\\\\' + p[4:]
         elif p[1:2] != ':':
             raise OSError('Bad path: ' + p)
     if not ':' in p:
         # No drive specifier, just convert slashes and quote the name
-        if p[:2] == '\\\\':
-        # path is something like \\host\path\on\remote\host
-        # convert this to ////host/path/on/remote/host
-        # (notice doubling of slashes at the start of the path)
-            p = '\\\\' + p
         components = p.split('\\')
         return urllib.parse.quote('/'.join(components))
     comp = p.split(':', maxsplit=2)

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1542,7 +1542,7 @@ class Pathname_Tests(unittest.TestCase):
         self.assertEqual(fn('\\\\some\\share\\a\\b%#c\xe9'), '//some/share/a/b%25%23c%C3%A9')
         # Round-tripping
         urls = ['///C:',
-                '/////folder/test/',
+                '///folder/test/',
                 '///C:/foo/bar/spam.foo']
         for url in urls:
             self.assertEqual(fn(urllib.request.url2pathname(url)), url)

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1524,7 +1524,7 @@ class Pathname_Tests(unittest.TestCase):
         # Test special prefixes are correctly handled in pathname2url()
         fn = urllib.request.pathname2url
         self.assertEqual(fn('\\\\?\\C:\\dir'), '///C:/dir')
-        self.assertEqual(fn('\\\\?\\unc\\server\\share\\dir'), '/server/share/dir')
+        self.assertEqual(fn('\\\\?\\unc\\server\\share\\dir'), '//server/share/dir')
         self.assertEqual(fn("C:"), '///C:')
         self.assertEqual(fn("C:\\"), '///C:')
         self.assertEqual(fn('C:\\a\\b.c'), '///C:/a/b.c')
@@ -1535,11 +1535,11 @@ class Pathname_Tests(unittest.TestCase):
         self.assertRaises(IOError, fn, "XX:\\")
         # No drive letter
         self.assertEqual(fn("\\folder\\test\\"), '/folder/test/')
-        self.assertEqual(fn("\\\\folder\\test\\"), '////folder/test/')
-        self.assertEqual(fn("\\\\\\folder\\test\\"), '/////folder/test/')
-        self.assertEqual(fn('\\\\some\\share\\'), '////some/share/')
-        self.assertEqual(fn('\\\\some\\share\\a\\b.c'), '////some/share/a/b.c')
-        self.assertEqual(fn('\\\\some\\share\\a\\b%#c\xe9'), '////some/share/a/b%25%23c%C3%A9')
+        self.assertEqual(fn("\\\\folder\\test\\"), '//folder/test/')
+        self.assertEqual(fn("\\\\\\folder\\test\\"), '///folder/test/')
+        self.assertEqual(fn('\\\\some\\share\\'), '//some/share/')
+        self.assertEqual(fn('\\\\some\\share\\a\\b.c'), '//some/share/a/b.c')
+        self.assertEqual(fn('\\\\some\\share\\a\\b%#c\xe9'), '//some/share/a/b%25%23c%C3%A9')
         # Round-tripping
         urls = ['///C:',
                 '/////folder/test/',

--- a/Misc/NEWS.d/next/Library/2024-10-30-20-45-17.gh-issue-126205.CHEmtx.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-30-20-45-17.gh-issue-126205.CHEmtx.rst
@@ -1,0 +1,2 @@
+Fix issue where :func:`urllib.request.pathname2url` generated URLs beginning
+with four slashes (rather than two) when given a Windows UNC path.


### PR DESCRIPTION
File URIs for Windows UNC paths should begin with two slashes, not four - see issue.

<!-- gh-issue-number: gh-126205 -->
* Issue: gh-126205
<!-- /gh-issue-number -->
