### PR TITLE
GH-115869: Make `jit_stencils.h` reproducible

### DIFF
--- a/Misc/NEWS.d/next/Build/2024-11-22-08-46-46.gh-issue-115869.UVLSKd.rst
+++ b/Misc/NEWS.d/next/Build/2024-11-22-08-46-46.gh-issue-115869.UVLSKd.rst
@@ -1,0 +1,1 @@
+Make ``jit_stencils.h`` (which is produced during JIT builds) reproducible.

--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -202,7 +202,8 @@ class Stencil:
         """Pad the stencil to the given alignment."""
         offset = len(self.body)
         padding = -offset % alignment
-        self.disassembly.append(f"{offset:x}: {' '.join(['00'] * padding)}")
+        if padding:
+            self.disassembly.append(f"{offset:x}: {' '.join(['00'] * padding)}")
         self.body.extend([0] * padding)
 
     def remove_jump(self, *, alignment: int = 1) -> None:

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -180,7 +180,6 @@ class _Target(typing.Generic[_S, _R]):
             )
         return stencil_groups
 
-
     def build(
         self, out: pathlib.Path, *, comment: str = "", force: bool = False
     ) -> None:

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -171,10 +171,6 @@ class _Target(typing.Generic[_S, _R]):
                     tasks.append(group.create_task(coro, name=opname))
         stencil_groups = {task.get_name(): task.result() for task in tasks}
         for stencil_group in stencil_groups.values():
-            # TODO: Get rid of this once we always have a trampoline (LLVM 19):
-            if not stencil_group.code.body:
-                continue
-            # TODO: Make this (and the other method it calls) a method on _Target:
             stencil_group.process_relocations(
                 known_symbols=self.known_symbols, alignment=self.alignment
             )

--- a/Tools/jit/_writer.py
+++ b/Tools/jit/_writer.py
@@ -77,6 +77,6 @@ def dump(
     groups: dict[str, _stencils.StencilGroup], symbols: dict[str, int]
 ) -> typing.Iterator[str]:
     """Yield a JIT compiler line-by-line as a C header file."""
-    for opname, group in sorted(groups.items()):
+    for opname, group in groups.items():
         yield from _dump_stencil(opname, group)
     yield from _dump_footer(groups, symbols)

--- a/Tools/jit/build.py
+++ b/Tools/jit/build.py
@@ -8,7 +8,7 @@ import sys
 import _targets
 
 if __name__ == "__main__":
-    comment = f"$ {shlex.join([sys.executable] + sys.argv)}"
+    comment = f"$ {shlex.join([pathlib.Path(sys.executable).name] + sys.argv)}"
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "target", type=_targets.get_target, help="a PEP 11 target triple to compile for"


### PR DESCRIPTION
At the core dev sprint, we discussed the possibility of hosting pre-built `jit_stencils.h` files for common platforms and build configurations.

While there's a lot of work involved in making that happen (I'll post a rough plan shortly), this is the first logical step in that direction. This PR replaces absolute file paths in the generated code with relative ones, and processes stencils in sorted order.



<!-- gh-issue-number: gh-115869 -->
* Issue: gh-115869
<!-- /gh-issue-number -->
