### PR TITLE
Add myself to CODEOWNERS for WASM/emscripten and Android

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -267,7 +267,7 @@ Lib/test/test_interpreters/   @ericsnowcurrently
 **/*-ios*                     @freakboy3742
 
 # WebAssembly
-/Tools/wasm/                  @brettcannon
+/Tools/wasm/                  @brettcannon @freakboy3742
 
 # SBOM
 /Misc/externals.spdx.json     @sethmlarson

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -255,8 +255,8 @@ Modules/_interp*module.c      @ericsnowcurrently
 Lib/test/test_interpreters/   @ericsnowcurrently
 
 # Android
-**/*Android*                  @mhsmith
-**/*android*                  @mhsmith
+**/*Android*                  @mhsmith @freakboy3742
+**/*android*                  @mhsmith @freakboy3742
 
 # iOS (but not termios)
 **/iOS*                       @freakboy3742


### PR DESCRIPTION
With the approval of python/steering-council#256, I've added myself to CODEOWNERS for the WASM folder.

I imagine this might get refined in future when there's a clearer emscripten/WASI split in the tools/wasm folder; but for now, a blanket "all wasm" seems appropriate.

Since I'm a core team sponsor of Android code, I figure I should add my name there as well.