### PR TITLE
gh-126209: Fix inconsistency of  `skip_file_prefixes` in `warnings.warn`'s C and Python implementations

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -542,6 +542,7 @@ class WarnTests(BaseTest):
             ) as w:
                 warning_tests.outer("msg", skip_file_prefixes=(skipped,))
 
+            self.assertEqual(len(w), 1)
             self.assertNotEqual(w[-1].filename, skipped)
 
     def test_skip_file_prefixes_type_errors(self):

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -533,6 +533,14 @@ class WarnTests(BaseTest):
                 warning_tests.package("prefix02", stacklevel=3)
                 self.assertIn("unittest", w[-1].filename)
 
+    def test_skip_file_prefixes_file_path(self):
+        with warnings_state(self.module):
+            with original_warnings.catch_warnings(record=True,
+                    module=self.module) as w:
+                warning_tests.outer(
+                    "msg", skip_file_prefixes=(warning_tests.__file__, ))
+                self.assertNotEqual(w[-1].filename, warning_tests.__file__)
+
     def test_skip_file_prefixes_type_errors(self):
         with warnings_state(self.module):
             warn = warning_tests.warnings.warn

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -536,11 +536,13 @@ class WarnTests(BaseTest):
     def test_skip_file_prefixes_file_path(self):
         # see: gh-126209
         with warnings_state(self.module):
-            with original_warnings.catch_warnings(record=True,
-                    module=self.module) as w:
-                warning_tests.outer(
-                    "msg", skip_file_prefixes=(warning_tests.__file__, ))
-                self.assertNotEqual(w[-1].filename, warning_tests.__file__)
+            skipped = warning_tests.__file__
+            with original_warnings.catch_warnings(
+                record=True, module=self.module,
+            ) as w:
+                warning_tests.outer("msg", skip_file_prefixes=(skipped,))
+
+            self.assertNotEqual(w[-1].filename, skipped)
 
     def test_skip_file_prefixes_type_errors(self):
         with warnings_state(self.module):

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -534,6 +534,7 @@ class WarnTests(BaseTest):
                 self.assertIn("unittest", w[-1].filename)
 
     def test_skip_file_prefixes_file_path(self):
+        # see: gh-126209
         with warnings_state(self.module):
             with original_warnings.catch_warnings(record=True,
                     module=self.module) as w:

--- a/Lib/test/test_warnings/data/stacklevel.py
+++ b/Lib/test/test_warnings/data/stacklevel.py
@@ -4,11 +4,13 @@
 import warnings
 from test.test_warnings.data import package_helper
 
-def outer(message, stacklevel=1):
-    inner(message, stacklevel)
 
-def inner(message, stacklevel=1):
-    warnings.warn(message, stacklevel=stacklevel)
+def outer(message, stacklevel=1, skip_file_prefixes=()):
+    inner(message, stacklevel, skip_file_prefixes)
+
+def inner(message, stacklevel=1, skip_file_prefixes=()):
+    warnings.warn(message, stacklevel=stacklevel,
+                  skip_file_prefixes=skip_file_prefixes)
 
 def package(message, *, stacklevel):
     package_helper.inner_api(message, stacklevel=stacklevel,

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-18-01-31.gh-issue-126209.2ZIhrS.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-18-01-31.gh-issue-126209.2ZIhrS.rst
@@ -1,3 +1,3 @@
-Fix an issue with ``skip_file_prefixes`` which resulted in an inconsistent
+Fix an issue with ``skip_file_prefixes`` parameter which resulted in an inconsistent
 behaviour between the C and Python implementations of :func:`warnings.warn`.
 Patch by Daehee Kim.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-18-01-31.gh-issue-126209.2ZIhrS.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-18-01-31.gh-issue-126209.2ZIhrS.rst
@@ -1,0 +1,2 @@
+Fix the inconsistent results of c and python implementations. Patch by
+Daehee Kim.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-18-01-31.gh-issue-126209.2ZIhrS.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-18-01-31.gh-issue-126209.2ZIhrS.rst
@@ -1,2 +1,3 @@
-Fix the inconsistent results of c and python implementations. Patch by
-Daehee Kim.
+Fix an issue with ``skip_file_prefixes`` which resulted in an inconsistent
+behaviour between the C and Python implementations of :func:`warnings.warn`.
+Patch by Daehee Kim.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -803,7 +803,8 @@ is_filename_to_skip(PyObject *filename, PyTupleObject *skip_file_prefixes)
         for (Py_ssize_t idx = 0; idx < prefixes; ++idx)
         {
             PyObject *prefix = PyTuple_GET_ITEM(skip_file_prefixes, idx);
-            Py_ssize_t found = PyUnicode_Tailmatch(filename, prefix, 0, -1, -1);
+            Py_ssize_t found = PyUnicode_Tailmatch(filename, prefix,
+                                                   0, PY_SSIZE_T_MAX, -1);
             if (found == 1) {
                 return true;
             }


### PR DESCRIPTION
- issue: gh-126209

I think setting the argument `end=-1` the function `tailmatch` may cause undefined behavior. Most of `tailmatch` functions I've seen are used with `end=PY_SSIZE_T_MAX` and never seen `end=-1` except for this case.

hopefully I will help

