### PR TITLE
gh-101865: Docs: Keep co_lnotab deprecation for at least 3.14

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.14.rst
+++ b/Doc/deprecations/pending-removal-in-3.14.rst
@@ -103,13 +103,6 @@ Pending removal in Python 3.14
     if :ref:`named placeholders <sqlite3-placeholders>` are used and
     *parameters* is a sequence instead of a :class:`dict`.
 
-* :class:`types.CodeType`: Accessing :attr:`~codeobject.co_lnotab` was
-  deprecated in :pep:`626`
-  since 3.10 and was planned to be removed in 3.12,
-  but it only got a proper :exc:`DeprecationWarning` in 3.12.
-  May be removed in 3.14.
-  (Contributed by Nikita Sobolev in :gh:`101866`.)
-
 * :mod:`typing`: :class:`!typing.ByteString`, deprecated since Python 3.9,
   now causes a :exc:`DeprecationWarning` to be emitted when it is used.
 

--- a/Doc/deprecations/pending-removal-in-3.15.rst
+++ b/Doc/deprecations/pending-removal-in-3.15.rst
@@ -59,6 +59,15 @@ Pending removal in Python 3.15
     but the C version allows any number of positional or keyword arguments,
     ignoring every argument.
 
+* :mod:`types`:
+
+  * :class:`types.CodeType`: Accessing :attr:`~codeobject.co_lnotab` was
+    deprecated in :pep:`626`
+    since 3.10 and was planned to be removed in 3.12,
+    but it only got a proper :exc:`DeprecationWarning` in 3.12.
+    May be removed in 3.15.
+    (Contributed by Nikita Sobolev in :gh:`101866`.)
+
 * :mod:`typing`:
 
   * The undocumented keyword argument syntax for creating

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1507,7 +1507,7 @@ Special read-only attributes
 
        .. deprecated:: 3.12
           This attribute of code objects is deprecated, and may be removed in
-          Python 3.14.
+          Python 3.15.
 
    * - .. attribute:: codeobject.co_stacksize
      - The required stack size of the code object

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1327,8 +1327,8 @@ Deprecated
 
 * Accessing :attr:`~codeobject.co_lnotab` on code objects was deprecated in
   Python 3.10 via :pep:`626`,
-  but it only got a proper :exc:`DeprecationWarning` in 3.12,
-  therefore it will be removed in 3.14.
+  but it only got a proper :exc:`DeprecationWarning` in 3.12.
+  May be removed in 3.15.
   (Contributed by Nikita Sobolev in :gh:`101866`.)
 
 .. include:: ../deprecations/pending-removal-in-3.13.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

There's still quite a bit of use [in the wild](https://grep.app/search?q=co_lnotab&case=true&filter[lang][0]=Python) and we're in no rush to remove this in Python 3.14.

Let's bump to 3.15 and reassess during the next cycle.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126392.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-101865 -->
* Issue: gh-101865
<!-- /gh-issue-number -->
