### PR TITLE
gh-126699: allow AsyncIterator to be used as a base for Protocols

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4255,6 +4255,9 @@ class ProtocolTests(BaseTestCase):
         class CustomContextManager(typing.ContextManager, Protocol):
             pass
 
+        class CustomAsyncIterator(typing.AsyncIterator, Protocol):
+            pass
+
     def test_non_runtime_protocol_isinstance_check(self):
         class P(Protocol):
             x: int

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1940,7 +1940,8 @@ def _allow_reckless_class_checks(depth=2):
 _PROTO_ALLOWLIST = {
     'collections.abc': [
         'Callable', 'Awaitable', 'Iterable', 'Iterator', 'AsyncIterable',
-        'Hashable', 'Sized', 'Container', 'Collection', 'Reversible', 'Buffer',
+        'AsyncIterator', 'Hashable', 'Sized', 'Container', 'Collection',
+        'Reversible', 'Buffer',
     ],
     'contextlib': ['AbstractContextManager', 'AbstractAsyncContextManager'],
 }

--- a/Misc/NEWS.d/next/Library/2024-11-11-13-24-22.gh-issue-126699.ONGbMd.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-11-13-24-22.gh-issue-126699.ONGbMd.rst
@@ -1,1 +1,1 @@
-Allow :class:`AsyncIterator` to be a base for Protocols.
+Allow :class:`collections.abc.AsyncIterator` to be a base for Protocols.

--- a/Misc/NEWS.d/next/Library/2024-11-11-13-24-22.gh-issue-126699.ONGbMd.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-11-13-24-22.gh-issue-126699.ONGbMd.rst
@@ -1,0 +1,1 @@
+Allow :class:`AsyncIterator` to be a base for Protocols.


### PR DESCRIPTION
AsyncIterator was removed from `_PROTO_ALLOWLIST` by https://github.com/python/cpython/pull/15647, without any discussion. It looks like an accident to me. This restores it to the list.

<!-- gh-issue-number: gh-126699 -->
* Issue: gh-126699
<!-- /gh-issue-number -->
