### PR TITLE
gh-126505: Do not use Unicode case folding in ASCII regexes

### DIFF
--- a/Lib/re/_compiler.py
+++ b/Lib/re/_compiler.py
@@ -298,7 +298,7 @@ def _optimize_charset(charset, iscased=None, fixup=None, fixes=None):
                 # Character set contains non-BMP character codes.
                 # For range, all BMP characters in the range are already
                 # proceeded.
-                if fixup:
+                if fixes:
                     hascased = True
                     # For now, IN_UNI_IGNORE+LITERAL and
                     # IN_UNI_IGNORE+RANGE_UNI_IGNORE work for all non-BMP

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -2626,6 +2626,15 @@ class ReTests(unittest.TestCase):
                 self.assertIsNone(re.search(p, s))
                 self.assertIsNone(re.search('(?s:.)' + p, s))
 
+    def test_ascii_character_range_non_bmp(self):
+        # gh-126505
+        # should match in Unicode mode
+        self.assertEqual(re.compile("[\ua7aa-\uffff]", re.IGNORECASE).match("\u0266").span(), (0, 1))
+        # should not match in ASCII mode
+        self.assertIsNone(re.compile("[\ua7aa-\uffff]", re.ASCII | re.IGNORECASE).match("\u0266"))
+        # should not match in ASCII mode, even if upper bound is outside of BMP
+        self.assertIsNone(re.compile("[\ua7aa-\U00010000]", re.ASCII | re.IGNORECASE).match("\u0266"))
+
 
 def get_debug_out(pat):
     with captured_stdout() as out:


### PR DESCRIPTION
When a pattern is being compiled in `_compiler.py`'s `optimize_charset`, the `RANGE` opcode is translated into the `RANGE_UNI_IGNORE` opcode. This should be done only in regexes which set the Unicode flag, otherwise we get Unicode case folding behavior in regexes which set the ASCII or Locale mode flags.

The correct way to check for Unicode mode in `optimize_charset` would be to check `if fixes:`, because the `fixes` argument is `None` in ASCII and Locale modes and a `dict` in Unicode mode. The code currently uses the condition `if fixup:`, but `fixup` is `None` only in Locale mode and it is a function in both ASCII and Unicode mode. This means that this replacement is used in ASCII mode too and the `RANGE` opcode is translated to a `RANGE_UNI_IGNORE` opcode for character sets which include characters outside of the basic multilingual plane (the second time an `IndexError` is thrown in `optimize_charset`).

<!-- gh-issue-number: gh-126505 -->
* Issue: gh-126505
<!-- /gh-issue-number -->
