### PR TITLE
gh-126240: handle `NULL` returned by  `_Py_asdl_expr_seq_new`

### DIFF
--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -1128,6 +1128,9 @@ expr_ty _PyPegen_collect_call_seqs(Parser *p, asdl_expr_seq *a, asdl_seq *b,
     }
 
     asdl_expr_seq *args = _Py_asdl_expr_seq_new(total_len, arena);
+    if (args == NULL) {
+        return NULL;
+    }
 
     Py_ssize_t i = 0;
     for (i = 0; i < args_len; i++) {
@@ -1298,6 +1301,9 @@ unpack_top_level_joined_strs(Parser *p, asdl_expr_seq *raw_expressions)
     }
 
     asdl_expr_seq *expressions = _Py_asdl_expr_seq_new(req_size, p->arena);
+    if (expressions == NULL) {
+        return NULL;
+    }
 
     Py_ssize_t raw_index, req_index = 0;
     for (raw_index = 0; raw_index < raw_size; raw_index++) {
@@ -1490,6 +1496,9 @@ expr_ty _PyPegen_formatted_value(Parser *p, expr_ty expression, Token *debug, Re
         }
 
         asdl_expr_seq *values = _Py_asdl_expr_seq_new(2, arena);
+        if (values == NULL) {
+            return NULL;
+        }
         asdl_seq_SET(values, 0, debug_text);
         asdl_seq_SET(values, 1, formatted_value);
         return _PyAST_JoinedStr(values, lineno, col_offset, debug_end_line, debug_end_offset, p->arena);


### PR DESCRIPTION
I've checked other constructors `_Py_asdl_*_seq_new` but couldn't find occurrences of them not having some `if (!res)` check after the call. I don't think this warrants a NEWS entry so I'll add the `skip news` label for now.

<!-- gh-issue-number: gh-126240 -->
* Issue: gh-126240
<!-- /gh-issue-number -->
