### PR TITLE
gh-119793: Prefer `map(..., strict=True)` over starmap/zip in examples

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -406,7 +406,7 @@ Number-theoretic and representation functions
 
    Roughly equivalent to::
 
-       sum(itertools.starmap(operator.mul, zip(p, q, strict=True)))
+       sum(map(operator.mul, p, q, strict=True))
 
    For float and mixed int/float inputs, the intermediate products
    and sums are computed with extended precision.

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -457,7 +457,7 @@ PyDoc_STRVAR(math_sumprod__doc__,
 "\n"
 "Roughly equivalent to:\n"
 "\n"
-"    sum(itertools.starmap(operator.mul, zip(p, q, strict=True)))\n"
+"    sum(map(operator.mul, p, q, strict=True))\n"
 "\n"
 "For float and mixed int/float inputs, the intermediate products\n"
 "and sums are computed with extended precision.");
@@ -1109,4 +1109,4 @@ math_ulp(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ee0a2f6bd1220061 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ff99a737c18d9210 input=a9049054013a1b77]*/

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2710,7 +2710,7 @@ Return the sum of products of values from two iterables p and q.
 
 Roughly equivalent to:
 
-    sum(itertools.starmap(operator.mul, zip(p, q, strict=True)))
+    sum(map(operator.mul, p, q, strict=True))
 
 For float and mixed int/float inputs, the intermediate products
 and sums are computed with extended precision.
@@ -2718,7 +2718,7 @@ and sums are computed with extended precision.
 
 static PyObject *
 math_sumprod_impl(PyObject *module, PyObject *p, PyObject *q)
-/*[clinic end generated code: output=6722dbfe60664554 input=82be54fe26f87e30]*/
+/*[clinic end generated code: output=6722dbfe60664554 input=a2880317828c61d2]*/
 {
     PyObject *p_i = NULL, *q_i = NULL, *term_i = NULL, *new_total = NULL;
     PyObject *p_it, *q_it, *total;


### PR DESCRIPTION
This is a docs-only change that updates the examples to use `map(..., strict=True)` instead of `starmap(..., zip(..., strict=True))` which should improve readability.

<!-- gh-issue-number: gh-119793 -->
* Issue: gh-119793
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126407.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->