### PR TITLE
gh-126664: Use `else` instead of `finally` in "The with statement" documentation.

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -534,18 +534,15 @@ is semantically equivalent to::
     enter = type(manager).__enter__
     exit = type(manager).__exit__
     value = enter(manager)
-    hit_except = False
 
     try:
         TARGET = value
         SUITE
     except:
-        hit_except = True
         if not exit(manager, *sys.exc_info()):
             raise
-    finally:
-        if not hit_except:
-            exit(manager, None, None, None)
+    else:
+        exit(manager, None, None, None)
 
 With more than one item, the context managers are processed as if multiple
 :keyword:`with` statements were nested::


### PR DESCRIPTION
# Documentation
In [8.5 The `with` statement](https://docs.python.org/3.13/reference/compound_stmts.html#the-with-statement), we can use `else` instead of `finally`.
```python
manager = (EXPRESSION)
enter = type(manager).__enter__
exit = type(manager).__exit__
value = enter(manager)
hit_except = False

try:
    TARGET = value
    SUITE
except:
    hit_except = True
    if not exit(manager, *sys.exc_info()):
        raise
finally:
    if not hit_except:
        exit(manager, None, None, None)
```
is semantically equivalent to:
```python
  manager = (EXPRESSION)
  enter = type(manager).__enter__
  exit = type(manager).__exit__
  value = enter(manager)

  try:
      TARGET = value
      SUITE
  except:
      if not exit(manager, *sys.exc_info()):
          raise
  else:
      exit(manager, None, None, None)
```

<!-- gh-issue-number: gh-126664 -->
* Issue: gh-126664
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126665.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->