### PR TITLE
[docs] Clarify mutating in-place operators for frozensets

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4416,8 +4416,8 @@ The constructors for both classes work the same:
    set('bc')`` returns an instance of :class:`frozenset`.
 
    The following mutating operations are available for :class:`set` instances.
-   For :class:`frozenset` instances, only the in-place variants of these operations
-   (``|=``, ``&=``, ``-=``, and ``^=``) are supported.
+   For :class:`frozenset` instances, only the augmented assignment variants of
+   these operations (``|=``, ``&=``, ``-=``, and ``^=``) are supported.
 
    .. method:: update(*others)
                set |= other | ...

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4415,8 +4415,9 @@ The constructors for both classes work the same:
    return the type of the first operand.  For example: ``frozenset('ab') |
    set('bc')`` returns an instance of :class:`frozenset`.
 
-   The following table lists operations available for :class:`set` that do not
-   apply to immutable instances of :class:`frozenset`:
+   The following mutating operations are available for :class:`set` instances.
+   For :class:`frozenset` instances, only the in-place variants of these operations
+   (``|=``, ``&=``, ``-=``, and ``^=``) are supported.
 
    .. method:: update(*others)
                set |= other | ...


### PR DESCRIPTION
Before this PR, it appears from the documentation that code like

```python
s = frozenset()
s |= {1}
print(s)  # prints frozenset({1})
```

would not work.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127312.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->