### PR TITLE
GH-126795: Increase the JIT threshold from 16 to 4096

### DIFF
--- a/Include/internal/pycore_backoff.h
+++ b/Include/internal/pycore_backoff.h
@@ -102,10 +102,9 @@ backoff_counter_triggers(_Py_BackoffCounter counter)
 }
 
 /* Initial JUMP_BACKWARD counter.
- * This determines when we create a trace for a loop.
-* Backoff sequence 16, 32, 64, 128, 256, 512, 1024, 2048, 4096. */
-#define JUMP_BACKWARD_INITIAL_VALUE 15
-#define JUMP_BACKWARD_INITIAL_BACKOFF 4
+ * This determines when we create a trace for a loop. */
+#define JUMP_BACKWARD_INITIAL_VALUE 4095
+#define JUMP_BACKWARD_INITIAL_BACKOFF 12
 static inline _Py_BackoffCounter
 initial_jump_backoff_counter(void)
 {

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -249,31 +249,31 @@ class TestUops(unittest.TestCase):
         exec(textwrap.dedent(f"""
             def many_vars():
                 # 260 vars, so z9 should have index 259
-                a0 = a1 = a2 = a3 = a4 = a5 = a6 = a7 = a8 = a9 = {TIER2_THRESHOLD}
-                b0 = b1 = b2 = b3 = b4 = b5 = b6 = b7 = b8 = b9 = {TIER2_THRESHOLD}
-                c0 = c1 = c2 = c3 = c4 = c5 = c6 = c7 = c8 = c9 = {TIER2_THRESHOLD}
-                d0 = d1 = d2 = d3 = d4 = d5 = d6 = d7 = d8 = d9 = {TIER2_THRESHOLD}
-                e0 = e1 = e2 = e3 = e4 = e5 = e6 = e7 = e8 = e9 = {TIER2_THRESHOLD}
-                f0 = f1 = f2 = f3 = f4 = f5 = f6 = f7 = f8 = f9 = {TIER2_THRESHOLD}
-                g0 = g1 = g2 = g3 = g4 = g5 = g6 = g7 = g8 = g9 = {TIER2_THRESHOLD}
-                h0 = h1 = h2 = h3 = h4 = h5 = h6 = h7 = h8 = h9 = {TIER2_THRESHOLD}
-                i0 = i1 = i2 = i3 = i4 = i5 = i6 = i7 = i8 = i9 = {TIER2_THRESHOLD}
-                j0 = j1 = j2 = j3 = j4 = j5 = j6 = j7 = j8 = j9 = {TIER2_THRESHOLD}
-                k0 = k1 = k2 = k3 = k4 = k5 = k6 = k7 = k8 = k9 = {TIER2_THRESHOLD}
-                l0 = l1 = l2 = l3 = l4 = l5 = l6 = l7 = l8 = l9 = {TIER2_THRESHOLD}
-                m0 = m1 = m2 = m3 = m4 = m5 = m6 = m7 = m8 = m9 = {TIER2_THRESHOLD}
-                n0 = n1 = n2 = n3 = n4 = n5 = n6 = n7 = n8 = n9 = {TIER2_THRESHOLD}
-                o0 = o1 = o2 = o3 = o4 = o5 = o6 = o7 = o8 = o9 = {TIER2_THRESHOLD}
-                p0 = p1 = p2 = p3 = p4 = p5 = p6 = p7 = p8 = p9 = {TIER2_THRESHOLD}
-                q0 = q1 = q2 = q3 = q4 = q5 = q6 = q7 = q8 = q9 = {TIER2_THRESHOLD}
-                r0 = r1 = r2 = r3 = r4 = r5 = r6 = r7 = r8 = r9 = {TIER2_THRESHOLD}
-                s0 = s1 = s2 = s3 = s4 = s5 = s6 = s7 = s8 = s9 = {TIER2_THRESHOLD}
-                t0 = t1 = t2 = t3 = t4 = t5 = t6 = t7 = t8 = t9 = {TIER2_THRESHOLD}
-                u0 = u1 = u2 = u3 = u4 = u5 = u6 = u7 = u8 = u9 = {TIER2_THRESHOLD}
-                v0 = v1 = v2 = v3 = v4 = v5 = v6 = v7 = v8 = v9 = {TIER2_THRESHOLD}
-                w0 = w1 = w2 = w3 = w4 = w5 = w6 = w7 = w8 = w9 = {TIER2_THRESHOLD}
-                x0 = x1 = x2 = x3 = x4 = x5 = x6 = x7 = x8 = x9 = {TIER2_THRESHOLD}
-                y0 = y1 = y2 = y3 = y4 = y5 = y6 = y7 = y8 = y9 = {TIER2_THRESHOLD}
+                a0 = a1 = a2 = a3 = a4 = a5 = a6 = a7 = a8 = a9 = 42
+                b0 = b1 = b2 = b3 = b4 = b5 = b6 = b7 = b8 = b9 = 42
+                c0 = c1 = c2 = c3 = c4 = c5 = c6 = c7 = c8 = c9 = 42
+                d0 = d1 = d2 = d3 = d4 = d5 = d6 = d7 = d8 = d9 = 42
+                e0 = e1 = e2 = e3 = e4 = e5 = e6 = e7 = e8 = e9 = 42
+                f0 = f1 = f2 = f3 = f4 = f5 = f6 = f7 = f8 = f9 = 42
+                g0 = g1 = g2 = g3 = g4 = g5 = g6 = g7 = g8 = g9 = 42
+                h0 = h1 = h2 = h3 = h4 = h5 = h6 = h7 = h8 = h9 = 42
+                i0 = i1 = i2 = i3 = i4 = i5 = i6 = i7 = i8 = i9 = 42
+                j0 = j1 = j2 = j3 = j4 = j5 = j6 = j7 = j8 = j9 = 42
+                k0 = k1 = k2 = k3 = k4 = k5 = k6 = k7 = k8 = k9 = 42
+                l0 = l1 = l2 = l3 = l4 = l5 = l6 = l7 = l8 = l9 = 42
+                m0 = m1 = m2 = m3 = m4 = m5 = m6 = m7 = m8 = m9 = 42
+                n0 = n1 = n2 = n3 = n4 = n5 = n6 = n7 = n8 = n9 = 42
+                o0 = o1 = o2 = o3 = o4 = o5 = o6 = o7 = o8 = o9 = 42
+                p0 = p1 = p2 = p3 = p4 = p5 = p6 = p7 = p8 = p9 = 42
+                q0 = q1 = q2 = q3 = q4 = q5 = q6 = q7 = q8 = q9 = 42
+                r0 = r1 = r2 = r3 = r4 = r5 = r6 = r7 = r8 = r9 = 42
+                s0 = s1 = s2 = s3 = s4 = s5 = s6 = s7 = s8 = s9 = 42
+                t0 = t1 = t2 = t3 = t4 = t5 = t6 = t7 = t8 = t9 = 42
+                u0 = u1 = u2 = u3 = u4 = u5 = u6 = u7 = u8 = u9 = 42
+                v0 = v1 = v2 = v3 = v4 = v5 = v6 = v7 = v8 = v9 = 42
+                w0 = w1 = w2 = w3 = w4 = w5 = w6 = w7 = w8 = w9 = 42
+                x0 = x1 = x2 = x3 = x4 = x5 = x6 = x7 = x8 = x9 = 42
+                y0 = y1 = y2 = y3 = y4 = y5 = y6 = y7 = y8 = y9 = 42
                 z0 = z1 = z2 = z3 = z4 = z5 = z6 = z7 = z8 = z9 = {TIER2_THRESHOLD}
                 while z9 > 0:
                     z9 = z9 - 1
@@ -1394,9 +1394,9 @@ class TestUopsOptimization(unittest.TestCase):
             x = 0
             for i in range(TIER2_THRESHOLD + 100):
                 x += a.attr
-                # for the first 90 iterations we set the attribute on this dummy function which shouldn't
+                # for the first (TIER2_THRESHOLD + 90) iterations we set the attribute on this dummy function which shouldn't
                 # trigger the type watcher
-                # then after 90  it should trigger it and stop optimizing
+                # then after for the next 10 it should trigger it and stop optimizing
                 # Note that the code needs to be in this weird form so it's optimized inline without any control flow
                 setattr((Foo, Bar)[i < TIER2_THRESHOLD + 90], "attr", 2)
                 x += a.attr

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-11-13-17-18-13.gh-issue-126795._JBX9e.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-11-13-17-18-13.gh-issue-126795._JBX9e.rst
@@ -1,2 +1,2 @@
-Increase the threshold for JIT code warmup. Depending on plaform and workload,
+Increase the threshold for JIT code warmup. Depending on platform and workload,
 this can result in performance gains of 1-9% and memory savings of 3-5%.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-11-13-17-18-13.gh-issue-126795._JBX9e.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-11-13-17-18-13.gh-issue-126795._JBX9e.rst
@@ -1,1 +1,2 @@
-Increase the threshold for JIT code warmup.
+Increase the threshold for JIT code warmup. Depending on plaform and workload,
+this can result in performance gains of 1-9% and memory savings of 3-5%.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-11-13-17-18-13.gh-issue-126795._JBX9e.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-11-13-17-18-13.gh-issue-126795._JBX9e.rst
@@ -1,0 +1,1 @@
+Increase the threshold for JIT code warmup.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -2222,7 +2222,7 @@ module_exec(PyObject *module)
     }
 
     if (PyModule_Add(module, "TIER2_THRESHOLD",
-                        PyLong_FromLong(JUMP_BACKWARD_INITIAL_VALUE)) < 0) {
+                        PyLong_FromLong(JUMP_BACKWARD_INITIAL_VALUE + 1)) < 0) {
         return 1;
     }
 

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -1,5 +1,5 @@
 #ifdef _Py_JIT
-// XXX: Touching this file for JIT CI!
+
 #include "Python.h"
 
 #include "pycore_abstract.h"

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -1,5 +1,5 @@
 #ifdef _Py_JIT
-
+// XXX: Touching this file for JIT CI!
 #include "Python.h"
 
 #include "pycore_abstract.h"


### PR DESCRIPTION
The core change itself is simple, and results in [2.1% speed improvement and a 3.6% memory improvement](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20241111-3.14.0a1%2B-a2be6fd-JIT/README.md) for JIT builds. The bulk of this PR is just modifying most of the tests in `test_capi.test_opt` to remove assumptions about the warmup threshold.

<!-- gh-issue-number: gh-126795 -->
* Issue: gh-126795
<!-- /gh-issue-number -->
