### PR TITLE
[3.13] Postpone `module.__loader__` deprecation to Python 3.16 (GH-126482)

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.14.rst
+++ b/Doc/deprecations/pending-removal-in-3.14.rst
@@ -1,13 +1,6 @@
 Pending Removal in Python 3.14
 ------------------------------
 
-* The import system:
-
-  * Setting :attr:`~module.__loader__` on a module while
-    failing to set :attr:`__spec__.loader <importlib.machinery.ModuleSpec.loader>`
-    is deprecated. In Python 3.14, :attr:`!__loader__` will cease to be set or
-    taken into consideration by the import system or the standard library.
-
 * :mod:`argparse`: The *type*, *choices*, and *metavar* parameters
   of :class:`!argparse.BooleanOptionalAction` are deprecated
   and will be removed in 3.14.

--- a/Doc/deprecations/pending-removal-in-3.16.rst
+++ b/Doc/deprecations/pending-removal-in-3.16.rst
@@ -1,5 +1,27 @@
-Pending Removal in Python 3.16
+Pending removal in Python 3.16
 ------------------------------
+
+* The import system:
+
+  * Setting :attr:`~module.__loader__` on a module while
+    failing to set :attr:`__spec__.loader <importlib.machinery.ModuleSpec.loader>`
+    is deprecated. In Python 3.16, :attr:`!__loader__` will cease to be set or
+    taken into consideration by the import system or the standard library.
+
+* :mod:`array`:
+
+  * The ``'u'`` format code (:c:type:`wchar_t`)
+    has been deprecated in documentation since Python 3.3
+    and at runtime since Python 3.13.
+    Use the ``'w'`` format code (:c:type:`Py_UCS4`)
+    for Unicode characters instead.
+
+* :mod:`asyncio`:
+
+  * :func:`!asyncio.iscoroutinefunction` is deprecated
+    and will be removed in Python 3.16,
+    use :func:`inspect.iscoroutinefunction` instead.
+    (Contributed by Jiahao Li and Kumar Aditya in :gh:`122875`.)
 
 * :mod:`builtins`:
 
@@ -9,14 +31,6 @@ Pending Removal in Python 3.16
     Use ``not x`` instead for the logical negation of a Boolean.
     In the rare case that you need the bitwise inversion of
     the underlying integer, convert to ``int`` explicitly (``~int(x)``).
-
-* :mod:`array`:
-
-  * The ``'u'`` format code (:c:type:`wchar_t`)
-    has been deprecated in documentation since Python 3.3
-    and at runtime since Python 3.13.
-    Use the ``'w'`` format code (:c:type:`Py_UCS4`)
-    for Unicode characters instead.
 
 * :mod:`shutil`:
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1013,9 +1013,9 @@ this approach.
       using the :class:`types.ModuleType` constructor.
       Previously the attribute was optional.
 
-   .. deprecated-removed:: 3.12 3.14
+   .. deprecated-removed:: 3.12 3.16
       Setting :attr:`!__loader__` on a module while failing to set
-      :attr:`!__spec__.loader` is deprecated. In Python 3.14,
+      :attr:`!__spec__.loader` is deprecated. In Python 3.16,
       :attr:`!__loader__` will cease to be set or taken into consideration by
       the import system or the standard library.
 


### PR DESCRIPTION
(cherry picked from commit 450db61a78989c5a1f1106be01e071798c783cf9)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126638.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->