### PR TITLE
[3.13] gh-109413: Enable `strict_optional` for `libregrtest/main.py` (GH-126394)

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -148,7 +148,7 @@ class Namespace(argparse.Namespace):
         self.randomize = False
         self.fromfile = None
         self.fail_env_changed = False
-        self.use_resources = None
+        self.use_resources: list[str] = []
         self.trace = False
         self.coverdir = 'coverage'
         self.runleaks = False
@@ -403,8 +403,6 @@ def _parse_args(args, **kwargs):
             raise TypeError('%r is an invalid keyword argument '
                             'for this function' % k)
         setattr(ns, k, v)
-    if ns.use_resources is None:
-        ns.use_resources = []
 
     parser = _create_parser()
     # Issue #14191: argparse doesn't support "intermixed" positional and

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -123,7 +123,7 @@ class Regrtest:
             self.python_cmd = None
         self.coverage: bool = ns.trace
         self.coverage_dir: StrPath | None = ns.coverdir
-        self.tmp_dir: StrPath | None = ns.tempdir
+        self._tmp_dir: StrPath | None = ns.tempdir
 
         # Randomize
         self.randomize: bool = ns.randomize
@@ -159,6 +159,8 @@ class Regrtest:
         self.logger.log(line)
 
     def find_tests(self, tests: TestList | None = None) -> tuple[TestTuple, TestList | None]:
+        if tests is None:
+            tests = []
         if self.single_test_run:
             self.next_single_filename = os.path.join(self.tmp_dir, 'pynexttest')
             try:
@@ -453,7 +455,12 @@ class Regrtest:
         if self.junit_filename:
             self.results.write_junit(self.junit_filename)
 
-    def display_summary(self):
+    def display_summary(self) -> None:
+        if self.first_runtests is None:
+            raise ValueError(
+                "Should never call `display_summary()` before calling `_run_test()`"
+            )
+
         duration = time.perf_counter() - self.logger.start_time
         filtered = bool(self.match_tests)
 
@@ -711,7 +718,15 @@ class Regrtest:
 
         strip_py_suffix(self.cmdline_args)
 
-        self.tmp_dir = get_temp_dir(self.tmp_dir)
+        self._tmp_dir = get_temp_dir(self._tmp_dir)
+
+    @property
+    def tmp_dir(self) -> StrPath:
+        if self._tmp_dir is None:
+            raise ValueError(
+                "Should never use `.tmp_dir` before calling `.main()`"
+            )
+        return self._tmp_dir
 
     def main(self, tests: TestList | None = None):
         if self.want_add_python_opts:

--- a/Lib/test/libregrtest/mypy.ini
+++ b/Lib/test/libregrtest/mypy.ini
@@ -22,10 +22,8 @@ disallow_untyped_defs = False
 check_untyped_defs = False
 warn_return_any = False
 
-disable_error_code = return
-
 # Enable --strict-optional for these ASAP:
-[mypy-Lib.test.libregrtest.main.*,Lib.test.libregrtest.run_workers.*]
+[mypy-Lib.test.libregrtest.run_workers.*]
 strict_optional = False
 
 # Various internal modules that typeshed deliberately doesn't have stubs for:

--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -205,6 +205,7 @@ class WorkerThread(threading.Thread):
                     # on reading closed stdout
                     raise ExitThread
                 raise
+            return None
         except:
             self._kill()
             raise
@@ -538,6 +539,7 @@ class RunWorkers:
                 running = get_running(self.workers)
                 if running:
                     self.log(running)
+        return None
 
     def display_result(self, mp_result: MultiprocessResult) -> None:
         result = mp_result.result


### PR DESCRIPTION
(cherry picked from commit 12ca7e622ff21ba3b7c90c62be6f6f82d543f25b)


<!-- gh-issue-number: gh-109413 -->
* Issue: gh-109413
<!-- /gh-issue-number -->
