### PR TITLE
gh-126172: Fix a misleading statement in PYTHON_BASIC_REPL documentation

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -1203,7 +1203,7 @@ conflict.
 
 .. envvar:: PYTHON_BASIC_REPL
 
-   If this variable is set to ``1``, the interpreter will not attempt to
+   If this variable is set to any value, the interpreter will not attempt to
    load the Python-based :term:`REPL` that requires :mod:`curses` and
    :mod:`readline`, and will instead use the traditional parser-based
    :term:`REPL`.


### PR DESCRIPTION


<!-- gh-issue-number: gh-126172 -->
* Issue: gh-126172
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127203.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->