### PR TITLE
gh-126543: Docs: change "bound type var" to "bounded" when used in the context of the 'bound' kw argument to TypeVar

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1726,10 +1726,10 @@ without the dedicated syntax, as documented below.
       class Sequence[T]:  # T is a TypeVar
           ...
 
-   This syntax can also be used to create bound and constrained type
+   This syntax can also be used to create bounded and constrained type
    variables::
 
-      class StrSequence[S: str]:  # S is a TypeVar bound to str
+      class StrSequence[S: str]:  # S is a TypeVar bounded by str
           ...
 
 
@@ -1763,8 +1763,8 @@ without the dedicated syntax, as documented below.
           """Add two strings or bytes objects together."""
           return x + y
 
-   Note that type variables can be *bound*, *constrained*, or neither, but
-   cannot be both bound *and* constrained.
+   Note that type variables can be *bounded*, *constrained*, or neither, but
+   cannot be both bounded *and* constrained.
 
    The variance of type variables is inferred by type checkers when they are created
    through the :ref:`type parameter syntax <type-params>` or when
@@ -1774,8 +1774,8 @@ without the dedicated syntax, as documented below.
    By default, manually created type variables are invariant.
    See :pep:`484` and :pep:`695` for more details.
 
-   Bound type variables and constrained type variables have different
-   semantics in several important ways. Using a *bound* type variable means
+   Bounded type variables and constrained type variables have different
+   semantics in several important ways. Using a *bounded* type variable means
    that the ``TypeVar`` will be solved using the most specific type possible::
 
       x = print_capitalized('a string')
@@ -1789,7 +1789,7 @@ without the dedicated syntax, as documented below.
 
       z = print_capitalized(45)  # error: int is not a subtype of str
 
-   Type variables can be bound to concrete types, abstract types (ABCs or
+   Type variables can be bounded by concrete types, abstract types (ABCs or
    protocols), and even unions of types::
 
       # Can be anything with an __abs__ method

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1729,7 +1729,7 @@ without the dedicated syntax, as documented below.
    This syntax can also be used to create bounded and constrained type
    variables::
 
-      class StrSequence[S: str]:  # S is a TypeVar bounded by str
+      class StrSequence[S: str]:  # S is a TypeVar with a `str` upper bound
           ...
 
 
@@ -1789,8 +1789,8 @@ without the dedicated syntax, as documented below.
 
       z = print_capitalized(45)  # error: int is not a subtype of str
 
-   Type variables can be bounded by concrete types, abstract types (ABCs or
-   protocols), and even unions of types::
+   The upper bound of a type variable can be a concrete type, abstract type
+   (ABC or Protocol), or even a union of types::
 
       # Can be anything with an __abs__ method
       def print_abs[T: SupportsAbs](arg: T) -> None:

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1729,8 +1729,8 @@ without the dedicated syntax, as documented below.
    This syntax can also be used to create bounded and constrained type
    variables::
 
-      class StrSequence[S: str]:  # S is a TypeVar with a `str` upper bound
-          ...
+      class StrSequence[S: str]:  # S is a TypeVar with a `str` upper bound;
+          ...                     # We can say that S is "bounded by `str`"
 
 
       class StrOrBytesSequence[A: (str, bytes)]:  # A is a TypeVar constrained to str or bytes

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1730,7 +1730,7 @@ without the dedicated syntax, as documented below.
    variables::
 
       class StrSequence[S: str]:  # S is a TypeVar with a `str` upper bound;
-          ...                     # We can say that S is "bounded by `str`"
+          ...                     # we can say that S is "bounded by `str`"
 
 
       class StrOrBytesSequence[A: (str, bytes)]:  # A is a TypeVar constrained to str or bytes

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -1834,7 +1834,7 @@ without the dedicated syntax, as documented below.
 
    .. attribute:: __bound__
 
-      The bound of the type variable, if any.
+      The upper bound of the type variable, if any.
 
       .. versionchanged:: 3.12
 
@@ -2100,7 +2100,7 @@ without the dedicated syntax, as documented below.
           return x + y
 
    Without ``ParamSpec``, the simplest way to annotate this previously was to
-   use a :class:`TypeVar` with bound ``Callable[..., Any]``.  However this
+   use a :class:`TypeVar` with upper bound ``Callable[..., Any]``.  However this
    causes two problems:
 
    1. The type checker can't type check the ``inner`` function because


### PR DESCRIPTION
I only changed instances of "bound" when they were being used as an adjective. I left other instances as they were:

1. Of course, instances of bound-as-in-binding were not touched.

2. The docs for the `TypeVar.__bound__` attribute use the word "bound" as a noun. I thought about changing it to "boundary" or "boundary type", but gave up because there is also a `TypeVar.evaluate_bound` method, so "bound" as a noun is kind of set in stone. One other possibility (which I believe would be a positive change) is to change "bound" to "upper bound" here, i.e.:

    ```diff
        .. attribute:: __bound__
     
    -      The bound of the type variable, if any.
    +      The upper bound of the type variable, if any.
     
           .. versionchanged:: 3.12
     
              For type variables created through :ref:`type parameter syntax <type-params>`,
              the bound is evaluated only when the attribute is accessed, not when
              the type variable is created (see :ref:`lazy-evaluation`).
    ```

    (I think the "bound" inside the versionchanged block is fine, I wouldn't touch it.)

3. The docs for `ParamSpec` also use "bound" as a noun, like this:
    > Without `ParamSpec`, the simplest way to annotate this previously was to use a `TypeVar` with bound `Callable[..., Any]`.

    I also though about changing it to "... a `TypeVar` bounded by ...", but I don't think it's necessary (though I also don't think it would be a negative change). If we end up changing "bound" to "upper bound" in the item above, then maybe the same should be done here. (But note that the expression "upper bound" does not currently appear in this document.)

<!-- gh-issue-number: gh-126543 -->
* Issue: gh-126543
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126584.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->