### PR TITLE
gh-126509: Update link to CPython's grammar docs in InternalDocs/parser.md

### DIFF
--- a/InternalDocs/parser.md
+++ b/InternalDocs/parser.md
@@ -17,7 +17,7 @@ Therefore, changes to the Python language are made by modifying the
 [grammar file](../Grammar/python.gram).
 Developers rarely need to modify the generator itself.
 
-See the devguide's [Changing CPython's grammar](./changing_grammar.md)
+See [Changing CPython's grammar](./changing_grammar.md)
 for a detailed description of the grammar and the process for changing it.
 
 How PEG parsers work

--- a/InternalDocs/parser.md
+++ b/InternalDocs/parser.md
@@ -17,7 +17,7 @@ Therefore, changes to the Python language are made by modifying the
 [grammar file](../Grammar/python.gram).
 Developers rarely need to modify the generator itself.
 
-See the devguide's [Changing CPython's grammar](https://devguide.python.org/developer-workflow/grammar/#grammar)
+See the devguide's [Changing CPython's grammar](./changing_grammar.md)
 for a detailed description of the grammar and the process for changing it.
 
 How PEG parsers work


### PR DESCRIPTION
Updated link to CPython's grammar docs.

<!-- gh-issue-number: gh-126509 -->
* Issue: gh-126509
<!-- /gh-issue-number -->
