### PR TITLE
Docs: re-create pages for removed modules to document their removal.

### DIFF
--- a/Doc/library/aifc.rst
+++ b/Doc/library/aifc.rst
@@ -1,0 +1,15 @@
+:mod:`!aifc` --- Read and write AIFF and AIFC files
+===================================================
+
+.. module:: aifc
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+The last version of Python that provided the :mod:`!aifc` module was
+`Python 3.12 <https://docs.python.org/3.12/library/aifc.html>`_.

--- a/Doc/library/asynchat.rst
+++ b/Doc/library/asynchat.rst
@@ -1,0 +1,17 @@
+:mod:`!asynchat` --- Asynchronous socket command/response handler
+=================================================================
+
+.. module:: asynchat
+   :synopsis: Removed in 3.12.
+   :deprecated:
+
+.. deprecated-removed:: 3.6 3.12
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.12 <whatsnew312-removed>` after
+being deprecated in Python 3.6.  The removal was decided in :pep:`594`.
+
+Applications should use the :mod:`asyncio` module instead.
+
+The last version of Python that provided the :mod:`!asynchat` module was
+`Python 3.11 <https://docs.python.org/3.11/library/asynchat.html>`_.

--- a/Doc/library/asyncore.rst
+++ b/Doc/library/asyncore.rst
@@ -1,0 +1,17 @@
+:mod:`!asyncore` --- Asynchronous socket handler
+================================================
+
+.. module:: asyncore
+   :synopsis: Removed in 3.12.
+   :deprecated:
+
+.. deprecated-removed:: 3.6 3.12
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.12 <whatsnew312-removed>` after
+being deprecated in Python 3.6.  The removal was decided in :pep:`594`.
+
+Applications should use the :mod:`asyncio` module instead.
+
+The last version of Python that provided the :mod:`!asyncore` module was
+`Python 3.11 <https://docs.python.org/3.11/library/asyncore.html>`_.

--- a/Doc/library/audioop.rst
+++ b/Doc/library/audioop.rst
@@ -1,0 +1,15 @@
+:mod:`!audioop` --- Manipulate raw audio data
+=============================================
+
+.. module:: audioop
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+The last version of Python that provided the :mod:`!audioop` module was
+`Python 3.12 <https://docs.python.org/3.12/library/audioop.html>`_.

--- a/Doc/library/cgi.rst
+++ b/Doc/library/cgi.rst
@@ -9,6 +9,8 @@ This module is no longer part of the Python standard library.
 It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
 being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
 
+.. deprecated-removed:: 3.11 3.13
+
 A fork of the module on PyPI can be used instead: :pypi:`legacy-cgi`.
 This is a copy of the cgi module, no longer maintained or supported by the core
 Python team.

--- a/Doc/library/cgi.rst
+++ b/Doc/library/cgi.rst
@@ -5,11 +5,11 @@
    :synopsis: Removed in 3.13.
    :deprecated:
 
+.. deprecated-removed:: 3.11 3.13
+
 This module is no longer part of the Python standard library.
 It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
 being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
-
-.. deprecated-removed:: 3.11 3.13
 
 A fork of the module on PyPI can be used instead: :pypi:`legacy-cgi`.
 This is a copy of the cgi module, no longer maintained or supported by the core

