### PR TITLE
gh-126946: Improve error message in getopt.do_longs based on existing comment

### DIFF
--- a/Lib/getopt.py
+++ b/Lib/getopt.py
@@ -185,7 +185,7 @@ def long_has_args(opt, longopts):
         return True, opt
     elif opt + '=?' in possibilities:
         return '?', opt
-    # No exact match, so better be unique.
+    # Possibilities must be unique to be accepted
     if len(possibilities) > 1:
         raise GetoptError(
             _("option --%s not a unique prefix; possible options: %s")

--- a/Lib/getopt.py
+++ b/Lib/getopt.py
@@ -187,9 +187,11 @@ def long_has_args(opt, longopts):
         return '?', opt
     # No exact match, so better be unique.
     if len(possibilities) > 1:
-        # XXX since possibilities contains all valid continuations, might be
-        # nice to work them into the error msg
-        raise GetoptError(_('option --%s not a unique prefix') % opt, opt)
+        raise GetoptError(
+            _("option --%s not a unique prefix; possible options: %s")
+            % (opt, ", ".join(possibilities)),
+            opt,
+        )
     assert len(possibilities) == 1
     unique_match = possibilities[0]
     if unique_match.endswith('=?'):

--- a/Lib/test/translationdata/getopt/msgids.txt
+++ b/Lib/test/translationdata/getopt/msgids.txt
@@ -1,6 +1,6 @@
 option -%s not recognized
 option -%s requires argument
 option --%s must not have an argument
-option --%s not a unique prefix
+option --%s not a unique prefix; possible options: %s
 option --%s not recognized
 option --%s requires argument

--- a/Misc/NEWS.d/next/Library/2024-11-18-16-43-11.gh-issue-126946.52Ou-B.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-18-16-43-11.gh-issue-126946.52Ou-B.rst
@@ -1,1 +1,3 @@
-Included possibilities in the error message of getopt.do_longs.
+Improve the :exc:`~getopt.GetoptError` error message when a long option
+prefix matches multiple accepted options in :func:`getopt.getopt` and
+:func:`getopt.gnu_getopt`.

--- a/Misc/NEWS.d/next/Library/2024-11-18-16-43-11.gh-issue-126946.52Ou-B.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-18-16-43-11.gh-issue-126946.52Ou-B.rst
@@ -1,0 +1,1 @@
+Included possibilities in the error message of getopt.do_longs.


### PR DESCRIPTION
This PR improves the error message in getopt.do_longs based on the existing comment

<!-- gh-issue-number: gh-126946 -->
* Issue: gh-126946
<!-- /gh-issue-number -->
