### PR TITLE
gh-127257: ssl: Raise OSError for ERR_LIB_SYS

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-11-28-14-14-46.gh-issue-127257.n6-jU9.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-28-14-14-46.gh-issue-127257.n6-jU9.rst
@@ -1,0 +1,2 @@
+In :mod:`ssl`, system call failures that OpenSSL reports using
+``ERR_LIB_SYS`` are now raised as :exc:`OSError`.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -667,6 +667,11 @@ PySSL_SetError(PySSLSocket *sslsock, const char *filename, int lineno)
                         ERR_GET_REASON(e) == SSL_R_CERTIFICATE_VERIFY_FAILED) {
                     type = state->PySSLCertVerificationErrorObject;
                 }
+                if (ERR_GET_LIB(e) == ERR_LIB_SYS) {
+                    // A system error is being reported; reason is set to errno
+                    errno = ERR_GET_REASON(e);
+                    return PyErr_SetFromErrno(PyExc_OSError);
+                }
                 p = PY_SSL_ERROR_SYSCALL;
             }
             break;
@@ -692,6 +697,11 @@ PySSL_SetError(PySSLSocket *sslsock, const char *filename, int lineno)
                 errstr = "EOF occurred in violation of protocol";
             }
 #endif
+            if (ERR_GET_LIB(e) == ERR_LIB_SYS) {
+                // A system error is being reported; reason is set to errno
+                errno = ERR_GET_REASON(e);
+                return PyErr_SetFromErrno(PyExc_OSError);
+            }
             break;
         }
         default:


### PR DESCRIPTION
One way OpenSSL can report a failed syscall is SSL_ERROR_SYSCALL. We have that one covered.

But, another way is ERR_LIB_SYS. Apparently, it's being used more now, and causing issues on OpenSSL 3.4.0 on Arch buildbots.

From the ERR_raise manpage:

    ERR_LIB_SYS

        This "library code" indicates that a system error is
        being reported.  In this case, the reason code given
        to `ERR_raise()` and `ERR_raise_data()` *must* be
        `errno(3)`.

This PR only handles `ERR_LIB_SYS` for the high-lever error types
`SSL_ERROR_SYSCALL` and `SSL_ERROR_SSL`, i.e., not the ones where
OpenSSL indicates it has some more information about the issue.

I believe it's correct to raise OSError rather that SSLError
in these cases. That makes this a backwards-incompatible change
(but one we still might want to backport as a bugfix).

The error on Arch with OpenSSL 3.4.0 is *broken pipe* (EPIPE) when a client reads after the server shuts down. On my Arch, raising OSError makes `test_poplip` pass.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127257 -->
* Issue: gh-127257
<!-- /gh-issue-number -->
