### PR TITLE
[3.12] gh-126595: fix a crash when calling `itertools.count(sys.maxsize)` (GH-126617)

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -599,6 +599,8 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(take(2, zip('abc',count(-3))), [('a', -3), ('b', -2)])
         self.assertRaises(TypeError, count, 2, 3, 4)
         self.assertRaises(TypeError, count, 'a')
+        self.assertEqual(take(3, count(maxsize)),
+                        [maxsize, maxsize + 1, maxsize + 2])
         self.assertEqual(take(10, count(maxsize-5)),
                          list(range(maxsize-5, maxsize+5)))
         self.assertEqual(take(10, count(-maxsize-5)),
@@ -654,6 +656,12 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(take(20, count(-maxsize-15, 3)), take(20, range(-maxsize-15,-maxsize+100, 3)))
         self.assertEqual(take(3, count(10, maxsize+5)),
                          list(range(10, 10+3*(maxsize+5), maxsize+5)))
+        self.assertEqual(take(3, count(maxsize, 2)),
+                         [maxsize, maxsize + 2, maxsize + 4])
+        self.assertEqual(take(3, count(maxsize, maxsize)),
+                         [maxsize, 2 * maxsize, 3 * maxsize])
+        self.assertEqual(take(3, count(-maxsize, maxsize)),
+                        [-maxsize, 0, maxsize])
         self.assertEqual(take(3, count(2, 1.25)), [2, 3.25, 4.5])
         self.assertEqual(take(3, count(2, 3.25-4j)), [2, 5.25-4j, 8.5-8j])
         self.assertEqual(take(3, count(Decimal('1.1'), Decimal('.1'))),

--- a/Misc/NEWS.d/next/Library/2024-11-09-10-31-10.gh-issue-126595.A-7MyC.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-09-10-31-10.gh-issue-126595.A-7MyC.rst
@@ -1,0 +1,2 @@
+Fix a crash when instantiating :class:`itertools.count` with an initial
+count of :data:`sys.maxsize` on debug builds. Patch by Bénédikt Tran.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -4037,6 +4037,9 @@ itertools_count_impl(PyTypeObject *type, PyObject *long_cnt,
                 PyErr_Clear();
                 fast_mode = 0;
             }
+            else if (cnt == PY_SSIZE_T_MAX) {
+                fast_mode = 0;
+            }
         }
     } else {
         cnt = 0;


### PR DESCRIPTION
(cherry picked from commit 6e3bb8a91380ba98d704f2dca8e98923c0abc8a8)

<!-- gh-issue-number: gh-126595 -->
* Issue: gh-126595
<!-- /gh-issue-number -->
