### PR TITLE
gh-126705: Make os.PathLike more like a protocol

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -1118,7 +1118,7 @@ if not _exists('fspath'):
     fspath.__name__ = "fspath"
 
 
-class PathLike(abc.ABC):
+class PathLike(metaclass=abc.ABCMeta):
 
     """Abstract base class for implementing the file system path protocol."""
 

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -1118,7 +1118,7 @@ if not _exists('fspath'):
     fspath.__name__ = "fspath"
 
 
-class PathLike(metaclass=abc.ABCMeta):
+class PathLike(abc.ABC):
 
     """Abstract base class for implementing the file system path protocol."""
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8,6 +8,7 @@ import gc
 import inspect
 import itertools
 import operator
+import os
 import pickle
 import re
 import sys

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4252,6 +4252,9 @@ class ProtocolTests(BaseTestCase):
             class CustomProtocol(TestCase, Protocol):
                 pass
 
+        class CustomPathLikeProtocol(os.PathLike, Protocol):
+            pass
+
         class CustomContextManager(typing.ContextManager, Protocol):
             pass
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1943,6 +1943,7 @@ _PROTO_ALLOWLIST = {
         'Hashable', 'Sized', 'Container', 'Collection', 'Reversible', 'Buffer',
     ],
     'contextlib': ['AbstractContextManager', 'AbstractAsyncContextManager'],
+    'os': ['PathLike'],
 }
 
 

--- a/Misc/NEWS.d/next/Library/2024-11-11-14-52-21.gh-issue-126705.0W7jFW.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-11-14-52-21.gh-issue-126705.0W7jFW.rst
@@ -1,0 +1,1 @@
+Allow :class:`os.PathLike` to be a base for Protocols.


### PR DESCRIPTION
This MR makes `os.PathLike` more protocol-like in two ways:

1) adds it to typing._PROTO_ALLOWLIST so it can be used as a base class in other protocols
2) use `class PathLike(metaclass=abc.ABCMeta)` instead of `class PathLike(abc.ABC)`. This aligns with the other protocol-like ABCs in `collections.abc`. Actual protocols do have that metaclass but don't have the `abc.ABC` base class. Doing this makes it a little smoother for typeshed to define the class as `class PathLike(Protocol)` in the stubs.

<!-- gh-issue-number: gh-126705 -->
* Issue: gh-126705
<!-- /gh-issue-number -->
