### PR TITLE
[3.12] Fix a few typos found in the docs (GH-127126)

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -133,7 +133,7 @@ Entry points
 
    Details of a collection of installed entry points.
 
-   Also provides a ``.groups`` attribute that reports all identifed entry
+   Also provides a ``.groups`` attribute that reports all identified entry
    point groups, and a ``.names`` attribute that reports all identified entry
    point names.
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -282,7 +282,7 @@ processes:
    of corruption from processes using different ends of the pipe at the same
    time.
 
-   The :meth:`~Connection.send` method serializes the the object and
+   The :meth:`~Connection.send` method serializes the object and
    :meth:`~Connection.recv` re-creates the object.
 
 Synchronization between processes
@@ -819,7 +819,7 @@ For an example of the usage of queues for interprocess communication see
    used for receiving messages and ``conn2`` can only be used for sending
    messages.
 
-   The :meth:`~multiprocessing.Connection.send` method serializes the the object using
+   The :meth:`~multiprocessing.Connection.send` method serializes the object using
    :mod:`pickle` and the :meth:`~multiprocessing.Connection.recv` re-creates the object.
 
 .. class:: Queue([maxsize])

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -966,7 +966,7 @@ The :mod:`socket` module also offers various network-related services:
       These addresses should generally be tried in order until a connection succeeds
       (possibly tried in parallel, for example, using a `Happy Eyeballs`_ algorithm).
       In these cases, limiting the *type* and/or *proto* can help eliminate
-      unsuccessful or unusable connecton attempts.
+      unsuccessful or unusable connection attempts.
 
       Some systems will, however, only return a single address.
       (For example, this was reported on Solaris and AIX configurations.)


### PR DESCRIPTION
(cherry picked from commit 39e60aeb3837f1f23d8b7f30d3b8d9faf805ef88)

Co-authored-by: Rafael Fontenelle <rffontenelle@users.noreply.github.com>

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127185.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->