### PR TITLE
gh-126554: ctypes: Correctly handle NULL dlsym values

### DIFF
--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -1,0 +1,69 @@
+import os.path
+import sys
+import unittest
+from ctypes import CDLL
+
+FOO_C = r"""
+#include <stdio.h>
+
+/* This is a 'GNU indirect function' (IFUNC) that will be called by
+   dlsym() to resolve the symbol "foo" to an address. Typically, such
+   a function would return the address of an actual function, but it
+   can also just return NULL.  For some background on IFUNCs, see
+   https://willnewton.name/uncategorized/using-gnu-indirect-functions/
+
+   Adapted from Michael Kerrisk's answer: https://stackoverflow.com/a/53590014
+*/
+
+asm (".type foo, @gnu_indirect_function");
+
+void *foo(void)
+{
+    fprintf(stderr, "foo IFUNC called\n");
+    return NULL;
+}
+"""
+
+
+@unittest.skipUnless(sys.platform.startswith('linux'),
+                     'Test only valid for Linux')
+class TestNullDlsym(unittest.TestCase):
+    def test_null_dlsym(self):
+        import subprocess
+        import tempfile
+
+        try:
+            p = subprocess.Popen(['gcc', '--version'], stdout=subprocess.PIPE,
+                                 stderr=subprocess.DEVNULL)
+            out, _ = p.communicate()
+        except OSError:
+            raise unittest.SkipTest('gcc, needed for test, not available')
+        with tempfile.TemporaryDirectory() as d:
+            # Create a source file foo.c, that uses
+            # a GNU Indirect Function. See FOO_C.
+            srcname = os.path.join(d, 'foo.c')
+            libname = 'py_ctypes_test_null_dlsym'
+            dstname = os.path.join(d, 'lib%s.so' % libname)
+            with open(srcname, 'w') as f:
+                f.write(FOO_C)
+            self.assertTrue(os.path.exists(srcname))
+            # Compile the file to a shared library
+            cmd = ['gcc', '-fPIC', '-shared', '-o', dstname, srcname]
+            out = subprocess.check_output(cmd)
+            self.assertTrue(os.path.exists(dstname))
+            # Load the shared library
+            L = CDLL(dstname)
+
+            with self.assertRaises(AttributeError) as cm:
+                # Try accessing the 'foo' symbol.
+                # It should resolve via dlsym() to NULL,
+                # and since we subjectively treat NULL
+                # addresses as errors, we should get
+                # an error.
+                L.foo
+
+            self.assertEqual(str(cm.exception),
+                             "function 'foo' not found")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -10,9 +10,9 @@ FOO_C = r"""
    dlsym() to resolve the symbol "foo" to an address. Typically, such
    a function would return the address of an actual function, but it
    can also just return NULL.  For some background on IFUNCs, see
-   https://willnewton.name/uncategorized/using-gnu-indirect-functions/
+   https://willnewton.name/uncategorized/using-gnu-indirect-functions.
 
-   Adapted from Michael Kerrisk's answer: https://stackoverflow.com/a/53590014
+   Adapted from Michael Kerrisk's answer: https://stackoverflow.com/a/53590014.
 */
 
 asm (".type foo, @gnu_indirect_function");

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -53,6 +53,17 @@ class TestNullDlsym(unittest.TestCase):
         import subprocess
         import tempfile
 
+        # When using 'shell=True', Python invokes
+        # /bin/sh -c 'args[0]' args[1] ...
+        #
+        # The shell uses arg[0] as the
+        # command to execute,
+        # while the rest are arguments
+        # to the shell itself.
+        #
+        # To avoid mistakes, pass a single string
+        # (equivalent to a single-elem list),
+        # with the shell command to execute.
         retcode = subprocess.call(["gcc --version"],
                                   stdout=subprocess.DEVNULL,
                                   stderr=subprocess.DEVNULL,

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -54,12 +54,9 @@ class TestNullDlsym(unittest.TestCase):
         import subprocess
         import tempfile
 
-        # Recall: using shell=True is equivalent to: /bin/sh -c 'args[0]' args[1] ...,
-        # so we need to pass a list with a single item, namely the command to run.
-        retcode = subprocess.call(["gcc --version"],
+        retcode = subprocess.call(["gcc", "--version"],
                                   stdout=subprocess.DEVNULL,
-                                  stderr=subprocess.DEVNULL,
-                                  shell=True)
+                                  stderr=subprocess.DEVNULL)
         if retcode != 0:
             self.skipTest("gcc is missing")
 

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -1,8 +1,6 @@
 import os
 import sys
 import unittest
-from ctypes import CDLL, c_int
-from _ctypes import dlopen, dlsym
 
 FOO_C = r"""
 #include <unistd.h>
