### PR TITLE
Clarify that random.uniform() returns values in [a, b)

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -310,6 +310,10 @@ be found in any statistics text.
    depending on floating-point rounding in the expression
    ``a + (b-a) * random()``.
 
+   .. note::
+      The value *b* is not included in the range due to the underlying implementation.
+      The random number N is drawn from a uniform distribution over the half-open interval ``[*a*, *b*\)``.
+
 
 .. function:: triangular(low, high, mode)
 


### PR DESCRIPTION
The documentation for `random.uniform(a, b)` currently states that the function returns a random floating point number N such that `a <= N <= b`.

However, due to the implementation (`a + (b - a) * random()`), the value `b` is not included in the possible return values. This PR updates the documentation to clarify that the function returns values in the half-open interval `[a, b)`.

A note has also been added to explain this behavior for users who might expect the value `b` to be included.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127087.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->