### PR TITLE
gh-127111: Emscripten Make web example work again

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -269,10 +269,6 @@ SRCDIRS= 	@SRCDIRS@
 # Other subdirectories
 SUBDIRSTOO=	Include Lib Misc
 
-# assets for Emscripten browser builds
-WASM_ASSETS_DIR=.$(prefix)
-WASM_STDLIB=$(WASM_ASSETS_DIR)/lib/python$(VERSION)/os.py
-
 # Files and directories to be distributed
 CONFIGFILES=	configure configure.ac acconfig.h pyconfig.h.in Makefile.pre.in
 DISTFILES=	README.rst ChangeLog $(CONFIGFILES)
@@ -737,6 +733,9 @@ build_all:	check-clean-src check-app-store-compliance $(BUILDPYTHON) platform sh
 build_wasm: check-clean-src $(BUILDPYTHON) platform sharedmods \
 		python-config checksharedmods
 
+.PHONY: build_emscripten
+build_emscripten: build_wasm web_example
+
 # Check that the source is clean when building out of source.
 .PHONY: check-clean-src
 check-clean-src:
@@ -1016,23 +1015,38 @@ $(DLLLIBRARY) libpython$(LDVERSION).dll.a: $(LIBRARY_OBJS)
 	else true; \
 	fi
 
-# wasm32-emscripten browser build
-# wasm assets directory is relative to current build dir, e.g. "./usr/local".
-# --preload-file turns a relative asset path into an absolute path.
+# wasm32-emscripten browser web example
 
-.PHONY: wasm_stdlib
-wasm_stdlib: $(WASM_STDLIB)
-$(WASM_STDLIB): $(srcdir)/Lib/*.py $(srcdir)/Lib/*/*.py \
-	    $(srcdir)/Tools/wasm/wasm_assets.py \
+WEBEX_DIR=$(srcdir)/Tools/wasm/emscripten/web_example/
+web_example/python.html: $(WEBEX_DIR)/python.html
+	@mkdir -p web_example
+	@cp $< $@
+
+web_example/python.worker.mjs: $(WEBEX_DIR)/python.worker.mjs
+	@mkdir -p web_example
+	@cp $< $@
+
+web_example/server.py: $(WEBEX_DIR)/server.py
+	@mkdir -p web_example
+	@cp $< $@
+
+WEB_STDLIB=web_example/python$(VERSION)$(ABI_THREAD).zip
+$(WEB_STDLIB): $(srcdir)/Lib/*.py $(srcdir)/Lib/*/*.py \
+	    $(WEBEX_DIR)/wasm_assets.py \
 	    Makefile pybuilddir.txt Modules/Setup.local
-	$(PYTHON_FOR_BUILD) $(srcdir)/Tools/wasm/wasm_assets.py \
-	    --buildroot . --prefix $(prefix)
+	$(PYTHON_FOR_BUILD) $(WEBEX_DIR)/wasm_assets.py \
+	    --buildroot . --prefix $(prefix) -o $@
 
-python.html: $(srcdir)/Tools/wasm/python.html python.worker.js
-	@cp $(srcdir)/Tools/wasm/python.html $@
+web_example/python.mjs web_example/python.wasm: $(BUILDPYTHON)
+	@if test $(HOST_GNU_TYPE) != 'wasm32-unknown-emscripten' ; then \
+		echo "Can only build web_example when target is Emscripten" ;\
+		exit 1 ;\
+	fi
+	cp python.mjs web_example/python.mjs
+	cp python.wasm web_example/python.wasm
 
-python.worker.js: $(srcdir)/Tools/wasm/python.worker.js
-	@cp $(srcdir)/Tools/wasm/python.worker.js $@
+.PHONY: web_example
+web_example: web_example/python.mjs web_example/python.worker.mjs web_example/python.html web_example/server.py $(WEB_STDLIB)
 
 ############################################################################
 # Header files
@@ -3053,8 +3067,7 @@ clean-retain-profile: pycremoval
 	find build -name '*.py[co]' -exec rm -f {} ';' || true
 	-rm -f pybuilddir.txt
 	-rm -f _bootstrap_python
