### PR TITLE
Add PEP 761 to What's New

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -65,7 +65,15 @@ Summary -- release highlights
 
 .. PEP-sized items next.
 
+PEP 761: Discontinuation of PGP signatures
+------------------------------------------
 
+PGP signatures will not be available for CPython 3.14 and onwards.
+Users verifying artifacts must use `Sigstore verification materials`_ for
+verifying CPython artifacts. This change in release process is specified
+in :pep:`761`. 
+
+.. _Sigstore verification materials: https://www.python.org/downloads/metadata/sigstore/
 
 New features
 ============

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -71,7 +71,7 @@ PEP 761: Discontinuation of PGP signatures
 PGP signatures will not be available for CPython 3.14 and onwards.
 Users verifying artifacts must use `Sigstore verification materials`_ for
 verifying CPython artifacts. This change in release process is specified
-in :pep:`761`. 
+in :pep:`761`.
 
 .. _Sigstore verification materials: https://www.python.org/downloads/metadata/sigstore/
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -65,6 +65,8 @@ Summary -- release highlights
 
 .. PEP-sized items next.
 
+
+
 New features
 ============
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -65,16 +65,6 @@ Summary -- release highlights
 
 .. PEP-sized items next.
 
-PEP 761: Discontinuation of PGP signatures
-------------------------------------------
-
-PGP signatures will not be available for CPython 3.14 and onwards.
-Users verifying artifacts must use `Sigstore verification materials`_ for
-verifying CPython artifacts. This change in release process is specified
-in :pep:`761`.
-
-.. _Sigstore verification materials: https://www.python.org/downloads/metadata/sigstore/
-
 New features
 ============
 
@@ -721,6 +711,16 @@ Changes in the Python API
 
 Build changes
 =============
+
+PEP 761: Discontinuation of PGP signatures
+------------------------------------------
+
+PGP signatures will not be available for CPython 3.14 and onwards.
+Users verifying artifacts must use `Sigstore verification materials`_ for
+verifying CPython artifacts. This change in release process is specified
+in :pep:`761`.
+
+.. _Sigstore verification materials: https://www.python.org/downloads/metadata/sigstore/
 
 
 C API changes


### PR DESCRIPTION
PEP 761 has been accepted and PGP has been disabled in the release workflow for 3.14 and onwards: https://github.com/python/release-tools/pull/189

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126550.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->