### PR TITLE
Docs: Delist default sqlite3 adapters and convertors deprecation from "Pending removal in 3.14"

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.14.rst
+++ b/Doc/deprecations/pending-removal-in-3.14.rst
@@ -103,9 +103,6 @@ Pending removal in Python 3.14
     if :ref:`named placeholders <sqlite3-placeholders>` are used and
     *parameters* is a sequence instead of a :class:`dict`.
 
-  * date and datetime adapter, date and timestamp converter:
-    see the :mod:`sqlite3` documentation for suggested replacement recipes.
-
 * :class:`types.CodeType`: Accessing :attr:`~codeobject.co_lnotab` was
   deprecated in :pep:`626`
   since 3.10 and was planned to be removed in 3.12,


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This was deprecated in 3.12 (https://github.com/python/cpython/pull/94276) but never planned to be removed in 3.14. It was added to the "Pending removal in Python 3.14" list by mistake, probably assuming it would be removed in +2 releases.

https://docs.python.org/3.13/library/sqlite3.html#default-adapters-and-converters-deprecated is correct: only says deprecated in 3.12.

See also https://discuss.python.org/t/deprecate-default-built-in-sqlite3-converters-and-adapters/15781.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126370.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->