### PR TITLE
gh-114940: Add a Per-Interpreter Lock For the List of Thread States

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -127,6 +127,7 @@ struct _is {
 
     uintptr_t last_restart_version;
     struct pythreads {
+        PyMutex mutex;
         uint64_t next_unique_id;
         /* The linked list of threads, newest first. */
         PyThreadState *head;

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -269,6 +269,11 @@ extern int _PyOS_InterruptOccurred(PyThreadState *tstate);
 #define HEAD_UNLOCK(runtime) \
     PyMutex_Unlock(&(runtime)->interpreters.mutex)
 
+#define THREADS_HEAD_LOCK(interp) \
+    PyMutex_LockFlags(&(interp)->threads.mutex, _Py_LOCK_DONT_DETACH)
+#define THREADS_HEAD_UNLOCK(interp) \
+    PyMutex_Unlock(&(interp)->threads.mutex)
+
 // Get the configuration of the current interpreter.
 // The caller must hold the GIL.
 // Export for test_peg_generator.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -2871,20 +2871,24 @@ get_indices_in_use(PyInterpreterState *interp, struct flag_set *in_use)
     assert(interp->stoptheworld.world_stopped);
     assert(in_use->flags == NULL);
     int32_t max_index = 0;
+    THREADS_HEAD_LOCK(interp);
     for (PyThreadState *p = interp->threads.head; p != NULL; p = p->next) {
         int32_t idx = ((_PyThreadStateImpl *) p)->tlbc_index;
         if (idx > max_index) {
             max_index = idx;
         }
     }
+    THREADS_HEAD_UNLOCK(interp);
     in_use->size = (size_t) max_index + 1;
     in_use->flags = PyMem_Calloc(in_use->size, sizeof(*in_use->flags));
     if (in_use->flags == NULL) {
         return -1;
     }
+    THREADS_HEAD_LOCK(interp);
     for (PyThreadState *p = interp->threads.head; p != NULL; p = p->next) {
         in_use->flags[((_PyThreadStateImpl *) p)->tlbc_index] = 1;
     }
+    THREADS_HEAD_UNLOCK(interp);
     return 0;
 }
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -119,11 +119,13 @@ get_reftotal(PyInterpreterState *interp)
        since we can't determine which interpreter updated it. */
     Py_ssize_t total = REFTOTAL(interp);
 #ifdef Py_GIL_DISABLED
+    THREADS_HEAD_LOCK(interp);
     for (PyThreadState *p = interp->threads.head; p != NULL; p = p->next) {
         /* This may race with other threads modifications to their reftotal */
         _PyThreadStateImpl *tstate_impl = (_PyThreadStateImpl *)p;
         total += _Py_atomic_load_ssize_relaxed(&tstate_impl->reftotal);
     }
+    THREADS_HEAD_UNLOCK(interp);
 #endif
     return total;
 }

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1405,6 +1405,7 @@ get_mimalloc_allocated_blocks(PyInterpreterState *interp)
 {
     size_t allocated_blocks = 0;
 #ifdef Py_GIL_DISABLED
+    THREADS_HEAD_LOCK(interp);
     for (PyThreadState *t = interp->threads.head; t != NULL; t = t->next) {
         _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)t;
         for (int i = 0; i < _Py_MIMALLOC_HEAP_COUNT; i++) {
@@ -1412,6 +1413,7 @@ get_mimalloc_allocated_blocks(PyInterpreterState *interp)
             mi_heap_visit_blocks(heap, false, &count_blocks, &allocated_blocks);
         }
     }
