### PR TITLE
cleanup multiprocessing comment and unusual import error message

### DIFF
--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -21,22 +21,21 @@ from . import context
 from . import process
 from . import util
 
-# Try to import the mp.synchronize module cleanly, if it fails
-# raise ImportError for platforms lacking a working sem_open implementation.
-# See issue 3770
+# TODO: Do any platforms still lack a functioning sem_open?
 try:
     from _multiprocessing import SemLock, sem_unlink
-except (ImportError):
+except ImportError:
     raise ImportError("This platform lacks a functioning sem_open" +
-                      " implementation, therefore, the required" +
-                      " synchronization primitives needed will not" +
-                      " function, see issue 3770.")
+                      " implementation. https://github.com/python/cpython/issues/48020.")
 
 #
 # Constants
 #
 
-RECURSIVE_MUTEX, SEMAPHORE = list(range(2))
+# These match the enum in Modules/_multiprocessing/semaphore.c
+RECURSIVE_MUTEX = 0
+SEMAPHORE = 1
+
 SEM_VALUE_MAX = _multiprocessing.SemLock.SEM_VALUE_MAX
 
 #

--- a/Modules/_multiprocessing/semaphore.c
+++ b/Modules/_multiprocessing/semaphore.c
@@ -15,6 +15,7 @@
 
 #ifdef HAVE_MP_SEMAPHORE
 
+// These match the values in Lib/multiprocessing/synchronize.py
 enum { RECURSIVE_MUTEX, SEMAPHORE };
 
 typedef struct {


### PR DESCRIPTION
Define constants as constants rather than calling `list(range(2))`. Explain which values must remain in sync via comments.