### PR TITLE
gh-126807: pygettext: Do not attempt to extract messages from function definitions.

### DIFF
--- a/Lib/test/test_tools/test_i18n.py
+++ b/Lib/test/test_tools/test_i18n.py
@@ -88,6 +88,7 @@ class Test_pygettext(unittest.TestCase):
         self.assertEqual(normalize_POT_file(expected), normalize_POT_file(actual))
 
     def extract_from_str(self, module_content, *, args=(), strict=True):
+        """Return all msgids extracted from module_content."""
         filename = 'test.py'
         with temp_cwd(None):
             with open(filename, 'w', encoding='utf-8') as fp:
@@ -102,10 +103,6 @@ class Test_pygettext(unittest.TestCase):
     def extract_docstrings_from_str(self, module_content):
         """Return all docstrings extracted from module_content."""
         return self.extract_from_str(module_content, args=('--docstrings',), strict=False)
-
-    def extract_messages_from_str(self, module_content):
-        """Return all msgids extracted from module_content."""
-        return self.extract_from_str(module_content)
 
     def test_header(self):
         """Make sure the required fields are in the header, according to:
@@ -355,7 +352,7 @@ class Test_pygettext(unittest.TestCase):
 
     def test_function_and_class_names(self):
         """Test that function and class names are not mistakenly extracted."""
-        msgids = self.extract_messages_from_str(dedent('''\
+        msgids = self.extract_from_str(dedent('''\
         def _(x):
             pass
 

--- a/Lib/test/test_tools/test_i18n.py
+++ b/Lib/test/test_tools/test_i18n.py
@@ -87,16 +87,25 @@ class Test_pygettext(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(normalize_POT_file(expected), normalize_POT_file(actual))
 
-    def extract_docstrings_from_str(self, module_content):
-        """ utility: return all msgids extracted from module_content """
-        filename = 'test_docstrings.py'
-        with temp_cwd(None) as cwd:
+    def extract_from_str(self, module_content, *, args=(), strict=True):
+        filename = 'test.py'
+        with temp_cwd(None):
             with open(filename, 'w', encoding='utf-8') as fp:
                 fp.write(module_content)
-            assert_python_ok('-Xutf8', self.script, '-D', filename)
+            res = assert_python_ok('-Xutf8', self.script, *args, filename)
+            if strict:
+                self.assertEqual(res.err, b'')
             with open('messages.pot', encoding='utf-8') as fp:
                 data = fp.read()
         return self.get_msgids(data)
+
+    def extract_docstrings_from_str(self, module_content):
+        """Return all docstrings extracted from module_content."""
+        return self.extract_from_str(module_content, args=('--docstrings',), strict=False)
+
+    def extract_messages_from_str(self, module_content):
+        """Return all msgids extracted from module_content."""
+        return self.extract_from_str(module_content)
 
     def test_header(self):
         """Make sure the required fields are in the header, according to:
@@ -343,6 +352,23 @@ class Test_pygettext(unittest.TestCase):
         '''))
         self.assertNotIn('foo', msgids)
         self.assertIn('bar', msgids)
+
+    def test_function_and_class_names(self):
+        """Test that function and class names are not mistakenly extracted."""
+        msgids = self.extract_messages_from_str(dedent('''\
+        def _(x):
+            pass
+
+        def _(x="foo"):
+            pass
+
+        async def _(x):
+            pass
+
+        class _(object):
+            pass
+        '''))
+        self.assertEqual(msgids, [''])
 
     def test_pygettext_output(self):
         """Test that the pygettext output exactly matches snapshots."""

--- a/Misc/NEWS.d/next/Tools-Demos/2024-11-13-22-23-36.gh-issue-126807.vpaWuN.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2024-11-13-22-23-36.gh-issue-126807.vpaWuN.rst
@@ -1,0 +1,2 @@
+Fix extraction warnings in :program:`pygettext.py` caused by mistaking
+function definitions for function calls.

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -1,10 +1,11 @@
 #! /usr/bin/env python3
+# -*- coding: iso-8859-1 -*-
 # Originally written by Barry Warsaw <barry@python.org>
 #
 # Minimally patched to make it even more xgettext compatible
 # by Peter Funk <pf@artcom-gmbh.de>
 #
-# 2002-11-22 Jürgen Hermann <jh@web.de>
+# 2002-11-22 J�rgen Hermann <jh@web.de>
 # Added checks that _() only contains string literals, and
 # command line args are resolved to module lists, i.e. you
 # can now pass a filename, a module or package name, or a
@@ -206,7 +207,7 @@ def make_escapes(pass_nonascii):
     global escapes, escape
     if pass_nonascii:
         # Allow non-ascii characters to pass through so that e.g. 'msgid
-        # "Höhe"' would result not result in 'msgid "H\366he"'.  Otherwise we
+        # "H�he"' would result not result in 'msgid "H\366he"'.  Otherwise we
         # escape any character outside the 32..126 range.
         mod = 128
         escape = escape_ascii
@@ -323,6 +324,10 @@ class TokenEater:
         self.__prev_token = None
 
     def __call__(self, ttype, tstring, stup, etup, line):
+        # dispatch
+##        import token
+##        print('ttype:', token.tok_name[ttype], 'tstring:', tstring,
+##              file=sys.stderr)
         self.__state(ttype, tstring, stup[0])
         self.__prev_token = (ttype, tstring, stup, etup, line)
 

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -306,11 +306,6 @@ def getFilesForName(name):
     return []
 
 
-def _is_def_or_class_keyword(token):
-    ttype, tstring, *_ = token
-    return ttype == tokenize.NAME and tstring in ('def', 'class')
-
-
 class TokenEater:
     def __init__(self, options):
         self.__options = options

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -5,7 +5,7 @@
 # Minimally patched to make it even more xgettext compatible
 # by Peter Funk <pf@artcom-gmbh.de>
 #
-# 2002-11-22 Jï¿½rgen Hermann <jh@web.de>
+# 2002-11-22 Jürgen Hermann <jh@web.de>
 # Added checks that _() only contains string literals, and
 # command line args are resolved to module lists, i.e. you
 # can now pass a filename, a module or package name, or a
@@ -207,7 +207,7 @@ def make_escapes(pass_nonascii):
     global escapes, escape
     if pass_nonascii:
         # Allow non-ascii characters to pass through so that e.g. 'msgid
-        # "Hï¿½he"' would result not result in 'msgid "H\366he"'.  Otherwise we
+        # "Höhe"' would result not result in 'msgid "H\366he"'.  Otherwise we
         # escape any character outside the 32..126 range.
         mod = 128
         escape = escape_ascii

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python3
-# -*- coding: iso-8859-1 -*-
 # Originally written by Barry Warsaw <barry@python.org>
 #
 # Minimally patched to make it even more xgettext compatible


### PR DESCRIPTION
Fixes a bug where pygettext would attempt to extract a message from a code like this:

```python
def _(x): pass
```

This is because pygettext only looks at one token at a time and `_(x)` looks like a function call.

However, since `x` is not a string literal, it would erroneously issue a warning.

This PR fixes that by keeping track of the previous token and checking if it's `def` or `class`.


<!-- gh-issue-number: gh-126807 -->
* Issue: gh-126807
<!-- /gh-issue-number -->
