### PR TITLE
[3.12] gh-126240: handle `NULL` returned by  `_Py_asdl_expr_seq_new` (GH-126241)

### DIFF
--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -1043,6 +1043,9 @@ expr_ty _PyPegen_collect_call_seqs(Parser *p, asdl_expr_seq *a, asdl_seq *b,
   }
 
   asdl_expr_seq *args = _Py_asdl_expr_seq_new(total_len, arena);
+  if (args == NULL) {
+    return NULL;
+  }
 
   Py_ssize_t i = 0;
   for (i = 0; i < args_len; i++) {
@@ -1210,6 +1213,9 @@ unpack_top_level_joined_strs(Parser *p, asdl_expr_seq *raw_expressions) {
   }
 
   asdl_expr_seq *expressions = _Py_asdl_expr_seq_new(req_size, p->arena);
+  if (expressions == NULL) {
+    return NULL;
+  }
 
   Py_ssize_t raw_index, req_index = 0;
   for (raw_index = 0; raw_index < raw_size; raw_index++) {
@@ -1400,6 +1406,9 @@ expr_ty _PyPegen_formatted_value(Parser *p, expr_ty expression, Token *debug,
     }
 
     asdl_expr_seq *values = _Py_asdl_expr_seq_new(2, arena);
+    if (values == NULL) {
+      return NULL;
+    }
     asdl_seq_SET(values, 0, debug_text);
     asdl_seq_SET(values, 1, formatted_value);
     return _PyAST_JoinedStr(values, lineno, col_offset, debug_end_line,


### PR DESCRIPTION
check return value of `_Py_asdl_expr_seq_new`
(cherry picked from commit 94639f6b7182c2e1a82f2f907b03b5b15202acfa)

<!-- gh-issue-number: gh-126240 -->
* Issue: gh-126240
<!-- /gh-issue-number -->
