### PR TITLE
GH-125866: Preserve Windows drive letter case in file URIs

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -153,6 +153,9 @@ The :mod:`urllib.request` module defines the following functions:
    value will already be quoted using the :func:`~urllib.parse.quote` function.
 
    .. versionchanged:: 3.14
+      Windows drive letters are no longer converted to uppercase.
+
+   .. versionchanged:: 3.14
       On Windows, ``:`` characters not following a drive letter are quoted. In
       previous versions, :exc:`OSError` was raised if a colon character was
       found in any position other than the second character.
@@ -163,6 +166,10 @@ The :mod:`urllib.request` module defines the following functions:
    Convert the path component *path* from a percent-encoded URL to the local syntax for a
    path.  This does not accept a complete URL.  This function uses
    :func:`~urllib.parse.unquote` to decode *path*.
+
+   .. versionchanged:: 3.14
+      Windows drive letters are no longer converted to uppercase.
+
 
 .. function:: getproxies()
 

--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -35,7 +35,7 @@ def url2pathname(url):
     if len(comp) != 2 or comp[0][-1] not in string.ascii_letters:
         error = 'Bad URL: ' + url
         raise OSError(error)
-    drive = comp[0][-1].upper()
+    drive = comp[0][-1]
     tail = urllib.parse.unquote(comp[1].replace('/', '\\'))
     return drive + ':' + tail
 
@@ -60,7 +60,7 @@ def pathname2url(p):
         # DOS drive specified. Add three slashes to the start, producing
         # an authority section with a zero-length authority, and a path
         # section starting with a single slash.
-        drive = f'///{drive.upper()}'
+        drive = f'///{drive}'
 
     drive = urllib.parse.quote(drive, safe='/:')
     tail = urllib.parse.quote(tail)

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1423,6 +1423,7 @@ class Pathname_Tests(unittest.TestCase):
         self.assertEqual(fn('\\\\?\\unc\\server\\share\\dir'), '//server/share/dir')
         self.assertEqual(fn("C:"), '///C:')
         self.assertEqual(fn("C:\\"), '///C:/')
+        self.assertEqual(fn('c:\\a\\b.c'), '///c:/a/b.c')
         self.assertEqual(fn('C:\\a\\b.c'), '///C:/a/b.c')
         self.assertEqual(fn('C:\\a\\b.c\\'), '///C:/a/b.c/')
         self.assertEqual(fn('C:\\a\\\\b.c'), '///C:/a//b.c')
@@ -1480,6 +1481,7 @@ class Pathname_Tests(unittest.TestCase):
         self.assertEqual(fn("///C/test/"), '\\C\\test\\')
         self.assertEqual(fn("////C/test/"), '\\\\C\\test\\')
         # DOS drive paths
+        self.assertEqual(fn('c:/path/to/file'), 'c:\\path\\to\\file')
         self.assertEqual(fn('C:/path/to/file'), 'C:\\path\\to\\file')
         self.assertEqual(fn('C:/path/to/file/'), 'C:\\path\\to\\file\\')
         self.assertEqual(fn('C:/path/to//file'), 'C:\\path\\to\\\\file')

--- a/Misc/NEWS.d/next/Library/2024-11-22-04-49-31.gh-issue-125866.TUtvPK.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-22-04-49-31.gh-issue-125866.TUtvPK.rst
@@ -1,0 +1,2 @@
+:func:`urllib.request.pathname2url` and :func:`~urllib.request.url2pathname`
+no longer convert Windows drive letters to uppercase.


### PR DESCRIPTION
Stop converting Windows drive letters to uppercase in `urllib.request.pathname2url()` and `url2pathname()`. This behaviour is unexpected and inconsistent with pathlib's file URI implementation.


<!-- gh-issue-number: gh-125866 -->
* Issue: gh-125866
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127138.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->