### PR TITLE
Docs: Miscellaneous corrections to simple statements in the language reference

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -408,7 +408,7 @@ The extended form, ``assert expression1, expression2``, is equivalent to ::
 
 These equivalences assume that :const:`__debug__` and :exc:`AssertionError` refer to
 the built-in variables with those names.  In the current implementation, the
-built-in variable :const:`__debug__` is ``True`` under normal circumstances,
+built-in variable ``__debug__`` is ``True`` under normal circumstances,
 ``False`` when optimization is requested (command line option :option:`-O`).  The current
 code generator emits no code for an :keyword:`assert` statement when optimization is
 requested at compile time.  Note that it is unnecessary to include the source
@@ -533,7 +533,7 @@ The :keyword:`!yield` statement
    yield_stmt: `yield_expression`
 
 A :keyword:`yield` statement is semantically equivalent to a :ref:`yield
-expression <yieldexpr>`. The :keyword:`yield` statement can be used to omit the
+expression <yieldexpr>`. The ``yield`` statement can be used to omit the
 parentheses that would otherwise be required in the equivalent yield expression
 statement. For example, the yield statements ::
 

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -410,7 +410,7 @@ These equivalences assume that :const:`__debug__` and :exc:`AssertionError` refe
 the built-in variables with those names.  In the current implementation, the
 built-in variable :const:`__debug__` is ``True`` under normal circumstances,
 ``False`` when optimization is requested (command line option :option:`-O`).  The current
-code generator emits no code for an assert statement when optimization is
+code generator emits no code for an :keyword:`assert` statement when optimization is
 requested at compile time.  Note that it is unnecessary to include the source
 code for the expression that failed in the error message; it will be displayed
 as part of the stack trace.
@@ -533,8 +533,8 @@ The :keyword:`!yield` statement
    yield_stmt: `yield_expression`
 
 A :keyword:`yield` statement is semantically equivalent to a :ref:`yield
-expression <yieldexpr>`. The yield statement can be used to omit the parentheses
-that would otherwise be required in the equivalent yield expression
+expression <yieldexpr>`. The :keyword:`yield` statement can be used to omit the
+parentheses that would otherwise be required in the equivalent yield expression
 statement. For example, the yield statements ::
 
   yield <expr>
@@ -546,7 +546,7 @@ are equivalent to the yield expression statements ::
   (yield from <expr>)
 
 Yield expressions and statements are only used when defining a :term:`generator`
-function, and are only used in the body of the generator function.  Using yield
+function, and are only used in the body of the generator function.  Using :keyword:`yield`
 in a function definition is sufficient to cause that definition to create a
 generator function instead of a normal function.
 
@@ -966,12 +966,12 @@ The :keyword:`!global` statement
 .. productionlist:: python-grammar
    global_stmt: "global" `identifier` ("," `identifier`)*
 
-The :keyword:`global` causes the listed identifiers to be interpreted
+The :keyword:`global` statement causes the listed identifiers to be interpreted
 as globals. It would be impossible to assign to a global variable without
 :keyword:`!global`, although free variables may refer to globals without being
 declared global.
 
-The global statement applies to the entire scope of a function or
+The :keyword:`global` statement applies to the entire scope of a function or
 class body. A :exc:`SyntaxError` is raised if a variable is used or
 assigned to prior to its global declaration in the scope.
 
@@ -1009,7 +1009,7 @@ identifiers.  If a name is bound in more than one nonlocal scope, the
 nearest binding is used. If a name is not bound in any nonlocal scope,
 or if there is no nonlocal scope, a :exc:`SyntaxError` is raised.
 
-The nonlocal statement applies to the entire scope of a function or
+The :keyword:`nonlocal` statement applies to the entire scope of a function or
 class body. A :exc:`SyntaxError` is raised if a variable is used or
 assigned to prior to its nonlocal declaration in the scope.
 


### PR DESCRIPTION
* Replace: The :keyword:`global` -> The :keyword:`global` statement
  * This deals with @merwok's comment in  https://github.com/python/cpython/pull/126523#discussion_r1837422925
* Add :keyword: when it's needed



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126720.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->