### PR TITLE
gh-104745: Limit starting a patcher more than once without stopping it

### DIFF
--- a/Lib/test/test_unittest/testmock/testpatch.py
+++ b/Lib/test/test_unittest/testmock/testpatch.py
@@ -774,6 +774,25 @@ class PatchTest(unittest.TestCase):
         patcher.stop()
 
 
+    def test_property_setters(self):
+        mock_object = Mock()
+        mock_bar = mock_object.bar
+        patcher = patch.object(mock_object, 'bar', 'x')
+        with patcher:
+            self.assertEqual(patcher.is_local, False)
+            self.assertIs(patcher.target, mock_object)
+            self.assertEqual(patcher.temp_original, mock_bar)
+            patcher.is_local = True
+            patcher.target = mock_bar
+            patcher.temp_original = mock_object
+            self.assertEqual(patcher.is_local, True)
+            self.assertIs(patcher.target, mock_bar)
+            self.assertEqual(patcher.temp_original, mock_object)
+        # if changes are left intact, they may lead to disruption as shown below (it might be what someone needs though)
+        self.assertEqual(mock_bar.bar, mock_object)
+        self.assertEqual(mock_object.bar, 'x')
+
+
     def test_patchobject_start_stop(self):
         original = something
         patcher = patch.object(PTModule, 'something', 'foo')

--- a/Lib/test/test_unittest/testmock/testpatch.py
+++ b/Lib/test/test_unittest/testmock/testpatch.py
@@ -745,6 +745,35 @@ class PatchTest(unittest.TestCase):
         self.assertIsNone(patcher.stop())
 
 
+    def test_exit_idempotent(self):
+        patcher = patch(foo_name, 'bar', 3)
+        with patcher:
+            patcher.stop()
+
+
+    def test_second_start_failure(self):
+        patcher = patch(foo_name, 'bar', 3)
+        patcher.start()
+        try:
+            self.assertRaises(RuntimeError, patcher.start)
+        finally:
+            patcher.stop()
+
+
+    def test_second_enter_failure(self):
+        patcher = patch(foo_name, 'bar', 3)
+        with patcher:
+            self.assertRaises(RuntimeError, patcher.start)
+
+
+    def test_second_start_after_stop(self):
+        patcher = patch(foo_name, 'bar', 3)
+        patcher.start()
+        patcher.stop()
+        patcher.start()
+        patcher.stop()
+
+
     def test_patchobject_start_stop(self):
         original = something
         patcher = patch.object(PTModule, 'something', 'foo')
@@ -1098,7 +1127,7 @@ class PatchTest(unittest.TestCase):
 
         self.assertIsNot(m1, m2)
         for mock in m1, m2:
-            self.assertNotCallable(m1)
+            self.assertNotCallable(mock)
 
 
     def test_new_callable_patch_object(self):
@@ -1111,7 +1140,7 @@ class PatchTest(unittest.TestCase):
 
         self.assertIsNot(m1, m2)
         for mock in m1, m2:
-            self.assertNotCallable(m1)
+            self.assertNotCallable(mock)
 
 
     def test_new_callable_keyword_arguments(self):

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1482,17 +1482,33 @@ class _patch(object):
     def is_local(self):
         return self._context.is_local
 
+    @is_local.setter
+    def is_local(self, value):
+        self._context.is_local = value
+
     @property
     def original(self):
         return self._context.original
+
+    @original.setter
+    def original(self, value):
+        self._context.original = value
 
     @property
     def target(self):
         return self._context.target
 
+    @target.setter
+    def target(self, value):
+        self._context.target = value
+
     @property
     def temp_original(self):  # backwards compatibility
         return self.original
+
+    @temp_original.setter
+    def temp_original(self, value):  # backwards compatibility
+        self.original = value
 
     def __enter__(self):
         """Perform the patch."""

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1470,6 +1470,7 @@ class _patch(object):
             )
         return original, local
 
+
     def __enter__(self):
         """Perform the patch."""
         if self.is_started:
