### PR TITLE
gh-126909: Fix running xattr tests on systems with lower limits

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3967,10 +3967,10 @@ class ExtendedAttributeTests(unittest.TestCase):
         xattr.remove("user.test")
         self.assertEqual(set(listxattr(fn)), xattr)
         self.assertEqual(getxattr(fn, s("user.test2"), **kwargs), b"foo")
-        setxattr(fn, s("user.test"), b"a"*1024, **kwargs)
-        self.assertEqual(getxattr(fn, s("user.test"), **kwargs), b"a"*1024)
+        setxattr(fn, s("user.test"), b"a"*256, **kwargs)
+        self.assertEqual(getxattr(fn, s("user.test"), **kwargs), b"a"*256)
         removexattr(fn, s("user.test"), **kwargs)
-        many = sorted("user.test{}".format(i) for i in range(100))
+        many = sorted("user.test{}".format(i) for i in range(32))
         for thing in many:
             setxattr(fn, thing, b"x", **kwargs)
         self.assertEqual(set(listxattr(fn)), set(init_xattr) | set(many))

--- a/Misc/NEWS.d/next/Tests/2024-11-17-16-56-48.gh-issue-126909.60VTxW.rst
+++ b/Misc/NEWS.d/next/Tests/2024-11-17-16-56-48.gh-issue-126909.60VTxW.rst
@@ -1,2 +1,2 @@
-Fix extended attribute tests to work on filesystems with 1 KiB xattr size
+Fix test_os extended attribute tests to work on filesystems with 1 KiB xattr size
 limit.

--- a/Misc/NEWS.d/next/Tests/2024-11-17-16-56-48.gh-issue-126909.60VTxW.rst
+++ b/Misc/NEWS.d/next/Tests/2024-11-17-16-56-48.gh-issue-126909.60VTxW.rst
@@ -1,0 +1,2 @@
+Fix extended attribute tests to work on filesystems with 1 KiB xattr size
+limit.


### PR DESCRIPTION
Modify the extended attribute tests to write fewer and smaller extended attributes, in order to fit within filesystems with total xattr limit of 1 KiB (e.g. ext4 with 1 KiB blocks).  Previously, the test would write over 2 KiB, making it fail with ENOSPC on such systems.

<!-- gh-issue-number: gh-126909 -->
* Issue: gh-126909
<!-- /gh-issue-number -->
