### PR TITLE
gh-125522: Remove bare except in test_zlib.test_flushes

### DIFF
--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -511,10 +511,9 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
                     b = obj.flush( sync )
                     c = obj.compress( data[3000:] )
                     d = obj.flush()
-                    
                     self.assertEqual(zlib.decompress(b''.join([a,b,c,d])),
-                    data, ("Decompress failed: flush "
-                    "mode=%i, level=%i") % (sync, level))
+                                     data, ("Decompress failed: flush "
+                                    "mode=%i, level=%i") % (sync, level))
                     del obj
 
     @unittest.skipUnless(hasattr(zlib, 'Z_SYNC_FLUSH'),

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -505,20 +505,17 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
 
         for sync in sync_opt:
             for level in range(10):
-                try:
+                with self.subTest(sync=sync, level=level):
                     obj = zlib.compressobj( level )
                     a = obj.compress( data[:3000] )
                     b = obj.flush( sync )
                     c = obj.compress( data[3000:] )
                     d = obj.flush()
-                except zlib.error:
-                    print("Error for flush mode={}, level={}"
-                          .format(sync, level))
-                    raise
-                self.assertEqual(zlib.decompress(b''.join([a,b,c,d])),
-                                 data, ("Decompress failed: flush "
-                                        "mode=%i, level=%i") % (sync, level))
-                del obj
+                    
+                    self.assertEqual(zlib.decompress(b''.join([a,b,c,d])),
+                    data, ("Decompress failed: flush "
+                    "mode=%i, level=%i") % (sync, level))
+                    del obj
 
     @unittest.skipUnless(hasattr(zlib, 'Z_SYNC_FLUSH'),
                          'requires zlib.Z_SYNC_FLUSH')

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -513,7 +513,7 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
                     d = obj.flush()
                     self.assertEqual(zlib.decompress(b''.join([a,b,c,d])),
                                      data, ("Decompress failed: flush "
-                                    "mode=%i, level=%i") % (sync, level))
+                                            "mode=%i, level=%i") % (sync, level))
                     del obj
 
     @unittest.skipUnless(hasattr(zlib, 'Z_SYNC_FLUSH'),

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -511,7 +511,7 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
                     b = obj.flush( sync )
                     c = obj.compress( data[3000:] )
                     d = obj.flush()
-                except:
+                except zlib.error:
                     print("Error for flush mode={}, level={}"
                           .format(sync, level))
                     raise


### PR DESCRIPTION
This is a simple rewrite of the test to avoid bare except and make the test's intention clearer.
- zlib only has single exception(zlib.error) but explicitly displaying error name would be better..!
- Reference:  https://docs.python.org/3/library/zlib.html

<!-- gh-issue-number: gh-125522 -->
* Issue: gh-125522
<!-- /gh-issue-number -->
