### PR TITLE
gh-126238: Fix possible null pointer dereference of freevars in _PyCompile_LookupArg

### DIFF
--- a/Misc/NEWS.d/next/Security/2024-10-31-13-14-27.gh-issue-126238.CZqaon.rst
+++ b/Misc/NEWS.d/next/Security/2024-10-31-13-14-27.gh-issue-126238.CZqaon.rst
@@ -1,1 +1,1 @@
-Fix a possible ``NULL`` pointer dereference in :c:func:`!_PyCompile_LookupArg`.
+Fix a possible crash internally when compiling.

--- a/Misc/NEWS.d/next/Security/2024-10-31-13-14-27.gh-issue-126238.CZqaon.rst
+++ b/Misc/NEWS.d/next/Security/2024-10-31-13-14-27.gh-issue-126238.CZqaon.rst
@@ -1,1 +1,0 @@
-Fix a possible crash internally when compiling.

--- a/Misc/NEWS.d/next/Security/2024-10-31-13-14-27.gh-issue-126238.CZqaon.rst
+++ b/Misc/NEWS.d/next/Security/2024-10-31-13-14-27.gh-issue-126238.CZqaon.rst
@@ -1,0 +1,1 @@
+Fix a possible ``NULL`` pointer dereference in :c:func:`!_PyCompile_LookupArg`.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -901,7 +901,7 @@ _PyCompile_LookupArg(compiler *c, PyCodeObject *co, PyObject *name)
             c->u->u_metadata.u_name,
             co->co_name,
             freevars);
-        Py_DECREF(freevars);
+        Py_XDECREF(freevars);
         return ERROR;
     }
     return arg;


### PR DESCRIPTION


<!-- gh-issue-number: gh-126238 -->
* Issue: gh-126238
<!-- /gh-issue-number -->
