### PR TITLE
gh-126211: Exclude preprocessor directives from statements containing escaping calls

### DIFF
--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -1429,6 +1429,39 @@ class TestGeneratedCases(unittest.TestCase):
         with self.assertRaisesRegex(SyntaxError, "All instructions containing a uop"):
             self.run_cases_test(input, output)
 
+    def test_escaping_call_next_to_cmacro(self):
+        input = """
+        inst(OP, (--)) {
+        #ifdef Py_GIL_DISABLED
+        escaping_call();
+        #else
+        another_escaping_call();
+        #endif
+        yet_another_escaping_call();
+        }
+        """
+        output = """
+        TARGET(OP) {
+            frame->instr_ptr = next_instr;
+            next_instr += 1;
+            INSTRUCTION_STATS(OP);
+            #ifdef Py_GIL_DISABLED
+            _PyFrame_SetStackPointer(frame, stack_pointer);
+            escaping_call();
+            stack_pointer = _PyFrame_GetStackPointer(frame);
+            #else
+            _PyFrame_SetStackPointer(frame, stack_pointer);
+            another_escaping_call();
+            stack_pointer = _PyFrame_GetStackPointer(frame);
+            #endif
+            _PyFrame_SetStackPointer(frame, stack_pointer);
+            yet_another_escaping_call();
+            stack_pointer = _PyFrame_GetStackPointer(frame);
+            DISPATCH();
+        }
+        """
+        self.run_cases_test(input, output)
+
 
 class TestGeneratedAbstractCases(unittest.TestCase):
     def setUp(self) -> None:

--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -1432,12 +1432,12 @@ class TestGeneratedCases(unittest.TestCase):
     def test_escaping_call_next_to_cmacro(self):
         input = """
         inst(OP, (--)) {
-        #ifdef Py_GIL_DISABLED
-        escaping_call();
-        #else
-        another_escaping_call();
-        #endif
-        yet_another_escaping_call();
+            #ifdef Py_GIL_DISABLED
+            escaping_call();
+            #else
+            another_escaping_call();
+            #endif
+            yet_another_escaping_call();
         }
         """
         output = """

--- a/Tools/cases_generator/analyzer.py
+++ b/Tools/cases_generator/analyzer.py
@@ -637,7 +637,7 @@ def find_stmt_start(node: parser.InstDef, idx: int) -> lexer.Token:
     assert idx < len(node.block.tokens)
     while True:
         tkn = node.block.tokens[idx-1]
-        if tkn.kind in {"SEMI", "LBRACE", "RBRACE"}:
+        if tkn.kind in {"SEMI", "LBRACE", "RBRACE", "CMACRO"}:
             break
         idx -= 1
         assert idx > 0


### PR DESCRIPTION
The cases generator inserts code to save and restore the stack pointer around statements that contain escaping calls. To find the beginning of such statements, we walk backwards from the escaping call until we encounter a token that is treated as a statement terminator. This set of terminators should include preprocessor directives.

<!-- gh-issue-number: gh-126211 -->
* Issue: gh-126211
<!-- /gh-issue-number -->
