### PR TITLE
Doc: C API: `PyThreadState::on_delete` was removed in v3.13

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1379,6 +1379,9 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
       This function now calls the :c:member:`PyThreadState.on_delete` callback.
       Previously, that happened in :c:func:`PyThreadState_Delete`.
 
+   .. versionchanged:: 3.13
+      The :c:member:`PyThreadState.on_delete` callback was removed.
+
 
 .. c:function:: void PyThreadState_Delete(PyThreadState *tstate)
 


### PR DESCRIPTION

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126536.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->