### PR TITLE
Incremental "mark alive" pass for cyclic GC

### DIFF
--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -282,6 +282,24 @@ struct gc_generation_stats {
     Py_ssize_t uncollectable;
 };
 
+struct gc_mark_state {
+    /* Objects in oldest generation that have be determined to be alive */
+    PyGC_Head old_alive;
+    /* Marker object for incremental mark alive process */
+    PyObject *thumb;
+    /* Size of oldest generation, on start of incremental mark process */
+    Py_ssize_t old_size;
+    /* Number of alive objects found in oldest generation */
+    Py_ssize_t old_alive_size;
+    int mark_phase;
+    int mark_steps;
+    int mark_steps_total;
+    PyTime_t gc_total_time;
+    PyTime_t gc_mark_time;
+    PyTime_t gc_max_pause;
+    PyTime_t gc_runs;
+};
+
 struct _gc_runtime_state {
     /* List of objects that still need to be cleaned up, singly linked
      * via their gc headers' gc_prev pointers.  */
@@ -295,14 +313,6 @@ struct _gc_runtime_state {
     /* linked lists of container objects */
     struct gc_generation generations[NUM_GENERATIONS];
     PyGC_Head *generation0;
-    /* Objects in oldest generation that have be determined to be alive */
-    PyGC_Head old_alive;
-    /* Size of oldest generation, on start of incremental mark process */
-    Py_ssize_t old_size;
-    /* Number of alive objects found in oldest generation */
-    Py_ssize_t old_alive_size;
-    int mark_steps;
-    int mark_steps_total;
     /* a permanent generation which won't be collected */
     struct gc_generation permanent_generation;
     struct gc_generation_stats generation_stats[NUM_GENERATIONS];
@@ -312,9 +322,7 @@ struct _gc_runtime_state {
     PyObject *garbage;
     /* a list of callbacks to be invoked when collection is performed */
     PyObject *callbacks;
-    /* Marker object for incremental mark alive process */
-    PyObject *thumb;
-    int mark_phase;
+    struct gc_mark_state mark_state;
 
     /* This is the number of objects that survived the last full
        collection. It approximates the number of long lived objects

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -295,6 +295,8 @@ struct _gc_runtime_state {
     /* linked lists of container objects */
     struct gc_generation generations[NUM_GENERATIONS];
     PyGC_Head *generation0;
+    /* Objects in oldest generation that have be determined to be alive */
+    struct gc_generation old_alive;
     /* a permanent generation which won't be collected */
     struct gc_generation permanent_generation;
     struct gc_generation_stats generation_stats[NUM_GENERATIONS];

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -145,8 +145,11 @@ static inline void _PyObject_GC_SET_SHARED_INLINE(PyObject *op) {
 #define _PyGC_PREV_MASK_FINALIZED  (1)
 /* Bit 1 is set when the object is in generation which is GCed currently. */
 #define _PyGC_PREV_MASK_COLLECTING (2)
-/* The (N-2) most significant bits contain the real address. */
-#define _PyGC_PREV_SHIFT           (2)
+/* Bit 2 is to mark the object as alive due to being reachable from a root
+ * object.  This is used when the incremental mark process is running. */
+#define _PyGC_PREV_MASK_OLD (4)
+/* The number of least least significant bits used for flags. */
+#define _PyGC_PREV_SHIFT (3)
 #define _PyGC_PREV_MASK            (((uintptr_t) -1) << _PyGC_PREV_SHIFT)
 
 /* set for debugging information */
@@ -301,6 +304,8 @@ struct _gc_runtime_state {
     PyObject *garbage;
     /* a list of callbacks to be invoked when collection is performed */
     PyObject *callbacks;
+    /* Marker object for incremental mark alive process */
+    PyObject *thumb;
 
     /* This is the number of objects that survived the last full
        collection. It approximates the number of long lived objects

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -291,12 +291,19 @@ struct gc_mark_state {
     Py_ssize_t old_size;
     /* Number of alive objects found in oldest generation */
     Py_ssize_t old_alive_size;
+    /* The phase of the mark process */
     int mark_phase;
+    /* Number of incremental mark steps done */
     int mark_steps;
+    /* Number of steps available before full collection */
     int mark_steps_total;
+    /* Total time spent inside cyclic GC */
     PyTime_t gc_total_time;
+    /* Time spent inside incremental mark part of cyclic GC */
     PyTime_t gc_mark_time;
+    /* Maximum GC pause time */
     PyTime_t gc_max_pause;
+    /* Total number of times GC was run */
     PyTime_t gc_runs;
 };
 
@@ -322,6 +329,7 @@ struct _gc_runtime_state {
     PyObject *garbage;
     /* a list of callbacks to be invoked when collection is performed */
     PyObject *callbacks;
+    /* state for the incremental "mark alive" logic */
     struct gc_mark_state mark_state;
 
     /* This is the number of objects that survived the last full

--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -296,7 +296,13 @@ struct _gc_runtime_state {
     struct gc_generation generations[NUM_GENERATIONS];
     PyGC_Head *generation0;
     /* Objects in oldest generation that have be determined to be alive */
-    struct gc_generation old_alive;
+    PyGC_Head old_alive;
+    /* Size of oldest generation, on start of incremental mark process */
+    Py_ssize_t old_size;
+    /* Number of alive objects found in oldest generation */
+    Py_ssize_t old_alive_size;
+    int mark_steps;
+    int mark_steps_total;
     /* a permanent generation which won't be collected */
     struct gc_generation permanent_generation;
     struct gc_generation_stats generation_stats[NUM_GENERATIONS];
@@ -308,6 +314,7 @@ struct _gc_runtime_state {
     PyObject *callbacks;
     /* Marker object for incremental mark alive process */
     PyObject *thumb;
+    int mark_phase;
 
     /* This is the number of objects that survived the last full
        collection. It approximates the number of long lived objects

--- a/Include/internal/pycore_runtime_init.h
+++ b/Include/internal/pycore_runtime_init.h
@@ -230,9 +230,9 @@ extern PyTypeObject _PyExc_MemoryError;
             .enabled = 1, \
             .generations = { \
                 /* .head is set in _PyGC_InitState(). */ \
-                { .threshold = 2000, }, \
-                { .threshold = 10, }, \
-                { .threshold = 10, }, \
+                { .threshold = 400, }, \
+                { .threshold = 5, }, \
+                { .threshold = 5, }, \
             }, \
         }, \
         .qsbr = { \

--- a/Modules/clinic/gcmodule.c.h
+++ b/Modules/clinic/gcmodule.c.h
@@ -440,6 +440,24 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(gc_get_alive_objects__doc__,
+"get_alive_objects($module, /)\n"
+"--\n"
+"\n"
+"Return a list of objects tracked by the collector (excluding the list returned).");
+
+#define GC_GET_ALIVE_OBJECTS_METHODDEF    \
+    {"get_alive_objects", (PyCFunction)gc_get_alive_objects, METH_NOARGS, gc_get_alive_objects__doc__},
+
+static PyObject *
+gc_get_alive_objects_impl(PyObject *module);
+
+static PyObject *
+gc_get_alive_objects(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return gc_get_alive_objects_impl(module);
+}
+
 PyDoc_STRVAR(gc_get_stats__doc__,
 "get_stats($module, /)\n"
 "--\n"
@@ -585,4 +603,4 @@ gc_get_freeze_count(PyObject *module, PyObject *Py_UNUSED(ignored))
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0a7e91917adcb937 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=debb8f0db8f3a13e input=a9049054013a1b77]*/

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -334,6 +334,23 @@ gc_get_objects_impl(PyObject *module, Py_ssize_t generation)
     return _PyGC_GetObjects(interp, (int)generation);
 }
 
+extern PyObject *_PyGC_GetOldAliveObjects(PyInterpreterState *interp);
+
+/*[clinic input]
+gc.get_alive_objects
+
+Return a list of objects tracked by the collector (excluding the list returned).
+
+[clinic start generated code]*/
+
+static PyObject *
+gc_get_alive_objects_impl(PyObject *module)
+/*[clinic end generated code: output=24e4083e0f1b0ebf input=e421931cb78142b8]*/
+{
+    PyInterpreterState *interp = _PyInterpreterState_GET();
+    return _PyGC_GetOldAliveObjects(interp);
+}
+
 /*[clinic input]
 gc.get_stats
 
@@ -481,6 +498,7 @@ PyDoc_STRVAR(gc__doc__,
 "set_threshold() -- Set the collection thresholds.\n"
 "get_threshold() -- Return the current the collection thresholds.\n"
 "get_objects() -- Return a list of all objects tracked by the collector.\n"
+"get_alive_objects() -- Return a list of objects determined to be alive.\n"
 "is_tracked() -- Returns true if a given object is tracked.\n"
 "is_finalized() -- Returns true if a given object has been already finalized.\n"
 "get_referrers() -- Return the list of objects that refer to an object.\n"
@@ -500,6 +518,7 @@ static PyMethodDef GcMethods[] = {
     GC_GET_THRESHOLD_METHODDEF
     GC_COLLECT_METHODDEF
     GC_GET_OBJECTS_METHODDEF
+    GC_GET_ALIVE_OBJECTS_METHODDEF
     GC_GET_STATS_METHODDEF
     GC_IS_TRACKED_METHODDEF
     GC_IS_FINALIZED_METHODDEF

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1342,6 +1342,11 @@ init_interp_main(PyThreadState *tstate)
         return _PyStatus_ERR("failed to set builtin dict watcher");
     }
 
+#if 1
+    fprintf(stderr, "freezing\n");
+    _PyGC_Freeze(interp);
+#endif
+
     assert(!_PyErr_Occurred(tstate));
 
     return _PyStatus_OK();
@@ -2212,6 +2217,7 @@ Py_Finalize(void)
     (void)_Py_Finalize(&_PyRuntime);
 }
 
+extern void _PyGC_Freeze(PyInterpreterState *interp);
 
 /* Create and initialize a new interpreter and thread, and return the
    new thread.  This requires that Py_Initialize() has been called

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1151,6 +1151,7 @@ run_presite(PyThreadState *tstate)
 }
 #endif
 
+extern void _PyGC_Freeze(PyInterpreterState *interp);
 
 static PyStatus
 init_interp_main(PyThreadState *tstate)
@@ -2216,8 +2217,6 @@ Py_Finalize(void)
 {
     (void)_Py_Finalize(&_PyRuntime);
 }
-
-extern void _PyGC_Freeze(PyInterpreterState *interp);
 
 /* Create and initialize a new interpreter and thread, and return the
    new thread.  This requires that Py_Initialize() has been called

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1342,7 +1342,7 @@ init_interp_main(PyThreadState *tstate)
         return _PyStatus_ERR("failed to set builtin dict watcher");
     }
 
-#if 1
+#if 0
     fprintf(stderr, "freezing\n");
     _PyGC_Freeze(interp);
 #endif


### PR DESCRIPTION
This adds a "mark alive" pass to the cyclic GC, done incrementally in order to reduce pause times for full GC collections.  The "mark alive" pass works by starting from known GC roots and then using `tp_traverse` to mark everything alive that's reachable from that.  Those objects will be skipped when the next full (gen 2) collection happens.  

Based on my benchmarking it is quite effective at reducing GC pause times (latency).  Here is some timing stats for a benchmark I ran.  Timing with the "mark alive" feature turned off:

```
gc times: total 3.846s mark 0.001s max 77711us avg 371us 
gc timing full Q50: 14438.00
gc timing full Q75: 16572.00
gc timing full Q90: 23492.00
gc timing full Q95: 31689.00
gc timing full Q99: 41860.00 
```

Meaning of terms: 
- total - total time spent inside the cyclic GC
- mark - time spent inside the "mark alive" process
- max - maximum GC pause
- avg - average GC pause
 
 The "gc timing full" are the times taken for full (generation 2) GC collections.  Qxx is the quantile of the time, units of microseconds.

With the mark alive feature on:

```
gc times: total 5.664s mark 3.938s max 16287us avg 616us
gc timing full Q50: 1112.02
gc timing full Q75: 1113.28
gc timing full Q90: 1232.18
gc timing full Q95: 1286.10
gc timing full Q99: 2176.05 
```

This benchmarking shows the overall time in the GC has slightly increased but the pause times have drastically decreased.  The 99% quantile pause time is 19x shorter.  It's possible with additional optimization the overall time can be further reduced.   If it can't be made comparable in overall cost, I think it could be turned on via a feature like the `PYTHON_GC_PRESET=min-latency`, as proposed in gh-124772.

This is still a WIP.  I would like to compare the pause times and overall performance with the incremental GC that is in the 3.14 and main branches.  