### PR TITLE
gh-127182: Fix `io.StringIO.__setstate__` crash when `None` is the first value

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -1149,7 +1149,7 @@ class TestIOCTypes(unittest.TestCase):
         support.check_disallow_instantiation(self, _io._BytesIOBuffer)
 
     def test_stringio_setstate(self):
-        # See https://github.com/python/cpython/issues/127182
+        # gh-127182: Calling __setstate__() with invalid arguments must not crash
         obj = self._io.StringIO()
         with self.assertRaisesRegex(
             TypeError,

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -1148,6 +1148,21 @@ class TestIOCTypes(unittest.TestCase):
         _io = self._io
         support.check_disallow_instantiation(self, _io._BytesIOBuffer)
 
+    def test_stringio_setstate(self):
+        # See https://github.com/python/cpython/issues/127182
+        obj = self._io.StringIO()
+        with self.assertRaisesRegex(
+            TypeError,
+            'initial_value must be str or None, not int',
+        ):
+            obj.__setstate__((1, '', 0, {}))
+
+        obj.__setstate__((None, '', 0, {}))  # should not crash
+        self.assertEqual(obj.getvalue(), '')
+
+        obj.__setstate__(('', '', 0, {}))
+        self.assertEqual(obj.getvalue(), '')
+
 class PyIOTest(IOTest):
     pass
 

--- a/Misc/NEWS.d/next/Library/2024-11-24-14-20-17.gh-issue-127182.WmfY2g.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-24-14-20-17.gh-issue-127182.WmfY2g.rst
@@ -1,0 +1,2 @@
+Fix :meth:`!io.StringIO.__setstate__` crash, when :const`None` was passed as
+the first value.

--- a/Misc/NEWS.d/next/Library/2024-11-24-14-20-17.gh-issue-127182.WmfY2g.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-24-14-20-17.gh-issue-127182.WmfY2g.rst
@@ -1,2 +1,2 @@
-Fix :meth:`!io.StringIO.__setstate__` crash, when :const`None` was passed as
+Fix :meth:`!io.StringIO.__setstate__` crash, when :const:`None` was passed as
 the first value.

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -908,23 +908,25 @@ _io_StringIO___setstate___impl(stringio *self, PyObject *state)
        once by __init__. So we do not take any chance and replace object's
        buffer completely. */
     {
-        PyObject *item;
-        Py_UCS4 *buf;
-        Py_ssize_t bufsize;
+        PyObject *item = PyTuple_GET_ITEM(state, 0);
+        if (PyUnicode_Check(item)) {
+            Py_UCS4 *buf = PyUnicode_AsUCS4Copy(item);
+            if (buf == NULL)
+                return NULL;
+            Py_ssize_t bufsize = PyUnicode_GET_LENGTH(item);
 
-        item = PyTuple_GET_ITEM(state, 0);
-        buf = PyUnicode_AsUCS4Copy(item);
-        if (buf == NULL)
-            return NULL;
-        bufsize = PyUnicode_GET_LENGTH(item);
-
-        if (resize_buffer(self, bufsize) < 0) {
+            if (resize_buffer(self, bufsize) < 0) {
+                PyMem_Free(buf);
+                return NULL;
+            }
+            memcpy(self->buf, buf, bufsize * sizeof(Py_UCS4));
             PyMem_Free(buf);
-            return NULL;
+            self->string_size = bufsize;
         }
-        memcpy(self->buf, buf, bufsize * sizeof(Py_UCS4));
-        PyMem_Free(buf);
-        self->string_size = bufsize;
+        else {
+            assert(item == Py_None);
+            self->string_size = 0;
+        }
     }
 
     /* Set carefully the position value. Alternatively, we could use the seek


### PR DESCRIPTION
Change:
- We now check for explicit `None` value in `__setstate__`, it cannot be recieved normally, because `__getstate__` never returns `None`, but we should not let a simple direct call to crash, when the fix is rather simple
- Why does it happen in the first place? Because we do the input validation with `__init__` method: https://github.com/python/cpython/blob/f7bb658124aba74be4c13f498bf46cfded710ef9/Modules/_io/stringio.c#L898
- But, `None` is an allowed input value, see https://github.com/python/cpython/blob/f7bb658124aba74be4c13f498bf46cfded710ef9/Modules/_io/stringio.c#L693
- We did not check for `None` in `__setstate__`
- `NULL` cannot be passed to `__setstate__`, because it requires a `tuple` input

<!-- gh-issue-number: gh-127182 -->
* Issue: gh-127182
<!-- /gh-issue-number -->
