### PR TITLE
gh-127221: Add colour to unittest output

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -78,6 +78,13 @@ rst_epilog = f"""
 .. |python_version_literal| replace:: ``Python {version}``
 .. |python_x_dot_y_literal| replace:: ``python{version}``
 .. |usr_local_bin_python_x_dot_y_literal| replace:: ``/usr/local/bin/python{version}``
+
+.. Apparently this how you hack together a formatted link:
+   (https://www.docutils.org/docs/ref/rst/directives.html#replacement-text)
+.. |FORCE_COLOR| replace:: ``FORCE_COLOR``
+.. _FORCE_COLOR: https://force-color.org/
+.. |NO_COLOR| replace:: ``NO_COLOR``
+.. _NO_COLOR: https://no-color.org/
 """
 
 # There are two options for replacing |today|. Either, you set today to some

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -136,6 +136,10 @@ examples of doctests in the standard Python test suite and libraries.
 Especially useful examples can be found in the standard test file
 :file:`Lib/test/test_doctest/test_doctest.py`.
 
+.. versionadded:: 3.13
+   Output is colorized by default and can be
+   :ref:`controlled using environment variables <using-on-controlling-color>`.
+
 
 .. _doctest-simple-testmod:
 

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -44,6 +44,10 @@ The module's API can be divided into two parts:
   necessary for later formatting without holding references to actual exception
   and traceback objects.
 
+.. versionadded:: 3.13
+   Output is colorized by default and can be
+   :ref:`controlled using environment variables <using-on-controlling-color>`.
+
 
 Module-Level Functions
 ----------------------

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -46,9 +46,6 @@ test runner
    a textual interface, or return a special value to indicate the results of
    executing the tests.
 
-Output is in color by default and can be
-:ref:`controlled using environment variables <using-on-controlling-color>`.
-
 .. seealso::
 
    Module :mod:`doctest`
@@ -200,6 +197,9 @@ For a list of all the command-line options::
    In earlier versions it was only possible to run individual test methods and
    not modules or classes.
 
+.. versionadded:: 3.14
+   Output is colorized by default and can be
+   :ref:`controlled using environment variables <using-on-controlling-color>`.
 
 Command-line options
 ~~~~~~~~~~~~~~~~~~~~

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -46,6 +46,8 @@ test runner
    a textual interface, or return a special value to indicate the results of
    executing the tests.
 
+Output is in color by default and can be
+:ref:`controlled using environment variables <using-on-controlling-color>`.
 
 .. seealso::
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -663,14 +663,6 @@ output. To control the color output only in the Python interpreter, the
 precedence over ``NO_COLOR``, which in turn takes precedence over
 ``FORCE_COLOR``.
 
-.. Apparently this how you hack together a formatted link:
-
-.. |FORCE_COLOR| replace:: ``FORCE_COLOR``
-.. _FORCE_COLOR: https://force-color.org/
-
-.. |NO_COLOR| replace:: ``NO_COLOR``
-.. _NO_COLOR: https://no-color.org/
-
 Options you shouldn't use
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -252,15 +252,6 @@ Improved error messages
   the canonical |NO_COLOR|_ and |FORCE_COLOR|_ environment variables.
   (Contributed by Pablo Galindo Salgado in :gh:`112730`.)
 