-	-rm -f python.html python*.js python.data python*.symbols python*.map
-	-rm -f $(WASM_STDLIB)
+	-rm -rf web_example python.mjs python.wasm python*.symbols python*.map
 	-rm -f Programs/_testembed Programs/_freeze_module
 	-rm -rf Python/deepfreeze
 	-rm -f Python/frozen_modules/*.h

--- a/Misc/NEWS.d/next/Build/2024-11-30-16-36-09.gh-issue-127111.QI9mMZ.rst
+++ b/Misc/NEWS.d/next/Build/2024-11-30-16-36-09.gh-issue-127111.QI9mMZ.rst
@@ -1,2 +1,2 @@
 Updated the Emscripten web example to use ES6 modules and be built into a
-distinct `web_example` subfolder.
+distinct ``web_example`` subfolder.

--- a/Misc/NEWS.d/next/Build/2024-11-30-16-36-09.gh-issue-127111.QI9mMZ.rst
+++ b/Misc/NEWS.d/next/Build/2024-11-30-16-36-09.gh-issue-127111.QI9mMZ.rst
@@ -1,0 +1,2 @@
+Updated the Emscripten web example to use ES6 modules and be built into a
+distinct `web_example` subfolder.

--- a/Tools/wasm/README.md
+++ b/Tools/wasm/README.md
@@ -72,8 +72,8 @@ python Tools/wasm/emscripten build --with-py-debug
 
 ### Running from node
 
-If you want to run the normal Python cli, you can use `python.sh`. It takes the
-same options as the normal Python cli entrypoint, though the REPL does not
+If you want to run the normal Python CLI, you can use `python.sh`. It takes the
+same options as the normal Python CLI entrypoint, though the REPL does not
 function and will crash.
 
 `python.sh` invokes `node_entry.mjs` which imports the Emscripten module for the

--- a/Tools/wasm/README.md
+++ b/Tools/wasm/README.md
@@ -85,16 +85,18 @@ CLI you will need to write your own alternative to `node_entry.mjs`.
 ### The Web Example
 
 When building for Emscripten, the web example will be built automatically. It is
-in the ``web_example`` directory. The web example uses ``SharedArrayBuffer``.
-For security reasons browsers only provide ``SharedArrayBuffer`` in secure
-environments with cross-origin isolation. The webserver must send cross-origin
-headers and correct MIME types for the JavaScript and WebAssembly files.
-Otherwise the terminal will fail to load with an error message like
-``ReferenceError: SharedArrayBuffer is not defined``. See more information here:
-https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements
+in the ``web_example`` directory. To run the web example, ``cd`` into the
+``web_example`` directory, then run ``python server.py``. This will start a web
+server; you can then visit ``http://localhost:8000/python.html`` in a browser to
+see a simple REPL example.
 
-If you serve the web example with ``python server.py`` and then visit
-``localhost:8000`` in a browser it should work.
+The web example uses ``SharedArrayBuffer``. For security reasons browsers only
+provide ``SharedArrayBuffer`` in secure environments with cross-origin
+isolation. The webserver must send cross-origin headers and correct MIME types
+for the JavaScript and WebAssembly files. Otherwise the terminal will fail to
+load with an error message like ``ReferenceError: SharedArrayBuffer is not
+defined``. See more information here:
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements
 
 Note that ``SharedArrayBuffer`` is _not required_ to use Python itself, only the
 web example. If cross-origin isolation is not appropriate for your use case you
@@ -117,9 +119,13 @@ file system into the Emscripten file system:
 import createEmscriptenModule from "./python.mjs";
 
 await createEmscriptenModule({
-  preRun(Module) {
-    Module.FS.mount(Module.FS.filesystems.NODEFS, { root: "/path/to/python/stdlib" }, "/lib/");
-  }
+    preRun(Module) {
+        Module.FS.mount(
+            Module.FS.filesystems.NODEFS,
+            { root: "/path/to/python/stdlib" },
+            "/lib/",
+        );
+    },
 });
 ```
 
@@ -131,14 +137,16 @@ file it and install it. With Python 3.14 this could look like:
 import createEmscriptenModule from "./python.mjs";
 
 await createEmscriptenModule({
-  preRun(Module) {
+  async preRun(Module) {
     Module.FS.mkdirTree("/lib/python3.14/lib-dynload/");
     Module.addRunDependency("install-stdlib");
     const resp = await fetch("python3.14.zip");
     const stdlibBuffer = await resp.arrayBuffer();
-    Module.FS.writeFile(`/lib/python314.zip`, new Uint8Array(stdlibBuffer), { canOwn: true });
+    Module.FS.writeFile(`/lib/python314.zip`, new Uint8Array(stdlibBuffer), {
+      canOwn: true,
+    });
     Module.removeRunDependency("install-stdlib");
-  }
+  },
 });
 ```
 

--- a/Tools/wasm/README.md
+++ b/Tools/wasm/README.md
@@ -23,9 +23,9 @@ https://github.com/psf/webassembly for more information.
 
 To cross compile to the ``wasm32-emscripten`` platform you need
 [the Emscripten compiler toolchain](https://emscripten.org/), 
-a Python interpreter, and an installation of Node version 18 or newer. Emscripten
-version 3.1.42 or newer is recommended. All commands below are relative to a checkout
-of the Python repository.
+a Python interpreter, and an installation of Node version 18 or newer.
+Emscripten version 3.1.73 or newer is recommended. All commands below are
+relative to a checkout of the Python repository.
 
 #### Install [the Emscripten compiler toolchain](https://emscripten.org/docs/getting_started/downloads.html)
 
@@ -90,12 +90,14 @@ in the ``web_example`` directory. To run the web example, ``cd`` into the
 server; you can then visit ``http://localhost:8000/python.html`` in a browser to
 see a simple REPL example.
 
-The web example uses ``SharedArrayBuffer``. For security reasons browsers only
-provide ``SharedArrayBuffer`` in secure environments with cross-origin
-isolation. The webserver must send cross-origin headers and correct MIME types
-for the JavaScript and WebAssembly files. Otherwise the terminal will fail to
-load with an error message like ``ReferenceError: SharedArrayBuffer is not
-defined``. See more information here:
+The web example relies on a bug fix in Emscripten version 3.1.73 so if you build
+with earlier versions of Emscripten it may not work. The web example uses
+``SharedArrayBuffer``. For security reasons browsers only provide
+``SharedArrayBuffer`` in secure environments with cross-origin isolation. The
+webserver must send cross-origin headers and correct MIME types for the
+JavaScript and WebAssembly files. Otherwise the terminal will fail to load with
+an error message like ``ReferenceError: SharedArrayBuffer is not defined``. See
+more information here:
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements
 
 Note that ``SharedArrayBuffer`` is _not required_ to use Python itself, only the

--- a/Tools/wasm/emscripten/__main__.py
+++ b/Tools/wasm/emscripten/__main__.py
@@ -215,29 +215,12 @@ def configure_emscripten_python(context, working_dir):
     exec_script = working_dir / "python.sh"
     exec_script.write_text(
         dedent(
-            """\
+            f"""\
             #!/bin/sh
 
-            # Macs come with free BSD coreutils which doesn't have the -s option
-            # so feature detect and work around it.
-            if which grealpath > /dev/null; then
-                # It has brew installed gnu core utils, use that
-                REALPATH="grealpath -s"
-            elif which realpath > /dev/null && realpath --version | grep GNU > /dev/null; then
-                # realpath points to GNU realpath so use it.
-                REALPATH="realpath -s"
-            else
-                # Shim for macs without GNU coreutils
-                abs_path () {
-                    echo "$(cd "$(dirname "$1")" || exit; pwd)/$(basename "$1")"
-                }
-                REALPATH=abs_path
-            fi
-            """
-            f"""
             # We compute our own path, not following symlinks and pass it in so that
             # node_entry.mjs can set sys.executable correctly.
-            exec {host_runner} {node_entry} "$($REALPATH "$0")" "$@"
+            exec {host_runner} {node_entry} "$(realpath -s $0)" "$@"
             """
         )
     )

--- a/Tools/wasm/emscripten/__main__.py
+++ b/Tools/wasm/emscripten/__main__.py
@@ -218,26 +218,26 @@ def configure_emscripten_python(context, working_dir):
             """\
             #!/bin/sh
 
-            # Macs come with a defective fork of coreutils so feature detect and
-            # work around it.
+            # Macs come with free BSD coreutils which doesn't have the -s option
+            # so feature detect and work around it.
             if which grealpath > /dev/null; then
                 # It has brew installed gnu core utils, use that
                 REALPATH="grealpath -s"
-            elif which readlink > /dev/null && realpath --version | grep GNU > /dev/null; then
+            elif which realpath > /dev/null && realpath --version | grep GNU > /dev/null; then
                 # realpath points to GNU realpath so use it.
                 REALPATH="realpath -s"
             else
                 # Shim for macs without GNU coreutils
                 abs_path () {
-                    echo "$(cd $(dirname "$1");pwd)/$(basename "$2")"
+                    echo "$(cd "$(dirname "$1")" || exit; pwd)/$(basename "$1")"
                 }
                 REALPATH=abs_path
             fi
             """
-            f"""\
+            f"""
             # We compute our own path, not following symlinks and pass it in so that
             # node_entry.mjs can set sys.executable correctly.
-            exec {host_runner} {node_entry} "$($REALPATH $0)" "$@"
+            exec {host_runner} {node_entry} "$($REALPATH "$0")" "$@"
             """
         )
     )

--- a/Tools/wasm/emscripten/__main__.py
+++ b/Tools/wasm/emscripten/__main__.py
@@ -215,12 +215,29 @@ def configure_emscripten_python(context, working_dir):
     exec_script = working_dir / "python.sh"
     exec_script.write_text(
         dedent(
-            f"""\
+            """\
             #!/bin/sh
 
+            # Macs come with a defective fork of coreutils so feature detect and
+            # work around it.
+            if which grealpath > /dev/null; then
+                # It has brew installed gnu core utils, use that
+                REALPATH="grealpath -s"
+            elif which readlink > /dev/null && realpath --version | grep GNU > /dev/null; then
+                # realpath points to GNU realpath so use it.
+                REALPATH="realpath -s"
+            else
+                # Shim for macs without GNU coreutils
+                abs_path () {
+                    echo "$(cd $(dirname "$1");pwd)/$(basename "$2")"
+                }
+                REALPATH=abs_path
+            fi
+            """
+            f"""\
             # We compute our own path, not following symlinks and pass it in so that
             # node_entry.mjs can set sys.executable correctly.
-            exec {host_runner} {node_entry} "$(realpath -s $0)" "$@"
+            exec {host_runner} {node_entry} "$($REALPATH $0)" "$@"
             """
         )
     )

--- a/Tools/wasm/emscripten/web_example/python.html
+++ b/Tools/wasm/emscripten/web_example/python.html
@@ -47,7 +47,7 @@ class WorkerManager {
 
     async initialiseWorker() {
         if (!this.worker) {
-            this.worker = new Worker(this.workerURL)
+            this.worker = new Worker(this.workerURL, {type: "module"})
             this.worker.addEventListener('message', this.handleMessageFromWorker)
         }
     }
@@ -347,7 +347,7 @@ window.onload = () => {
         programRunning(false)
     }
 
-    const pythonWorkerManager = new WorkerManager('./python.worker.js', stdio, readyCallback, finishedCallback)
+    const pythonWorkerManager = new WorkerManager('./python.worker.mjs', stdio, readyCallback, finishedCallback)
 }
     </script>
 </head>

--- a/Tools/wasm/emscripten/web_example/python.worker.mjs
+++ b/Tools/wasm/emscripten/web_example/python.worker.mjs
@@ -70,13 +70,15 @@ const emscriptenSettings = {
         postMessage({type: 'ready', stdinBuffer: stdinBuffer.sab})
     },
     async preRun(Module) {
-        // TODO: remove fixed version number
+        const versionHex = Module.HEAPU32[Module._Py_Version/4].toString(16);
+        const versionTuple = versionHex.padStart(8, "0").match(/.{1,2}/g).map((x) => parseInt(x, 16));
+        const [major, minor, ..._] = versionTuple;
         // Prevent complaints about not finding exec-prefix by making a lib-dynload directory
-        Module.FS.mkdirTree("/lib/python3.14/lib-dynload/");
+        Module.FS.mkdirTree(`/lib/python${major}.${minor}/lib-dynload/`);
         Module.addRunDependency("install-stdlib");
-        const resp = await fetch("python3.14.zip");
+        const resp = await fetch(`python${major}.${minor}.zip`);
         const stdlibBuffer = await resp.arrayBuffer();
-        Module.FS.writeFile(`/lib/python314.zip`, new Uint8Array(stdlibBuffer), { canOwn: true });
+        Module.FS.writeFile(`/lib/python${major}${minor}.zip`, new Uint8Array(stdlibBuffer), { canOwn: true });
         Module.removeRunDependency("install-stdlib");
     }
 }

--- a/Tools/wasm/emscripten/web_example/server.py
+++ b/Tools/wasm/emscripten/web_example/server.py
@@ -14,13 +14,6 @@ parser.add_argument(
 
 
 class MyHTTPRequestHandler(server.SimpleHTTPRequestHandler):
-    extensions_map = server.SimpleHTTPRequestHandler.extensions_map.copy()
-    extensions_map.update(
-        {
-            ".wasm": "application/wasm",
-        }
-    )
-
     def end_headers(self) -> None:
         self.send_my_headers()
         super().end_headers()
@@ -41,6 +34,7 @@ def main() -> None:
         port=args.port,
         bind=args.bind,
     )
+
 
 if __name__ == "__main__":
     main()

--- a/configure
+++ b/configure
@@ -8335,8 +8335,12 @@ fi
 
 
 fi
-elif test "$ac_sys_system" = "Emscripten" -o "$ac_sys_system" = "WASI"; then
-      DEF_MAKE_ALL_RULE="build_wasm"
+elif test "$ac_sys_system" = "Emscripten"; then
+    DEF_MAKE_ALL_RULE="build_emscripten"
+  REQUIRE_PGO="no"
+  DEF_MAKE_RULE="all"
+elif test "$ac_sys_system" = "WASI"; then
+    DEF_MAKE_ALL_RULE="build_wasm"
   REQUIRE_PGO="no"
   DEF_MAKE_RULE="all"
 else
@@ -9427,12 +9431,12 @@ else $as_nop
   wasm_debug=no
 fi
 
-        as_fn_append LDFLAGS_NODIST " -sALLOW_MEMORY_GROWTH -sTOTAL_MEMORY=20971520"
+        as_fn_append LDFLAGS_NODIST " -sALLOW_MEMORY_GROWTH -sINITIAL_MEMORY=20971520"
 
         as_fn_append LDFLAGS_NODIST " -sWASM_BIGINT"
 
         as_fn_append LDFLAGS_NODIST " -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"
-    as_fn_append LDFLAGS_NODIST " -sEXPORTED_RUNTIME_METHODS=FS"
+    as_fn_append LDFLAGS_NODIST " -sEXPORTED_RUNTIME_METHODS=FS,callMain"
 
     if test "x$enable_wasm_dynamic_linking" = xyes
 then :
@@ -9449,7 +9453,6 @@ then :
       as_fn_append LINKFORSHARED " -sPROXY_TO_PTHREAD"
 
 fi
-    as_fn_append LDFLAGS_NODIST " -sALLOW_MEMORY_GROWTH"
         as_fn_append LDFLAGS_NODIST " -sEXIT_RUNTIME"
     WASM_LINKFORSHARED_DEBUG="-gseparate-dwarf --emit-symbol-map"
 

--- a/configure
+++ b/configure
@@ -9437,6 +9437,7 @@ fi
 
         as_fn_append LDFLAGS_NODIST " -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"
     as_fn_append LDFLAGS_NODIST " -sEXPORTED_RUNTIME_METHODS=FS,callMain"
+    as_fn_append LDFLAGS_NODIST " -sEXPORTED_FUNCTIONS=_main,_Py_Version"
 
     if test "x$enable_wasm_dynamic_linking" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -1854,9 +1854,13 @@ if test "$Py_OPT" = 'true' ; then
       LDFLAGS_NODIST="$LDFLAGS_NODIST -fno-semantic-interposition"
       ], [], [-Werror])
   ])
-elif test "$ac_sys_system" = "Emscripten" -o "$ac_sys_system" = "WASI"; then
-  dnl Emscripten does not support shared extensions yet. Build
-  dnl "python.[js,wasm]", "pybuilddir.txt", and "platform" files.
+elif test "$ac_sys_system" = "Emscripten"; then
+  dnl Build "python.[js,wasm]", "pybuilddir.txt", and "platform" files.
+  DEF_MAKE_ALL_RULE="build_emscripten"
+  REQUIRE_PGO="no"
+  DEF_MAKE_RULE="all"
+elif test "$ac_sys_system" = "WASI"; then
+  dnl Build "python.wasm", "pybuilddir.txt", and "platform" files.
   DEF_MAKE_ALL_RULE="build_wasm"
   REQUIRE_PGO="no"
   DEF_MAKE_RULE="all"
@@ -2321,14 +2325,14 @@ AS_CASE([$ac_sys_system],
     AS_VAR_IF([Py_DEBUG], [yes], [wasm_debug=yes], [wasm_debug=no])
 
     dnl Start with 20 MB and allow to grow
-    AS_VAR_APPEND([LDFLAGS_NODIST], [" -sALLOW_MEMORY_GROWTH -sTOTAL_MEMORY=20971520"])
+    AS_VAR_APPEND([LDFLAGS_NODIST], [" -sALLOW_MEMORY_GROWTH -sINITIAL_MEMORY=20971520"])
 
     dnl map int64_t and uint64_t to JS bigint
     AS_VAR_APPEND([LDFLAGS_NODIST], [" -sWASM_BIGINT"])
 
     dnl Include file system support
     AS_VAR_APPEND([LDFLAGS_NODIST], [" -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"])
-    AS_VAR_APPEND([LDFLAGS_NODIST], [" -sEXPORTED_RUNTIME_METHODS=FS"])
+    AS_VAR_APPEND([LDFLAGS_NODIST], [" -sEXPORTED_RUNTIME_METHODS=FS,callMain"])
 
     AS_VAR_IF([enable_wasm_dynamic_linking], [yes], [
       AS_VAR_APPEND([LINKFORSHARED], [" -sMAIN_MODULE"])
@@ -2339,7 +2343,6 @@ AS_CASE([$ac_sys_system],
       AS_VAR_APPEND([LDFLAGS_NODIST], [" -sUSE_PTHREADS"])
       AS_VAR_APPEND([LINKFORSHARED], [" -sPROXY_TO_PTHREAD"])
     ])
-    AS_VAR_APPEND([LDFLAGS_NODIST], [" -sALLOW_MEMORY_GROWTH"])
     dnl not completely sure whether or not we want -sEXIT_RUNTIME, keeping it for now.
     AS_VAR_APPEND([LDFLAGS_NODIST], [" -sEXIT_RUNTIME"])
     WASM_LINKFORSHARED_DEBUG="-gseparate-dwarf --emit-symbol-map"

--- a/configure.ac
+++ b/configure.ac
@@ -2333,6 +2333,7 @@ AS_CASE([$ac_sys_system],
     dnl Include file system support
     AS_VAR_APPEND([LDFLAGS_NODIST], [" -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"])
     AS_VAR_APPEND([LDFLAGS_NODIST], [" -sEXPORTED_RUNTIME_METHODS=FS,callMain"])
+    AS_VAR_APPEND([LDFLAGS_NODIST], [" -sEXPORTED_FUNCTIONS=_main,_Py_Version"])
 
     AS_VAR_IF([enable_wasm_dynamic_linking], [yes], [
       AS_VAR_APPEND([LINKFORSHARED], [" -sMAIN_MODULE"])


### PR DESCRIPTION
I moved the web example from `Tools/wasm` into `Tools/wasm/emscripten/web_example`. I also added a new target `build_emscripten` which is `build_wasm` but also builds the web_example. The web_example needs:
1. python.html, copied
2. python.worker.mjs copied
3. python.mjs and python.wasm output from the main linking of the Python interpreter
4. The webserver that sets COOP and COEP
5. python3.14.zip

This last is created by the `wasm_assets.py` script, which required a pretty small set of changes to work fine for us.

The last thing that should be done is the `python.worker.mjs` script should be made independent of the Python version: currently 3.14 is hard coded. [I ran into trouble doing this](https://github.com/emscripten-core/emscripten/issues/22980), so maybe I can leave it to a followup.



<!-- gh-issue-number: gh-127111 -->
* Issue: gh-127111
<!-- /gh-issue-number -->
