### PR TITLE
gh-126451: Register contextvars.Context to collections.abc.Mapping

### DIFF
--- a/Lib/contextvars.py
+++ b/Lib/contextvars.py
@@ -1,8 +1,8 @@
-import collections.abc
+import _collections_abc
 from _contextvars import Context, ContextVar, Token, copy_context
 
 
 __all__ = ('Context', 'ContextVar', 'Token', 'copy_context')
 
 
-collections.abc.Mapping.register(Context)
+_collections_abc.Mapping.register(Context)

--- a/Lib/contextvars.py
+++ b/Lib/contextvars.py
@@ -1,4 +1,8 @@
+import collections.abc
 from _contextvars import Context, ContextVar, Token, copy_context
 
 
 __all__ = ('Context', 'ContextVar', 'Token', 'copy_context')
+
+
+collections.abc.Mapping.register(Context)

--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -355,10 +355,12 @@ class ContextTest(unittest.TestCase):
         ctx = contextvars.Context()
         self.assertIsInstance(ctx, collections.abc.Mapping)
 
-        mapping_methods = ("__getitem__", "__iter__", "__len__", "__contains__", "keys",
-                           "items", "values", "get", "__eq__", "__ne__")
+        mapping_methods = (
+            '__contains__', '__eq__', '__getitem__', '__iter__', '__len__',
+            '__ne__','get', 'items', 'keys', 'values',
+        )
         for name in mapping_methods:
-            self.assertIn(name, dir(ctx))
+            self.assertTrue(callable(getattr(ctx, name)))
 
     @isolated_context
     @threading_helper.requires_working_threading()

--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -360,7 +360,8 @@ class ContextTest(unittest.TestCase):
             '__ne__', 'get', 'items', 'keys', 'values',
         )
         for name in mapping_methods:
-            self.assertTrue(callable(getattr(ctx, name)))
+            with self.subTest(name=name):
+                self.assertTrue(callable(getattr(ctx, name)))
 
     @isolated_context
     @threading_helper.requires_working_threading()

--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -357,7 +357,7 @@ class ContextTest(unittest.TestCase):
 
         mapping_methods = (
             '__contains__', '__eq__', '__getitem__', '__iter__', '__len__',
-            '__ne__','get', 'items', 'keys', 'values',
+            '__ne__', 'get', 'items', 'keys', 'values',
         )
         for name in mapping_methods:
             self.assertTrue(callable(getattr(ctx, name)))

--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -355,7 +355,6 @@ class ContextTest(unittest.TestCase):
         ctx = contextvars.Context()
         self.assertIsInstance(ctx, collections.abc.Mapping)
         self.assertTrue(issubclass(contextvars.Context, collections.abc.Mapping))
-        self.assertTrue(issubclass(contextvars.Context, collections.abc.Mapping))
 
         mapping_methods = (
             '__contains__', '__eq__', '__getitem__', '__iter__', '__len__',

--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -354,6 +354,7 @@ class ContextTest(unittest.TestCase):
     def test_context_isinstance(self):
         ctx = contextvars.Context()
         self.assertIsInstance(ctx, collections.abc.Mapping)
+        self.assertTrue(issubclass(contextvars.Context, collections.abc.Mapping))
 
         mapping_methods = (
             '__contains__', '__eq__', '__getitem__', '__iter__', '__len__',

--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -355,6 +355,11 @@ class ContextTest(unittest.TestCase):
         ctx = contextvars.Context()
         self.assertIsInstance(ctx, collections.abc.Mapping)
 
+        mapping_methods = ("__getitem__", "__iter__", "__len__", "__contains__", "keys",
+                           "items", "values", "get", "__eq__", "__ne__")
+        for name in mapping_methods:
+            self.assertIn(name, dir(ctx))
+
     @isolated_context
     @threading_helper.requires_working_threading()
     def test_context_threads_1(self):

--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -355,6 +355,7 @@ class ContextTest(unittest.TestCase):
         ctx = contextvars.Context()
         self.assertIsInstance(ctx, collections.abc.Mapping)
         self.assertTrue(issubclass(contextvars.Context, collections.abc.Mapping))
+        self.assertTrue(issubclass(contextvars.Context, collections.abc.Mapping))
 
         mapping_methods = (
             '__contains__', '__eq__', '__getitem__', '__iter__', '__len__',

--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -1,3 +1,4 @@
+import collections.abc
 import concurrent.futures
 import contextvars
 import functools
@@ -349,6 +350,10 @@ class ContextTest(unittest.TestCase):
             self.assertEqual(c.get(), 30)
 
         ctx1.run(ctx1_fun)
+
+    def test_context_isinstance(self):
+        ctx = contextvars.Context()
+        self.assertIsInstance(ctx, collections.abc.Mapping)
 
     @isolated_context
     @threading_helper.requires_working_threading()

--- a/Misc/NEWS.d/next/Library/2024-11-05-11-28-45.gh-issue-126451.XJMtqz.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-05-11-28-45.gh-issue-126451.XJMtqz.rst
@@ -1,2 +1,2 @@
-Register the :class:`!contextvars.Context` type to
-:class:`!collections.abc.Mapping`.
+Register the :class:`contextvars.Context` type to
+:class:`collections.abc.Mapping`.

--- a/Misc/NEWS.d/next/Library/2024-11-05-11-28-45.gh-issue-126451.XJMtqz.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-05-11-28-45.gh-issue-126451.XJMtqz.rst
@@ -1,0 +1,2 @@
+Register the :class:`!contextvars.Context` type to
+:class:`!collections.abc.Mapping`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This MR registers `contextvars.Context` to `collections.abc.Mapping`. It's already documented that `Context` implements the `Mapping` interface.

<!-- gh-issue-number: gh-126451 -->
* Issue: gh-126451
<!-- /gh-issue-number -->
