### PR TITLE
GH-89435: os.path should not be a frozen module

### DIFF
--- a/Python/frozen.c
+++ b/Python/frozen.c
@@ -84,7 +84,6 @@ static const struct _frozen stdlib_modules[] = {
     {"genericpath", _Py_M__genericpath, (int)sizeof(_Py_M__genericpath), false},
     {"ntpath", _Py_M__ntpath, (int)sizeof(_Py_M__ntpath), false},
     {"posixpath", _Py_M__posixpath, (int)sizeof(_Py_M__posixpath), false},
-    {"os.path", _Py_M__posixpath, (int)sizeof(_Py_M__posixpath), false},
     {"os", _Py_M__os, (int)sizeof(_Py_M__os), false},
     {"site", _Py_M__site, (int)sizeof(_Py_M__site), false},
     {"stat", _Py_M__stat, (int)sizeof(_Py_M__stat), false},
@@ -116,7 +115,6 @@ const struct _frozen *_PyImport_FrozenTest = test_modules;
 static const struct _module_alias aliases[] = {
     {"_frozen_importlib", "importlib._bootstrap"},
     {"_frozen_importlib_external", "importlib._bootstrap_external"},
-    {"os.path", "posixpath"},
     {"__hello_alias__", "__hello__"},
     {"__phello_alias__", "__hello__"},
     {"__phello_alias__.spam", "__hello__"},

--- a/Tools/build/freeze_modules.py
+++ b/Tools/build/freeze_modules.py
@@ -63,9 +63,6 @@ FROZEN = [
         'genericpath',
         'ntpath',
         'posixpath',
-        # We must explicitly mark os.path as a frozen module
-        # even though it will never be imported.
-        f'{OS_PATH} : os.path',
         'os',
         'site',
         'stat',


### PR DESCRIPTION
As Eric mentioned in GH-29329, this workaround might not be needed anymore. The test suite does not seem to complain on my machine, so I think that may be the case, let's see if the CI complains. If there are no CI failures, then I think it should probably be okay to drop this workaround.

<!-- gh-issue-number: gh-89435 -->
* Issue: gh-89435
<!-- /gh-issue-number -->
