### PR TITLE
pathlib tests: move `walk()` tests into their own classes

### DIFF
--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1807,8 +1807,14 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         with self.assertRaises(pathlib.UnsupportedOperation):
             P('c:/').group()
 
-    def setUpWalk(self):
-        super().setUpWalk()
+
+class PathWalkTest(test_pathlib_abc.DummyPathWalkTest):
+    cls = pathlib.Path
+    base = PathTest.base
+    can_symlink = PathTest.can_symlink
+
+    def setUp(self):
+        super().setUp()
         sub21_path= self.sub2_path / "SUB21"
         tmp5_path = sub21_path / "tmp3"
         broken_link3_path = self.sub2_path / "broken_link3"
@@ -1831,8 +1837,13 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
             os.unlink(tmp5_path)
             os.rmdir(sub21_path)
 
+    def tearDown(self):
+        if not is_emscripten:
+            sub21_path = self.sub2_path / "SUB21"
+            os.chmod(sub21_path, stat.S_IRWXU)
+        super().tearDown()
+
     def test_walk_bad_dir(self):
-        self.setUpWalk()
         errors = []
         walk_it = self.walk_path.walk(on_error=errors.append)
         root, dirs, files = next(walk_it)

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1838,9 +1838,8 @@ class PathWalkTest(test_pathlib_abc.DummyPathWalkTest):
             os.rmdir(sub21_path)
 
     def tearDown(self):
-        if not is_emscripten:
-            sub21_path = self.sub2_path / "SUB21"
-            os.chmod(sub21_path, stat.S_IRWXU)
+        if 'SUB21' in self.sub2_tree[1]:
+            os.chmod(self.sub2_path / "SUB21", stat.S_IRWXU)
         super().tearDown()
 
     def test_walk_bad_dir(self):

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -2922,7 +2922,16 @@ class DummyPathTest(DummyPurePathTest):
         filename = tmp / 'foo'
         self.assertRaises(FileNotFoundError, filename._delete)
 
-    def setUpWalk(self):
+
+class DummyPathWalkTest(unittest.TestCase):
+    cls = DummyPath
+    base = DummyPathTest.base
+    can_symlink = False
+
+    def setUp(self):
+        name = self.id().split('.')[-1]
+        if name in _tests_needing_symlinks and not self.can_symlink:
+            self.skipTest('requires symlinks')
         # Build:
         #     TESTFN/
         #       TEST1/              a file kid and two directory kids
@@ -2966,8 +2975,11 @@ class DummyPathTest(DummyPurePathTest):
         else:
             self.sub2_tree = (self.sub2_path, [], ["tmp3"])
 
+    def tearDown(self):
+        base = self.cls(self.base)
+        base._rmtree()
+
     def test_walk_topdown(self):
-        self.setUpWalk()
         walker = self.walk_path.walk()
         entry = next(walker)
         entry[1].sort()  # Ensure we visit SUB1 before SUB2
@@ -2984,7 +2996,6 @@ class DummyPathTest(DummyPurePathTest):
             next(walker)
 
     def test_walk_prune(self):
-        self.setUpWalk()
         # Prune the search.
         all = []
         for root, dirs, files in self.walk_path.walk():
@@ -3001,7 +3012,6 @@ class DummyPathTest(DummyPurePathTest):
         self.assertEqual(all[1], self.sub2_tree)
 
     def test_walk_bottom_up(self):
-        self.setUpWalk()
         seen_testfn = seen_sub1 = seen_sub11 = seen_sub2 = False
         for path, dirnames, filenames in self.walk_path.walk(top_down=False):
             if path == self.walk_path:
@@ -3036,7 +3046,6 @@ class DummyPathTest(DummyPurePathTest):
 
     @needs_symlinks
     def test_walk_follow_symlinks(self):
-        self.setUpWalk()
         walk_it = self.walk_path.walk(follow_symlinks=True)
         for root, dirs, files in walk_it:
             if root == self.link_path:
@@ -3048,7 +3057,6 @@ class DummyPathTest(DummyPurePathTest):
 
     @needs_symlinks
     def test_walk_symlink_location(self):
-        self.setUpWalk()
         # Tests whether symlinks end up in filenames or dirnames depending
         # on the `follow_symlinks` argument.
         walk_it = self.walk_path.walk(follow_symlinks=False)
@@ -3093,6 +3101,11 @@ class DummyPathWithSymlinks(DummyPath):
 
 
 class DummyPathWithSymlinksTest(DummyPathTest):
+    cls = DummyPathWithSymlinks
+    can_symlink = True
+
+
+class DummyPathWithSymlinksWalkTest(DummyPathWalkTest):
     cls = DummyPathWithSymlinks
     can_symlink = True
 


### PR DESCRIPTION
Move tests for `Path.walk()` into a new `PathWalkTest` class, and apply a similar change in tests for the ABCs. This allows us to properly tear down the walk test hierarchy in `tearDown()`, rather than leaving it to `os_helper.rmtree()`.

This PR has two initial commits: the first commit re-orders test methods in order to make the second commit diff more readable.