### PR TITLE
GH-126920: fix Makefile overwriting sysconfig.get_config_vars

### DIFF
--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -353,7 +353,8 @@ def _init_posix(vars):
     else:
         _temp = __import__(name, globals(), locals(), ['build_time_vars'], 0)
     build_time_vars = _temp.build_time_vars
-    vars.update(build_time_vars)
+    # GH-126920: Make sure we don't overwrite any of the keys already set
+    vars.update(build_time_vars | vars)
 
 def _init_non_posix(vars):
     """Initialize the module as appropriate for NT"""

--- a/Misc/NEWS.d/next/Library/2024-11-17-01-14-59.gh-issue-126920.s8-f_L.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-17-01-14-59.gh-issue-126920.s8-f_L.rst
@@ -1,0 +1,5 @@
+Fix the ``prefix`` and ``exec_prefix`` keys from
+:py:func:`sysconfig.get_config_vars` incorrectly having the same value as
+:py:const:`sys.base_prefix` and :py:const:`sys.base_exec_prefix`,
+respectively, inside virtual environments. They now accurately reflect
+:py:const:`sys.prefix` and :py:const:`sys.exec_prefix`.


### PR DESCRIPTION


<!-- gh-issue-number: gh-126920 -->
* Issue: gh-126920
<!-- /gh-issue-number -->