@@ -53,6 +51,8 @@ class TestNullDlsym(unittest.TestCase):
     def test_null_dlsym(self):
         import subprocess
         import tempfile
+        from ctypes import CDLL, c_int
+        from _ctypes import dlopen, dlsym
 
         retcode = subprocess.call(["gcc", "--version"],
                                   stdout=subprocess.DEVNULL,

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -82,6 +82,7 @@ class TestNullDlsym(unittest.TestCase):
                 # addresses as errors, we should get
                 # an error.
                 L.foo
+                self.fail("AttributeError should have been raised!")
 
             self.assertEqual(str(cm.exception),
                              "function 'foo' not found")

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -53,18 +53,9 @@ class TestNullDlsym(unittest.TestCase):
         import subprocess
         import tempfile
 
-        # When using 'shell=True', Python invokes
-        # /bin/sh -c 'args[0]' args[1] ...
-        #
-        # The shell uses arg[0] as the
-        # command to execute,
-        # while the rest are arguments
-        # to the shell itself.
-        #
-        # To avoid mistakes, pass a single string
-        # (equivalent to a single-elem list),
-        # with the shell command to execute.
-        retcode = subprocess.call("gcc --version",
+        # Recall: using shell=True is equivalent to: /bin/sh -c 'args[0]' args[1] ...,
+        # so we need to pass a list with a single item, namely the command to run.
+        retcode = subprocess.call(["gcc --version"],
                                   stdout=subprocess.DEVNULL,
                                   stderr=subprocess.DEVNULL,
                                   shell=True)

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -83,10 +83,8 @@ class TestNullDlsym(unittest.TestCase):
                 # an error.
                 L.foo
 
-            pred = "function 'foo' not found" in str(cm.exception)
-            self.assertTrue(pred)
-            # self.assertEqual(str(cm.exception),
-            #                  "function 'foo' not found")
+            self.assertEqual(str(cm.exception),
+                             "function 'foo' not found")
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -58,7 +58,7 @@ class TestNullDlsym(unittest.TestCase):
                                  stderr=subprocess.DEVNULL)
             out, _ = p.communicate()
         except OSError:
-            raise unittest.SkipTest('gcc, needed for test, not available')
+            self.skipTest('gcc is missing')
         with tempfile.TemporaryDirectory() as d:
             # Create a source file foo.c, that uses
             # a GNU Indirect Function. See FOO_C.

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -64,7 +64,7 @@ class TestNullDlsym(unittest.TestCase):
         # To avoid mistakes, pass a single string
         # (equivalent to a single-elem list),
         # with the shell command to execute.
-        retcode = subprocess.call(["gcc --version"],
+        retcode = subprocess.call("gcc --version",
                                   stdout=subprocess.DEVNULL,
                                   stderr=subprocess.DEVNULL,
                                   shell=True)

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -75,17 +75,14 @@ class TestNullDlsym(unittest.TestCase):
             # Load the shared library
             L = CDLL(dstname)
 
-            with self.assertRaises(AttributeError) as cm:
+            with self.assertRaisesRegex(AttributeError, "function 'foo' not found"):
                 # Try accessing the 'foo' symbol.
                 # It should resolve via dlsym() to NULL,
                 # and since we subjectively treat NULL
                 # addresses as errors, we should get
                 # an error.
                 L.foo
-                self.fail("AttributeError should have been raised!")
 
-            self.assertEqual(str(cm.exception),
-                             "function 'foo' not found")
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -14,7 +14,7 @@ FOO_C = r"""
    Adapted from Michael Kerrisk's answer: https://stackoverflow.com/a/53590014.
 */
 
-asm (".type foo, @gnu_indirect_function");
+asm (".type foo STT_GNU_IFUNC");
 
 void *foo(void)
 {

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import unittest
+from ctypes import CDLL, c_int
+from _ctypes import dlopen, dlsym
 
 FOO_C = r"""
 #include <unistd.h>
@@ -47,11 +49,10 @@ class TestNullDlsym(unittest.TestCase):
     This test case ensures that we correctly enforce
     this 'dlsym returned NULL -> throw Error' rule.
     """
+
     def test_null_dlsym(self):
         import subprocess
         import tempfile
-        from ctypes import CDLL, c_int
-        from _ctypes import dlopen, dlsym
 
         # Recall: using shell=True is equivalent to: /bin/sh -c 'args[0]' args[1] ...,
         # so we need to pass a list with a single item, namely the command to run.

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -51,6 +51,12 @@ class TestNullDlsym(unittest.TestCase):
     def test_null_dlsym(self):
         import subprocess
         import tempfile
+
+        # To avoid ImportErrors on Windows, where _ctypes does not have
+        # dlopen and dlsym,
+        # import here, i.e., inside the test function.
+        # The skipUnless('linux') decorator ensures that we're on linux
+        # if we're executing these statements.
         from ctypes import CDLL, c_int
         from _ctypes import dlopen, dlsym
 

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -1,8 +1,6 @@
 import os
 import sys
 import unittest
-from ctypes import CDLL, c_int
-from _ctypes import dlopen, dlsym
 
 FOO_C = r"""
 #include <unistd.h>
@@ -49,10 +47,11 @@ class TestNullDlsym(unittest.TestCase):
     This test case ensures that we correctly enforce
     this 'dlsym returned NULL -> throw Error' rule.
     """
-
     def test_null_dlsym(self):
         import subprocess
         import tempfile
+        from ctypes import CDLL, c_int
+        from _ctypes import dlopen, dlsym
 
         # Recall: using shell=True is equivalent to: /bin/sh -c 'args[0]' args[1] ...,
         # so we need to pass a list with a single item, namely the command to run.

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -61,18 +61,15 @@ class TestNullDlsym(unittest.TestCase):
             self.skipTest("gcc is missing")
 
         with tempfile.TemporaryDirectory() as d:
-            # Create a source file foo.c, that uses
-            # a GNU Indirect Function. See FOO_C.
+            # Create a C file with a GNU Indirect Function (FOO_C)
+            # and compile it into a shared library.
             srcname = os.path.join(d, 'foo.c')
-            libname = 'py_ctypes_test_null_dlsym'
-            dstname = os.path.join(d, 'lib%s.so' % libname)
+            dstname = os.path.join(d, 'libfoo.so')
             with open(srcname, 'w') as f:
                 f.write(FOO_C)
-            self.assertTrue(os.path.exists(srcname))
-            # Compile the file to a shared library
-            cmd = ['gcc', '-fPIC', '-shared', '-o', dstname, srcname]
-            out = subprocess.check_output(cmd)
-            self.assertTrue(os.path.exists(dstname))
+            args = ['gcc', '-fPIC', '-shared', '-o', dstname, srcname]
+            p = subprocess.run(args, capture_output=True)
+            self.assertEqual(p.returncode, 0, p)
             # Load the shared library
             L = CDLL(dstname)
 

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 import sys
 import unittest
 from ctypes import CDLL

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -53,12 +53,13 @@ class TestNullDlsym(unittest.TestCase):
         import subprocess
         import tempfile
 
-        try:
-            p = subprocess.Popen(['gcc', '--version'], stdout=subprocess.PIPE,
-                                 stderr=subprocess.DEVNULL)
-            out, _ = p.communicate()
-        except OSError:
-            self.skipTest('gcc is missing')
+        retcode = subprocess.call(["gcc --version"],
+                                  stdout=subprocess.DEVNULL,
+                                  stderr=subprocess.DEVNULL,
+                                  shell=True)
+        if retcode != 0:
+            self.skipTest("gcc is missing")
+
         with tempfile.TemporaryDirectory() as d:
             # Create a source file foo.c, that uses
             # a GNU Indirect Function. See FOO_C.

--- a/Misc/NEWS.d/next/C_API/2024-11-07-20-24-58.gh-issue-126554.ri12eb.rst
+++ b/Misc/NEWS.d/next/C_API/2024-11-07-20-24-58.gh-issue-126554.ri12eb.rst
@@ -1,1 +1,1 @@
-Correctly handle NULL dlsym() values in ctypes.
+Fix rare crash upon system failure in :class:`ctypes.CDLL`.

--- a/Misc/NEWS.d/next/C_API/2024-11-07-20-24-58.gh-issue-126554.ri12eb.rst
+++ b/Misc/NEWS.d/next/C_API/2024-11-07-20-24-58.gh-issue-126554.ri12eb.rst
@@ -1,1 +1,2 @@
-Fix rare crash upon system failure in :class:`ctypes.CDLL`.
+Fix error handling in :class:`ctypes.CDLL` objects
+which could result in a crash in rare situations.

--- a/Misc/NEWS.d/next/C_API/2024-11-07-20-24-58.gh-issue-126554.ri12eb.rst
+++ b/Misc/NEWS.d/next/C_API/2024-11-07-20-24-58.gh-issue-126554.ri12eb.rst
@@ -1,0 +1,1 @@
+Correctly handle NULL dlsym() values in ctypes.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -986,8 +986,13 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
     // Investigate if this can cause problems.
     const char *dlerr = dlerror();
     if (dlerr) {
-        PyErr_SetString(PyExc_ValueError, dlerr);
-        return NULL;
+        PyObject *message = PyUnicode_DecodeLocale(dlerr, "strict");
+        if (message) {
+            PyErr_SetObject(PyExc_ValueError, message);
+            return NULL;
+        }
+        // Ignore errors from converting the message to str
+        PyErr_Clear();
     }
 #endif
 #undef USE_DLERROR

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3811,8 +3811,8 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
 #else
     char *dlerr = dlerror();
     if (dlerr) {
-		// XXX: This assumes that UTF-8 is the default locale.
-		//      Investigate if this can cause problems.
+		  // XXX: This assumes that UTF-8 is the default locale.
+		  //      Investigate if this can cause problems.
         PyErr_SetString(PyExc_AttributeError, dlerr);
         Py_DECREF(ftuple);
         return NULL;

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -967,6 +967,11 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
         return NULL;
     }
 #else
+	/* dlerror() always returns the latest error.
+	 *
+	 * Clear the previous value before calling dlsym(),
+	 * to ensure we can tell if our call resulted in an error.
+	 */
     dlerror();
     address = (void *)dlsym(handle, name);
 #ifdef __CYGWIN__
@@ -3785,6 +3790,11 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
 #else
+	/* dlerror() always returns the latest error.
+	 *
+	 * Clear the previous value before calling dlsym(),
+	 * to ensure we can tell if our call resulted in an error.
+	 */
     dlerror();
     address = (PPROC)dlsym(handle, name);
 #ifdef __CYGWIN__

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -983,7 +983,7 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
         return NULL;
     }
 #else
-    char *dlerr = dlerror();
+    const char *dlerr = dlerror();
     if (dlerr) {
         // XXX: This assumes that UTF-8 is the default locale.
         // Investigate if this can cause problems.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -987,6 +987,7 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
         PyObject *message = PyUnicode_DecodeLocale(dlerr, "surrogateescape");
         if (message) {
             PyErr_SetObject(PyExc_ValueError, message);
+            Py_DECREF(message);
             return NULL;
         }
         // Ignore errors from PyUnicode_DecodeLocale,
@@ -3813,6 +3814,7 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
             if (message) {
                 PyErr_SetObject(PyExc_AttributeError, message);
                 Py_DECREF(ftuple);
+                Py_DECREF(message);
                 return NULL;
             }
             // Ignore errors from PyUnicode_DecodeLocale,

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -984,13 +984,11 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
 #ifdef USE_DLERROR
     const char *dlerr = dlerror();
     if (dlerr) {
-        PyObject *message = PyUnicode_DecodeLocale(dlerr, "strict");
+        PyObject *message = PyUnicode_DecodeLocale(dlerr, "surrogateescape");
         if (message) {
             PyErr_SetObject(PyExc_ValueError, message);
             return NULL;
         }
-        // Ignore errors from converting the message to str
-        PyErr_Clear();
     }
 #endif
 #undef USE_DLERROR
@@ -3809,14 +3807,12 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
 	#ifdef USE_DLERROR
         const char *dlerr = dlerror();
         if (dlerr) {
-            PyObject *message = PyUnicode_DecodeLocale(dlerr, "strict");
+            PyObject *message = PyUnicode_DecodeLocale(dlerr, "surrogateescape");
             if (message) {
                 PyErr_SetObject(PyExc_AttributeError, message);
                 Py_DECREF(ftuple);
                 return NULL;
             }
-            // Ignore errors from converting the message to str
-            PyErr_Clear();
         }
 	#endif
         PyErr_Format(PyExc_AttributeError,

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -996,8 +996,8 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
 #undef USE_DLERROR
 
     PyErr_Format(PyExc_ValueError,
-                    "symbol '%s' not found",
-                    name);
+                 "symbol '%s' not found",
+                 name);
     return NULL;
 }
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3836,6 +3836,12 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
 #endif
 
 dlsym_ok:
+    /* Add an empty statement (;) to placate some C compilers
+     that do not allow declarations after labels.
+
+     See https://stackoverflow.com/a/18496437.
+    */
+    ;
     ctypes_state *st = get_module_state_by_def(Py_TYPE(type));
     if (!_validate_paramflags(st, type, paramflags)) {
         Py_DECREF(ftuple);

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3833,8 +3833,6 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
         Py_DECREF(ftuple);
         return NULL;
     }
-#endif
-
 dlsym_ok:
     /* Add an empty statement (;) to placate some C compilers
      that do not allow declarations after labels.
@@ -3842,6 +3840,7 @@ dlsym_ok:
      See https://stackoverflow.com/a/18496437.
     */
     ;
+#endif
     ctypes_state *st = get_module_state_by_def(Py_TYPE(type));
     if (!_validate_paramflags(st, type, paramflags)) {
         Py_DECREF(ftuple);

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3797,8 +3797,7 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
 #else
-    char *dlerr;
-    dlerr = dlerror();
+    char *dlerr = dlerror();
     if (dlerr) {
         PyErr_SetString(PyExc_AttributeError, dlerr);
         Py_DECREF(ftuple);

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -992,7 +992,7 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
     }
     else if (!address) {
         PyErr_Format(PyExc_ValueError,
-                     "[CDataType_in_dll_impl]: symbol '%s' not found",
+                     "symbol '%s' not found",
                      name);
         return NULL;
     }
@@ -3819,7 +3819,7 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
     }
     else if (!address) {
         PyErr_Format(PyExc_AttributeError,
-                     "[PyCFuncPtr_FromDll]: function '%s' not found",
+                     "function '%s' not found",
                      name);
         Py_DECREF(ftuple);
         return NULL;

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -985,8 +985,8 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
 #else
     char *dlerr = dlerror();
     if (dlerr) {
-		  // XXX: This assumes that UTF-8 is the default locale.
-		  //      Investigate if this can cause problems.
+        // XXX: This assumes that UTF-8 is the default locale.
+        // Investigate if this can cause problems.
         PyErr_SetString(PyExc_ValueError, dlerr);
         return NULL;
     }

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3811,8 +3811,6 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
 #else
     char *dlerr = dlerror();
     if (dlerr) {
-		  // XXX: This assumes that UTF-8 is the default locale.
-		  //      Investigate if this can cause problems.
         PyErr_SetString(PyExc_AttributeError, dlerr);
         Py_DECREF(ftuple);
         return NULL;

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -996,9 +996,7 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
     }
     #endif
 #undef USE_DLERROR
-    PyErr_Format(PyExc_ValueError,
-                 "symbol '%s' not found",
-                 name);
+    PyErr_Format(PyExc_ValueError, "symbol '%s' not found", name);
     return NULL;
 }
 
@@ -3822,9 +3820,7 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
             PyErr_Clear();
         }
 	#endif
-        PyErr_Format(PyExc_AttributeError,
-                     "function '%s' not found",
-                     name);
+        PyErr_Format(PyExc_AttributeError, "function '%s' not found", name);
         Py_DECREF(ftuple);
         return NULL;
     }

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -978,8 +978,7 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
         return NULL;
     }
 #else
-    char *dlerr;
-    dlerr = dlerror();
+    char *dlerr = dlerror();
     if (dlerr) {
         PyErr_SetString(PyExc_ValueError, dlerr);
         return NULL;

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3797,7 +3797,7 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
 	 * Clear the previous value before calling dlsym(),
 	 * to ensure we can tell if our call resulted in an error.
 	 */
-    dlerror();
+    (void)dlerror();
     address = (PPROC)dlsym(handle, name);
 #ifdef __CYGWIN__
     if (!address) {

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -981,7 +981,7 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
         return PyCData_AtAddress(st, type, address);
     }
 
-#ifdef USE_DLERROR
+    #ifdef USE_DLERROR
     const char *dlerr = dlerror();
     if (dlerr) {
         PyObject *message = PyUnicode_DecodeLocale(dlerr, "surrogateescape");
@@ -989,10 +989,12 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
             PyErr_SetObject(PyExc_ValueError, message);
             return NULL;
         }
+        // Ignore errors from PyUnicode_DecodeLocale,
+        // fall back to the generic error below.
+        PyErr_Clear();
     }
-#endif
+    #endif
 #undef USE_DLERROR
-
     PyErr_Format(PyExc_ValueError,
                  "symbol '%s' not found",
                  name);
@@ -3813,6 +3815,9 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
                 Py_DECREF(ftuple);
                 return NULL;
             }
+            // Ignore errors from PyUnicode_DecodeLocale,
+            // fall back to the generic error below.
+            PyErr_Clear();
         }
 	#endif
         PyErr_Format(PyExc_AttributeError,

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3809,7 +3809,7 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
 #else
-    char *dlerr = dlerror();
+    const char *dlerr = dlerror();
     if (dlerr) {
         PyErr_SetString(PyExc_AttributeError, dlerr);
         Py_DECREF(ftuple);

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -972,7 +972,7 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
 	 * Clear the previous value before calling dlsym(),
 	 * to ensure we can tell if our call resulted in an error.
 	 */
-    dlerror();
+    (void)dlerror();
     address = (void *)dlsym(handle, name);
 #ifdef __CYGWIN__
     if (!address) {

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -985,12 +985,14 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
 #else
     char *dlerr = dlerror();
     if (dlerr) {
+		// XXX: This assumes that UTF-8 is the default locale.
+		//      Investigate if this can cause problems.
         PyErr_SetString(PyExc_ValueError, dlerr);
         return NULL;
     }
     else if (!address) {
         PyErr_Format(PyExc_ValueError,
-                     "symbol '%s' not found",
+                     "[CDataType_in_dll_impl]: symbol '%s' not found",
                      name);
         return NULL;
     }
@@ -3809,13 +3811,15 @@ PyCFuncPtr_FromDll(PyTypeObject *type, PyObject *args, PyObject *kwds)
 #else
     char *dlerr = dlerror();
     if (dlerr) {
+		// XXX: This assumes that UTF-8 is the default locale.
+		//      Investigate if this can cause problems.
         PyErr_SetString(PyExc_AttributeError, dlerr);
         Py_DECREF(ftuple);
         return NULL;
     }
     else if (!address) {
         PyErr_Format(PyExc_AttributeError,
-                     "function '%s' not found",
+                     "[PyCFuncPtr_FromDll]: function '%s' not found",
                      name);
         Py_DECREF(ftuple);
         return NULL;

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -985,8 +985,8 @@ CDataType_in_dll_impl(PyObject *type, PyTypeObject *cls, PyObject *dll,
 #else
     char *dlerr = dlerror();
     if (dlerr) {
-		// XXX: This assumes that UTF-8 is the default locale.
-		//      Investigate if this can cause problems.
+		  // XXX: This assumes that UTF-8 is the default locale.
+		  //      Investigate if this can cause problems.
         PyErr_SetString(PyExc_ValueError, dlerr);
         return NULL;
     }

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1654,9 +1654,7 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
     }
 	#endif
 	#undef USE_DLERROR
-    PyErr_Format(PyExc_OSError,
-                 "symbol '%s' not found",
-                 name);
+    PyErr_Format(PyExc_OSError, "symbol '%s' not found", name);
     return NULL;
 }
 #endif

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1631,7 +1631,7 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
 	 */
 	(void)dlerror();
     ptr = dlsym((void*)handle, name);
-	char *dlerr = dlerror();
+	const char *dlerr = dlerror();
     if (dlerr) {
         PyErr_SetString(PyExc_OSError, dlerr);
         return NULL;

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1638,7 +1638,7 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
     ptr = dlsym((void*)handle, name);
     if (ptr)
         return PyLong_FromVoidPtr(ptr);
-#ifdef USE_DLERROR
+	#ifdef USE_DLERROR
     const char *dlerr = dlerror();
     if (dlerr) {
         PyObject *message = PyUnicode_DecodeLocale(dlerr, "surrogateescape");
@@ -1646,9 +1646,12 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
             PyErr_SetObject(PyExc_OSError, message);
             return NULL;
         }
+        // Ignore errors from PyUnicode_DecodeLocale,
+        // fall back to the generic error below.
+        PyErr_Clear();
     }
-#endif
-#undef USE_DLERROR
+	#endif
+	#undef USE_DLERROR
     PyErr_Format(PyExc_OSError,
                  "symbol '%s' not found",
                  name);

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1640,13 +1640,11 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
 #ifdef USE_DLERROR
     const char *dlerr = dlerror();
     if (dlerr) {
-        PyObject *message = PyUnicode_DecodeLocale(dlerr, "strict");
+        PyObject *message = PyUnicode_DecodeLocale(dlerr, "surrogateescape");
         if (message) {
             PyErr_SetObject(PyExc_OSError, message);
             return NULL;
         }
-        // Ignore errors from converting the message to str
-        PyErr_Clear();
     }
 #endif
 #undef USE_DLERROR

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1633,8 +1633,8 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
     ptr = dlsym((void*)handle, name);
 	char *dlerr = dlerror();
     if (dlerr) {
-		// XXX: This assumes that UTF-8 is the default locale.
-		//      Investigate if this can cause problems.
+		  // XXX: This assumes that UTF-8 is the default locale.
+		  //      Investigate if this can cause problems.
         PyErr_SetString(PyExc_OSError, dlerr);
         return NULL;
     }

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1644,6 +1644,7 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
         PyObject *message = PyUnicode_DecodeLocale(dlerr, "surrogateescape");
         if (message) {
             PyErr_SetObject(PyExc_OSError, message);
+            Py_DECREF(message);
             return NULL;
         }
         // Ignore errors from PyUnicode_DecodeLocale,

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1638,8 +1638,6 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
     if (ptr)
         return PyLong_FromVoidPtr(ptr);
 #ifdef USE_DLERROR
-    // This assumes the error message is UTF-8 (or ASCII).
-    // Investigate if this can cause problems.
     const char *dlerr = dlerror();
     if (dlerr) {
         PyObject *message = PyUnicode_DecodeLocale(dlerr, "strict");

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1640,7 +1640,7 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
     }
     else if (!ptr) {
         PyErr_Format(PyExc_OSError,
-                     "[py_dl_sym]:symbol '%s' not found",
+                     "symbol '%s' not found",
                      name);
         return NULL;
     }

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1636,8 +1636,9 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
         (void)dlerror();
     #endif
     ptr = dlsym((void*)handle, name);
-    if (ptr)
+    if (ptr) {
         return PyLong_FromVoidPtr(ptr);
+    }
 	#ifdef USE_DLERROR
     const char *dlerr = dlerror();
     if (dlerr) {

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1633,8 +1633,6 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
     ptr = dlsym((void*)handle, name);
 	char *dlerr = dlerror();
     if (dlerr) {
-		  // XXX: This assumes that UTF-8 is the default locale.
-		  //      Investigate if this can cause problems.
         PyErr_SetString(PyExc_OSError, dlerr);
         return NULL;
     }

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1623,6 +1623,7 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
     if (PySys_Audit("ctypes.dlsym/handle", "O", args) < 0) {
         return NULL;
     }
+#undef USE_DLERROR
     #ifdef __CYGWIN__
         // dlerror() isn't very helpful on cygwin
     #else

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1633,12 +1633,14 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
     ptr = dlsym((void*)handle, name);
 	char *dlerr = dlerror();
     if (dlerr) {
+		// XXX: This assumes that UTF-8 is the default locale.
+		//      Investigate if this can cause problems.
         PyErr_SetString(PyExc_OSError, dlerr);
         return NULL;
     }
     else if (!ptr) {
         PyErr_Format(PyExc_OSError,
-                     "symbol '%s' not found",
+                     "[py_dl_sym]:symbol '%s' not found",
                      name);
         return NULL;
     }

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1629,7 +1629,7 @@ static PyObject *py_dl_sym(PyObject *self, PyObject *args)
 	 * Clear the previous value before calling dlsym(),
 	 * to ensure we can tell if our call resulted in an error.
 	 */
-	dlerror();
+	(void)dlerror();
     ptr = dlsym((void*)handle, name);
 	char *dlerr = dlerror();
     if (dlerr) {


### PR DESCRIPTION
For dlsym(), a return value of NULL does not necessarily indicate an error [1].

Therefore, to avoid using stale (or NULL) dlerror() values, we must:

 1. clear the previous error state by calling dlerror()
 2. call dlsym()
 3. call dlerror()

If the return value of dlerror() is not NULL, an error occured.

In our case of ctypes, I understand that we subjectively treat a NULL return value from dlsym() as an error, so we must format a special string for that.

[1] https://man7.org/linux/man-pages/man3/dlsym.3.html

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-126554 -->
* Issue: gh-126554
<!-- /gh-issue-number -->
