### PR TITLE
gh-127076: Disable strace tests under LD_PRELOAD

### DIFF
--- a/Lib/test/support/strace_helper.py
+++ b/Lib/test/support/strace_helper.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import textwrap
+import os
 import unittest
 from dataclasses import dataclass
 from functools import cache
@@ -162,6 +163,13 @@ def _can_strace():
 def requires_strace():
     if sys.platform != "linux":
         return unittest.skip("Linux only, requires strace.")
+
+    if 'LD_PRELOAD' in os.environ:
+        # Distribution packaging (ex. Debian `fakeroot` and Gentoo `sandbox`)
+        # use LD_PRELOAD to intercept system calls, which changes the overall
+        # set of system calls which breaks tests expecting a specific set of
+        # system calls).
+        return unittest.skip("Not supported when LD_PRELOAD is intercepting system calls.")
 
     if support.check_sanitizer(address=True, memory=True):
         return unittest.skip("LeakSanitizer does not work under ptrace (strace, gdb, etc)")

--- a/Lib/test/support/strace_helper.py
+++ b/Lib/test/support/strace_helper.py
@@ -164,7 +164,7 @@ def requires_strace():
     if sys.platform != "linux":
         return unittest.skip("Linux only, requires strace.")
 
-    if 'LD_PRELOAD' in os.environ:
+    if "LD_PRELOAD" in os.environ:
         # Distribution packaging (ex. Debian `fakeroot` and Gentoo `sandbox`)
         # use LD_PRELOAD to intercept system calls, which changes the overall
         # set of system calls which breaks tests expecting a specific set of

--- a/Misc/NEWS.d/next/Tests/2024-11-21-02-03-48.gh-issue-127076.a3avV1.rst
+++ b/Misc/NEWS.d/next/Tests/2024-11-21-02-03-48.gh-issue-127076.a3avV1.rst
@@ -1,0 +1,1 @@
+Disable strace based system call tests when LD_PRELOAD is set.


### PR DESCRIPTION
Distribution tooling (ex. sandbox on Gentoo and fakeroot on Debian) uses LD_PRELOAD to intercept system calls and potentially modify them when building. These tools can change the set of system calls, so disable system call testing under these cases.

```
$ fakeroot ./python -m test.test_fileio -vvv CAutoFileTests.test_syscalls_read
test_syscalls_read (__main__.CAutoFileTests.test_syscalls_read)
Check that the set of system calls produced by the I/O stack is what ... skipped 'Not supported when LD_PRELOAD is intercepting system calls.'

----------------------------------------------------------------------
Ran 1 test in 0.000s

OK (skipped=1)
```

cc: @mgorny this should fix the Gentoo `sandbox` case (just disables the test). `mmap` used for memory allocation will be a different PR.

<!-- gh-issue-number: gh-127076 -->
* Issue: gh-127076
<!-- /gh-issue-number -->
