### PR TITLE
gh-126464 Fix jit build on aarch64 macos

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -79,11 +79,10 @@ jobs:
             architecture: x86_64
             runner: macos-13
             compiler: clang
-          # GH-126464: A recent change to either GHA or LLVM broke this job:
-          # - target: aarch64-apple-darwin/clang
-          #   architecture: aarch64
-          #   runner: macos-14
-          #   compiler: clang
+          - target: aarch64-apple-darwin/clang
+            architecture: aarch64
+            runner: macos-14
+            compiler: clang
           - target: x86_64-unknown-linux-gnu/gcc
             architecture: x86_64
             runner: ubuntu-22.04
@@ -132,6 +131,7 @@ jobs:
           brew update
           find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
           brew install llvm@${{ matrix.llvm }}
+          softwareupdate -i "Command Line Tools for Xcode-16.1"
           SDKROOT="$(xcrun --show-sdk-path)" \
             ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations --with-lto' }}
           make all --jobs 4

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -131,9 +131,9 @@ jobs:
           brew update
           find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
           brew install llvm@${{ matrix.llvm }}
-          SDKROOT="$(xcrun --show-sdk-path)" \
-            ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations --with-lto' }}
-          SDKROOT="$(xcrun --show-sdk-path)" make all --jobs 4
+          export SDKROOT="$(xcrun --show-sdk-path)"
+          ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations --with-lto' }}
+          make all --jobs 4
           ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
       - name: Native Linux

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -52,7 +52,7 @@ jobs:
           - x86_64-pc-windows-msvc/msvc
           - aarch64-pc-windows-msvc/msvc
           - x86_64-apple-darwin/clang
-          # - aarch64-apple-darwin/clang
+          - aarch64-apple-darwin/clang
           - x86_64-unknown-linux-gnu/gcc
           - x86_64-unknown-linux-gnu/clang
           - aarch64-unknown-linux-gnu/gcc

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -131,10 +131,9 @@ jobs:
           brew update
           find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
           brew install llvm@${{ matrix.llvm }}
-          softwareupdate -i "Command Line Tools for Xcode-16.1"
           SDKROOT="$(xcrun --show-sdk-path)" \
             ./configure --enable-experimental-jit ${{ matrix.debug && '--with-pydebug' || '--enable-optimizations --with-lto' }}
-          make all --jobs 4
+          SDKROOT="$(xcrun --show-sdk-path)" make all --jobs 4
           ./python.exe -m test --multiprocess 0 --timeout 4500 --verbose2 --verbose3
 
       - name: Native Linux


### PR DESCRIPTION
Updating the `Command Line Tools for Xcode` version in hope it will solve jit build failure on macos

<!-- gh-issue-number: gh-126464 -->
* Issue: gh-126464
<!-- /gh-issue-number -->
