### PR TITLE
gh-127248: Fix several issues in the pythoncore.vcxproj.

### DIFF
--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -169,9 +169,7 @@
     <ClInclude Include="..\Include\cpython\object.h" />
     <ClInclude Include="..\Include\cpython\objimpl.h" />
     <ClInclude Include="..\Include\cpython\odictobject.h" />
-    <ClInclude Include="..\Include\cpython\parser_interface.h" />
     <ClInclude Include="..\Include\cpython\picklebufobject.h" />
-    <ClInclude Include="..\Include\cpython\pyarena.h" />
     <ClInclude Include="..\Include\cpython\pyatomic.h" />
     <ClInclude Include="..\Include\cpython\pyatomic_msc.h" />
     <ClInclude Include="..\Include\cpython\pyctype.h" />
@@ -220,7 +218,6 @@
     <ClInclude Include="..\Include\internal\pycore_cell.h" />
     <ClInclude Include="..\Include\internal\pycore_ceval.h" />
     <ClInclude Include="..\Include\internal\pycore_ceval_state.h" />
-    <ClInclude Include="..\Include\internal\pycore_cfg.h" />
     <ClInclude Include="..\Include\internal\pycore_code.h" />
     <ClInclude Include="..\Include\internal\pycore_codecs.h" />
     <ClInclude Include="..\Include\internal\pycore_compile.h" />
@@ -366,14 +363,12 @@
     <ClInclude Include="..\Include\sliceobject.h" />
     <ClInclude Include="..\Include\structmember.h" />
     <ClInclude Include="..\Include\structseq.h" />
-    <ClInclude Include="..\Include\symtable.h" />
     <ClInclude Include="..\Include\sysmodule.h" />
     <ClInclude Include="..\Include\traceback.h" />
     <ClInclude Include="..\Include\tupleobject.h" />
     <ClInclude Include="..\Include\unicodeobject.h" />
     <ClInclude Include="..\Include\weakrefobject.h" />
     <ClInclude Include="..\Modules\_math.h" />
-    <ClInclude Include="..\Modules\hashtable.h" />
     <ClInclude Include="..\Modules\rotatingtree.h" />
     <ClInclude Include="..\Modules\_io\_iomodule.h" />
     <ClInclude Include="..\Modules\cjkcodecs\alg_jisx0201.h" />
@@ -415,7 +410,7 @@
     <ClInclude Include="$(zlibDir)\inftrees.h" />
     <ClInclude Include="$(zlibDir)\trees.h" />
     <ClInclude Include="$(zlibDir)\zconf.h" />
-    <ClInclude Include="$(zlibDir)\zconf.in.h" />
+    <ClInclude Include="$(zlibDir)\zconf.h.in" />
     <ClInclude Include="$(zlibDir)\zlib.h" />
     <ClInclude Include="$(zlibDir)\zutil.h" />
   </ItemGroup>

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -231,9 +231,6 @@
     <ClInclude Include="..\Include\structseq.h">
       <Filter>Include</Filter>
     </ClInclude>
-    <ClInclude Include="..\Include\symtable.h">
-      <Filter>Include</Filter>
-    </ClInclude>
     <ClInclude Include="..\Include\sysmodule.h">
       <Filter>Include</Filter>
     </ClInclude>
@@ -342,9 +339,6 @@
     <ClInclude Include="..\Include\pyhash.h">
       <Filter>Include</Filter>
     </ClInclude>
-    <ClInclude Include="..\Modules\hashtable.h">
-      <Filter>Modules</Filter>
-    </ClInclude>
     <ClInclude Include="..\Parser\pegen.h">
       <Filter>Parser</Filter>
     </ClInclude>
@@ -447,13 +441,7 @@
     <ClInclude Include="..\Include\cpython\object.h">
       <Filter>Include\cpython</Filter>
     </ClInclude>
-    <ClInclude Include="..\Include\cpython\parser_interface.h">
-      <Filter>Include</Filter>
-    </ClInclude>
     <ClInclude Include="..\Include\cpython\picklebufobject.h">
-      <Filter>Include</Filter>
-    </ClInclude>
-    <ClInclude Include="..\Include\cpython\pyarena.h">
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\cpython\pyatomic.h">
@@ -903,7 +891,7 @@
     <ClInclude Include="$(zlibDir)\zconf.h">
       <Filter>Modules\zlib</Filter>
     </ClInclude>
-    <ClInclude Include="$(zlibDir)\zconf.in.h">
+    <ClInclude Include="$(zlibDir)\zconf.h.in">
       <Filter>Modules\zlib</Filter>
     </ClInclude>
     <ClInclude Include="$(zlibDir)\zlib.h">


### PR DESCRIPTION
```
1. gh-25001: The reference to the parser_interface.h has been deleted. (bpo-43244: Remove parser_interface.h header file #25001)
2. gh-25007: The reference to the pyarena.h has been deleted. (bpo-43244: Remove pyarena.h header #25007)
3. gh-87092: The reference to the pycore_cfg.h has been deleted. This file was mentioned in gh-87092 (move CFG related code from compile.c to flowgraph.c #103021) but it has never been in python/cpython repo (https://github.com/python/cpython/commits/main/Include/internal/pycore_cfg.h)
4. gh-24910: The reference to the symtable.h has been deleted. (bpo-43244: Remove symtable.h header file #24910)
5. gh-20044: The reference to the hashtable.h has been deleted due to the reference to the pycore_hashtable.h exists. (bpo-40602: Rename hashtable.h to pycore_hashtable.h #20044)
6. gh-127248: Reference to zconf.in.h was renamed. Correct name of zconf.in.h is zconf.h.in (https://github.com/python/cpython-source-deps/blob/4dc98e1909830e2bdc2a9cc2236e3c5d5037335b/zconf.h.in)
```