### PR TITLE
🦃 Use sccache in CI with GHA storage, mac & wasi included

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,8 @@ jobs:
     timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
+    env:
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -99,6 +101,14 @@ jobs:
           python-version: '3.x'
       - name: Runner image version
         run: echo "IMAGE_VERSION=${ImageVersion}" >> "$GITHUB_ENV"
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
+        with:
+          version: "v0.8.2"
+      - name: Configure CC and CXX environment variables
+        run: |
+          echo "CC=sccache gcc" >> "$GITHUB_ENV"
+          echo "CXX=sccache gcc" >> "$GITHUB_ENV"
       - name: Restore config.cache
         uses: actions/cache@v4
         with:
@@ -107,12 +117,6 @@ jobs:
           key: ${{ github.job }}-${{ runner.os }}-${{ env.IMAGE_VERSION }}-${{ needs.check_source.outputs.config_hash }}-${{ env.pythonLocation }}
       - name: Install Dependencies
         run: sudo ./.github/workflows/posix-deps-apt.sh
-      - name: Add ccache to PATH
-        run: echo "PATH=/usr/lib/ccache:$PATH" >> "$GITHUB_ENV"
-      - name: Configure ccache action
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          save: false
       - name: Configure CPython
         run: |
           # Build Python with the libpython dynamic library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,14 +101,6 @@ jobs:
           python-version: '3.x'
       - name: Runner image version
         run: echo "IMAGE_VERSION=${ImageVersion}" >> "$GITHUB_ENV"
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
-        with:
-          version: "v0.8.2"
-      - name: Configure CC and CXX environment variables
-        run: |
-          echo "CC=sccache gcc" >> "$GITHUB_ENV"
-          echo "CXX=sccache gcc" >> "$GITHUB_ENV"
       - name: Restore config.cache
         uses: actions/cache@v4
         with:
@@ -117,6 +109,12 @@ jobs:
           key: ${{ github.job }}-${{ runner.os }}-${{ env.IMAGE_VERSION }}-${{ needs.check_source.outputs.config_hash }}-${{ env.pythonLocation }}
       - name: Install Dependencies
         run: sudo ./.github/workflows/posix-deps-apt.sh
+      - name: Start sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
+      - name: Configure CC and CXX environment variables
+        run: |
+          echo "CC=sccache gcc" >> "$GITHUB_ENV"
+          echo "CXX=sccache gcc" >> "$GITHUB_ENV"
       - name: Configure CPython
         run: |
           # Build Python with the libpython dynamic library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,8 +92,6 @@ jobs:
     timeout-minutes: 60
     needs: check_source
     if: needs.check_source.outputs.run_tests == 'true'
-    env:
-      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -111,10 +109,11 @@ jobs:
         run: sudo ./.github/workflows/posix-deps-apt.sh
       - name: Start sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
-      - name: Configure CC and CXX environment variables
+      - name: Configure CC and CXX env vars
         run: |
           echo "CC=sccache gcc" >> "$GITHUB_ENV"
           echo "CXX=sccache gcc" >> "$GITHUB_ENV"
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
       - name: Configure CPython
         run: |
           # Build Python with the libpython dynamic library
@@ -286,13 +285,13 @@ jobs:
     - name: Install OpenSSL
       if: steps.cache-openssl.outputs.cache-hit != 'true'
       run: python3 Tools/ssl/multissltests.py --steps=library --base-directory "$MULTISSL_DIR" --openssl "$OPENSSL_VER" --system Linux
-    - name: Add ccache to PATH
+    - name: Start sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.6
+    - name: Configure CC and CXX env vars
       run: |
-        echo "PATH=/usr/lib/ccache:$PATH" >> "$GITHUB_ENV"
-    - name: Configure ccache action
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        save: false
+        echo "CC=sccache gcc" >> "$GITHUB_ENV"
+        echo "CXX=sccache gcc" >> "$GITHUB_ENV"
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
     - name: Configure CPython
       run: ./configure CFLAGS="-fdiagnostics-format=json" --config-cache --enable-slower-safety --with-pydebug --with-openssl="$OPENSSL_DIR"
     - name: Build CPython
@@ -339,13 +338,13 @@ jobs:
     - name: Install OpenSSL
       if: steps.cache-openssl.outputs.cache-hit != 'true'
       run: python3 Tools/ssl/multissltests.py --steps=library --base-directory "$MULTISSL_DIR" --openssl "$OPENSSL_VER" --system Linux