@@ -1494,7 +1495,7 @@ class _patch(object):
             spec_set not in (True, None)):
             raise TypeError("Can't provide explicit spec_set *and* spec or autospec")
 
-        original, is_local = self.get_original()
+        original, local = self.get_original()
 
         if new is DEFAULT and autospec is None:
             inherit = False
@@ -1604,7 +1605,7 @@ class _patch(object):
         new_attr = new
 
         self.temp_original = original
-        self.is_local = is_local
+        self.is_local = local
         self._exit_stack = contextlib.ExitStack()
         self.is_started = True
         try:
@@ -1640,12 +1641,12 @@ class _patch(object):
                 # needed for proxy objects like django settings
                 setattr(self.target, self.attribute, self.temp_original)
 
-        self.is_started = False
+        del self.temp_original
+        del self.is_local
+        del self.target
         exit_stack = self._exit_stack
         del self._exit_stack
-        del self.is_local
-        del self.temp_original
-        del self.target
+        self.is_started = False
         return exit_stack.__exit__(*exc_info)
 
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1487,14 +1487,6 @@ class _patch(object):
         self._context.is_local = value
 
     @property
-    def original(self):
-        return self._context.original
-
-    @original.setter
-    def original(self, value):
-        self._context.original = value
-
-    @property
     def target(self):
         return self._context.target
 
@@ -1503,12 +1495,12 @@ class _patch(object):
         self._context.target = value
 
     @property
-    def temp_original(self):  # backwards compatibility
-        return self.original
+    def temp_original(self):
+        return self._context.original
 
     @temp_original.setter
-    def temp_original(self, value):  # backwards compatibility
-        self.original = value
+    def temp_original(self, value):
+        self._context.original = value
 
     def __enter__(self):
         """Perform the patch."""
@@ -1672,8 +1664,8 @@ class _patch(object):
         if not self.is_started:
             return
 
-        if self.is_local and self.original is not DEFAULT:
-            setattr(self.target, self.attribute, self.original)
+        if self.is_local and self.temp_original is not DEFAULT:
+            setattr(self.target, self.attribute, self.temp_original)
         else:
             delattr(self.target, self.attribute)
             if not self.create and (not hasattr(self.target, self.attribute) or
@@ -1681,7 +1673,7 @@ class _patch(object):
                                            '__defaults__', '__annotations__',
                                            '__kwdefaults__')):
                 # needed for proxy objects like django settings
-                setattr(self.target, self.attribute, self.original)
+                setattr(self.target, self.attribute, self.temp_original)
 
         exit_stack = self._context.exit_stack
         self._context = None

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1482,25 +1482,40 @@ class _patch(object):
     def is_local(self):
         return self._context.is_local
 
-    @is_local.setter
-    def is_local(self, value):
-        self._context.is_local = value
-
     @property
     def target(self):
         return self._context.target
-
-    @target.setter
-    def target(self, value):
-        self._context.target = value
 
     @property
     def temp_original(self):
         return self._context.original
 
+    @is_local.setter
+    def is_local(self, value):
+        self._context = _PatchContext(
+            exit_stack=self._context.exit_stack,
+            is_local=value,
+            original=self._context.original,
+            target=self._context.target,
+        )
+
+    @target.setter
+    def target(self, value):
+        self._context = _PatchContext(
+            exit_stack=self._context.exit_stack,
+            is_local=self._context.is_local,
+            original=self._context.original,
+            target=value,
+        )
+
     @temp_original.setter
     def temp_original(self, value):
-        self._context.original = value
+        self._context = _PatchContext(
+            exit_stack=self._context.exit_stack,
+            is_local=self._context.is_local,
+            original=value,
+            target=self._context.target,
+        )
 
     def __enter__(self):
         """Perform the patch."""

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1648,7 +1648,7 @@ class _patch(object):
             exit_stack=exit_stack,
             is_local=is_local,
             original=original,
