### PR TITLE
[3.11] gh-87846: test_io: Ignore OpenWrapper in test___all__

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4504,6 +4504,7 @@ class CMiscIOTest(MiscIOTest):
     io = io
     name_of_module = "io", "_io"
     extra_exported = "BlockingIOError",
+    not_exported = "OpenWrapper",  # deprecated, added on demand
 
     def test_readinto_buffer_overflow(self):
         # Issue #18025
@@ -4570,7 +4571,10 @@ class PyMiscIOTest(MiscIOTest):
     io = pyio
     name_of_module = "_pyio", "io"
     extra_exported = "BlockingIOError", "open_code",
-    not_exported = "valid_seek_flags",
+    not_exported = (
+        "valid_seek_flags",
+        "OpenWrapper",   # deprecated, added on demand
+    )
 
 
 @unittest.skipIf(os.name == 'nt', 'POSIX signals required for this test.')


### PR DESCRIPTION
@pablogsal, are you interested in fixing 3.11 buildbots that consistently *warn*, rather than fail?

---

`test_io` fails if `test_openwrapper` runs before `test___all__`. This consistently happens  on some refleaks buildbots, for example [Windows](https://buildbot.python.org/#/builders/987/builds/849) or [Fedora](https://buildbot.python.org/#/builders/1027/builds/790), but it's only marked as a warning: when only `test___all__` is re-run in a fresh process, it succeeds.

Locally, this can be reproduced by running `test_openwrapper` and `test__all__`, *twice* (since in a single run, `test_openwrapper` comes after `test___all__`). I don't know of a more elegant way than:

    ./python -m test test_io test_io -m '*test_[o_][p_][ea][nl][wl]*' -v

The reason is that the deprecated `OpenWrapper` is added to the module on demand in `__getattr__`, after which it shows up in `dir(io)`.

Add it to `not_exported` so that `check__all__` ignores it when it exists.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-87846 -->
* Issue: gh-87846
<!-- /gh-issue-number -->