+    THREADS_HEAD_UNLOCK(interp);
 
     mi_abandoned_pool_t *pool = &interp->mimalloc.abandoned_pool;
     for (uint8_t tag = 0; tag < _Py_MIMALLOC_HEAP_COUNT; tag++) {

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -296,11 +296,13 @@ Py_SetRecursionLimit(int new_limit)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET();
     interp->ceval.recursion_limit = new_limit;
+    THREADS_HEAD_LOCK(interp);
     for (PyThreadState *p = interp->threads.head; p != NULL; p = p->next) {
         int depth = p->py_recursion_limit - p->py_recursion_remaining;
         p->py_recursion_limit = new_limit;
         p->py_recursion_remaining = new_limit - depth;
     }
+    THREADS_HEAD_UNLOCK(interp);
 }
 
 /* The function _Py_EnterRecursiveCallTstate() only calls _Py_CheckRecursiveCall()

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -977,25 +977,21 @@ make_pending_calls(PyThreadState *tstate)
 void
 _Py_set_eval_breaker_bit_all(PyInterpreterState *interp, uintptr_t bit)
 {
-    _PyRuntimeState *runtime = &_PyRuntime;
-
-    HEAD_LOCK(runtime);
+    THREADS_HEAD_LOCK(interp);
     for (PyThreadState *tstate = interp->threads.head; tstate != NULL; tstate = tstate->next) {
         _Py_set_eval_breaker_bit(tstate, bit);
     }
-    HEAD_UNLOCK(runtime);
+    THREADS_HEAD_UNLOCK(interp);
 }
 
 void
 _Py_unset_eval_breaker_bit_all(PyInterpreterState *interp, uintptr_t bit)
 {
-    _PyRuntimeState *runtime = &_PyRuntime;
-
-    HEAD_LOCK(runtime);
+    THREADS_HEAD_LOCK(interp);
     for (PyThreadState *tstate = interp->threads.head; tstate != NULL; tstate = tstate->next) {
         _Py_unset_eval_breaker_bit(tstate, bit);
     }
-    HEAD_UNLOCK(runtime);
+    THREADS_HEAD_UNLOCK(interp);
 }
 
 void

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -304,7 +304,6 @@ gc_visit_heaps_lock_held(PyInterpreterState *interp, mi_block_visit_fun *visitor
     Py_ssize_t offset_pre = offset_base + 2 * sizeof(PyObject*);
 
     // visit each thread's heaps for GC objects
-    // XXX THREADS_HEAD_LOCK()?
     for (PyThreadState *p = interp->threads.head; p != NULL; p = p->next) {
         struct _mimalloc_thread_state *m = &((_PyThreadStateImpl *)p)->mimalloc;
         if (!_Py_atomic_load_int(&m->initialized)) {
@@ -351,9 +350,9 @@ gc_visit_heaps(PyInterpreterState *interp, mi_block_visit_fun *visitor,
     assert(interp->stoptheworld.world_stopped);
 
     int err;
-    HEAD_LOCK(&_PyRuntime);
+    THREADS_HEAD_LOCK(interp);
     err = gc_visit_heaps_lock_held(interp, visitor, arg);
-    HEAD_UNLOCK(&_PyRuntime);
+    THREADS_HEAD_UNLOCK(interp);
     return err;
 }
 

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1006,13 +1006,12 @@ set_global_version(PyThreadState *tstate, uint32_t version)
 
 #ifdef Py_GIL_DISABLED
     // Set the version on all threads in free-threaded builds.
-    _PyRuntimeState *runtime = &_PyRuntime;
-    HEAD_LOCK(runtime);
+    THREADS_HEAD_LOCK(interp);
     for (tstate = interp->threads.head; tstate;
          tstate = PyThreadState_Next(tstate)) {
         set_version_raw(&tstate->eval_breaker, version);
     };
-    HEAD_UNLOCK(runtime);
+    THREADS_HEAD_UNLOCK(interp);
 #else
     // Normal builds take the current version from instrumentation_version when
     // attaching a thread, so we only have to set the current thread's version.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2369,7 +2369,7 @@ PyThreadState_SetAsyncExc(unsigned long id, PyObject *exc)
         _Py_set_eval_breaker_bit(tstate, _PY_ASYNC_EXCEPTION_BIT);
         return 1;
     }
-    THREADS_HEAD_LOCK(interp);
+    THREADS_HEAD_UNLOCK(interp);
     return 0;
 }
 


### PR DESCRIPTION
The new lock may be used instead of the global "HEAD" lock.  That global lock guards the list of interpreters, but unfortunately also gets used as a generic "lock everything".  This change helps us move away from that situation.

FYI, this is very similar to gh-125561.

<!-- gh-issue-number: gh-114940 -->
* Issue: gh-114940
<!-- /gh-issue-number -->
