### PR TITLE
gh-99108: Cleanup references to inexisting `Modules/_blake2`.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -88,7 +88,6 @@ Objects/exceptions.c          @iritkatriel
 **/sha*                       @gpshead @tiran
 Modules/md5*                  @gpshead @tiran
 **/*blake*                    @gpshead @tiran
-Modules/_blake2/**            @gpshead @tiran
 Modules/_hacl/**              @gpshead
 
 # logging

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -917,15 +917,6 @@
     <ClCompile Include="..\Modules\_bisectmodule.c">
       <Filter>Modules</Filter>
     </ClCompile>
-    <ClCompile Include="..\Modules\_blake2\blake2module.c">
-      <Filter>Modules</Filter>
-    </ClCompile>
-    <ClCompile Include="..\Modules\_blake2\blake2b_impl.c">
-      <Filter>Modules</Filter>
-    </ClCompile>
-    <ClCompile Include="..\Modules\_blake2\blake2s_impl.c">
-      <Filter>Modules</Filter>
-    </ClCompile>
     <ClCompile Include="..\Modules\_codecsmodule.c">
       <Filter>Modules</Filter>
     </ClCompile>

--- a/Tools/c-analyzer/TODO
+++ b/Tools/c-analyzer/TODO
@@ -562,8 +562,6 @@ Objects/unicodeobject.c:static_strings                           static _Py_Iden
 
 # PyTypeObject (311)
 Modules/_abc.c:_abc_data_type                                    static PyTypeObject _abc_data_type
-Modules/_blake2/blake2b_impl.c:PyBlake2_BLAKE2bType              PyTypeObject PyBlake2_BLAKE2bType
-Modules/_blake2/blake2s_impl.c:PyBlake2_BLAKE2sType              PyTypeObject PyBlake2_BLAKE2sType
 Modules/_collectionsmodule.c:defdict_type                        static PyTypeObject defdict_type
 Modules/_collectionsmodule.c:deque_type                          static PyTypeObject deque_type
 Modules/_collectionsmodule.c:dequeiter_type                      static PyTypeObject dequeiter_type

--- a/Tools/c-analyzer/cpython/ignored.tsv
+++ b/Tools/c-analyzer/cpython/ignored.tsv
@@ -629,8 +629,6 @@ Modules/_xxtestfuzz/fuzzer.c	LLVMFuzzerTestOneInput	ELEMENTTREE_PARSEWHOLE_INITI
 Include/internal/pycore_importdl.h	-	_PyImport_DynLoadFiletab	-
 Include/py_curses.h	-	PyCurses_API	-
 Include/pydecimal.h	-	_decimal_api	-
-Modules/_blake2/blake2module.c	-	blake2b_type_spec	-
-Modules/_blake2/blake2module.c	-	blake2s_type_spec	-
 Modules/_io/fileio.c	-	_Py_open_cloexec_works	-
 Modules/_io/_iomodule.h	-	PyIOBase_Type	-
 Modules/_io/_iomodule.h	-	PyRawIOBase_Type	-

--- a/configure
+++ b/configure
@@ -28091,7 +28091,6 @@ done
 
 SRCDIRS="\
   Modules \
-  Modules/_blake2 \
   Modules/_ctypes \
   Modules/_decimal \
   Modules/_decimal/libmpdec \

--- a/configure.ac
+++ b/configure.ac
@@ -7074,7 +7074,6 @@ done
 AC_SUBST([SRCDIRS])
 SRCDIRS="\
   Modules \
-  Modules/_blake2 \
   Modules/_ctypes \
   Modules/_decimal \
   Modules/_decimal/libmpdec \


### PR DESCRIPTION
Since https://github.com/python/cpython/pull/119316, we removed the internal `Modules/_blake2` folder but there were some occurrences left. Somtimes I see this (empty) folder appear in my branch, probably generated by `configure` or something else. This PR removes the bits related to this (now) inexisting folder.

cc @msprotz @gpshead 

<!-- gh-issue-number: gh-99108 -->
* Issue: gh-99108
<!-- /gh-issue-number -->
