### PR TITLE
gh-87506: Document that `json.load*()` can raise `UnicodeDecodeError`

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -323,6 +323,7 @@ Basic Usage
 
    :raises JSONDecodeError:
       When the data being deserialized is not a valid JSON document.
+      Or if the binary file does not contain UTF-8, UTF-16 or UTF-32 encoded data.
 
    .. versionchanged:: 3.1
 
@@ -349,8 +350,9 @@ Basic Usage
 
    The other arguments have the same meaning as in :func:`load`.
 
-   If the data being deserialized is not a valid JSON document, a
-   :exc:`JSONDecodeError` will be raised.
+   If the data is not a valid JSON document, a :exc:`JSONDecodeError` will be
+   raised. If the binary file does not contain UTF-8, UTF-16 or UTF-32 encoded
+   data, a :exc:`UnicodeDecodeError` will be raised.
 
    .. versionchanged:: 3.6
       *s* can now be of type :class:`bytes` or :class:`bytearray`. The

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -323,7 +323,9 @@ Basic Usage
 
    :raises JSONDecodeError:
       When the data being deserialized is not a valid JSON document.
-      Or if the binary file does not contain UTF-8, UTF-16 or UTF-32 encoded data.
+
+   : raises UnicodeDecodeError:
+      If the binary file does not contain UTF-8, UTF-16 or UTF-32 encoded data.
 
    .. versionchanged:: 3.1
 

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -324,7 +324,7 @@ Basic Usage
    :raises JSONDecodeError:
       When the data being deserialized is not a valid JSON document.
 
-   : raises UnicodeDecodeError:
+   :raises UnicodeDecodeError:
       If the binary file does not contain UTF-8, UTF-16 or UTF-32 encoded data.
 
    .. versionchanged:: 3.1

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -354,8 +354,7 @@ Basic Usage
    The other arguments have the same meaning as in :func:`load`.
 
    If the data is not a valid JSON document, a :exc:`JSONDecodeError` will be
-   raised. If the binary file does not contain UTF-8, UTF-16 or UTF-32 encoded
-   data, a :exc:`UnicodeDecodeError` will be raised.
+   raised.
 
    .. versionchanged:: 3.6
       *s* can now be of type :class:`bytes` or :class:`bytearray`. The

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -325,7 +325,8 @@ Basic Usage
       When the data being deserialized is not a valid JSON document.
 
    :raises UnicodeDecodeError:
-      If the binary file does not contain UTF-8, UTF-16 or UTF-32 encoded data.
+      When the data being deserialized does not contain
+      UTF-8, UTF-16 or UTF-32 encoded data.
 
    .. versionchanged:: 3.1
 

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -353,8 +353,8 @@ Basic Usage
 
    The other arguments have the same meaning as in :func:`load`.
 
-   If the data is not a valid JSON document, a :exc:`JSONDecodeError` will be
-   raised.
+   If the data being deserialized is not a valid JSON document, a
+   :exc:`JSONDecodeError` will be raised.
 
    .. versionchanged:: 3.6
       *s* can now be of type :class:`bytes` or :class:`bytearray`. The


### PR DESCRIPTION
gh-87506: Improve the documentation for json.load() and json.loads()
