### PR TITLE
gh-86463: Fix a trailing space in argparse.rst

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -195,7 +195,7 @@ your usage messages.
 When a custom usage message is specified for the main parser, you may also want to
 consider passing  the ``prog`` argument to :meth:`~ArgumentParser.add_subparsers`
 or the ``prog`` and the ``usage`` arguments to
-:meth:`~_SubParsersAction.add_parser`, to ensure consistent command prefixes and 
+:meth:`~_SubParsersAction.add_parser`, to ensure consistent command prefixes and
 usage information across subparsers.
 
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-86463 -->
* Issue: gh-86463
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127162.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->