### PR TITLE
GH-126464: Temporarily disable `aarch64-apple-darwin` JIT CI jobs

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -79,10 +79,11 @@ jobs:
             architecture: x86_64
             runner: macos-13
             compiler: clang
-          - target: aarch64-apple-darwin/clang
-            architecture: aarch64
-            runner: macos-14
-            compiler: clang
+          # GH-126464: A recent change to either GHA or LLVM broke this job:
+          # - target: aarch64-apple-darwin/clang
+          #   architecture: aarch64
+          #   runner: macos-14
+          #   compiler: clang
           - target: x86_64-unknown-linux-gnu/gcc
             architecture: x86_64
             runner: ubuntu-22.04

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -52,7 +52,7 @@ jobs:
           - x86_64-pc-windows-msvc/msvc
           - aarch64-pc-windows-msvc/msvc
           - x86_64-apple-darwin/clang
-          - aarch64-apple-darwin/clang
+          # - aarch64-apple-darwin/clang
           - x86_64-unknown-linux-gnu/gcc
           - x86_64-unknown-linux-gnu/clang
           - aarch64-unknown-linux-gnu/gcc


### PR DESCRIPTION


<!-- gh-issue-number: gh-126464 -->
* Issue: gh-126464
<!-- /gh-issue-number -->
