### PR TITLE
Fix typo: Use AsyncFor element access in codegen

### DIFF
--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -2033,7 +2033,7 @@ codegen_async_for(compiler *c, stmt_ty s)
     ADDOP(c, loc, END_ASYNC_FOR);
 
     /* `else` block */
-    VISIT_SEQ(c, stmt, s->v.For.orelse);
+    VISIT_SEQ(c, stmt, s->v.AsyncFor.orelse);
 
     USE_LABEL(c, end);
     return SUCCESS;


### PR DESCRIPTION
Use `AsyncFor` instead of `For` for element access in `codegen_async_for`.
It hasn't been an issue so far as both structs have the same elements.