### PR TITLE
gh-127217: Fix pathname2url() for paths starting with multiple slashes on Posix

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1458,6 +1458,9 @@ class Pathname_Tests(unittest.TestCase):
         fn = urllib.request.pathname2url
         self.assertEqual(fn('/'), '/')
         self.assertEqual(fn('/a/b.c'), '/a/b.c')
+        self.assertEqual(fn('//a/b.c'), '////a/b.c')
+        self.assertEqual(fn('///a/b.c'), '/////a/b.c')
+        self.assertEqual(fn('////a/b.c'), '//////a/b.c')
         self.assertEqual(fn('/a/b%#c'), '/a/b%25%23c')
 
     @unittest.skipUnless(os_helper.FS_NONASCII, 'need os_helper.FS_NONASCII')

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1667,6 +1667,10 @@ else:
     def pathname2url(pathname):
         """OS-specific conversion from a file system path to a relative URL
         of the 'file' scheme; not recommended for general use."""
+        if pathname[:2] == '//':
+            # Add explicitly empty authority to avoid interpreting the path
+            # as authority.
+            pathname = '//' + pathname
         encoding = sys.getfilesystemencoding()
         errors = sys.getfilesystemencodeerrors()
         return quote(pathname, encoding=encoding, errors=errors)

--- a/Misc/NEWS.d/next/Library/2024-11-24-12-41-31.gh-issue-127217.UAXGFr.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-24-12-41-31.gh-issue-127217.UAXGFr.rst
@@ -1,0 +1,2 @@
+Fix :func:`urllib.request.pathname2url` for paths starting with multiple
+slashes on Posix.


### PR DESCRIPTION


<!-- gh-issue-number: gh-127217 -->
* Issue: gh-127217
<!-- /gh-issue-number -->
