### PR TITLE
gh-126400: Add TCP socket timeout to SysLogHandler to prevent blocking

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -613,7 +613,7 @@ The :class:`SysLogHandler` class, located in the :mod:`logging.handlers` module,
 supports sending logging messages to a remote or local Unix syslog.
 
 
-.. class:: SysLogHandler(address=('localhost', SYSLOG_UDP_PORT), facility=LOG_USER, socktype=socket.SOCK_DGRAM)
+.. class:: SysLogHandler(address=('localhost', SYSLOG_UDP_PORT), facility=LOG_USER, socktype=socket.SOCK_DGRAM, timeout=None)
 
    Returns a new instance of the :class:`SysLogHandler` class intended to
    communicate with a remote Unix machine whose address is given by *address* in
@@ -626,6 +626,11 @@ supports sending logging messages to a remote or local Unix syslog.
    *socktype* argument, which defaults to :const:`socket.SOCK_DGRAM` and thus
    opens a UDP socket. To open a TCP socket (for use with the newer syslog
    daemons such as rsyslog), specify a value of :const:`socket.SOCK_STREAM`.
+   If *timeout* is specified, it sets a timeout (in seconds) for the socket operations.
+   This can help prevent the program from hanging indefinitely if the syslog server is
+   unreachable. By default, *timeout* is `None`, meaning no timeout is applied.
+
+
 
    Note that if your server is not listening on UDP port 514,
    :class:`SysLogHandler` may appear not to work. In that case, check what
@@ -645,6 +650,8 @@ supports sending logging messages to a remote or local Unix syslog.
    .. versionchanged:: 3.2
       *socktype* was added.
 
+   .. versionchanged:: 3.x
+      *timeout* was added.
 
    .. method:: close()
 

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -628,7 +628,7 @@ supports sending logging messages to a remote or local Unix syslog.
    daemons such as rsyslog), specify a value of :const:`socket.SOCK_STREAM`.
    If *timeout* is specified, it sets a timeout (in seconds) for the socket operations.
    This can help prevent the program from hanging indefinitely if the syslog server is
-   unreachable. By default, *timeout* is `None`, meaning no timeout is applied.
+   unreachable. By default, *timeout* is ``None``, meaning no timeout is applied.
 
 
 

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -650,7 +650,7 @@ supports sending logging messages to a remote or local Unix syslog.
    .. versionchanged:: 3.2
       *socktype* was added.
 
-   .. versionchanged:: 3.x
+   .. versionchanged:: 3.14
       *timeout* was added.
 
    .. method:: close()

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -855,7 +855,7 @@ class SysLogHandler(logging.Handler):
     }
 
     def __init__(self, address=('localhost', SYSLOG_UDP_PORT),
-                 facility=LOG_USER, socktype=None):
+                 facility=LOG_USER, socktype=None, timeout=None):
         """
         Initialize a handler.
 
@@ -872,6 +872,7 @@ class SysLogHandler(logging.Handler):
         self.address = address
         self.facility = facility
         self.socktype = socktype
+        self.timeout = timeout
         self.socket = None
         self.createSocket()
 
@@ -933,6 +934,8 @@ class SysLogHandler(logging.Handler):
                 err = sock = None
                 try:
                     sock = socket.socket(af, socktype, proto)
+                    if self.timeout:
+                        sock.settimeout(self.timeout)
                     if socktype == socket.SOCK_STREAM:
                         sock.connect(sa)
                     break

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -22,6 +22,7 @@ import logging
 import logging.handlers
 import logging.config
 
+
 import codecs
 import configparser
 import copy
@@ -2097,6 +2098,18 @@ class SysLogHandlerTest(BaseTest):
         logger.error("sp\xe4m")
         self.handled.wait(support.LONG_TIMEOUT)
         self.assertEqual(self.log_output, b'<11>sp\xc3\xa4m\x00')
+
+    @patch('socket.socket')
+    def test_tcp_timeout(self, mock_socket):
+        instance_mock_sock = mock_socket.return_value
+        instance_mock_sock.connect.side_effect = socket.timeout
+
+        with self.assertRaises(socket.timeout):
+            logging.handlers.SysLogHandler(address=('localhost', 514),
+                                           socktype=socket.SOCK_STREAM,
+                                           timeout=1)
+
+        instance_mock_sock.close.assert_called()
 
 @unittest.skipUnless(hasattr(socket, "AF_UNIX"), "Unix sockets required")
 class UnixSysLogHandlerTest(SysLogHandlerTest):

--- a/Misc/NEWS.d/3.10.0b1.rst
+++ b/Misc/NEWS.d/3.10.0b1.rst
@@ -941,7 +941,7 @@ result from ``entry_points()`` as deprecated.
 
 ..
 
-.. gh: 47383
+.. gh-issue: 47383
 .. date: 2021-04-08-19-32-26
 .. nonce: YI1hdL
 .. section: Library

--- a/Misc/NEWS.d/3.11.0b1.rst
+++ b/Misc/NEWS.d/3.11.0b1.rst
@@ -570,7 +570,7 @@ planned). Patch by Alex Waygood.
 
 ..
 
-.. gh: 78157
+.. gh-issue: 78157
 .. date: 2022-05-05-20-40-45
 .. nonce: IA_9na
 .. section: Library
@@ -1289,7 +1289,7 @@ Deprecate the chunk module.
 
 ..
 
-.. gh: 91498
+.. gh-issue: 91498
 .. date: 2022-04-10-08-39-44
 .. nonce: 8oII92
 .. section: Library

--- a/Misc/NEWS.d/next/Library/2025-01-29-13-37-18.gh-issue-126400.DaBaR3.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-29-13-37-18.gh-issue-126400.DaBaR3.rst
@@ -1,0 +1,2 @@
+Add a socket *timeout* keyword argument to
+:class:`logging.handlers.SysLogHandler`.


### PR DESCRIPTION
Issue #126400.
branch name - fix-issue-126400

### Summary
In the current implementation of the `SysLogHandler` class from the `logging.handlers` module, if the specified address does not respond or is unreachable, the `createSocket` method may block indefinitely in case of using TCP socket (based on stream). This is problematic because there is no way to set a socket timeout during the connection's creation without overriding the entire `createSocket` method.

### Changes
1. Added a `timeout` parameter to the `SysLogHandler.__init__` method, allowing users to specify a timeout for the socket connection.
2. Updated the `createSocket` method to apply the `timeout` to the socket if provided.

This change allows users to prevent indefinite blocking on socket creation, enabling more robust error handling when the SysLog server is unresponsive.

### Example Usage
With this update, users can now create a `SysLogHandler` with a timeout as follows:

```python
import logging
from logging.handlers import SysLogHandler

# Create a SysLogHandler with a 5-second timeout
handler = SysLogHandler(address=('localhost', 514), timeout=5)
```

<!-- gh-issue-number: gh-126400 -->
* Issue: gh-126400
<!-- /gh-issue-number -->
