### PR TITLE
GH-126748: amend configure.rst description for the 'build_wasm' make target

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -1097,7 +1097,7 @@ CPython project) this is usually the ``all`` target. The
 all`` will build. The three choices are:
 
 * ``profile-opt`` (configured with ``--enable-optimizations``)
-* ``build_wasm`` (chosen if the host platform is either ``wasm32-wasi`` or
+* ``build_wasm`` (chosen if the host platform matches ``wasm32-wasi*`` or
   ``wasm32-emscripten``)
 * ``build_all`` (configured without explicitly using either of the others)
 

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -1097,7 +1097,8 @@ CPython project) this is usually the ``all`` target. The
 all`` will build. The three choices are:
 
 * ``profile-opt`` (configured with ``--enable-optimizations``)
-* ``build_wasm`` (configured with ``--with-emscripten-target``)
+* ``build_wasm`` (chosen if the host platform is either ``wasm32-wasi`` or
+  ``wasm32-emscripten``)
 * ``build_all`` (configured without explicitly using either of the others)
 
 Depending on the most recent source file changes, Make will rebuild


### PR DESCRIPTION
It has nothing to do with `--with-emscripten-target` but rather is selected when the host is either wasm32-wasi or wasm32-emscripten.

cc @brettcannon @freakboy3742

@brettcannon this is another spot where wasi and emscripten are mixed together. We could consider splitting `build_wasm` into `build_emscripten` and `build_wasi` if it seems like a problem.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126687.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-126748 -->
* Issue: gh-126748
<!-- /gh-issue-number -->
