### PR TITLE
Doc: Reorganize math module documentation

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -121,31 +121,6 @@ noted otherwise, all return values are floats.
 ====================================================  ============================================
 
 
-.. impl-detail::
-
-   The :mod:`math` module consists mostly of thin wrappers around the platform C
-   math library functions.  Behavior in exceptional cases follows Annex F of
-   the C99 standard where appropriate.  The current implementation will raise
-   :exc:`ValueError` for invalid operations like ``sqrt(-1.0)`` or ``log(0.0)``
-   (where C99 Annex F recommends signaling invalid operation or divide-by-zero),
-   and :exc:`OverflowError` for results that overflow (for example,
-   ``exp(1000.0)``).  A NaN will not be returned from any of the functions
-   above unless one or more of the input arguments was a NaN; in that case,
-   most functions will return a NaN, but (again following C99 Annex F) there
-   are some exceptions to this rule, for example ``pow(float('nan'), 0.0)`` or
-   ``hypot(float('nan'), float('inf'))``.
-
-   Note that Python makes no effort to distinguish signaling NaNs from
-   quiet NaNs, and behavior for signaling NaNs remains unspecified.
-   Typical behavior is to treat all NaNs as though they were quiet.
-
-
-.. seealso::
-
-   Module :mod:`cmath`
-      Complex number versions of many of these functions.
-
-
 Number-theoretic functions
 --------------------------
 
@@ -838,6 +813,30 @@ Constants
    .. versionchanged:: 3.11
       It is now always available.
 
+
+.. impl-detail::
+
+   The :mod:`math` module consists mostly of thin wrappers around the platform C
+   math library functions.  Behavior in exceptional cases follows Annex F of
+   the C99 standard where appropriate.  The current implementation will raise
+   :exc:`ValueError` for invalid operations like ``sqrt(-1.0)`` or ``log(0.0)``
+   (where C99 Annex F recommends signaling invalid operation or divide-by-zero),
+   and :exc:`OverflowError` for results that overflow (for example,
+   ``exp(1000.0)``).  A NaN will not be returned from any of the functions
+   above unless one or more of the input arguments was a NaN; in that case,
+   most functions will return a NaN, but (again following C99 Annex F) there
+   are some exceptions to this rule, for example ``pow(float('nan'), 0.0)`` or
+   ``hypot(float('nan'), float('inf'))``.
+
+   Note that Python makes no effort to distinguish signaling NaNs from
+   quiet NaNs, and behavior for signaling NaNs remains unspecified.
+   Typical behavior is to treat all NaNs as though they were quiet.
+
+
+.. seealso::
+
+   Module :mod:`cmath`
+      Complex number versions of many of these functions.
 
 .. |nbsp| unicode:: 0xA0
    :trim:

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -169,6 +169,55 @@ Number-theoretic functions
 
 .. function:: factorial(n)
 
+   Return *n* factorial as an integer.  Raises :exc:`ValueError` if *n* is not integral or
+   is negative.
+
+   .. versionchanged:: 3.10
+      Floats with integral values (like ``5.0``) are no longer accepted.
+
+
+.. function:: gcd(*integers)
+
+   Return the greatest common divisor of the specified integer arguments.
+   If any of the arguments is nonzero, then the returned value is the largest
+   positive integer that is a divisor of all arguments.  If all arguments
+   are zero, then the returned value is ``0``.  ``gcd()`` without arguments
+   returns ``0``.
+
+   .. versionadded:: 3.5
+
+   .. versionchanged:: 3.9
+      Added support for an arbitrary number of arguments. Formerly, only two
+      arguments were supported.
+
+
+.. function:: isqrt(n)
+
+   Return the integer square root of the nonnegative integer *n*. This is the
+   floor of the exact square root of *n*, or equivalently the greatest integer
+   *a* such that *a*\ ² |nbsp| ≤ |nbsp| *n*.
+
+   For some applications, it may be more convenient to have the least integer
+   *a* such that *n* |nbsp| ≤ |nbsp| *a*\ ², or in other words the ceiling of
+   the exact square root of *n*. For positive *n*, this can be computed using
+   ``a = 1 + isqrt(n - 1)``.
+
+   .. versionadded:: 3.8
+
+
+.. function:: lcm(*integers)
+
+   Return the least common multiple of the specified integer arguments.
+   If all arguments are nonzero, then the returned value is the smallest
+   positive integer that is a multiple of all arguments.  If any of the arguments
+   is zero, then the returned value is ``0``.  ``lcm()`` without arguments
+   returns ``1``.
+
+   .. versionadded:: 3.9
+
+
+.. function:: perm(n, k=None)
+
    Return the number of ways to choose *k* items from *n* items
    without repetition and with order.
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -291,6 +291,11 @@ Floating point arithmetic
    Return the fractional and integer parts of *x*.  Both results carry the sign
    of *x* and are floats.
 
