### PR TITLE
gh-126691: Remove --with-emscripten-target

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -454,15 +454,6 @@ Options for third-party dependencies
 WebAssembly Options
 -------------------
 
-.. option:: --with-emscripten-target=[browser|node]
-
-   Set build flavor for ``wasm32-emscripten``.
-
-   * ``browser`` (default): preload minimal stdlib, default MEMFS.
-   * ``node``: NODERAWFS and pthread support.
-
-   .. versionadded:: 3.11
-
 .. option:: --enable-wasm-dynamic-linking
 
    Turn on dynamic linking support for WASM.

--- a/Misc/NEWS.d/next/Build/2024-11-13-15-47-09.gh-issue-126691.ni4K-b.rst
+++ b/Misc/NEWS.d/next/Build/2024-11-13-15-47-09.gh-issue-126691.ni4K-b.rst
@@ -1,0 +1,3 @@
+Removed the ``--with-emscripten-target`` configure flag. We unified the
+``node`` and ``browser`` options and same build can now be used independent
+of target runtime.

--- a/Misc/NEWS.d/next/Build/2024-11-13-15-47-09.gh-issue-126691.ni4K-b.rst
+++ b/Misc/NEWS.d/next/Build/2024-11-13-15-47-09.gh-issue-126691.ni4K-b.rst
@@ -1,3 +1,3 @@
 Removed the ``--with-emscripten-target`` configure flag. We unified the
-``node`` and ``browser`` options and same build can now be used independent
+``node`` and ``browser`` options and the same build can now be used, independent
 of target runtime.

--- a/Tools/wasm/README.md
+++ b/Tools/wasm/README.md
@@ -21,12 +21,6 @@ https://github.com/psf/webassembly for more information.
 
 ### Build
 
