### PR TITLE
gh-76785: Minor Cleanup of "Cross-interpreter" Code

### DIFF
--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -143,32 +143,9 @@ PyAPI_FUNC(void) _PyXIData_Clear( PyInterpreterState *, _PyXIData_t *);
 
 /* cross-interpreter data registry */
 
-// For now we use a global registry of shareable classes.  An
-// alternative would be to add a tp_* slot for a class's
-// xidatafunc. It would be simpler and more efficient.
-
-struct _xidregitem;
-
-struct _xidregitem {
-    struct _xidregitem *prev;
-    struct _xidregitem *next;
-    /* This can be a dangling pointer, but only if weakref is set. */
-    PyTypeObject *cls;
-    /* This is NULL for builtin types. */
-    PyObject *weakref;
-    size_t refcount;
-    xidatafunc getdata;
-};
-
-struct _xidregistry {
-    int global;  /* builtin types or heap types */
-    int initialized;
-    PyMutex mutex;
-    struct _xidregitem *head;
-};
-
-PyAPI_FUNC(int) _PyXIData_RegisterClass(PyTypeObject *, xidatafunc);
-PyAPI_FUNC(int) _PyXIData_UnregisterClass(PyTypeObject *);
+#define Py_CORE_CROSSINTERP_DATA_REGISTRY_H
+#include "pycore_crossinterp_data_registry.h"
+#undef Py_CORE_CROSSINTERP_DATA_REGISTRY_H
 
 
 /*****************************/

