### PR TITLE
gh-48020: [docs] Remove the logging howto suggested future FileHandler multiprocessing support

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1267,11 +1267,8 @@ to adapt in your own applications.
 
 You could also write your own handler which uses the :class:`~multiprocessing.Lock`
 class from the :mod:`multiprocessing` module to serialize access to the
-file from your processes. The existing :class:`FileHandler` and subclasses do
-not make use of :mod:`multiprocessing` at present, though they may do so in the
-future. Note that at present, the :mod:`multiprocessing` module does not provide
-working lock functionality on all platforms (see
-https://bugs.python.org/issue3770).
+file from your processes. The stdlib :class:`FileHandler` and subclasses do
+not make use of :mod:`multiprocessing`.
 
 .. currentmodule:: logging.handlers
 


### PR DESCRIPTION
Stick to the facts and suggestions, don't provide hope where we're not going to implement complexity that we'd rather the user implement themselves when needed (as already described).

<!-- gh-issue-number: gh-48020 -->
* Issue: gh-48020
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126531.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->