### PR TITLE
gh-126654: Fix crash in several functions in `_interpreters` module

### DIFF
--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -551,6 +551,24 @@ class DestroyTests(TestBase):
             self.assertTrue(_interpreters.is_running(interp))
 
 
+class CommonTests(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.id = _interpreters.create()
+
+    def test_signatures(self):
+        # for method in ['exec', 'run_string', 'run_func']:
+        msg = "expected 'shared' to be a dict"
+        with self.assertRaisesRegex(TypeError, msg):
+            _interpreters.exec(self.id, 'a', 1)
+        with self.assertRaisesRegex(TypeError, msg):
+            _interpreters.exec(self.id, 'a', shared=1)
+        with self.assertRaisesRegex(TypeError, msg):
+            _interpreters.run_string(self.id, 'a', shared=1)
+        with self.assertRaisesRegex(TypeError, msg):
+            _interpreters.run_func(self.id, lambda: None, shared=1)
+
+
 class RunStringTests(TestBase):
 
     def setUp(self):

--- a/Misc/NEWS.d/next/Library/2024-11-11-13-00-21.gh-issue-126654.4gfP2y.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-11-13-00-21.gh-issue-126654.4gfP2y.rst
@@ -1,0 +1,2 @@
+Fix crash when non-dict was passed to several functions in ``_interpreters``
+module.

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -936,6 +936,11 @@ static int
 _interp_exec(PyObject *self, PyInterpreterState *interp,
              PyObject *code_arg, PyObject *shared_arg, PyObject **p_excinfo)
 {
+    if (shared_arg != NULL && !PyDict_CheckExact(shared_arg)) {
+        PyErr_SetString(PyExc_TypeError, "expected 'shared' to be a dict");
+        return -1;
+    }
+
     // Extract code.
     Py_ssize_t codestrlen = -1;
     PyObject *bytes_obj = NULL;


### PR DESCRIPTION
This was the cause: 
- We checked that passed arg is not a `dict` here: https://github.com/python/cpython/blob/6ee542d491589b470ec7cdd353463ff9ff52d098/Python/crossinterp.c#L1479-L1482
- Later we had an assertion about `!PyErr_Occurred()`

So, I went with the early validation.

<!-- gh-issue-number: gh-126654 -->
* Issue: gh-126654
<!-- /gh-issue-number -->
