### PR TITLE
gh-126417: Register multiprocessing proxy types to an appropriate collections.abc class

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -1170,7 +1170,7 @@ class ListProxy(BaseListProxy):
 
 collections.abc.MutableSequence.register(BaseListProxy)
 
-_BaseDictProxy = MakeProxyType('DictProxy', (
+_BaseDictProxy = MakeProxyType('_BaseDictProxy', (
     '__contains__', '__delitem__', '__getitem__', '__ior__', '__iter__',
     '__len__', '__or__', '__reversed__', '__ror__',
     '__setitem__', 'clear', 'copy', 'fromkeys', 'get', 'items',

--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -18,6 +18,7 @@ import sys
 import threading
 import signal
 import array
+import collections.abc
 import queue
 import time
 import types
@@ -1167,6 +1168,7 @@ class ListProxy(BaseListProxy):
 
     __class_getitem__ = classmethod(types.GenericAlias)
 
+collections.abc.MutableSequence.register(BaseListProxy)
 
 _BaseDictProxy = MakeProxyType('DictProxy', (
     '__contains__', '__delitem__', '__getitem__', '__ior__', '__iter__',
@@ -1183,6 +1185,8 @@ class DictProxy(_BaseDictProxy):
         return self
 
     __class_getitem__ = classmethod(types.GenericAlias)
+
+collections.abc.MutableMapping.register(_BaseDictProxy)
 
 ArrayProxy = MakeProxyType('ArrayProxy', (
     '__len__', '__getitem__', '__setitem__'

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -16,6 +16,7 @@ import errno
 import functools
 import signal
 import array
+import collections.abc
 import socket
 import random
 import logging
@@ -2331,6 +2332,10 @@ class _TestContainers(BaseTestCase):
         a.append('hello')
         self.assertEqual(f[0][:], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'hello'])
 
+    def test_list_isinstance(self):
+        a = self.list()
+        self.assertIsInstance(a, collections.abc.MutableSequence)
+
     def test_list_iter(self):
         a = self.list(list(range(10)))
         it = iter(a)
@@ -2370,6 +2375,10 @@ class _TestContainers(BaseTestCase):
         self.assertEqual(sorted(d.keys()), indices)
         self.assertEqual(sorted(d.values()), [chr(i) for i in indices])
         self.assertEqual(sorted(d.items()), [(i, chr(i)) for i in indices])
+
+    def test_dict_isinstance(self):
+        a = self.dict()
+        self.assertIsInstance(a, collections.abc.MutableMapping)
 
     def test_dict_iter(self):
         d = self.dict()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1273,6 +1273,7 @@ Emily Morehouse
 Derek Morr
 James A Morrison
 Martin Morrison
+Stephen Morton
 Derek McTavish Mounce
 Alessandro Moura
 Pablo Mouzo

--- a/Misc/NEWS.d/next/Library/2024-11-04-16-40-02.gh-issue-126417.OWPqn0.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-04-16-40-02.gh-issue-126417.OWPqn0.rst
@@ -1,3 +1,3 @@
-Register the ``DictProxy`` and ``ListProxy`` types in
-:mod:`multiprocessing.managers` to collections.abc.MutableMapping and
-collections.abc.MutableSequence, respectively.
+Register the :class:`!multiprocessing.managers.DictProxy` and :class:`!multiprocessing.managers.ListProxy` types in
+:mod:`multiprocessing.managers` to :class:`collections.abc.MutableMapping` and
+:class:`collections.abc.MutableSequence`, respectively.

--- a/Misc/NEWS.d/next/Library/2024-11-04-16-40-02.gh-issue-126417.OWPqn0.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-04-16-40-02.gh-issue-126417.OWPqn0.rst
@@ -1,0 +1,3 @@
+Register the ``DictProxy`` and ``ListProxy`` types in
+:mod:`multiprocessing.managers` to collections.abc.MutableMapping and
+collections.abc.MutableSequence, respectively.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This MR registers BaseListProxy and _BaseDictProxy in `multiprocessing.managers` to an appropriate ABC from `collections.abc`. This improves their consistency with the types they proxy.

While I was here, I also updated the name of _BaseDictProxy so it's consistent with the variable that the type is assigned to. I think that kind of naming consistency is good, but it's less important and I can take that change out if it's not appropriate to include here.

<!-- gh-issue-number: gh-126417 -->
* Issue: gh-126417
<!-- /gh-issue-number -->
