### PR TITLE
gh-127165: Disallow embedded NULL characters in `_interpreters`

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -1649,6 +1649,10 @@ class LowLevelTests(TestBase):
             self.assertIs(after2, None)
             self.assertEqual(after3.type.__name__, 'AssertionError')
 
+            with self.assertRaises(ValueError):
+                # GH-127165: Embedded NULL characters broke the lookup
+                _interpreters.set___main___attrs(interpid, {"\x00": 1})
+
         with self.subTest('from C-API'):
             with self.interpreter_from_capi() as interpid:
                 with self.assertRaisesRegex(InterpreterError, 'unrecognized'):

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -342,8 +342,7 @@ _copy_string_obj_raw(PyObject *strobj, Py_ssize_t *p_size)
         return NULL;
     }
 
-    if (size != (Py_ssize_t) strlen(str))
-    {
+    if (size != (Py_ssize_t)strlen(str)) {
         PyErr_SetString(PyExc_ValueError, "found embedded NULL character");
         return NULL;
     }

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -342,6 +342,12 @@ _copy_string_obj_raw(PyObject *strobj, Py_ssize_t *p_size)
         return NULL;
     }
 
+    if (size != (Py_ssize_t) strlen(str))
+    {
+        PyErr_SetString(PyExc_ValueError, "found embedded NULL character");
+        return NULL;
+    }
+
     char *copied = PyMem_RawMalloc(size+1);
     if (copied == NULL) {
         PyErr_NoMemory();


### PR DESCRIPTION
Currently, null characters in shared namespaces cause truncation of the actual string, because it's eventually passed to `PyUnicode_FromString`, which uses the `strlen` instead of the actual size. Then, things break because the string unexpectedly is not in the namespace dictionary. This fixes that by just raising if we find an embedded NULL character in `_copy_string_obj_raw`.

We *could* support embedded NULLs by storing the size alongside the name, but this is much simpler (and in practice, nobody is trying to name variables containing `\x00`).

<!-- gh-issue-number: gh-127165 -->
* Issue: gh-127165
<!-- /gh-issue-number -->
