### PR TITLE
gh-126662: Name consistency for xml.parsers.expat.XMLParserType

### DIFF
--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -104,7 +104,7 @@ The :mod:`xml.parsers.expat` module contains two functions:
       http://www.python.org/ns/ elem1
       elem2
 
-   Due to limitations in the ``Expat`` library used by :mod:`pyexpat`,
+   Due to limitations in the ``Expat`` library used by :mod:`!pyexpat`,
    the :class:`XMLParserType` instance returned can only be used to parse a single
    XML document.  Call ``ParserCreate`` for each document to provide unique
    parser instances.
@@ -283,7 +283,7 @@ XMLParser Objects
 
 The following attributes contain values relating to the most recent error
 encountered by an :class:`XMLParserType` object, and will only have correct values
-once a call to :meth:`Parse` or :meth:`ParseFile` has raised an
+once a call to :meth:`~XMLParserType.Parse` or :meth:`~XMLParserType.ParseFile` has raised an
 :exc:`xml.parsers.expat.ExpatError` exception.
 
 

--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -27,8 +27,8 @@
 
 The :mod:`xml.parsers.expat` module is a Python interface to the Expat
 non-validating XML parser. The module provides a single extension type,
-:class:`xmlparser`, that represents the current state of an XML parser.  After
-an :class:`xmlparser` object has been created, various attributes of the object
+:class:`XMLParserType`, that represents the current state of an XML parser.  After
+an :class:`XMLParserType` object has been created, various attributes of the object
 can be set to handler functions.  When an XML document is then fed to the
 parser, the handler functions are called for the character data and markup in
 the XML document.
@@ -66,7 +66,7 @@ The :mod:`xml.parsers.expat` module contains two functions:
 
 .. function:: ParserCreate(encoding=None, namespace_separator=None)
 
-   Creates and returns a new :class:`xmlparser` object.   *encoding*, if specified,
+   Creates and returns a new :class:`XMLParserType` object.   *encoding*, if specified,
    must be a string naming the encoding  used by the XML data.  Expat doesn't
    support as many encodings as Python does, and its repertoire of encodings can't
    be extended; it supports UTF-8, UTF-16, ISO-8859-1 (Latin1), and ASCII.  If
@@ -105,7 +105,7 @@ The :mod:`xml.parsers.expat` module contains two functions:
       elem2
 
    Due to limitations in the ``Expat`` library used by :mod:`pyexpat`,
-   the :class:`xmlparser` instance returned can only be used to parse a single
+   the :class:`XMLParserType` instance returned can only be used to parse a single
    XML document.  Call ``ParserCreate`` for each document to provide unique
    parser instances.
 
@@ -121,10 +121,10 @@ The :mod:`xml.parsers.expat` module contains two functions:
 XMLParser Objects
 -----------------
 
-:class:`xmlparser` objects have the following methods:
+:class:`XMLParserType` objects have the following methods:
 
 
-.. method:: xmlparser.Parse(data[, isfinal])
+.. method:: XMLParserType.Parse(data[, isfinal])
 
    Parses the contents of the string *data*, calling the appropriate handler
    functions to process the parsed data.  *isfinal* must be true on the final call
@@ -133,14 +133,14 @@ XMLParser Objects
    *data* can be the empty string at any time.
 
 
-.. method:: xmlparser.ParseFile(file)
+.. method:: XMLParserType.ParseFile(file)
 
    Parse XML data reading from the object *file*.  *file* only needs to provide
    the ``read(nbytes)`` method, returning the empty string when there's no more
    data.
 
 
-.. method:: xmlparser.SetBase(base)
+.. method:: XMLParserType.SetBase(base)
 
    Sets the base to be used for resolving relative URIs in system identifiers in
    declarations.  Resolving relative identifiers is left to the application: this
@@ -149,20 +149,20 @@ XMLParser Objects
    :func:`UnparsedEntityDeclHandler` functions.
 
 
-.. method:: xmlparser.GetBase()
+.. method:: XMLParserType.GetBase()
 
    Returns a string containing the base set by a previous call to :meth:`SetBase`,
    or ``None`` if  :meth:`SetBase` hasn't been called.
 
 
-.. method:: xmlparser.GetInputContext()
+.. method:: XMLParserType.GetInputContext()
 
    Returns the input data that generated the current event as a string. The data is
    in the encoding of the entity which contains the text. When called while an
    event handler is not active, the return value is ``None``.
 
 
-.. method:: xmlparser.ExternalEntityParserCreate(context[, encoding])
+.. method:: XMLParserType.ExternalEntityParserCreate(context[, encoding])
 
    Create a "child" parser which can be used to parse an external parsed entity
    referred to by content parsed by the parent parser.  The *context* parameter
@@ -171,7 +171,7 @@ XMLParser Objects
    :attr:`ordered_attributes` and :attr:`specified_attributes` set to the values of
    this parser.
 
-.. method:: xmlparser.SetParamEntityParsing(flag)
+.. method:: XMLParserType.SetParamEntityParsing(flag)
 
    Control parsing of parameter entities (including the external DTD subset).
    Possible *flag* values are :const:`XML_PARAM_ENTITY_PARSING_NEVER`,
@@ -179,7 +179,7 @@ XMLParser Objects
    :const:`XML_PARAM_ENTITY_PARSING_ALWAYS`.  Return true if setting the flag
    was successful.
 
-.. method:: xmlparser.UseForeignDTD([flag])
+.. method:: XMLParserType.UseForeignDTD([flag])
 
    Calling this with a true value for *flag* (the default) will cause Expat to call
    the :attr:`ExternalEntityRefHandler` with :const:`None` for all arguments to
@@ -196,7 +196,7 @@ XMLParser Objects
    :exc:`ExpatError` to be raised with the :attr:`code` attribute set to
    ``errors.codes[errors.XML_ERROR_CANT_CHANGE_FEATURE_ONCE_PARSING]``.
 
-.. method:: xmlparser.SetReparseDeferralEnabled(enabled)
+.. method:: XMLParserType.SetReparseDeferralEnabled(enabled)
 
    .. warning::
 
@@ -224,7 +224,7 @@ XMLParser Objects
 
    .. versionadded:: 3.13
 
-.. method:: xmlparser.GetReparseDeferralEnabled()
+.. method:: XMLParserType.GetReparseDeferralEnabled()
 
    Returns whether reparse deferral is currently enabled for the given
    Expat parser instance.
@@ -232,10 +232,10 @@ XMLParser Objects
    .. versionadded:: 3.13
 
 
-:class:`xmlparser` objects have the following attributes:
+:class:`XMLParserType` objects have the following attributes:
 
 
-.. attribute:: xmlparser.buffer_size
+.. attribute:: XMLParserType.buffer_size
 
    The size of the buffer used when :attr:`buffer_text` is true.
    A new buffer size can be set by assigning a new integer value
