### PR TITLE
GH-120423: `pathname2url()`: handle forward slashes in Windows paths

### DIFF
--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -42,22 +42,23 @@ def pathname2url(p):
     # becomes
     #   ///C:/foo/bar/spam.foo
     import urllib.parse
+    p = p.replace('\\', '/')
     # First, clean up some special forms. We are going to sacrifice
     # the additional information anyway
-    if p[:4] == '\\\\?\\':
+    if p[:4] == '//?/':
         p = p[4:]
-        if p[:4].upper() == 'UNC\\':
-            p = '\\\\' + p[4:]
+        if p[:4].upper() == 'UNC/':
+            p = '//' + p[4:]
         elif p[1:2] != ':':
             raise OSError('Bad path: ' + p)
     if not ':' in p:
         # No drive specifier, just convert slashes and quote the name
-        return urllib.parse.quote(p.replace('\\', '/'))
+        return urllib.parse.quote(p)
     comp = p.split(':', maxsplit=2)
     if len(comp) != 2 or len(comp[0]) > 1:
         error = 'Bad path: ' + p
         raise OSError(error)
 
     drive = urllib.parse.quote(comp[0].upper())
-    tail = urllib.parse.quote(comp[1].replace('\\', '/'))
+    tail = urllib.parse.quote(comp[1])
     return '///' + drive + ':' + tail

--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -42,9 +42,9 @@ def pathname2url(p):
     # becomes
     #   ///C:/foo/bar/spam.foo
     import urllib.parse
-    p = p.replace('\\', '/')
     # First, clean up some special forms. We are going to sacrifice
     # the additional information anyway
+    p = p.replace('\\', '/')
     if p[:4] == '//?/':
         p = p[4:]
         if p[:4].upper() == 'UNC/':
@@ -52,7 +52,7 @@ def pathname2url(p):
         elif p[1:2] != ':':
             raise OSError('Bad path: ' + p)
     if not ':' in p:
-        # No drive specifier, just quote the name
+        # No DOS drive specified, just quote the pathname
         return urllib.parse.quote(p)
     comp = p.split(':', maxsplit=2)
     if len(comp) != 2 or len(comp[0]) > 1:

--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -52,7 +52,7 @@ def pathname2url(p):
         elif p[1:2] != ':':
             raise OSError('Bad path: ' + p)
     if not ':' in p:
-        # No drive specifier, just convert slashes and quote the name
+        # No drive specifier, just quote the name
         return urllib.parse.quote(p)
     comp = p.split(':', maxsplit=2)
     if len(comp) != 2 or len(comp[0]) > 1:

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1542,6 +1542,11 @@ class Pathname_Tests(unittest.TestCase):
         self.assertEqual(fn('\\\\some\\share\\'), '//some/share/')
         self.assertEqual(fn('\\\\some\\share\\a\\b.c'), '//some/share/a/b.c')
         self.assertEqual(fn('\\\\some\\share\\a\\b%#c\xe9'), '//some/share/a/b%25%23c%C3%A9')
+        # Alternate path separator
+        self.assertEqual(fn('C:/a/b.c'), '///C:/a/b.c')
+        self.assertEqual(fn('//some/share/a/b.c'), '//some/share/a/b.c')
+        self.assertEqual(fn('//?/C:/dir'), '///C:/dir')
+        self.assertEqual(fn('//?/unc/server/share/dir'), '//server/share/dir')
         # Round-tripping
         urls = ['///C:',
                 '///folder/test/',

--- a/Misc/NEWS.d/next/Library/2024-11-08-17-05-10.gh-issue-120423.7rdLVV.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-08-17-05-10.gh-issue-120423.7rdLVV.rst
@@ -1,0 +1,2 @@
+Fix issue where :func:`urllib.request.pathname2url` mishandled Windows paths
+with embedded forward slashes.


### PR DESCRIPTION
Adjust `urllib.request.pathname2url()` so that forward slashes in Windows paths are handled identically to backward slashes. This fixes an issue where `pathname2url()` would not properly recognise some UNC paths that use forward slashes


<!-- gh-issue-number: gh-120423 -->
* Issue: gh-120423
<!-- /gh-issue-number -->
