### PR TITLE
Add missing fullstop to whatsnew/3.8.rst

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -936,7 +936,7 @@ Add option ``--json-lines`` to parse every input line as a separate JSON object.
 logging
 -------
 
-Added a *force* keyword argument to :func:`logging.basicConfig`
+Added a *force* keyword argument to :func:`logging.basicConfig`.
 When set to true, any existing handlers attached
 to the root logger are removed and closed before carrying out the
 configuration specified by the other arguments.


### PR DESCRIPTION
How it looks today without the fix ([link to published doc](https://docs.python.org/pt-br/3.14/whatsnew/3.8.html#logging)):
> Added a _force_ keyword argument to [logging.basicConfig()](https://docs.python.org/pt-br/3.13/library/logging.html#logging.basicConfig) When set to true, any existing handlers attached to the root logger are removed and closed before carrying out the configuration specified by the other arguments.

Please backport it to 3.12 and 3.13.