### PR TITLE
gh-127079, pickletools: Remove check for items on stack

### DIFF
--- a/Lib/pickletools.py
+++ b/Lib/pickletools.py
@@ -2539,8 +2539,6 @@ def dis(pickle, out=None, memo=None, indentlevel=4, annotate=0):
         stack.extend(after)
 
     print("highest protocol among opcodes =", maxproto, file=out)
-    if stack:
-        raise ValueError("stack not empty after STOP: %r" % stack)
 
 # For use in the doctest, simply as an example of a class to pickle.
 class _Example:

--- a/Misc/NEWS.d/next/Library/2024-11-20-22-30-55.gh-issue-127079.egXnLz.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-20-22-30-55.gh-issue-127079.egXnLz.rst
@@ -1,0 +1,1 @@
+:mod:`pickletools` no longer errors out when more than one item is left in the stack upon reaching the `STOP` opcode


### PR DESCRIPTION
Removed the check to see if there's more than one item on the stack when the `STOP` opcode is reached, as this isn't enforced by pickle. 

<!-- gh-issue-number: gh-127079 -->
* Issue: gh-127079
<!-- /gh-issue-number -->