+   Note that :func:`modf` has a different call/return pattern
+   than its C equivalents: it takes a single argument and return a pair of
+   values, rather than returning its second return value through an 'output
+   parameter' (there is no such thing in Python).
+
 
 .. function:: remainder(x, y)
 
@@ -328,11 +333,6 @@ Python floats typically carry no more than 53 bits of precision (the same as the
 platform C double type), in which case any float *x* with ``abs(x) >= 2**52``
 necessarily has no fractional bits.
 
-Note that :func:`modf` has a different call/return pattern
-than its C equivalents: it takes a single argument and return a pair of
-values, rather than returning its second return value through an 'output
-parameter' (there is no such thing in Python).
-
 
 Floating point manipulation functions
 -------------------------------------
@@ -351,6 +351,10 @@ Floating point manipulation functions
    returns ``(0.0, 0)``, otherwise ``0.5 <= abs(m) < 1``.  This is used to "pick
    apart" the internal representation of a float in a portable way.
 
+   Note that :func:`frexp` has a different call/return pattern
+   than its C equivalents: it takes a single argument and return a pair of
+   values, rather than returning its second return value through an 'output
+   parameter' (there is no such thing in Python).
 
 .. function:: isclose(a, b, *, rel_tol=1e-09, abs_tol=0.0)
 
@@ -455,12 +459,6 @@ Floating point manipulation functions
    <sys.float_info>`.
 
    .. versionadded:: 3.9
-
-
-Note that :func:`frexp` has a different call/return pattern
-than its C equivalents: it takes a single argument and return a pair of
-values, rather than returning its second return value through an 'output
-parameter' (there is no such thing in Python).
 
 
 Power, exponential and logarithmic functions

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -69,6 +69,11 @@ noted otherwise, all return values are floats.
 :func:`pow(x, y) <math.pow>`                          *x* raised to the power *y*
 :func:`sqrt(x) <sqrt>`                                Square root of *x*
 
+**Angular conversion**
+--------------------------------------------------------------------------------------------------
+:func:`degrees(x) <degrees>`                          Convert angle *x* from radians to degrees
+:func:`radians(x) <radians>`                          Convert angle *x* from degrees to radians
+
 **Trigonometric functions**
 --------------------------------------------------------------------------------------------------
 :func:`acos(x) <acos>`                                Arc cosine of *x*
@@ -80,11 +85,6 @@ noted otherwise, all return values are floats.
 :func:`hypot(*coordinates) <hypot>`                   Euclidean norm of an iterable of coordinates
 :func:`sin(x) <sin>`                                  Sine of *x*
 :func:`tan(x) <tan>`                                  Tangent of *x*
-
-**Angular conversion**
---------------------------------------------------------------------------------------------------
-:func:`degrees(x) <degrees>`                          Convert angle *x* from radians to degrees
-:func:`radians(x) <radians>`                          Convert angle *x* from degrees to radians
 
 **Hyperbolic functions**
 --------------------------------------------------------------------------------------------------
@@ -557,6 +557,19 @@ Power and logarithmic functions
    Return the square root of *x*.
 
 
+Angular conversion
+------------------
+
+.. function:: degrees(x)
+
+   Convert angle *x* from radians to degrees.
+
+
+.. function:: radians(x)
+
+   Convert angle *x* from degrees to radians.
+
+
 Trigonometric functions
 -----------------------
 
@@ -634,19 +647,6 @@ Trigonometric functions
 .. function:: tan(x)
 
    Return the tangent of *x* radians.
-
-
-Angular conversion
-------------------
-
-.. function:: degrees(x)
-
-   Convert angle *x* from radians to degrees.
-
-
-.. function:: radians(x)
-
-   Convert angle *x* from degrees to radians.
 
 
 Hyperbolic functions

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -186,7 +186,10 @@ Number-theoretic and representation functions
 
 .. function:: fmod(x, y)
 
-   Return ``fmod(x, y)``, as defined by the platform C library. Note that the
+   Return the remainder of division ``x / y``,
+   as defined by the platform C library function ``fmod(x, y)``.
+
+   Note that the
    Python expression ``x % y`` may not return the same result.  The intent of the C
    standard is that ``fmod(x, y)`` be exactly (mathematically; to infinite
    precision) equal to ``x - n*y`` for some integer *n* such that the result has

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -95,7 +95,7 @@ noted otherwise, all return values are floats.
 :func:`sinh(x) <sinh>`                                Hyperbolic sine of *x*
 :func:`tanh(x) <tanh>`                                Hyperbolic tangent of *x*
 
-**Special functions**
+**Error and gamma functions**
 --------------------------------------------------------------------------------------------------
 :func:`erf(x) <erf>`                                  `Error function <https://en.wikipedia.org/wiki/Error_function>`_ at *x*
 :func:`erfc(x) <erfc>`                                `Complementary error function <https://en.wikipedia.org/wiki/Error_function>`_ at *x*
