### PR TITLE
Remove HAVE_STAT_H conditional

### DIFF
--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -7,8 +7,6 @@
 
 #ifdef HAVE_SYS_STAT_H
 #  include <sys/stat.h>           // S_ISREG()
-#elif defined(HAVE_STAT_H)
-#  include <stat.h>               // S_ISREG()
 #endif
 
 #ifndef S_IFMT


### PR DESCRIPTION
As far as I can tell no supported platforms use this, and the OSes it was for are 10+ years old, configure checks and sets only HAVE_SYS_STAT_H currently.

I think this is / can be both skip issue and skip news