### PR TITLE
gh-127265: Remove single quotes from 'arrow's in tutorial/errors.rst

### DIFF
--- a/Doc/tutorial/errors.rst
+++ b/Doc/tutorial/errors.rst
@@ -23,7 +23,7 @@ complaint you get while you are still learning Python::
                   ^^^^^
    SyntaxError: invalid syntax
 
-The parser repeats the offending line and displays little 'arrow's pointing
+The parser repeats the offending line and displays little arrows pointing
 at the token in the line where the error was detected.  The error may be
 caused by the absence of a token *before* the indicated token.  In the
 example, the error is detected at the function :func:`print`, since a colon


### PR DESCRIPTION
```
gh-127265: Remove single quotes around arrow
```

#127265

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127267.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->