-For now the build system has two target flavors. The ``Emscripten/browser``
-target (``--with-emscripten-target=browser``) is optimized for browsers.
-It comes with a reduced and preloaded stdlib without tests and threading
-support. The ``Emscripten/node`` target has threading enabled and can
-access the file system directly.
-
 To cross compile to the ``wasm32-emscripten`` platform you need
 [the Emscripten compiler toolchain](https://emscripten.org/), 
 a Python interpreter, and an installation of Node version 18 or newer. Emscripten

--- a/Tools/wasm/emscripten/node_pre.js
+++ b/Tools/wasm/emscripten/node_pre.js
@@ -1,9 +1,15 @@
 // If process is undefined, we're not running in the node runtime let it go I
 // guess?
 if (typeof process !== "undefined") {
-    const nodeVersion = Number(process.versions.node.split('.',1)[0]);
+    const nodeVersion = Number(process.versions.node.split(".", 1)[0]);
     if (nodeVersion < 18) {
-        process.stderr.write(`Node version must be >= 18, got version ${process.version}\n`);
+        process.stderr.write(
+            `Node version must be >= 18, got version ${process.version}\n`,
+        );
         process.exit(1);
     }
+    Module.preRun = () => {
+        FS.mkdirTree("/lib/");
+        FS.mount(NODEFS, { root: __dirname + "/lib/" }, "/lib/");
+    };
 }

--- a/configure
+++ b/configure
@@ -9448,6 +9448,8 @@ then :
       as_fn_append LINKFORSHARED " -sPROXY_TO_PTHREAD"
 
 fi
+    as_fn_append LDFLAGS_NODIST " -sALLOW_MEMORY_GROWTH"
+        as_fn_append LDFLAGS_NODIST " -sEXIT_RUNTIME"
     as_fn_append LDFLAGS_NODIST " --pre-js=\$(srcdir)/Tools/wasm/emscripten/node_pre.js"
     WASM_LINKFORSHARED_DEBUG="-gseparate-dwarf --emit-symbol-map"
 

--- a/configure
+++ b/configure
@@ -1082,7 +1082,6 @@ with_universal_archs
 with_framework_name
 enable_framework
 with_app_store_compliance
-with_emscripten_target
 enable_wasm_dynamic_linking
 enable_wasm_pthreads
 with_suffix
@@ -1868,8 +1867,6 @@ Optional Packages:
                           Enable any patches required for compiliance with app
                           stores. Optional PATCH-FILE specifies the custom
                           patch to apply.
-  --with-emscripten-target=[browser|node]
-                          Emscripten platform
   --with-suffix=SUFFIX    set executable suffix to SUFFIX (default is empty,
                           yes is mapped to '.exe')
   --without-static-libpython
@@ -7223,48 +7220,6 @@ case $ac_sys_system/$ac_sys_release in #(
      ;;
 esac
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --with-emscripten-target" >&5
-printf %s "checking for --with-emscripten-target... " >&6; }
-
-# Check whether --with-emscripten-target was given.
-if test ${with_emscripten_target+y}
-then :
-  withval=$with_emscripten_target;
-	if test "x$ac_sys_system" = xEmscripten
-then :
-
-    case $with_emscripten_target in #(
-  browser) :
-    ac_sys_emscripten_target=browser ;; #(
-  node) :
-    ac_sys_emscripten_target=node ;; #(
-        browser-debug) :
-    ac_sys_emscripten_target=browser-debug ;; #(
-  node-debug) :
-    ac_sys_emscripten_target=node-debug ;; #(
-  *) :
-    as_fn_error $? "Invalid argument: --with-emscripten-target=browser|node" "$LINENO" 5
-     ;;
-esac
-
-else $as_nop
-
-    as_fn_error $? "--with-emscripten-target only applies to Emscripten" "$LINENO" 5
-
-fi
-
-else $as_nop
-
-  if test "x$ac_sys_system" = xEmscripten
-then :
-  ac_sys_emscripten_target=browser
-fi
-
-fi
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_sys_emscripten_target" >&5
-printf "%s\n" "$ac_sys_emscripten_target" >&6; }
-
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for --enable-wasm-dynamic-linking" >&5
 printf %s "checking for --enable-wasm-dynamic-linking... " >&6; }
 # Check whether --enable-wasm-dynamic-linking was given.
@@ -7334,12 +7289,10 @@ esac
 
 else $as_nop
 
-  case $ac_sys_system/$ac_sys_emscripten_target in #(
-  Emscripten/browser*) :
+  case $ac_sys_system in #(
+  Emscripten) :
     EXEEXT=.js ;; #(
