### PR TITLE
gh-126525: Fix `makeunicodedata.py` output on macOS and Windows

### DIFF
--- a/Tools/unicode/makeunicodedata.py
+++ b/Tools/unicode/makeunicodedata.py
@@ -35,7 +35,7 @@ from functools import partial
 from textwrap import dedent
 from typing import Iterator, List, Optional, Set, Tuple
 
-SCRIPT = sys.argv[0]
+SCRIPT = os.path.normpath(sys.argv[0])
 VERSION = "3.3"
 
 # The Unicode Database


### PR DESCRIPTION
After - it generates the expected file. To test run `make regen-unicodedata`

<!-- gh-issue-number: gh-126525 -->
* Issue: gh-126525
<!-- /gh-issue-number -->
