### PR TITLE
GH-126491: Increase the threshold for the GC fast cycle test.

### DIFF
--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1172,7 +1172,7 @@ class IncrementalGCTests(unittest.TestCase):
             olds.append(newhead)
             if len(olds) == 20:
                 new_objects = _testinternalcapi.get_heap_size() - initial_heap_size
-                self.assertLess(new_objects, 25_000)
+                self.assertLess(new_objects, 26_000)
                 del olds[:]
         if not enabled:
             gc.disable()

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1172,7 +1172,7 @@ class IncrementalGCTests(unittest.TestCase):
             olds.append(newhead)
             if len(olds) == 20:
                 new_objects = _testinternalcapi.get_heap_size() - initial_heap_size
-                self.assertLess(new_objects, 26_000)
+                self.assertLess(new_objects, 27_000)
                 del olds[:]
         if not enabled:
             gc.disable()


### PR DESCRIPTION
#126502 Modified added an improvement to the behavior of the garbage collector, along with a test to verify that behavior. However, that test fails on iOS and Android (and quite possibly any test run that runs the test suite sequentially); the test imposes a limit of 25k objects, but iOS and Android both generate 25032 objects. 

The 32 extra object count seems to be something baked in - if you increase the iteration count of the test to 100k, you get the same 25032 object count on iOS and Android.

Following [this comment](https://github.com/python/cpython/pull/126502#issuecomment-2484212167), this PR increases the threshold to ~26k~ 27k. 


<!-- gh-issue-number: gh-126491 -->
* Issue: gh-126491
<!-- /gh-issue-number -->
