### PR TITLE
gh-92347: Throw a warning when converting a pointer to an iterator

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -870,6 +870,14 @@ invalid non-\ ``NULL`` pointers would crash Python)::
    ValueError: NULL pointer access
    >>>
 
+Converting pointer to iterator causes Python to crash::
+
+   >>> x = c_int32(54321)
+   >>> list(pointer(x))
+   Traceback (most recent call last):
+      ...
+   NotImplementedError: Pointer object does not support iterator
+
 
 .. _ctypes-type-conversions:
 

--- a/Lib/test/test_ctypes/test_pointers.py
+++ b/Lib/test/test_ctypes/test_pointers.py
@@ -48,6 +48,11 @@ class PointersTestCase(unittest.TestCase):
         # Pointer can't set contents: has no _type_
         self.assertRaises(TypeError, A, c_ulong(33))
 
+    def test_disable_iter(self):
+        self.assertRaises(NotImplementedError, list, pointer(c_int(123)))
+        self.assertRaises(NotImplementedError, set, pointer(c_int(123)))
+        self.assertRaises(NotImplementedError, tuple, pointer(c_int(123)))
+
     def test_pass_pointers(self):
         dll = CDLL(_ctypes_test.__file__)
         func = dll._testfunc_p_p

--- a/Misc/NEWS.d/next/Library/2024-11-02-10-58-32.gh-issue-126272.SemJLX.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-02-10-58-32.gh-issue-126272.SemJLX.rst
@@ -1,0 +1,1 @@
+:exc:`NotImplementedError` error thrown when converting :func:`ctypes.pointer` to iterator.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5477,11 +5477,20 @@ Pointer_bool(CDataObject *self)
     return (*(void **)self->b_ptr != NULL);
 }
 
+static PyObject *
+Pointer_iter(PyObject *myself)
+{
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "Pointer object does not support iterator");
+    return NULL;
+}
+
 static PyType_Slot pycpointer_slots[] = {
     {Py_tp_doc, PyDoc_STR("XXX to be provided")},
     {Py_tp_getset, Pointer_getsets},
     {Py_tp_init, Pointer_init},
     {Py_tp_new, Pointer_new},
+    {Py_tp_iter, Pointer_iter},
     {Py_bf_getbuffer, PyCData_NewGetBuffer},
     {Py_nb_bool, Pointer_bool},
     {Py_mp_subscript, Pointer_subscript},


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```


Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
> Similar to https://github.com/python/cpython/pull/92262. I think we should fix this (by setting tp_iter to None) but only on the main branch in case people rely on calling next() on a pointer object.

cc @JelleZijlstra

Since it is implemented in an extension, I added an exception when getting it. Do you think?

<!-- gh-issue-number: gh-92347 -->
* Issue: gh-92347
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126318.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->