### PR TITLE
Improve comment for co_nlocalsplus

### DIFF
--- a/Include/cpython/code.h
+++ b/Include/cpython/code.h
@@ -131,7 +131,8 @@ typedef struct {
                                                                                \
     /* redundant values (derived from co_localsplusnames and                   \
        co_localspluskinds) */                                                  \
-    int co_nlocalsplus;           /* number of local + cell + free variables */ \
+    int co_nlocalsplus;           /* number of spaces for holding local, cell, \
+                                     and free variables */                     \
     int co_framesize;             /* Size of frame in words */                 \
     int co_nlocals;               /* number of local variables */              \
     int co_ncellvars;             /* total number of cell variables */         \


### PR DESCRIPTION
I just spent several hours fixing a bug in the Cinder JIT as a result of a misunderstanding of the value of `co_nlocalsplus`. The existing comment implied `co_nlocalsplus` is just the literal sum of `co_nlocals` + `co_ncellvars` + `co_nfreevars`. However, this is not the case. It may be smaller than this as locals can also be cells.