### PR TITLE
gh-115999: Record success in `specialize`

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -715,6 +715,7 @@ specialize(_Py_CODEUNIT *instr, uint8_t specialized_opcode)
                             SPEC_FAIL_OTHER);
         return;
     }
+    STAT_INC(_PyOpcode_Deopt[specialized_opcode], success);
     set_counter((_Py_BackoffCounter *)instr + 1, adaptive_counter_cooldown());
 }
 


### PR DESCRIPTION
This matches the existing behavior where we increment the success stat for the generic opcode each time we successfully specialize an instruction.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-115999 -->
* Issue: gh-115999
<!-- /gh-issue-number -->
