### PR TITLE
gh-127356: Fix prepend doctrees directory for gettext target

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -144,7 +144,7 @@ pydoc-topics: build
 
 .PHONY: gettext
 gettext: BUILDER = gettext
-gettext: SPHINXOPTS += -d build/doctrees-gettext
+gettext: override SPHINXOPTS := -d build/doctrees-gettext $(SPHINXOPTS)
 gettext: build
 
 .PHONY: htmlview


### PR DESCRIPTION
This allows SPHINXOPTS be passed via command-line for gettext target, and puts the `-d doctree-gettext` value before any SPHINXOPTS passed, hence allowing that value to be replaced if wanted. 

<!-- gh-issue-number: gh-127356 -->
* Issue: gh-127356
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127357.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->