### PR TITLE
Replace `:platform:` with `.. availability::` in `socket.ioctl` doc.

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1596,8 +1596,6 @@ to sockets.
 
 .. method:: socket.ioctl(control, option)
 
-   :platform: Windows
-
    The :meth:`ioctl` method is a limited interface to the WSAIoctl system
    interface.  Please refer to the `Win32 documentation
    <https://msdn.microsoft.com/en-us/library/ms741621%28VS.85%29.aspx>`_ for more
@@ -1609,8 +1607,11 @@ to sockets.
    Currently only the following control codes are supported:
    ``SIO_RCVALL``, ``SIO_KEEPALIVE_VALS``, and ``SIO_LOOPBACK_FAST_PATH``.
 
+   .. availability:: Windows
+
    .. versionchanged:: 3.6
       ``SIO_LOOPBACK_FAST_PATH`` was added.
+
 
 .. method:: socket.listen([backlog])
 


### PR DESCRIPTION
When documenting the platforms on which an API is available, it was clarified in the discussion on gh-126686 that ["`.. availability::` is generally the correct one to use"](https://github.com/python/cpython/pull/126686#discussion_r1846505896) rather than `:platform:`.  

I was a bit confused after seeing both being used in the `socket` documentation, and I’d like to ensure that similar confusion doesn’t arise in the future.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127122.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->