### PR TITLE
gh-126399 add test of turtle module's RawTurtle.clone()

### DIFF
--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -466,6 +466,20 @@ class TestTPen(unittest.TestCase):
             self.assertTrue(tpen.isdown())
 
 
+
+class TestRawTurtle(unittest.TestCase):
+    def setUp(self):
+        try:
+            self.screen = turtle.Screen()
+        except turtle.TK.TclError:
+            raise unittest.SkipTest() # cannot instantiate RawTurtle without a screen
+
+    def test_clone(self):
+        rawturtle = turtle.RawTurtle(self.screen)
+        another_turtle = rawturtle.clone()
+        self.assertEqual(another_turtle.currentLineItem, another_turtle.items[-1])
+        self.assertFalse(rawturtle.currentLineItem in another_turtle.items)
+
 class TestTurtleScreen(unittest.TestCase):
     def test_save_raises_if_wrong_extension(self) -> None:
         screen = unittest.mock.Mock()

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -466,7 +466,6 @@ class TestTPen(unittest.TestCase):
             self.assertTrue(tpen.isdown())
 
 
-
 class TestRawTurtle(unittest.TestCase):
     def setUp(self):
         try:
@@ -479,6 +478,7 @@ class TestRawTurtle(unittest.TestCase):
         another_turtle = rawturtle.clone()
         self.assertEqual(another_turtle.currentLineItem, another_turtle.items[-1])
         self.assertFalse(rawturtle.currentLineItem in another_turtle.items)
+
 
 class TestTurtleScreen(unittest.TestCase):
     def test_save_raises_if_wrong_extension(self) -> None:


### PR DESCRIPTION
The corresponding issue proposes a modification on turtle module's RawTurtle.clone() function.

Specifically, items of cloned RawTurtle object to have its own currentLineItem, and not the currentLineItem of the original.

This test checks the items of cloned RawTurtle to meet the proposal.



The test is expected to fail without #126401 and pass with it.

The test is skipped when Tk/Tcl is not supported.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-126399 -->
* Issue: gh-126399
<!-- /gh-linked-prs -->
* Related PR: gh-126401
