### PR TITLE
gh-126980: Fix `bytearray.__buffer__` crash on `PyBUF_{READ,WRITE}`

### DIFF
--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4441,10 +4441,11 @@ class TestBufferProtocol(unittest.TestCase):
 
     def test_bytearray_release_buffer_read_flag(self):
         # See https://github.com/python/cpython/issues/126980
+        obj = bytearray(b'abc')
         with self.assertRaises(SystemError):
-            bytearray().__buffer__(inspect.BufferFlags.READ)
+            obj.__buffer__(inspect.BufferFlags.READ)
         with self.assertRaises(SystemError):
-            bytearray().__buffer__(inspect.BufferFlags.WRITE)
+            obj.__buffer__(inspect.BufferFlags.WRITE)
 
     @support.cpython_only
     def test_pybuffer_size_from_format(self):

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -4439,6 +4439,13 @@ class TestBufferProtocol(unittest.TestCase):
         x = ndarray([1,2,3], shape=[3], flags=ND_GETBUF_FAIL)
         self.assertRaises(BufferError, memoryview, x)
 
+    def test_bytearray_release_buffer_read_flag(self):
+        # See https://github.com/python/cpython/issues/126980
+        with self.assertRaises(SystemError):
+            bytearray().__buffer__(inspect.BufferFlags.READ)
+        with self.assertRaises(SystemError):
+            bytearray().__buffer__(inspect.BufferFlags.WRITE)
+
     @support.cpython_only
     def test_pybuffer_size_from_format(self):
         # basic tests

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-11-18-23-18-17.gh-issue-126980.r8QHdi.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-11-18-23-18-17.gh-issue-126980.r8QHdi.rst
@@ -1,0 +1,3 @@
+Fix :meth:`~object.__buffer__` of :class:`bytearray` crashing when
+:attr:`~inspect.BufferFlags.READ` or :attr:`~inspect.BufferFlags.WRITE` are
+passed as flags.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -52,8 +52,9 @@ bytearray_getbuffer(PyObject *self, Py_buffer *view, int flags)
     }
 
     void *ptr = (void *) PyByteArray_AS_STRING(obj);
-    /* cannot fail if view != NULL and readonly == 0 */
-    (void)PyBuffer_FillInfo(view, (PyObject*)obj, ptr, Py_SIZE(obj), 0, flags);
+    if (PyBuffer_FillInfo(view, (PyObject*)obj, ptr, Py_SIZE(obj), 0, flags) < 0) {
+        return -1;
+    }
     obj->ob_exports++;
     return 0;
 }


### PR DESCRIPTION
Related https://github.com/python/cpython/pull/114802

@JelleZijlstra, since you are `__buffer__` PEP author, could you please take a look? :)

<!-- gh-issue-number: gh-126980 -->
* Issue: gh-126980
<!-- /gh-issue-number -->
