### PR TITLE
gh-126688:  Support Fork Parent and Child With Different Thread ID

### DIFF
--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -9,6 +9,7 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
+#include "pycore_pythread.h"      // PyThread_ident_t
 #include "pycore_lock.h"          // PyMutex
 #include "pycore_hashtable.h"     // _Py_hashtable_t
 
@@ -21,7 +22,11 @@ extern int _PyImport_SetModuleString(const char *name, PyObject* module);
 
 extern void _PyImport_AcquireLock(PyInterpreterState *interp);
 extern void _PyImport_ReleaseLock(PyInterpreterState *interp);
-extern void _PyImport_ReInitLock(PyInterpreterState *interp);
+#ifdef HAVE_FORK
+extern void _PyImport_ReInitLock(
+    PyInterpreterState *interp,
+    PyThread_ident_t parent);
+#endif
 
 // This is used exclusively for the sys and builtins modules:
 extern int _PyImport_FixupBuiltin(

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -219,7 +219,9 @@ extern PyStatus _PyRuntimeState_Init(_PyRuntimeState *runtime);
 extern void _PyRuntimeState_Fini(_PyRuntimeState *runtime);
 
 #ifdef HAVE_FORK
-extern PyStatus _PyRuntimeState_ReInitThreads(_PyRuntimeState *runtime);
+extern PyStatus _PyRuntimeState_ReInitThreads(
+    _PyRuntimeState *runtime,
+    PyThread_ident_t parent);
 #endif
 
 /* Initialize _PyRuntimeState.

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -164,6 +164,12 @@ typedef struct pyruntimestate {
         _Py_AuditHookEntry *head;
     } audit_hooks;
 
+#ifdef HAVE_FORK
+    struct {
+        PyMutex mutex;
+    } os_fork;
+#endif
+
     struct _py_object_runtime_state object_state;
     struct _Py_float_runtime_state float_state;
     struct _Py_unicode_runtime_state unicode_state;

--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -167,6 +167,9 @@ typedef struct pyruntimestate {
 #ifdef HAVE_FORK
     struct {
         PyMutex mutex;
+        struct _os_fork_parent {
+            PyThread_ident_t tid;
+        } parent;
     } os_fork;
 #endif
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -697,7 +697,7 @@ PyOS_AfterFork_Child(void)
     _PyEval_StartTheWorldAll(&_PyRuntime);
     _PyThreadState_DeleteList(list);
 
-    _PyImport_ReInitLock(tstate->interp);
+    _PyImport_ReInitLock(tstate->interp, _PyRuntime.os_fork.parent.tid);
     _PyImport_ReleaseLock(tstate->interp);
 
     _PySignal_AfterFork();

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -654,7 +654,8 @@ PyOS_AfterFork_Child(void)
     _PyRuntimeState *runtime = &_PyRuntime;
 
     // re-creates runtime->interpreters.mutex (HEAD_UNLOCK)
-    status = _PyRuntimeState_ReInitThreads(runtime);
+    status = _PyRuntimeState_ReInitThreads(
+                                runtime, runtime->os_fork.parent.tid);
     if (_PyStatus_EXCEPTION(status)) {
         goto fatal_error;
     }
@@ -697,7 +698,6 @@ PyOS_AfterFork_Child(void)
     _PyEval_StartTheWorldAll(&_PyRuntime);
     _PyThreadState_DeleteList(list);
 
-    _PyImport_ReInitLock(tstate->interp, _PyRuntime.os_fork.parent.tid);
     _PyImport_ReleaseLock(tstate->interp);
 
     _PySignal_AfterFork();

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -663,11 +663,15 @@ PyOS_AfterFork_Child(void)
     _Py_EnsureTstateNotNULL(tstate);
     assert(tstate->interp->runtime == &_PyRuntime);
 
-    // XXX We are assuming that the parent and child always have
-    // the same thread ID.  That isn't necessarily true.
+    // We cannot assume that the parent and child always have
+    // the same thread ID.
     // See https://github.com/python/cpython/issues/126688.
-    assert(_PyRuntime.os_fork.parent.tid == PyThread_get_thread_ident_ex());
-    assert(tstate->thread_id == PyThread_get_thread_ident());
+    if (_PyRuntime.os_fork.parent.tid != PyThread_get_thread_ident_ex()) {
+        tstate->thread_id = PyThread_get_thread_ident();
+    }
+    else {
+        assert(tstate->thread_id == PyThread_get_thread_ident());
+    }
 #ifdef PY_HAVE_THREAD_NATIVE_ID
     tstate->native_thread_id = PyThread_get_thread_native_id();
 #endif

--- a/Python/import.c
+++ b/Python/import.c
@@ -122,12 +122,15 @@ _PyImport_ReleaseLock(PyInterpreterState *interp)
     _PyRecursiveMutex_Unlock(&IMPORT_LOCK(interp));
 }
 
+#ifdef HAVE_FORK
 void
-_PyImport_ReInitLock(PyInterpreterState *interp)
+_PyImport_ReInitLock(PyInterpreterState *interp, PyThread_ident_t parent)
 {
-    // gh-126688: Thread id may change after fork() on some operating systems.
-    IMPORT_LOCK(interp).thread = PyThread_get_thread_ident_ex();
+    /* The forking thread always holds the import lock. */
+    assert(IMPORT_LOCK(interp).thread == parent);
+    _PyRecursiveMutex_at_fork_reinit(&IMPORT_LOCK(interp), parent);
 }
