### PR TITLE
gh-126947: Typechecking for _pydatetime.timedelta.__new__ arguments

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -651,7 +651,19 @@ class timedelta:
         # guide the C implementation; it's way more convoluted than speed-
         # ignoring auto-overflow-to-long idiomatic Python could be.
 
-        # XXX Check that all inputs are ints or floats.
+        for name, value in (
+            ("days", days),
+            ("seconds", seconds),
+            ("microseconds", microseconds),
+            ("milliseconds", milliseconds),
+            ("minutes", minutes),
+            ("hours", hours),
+            ("weeks", weeks)
+        ):
+            if not isinstance(value, (int, float)):
+                raise TypeError(
+                    f"unsupported type for timedelta {name} component: {type(value).__name__}"
+                )
 
         # Final values, all integer.
         # s and us fit in 32-bit signed ints; d isn't bounded.

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -510,6 +510,7 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
 
     def test_constructor(self):
         eq = self.assertEqual
+        ra = self.assertRaises
         td = timedelta
 
         # Check keyword args to constructor
@@ -532,6 +533,15 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
         eq(td(minutes=1.0/60), td(seconds=1))
         eq(td(seconds=0.001), td(milliseconds=1))
         eq(td(milliseconds=0.001), td(microseconds=1))
+
+        # Check type of args to constructor
+        ra(TypeError, lambda: td(weeks='1'))
+        ra(TypeError, lambda: td(days='1'))
+        ra(TypeError, lambda: td(hours='1'))
+        ra(TypeError, lambda: td(minutes='1'))
+        ra(TypeError, lambda: td(seconds='1'))
+        ra(TypeError, lambda: td(milliseconds='1'))
+        ra(TypeError, lambda: td(microseconds='1'))
 
     def test_computations(self):
         eq = self.assertEqual

--- a/Misc/NEWS.d/next/Library/2024-11-18-19-03-46.gh-issue-126947.NiDYUe.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-18-19-03-46.gh-issue-126947.NiDYUe.rst
@@ -1,2 +1,2 @@
-Add typechecking for _pydatetime.timedelta.__new__ arguments so that python
-implementation is in line with C implementation
+Raise :exc:`TypeError` in :meth:`!_pydatetime.timedelta.__new__` arguments are not :class:`int` or :class:`float`, so that python
+implementation is in line with C implementation.

--- a/Misc/NEWS.d/next/Library/2024-11-18-19-03-46.gh-issue-126947.NiDYUe.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-18-19-03-46.gh-issue-126947.NiDYUe.rst
@@ -1,0 +1,2 @@
+Add typechecking for _pydatetime.timedelta.__new__ arguments so that python
+implementation is in line with C implementation

--- a/Misc/NEWS.d/next/Library/2024-11-18-19-03-46.gh-issue-126947.NiDYUe.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-18-19-03-46.gh-issue-126947.NiDYUe.rst
@@ -1,2 +1,2 @@
-Raise :exc:`TypeError` in :meth:`!_pydatetime.timedelta.__new__` arguments are not :class:`int` or :class:`float`, so that python
-implementation is in line with C implementation.
+Raise :exc:`TypeError` in :meth:`!_pydatetime.timedelta.__new__` if the passed arguments are not :class:`int` or :class:`float`, so that the Python
+implementation is in line with the C implementation.


### PR DESCRIPTION
* Add typecheck in _pydatetime.timedelta so that same format error is raised as in _datetime.timedelta
* Add relevant tests for the new typecheck in datetime module

<!-- gh-issue-number: gh-126947 -->
* Issue: gh-126947
<!-- /gh-issue-number -->
