### PR TITLE
[3.13] gh-126986: Stop Using _PyInterpreterState_FailIfNotRunning()

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -84,7 +84,7 @@ PyAPI_FUNC(PyObject *) _PyInterpreterState_GetIDObject(PyInterpreterState *);
 PyAPI_FUNC(int) _PyInterpreterState_SetRunningMain(PyInterpreterState *);
 PyAPI_FUNC(void) _PyInterpreterState_SetNotRunningMain(PyInterpreterState *);
 PyAPI_FUNC(int) _PyInterpreterState_IsRunningMain(PyInterpreterState *);
-PyAPI_FUNC(void) _PyErr_SetInterpreterAlreadyRunning(void);
+PyAPI_FUNC(int) _PyInterpreterState_FailIfRunningMain(PyInterpreterState *);
 
 extern int _PyThreadState_IsRunningMain(PyThreadState *);
 extern void _PyInterpreterState_ReinitRunningMain(PyThreadState *);

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -84,7 +84,7 @@ PyAPI_FUNC(PyObject *) _PyInterpreterState_GetIDObject(PyInterpreterState *);
 PyAPI_FUNC(int) _PyInterpreterState_SetRunningMain(PyInterpreterState *);
 PyAPI_FUNC(void) _PyInterpreterState_SetNotRunningMain(PyInterpreterState *);
 PyAPI_FUNC(int) _PyInterpreterState_IsRunningMain(PyInterpreterState *);
-PyAPI_FUNC(int) _PyInterpreterState_FailIfRunningMain(PyInterpreterState *);
+PyAPI_FUNC(void) _PyErr_SetInterpreterAlreadyRunning(void);
 
 extern int _PyThreadState_IsRunningMain(PyThreadState *);
 extern void _PyInterpreterState_ReinitRunningMain(PyThreadState *);

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -985,8 +985,7 @@ _PyXI_ApplyErrorCode(_PyXI_errcode code, PyInterpreterState *interp)
         break;
     case _PyXI_ERR_ALREADY_RUNNING:
         assert(interp != NULL);
-        assert(_PyInterpreterState_IsRunningMain(interp));
-        _PyInterpreterState_FailIfRunningMain(interp);
+        _PyErr_SetInterpreterAlreadyRunning();
         break;
     case _PyXI_ERR_MAIN_NS_FAILURE:
         PyErr_SetString(PyExc_InterpreterError,

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -985,7 +985,8 @@ _PyXI_ApplyErrorCode(_PyXI_errcode code, PyInterpreterState *interp)
         break;
     case _PyXI_ERR_ALREADY_RUNNING:
         assert(interp != NULL);
-        _PyErr_SetInterpreterAlreadyRunning();
+        // In 3.14+ we use _PyErr_SetInterpreterAlreadyRunning().
+        PyErr_SetString(PyExc_InterpreterError, "interpreter already running");
         break;
     case _PyXI_ERR_MAIN_NS_FAILURE:
         PyErr_SetString(PyExc_InterpreterError,

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1050,10 +1050,17 @@ get_main_thread(PyInterpreterState *interp)
     return _Py_atomic_load_ptr_relaxed(&interp->threads.main);
 }
 
+void
+_PyErr_SetInterpreterAlreadyRunning(void)
+{
+    PyErr_SetString(PyExc_InterpreterError, "interpreter already running");
+}
+
 int
 _PyInterpreterState_SetRunningMain(PyInterpreterState *interp)
 {
-    if (_PyInterpreterState_FailIfRunningMain(interp) < 0) {
+    if (get_main_thread(interp) != NULL) {
+        _PyErr_SetInterpreterAlreadyRunning();
         return -1;
     }
     PyThreadState *tstate = current_fast_get();
@@ -1097,17 +1104,6 @@ _PyThreadState_IsRunningMain(PyThreadState *tstate)
     // See the note in _PyInterpreterState_IsRunningMain() about
     // possible false negatives here for embedders.
     return get_main_thread(interp) == tstate;
-}
-
-int
-_PyInterpreterState_FailIfRunningMain(PyInterpreterState *interp)
-{
-    if (get_main_thread(interp) != NULL) {
-        PyErr_SetString(PyExc_InterpreterError,
-                        "interpreter already running");
-        return -1;
-    }
-    return 0;
 }
 
 void

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1050,17 +1050,12 @@ get_main_thread(PyInterpreterState *interp)
     return _Py_atomic_load_ptr_relaxed(&interp->threads.main);
 }
 
-void
-_PyErr_SetInterpreterAlreadyRunning(void)
-{
-    PyErr_SetString(PyExc_InterpreterError, "interpreter already running");
-}
-
 int
 _PyInterpreterState_SetRunningMain(PyInterpreterState *interp)
 {
     if (get_main_thread(interp) != NULL) {
-        _PyErr_SetInterpreterAlreadyRunning();
+        // In 3.14+ we use _PyErr_SetInterpreterAlreadyRunning().
+        PyErr_SetString(PyExc_InterpreterError, "interpreter already running");
         return -1;
     }
     PyThreadState *tstate = current_fast_get();
@@ -1104,6 +1099,18 @@ _PyThreadState_IsRunningMain(PyThreadState *tstate)
     // See the note in _PyInterpreterState_IsRunningMain() about
     // possible false negatives here for embedders.
     return get_main_thread(interp) == tstate;
+}
+
+// This has been removed in 3.14.
+int
+_PyInterpreterState_FailIfRunningMain(PyInterpreterState *interp)
+{
+    if (get_main_thread(interp) != NULL) {
+        PyErr_SetString(PyExc_InterpreterError,
+                        "interpreter already running");
+        return -1;
+    }
+    return 0;
 }
 
 void


### PR DESCRIPTION
This is a pseudo-backport of d6b3e78504b3168c432b20002dbcf8ec9a435e61 (gh-126988).  In that change for 3.14+, we dropped `_PyInterpreterState_FailIfNotRunning()` and added `_PyErr_SetInterpreterAlreadyRunning()`.  Here, we replace usage of `_PyInterpreterState_FailIfNotRunning()` with the inlined equivalent of `_PyErr_SetInterpreterAlreadyRunning()`, without adding that function.  That way we avoid changing the 3.13 ABI.

<!-- gh-issue-number: gh-126986 -->
* Issue: gh-126986
<!-- /gh-issue-number -->
