### PR TITLE
gh-126413: Add translation tests for `getopt` and `optparse`

### DIFF
--- a/Lib/test/support/i18n_helper.py
+++ b/Lib/test/support/i18n_helper.py
@@ -1,0 +1,63 @@
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from test.support import REPO_ROOT, TEST_HOME_DIR, requires_subprocess
+from test.test_tools import skip_if_missing
+
+
+pygettext = Path(REPO_ROOT) / 'Tools' / 'i18n' / 'pygettext.py'
+
+msgid_pattern = re.compile(r'msgid(.*?)(?:msgid_plural|msgctxt|msgstr)',
+                           re.DOTALL)
+msgid_string_pattern = re.compile(r'"((?:\\"|[^"])*)"')
+
+
+def _generate_po_file(path, *, stdout_only=True):
+    res = subprocess.run([sys.executable, pygettext,
+                          '--no-location', '-o', '-', path],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                         text=True)
+    if stdout_only:
+        return res.stdout
+    return res
+
+
+def _extract_msgids(po):
+    msgids = []
+    for msgid in msgid_pattern.findall(po):
+        msgid_string = ''.join(msgid_string_pattern.findall(msgid))
+        msgid_string = msgid_string.replace(r'\"', '"')
+        if msgid_string:
+            msgids.append(msgid_string)
+    return sorted(msgids)
+
+
+def _get_snapshot_path(module_name):
+    return Path(TEST_HOME_DIR) / 'translationdata' / module_name / 'msgids.txt'
+
+
+@requires_subprocess()
+class TestTranslationsBase(unittest.TestCase):
+
+    def assertMsgidsEqual(self, module):
+        '''Assert that msgids extracted from a given module match a
+        snapshot.
+
+        '''
+        skip_if_missing('i18n')
+        res = _generate_po_file(module.__file__, stdout_only=False)
+        self.assertEqual(res.returncode, 0)
+        self.assertEqual(res.stderr, '')
+        msgids = _extract_msgids(res.stdout)
+        snapshot_path = _get_snapshot_path(module.__name__)
+        snapshot = snapshot_path.read_text().splitlines()
+        self.assertListEqual(msgids, snapshot)
+
+
+def update_translation_snapshots(module):
+    contents = _generate_po_file(module.__file__)
+    msgids = _extract_msgids(contents)
+    snapshot_path = _get_snapshot_path(module.__name__)
+    snapshot_path.write_text('\n'.join(msgids))

--- a/Lib/test/test_getopt.py
+++ b/Lib/test/test_getopt.py
@@ -1,11 +1,12 @@
 # test_getopt.py
 # David Goodger <dgoodger@bigfoot.com> 2000-08-19
 
-from test.support.os_helper import EnvironmentVarGuard
 import doctest
-import unittest
-
 import getopt
+import sys
+import unittest
+from test.support.i18n_helper import TestTranslationsBase, update_translation_snapshots
+from test.support.os_helper import EnvironmentVarGuard
 
 sentinel = object()
 
@@ -224,10 +225,20 @@ def test_libref_examples():
     ['a1', 'a2']
     """
 
+
+class TestTranslations(TestTranslationsBase):
+    def test_translations(self):
+        self.assertMsgidsEqual(getopt)
+
+
 def load_tests(loader, tests, pattern):
     tests.addTest(doctest.DocTestSuite())
     return tests
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
+    # To regenerate translation snapshots
+    if len(sys.argv) > 1 and sys.argv[1] == '--snapshot-update':
+        update_translation_snapshots(getopt)
+        sys.exit(0)
     unittest.main()

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -15,7 +15,7 @@ import unittest
 from io import StringIO
 from test import support
 from test.support import os_helper
-
+from test.support.i18n_helper import TestTranslationsBase, update_translation_snapshots
 
 import optparse
 from optparse import make_option, Option, \
@@ -1656,5 +1656,14 @@ class MiscTestCase(unittest.TestCase):
         support.check__all__(self, optparse, not_exported=not_exported)
 
 
+class TestTranslations(TestTranslationsBase):
+    def test_translations(self):
+        self.assertMsgidsEqual(optparse)
+
+
 if __name__ == '__main__':
+    # To regenerate translation snapshots
+    if len(sys.argv) > 1 and sys.argv[1] == '--snapshot-update':
+        update_translation_snapshots(optparse)
+        sys.exit(0)
     unittest.main()

--- a/Lib/test/translationdata/getopt/msgids.txt
+++ b/Lib/test/translationdata/getopt/msgids.txt
@@ -1,0 +1,6 @@
+option -%s not recognized
+option -%s requires argument
+option --%s must not have an argument
+option --%s not a unique prefix
+option --%s not recognized
+option --%s requires argument

--- a/Lib/test/translationdata/optparse/msgids.txt
+++ b/Lib/test/translationdata/optparse/msgids.txt
@@ -1,0 +1,14 @@
+%prog [options]
+%s option does not take a value
+Options
+Usage
+Usage: %s\n
+ambiguous option: %s (%s?)
+complex
+floating-point
+integer
+no such option: %s
+option %s: invalid %s value: %r
+option %s: invalid choice: %r (choose from %s)
+show program's version number and exit
+show this help message and exit

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2567,6 +2567,8 @@ TESTSUBDIRS=	idlelib/idle_test \
 		test/tracedmodules \
 		test/translationdata \
 		test/translationdata/argparse \
+		test/translationdata/getopt \
+		test/translationdata/optparse \
 		test/typinganndata \
 		test/wheeldata \
 		test/xmltestdata \


### PR DESCRIPTION
This is a followup from https://github.com/python/cpython/issues/124295

Given that the tests for `getopt` and `optparse` are essentially the same as the ones for `argparse`, I extracted the snapshot file generation and comparison into `test.support.i18n_helper` in order not to repeat the code three times. The majority of the diff is just moving that code from `test_argpase` to `test.support.i18n_helper`.

Just like for `argparse`, the snapshots are generated in `Lib/test/translationdata` and are updated the same way using `--snapshot-update`.

<!-- gh-issue-number: gh-126413 -->
* Issue: gh-126413
<!-- /gh-issue-number -->