@@ -243,9 +243,9 @@ XMLParser Objects
    When the size is changed, the buffer will be flushed.
 
 
-.. attribute:: xmlparser.buffer_text
+.. attribute:: XMLParserType.buffer_text
 
-   Setting this to true causes the :class:`xmlparser` object to buffer textual
+   Setting this to true causes the :class:`XMLParserType` object to buffer textual
    content returned by Expat to avoid multiple calls to the
    :meth:`CharacterDataHandler` callback whenever possible.  This can improve
    performance substantially since Expat normally breaks character data into chunks
@@ -254,14 +254,14 @@ XMLParser Objects
    may be chunked too.
 
 
-.. attribute:: xmlparser.buffer_used
+.. attribute:: XMLParserType.buffer_used
 
    If :attr:`buffer_text` is enabled, the number of bytes stored in the buffer.
    These bytes represent UTF-8 encoded text.  This attribute has no meaningful
    interpretation when :attr:`buffer_text` is false.
 
 
-.. attribute:: xmlparser.ordered_attributes
+.. attribute:: XMLParserType.ordered_attributes
 
    Setting this attribute to a non-zero integer causes the attributes to be
    reported as a list rather than a dictionary.  The attributes are presented in
@@ -271,7 +271,7 @@ XMLParser Objects
    changed at any time.
 
 
-.. attribute:: xmlparser.specified_attributes
+.. attribute:: XMLParserType.specified_attributes
 
    If set to a non-zero integer, the parser will report only those attributes which
    were specified in the document instance and not those which were derived from
@@ -282,62 +282,62 @@ XMLParser Objects
 
 
 The following attributes contain values relating to the most recent error
-encountered by an :class:`xmlparser` object, and will only have correct values
+encountered by an :class:`XMLParserType` object, and will only have correct values
 once a call to :meth:`Parse` or :meth:`ParseFile` has raised an
 :exc:`xml.parsers.expat.ExpatError` exception.
 
 
-.. attribute:: xmlparser.ErrorByteIndex
+.. attribute:: XMLParserType.ErrorByteIndex
 
    Byte index at which an error occurred.
 
 
-.. attribute:: xmlparser.ErrorCode
+.. attribute:: XMLParserType.ErrorCode
 
    Numeric code specifying the problem.  This value can be passed to the
    :func:`ErrorString` function, or compared to one of the constants defined in the
    ``errors`` object.
 
 
-.. attribute:: xmlparser.ErrorColumnNumber
+.. attribute:: XMLParserType.ErrorColumnNumber
 
    Column number at which an error occurred.
 
 
-.. attribute:: xmlparser.ErrorLineNumber
+.. attribute:: XMLParserType.ErrorLineNumber
 
    Line number at which an error occurred.
 
 The following attributes contain values relating to the current parse location
-in an :class:`xmlparser` object.  During a callback reporting a parse event they
+in an :class:`XMLParserType` object.  During a callback reporting a parse event they
 indicate the location of the first of the sequence of characters that generated
 the event.  When called outside of a callback, the position indicated will be
 just past the last parse event (regardless of whether there was an associated
 callback).
 
 
-.. attribute:: xmlparser.CurrentByteIndex
+.. attribute:: XMLParserType.CurrentByteIndex
 
    Current byte index in the parser input.
 
 
-.. attribute:: xmlparser.CurrentColumnNumber
+.. attribute:: XMLParserType.CurrentColumnNumber
 
    Current column number in the parser input.
 
 
-.. attribute:: xmlparser.CurrentLineNumber
+.. attribute:: XMLParserType.CurrentLineNumber
 
    Current line number in the parser input.
 
 Here is the list of handlers that can be set.  To set a handler on an
-:class:`xmlparser` object *o*, use ``o.handlername = func``.  *handlername* must
+:class:`XMLParserType` object *o*, use ``o.handlername = func``.  *handlername* must
 be taken from the following list, and *func* must be a callable object accepting
 the correct number of arguments.  The arguments are all strings, unless
 otherwise stated.
 
 
-.. method:: xmlparser.XmlDeclHandler(version, encoding, standalone)
+.. method:: XMLParserType.XmlDeclHandler(version, encoding, standalone)
 
    Called when the XML declaration is parsed.  The XML declaration is the
    (optional) declaration of the applicable version of the XML recommendation, the
@@ -348,7 +348,7 @@ otherwise stated.
    Expat version 1.95.0 or newer.
 
 
-.. method:: xmlparser.StartDoctypeDeclHandler(doctypeName, systemId, publicId, has_internal_subset)
+.. method:: XMLParserType.StartDoctypeDeclHandler(doctypeName, systemId, publicId, has_internal_subset)
 
    Called when Expat begins parsing the document type declaration (``<!DOCTYPE
    ...``).  The *doctypeName* is provided exactly as presented.  The *systemId* and
@@ -358,19 +358,19 @@ otherwise stated.
    1.2 or newer.
 
 
-.. method:: xmlparser.EndDoctypeDeclHandler()
+.. method:: XMLParserType.EndDoctypeDeclHandler()
 
    Called when Expat is done parsing the document type declaration. This requires
    Expat version 1.2 or newer.
 
 
-.. method:: xmlparser.ElementDeclHandler(name, model)
+.. method:: XMLParserType.ElementDeclHandler(name, model)
 
    Called once for each element type declaration.  *name* is the name of the
    element type, and *model* is a representation of the content model.
 
 
-.. method:: xmlparser.AttlistDeclHandler(elname, attname, type, default, required)
+.. method:: XMLParserType.AttlistDeclHandler(elname, attname, type, default, required)
 
    Called for each declared attribute for an element type.  If an attribute list
    declaration declares three attributes, this handler is called three times, once
@@ -384,7 +384,7 @@ otherwise stated.
    true. This requires Expat version 1.95.0 or newer.
 
 
-.. method:: xmlparser.StartElementHandler(name, attributes)
+.. method:: XMLParserType.StartElementHandler(name, attributes)
 
    Called for the start of every element.  *name* is a string containing the
    element name, and *attributes* is the element attributes. If
@@ -393,17 +393,17 @@ otherwise stated.
    dictionary mapping names to values.
 
 
-.. method:: xmlparser.EndElementHandler(name)
+.. method:: XMLParserType.EndElementHandler(name)
 
    Called for the end of every element.
 
 
-.. method:: xmlparser.ProcessingInstructionHandler(target, data)
+.. method:: XMLParserType.ProcessingInstructionHandler(target, data)
 
    Called for every processing instruction.
 
 
-.. method:: xmlparser.CharacterDataHandler(data)
+.. method:: XMLParserType.CharacterDataHandler(data)
 
    Called for character data.  This will be called for normal character data, CDATA
    marked content, and ignorable whitespace.  Applications which must distinguish
