### PR TITLE
Fix for broken xml

### DIFF
--- a/PCbuild/_freeze_module.vcxproj.filters
+++ b/PCbuild/_freeze_module.vcxproj.filters
@@ -239,6 +239,8 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\Python\instruction_sequence.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\Python\interpconfig.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
# Fix for broken xml

```
Structure of PCBuild/_freeze_module.vcxproj.filters was fixed.
```