### PR TITLE
[3.13] gh-126312: Don't traverse frozen objects on the free-threaded build (GH-126338)

### DIFF
--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1129,6 +1129,45 @@ class GCTests(unittest.TestCase):
         gc.collect()
         self.assertTrue(collected)
 
+    def test_traverse_frozen_objects(self):
+        # See GH-126312: Objects that were not frozen could traverse over
+        # a frozen object on the free-threaded build, which would cause
+        # a negative reference count.
+        x = [1, 2, 3]
+        gc.freeze()
+        y = [x]
+        y.append(y)
+        del y
+        gc.collect()
+        gc.unfreeze()
+
+    def test_deferred_refcount_frozen(self):
+        # Also from GH-126312: objects that use deferred reference counting
+        # weren't ignored if they were frozen. Unfortunately, it's pretty
+        # difficult to come up with a case that triggers this.
+        #
+        # Calling gc.collect() while the garbage collector is frozen doesn't
+        # trigger this normally, but it *does* if it's inside unittest for whatever
+        # reason. We can't call unittest from inside a test, so it has to be
+        # in a subprocess.
+        source = textwrap.dedent("""
+        import gc
+        import unittest
+
+
+        class Test(unittest.TestCase):
+            def test_something(self):
+                gc.freeze()
+                gc.collect()
+                gc.unfreeze()
+
+
+        if __name__ == "__main__":
+            unittest.main()
+        """)
+        assert_python_ok("-c", source)
+
+
 class GCCallbackTests(unittest.TestCase):
     def setUp(self):
         # Save gc state and disable it.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-14-43-46.gh-issue-126312.LMHzLT.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-11-02-14-43-46.gh-issue-126312.LMHzLT.rst
@@ -1,0 +1,2 @@
+Fix crash during garbage collection on an object frozen by :func:`gc.freeze` on the
+free-threaded build.


### PR DESCRIPTION
Also, _PyGC_Freeze() no longer freezes unreachable objects.

(cherry picked from commit d4c72fed8cba8e15ab7bb6c30a92bc9f2c8f0a2c)

Co-authored-by: Sergey B Kirpichev <skirpichev@gmail.com>

<!-- gh-issue-number: gh-126312 -->
* Issue: gh-126312
<!-- /gh-issue-number -->
