### PR TITLE
Fix open bracket in invalid_parameter_handle.c

### DIFF
--- a/PC/invalid_parameter_handler.c
+++ b/PC/invalid_parameter_handler.c
@@ -16,6 +16,7 @@ static void __cdecl _silent_invalid_parameter_handler(
     uintptr_t pReserved) { }
 
 _invalid_parameter_handler _Py_silent_invalid_parameter_handler = _silent_invalid_parameter_handler;
+)
 
 #endif
 


### PR DESCRIPTION

# Fix typo in invalid_parameter_handle.c
It should be in the following format:

Fixed the missing closing bracket in invalid_parameter_handle.c, making sure invalid parameters are handled better.
(This is a very small PR)
