### PR TITLE
gh-76785: Minor Cleanup of Exception-related Cross-interpreter State

### DIFF
--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -11,6 +11,7 @@ extern "C" {
 #include "pycore_lock.h"            // PyMutex
 #include "pycore_pyerrors.h"
 
+
 /**************/
 /* exceptions */
 /**************/
@@ -163,8 +164,13 @@ struct _xi_state {
     // heap types
     _PyXIData_lookup_t data_lookup;
 
-    // heap types
-    PyObject *PyExc_NotShareableError;
+    struct xi_exceptions {
+        // static types
+        PyObject *PyExc_InterpreterError;
+        PyObject *PyExc_InterpreterNotFoundError;
+        // heap types
+        PyObject *PyExc_NotShareableError;
+    } exceptions;
 };
 
 extern PyStatus _PyXI_Init(PyInterpreterState *interp);

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -1502,7 +1502,7 @@ module_exec(PyObject *mod)
         goto error;
     }
     PyObject *PyExc_NotShareableError = \
-                _PyInterpreterState_GetXIState(interp)->PyExc_NotShareableError;
+                _PyInterpreterState_GetXIState(interp)->exceptions.PyExc_NotShareableError;
     if (PyModule_AddType(mod, (PyTypeObject *)PyExc_NotShareableError) < 0) {
         goto error;
     }


### PR DESCRIPTION
This change makes it easier to backport the _interpreters, _interpqueues, and _interpchannels modules to Python 3.12.

<!-- gh-issue-number: gh-76785 -->
* Issue: gh-76785
<!-- /gh-issue-number -->