@@ -415,7 +415,7 @@ otherwise stated.
    to ``True`` to avoid that.
 
 
-.. method:: xmlparser.UnparsedEntityDeclHandler(entityName, base, systemId, publicId, notationName)
+.. method:: XMLParserType.UnparsedEntityDeclHandler(entityName, base, systemId, publicId, notationName)
 
    Called for unparsed (NDATA) entity declarations.  This is only present for
    version 1.2 of the Expat library; for more recent versions, use
@@ -423,7 +423,7 @@ otherwise stated.
    library has been declared obsolete.)
 
 
-.. method:: xmlparser.EntityDeclHandler(entityName, is_parameter_entity, value, base, systemId, publicId, notationName)
+.. method:: XMLParserType.EntityDeclHandler(entityName, is_parameter_entity, value, base, systemId, publicId, notationName)
 
    Called for all entity declarations.  For parameter and internal entities,
    *value* will be a string giving the declared contents of the entity; this will
@@ -435,21 +435,21 @@ otherwise stated.
    Expat library.
 
 
-.. method:: xmlparser.NotationDeclHandler(notationName, base, systemId, publicId)
+.. method:: XMLParserType.NotationDeclHandler(notationName, base, systemId, publicId)
 
    Called for notation declarations.  *notationName*, *base*, and *systemId*, and
    *publicId* are strings if given.  If the public identifier is omitted,
    *publicId* will be ``None``.
 
 
-.. method:: xmlparser.StartNamespaceDeclHandler(prefix, uri)
+.. method:: XMLParserType.StartNamespaceDeclHandler(prefix, uri)
 
    Called when an element contains a namespace declaration.  Namespace declarations
    are processed before the :attr:`StartElementHandler` is called for the element
    on which declarations are placed.
 
 
-.. method:: xmlparser.EndNamespaceDeclHandler(prefix)
+.. method:: XMLParserType.EndNamespaceDeclHandler(prefix)
 
    Called when the closing tag is reached for an element  that contained a
    namespace declaration.  This is called once for each namespace declaration on
@@ -459,39 +459,39 @@ otherwise stated.
    corresponding :attr:`EndElementHandler` for the end of the element.
 
 
-.. method:: xmlparser.CommentHandler(data)
+.. method:: XMLParserType.CommentHandler(data)
 
    Called for comments.  *data* is the text of the comment, excluding the leading
    ``'<!-``\ ``-'`` and trailing ``'-``\ ``->'``.
 
 
-.. method:: xmlparser.StartCdataSectionHandler()
+.. method:: XMLParserType.StartCdataSectionHandler()
 
    Called at the start of a CDATA section.  This and :attr:`EndCdataSectionHandler`
    are needed to be able to identify the syntactical start and end for CDATA
    sections.
 
 
-.. method:: xmlparser.EndCdataSectionHandler()
+.. method:: XMLParserType.EndCdataSectionHandler()
 
    Called at the end of a CDATA section.
 
 
-.. method:: xmlparser.DefaultHandler(data)
+.. method:: XMLParserType.DefaultHandler(data)
 
    Called for any characters in the XML document for which no applicable handler
    has been specified.  This means characters that are part of a construct which
    could be reported, but for which no handler has been supplied.
 
 
-.. method:: xmlparser.DefaultHandlerExpand(data)
+.. method:: XMLParserType.DefaultHandlerExpand(data)
 
    This is the same as the :func:`DefaultHandler`,  but doesn't inhibit expansion
    of internal entities. The entity reference will not be passed to the default
    handler.
 
 
-.. method:: xmlparser.NotStandaloneHandler()
+.. method:: XMLParserType.NotStandaloneHandler()
 
    Called if the XML document hasn't been declared as being a standalone document.
    This happens when there is an external subset or a reference to a parameter
@@ -501,7 +501,7 @@ otherwise stated.
    exception is raised by the parser for this condition.
 
 
-.. method:: xmlparser.ExternalEntityRefHandler(context, base, systemId, publicId)
+.. method:: XMLParserType.ExternalEntityRefHandler(context, base, systemId, publicId)
 
    Called for references to external entities.  *base* is the current base, as set
    by a previous call to :meth:`SetBase`.  The public and system identifiers,
@@ -947,4 +947,3 @@ The ``errors`` module has the following attributes:
    appropriate standards. For example, "UTF-8" is valid, but "UTF8" is
    not. See https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EncodingDecl
    and https://www.iana.org/assignments/character-sets/character-sets.xhtml.
-

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -1397,7 +1397,7 @@ XMLParser Objects
       The implementation of :meth:`flush` temporarily disables reparse deferral
       with Expat (if currently enabled) and triggers a reparse.
       Disabling reparse deferral has security consequences; please see
-      :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
+      :meth:`xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled` for details.
 
       Note that :meth:`flush` has been backported to some prior releases of
       CPython as a security fix.  Check for availability of :meth:`flush`
@@ -1475,7 +1475,7 @@ XMLPullParser Objects
       The implementation of :meth:`flush` temporarily disables reparse deferral
       with Expat (if currently enabled) and triggers a reparse.
       Disabling reparse deferral has security consequences; please see
