### PR TITLE
gh-126927: Add functools.retry decorator function

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -324,7 +324,7 @@ functools
   as a keyword argument.
   (Contributed by Sayandip Dutta in :gh:`125916`.)
 
-* Add function decorator :func:`functools.retry` that allows configurable
+* Add function decorator ``functools.retry`` that allows configurable
   retries for functions that raise an exception.  It can be used with or
   without keyword arguments.
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -324,6 +324,9 @@ functools
   as a keyword argument.
   (Contributed by Sayandip Dutta in :gh:`125916`.)
 
+* Add function decorator :func:`functools.retry` that allows configurable
+  retries for functions that raise an exception.  It can be used with or
+  without keyword arguments.
 
 getopt
 ------

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1124,11 +1124,9 @@ class cached_property:
     __class_getitem__ = classmethod(GenericAlias)
 
 
-################################################################################
-### retry() - simple retry decorator
-################################################################################
-
-def retry(_kwargs=None, *, retry_attempts=3, interval_seconds=.1, backoff_type='linear'):
+def retry(
+    _kwargs=None, *, retry_attempts=3, interval_seconds=0.1, backoff_type="linear"
+):
     """
     This function is intended to be used as a decorator and will retry
     the function that it decorates if an excpetion is raised in that
@@ -1136,34 +1134,37 @@ def retry(_kwargs=None, *, retry_attempts=3, interval_seconds=.1, backoff_type='
     keyword arguments.  Also, no keyword arguments can be used to retry
     with the default values.
 
-    NOTE: if using backoff_type='exponential', ensure that 
-    interval_seconds > 1, otherise the subsequent retries will be 
+    NOTE: if using backoff_type='exponential', ensure that
+    interval_seconds > 1, otherise the subsequent retries will be
     shorter.
     """
 
     def _retry(user_function):
         @wraps(user_function)
         def _retry_wrapper_user_function(*args, **kwargs):
-            for attempt_number in range(retry_attempts+1):
+            for attempt_number in range(retry_attempts + 1):
                 try:
                     return_value = user_function(*args, **kwargs)
                     break
                 except Exception as e:
                     if attempt_number < retry_attempts:
-                        if backoff_type == 'exponential':
+                        if backoff_type == "exponential":
                             # If user inputs interval_seconds < 1 with exponential backoff, retries will get shorter
-                            sleep(interval_seconds * (attempt_number + 1)**2)
-                        elif backoff_type == 'linear':
+                            sleep(interval_seconds * (attempt_number + 1) ** 2)
+                        elif backoff_type == "linear":
                             sleep(interval_seconds)
                     else:
                         # Retry attempts reached, raise the last exception
-                        raise e 
+                        raise e
             return return_value
+
         return _retry_wrapper_user_function
-    
-    if backoff_type != 'linear' and  backoff_type != 'exponential':
-        raise TypeError("Keyword argument backoff_type must be 'exponential' or 'linear'.")
-    
+
+    if backoff_type != "linear" and backoff_type != "exponential":
+        raise TypeError(
+            "Keyword argument backoff_type must be 'exponential' or 'linear'."
+        )
+
     if _kwargs is None:
         return _retry
     else:

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3388,14 +3388,14 @@ class TestRetry(unittest.TestCase):
         @functools.retry
         def fail_function1():
             raise ValueError
-        
+
         with self.assertRaises(ValueError):
             fail_function1()
 
         @functools.retry(interval_seconds=.1, retry_attempts=1, backoff_type='exponential')
         def fail_function2():
             raise ValueError
-        
+
         with self.assertRaises(ValueError):
             fail_function2()
 
@@ -3404,7 +3404,7 @@ class TestRetry(unittest.TestCase):
         @functools.retry
         def success_function(a, b, c='test_value'):
             return (a, b, c)
-        
+
         value = success_function('a', 'b')
 
         self.assertEqual(value, ('a', 'b', 'test_value'))
@@ -3420,7 +3420,7 @@ class TestRetry(unittest.TestCase):
             if test_object.call_count > 3:
                 return True
             raise ValueError('Some error message!')
-        
+
         value = success_function_after_3_failures(test_object)
         self.assertTrue(value)
 
@@ -3441,7 +3441,7 @@ class TestRetry(unittest.TestCase):
             @functools.retry(backoff_type='incorrect_value')
             def user_function3():
                 return True
-            
+
             user_function3()
 
 

--- a/Misc/NEWS.d/next/Library/2024-11-18-03-26-52.gh-issue-126927.K-gKnU.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-18-03-26-52.gh-issue-126927.K-gKnU.rst
@@ -1,4 +1,4 @@
-Add :func:`functools.retry` function to be used as a decorator.  The
+Add ``functools.retry`` function to be used as a decorator.  The
 decorator gives retries to a function that raises exeptions.  It can be
 used with default options or have options specified with keyword
 arguments.

--- a/Misc/NEWS.d/next/Library/2024-11-18-03-26-52.gh-issue-126927.K-gKnU.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-18-03-26-52.gh-issue-126927.K-gKnU.rst
@@ -1,0 +1,4 @@
+Add :func:`functools.retry` function to be used as a decorator.  The
+decorator gives retries to a function that raises exeptions.  It can be
+used with default options or have options specified with keyword
+arguments.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

__Past PR:__ https://github.com/python/cpython/pull/126928

__NEW PR NOTE:__ I added updates to the past PR that I raised such as formatting the code and adding news/whats new.  I do not have time at the moment to have a discussion about adding this feature, so I will mark this PR as a draft, then update the description and publish this review after.

I added a `retry` decorator to `functools`, written in pure python so it should be maximally portable.  I also added unit tests covering all aspects of the functionality.  This is something I have been wishing to have for years and I explain in this issue: https://github.com/python/cpython/issues/126927

It has some keyword arguments that can be configured for different retry behavior and smart defaults.

This is my first contribution to CPython and I would really appreciate any feedback or pointers to add this change.

## Tests
- I ran `./python -m unittest Lib/test/test_functools.py -v` with no errors
  - I ensured that the new tests I wrote work
-   I ran `make patchcheck` successfully






<!-- gh-issue-number: gh-126927 -->
* Issue: gh-126927
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126943.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->