### PR TITLE
gh-126313: Fix a crash in `curse.napms` due to incorrect error handling

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-11-03-09-42-42.gh-issue-126313.EFP6Dl.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-03-09-42-42.gh-issue-126313.EFP6Dl.rst
@@ -1,0 +1,2 @@
+Fix an issue in :func:`curses.napms` when :func:`curses.initscr` has not yet
+been called. Patch by Bénédikt Tran.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -3815,8 +3815,11 @@ static int
 _curses_napms_impl(PyObject *module, int ms)
 /*[clinic end generated code: output=5f292a6a724491bd input=c6d6e01f2f1df9f7]*/
 {
-    PyCursesStatefulInitialised(module);
-
+    if (!_PyCursesStatefulCheckFunction(module,
+                                        curses_initscr_called,
+                                        "initscr")) {
+        return -1;
+    }
     return napms(ms);
 }
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-126313 -->
* Issue: gh-126313
<!-- /gh-issue-number -->
