### PR TITLE
Update docs 'make serve' to suggest 'make htmllive'

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -294,7 +294,7 @@ check: _ensure-pre-commit
 
 .PHONY: serve
 serve:
-	@echo "The serve target was removed, use htmlview instead (see bpo-36329)"
+	@echo "The serve target was removed, use htmllive instead (see gh-80510)"
 
 # Targets for daily automated doc build
 # By default, Sphinx only rebuilds pages where the page content has changed.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

* `make serve` was removed in https://github.com/python/cpython/issues/80510.

* `make htmllive` was added in https://github.com/python/cpython/pull/111900.

Let's suggest `make htmllive` as the replacement for `make serve`, instead of `make htmlview`.

Also update bpo-36329 to point to the migrated gh-80510.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--126969.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->