### PR TITLE
gh-126513: Use helpers for `_Py_Specialize_ConstainsOp`

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2760,8 +2760,8 @@ success:
     cache->counter = adaptive_counter_cooldown();
 }
 
-#ifdef Py_STATS
-static int containsop_fail_kind(PyObject *value) {
+static int
+containsop_fail_kind(PyObject *value) {
     if (PyUnicode_CheckExact(value)) {
         return SPEC_FAIL_CONTAINS_OP_STR;
     }
@@ -2776,7 +2776,6 @@ static int containsop_fail_kind(PyObject *value) {
     }
     return SPEC_FAIL_OTHER;
 }
-#endif   // Py_STATS
 
 void
 _Py_Specialize_ContainsOp(_PyStackRef value_st, _Py_CODEUNIT *instr)
@@ -2786,25 +2785,17 @@ _Py_Specialize_ContainsOp(_PyStackRef value_st, _Py_CODEUNIT *instr)
     assert(ENABLE_SPECIALIZATION_FT);
     assert(_PyOpcode_Caches[CONTAINS_OP] == INLINE_CACHE_ENTRIES_COMPARE_OP);
     uint8_t specialized_op;
-    _PyContainsOpCache *cache = (_PyContainsOpCache  *)(instr + 1);
     if (PyDict_CheckExact(value)) {
-        specialized_op = CONTAINS_OP_DICT;
-        goto success;
+        specialize(instr, CONTAINS_OP_DICT);
+        return;
     }
     if (PySet_CheckExact(value) || PyFrozenSet_CheckExact(value)) {
-        specialized_op = CONTAINS_OP_SET;
-        goto success;
+        specialize(instr, CONTAINS_OP_SET);
+        return;
     }
 
-    SPECIALIZATION_FAIL(CONTAINS_OP, containsop_fail_kind(value));
-    STAT_INC(CONTAINS_OP, failure);
-    SET_OPCODE_OR_RETURN(instr, CONTAINS_OP);
-    cache->counter = adaptive_counter_backoff(cache->counter);
+    unspecialize(instr, containsop_fail_kind(value));
     return;
-success:
-    STAT_INC(CONTAINS_OP, success);
-    SET_OPCODE_OR_RETURN(instr, specialized_op);
-    cache->counter = adaptive_counter_cooldown();
 }
 
 /* Code init cleanup.

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2784,7 +2784,6 @@ _Py_Specialize_ContainsOp(_PyStackRef value_st, _Py_CODEUNIT *instr)
 
     assert(ENABLE_SPECIALIZATION_FT);
     assert(_PyOpcode_Caches[CONTAINS_OP] == INLINE_CACHE_ENTRIES_COMPARE_OP);
-    uint8_t specialized_op;
     if (PyDict_CheckExact(value)) {
         specialize(instr, CONTAINS_OP_DICT);
         return;


### PR DESCRIPTION
This PR actually does two things:
* Fix bug from #126513
* Convert `_Py_Specialize_ConstainsOp` to use helpers

If you think that we should only fix the bug here, I'll revert the usage of helpers.

<!-- gh-issue-number: gh-126513 -->
* Issue: gh-126513
<!-- /gh-issue-number -->
