### PR TITLE
gh-126256: Update time.rst to use the same clock as instead of the same clock than

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -327,7 +327,7 @@ Functions
 
    .. impl-detail::
 
-      On CPython, use the same clock than :func:`time.monotonic` and is a
+      On CPython, use the same clock as :func:`time.monotonic` and is a
       monotonic clock, i.e. a clock that cannot go backwards.
 
    Use :func:`perf_counter_ns` to avoid the precision loss caused by the
@@ -339,7 +339,7 @@ Functions
       On Windows, the function is now system-wide.
 
    .. versionchanged:: 3.13
-      Use the same clock than :func:`time.monotonic`.
+      Use the same clock as :func:`time.monotonic`.
 
 
 .. function:: perf_counter_ns() -> int


### PR DESCRIPTION
The time documentation uses the same clock than time.monotonic instead of the same clock as time.monotonic, which is grammatically false. This PR fixes changes two instances of the same clock than to the same clock as.

https://github.com/python/cpython/issues/126256

<!-- gh-issue-number: gh-126256 -->
* Issue: gh-126256
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126257.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->