-    - name: Add ccache to PATH
+    - name: Start sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.6
+    - name: Configure CC and CXX env vars
       run: |
-        echo "PATH=/usr/lib/ccache:$PATH" >> "$GITHUB_ENV"
-    - name: Configure ccache action
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        save: false
+        echo "CC=sccache gcc" >> "$GITHUB_ENV"
+        echo "CXX=sccache gcc" >> "$GITHUB_ENV"
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
     - name: Setup directory envs for out-of-tree builds
       run: |
         echo "CPYTHON_RO_SRCDIR=$(realpath -m "${GITHUB_WORKSPACE}"/../cpython-ro-srcdir)" >> "$GITHUB_ENV"
@@ -468,14 +467,13 @@ jobs:
     - name: Install OpenSSL
       if: steps.cache-openssl.outputs.cache-hit != 'true'
       run: python3 Tools/ssl/multissltests.py --steps=library --base-directory "$MULTISSL_DIR" --openssl "$OPENSSL_VER" --system Linux
-    - name: Add ccache to PATH
+    - name: Start sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.6
+    - name: Configure CC and CXX env vars
       run: |
-        echo "PATH=/usr/lib/ccache:$PATH" >> "$GITHUB_ENV"
-    - name: Configure ccache action
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        save: ${{ github.event_name == 'push' }}
-        max-size: "200M"
+        echo "CC=sccache gcc" >> "$GITHUB_ENV"
+        echo "CXX=sccache gcc" >> "$GITHUB_ENV"
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
     - name: Configure CPython
       run: ./configure --config-cache --with-address-sanitizer --without-pymalloc
     - name: Build CPython

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -25,7 +25,6 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       PYTHONSTRICTEXTENSIONBUILD: 1
-      SCCACHE_GHA_ENABLED: "true"
       TERM: linux
     runs-on: ${{ inputs.os }}
     steps:
@@ -44,10 +43,11 @@ jobs:
         brew link tcl-tk@8
     - name: Start sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.6
-    - name: Configure CC and CXX environment variables
+    - name: Configure CC and CXX env vars
       run: |
         echo "CC=sccache clang" >> "$GITHUB_ENV"
         echo "CXX=sccache clang" >> "$GITHUB_ENV"
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
     - name: Configure CPython
       run: |
         GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -25,6 +25,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       PYTHONSTRICTEXTENSIONBUILD: 1
+      SCCACHE_GHA_ENABLED: "true"
       TERM: linux
     runs-on: ${{ inputs.os }}
     steps:
@@ -41,6 +42,12 @@ jobs:
         brew install pkg-config openssl@3.0 xz gdbm tcl-tk@8 make
         # Because alternate versions are not symlinked into place by default:
         brew link tcl-tk@8
+    - name: Start sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.6
+    - name: Configure CC and CXX environment variables
+      run: |
+        echo "CC=sccache clang" >> "$GITHUB_ENV"
+        echo "CXX=sccache clang" >> "$GITHUB_ENV"
     - name: Configure CPython
       run: |
         GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \

--- a/.github/workflows/reusable-tsan.yml
+++ b/.github/workflows/reusable-tsan.yml
@@ -45,19 +45,14 @@ jobs:
         sudo update-alternatives --set clang++ /usr/bin/clang++-17
         # Reduce ASLR to avoid TSAN crashing
         sudo sysctl -w vm.mmap_rnd_bits=28
+    - name: Start sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.6
     - name: TSAN Option Setup
       run: |
         echo "TSAN_OPTIONS=log_path=${GITHUB_WORKSPACE}/tsan_log suppressions=${GITHUB_WORKSPACE}/${{ inputs.suppressions_path }} handle_segv=0" >> "$GITHUB_ENV"
-        echo "CC=clang" >> "$GITHUB_ENV"
-        echo "CXX=clang++" >> "$GITHUB_ENV"
-    - name: Add ccache to PATH
-      run: |
-        echo "PATH=/usr/lib/ccache:$PATH" >> "$GITHUB_ENV"
-    - name: Configure ccache action
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        save: ${{ github.event_name == 'push' }}
-        max-size: "200M"
+        echo "CC=sccache clang" >> "$GITHUB_ENV"
+        echo "CXX=sccache clang++" >> "$GITHUB_ENV"
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
     - name: Configure CPython
       run: ${{ inputs.options }}
     - name: Build CPython

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -25,22 +25,20 @@ jobs:
       FORCE_COLOR: 1
       OPENSSL_VER: 3.0.15
       PYTHONSTRICTEXTENSIONBUILD: 1
