### PR TITLE
Reformat paragraphs, add backquotes, and add directives to (parts of) `ctypes` doc.

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -2036,7 +2036,7 @@ Utility functions
 .. function:: FormatError([code])
 
    Returns a textual description of the error code *code*.  If no error code is
-   specified, the last error code is used by calling the Windows api function
+   specified, the last error code is used by calling the Windows API function
    :func:`GetLastError`.
 
    .. availability:: Windows
@@ -2142,10 +2142,10 @@ Utility functions
 
 .. function:: WinError(code=None, descr=None)
 
-   This function is probably the worst-named thing in ``ctypes``. It creates an
-   instance of :exc:`OSError`.  If *code* is not specified, :func:`GetLastError`
-   is called to determine the error code. If *descr* is not specified,
-   :func:`FormatError` is called to get a textual description of the error.
+   Creates an instance of :exc:`OSError`.  If *code* is not specified,
+   ``GetLastError`` is called to determine the error code. If *descr* is not
+   specified, :func:`FormatError` is called to get a textual description of the
+   error.
 
    .. availability:: Windows
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1992,28 +1992,20 @@ Utility functions
 
 .. function:: DllCanUnloadNow()
 
-   This function is a hook which allows implementing in-process COM servers with
-   ``ctypes``.  It is called from the ``DllCanUnloadNow`` function that the
-   ``_ctypes`` extension dll exports.
+   This function is a hook which allows implementing in-process
+   COM servers with ctypes.  It is called from the DllCanUnloadNow function that
+   the _ctypes extension dll exports.
 
    .. availability:: Windows
-
-   .. seealso::
-
-      `DllCanUnloadNow function official documentation <https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-dllcanunloadnow>`_
 
 
 .. function:: DllGetClassObject()
 
-   This function is a hook which allows implementing in-process COM servers with
-   ``ctypes``.  It is called from the ``DllGetClassObject`` function that the
-   ``_ctypes`` extension dll exports.
+   This function is a hook which allows implementing in-process
+   COM servers with ctypes.  It is called from the DllGetClassObject function
+   that the ``_ctypes`` extension dll exports.
 
    .. availability:: Windows
-
-   .. seealso::
-
-      `DllGetClassObject function official documentation <https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-dllgetclassobject>`_
 
 
 .. function:: find_library(name)

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -2151,7 +2151,7 @@ Utility functions
 .. function:: WinError(code=None, descr=None)
 
    Creates an instance of :exc:`OSError`.  If *code* is not specified,
-   ``GetLastError`` is called to determine the error code. If *descr* is not
+   :func:`GetLastError` is called to determine the error code. If *descr* is not
    specified, :func:`FormatError` is called to get a textual description of the
    error.
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1992,18 +1992,18 @@ Utility functions
 
 .. function:: DllCanUnloadNow()
 
-   This function is a hook which allows implementing in-process
-   COM servers with ctypes.  It is called from the DllCanUnloadNow function that
-   the _ctypes extension dll exports.
+   This function is a hook which allows implementing in-process COM servers with
+   ``ctypes``.  It is called from the ``DllCanUnloadNow`` function that the
+   ``_ctypes`` extension dll exports.
 
    .. availability:: Windows
 
 
 .. function:: DllGetClassObject()
 
-   This function is a hook which allows implementing in-process
-   COM servers with ctypes.  It is called from the DllGetClassObject function
-   that the ``_ctypes`` extension dll exports.
+   This function is a hook which allows implementing in-process COM servers with
+   ``ctypes``.  It is called from the ``DllGetClassObject`` function that the
+   ``_ctypes`` extension dll exports.
 
    .. availability:: Windows
 
@@ -2035,9 +2035,9 @@ Utility functions
 
 .. function:: FormatError([code])
 
-   Returns a textual description of the error code *code*.  If no
-   error code is specified, the last error code is used by calling the Windows
-   api function GetLastError.
+   Returns a textual description of the error code *code*.  If no error code is
+   specified, the last error code is used by calling the Windows api function
+   :func:`GetLastError`.
 
    .. availability:: Windows
 
@@ -2142,11 +2142,10 @@ Utility functions
 
 .. function:: WinError(code=None, descr=None)
 
-   This function is probably the worst-named thing in ctypes. It
-   creates an instance of :exc:`OSError`.  If *code* is not specified,
-   ``GetLastError`` is called to determine the error code. If *descr* is not
-   specified, :func:`FormatError` is called to get a textual description of the
-   error.
+   This function is probably the worst-named thing in ``ctypes``. It creates an
+   instance of :exc:`OSError`.  If *code* is not specified, :func:`GetLastError`
+   is called to determine the error code. If *descr* is not specified,
+   :func:`FormatError` is called to get a textual description of the error.
 
    .. availability:: Windows
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1998,6 +1998,10 @@ Utility functions
 
    .. availability:: Windows
 
+   .. seealso::
+
+      `DllCanUnloadNow function official documentation <https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-dllcanunloadnow>`_
+
 
 .. function:: DllGetClassObject()
 
@@ -2006,6 +2010,10 @@ Utility functions
    ``_ctypes`` extension dll exports.
 
    .. availability:: Windows
+
+   .. seealso::
+
+      `DllGetClassObject function official documentation <https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-dllgetclassobject>`_
 
 
 .. function:: find_library(name)


### PR DESCRIPTION
In gh-127099, I reverted the reformatting paragraphs, leaving the lines in an unorganized state.

I noticed that in the recent documentation, certain parts that should be enclosed in backquotes or use directives were not properly formatted in the `ctypes` documentation.

I found similar parts in other sections, but for now, I focused on improving only the sections related to gh-127099.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127210.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->