@@ -686,8 +686,8 @@ instead of circles.
    Return the hyperbolic tangent of *x*.
 
 
-Special functions
------------------
+Error and gamma functions
+-------------------------
 
 .. function:: erf(x)
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -56,7 +56,7 @@ noted otherwise, all return values are floats.
 :func:`trunc(x) <trunc>`                              Integer part of *x*
 :func:`ulp(x) <ulp>`                                  Value of the least significant bit of *x*
 
-**Power and logarithmic functions**
+**Power, exponential and logarithmic functions**
 --------------------------------------------------------------------------------------------------
 :func:`cbrt(x) <cbrt>`                                Cube root of *x*
 :func:`exp(x) <exp>`                                  *e* raised to the power *x*
@@ -459,8 +459,8 @@ platform C double type), in which case any float *x* with ``abs(x) >= 2**52``
 necessarily has no fractional bits.
 
 
-Power and logarithmic functions
--------------------------------
+Power, exponential and logarithmic functions
+--------------------------------------------
 
 .. function:: cbrt(x)
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -273,10 +273,7 @@ Floating point arithmetic
 
 .. function:: fmod(x, y)
 
-   Return the remainder of division ``x / y``,
-   as defined by the platform C library function ``fmod(x, y)``.
-
-   Note that the
+   Return ``fmod(x, y)``, as defined by the platform C library. Note that the
    Python expression ``x % y`` may not return the same result.  The intent of the C
    standard is that ``fmod(x, y)`` be exactly (mathematically; to infinite
    precision) equal to ``x - n*y`` for some integer *n* such that the result has

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -104,7 +104,7 @@ noted otherwise, all return values are floats.
 :func:`sinh(x) <sinh>`                                Hyperbolic sine of *x*
 :func:`tanh(x) <tanh>`                                Hyperbolic tangent of *x*
 
-**Error and gamma functions**
+**Special functions**
 --------------------------------------------------------------------------------------------------
 :func:`erf(x) <erf>`                                  `Error function <https://en.wikipedia.org/wiki/Error_function>`_ at *x*
 :func:`erfc(x) <erfc>`                                `Complementary error function <https://en.wikipedia.org/wiki/Error_function>`_ at *x*
@@ -691,7 +691,7 @@ instead of circles.
    Return the hyperbolic tangent of *x*.
 
 
-Error and gamma functions
+Special functions
 -------------------------
 
 .. function:: erf(x)

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -40,7 +40,7 @@ noted otherwise, all return values are floats.
 --------------------------------------------------------------------------------------------------
 :func:`ceil(x) <ceil>`                                Ceiling of *x*, the smallest integer greater than or equal to *x*
 :func:`fabs(x) <fabs>`                                Absolute value of *x*
-:func:`floor (x)  <floor>`                            Floor of *x*, the largest integer less than or equal to *x*
+:func:`floor(x)  <floor>`                             Floor of *x*, the largest integer less than or equal to *x*
 :func:`fma(x, y, z) <fma>`                            Fused multiply-add operation: ``(x * y) + z``
 :func:`fmod(x, y) <fmod>`                             Remainder of division ``x / y``
 :func:`modf(x) <modf>`                                Fractional and integer parts of *x*

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -692,7 +692,7 @@ instead of circles.
 
 
 Special functions
--------------------------
+-----------------
 
 .. function:: erf(x)
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -184,8 +184,8 @@ Number-theoretic functions
    .. versionadded:: 3.8
 
 
-Basic floating point operations
--------------------------------
+Floating point arithmetic
+-------------------------
 
 .. function:: ceil(x)
 

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -36,7 +36,7 @@ noted otherwise, all return values are floats.
 :func:`lcm(*integers) <lcm>`                          Least common multiple of the integer arguments
 :func:`perm(n, k) <perm>`                             Number of ways to choose *k* items from *n* items without repetition and with order
 
-**Basic floating point operations**
+**Floating point arithmetic**
 --------------------------------------------------------------------------------------------------
 :func:`ceil(x) <ceil>`                                Ceiling of *x*, the smallest integer greater than or equal to *x*
 :func:`fabs(x) <fabs>`                                Absolute value of *x*

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -27,33 +27,36 @@ noted otherwise, all return values are floats.
 
 
 ====================================================  ============================================
-**Number-theoretic and representation functions**
+**Number-theoretic functions**
+--------------------------------------------------------------------------------------------------
+:func:`comb(n, k) <comb>`                             Number of ways to choose *k* items from *n* items without repetition and without order
+:func:`factorial(n) <factorial>`                      *n* factorial
+:func:`gcd(*integers) <gcd>`                          Greatest common divisor of the integer arguments
+:func:`isqrt(n) <isqrt>`                              Integer square root of a nonnegative integer *n*
+:func:`lcm(*integers) <lcm>`                          Least common multiple of the integer arguments
+:func:`perm(n, k) <perm>`                             Number of ways to choose *k* items from *n* items without repetition and with order
+
+**Basic floating point operations**
 --------------------------------------------------------------------------------------------------
 :func:`ceil(x) <ceil>`                                Ceiling of *x*, the smallest integer greater than or equal to *x*
