### PR TITLE
Doc: Generate Pathlib table with autosummary

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -34,6 +34,8 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
 ]
 
 # Skip if downstream redistributors haven't installed them

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -96,15 +96,125 @@ Opening a file::
 Summary
 -------
 
+.. currentmodule:: pathlib
+
 .. autosummary::
+
+   .. **Exceptions**
+
+   UnsupportedOperation
+
+   .. **Pure paths**
 
    PurePath
    PurePosixPath
    PureWindowsPath
+
+   .. **Pure path attributes**
+
+   PurePath.parts
+   PurePath.parser
+   PurePath.drive
+   PurePath.root
+   PurePath.anchor
+   PurePath.parents
+   PurePath.parent
+   PurePath.name
+   PurePath.suffix
+   PurePath.suffixes
+   PurePath.stem
+
+   .. **Pure path methods**
+
+   PurePath.as_posix
+   PurePath.is_absolute
+   PurePath.is_relative_to
+   PurePath.is_reserved
+   PurePath.joinpath
+   PurePath.full_match
+   PurePath.match
+   PurePath.relative_to
+   PurePath.with_name
+   PurePath.with_stem
+   PurePath.with_suffix
+   PurePath.with_segments
+
+   .. **Concrete paths**
+
    Path
    PosixPath
    WindowsPath
-   PurePath.as_posix
+
+   .. **Parsing and generating URIs**
+
+   Path.from_uri
+   Path.as_uri
+
+   .. **Expanding and resolving paths**
+
+   Path.home
+   Path.expanduser
+   Path.cwd
+   Path.absolute
+   Path.resolve
+   Path.readlink
+
+   .. **Querying file type and status**
+
+   Path.stat
+   Path.lstat
+   Path.exists
+   Path.is_file
+   Path.is_dir
+   Path.is_symlink
+   Path.is_junction
+   Path.is_mount
+   Path.is_socket
+   Path.is_fifo
+   Path.is_block_device
+   Path.is_char_device
+   Path.samefile
+
+   .. **Reading and writing files**
+
+   Path.open
+   Path.read_text
+   Path.read_bytes
+   Path.write_text
+   Path.write_bytes
+
+   .. **Reading directories**
+
+   Path.iterdir
+   Path.scandir
+   Path.glob
+   Path.rglob
+   Path.walk
+
+   .. **Creating files and directories**
+
+   Path.touch
+   Path.mkdir
+   Path.symlink_to
+   Path.hardlink_to
+
+   .. **Copying, moving and deleting**
+
+   Path.copy
+   Path.copy_into
+   Path.rename
+   Path.replace
+   Path.move
+   Path.move_into
+   Path.unlink
+   Path.rmdir
+
+   .. **Permissions and ownership**
+
+   Path.owner
+   Path.group
+   Path.chmod
+   Path.lchmod
 
 
 Exceptions

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -93,6 +93,20 @@ Opening a file::
    '#!/bin/bash\n'
 
 
+Summary
+-------
+
+.. autosummary::
+
+   PurePath
+   PurePosixPath
+   PureWindowsPath
+   Path
+   PosixPath
+   WindowsPath
+   PurePath.as_posix
+
+
 Exceptions
 ----------
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This is a test in response to https://github.com/python/cpython/pull/126342#issuecomment-2465672249.

@barneygale This is what it looks like with [sphinx.ext.autosummary](https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html). The table is effectively included in the page, but not all members are present, there is no formatting and no link in the short descriptions, and I don't think that we can add intermediate titles. Also the Sphinx log shown unrelated errors in the log. Event if the errors were fixed, my conclusion is that the page would be easier to maintain, but at the cost of readability in the documentation.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126753.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

Edit: Oh well, when there are warnings the preview is not available. Here is what it looks like on my computer:

<details>

![image](https://github.com/user-attachments/assets/f32a002e-dd7e-4f14-b260-ddb94df784b0)

</details>