### PR TITLE
gh-126061: add PyLong_IsPositive/Negative/Zero/GetSign functions to `refcounts.dat`

### DIFF
--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -1284,6 +1284,19 @@ PyLong_FromUnsignedLong:unsignedlong:v::
 PyLong_FromVoidPtr:PyObject*::+1:
 PyLong_FromVoidPtr:void*:p::
 
+PyLong_IsPositive:int:::
+PyLong_IsPositive:PyObject*:obj:0:
+
+PyLong_IsNegative:int:::
+PyLong_IsNegative:PyObject*:obj:0:
+
+PyLong_IsZero:int:::
+PyLong_IsZero:PyObject*:obj:0:
+
+PyLong_GetSign:int:::
+PyLong_GetSign:PyObject*:v:0:
+PyLong_GetSign:int*:sign::
+
 PyMapping_Check:int:::
 PyMapping_Check:PyObject*:o:0:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126788.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->


This PR completes the proposal in https://github.com/python/cpython/pull/126065, but it only adds GetSign/IsZero/IsPositive/IsNegative

Although it is a draft PR, it is open for review. For other recently added C-API, I need to spend a little time looking for them, if there are no such requirements, it can be merged directly.

<!-- gh-issue-number: gh-126061 -->
* Issue: gh-126061
<!-- /gh-issue-number -->
