### PR TITLE
gh-127353: Allow to force color output on Windows

### DIFF
--- a/Lib/_colorize.py
+++ b/Lib/_colorize.py
@@ -32,14 +32,6 @@ def get_colors(colorize: bool = False) -> ANSIColors:
 
 
 def can_colorize() -> bool:
-    if sys.platform == "win32":
-        try:
-            import nt
-
-            if not nt._supports_virtual_terminal():
-                return False
-        except (ImportError, AttributeError):
-            return False
     if not sys.flags.ignore_environment:
         if os.environ.get("PYTHON_COLORS") == "0":
             return False
@@ -57,6 +49,15 @@ def can_colorize() -> bool:
 
     if not hasattr(sys.stderr, "fileno"):
         return False
+
+    if sys.platform == "win32":
+        try:
+            import nt
+
+            if not nt._supports_virtual_terminal():
+                return False
+        except (ImportError, AttributeError):
+            return False
 
     try:
         return os.isatty(sys.stderr.fileno())

--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -1,4 +1,3 @@
-import contextlib
 import sys
 import unittest
 import unittest.mock
@@ -18,38 +17,93 @@ def tearDownModule():
 
 class TestColorizeFunction(unittest.TestCase):
     @force_not_colorized
+    @unittest.skipUnless(sys.platform != "win32", "non-Windows only")
     def test_colorized_detection_checks_for_environment_variables(self):
-        if sys.platform == "win32":
-            virtual_patching = unittest.mock.patch("nt._supports_virtual_terminal",
-                                                   return_value=True)
-        else:
-            virtual_patching = contextlib.nullcontext()
-        with virtual_patching:
+        with (unittest.mock.patch("os.isatty") as isatty_mock,
+              unittest.mock.patch("sys.flags", unittest.mock.MagicMock(ignore_environment=False)),
+              unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE)):
+            isatty_mock.return_value = True
+            with unittest.mock.patch("os.environ", {}):
+                self.assertEqual(_colorize.can_colorize(), True)
+            with unittest.mock.patch("os.environ", {"TERM": "dumb"}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "1"}):
+                self.assertEqual(_colorize.can_colorize(), True)
+            with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "0"}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ", {"NO_COLOR": "1"}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ", {"NO_COLOR": "1", "PYTHON_COLORS": "1"}):
+                self.assertEqual(_colorize.can_colorize(), True)
+            with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1"}):
+                self.assertEqual(_colorize.can_colorize(), True)
+            with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "NO_COLOR": "1"}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "PYTHON_COLORS": "0"}):
+                self.assertEqual(_colorize.can_colorize(), False)
 
-            flags = unittest.mock.MagicMock(ignore_environment=False)
+            isatty_mock.return_value = False
+            with unittest.mock.patch("os.environ", {}):
+                self.assertEqual(_colorize.can_colorize(), False)
+
+    @force_not_colorized
+    @unittest.skipUnless(sys.platform == "win32", "Windows only")
+    def test_colorized_detection_checks_for_environment_variables_on_windows(self):
+        with unittest.mock.patch("nt._supports_virtual_terminal") as supports_vt_mock:
+            # If virtual terminal sequences are supported
+            supports_vt_mock.return_value = True
             with (unittest.mock.patch("os.isatty") as isatty_mock,
-                  unittest.mock.patch("sys.flags", flags),
+                  unittest.mock.patch("sys.flags", unittest.mock.MagicMock(ignore_environment=False)),
                   unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE)):
                 isatty_mock.return_value = True
-                with unittest.mock.patch("os.environ", {'TERM': 'dumb'}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {'PYTHON_COLORS': '1'}):
+                with unittest.mock.patch("os.environ", {}):
                     self.assertEqual(_colorize.can_colorize(), True)
-                with unittest.mock.patch("os.environ", {'PYTHON_COLORS': '0'}):
+                with unittest.mock.patch("os.environ", {"TERM": "dumb"}):
                     self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {'NO_COLOR': '1'}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ",
-                                         {'NO_COLOR': '1', "PYTHON_COLORS": '1'}):
+                with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "1"}):
                     self.assertEqual(_colorize.can_colorize(), True)
-                with unittest.mock.patch("os.environ", {'FORCE_COLOR': '1'}):
+                with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "0"}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ", {"NO_COLOR": "1"}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ", {"NO_COLOR": "1", "PYTHON_COLORS": "1"}):
                     self.assertEqual(_colorize.can_colorize(), True)
-                with unittest.mock.patch("os.environ",
-                                         {'FORCE_COLOR': '1', 'NO_COLOR': '1'}):
+                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1"}):
+                    self.assertEqual(_colorize.can_colorize(), True)
+                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "NO_COLOR": "1"}):
                     self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ",