-            target=self.getter(),
+            target=target,
         )
         try:
             setattr(self.target, self.attribute, new_attr)

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -25,7 +25,6 @@ __all__ = (
 
 
 import asyncio
-from collections import namedtuple
 import contextlib
 import io
 import inspect
@@ -1321,7 +1320,14 @@ def _check_spec_arg_typos(kwargs_to_check):
             )
 
 
-_PatchContext = namedtuple("_PatchContext", "exit_stack is_local original target")
+class _PatchContext:
+    __slots__ = ('exit_stack', 'is_local', 'original', 'target')
+
+    def __init__(self, exit_stack, is_local, original, target):
+        self.exit_stack = exit_stack
+        self.is_local = is_local
+        self.original = original
+        self.target = target
 
 
 class _patch(object):
@@ -1482,40 +1488,25 @@ class _patch(object):
     def is_local(self):
         return self._context.is_local
 
+    @is_local.setter
+    def is_local(self, value):
+        self._context.is_local = value
+
     @property
     def target(self):
         return self._context.target
+
+    @target.setter
+    def target(self, value):
+        self._context.target = value
 
     @property
     def temp_original(self):
         return self._context.original
 
-    @is_local.setter
-    def is_local(self, value):
-        self._context = _PatchContext(
-            exit_stack=self._context.exit_stack,
-            is_local=value,
-            original=self._context.original,
-            target=self._context.target,
-        )
-
-    @target.setter
-    def target(self, value):
-        self._context = _PatchContext(
-            exit_stack=self._context.exit_stack,
-            is_local=self._context.is_local,
-            original=self._context.original,
-            target=value,
-        )
-
     @temp_original.setter
     def temp_original(self, value):
-        self._context = _PatchContext(
-            exit_stack=self._context.exit_stack,
-            is_local=self._context.is_local,
-            original=value,
-            target=self._context.target,
-        )
+        self._context.original = value
 
     def __enter__(self):
         """Perform the patch."""

--- a/Misc/NEWS.d/next/Library/2024-11-10-18-14-51.gh-issue-104745.zAa5Ke.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-10-18-14-51.gh-issue-104745.zAa5Ke.rst
@@ -1,0 +1,5 @@
+Limit starting a patcher (from :func:`unittest.mock.patch`,
+:func:`unittest.mock.patch.object` or :func:`unittest.mock.dict`) more than
+once without stopping it. Previously, this would cause an
+:exc:`AttributeError` if the patch stopped more than once after this, and
+would also disrupt the original patched object.

--- a/Misc/NEWS.d/next/Library/2024-11-10-18-14-51.gh-issue-104745.zAa5Ke.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-10-18-14-51.gh-issue-104745.zAa5Ke.rst
@@ -1,3 +1,3 @@
-Limit starting a patcher (from :func:`unittest.mock.patch`,
-:func:`unittest.mock.patch.object` or :func:`unittest.mock.patch.dict`) more than
-once without stopping it.
+Limit starting a patcher (from :func:`unittest.mock.patch` or
+:func:`unittest.mock.patch.object`) more than
+once without stopping it

--- a/Misc/NEWS.d/next/Library/2024-11-10-18-14-51.gh-issue-104745.zAa5Ke.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-10-18-14-51.gh-issue-104745.zAa5Ke.rst
@@ -1,5 +1,3 @@
 Limit starting a patcher (from :func:`unittest.mock.patch`,
-:func:`unittest.mock.patch.object` or :func:`unittest.mock.dict`) more than
-once without stopping it. Previously, this would cause an
-:exc:`AttributeError` if the patch stopped more than once after this, and
-would also disrupt the original patched object.
+:func:`unittest.mock.patch.object` or :func:`unittest.mock.patch.dict`) more than
+once without stopping it.


### PR DESCRIPTION
Previously, this would cause an `AttributeError` if the patch stopped more than once after this, and would also disrupt the original patched object.


<!-- gh-issue-number: gh-104745 -->
* Issue: gh-104745
<!-- /gh-issue-number -->
