### PR TITLE
Document that return-less user-defined functions return None

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1156,7 +1156,7 @@ a user-defined function:
    first thing the code block will do is bind the formal parameters to the
    arguments; this is described in section :ref:`function`.  When the code block
    executes a :keyword:`return` statement, this specifies the return value of the
-   function call.  If execution falls off the end of the code block without
+   function call.  If execution reaches the end of the code block without
    executing a :keyword:`return` statement, the return value is ``None``.
 
 a built-in function or method:

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1156,7 +1156,8 @@ a user-defined function:
    first thing the code block will do is bind the formal parameters to the
    arguments; this is described in section :ref:`function`.  When the code block
    executes a :keyword:`return` statement, this specifies the return value of the
-   function call.
+   function call.  If execution falls off the end of the code block without
+   executing a :keyword:`return` statement, the return value is ``None``.
 
 a built-in function or method:
    .. index::


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

I hunted through [Calls](https://docs.python.org/3/reference/expressions.html#calls), [Function definitons](https://docs.python.org/3/reference/compound_stmts.html#function-definitions), and [Execution model](https://docs.python.org/3/reference/executionmodel.html#execution-model), but did not spot any text actually specifying that `None` is returned by user-defined functions that fall off the end of their code block without encountering a `return` statement.

This adds such text to the description of return values in the **Calls** section, which IMHO is the most likely place readers would look for it.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126769.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->