### PR TITLE
Skip test in test_socket.py if there is no sys.getrefcount, like on pypy

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5334,6 +5334,8 @@ class UnbufferedFileObjectClassTestCase(FileObjectClassTestCase):
         self.write_file.write(self.write_msg)
         self.write_file.flush()
 
+    @unittest.skipUnless(hasattr(sys, 'getrefcount'),
+                         'test needs sys.getrefcount()')
     def testMakefileCloseSocketDestroy(self):
         refcount_before = sys.getrefcount(self.cli_conn)
         self.read_file.close()


### PR DESCRIPTION
this is already done for `testRefCountGetNameInfo` in the same file. on pypy and other non-cpython implementations there is no `getrefcount`.