### PR TITLE
[3.13] Enable aarch64 Ubuntu CI jobs (GH-125786)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,16 +193,28 @@ jobs:
     needs: check_source
     if: fromJSON(needs.check_source.outputs.run_tests)
     strategy:
+      fail-fast: false
       matrix:
+        os:
+          - windows-latest
         arch:
-        - Win32
-        - x64
-        - arm64
+          - x64
         free-threading:
-        - false
-        - true
+          - false
+          - true
+        include:
+          - os: windows-latest # FIXME(diegorusso): change to os: windows-aarch64
+            arch: arm64
+            free-threading: false
+          - os: windows-latest # FIXME(diegorusso): change to os: windows-aarch64
+            arch: arm64
+            free-threading: true
+          - os: windows-latest
+            arch: Win32
+            free-threading: false
     uses: ./.github/workflows/reusable-windows.yml
     with:
+      os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       free-threading: ${{ matrix.free-threading }}
 

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-24.04, ubuntu-24.04-aarch64]
     env:
       FORCE_COLOR: 1
       OPENSSL_VER: 3.0.15
@@ -79,7 +79,7 @@ jobs:
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
     - name: Build CPython out-of-tree
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
-      run: make -j4
+      run: make -j
     - name: Display build info
       working-directory: ${{ env.CPYTHON_BUILDDIR }}
       run: make pythoninfo

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -3,6 +3,10 @@ name: Reusable Windows
 on:
   workflow_call:
     inputs:
+      os:
+        description: OS to run on
+        required: true
+        type: string
       arch:
         description: CPU architecture
         required: true
@@ -19,10 +23,8 @@ env:
 
 jobs:
   build:
-    name: >-
-      build${{ inputs.arch != 'arm64' && ' and test' || '' }}
-      (${{ inputs.arch }})
-    runs-on: windows-latest
+    name: 'build and test (${{ inputs.arch }})'
+    runs-on: ${{ inputs.os }}
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
@@ -31,17 +33,17 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
       run: >-
-        .\PCbuild\build.bat
+        .\\PCbuild\\build.bat
         -e -d -v
         -p ${{ inputs.arch }}
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
-    - name: Display build info
+    - name: Display build info  # FIXME(diegorusso): remove the `if`
       if: inputs.arch != 'arm64'
-      run: .\python.bat -m test.pythoninfo
-    - name: Tests
+      run: .\\python.bat -m test.pythoninfo
+    - name: Tests  # FIXME(diegorusso): remove the `if`
       if: inputs.arch != 'arm64'
       run: >-
-        .\PCbuild\rt.bat
+        .\\PCbuild\\rt.bat
         -p ${{ inputs.arch }}
         -d -q --fast-ci
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}


### PR DESCRIPTION
This change enables custom GHA runners for Ubuntu-24.04 that run on Arm hardware. It also prepares for Windows runners on Arm hardware, but doesn't enable that just yet, because the Arm GHA runner images for Windows need to be updated. (cherry picked from commit 8214e0f709010a0e1fa06dc2ce004b5f6103cc6b)