-.. Apparently this how you hack together a formatted link:
-   (https://www.docutils.org/docs/ref/rst/directives.html#replacement-text)
-
-.. |FORCE_COLOR| replace:: ``FORCE_COLOR``
-.. _FORCE_COLOR: https://force-color.org/
-
-.. |NO_COLOR| replace:: ``NO_COLOR``
-.. _NO_COLOR: https://no-color.org/
-
 * A common mistake is to write a script with the same name as a
   standard library module. When this results in errors, we now
   display a more helpful error message:

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -552,15 +552,6 @@ unittest
   See also :ref:`using-on-controlling-color`.
   (Contributed by Hugo van Kemenade in :gh:`127221`.)
 
-.. Apparently this how you hack together a formatted link:
-   (https://www.docutils.org/docs/ref/rst/directives.html#replacement-text)
-
-.. |FORCE_COLOR| replace:: ``FORCE_COLOR``
-.. _FORCE_COLOR: https://force-color.org/
-
-.. |NO_COLOR| replace:: ``NO_COLOR``
-.. _NO_COLOR: https://no-color.org/
-
 * unittest discovery supports :term:`namespace package` as start
   directory again. It was removed in Python 3.11.
   (Contributed by Jacob Walls in :gh:`80958`.)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -545,6 +545,22 @@ unicodedata
 unittest
 --------
 
+* :mod:`unittest` output is now colored by default.
+  This can be controlled via the :envvar:`PYTHON_COLORS` environment
+  variable as well as the canonical |NO_COLOR|_
+  and |FORCE_COLOR|_ environment variables.
+  See also :ref:`using-on-controlling-color`.
+  (Contributed by Hugo van Kemenade in :gh:`127221`.)
+
+.. Apparently this how you hack together a formatted link:
+   (https://www.docutils.org/docs/ref/rst/directives.html#replacement-text)
+
+.. |FORCE_COLOR| replace:: ``FORCE_COLOR``
+.. _FORCE_COLOR: https://force-color.org/
+
+.. |NO_COLOR| replace:: ``NO_COLOR``
+.. _NO_COLOR: https://no-color.org/
+
 * unittest discovery supports :term:`namespace package` as start
   directory again. It was removed in Python 3.11.
   (Contributed by Jacob Walls in :gh:`80958`.)

--- a/Lib/test/test_unittest/test_async_case.py
+++ b/Lib/test/test_unittest/test_async_case.py
@@ -2,6 +2,7 @@ import asyncio
 import contextvars
 import unittest
 from test import support
+from test.support import force_not_colorized
 
 support.requires_working_socket(module=True)
 
@@ -252,6 +253,7 @@ class TestAsyncCase(unittest.TestCase):
         test.doCleanups()
         self.assertEqual(events, ['asyncSetUp', 'test', 'asyncTearDown', 'cleanup'])
 
+    @force_not_colorized
     def test_exception_in_tear_clean_up(self):
         class Test(unittest.IsolatedAsyncioTestCase):
             async def asyncSetUp(self):

--- a/Lib/test/test_unittest/test_program.py
+++ b/Lib/test/test_unittest/test_program.py
@@ -4,6 +4,7 @@ import subprocess
 from test import support
 import unittest
 import test.test_unittest
+from test.support import force_not_colorized
 from test.test_unittest.test_result import BufferedWriter
 
 
@@ -120,6 +121,7 @@ class Test_TestProgram(unittest.TestCase):
         self.assertEqual(['test.test_unittest', 'test.test_unittest2'],
                           program.testNames)
 
+    @force_not_colorized
     def test_NonExit(self):
         stream = BufferedWriter()
         program = unittest.main(exit=False,
@@ -135,6 +137,7 @@ class Test_TestProgram(unittest.TestCase):
                     'expected failures=1, unexpected successes=1)\n')
         self.assertTrue(out.endswith(expected))
 
+    @force_not_colorized
     def test_Exit(self):
         stream = BufferedWriter()
         with self.assertRaises(SystemExit) as cm:
@@ -152,6 +155,7 @@ class Test_TestProgram(unittest.TestCase):
                     'expected failures=1, unexpected successes=1)\n')
         self.assertTrue(out.endswith(expected))
 
+    @force_not_colorized
     def test_ExitAsDefault(self):
         stream = BufferedWriter()
         with self.assertRaises(SystemExit):
@@ -167,6 +171,7 @@ class Test_TestProgram(unittest.TestCase):
                     'expected failures=1, unexpected successes=1)\n')
         self.assertTrue(out.endswith(expected))
 
+    @force_not_colorized
     def test_ExitSkippedSuite(self):
         stream = BufferedWriter()
         with self.assertRaises(SystemExit) as cm:
@@ -179,6 +184,7 @@ class Test_TestProgram(unittest.TestCase):
         expected = '\n\nOK (skipped=1)\n'
         self.assertTrue(out.endswith(expected))
 
+    @force_not_colorized
     def test_ExitEmptySuite(self):
         stream = BufferedWriter()
         with self.assertRaises(SystemExit) as cm:

--- a/Lib/test/test_unittest/test_result.py
+++ b/Lib/test/test_unittest/test_result.py
@@ -7,6 +7,7 @@ from test.support import warnings_helper, captured_stdout
 import traceback
 import unittest
 from unittest.util import strclass
+from test.support import force_not_colorized
 from test.test_unittest.support import BufferedWriter
 
 
@@ -14,7 +15,7 @@ class MockTraceback(object):
     class TracebackException:
         def __init__(self, *args, **kwargs):
             self.capture_locals = kwargs.get('capture_locals', False)
-        def format(self):
+        def format(self, **kwargs):
             result = ['A traceback']
             if self.capture_locals:
                 result.append('locals')
@@ -205,6 +206,7 @@ class Test_TestResult(unittest.TestCase):
         self.assertIs(test_case, test)
         self.assertIsInstance(formatted_exc, str)
 
+    @force_not_colorized
     def test_addFailure_filter_traceback_frames(self):
         class Foo(unittest.TestCase):
             def test_1(self):
@@ -231,6 +233,7 @@ class Test_TestResult(unittest.TestCase):
         self.assertEqual(len(dropped), 1)
         self.assertIn("raise self.failureException(msg)", dropped[0])
 
+    @force_not_colorized
     def test_addFailure_filter_traceback_frames_context(self):
         class Foo(unittest.TestCase):
             def test_1(self):
@@ -260,6 +263,7 @@ class Test_TestResult(unittest.TestCase):
         self.assertEqual(len(dropped), 1)
         self.assertIn("raise self.failureException(msg)", dropped[0])
 
+    @force_not_colorized
     def test_addFailure_filter_traceback_frames_chained_exception_self_loop(self):
         class Foo(unittest.TestCase):
             def test_1(self):
@@ -285,6 +289,7 @@ class Test_TestResult(unittest.TestCase):
         formatted_exc = result.failures[0][1]
         self.assertEqual(formatted_exc.count("Exception: Loop\n"), 1)
 
+    @force_not_colorized
     def test_addFailure_filter_traceback_frames_chained_exception_cycle(self):
         class Foo(unittest.TestCase):
             def test_1(self):
@@ -446,6 +451,7 @@ class Test_TestResult(unittest.TestCase):
         result.addUnexpectedSuccess(None)
         self.assertTrue(result.shouldStop)
 
+    @force_not_colorized
     def testFailFastSetByRunner(self):
         stream = BufferedWriter()
         runner = unittest.TextTestRunner(stream=stream, failfast=True)
@@ -619,6 +625,7 @@ class Test_TextTestResult(unittest.TestCase):
         test.run(result)
         return stream.getvalue()
 
+    @force_not_colorized
     def testDotsOutput(self):
         self.assertEqual(self._run_test('testSuccess', 1), '.')
         self.assertEqual(self._run_test('testSkip', 1), 's')
@@ -627,6 +634,7 @@ class Test_TextTestResult(unittest.TestCase):
         self.assertEqual(self._run_test('testExpectedFailure', 1), 'x')
         self.assertEqual(self._run_test('testUnexpectedSuccess', 1), 'u')
 
+    @force_not_colorized
     def testLongOutput(self):
         classname = f'{__name__}.{self.Test.__qualname__}'
         self.assertEqual(self._run_test('testSuccess', 2),
@@ -642,17 +650,21 @@ class Test_TextTestResult(unittest.TestCase):
         self.assertEqual(self._run_test('testUnexpectedSuccess', 2),
                          f'testUnexpectedSuccess ({classname}.testUnexpectedSuccess) ... unexpected success\n')
 
+    @force_not_colorized
     def testDotsOutputSubTestSuccess(self):
         self.assertEqual(self._run_test('testSubTestSuccess', 1), '.')
 
+    @force_not_colorized
     def testLongOutputSubTestSuccess(self):
         classname = f'{__name__}.{self.Test.__qualname__}'
         self.assertEqual(self._run_test('testSubTestSuccess', 2),
                          f'testSubTestSuccess ({classname}.testSubTestSuccess) ... ok\n')
 
+    @force_not_colorized
     def testDotsOutputSubTestMixed(self):
         self.assertEqual(self._run_test('testSubTestMixed', 1), 'sFE')
 
+    @force_not_colorized
     def testLongOutputSubTestMixed(self):
         classname = f'{__name__}.{self.Test.__qualname__}'
         self.assertEqual(self._run_test('testSubTestMixed', 2),
@@ -661,6 +673,7 @@ class Test_TextTestResult(unittest.TestCase):
                 f'  testSubTestMixed ({classname}.testSubTestMixed) [fail] (c=3) ... FAIL\n'
                 f'  testSubTestMixed ({classname}.testSubTestMixed) [error] (d=4) ... ERROR\n')
 
+    @force_not_colorized
     def testDotsOutputTearDownFail(self):
         out = self._run_test('testSuccess', 1, AssertionError('fail'))
         self.assertEqual(out, 'F')
@@ -671,6 +684,7 @@ class Test_TextTestResult(unittest.TestCase):
         out = self._run_test('testSkip', 1, AssertionError('fail'))
         self.assertEqual(out, 'sF')
 
+    @force_not_colorized
     def testLongOutputTearDownFail(self):
         classname = f'{__name__}.{self.Test.__qualname__}'
         out = self._run_test('testSuccess', 2, AssertionError('fail'))

--- a/Lib/test/test_unittest/test_runner.py
+++ b/Lib/test/test_unittest/test_runner.py
@@ -4,6 +4,7 @@ import sys
 import pickle
 import subprocess
 from test import support
+from test.support import force_not_colorized
 
 import unittest
 from unittest.case import _Outcome
@@ -106,6 +107,7 @@ class TestCleanUp(unittest.TestCase):
         self.assertTrue(test.doCleanups())
         self.assertEqual(cleanups, [(2, (), {}), (1, (1, 2, 3), dict(four='hello', five='goodbye'))])
 
+    @force_not_colorized
     def testCleanUpWithErrors(self):
         class TestableTest(unittest.TestCase):
             def testNothing(self):
@@ -416,6 +418,7 @@ class TestClassCleanup(unittest.TestCase):
         self.assertIsInstance(e2[1], CustomError)
         self.assertEqual(str(e2[1]), 'cleanup1')
 
+    @force_not_colorized
     def test_with_errors_addCleanUp(self):
         ordering = []
         class TestableTest(unittest.TestCase):
@@ -439,6 +442,7 @@ class TestClassCleanup(unittest.TestCase):
                          ['setUpClass', 'setUp', 'cleanup_exc',
                           'tearDownClass', 'cleanup_good'])
 
+    @force_not_colorized
     def test_run_with_errors_addClassCleanUp(self):
         ordering = []
         class TestableTest(unittest.TestCase):
@@ -462,6 +466,7 @@ class TestClassCleanup(unittest.TestCase):
                          ['setUpClass', 'setUp', 'test', 'cleanup_good',
                           'tearDownClass', 'cleanup_exc'])
 
