### PR TITLE
gh-126259: Fix warning in doctest of `sqlite3`

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -2442,6 +2442,7 @@ Some useful URI tricks include:
    >>> con.execute("CREATE TABLE readonly(data)")
    Traceback (most recent call last):
    OperationalError: attempt to write a readonly database
+   >>> con.close()
 
 * Do not implicitly create a new database file if it does not already exist;
   will raise :exc:`~sqlite3.OperationalError` if unable to create a new file:


### PR DESCRIPTION
After:
<img width="788" alt="Снимок экрана 2024-11-01 в 01 32 18" src="https://github.com/user-attachments/assets/be2e1f3d-d1a9-45e8-b2fc-27fd37ec8f25">


<!-- gh-issue-number: gh-126259 -->
* Issue: gh-126259
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126260.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->