### PR TITLE
gh-127316: fix incorrect assertion in setting `__class__` in free-threading

### DIFF
--- a/Lib/test/test_free_threading/test_type.py
+++ b/Lib/test/test_free_threading/test_type.py
@@ -124,6 +124,21 @@ class TestType(TestCase):
         for thread in threads:
             thread.join()
 
+    def test_object_class_change(self):
+        class Base:
+            def __init__(self):
+                self.attr = 123
+        class ClassA(Base):
+            pass
+        class ClassB(Base):
+            pass
+
+        obj = ClassA()
+        # keep reference to __dict__
+        d = obj.__dict__
+        obj.__class__ = ClassB
+
+
     def run_one(self, writer_func, reader_func):
         writer = Thread(target=writer_func)
         readers = []

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -7300,7 +7300,7 @@ _PyDict_DetachFromObject(PyDictObject *mp, PyObject *obj)
 
     // We could be called with an unlocked dict when the caller knows the
     // values are already detached, so we assert after inline values check.
-    _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(mp);
+    ASSERT_WORLD_STOPPED_OR_OBJ_LOCKED(mp);
     assert(mp->ma_values->embedded == 1);
     assert(mp->ma_values->valid == 1);
     assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127316 -->
* Issue: gh-127316
<!-- /gh-issue-number -->
