### PR TITLE
gh-124873: Skip timerfd tests on Android

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4174,7 +4174,7 @@ class EventfdTests(unittest.TestCase):
         os.eventfd_read(fd)
 
 @unittest.skipUnless(hasattr(os, 'timerfd_create'), 'requires os.timerfd_create')
-@unittest.skipIf(sys.platform == "android", "#124873: Test is flaky on Android")
+@unittest.skipIf(sys.platform == "android", "gh-124873: Test is flaky on Android")
 @support.requires_linux_version(2, 6, 30)
 class TimerfdTests(unittest.TestCase):
     # 1 ms accuracy is reliably achievable on every platform except Android

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4177,9 +4177,9 @@ class EventfdTests(unittest.TestCase):
 @support.requires_linux_version(2, 6, 30)
 class TimerfdTests(unittest.TestCase):
     # 1 ms accuracy is reliably achievable on every platform except Android
-    # emulators, where we allow 100 ms (gh-124873).
+    # emulators, where we allow 10 ms (gh-108277).
     if sys.platform == "android" and platform.android_ver().is_emulator:
-        CLOCK_RES_PLACES = 1
+        CLOCK_RES_PLACES = 2
     else:
         CLOCK_RES_PLACES = 3
 

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4174,6 +4174,7 @@ class EventfdTests(unittest.TestCase):
         os.eventfd_read(fd)
 
 @unittest.skipUnless(hasattr(os, 'timerfd_create'), 'requires os.timerfd_create')
+@unittest.skipIf(sys.platform == "android", "#124873: Test is flaky on Android")
 @support.requires_linux_version(2, 6, 30)
 class TimerfdTests(unittest.TestCase):
     # 1 ms accuracy is reliably achievable on every platform except Android


### PR DESCRIPTION
See https://github.com/python/cpython/issues/124873#issuecomment-2499297642.

<!-- gh-issue-number: gh-124873 -->
* Issue: gh-124873
<!-- /gh-issue-number -->