+#endif
 
 
 /***************/

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -497,7 +497,8 @@ _PyRuntimeState_Fini(_PyRuntimeState *runtime)
 /* This function is called from PyOS_AfterFork_Child to ensure that
    newly created child processes do not share locks with the parent. */
 PyStatus
-_PyRuntimeState_ReInitThreads(_PyRuntimeState *runtime)
+_PyRuntimeState_ReInitThreads(_PyRuntimeState *runtime,
+                              PyThread_ident_t parent)
 {
     // This was initially set in _PyRuntimeState_Init().
     runtime->main_thread = PyThread_get_thread_ident();
@@ -515,6 +516,7 @@ _PyRuntimeState_ReInitThreads(_PyRuntimeState *runtime)
     for (PyInterpreterState *interp = runtime->interpreters.head;
          interp != NULL; interp = interp->next)
     {
+        _PyImport_ReInitLock(interp, parent);
         for (int i = 0; i < NUM_WEAKREF_LIST_LOCKS; i++) {
             _PyMutex_at_fork_reinit(&interp->weakref_locks[i]);
         }


### PR DESCRIPTION
gh-126692 took care of one situation where we were assuming the thread ID did not change across fork.  However, there is at least one other, in `PyOS_AfterFork_Child()`.  This PR addresses that case along with making the parent's thread ID available to the child.

Here's a breakdown:

* add `_PyRuntimeState.os_fork.mutex` to allow only one instance of forking to happen at once (in part, to protect the rest of `_PyRuntimeState.os_fork`)
* add `_PyRuntimeState.os_fork.parent.tid` to make the parent's thread ID available to the child
* add `_PyRecursiveMutex_at_fork_reinit()`, which makes use of the parent thread ID
* use `_PyRecursiveMutex_at_fork_reinit()` in `_PyImport_ReInitLock()`

I've also moved the `_PyImport_ReInitLock()` call from `PyOS_AfterFork_Child()` to `_PyRuntimeState_ReInitThreads()`, to be more consistent about where we reinitialize locks after forking.  If there are any objections, I don't mind dropping that part.

One motivation I have here is that I'd like to use a `_PyRecursiveMutex` elsewhere and need to be able to correctly reinitialize after forking.  That requires knowing the parent's thread ID, to decide if the forking thread held the lock or not.  (This wasn't a problem for the import lock, which is a `_PyRecursiveMutex`, since we always acquire and hold that lock while forking.)

@gpshead, I'd be particularly interested in your thoughts on this.

<!-- gh-issue-number: gh-126688 -->
* Issue: gh-126688
<!-- /gh-issue-number -->
