### PR TITLE
GH-123877: default to `wasm32-wasip1` instead of `wasm32-wasi` to be more specific

### DIFF
--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -17,7 +17,7 @@ jobs:
       WASI_SDK_VERSION: 24
       WASI_SDK_PATH: /opt/wasi-sdk
       CROSS_BUILD_PYTHON: cross-build/build
-      CROSS_BUILD_WASI: cross-build/wasm32-wasi
+      CROSS_BUILD_WASI: cross-build/wasm32-wasip1
     steps:
     - uses: actions/checkout@v4
     # No problem resolver registered as one doesn't currently exist for Clang.
@@ -31,7 +31,7 @@ jobs:
       with:
         path: ${{ env.WASI_SDK_PATH }}
         key: ${{ runner.os }}-wasi-sdk-${{ env.WASI_SDK_VERSION }}
-    - name: "Install WASI SDK"
+    - name: "Install WASI SDK"  # Hard-coded to x64.
       if: steps.cache-wasi-sdk.outputs.cache-hit != 'true'
       run: |
         mkdir ${{ env.WASI_SDK_PATH }} && \

--- a/Misc/NEWS.d/next/Build/2024-11-07-11-09-31.gh-issue-123877.CVdd0b.rst
+++ b/Misc/NEWS.d/next/Build/2024-11-07-11-09-31.gh-issue-123877.CVdd0b.rst
@@ -1,0 +1,3 @@
+Use ``wasm32-wasip1`` as the target triple for WASI instead of
+``wasm32-wasi``. The latter will eventually be reclaimed for WASI 1.0 while
+CPython currently only supports WASI preview1.

--- a/Tools/wasm/wasi.py
+++ b/Tools/wasm/wasi.py
@@ -346,7 +346,7 @@ def main():
                              "(default designed for wasmtime 14 or newer: "
                                 f"`{default_host_runner}`)")
     for subcommand in build, configure_host, make_host:
-        subcommand.add_argument("--host-triple", action="store", default="wasm32-wasi",
+        subcommand.add_argument("--host-triple", action="store", default="wasm32-wasip1",
                         help="The target triple for the WASI host build")
 
     context = parser.parse_args()

--- a/configure
+++ b/configure
@@ -4062,7 +4062,7 @@ then
 	*-*-emscripten)
 	    ac_sys_system=Emscripten
 	    ;;
-	*-*-wasi)
+	*-*-wasi*)
 	    ac_sys_system=WASI
 	    ;;
 	*)
@@ -7086,7 +7086,7 @@ case $host/$ac_cv_cc_name in #(
     PY_SUPPORT_TIER=2 ;; #(
   powerpc64le-*-linux-gnu/gcc) :
     PY_SUPPORT_TIER=2 ;; #(
-    wasm32-unknown-wasi/clang) :
+    wasm32-unknown-wasip1/clang) :
     PY_SUPPORT_TIER=2 ;; #(
     x86_64-*-linux-gnu/clang) :
     PY_SUPPORT_TIER=2 ;; #(
@@ -7792,7 +7792,7 @@ then :
 fi
      ;; #(
               WASI/*) :
-    HOSTRUNNER='wasmtime run --wasm max-wasm-stack=16777216 --wasi preview2 --env PYTHONPATH=/$(shell realpath --relative-to $(abs_srcdir) $(abs_builddir))/$(shell cat pybuilddir.txt):/Lib --dir $(srcdir)::/' ;; #(
+    HOSTRUNNER='wasmtime run --wasm max-wasm-stack=16777216 --wasi preview2=n --env PYTHONPATH=/$(shell realpath --relative-to $(abs_srcdir) $(abs_builddir))/$(shell cat pybuilddir.txt):/Lib --dir $(srcdir)::/' ;; #(
   *) :
     HOSTRUNNER=''
    ;;

--- a/configure.ac
+++ b/configure.ac
@@ -336,7 +336,7 @@ then
 	*-*-emscripten)
 	    ac_sys_system=Emscripten
 	    ;;
-	*-*-wasi)
+	*-*-wasi*)
 	    ac_sys_system=WASI
 	    ;;
 	*)
@@ -1201,7 +1201,7 @@ AS_CASE([$host/$ac_cv_cc_name],
   [aarch64-*-linux-gnu/gcc],         [PY_SUPPORT_TIER=2], dnl Linux ARM64, glibc, gcc+clang
   [aarch64-*-linux-gnu/clang],       [PY_SUPPORT_TIER=2],
   [powerpc64le-*-linux-gnu/gcc],     [PY_SUPPORT_TIER=2], dnl Linux on PPC64 little endian, glibc, gcc
-  [wasm32-unknown-wasi/clang],       [PY_SUPPORT_TIER=2], dnl WebAssembly System Interface, clang
+  [wasm32-unknown-wasip1/clang],       [PY_SUPPORT_TIER=2], dnl WebAssembly System Interface preview1, clang
   [x86_64-*-linux-gnu/clang],        [PY_SUPPORT_TIER=2], dnl Linux on AMD64, any vendor, glibc, clang
 
   [aarch64-pc-windows-msvc/msvc],    [PY_SUPPORT_TIER=3], dnl Windows ARM64, MSVC
@@ -1647,7 +1647,7 @@ then
     dnl TODO: support other WASI runtimes
     dnl wasmtime starts the process with "/" as CWD. For OOT builds add the
     dnl directory containing _sysconfigdata to PYTHONPATH.
-    [WASI/*], [HOSTRUNNER='wasmtime run --wasm max-wasm-stack=16777216 --wasi preview2 --env PYTHONPATH=/$(shell realpath --relative-to $(abs_srcdir) $(abs_builddir))/$(shell cat pybuilddir.txt):/Lib --dir $(srcdir)::/'],
+    [WASI/*], [HOSTRUNNER='wasmtime run --wasm max-wasm-stack=16777216 --wasi preview2=n --env PYTHONPATH=/$(shell realpath --relative-to $(abs_srcdir) $(abs_builddir))/$(shell cat pybuilddir.txt):/Lib --dir $(srcdir)::/'],
     [HOSTRUNNER='']
   )
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1201,7 +1201,7 @@ AS_CASE([$host/$ac_cv_cc_name],
   [aarch64-*-linux-gnu/gcc],         [PY_SUPPORT_TIER=2], dnl Linux ARM64, glibc, gcc+clang
   [aarch64-*-linux-gnu/clang],       [PY_SUPPORT_TIER=2],
   [powerpc64le-*-linux-gnu/gcc],     [PY_SUPPORT_TIER=2], dnl Linux on PPC64 little endian, glibc, gcc
-  [wasm32-unknown-wasip1/clang],       [PY_SUPPORT_TIER=2], dnl WebAssembly System Interface preview1, clang
+  [wasm32-unknown-wasip1/clang],     [PY_SUPPORT_TIER=2], dnl WebAssembly System Interface preview1, clang
   [x86_64-*-linux-gnu/clang],        [PY_SUPPORT_TIER=2], dnl Linux on AMD64, any vendor, glibc, clang
 
   [aarch64-pc-windows-msvc/msvc],    [PY_SUPPORT_TIER=3], dnl Windows ARM64, MSVC


### PR DESCRIPTION
Eventually wasm32-wasi will represent WASI 1.0, and so it's currently deprecated for that eventual transition. wasm32-wasip1 is also more specific to what version of WASI that is currently supported.

<!-- gh-issue-number: gh-123877 -->
* Issue: gh-123877
<!-- /gh-issue-number -->
