### PR TITLE
gh-126476: Raise `IllegalMonthError` for calendar.formatmonth method when the input month is not corret

### DIFF
--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -158,11 +158,14 @@ def weekday(year, month, day):
     return Day(datetime.date(year, month, day).weekday())
 
 
+def _validate_month(month):
+    if not 1 <= month <= 12:
+        raise IllegalMonthError(month)
+
 def monthrange(year, month):
     """Return weekday of first day of month (0-6 ~ Mon-Sun)
        and number of days (28-31) for year, month."""
-    if not 1 <= month <= 12:
-        raise IllegalMonthError(month)
+    _validate_month(month)
     day1 = weekday(year, month, 1)
     ndays = mdays[month] + (month == FEBRUARY and isleap(year))
     return day1, ndays
@@ -370,6 +373,8 @@ class TextCalendar(Calendar):
         """
         Return a formatted month name.
         """
+        _validate_month(themonth)
+
         s = month_name[themonth]
         if withyear:
             s = "%s %r" % (s, theyear)
@@ -500,6 +505,7 @@ class HTMLCalendar(Calendar):
         """
         Return a month name as a table row.
         """
+        _validate_month(themonth)
         if withyear:
             s = '%s %s' % (month_name[themonth], theyear)
         else:

--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -27,7 +27,9 @@ __all__ = ["IllegalMonthError", "IllegalWeekdayError", "setfirstweekday",
 error = ValueError
 
 # Exceptions raised for bad input
-class IllegalMonthError(ValueError):
+# This is trick for backward compatibility. Since 3.13, we will raise IllegalMonthError instead of
+# IndexError for bad month number(out of 1-12). But we can't remove IndexError for backward compatibility.
+class IllegalMonthError(ValueError, IndexError):
     def __init__(self, month):
         self.month = month
     def __str__(self):
@@ -792,6 +794,8 @@ def main(args=None):
         if options.month is None:
             optdict["c"] = options.spacing
             optdict["m"] = options.months
+        if options.month is not None:
+            _validate_month(options.month)
         if options.year is None:
             result = cal.formatyear(datetime.date.today().year, **optdict)
         elif options.month is None:

--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -457,6 +457,11 @@ class OutputTestCase(unittest.TestCase):
             calendar.TextCalendar().formatmonth(0, 2),
             result_0_02_text
         )
+    def test_formatmonth_with_invalid_month(self):
+        with self.assertRaises(calendar.IllegalMonthError):
+            calendar.TextCalendar().formatmonth(2017, 13)
+        with self.assertRaises(calendar.IllegalMonthError):
+            calendar.TextCalendar().formatmonth(2017, -1)
 
     def test_formatmonthname_with_year(self):
         self.assertEqual(
@@ -1121,7 +1126,7 @@ class MiscTestCase(unittest.TestCase):
         not_exported = {
             'mdays', 'January', 'February', 'EPOCH',
             'different_locale', 'c', 'prweek', 'week', 'format',
-            'formatstring', 'main', 'monthlen', 'prevmonth', 'nextmonth'}
+            'formatstring', 'main', 'monthlen', 'prevmonth', 'nextmonth', ""}
         support.check__all__(self, calendar, not_exported=not_exported)
 
 
@@ -1148,6 +1153,13 @@ class TestSubClassingCase(unittest.TestCase):
     def test_formatmonth(self):
         self.assertIn('class="text-center month"',
                       self.cal.formatmonth(2017, 5))
+
+    def test_formatmonth_with_invalid_month(self):
+        with self.assertRaises(calendar.IllegalMonthError):
+            self.cal.formatmonth(2017, 13)
+        with self.assertRaises(calendar.IllegalMonthError):
+            self.cal.formatmonth(2017, -1)
+
 
     def test_formatweek(self):
         weeks = self.cal.monthdays2calendar(2017, 5)

--- a/Misc/NEWS.d/next/Library/2024-11-06-18-30-50.gh-issue-126476.F1wh3c.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-06-18-30-50.gh-issue-126476.F1wh3c.rst
@@ -1,2 +1,2 @@
-Raise :class:`calendar.IllegalMonthError` for :func:`calendar.month`
+Raise :class:`calendar.IllegalMonthError` (now a subclass of :class:`IndexError`) for :func:`calendar.month`
 when the input month is not correct.

--- a/Misc/NEWS.d/next/Library/2024-11-06-18-30-50.gh-issue-126476.F1wh3c.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-06-18-30-50.gh-issue-126476.F1wh3c.rst
@@ -1,2 +1,2 @@
-Raise :class:`calendar.IllegalMonthError` for :function:`calendar.month`
+Raise :class:`calendar.IllegalMonthError` for :func:`calendar.month`
 when the input month is not correct.

--- a/Misc/NEWS.d/next/Library/2024-11-06-18-30-50.gh-issue-126476.F1wh3c.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-06-18-30-50.gh-issue-126476.F1wh3c.rst
@@ -1,0 +1,2 @@
+Raise :class:`calendar.IllegalMonthError` for :function:`calendar.month`
+when the input month is not correct.


### PR DESCRIPTION
Fix: #126476


<!-- gh-issue-number: gh-126476 -->
* Issue: gh-126476
<!-- /gh-issue-number -->
