### PR TITLE
[3.12] gh-123967: Fix faulthandler for trampoline frames (#127329)

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-11-27-14-06-35.gh-issue-123967.wxUmnW.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-27-14-06-35.gh-issue-123967.wxUmnW.rst
@@ -1,0 +1,2 @@
+Fix faulthandler for trampoline frames. If the top-most frame is a
+trampoline frame, skip it. Patch by Victor Stinner.


### PR DESCRIPTION
If the top-most frame is a trampoline frame, skip it.

(cherry picked from commit 58e334e1431b2ed6b70ee42501ea73e08084e769)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123967 -->
* Issue: gh-123967
<!-- /gh-issue-number -->
