### PR TITLE
[3.13] Fix possible null pointer dereference of freevars in _PyCompile_LookupArg (gh-126238)

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1815,7 +1815,7 @@ compiler_make_closure(struct compiler *c, location loc,
                     c->u->u_metadata.u_name,
                     co->co_name,
                     freevars);
-                Py_DECREF(freevars);
+                Py_XDECREF(freevars);
                 return ERROR;
             }
             ADDOP_I(c, loc, LOAD_CLOSURE, arg);


### PR DESCRIPTION
gh-126238: Fix possible null pointer dereference of freevars in _PyCompile_LookupArg (#126239)

* Replace Py_DECREF by Py_XDECREF

Co-authored-by: blurb-it[bot] <43283697+blurb-it[bot]@users.noreply.github.com>
Co-authored-by: Peter Bierma <zintensitydev@gmail.com>
(cherry picked from commit 8525c9375f25e6ec0c0b5dfcab464703f6e78082)
