### PR TITLE
gh-126935: added handler frame to output of traceback of a chained exception

### DIFF
--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -397,18 +397,32 @@ def walk_tb(tb):
         tb = tb.tb_next
 
 
-def _walk_tb_with_full_positions(tb):
+def _get_tb_position(tb):
+    positions = _get_code_position(tb.tb_frame.f_code, tb.tb_lasti)
+    # Yield tb_lineno when co_positions does not have a line number to
+    # maintain behavior with walk_tb.
+    if positions[0] is None:
+        return tb.tb_frame, (tb.tb_lineno, ) + positions[1:]
+    return tb.tb_frame, positions
+
+
+def _walk_tb_with_full_positions(tb, _seen=None):
     # Internal version of walk_tb that yields full code positions including
     # end line and column information.
+    handler_tb = None
     while tb is not None:
-        positions = _get_code_position(tb.tb_frame.f_code, tb.tb_lasti)
-        # Yield tb_lineno when co_positions does not have a line number to
-        # maintain behavior with walk_tb.
-        if positions[0] is None:
-            yield tb.tb_frame, (tb.tb_lineno, ) + positions[1:]
-        else:
-            yield tb.tb_frame, positions
+        yield _get_tb_position(tb)
+        if tb.tb_lineno != tb.tb_frame.f_lineno and _seen:
+            for exc in reversed(_seen.values()):
+                if (handler_tb := exc.__traceback__) is not tb:
+                    while handler_tb.tb_lineno != tb.tb_frame.f_lineno:
+                        if not (handler_tb := handler_tb.tb_next):
+                            break
+                    else:
+                        break
         tb = tb.tb_next
+    if handler_tb:
+        yield _get_tb_position(handler_tb)
 
 
 def _get_code_position(code, instruction_index):
@@ -1035,14 +1049,14 @@ class TracebackException:
         # Handle loops in __cause__ or __context__.
         is_recursive_call = _seen is not None
         if _seen is None:
-            _seen = set()
-        _seen.add(id(exc_value))
+            _seen = {}
+        _seen[id(exc_value)] = exc_value
 
         self.max_group_width = max_group_width
         self.max_group_depth = max_group_depth
 
         self.stack = StackSummary._extract_from_extended_frame_gen(
-            _walk_tb_with_full_positions(exc_traceback),
+            _walk_tb_with_full_positions(exc_traceback, _seen),
             limit=limit, lookup_lines=lookup_lines,
             capture_locals=capture_locals)
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -415,7 +415,7 @@ def _walk_tb_with_full_positions(tb, _seen=None):
         if tb.tb_lineno != tb.tb_frame.f_lineno and _seen:
             for exc in reversed(_seen.values()):
                 if (handler_tb := exc.__traceback__) is not tb:
-                    while handler_tb.tb_lineno != tb.tb_frame.f_lineno:
+                    while handler_tb.tb_frame != tb.tb_frame:
                         if not (handler_tb := handler_tb.tb_next):
                             break
                     else:

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -473,8 +473,11 @@ class StackSummary(list):
 
         result = klass()
         fnames = set()
-        cause_frame = cause and cause.__traceback__.tb_frame
-        context_frame = context and context.__traceback__.tb_frame
+        cause_frame = context_frame = None
+        with suppress(AttributeError):
+            cause_frame = cause.__traceback__.tb_frame
+        with suppress(AttributeError):
+            context_frame = context.__traceback__.tb_frame
         for f, (lineno, end_lineno, colno, end_colno) in frame_gen:
             co = f.f_code
             filename = co.co_filename


### PR DESCRIPTION
When an exception is chained, the traceback of the `__context__` of the new exception would be pointing to the handler frame. This PR makes use of this behavior to produce a traceback output with the handler frame noted with the wording `(from context)` for better traceability. Same goes for a frame raising from a cause, which is noted with the wording `(from cause)`.

For example, the following snippet:
```python
class OriginalException(Exception):
    pass

class AnotherException(Exception):
    pass

def raise_exception():
    raise OriginalException()

def raise_another_exception():
    raise AnotherException()

def show_something():
    try:
        raise_exception()
    except OriginalException:
        raise_another_exception()

show_something()
```
would now with this PR produce something like:
```
Traceback (most recent call last):
  File "test.py", line 15, in show_something
    raise_exception()
  File "test.py", line 8, in raise_exception
    raise OriginalException()
OriginalException

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 19, in <module>
    show_something()
  File "test.py", line 17, in show_something (from context)
    raise_another_exception()
  File "test.py", line 11, in raise_another_exception
    raise AnotherException()
AnotherException
```

<!-- gh-issue-number: gh-126935 -->
* Issue: gh-126935
<!-- /gh-issue-number -->