-:func:`comb(n, k) <comb>`                             Number of ways to choose *k* items from *n* items without repetition and without order
-:func:`copysign(x, y) <copysign>`                     Magnitude (absolute value) of *x* with the sign of *y*
 :func:`fabs(x) <fabs>`                                Absolute value of *x*
-:func:`factorial(n) <factorial>`                      *n* factorial
 :func:`floor (x)  <floor>`                            Floor of *x*, the largest integer less than or equal to *x*
 :func:`fma(x, y, z) <fma>`                            Fused multiply-add operation: ``(x * y) + z``
 :func:`fmod(x, y) <fmod>`                             Remainder of division ``x / y``
+:func:`modf(x) <modf>`                                Fractional and integer parts of *x*
+:func:`remainder(x, y) <remainder>`                   Remainder of *x* with respect to *y*
+:func:`trunc(x) <trunc>`                              Integer part of *x*
+
+**Floating point manipulation functions**
+--------------------------------------------------------------------------------------------------
+:func:`copysign(x, y) <copysign>`                     Magnitude (absolute value) of *x* with the sign of *y*
 :func:`frexp(x) <frexp>`                              Mantissa and exponent of *x*
-:func:`fsum(iterable) <fsum>`                         Sum of values in the input *iterable*
-:func:`gcd(*integers) <gcd>`                          Greatest common divisor of the integer arguments
 :func:`isclose(a, b, rel_tol, abs_tol) <isclose>`     Check if the values *a* and *b* are close to each other
 :func:`isfinite(x) <isfinite>`                        Check if *x* is neither an infinity nor a NaN
 :func:`isinf(x) <isinf>`                              Check if *x* is a positive or negative infinity
 :func:`isnan(x) <isnan>`                              Check if *x* is a NaN  (not a number)
-:func:`isqrt(n) <isqrt>`                              Integer square root of a nonnegative integer *n*
-:func:`lcm(*integers) <lcm>`                          Least common multiple of the integer arguments
 :func:`ldexp(x, i) <ldexp>`                           ``x * (2**i)``, inverse of function :func:`frexp`
-:func:`modf(x) <modf>`                                Fractional and integer parts of *x*
 :func:`nextafter(x, y, steps) <nextafter>`            Floating-point value *steps* steps after *x* towards *y*
-:func:`perm(n, k) <perm>`                             Number of ways to choose *k* items from *n* items without repetition and with order
-:func:`prod(iterable, start) <prod>`                  Product of elements in the input *iterable* with a *start* value
-:func:`remainder(x, y) <remainder>`                   Remainder of *x* with respect to *y*
-:func:`sumprod(p, q) <sumprod>`                       Sum of products from two iterables *p* and *q*
-:func:`trunc(x) <trunc>`                              Integer part of *x*
 :func:`ulp(x) <ulp>`                                  Value of the least significant bit of *x*
 
 **Power, exponential and logarithmic functions**
@@ -69,6 +72,14 @@ noted otherwise, all return values are floats.
 :func:`pow(x, y) <math.pow>`                          *x* raised to the power *y*
 :func:`sqrt(x) <sqrt>`                                Square root of *x*
 
+**Summation and product functions**
+--------------------------------------------------------------------------------------------------
+:func:`dist(p, q) <dist>`                             Euclidean distance between two points *p* and *q* given as an iterable of coordinates
+:func:`fsum(iterable) <fsum>`                         Sum of values in the input *iterable*
+:func:`hypot(*coordinates) <hypot>`                   Euclidean norm of an iterable of coordinates
+:func:`prod(iterable, start) <prod>`                  Product of elements in the input *iterable* with a *start* value
+:func:`sumprod(p, q) <sumprod>`                       Sum of products from two iterables *p* and *q*
+
 **Angular conversion**
 --------------------------------------------------------------------------------------------------
 :func:`degrees(x) <degrees>`                          Convert angle *x* from radians to degrees
@@ -81,8 +92,6 @@ noted otherwise, all return values are floats.
 :func:`atan(x) <atan>`                                Arc tangent of *x*
 :func:`atan2(y, x) <atan2>`                           ``atan(y / x)``
 :func:`cos(x) <cos>`                                  Cosine of *x*
-:func:`dist(p, q) <dist>`                             Euclidean distance between two points *p* and *q* given as an iterable of coordinates
-:func:`hypot(*coordinates) <hypot>`                   Euclidean norm of an iterable of coordinates
 :func:`sin(x) <sin>`                                  Sine of *x*
 :func:`tan(x) <tan>`                                  Tangent of *x*
 
@@ -112,15 +121,33 @@ noted otherwise, all return values are floats.
 ====================================================  ============================================
 
 
