### PR TITLE
gh-109564: Add `None` check for `asyncio.Server._wakeup`

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -303,6 +303,8 @@ class Server(events.AbstractServer):
             self._wakeup()
 
     def _wakeup(self):
+        if self._waiters is None:
+            return
         waiters = self._waiters
         self._waiters = None
         for waiter in waiters:

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -956,7 +956,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         try:
             return await self._sock_sendfile_native(sock, file,
                                                     offset, count)
-        except exceptions.SendfileNotAvailableError:
+        except exceptions.SendfileNotAvailableError as exc:
             if not fallback:
                 raise
         return await self._sock_sendfile_fallback(sock, file,
@@ -1269,7 +1269,7 @@ class BaseEventLoop(events.AbstractEventLoop):
             try:
                 return await self._sendfile_native(transport, file,
                                                    offset, count)
-            except exceptions.SendfileNotAvailableError:
+            except exceptions.SendfileNotAvailableError as exc:
                 if not fallback:
                     raise
 

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -243,8 +243,10 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
                 # It's now up to the protocol to handle the connection.
 
         except (SystemExit, KeyboardInterrupt):
+            conn.close()
             raise
         except BaseException as exc:
+            conn.close()
             if self._debug:
                 context = {
                     'message':

--- a/Misc/NEWS.d/next/Library/2024-11-11-11-13-30.gh-issue-109564._f7W0v.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-11-11-13-30.gh-issue-109564._f7W0v.rst
@@ -1,1 +1,2 @@
-Add ``None`` check for :meth:`asyncio.Server._wakeup`. Patch by Jamie Phan.
+Add ``None`` check for :class:`asyncio.base_events.Server` internal ``_wakeup``
+method. Patch by Jamie Phan.

--- a/Misc/NEWS.d/next/Library/2024-11-11-11-13-30.gh-issue-109564._f7W0v.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-11-11-13-30.gh-issue-109564._f7W0v.rst
@@ -1,2 +1,1 @@
-Add ``None`` check for :class:`asyncio.base_events.Server` internal ``_wakeup``
-method. Patch by Jamie Phan.
+Fix race condition in :meth:`asyncio.Server.close`. Patch by Jamie Phan.

--- a/Misc/NEWS.d/next/Library/2024-11-11-11-13-30.gh-issue-109564._f7W0v.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-11-11-13-30.gh-issue-109564._f7W0v.rst
@@ -1,0 +1,1 @@
+Add ``None`` check for :meth:`asyncio.Server._wakeup`. Patch by Jamie Phan.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Adds a `None` check for `asyncio.Server._wakeup` to prevent crashing when it is called multiple times.

Because the method clears `self._waiters` the next call to this method will fail when it attempts to iterate on `None`.

This can happen when the public `asyncio.Server.close` API and internal `asyncio.Server._detach` are both called, and this is demonstrated in #109564, when the server is closed after a socket connection is accepted but before it is handled.

## Example error of missing `None` check

Repro:

```py
# repro.py

import asyncio
import sys
import socket

async def server():
    server = await asyncio.start_server(lambda *_: None, host="127.0.0.1", port=4445)
    await asyncio.sleep(0)
    server.close()
    await server.wait_closed()


def client():

    while True:
        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
            try:
                sock.connect(("127.0.0.1", 4445))
            except IOError:
                pass
            finally:
                sock.close()


if __name__ == '__main__':
    if len(sys.argv) > 1 and sys.argv[1] == 'server':
        asyncio.run(server())
    else:
        client()
```

Usage:

```sh
python repro.py &

# May have to call multiple times before observing error
python repro.py server 
```

Retracted stack trace:

```
/cpython/Lib/asyncio/selector_events.py:869: ResourceWarning: unclosed transport <_SelectorSocketTransport fd=10>
  _warn(f"unclosed transport {self!r}", ResourceWarning, source=self)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
Exception ignored in: <function _SelectorTransport.__del__ at 0x10194b650>
Traceback (most recent call last):
  File "/cpython/Lib/asyncio/selector_events.py", line 872, in __del__
    self._server._detach(self)
  File "/cpython/Lib/asyncio/base_events.py", line 303, in _detach
    self._wakeup()
  File "/cpython/Lib/asyncio/base_events.py", line 308, in _wakeup
    for waiter in waiters:
TypeError: 'NoneType' object is not iterable
```


<!-- gh-issue-number: gh-109564 -->
* Issue: gh-109564
<!-- /gh-issue-number -->