--- a/Doc/library/cgi.rst
+++ b/Doc/library/cgi.rst
@@ -1,0 +1,37 @@
+:mod:`!cgi` --- Common Gateway Interface support
+================================================
+
+.. module:: cgi
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+A fork of the module on PyPI can be used instead: :pypi:`legacy-cgi`.
+
+If you want to update your code using supported standard library modules:
+
+* ``cgi.FieldStorage`` can typically be replaced with
+  :func:`urllib.parse.parse_qsl` for ``GET`` and ``HEAD`` requests, and the
+  :mod:`email.message` module or :pypi:`multipart` PyPI project for ``POST``
+  and ``PUT``.
+
+* ``cgi.parse()`` can be replaced by calling :func:`urllib.parse.parse_qs`
+  directly on the desired query string, except for ``multipart/form-data``
+  input, which can be handled as described for ``cgi.parse_multipart()``.
+
+* ``cgi.parse_multipart()`` can be replaced with the functionality in the
+  :mod:`email` package (e.g. :class:`email.message.EmailMessage` and
+  :class:`email.message.Message`) which implements the same MIME RFCs, or
+  with the :pypi:`multipart` PyPI project.
+
+* ``cgi.parse_header()`` can be replaced with the functionality in the
+  :mod:`email` package, which implements the same MIME RFCs. For example,
+  with :class:`email.message.EmailMessage`::
+
+      from email.message import EmailMessage
+      msg = EmailMessage()
+      msg['content-type'] = 'application/json; charset="utf8"'
+      main, params = msg.get_content_type(), msg['content-type'].params

--- a/Doc/library/cgi.rst
+++ b/Doc/library/cgi.rst
@@ -10,28 +10,8 @@ It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
 being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
 
 A fork of the module on PyPI can be used instead: :pypi:`legacy-cgi`.
+This is a copy of the cgi module, no longer maintained or supported by the core
+Python team.
 
-If you want to update your code using supported standard library modules:
-
-* ``cgi.FieldStorage`` can typically be replaced with
-  :func:`urllib.parse.parse_qsl` for ``GET`` and ``HEAD`` requests, and the
-  :mod:`email.message` module or :pypi:`multipart` PyPI project for ``POST``
-  and ``PUT``.
-
-* ``cgi.parse()`` can be replaced by calling :func:`urllib.parse.parse_qs`
-  directly on the desired query string, except for ``multipart/form-data``
-  input, which can be handled as described for ``cgi.parse_multipart()``.
-
-* ``cgi.parse_multipart()`` can be replaced with the functionality in the
-  :mod:`email` package (e.g. :class:`email.message.EmailMessage` and
-  :class:`email.message.Message`) which implements the same MIME RFCs, or
-  with the :pypi:`multipart` PyPI project.
-
-* ``cgi.parse_header()`` can be replaced with the functionality in the
-  :mod:`email` package, which implements the same MIME RFCs. For example,
-  with :class:`email.message.EmailMessage`::
-
-      from email.message import EmailMessage
-      msg = EmailMessage()
-      msg['content-type'] = 'application/json; charset="utf8"'
-      main, params = msg.get_content_type(), msg['content-type'].params
+The last version of Python that provided the :mod:`!cgi` module was
+`Python 3.12 <https://docs.python.org/3.12/library/cgi.html>`_.

--- a/Doc/library/cgitb.rst
+++ b/Doc/library/cgitb.rst
@@ -9,4 +9,9 @@ This module is no longer part of the Python standard library.
 It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
 being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
 
-A fork of the module on PyPI can be used instead: :pypi:`legacy-cgi`.
+A fork of the module on PyPI can now be used instead: :pypi:`legacy-cgi`.
+This is a copy of the cgi module, no longer maintained or supported by the core
+Python team.
+
+The last version of Python that provided the :mod:`!cgitb` module was
+`Python 3.12 <https://docs.python.org/3.12/library/cgitb.html>`_.

--- a/Doc/library/cgitb.rst
+++ b/Doc/library/cgitb.rst
@@ -1,0 +1,12 @@
+:mod:`!cgitb` --- Traceback manager for CGI scripts
+===================================================
+
+.. module:: cgitb
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+A fork of the module on PyPI can be used instead: :pypi:`legacy-cgi`.

--- a/Doc/library/cgitb.rst
+++ b/Doc/library/cgitb.rst
@@ -9,6 +9,8 @@ This module is no longer part of the Python standard library.
 It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
 being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
 
+.. deprecated-removed:: 3.11 3.13
+
 A fork of the module on PyPI can now be used instead: :pypi:`legacy-cgi`.
 This is a copy of the cgi module, no longer maintained or supported by the core
 Python team.

