### PR TITLE
[3.11]gh-127213: Replace os._exit() to sys.exit(), so that .so will alos be unloaded in child process

### DIFF
--- a/Lib/multiprocessing/popen_fork.py
+++ b/Lib/multiprocessing/popen_fork.py
@@ -1,5 +1,6 @@
 import os
 import signal
+import sys
 
 from . import util
 
@@ -70,7 +71,7 @@ class Popen(object):
                 os.close(parent_w)
                 code = process_obj._bootstrap(parent_sentinel=child_r)
             finally:
-                os._exit(code)
+                sys.exit(code)
         else:
             os.close(child_w)
             os.close(child_r)

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -130,7 +130,8 @@ class BaseProcess(object):
         Terminate process; sends SIGTERM signal or uses TerminateProcess()
         '''
         self._check_closed()
-        self._popen.terminate()
+        if self._popen is not None:
+            self._popen.terminate()
 
     def kill(self):
         '''

--- a/Misc/NEWS.d/next/Library/2024-11-25-09-55-04.gh-issue-127213.d2pVyU.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-25-09-55-04.gh-issue-127213.d2pVyU.rst
@@ -1,0 +1,1 @@
+Replace os._exit() to sys.exit(), so that .so will alos be unloaded in child process


### PR DESCRIPTION
https://github.com/python/cpython/issues/127213

As mentioned in this issue, a child process created by multiprocessing.Process() with method 'fork' works not the same as os.fork() or c fork() on unloading of .so files.

replace os._exit() to sys.exit() to fix it.

<!-- gh-issue-number: gh-127213 -->
* Issue: gh-127213
<!-- /gh-issue-number -->
