### PR TITLE
gh-127065: Make `methodcaller` thread-safe in free threading build

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-11-21-16-23-16.gh-issue-127065.cfL1zd.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-21-16-23-16.gh-issue-127065.cfL1zd.rst
@@ -1,0 +1,2 @@
+Fix crash when calling a :func:`operator.methodcaller` instance from
+multiple threads in the free threading build.


### PR DESCRIPTION
The `methodcaller` C vectorcall implementation uses an arguments array that is shared across calls. The first argument is modified on every invocation. This isn't thread-safe in the free threading build. I think it's also not safe in general, but for now just disable it in the free threading build.

<!-- gh-issue-number: gh-127065 -->
* Issue: gh-127065
<!-- /gh-issue-number -->
