### PR TITLE
gh-126425: Refactor `_lsprof_Profiler_enable`

### DIFF
--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -799,7 +799,8 @@ _lsprof_Profiler_enable_impl(ProfilerObject *self, int subcalls,
         PyObject *register_result = PyObject_CallMethod(monitoring, "register_callback",
                                                         "iiO", self->tool_id,
                                                         event, callback);
-        Py_DECREF(callback);  // register_result is callback
+        Py_DECREF(register_result);
+        Py_DECREF(callback);
         if (register_result == NULL) {
             goto error;
         }

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -780,34 +780,47 @@ _lsprof_Profiler_enable_impl(ProfilerObject *self, int subcalls,
         return NULL;
     }
 
-    if (PyObject_CallMethod(monitoring, "use_tool_id", "is", self->tool_id, "cProfile") == NULL) {
+    PyObject *check = PyObject_CallMethod(monitoring,
+                                          "use_tool_id", "is",
+                                          self->tool_id, "cProfile");
+    if (check == NULL) {
+        PyErr_Clear();
         PyErr_Format(PyExc_ValueError, "Another profiling tool is already active");
-        Py_DECREF(monitoring);
-        return NULL;
+        goto error;
     }
+    Py_DECREF(check);
 
     for (int i = 0; callback_table[i].callback_method; i++) {
+        int event = (1 << callback_table[i].event);
         PyObject* callback = PyObject_GetAttrString((PyObject*)self, callback_table[i].callback_method);
         if (!callback) {
-            Py_DECREF(monitoring);
-            return NULL;
+            goto error;
         }
-        Py_XDECREF(PyObject_CallMethod(monitoring, "register_callback", "iiO", self->tool_id,
-                                       (1 << callback_table[i].event),
-                                       callback));
-        Py_DECREF(callback);
-        all_events |= (1 << callback_table[i].event);
+        PyObject *register_result = PyObject_CallMethod(monitoring, "register_callback",
+                                                        "iiO", self->tool_id,
+                                                        event, callback);
+        Py_DECREF(callback);  // register_result is callback
+        if (register_result == NULL) {
+            goto error;
+        }
+        all_events |= event;
     }
 
-    if (!PyObject_CallMethod(monitoring, "set_events", "ii", self->tool_id, all_events)) {
-        Py_DECREF(monitoring);
-        return NULL;
+    PyObject *event_result = PyObject_CallMethod(monitoring, "set_events", "ii",
+                                                 self->tool_id, all_events);
+    if (event_result == NULL) {
+        goto error;
     }
 
+    Py_DECREF(event_result);
     Py_DECREF(monitoring);
 
     self->flags |= POF_ENABLED;
     Py_RETURN_NONE;
+
+error:
+    Py_DECREF(monitoring);
+    return NULL;
 }
 
 static void

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -784,7 +784,6 @@ _lsprof_Profiler_enable_impl(ProfilerObject *self, int subcalls,
                                           "use_tool_id", "is",
                                           self->tool_id, "cProfile");
     if (check == NULL) {
-        PyErr_Clear();
         PyErr_Format(PyExc_ValueError, "Another profiling tool is already active");
         goto error;
     }
@@ -799,11 +798,11 @@ _lsprof_Profiler_enable_impl(ProfilerObject *self, int subcalls,
         PyObject *register_result = PyObject_CallMethod(monitoring, "register_callback",
                                                         "iiO", self->tool_id,
                                                         event, callback);
-        Py_DECREF(register_result);
         Py_DECREF(callback);
         if (register_result == NULL) {
             goto error;
         }
+        Py_DECREF(register_result);
         all_events |= event;
     }
 


### PR DESCRIPTION
- Explicit memory management for `None` objects (since we still try to treat immortal objects as regular objects)
- Respect possible errors of `sys.monitoring.register_callback` call

<!-- gh-issue-number: gh-126425 -->
* Issue: gh-126425
<!-- /gh-issue-number -->