+    @force_not_colorized
     def test_with_errors_in_addClassCleanup_and_setUps(self):
         ordering = []
         class_blow_up = False
@@ -514,6 +519,7 @@ class TestClassCleanup(unittest.TestCase):
                          ['setUpClass', 'setUp', 'tearDownClass',
                           'cleanup_exc'])
 
+    @force_not_colorized
     def test_with_errors_in_tearDownClass(self):
         ordering = []
         class TestableTest(unittest.TestCase):
@@ -590,6 +596,7 @@ class TestClassCleanup(unittest.TestCase):
                 'inner setup', 'inner test', 'inner cleanup',
                 'end outer test', 'outer cleanup'])
 
+    @force_not_colorized
     def test_run_empty_suite_error_message(self):
         class EmptyTest(unittest.TestCase):
             pass
@@ -663,6 +670,7 @@ class TestModuleCleanUp(unittest.TestCase):
         self.assertEqual(cleanups,
                          [((1, 2), {'function': 'hello'})])
 
+    @force_not_colorized
     def test_run_module_cleanUp(self):
         blowUp = True
         ordering = []
@@ -802,6 +810,7 @@ class TestModuleCleanUp(unittest.TestCase):
                                     'tearDownClass', 'cleanup_good'])
         self.assertEqual(unittest.case._module_cleanups, [])
 
