### PR TITLE
gh-89640: Restore configure error message on failure to detect float word order

### DIFF
--- a/configure
+++ b/configure
@@ -24219,8 +24219,15 @@ printf "%s\n" "#define DOUBLE_IS_ARM_MIXED_ENDIAN_IEEE754 1" >>confdefs.h
 printf "%s\n" "#define DOUBLE_IS_LITTLE_ENDIAN_IEEE754 1" >>confdefs.h
  ;; #(
   *) :
-     ;;
-esac ;;
+    as_fn_error $? "
+
+Unknown float word ordering. You need to manually preset
+ax_cv_c_float_words_bigendian=no (or yes) according to your system.
+
+           " "$LINENO" 5
+   ;;
+esac
+ ;;
 esac
 
 

--- a/configure
+++ b/configure
@@ -24219,15 +24219,8 @@ printf "%s\n" "#define DOUBLE_IS_ARM_MIXED_ENDIAN_IEEE754 1" >>confdefs.h
 printf "%s\n" "#define DOUBLE_IS_LITTLE_ENDIAN_IEEE754 1" >>confdefs.h
  ;; #(
   *) :
-    as_fn_error $? "
-
-Unknown float word ordering. You need to manually preset
-ax_cv_c_float_words_bigendian=no (or yes) according to your system.
-
-           " "$LINENO" 5
-   ;;
-esac
- ;;
+    as_fn_error $? "Unknown float word ordering. You need to manually preset ax_cv_c_float_words_bigendian=no (or yes) according to your system." "$LINENO" 5 ;;
+esac ;;
 esac
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -5921,14 +5921,11 @@ AX_C_FLOAT_WORDS_BIGENDIAN(
            [wasm*], [AC_DEFINE([DOUBLE_IS_LITTLE_ENDIAN_IEEE754], [1],
                                [Define if C doubles are 64-bit IEEE 754 binary format,
                                 stored with the least significant byte first])],
-           [AC_MSG_ERROR([
-
-Unknown float word ordering. You need to manually preset
-ax_cv_c_float_words_bigendian=no (or yes) according to your system.
-
-           ])]
-  )]
-)
+           [AC_MSG_ERROR([m4_normalize([
+             Unknown float word ordering. You need to manually
+             preset ax_cv_c_float_words_bigendian=no (or yes)
+             according to your system.
+           ])])])])
 
 # The short float repr introduced in Python 3.1 requires the
 # correctly-rounded string <-> double conversion functions from

--- a/configure.ac
+++ b/configure.ac
@@ -5920,7 +5920,15 @@ AX_C_FLOAT_WORDS_BIGENDIAN(
                                 stored in ARM mixed-endian order (byte order 45670123)])],
            [wasm*], [AC_DEFINE([DOUBLE_IS_LITTLE_ENDIAN_IEEE754], [1],
                                [Define if C doubles are 64-bit IEEE 754 binary format,
-                                stored with the least significant byte first])])])
+                                stored with the least significant byte first])],
+           [AC_MSG_ERROR([
+
+Unknown float word ordering. You need to manually preset
+ax_cv_c_float_words_bigendian=no (or yes) according to your system.
+
+           ])]
+  )]
+)
 
 # The short float repr introduced in Python 3.1 requires the
 # correctly-rounded string <-> double conversion functions from


### PR DESCRIPTION
Before #126387, if we didn't detect float word order we'd raise the following configure error:
```
Unknown float word ordering. You need to manually preset
ax_cv_c_float_words_bigendian=no (or yes) according to your system.
```
This puts it back (except for host_cpu arm or wasm).

cc @erlend-aasland

<!-- gh-issue-number: gh-89640 -->
* Issue: gh-89640
<!-- /gh-issue-number -->
