### PR TITLE
[3.12] Fix possible null pointer dereference of freevars in _PyCompile_LookupArg (gh-126238)

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1835,7 +1835,7 @@ compiler_make_closure(struct compiler *c, location loc,
                     c->u->u_metadata.u_name,
                     co->co_name,
                     freevars);
-                Py_DECREF(freevars);
+                Py_XDECREF(freevars);
                 return ERROR;
             }
             ADDOP_I(c, loc, LOAD_CLOSURE, arg);


### PR DESCRIPTION
* Replace Py_DECREF by Py_XDECREF

(cherry picked from commit https://github.com/python/cpython/commit/8525c9375f25e6ec0c0b5dfcab464703f6e78082)

Co-authored-by: Valery Fedorenko <federicovalenso@gmail.com>
Co-authored-by: blurb-it[bot] <43283697+blurb-it[bot]@users.noreply.github.com>
Co-authored-by: Peter Bierma <zintensitydev@gmail.com>


<!-- gh-issue-number: gh-126238 -->
* Issue: gh-126238
<!-- /gh-issue-number -->
