### PR TITLE
gh-126529: Update devguide links to relative filenames in InternalDocs/parser.md and InternalDocs/compiler.md

### DIFF
--- a/InternalDocs/compiler.md
+++ b/InternalDocs/compiler.md
@@ -42,10 +42,10 @@ The definitions for literal tokens (such as `:`, numbers, etc.) can be found in
 
 See Also:
 
-* [Guide to the parser](https://devguide.python.org/internals/parser/index.html)
+* [Guide to the parser](parser.md)
   for a detailed description of the parser.
 
-* [Changing CPython’s grammar](https://devguide.python.org/developer-workflow/grammar/#grammar)
+* [Changing CPython’s grammar](changing_grammar.md)
   for a detailed description of the grammar.
 
 

--- a/InternalDocs/parser.md
+++ b/InternalDocs/parser.md
@@ -17,7 +17,7 @@ Therefore, changes to the Python language are made by modifying the
 [grammar file](../Grammar/python.gram).
 Developers rarely need to modify the generator itself.
 
-See [Changing CPython's grammar](./changing_grammar.md)
+See [Changing CPython's grammar](changing_grammar.md)
 for a detailed description of the grammar and the process for changing it.
 
 How PEG parsers work


### PR DESCRIPTION
Mentioned it for parsed.md in this Issue https://github.com/python/cpython/issues/126509

Closed in this PR https://github.com/python/cpython/pull/126510

Found the same issue in compiler.md, and searched through InternalDocs for any other appearance of devguide links, found nothing except two in compiler.md ("Guide to the parser" and "Changing CPython’s grammar").
Also mentioned that in this PR https://github.com/python/cpython/pull/126510 I added a relative link as `./`, but in InternalDocs only filename as a path is used, so changed it from `./changing_grammar.md` to `changing_grammar.md`


<!-- gh-issue-number: gh-126529 -->
* Issue: gh-126529
<!-- /gh-issue-number -->
