### PR TITLE
gh-126107: Remove copyright block from Modules/config.c.in

### DIFF
--- a/Modules/config.c.in
+++ b/Modules/config.c.in
@@ -1,13 +1,3 @@
-/* -*- C -*- ***********************************************
-Copyright (c) 2000, BeOpen.com.
-Copyright (c) 1995-2000, Corporation for National Research Initiatives.
-Copyright (c) 1990-1995, Stichting Mathematisch Centrum.
-All rights reserved.
-
-See the file "Misc/COPYRIGHT" for information on usage and
-redistribution of this file, and for a DISCLAIMER OF ALL WARRANTIES.
-******************************************************************/
-
 /* Module configuration */
 
 /* !!! !!! !!! This file is edited by the makesetup script !!! !!! !!! */


### PR DESCRIPTION
Based on the last message I decided to make the this changes:
* https://github.com/python/cpython/issues/126107#issuecomment-2444532930


<!-- gh-issue-number: gh-126107 -->
* Issue: gh-126107
<!-- /gh-issue-number -->
