### PR TITLE
gh-126595: fix a crash when calling `itertools.count(sys.maxsize)`

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -494,6 +494,14 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(take(2, zip('abc',count(-3))), [('a', -3), ('b', -2)])
         self.assertRaises(TypeError, count, 2, 3, 4)
         self.assertRaises(TypeError, count, 'a')
+        self.assertEqual(take(3, count(maxsize)),
+                        [maxsize, maxsize + 1, maxsize + 2])
+        self.assertEqual(take(3, count(maxsize, 2)),
+                         [maxsize, maxsize + 2, maxsize + 4])
+        self.assertEqual(take(3, count(maxsize, maxsize)),
+                         [maxsize, 2 * maxsize, 3 * maxsize])
+        self.assertEqual(take(3, count(-maxsize, maxsize)),
+                        [-maxsize, 0, maxsize])
         self.assertEqual(take(10, count(maxsize-5)),
                          list(range(maxsize-5, maxsize+5)))
         self.assertEqual(take(10, count(-maxsize-5)),

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -496,12 +496,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertRaises(TypeError, count, 'a')
         self.assertEqual(take(3, count(maxsize)),
                         [maxsize, maxsize + 1, maxsize + 2])
-        self.assertEqual(take(3, count(maxsize, 2)),
-                         [maxsize, maxsize + 2, maxsize + 4])
-        self.assertEqual(take(3, count(maxsize, maxsize)),
-                         [maxsize, 2 * maxsize, 3 * maxsize])
-        self.assertEqual(take(3, count(-maxsize, maxsize)),
-                        [-maxsize, 0, maxsize])
         self.assertEqual(take(10, count(maxsize-5)),
                          list(range(maxsize-5, maxsize+5)))
         self.assertEqual(take(10, count(-maxsize-5)),
@@ -548,6 +542,12 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(take(20, count(-maxsize-15, 3)), take(20, range(-maxsize-15,-maxsize+100, 3)))
         self.assertEqual(take(3, count(10, maxsize+5)),
                          list(range(10, 10+3*(maxsize+5), maxsize+5)))
+        self.assertEqual(take(3, count(maxsize, 2)),
+                         [maxsize, maxsize + 2, maxsize + 4])
+        self.assertEqual(take(3, count(maxsize, maxsize)),
+                         [maxsize, 2 * maxsize, 3 * maxsize])
+        self.assertEqual(take(3, count(-maxsize, maxsize)),
+                        [-maxsize, 0, maxsize])
         self.assertEqual(take(3, count(2, 1.25)), [2, 3.25, 4.5])
         self.assertEqual(take(3, count(2, 3.25-4j)), [2, 5.25-4j, 8.5-8j])
         self.assertEqual(take(3, count(Decimal('1.1'), Decimal('.1'))),

--- a/Misc/NEWS.d/next/Library/2024-11-09-10-31-10.gh-issue-126595.A-7MyC.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-09-10-31-10.gh-issue-126595.A-7MyC.rst
@@ -1,0 +1,2 @@
+Fix a crash when instantiating :class:`itertools.count` with an initial
+count of :data:`sys.maxsize` on debug builds. Patch by Bénédikt Tran.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3287,7 +3287,10 @@ itertools_count_impl(PyTypeObject *type, PyObject *long_cnt,
         if (fast_mode) {
             assert(PyLong_Check(long_cnt));
             cnt = PyLong_AsSsize_t(long_cnt);
-            if (cnt == -1 && PyErr_Occurred()) {
+            if (cnt == PY_SSIZE_T_MAX) {
+                fast_mode = 0;
+            }
+            else if (cnt == -1 && PyErr_Occurred()) {
                 PyErr_Clear();
                 fast_mode = 0;
             }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3386,35 +3386,13 @@ count_nextlong(countobject *lz)
     return long_cnt;
 }
 
-static inline int
-count_switch_to_slow_mode(countobject *lz)
-{
-    assert(lz->cnt == PY_SSIZE_T_MAX);
-    assert(lz->long_cnt == NULL);
-    /* Switch to slow_mode */
-    PyObject *long_cnt = PyLong_FromSsize_t(PY_SSIZE_T_MAX);
-    if (long_cnt == NULL) {
-        return -1;
-    }
-    lz->long_cnt = long_cnt;
-    return 0;
-}
-
 static PyObject *
 count_next(countobject *lz)
 {
 #ifndef Py_GIL_DISABLED
     if (lz->cnt == PY_SSIZE_T_MAX)
         return count_nextlong(lz);
-    PyObject *res = PyLong_FromSsize_t(lz->cnt++);
-    if (lz->cnt == PY_SSIZE_T_MAX && lz->long_cnt == NULL) {
-        /* populate lz->long_cnt since it could be used by repr() */
-        if (count_switch_to_slow_mode(lz) < 0) {
-            Py_DECREF(res);
-            return NULL;
-        }
-    }
-    return res;
+    return PyLong_FromSsize_t(lz->cnt++);
 #else
     // free-threading version
     // fast mode uses compare-exchange loop
@@ -3431,19 +3409,7 @@ count_next(countobject *lz)
             return returned;
         }
         if (_Py_atomic_compare_exchange_ssize(&lz->cnt, &cnt, cnt + 1)) {
-            /* populate lz->long_cnt now since it could be used by repr() */
-            returned = PyLong_FromSsize_t(cnt);
-            if (lz->cnt == PY_SSIZE_T_MAX && lz->long_cnt == NULL) {
-                int rc;
-                Py_BEGIN_CRITICAL_SECTION(lz);
-                rc = count_switch_to_slow_mode(lz);
-                Py_END_CRITICAL_SECTION();
-                if (rc < 0) {
-                    Py_DECREF(returned);
-                    return NULL;
-                }
-            }
-            return returned;
+            return PyLong_FromSsize_t(cnt);
         }
     }
 #endif

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3287,11 +3287,11 @@ itertools_count_impl(PyTypeObject *type, PyObject *long_cnt,
         if (fast_mode) {
             assert(PyLong_Check(long_cnt));
             cnt = PyLong_AsSsize_t(long_cnt);
-            if (cnt == PY_SSIZE_T_MAX) {
+            if (cnt == -1 && PyErr_Occurred()) {
+                PyErr_Clear();
                 fast_mode = 0;
             }
-            else if (cnt == -1 && PyErr_Occurred()) {
-                PyErr_Clear();
+            else if (cnt == PY_SSIZE_T_MAX) {
                 fast_mode = 0;
             }
         }


### PR DESCRIPTION


<!-- gh-issue-number: gh-126595 -->
* Issue: gh-126595
<!-- /gh-issue-number -->