--- a/Doc/library/cgitb.rst
+++ b/Doc/library/cgitb.rst
@@ -5,11 +5,11 @@
    :synopsis: Removed in 3.13.
    :deprecated:
 
+.. deprecated-removed:: 3.11 3.13
+
 This module is no longer part of the Python standard library.
 It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
 being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
-
-.. deprecated-removed:: 3.11 3.13
 
 A fork of the module on PyPI can now be used instead: :pypi:`legacy-cgi`.
 This is a copy of the cgi module, no longer maintained or supported by the core

--- a/Doc/library/chunk.rst
+++ b/Doc/library/chunk.rst
@@ -1,0 +1,15 @@
+:mod:`!chunk` --- Read IFF chunked data
+=======================================
+
+.. module:: chunk
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+The last version of Python that provided the :mod:`!chunk` module was
+`Python 3.12 <https://docs.python.org/3.12/library/chunk.html>`_.

--- a/Doc/library/crypt.rst
+++ b/Doc/library/crypt.rst
@@ -1,0 +1,20 @@
+:mod:`!crypt` --- Function to check Unix passwords
+==================================================
+
+.. module:: crypt
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+Applications can use the :mod:`hashlib` module from the standard library.
+Other possible replacements are third-party libraries from PyPI:
+:pypi:`legacycrypt`, :pypi:`bcrypt`, :pypi:`argon2-cffi`, or :pypi:`passlib`.
+These are not supported or maintained by the Python core team.
+
+The last version of Python that provided the :mod:`!crypt` module was
+`Python 3.12 <https://docs.python.org/3.12/library/crypt.html>`_.

--- a/Doc/library/distutils.rst
+++ b/Doc/library/distutils.rst
@@ -1,0 +1,17 @@
+:mod:`!distutils` --- Building and installing Python modules
+============================================================
+
+.. module:: distutils
+   :synopsis: Removed in 3.12.
+   :deprecated:
+
+.. deprecated-removed:: 3.10 3.12
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.12 <whatsnew312-removed>` after
+being deprecated in Python 3.10.  The removal was decided in :pep:`632`,
+which has `migration advice
+<https://peps.python.org/pep-0632/#migration-advice>`_.
+
+The last version of Python that provided the :mod:`!distutils` module was
+`Python 3.11 <https://docs.python.org/3.11/library/distutils.html>`_.

--- a/Doc/library/distutils.rst
+++ b/Doc/library/distutils.rst
@@ -8,7 +8,7 @@
 .. deprecated-removed:: 3.10 3.12
 
 This module is no longer part of the Python standard library.
-It was :ref:`removed in Python 3.12 <whatsnew312-removed>` after
+It was :ref:`removed in Python 3.12 <whatsnew312-removed-distutils>` after
 being deprecated in Python 3.10.  The removal was decided in :pep:`632`,
 which has `migration advice
 <https://peps.python.org/pep-0632/#migration-advice>`_.

--- a/Doc/library/imghdr.rst
+++ b/Doc/library/imghdr.rst
@@ -1,0 +1,19 @@
+:mod:`!imghdr` --- Determine the type of an image
+=================================================
+
+.. module:: imghdr
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+Possible replacements are third-party libraries from PyPI:
+:pypi:`filetype`, :pypi:`puremagic`, or :pypi:`python-magic`.
+These are not supported or maintained by the Python core team.
+
+The last version of Python that provided the :mod:`!imghdr` module was
+`Python 3.12 <https://docs.python.org/3.12/library/imghdr.html>`_.

--- a/Doc/library/imp.rst
+++ b/Doc/library/imp.rst
@@ -1,0 +1,15 @@
+:mod:`!imp` --- Access the import internals
+===========================================
+
+.. module:: imp
+   :synopsis: Removed in 3.12.
+   :deprecated:
+
+.. deprecated-removed:: 3.4 3.12
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.12 <whatsnew312-removed>` after
+being deprecated in Python 3.4.
+
+The last version of Python that provided the :mod:`!imp` module was
+`Python 3.11 <https://docs.python.org/3.11/library/imp.html>`_.