--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -54,7 +54,7 @@ struct _xid {
     // is non-NULL only if the data remains bound to the object in some
     // way, such that the object must be "released" (via a decref) when
     // the data is released.  In that case the code that sets the field,
-    // likely a registered "crossinterpdatafunc", is responsible for
+    // likely a registered "xidatafunc", is responsible for
     // ensuring it owns the reference (i.e. incref).
     PyObject *obj;
     // interp is the ID of the owning interpreter of the original
@@ -114,9 +114,9 @@ PyAPI_FUNC(void) _PyCrossInterpreterData_Clear(
         (DATA)->free = (FUNC); \
     } while (0)
 // Additionally, some shareable types are essentially light wrappers
-// around other shareable types.  The crossinterpdatafunc of the wrapper
+// around other shareable types.  The xidatafunc of the wrapper
 // can often be implemented by calling the wrapped object's
-// crossinterpdatafunc and then changing the "new_object" function.
+// xidatafunc and then changing the "new_object" function.
 // We have _PyCrossInterpreterData_SET_NEW_OBJECT() here for that,
 // but might be better to have a function like
 // _PyCrossInterpreterData_AdaptToWrapper() instead.
@@ -139,10 +139,9 @@ PyAPI_FUNC(int) _PyCrossInterpreterData_ReleaseAndRawFree(_PyXIData_t *);
 
 // For now we use a global registry of shareable classes.  An
 // alternative would be to add a tp_* slot for a class's
-// crossinterpdatafunc. It would be simpler and more efficient.
+// xidatafunc. It would be simpler and more efficient.
 
-typedef int (*crossinterpdatafunc)(PyThreadState *tstate, PyObject *,
-                                   _PyXIData_t *);
+typedef int (*xidatafunc)(PyThreadState *tstate, PyObject *, _PyXIData_t *);
 
 struct _xidregitem;
 
@@ -154,7 +153,7 @@ struct _xidregitem {
     /* This is NULL for builtin types. */
     PyObject *weakref;
     size_t refcount;
-    crossinterpdatafunc getdata;
+    xidatafunc getdata;
 };
 
 struct _xidregistry {
@@ -164,9 +163,9 @@ struct _xidregistry {
     struct _xidregitem *head;
 };
 
-PyAPI_FUNC(int) _PyCrossInterpreterData_RegisterClass(PyTypeObject *, crossinterpdatafunc);
+PyAPI_FUNC(int) _PyCrossInterpreterData_RegisterClass(PyTypeObject *, xidatafunc);
 PyAPI_FUNC(int) _PyCrossInterpreterData_UnregisterClass(PyTypeObject *);
-PyAPI_FUNC(crossinterpdatafunc) _PyCrossInterpreterData_Lookup(PyObject *);
+PyAPI_FUNC(xidatafunc) _PyCrossInterpreterData_Lookup(PyObject *);
 
 
 /*****************************/

--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -93,6 +93,22 @@ PyAPI_FUNC(void) _PyXIData_Free(_PyXIData_t *data);
 // Users should not need getters for "new_object" or "free".
 
 
+/* getting cross-interpreter data */
+
+typedef int (*xidatafunc)(PyThreadState *tstate, PyObject *, _PyXIData_t *);
+
+PyAPI_FUNC(xidatafunc) _PyXIData_Lookup(PyObject *);
+PyAPI_FUNC(int) _PyObject_CheckXIData(PyObject *);
+PyAPI_FUNC(int) _PyObject_GetXIData(PyObject *, _PyXIData_t *);
+
+
+/* using cross-interpreter data */
+
+PyAPI_FUNC(PyObject *) _PyXIData_NewObject(_PyXIData_t *);
+PyAPI_FUNC(int) _PyXIData_Release(_PyXIData_t *);
+PyAPI_FUNC(int) _PyXIData_ReleaseAndRawFree(_PyXIData_t *);
+
+
 /* defining cross-interpreter data */
 
 PyAPI_FUNC(void) _PyXIData_Init(
@@ -125,22 +141,11 @@ PyAPI_FUNC(void) _PyXIData_Clear( PyInterpreterState *, _PyXIData_t *);
     } while (0)
 
 
-/* using cross-interpreter data */
-
-PyAPI_FUNC(int) _PyObject_CheckXIData(PyObject *);
-PyAPI_FUNC(int) _PyObject_GetXIData(PyObject *, _PyXIData_t *);
-PyAPI_FUNC(PyObject *) _PyXIData_NewObject(_PyXIData_t *);
-PyAPI_FUNC(int) _PyXIData_Release(_PyXIData_t *);
-PyAPI_FUNC(int) _PyXIData_ReleaseAndRawFree(_PyXIData_t *);
-
-
 /* cross-interpreter data registry */
 
 // For now we use a global registry of shareable classes.  An
 // alternative would be to add a tp_* slot for a class's
 // xidatafunc. It would be simpler and more efficient.
-
-typedef int (*xidatafunc)(PyThreadState *tstate, PyObject *, _PyXIData_t *);
 
 struct _xidregitem;
 
@@ -164,7 +169,6 @@ struct _xidregistry {
 
 PyAPI_FUNC(int) _PyXIData_RegisterClass(PyTypeObject *, xidatafunc);
 PyAPI_FUNC(int) _PyXIData_UnregisterClass(PyTypeObject *);
-PyAPI_FUNC(xidatafunc) _PyXIData_Lookup(PyObject *);
 
 
 /*****************************/

--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -38,11 +38,11 @@ extern int _Py_CallInInterpreterAndRawFree(
 /* cross-interpreter data */
 /**************************/
 
-typedef struct _xid _PyCrossInterpreterData;
-typedef PyObject *(*xid_newobjectfunc)(_PyCrossInterpreterData *);
+typedef struct _xid _PyXIData_t;
+typedef PyObject *(*xid_newobjectfunc)(_PyXIData_t *);
 typedef void (*xid_freefunc)(void *);
 
-// _PyCrossInterpreterData is similar to Py_buffer as an effectively
+// _PyXIData_t is similar to Py_buffer as an effectively
 // opaque struct that holds data outside the object machinery.  This
 // is necessary to pass safely between interpreters in the same process.
 struct _xid {
@@ -84,8 +84,8 @@ struct _xid {
     xid_freefunc free;
 };
 
-PyAPI_FUNC(_PyCrossInterpreterData *) _PyCrossInterpreterData_New(void);
-PyAPI_FUNC(void) _PyCrossInterpreterData_Free(_PyCrossInterpreterData *data);
+PyAPI_FUNC(_PyXIData_t *) _PyCrossInterpreterData_New(void);
+PyAPI_FUNC(void) _PyCrossInterpreterData_Free(_PyXIData_t *data);
 
 #define _PyCrossInterpreterData_DATA(DATA) ((DATA)->data)
 #define _PyCrossInterpreterData_OBJ(DATA) ((DATA)->obj)
@@ -96,15 +96,15 @@ PyAPI_FUNC(void) _PyCrossInterpreterData_Free(_PyCrossInterpreterData *data);
 /* defining cross-interpreter data */
 
 PyAPI_FUNC(void) _PyCrossInterpreterData_Init(
-        _PyCrossInterpreterData *data,
+        _PyXIData_t *data,
         PyInterpreterState *interp, void *shared, PyObject *obj,
         xid_newobjectfunc new_object);
 PyAPI_FUNC(int) _PyCrossInterpreterData_InitWithSize(
-        _PyCrossInterpreterData *,
+        _PyXIData_t *,
         PyInterpreterState *interp, const size_t, PyObject *,
         xid_newobjectfunc);
 PyAPI_FUNC(void) _PyCrossInterpreterData_Clear(
-        PyInterpreterState *, _PyCrossInterpreterData *);
+        PyInterpreterState *, _PyXIData_t *);
 
 // Normally the Init* functions are sufficient.  The only time
 // additional initialization might be needed is to set the "free" func,
@@ -129,10 +129,10 @@ PyAPI_FUNC(void) _PyCrossInterpreterData_Clear(
 /* using cross-interpreter data */
 
 PyAPI_FUNC(int) _PyObject_CheckCrossInterpreterData(PyObject *);
-PyAPI_FUNC(int) _PyObject_GetCrossInterpreterData(PyObject *, _PyCrossInterpreterData *);
-PyAPI_FUNC(PyObject *) _PyCrossInterpreterData_NewObject(_PyCrossInterpreterData *);
-PyAPI_FUNC(int) _PyCrossInterpreterData_Release(_PyCrossInterpreterData *);
-PyAPI_FUNC(int) _PyCrossInterpreterData_ReleaseAndRawFree(_PyCrossInterpreterData *);
+PyAPI_FUNC(int) _PyObject_GetCrossInterpreterData(PyObject *, _PyXIData_t *);
+PyAPI_FUNC(PyObject *) _PyCrossInterpreterData_NewObject(_PyXIData_t *);
+PyAPI_FUNC(int) _PyCrossInterpreterData_Release(_PyXIData_t *);
+PyAPI_FUNC(int) _PyCrossInterpreterData_ReleaseAndRawFree(_PyXIData_t *);
 
 
 /* cross-interpreter data registry */
@@ -142,7 +142,7 @@ PyAPI_FUNC(int) _PyCrossInterpreterData_ReleaseAndRawFree(_PyCrossInterpreterDat
 // crossinterpdatafunc. It would be simpler and more efficient.
 
 typedef int (*crossinterpdatafunc)(PyThreadState *tstate, PyObject *,
-                                   _PyCrossInterpreterData *);
+                                   _PyXIData_t *);
 
 struct _xidregitem;
 

--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -97,6 +97,8 @@ PyAPI_FUNC(void) _PyXIData_Free(_PyXIData_t *data);
 
 typedef int (*xidatafunc)(PyThreadState *tstate, PyObject *, _PyXIData_t *);
 
+typedef struct _xid_lookup_state _PyXIData_lookup_t;
+
 PyAPI_FUNC(xidatafunc) _PyXIData_Lookup(PyObject *);
 PyAPI_FUNC(int) _PyObject_CheckXIData(PyObject *);
 PyAPI_FUNC(int) _PyObject_GetXIData(PyObject *, _PyXIData_t *);
@@ -154,14 +156,12 @@ PyAPI_FUNC(void) _PyXIData_Clear( PyInterpreterState *, _PyXIData_t *);
 
 struct _xi_runtime_state {
     // builtin types
-    // XXX Remove this field once we have a tp_* slot.
-    struct _xidregistry registry;
+    _PyXIData_lookup_t data_lookup;
 };
 
 struct _xi_state {
     // heap types
-    // XXX Remove this field once we have a tp_* slot.
-    struct _xidregistry registry;
+    _PyXIData_lookup_t data_lookup;
 
     // heap types
     PyObject *PyExc_NotShareableError;
@@ -169,7 +169,6 @@ struct _xi_state {
 
 extern PyStatus _PyXI_Init(PyInterpreterState *interp);
 extern void _PyXI_Fini(PyInterpreterState *interp);
-
 extern PyStatus _PyXI_InitTypes(PyInterpreterState *interp);
 extern void _PyXI_FiniTypes(PyInterpreterState *interp);
 

--- a/Include/internal/pycore_crossinterp_data_registry.h
+++ b/Include/internal/pycore_crossinterp_data_registry.h
@@ -29,3 +29,8 @@ struct _xidregistry {
 
 PyAPI_FUNC(int) _PyXIData_RegisterClass(PyTypeObject *, xidatafunc);
 PyAPI_FUNC(int) _PyXIData_UnregisterClass(PyTypeObject *);
+
+struct _xid_lookup_state {
+    // XXX Remove this field once we have a tp_* slot.
+    struct _xidregistry registry;
+};

--- a/Include/internal/pycore_crossinterp_data_registry.h
+++ b/Include/internal/pycore_crossinterp_data_registry.h
@@ -1,0 +1,31 @@
+#ifndef Py_CORE_CROSSINTERP_DATA_REGISTRY_H
+#  error "this header must not be included directly"
+#endif
+
+
+// For now we use a global registry of shareable classes.  An
+// alternative would be to add a tp_* slot for a class's
+// xidatafunc. It would be simpler and more efficient.
+
+struct _xidregitem;
+
+struct _xidregitem {
+    struct _xidregitem *prev;
+    struct _xidregitem *next;
+    /* This can be a dangling pointer, but only if weakref is set. */
+    PyTypeObject *cls;
+    /* This is NULL for builtin types. */
+    PyObject *weakref;
+    size_t refcount;
+    xidatafunc getdata;
+};
+
+struct _xidregistry {
+    int global;  /* builtin types or heap types */
+    int initialized;
+    PyMutex mutex;
+    struct _xidregitem *head;
+};
+
+PyAPI_FUNC(int) _PyXIData_RegisterClass(PyTypeObject *, xidatafunc);
+PyAPI_FUNC(int) _PyXIData_UnregisterClass(PyTypeObject *);

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -50,8 +50,10 @@ extern PyTypeObject _PyExc_MemoryError;
             .next_id = -1, \
         }, \
         .xi = { \
-            .registry = { \
-                .global = 1, \
+            .data_lookup = { \
+                .registry = { \
+                    .global = 1, \
+                }, \
             }, \
         }, \
         /* A TSS key must be initialized with Py_tss_NEEDS_INIT \

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1202,6 +1202,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/internal/pycore_context.h \
 		$(srcdir)/Include/internal/pycore_critical_section.h \
 		$(srcdir)/Include/internal/pycore_crossinterp.h \
+		$(srcdir)/Include/internal/pycore_crossinterp_data_registry.h \
 		$(srcdir)/Include/internal/pycore_debug_offsets.h \
 		$(srcdir)/Include/internal/pycore_descrobject.h \
 		$(srcdir)/Include/internal/pycore_dict.h \

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -6,7 +6,7 @@
 #endif
 
 #include "Python.h"
-#include "pycore_crossinterp.h"   // struct _xid
+#include "pycore_crossinterp.h"   // _PyXIData_t
 #include "pycore_interp.h"        // _PyInterpreterState_LookUpID()
 #include "pycore_pystate.h"       // _PyInterpreterState_GetIDObject()
 
@@ -59,7 +59,7 @@ _globals (static struct globals):
                     first (struct _channelitem *):
                         next (struct _channelitem *):
                             ...
-                        data (_PyCrossInterpreterData *):
+                        data (_PyXIData_t *):
                             data (void *)
                             obj (PyObject *)
                             interpid (int64_t)
@@ -80,7 +80,7 @@ The above state includes the following allocations by the module:
    * 1 struct _channelqueue
 * for each item in each channel:
    * 1 struct _channelitem
-   * 1 _PyCrossInterpreterData
+   * 1 _PyXIData_t
 
 The only objects in that global state are the references held by each
 channel's queue, which are safely managed via the _PyCrossInterpreterData_*()
@@ -102,7 +102,7 @@ API..  The module does not create any objects that are shared globally.
 #define XID_FREE 2
 
 static int
-_release_xid_data(_PyCrossInterpreterData *data, int flags)
+_release_xid_data(_PyXIData_t *data, int flags)
 {
     int ignoreexc = flags & XID_IGNORE_EXC;
     PyObject *exc;
@@ -519,7 +519,7 @@ typedef struct _channelitem {
        This is necessary because item->data might be NULL,
        meaning the interpreter has been destroyed. */
     int64_t interpid;
-    _PyCrossInterpreterData *data;
+    _PyXIData_t *data;
     _waiting_t *waiting;
     int unboundop;
     struct _channelitem *next;
@@ -533,7 +533,7 @@ _channelitem_ID(_channelitem *item)
 
 static void
 _channelitem_init(_channelitem *item,
-                  int64_t interpid, _PyCrossInterpreterData *data,
+                  int64_t interpid, _PyXIData_t *data,
                   _waiting_t *waiting, int unboundop)
 {
     if (interpid < 0) {
@@ -580,7 +580,7 @@ _channelitem_clear(_channelitem *item)
 }
 
 static _channelitem *
-_channelitem_new(int64_t interpid, _PyCrossInterpreterData *data,
+_channelitem_new(int64_t interpid, _PyXIData_t *data,
                  _waiting_t *waiting, int unboundop)
 {
     _channelitem *item = GLOBAL_MALLOC(_channelitem);
@@ -611,7 +611,7 @@ _channelitem_free_all(_channelitem *item)
 
 static void
 _channelitem_popped(_channelitem *item,
-                    _PyCrossInterpreterData **p_data, _waiting_t **p_waiting,
+                    _PyXIData_t **p_data, _waiting_t **p_waiting,
                     int *p_unboundop)
 {
     assert(item->waiting == NULL || item->waiting->status == WAITING_ACQUIRED);
@@ -691,7 +691,7 @@ _channelqueue_free(_channelqueue *queue)
 
 static int
 _channelqueue_put(_channelqueue *queue,
-                  int64_t interpid, _PyCrossInterpreterData *data,
+                  int64_t interpid, _PyXIData_t *data,
                   _waiting_t *waiting, int unboundop)
 {
     _channelitem *item = _channelitem_new(interpid, data, waiting, unboundop);
@@ -717,7 +717,7 @@ _channelqueue_put(_channelqueue *queue,
 
 static int
 _channelqueue_get(_channelqueue *queue,
-                  _PyCrossInterpreterData **p_data, _waiting_t **p_waiting,
+                  _PyXIData_t **p_data, _waiting_t **p_waiting,
                   int *p_unboundop)
 {
     _channelitem *item = queue->first;
@@ -769,7 +769,7 @@ _channelqueue_find(_channelqueue *queue, _channelitem_id_t itemid,
 
 static void
 _channelqueue_remove(_channelqueue *queue, _channelitem_id_t itemid,
-                     _PyCrossInterpreterData **p_data, _waiting_t **p_waiting)
+                     _PyXIData_t **p_data, _waiting_t **p_waiting)
 {
     _channelitem *prev = NULL;
     _channelitem *item = NULL;
@@ -1128,8 +1128,7 @@ _channel_free(_channel_state *chan)
 
 static int
 _channel_add(_channel_state *chan, int64_t interpid,
-             _PyCrossInterpreterData *data, _waiting_t *waiting,
-             int unboundop)
+             _PyXIData_t *data, _waiting_t *waiting, int unboundop)
 {
     int res = -1;
     PyThread_acquire_lock(chan->mutex, WAIT_LOCK);
@@ -1156,8 +1155,7 @@ done:
 
 static int
 _channel_next(_channel_state *chan, int64_t interpid,
-              _PyCrossInterpreterData **p_data, _waiting_t **p_waiting,
-              int *p_unboundop)
+              _PyXIData_t **p_data, _waiting_t **p_waiting, int *p_unboundop)
 {
     int err = 0;
     PyThread_acquire_lock(chan->mutex, WAIT_LOCK);
@@ -1193,7 +1191,7 @@ done:
 static void
 _channel_remove(_channel_state *chan, _channelitem_id_t itemid)
 {
-    _PyCrossInterpreterData *data = NULL;
+    _PyXIData_t *data = NULL;
     _waiting_t *waiting = NULL;
 
     PyThread_acquire_lock(chan->mutex, WAIT_LOCK);
@@ -1776,7 +1774,7 @@ channel_send(_channels *channels, int64_t cid, PyObject *obj,
     }
 
     // Convert the object to cross-interpreter data.
-    _PyCrossInterpreterData *data = GLOBAL_MALLOC(_PyCrossInterpreterData);
+    _PyXIData_t *data = GLOBAL_MALLOC(_PyXIData_t);
     if (data == NULL) {
         PyThread_release_lock(mutex);
         return -1;
@@ -1904,7 +1902,7 @@ channel_recv(_channels *channels, int64_t cid, PyObject **res, int *p_unboundop)
     // Past this point we are responsible for releasing the mutex.
 
     // Pop off the next item from the channel.
-    _PyCrossInterpreterData *data = NULL;
+    _PyXIData_t *data = NULL;
     _waiting_t *waiting = NULL;
     err = _channel_next(chan, interpid, &data, &waiting, p_unboundop);
     PyThread_release_lock(mutex);
@@ -2545,7 +2543,7 @@ struct _channelid_xid {
 };
 
 static PyObject *
-_channelid_from_xid(_PyCrossInterpreterData *data)
+_channelid_from_xid(_PyXIData_t *data)
 {
     struct _channelid_xid *xid = \
                 (struct _channelid_xid *)_PyCrossInterpreterData_DATA(data);
@@ -2594,8 +2592,7 @@ done:
 }
 
 static int
-_channelid_shared(PyThreadState *tstate, PyObject *obj,
-                  _PyCrossInterpreterData *data)
+_channelid_shared(PyThreadState *tstate, PyObject *obj, _PyXIData_t *data)
 {
     if (_PyCrossInterpreterData_InitWithSize(
             data, tstate->interp, sizeof(struct _channelid_xid), obj,
@@ -2745,7 +2742,7 @@ _get_current_channelend_type(int end)
 }
 
 static PyObject *
-_channelend_from_xid(_PyCrossInterpreterData *data)
+_channelend_from_xid(_PyXIData_t *data)
 {
     channelid *cidobj = (channelid *)_channelid_from_xid(data);
     if (cidobj == NULL) {
@@ -2762,8 +2759,7 @@ _channelend_from_xid(_PyCrossInterpreterData *data)
 }
 
 static int
-_channelend_shared(PyThreadState *tstate, PyObject *obj,
-                    _PyCrossInterpreterData *data)
+_channelend_shared(PyThreadState *tstate, PyObject *obj, _PyXIData_t *data)
 {
     PyObject *cidobj = PyObject_GetAttrString(obj, "_id");
     if (cidobj == NULL) {

--- a/Modules/_interpreters_common.h
+++ b/Modules/_interpreters_common.h
@@ -9,14 +9,14 @@ static int
 ensure_xid_class(PyTypeObject *cls, xidatafunc getdata)
 {
     //assert(cls->tp_flags & Py_TPFLAGS_HEAPTYPE);
-    return _PyCrossInterpreterData_RegisterClass(cls, getdata);
+    return _PyXIData_RegisterClass(cls, getdata);
 }
 
 #ifdef REGISTERS_HEAP_TYPES
 static int
 clear_xid_class(PyTypeObject *cls)
 {
-    return _PyCrossInterpreterData_UnregisterClass(cls);
+    return _PyXIData_UnregisterClass(cls);
 }
 #endif
 
@@ -26,7 +26,7 @@ _get_interpid(_PyXIData_t *data)
 {
     int64_t interpid;
     if (data != NULL) {
-        interpid = _PyCrossInterpreterData_INTERPID(data);
+        interpid = _PyXIData_INTERPID(data);
         assert(!PyErr_Occurred());
     }
     else {

--- a/Modules/_interpreters_common.h
+++ b/Modules/_interpreters_common.h
@@ -6,7 +6,7 @@
 
 
 static int
-ensure_xid_class(PyTypeObject *cls, crossinterpdatafunc getdata)
+ensure_xid_class(PyTypeObject *cls, xidatafunc getdata)
 {
     //assert(cls->tp_flags & Py_TPFLAGS_HEAPTYPE);
     return _PyCrossInterpreterData_RegisterClass(cls, getdata);

--- a/Modules/_interpreters_common.h
+++ b/Modules/_interpreters_common.h
@@ -22,7 +22,7 @@ clear_xid_class(PyTypeObject *cls)
 
 
 static inline int64_t
-_get_interpid(_PyCrossInterpreterData *data)
+_get_interpid(_PyXIData_t *data)
 {
     int64_t interpid;
     if (data != NULL) {

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -86,16 +86,16 @@ typedef struct {
 static PyObject *
 xibufferview_from_xid(PyTypeObject *cls, _PyXIData_t *data)
 {
-    assert(_PyCrossInterpreterData_DATA(data) != NULL);
-    assert(_PyCrossInterpreterData_OBJ(data) == NULL);
-    assert(_PyCrossInterpreterData_INTERPID(data) >= 0);
+    assert(_PyXIData_DATA(data) != NULL);
+    assert(_PyXIData_OBJ(data) == NULL);
+    assert(_PyXIData_INTERPID(data) >= 0);
     XIBufferViewObject *self = PyObject_Malloc(sizeof(XIBufferViewObject));
     if (self == NULL) {
         return NULL;
     }
     PyObject_Init((PyObject *)self, cls);
-    self->view = (Py_buffer *)_PyCrossInterpreterData_DATA(data);
-    self->interpid = _PyCrossInterpreterData_INTERPID(data);
+    self->view = (Py_buffer *)_PyXIData_DATA(data);
+    self->interpid = _PyXIData_INTERPID(data);
     return (PyObject *)self;
 }
 
@@ -178,8 +178,7 @@ _memoryview_shared(PyThreadState *tstate, PyObject *obj, _PyXIData_t *data)
         PyMem_RawFree(view);
         return -1;
     }
-    _PyCrossInterpreterData_Init(data, tstate->interp, view, NULL,
-                                 _memoryview_from_xid);
+    _PyXIData_Init(data, tstate->interp, view, NULL, _memoryview_from_xid);
     return 0;
 }
 
@@ -1182,7 +1181,7 @@ object_is_shareable(PyObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    if (_PyObject_CheckCrossInterpreterData(obj) == 0) {
+    if (_PyObject_CheckXIData(obj) == 0) {
         Py_RETURN_TRUE;
     }
     PyErr_Clear();

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -7,7 +7,7 @@
 
 #include "Python.h"
 #include "pycore_abstract.h"      // _PyIndex_Check()
-#include "pycore_crossinterp.h"   // struct _xid
+#include "pycore_crossinterp.h"   // _PyXIData_t
 #include "pycore_interp.h"        // _PyInterpreterState_IDIncref()
 #include "pycore_initconfig.h"    // _PyErr_SetFromPyStatus()
 #include "pycore_modsupport.h"    // _PyArg_BadArgument()
@@ -84,7 +84,7 @@ typedef struct {
 } XIBufferViewObject;
 
 static PyObject *
-xibufferview_from_xid(PyTypeObject *cls, _PyCrossInterpreterData *data)
+xibufferview_from_xid(PyTypeObject *cls, _PyXIData_t *data)
 {
     assert(_PyCrossInterpreterData_DATA(data) != NULL);
     assert(_PyCrossInterpreterData_OBJ(data) == NULL);
@@ -154,7 +154,7 @@ static PyType_Spec XIBufferViewType_spec = {
 static PyTypeObject * _get_current_xibufferview_type(void);
 
 static PyObject *
-_memoryview_from_xid(_PyCrossInterpreterData *data)
+_memoryview_from_xid(_PyXIData_t *data)
 {
     PyTypeObject *cls = _get_current_xibufferview_type();
     if (cls == NULL) {
@@ -168,8 +168,7 @@ _memoryview_from_xid(_PyCrossInterpreterData *data)
 }
 
 static int
-_memoryview_shared(PyThreadState *tstate, PyObject *obj,
-                   _PyCrossInterpreterData *data)
+_memoryview_shared(PyThreadState *tstate, PyObject *obj, _PyXIData_t *data)
 {
     Py_buffer *view = PyMem_RawMalloc(sizeof(Py_buffer));
     if (view == NULL) {

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -1788,8 +1788,8 @@ _xid_capsule_destructor(PyObject *capsule)
 {
     _PyXIData_t *data = (_PyXIData_t *)PyCapsule_GetPointer(capsule, NULL);
     if (data != NULL) {
-        assert(_PyCrossInterpreterData_Release(data) == 0);
-        _PyCrossInterpreterData_Free(data);
+        assert(_PyXIData_Release(data) == 0);
+        _PyXIData_Free(data);
     }
 }
 
@@ -1801,18 +1801,18 @@ get_crossinterp_data(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    _PyXIData_t *data = _PyCrossInterpreterData_New();
+    _PyXIData_t *data = _PyXIData_New();
     if (data == NULL) {
         return NULL;
     }
-    if (_PyObject_GetCrossInterpreterData(obj, data) != 0) {
-        _PyCrossInterpreterData_Free(data);
+    if (_PyObject_GetXIData(obj, data) != 0) {
+        _PyXIData_Free(data);
         return NULL;
     }
     PyObject *capsule = PyCapsule_New(data, NULL, _xid_capsule_destructor);
     if (capsule == NULL) {
-        assert(_PyCrossInterpreterData_Release(data) == 0);
-        _PyCrossInterpreterData_Free(data);
+        assert(_PyXIData_Release(data) == 0);
+        _PyXIData_Free(data);
     }
     return capsule;
 }
@@ -1829,7 +1829,7 @@ restore_crossinterp_data(PyObject *self, PyObject *args)
     if (data == NULL) {
         return NULL;
     }
-    return _PyCrossInterpreterData_NewObject(data);
+    return _PyXIData_NewObject(data);
 }
 
 

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -1786,8 +1786,7 @@ interpreter_refcount_linked(PyObject *self, PyObject *idobj)
 static void
 _xid_capsule_destructor(PyObject *capsule)
 {
-    _PyCrossInterpreterData *data = \
-            (_PyCrossInterpreterData *)PyCapsule_GetPointer(capsule, NULL);
+    _PyXIData_t *data = (_PyXIData_t *)PyCapsule_GetPointer(capsule, NULL);
     if (data != NULL) {
         assert(_PyCrossInterpreterData_Release(data) == 0);
         _PyCrossInterpreterData_Free(data);
@@ -1802,7 +1801,7 @@ get_crossinterp_data(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    _PyCrossInterpreterData *data = _PyCrossInterpreterData_New();
+    _PyXIData_t *data = _PyCrossInterpreterData_New();
     if (data == NULL) {
         return NULL;
     }
@@ -1826,8 +1825,7 @@ restore_crossinterp_data(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    _PyCrossInterpreterData *data = \
-            (_PyCrossInterpreterData *)PyCapsule_GetPointer(capsule, NULL);
+    _PyXIData_t *data = (_PyXIData_t *)PyCapsule_GetPointer(capsule, NULL);
     if (data == NULL) {
         return NULL;
     }

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -229,6 +229,7 @@
     <ClInclude Include="..\Include\internal\pycore_context.h" />
     <ClInclude Include="..\Include\internal\pycore_critical_section.h" />
     <ClInclude Include="..\Include\internal\pycore_crossinterp.h" />
+    <ClInclude Include="..\Include\internal\pycore_crossinterp_data_registry.h" />
     <ClInclude Include="..\Include\internal\pycore_debug_offsets.h" />
     <ClInclude Include="..\Include\internal\pycore_descrobject.h" />
     <ClInclude Include="..\Include\internal\pycore_dict.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -609,6 +609,9 @@
     <ClInclude Include="..\Include\internal\pycore_crossinterp.h">
       <Filter>Include\internal</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_crossinterp_data_registry.h">
+      <Filter>Include\internal</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_debug_offsets.h">
       <Filter>Include\internal</Filter>
     </ClInclude>

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -57,15 +57,15 @@ _Py_CallInInterpreterAndRawFree(PyInterpreterState *interp,
 /* cross-interpreter data */
 /**************************/
 
-/* registry of {type -> crossinterpdatafunc} */
+/* registry of {type -> xidatafunc} */
 
 /* For now we use a global registry of shareable classes.  An
    alternative would be to add a tp_* slot for a class's
-   crossinterpdatafunc. It would be simpler and more efficient. */
+   xidatafunc. It would be simpler and more efficient. */
 
 static void xid_lookup_init(PyInterpreterState *);
 static void xid_lookup_fini(PyInterpreterState *);
-static crossinterpdatafunc lookup_getdata(PyInterpreterState *, PyObject *);
+static xidatafunc lookup_getdata(PyInterpreterState *, PyObject *);
 #include "crossinterp_data_lookup.h"
 
 
@@ -222,7 +222,7 @@ int
 _PyObject_CheckCrossInterpreterData(PyObject *obj)
 {
     PyInterpreterState *interp = PyInterpreterState_Get();
-    crossinterpdatafunc getdata = lookup_getdata(interp, obj);
+    xidatafunc getdata = lookup_getdata(interp, obj);
     if (getdata == NULL) {
         if (!PyErr_Occurred()) {
             _set_xid_lookup_failure(interp, obj, NULL);
@@ -244,7 +244,7 @@ _PyObject_GetCrossInterpreterData(PyObject *obj, _PyXIData_t *data)
 
     // Call the "getdata" func for the object.
     Py_INCREF(obj);
-    crossinterpdatafunc getdata = lookup_getdata(interp, obj);
+    xidatafunc getdata = lookup_getdata(interp, obj);
     if (getdata == NULL) {
         Py_DECREF(obj);
         if (!PyErr_Occurred()) {

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -7,7 +7,6 @@
 #include "pycore_initconfig.h"    // _PyStatus_OK()
 #include "pycore_namespace.h"     //_PyNamespace_New()
 #include "pycore_pyerrors.h"      // _PyErr_Clear()
-#include "pycore_weakref.h"       // _PyWeakref_GET_REF()
 
 
 /**************/

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -1,3 +1,5 @@
+#include "pycore_weakref.h"       // _PyWeakref_GET_REF()
+
 
 static xidatafunc _lookup_getdata_from_registry(PyInterpreterState *, PyObject *);
 

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -1,8 +1,7 @@
 
-static crossinterpdatafunc _lookup_getdata_from_registry(
-                                            PyInterpreterState *, PyObject *);
+static xidatafunc _lookup_getdata_from_registry(PyInterpreterState *, PyObject *);
 
-static crossinterpdatafunc
+static xidatafunc
 lookup_getdata(PyInterpreterState *interp, PyObject *obj)
 {
    /* Cross-interpreter objects are looked up by exact match on the class.
@@ -11,7 +10,7 @@ lookup_getdata(PyInterpreterState *interp, PyObject *obj)
     return _lookup_getdata_from_registry(interp, obj);
 }
 
-crossinterpdatafunc
+xidatafunc
 _PyCrossInterpreterData_Lookup(PyObject *obj)
 {
     PyInterpreterState *interp = PyInterpreterState_Get();
@@ -20,12 +19,12 @@ _PyCrossInterpreterData_Lookup(PyObject *obj)
 
 
 /***********************************************/
-/* a registry of {type -> crossinterpdatafunc} */
+/* a registry of {type -> xidatafunc} */
 /***********************************************/
 
 /* For now we use a global registry of shareable classes.  An
    alternative would be to add a tp_* slot for a class's
-   crossinterpdatafunc. It would be simpler and more efficient.  */
+   xidatafunc. It would be simpler and more efficient.  */
 
 
 /* registry lifecycle */
@@ -155,7 +154,7 @@ _xidregistry_find_type(struct _xidregistry *xidregistry, PyTypeObject *cls)
     return NULL;
 }
 
-static crossinterpdatafunc
+static xidatafunc
 _lookup_getdata_from_registry(PyInterpreterState *interp, PyObject *obj)
 {
     PyTypeObject *cls = Py_TYPE(obj);
@@ -164,7 +163,7 @@ _lookup_getdata_from_registry(PyInterpreterState *interp, PyObject *obj)
     _xidregistry_lock(xidregistry);
 
     struct _xidregitem *matched = _xidregistry_find_type(xidregistry, cls);
-    crossinterpdatafunc func = matched != NULL ? matched->getdata : NULL;
+    xidatafunc func = matched != NULL ? matched->getdata : NULL;
 
     _xidregistry_unlock(xidregistry);
     return func;
@@ -175,7 +174,7 @@ _lookup_getdata_from_registry(PyInterpreterState *interp, PyObject *obj)
 
 static int
 _xidregistry_add_type(struct _xidregistry *xidregistry,
-                      PyTypeObject *cls, crossinterpdatafunc getdata)
+                      PyTypeObject *cls, xidatafunc getdata)
 {
     struct _xidregitem *newhead = PyMem_RawMalloc(sizeof(struct _xidregitem));
     if (newhead == NULL) {
@@ -238,8 +237,7 @@ _xidregistry_clear(struct _xidregistry *xidregistry)
 }
 
 int
-_PyCrossInterpreterData_RegisterClass(PyTypeObject *cls,
-                                      crossinterpdatafunc getdata)
+_PyCrossInterpreterData_RegisterClass(PyTypeObject *cls, xidatafunc getdata)
 {
     if (!PyType_Check(cls)) {
         PyErr_Format(PyExc_ValueError, "only classes may be registered");

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -396,7 +396,7 @@ _Py_COMP_DIAG_POP
 #define LOCKS_INIT(runtime) \
     { \
         &(runtime)->interpreters.mutex, \
-        &(runtime)->xi.registry.mutex, \
+        &(runtime)->xi.data_lookup.registry.mutex, \
         &(runtime)->unicode_state.ids.mutex, \
         &(runtime)->imports.extensions.mutex, \
         &(runtime)->ceval.pending_mainthread.mutex, \

--- a/Tools/c-analyzer/cpython/_parser.py
+++ b/Tools/c-analyzer/cpython/_parser.py
@@ -290,6 +290,7 @@ Modules/_dbmmodule.c	HAVE_GDBM_DASH_NDBM_H	1
 Modules/_sre/sre_lib.h	LOCAL(type)	static inline type
 Modules/_sre/sre_lib.h	SRE(F)	sre_ucs2_##F
 Objects/stringlib/codecs.h	STRINGLIB_IS_UNICODE	1
+Include/internal/pycore_crossinterp_data_registry.h	Py_CORE_CROSSINTERP_DATA_REGISTRY_H	1
 
 # @end=tsv@
 ''')[1:]


### PR DESCRIPTION
The primary objective here is to allow some later changes to be cleaner.  Mostly this involves renaming things and moving a few things around.

* `*CrossInterpreterData*` -> `*XIData*`
* `crossinterpdatafunc` -> `xidatafunc`
* split out pycore_crossinterp_data_registry.h
* add `_PyXIData_lookup_t`

<!-- gh-issue-number: gh-76785 -->
* Issue: gh-76785
<!-- /gh-issue-number -->
