### PR TITLE
gh-126223: Propagate unicode errors in `_interpreters.create()`

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -54,6 +54,10 @@ class CreateTests(TestBase):
         self.assertIsInstance(interp, interpreters.Interpreter)
         self.assertIn(interp, interpreters.list_all())
 
+        # GH-126221: Passing an invalid unicode character used to cause a SystemError
+        with self.assertRaises(UnicodeEncodeError):
+            _interpreters.create('\udc80')
+
     def test_in_thread(self):
         lock = threading.Lock()
         interp = None

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -54,7 +54,7 @@ class CreateTests(TestBase):
         self.assertIsInstance(interp, interpreters.Interpreter)
         self.assertIn(interp, interpreters.list_all())
 
-        # GH-126221: Passing an invalid unicode character used to cause a SystemError
+        # GH-126221: Passing an invalid Unicode character used to cause a SystemError
 		self.assertRaises(UnicodeEncodeError, _interpreters.create, '\udc80')
 
     def test_in_thread(self):

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -55,8 +55,7 @@ class CreateTests(TestBase):
         self.assertIn(interp, interpreters.list_all())
 
         # GH-126221: Passing an invalid unicode character used to cause a SystemError
-        with self.assertRaises(UnicodeEncodeError):
-            _interpreters.create('\udc80')
+		self.assertRaises(UnicodeEncodeError, _interpreters.create, '\udc80')
 
     def test_in_thread(self):
         lock = threading.Lock()

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -55,7 +55,7 @@ class CreateTests(TestBase):
         self.assertIn(interp, interpreters.list_all())
 
         # GH-126221: Passing an invalid Unicode character used to cause a SystemError
-		self.assertRaises(UnicodeEncodeError, _interpreters.create, '\udc80')
+        self.assertRaises(UnicodeEncodeError, _interpreters.create, '\udc80')
 
     def test_in_thread(self):
         lock = threading.Lock()

--- a/Misc/NEWS.d/next/Library/2024-10-30-23-42-44.gh-issue-126223.k2qooc.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-30-23-42-44.gh-issue-126223.k2qooc.rst
@@ -1,0 +1,2 @@
+Fixed :exc:`SystemError` upon calling :func:`!_interpreters.create` without
+an invalid unicode character.

--- a/Misc/NEWS.d/next/Library/2024-10-30-23-42-44.gh-issue-126223.k2qooc.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-30-23-42-44.gh-issue-126223.k2qooc.rst
@@ -1,2 +1,2 @@
-Fixed :exc:`SystemError` upon calling :func:`!_interpreters.create` with
-an invalid unicode character.
+Raise a :exc:`UnicodeEncodeError` instead of a :exc:`SystemError` upon
+calling :func:`!_interpreters.create` with an invalid Unicode character.

--- a/Misc/NEWS.d/next/Library/2024-10-30-23-42-44.gh-issue-126223.k2qooc.rst
+++ b/Misc/NEWS.d/next/Library/2024-10-30-23-42-44.gh-issue-126223.k2qooc.rst
@@ -1,2 +1,2 @@
-Fixed :exc:`SystemError` upon calling :func:`!_interpreters.create` without
+Fixed :exc:`SystemError` upon calling :func:`!_interpreters.create` with
 an invalid unicode character.

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -407,7 +407,7 @@ config_from_object(PyObject *configobj, PyInterpreterConfig *config)
         {
             return -1;
         }
-        if (init_named_config(config, PyUnicode_AsUTF8(configobj)) < 0) {
+        if (init_named_config(config, utf8) < 0) {
             return -1;
         }
     }

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -402,6 +402,11 @@ config_from_object(PyObject *configobj, PyInterpreterConfig *config)
         }
     }
     else if (PyUnicode_Check(configobj)) {
+        const char *utf8 = PyUnicode_AsUTF8(configobj);
+        if (utf8 == NULL)
+        {
+            return -1;
+        }
         if (init_named_config(config, PyUnicode_AsUTF8(configobj)) < 0) {
             return -1;
         }

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -402,11 +402,11 @@ config_from_object(PyObject *configobj, PyInterpreterConfig *config)
         }
     }
     else if (PyUnicode_Check(configobj)) {
-        const char *utf8 = PyUnicode_AsUTF8(configobj);
-        if (utf8 == NULL) {
+        const char *utf8name = PyUnicode_AsUTF8(configobj);
+        if (utf8name == NULL) {
             return -1;
         }
-        if (init_named_config(config, utf8) < 0) {
+        if (init_named_config(config, utf8name) < 0) {
             return -1;
         }
     }

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -403,8 +403,7 @@ config_from_object(PyObject *configobj, PyInterpreterConfig *config)
     }
     else if (PyUnicode_Check(configobj)) {
         const char *utf8 = PyUnicode_AsUTF8(configobj);
-        if (utf8 == NULL)
-        {
+        if (utf8 == NULL) {
             return -1;
         }
         if (init_named_config(config, utf8) < 0) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-126223 -->
* Issue: gh-126223
<!-- /gh-issue-number -->
