### PR TITLE
gh-127187: Set correct `__module__` attribute for methods of named tuple types

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -448,15 +448,13 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
     if defaults is not None:
         __new__.__defaults__ = defaults
 
-    @classmethod
-    def _make(cls, iterable):
+    def _make(cls, iterable):  # will be wrapped as classmethod below
         result = tuple_new(cls, iterable)
         if _len(result) != num_fields:
             raise TypeError(f'Expected {num_fields} arguments, got {len(result)}')
         return result
 
-    _make.__func__.__doc__ = (f'Make a new {typename} object from a sequence '
-                              'or iterable')
+    _make.__doc__ = f'Make a new {typename} object from a sequence or iterable'
 
     def _replace(self, /, **kwds):
         result = self._make(_map(kwds.pop, field_names, self))
@@ -496,7 +494,7 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
     # Modify function metadata to help with introspection and debugging
     methods = (
         __new__,
-        _make.__func__,
+        _make,
         _replace,
         __repr__,
         _asdict,
@@ -515,7 +513,7 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
         '_fields': field_names,
         '_field_defaults': field_defaults,
         '__new__': __new__,
-        '_make': _make,
+        '_make': classmethod(_make),
         '__replace__': _replace,
         '_replace': _replace,
         '__repr__': __repr__,

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -503,7 +503,8 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
     for method in methods:
         method.__qualname__ = f'{typename}.{method.__name__}'
     if module is not None:
-        method.__module__ = module
+        for method in methods:
+            method.__module__ = module
 
     # Build-up the class namespace dictionary
     # and use type() to build the result class

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -468,6 +468,21 @@ class TestNamedTuple(unittest.TestCase):
         NT = namedtuple('NT', ['x', 'y'], module=collections)
         self.assertEqual(NT.__module__, collections)
 
+    def test_module_attribute(self):
+        method_names = (
+            '__new__',
+            '_make',
+            '_replace',
+            '__repr__',
+            '_asdict',
+            '__getnewargs__',
+        )
+        for module in ('some.module', collections):
+            NT = namedtuple('NT', ['x', 'y'], module=module)
+            self.assertEqual(NT.__module__, module)
+            for method in method_names:
+                self.assertEqual(getattr(NT, method).__module__, module)
+
     def test_instance(self):
         Point = namedtuple('Point', 'x y')
         p = Point(11, 22)

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -468,6 +468,8 @@ class TestNamedTuple(unittest.TestCase):
         NT = namedtuple('NT', ['x', 'y'], module=collections)
         self.assertEqual(NT.__module__, collections)
 
+    @unittest.skipUnless(hasattr(sys, '_getframemodulename') or hasattr(sys, '_getframe'),
+                         "Maybe cannot get the module name from the frame.")
     def test_module_attribute(self):
         method_names = (
             '__new__',

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -479,8 +479,10 @@ class TestNamedTuple(unittest.TestCase):
             '_asdict',
             '__getnewargs__',
         )
-        for module in ('some.module', collections):
+        for module in (None, 'some.module', collections):
             NT = namedtuple('NT', ['x', 'y'], module=module)
+            if module is None:
+                module = __name__
             self.assertEqual(NT.__module__, module)
             for method in method_names:
                 self.assertEqual(getattr(NT, method).__module__, module)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7839,6 +7839,20 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(Emp.__annotations__,
                          collections.OrderedDict([('name', str), ('id', int)]))
 
+    def test_module_attribute(self):
+        method_names = (
+            '__new__',
+            '_make',
+            '_replace',
+            '__repr__',
+            '_asdict',
+            '__getnewargs__',
+        )
+        for nt in (CoolEmployee, self.NestedEmployee):
+            self.assertEqual(nt.__module__, __name__)
+            for method in method_names:
+                self.assertEqual(getattr(nt, method).__module__, __name__)
+
     def test_annotation_usage(self):
         tim = CoolEmployee('Tim', 9000)
         self.assertIsInstance(tim, CoolEmployee)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -12,7 +12,7 @@ import os
 import pickle
 import re
 import sys
-from unittest import TestCase, main, skip
+from unittest import TestCase, main, skip, skipUnless
 from unittest.mock import patch
 from copy import copy, deepcopy
 
@@ -7839,6 +7839,8 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(Emp.__annotations__,
                          collections.OrderedDict([('name', str), ('id', int)]))
 
+    @skipUnless(hasattr(sys, '_getframemodulename') or hasattr(sys, '_getframe'),
+                "Maybe cannot get the module name from the frame.")
     def test_module_attribute(self):
         method_names = (
             '__new__',

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1389,6 +1389,7 @@ Todd R. Palmer
 Juan David Ibáñez Palomar
 Nicola Palumbo
 Jan Palus
+Xuehai Pan
 Yongzhi Pan
 Martin Panter
 Mathias Panzenböck

--- a/Misc/NEWS.d/next/Library/2024-11-23-05-55-03.gh-issue-127187.ruRv7S.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-23-05-55-03.gh-issue-127187.ruRv7S.rst
@@ -1,0 +1,1 @@
+Set correct ``__module__`` attribute for methods of named tuple types. Patch by Xuehai Pan.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Set correct `__module__` attribute for methods of named tuple types.

Fixes #127187

<!-- gh-issue-number: gh-127187 -->
* Issue: gh-127187
<!-- /gh-issue-number -->
