### PR TITLE
[3.12] Docs: Miscellaneous corrections to simple statements in the language reference (GH-126720)

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -406,9 +406,9 @@ The extended form, ``assert expression1, expression2``, is equivalent to ::
 
 These equivalences assume that :const:`__debug__` and :exc:`AssertionError` refer to
 the built-in variables with those names.  In the current implementation, the
-built-in variable :const:`__debug__` is ``True`` under normal circumstances,
+built-in variable ``__debug__`` is ``True`` under normal circumstances,
 ``False`` when optimization is requested (command line option :option:`-O`).  The current
-code generator emits no code for an assert statement when optimization is
+code generator emits no code for an :keyword:`assert` statement when optimization is
 requested at compile time.  Note that it is unnecessary to include the source
 code for the expression that failed in the error message; it will be displayed
 as part of the stack trace.
@@ -531,8 +531,8 @@ The :keyword:`!yield` statement
    yield_stmt: `yield_expression`
 
 A :keyword:`yield` statement is semantically equivalent to a :ref:`yield
-expression <yieldexpr>`. The yield statement can be used to omit the parentheses
-that would otherwise be required in the equivalent yield expression
+expression <yieldexpr>`. The ``yield`` statement can be used to omit the
+parentheses that would otherwise be required in the equivalent yield expression
 statement. For example, the yield statements ::
 
   yield <expr>
@@ -544,7 +544,7 @@ are equivalent to the yield expression statements ::
   (yield from <expr>)
 
 Yield expressions and statements are only used when defining a :term:`generator`
-function, and are only used in the body of the generator function.  Using yield
+function, and are only used in the body of the generator function.  Using :keyword:`yield`
 in a function definition is sufficient to cause that definition to create a
 generator function instead of a normal function.
 
@@ -964,25 +964,14 @@ The :keyword:`!global` statement
 .. productionlist:: python-grammar
    global_stmt: "global" `identifier` ("," `identifier`)*
 
-The :keyword:`global` statement is a declaration which holds for the entire
-current code block.  It means that the listed identifiers are to be interpreted
-as globals.  It would be impossible to assign to a global variable without
+The :keyword:`global` statement causes the listed identifiers to be interpreted
+as globals. It would be impossible to assign to a global variable without
 :keyword:`!global`, although free variables may refer to globals without being
 declared global.
 
-Names listed in a :keyword:`global` statement must not be used in the same code
-block textually preceding that :keyword:`!global` statement.
-
-Names listed in a :keyword:`global` statement must not be defined as formal
-parameters, or as targets in :keyword:`with` statements or :keyword:`except` clauses, or in a :keyword:`for` target list, :keyword:`class`
-definition, function definition, :keyword:`import` statement, or variable
-annotation.
-
-.. impl-detail::
-
-   The current implementation does not enforce some of these restrictions, but
-   programs should not abuse this freedom, as future implementations may enforce
-   them or silently change the meaning of the program.
+The :keyword:`global` statement applies to the entire scope of a function or
+class body. A :exc:`SyntaxError` is raised if a variable is used or
+assigned to prior to its global declaration in the scope.
 
 .. index::
    pair: built-in function; exec
@@ -1018,7 +1007,7 @@ identifiers.  If a name is bound in more than one nonlocal scope, the
 nearest binding is used. If a name is not bound in any nonlocal scope,
 or if there is no nonlocal scope, a :exc:`SyntaxError` is raised.
 
-The nonlocal statement applies to the entire scope of a function or
+The :keyword:`nonlocal` statement applies to the entire scope of a function or
 class body. A :exc:`SyntaxError` is raised if a variable is used or
 assigned to prior to its nonlocal declaration in the scope.
 


### PR DESCRIPTION
* Replace: The :keyword:`global` -> The :keyword:`global` statement
Add :keyword: when it's needed

* Replace repeated links with duoble backticks (cherry picked from commit 94a7a4e22fb8f567090514785c69e65298acca42)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126891.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->