-Number-theoretic and representation functions
----------------------------------------------
+.. impl-detail::
 
-.. function:: ceil(x)
+   The :mod:`math` module consists mostly of thin wrappers around the platform C
+   math library functions.  Behavior in exceptional cases follows Annex F of
+   the C99 standard where appropriate.  The current implementation will raise
+   :exc:`ValueError` for invalid operations like ``sqrt(-1.0)`` or ``log(0.0)``
+   (where C99 Annex F recommends signaling invalid operation or divide-by-zero),
+   and :exc:`OverflowError` for results that overflow (for example,
+   ``exp(1000.0)``).  A NaN will not be returned from any of the functions
+   above unless one or more of the input arguments was a NaN; in that case,
+   most functions will return a NaN, but (again following C99 Annex F) there
+   are some exceptions to this rule, for example ``pow(float('nan'), 0.0)`` or
+   ``hypot(float('nan'), float('inf'))``.
 
-   Return the ceiling of *x*, the smallest integer greater than or equal to *x*.
-   If *x* is not a float, delegates to :meth:`x.__ceil__ <object.__ceil__>`,
-   which should return an :class:`~numbers.Integral` value.
+   Note that Python makes no effort to distinguish signaling NaNs from
+   quiet NaNs, and behavior for signaling NaNs remains unspecified.
+   Typical behavior is to treat all NaNs as though they were quiet.
 
+
+.. seealso::
+
+   Module :mod:`cmath`
+      Complex number versions of many of these functions.
+
+
+Number-theoretic functions
+--------------------------
 
 .. function:: comb(n, k)
 
@@ -140,25 +167,36 @@ Number-theoretic and representation functions
    .. versionadded:: 3.8
 
 
-.. function:: copysign(x, y)
+.. function:: factorial(n)
 
-   Return a float with the magnitude (absolute value) of *x* but the sign of
-   *y*.  On platforms that support signed zeros, ``copysign(1.0, -0.0)``
-   returns *-1.0*.
+   Return the number of ways to choose *k* items from *n* items
+   without repetition and with order.
+
+   Evaluates to ``n! / (n - k)!`` when ``k <= n`` and evaluates
+   to zero when ``k > n``.
+
+   If *k* is not specified or is ``None``, then *k* defaults to *n*
+   and the function returns ``n!``.
+
+   Raises :exc:`TypeError` if either of the arguments are not integers.
+   Raises :exc:`ValueError` if either of the arguments are negative.
+
+   .. versionadded:: 3.8
+
+
+Basic floating point operations
+-------------------------------
+
+.. function:: ceil(x)
+
+   Return the ceiling of *x*, the smallest integer greater than or equal to *x*.
+   If *x* is not a float, delegates to :meth:`x.__ceil__ <object.__ceil__>`,
+   which should return an :class:`~numbers.Integral` value.
 
 
 .. function:: fabs(x)
 
    Return the absolute value of *x*.
-
-
-.. function:: factorial(n)
-
-   Return *n* factorial as an integer.  Raises :exc:`ValueError` if *n* is not integral or
-   is negative.
-
-   .. versionchanged:: 3.10
-      Floats with integral values (like ``5.0``) are no longer accepted.
 
 
 .. function:: floor(x)
@@ -202,43 +240,70 @@ Number-theoretic and representation functions
    floats, while Python's ``x % y`` is preferred when working with integers.
 
 
+.. function:: modf(x)
+
+   Return the fractional and integer parts of *x*.  Both results carry the sign
+   of *x* and are floats.
+
+
+.. function:: remainder(x, y)
+
+   Return the IEEE 754-style remainder of *x* with respect to *y*.  For
+   finite *x* and finite nonzero *y*, this is the difference ``x - n*y``,
+   where ``n`` is the closest integer to the exact value of the quotient ``x /
+   y``.  If ``x / y`` is exactly halfway between two consecutive integers, the
+   nearest *even* integer is used for ``n``.  The remainder ``r = remainder(x,
+   y)`` thus always satisfies ``abs(r) <= 0.5 * abs(y)``.
+
+   Special cases follow IEEE 754: in particular, ``remainder(x, math.inf)`` is
+   *x* for any finite *x*, and ``remainder(x, 0)`` and
+   ``remainder(math.inf, x)`` raise :exc:`ValueError` for any non-NaN *x*.
+   If the result of the remainder operation is zero, that zero will have
+   the same sign as *x*.
+
+   On platforms using IEEE 754 binary floating point, the result of this
+   operation is always exactly representable: no rounding error is introduced.
+
+   .. versionadded:: 3.7
+
+
+.. function:: trunc(x)
+
+   Return *x* with the fractional part
+   removed, leaving the integer part.  This rounds toward 0: ``trunc()`` is
+   equivalent to :func:`floor` for positive *x*, and equivalent to :func:`ceil`
+   for negative *x*. If *x* is not a float, delegates to :meth:`x.__trunc__
+   <object.__trunc__>`, which should return an :class:`~numbers.Integral` value.
+
+
+For the :func:`ceil`, :func:`floor`, and :func:`modf` functions, note that *all*
+floating-point numbers of sufficiently large magnitude are exact integers.
+Python floats typically carry no more than 53 bits of precision (the same as the
+platform C double type), in which case any float *x* with ``abs(x) >= 2**52``
+necessarily has no fractional bits.
+
+Note that :func:`modf` has a different call/return pattern
+than its C equivalents: it takes a single argument and return a pair of
+values, rather than returning its second return value through an 'output
+parameter' (there is no such thing in Python).
+
+
+Floating point manipulation functions
+-------------------------------------
+
+.. function:: copysign(x, y)
+
+   Return a float with the magnitude (absolute value) of *x* but the sign of
+   *y*.  On platforms that support signed zeros, ``copysign(1.0, -0.0)``
+   returns *-1.0*.
+
+
 .. function:: frexp(x)
 
    Return the mantissa and exponent of *x* as the pair ``(m, e)``.  *m* is a float
    and *e* is an integer such that ``x == m * 2**e`` exactly. If *x* is zero,
    returns ``(0.0, 0)``, otherwise ``0.5 <= abs(m) < 1``.  This is used to "pick
    apart" the internal representation of a float in a portable way.
