### PR TITLE
gh-127190: Fix local_setattro() error handling

### DIFF
--- a/Lib/test/test_threading_local.py
+++ b/Lib/test/test_threading_local.py
@@ -208,6 +208,21 @@ class BaseLocalTest:
 
         _testcapi.join_temporary_c_thread()
 
+    @support.cpython_only
+    def test_error(self):
+        class Loop(self._local):
+            attr = 1
+
+        # Trick the "if name == '__dict__':" test of __setattr__()
+        # to always be true
+        class NameCompareTrue:
+            def __eq__(self, other):
+                return True
+
+        loop = Loop()
+        with self.assertRaisesRegex(AttributeError, 'Loop.*read-only'):
+            loop.__setattr__(NameCompareTrue(), 2)
+
 
 class ThreadLocalTest(unittest.TestCase, BaseLocalTest):
     _local = _thread._local

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1624,7 +1624,7 @@ local_setattro(localobject *self, PyObject *name, PyObject *v)
     }
     if (r == 1) {
         PyErr_Format(PyExc_AttributeError,
-                     "'%.100s' object attribute '%U' is read-only",
+                     "'%.100s' object attribute %R is read-only",
                      Py_TYPE(self)->tp_name, name);
         goto err;
     }


### PR DESCRIPTION
Don't make the assumption that the 'name' argument is a string. Use repr() to format the 'name' argument instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127190 -->
* Issue: gh-127190
<!-- /gh-issue-number -->
