### PR TITLE
Doc: Recommend shlex.quote alongside pipes removal

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1568,6 +1568,8 @@ and are now removed:
   For audio playback, use the :pypi:`pygame` library from PyPI instead.
 * :mod:`!pipes`:
   Use the :mod:`subprocess` module instead.
+  Use :func:`shlex.quote` to replace the undocumented ``pipes.quote``
+  function.
 * :mod:`!sndhdr`:
   The :pypi:`filetype`, :pypi:`puremagic`, or :pypi:`python-magic` libraries
   should be used as replacements.


### PR DESCRIPTION
One of the most common reasons I see the old `pipes` module still in use when porting to Python 3.13 is for the undocumented `pipes.quote` function, which can easily be replaced with `shlex.quote`.  I think it's worth specifically calling this out, since being directed to the `subprocess` module would be confusing in this case.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126570.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->