### PR TITLE
gh-114940: Add a Per-Interpreter Lock For the List of Thread States

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -127,6 +127,7 @@ struct _is {
 
     uintptr_t last_restart_version;
     struct pythreads {
+        PyMutex mutex;
         uint64_t next_unique_id;
         /* The linked list of threads, newest first. */
         PyThreadState *head;

--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -127,7 +127,7 @@ struct _is {
 
     uintptr_t last_restart_version;
     struct pythreads {
-        PyMutex mutex;
+        _PyRecursiveMutex mutex;
         uint64_t next_unique_id;
         /* The linked list of threads, newest first. */
         PyThreadState *head;

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -269,14 +269,18 @@ extern int _PyOS_InterruptOccurred(PyThreadState *tstate);
 #define HEAD_UNLOCK(runtime) \
     PyMutex_Unlock(&(runtime)->interpreters.mutex)
 
+#define THREADS_HEAD_LOCK(interp) \
+    PyMutex_LockFlags(&(interp)->threads.mutex, _Py_LOCK_DONT_DETACH)
+#define THREADS_HEAD_UNLOCK(interp) \
+    PyMutex_Unlock(&(interp)->threads.mutex)
+
 #define _Py_FOR_EACH_TSTATE_UNLOCKED(interp, t) \
     for (PyThreadState *t = interp->threads.head; t; t = t->next)
 #define _Py_FOR_EACH_TSTATE_BEGIN(interp, t) \
-    HEAD_LOCK(interp->runtime); \
+    THREADS_HEAD_LOCK(interp); \
     _Py_FOR_EACH_TSTATE_UNLOCKED(interp, t)
 #define _Py_FOR_EACH_TSTATE_END(interp) \
-    HEAD_UNLOCK(interp->runtime)
-
+    THREADS_HEAD_UNLOCK(interp)
 
 // Get the configuration of the current interpreter.
 // The caller must hold the GIL.

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -270,9 +270,9 @@ extern int _PyOS_InterruptOccurred(PyThreadState *tstate);
     PyMutex_Unlock(&(runtime)->interpreters.mutex)
 
 #define THREADS_HEAD_LOCK(interp) \
-    PyMutex_LockFlags(&(interp)->threads.mutex, _Py_LOCK_DONT_DETACH)
+    _PyRecursiveMutex_LockFlags(&(interp)->threads.mutex, _Py_LOCK_DONT_DETACH)
 #define THREADS_HEAD_UNLOCK(interp) \
-    PyMutex_Unlock(&(interp)->threads.mutex)
+    _PyRecursiveMutex_Unlock(&(interp)->threads.mutex)
 
 #define _Py_FOR_EACH_TSTATE_UNLOCKED(interp, t) \
     for (PyThreadState *t = interp->threads.head; t; t = t->next)

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -164,6 +164,11 @@ typedef struct pyruntimestate {
         _Py_AuditHookEntry *head;
     } audit_hooks;
 
+#ifdef HAVE_FORK
+    // Guarded by multiple global locks.
+    PyThread_ident_t fork_tid;
+#endif
+
     struct _py_object_runtime_state object_state;
     struct _Py_float_runtime_state float_state;
     struct _Py_unicode_runtime_state unicode_state;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -624,11 +624,13 @@ PyOS_BeforeFork(void)
     _PyImport_AcquireLock(interp);
     _PyEval_StopTheWorldAll(&_PyRuntime);
     HEAD_LOCK(&_PyRuntime);
+    _PyRuntime.fork_tid = PyThread_get_thread_ident_ex();
 }
 
 void
 PyOS_AfterFork_Parent(void)
 {
+    _PyRuntime.fork_tid = 0;
     HEAD_UNLOCK(&_PyRuntime);
     _PyEval_StartTheWorldAll(&_PyRuntime);
 
@@ -648,6 +650,7 @@ PyOS_AfterFork_Child(void)
     if (_PyStatus_EXCEPTION(status)) {
         goto fatal_error;
     }
+    _PyRuntime.fork_tid = 0;
 
     PyThreadState *tstate = _PyThreadState_GET();
     _Py_EnsureTstateNotNULL(tstate);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -119,11 +119,11 @@ get_reftotal(PyInterpreterState *interp)
        since we can't determine which interpreter updated it. */
     Py_ssize_t total = REFTOTAL(interp);
 #ifdef Py_GIL_DISABLED
-    _Py_FOR_EACH_TSTATE_UNLOCKED(interp, p) {
-        /* This may race with other threads modifications to their reftotal */
+    _Py_FOR_EACH_TSTATE_BEGIN(interp, p) {
         _PyThreadStateImpl *tstate_impl = (_PyThreadStateImpl *)p;
         total += _Py_atomic_load_ssize_relaxed(&tstate_impl->reftotal);
     }
+    _Py_FOR_EACH_TSTATE_END(interp);
 #endif
     return total;
 }
@@ -317,10 +317,7 @@ _Py_GetLegacyRefTotal(void)
 Py_ssize_t
 _PyInterpreterState_GetRefTotal(PyInterpreterState *interp)
 {
-    HEAD_LOCK(&_PyRuntime);
-    Py_ssize_t total = get_reftotal(interp);
-    HEAD_UNLOCK(&_PyRuntime);
-    return total;
+    return get_reftotal(interp);
 }
 
 #endif /* Py_REF_DEBUG */

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1439,13 +1439,14 @@ get_mimalloc_allocated_blocks(PyInterpreterState *interp)
 {
     size_t allocated_blocks = 0;
 #ifdef Py_GIL_DISABLED
-    _Py_FOR_EACH_TSTATE_UNLOCKED(interp, t) {
+    _Py_FOR_EACH_TSTATE_BEGIN(interp, t) {
         _PyThreadStateImpl *tstate = (_PyThreadStateImpl *)t;
         for (int i = 0; i < _Py_MIMALLOC_HEAP_COUNT; i++) {
             mi_heap_t *heap = &tstate->mimalloc.heaps[i];
             mi_heap_visit_blocks(heap, false, &count_blocks, &allocated_blocks);
         }
     }
+    _Py_FOR_EACH_TSTATE_END(interp);
 
     mi_abandoned_pool_t *pool = &interp->mimalloc.abandoned_pool;
     for (uint8_t tag = 0; tag < _Py_MIMALLOC_HEAP_COUNT; tag++) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1801,11 +1801,12 @@ zapthreads(PyInterpreterState *interp)
 {
     /* No need to lock the mutex here because this should only happen
        when the threads are all really dead (XXX famous last words). */
-    _Py_FOR_EACH_TSTATE_UNLOCKED(interp, tstate) {
+    _Py_FOR_EACH_TSTATE_BEGIN(interp, tstate) {
         tstate_verify_not_active(tstate);
         tstate_delete_common(tstate, 0);
         free_threadstate((_PyThreadStateImpl *)tstate);
     }
+    _Py_FOR_EACH_TSTATE_END(interp);
 }
 
 
@@ -2184,7 +2185,7 @@ park_detached_threads(struct _stoptheworld_state *stw)
 {
     int num_parked = 0;
     _Py_FOR_EACH_STW_INTERP(stw, i) {
-        _Py_FOR_EACH_TSTATE_UNLOCKED(i, t) {
+        _Py_FOR_EACH_TSTATE_BEGIN(i, t) {
             int state = _Py_atomic_load_int_relaxed(&t->state);
             if (state == _Py_THREAD_DETACHED) {
                 // Atomically transition to "suspended" if in "detached" state.
@@ -2197,6 +2198,7 @@ park_detached_threads(struct _stoptheworld_state *stw)
                 _Py_set_eval_breaker_bit(t, _PY_EVAL_PLEASE_STOP_BIT);
             }
         }
+        _Py_FOR_EACH_TSTATE_END(i);
     }
     stw->thread_countdown -= num_parked;
     assert(stw->thread_countdown >= 0);
@@ -2223,12 +2225,13 @@ stop_the_world(struct _stoptheworld_state *stw)
     stw->requester = _PyThreadState_GET();  // may be NULL
 
     _Py_FOR_EACH_STW_INTERP(stw, i) {
-        _Py_FOR_EACH_TSTATE_UNLOCKED(i, t) {
+        _Py_FOR_EACH_TSTATE_BEGIN(i, t) {
             if (t != stw->requester) {
                 // Count all the other threads (we don't wait on ourself).
                 stw->thread_countdown++;
             }
         }
+        _Py_FOR_EACH_TSTATE_END(i);
     }
 
     if (stw->thread_countdown == 0) {
@@ -2269,7 +2272,7 @@ start_the_world(struct _stoptheworld_state *stw)
     stw->world_stopped = 0;
     // Switch threads back to the detached state.
     _Py_FOR_EACH_STW_INTERP(stw, i) {
-        _Py_FOR_EACH_TSTATE_UNLOCKED(i, t) {
+        _Py_FOR_EACH_TSTATE_BEGIN(i, t) {
             if (t != stw->requester) {
                 assert(_Py_atomic_load_int_relaxed(&t->state) ==
                        _Py_THREAD_SUSPENDED);
@@ -2277,6 +2280,7 @@ start_the_world(struct _stoptheworld_state *stw)
                 _PyParkingLot_UnparkAll(&t->state);
             }
         }
+        _Py_FOR_EACH_TSTATE_END(i);
     }
     stw->requester = NULL;
     HEAD_UNLOCK(runtime);
@@ -2511,7 +2515,8 @@ _PyThread_CurrentFrames(void)
     HEAD_LOCK(runtime);
     PyInterpreterState *i;
     for (i = runtime->interpreters.head; i != NULL; i = i->next) {
-        _Py_FOR_EACH_TSTATE_UNLOCKED(i, t) {
+        int failed = 0;
+        _Py_FOR_EACH_TSTATE_BEGIN(i, t) {
             _PyInterpreterFrame *frame = t->current_frame;
             frame = _PyFrame_GetFirstComplete(frame);
             if (frame == NULL) {
@@ -2519,18 +2524,25 @@ _PyThread_CurrentFrames(void)
             }
             PyObject *id = PyLong_FromUnsignedLong(t->thread_id);
             if (id == NULL) {
-                goto fail;
+                failed = 1;
+                break;
             }
             PyObject *frameobj = (PyObject *)_PyFrame_GetFrameObject(frame);
             if (frameobj == NULL) {
                 Py_DECREF(id);
-                goto fail;
+                failed = 1;
+                break;
             }
             int stat = PyDict_SetItem(result, id, frameobj);
             Py_DECREF(id);
             if (stat < 0) {
-                goto fail;
+                failed = 1;
+                break;
             }
+        }
+        _Py_FOR_EACH_TSTATE_END(i);
+        if (failed) {
+            goto fail;
         }
     }
     goto done;
@@ -2576,14 +2588,16 @@ _PyThread_CurrentExceptions(void)
     HEAD_LOCK(runtime);
     PyInterpreterState *i;
     for (i = runtime->interpreters.head; i != NULL; i = i->next) {
-        _Py_FOR_EACH_TSTATE_UNLOCKED(i, t) {
+        int failed = 0;
+        _Py_FOR_EACH_TSTATE_BEGIN(i, t) {
             _PyErr_StackItem *err_info = _PyErr_GetTopmostException(t);
             if (err_info == NULL) {
                 continue;
             }
             PyObject *id = PyLong_FromUnsignedLong(t->thread_id);
             if (id == NULL) {
-                goto fail;
+                failed = 1;
+                break;
             }
             PyObject *exc = err_info->exc_value;
             assert(exc == NULL ||
@@ -2593,8 +2607,13 @@ _PyThread_CurrentExceptions(void)
             int stat = PyDict_SetItem(result, id, exc == NULL ? Py_None : exc);
             Py_DECREF(id);
             if (stat < 0) {
-                goto fail;
+                failed = 1;
+                break;
             }
+        }
+        _Py_FOR_EACH_TSTATE_END(i);
+        if (failed) {
+            goto fail;
         }
     }
     goto done;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -515,6 +515,7 @@ _PyRuntimeState_ReInitThreads(_PyRuntimeState *runtime)
     for (PyInterpreterState *interp = runtime->interpreters.head;
          interp != NULL; interp = interp->next)
     {
+        _PyMutex_at_fork_reinit(&interp->threads.mutex);
         for (int i = 0; i < NUM_WEAKREF_LIST_LOCKS; i++) {
             _PyMutex_at_fork_reinit(&interp->weakref_locks[i]);
         }


### PR DESCRIPTION
The new lock may be used instead of the global "HEAD" lock. That global lock guards the list of interpreters, but unfortunately in some situations (like for `interp->threads.head`) it has been used as a generic "lock everything".  This change helps us move away from that situation.

Note that there are 3 places in pystate.c where we have left `HEAD_LOCK()`/`HEAD_UNLOCK()` in place:

* `interpreter_clear()`
* `new_threadstate()`
* `tstate_delete_common()`

Otherwise we end up breaking a constraint on free-threaded builds.

Co-authored-by: RUANG (James Roy) <longjinyii@outlook.com>

<!-- gh-issue-number: gh-114940 -->
* Issue: gh-114940
<!-- /gh-issue-number -->