### PR TITLE
gh-127258: Fix asyncio test_staggered_race_with_eager_tasks()

### DIFF
--- a/Lib/test/test_asyncio/test_eager_task_factory.py
+++ b/Lib/test/test_asyncio/test_eager_task_factory.py
@@ -223,7 +223,7 @@ class EagerTaskFactoryLoopTests:
         async def run():
             winner, index, excs = await asyncio.staggered.staggered_race(
                 [
-                    lambda: asyncio.sleep(2, result="sleep2"),
+                    lambda: asyncio.sleep(60, result="sleep2"),
                     lambda: asyncio.sleep(1, result="sleep1"),
                     lambda: fail()
                 ],


### PR DESCRIPTION
Use a longer sleep for the "sleep2" task, 60 seconds instead of 2 seconds, to make sure that "sleep1" task (1 second) is more likely to win the race.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127258 -->
* Issue: gh-127258
<!-- /gh-issue-number -->
