### PR TITLE
gh-124873: Tolerate 100 ms in TimerfdTests on Android

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4177,9 +4177,9 @@ class EventfdTests(unittest.TestCase):
 @support.requires_linux_version(2, 6, 30)
 class TimerfdTests(unittest.TestCase):
     # 1 ms accuracy is reliably achievable on every platform except Android
-    # emulators, where we allow 10 ms (gh-108277).
+    # emulators, where we allow 100 ms (gh-124873).
     if sys.platform == "android" and platform.android_ver().is_emulator:
-        CLOCK_RES_PLACES = 2
+        CLOCK_RES_PLACES = 1
     else:
         CLOCK_RES_PLACES = 3
 


### PR DESCRIPTION
On Android, TimerfdTests of test_os now uses 100 ms accuracy instead of 10 ms.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124873 -->
* Issue: gh-124873
<!-- /gh-issue-number -->
