### PR TITLE
gh-125063: Move slice constant-folding to AST

### DIFF
--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -240,6 +240,7 @@ class TestTranforms(BytecodeTestCase):
             ('a = 2+3', 5),                     # binary add
             ('a = 13-4', 9),                    # binary subtract
             ('a = (12,13)[1]', 13),             # binary subscr
+            ('a = (12,13)[:1]', (12,)),         # binary subscr (slice)
             ('a = 13 << 2', 52),                # binary lshift
             ('a = 13 >> 2', 3),                 # binary rshift
             ('a = 13 & 7', 5),                  # binary and
@@ -282,8 +283,14 @@ class TestTranforms(BytecodeTestCase):
         self.assertInBytecode(code, 'LOAD_CONST', 'f')
         self.assertNotInBytecode(code, 'BINARY_SUBSCR')
         self.check_lnotab(code)
+
         code = compile('"\u0061\uffff"[1]', '', 'single')
         self.assertInBytecode(code, 'LOAD_CONST', '\uffff')
+        self.assertNotInBytecode(code,'BINARY_SUBSCR')
+        self.check_lnotab(code)
+
+        code = compile('"\u0061\uffffxx"[1::2]', '', 'single')
+        self.assertInBytecode(code, 'LOAD_CONST', '\uffffx')
         self.assertNotInBytecode(code,'BINARY_SUBSCR')
         self.check_lnotab(code)
 

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -5040,22 +5040,9 @@ codegen_visit_expr(compiler *c, expr_ty e)
 }
 
 static bool
-is_constant_slice(expr_ty s)
-{
-    return s->kind == Slice_kind &&
-        (s->v.Slice.lower == NULL ||
-         s->v.Slice.lower->kind == Constant_kind) &&
-        (s->v.Slice.upper == NULL ||
-         s->v.Slice.upper->kind == Constant_kind) &&
-        (s->v.Slice.step == NULL ||
-         s->v.Slice.step->kind == Constant_kind);
-}
-
-static bool
 should_apply_two_element_slice_optimization(expr_ty s)
 {
-    return !is_constant_slice(s) &&
-           s->kind == Slice_kind &&
+    return s->kind == Slice_kind &&
            s->v.Slice.step == NULL;
 }
 
@@ -5311,27 +5298,6 @@ codegen_slice(compiler *c, expr_ty s)
 {
     int n = 2;
     assert(s->kind == Slice_kind);
-
-    if (is_constant_slice(s)) {
-        PyObject *start = NULL;
-        if (s->v.Slice.lower) {
-            start = s->v.Slice.lower->v.Constant.value;
-        }
-        PyObject *stop = NULL;
-        if (s->v.Slice.upper) {
-            stop = s->v.Slice.upper->v.Constant.value;
-        }
-        PyObject *step = NULL;
-        if (s->v.Slice.step) {
-            step = s->v.Slice.step->v.Constant.value;
-        }
-        PyObject *slice = PySlice_New(start, stop, step);
-        if (slice == NULL) {
-            return ERROR;
-        }
-        ADDOP_LOAD_CONST_NEW(c, LOC(s), slice);
-        return SUCCESS;
-    }
 
     RETURN_IF_ERROR(codegen_slice_two_parts(c, s));
 


### PR DESCRIPTION
Generate slice constants in AST, rather than in codegen.

This could allow more optimizations in earlier steps, albeit in practice it probably only helps rare cases (e.g. `"abc"[:1]` -> `"a'`).

Tests for the final result were added in GH-125064.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-125063 -->
* Issue: gh-125063
<!-- /gh-issue-number -->