-
-
-.. function:: fsum(iterable)
-
-   Return an accurate floating-point sum of values in the iterable.  Avoids
-   loss of precision by tracking multiple intermediate partial sums.
-
-   The algorithm's accuracy depends on IEEE-754 arithmetic guarantees and the
-   typical case where the rounding mode is half-even.  On some non-Windows
-   builds, the underlying C library uses extended precision addition and may
-   occasionally double-round an intermediate sum causing it to be off in its
-   least significant bit.
-
-   For further discussion and two alternative approaches, see the `ASPN cookbook
-   recipes for accurate floating-point summation
-   <https://code.activestate.com/recipes/393090-binary-floating-point-summation-accurate-to-full-p/>`_\.
-
-
-.. function:: gcd(*integers)
-
-   Return the greatest common divisor of the specified integer arguments.
-   If any of the arguments is nonzero, then the returned value is the largest
-   positive integer that is a divisor of all arguments.  If all arguments
-   are zero, then the returned value is ``0``.  ``gcd()`` without arguments
-   returns ``0``.
-
-   .. versionadded:: 3.5
-
-   .. versionchanged:: 3.9
-      Added support for an arbitrary number of arguments. Formerly, only two
-      arguments were supported.
 
 
 .. function:: isclose(a, b, *, rel_tol=1e-09, abs_tol=0.0)
@@ -294,41 +359,10 @@ Number-theoretic and representation functions
    Return ``True`` if *x* is a NaN (not a number), and ``False`` otherwise.
 
 
-.. function:: isqrt(n)
-
-   Return the integer square root of the nonnegative integer *n*. This is the
-   floor of the exact square root of *n*, or equivalently the greatest integer
-   *a* such that *a*\ ² |nbsp| ≤ |nbsp| *n*.
-
-   For some applications, it may be more convenient to have the least integer
-   *a* such that *n* |nbsp| ≤ |nbsp| *a*\ ², or in other words the ceiling of
-   the exact square root of *n*. For positive *n*, this can be computed using
-   ``a = 1 + isqrt(n - 1)``.
-
-   .. versionadded:: 3.8
-
-
-.. function:: lcm(*integers)
-
-   Return the least common multiple of the specified integer arguments.
-   If all arguments are nonzero, then the returned value is the smallest
-   positive integer that is a multiple of all arguments.  If any of the arguments
-   is zero, then the returned value is ``0``.  ``lcm()`` without arguments
-   returns ``1``.
-
-   .. versionadded:: 3.9
-
-
 .. function:: ldexp(x, i)
 
    Return ``x * (2**i)``.  This is essentially the inverse of function
    :func:`frexp`.
-
-
-.. function:: modf(x)
-
-   Return the fractional and integer parts of *x*.  Both results carry the sign
-   of *x* and are floats.
 
 
 .. function:: nextafter(x, y, steps=1)
@@ -351,79 +385,6 @@ Number-theoretic and representation functions
    .. versionchanged:: 3.12
       Added the *steps* argument.
 
