### PR TITLE
gh-126662: Naming consistency for shutil._ntuple_diskusage

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1362,7 +1362,7 @@ def unpack_archive(filename, extract_dir=None, format=None, *, filter=None):
 if hasattr(os, 'statvfs'):
 
     __all__.append('disk_usage')
-    _ntuple_diskusage = collections.namedtuple('usage', 'total used free')
+    _ntuple_diskusage = collections.namedtuple('_ntuple_diskusage', 'total used free')
     _ntuple_diskusage.total.__doc__ = 'Total space in bytes'
     _ntuple_diskusage.used.__doc__ = 'Used space in bytes'
     _ntuple_diskusage.free.__doc__ = 'Free space in bytes'
@@ -1382,7 +1382,7 @@ if hasattr(os, 'statvfs'):
 elif _WINDOWS:
 
     __all__.append('disk_usage')
-    _ntuple_diskusage = collections.namedtuple('usage', 'total used free')
+    _ntuple_diskusage = collections.namedtuple('_ntuple_diskusage', 'total used free')
 
     def disk_usage(path):
         """Return disk usage statistics about the given path.


### PR DESCRIPTION
This MR updates `shutil._ntuple_diskusage` so it's named consistently.

<!-- gh-issue-number: gh-126662 -->
* Issue: gh-126662
<!-- /gh-issue-number -->