-      TERM: linux
       SCCACHE_GHA_ENABLED: "true"
+      TERM: linux
     steps:
     - uses: actions/checkout@v4
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
-    - name: Run sccache-cache
+    - name: Install dependencies
+      run: sudo ./.github/workflows/posix-deps-apt.sh
+    - name: Start sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.6
-      with:
-        version: "v0.8.2"
     - name: Configure CC and CXX environment variables
       run: |
         echo "CC=sccache gcc" >> "$GITHUB_ENV"
         echo "CXX=sccache gcc" >> "$GITHUB_ENV"
-    - name: Install dependencies
-      run: sudo ./.github/workflows/posix-deps-apt.sh
     - name: Configure OpenSSL env vars
       run: |
         echo "MULTISSL_DIR=${GITHUB_WORKSPACE}/multissl" >> "$GITHUB_ENV"

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -25,7 +25,6 @@ jobs:
       FORCE_COLOR: 1
       OPENSSL_VER: 3.0.15
       PYTHONSTRICTEXTENSIONBUILD: 1
-      SCCACHE_GHA_ENABLED: "true"
       TERM: linux
     steps:
     - uses: actions/checkout@v4
@@ -35,10 +34,11 @@ jobs:
       run: sudo ./.github/workflows/posix-deps-apt.sh
     - name: Start sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.6
-    - name: Configure CC and CXX environment variables
+    - name: Configure CC and CXX env vars
       run: |
         echo "CC=sccache gcc" >> "$GITHUB_ENV"
         echo "CXX=sccache gcc" >> "$GITHUB_ENV"
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
     - name: Configure OpenSSL env vars
       run: |
         echo "MULTISSL_DIR=${GITHUB_WORKSPACE}/multissl" >> "$GITHUB_ENV"

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -31,8 +31,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
-    - name: Run sccache-cache on push
-      if: github.event_name == 'push'
+    - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.6
       with:
         version: "v0.8.2"

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -26,10 +26,20 @@ jobs:
       OPENSSL_VER: 3.0.15
       PYTHONSTRICTEXTENSIONBUILD: 1
       TERM: linux
+      SCCACHE_GHA_ENABLED: "true"
     steps:
     - uses: actions/checkout@v4
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
+    - name: Run sccache-cache on push
+      if: github.event_name == 'push'
+      uses: mozilla-actions/sccache-action@v0.0.6
+      with:
+        version: "v0.8.2"
+    - name: Configure CC and CXX environment variables
+      run: |
+        echo "CC=sccache gcc" >> "$GITHUB_ENV"
+        echo "CXX=sccache gcc" >> "$GITHUB_ENV"
     - name: Install dependencies
       run: sudo ./.github/workflows/posix-deps-apt.sh
     - name: Configure OpenSSL env vars
@@ -46,14 +56,6 @@ jobs:
     - name: Install OpenSSL
       if: steps.cache-openssl.outputs.cache-hit != 'true'
       run: python3 Tools/ssl/multissltests.py --steps=library --base-directory "$MULTISSL_DIR" --openssl "$OPENSSL_VER" --system Linux
-    - name: Add ccache to PATH
-      run: |
-        echo "PATH=/usr/lib/ccache:$PATH" >> "$GITHUB_ENV"
-    - name: Configure ccache action
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        save: ${{ github.event_name == 'push' }}
-        max-size: "200M"
     - name: Setup directory envs for out-of-tree builds
       run: |
         echo "CPYTHON_RO_SRCDIR=$(realpath -m "${GITHUB_WORKSPACE}"/../cpython-ro-srcdir)" >> "$GITHUB_ENV"

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -18,6 +18,7 @@ jobs:
       WASI_SDK_PATH: /opt/wasi-sdk
       CROSS_BUILD_PYTHON: cross-build/build
       CROSS_BUILD_WASI: cross-build/wasm32-wasip1
+      SCCACHE_GHA_ENABLED: "true"
     steps:
     - uses: actions/checkout@v4
     # No problem resolver registered as one doesn't currently exist for Clang.
@@ -37,13 +38,8 @@ jobs:
         mkdir ${{ env.WASI_SDK_PATH }} && \
         curl -s -S --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ env.WASI_SDK_VERSION }}/wasi-sdk-${{ env.WASI_SDK_VERSION }}.0-x86_64-linux.tar.gz | \
         tar --strip-components 1 --directory ${{ env.WASI_SDK_PATH }} --extract --gunzip