-.. function:: perm(n, k=None)
-
-   Return the number of ways to choose *k* items from *n* items
-   without repetition and with order.
-
-   Evaluates to ``n! / (n - k)!`` when ``k <= n`` and evaluates
-   to zero when ``k > n``.
-
-   If *k* is not specified or is ``None``, then *k* defaults to *n*
-   and the function returns ``n!``.
-
-   Raises :exc:`TypeError` if either of the arguments are not integers.
-   Raises :exc:`ValueError` if either of the arguments are negative.
-
-   .. versionadded:: 3.8
-
-
-.. function:: prod(iterable, *, start=1)
-
-   Calculate the product of all the elements in the input *iterable*.
-   The default *start* value for the product is ``1``.
-
-   When the iterable is empty, return the start value.  This function is
-   intended specifically for use with numeric values and may reject
-   non-numeric types.
-
-   .. versionadded:: 3.8
-
-
-.. function:: remainder(x, y)
-
-   Return the IEEE 754-style remainder of *x* with respect to *y*.  For
-   finite *x* and finite nonzero *y*, this is the difference ``x - n*y``,
-   where ``n`` is the closest integer to the exact value of the quotient ``x /
-   y``.  If ``x / y`` is exactly halfway between two consecutive integers, the
-   nearest *even* integer is used for ``n``.  The remainder ``r = remainder(x,
-   y)`` thus always satisfies ``abs(r) <= 0.5 * abs(y)``.
-
-   Special cases follow IEEE 754: in particular, ``remainder(x, math.inf)`` is
-   *x* for any finite *x*, and ``remainder(x, 0)`` and
-   ``remainder(math.inf, x)`` raise :exc:`ValueError` for any non-NaN *x*.
-   If the result of the remainder operation is zero, that zero will have
-   the same sign as *x*.
-
-   On platforms using IEEE 754 binary floating point, the result of this
-   operation is always exactly representable: no rounding error is introduced.
-
-   .. versionadded:: 3.7
-
-
-.. function:: sumprod(p, q)
-
-   Return the sum of products of values from two iterables *p* and *q*.
-
-   Raises :exc:`ValueError` if the inputs do not have the same length.
-
-   Roughly equivalent to::
-
-       sum(map(operator.mul, p, q, strict=True))
-
-   For float and mixed int/float inputs, the intermediate products
-   and sums are computed with extended precision.
-
-   .. versionadded:: 3.12
-
-
-.. function:: trunc(x)
-
-   Return *x* with the fractional part
-   removed, leaving the integer part.  This rounds toward 0: ``trunc()`` is
-   equivalent to :func:`floor` for positive *x*, and equivalent to :func:`ceil`
-   for negative *x*. If *x* is not a float, delegates to :meth:`x.__trunc__
-   <object.__trunc__>`, which should return an :class:`~numbers.Integral` value.
 
 .. function:: ulp(x)
 
@@ -450,16 +411,10 @@ Number-theoretic and representation functions
    .. versionadded:: 3.9
 
 
-Note that :func:`frexp` and :func:`modf` have a different call/return pattern
-than their C equivalents: they take a single argument and return a pair of
-values, rather than returning their second return value through an 'output
+Note that :func:`frexp` has a different call/return pattern
+than its C equivalents: it takes a single argument and return a pair of
+values, rather than returning its second return value through an 'output
 parameter' (there is no such thing in Python).
-
-For the :func:`ceil`, :func:`floor`, and :func:`modf` functions, note that *all*
-floating-point numbers of sufficiently large magnitude are exact integers.
-Python floats typically carry no more than 53 bits of precision (the same as the
-platform C double type), in which case any float *x* with ``abs(x) >= 2**52``
-necessarily has no fractional bits.
 
 
 Power, exponential and logarithmic functions
@@ -560,6 +515,86 @@ Power, exponential and logarithmic functions
    Return the square root of *x*.
 
 
+Summation and product functions
+-------------------------------
+
+.. function:: dist(p, q)
+
+   Return the Euclidean distance between two points *p* and *q*, each
+   given as a sequence (or iterable) of coordinates.  The two points
+   must have the same dimension.
+
+   Roughly equivalent to::
+
+       sqrt(sum((px - qx) ** 2.0 for px, qx in zip(p, q)))
+
+   .. versionadded:: 3.8
+
+
+.. function:: fsum(iterable)
+
+   Return an accurate floating-point sum of values in the iterable.  Avoids
+   loss of precision by tracking multiple intermediate partial sums.
+
+   The algorithm's accuracy depends on IEEE-754 arithmetic guarantees and the
+   typical case where the rounding mode is half-even.  On some non-Windows
+   builds, the underlying C library uses extended precision addition and may
+   occasionally double-round an intermediate sum causing it to be off in its
+   least significant bit.
+
+   For further discussion and two alternative approaches, see the `ASPN cookbook
+   recipes for accurate floating-point summation
+   <https://code.activestate.com/recipes/393090-binary-floating-point-summation-accurate-to-full-p/>`_\.
+
+
+.. function:: hypot(*coordinates)
+
+   Return the Euclidean norm, ``sqrt(sum(x**2 for x in coordinates))``.
+   This is the length of the vector from the origin to the point
+   given by the coordinates.
+
+   For a two dimensional point ``(x, y)``, this is equivalent to computing
+   the hypotenuse of a right triangle using the Pythagorean theorem,
+   ``sqrt(x*x + y*y)``.
+
+   .. versionchanged:: 3.8
+      Added support for n-dimensional points. Formerly, only the two
+      dimensional case was supported.
+
+   .. versionchanged:: 3.10
+      Improved the algorithm's accuracy so that the maximum error is
+      under 1 ulp (unit in the last place).  More typically, the result
+      is almost always correctly rounded to within 1/2 ulp.
+
+
+.. function:: prod(iterable, *, start=1)
+
+   Calculate the product of all the elements in the input *iterable*.
+   The default *start* value for the product is ``1``.
+
+   When the iterable is empty, return the start value.  This function is
+   intended specifically for use with numeric values and may reject
+   non-numeric types.
+
+   .. versionadded:: 3.8
+
+
+.. function:: sumprod(p, q)
+
+   Return the sum of products of values from two iterables *p* and *q*.
+
+   Raises :exc:`ValueError` if the inputs do not have the same length.
+
+   Roughly equivalent to::
+
+       sum(map(operator.mul, p, q, strict=True))
+
+   For float and mixed int/float inputs, the intermediate products
+   and sums are computed with extended precision.
+
+   .. versionadded:: 3.12
+
+
 Angular conversion
 ------------------
 