--- a/Doc/library/imp.rst
+++ b/Doc/library/imp.rst
@@ -8,8 +8,11 @@
 .. deprecated-removed:: 3.4 3.12
 
 This module is no longer part of the Python standard library.
-It was :ref:`removed in Python 3.12 <whatsnew312-removed>` after
+It was :ref:`removed in Python 3.12 <whatsnew312-removed-imp>` after
 being deprecated in Python 3.4.
+
+The :ref:`removal notice <whatsnew312-removed-imp>` includes guidance for
+migrating code from :mod:`!imp` to :mod:`importlib`.
 
 The last version of Python that provided the :mod:`!imp` module was
 `Python 3.11 <https://docs.python.org/3.11/library/imp.html>`_.

--- a/Doc/library/index.rst
+++ b/Doc/library/index.rst
@@ -75,4 +75,5 @@ the `Python Package Index <https://pypi.org>`_.
    unix.rst
    cmdline.rst
    superseded.rst
+   removed.rst
    security_warnings.rst

--- a/Doc/library/mailcap.rst
+++ b/Doc/library/mailcap.rst
@@ -1,0 +1,15 @@
+:mod:`!mailcap` --- Mailcap file handling
+=========================================
+
+.. module:: mailcap
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+The last version of Python that provided the :mod:`!mailcap` module was
+`Python 3.12 <https://docs.python.org/3.12/library/mailcap.html>`_.

--- a/Doc/library/msilib.rst
+++ b/Doc/library/msilib.rst
@@ -1,0 +1,15 @@
+:mod:`!msilib` --- Read and write Microsoft Installer files
+===========================================================
+
+.. module:: msilib
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+The last version of Python that provided the :mod:`!msilib` module was
+`Python 3.12 <https://docs.python.org/3.12/library/msilib.html>`_.

--- a/Doc/library/nis.rst
+++ b/Doc/library/nis.rst
@@ -1,0 +1,15 @@
+:mod:`!nis` --- Interface to Sun’s NIS (Yellow Pages)
+=====================================================
+
+.. module:: nis
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+The last version of Python that provided the :mod:`!nis` module was
+`Python 3.12 <https://docs.python.org/3.12/library/nis.html>`_.

--- a/Doc/library/nntplib.rst
+++ b/Doc/library/nntplib.rst
@@ -1,0 +1,15 @@
+:mod:`!nntplib` --- NNTP protocol client
+========================================
+
+.. module:: nntplib
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+The last version of Python that provided the :mod:`!nntplib` module was
+`Python 3.12 <https://docs.python.org/3.12/library/nntplib.html>`_.

--- a/Doc/library/ossaudiodev.rst
+++ b/Doc/library/ossaudiodev.rst
@@ -1,0 +1,15 @@
+:mod:`!ossaudiodev` --- Access to OSS-compatible audio devices
+==============================================================
+
+.. module:: ossaudiodev
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+The last version of Python that provided the :mod:`!ossaudiodev` module was
+`Python 3.12 <https://docs.python.org/3.12/library/ossaudiodev.html>`_.

--- a/Doc/library/pipes.rst
+++ b/Doc/library/pipes.rst
@@ -1,0 +1,17 @@
+:mod:`!pipes` --- Interface to shell pipelines
+==============================================
+
+.. module:: pipes
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+Applications should use the :mod:`subprocess` module instead.
+
+The last version of Python that provided the :mod:`!pipes` module was
+`Python 3.12 <https://docs.python.org/3.12/library/pipes.html>`_.

--- a/Doc/library/removed.rst
+++ b/Doc/library/removed.rst
@@ -13,5 +13,25 @@ standard library.  They are documented here to help people find replacements.
 .. toctree::
    :maxdepth: 1
 
