### PR TITLE
[See Discourse] Remove peg to arbitrary minor version of python for black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,12 @@ repos:
       - id: black
         name: Run Black on Tools/build/check_warnings.py
         files: ^Tools/build/check_warnings.py
-        language_version: python3.12
+        language_version: python3
         args: [--line-length=79]
       - id: black
         name: Run Black on Tools/jit/
         files: ^Tools/jit/
-        language_version: python3.12
+        language_version: python3
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
[Base thread in Discourse](https://discuss.python.org/t/pre-commit-config-specifies-python-3-12-for-black/71564)

Per local testing, the pre-commit hook works fine with python 3.14.  I think the 3.12 peg is arbitrary.  When a contributor doesn't have 3.12 installed on their machine, pre-commit won't work.  This isn't a documented requirement for contributing.

I didn't create an issue for this PR because none of the categories seemed appropriate.  If told to, I'll close the thread and create an issue.  I don't imagine we should have both a thread and issue active at the same time.  I'm open to guidance on that.