### PR TITLE
gh-126312: Don't traverse frozen objects on the free-threaded build

### DIFF
--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1086,11 +1086,13 @@ class GCTests(unittest.TestCase):
         # See GH-126312: Objects that were not frozen could traverse over
         # a frozen object on the free-threaded build, which would cause
         # a negative reference count.
+        x = [1, 2, 3]
         gc.freeze()
-        gc.is_finalized(lambda: None)
+        y = [x]
+        y.append(y)
+        del y
         gc.collect()
         gc.unfreeze()
-        gc.collect()
 
 
 class IncrementalGCTests(unittest.TestCase):

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1088,12 +1088,6 @@ class GCTests(unittest.TestCase):
         # a negative reference count.
         import textwrap
 
-        # We have to run this in subprocess because
-        # freezing the GC alongside deferred reference counting
-        # causes a seperate bug, that needs to get addressed in another PR.
-        source = textwrap.dedent("""
-        import gc
-
         x = [1, 2, 3]
         gc.freeze()
         y = [x]
@@ -1101,6 +1095,21 @@ class GCTests(unittest.TestCase):
         del y
         gc.collect()
         gc.unfreeze()
+
+        source = textwrap.dedent("""
+        import gc
+        import unittest
+
+
+        class Test(unittest.TestCase):
+            def test_something(self):
+                gc.freeze()
+                gc.collect()
+                gc.unfreeze()
+
+
+        if __name__ == "__main__":
+            unittest.main()
         """)
         assert_python_ok("-c", source)
 

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1082,12 +1082,10 @@ class GCTests(unittest.TestCase):
         gc.collect()
         self.assertTrue(collected)
 
-    @support.requires_subprocess()
     def test_traverse_frozen_objects(self):
         # See GH-126312: Objects that were not frozen could traverse over
         # a frozen object on the free-threaded build, which would cause
         # a negative reference count.
-        import subprocess
         import textwrap
 
         # We have to run this in subprocess because
@@ -1104,9 +1102,7 @@ class GCTests(unittest.TestCase):
         gc.collect()
         gc.unfreeze()
         """)
-        proc = subprocess.Popen([sys.executable, "-c", source])
-        proc.wait()
-        self.assertEqual(proc.returncode, 0)
+        assert_python_ok("-c", source)
 
 
 class IncrementalGCTests(unittest.TestCase):

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1083,8 +1083,8 @@ class GCTests(unittest.TestCase):
         self.assertTrue(collected)
 
     def test_traverse_frozen_objects(self):
-        # See GH-126312: Frozen objects would get
-        # traversed on the free-threaded build, and cause
+        # See GH-126312: Objects that were not frozen could traverse over
+        # a frozen object on the free-threaded build, which would cause
         # a negative reference count.
         gc.freeze()
         gc.is_finalized(lambda: None)

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1082,6 +1082,16 @@ class GCTests(unittest.TestCase):
         gc.collect()
         self.assertTrue(collected)
 
+    def test_traverse_frozen_objects(self):
+        # See GH-126312: Frozen objects would get
+        # traversed on the free-threaded build, and cause
+        # a negative reference count.
+        gc.freeze()
+        gc.is_finalized(lambda: None)
+        gc.collect()
+        gc.unfreeze()
+        gc.collect()
+
 
 class IncrementalGCTests(unittest.TestCase):
 

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1094,6 +1094,7 @@ class GCTests(unittest.TestCase):
         gc.collect()
         gc.unfreeze()
 
+    def test_deferred_refcount_frozen(self):
         # Also from GH-126312: objects that use deferred reference counting
         # weren't ignored if they were frozen. Unfortunately, it's pretty
         # difficult to come up with a case that triggers this.

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1086,8 +1086,6 @@ class GCTests(unittest.TestCase):
         # See GH-126312: Objects that were not frozen could traverse over
         # a frozen object on the free-threaded build, which would cause
         # a negative reference count.
-        import textwrap
-
         x = [1, 2, 3]
         gc.freeze()
         y = [x]

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1094,6 +1094,14 @@ class GCTests(unittest.TestCase):
         gc.collect()
         gc.unfreeze()
 