+   aifc.rst
+   asynchat.rst
+   asyncore.rst
+   audioop.rst
    cgi.rst
    cgitb.rst
+   chunk.rst
+   crypt.rst
+   imghdr.rst
+   mailcap.rst
+   msilib.rst
+   nis.rst
+   nntplib.rst
+   ossaudiodev.rst
+   pipes.rst
+   smtpd.rst
+   sndhdr.rst
+   spwd.rst
+   sunau.rst
+   telnetlib.rst
+   uu.rst
+   xdrlib.rst

--- a/Doc/library/removed.rst
+++ b/Doc/library/removed.rst
@@ -21,7 +21,9 @@ standard library.  They are documented here to help people find replacements.
    cgitb.rst
    chunk.rst
    crypt.rst
+   distutils.rst
    imghdr.rst
+   imp.rst
    mailcap.rst
    msilib.rst
    nis.rst

--- a/Doc/library/removed.rst
+++ b/Doc/library/removed.rst
@@ -1,0 +1,17 @@
+:tocdepth: 1
+
+.. _removed:
+
+***************
+Removed Modules
+***************
+
+The modules described in this chapter have been removed from the Python
+standard library.  They are documented here to help people find replacements.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   cgi.rst
+   cgitb.rst

--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -1,0 +1,18 @@
+:mod:`!smtpd` --- SMTP Server
+=============================
+
+.. module:: smtpd
+   :synopsis: Removed in 3.12.
+   :deprecated:
+
+.. deprecated-removed:: 3.6 3.12
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.12 <whatsnew312-removed>` after
+being deprecated in Python 3.6.  The removal was decided in :pep:`594`.
+
+A possible replacement is the third-party :pypi:`aiosmtpd` library. This
+library is not maintained or supported by the Python core team.
+
+The last version of Python that provided the :mod:`!smtpd` module was
+`Python 3.11 <https://docs.python.org/3.11/library/smtpd.html>`_.

--- a/Doc/library/sndhdr.rst
+++ b/Doc/library/sndhdr.rst
@@ -1,0 +1,19 @@
+:mod:`!sndhdr` --- Determine type of sound file
+===============================================
+
+.. module:: sndhdr
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+Possible replacements are third-party modules from PyPI:
+:pypi:`filetype`, :pypi:`puremagic`, or :pypi:`python-magic`.
+These are not supported or maintained by the Python core team.
+
+The last version of Python that provided the :mod:`!sndhdr` module was
+`Python 3.12 <https://docs.python.org/3.12/library/sndhdr.html>`_.

--- a/Doc/library/spwd.rst
+++ b/Doc/library/spwd.rst
@@ -1,0 +1,18 @@
+:mod:`!spwd` --- The shadow password database
+=============================================
+
+.. module:: spwd
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+A possible replacement is the third-party library :pypi:`python-pam`.
+This library is not supported or maintained by the Python core team.
+
+The last version of Python that provided the :mod:`!spwd` module was
+`Python 3.12 <https://docs.python.org/3.12/library/spwd.html>`_.

--- a/Doc/library/sunau.rst
+++ b/Doc/library/sunau.rst
@@ -1,0 +1,15 @@
+:mod:`!sunau` --- Read and write Sun AU files
+=============================================
+
+.. module:: sunau
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+The last version of Python that provided the :mod:`!sunau` module was
+`Python 3.12 <https://docs.python.org/3.12/library/sunau.html>`_.

--- a/Doc/library/telnetlib.rst
+++ b/Doc/library/telnetlib.rst
@@ -1,0 +1,19 @@
+:mod:`!telnetlib` --- Telnet client
+===================================
+
+.. module:: telnetlib
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+Possible replacements are third-party libraries from PyPI: :pypi:`telnetlib3`
+or :pypi:`Exscript`.  These are not supported or maintained by the Python core
+team.
+
+The last version of Python that provided the :mod:`!telnetlib` module was
+`Python 3.12 <https://docs.python.org/3.12/library/telnetlib.html>`_.