-                                         {'FORCE_COLOR': '1', "PYTHON_COLORS": '0'}):
+                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "PYTHON_COLORS": "0"}):
                     self.assertEqual(_colorize.can_colorize(), False)
+
+                isatty_mock.return_value = False
+                with unittest.mock.patch("os.environ", {}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+
+            # If virtual terminal sequences are not supported
+            supports_vt_mock.return_value = False
+            with (unittest.mock.patch("os.isatty") as isatty_mock,
+                  unittest.mock.patch("sys.flags", unittest.mock.MagicMock(ignore_environment=False)),
+                  unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE)):
+                isatty_mock.return_value = True
+                with unittest.mock.patch("os.environ", {}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ", {"TERM": "dumb"}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "1"}):
+                    self.assertEqual(_colorize.can_colorize(), True)
+                with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "0"}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ", {"NO_COLOR": "1"}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ", {"NO_COLOR": "1", "PYTHON_COLORS": "1"}):
+                    self.assertEqual(_colorize.can_colorize(), True)
+                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1"}):
+                    self.assertEqual(_colorize.can_colorize(), True)
+                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "NO_COLOR": "1"}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "PYTHON_COLORS": "0"}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+
                 isatty_mock.return_value = False
                 with unittest.mock.patch("os.environ", {}):
                     self.assertEqual(_colorize.can_colorize(), False)

--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -1,3 +1,4 @@
+import contextlib
 import sys
 import unittest
 import unittest.mock
@@ -17,96 +18,78 @@ def tearDownModule():
 
 class TestColorizeFunction(unittest.TestCase):
     @force_not_colorized
-    @unittest.skipUnless(sys.platform != "win32", "non-Windows only")
     def test_colorized_detection_checks_for_environment_variables(self):
-        with (unittest.mock.patch("os.isatty") as isatty_mock,
+        if sys.platform == "win32":
+            virtual_patching = unittest.mock.patch("nt._supports_virtual_terminal",
+                                                   return_value=True)
+        else:
+            virtual_patching = contextlib.nullcontext()
+        with virtual_patching:
+
+            flags = unittest.mock.MagicMock(ignore_environment=False)
+            with (unittest.mock.patch("os.isatty") as isatty_mock,
+                  unittest.mock.patch("sys.flags", flags),
+                  unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE)):
+                isatty_mock.return_value = True
+                with unittest.mock.patch("os.environ", {'TERM': 'dumb'}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ", {'PYTHON_COLORS': '1'}):
+                    self.assertEqual(_colorize.can_colorize(), True)
+                with unittest.mock.patch("os.environ", {'PYTHON_COLORS': '0'}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ", {'NO_COLOR': '1'}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ",
+                                         {'NO_COLOR': '1', "PYTHON_COLORS": '1'}):
+                    self.assertEqual(_colorize.can_colorize(), True)
+                with unittest.mock.patch("os.environ", {'FORCE_COLOR': '1'}):
+                    self.assertEqual(_colorize.can_colorize(), True)
+                with unittest.mock.patch("os.environ",
+                                         {'FORCE_COLOR': '1', 'NO_COLOR': '1'}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ",
+                                         {'FORCE_COLOR': '1', "PYTHON_COLORS": '0'}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ", {}):
+                    self.assertEqual(_colorize.can_colorize(), True)
+
+                isatty_mock.return_value = False
+                with unittest.mock.patch("os.environ", {}):
+                    self.assertEqual(_colorize.can_colorize(), False)
+
+    @force_not_colorized
+    @unittest.skipUnless(sys.platform == "win32", "Windows only")
+    def test_colorized_detection_checks_for_environment_variables_no_vt(self):
+        with (unittest.mock.patch("nt._supports_virtual_terminal", return_value=False),
+              unittest.mock.patch("os.isatty") as isatty_mock,
               unittest.mock.patch("sys.flags", unittest.mock.MagicMock(ignore_environment=False)),
               unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE)):
             isatty_mock.return_value = True
+            with unittest.mock.patch("os.environ", {'TERM': 'dumb'}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ", {'PYTHON_COLORS': '1'}):
+                self.assertEqual(_colorize.can_colorize(), True)
+            with unittest.mock.patch("os.environ", {'PYTHON_COLORS': '0'}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ", {'NO_COLOR': '1'}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ",
+                                     {'NO_COLOR': '1', "PYTHON_COLORS": '1'}):
+                self.assertEqual(_colorize.can_colorize(), True)
+            with unittest.mock.patch("os.environ", {'FORCE_COLOR': '1'}):
+                self.assertEqual(_colorize.can_colorize(), True)
+            with unittest.mock.patch("os.environ",
+                                     {'FORCE_COLOR': '1', 'NO_COLOR': '1'}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ",
+                                     {'FORCE_COLOR': '1', "PYTHON_COLORS": '0'}):
+                self.assertEqual(_colorize.can_colorize(), False)
             with unittest.mock.patch("os.environ", {}):
-                self.assertEqual(_colorize.can_colorize(), True)
-            with unittest.mock.patch("os.environ", {"TERM": "dumb"}):
-                self.assertEqual(_colorize.can_colorize(), False)
-            with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "1"}):
-                self.assertEqual(_colorize.can_colorize(), True)
-            with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "0"}):
-                self.assertEqual(_colorize.can_colorize(), False)
-            with unittest.mock.patch("os.environ", {"NO_COLOR": "1"}):
-                self.assertEqual(_colorize.can_colorize(), False)
-            with unittest.mock.patch("os.environ", {"NO_COLOR": "1", "PYTHON_COLORS": "1"}):
-                self.assertEqual(_colorize.can_colorize(), True)
-            with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1"}):
-                self.assertEqual(_colorize.can_colorize(), True)
-            with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "NO_COLOR": "1"}):
-                self.assertEqual(_colorize.can_colorize(), False)
-            with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "PYTHON_COLORS": "0"}):
                 self.assertEqual(_colorize.can_colorize(), False)
 
             isatty_mock.return_value = False
             with unittest.mock.patch("os.environ", {}):
                 self.assertEqual(_colorize.can_colorize(), False)
