### PR TITLE
gh-126896: Fix docs about `asyncio.start_server()`

### DIFF
--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -92,7 +92,8 @@ and work with streams:
                           family=socket.AF_UNSPEC, \
                           flags=socket.AI_PASSIVE, sock=None, \
                           backlog=100, ssl=None, reuse_address=None, \
-                          reuse_port=None, ssl_handshake_timeout=None, \
+                          reuse_port=None, keep_alive=None, \
+                          ssl_handshake_timeout=None, \
                           ssl_shutdown_timeout=None, start_serving=True)
 
    Start a socket server.

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -129,6 +129,9 @@ and work with streams:
    .. versionchanged:: 3.11
       Added the *ssl_shutdown_timeout* parameter.
 
+   .. versionchanged:: 3.13
+      Added the *keep_alive* parameter.
+
 
 .. rubric:: Unix Sockets
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-126896 -->
* Issue: gh-126896
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126897.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->