### PR TITLE
gh-127049: Fix `asyncio.subprocess.Process` race condition killing an unrelated process on Unix

### DIFF
--- a/Lib/asyncio/base_subprocess.py
+++ b/Lib/asyncio/base_subprocess.py
@@ -211,10 +211,6 @@ class BaseSubprocessTransport(transports.SubprocessTransport):
         if self._loop.get_debug():
             logger.info('%r exited with return code %r', self, returncode)
         self._returncode = returncode
-        if self._proc.returncode is None:
-            # asyncio uses a child watcher: copy the status into the Popen
-            # object. On Python 3.6, it is required to avoid a ResourceWarning.
-            self._proc.returncode = returncode
         self._call(self._protocol.process_exited)
 
         self._try_finish()

--- a/Lib/asyncio/base_subprocess.py
+++ b/Lib/asyncio/base_subprocess.py
@@ -1,9 +1,6 @@
 import collections
 import subprocess
 import warnings
-import os
-import signal
-import sys
 
 from . import protocols
 from . import transports
@@ -145,31 +142,17 @@ class BaseSubprocessTransport(transports.SubprocessTransport):
         if self._proc is None:
             raise ProcessLookupError()
 
-    if sys.platform == 'win32':
-        def send_signal(self, signal):
-            self._check_proc()
-            self._proc.send_signal(signal)
+    def send_signal(self, signal):
+        self._check_proc()
+        self._proc.send_signal(signal)
 
-        def terminate(self):
-            self._check_proc()
-            self._proc.terminate()
+    def terminate(self):
+        self._check_proc()
+        self._proc.terminate()
 
-        def kill(self):
-            self._check_proc()
-            self._proc.kill()
-    else:
-        def send_signal(self, signal):
-            self._check_proc()
-            try:
-                os.kill(self._proc.pid, signal)
-            except ProcessLookupError:
-                pass
-
-        def terminate(self):
-            self.send_signal(signal.SIGTERM)
-
-        def kill(self):
-            self.send_signal(signal.SIGKILL)
+    def kill(self):
+        self._check_proc()
+        self._proc.kill()
 
     async def _connect_pipes(self, waiter):
         try:

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -870,6 +870,7 @@ class Popen:
         self.stderr = None
         self.pid = None
         self.returncode = None
+        self._returncode_is_a_lie = False
         self.encoding = encoding
         self.errors = errors
         self.pipesize = pipesize
@@ -2005,6 +2006,7 @@ class Popen:
                         # disabled for our process.  This child is dead, we
                         # can't get the status.
                         # http://bugs.python.org/issue15756
+                        self._returncode_is_a_lie = True
                         self.returncode = 0
                 finally:
                     self._waitpid_lock.release()
@@ -2019,6 +2021,7 @@ class Popen:
                 # This happens if SIGCLD is set to be ignored or waiting
                 # for child processes has otherwise been disabled for our
                 # process.  This child is dead, we can't get the status.
+                self._returncode_is_a_lie = True
                 pid = self.pid
                 sts = 0
             return (pid, sts)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1642,6 +1642,7 @@ Ben Sayer
 Luca Sbardella
 Marco Scataglini
 Andrew Schaaf
+Ganden Schaffner
 Michael Scharf
 Andreas Schawo
 Neil Schemenauer

--- a/Misc/NEWS.d/next/Library/2024-11-19-21-58-18.gh-issue-127049.dk76iD.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-19-21-58-18.gh-issue-127049.dk76iD.rst
@@ -1,0 +1,4 @@
+Fix race condition where :meth:`asyncio.subprocess.Process.send_signal`,
+:meth:`asyncio.subprocess.Process.terminate`, and
+:meth:`asyncio.subprocess.Process.kill` could signal an already-freed PID on
+non-Windows platforms. Patch by Ganden Schaffner.


### PR DESCRIPTION
Proposal that fixes GH-127049. The idea is to revert GH-121126 and re-fix GH-87744 in a way that doesn't introduce GH-127049. The proposed approach here is to change child watchers to behave closer to their analog on Windows (`_WindowsSubprocessTransport`), i.e. let `subprocess` handle the PID lifetime management instead of having `subprocess` do the allocation and `asyncio` do the deallocation, i.e. follow the guidance of https://github.com/python/cpython/issues/86724#issuecomment-1159681363.

In the `_ThreadedChildWatcher` case this borrows the `waitid` + `WNOWAIT` idea from Trio. (See also https://github.com/python/cpython/issues/82811#issuecomment-1093845693.) Note that in the `_ThreadedChildWatcher` case, while it would ideally be safe to just call `Popen.wait` in the thread instead of involving `waitid` + `WNOWAIT`, `Popen` currently has some thread-unsafeties, so running `Popen.wait` or `Popen.poll` in the thread in practice resulted in unsafe `kill` calls and broken `transport._process_exited(returncode=None)` calls. See the longer commit message.

I have marked this as a draft because it does not yet have regression tests. Both cases (`_PidfdChildWatcher` and `_ThreadedChildWatcher`) can have (nearly-)deterministic (but consistent regardless) regression tests, but I am not sure how folks would want them implemented, as the reproducers I put together for the report involve monkeypatching `os.waitpid` and `os.kill` (which is nontrivial in part because `subprocess` holds strong references to `os.waitpid`, and which will miss any `os.waitid` calls made without `WNOWAIT` unless we patch that too).

Anyway, if this PR is pursued, I'd appreciate some help with adding tests. This is also my first PR proposed to CPython so any feedback/pointers are appreciated. :)