### PR TITLE
gh-127255: Make `CopyComPointer` public and add to `ctypes` doc.

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1957,9 +1957,10 @@ Utility functions
    If *src* is not ``NULL``, its ``AddRef`` method is called, incrementing the
    reference count.
 
-   In contrast, even if *dst* is not ``NULL``, its reference count will not be
-   decremented before assigning the new value.  You need to call its ``Release``
-   to free it appropriately.
+   In contrast, the reference count of *dst* will not be decremented before
+   assigning the new value. Unless *dst* is ``NULL``, the caller is responsible
+   for decrementing the reference count by calling its ``Release`` method when
+   necessary.
 
    .. availability:: Windows
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1949,6 +1949,23 @@ Utility functions
    It behaves similar to ``pointer(obj)``, but the construction is a lot faster.
 
 
+.. function:: CopyComPointer(src, dst)
+
+   Copies a COM pointer from *src* to *dst* and returns the Windows specific
+   :c:type:`!HRESULT` value.
+
+   If *src* is not ``NULL``, its ``AddRef`` method is called, incrementing the
+   reference count.
+
+   In contrast, even if *dst* is not ``NULL``, its reference count will not be
+   decremented before assigning the new value.  You need to call its ``Release``
+   to free it appropriately.
+
+   .. availability:: Windows
+
+   .. versionadded:: next
+
+
 .. function:: cast(obj, type)
 
    This function is similar to the cast operator in C. It returns a new instance

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -309,10 +309,10 @@ ctypes
   to help match a non-default ABI.
   (Contributed by Petr Viktorin in :gh:`97702`.)
 
-* The :exc:`~ctypes.COMError` exception is now public.
+* On Windows, the :exc:`~ctypes.COMError` exception is now public.
   (Contributed by Jun Komoda in :gh:`126686`.)
 
-* The :func:`~ctypes.CopyComPointer` function is now public.
+* On Windows, the :func:`~ctypes.CopyComPointer` function is now public.
   (Contributed by Jun Komoda in :gh:`127275`.)
 
 datetime

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -312,6 +312,9 @@ ctypes
 * The :exc:`~ctypes.COMError` exception is now public.
   (Contributed by Jun Komoda in :gh:`126686`.)
 
+* The :func:`~ctypes.CopyComPointer` function is now public.
+  (Contributed by Jun Komoda in :gh:`127275`.)
+
 datetime
 --------
 

--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -19,7 +19,7 @@ if __version__ != _ctypes_version:
     raise Exception("Version number mismatch", __version__, _ctypes_version)
 
 if _os.name == "nt":
-    from _ctypes import COMError, FormatError
+    from _ctypes import COMError, CopyComPointer, FormatError
 
 DEFAULT_MODE = RTLD_LOCAL
 if _os.name == "posix" and _sys.platform == "darwin":

--- a/Lib/test/test_ctypes/test_win32_com_foreign_func.py
+++ b/Lib/test/test_ctypes/test_win32_com_foreign_func.py
@@ -9,8 +9,7 @@ if sys.platform != "win32":
     raise unittest.SkipTest("Windows-specific test")
 
 
-from _ctypes import COMError, CopyComPointer
-from ctypes import HRESULT
+from ctypes import COMError, CopyComPointer, HRESULT
 
 
 COINIT_APARTMENTTHREADED = 0x2

--- a/Misc/NEWS.d/next/Library/2024-11-25-15-02-44.gh-issue-127255.UXeljc.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-25-15-02-44.gh-issue-127255.UXeljc.rst
@@ -1,0 +1,2 @@
+The :func:`~ctypes.CopyComPointer` function is now public.
+Previously, this was private and only available in ``_ctypes``.


### PR DESCRIPTION
Please refer also to gh-127183 and gh-127184 for the behavior of `CopyComPointer`.

<!-- gh-issue-number: gh-127255 -->
* Issue: gh-127255
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127275.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->