### PR TITLE
gh-127314: Don't mention the GIL when calling without a thread state on the free-threaded build

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -198,7 +198,7 @@ _Py_EnsureFuncTstateNotNULL(const char *func, PyThreadState *tstate)
 #else
         _Py_FatalErrorFunc(func,
             "the function must be called with an active thread state, "
-            "after Python initialization and before Python finalization, but it is NULL "
+            "after Python initialization and before Python finalization, but the thread state is NULL. "
             "(are you trying to call the C API inside of a Py_BEGIN_ALLOW_THREADS block?)");
 #endif
     }

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -198,8 +198,9 @@ _Py_EnsureFuncTstateNotNULL(const char *func, PyThreadState *tstate)
 #else
         _Py_FatalErrorFunc(func,
             "the function must be called with an active thread state, "
-            "after Python initialization and before Python finalization, but the thread state is NULL. "
-            "(are you trying to call the C API inside of a Py_BEGIN_ALLOW_THREADS block?)");
+            "after Python initialization and before Python finalization, "
+            "but it was called without an active thread state. "
+            "Are you trying to call the C API inside of a Py_BEGIN_ALLOW_THREADS block?");
 #endif
     }
 }

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -190,10 +190,17 @@ static inline void
 _Py_EnsureFuncTstateNotNULL(const char *func, PyThreadState *tstate)
 {
     if (tstate == NULL) {
+#ifndef Py_GIL_DISABLED
         _Py_FatalErrorFunc(func,
             "the function must be called with the GIL held, "
             "after Python initialization and before Python finalization, "
             "but the GIL is released (the current Python thread state is NULL)");
+#else
+        _Py_FatalErrorFunc(func,
+            "the function must be called with an active thread state, "
+            "after Python initialization and before Python finalization, but it is NULL "
+            "(are you trying to call the C API inside of a Py_BEGIN_ALLOW_THREADS block?)");
+#endif
     }
 }
 

--- a/Lib/test/test_capi/test_mem.py
+++ b/Lib/test/test_capi/test_mem.py
@@ -68,8 +68,13 @@ class PyMemDebugTests(unittest.TestCase):
 
     def check_malloc_without_gil(self, code):
         out = self.check(code)
-        expected = ('Fatal Python error: _PyMem_DebugMalloc: '
-                    'Python memory allocator called without holding the GIL')
+        if not support.Py_GIL_DISABLED:
+            expected = ('Fatal Python error: _PyMem_DebugMalloc: '
+                        'Python memory allocator called without holding the GIL')
+        else:
+            expected = ('Fatal Python error: _PyMem_DebugMalloc: '
+                        'Python memory allocator called without an active thread state. '
+                        '(Are you trying to call it inside of a Py_BEGIN_ALLOW_THREADS block?)')
         self.assertIn(expected, out)
 
     def test_pymem_malloc_without_gil(self):

--- a/Lib/test/test_capi/test_mem.py
+++ b/Lib/test/test_capi/test_mem.py
@@ -74,7 +74,7 @@ class PyMemDebugTests(unittest.TestCase):
         else:
             expected = ('Fatal Python error: _PyMem_DebugMalloc: '
                         'Python memory allocator called without an active thread state. '
-                        '(Are you trying to call it inside of a Py_BEGIN_ALLOW_THREADS block?)')
+                        'Are you trying to call it inside of a Py_BEGIN_ALLOW_THREADS block?')
         self.assertIn(expected, out)
 
     def test_pymem_malloc_without_gil(self):

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -109,7 +109,7 @@ class CAPITest(unittest.TestCase):
         else:
             msg = ("Fatal Python error: PyThreadState_Get: "
                    "the function must be called with an active thread state, "
-                   "after Python initialization and before Python finalization, but it is NULL "
+                   "after Python initialization and before Python finalization, but the thread state is NULL "
                    "(are you trying to call the C API inside of a Py_BEGIN_ALLOW_THREADS block?)").encode()
         self.assertTrue(err.rstrip().startswith(msg),
                         err)

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -107,7 +107,8 @@ class CAPITest(unittest.TestCase):
                    "but the GIL is released "
                    "(the current Python thread state is NULL)").encode()
         else:
