### PR TITLE
[3.13] gh-125832: Clarify comment for inlined comprehensions as per PEP-709 (gh-126322)

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5314,10 +5314,12 @@ ex_call:
     return SUCCESS;
 }
 
-
-/* List and set comprehensions and generator expressions work by creating a
-  nested function to perform the actual iteration. This means that the
-  iteration variables don't leak into the current scope.
+/* List and set comprehensions work by being inlined at the location where
+  they are defined. The isolation of iteration variables is provided by
+  pushing/popping clashing locals on the stack. Generator expressions work
+  by creating a nested function to perform the actual iteration.
+  This means that the iteration variables don't leak into the current scope.
+  See https://peps.python.org/pep-0709/ for additional information.
   The defined function is called immediately following its definition, with the
   result of that call being the result of the expression.
   The LC/SC version returns the populated container, while the GE version is

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5314,6 +5314,7 @@ ex_call:
     return SUCCESS;
 }
 
+
 /* List and set comprehensions work by being inlined at the location where
   they are defined. The isolation of iteration variables is provided by
   pushing/popping clashing locals on the stack. Generator expressions work


### PR DESCRIPTION

* Fix comprehensions comment to inlined by pep 709

* Update spacing

Co-authored-by: RUANG (James Roy) <longjinyii@outlook.com>

* Add reference to PEP 709

---------

Co-authored-by: Carol Willing <carolcode@willingconsulting.com>
Co-authored-by: RUANG (James Roy) <longjinyii@outlook.com>
(cherry picked from commit 868bfcc02ed42a1042851830b79c6877b7f1c7a8)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125832 -->
* Issue: gh-125832
<!-- /gh-issue-number -->
