### PR TITLE
[3.11] gh-111942: Remove an extra incref in textiowrapper_change_encoding

### DIFF
--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1313,7 +1313,6 @@ textiowrapper_change_encoding(textio *self, PyObject *encoding,
     }
     Py_DECREF(codec_info);
 
-    Py_INCREF(errors);
     Py_SETREF(self->encoding, encoding);
     Py_SETREF(self->errors, errors);
 


### PR DESCRIPTION
A recent [test fix](https://github.com/python/cpython/pull/126478) uncovered a refleak that went in 3.11 on November due to a Git mis-merge.

So, @pablogsal, here's a RM decision for you. (Not time-sensitive, of course.)
This is not a security issue, but it should fix failing buildbots. (The other way to fix them would be to revert the change that uncovered the issue, which would mean we probably won't notice future refleaks in `test_io`.)


---

There's an issue with the 3.11 backport commit e2421a36f0868e2c5eb492ca9e74ae3d7c37357e The change for the main branch was:

```diff
+    Py_INCREF(errors);
 ...
     Py_SETREF(self->encoding, encoding);
-    Py_SETREF(self->errors, Py_NewRef(errors));
+    Py_SETREF(self->errors, errors);
```

but in 3.11 this became:

```diff
+    Py_INCREF(errors);
...
     Py_INCREF(errors);
     Py_SETREF(self->encoding, encoding);
     Py_SETREF(self->errors, errors);
```
i.e. there's an extra incref, but it looks -- at least to Git -- like the change that removes `Py_NewRef` was already applied.

This was not caught because `test_io` refleaks tests were ineffective on 3.11 (see https://github.com/python/cpython/pull/126478#issuecomment-2462070264).

Remove the extraneous incref.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111942 -->
* Issue: gh-111942
<!-- /gh-issue-number -->
