### PR TITLE
Chore: Fix typo in `pyarena.c`

### DIFF
--- a/Python/pyarena.c
+++ b/Python/pyarena.c
@@ -4,7 +4,7 @@
 /* A simple arena block structure.
 
    Measurements with standard library modules suggest the average
-   allocation is about 20 bytes and that most compiles use a single
+   allocation is about 20 bytes and that most compilers use a single
    block.
 */
 


### PR DESCRIPTION
I noticed a small typo in pyarena.c. 

The lines should likely read:

`Measurements with standard library modules suggest the average allocation is about 20 bytes and that most compilers use a single block.`

"Compiles" should be "compilers."