### PR TITLE
gh-126789: Correct sysconfig test exclusions for iOS and Android.

### DIFF
--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -656,7 +656,7 @@ class TestSysConfig(unittest.TestCase):
 
         self.assertNotEqual(site_paths, no_site_paths)
 
-    @unittest.skipIf(is_wasi, 'venv is unsupported on WASI')
+    @requires_subprocess()
     def test_makefile_overwrites_config_vars(self):
         script = textwrap.dedent("""
             import sys, sysconfig
@@ -688,6 +688,7 @@ class TestSysConfig(unittest.TestCase):
         # prefix/exec_prefix Makefile variables, so we use them in the comparison.
         self.assertNotEqual(data['prefix'], data['base_prefix'])
         self.assertNotEqual(data['exec_prefix'], data['base_exec_prefix'])
+
 
 class MakefileTests(unittest.TestCase):
 

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -591,7 +591,7 @@ class TestSysConfig(unittest.TestCase):
         suffix = sysconfig.get_config_var('EXT_SUFFIX')
         self.assertTrue(suffix.endswith('-darwin.so'), suffix)
 
-    @unittest.skipIf(sys.platform == 'wasi', 'venv is unsupported on WASI')
+    @requires_subprocess
     def test_config_vars_depend_on_site_initialization(self):
         script = textwrap.dedent("""
             import sysconfig
@@ -615,7 +615,7 @@ class TestSysConfig(unittest.TestCase):
         self.assertEqual(no_site_config_vars['base'], site_config_vars['installed_base'])
         self.assertEqual(no_site_config_vars['platbase'], site_config_vars['installed_platbase'])
 
-    @unittest.skipIf(sys.platform == 'wasi', 'venv is unsupported on WASI')
+    @requires_subprocess
     def test_config_vars_recalculation_after_site_initialization(self):
         script = textwrap.dedent("""
             import sysconfig
@@ -639,7 +639,7 @@ class TestSysConfig(unittest.TestCase):
         #self.assertEqual(config_vars['after']['prefix'], venv.prefix)  # FIXME: prefix gets overwriten by _init_posix
         #self.assertEqual(config_vars['after']['exec_prefix'], venv.prefix)  # FIXME: exec_prefix gets overwriten by _init_posix
 
-    @unittest.skipIf(sys.platform == 'wasi', 'venv is unsupported on WASI')
+    @requires_subprocess
     def test_paths_depend_on_site_initialization(self):
         script = textwrap.dedent("""
             import sysconfig
@@ -656,7 +656,7 @@ class TestSysConfig(unittest.TestCase):
 
         self.assertNotEqual(site_paths, no_site_paths)
 
-    @unittest.skipIf(sys.platform == 'wasi', 'venv is unsupported on WASI')
+    @unittest.skipIf(is_wasi, 'venv is unsupported on WASI')
     def test_makefile_overwrites_config_vars(self):
         script = textwrap.dedent("""
             import sys, sysconfig

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -591,7 +591,7 @@ class TestSysConfig(unittest.TestCase):
         suffix = sysconfig.get_config_var('EXT_SUFFIX')
         self.assertTrue(suffix.endswith('-darwin.so'), suffix)
 
-    @requires_subprocess
+    @requires_subprocess()
     def test_config_vars_depend_on_site_initialization(self):
         script = textwrap.dedent("""
             import sysconfig
@@ -615,7 +615,7 @@ class TestSysConfig(unittest.TestCase):
         self.assertEqual(no_site_config_vars['base'], site_config_vars['installed_base'])
         self.assertEqual(no_site_config_vars['platbase'], site_config_vars['installed_platbase'])
 
-    @requires_subprocess
+    @requires_subprocess()
     def test_config_vars_recalculation_after_site_initialization(self):
         script = textwrap.dedent("""
             import sysconfig
@@ -639,7 +639,7 @@ class TestSysConfig(unittest.TestCase):
         #self.assertEqual(config_vars['after']['prefix'], venv.prefix)  # FIXME: prefix gets overwriten by _init_posix
         #self.assertEqual(config_vars['after']['exec_prefix'], venv.prefix)  # FIXME: exec_prefix gets overwriten by _init_posix
 
-    @requires_subprocess
+    @requires_subprocess()
     def test_paths_depend_on_site_initialization(self):
         script = textwrap.dedent("""
             import sysconfig


### PR DESCRIPTION
#126812 (backported to 3.13 as #126918) added some new tests for the sysconfig module. These tests were skipped on WASI platforms - but the underlying problem exists on *all* platforms that don't provide subprocess.

This PR modifies the test skip to check for subprocess availability.

There's an argument to be made that this should also be backported to 3.12, as the original PR was backported (see #126919); but the fix isn't *required* there because iOS and Android aren't supported on 3.12.

<!-- gh-issue-number: gh-126789 -->
* Issue: gh-126789
<!-- /gh-issue-number -->
