### PR TITLE
Postpone `module.__loader__` deprecation to Python 3.16

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.14.rst
+++ b/Doc/deprecations/pending-removal-in-3.14.rst
@@ -1,13 +1,6 @@
 Pending removal in Python 3.14
 ------------------------------
 
-* The import system:
-
-  * Setting :attr:`~module.__loader__` on a module while
-    failing to set :attr:`__spec__.loader <importlib.machinery.ModuleSpec.loader>`
-    is deprecated. In Python 3.14, :attr:`!__loader__` will cease to be set or
-    taken into consideration by the import system or the standard library.
-
 * :mod:`argparse`: The *type*, *choices*, and *metavar* parameters
   of :class:`!argparse.BooleanOptionalAction` are deprecated
   and will be removed in 3.14.

--- a/Doc/deprecations/pending-removal-in-3.16.rst
+++ b/Doc/deprecations/pending-removal-in-3.16.rst
@@ -1,6 +1,13 @@
 Pending removal in Python 3.16
 ------------------------------
 
+* The import system:
+
+  * Setting :attr:`~module.__loader__` on a module while
+    failing to set :attr:`__spec__.loader <importlib.machinery.ModuleSpec.loader>`
+    is deprecated. In Python 3.16, :attr:`!__loader__` will cease to be set or
+    taken into consideration by the import system or the standard library.
+
 * :mod:`array`:
 
   * The ``'u'`` format code (:c:type:`wchar_t`)

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1028,9 +1028,9 @@ this approach.
       using the :class:`types.ModuleType` constructor.
       Previously the attribute was optional.
 
-   .. deprecated-removed:: 3.12 3.14
+   .. deprecated-removed:: 3.12 3.16
       Setting :attr:`!__loader__` on a module while failing to set
-      :attr:`!__spec__.loader` is deprecated. In Python 3.14,
+      :attr:`!__spec__.loader` is deprecated. In Python 3.16,
       :attr:`!__loader__` will cease to be set or taken into consideration by
       the import system or the standard library.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Related to https://github.com/python/cpython/issues/122255:

There was a flaw in implementation of the warnings so we should first fix the warnings in 3.14 and prolong the deprecation period until 3.16.

See also https://github.com/python/cpython/issues/123011.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126482.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->