-
-    @force_not_colorized
-    @unittest.skipUnless(sys.platform == "win32", "Windows only")
-    def test_colorized_detection_checks_for_environment_variables_on_windows(self):
-        with unittest.mock.patch("nt._supports_virtual_terminal") as supports_vt_mock:
-            # If virtual terminal sequences are supported
-            supports_vt_mock.return_value = True
-            with (unittest.mock.patch("os.isatty") as isatty_mock,
-                  unittest.mock.patch("sys.flags", unittest.mock.MagicMock(ignore_environment=False)),
-                  unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE)):
-                isatty_mock.return_value = True
-                with unittest.mock.patch("os.environ", {}):
-                    self.assertEqual(_colorize.can_colorize(), True)
-                with unittest.mock.patch("os.environ", {"TERM": "dumb"}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "1"}):
-                    self.assertEqual(_colorize.can_colorize(), True)
-                with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "0"}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {"NO_COLOR": "1"}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {"NO_COLOR": "1", "PYTHON_COLORS": "1"}):
-                    self.assertEqual(_colorize.can_colorize(), True)
-                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1"}):
-                    self.assertEqual(_colorize.can_colorize(), True)
-                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "NO_COLOR": "1"}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "PYTHON_COLORS": "0"}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-
-                isatty_mock.return_value = False
-                with unittest.mock.patch("os.environ", {}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-
-            # If virtual terminal sequences are not supported
-            supports_vt_mock.return_value = False
-            with (unittest.mock.patch("os.isatty") as isatty_mock,
-                  unittest.mock.patch("sys.flags", unittest.mock.MagicMock(ignore_environment=False)),
-                  unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE)):
-                isatty_mock.return_value = True
-                with unittest.mock.patch("os.environ", {}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {"TERM": "dumb"}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "1"}):
-                    self.assertEqual(_colorize.can_colorize(), True)
-                with unittest.mock.patch("os.environ", {"PYTHON_COLORS": "0"}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {"NO_COLOR": "1"}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {"NO_COLOR": "1", "PYTHON_COLORS": "1"}):
-                    self.assertEqual(_colorize.can_colorize(), True)
-                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1"}):
-                    self.assertEqual(_colorize.can_colorize(), True)
-                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "NO_COLOR": "1"}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {"FORCE_COLOR": "1", "PYTHON_COLORS": "0"}):
-                    self.assertEqual(_colorize.can_colorize(), False)
-
-                isatty_mock.return_value = False
-                with unittest.mock.patch("os.environ", {}):
-                    self.assertEqual(_colorize.can_colorize(), False)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Windows/2024-11-28-15-55-48.gh-issue-127353.i-XOXg.rst
+++ b/Misc/NEWS.d/next/Windows/2024-11-28-15-55-48.gh-issue-127353.i-XOXg.rst
@@ -1,0 +1,2 @@
+Allow to force color output on Windows using environment variables. Patch by
+Andrey Efremov.


### PR DESCRIPTION
I think nt._supports_virtual_terminal call should be placed above the isatty check so that the behavior of can_colorize function on Windows matches its behavior on POSIX OSes.

Screenshot of exception with patched can_colorize function in ConEmu terminal:
![241128153324_p](https://github.com/user-attachments/assets/27158b6a-f11b-42fa-b8da-964ab76b4294)


<!-- gh-issue-number: gh-127353 -->
* Issue: gh-127353
<!-- /gh-issue-number -->
