### PR TITLE
gh-76785: Improved Subinterpreters Compatibility with 3.12 (1/2)

### DIFF
--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -155,10 +155,10 @@ PyAPI_FUNC(void) _PyXIData_Clear( PyInterpreterState *, _PyXIData_t *);
 /* runtime state & lifecycle */
 /*****************************/
 
-struct _xi_runtime_state {
+typedef struct {
     // builtin types
     _PyXIData_lookup_t data_lookup;
-};
+} _PyXI_global_state_t;
 
 struct _xi_state {
     // heap types

--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -40,7 +40,7 @@ extern int _Py_CallInInterpreterAndRawFree(
 /**************************/
 
 typedef struct _xid _PyXIData_t;
-typedef PyObject *(*xid_newobjectfunc)(_PyXIData_t *);
+typedef PyObject *(*xid_newobjfunc)(_PyXIData_t *);
 typedef void (*xid_freefunc)(void *);
 
 // _PyXIData_t is similar to Py_buffer as an effectively
@@ -72,7 +72,7 @@ struct _xid {
     // interpreter given the data.  The resulting object (a new
     // reference) will be equivalent to the original object.  This field
     // is required.
-    xid_newobjectfunc new_object;
+    xid_newobjfunc new_object;
     // free is called when the data is released.  If it is NULL then
     // nothing will be done to free the data.  For some types this is
     // okay (e.g. bytes) and for those types this field should be set
@@ -117,11 +117,11 @@ PyAPI_FUNC(int) _PyXIData_ReleaseAndRawFree(_PyXIData_t *);
 PyAPI_FUNC(void) _PyXIData_Init(
         _PyXIData_t *data,
         PyInterpreterState *interp, void *shared, PyObject *obj,
-        xid_newobjectfunc new_object);
+        xid_newobjfunc new_object);
 PyAPI_FUNC(int) _PyXIData_InitWithSize(
         _PyXIData_t *,
         PyInterpreterState *interp, const size_t, PyObject *,
-        xid_newobjectfunc);
+        xid_newobjfunc);
 PyAPI_FUNC(void) _PyXIData_Clear( PyInterpreterState *, _PyXIData_t *);
 
 // Normally the Init* functions are sufficient.  The only time

--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -160,7 +160,7 @@ typedef struct {
     _PyXIData_lookup_t data_lookup;
 } _PyXI_global_state_t;
 
-struct _xi_state {
+typedef struct {
     // heap types
     _PyXIData_lookup_t data_lookup;
 
@@ -171,7 +171,7 @@ struct _xi_state {
         // heap types
         PyObject *PyExc_NotShareableError;
     } exceptions;
-};
+} _PyXI_state_t;
 
 extern PyStatus _PyXI_Init(PyInterpreterState *interp);
 extern void _PyXI_Fini(PyInterpreterState *interp);

--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -39,14 +39,14 @@ extern int _Py_CallInInterpreterAndRawFree(
 /* cross-interpreter data */
 /**************************/
 
-typedef struct _xid _PyXIData_t;
+typedef struct _xidata _PyXIData_t;
 typedef PyObject *(*xid_newobjfunc)(_PyXIData_t *);
 typedef void (*xid_freefunc)(void *);
 
 // _PyXIData_t is similar to Py_buffer as an effectively
 // opaque struct that holds data outside the object machinery.  This
 // is necessary to pass safely between interpreters in the same process.
-struct _xid {
+struct _xidata {
     // data is the cross-interpreter-safe derivation of a Python object
     // (see _PyObject_GetXIData).  It will be NULL if the
     // new_object func (below) encodes the data.

--- a/Include/internal/pycore_crossinterp_data_registry.h
+++ b/Include/internal/pycore_crossinterp_data_registry.h
@@ -20,17 +20,17 @@ typedef struct _xid_regitem {
     xidatafunc getdata;
 } _PyXIData_regitem_t;
 
-struct _xidregistry {
+typedef struct {
     int global;  /* builtin types or heap types */
     int initialized;
     PyMutex mutex;
     _PyXIData_regitem_t *head;
-};
+} _PyXIData_registry_t;
 
 PyAPI_FUNC(int) _PyXIData_RegisterClass(PyTypeObject *, xidatafunc);
 PyAPI_FUNC(int) _PyXIData_UnregisterClass(PyTypeObject *);
 
 struct _xid_lookup_state {
     // XXX Remove this field once we have a tp_* slot.
-    struct _xidregistry registry;
+    _PyXIData_registry_t registry;
 };

--- a/Include/internal/pycore_crossinterp_data_registry.h
+++ b/Include/internal/pycore_crossinterp_data_registry.h
@@ -7,24 +7,24 @@
 // alternative would be to add a tp_* slot for a class's
 // xidatafunc. It would be simpler and more efficient.
 
-struct _xidregitem;
+struct _xid_regitem;
 
-struct _xidregitem {
-    struct _xidregitem *prev;
-    struct _xidregitem *next;
+typedef struct _xid_regitem {
+    struct _xid_regitem *prev;
+    struct _xid_regitem *next;
     /* This can be a dangling pointer, but only if weakref is set. */
     PyTypeObject *cls;
     /* This is NULL for builtin types. */
     PyObject *weakref;
     size_t refcount;
     xidatafunc getdata;
-};
+} _PyXIData_regitem_t;
 
 struct _xidregistry {
     int global;  /* builtin types or heap types */
     int initialized;
     PyMutex mutex;
-    struct _xidregitem *head;
+    _PyXIData_regitem_t *head;
 };
 
 PyAPI_FUNC(int) _PyXIData_RegisterClass(PyTypeObject *, xidatafunc);

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -16,7 +16,7 @@ extern "C" {
 #include "pycore_code.h"          // struct callable_cache
 #include "pycore_codecs.h"        // struct codecs_state
 #include "pycore_context.h"       // struct _Py_context_state
-#include "pycore_crossinterp.h"   // struct _xi_state
+#include "pycore_crossinterp.h"   // _PyXI_state_t
 #include "pycore_dict_state.h"    // struct _Py_dict_state
 #include "pycore_dtoa.h"          // struct _dtoa_state
 #include "pycore_exceptions.h"    // struct _Py_exc_state
@@ -205,7 +205,7 @@ struct _is {
     freefunc co_extra_freefuncs[MAX_CO_EXTRA_USERS];
 
     /* cross-interpreter data and utils */
-    struct _xi_state xi;
+    _PyXI_state_t xi;
 
 #ifdef HAVE_FORK
     PyObject *before_forkers;

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -16,7 +16,7 @@ extern "C" {
 #include "pycore_code.h"          // struct callable_cache
 #include "pycore_codecs.h"        // struct codecs_state
 #include "pycore_context.h"       // struct _Py_context_state
-#include "pycore_crossinterp.h"   // struct _xidregistry
+#include "pycore_crossinterp.h"   // struct _xi_state
 #include "pycore_dict_state.h"    // struct _Py_dict_state
 #include "pycore_dtoa.h"          // struct _dtoa_state
 #include "pycore_exceptions.h"    // struct _Py_exc_state

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -141,6 +141,12 @@ _PyThreadState_GET(void)
 #endif
 }
 
+static inline int
+_PyThreadState_IsAttached(PyThreadState *tstate)
+{
+    return (_Py_atomic_load_int_relaxed(&tstate->state) == _Py_THREAD_ATTACHED);
+}
+
 // Attaches the current thread to the interpreter.
 //
 // This may block while acquiring the GIL (if the GIL is enabled) or while

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -11,7 +11,7 @@ extern "C" {
 #include "pycore_atexit.h"          // struct _atexit_runtime_state
 #include "pycore_audit.h"           // _Py_AuditHookEntry
 #include "pycore_ceval_state.h"     // struct _ceval_runtime_state
-#include "pycore_crossinterp.h"     // struct _xi_runtime_state
+#include "pycore_crossinterp.h"     // _PyXI_global_state_t
 #include "pycore_debug_offsets.h"   // _Py_DebugOffsets
 #include "pycore_faulthandler.h"    // struct _faulthandler_runtime_state
 #include "pycore_floatobject.h"     // struct _Py_float_runtime_state
@@ -106,7 +106,7 @@ typedef struct pyruntimestate {
      tools. */
 
     /* cross-interpreter data and utils */
-    struct _xi_runtime_state xi;
+    _PyXI_global_state_t xi;
 
     struct _pymem_allocators allocators;
     struct _obmalloc_global_state obmalloc;

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -11,7 +11,7 @@ extern "C" {
 #include "pycore_atexit.h"          // struct _atexit_runtime_state
 #include "pycore_audit.h"           // _Py_AuditHookEntry
 #include "pycore_ceval_state.h"     // struct _ceval_runtime_state
-#include "pycore_crossinterp.h"     // struct _xidregistry
+#include "pycore_crossinterp.h"     // struct _xi_runtime_state
 #include "pycore_debug_offsets.h"   // _Py_DebugOffsets
 #include "pycore_faulthandler.h"    // struct _faulthandler_runtime_state
 #include "pycore_floatobject.h"     // struct _Py_float_runtime_state

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -63,7 +63,7 @@ _globals (static struct globals):
                             data (void *)
                             obj (PyObject *)
                             interpid (int64_t)
-                            new_object (xid_newobjectfunc)
+                            new_object (xid_newobjfunc)
                             free (xid_freefunc)
                     last (struct _channelitem *):
                         ...

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -126,7 +126,7 @@ void
 _PyXIData_Init(_PyXIData_t *data,
                PyInterpreterState *interp,
                void *shared, PyObject *obj,
-               xid_newobjectfunc new_object)
+               xid_newobjfunc new_object)
 {
     assert(data != NULL);
     assert(new_object != NULL);
@@ -150,7 +150,7 @@ int
 _PyXIData_InitWithSize(_PyXIData_t *data,
                        PyInterpreterState *interp,
                        const size_t size, PyObject *obj,
-                       xid_newobjectfunc new_object)
+                       xid_newobjfunc new_object)
 {
     assert(size > 0);
     // For now we always free the shared data in the same interpreter

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -1,7 +1,7 @@
 #include "pycore_weakref.h"       // _PyWeakref_GET_REF()
 
 
-typedef struct _xidregistry dlregistry_t;
+typedef _PyXIData_registry_t dlregistry_t;
 typedef _PyXIData_regitem_t dlregitem_t;
 
 

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -2,7 +2,7 @@
 
 
 typedef struct _xidregistry dlregistry_t;
-typedef struct _xidregitem dlregitem_t;
+typedef _PyXIData_regitem_t dlregitem_t;
 
 
 // forward

--- a/Python/parking_lot.c
+++ b/Python/parking_lot.c
@@ -221,8 +221,7 @@ _PySemaphore_Wait(_PySemaphore *sema, PyTime_t timeout, int detach)
     PyThreadState *tstate = NULL;
     if (detach) {
         tstate = _PyThreadState_GET();
-        if (tstate && _Py_atomic_load_int_relaxed(&tstate->state) ==
-                          _Py_THREAD_ATTACHED) {
+        if (tstate && _PyThreadState_IsAttached(tstate)) {
             // Only detach if we are attached
             PyEval_ReleaseThread(tstate);
         }


### PR DESCRIPTION
These changes makes it easier to backport the _interpreters, _interpqueues, and _interpchannels modules to Python 3.12.

This involves the following:

* rename several structs and typedefs
* add several typedefs
* stop using the `PyThreadState.state` field directly in parking_lot.c

<!-- gh-issue-number: gh-76785 -->
* Issue: gh-76785
<!-- /gh-issue-number -->
