### PR TITLE
gh-118761: Improve import time of `mimetypes`

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -447,7 +447,7 @@ def _default_mime_types():
         }
 
     # Before adding new types, make sure they are either registered with IANA,
-    # at http://www.iana.org/assignments/media-types
+    # at https://www.iana.org/assignments/media-types/media-types.xhtml
     # or extensions, i.e. using the x- prefix
 
     # If you add to these, please keep them sorted by mime type.

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -23,10 +23,6 @@ init([files]) -- parse a list of files, default knownfiles (on Windows, the
 read_mime_types(file) -- parse one file, return a dictionary or None
 """
 
-import os
-import sys
-import posixpath
-
 try:
     from _winapi import _mimetypes_read_windows_registry
 except ImportError:
@@ -119,6 +115,7 @@ class MimeTypes:
         but non-standard types.
         """
         # Lazy import to improve module import time
+        import os
         import urllib.parse
 
         # TODO: Deprecate accepting file paths (in particular path-like objects).
@@ -148,6 +145,10 @@ class MimeTypes:
             if '=' in type or '/' not in type:
                 type = 'text/plain'
             return type, None           # never compressed, so encoding is None
+
+        # Lazy import to improve module import time
+        import posixpath
+
         return self._guess_file_type(url, strict, posixpath.splitext)
 
     def guess_file_type(self, path, *, strict=True):
@@ -155,6 +156,9 @@ class MimeTypes:
 
         Similar to guess_type(), but takes file path instead of URL.
         """
+        # Lazy import to improve module import time
+        import os
+
         path = os.fsdecode(path)
         path = os.path.splitdrive(path)[1]
         return self._guess_file_type(path, strict, os.path.splitext)
@@ -401,6 +405,9 @@ def init(files=None):
     else:
         db = _db
 
+    # Lazy import to improve module import time
+    import os
+
     for file in files:
         if os.path.isfile(file):
             db.read(file)
@@ -639,6 +646,7 @@ _default_mime_types()
 
 def _main():
     import getopt
+    import sys
 
     USAGE = """\
 Usage: mimetypes.py [options] type

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -26,7 +26,6 @@ read_mime_types(file) -- parse one file, return a dictionary or None
 import os
 import sys
 import posixpath
-import urllib.parse
 
 try:
     from _winapi import _mimetypes_read_windows_registry
@@ -119,6 +118,9 @@ class MimeTypes:
         Optional 'strict' argument when False adds a bunch of commonly found,
         but non-standard types.
         """
+        # Lazy import to improve module import time
+        import urllib.parse
+
         # TODO: Deprecate accepting file paths (in particular path-like objects).
         url = os.fspath(url)
         p = urllib.parse.urlparse(url)

--- a/Misc/NEWS.d/next/Library/2024-11-18-22-02-47.gh-issue-118761.GQKD_J.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-18-22-02-47.gh-issue-118761.GQKD_J.rst
@@ -1,0 +1,2 @@
+Improve import time of :mod:`mimetypes` by around 11-16 times. Patch by Hugo
+van Kemenade.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Makes import time 11 to 16 times as fast. Measured with a PGO and LTO non-debug build on macOS.

* The slowest import in `mimetypes` is `urllib.parse` (taking 5,174 of `mimetypes` 5,448 μs = 95%).

* After deferring `urllib.parse`, import time is 480 μs. That's 11.35 times as fast.

* We could stop here. The other imports are easy enough to defer as well and have some benefit when running with `-S` to not `import site` on initialisation: 7,540 μs -> 469 μs = 16.08 times as fast.

# `-X importtime`

## `python.exe`

### total import time: 0.010s -> 0.006s -> 0.005s

| main | defer `urllib.parse` | defer rest |
| - | - | - |
| <img width="240" alt="image" src="https://github.com/user-attachments/assets/cc0d4584-d564-49b5-bd63-220fc1200bda"> | <img width="240" alt="image" src="https://github.com/user-attachments/assets/504b8a6d-90b0-43b4-84d7-e69366c670d2"> | <img width="240" alt="image" src="https://github.com/user-attachments/assets/372f6edc-aa61-45cd-8ddf-3e14175a8a2b"> |

### `mimetypes` import time: 0.005s -> 0.000s -> 0.000s

| main | defer `urllib.parse` | defer rest |
| - | - | - |
| <img width="240" alt="image" src="https://github.com/user-attachments/assets/a72b1257-0b45-4f0d-a64f-c614af5e3221"> | <img width="240" alt="image" src="https://github.com/user-attachments/assets/cfe3384d-5463-45be-afc0-69c6e62aa36b"> | <img width="240" alt="image" src="https://github.com/user-attachments/assets/27c61858-20b9-47f1-b899-fd4370d18516"> |

## `python.exe -S`

### total import time: 0.013s -> 0.009s -> 0.006s 

| main | defer `urllib.parse` | defer rest |
| - | - | - |
| <img width="240" alt="image" src="https://github.com/user-attachments/assets/ac89fea4-b8a9-454c-ad87-de32820bbc1c"> | <img width="240" alt="image" src="https://github.com/user-attachments/assets/726b0fa7-5445-495f-bf4f-4cdc5247c9df"> | <img width="240" alt="image" src="https://github.com/user-attachments/assets/abd3b0af-b061-41ae-9136-b67353c8d35c"> |

### `mimetypes` import time: 0.013s -> 0.004s -> 0.001s 

| main | defer `urllib.parse` | defer rest |
| - | - | - |
| <img width="240" alt="image" src="https://github.com/user-attachments/assets/5c3a4fe2-fa05-4d11-89e3-50a1f7a9ff75"> | <img width="240" alt="image" src="https://github.com/user-attachments/assets/27a08fe3-af52-4f19-adf3-9f8ab782a01b"> | <img width="240" alt="image" src="https://github.com/user-attachments/assets/a8acfb4d-c19f-40c3-bdd6-38d1e31366eb"> |

# hyperfine

## `python.exe`: 24.2 ms -> 11.2 ms

### `main`

```console
❯ hyperfine --warmup 8 "./python.exe -c 'import mimetypes'"
Benchmark 1: ./python.exe -c 'import mimetypes'
  Time (mean ± σ):      24.2 ms ±  11.3 ms    [User: 15.2 ms, System: 5.7 ms]
  Range (min … max):    16.2 ms …  59.6 ms    133 runs
```

## PR

```console
❯ hyperfine --warmup 8 "./python.exe -c 'import mimetypes'"
Benchmark 1: ./python.exe -c 'import mimetypes'
  Time (mean ± σ):      11.2 ms ±   0.7 ms    [User: 8.1 ms, System: 2.6 ms]
  Range (min … max):    10.3 ms …  14.2 ms    170 runs
```

## `python.exe -S`: 15.1 ms -> 8.4 ms

### `main`

```console
❯ hyperfine --warmup 8 "./python.exe -S -c 'import mimetypes'"
Benchmark 1: ./python.exe -S -c 'import mimetypes'
  Time (mean ± σ):      15.1 ms ±   0.7 ms    [User: 11.4 ms, System: 3.1 ms]
  Range (min … max):    14.3 ms …  19.2 ms    133 runs
```

### PR

```console
❯ hyperfine --warmup 8 "./python.exe -S -c 'import mimetypes'"
Benchmark 1: ./python.exe -S -c 'import mimetypes'
  Time (mean ± σ):       8.4 ms ±   0.4 ms    [User: 5.7 ms, System: 2.2 ms]
  Range (min … max):     7.9 ms …  12.3 ms    216 runs
```



<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