+    @force_not_colorized
     def test_run_module_cleanUp_when_teardown_exception(self):
         ordering = []
         class Module(object):
@@ -963,6 +972,7 @@ class TestModuleCleanUp(unittest.TestCase):
         self.assertEqual(cleanups,
                          [((1, 2), {'function': 3, 'self': 4})])
 
+    @force_not_colorized
     def test_with_errors_in_addClassCleanup(self):
         ordering = []
 
@@ -996,6 +1006,7 @@ class TestModuleCleanUp(unittest.TestCase):
                          ['setUpModule', 'setUpClass', 'test', 'tearDownClass',
                           'cleanup_exc', 'tearDownModule', 'cleanup_good'])
 
+    @force_not_colorized
     def test_with_errors_in_addCleanup(self):
         ordering = []
         class Module(object):
@@ -1026,6 +1037,7 @@ class TestModuleCleanUp(unittest.TestCase):
                          ['setUpModule', 'setUp', 'test', 'tearDown',
                           'cleanup_exc', 'tearDownModule', 'cleanup_good'])
 
+    @force_not_colorized
     def test_with_errors_in_addModuleCleanup_and_setUps(self):
         ordering = []
         module_blow_up = False
@@ -1318,6 +1330,7 @@ class Test_TextTestRunner(unittest.TestCase):
         expectedresult = (runner.stream, DESCRIPTIONS, VERBOSITY)
         self.assertEqual(runner._makeResult(), expectedresult)
 
