### PR TITLE
[3.13] gh-126451: Revert backports of ABC registrations for `contextvars.Context` and multiprocessing proxies

### DIFF
--- a/Lib/contextvars.py
+++ b/Lib/contextvars.py
@@ -1,8 +1,4 @@
-import _collections_abc
 from _contextvars import Context, ContextVar, Token, copy_context
 
 
 __all__ = ('Context', 'ContextVar', 'Token', 'copy_context')
-
-
-_collections_abc.Mapping.register(Context)

--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -18,7 +18,6 @@ import sys
 import threading
 import signal
 import array
-import collections.abc
 import queue
 import time
 import types
@@ -1168,7 +1167,6 @@ class ListProxy(BaseListProxy):
 
     __class_getitem__ = classmethod(types.GenericAlias)
 
-collections.abc.MutableSequence.register(BaseListProxy)
 
 _BaseDictProxy = MakeProxyType('DictProxy', (
     '__contains__', '__delitem__', '__getitem__', '__iter__', '__len__',
@@ -1181,7 +1179,6 @@ _BaseDictProxy._method_to_typeid_ = {
 class DictProxy(_BaseDictProxy):
     __class_getitem__ = classmethod(types.GenericAlias)
 
-collections.abc.MutableMapping.register(_BaseDictProxy)
 
 ArrayProxy = MakeProxyType('ArrayProxy', (
     '__len__', '__getitem__', '__setitem__'

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -17,7 +17,6 @@ import errno
 import functools
 import signal
 import array
-import collections.abc
 import socket
 import random
 import logging
@@ -2460,10 +2459,6 @@ class _TestContainers(BaseTestCase):
         a.append('hello')
         self.assertEqual(f[0][:], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'hello'])
 
-    def test_list_isinstance(self):
-        a = self.list()
-        self.assertIsInstance(a, collections.abc.MutableSequence)
-
     def test_list_iter(self):
         a = self.list(list(range(10)))
         it = iter(a)
@@ -2503,10 +2498,6 @@ class _TestContainers(BaseTestCase):
         self.assertEqual(sorted(d.keys()), indices)
         self.assertEqual(sorted(d.values()), [chr(i) for i in indices])
         self.assertEqual(sorted(d.items()), [(i, chr(i)) for i in indices])
-
-    def test_dict_isinstance(self):
-        a = self.dict()
-        self.assertIsInstance(a, collections.abc.MutableMapping)
 
     def test_dict_iter(self):
         d = self.dict()

--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -1,4 +1,3 @@
-import collections.abc
 import concurrent.futures
 import contextvars
 import functools
@@ -342,19 +341,6 @@ class ContextTest(unittest.TestCase):
             self.assertEqual(c.get(), 30)
 
         ctx1.run(ctx1_fun)
-
-    def test_context_isinstance(self):
-        ctx = contextvars.Context()
-        self.assertIsInstance(ctx, collections.abc.Mapping)
-        self.assertTrue(issubclass(contextvars.Context, collections.abc.Mapping))
-
-        mapping_methods = (
-            '__contains__', '__eq__', '__getitem__', '__iter__', '__len__',
-            '__ne__', 'get', 'items', 'keys', 'values',
-        )
-        for name in mapping_methods:
-            with self.subTest(name=name):
-                self.assertTrue(callable(getattr(ctx, name)))
 
     @isolated_context
     @threading_helper.requires_working_threading()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1270,7 +1270,6 @@ Emily Morehouse
 Derek Morr
 James A Morrison
 Martin Morrison
-Stephen Morton
 Derek McTavish Mounce
 Alessandro Moura
 Pablo Mouzo

--- a/Misc/NEWS.d/next/Library/2024-11-04-16-40-02.gh-issue-126417.OWPqn0.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-04-16-40-02.gh-issue-126417.OWPqn0.rst
@@ -1,3 +1,0 @@
-Register the :class:`!multiprocessing.managers.DictProxy` and :class:`!multiprocessing.managers.ListProxy` types in
-:mod:`multiprocessing.managers` to :class:`collections.abc.MutableMapping` and
-:class:`collections.abc.MutableSequence`, respectively.

--- a/Misc/NEWS.d/next/Library/2024-11-05-11-28-45.gh-issue-126451.XJMtqz.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-05-11-28-45.gh-issue-126451.XJMtqz.rst
@@ -1,2 +1,0 @@
-Register the :class:`contextvars.Context` type to
-:class:`collections.abc.Mapping`.


### PR DESCRIPTION
These registrations were added in https://github.com/python/cpython/pull/126452 and https://github.com/python/cpython/pull/126419. They were backported to 3.13 in https://github.com/python/cpython/pull/126518 and https://github.com/python/cpython/pull/126435. Following discussion in https://github.com/python/cpython/issues/126451, we're keeping the new registrations in Python 3.14+ but reverting the backports to 3.13 and 3.12.

---

Revert "[3.13] gh-126451: Register contextvars.Context to collections.abc.Mapping (GH-126452) (#126518)"

Revert "[3.13] gh-126417: Register multiprocessing proxy types to an appropriate collections.abc class (#126419) (#126435)"