-    - name: "Configure ccache action"
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        save: ${{ github.event_name == 'push' }}
-        max-size: "200M"
-    - name: "Add ccache to PATH"
-      run: echo "PATH=/usr/lib/ccache:$PATH" >> "$GITHUB_ENV"
+    - name: Start sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.6
     - name: "Install Python"
       uses: actions/setup-python@v5
       with:

--- a/Tools/wasm/wasi.py
+++ b/Tools/wasm/wasi.py
@@ -180,6 +180,8 @@ def wasi_sdk_env(context):
     if wasi_sdk_path != pathlib.Path("/opt/wasi-sdk"):
         for compiler in compiler_env_names:
             env[compiler] += f" --sysroot={sysroot}"
+
+    # sccache used in CI via .github/workflows/reusable-wasi.yaml
     if subprocess.call(("sccache", "--version"), stderr=subprocess.DEVNULL) == 0:
         for compiler in compiler_env_names:
             env[compiler] = 'sccache ' + env[compiler]

--- a/Tools/wasm/wasi.py
+++ b/Tools/wasm/wasi.py
@@ -173,12 +173,23 @@ def wasi_sdk_env(context):
     env = {"CC": "clang", "CPP": "clang-cpp", "CXX": "clang++",
            "AR": "llvm-ar", "RANLIB": "ranlib"}
 
+    # sccache available? wire it up!
+    # used in GHA CI via .github/workflows/reusable-wasi.yaml
+    if subprocess.call(["sccache", "--version"], stderr=subprocess.DEVNULL) == 0:
+        env["CC"] = f'sccache {env["CC"]}'
+        env["CPP"] = f'sccache {env["CPP"]}'
+        env["CXX"] = f'sccache {env["CXX"]}'
+
     for env_var, binary_name in list(env.items()):
         env[env_var] = os.fsdecode(wasi_sdk_path / "bin" / binary_name)
 
+    compiler_env_names = ("CC", "CPP", "CXX")
     if wasi_sdk_path != pathlib.Path("/opt/wasi-sdk"):
-        for compiler in ["CC", "CPP", "CXX"]:
+        for compiler in compiler_env_names:
             env[compiler] += f" --sysroot={sysroot}"
+    if subprocess.call(("sccache", "--version"), stderr=subprocess.DEVNULL) == 0:
+        for compiler in compiler_env_names:
+            env[compiler] = 'sccache ' + env[compiler]
 
     env["PKG_CONFIG_PATH"] = ""
     env["PKG_CONFIG_LIBDIR"] = os.pathsep.join(

--- a/Tools/wasm/wasi.py
+++ b/Tools/wasm/wasi.py
@@ -173,13 +173,6 @@ def wasi_sdk_env(context):
     env = {"CC": "clang", "CPP": "clang-cpp", "CXX": "clang++",
            "AR": "llvm-ar", "RANLIB": "ranlib"}
 
-    # sccache available? wire it up!
-    # used in GHA CI via .github/workflows/reusable-wasi.yaml
-    if subprocess.call(["sccache", "--version"], stderr=subprocess.DEVNULL) == 0:
-        env["CC"] = f'sccache {env["CC"]}'
-        env["CPP"] = f'sccache {env["CPP"]}'
-        env["CXX"] = f'sccache {env["CXX"]}'
-
     for env_var, binary_name in list(env.items()):
         env[env_var] = os.fsdecode(wasi_sdk_path / "bin" / binary_name)
 


### PR DESCRIPTION
https://github.com/mozilla/sccache from Mozilla is a modern ccache replacement that uses cloud storage such as GHA directly.

If successful, this adds ccache to places we didn't have it before (macOS), and uses GHA storage directly instead of the old ccache based flow of storing a bundle into the GHA cache after the run.

Q: is that an accurate description of how the old ccache flow actually worked?

Windows? it can!  That'll take a little more plumbing into its build flow but it should just work.

### TODO items

 * [ ] look at the dumped cache stats across GHA CI runs on commits below, why are many of them so low when they should've just rebuilt the same thing?  what inputs does sccache use as a key?  is there a unique path or env var mixing things up?  they in theory designed this in part for CI usage so...
 * [ ] figure out the [debugging story for sccache in CI](https://github.com/mozilla/sccache?tab=readme-ov-file#debugging) to understand why it is or isn't caching some stuff.
 * [ ] decide which places this is worth enabling vs the older ccache stuff.
 * [ ] Q: how do we monitor GHA Cache storage and rate limits for the project?