### PR TITLE
GH-84850: Improve whatsnew entry for `[Fancy]URLopener` removal

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -772,6 +772,13 @@ urllib
 * Remove deprecated :class:`!URLopener` and :class:`!FancyURLopener` classes
   from :mod:`urllib.request`. They had previously raised a
   :exc:`DeprecationWarning` since Python 3.3.
+
+  ``myopener.open()`` can be replaced with :func:`~urllib.request.urlopen`,
+  and ``myopener.retrieve()`` can be replaced with
+  :func:`~urllib.request.urlretrieve`. Customizations to the opener
+  classes can be replaced by passing customized handlers to
+  :func:`~urllib.request.build_opener`.
+
   (Contributed by Barney Gale in :gh:`84850`.)
 
 Others


### PR DESCRIPTION
Add a couple of examples of how to replace `URLopener` and `FancyURLopener`.

<!-- gh-issue-number: gh-84850 -->
* Issue: gh-84850
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127032.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->