### PR TITLE
Fix error message of "Check if Autoconf files are up to date" job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           # Check for changes in regenerated files
           if test -n "$changes"; then
             echo "Generated files not up to date."
-            echo "Perhaps you forgot to run `make regen-configure` ;)"
+            echo "Perhaps you forgot to run make regen-configure ;)"
             echo "configure files must be regenerated with a specific version of autoconf."
             echo "$changes"
             echo ""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           # Check for changes in regenerated files
           if test -n "$changes"; then
             echo "Generated files not up to date."
-            echo "Perhaps you forgot to run make regen-all or build.bat --regen. ;)"
+            echo "Perhaps you forgot to run `make regen-configure` ;)"
             echo "configure files must be regenerated with a specific version of autoconf."
             echo "$changes"
             echo ""


### PR DESCRIPTION
`make regen-all` does not run `make regen-configure` see:  https://github.com/python/cpython/blob/9fc2808eaf4e74a9f52f44d20a7d1110bd949d41/Makefile.pre.in#L1732-L1733