### PR TITLE
Doc: C API: Delete claim that `PyObject_Init` is GC-aware

### DIFF
--- a/Doc/c-api/allocation.rst
+++ b/Doc/c-api/allocation.rst
@@ -15,10 +15,8 @@ Allocating Objects on the Heap
 .. c:function:: PyObject* PyObject_Init(PyObject *op, PyTypeObject *type)
 
    Initialize a newly allocated object *op* with its type and initial
-   reference.  Returns the initialized object.  If *type* indicates that the
-   object participates in the cyclic garbage detector, it is added to the
-   detector's set of observed objects. Other fields of the object are not
-   affected.
+   reference.  Returns the initialized object.  Other fields of the object are
+   not affected.
 
 
 .. c:function:: PyVarObject* PyObject_InitVar(PyVarObject *op, PyTypeObject *type, Py_ssize_t size)


### PR DESCRIPTION
As far as I can tell, `PyObject_Init` never tells the garbage collector about the memory even if the `Py_TPFLAGS_HAVE_GC` flag is set.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126418.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->