+        # Also from GH-126312: objects that use deferred reference counting
+        # weren't ignored if they were frozen. Unfortunately, it's pretty
+        # difficult to come up with a case that triggers this.
+        #
+        # Calling gc.collect() while the garbage collector is frozen doesn't
+        # trigger this normally, but it *does* if it's inside unittest for whatever
+        # reason. We can't call unittest from inside a test, so it has to be
+        # in a subprocess.
         source = textwrap.dedent("""
         import gc
         import unittest

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-14-43-46.gh-issue-126312.LMHzLT.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-14-43-46.gh-issue-126312.LMHzLT.rst
@@ -1,0 +1,2 @@
+Fix crash when traversing an object frozen by the garbage collector on the
+free-threaded build.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-14-43-46.gh-issue-126312.LMHzLT.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-14-43-46.gh-issue-126312.LMHzLT.rst
@@ -1,2 +1,2 @@
-Fix crash when traversing an object frozen by the garbage collector on the
+Fix crash during garbage collection on an object frozen by :func:`gc.freeze` on the
 free-threaded build.

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -439,7 +439,10 @@ process_delayed_frees(PyInterpreterState *interp)
 static int
 visit_decref(PyObject *op, void *arg)
 {
-    if (_PyObject_GC_IS_TRACKED(op) && !_Py_IsImmortal(op)) {
+    if (_PyObject_GC_IS_TRACKED(op)
+        && !_Py_IsImmortal(op)
+        && (op->ob_gc_bits & _PyGC_BITS_FROZEN) == 0
+    ) {
         // If update_refs hasn't reached this object yet, mark it
         // as (tentatively) unreachable and initialize ob_tid to zero.
         gc_maybe_init_refs(op);

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -358,7 +358,8 @@ gc_visit_stackref(_PyStackRef stackref)
     // being dead already.
     if (PyStackRef_IsDeferred(stackref) && !PyStackRef_IsNull(stackref)) {
         PyObject *obj = PyStackRef_AsPyObjectBorrow(stackref);
-        if (_PyObject_GC_IS_TRACKED(obj)) {
+        if (_PyObject_GC_IS_TRACKED(obj)
+            && (obj->ob_gc_bits & _PyGC_BITS_FROZEN) == 0) {
             gc_add_refs(obj, 1);
         }
     }

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -441,8 +441,8 @@ visit_decref(PyObject *op, void *arg)
 {
     if (_PyObject_GC_IS_TRACKED(op)
         && !_Py_IsImmortal(op)
-        && (op->ob_gc_bits & _PyGC_BITS_FROZEN) == 0
-    ) {
+        && (op->ob_gc_bits & _PyGC_BITS_FROZEN) == 0)
+    {
         // If update_refs hasn't reached this object yet, mark it
         // as (tentatively) unreachable and initialize ob_tid to zero.
         gc_maybe_init_refs(op);

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -114,6 +114,12 @@ worklist_remove(struct worklist_iter *iter)
 }
 
 static inline int
+gc_is_frozen(PyObject *op)
+{
+    return (op->ob_gc_bits & _PyGC_BITS_FROZEN) != 0;
+}
+
+static inline int
 gc_is_unreachable(PyObject *op)
 {
     return (op->ob_gc_bits & _PyGC_BITS_UNREACHABLE) != 0;
@@ -277,7 +283,7 @@ op_from_block(void *block, void *arg, bool include_frozen)
     if (!_PyObject_GC_IS_TRACKED(op)) {
         return NULL;
     }
-    if (!include_frozen && (op->ob_gc_bits & _PyGC_BITS_FROZEN) != 0) {
+    if (!include_frozen && gc_is_frozen(op)) {
         return NULL;
     }
     return op;
@@ -358,8 +364,7 @@ gc_visit_stackref(_PyStackRef stackref)
     // being dead already.
     if (PyStackRef_IsDeferred(stackref) && !PyStackRef_IsNull(stackref)) {
         PyObject *obj = PyStackRef_AsPyObjectBorrow(stackref);
-        if (_PyObject_GC_IS_TRACKED(obj)
-            && (obj->ob_gc_bits & _PyGC_BITS_FROZEN) == 0) {
+        if (_PyObject_GC_IS_TRACKED(obj) && !gc_is_frozen(obj)) {
             gc_add_refs(obj, 1);
         }
     }
@@ -442,7 +447,7 @@ visit_decref(PyObject *op, void *arg)
 {
     if (_PyObject_GC_IS_TRACKED(op)
         && !_Py_IsImmortal(op)
-        && (op->ob_gc_bits & _PyGC_BITS_FROZEN) == 0)
+        && !gc_is_frozen(op))
     {
         // If update_refs hasn't reached this object yet, mark it
         // as (tentatively) unreachable and initialize ob_tid to zero.
@@ -1543,7 +1548,7 @@ visit_freeze(const mi_heap_t *heap, const mi_heap_area_t *area,
              void *block, size_t block_size, void *args)
 {
     PyObject *op = op_from_block(block, args, true);
-    if (op != NULL && ((op->ob_gc_bits & _PyGC_BITS_UNREACHABLE) == 0)) {
+    if (op != NULL && !gc_is_unreachable(op)) {
         op->ob_gc_bits |= _PyGC_BITS_FROZEN;
     }
     return true;
@@ -1588,7 +1593,7 @@ visit_count_frozen(const mi_heap_t *heap, const mi_heap_area_t *area,
                    void *block, size_t block_size, void *args)
 {
     PyObject *op = op_from_block(block, args, true);
-    if (op != NULL && (op->ob_gc_bits & _PyGC_BITS_FROZEN) != 0) {
+    if (op != NULL && gc_is_frozen(op)) {
         struct count_frozen_args *arg = (struct count_frozen_args *)args;
         arg->count++;
     }

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1543,7 +1543,7 @@ visit_freeze(const mi_heap_t *heap, const mi_heap_area_t *area,
              void *block, size_t block_size, void *args)
 {
     PyObject *op = op_from_block(block, args, true);
-    if (op != NULL) {
+    if (op != NULL && ((op->ob_gc_bits & _PyGC_BITS_UNREACHABLE) == 0)) {
         op->ob_gc_bits |= _PyGC_BITS_FROZEN;
     }
     return true;


### PR DESCRIPTION


<!-- gh-issue-number: gh-126312 -->
* Issue: gh-126312
<!-- /gh-issue-number -->
