### PR TITLE
gh-127183: Add `_ctypes.CopyComPointer` tests

### DIFF
--- a/Lib/test/test_ctypes/test_win32_com_foreign_func.py
+++ b/Lib/test/test_ctypes/test_win32_com_foreign_func.py
@@ -240,7 +240,7 @@ class CopyComPointerTests(unittest.TestCase):
         dst_orig = create_shelllink_persist(self.IPersist)
         dst = self.IPersist()
         CopyComPointer(dst_orig, byref(dst))
-        dst_orig.Release()  # The refcount of `dst_orig` is 1 here.
+        self.assertEqual(1, dst_orig.Release())
 
         clsid = dst.GetClassID()
         self.assertEqual(TRUE, is_equal_guid(CLSID_ShellLink, clsid))
@@ -262,7 +262,7 @@ class CopyComPointerTests(unittest.TestCase):
         dst_orig = create_shelllink_persist(self.IPersist)
         dst = self.IPersist()
         CopyComPointer(dst_orig, byref(dst))
-        dst_orig.Release()
+        self.assertEqual(1, dst_orig.Release())
 
         self.assertEqual(dst.value, dst_orig.value)
         self.assertNotEqual(src.value, dst.value)


### PR DESCRIPTION
I would like to backport this to 3.12 and 3.13 as well.
This is internal-only, so I don’t think it needs a NEWS entry.

<!-- gh-issue-number: gh-127183 -->
* Issue: gh-127183
<!-- /gh-issue-number -->