--- a/Doc/library/uu.rst
+++ b/Doc/library/uu.rst
@@ -1,0 +1,15 @@
+:mod:`!uu` --- Encode and decode uuencode files
+===============================================
+
+.. module:: uu
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+The last version of Python that provided the :mod:`!uu` module was
+`Python 3.12 <https://docs.python.org/3.12/library/uu.html>`_.

--- a/Doc/library/xdrlib.rst
+++ b/Doc/library/xdrlib.rst
@@ -1,0 +1,15 @@
+:mod:`!xdrlib` --- Encode and decode XDR data
+=============================================
+
+.. module:: xdrlib
+   :synopsis: Removed in 3.13.
+   :deprecated:
+
+.. deprecated-removed:: 3.11 3.13
+
+This module is no longer part of the Python standard library.
+It was :ref:`removed in Python 3.13 <whatsnew313-pep594>` after
+being deprecated in Python 3.11.  The removal was decided in :pep:`594`.
+
+The last version of Python that provided the :mod:`!xdrlib` module was
+`Python 3.12 <https://docs.python.org/3.12/library/xdrlib.html>`_.

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1341,6 +1341,8 @@ Deprecated
 
 .. include:: ../deprecations/pending-removal-in-future.rst
 
+.. _whatsnew312-removed:
+
 Removed
 =======
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -1368,6 +1368,8 @@ configparser
   * :class:`configparser.ConfigParser` no longer has a ``readfp`` method.
     Use :meth:`~configparser.ConfigParser.read_file` instead.
 
+.. _whatsnew312-removed-distutils:
+
 distutils
 ---------
 
@@ -1448,6 +1450,8 @@ importlib
 
   * ``importlib.abc.Finder``, ``pkgutil.ImpImporter``, and ``pkgutil.ImpLoader``
     have been removed.  (Contributed by Barry Warsaw in :gh:`98040`.)
+
+.. _whatsnew312-removed-imp:
 
 imp
 ---

--- a/Misc/NEWS.d/next/Documentation/2024-11-09-19-43-10.gh-issue-126622.YacfDc.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-11-09-19-43-10.gh-issue-126622.YacfDc.rst
@@ -1,0 +1,3 @@
+Added stub pages for removed modules explaining their removal, where to find
+replacements, and linking to the last Python version that supported them.
+Contributed by Ned Batchelder.

--- a/Misc/NEWS.d/next/Documentation/2024-11-09-19-43-10.gh-issue-none.YacfDc.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-11-09-19-43-10.gh-issue-none.YacfDc.rst
@@ -1,0 +1,1 @@
+Added stub pages for removed modules explaining their removal, where to find replacements, and linking to the last Python version that supported them.

--- a/Misc/NEWS.d/next/Documentation/2024-11-09-19-43-10.gh-issue-none.YacfDc.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-11-09-19-43-10.gh-issue-none.YacfDc.rst
@@ -1,1 +1,0 @@
-Added stub pages for removed modules explaining their removal, where to find replacements, and linking to the last Python version that supported them.


### PR DESCRIPTION
~This shows just two modules as an example.  Will flesh it out with the rest of PEP 594 if people like the approach.~
This adds a "Removed modules" page that lists modules which have been removed. Each module gets a page (with the original URL) that explains why the module is gone.

Will also need to change the redirects that were created here: https://github.com/python/psf-salt/pull/521/files

Things to notice:
- A new "Removed modules" section, but it doesn't list all the modules in the main table of contents.
- Links are provided to PyPI alternatives
- ~Where existing suggested replacements text was available, I've put it on the removed module page.~
- The modules are still listed in the index, but as: "**Deprecated:** Removed in Python 3.13"
- When the modules were first removed, existing mentions in What's New pages were changed to not try to link to the missing pages.  I haven't restored those links, and am torn about whether it is worthwhile.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126622.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->