### PR TITLE
GH-126795: Increase the JIT side-exit threshold from 64 to 4096

### DIFF
--- a/Include/internal/pycore_backoff.h
+++ b/Include/internal/pycore_backoff.h
@@ -115,10 +115,9 @@ initial_jump_backoff_counter(void)
 /* Initial exit temperature.
  * Must be larger than ADAPTIVE_COOLDOWN_VALUE,
  * otherwise when a side exit warms up we may construct
- * a new trace before the Tier 1 code has properly re-specialized.
- * Backoff sequence 1024, 2048, 4096. */
-#define SIDE_EXIT_INITIAL_VALUE 1023
-#define SIDE_EXIT_INITIAL_BACKOFF 10
+ * a new trace before the Tier 1 code has properly re-specialized. */
+#define SIDE_EXIT_INITIAL_VALUE 4095
+#define SIDE_EXIT_INITIAL_BACKOFF 12
 
 static inline _Py_BackoffCounter
 initial_temperature_backoff_counter(void)

--- a/Include/internal/pycore_backoff.h
+++ b/Include/internal/pycore_backoff.h
@@ -116,9 +116,9 @@ initial_jump_backoff_counter(void)
  * Must be larger than ADAPTIVE_COOLDOWN_VALUE,
  * otherwise when a side exit warms up we may construct
  * a new trace before the Tier 1 code has properly re-specialized.
- * Backoff sequence 256, 512, 1024, 2048, 4096. */
-#define SIDE_EXIT_INITIAL_VALUE 255
-#define SIDE_EXIT_INITIAL_BACKOFF 8
+ * Backoff sequence 1024, 2048, 4096. */
+#define SIDE_EXIT_INITIAL_VALUE 1023
+#define SIDE_EXIT_INITIAL_BACKOFF 10
 
 static inline _Py_BackoffCounter
 initial_temperature_backoff_counter(void)

--- a/Include/internal/pycore_backoff.h
+++ b/Include/internal/pycore_backoff.h
@@ -116,9 +116,9 @@ initial_jump_backoff_counter(void)
  * Must be larger than ADAPTIVE_COOLDOWN_VALUE,
  * otherwise when a side exit warms up we may construct
  * a new trace before the Tier 1 code has properly re-specialized.
- * Backoff sequence 64, 128, 256, 512, 1024, 2048, 4096. */
-#define SIDE_EXIT_INITIAL_VALUE 63
-#define SIDE_EXIT_INITIAL_BACKOFF 6
+ * Backoff sequence 256, 512, 1024, 2048, 4096. */
+#define SIDE_EXIT_INITIAL_VALUE 255
+#define SIDE_EXIT_INITIAL_BACKOFF 8
 
 static inline _Py_BackoffCounter
 initial_temperature_backoff_counter(void)


### PR DESCRIPTION
This should be covered by the NEWS entry in GH-126816. Looks like a ~0.5% speedup and ~0.5% memory savings, so nothing too dramatic there. Only 1/3 as many traces created though, with no change to the number of uops executed, so the memory and time we're saving does seem like it's completely wasted currently ([stats](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20241120-3.14.0a2%2B-bba66e4-JIT/README.md)).

I'm running benchmarks across all platforms now.

<!-- gh-issue-number: gh-126795 -->
* Issue: gh-126795
<!-- /gh-issue-number -->
