### PR TITLE
gh-126881: store `debug` flag for event loops as a boolean

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -2052,7 +2052,9 @@ class BaseEventLoop(events.AbstractEventLoop):
         return self._debug
 
     def set_debug(self, enabled):
-        self._debug = enabled
+        # Storing a non-boolean 'debug' flag causes a crash upon finalization.
+        # See: https://github.com/python/cpython/issues/126881.
+        self._debug = enabled = bool(enabled)
 
         if self.is_running():
             self.call_soon_threadsafe(self._set_coroutine_origin_tracking, enabled)

--- a/Misc/NEWS.d/next/Library/2024-11-16-10-44-58.gh-issue-126881.W4TXxX.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-16-10-44-58.gh-issue-126881.W4TXxX.rst
@@ -1,0 +1,2 @@
+Fix a crash upon finalization when passing a non-boolean value to
+:meth:`loop.set_debug <asyncio.loop.set_debug>`. Patch by Bénédikt Tran.


### PR DESCRIPTION
I'm opening this one as a possible fix. I'm totally unsure whether this is the way to patch it (see the corresponding issue).

<!-- gh-issue-number: gh-126881 -->
* Issue: gh-126881
<!-- /gh-issue-number -->