@@ -607,39 +642,6 @@ Trigonometric functions
 .. function:: cos(x)
 
    Return the cosine of *x* radians.
-
-
-.. function:: dist(p, q)
-
-   Return the Euclidean distance between two points *p* and *q*, each
-   given as a sequence (or iterable) of coordinates.  The two points
-   must have the same dimension.
-
-   Roughly equivalent to::
-
-       sqrt(sum((px - qx) ** 2.0 for px, qx in zip(p, q)))
-
-   .. versionadded:: 3.8
-
-
-.. function:: hypot(*coordinates)
-
-   Return the Euclidean norm, ``sqrt(sum(x**2 for x in coordinates))``.
-   This is the length of the vector from the origin to the point
-   given by the coordinates.
-
-   For a two dimensional point ``(x, y)``, this is equivalent to computing
-   the hypotenuse of a right triangle using the Pythagorean theorem,
-   ``sqrt(x*x + y*y)``.
-
-   .. versionchanged:: 3.8
-      Added support for n-dimensional points. Formerly, only the two
-      dimensional case was supported.
-
-   .. versionchanged:: 3.10
-      Improved the algorithm's accuracy so that the maximum error is
-      under 1 ulp (unit in the last place).  More typically, the result
-      is almost always correctly rounded to within 1/2 ulp.
 
 
 .. function:: sin(x)
@@ -792,30 +794,6 @@ Constants
    .. versionchanged:: 3.11
       It is now always available.
 
-
-.. impl-detail::
-
-   The :mod:`math` module consists mostly of thin wrappers around the platform C
-   math library functions.  Behavior in exceptional cases follows Annex F of
-   the C99 standard where appropriate.  The current implementation will raise
-   :exc:`ValueError` for invalid operations like ``sqrt(-1.0)`` or ``log(0.0)``
-   (where C99 Annex F recommends signaling invalid operation or divide-by-zero),
-   and :exc:`OverflowError` for results that overflow (for example,
-   ``exp(1000.0)``).  A NaN will not be returned from any of the functions
-   above unless one or more of the input arguments was a NaN; in that case,
-   most functions will return a NaN, but (again following C99 Annex F) there
-   are some exceptions to this rule, for example ``pow(float('nan'), 0.0)`` or
-   ``hypot(float('nan'), float('inf'))``.
-
-   Note that Python makes no effort to distinguish signaling NaNs from
-   quiet NaNs, and behavior for signaling NaNs remains unspecified.
-   Typical behavior is to treat all NaNs as though they were quiet.
-
-
-.. seealso::
-
-   Module :mod:`cmath`
-      Complex number versions of many of these functions.
 
 .. |nbsp| unicode:: 0xA0
    :trim:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Following #125810, here is a proposal to reorganize the `math` documentation. I took into account the comments from the previous PRs : https://github.com/python/cpython/pull/125810#discussion_r1814366833 https://github.com/python/cpython/pull/125810#pullrequestreview-2409299006 https://github.com/python/cpython/pull/125810#discussion_r1814370755 and tried to improve from here. As suggested in a comment, I used https://en.cppreference.com/w/c/numeric/math as reference.

One thing I'm not fond of is the duplication of the paragraph about the return values, now that `frexp` and `modf` are in different sections. Note that `modf` is also cited in another paragraph in *Basic floating point operations*.

Another question I have is, should the functions be listed in alphabetic order, or in a logical order ? For example, the trigonometric functions could start with `sin` and `cos` instead of `acos` and `asin`, or `gcd` and `lcm` could be listed together. Same with `sqrt` and `cbrt`.

[Direct link to the updated `math` module documentation](https://cpython-previews--126337.org.readthedocs.build/en/126337/library/math.html)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126337.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->