### PR TITLE
fix param type in PyObject_HasAttrWithError (docs)

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -85,7 +85,7 @@ Object Protocol
    instead of the :func:`repr`.
 
 
-.. c:function:: int PyObject_HasAttrWithError(PyObject *o, const char *attr_name)
+.. c:function:: int PyObject_HasAttrWithError(PyObject *o, PyObject *attr_name)
 
    Returns ``1`` if *o* has the attribute *attr_name*, and ``0`` otherwise.
    This is equivalent to the Python expression ``hasattr(o, attr_name)``.


### PR DESCRIPTION
# fix param type in PyObject_HasAttrWithError (docs)
I was reading through the docs and found out that the ``attr_name`` parameter in the function ``PyObject_HasAttrWithError`` was mixed up with ``PyObject_HasAttrStringWithError``

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127403.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->