### PR TITLE
gh-126255: Ignore warning about JIT being deactivated when perf support is active in `test_embed.InitConfigTests.test_initconfig_api`

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1781,13 +1781,10 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'perf_profiling': 2,
         }
         config_dev_mode(preconfig, config)
-        using_jit = any(x.startswith("JIT") for x in get_build_info())
-        if using_jit:
-            stderr = "<sys>:0: RuntimeWarning: JIT deactivated as perf profiling support is active"
-        else:
-            stderr = ""
+        # Temporarily enable ignore_stderr=True to ignore warnings on JIT builds
+        # See gh-126255 for more information
         self.check_all_configs("test_initconfig_api", config, preconfig,
-                               api=API_ISOLATED, stderr=stderr)
+                               api=API_ISOLATED, ignore_stderr=True)
 
     def test_initconfig_get_api(self):
         self.run_embedded_interpreter("test_initconfig_get_api")

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1,5 +1,6 @@
 # Run the tests in Programs/_testembed.c (tests for the CPython embedding APIs)
 from test import support
+from test.libregrtest.utils import get_build_info
 from test.support import import_helper, os_helper, threading_helper, MS_WINDOWS
 import unittest
 
@@ -1780,8 +1781,13 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'perf_profiling': 2,
         }
         config_dev_mode(preconfig, config)
+        using_jit = any(x.startswith("JIT") for x in get_build_info())
+        if using_jit:
+            stderr = "<sys>:0: RuntimeWarning: JIT deactivated as perf profiling support is active"
+        else:
+            stderr = ""
         self.check_all_configs("test_initconfig_api", config, preconfig,
-                               api=API_ISOLATED)
+                               api=API_ISOLATED, stderr=stderr)
 
     def test_initconfig_get_api(self):
         self.run_embedded_interpreter("test_initconfig_get_api")

--- a/Lib/test/test_perf_profiler.py
+++ b/Lib/test/test_perf_profiler.py
@@ -210,14 +210,14 @@ class TestPerfTrampoline(unittest.TestCase):
                 sys.activate_stack_trampoline("perf")
                 sys.activate_stack_trampoline("perf")
                 """
-        assert_python_ok("-c", code)
+        assert_python_ok("-c", code, PYTHON_JIT="0")
 
     def test_sys_api_with_invalid_trampoline(self):
         code = """if 1:
                 import sys
                 sys.activate_stack_trampoline("invalid")
                 """
-        rc, out, err = assert_python_failure("-c", code)
+        rc, out, err = assert_python_failure("-c", code, PYTHON_JIT="0")
         self.assertIn("invalid backend: invalid", err.decode())
 
     def test_sys_api_get_status(self):
@@ -228,7 +228,7 @@ class TestPerfTrampoline(unittest.TestCase):
                 sys.deactivate_stack_trampoline()
                 assert sys.is_stack_trampoline_active() is False
                 """
-        assert_python_ok("-c", code)
+        assert_python_ok("-c", code, PYTHON_JIT="0")
 
 
 def is_unwinding_reliable_with_frame_pointers():

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1699,4 +1699,5 @@ error:
     _Py_Executors_InvalidateAll(interp, 0);
 }
 
+
 #endif /* _Py_TIER2 */

--- a/Python/optimizer.c
+++ b/Python/optimizer.c
@@ -1699,5 +1699,4 @@ error:
     _Py_Executors_InvalidateAll(interp, 0);
 }
 
-
 #endif /* _Py_TIER2 */

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1310,12 +1310,15 @@ init_interp_main(PyThreadState *tstate)
             enabled = *env != '0';
         }
         if (enabled) {
+#ifdef _Py_JIT
             if (config->perf_profiling > 0) {
                 (void)PyErr_WarnEx(
                     PyExc_RuntimeWarning,
                     "JIT deactivated as perf profiling support is active",
                     0);
-            } else {
+            } else 
+#endif
+            {
                 PyObject *opt = _PyOptimizer_NewUOpOptimizer();
                 if (opt == NULL) {
                     return _PyStatus_ERR("can't initialize optimizer");

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1311,6 +1311,8 @@ init_interp_main(PyThreadState *tstate)
         }
         if (enabled) {
 #ifdef _Py_JIT
+            // perf profiler works fine with tier 2 interpreter, so
+            // only checking for a "real JIT".
             if (config->perf_profiling > 0) {
                 (void)PyErr_WarnEx(
                     PyExc_RuntimeWarning,

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1316,7 +1316,7 @@ init_interp_main(PyThreadState *tstate)
                     PyExc_RuntimeWarning,
                     "JIT deactivated as perf profiling support is active",
                     0);
-            } else 
+            } else
 #endif
             {
                 PyObject *opt = _PyOptimizer_NewUOpOptimizer();

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2290,6 +2290,7 @@ sys_activate_stack_trampoline_impl(PyObject *module, const char *backend)
 #ifdef _Py_JIT
     _PyOptimizerObject* optimizer = _Py_GetOptimizer();
     if (optimizer != NULL) {
+        Py_DECREF(optimizer);
         PyErr_SetString(PyExc_ValueError, "Cannot activate the perf trampoline if the JIT is active");
         return NULL;
     }


### PR DESCRIPTION
This is a temporary measure to get JIT tests passing again while other folks work on a more comprehensive solution.


<!-- gh-issue-number: gh-126255 -->
* Issue: gh-126255
<!-- /gh-issue-number -->