-      :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled` for details.
+      :meth:`xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled` for details.
 
       Note that :meth:`flush` has been backported to some prior releases of
       CPython as a security fix.  Check for availability of :meth:`flush`

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -1405,7 +1405,7 @@ complete list of changes, or look through the CVS logs for all the details.
 * The parser objects provided by the :mod:`pyexpat <xml.parsers.expat>` module can now optionally
   buffer character data, resulting in fewer calls to your character data handler
   and therefore faster performance.  Setting the parser object's
-  :attr:`~xml.parsers.expat.xmlparser.buffer_text` attribute to :const:`True` will enable buffering.
+  :attr:`~xml.parsers.expat.XMLParserType.buffer_text` attribute to :const:`True` will enable buffering.
 
 * The ``sample(population, k)`` function was added to the :mod:`random`
   module.  *population* is a sequence or :class:`!xrange` object containing the

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1438,8 +1438,8 @@ xml
 
   * :meth:`xml.etree.ElementTree.XMLParser.flush`
   * :meth:`xml.etree.ElementTree.XMLPullParser.flush`
-  * :meth:`xml.parsers.expat.xmlparser.GetReparseDeferralEnabled`
-  * :meth:`xml.parsers.expat.xmlparser.SetReparseDeferralEnabled`
+  * :meth:`xml.parsers.expat.XMLParserType.GetReparseDeferralEnabled`
+  * :meth:`xml.parsers.expat.XMLParserType.SetReparseDeferralEnabled`
   * :meth:`!xml.sax.expatreader.ExpatParser.flush`
 
   (Contributed by Sebastian Pipping in :gh:`115623`.)

--- a/Misc/NEWS.d/next/Library/2024-11-12-00-10-34.gh-issue-126662.zd5LEW.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-12-00-10-34.gh-issue-126662.zd5LEW.rst
@@ -1,1 +1,1 @@
-Update :class:`pyexpat.XMLParserType` to use that name consisently.
+Update :class:`xml.parsers.expat.XMLParserType` to use that name consisently.

--- a/Misc/NEWS.d/next/Library/2024-11-12-00-10-34.gh-issue-126662.zd5LEW.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-12-00-10-34.gh-issue-126662.zd5LEW.rst
@@ -1,0 +1,1 @@
+Update :class:`pyexpat.XMLParserType` to use that name consisently.

--- a/Modules/clinic/pyexpat.c.h
+++ b/Modules/clinic/pyexpat.c.h
@@ -8,21 +8,21 @@ preserve
 #endif
 #include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
-PyDoc_STRVAR(pyexpat_xmlparser_SetReparseDeferralEnabled__doc__,
+PyDoc_STRVAR(pyexpat_XMLParserType_SetReparseDeferralEnabled__doc__,
 "SetReparseDeferralEnabled($self, enabled, /)\n"
 "--\n"
 "\n"
 "Enable/Disable reparse deferral; enabled by default with Expat >=2.6.0.");
 
-#define PYEXPAT_XMLPARSER_SETREPARSEDEFERRALENABLED_METHODDEF    \
-    {"SetReparseDeferralEnabled", (PyCFunction)pyexpat_xmlparser_SetReparseDeferralEnabled, METH_O, pyexpat_xmlparser_SetReparseDeferralEnabled__doc__},
+#define PYEXPAT_XMLPARSERTYPE_SETREPARSEDEFERRALENABLED_METHODDEF    \
+    {"SetReparseDeferralEnabled", (PyCFunction)pyexpat_XMLParserType_SetReparseDeferralEnabled, METH_O, pyexpat_XMLParserType_SetReparseDeferralEnabled__doc__},
 
 static PyObject *
-pyexpat_xmlparser_SetReparseDeferralEnabled_impl(xmlparseobject *self,
-                                                 int enabled);
+pyexpat_XMLParserType_SetReparseDeferralEnabled_impl(xmlparseobject *self,
+                                                     int enabled);
 
 static PyObject *
-pyexpat_xmlparser_SetReparseDeferralEnabled(xmlparseobject *self, PyObject *arg)
+pyexpat_XMLParserType_SetReparseDeferralEnabled(xmlparseobject *self, PyObject *arg)
 {
     PyObject *return_value = NULL;
     int enabled;
@@ -31,31 +31,31 @@ pyexpat_xmlparser_SetReparseDeferralEnabled(xmlparseobject *self, PyObject *arg)
     if (enabled < 0) {
         goto exit;
     }
-    return_value = pyexpat_xmlparser_SetReparseDeferralEnabled_impl(self, enabled);
+    return_value = pyexpat_XMLParserType_SetReparseDeferralEnabled_impl(self, enabled);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(pyexpat_xmlparser_GetReparseDeferralEnabled__doc__,
+PyDoc_STRVAR(pyexpat_XMLParserType_GetReparseDeferralEnabled__doc__,
 "GetReparseDeferralEnabled($self, /)\n"
 "--\n"
 "\n"
 "Retrieve reparse deferral enabled status; always returns false with Expat <2.6.0.");
 
-#define PYEXPAT_XMLPARSER_GETREPARSEDEFERRALENABLED_METHODDEF    \
-    {"GetReparseDeferralEnabled", (PyCFunction)pyexpat_xmlparser_GetReparseDeferralEnabled, METH_NOARGS, pyexpat_xmlparser_GetReparseDeferralEnabled__doc__},
+#define PYEXPAT_XMLPARSERTYPE_GETREPARSEDEFERRALENABLED_METHODDEF    \
+    {"GetReparseDeferralEnabled", (PyCFunction)pyexpat_XMLParserType_GetReparseDeferralEnabled, METH_NOARGS, pyexpat_XMLParserType_GetReparseDeferralEnabled__doc__},
 
 static PyObject *
-pyexpat_xmlparser_GetReparseDeferralEnabled_impl(xmlparseobject *self);
+pyexpat_XMLParserType_GetReparseDeferralEnabled_impl(xmlparseobject *self);
 
 static PyObject *
-pyexpat_xmlparser_GetReparseDeferralEnabled(xmlparseobject *self, PyObject *Py_UNUSED(ignored))
+pyexpat_XMLParserType_GetReparseDeferralEnabled(xmlparseobject *self, PyObject *Py_UNUSED(ignored))
 {
-    return pyexpat_xmlparser_GetReparseDeferralEnabled_impl(self);
+    return pyexpat_XMLParserType_GetReparseDeferralEnabled_impl(self);
 }
 
-PyDoc_STRVAR(pyexpat_xmlparser_Parse__doc__,
+PyDoc_STRVAR(pyexpat_XMLParserType_Parse__doc__,
 "Parse($self, data, isfinal=False, /)\n"
 "--\n"
 "\n"
@@ -63,15 +63,15 @@ PyDoc_STRVAR(pyexpat_xmlparser_Parse__doc__,
 "\n"
 "\'isfinal\' should be true at end of input.");
 
-#define PYEXPAT_XMLPARSER_PARSE_METHODDEF    \
-    {"Parse", _PyCFunction_CAST(pyexpat_xmlparser_Parse), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, pyexpat_xmlparser_Parse__doc__},
+#define PYEXPAT_XMLPARSERTYPE_PARSE_METHODDEF    \
+    {"Parse", _PyCFunction_CAST(pyexpat_XMLParserType_Parse), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, pyexpat_XMLParserType_Parse__doc__},
 
 static PyObject *
-pyexpat_xmlparser_Parse_impl(xmlparseobject *self, PyTypeObject *cls,
-                             PyObject *data, int isfinal);
+pyexpat_XMLParserType_Parse_impl(xmlparseobject *self, PyTypeObject *cls,
+                                 PyObject *data, int isfinal);
 
 static PyObject *
-pyexpat_xmlparser_Parse(xmlparseobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+pyexpat_XMLParserType_Parse(xmlparseobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
@@ -105,27 +105,27 @@ pyexpat_xmlparser_Parse(xmlparseobject *self, PyTypeObject *cls, PyObject *const
         goto exit;
     }
 skip_optional_posonly:
-    return_value = pyexpat_xmlparser_Parse_impl(self, cls, data, isfinal);
+    return_value = pyexpat_XMLParserType_Parse_impl(self, cls, data, isfinal);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(pyexpat_xmlparser_ParseFile__doc__,
+PyDoc_STRVAR(pyexpat_XMLParserType_ParseFile__doc__,
 "ParseFile($self, file, /)\n"
 "--\n"
 "\n"
 "Parse XML data from file-like object.");
 
-#define PYEXPAT_XMLPARSER_PARSEFILE_METHODDEF    \
-    {"ParseFile", _PyCFunction_CAST(pyexpat_xmlparser_ParseFile), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, pyexpat_xmlparser_ParseFile__doc__},
+#define PYEXPAT_XMLPARSERTYPE_PARSEFILE_METHODDEF    \
+    {"ParseFile", _PyCFunction_CAST(pyexpat_XMLParserType_ParseFile), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, pyexpat_XMLParserType_ParseFile__doc__},
 
 static PyObject *
-pyexpat_xmlparser_ParseFile_impl(xmlparseobject *self, PyTypeObject *cls,
-                                 PyObject *file);
+pyexpat_XMLParserType_ParseFile_impl(xmlparseobject *self, PyTypeObject *cls,
+                                     PyObject *file);
 
 static PyObject *
-pyexpat_xmlparser_ParseFile(xmlparseobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+pyexpat_XMLParserType_ParseFile(xmlparseobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
@@ -150,26 +150,26 @@ pyexpat_xmlparser_ParseFile(xmlparseobject *self, PyTypeObject *cls, PyObject *c
         goto exit;
     }
     file = args[0];
-    return_value = pyexpat_xmlparser_ParseFile_impl(self, cls, file);
+    return_value = pyexpat_XMLParserType_ParseFile_impl(self, cls, file);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(pyexpat_xmlparser_SetBase__doc__,
+PyDoc_STRVAR(pyexpat_XMLParserType_SetBase__doc__,
 "SetBase($self, base, /)\n"
 "--\n"
 "\n"
 "Set the base URL for the parser.");
 
-#define PYEXPAT_XMLPARSER_SETBASE_METHODDEF    \
-    {"SetBase", (PyCFunction)pyexpat_xmlparser_SetBase, METH_O, pyexpat_xmlparser_SetBase__doc__},
+#define PYEXPAT_XMLPARSERTYPE_SETBASE_METHODDEF    \
+    {"SetBase", (PyCFunction)pyexpat_XMLParserType_SetBase, METH_O, pyexpat_XMLParserType_SetBase__doc__},
 
 static PyObject *
-pyexpat_xmlparser_SetBase_impl(xmlparseobject *self, const char *base);
+pyexpat_XMLParserType_SetBase_impl(xmlparseobject *self, const char *base);
 
 static PyObject *
-pyexpat_xmlparser_SetBase(xmlparseobject *self, PyObject *arg)
+pyexpat_XMLParserType_SetBase(xmlparseobject *self, PyObject *arg)
 {
     PyObject *return_value = NULL;
     const char *base;
@@ -187,31 +187,31 @@ pyexpat_xmlparser_SetBase(xmlparseobject *self, PyObject *arg)
         PyErr_SetString(PyExc_ValueError, "embedded null character");
         goto exit;
     }
-    return_value = pyexpat_xmlparser_SetBase_impl(self, base);
+    return_value = pyexpat_XMLParserType_SetBase_impl(self, base);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(pyexpat_xmlparser_GetBase__doc__,
+PyDoc_STRVAR(pyexpat_XMLParserType_GetBase__doc__,
 "GetBase($self, /)\n"
 "--\n"
 "\n"
 "Return base URL string for the parser.");
 
-#define PYEXPAT_XMLPARSER_GETBASE_METHODDEF    \
-    {"GetBase", (PyCFunction)pyexpat_xmlparser_GetBase, METH_NOARGS, pyexpat_xmlparser_GetBase__doc__},
+#define PYEXPAT_XMLPARSERTYPE_GETBASE_METHODDEF    \
+    {"GetBase", (PyCFunction)pyexpat_XMLParserType_GetBase, METH_NOARGS, pyexpat_XMLParserType_GetBase__doc__},
 
 static PyObject *
-pyexpat_xmlparser_GetBase_impl(xmlparseobject *self);
+pyexpat_XMLParserType_GetBase_impl(xmlparseobject *self);
 
 static PyObject *
-pyexpat_xmlparser_GetBase(xmlparseobject *self, PyObject *Py_UNUSED(ignored))
+pyexpat_XMLParserType_GetBase(xmlparseobject *self, PyObject *Py_UNUSED(ignored))
 {
-    return pyexpat_xmlparser_GetBase_impl(self);
+    return pyexpat_XMLParserType_GetBase_impl(self);
 }
 
-PyDoc_STRVAR(pyexpat_xmlparser_GetInputContext__doc__,
+PyDoc_STRVAR(pyexpat_XMLParserType_GetInputContext__doc__,
 "GetInputContext($self, /)\n"
 "--\n"
 "\n"
@@ -220,36 +220,36 @@ PyDoc_STRVAR(pyexpat_xmlparser_GetInputContext__doc__,
 "If the event was generated by a large amount of text (such as a start tag\n"
 "for an element with many attributes), not all of the text may be available.");
 
-#define PYEXPAT_XMLPARSER_GETINPUTCONTEXT_METHODDEF    \
-    {"GetInputContext", (PyCFunction)pyexpat_xmlparser_GetInputContext, METH_NOARGS, pyexpat_xmlparser_GetInputContext__doc__},
+#define PYEXPAT_XMLPARSERTYPE_GETINPUTCONTEXT_METHODDEF    \
+    {"GetInputContext", (PyCFunction)pyexpat_XMLParserType_GetInputContext, METH_NOARGS, pyexpat_XMLParserType_GetInputContext__doc__},
 
 static PyObject *
-pyexpat_xmlparser_GetInputContext_impl(xmlparseobject *self);
+pyexpat_XMLParserType_GetInputContext_impl(xmlparseobject *self);
 
 static PyObject *
-pyexpat_xmlparser_GetInputContext(xmlparseobject *self, PyObject *Py_UNUSED(ignored))
+pyexpat_XMLParserType_GetInputContext(xmlparseobject *self, PyObject *Py_UNUSED(ignored))
 {
-    return pyexpat_xmlparser_GetInputContext_impl(self);
+    return pyexpat_XMLParserType_GetInputContext_impl(self);
 }
 
-PyDoc_STRVAR(pyexpat_xmlparser_ExternalEntityParserCreate__doc__,
+PyDoc_STRVAR(pyexpat_XMLParserType_ExternalEntityParserCreate__doc__,
 "ExternalEntityParserCreate($self, context, encoding=<unrepresentable>,\n"
 "                           /)\n"
 "--\n"
 "\n"
 "Create a parser for parsing an external entity based on the information passed to the ExternalEntityRefHandler.");
 
-#define PYEXPAT_XMLPARSER_EXTERNALENTITYPARSERCREATE_METHODDEF    \
-    {"ExternalEntityParserCreate", _PyCFunction_CAST(pyexpat_xmlparser_ExternalEntityParserCreate), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, pyexpat_xmlparser_ExternalEntityParserCreate__doc__},
+#define PYEXPAT_XMLPARSERTYPE_EXTERNALENTITYPARSERCREATE_METHODDEF    \
+    {"ExternalEntityParserCreate", _PyCFunction_CAST(pyexpat_XMLParserType_ExternalEntityParserCreate), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, pyexpat_XMLParserType_ExternalEntityParserCreate__doc__},
 
 static PyObject *
-pyexpat_xmlparser_ExternalEntityParserCreate_impl(xmlparseobject *self,
-                                                  PyTypeObject *cls,
-                                                  const char *context,
-                                                  const char *encoding);
+pyexpat_XMLParserType_ExternalEntityParserCreate_impl(xmlparseobject *self,
+                                                      PyTypeObject *cls,
+                                                      const char *context,
+                                                      const char *encoding);
 
 static PyObject *
-pyexpat_xmlparser_ExternalEntityParserCreate(xmlparseobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+pyexpat_XMLParserType_ExternalEntityParserCreate(xmlparseobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
@@ -309,13 +309,13 @@ pyexpat_xmlparser_ExternalEntityParserCreate(xmlparseobject *self, PyTypeObject 
         goto exit;
     }
 skip_optional_posonly:
-    return_value = pyexpat_xmlparser_ExternalEntityParserCreate_impl(self, cls, context, encoding);
+    return_value = pyexpat_XMLParserType_ExternalEntityParserCreate_impl(self, cls, context, encoding);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(pyexpat_xmlparser_SetParamEntityParsing__doc__,
+PyDoc_STRVAR(pyexpat_XMLParserType_SetParamEntityParsing__doc__,
 "SetParamEntityParsing($self, flag, /)\n"
 "--\n"
 "\n"
@@ -326,14 +326,15 @@ PyDoc_STRVAR(pyexpat_xmlparser_SetParamEntityParsing__doc__,
 "XML_PARAM_ENTITY_PARSING_ALWAYS. Returns true if setting the flag\n"
 "was successful.");
 
-#define PYEXPAT_XMLPARSER_SETPARAMENTITYPARSING_METHODDEF    \
-    {"SetParamEntityParsing", (PyCFunction)pyexpat_xmlparser_SetParamEntityParsing, METH_O, pyexpat_xmlparser_SetParamEntityParsing__doc__},
+#define PYEXPAT_XMLPARSERTYPE_SETPARAMENTITYPARSING_METHODDEF    \
+    {"SetParamEntityParsing", (PyCFunction)pyexpat_XMLParserType_SetParamEntityParsing, METH_O, pyexpat_XMLParserType_SetParamEntityParsing__doc__},
 
 static PyObject *
-pyexpat_xmlparser_SetParamEntityParsing_impl(xmlparseobject *self, int flag);
+pyexpat_XMLParserType_SetParamEntityParsing_impl(xmlparseobject *self,
+                                                 int flag);
 
 static PyObject *
-pyexpat_xmlparser_SetParamEntityParsing(xmlparseobject *self, PyObject *arg)
+pyexpat_XMLParserType_SetParamEntityParsing(xmlparseobject *self, PyObject *arg)
 {
     PyObject *return_value = NULL;
     int flag;
@@ -342,7 +343,7 @@ pyexpat_xmlparser_SetParamEntityParsing(xmlparseobject *self, PyObject *arg)
     if (flag == -1 && PyErr_Occurred()) {
         goto exit;
     }
-    return_value = pyexpat_xmlparser_SetParamEntityParsing_impl(self, flag);
+    return_value = pyexpat_XMLParserType_SetParamEntityParsing_impl(self, flag);
 
 exit:
     return return_value;
@@ -350,7 +351,7 @@ exit:
 
 #if (XML_COMBINED_VERSION >= 19505)
 
-PyDoc_STRVAR(pyexpat_xmlparser_UseForeignDTD__doc__,
+PyDoc_STRVAR(pyexpat_XMLParserType_UseForeignDTD__doc__,
 "UseForeignDTD($self, flag=True, /)\n"
 "--\n"
 "\n"
@@ -360,15 +361,15 @@ PyDoc_STRVAR(pyexpat_xmlparser_UseForeignDTD__doc__,
 "application, while still getting the advantage of providing document type\n"
 "information to the parser. \'flag\' defaults to True if not provided.");
 
-#define PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF    \
-    {"UseForeignDTD", _PyCFunction_CAST(pyexpat_xmlparser_UseForeignDTD), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, pyexpat_xmlparser_UseForeignDTD__doc__},
+#define PYEXPAT_XMLPARSERTYPE_USEFOREIGNDTD_METHODDEF    \
+    {"UseForeignDTD", _PyCFunction_CAST(pyexpat_XMLParserType_UseForeignDTD), METH_METHOD|METH_FASTCALL|METH_KEYWORDS, pyexpat_XMLParserType_UseForeignDTD__doc__},
 
 static PyObject *
-pyexpat_xmlparser_UseForeignDTD_impl(xmlparseobject *self, PyTypeObject *cls,
-                                     int flag);
+pyexpat_XMLParserType_UseForeignDTD_impl(xmlparseobject *self,
+                                         PyTypeObject *cls, int flag);
 
 static PyObject *
-pyexpat_xmlparser_UseForeignDTD(xmlparseobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+pyexpat_XMLParserType_UseForeignDTD(xmlparseobject *self, PyTypeObject *cls, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
@@ -400,7 +401,7 @@ pyexpat_xmlparser_UseForeignDTD(xmlparseobject *self, PyTypeObject *cls, PyObjec
         goto exit;
     }
 skip_optional_posonly:
-    return_value = pyexpat_xmlparser_UseForeignDTD_impl(self, cls, flag);
+    return_value = pyexpat_XMLParserType_UseForeignDTD_impl(self, cls, flag);
 
 exit:
     return return_value;
@@ -547,7 +548,7 @@ exit:
     return return_value;
 }
 
-#ifndef PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
-    #define PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
-#endif /* !defined(PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF) */
-/*[clinic end generated code: output=63be65cb1823b5f8 input=a9049054013a1b77]*/
+#ifndef PYEXPAT_XMLPARSERTYPE_USEFOREIGNDTD_METHODDEF
+    #define PYEXPAT_XMLPARSERTYPE_USEFOREIGNDTD_METHODDEF
+#endif /* !defined(PYEXPAT_XMLPARSERTYPE_USEFOREIGNDTD_METHODDEF) */
+/*[clinic end generated code: output=40c6906bfe36af28 input=a9049054013a1b77]*/

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -68,7 +68,7 @@ pyexpat_get_state(PyObject *module)
 
 /* ----------------------------------------------------- */
 
-/* Declarations for objects of type xmlparser */
+/* Declarations for objects of type XMLParserType */
 
 typedef struct {
     PyObject_HEAD
@@ -1555,14 +1555,14 @@ static PyType_Slot _xml_parse_type_spec_slots[] = {
 };
 
 static PyType_Spec _xml_parse_type_spec = {
-    .name = "pyexpat.xmlparser",
+    .name = "xml.parsers.expat.XMLParserType",
     .basicsize = sizeof(xmlparseobject),
     .flags = (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
               Py_TPFLAGS_DISALLOW_INSTANTIATION | Py_TPFLAGS_IMMUTABLETYPE),
     .slots = _xml_parse_type_spec_slots,
 };
 
-/* End of code for xmlparser objects */
+/* End of code for XMLParserType objects */
 /* -------------------------------------------------------- */
 
 /*[clinic input]

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -688,9 +688,9 @@ VOID_HANDLER(EndDoctypeDecl, (void *userData), ("()"))
 
 /* ---------------------------------------------------------------- */
 /*[clinic input]
-class pyexpat.xmlparser "xmlparseobject *" "&Xmlparsetype"
+class pyexpat.XMLParserType "xmlparseobject *" "&Xmlparsetype"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=2393162385232e1c]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=8c2756d92062c835]*/
 
 
 static PyObject *
@@ -711,7 +711,7 @@ get_parse_result(pyexpat_state *state, xmlparseobject *self, int rv)
 #define MAX_CHUNK_SIZE (1 << 20)
 
 /*[clinic input]
-pyexpat.xmlparser.SetReparseDeferralEnabled
+pyexpat.XMLParserType.SetReparseDeferralEnabled
 
     enabled: bool
     /
@@ -720,9 +720,9 @@ Enable/Disable reparse deferral; enabled by default with Expat >=2.6.0.
 [clinic start generated code]*/
 
 static PyObject *
-pyexpat_xmlparser_SetReparseDeferralEnabled_impl(xmlparseobject *self,
-                                                 int enabled)
-/*[clinic end generated code: output=5ec539e3b63c8c49 input=021eb9e0bafc32c5]*/
+pyexpat_XMLParserType_SetReparseDeferralEnabled_impl(xmlparseobject *self,
+                                                     int enabled)
+/*[clinic end generated code: output=9096684b583f2e09 input=df2809c8f1c00a56]*/
 {
 #if XML_COMBINED_VERSION >= 20600
     XML_SetReparseDeferralEnabled(self->itself, enabled ? XML_TRUE : XML_FALSE);
@@ -732,20 +732,20 @@ pyexpat_xmlparser_SetReparseDeferralEnabled_impl(xmlparseobject *self,
 }
 
 /*[clinic input]
-pyexpat.xmlparser.GetReparseDeferralEnabled
+pyexpat.XMLParserType.GetReparseDeferralEnabled
 
 Retrieve reparse deferral enabled status; always returns false with Expat <2.6.0.
 [clinic start generated code]*/
 
 static PyObject *
-pyexpat_xmlparser_GetReparseDeferralEnabled_impl(xmlparseobject *self)
-/*[clinic end generated code: output=4e91312e88a595a8 input=54b5f11d32b20f3e]*/
+pyexpat_XMLParserType_GetReparseDeferralEnabled_impl(xmlparseobject *self)
+/*[clinic end generated code: output=9787b845dcad7655 input=5e6bd748de87a192]*/
 {
     return PyBool_FromLong(self->reparse_deferral_enabled);
 }
 
 /*[clinic input]
-pyexpat.xmlparser.Parse
+pyexpat.XMLParserType.Parse
 
     cls: defining_class
     data: object
@@ -758,9 +758,9 @@ Parse XML data.
 [clinic start generated code]*/
 
 static PyObject *
-pyexpat_xmlparser_Parse_impl(xmlparseobject *self, PyTypeObject *cls,
-                             PyObject *data, int isfinal)
-/*[clinic end generated code: output=8faffe07fe1f862a input=053e0f047e55c05a]*/
+pyexpat_XMLParserType_Parse_impl(xmlparseobject *self, PyTypeObject *cls,
+                                 PyObject *data, int isfinal)
+/*[clinic end generated code: output=2871a4863ff36115 input=b4626b0268d178fa]*/
 {
     const char *s;
     Py_ssize_t slen;
@@ -847,7 +847,7 @@ error:
 }
 
 /*[clinic input]
-pyexpat.xmlparser.ParseFile
+pyexpat.XMLParserType.ParseFile
 
     cls: defining_class
     file: object
@@ -857,9 +857,9 @@ Parse XML data from file-like object.
 [clinic start generated code]*/
 
 static PyObject *
-pyexpat_xmlparser_ParseFile_impl(xmlparseobject *self, PyTypeObject *cls,
-                                 PyObject *file)
-/*[clinic end generated code: output=34780a094c8ca3ae input=ba4bc9c541684793]*/
+pyexpat_XMLParserType_ParseFile_impl(xmlparseobject *self, PyTypeObject *cls,
+                                     PyObject *file)
+/*[clinic end generated code: output=696afaba97fb9c63 input=10851bcd5db378ec]*/
 {
     int rv = 1;
     PyObject *readmethod = NULL;
@@ -901,7 +901,7 @@ pyexpat_xmlparser_ParseFile_impl(xmlparseobject *self, PyTypeObject *cls,
 }
 
 /*[clinic input]
-pyexpat.xmlparser.SetBase
+pyexpat.XMLParserType.SetBase
 
     base: str
     /
@@ -910,8 +910,8 @@ Set the base URL for the parser.
 [clinic start generated code]*/
 
 static PyObject *
-pyexpat_xmlparser_SetBase_impl(xmlparseobject *self, const char *base)
-/*[clinic end generated code: output=c212ddceb607b539 input=c684e5de895ee1a8]*/
+pyexpat_XMLParserType_SetBase_impl(xmlparseobject *self, const char *base)
+/*[clinic end generated code: output=1713c8a44ca3ed99 input=c1bab540c5319b06]*/
 {
     if (!XML_SetBase(self->itself, base)) {
         return PyErr_NoMemory();
@@ -920,20 +920,20 @@ pyexpat_xmlparser_SetBase_impl(xmlparseobject *self, const char *base)
 }
 
 /*[clinic input]
-pyexpat.xmlparser.GetBase
+pyexpat.XMLParserType.GetBase
 
 Return base URL string for the parser.
 [clinic start generated code]*/
 
 static PyObject *
-pyexpat_xmlparser_GetBase_impl(xmlparseobject *self)
-/*[clinic end generated code: output=2886cb21f9a8739a input=918d71c38009620e]*/
+pyexpat_XMLParserType_GetBase_impl(xmlparseobject *self)
+/*[clinic end generated code: output=75a6a73ec83bf289 input=07ad9c39dde3ccda]*/
 {
     return conv_string_to_unicode(XML_GetBase(self->itself));
 }
 
 /*[clinic input]
-pyexpat.xmlparser.GetInputContext
+pyexpat.XMLParserType.GetInputContext
 
 Return the untranslated text of the input that caused the current event.
 
@@ -942,8 +942,8 @@ for an element with many attributes), not all of the text may be available.
 [clinic start generated code]*/
 
 static PyObject *
-pyexpat_xmlparser_GetInputContext_impl(xmlparseobject *self)
-/*[clinic end generated code: output=a88026d683fc22cc input=034df8712db68379]*/
+pyexpat_XMLParserType_GetInputContext_impl(xmlparseobject *self)
+/*[clinic end generated code: output=2733f450a6ff30a2 input=4b6004450c1a05db]*/
 {
     if (self->in_callback) {
         int offset, size;
@@ -961,7 +961,7 @@ pyexpat_xmlparser_GetInputContext_impl(xmlparseobject *self)
 }
 
 /*[clinic input]
-pyexpat.xmlparser.ExternalEntityParserCreate
+pyexpat.XMLParserType.ExternalEntityParserCreate
 
     cls: defining_class
     context: str(accept={str, NoneType})
@@ -972,11 +972,11 @@ Create a parser for parsing an external entity based on the information passed t
 [clinic start generated code]*/
 
 static PyObject *
-pyexpat_xmlparser_ExternalEntityParserCreate_impl(xmlparseobject *self,
-                                                  PyTypeObject *cls,
-                                                  const char *context,
-                                                  const char *encoding)
-/*[clinic end generated code: output=01d4472b49cb3f92 input=ec70c6b9e6e9619a]*/
+pyexpat_XMLParserType_ExternalEntityParserCreate_impl(xmlparseobject *self,
+                                                      PyTypeObject *cls,
+                                                      const char *context,
+                                                      const char *encoding)
+/*[clinic end generated code: output=7ed6bcf7c4ce354c input=ea9ebb87800c05af]*/
 {
     xmlparseobject *new_parser;
     int i;
@@ -1040,7 +1040,7 @@ pyexpat_xmlparser_ExternalEntityParserCreate_impl(xmlparseobject *self,
 }
 
 /*[clinic input]
-pyexpat.xmlparser.SetParamEntityParsing
+pyexpat.XMLParserType.SetParamEntityParsing
 
     flag: int
     /
@@ -1054,8 +1054,9 @@ was successful.
 [clinic start generated code]*/
 
 static PyObject *
-pyexpat_xmlparser_SetParamEntityParsing_impl(xmlparseobject *self, int flag)
-/*[clinic end generated code: output=18668ee8e760d64c input=8aea19b4b15e9af1]*/
+pyexpat_XMLParserType_SetParamEntityParsing_impl(xmlparseobject *self,
+                                                 int flag)
+/*[clinic end generated code: output=0831fe5d1be5f3a9 input=5fedf97c504cb580]*/
 {
     flag = XML_SetParamEntityParsing(self->itself, flag);
     return PyLong_FromLong(flag);
@@ -1064,7 +1065,7 @@ pyexpat_xmlparser_SetParamEntityParsing_impl(xmlparseobject *self, int flag)
 
 #if XML_COMBINED_VERSION >= 19505
 /*[clinic input]
-pyexpat.xmlparser.UseForeignDTD
+pyexpat.XMLParserType.UseForeignDTD
 
     cls: defining_class
     flag: bool = True
@@ -1078,9 +1079,9 @@ information to the parser. 'flag' defaults to True if not provided.
 [clinic start generated code]*/
 
 static PyObject *
-pyexpat_xmlparser_UseForeignDTD_impl(xmlparseobject *self, PyTypeObject *cls,
-                                     int flag)
-/*[clinic end generated code: output=d7d98252bd25a20f input=23440ecb0573fb29]*/
+pyexpat_XMLParserType_UseForeignDTD_impl(xmlparseobject *self,
+                                         PyTypeObject *cls, int flag)
+/*[clinic end generated code: output=c76149399c6a77e3 input=3a758cf97b6aeaa9]*/
 {
     pyexpat_state *state = PyType_GetModuleState(cls);
     enum XML_Error rc;
@@ -1094,18 +1095,18 @@ pyexpat_xmlparser_UseForeignDTD_impl(xmlparseobject *self, PyTypeObject *cls,
 #endif
 
 static struct PyMethodDef xmlparse_methods[] = {
-    PYEXPAT_XMLPARSER_PARSE_METHODDEF
-    PYEXPAT_XMLPARSER_PARSEFILE_METHODDEF
-    PYEXPAT_XMLPARSER_SETBASE_METHODDEF
-    PYEXPAT_XMLPARSER_GETBASE_METHODDEF
-    PYEXPAT_XMLPARSER_GETINPUTCONTEXT_METHODDEF
-    PYEXPAT_XMLPARSER_EXTERNALENTITYPARSERCREATE_METHODDEF
-    PYEXPAT_XMLPARSER_SETPARAMENTITYPARSING_METHODDEF
+    PYEXPAT_XMLPARSERTYPE_PARSE_METHODDEF
+    PYEXPAT_XMLPARSERTYPE_PARSEFILE_METHODDEF
+    PYEXPAT_XMLPARSERTYPE_SETBASE_METHODDEF
+    PYEXPAT_XMLPARSERTYPE_GETBASE_METHODDEF
+    PYEXPAT_XMLPARSERTYPE_GETINPUTCONTEXT_METHODDEF
+    PYEXPAT_XMLPARSERTYPE_EXTERNALENTITYPARSERCREATE_METHODDEF
+    PYEXPAT_XMLPARSERTYPE_SETPARAMENTITYPARSING_METHODDEF
 #if XML_COMBINED_VERSION >= 19505
-    PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
+    PYEXPAT_XMLPARSERTYPE_USEFOREIGNDTD_METHODDEF
 #endif
-    PYEXPAT_XMLPARSER_SETREPARSEDEFERRALENABLED_METHODDEF
-    PYEXPAT_XMLPARSER_GETREPARSEDEFERRALENABLED_METHODDEF
+    PYEXPAT_XMLPARSERTYPE_SETREPARSEDEFERRALENABLED_METHODDEF
+    PYEXPAT_XMLPARSERTYPE_GETREPARSEDEFERRALENABLED_METHODDEF
     {NULL, NULL}  /* sentinel */
 };
 


### PR DESCRIPTION
This MR updates `xml.parsers.expat.XMLParserType` to use that name consistently. I also updated the related documentation and argument clinic configuration, but I'm a little unsure about whether that last part was the right thing to do or not. It's not clear to me what risks might be involved with changing the names of the implementation methods, or what possible inconsistencies might occur if that part wasn't updated.

<!-- gh-issue-number: gh-126662 -->
* Issue: gh-126662
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126724.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->