### PR TITLE
gh-126662: harmonize naming for three namedtuple base classes in urllib.parse

### DIFF
--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -247,11 +247,11 @@ class _NetlocResultMixinBytes(_NetlocResultMixinBase, _ResultMixinBytes):
         return hostname, port
 
 
-_DefragResultBase = namedtuple('DefragResult', 'url fragment')
+_DefragResultBase = namedtuple('_DefragResultBase', 'url fragment')
 _SplitResultBase = namedtuple(
-    'SplitResult', 'scheme netloc path query fragment')
+    '_SplitResultBase', 'scheme netloc path query fragment')
 _ParseResultBase = namedtuple(
-    'ParseResult', 'scheme netloc path params query fragment')
+    '_ParseResultBase', 'scheme netloc path params query fragment')
 
 _DefragResultBase.__doc__ = """
 DefragResult(url, fragment)


### PR DESCRIPTION
This MR improves naming consistency for three private namedtuples in urllib.parse. This isn't very important, but the consistency helps typeshed. I figured I'd start MRs for gh-126662 with a low-stakes one.