### PR TITLE
pathlib ABCs: support initializing paths with no arguments

### DIFF
--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -268,7 +268,7 @@ class PurePathBase:
                 raise ValueError(f"'..' segment in {str(other)!r} cannot be walked")
             else:
                 parts0.append('..')
-        return self.with_segments('', *reversed(parts0))
+        return self.with_segments(*reversed(parts0))
 
     def is_relative_to(self, other):
         """Return True if the path is relative to another path or False.
@@ -744,7 +744,7 @@ class PathBase(PurePathBase):
         # enable users to replace the implementation of 'absolute()' in a
         # subclass and benefit from the new behaviour here. This works because
         # os.path.abspath('.') == os.getcwd().
-        return cls('').absolute()
+        return cls().absolute()
 
     def expanduser(self):
         """ Return a new path with expanded ~ and ~user constructs

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -124,14 +124,12 @@ class PurePathBase:
     parser = ParserBase()
     _globber = PathGlobber
 
-    def __init__(self, arg, *args):
-        paths = [arg]
-        paths.extend(args)
-        for path in paths:
-            if not isinstance(path, str):
+    def __init__(self, *args):
+        for arg in args:
+            if not isinstance(arg, str):
                 raise TypeError(
-                    f"path should be a str, not {type(path).__name__!r}")
-        self._raw_paths = paths
+                    f"argument should be a str, not {type(arg).__name__!r}")
+        self._raw_paths = list(args)
         self._resolving = False
 
     def with_segments(self, *pathsegments):

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -148,6 +148,7 @@ class DummyPurePathTest(unittest.TestCase):
         P = self.cls
         p = P('a')
         self.assertIsInstance(p, P)
+        P()
         P('a', 'b', 'c')
         P('/a', 'b', 'c')
         P('a/b/c')


### PR DESCRIPTION
In the past I've equivocated about whether to require at least one argument in the `PurePathBase` (and `PathBase`) initializer, and what the default should be if we make it optional. I now have a local use case that has persuaded me to make it optional and default to the empty string (a `zipp.Path`-like class that treats relative and absolute paths similarly.) Happily this brings the base class more in line with `PurePath` and `Path`.

No user-facing changes because the pathlib ABCs are still private, and `PurePath` provides its own initializer.
