### PR TITLE
GH-124567: Reduce overhead of debug build for GC. Should help CI performance

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -358,6 +358,3 @@ The following constants are provided for use with :func:`set_debug`:
    The debugging flags necessary for the collector to print information about a
    leaking program (equal to ``DEBUG_COLLECTABLE | DEBUG_UNCOLLECTABLE |
    DEBUG_SAVEALL``).
-
-
-Spurious change to force doctests to run in CI.

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -358,3 +358,6 @@ The following constants are provided for use with :func:`set_debug`:
    The debugging flags necessary for the collector to print information about a
    leaking program (equal to ``DEBUG_COLLECTABLE | DEBUG_UNCOLLECTABLE |
    DEBUG_SAVEALL``).
+
+
+Spurious change to force doctests to run in CI.

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -23,6 +23,10 @@ typedef struct _gc_runtime_state GCState;
 #  define GC_DEBUG
 #endif
 
+// Define this when debugging the GC
+// #define GC_EXTRA_DEBUG
+
+
 #define GC_NEXT _PyGCHead_NEXT
 #define GC_PREV _PyGCHead_PREV
 
@@ -421,6 +425,11 @@ validate_list(PyGC_Head *head, enum flagstates flags)
     assert(prev == GC_PREV(head));
 }
 
+#else
+#define validate_list(x, y) do{}while(0)
+#endif
+
+#ifdef GC_EXTRA_DEBUG
 static void
 validate_old(GCState *gcstate)
 {
@@ -464,7 +473,6 @@ gc_list_validate_space(PyGC_Head *head, int space) {
 }
 
 #else
-#define validate_list(x, y) do{}while(0)
 #define validate_old(g) do{}while(0)
 #define validate_consistent_old_space(l) do{}while(0)
 #define gc_list_validate_space(l, s) do{}while(0)


### PR DESCRIPTION
The doctests CI takes ages and it uses a debug build.

Arguably debug builds should be good for debugging, i.e. lots of asserts. If you want performance don't use a debug build.

However, the incremental GC does adds a *lot* of extra sanity checks and it is a pain if CI jobs take half an hour or more.

So, this PR adds an extra debug option to reduce the amount of checking done in a normal debug build, but keeps the extra sanity checks if needed for debugging the GC.


<!-- gh-issue-number: gh-124567 -->
* Issue: gh-124567
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126777.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->