### PR TITLE
GH-127078: `url2pathname()`: handle extra slash before UNC drive in URL path

### DIFF
--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -22,6 +22,9 @@ def url2pathname(url):
     elif url[:12] == '//localhost/':
         # Skip past 'localhost' authority.
         url = url[11:]
+    if url[:3] == '///':
+        # Skip past extra slash before UNC drive in URL path.
+        url = url[1:]
     # Windows itself uses ":" even in URLs.
     url = url.replace(':', '|')
     if not '|' in url:

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1492,7 +1492,7 @@ class Pathname_Tests(unittest.TestCase):
         # UNC paths
         self.assertEqual(fn('//server/path/to/file'), '\\\\server\\path\\to\\file')
         self.assertEqual(fn('////server/path/to/file'), '\\\\server\\path\\to\\file')
-        self.assertEqual(fn('/////server/path/to/file'), '\\\\\\server\\path\\to\\file')
+        self.assertEqual(fn('/////server/path/to/file'), '\\\\server\\path\\to\\file')
         # Localhost paths
         self.assertEqual(fn('//localhost/C:/path/to/file'), 'C:\\path\\to\\file')
         self.assertEqual(fn('//localhost/C|/path/to/file'), 'C:\\path\\to\\file')

--- a/Misc/NEWS.d/next/Library/2024-11-22-03-40-02.gh-issue-127078.gI_PaP.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-22-03-40-02.gh-issue-127078.gI_PaP.rst
@@ -1,0 +1,2 @@
+Fix issue where :func:`urllib.request.url2pathname` failed to discard an
+extra slash before a UNC drive in the URL path on Windows.


### PR DESCRIPTION
Decode a file URI like `file://///server/share` as a UNC path like `\\server\share`. This form of file URI is created by software the simply prepends `file:///` to any absolute Windows path.

<!-- gh-issue-number: gh-127078 -->
* Issue: gh-127078
<!-- /gh-issue-number -->
