### PR TITLE
gh-109413: Enable `strict_optional` for `libregrtest/main.py`

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -148,7 +148,7 @@ class Namespace(argparse.Namespace):
         self.randomize = False
         self.fromfile = None
         self.fail_env_changed = False
-        self.use_resources = None
+        self.use_resources: list[str] = []
         self.trace = False
         self.coverdir = 'coverage'
         self.runleaks = False
@@ -403,8 +403,6 @@ def _parse_args(args, **kwargs):
             raise TypeError('%r is an invalid keyword argument '
                             'for this function' % k)
         setattr(ns, k, v)
-    if ns.use_resources is None:
-        ns.use_resources = []
 
     parser = _create_parser()
     # Issue #14191: argparse doesn't support "intermixed" positional and

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -463,7 +463,9 @@ class Regrtest:
         print()
         print("Total duration: %s" % format_duration(duration))
 
-        assert self.first_runtests, "self.first_runtests is None"
+        assert self.first_runtests, (
+            "Should never call `display_summary()` before calling `_run_test()`"
+        )
         self.results.display_summary(self.first_runtests, filtered)
 
         # Result
@@ -715,7 +717,9 @@ class Regrtest:
 
     @property
     def tmp_dir(self) -> StrPath:
-        assert self._tmp_dir is not None, "self._tmp_dir is None"
+        assert self._tmp_dir is not None, (
+            "Should never use `.tmp_dir` before calling `.main()`"
+        )
         return self._tmp_dir
 
     def main(self, tests: TestList | None = None) -> NoReturn:

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -460,7 +460,7 @@ class Regrtest:
             raise ValueError(
                 "Should never call `display_summary()` before calling `_run_test()`"
             )
-        
+
         duration = time.perf_counter() - self.logger.start_time
         filtered = bool(self.match_tests)
 

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -123,7 +123,7 @@ class Regrtest:
             self.python_cmd = None
         self.coverage: bool = ns.trace
         self.coverage_dir: StrPath | None = ns.coverdir
-        self.tmp_dir: StrPath | None = ns.tempdir
+        self._tmp_dir: StrPath | None = ns.tempdir
 
         # Randomize
         self.randomize: bool = ns.randomize
@@ -159,6 +159,8 @@ class Regrtest:
         self.logger.log(line)
 
     def find_tests(self, tests: TestList | None = None) -> tuple[TestTuple, TestList | None]:
+        if tests is None:
+            tests = []
         if self.single_test_run:
             self.next_single_filename = os.path.join(self.tmp_dir, 'pynexttest')
             try:
@@ -461,6 +463,7 @@ class Regrtest:
         print()
         print("Total duration: %s" % format_duration(duration))
 
+        assert self.first_runtests, "self.first_runtests is None"
         self.results.display_summary(self.first_runtests, filtered)
 
         # Result
@@ -708,7 +711,12 @@ class Regrtest:
 
         strip_py_suffix(self.cmdline_args)
 
-        self.tmp_dir = get_temp_dir(self.tmp_dir)
+        self._tmp_dir = get_temp_dir(self._tmp_dir)
+
+    @property
+    def tmp_dir(self) -> StrPath:
+        assert self._tmp_dir is not None, "self._tmp_dir is None"
+        return self._tmp_dir
 
     def main(self, tests: TestList | None = None) -> NoReturn:
         if self.want_add_python_opts:

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -456,6 +456,11 @@ class Regrtest:
             self.results.write_junit(self.junit_filename)
 
     def display_summary(self) -> None:
+        if self.first_runtests is None:
+            raise ValueError(
+                "Should never call `display_summary()` before calling `_run_test()`"
+            )
+        
         duration = time.perf_counter() - self.logger.start_time
         filtered = bool(self.match_tests)
 
@@ -463,9 +468,6 @@ class Regrtest:
         print()
         print("Total duration: %s" % format_duration(duration))
 
-        assert self.first_runtests, (
-            "Should never call `display_summary()` before calling `_run_test()`"
-        )
         self.results.display_summary(self.first_runtests, filtered)
 
         # Result
@@ -717,9 +719,10 @@ class Regrtest:
 
     @property
     def tmp_dir(self) -> StrPath:
-        assert self._tmp_dir is not None, (
-            "Should never use `.tmp_dir` before calling `.main()`"
-        )
+        if self._tmp_dir is None:
+            raise ValueError(
+                "Should never use `.tmp_dir` before calling `.main()`"
+            )
         return self._tmp_dir
 
     def main(self, tests: TestList | None = None) -> NoReturn:

--- a/Lib/test/libregrtest/mypy.ini
+++ b/Lib/test/libregrtest/mypy.ini
@@ -22,10 +22,8 @@ disallow_untyped_defs = False
 check_untyped_defs = False
 warn_return_any = False
 
-disable_error_code = return
-
 # Enable --strict-optional for these ASAP:
-[mypy-Lib.test.libregrtest.main.*,Lib.test.libregrtest.run_workers.*]
+[mypy-Lib.test.libregrtest.run_workers.*]
 strict_optional = False
 
 # Various internal modules that typeshed deliberately doesn't have stubs for:

--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -211,6 +211,7 @@ class WorkerThread(threading.Thread):
                     # on reading closed stdout
                     raise ExitThread
                 raise
+            return None
         except:
             self._kill()
             raise
@@ -544,6 +545,7 @@ class RunWorkers:
                 running = get_running(self.workers)
                 if running:
                     self.log(running)
+        return None
 
     def display_result(self, mp_result: MultiprocessResult) -> None:
         result = mp_result.result


### PR DESCRIPTION
I also enabled `return` error code and fix two problems with it.
I decided to split `strict_optional` PRs based on modules for easier reviews :)

<!-- gh-issue-number: gh-109413 -->
* Issue: gh-109413
<!-- /gh-issue-number -->
