### PR TITLE
gh-127096: Do not recreate unnamed section on every read in ConfigParser

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -1105,13 +1105,7 @@ class RawConfigParser(MutableMapping):
     def _handle_rest(self, st, line, fpname):
         # a section header or option header?
         if self._allow_unnamed_section and st.cursect is None:
-            st.sectname = UNNAMED_SECTION
-            if st.sectname in self._sections:
-                st.cursect = self._sections[st.sectname]
-            else:
-                st.cursect = self._dict()
-                self._sections[st.sectname] = st.cursect
-                self._proxies[st.sectname] = SectionProxy(self, st.sectname)
+            self._handle_header(st, UNNAMED_SECTION, fpname)
 
         st.indent_level = st.cur_indent_level
         # is it a section header?
@@ -1120,10 +1114,10 @@ class RawConfigParser(MutableMapping):
         if not mo and st.cursect is None:
             raise MissingSectionHeaderError(fpname, st.lineno, line)
 
-        self._handle_header(st, mo, fpname) if mo else self._handle_option(st, line, fpname)
+        self._handle_header(st, mo.group('header'), fpname) if mo else self._handle_option(st, line, fpname)
 
-    def _handle_header(self, st, mo, fpname):
-        st.sectname = mo.group('header')
+    def _handle_header(self, st, sectname, fpname):
+        st.sectname = sectname
         if st.sectname in self._sections:
             if self._strict and st.sectname in st.elements_added:
                 raise DuplicateSectionError(st.sectname, fpname,

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -1106,10 +1106,12 @@ class RawConfigParser(MutableMapping):
         # a section header or option header?
         if self._allow_unnamed_section and st.cursect is None:
             st.sectname = UNNAMED_SECTION
-            st.cursect = self._dict()
-            self._sections[st.sectname] = st.cursect
-            self._proxies[st.sectname] = SectionProxy(self, st.sectname)
-            st.elements_added.add(st.sectname)
+            if st.sectname in self._sections:
+                st.cursect = self._sections[st.sectname]
+            else:
+                st.cursect = self._dict()
+                self._sections[st.sectname] = st.cursect
+                self._proxies[st.sectname] = SectionProxy(self, st.sectname)
 
         st.indent_level = st.cur_indent_level
         # is it a section header?

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -2174,6 +2174,15 @@ class SectionlessTestCase(unittest.TestCase):
         with self.assertRaises(configparser.UnnamedSectionDisabledError):
             configparser.ConfigParser().add_section(configparser.UNNAMED_SECTION)
 
+    def test_multiple_configs(self):
+        cfg = configparser.ConfigParser(allow_unnamed_section=True)
+        cfg.read_string('a = 1')
+        cfg.read_string('b = 2')
+
+        self.assertEqual([configparser.UNNAMED_SECTION], cfg.sections())
+        self.assertEqual('1', cfg[configparser.UNNAMED_SECTION]['a'])
+        self.assertEqual('2', cfg[configparser.UNNAMED_SECTION]['b'])
+
 
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):

--- a/Misc/NEWS.d/next/Library/2024-11-24-22-06-42.gh-issue-127096.R7LLpQ.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-24-22-06-42.gh-issue-127096.R7LLpQ.rst
@@ -1,0 +1,2 @@
+Do not recreate unnamed section on every read in
+:class:`configparser.ConfigParser`. Patch by Andrey Efremov.


### PR DESCRIPTION
The fix is based on the code from the _handle_header method. Except that I removed the part related to checking for section duplication because an unnamed section cannot be repeated within a file, and because UNNAMED_SECTION is [an object](https://github.com/python/cpython/blob/2104bde572aa60f547274fd529312c5708599001/Lib/configparser.py#L373) and elements_added is [defined as set[str]](https://github.com/python/cpython/blob/2104bde572aa60f547274fd529312c5708599001/Lib/configparser.py#L551).

<!-- gh-issue-number: gh-127096 -->
* Issue: gh-127096
<!-- /gh-issue-number -->
