### PR TITLE
[3.12] gh-126417: Register multiprocessing proxy types to an appropriate collections.abc class (#126419)

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -18,6 +18,7 @@ import sys
 import threading
 import signal
 import array
+import collections.abc
 import queue
 import time
 import types
@@ -1160,6 +1161,8 @@ class ListProxy(BaseListProxy):
         return self
 
 
+collections.abc.MutableSequence.register(BaseListProxy)
+
 DictProxy = MakeProxyType('DictProxy', (
     '__contains__', '__delitem__', '__getitem__', '__iter__', '__len__',
     '__setitem__', 'clear', 'copy', 'get', 'items',
@@ -1169,6 +1172,7 @@ DictProxy._method_to_typeid_ = {
     '__iter__': 'Iterator',
     }
 
+collections.abc.MutableMapping.register(DictProxy)
 
 ArrayProxy = MakeProxyType('ArrayProxy', (
     '__len__', '__getitem__', '__setitem__'

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -16,6 +16,7 @@ import errno
 import functools
 import signal
 import array
+import collections.abc
 import socket
 import random
 import logging
@@ -2331,6 +2332,10 @@ class _TestContainers(BaseTestCase):
         a.append('hello')
         self.assertEqual(f[0][:], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'hello'])
 
+    def test_list_isinstance(self):
+        a = self.list()
+        self.assertIsInstance(a, collections.abc.MutableSequence)
+
     def test_list_iter(self):
         a = self.list(list(range(10)))
         it = iter(a)
@@ -2370,6 +2375,10 @@ class _TestContainers(BaseTestCase):
         self.assertEqual(sorted(d.keys()), indices)
         self.assertEqual(sorted(d.values()), [chr(i) for i in indices])
         self.assertEqual(sorted(d.items()), [(i, chr(i)) for i in indices])
+
+    def test_dict_isinstance(self):
+        a = self.dict()
+        self.assertIsInstance(a, collections.abc.MutableMapping)
 
     def test_dict_iter(self):
         d = self.dict()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1259,6 +1259,7 @@ Emily Morehouse
 Derek Morr
 James A Morrison
 Martin Morrison
+Stephen Morton
 Derek McTavish Mounce
 Alessandro Moura
 Pablo Mouzo

--- a/Misc/NEWS.d/next/Library/2024-11-04-16-40-02.gh-issue-126417.OWPqn0.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-04-16-40-02.gh-issue-126417.OWPqn0.rst
@@ -1,0 +1,3 @@
+Register the :class:`!multiprocessing.managers.DictProxy` and :class:`!multiprocessing.managers.ListProxy` types in
+:mod:`multiprocessing.managers` to :class:`collections.abc.MutableMapping` and
+:class:`collections.abc.MutableSequence`, respectively.


### PR DESCRIPTION
(cherry-picked from commit 78842e4a98994a218a93992a2a1e3ca3eaa28e79)

I backported the ABC registrations but not the renaming that @tungol mentioned in https://github.com/python/cpython/pull/126419#issue-2634182197; that seemed less like a bugfix, and also possibly more likely to result in breakage in a backport

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-126417 -->
* Issue: gh-126417
<!-- /gh-issue-number -->