+    @force_not_colorized
     @support.requires_subprocess()
     def test_warnings(self):
         """

--- a/Lib/test/test_unittest/test_skipping.py
+++ b/Lib/test/test_unittest/test_skipping.py
@@ -1,5 +1,6 @@
 import unittest
 
+from test.support import force_not_colorized
 from test.test_unittest.support import LoggingResult
 
 
@@ -293,6 +294,7 @@ class Test_TestSkipping(unittest.TestCase):
         self.assertFalse(result.unexpectedSuccesses)
         self.assertTrue(result.wasSuccessful())
 
+    @force_not_colorized
     def test_expected_failure_and_fail_in_cleanup(self):
         class Foo(unittest.TestCase):
             @unittest.expectedFailure
@@ -372,6 +374,7 @@ class Test_TestSkipping(unittest.TestCase):
         self.assertEqual(result.unexpectedSuccesses, [test])
         self.assertFalse(result.wasSuccessful())
 
+    @force_not_colorized
     def test_unexpected_success_and_fail_in_cleanup(self):
         class Foo(unittest.TestCase):
             @unittest.expectedFailure

--- a/Lib/unittest/result.py
+++ b/Lib/unittest/result.py
@@ -189,7 +189,9 @@ class TestResult(object):
         tb_e = traceback.TracebackException(
             exctype, value, tb,
             capture_locals=self.tb_locals, compact=True)
-        msgLines = list(tb_e.format())
+        from _colorize import can_colorize
+
+        msgLines = list(tb_e.format(colorize=can_colorize()))
 
         if self.buffer:
             output = sys.stdout.getvalue()

--- a/Lib/unittest/runner.py
+++ b/Lib/unittest/runner.py
@@ -160,7 +160,7 @@ class TextTestResult(result.TestResult):
         self.printErrorList(f"{red}FAIL{reset}", self.failures)
         unexpectedSuccesses = getattr(self, "unexpectedSuccesses", ())
         if unexpectedSuccesses:
-            self.stream.writeln(f"{bold_red}{self.separator1}{reset}")
+            self.stream.writeln(self.separator1)
             for test in unexpectedSuccesses:
                 self.stream.writeln(
                     f"{red}UNEXPECTED SUCCESS{bold_red}: "
@@ -171,11 +171,11 @@ class TextTestResult(result.TestResult):
     def printErrorList(self, flavour, errors):
         bold_red, reset = self._ansi.BOLD_RED, self._ansi.RESET
         for test, err in errors:
-            self.stream.writeln(f"{bold_red}{self.separator1}{reset}")
+            self.stream.writeln(self.separator1)
             self.stream.writeln(
                 f"{flavour}{bold_red}: {self.getDescription(test)}{reset}"
             )
-            self.stream.writeln(f"{bold_red}{self.separator2}{reset}")
+            self.stream.writeln(self.separator2)
             self.stream.writeln("%s" % err)
             self.stream.flush()
 

--- a/Lib/unittest/runner.py
+++ b/Lib/unittest/runner.py
@@ -15,18 +15,18 @@ __unittest = True
 
 class _WritelnDecorator(object):
     """Used to decorate file-like objects with a handy 'writeln' method"""
-    def __init__(self,stream):
+    def __init__(self, stream):
         self.stream = stream
 
     def __getattr__(self, attr):
         if attr in ('stream', '__getstate__'):
             raise AttributeError(attr)
-        return getattr(self.stream,attr)
+        return getattr(self.stream, attr)
 
     def writeln(self, arg=None):
         if arg:
             self.write(arg)
-        self.write('\n') # text-mode streams translate to \r\n if needed
+        self.write('\n')  # text-mode streams translate to \r\n if needed
 
 
 class TextTestResult(result.TestResult):
@@ -251,7 +251,7 @@ class TextTestRunner(object):
             if self.warnings:
                 # if self.warnings is set, use it to filter all the warnings
                 warnings.simplefilter(self.warnings)
-            startTime = time.perf_counter()
+            start_time = time.perf_counter()
             startTestRun = getattr(result, 'startTestRun', None)
             if startTestRun is not None:
                 startTestRun()
@@ -261,8 +261,8 @@ class TextTestRunner(object):
                 stopTestRun = getattr(result, 'stopTestRun', None)
                 if stopTestRun is not None:
                     stopTestRun()
-            stopTime = time.perf_counter()
-        timeTaken = stopTime - startTime
+            stop_time = time.perf_counter()
+        time_taken = stop_time - start_time
         result.printErrors()
         if self.durations is not None:
             self._printDurations(result)
@@ -272,10 +272,10 @@ class TextTestRunner(object):
 
         run = result.testsRun
         self.stream.writeln("Ran %d test%s in %.3fs" %
-                            (run, run != 1 and "s" or "", timeTaken))
+                            (run, run != 1 and "s" or "", time_taken))
         self.stream.writeln()
 
-        expectedFails = unexpectedSuccesses = skipped = 0
+        expected_fails = unexpected_successes = skipped = 0
         try:
             results = map(len, (result.expectedFailures,
                                 result.unexpectedSuccesses,
@@ -283,7 +283,7 @@ class TextTestRunner(object):
         except AttributeError:
             pass
         else:
-            expectedFails, unexpectedSuccesses, skipped = results
+            expected_fails, unexpected_successes, skipped = results
 
         infos = []
         ansi = get_colors()
@@ -306,11 +306,11 @@ class TextTestRunner(object):
             self.stream.write(f"{green}OK{reset}")
         if skipped:
             infos.append(f"{yellow}skipped={skipped}{reset}")
-        if expectedFails:
-            infos.append(f"{yellow}expected failures={expectedFails}{reset}")
-        if unexpectedSuccesses:
+        if expected_fails:
+            infos.append(f"{yellow}expected failures={expected_fails}{reset}")
+        if unexpected_successes:
             infos.append(
-                f"{red}unexpected successes={unexpectedSuccesses}{reset}"
+                f"{red}unexpected successes={unexpected_successes}{reset}"
             )
         if infos:
             self.stream.writeln(" (%s)" % (", ".join(infos),))

--- a/Misc/NEWS.d/next/Library/2024-11-23-00-17-29.gh-issue-127221.OSXdFE.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-23-00-17-29.gh-issue-127221.OSXdFE.rst
@@ -1,0 +1,1 @@
+Add colour to unittest output. Patch by Hugo van Kemenade.

--- a/Misc/NEWS.d/next/Library/2024-11-23-00-17-29.gh-issue-127221.OSXdFE.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-23-00-17-29.gh-issue-127221.OSXdFE.rst
@@ -1,1 +1,1 @@
-Add colour to unittest output. Patch by Hugo van Kemenade.
+Add colour to :mod:`unittest` output. Patch by Hugo van Kemenade.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Use the existing `_colorize` module already used for tracebacks and doctest so output can be controlled with the `PYTHON_COLORS`, `NO_COLOR` and `FORCE_COLOR` environment variables.

This PR does a couple of things to add colour:

* Enable colour for tracebacks by passing in `colorize` to `msgLines = list(tb_e.format(colorize=can_colorize()))`
* Add colour for pass/fail/errors, using pytest as a guide
* Plus some unrelated tidy-up (use more specific test methods, new-style objects, underscore variables)

Tested with some small demo scripts:

# No tests ran

<details>
<summary>run-unittests-none.py</summary>

```python
import unittest

if __name__ == "__main__":
    unittest.main()
```

</details>


<table>
<tr>
<th>Before
<th>After
<th>pytest
<tr>
<td>
<img width="495" alt="image" src="https://github.com/user-attachments/assets/a065ab2c-a3d4-49fd-9e1d-a11144ac069f">
<td>
<img width="594" alt="image" src="https://github.com/user-attachments/assets/5312e2f5-03e5-446b-b5f9-e9f752f3937c">
<td>
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/954e93a8-f5de-4453-b7fa-e57c2c9d7b31">
</table>


# Passed

<details>
<summary>run-unittests-pass.py</summary>

```python
```

</details>


<table>
<tr>
<th>Mode
<th>Before
<th>After
<th>pytest
<tr>
<td>Regular
<td>
<img width="506" alt="image" src="https://github.com/user-attachments/assets/5d4bde87-9db6-498c-851e-40c501715e8c">
<td>
<img width="604" alt="image" src="https://github.com/user-attachments/assets/ef1d1edc-be21-438c-861d-4bc4eebd9e9f">
<td>
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/0f8d42db-9e5d-4669-9e34-33b4cc5ec91c">
<tr>
<td>Verbose
<td>
<img width="502" alt="image" src="https://github.com/user-attachments/assets/6c18ae12-c20c-4f9c-889f-c78f52202ab7">
<td>
<img width="599" alt="image" src="https://github.com/user-attachments/assets/2cc7ae0d-bea1-4318-92f2-9b21a500a45c">
<td>
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/df71396b-c629-4b90-9718-4145f0f52e98">
</table>



# Failing

<details>
<summary>run-unittests.py</summary>

```python
import unittest


class TestThings(unittest.TestCase):
    def test_pass(self):
        self.assertTrue(True)

    def test_fail(self):
        self.assertTrue(False)

    def test_error(self):
        raise Exception("Manually raised exception")

    def test_pass2(self):
        self.assertEqual(1, 1)

    @unittest.skip("demonstrating skipping")
    def test_skip(self):
        self.fail("shouldn't happen")


class ExpectedFailureTestCase(unittest.TestCase):
    @unittest.expectedFailure
    def test_fail(self):
        self.assertEqual(1, 0, "broken")

    @unittest.expectedFailure
    def test_pass(self):
        self.assertEqual(1, 1, "not broken")


if __name__ == "__main__":
    unittest.main()
```

</details>

<table>
<tr>
<th>Mode
<th>Before
<th>After
<th>pytest
<tr>
<td>Regular
<td>
<img width="627" alt="image" src="https://github.com/user-attachments/assets/132b6387-547f-4a10-bf1e-f0c1134f9974">
<td>
<img width="625" alt="image" src="https://github.com/user-attachments/assets/98554dff-8ebe-48c8-8aac-345f555015b1">
<td>
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/9884af5b-de50-4318-984b-248b04b7d020">
<tr>
<td>Verbose
<td><img width="639" alt="image" src="https://github.com/user-attachments/assets/a2af9567-7118-44ba-8bde-b021542935d5">
<td>
<img width="629" alt="image" src="https://github.com/user-attachments/assets/4256e47c-06de-4665-956a-aa32534a1534">
<td>
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/b7f06d2a-9304-44b1-a15c-a690fa8037f9">
</table>


# Subtests

<details>
<summary>run-unittests-subtests.py</summary>

```python
import unittest


class DoSubTest(unittest.TestCase):
    def test_subtest(self):
        """Test with subtest"""
        for i in range(0, 4):
            with self.subTest(i=i):
                if i == 2:
                    raise Exception("Manually raised exception")
                self.assertEqual(i % 2, 0)


if __name__ == "__main__":
    unittest.main()
```

</details>


<table>
<tr>
<th>Mode
<th>Before
<th>After
<th>pytest
<tr>
<td>Regular
<td>
<img width="705" alt="image" src="https://github.com/user-attachments/assets/111470ea-3597-44ca-a2d3-8eef259b679a">
<td>
<img width="709" alt="image" src="https://github.com/user-attachments/assets/11c60c33-c6cc-4d46-8d2f-e2629ece80d2">
<td>
<img width="1047" alt="image" src="https://github.com/user-attachments/assets/47286a73-ea96-44b8-9908-82cf611704ce">
<tr>
<td>Verbose
<td>
<img width="710" alt="image" src="https://github.com/user-attachments/assets/ed35f658-228f-40b8-b413-cc569a4c709d">
<td>
<img width="705" alt="image" src="https://github.com/user-attachments/assets/e06b226a-1f8c-435c-99a9-35b3daa99d2c">
<td>
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/f04c1718-d8c8-49c0-809b-8b490d3e9e5b">
</table>



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127223.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-127221 -->
* Issue: gh-127221
<!-- /gh-issue-number -->