-            msg = ("the function must be called with an active thread state, "
+            msg = ("Fatal Python error: PyThreadState_Get: "
+                   "the function must be called with an active thread state, "
                    "after Python initialization and before Python finalization, "
                    "but it was called without an active thread state. "
                    "Are you trying to call the C API inside of a Py_BEGIN_ALLOW_THREADS block?").encode()

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -109,7 +109,7 @@ class CAPITest(unittest.TestCase):
         else:
             msg = ("Fatal Python error: PyThreadState_Get: "
                    "the function must be called with an active thread state, "
-                   "after Python initialization and before Python finalization, but the thread state is NULL "
+                   "after Python initialization and before Python finalization, but the thread state is NULL. "
                    "(are you trying to call the C API inside of a Py_BEGIN_ALLOW_THREADS block?)").encode()
         self.assertTrue(err.rstrip().startswith(msg),
                         err)

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -100,11 +100,17 @@ class CAPITest(unittest.TestCase):
         _rc, out, err = run_result
         self.assertEqual(out, b'')
         # This used to cause an infinite loop.
-        msg = ("Fatal Python error: PyThreadState_Get: "
-               "the function must be called with the GIL held, "
-               "after Python initialization and before Python finalization, "
-               "but the GIL is released "
-               "(the current Python thread state is NULL)").encode()
+        if not support.Py_GIL_DISABLED:
+            msg = ("Fatal Python error: PyThreadState_Get: "
+                   "the function must be called with the GIL held, "
+                   "after Python initialization and before Python finalization, "
+                   "but the GIL is released "
+                   "(the current Python thread state is NULL)").encode()
+        else:
+            msg = ("Fatal Python error: PyThreadState_Get: "
+                   "the function must be called with an active thread state, "
+                   "after Python initialization and before Python finalization, but it is NULL "
+                   "(are you trying to call the C API inside of a Py_BEGIN_ALLOW_THREADS block?)").encode()
         self.assertTrue(err.rstrip().startswith(msg),
                         err)
 

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -107,10 +107,10 @@ class CAPITest(unittest.TestCase):
                    "but the GIL is released "
                    "(the current Python thread state is NULL)").encode()
         else:
-            msg = ("Fatal Python error: PyThreadState_Get: "
-                   "the function must be called with an active thread state, "
-                   "after Python initialization and before Python finalization, but the thread state is NULL. "
-                   "(are you trying to call the C API inside of a Py_BEGIN_ALLOW_THREADS block?)").encode()
+            msg = ("the function must be called with an active thread state, "
+                   "after Python initialization and before Python finalization, "
+                   "but it was called without an active thread state. "
+                   "Are you trying to call the C API inside of a Py_BEGIN_ALLOW_THREADS block?").encode()
         self.assertTrue(err.rstrip().startswith(msg),
                         err)
 

--- a/Misc/NEWS.d/next/C_API/2024-11-26-22-06-10.gh-issue-127314.SsRrIu.rst
+++ b/Misc/NEWS.d/next/C_API/2024-11-26-22-06-10.gh-issue-127314.SsRrIu.rst
@@ -1,0 +1,2 @@
+Improve error message when calling the C API without an active thread state
+on the :term:`free-threaded <free threading>` build.

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -2918,7 +2918,7 @@ _PyMem_DebugCheckGIL(const char *func)
         _Py_FatalErrorFunc(func,
                            "Python memory allocator called "
                            "without an active thread state. "
-                           "(Are you trying to call it inside of a Py_BEGIN_ALLOW_THREADS block?)");
+                           "Are you trying to call it inside of a Py_BEGIN_ALLOW_THREADS block?");
 #endif
     }
 }

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -2910,9 +2910,16 @@ static inline void
 _PyMem_DebugCheckGIL(const char *func)
 {
     if (!PyGILState_Check()) {
+#ifndef Py_GIL_DISABLED
         _Py_FatalErrorFunc(func,
                            "Python memory allocator called "
                            "without holding the GIL");
+#else
+        _Py_FatalErrorFunc(func,
+                           "Python memory allocator called "
+                           "without an active thread state. "
+                           "(Are you trying to call it inside of a Py_BEGIN_ALLOW_THREADS block?)");
+#endif
     }
 }
 


### PR DESCRIPTION
Releasing the thread state via `Py_BEGIN_ALLOW_THREADS` can be confusing for users on free-threading, because the common error messages that come up mention that the GIL must be held, but that won't make sense if it's disabled.

(Technically, the part of the new message mentioning `Py_BEGIN_ALLOW_THREADS` is true for the default build as well, but I don't see enough justification to change it there too.)

<!-- gh-issue-number: gh-127314 -->
* Issue: gh-127314
<!-- /gh-issue-number -->
