### PR TITLE
GH-126766: `url2pathname()`: handle 'localhost' authority

### DIFF
--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -15,17 +15,17 @@ def url2pathname(url):
     # become
     #   C:\foo\bar\spam.foo
     import string, urllib.parse
+    if url[:3] == '///':
+        # URL has an empty authority section, so the path begins on the third
+        # character.
+        url = url[2:]
+    elif url[:12] == '//localhost/':
+        # Skip past 'localhost' authority.
+        url = url[11:]
     # Windows itself uses ":" even in URLs.
     url = url.replace(':', '|')
     if not '|' in url:
         # No drive specifier, just convert slashes
-        if url[:3] == '///':
-            # URL has an empty authority section, so the path begins on the
-            # third character.
-            url = url[2:]
-        elif url[:12] == '//localhost/':
-            # Skip past 'localhost' authority.
-            url = url[11:]
         # make sure not to convert quoted slashes :-)
         return urllib.parse.unquote(url.replace('/', '\\'))
     comp = url.split('|')

--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -23,6 +23,9 @@ def url2pathname(url):
             # URL has an empty authority section, so the path begins on the
             # third character.
             url = url[2:]
+        elif url[:12] == '//localhost/':
+            # Skip past 'localhost' authority.
+            url = url[11:]
         # make sure not to convert quoted slashes :-)
         return urllib.parse.unquote(url.replace('/', '\\'))
     comp = url.split('|')

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1496,6 +1496,8 @@ class Pathname_Tests(unittest.TestCase):
         # Localhost paths
         self.assertEqual(fn('//localhost/C:/path/to/file'), 'C:\\path\\to\\file')
         self.assertEqual(fn('//localhost/C|/path/to/file'), 'C:\\path\\to\\file')
+        self.assertEqual(fn('//localhost/path/to/file'), '\\path\\to\\file')
+        self.assertEqual(fn('//localhost//server/path/to/file'), '\\\\server\\path\\to\\file')
         # Percent-encoded forward slashes are preserved for backwards compatibility
         self.assertEqual(fn('C:/foo%2fbar'), 'C:\\foo/bar')
         self.assertEqual(fn('//server/share/foo%2fbar'), '\\\\server\\share\\foo/bar')
@@ -1514,7 +1516,7 @@ class Pathname_Tests(unittest.TestCase):
         self.assertEqual(fn('//foo/bar'), '//foo/bar')
         self.assertEqual(fn('///foo/bar'), '/foo/bar')
         self.assertEqual(fn('////foo/bar'), '//foo/bar')
-        self.assertEqual(fn('//localhost/foo/bar'), '//localhost/foo/bar')
+        self.assertEqual(fn('//localhost/foo/bar'), '/foo/bar')
 
     @unittest.skipUnless(os_helper.FS_NONASCII, 'need os_helper.FS_NONASCII')
     def test_url2pathname_nonascii(self):

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1657,6 +1657,9 @@ else:
             # URL has an empty authority section, so the path begins on the
             # third character.
             pathname = pathname[2:]
+        elif pathname[:12] == '//localhost/':
+            # Skip past 'localhost' authority.
+            pathname = pathname[11:]
         encoding = sys.getfilesystemencoding()
         errors = sys.getfilesystemencodeerrors()
         return unquote(pathname, encoding=encoding, errors=errors)

--- a/Misc/NEWS.d/next/Library/2024-11-22-02-31-55.gh-issue-126766.jfkhBH.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-22-02-31-55.gh-issue-126766.jfkhBH.rst
@@ -1,0 +1,2 @@
+Fix issue where :func:`urllib.request.url2pathname` failed to discard any
+'localhost' authority present in the URL.


### PR DESCRIPTION
Discard any 'localhost' authority from the beginning of a `file:` URI. As a result, file URIs like `//localhost/etc/hosts` are correctly decoded as `/etc/hosts`.

<!-- gh-issue-number: gh-126766 -->
* Issue: gh-126766
<!-- /gh-issue-number -->
