### PR TITLE
gh-126629 Allow the use of strings as loading or saving paths for JSON

### DIFF
--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -182,6 +182,9 @@ def dump(obj, fp, *, skipkeys=False, ensure_ascii=True, check_circular=True,
     # a debuggability cost
     for chunk in iterable:
         fp.write(chunk)
+        
+    if type(fp) == str:
+        fp.close()
 
 
 def dumps(obj, *, skipkeys=False, ensure_ascii=True, check_circular=True,
@@ -297,10 +300,15 @@ def load(fp, *, cls=None, object_hook=None, parse_float=None,
     if type(fp) == str:
         fp = open(fp)
     
-    return loads(fp.read(),
+    data = loads(fp.read(),
         cls=cls, object_hook=object_hook,
         parse_float=parse_float, parse_int=parse_int,
         parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
+    
+    if type(fp) == str:
+        fp.close()
+        
+    return data
 
 
 def loads(s, *, cls=None, object_hook=None, parse_float=None,

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -121,7 +121,7 @@ def dump(obj, fp, *, skipkeys=False, ensure_ascii=True, check_circular=True,
         allow_nan=True, cls=None, indent=None, separators=None,
         default=None, sort_keys=False, **kw):
     """Serialize ``obj`` as a JSON formatted stream to ``fp`` (a
-    ``.write()``-supporting file-like object).
+    ``.write()``-supporting file-like object or file path).
 
     If ``skipkeys`` is true then ``dict`` keys that are not basic types
     (``str``, ``int``, ``float``, ``bool``, ``None``) will be skipped
@@ -174,6 +174,10 @@ def dump(obj, fp, *, skipkeys=False, ensure_ascii=True, check_circular=True,
             check_circular=check_circular, allow_nan=allow_nan, indent=indent,
             separators=separators,
             default=default, sort_keys=sort_keys, **kw).iterencode(obj)
+        
+    if type(fp) == str:
+        fp = open(fp, "w")
+        
     # could accelerate with writelines in some versions of Python, at
     # a debuggability cost
     for chunk in iterable:
@@ -273,7 +277,7 @@ def detect_encoding(b):
 
 def load(fp, *, cls=None, object_hook=None, parse_float=None,
         parse_int=None, parse_constant=None, object_pairs_hook=None, **kw):
-    """Deserialize ``fp`` (a ``.read()``-supporting file-like object containing
+    """Deserialize ``fp`` (a ``.read()``-supporting file-like object or fiel path containing
     a JSON document) to a Python object.
 
     ``object_hook`` is an optional function that will be called with the
@@ -290,6 +294,9 @@ def load(fp, *, cls=None, object_hook=None, parse_float=None,
     To use a custom ``JSONDecoder`` subclass, specify it with the ``cls``
     kwarg; otherwise ``JSONDecoder`` is used.
     """
+    if type(fp) == str:
+        fp = open(fp)
+    
     return loads(fp.read(),
         cls=cls, object_hook=object_hook,
         parse_float=parse_float, parse_int=parse_int,

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -51,6 +51,7 @@ knownfiles = [
     "/etc/httpd/conf/mime.types",               # Apache
     "/etc/apache/mime.types",                   # Apache 1
     "/etc/apache2/mime.types",                  # Apache 2
+    "/etc/nginx/mime.types",                    # Nginx
     "/usr/local/etc/httpd/conf/mime.types",
     "/usr/local/lib/netscape/mime.types",
     "/usr/local/etc/httpd/conf/mime.types",     # Apache 1.2
@@ -442,6 +443,8 @@ def _default_mime_types():
         '.bz2': 'bzip2',
         '.xz': 'xz',
         '.br': 'br',
+        '.7z': 'lzma',
+        '.zst': 'zstd'
         }
 
     # Before adding new types, make sure they are either registered with IANA,

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -51,7 +51,6 @@ knownfiles = [
     "/etc/httpd/conf/mime.types",               # Apache
     "/etc/apache/mime.types",                   # Apache 1
     "/etc/apache2/mime.types",                  # Apache 2
-    "/etc/nginx/mime.types",                    # Nginx
     "/usr/local/etc/httpd/conf/mime.types",
     "/usr/local/lib/netscape/mime.types",
     "/usr/local/etc/httpd/conf/mime.types",     # Apache 1.2
@@ -442,9 +441,7 @@ def _default_mime_types():
         '.Z': 'compress',
         '.bz2': 'bzip2',
         '.xz': 'xz',
-        '.br': 'br',
-        '.7z': 'lzma',
-        '.zst': 'zstd'
+        '.br': 'br'
         }
 
     # Before adding new types, make sure they are either registered with IANA,


### PR DESCRIPTION
Allow the use of strings as loading or saving paths for JSON. 

It maintains the original API, but allows strings to be passed in when passing in file descriptors.This makes it easy to load or save JSON files.

Just like this:
```python
import json

data = {
    "a":"b"
}
json.dump(data, "a.json")  # before: json.dump(data, open("a.json","w"))
```

<!-- gh-issue-number: gh-126629 -->
* Issue: gh-126629
<!-- /gh-issue-number -->