-  Emscripten/node*) :
-    EXEEXT=.js ;; #(
-  WASI/*) :
+  WASI) :
     EXEEXT=.wasm ;; #(
   *) :
     EXEEXT=
@@ -7674,8 +7627,8 @@ printf %s "checking HOSTRUNNER... " >&6; }
 
 if test -z "$HOSTRUNNER"
 then
-  case $ac_sys_system/$ac_sys_emscripten_target in #(
-  Emscripten/node*) :
+  case $ac_sys_system in #(
+  Emscripten) :
 
       if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}node", so it can be a program name with args.
@@ -7791,7 +7744,7 @@ then :
   as_fn_append HOSTRUNNER " --experimental-wasm-memory64"
 fi
      ;; #(
-              WASI/*) :
+              WASI) :
     HOSTRUNNER='wasmtime run --wasm max-wasm-stack=16777216 --wasi preview2=n --env PYTHONPATH=/$(shell realpath --relative-to $(abs_srcdir) $(abs_builddir))/$(shell cat pybuilddir.txt):/Lib --dir $(srcdir)::/' ;; #(
   *) :
     HOSTRUNNER=''
@@ -7807,13 +7760,8 @@ if test -n "$HOSTRUNNER"; then
 fi
 
 # LIBRARY_DEPS, LINK_PYTHON_OBJS and LINK_PYTHON_DEPS variable
-case $ac_sys_system/$ac_sys_emscripten_target in #(
-  Emscripten/browser*) :
-    LIBRARY_DEPS='$(PY3LIBRARY) $(WASM_STDLIB) python.html python.worker.js' ;; #(
-  *) :
-    LIBRARY_DEPS='$(PY3LIBRARY) $(EXPORTSYMS)'
- ;;
-esac
+LIBRARY_DEPS='$(PY3LIBRARY) $(EXPORTSYMS)'
+
 LINK_PYTHON_DEPS='$(LIBRARY_DEPS)'
 if test "$PY_ENABLE_SHARED" = 1 || test "$enable_framework" ; then
     LIBRARY_DEPS="\$(LDLIBRARY) $LIBRARY_DEPS"
@@ -9500,34 +9448,8 @@ then :
       as_fn_append LINKFORSHARED " -sPROXY_TO_PTHREAD"
 
 fi
-
-    case $ac_sys_emscripten_target in #(
-  browser*) :
-
-        if test "x$ac_sys_emscripten_target" = xbrowser-debug
-then :
-  wasm_debug=yes
-fi
-        as_fn_append LINKFORSHARED " --preload-file=\$(WASM_ASSETS_DIR)"
-        WASM_ASSETS_DIR=".\$(prefix)"
-        WASM_STDLIB="\$(WASM_ASSETS_DIR)/local/lib/python\$(VERSION)/os.py"
-                WASM_LINKFORSHARED_DEBUG="-gsource-map --emit-symbol-map"
-       ;; #(
-  node*) :
-
-        if test "x$ac_sys_emscripten_target" = xnode-debug
-then :
-  wasm_debug=yes
-fi
-        as_fn_append LDFLAGS_NODIST " --pre-js=\$(srcdir)/Tools/wasm/emscripten/node_pre.js"
-        as_fn_append LDFLAGS_NODIST " -sALLOW_MEMORY_GROWTH -sNODERAWFS"
-        as_fn_append LINKFORSHARED " -sEXIT_RUNTIME"
-        WASM_LINKFORSHARED_DEBUG="-gseparate-dwarf --emit-symbol-map"
-
-     ;; #(
-  *) :
-     ;;
-esac
+    as_fn_append LDFLAGS_NODIST " --pre-js=\$(srcdir)/Tools/wasm/emscripten/node_pre.js"
+    WASM_LINKFORSHARED_DEBUG="-gseparate-dwarf --emit-symbol-map"
 
     if test "x$wasm_debug" = xyes
 then :
@@ -29062,15 +28984,7 @@ else $as_nop
 fi
 
 else $as_nop
-
-  case $ac_sys_system/$ac_sys_emscripten_target in #(
-  Emscripten/browser*) :
-    TEST_MODULES=no ;; #(
-  *) :
-    TEST_MODULES=yes
-   ;;
-esac
-
+  TEST_MODULES=yes
 fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $TEST_MODULES" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -2338,6 +2338,9 @@ AS_CASE([$ac_sys_system],
       AS_VAR_APPEND([LDFLAGS_NODIST], [" -sUSE_PTHREADS"])
       AS_VAR_APPEND([LINKFORSHARED], [" -sPROXY_TO_PTHREAD"])
     ])
+    AS_VAR_APPEND([LDFLAGS_NODIST], [" -sALLOW_MEMORY_GROWTH"])
+    dnl not completely sure whether or not we want -sEXIT_RUNTIME, keeping it for now.
+    AS_VAR_APPEND([LDFLAGS_NODIST], [" -sEXIT_RUNTIME"])
     AS_VAR_APPEND([LDFLAGS_NODIST], [" --pre-js=\$(srcdir)/Tools/wasm/emscripten/node_pre.js"])
     WASM_LINKFORSHARED_DEBUG="-gseparate-dwarf --emit-symbol-map"
 

--- a/configure.ac
+++ b/configure.ac
@@ -1282,30 +1282,6 @@ AS_CASE([$ac_sys_system/$ac_sys_release],
  ]
 )
 
-AC_MSG_CHECKING([for --with-emscripten-target])
-AC_ARG_WITH([emscripten-target],
-  [AS_HELP_STRING([--with-emscripten-target=@<:@browser|node@:>@], [Emscripten platform])],
-[
-	AS_VAR_IF([ac_sys_system], [Emscripten], [
-    AS_CASE([$with_emscripten_target],
-      [browser], [ac_sys_emscripten_target=browser],
-      [node], [ac_sys_emscripten_target=node],
-dnl Debug builds with source map / dwarf symbols. Py_DEBUG builds easily
-dnl run out of stack space. Detached sybmols and map prohibit some
-dnl optimizations and increase file size. Options are undocumented so we
-dnl are free to remove them in the future.
-      [browser-debug], [ac_sys_emscripten_target=browser-debug],
-      [node-debug], [ac_sys_emscripten_target=node-debug],
-      [AC_MSG_ERROR([Invalid argument: --with-emscripten-target=browser|node])]
-    )
-  ], [
-    AC_MSG_ERROR([--with-emscripten-target only applies to Emscripten])
-  ])
-], [
-  AS_VAR_IF([ac_sys_system], [Emscripten], [ac_sys_emscripten_target=browser])
-])
-AC_MSG_RESULT([$ac_sys_emscripten_target])
-
 dnl On Emscripten dlopen() requires -s MAIN_MODULE and -fPIC. The flags
 dnl disables dead code elimination and increases the size of the WASM module
 dnl by about 1.5 to 2MB. MAIN_MODULE defines __wasm_mutable_globals__.
@@ -1350,10 +1326,9 @@ AC_ARG_WITH([suffix],
     [EXEEXT=$with_suffix]
   )
 ], [
-  AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
-    [Emscripten/browser*], [EXEEXT=.js],
-    [Emscripten/node*], [EXEEXT=.js],
-    [WASI/*], [EXEEXT=.wasm],
+  AS_CASE([$ac_sys_system],
+    [Emscripten], [EXEEXT=.js],
+    [WASI], [EXEEXT=.wasm],
     [EXEEXT=]
   )
 ])
@@ -1638,8 +1613,8 @@ AC_MSG_CHECKING([HOSTRUNNER])
 AC_ARG_VAR([HOSTRUNNER], [Program to run CPython for the host platform])
 if test -z "$HOSTRUNNER"
 then
-  AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
-    [Emscripten/node*], [
+  AS_CASE([$ac_sys_system],
+    [Emscripten], [
       AC_PATH_TOOL([NODE], [node], [node])
       HOSTRUNNER="$NODE"
       AS_VAR_IF([host_cpu], [wasm64], [AS_VAR_APPEND([HOSTRUNNER], [" --experimental-wasm-memory64"])])
@@ -1647,7 +1622,7 @@ then
     dnl TODO: support other WASI runtimes
     dnl wasmtime starts the process with "/" as CWD. For OOT builds add the
     dnl directory containing _sysconfigdata to PYTHONPATH.
-    [WASI/*], [HOSTRUNNER='wasmtime run --wasm max-wasm-stack=16777216 --wasi preview2=n --env PYTHONPATH=/$(shell realpath --relative-to $(abs_srcdir) $(abs_builddir))/$(shell cat pybuilddir.txt):/Lib --dir $(srcdir)::/'],
+    [WASI], [HOSTRUNNER='wasmtime run --wasm max-wasm-stack=16777216 --wasi preview2=n --env PYTHONPATH=/$(shell realpath --relative-to $(abs_srcdir) $(abs_builddir))/$(shell cat pybuilddir.txt):/Lib --dir $(srcdir)::/'],
     [HOSTRUNNER='']
   )
 fi
@@ -1660,10 +1635,8 @@ if test -n "$HOSTRUNNER"; then
 fi
 
 # LIBRARY_DEPS, LINK_PYTHON_OBJS and LINK_PYTHON_DEPS variable
-AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
-  [Emscripten/browser*], [LIBRARY_DEPS='$(PY3LIBRARY) $(WASM_STDLIB) python.html python.worker.js'],
-  [LIBRARY_DEPS='$(PY3LIBRARY) $(EXPORTSYMS)']
-)
+LIBRARY_DEPS='$(PY3LIBRARY) $(EXPORTSYMS)'
+
 LINK_PYTHON_DEPS='$(LIBRARY_DEPS)'
 if test "$PY_ENABLE_SHARED" = 1 || test "$enable_framework" ; then
     LIBRARY_DEPS="\$(LDLIBRARY) $LIBRARY_DEPS"
@@ -2365,24 +2338,8 @@ AS_CASE([$ac_sys_system],
       AS_VAR_APPEND([LDFLAGS_NODIST], [" -sUSE_PTHREADS"])
       AS_VAR_APPEND([LINKFORSHARED], [" -sPROXY_TO_PTHREAD"])
     ])
-
-    AS_CASE([$ac_sys_emscripten_target],
-      [browser*], [
-        AS_VAR_IF([ac_sys_emscripten_target], [browser-debug], [wasm_debug=yes])
-        AS_VAR_APPEND([LINKFORSHARED], [" --preload-file=\$(WASM_ASSETS_DIR)"])
-        WASM_ASSETS_DIR=".\$(prefix)"
-        WASM_STDLIB="\$(WASM_ASSETS_DIR)/local/lib/python\$(VERSION)/os.py"
-        dnl separate-dwarf does not seem to work in Chrome DevTools Support.
-        WASM_LINKFORSHARED_DEBUG="-gsource-map --emit-symbol-map"
-      ],
-      [node*], [
-        AS_VAR_IF([ac_sys_emscripten_target], [node-debug], [wasm_debug=yes])
-        AS_VAR_APPEND([LDFLAGS_NODIST], [" --pre-js=\$(srcdir)/Tools/wasm/emscripten/node_pre.js"])
-        AS_VAR_APPEND([LDFLAGS_NODIST], [" -sALLOW_MEMORY_GROWTH -sNODERAWFS"])
-        AS_VAR_APPEND([LINKFORSHARED], [" -sEXIT_RUNTIME"])
-        WASM_LINKFORSHARED_DEBUG="-gseparate-dwarf --emit-symbol-map"
-      ]
-    )
+    AS_VAR_APPEND([LDFLAGS_NODIST], [" --pre-js=\$(srcdir)/Tools/wasm/emscripten/node_pre.js"])
+    WASM_LINKFORSHARED_DEBUG="-gseparate-dwarf --emit-symbol-map"
 
     AS_VAR_IF([wasm_debug], [yes], [
       AS_VAR_APPEND([LDFLAGS_NODIST], [" -sASSERTIONS"])
@@ -7466,12 +7423,7 @@ AC_MSG_CHECKING([for --disable-test-modules])
 AC_ARG_ENABLE([test-modules],
   [AS_HELP_STRING([--disable-test-modules], [don't build nor install test modules])], [
   AS_VAR_IF([enable_test_modules], [yes], [TEST_MODULES=yes], [TEST_MODULES=no])
-], [
-  AS_CASE([$ac_sys_system/$ac_sys_emscripten_target],
-    [Emscripten/browser*], [TEST_MODULES=no],
-    [TEST_MODULES=yes]
-  )
-])
+], [TEST_MODULES=yes])
 AC_MSG_RESULT([$TEST_MODULES])
 AC_SUBST([TEST_MODULES])
 


### PR DESCRIPTION
This unifies the code for nodejs and the code for the browser. After this commit, the browser example doesn't work because I deleted the code to copy the files around. However, I have a fix for this prepared as a followup.

<!-- gh-issue-number: gh-126691 -->
* Issue: gh-126691
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126787.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->