### PR TITLE
gh-115999: Add free-threaded specialization for `SEND`.

### DIFF
--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -1289,15 +1289,15 @@ class TestSpecializer(TestBase):
             async def __aexit__(self, *exc):
                 pass
 
-        async def f():
+        async def send_with():
             for i in range(100):
                 async with CM():
                     x = 1
 
-        run_async(f())
+        run_async(send_with())
         # Note there are still unspecialized "SEND" opcodes in the
         # cleanup paths of the 'with' statement.
-        self.assert_specialized(f, "SEND_GEN")
+        self.assert_specialized(send_with, "SEND_GEN")
 
     @cpython_only
     @requires_specialization_ft
@@ -1305,14 +1305,14 @@ class TestSpecializer(TestBase):
         def g():
             yield None
 
-        def f():
+        def send_yield_from():
             yield from g()
 
         for i in range(100):
-            list(f())
+            list(send_yield_from())
 
-        self.assert_specialized(f, "SEND_GEN")
-        self.assert_no_opcode(f, "SEND")
+        self.assert_specialized(send_yield_from, "SEND_GEN")
+        self.assert_no_opcode(send_yield_from, "SEND")
 
     @cpython_only
     @requires_specialization_ft

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1111,7 +1111,7 @@ dummy_func(
         };
 
         specializing op(_SPECIALIZE_SEND, (counter/1, receiver, unused -- receiver, unused)) {
-            #if ENABLE_SPECIALIZATION
+            #if ENABLE_SPECIALIZATION_FT
             if (ADAPTIVE_COUNTER_TRIGGERS(counter)) {
                 next_instr = this_instr;
                 _Py_Specialize_Send(receiver, next_instr);
@@ -1119,7 +1119,7 @@ dummy_func(
             }
             OPCODE_DEFERRED_INC(SEND);
             ADVANCE_ADAPTIVE_COUNTER(this_instr[1].counter);
-            #endif  /* ENABLE_SPECIALIZATION */
+            #endif  /* ENABLE_SPECIALIZATION_FT */
         }
 
         op(_SEND, (receiver, v -- receiver, retval)) {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -7057,7 +7057,7 @@
                 receiver = stack_pointer[-2];
                 uint16_t counter = read_u16(&this_instr[1].cache);
                 (void)counter;
-                #if ENABLE_SPECIALIZATION
+                #if ENABLE_SPECIALIZATION_FT
                 if (ADAPTIVE_COUNTER_TRIGGERS(counter)) {
                     next_instr = this_instr;
                     _PyFrame_SetStackPointer(frame, stack_pointer);
@@ -7067,7 +7067,7 @@
                 }
                 OPCODE_DEFERRED_INC(SEND);
                 ADVANCE_ADAPTIVE_COUNTER(this_instr[1].counter);
-                #endif  /* ENABLE_SPECIALIZATION */
+                #endif  /* ENABLE_SPECIALIZATION_FT */
             }
             // _SEND
             {

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2645,14 +2645,12 @@ _Py_Specialize_Send(_PyStackRef receiver_st, _Py_CODEUNIT *instr)
             goto failure;
         }
         specialize(instr, SEND_GEN);
-        goto success;
+        return;
     }
     SPECIALIZATION_FAIL(SEND,
                         _PySpecialization_ClassifyIterator(receiver));
 failure:
     unspecialize(instr);
-success:
-    return;
 }
 
 #ifdef Py_STATS

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -2636,28 +2636,23 @@ _Py_Specialize_Send(_PyStackRef receiver_st, _Py_CODEUNIT *instr)
 {
     PyObject *receiver = PyStackRef_AsPyObjectBorrow(receiver_st);
 
-    assert(ENABLE_SPECIALIZATION);
+    assert(ENABLE_SPECIALIZATION_FT);
     assert(_PyOpcode_Caches[SEND] == INLINE_CACHE_ENTRIES_SEND);
-    _PySendCache *cache = (_PySendCache *)(instr + 1);
     PyTypeObject *tp = Py_TYPE(receiver);
     if (tp == &PyGen_Type || tp == &PyCoro_Type) {
         if (_PyInterpreterState_GET()->eval_frame) {
             SPECIALIZATION_FAIL(SEND, SPEC_FAIL_OTHER);
             goto failure;
         }
-        instr->op.code = SEND_GEN;
+        specialize(instr, SEND_GEN);
         goto success;
     }
     SPECIALIZATION_FAIL(SEND,
                         _PySpecialization_ClassifyIterator(receiver));
 failure:
-    STAT_INC(SEND, failure);
-    instr->op.code = SEND;
-    cache->counter = adaptive_counter_backoff(cache->counter);
-    return;
+    unspecialize(instr);
 success:
-    STAT_INC(SEND, success);
-    cache->counter = adaptive_counter_cooldown();
+    return;
 }
 
 #ifdef Py_STATS


### PR DESCRIPTION
No additional thread safety changes are required.  Note that sending to a generator that is shared between threads is not safe in the free-threaded build.

<!-- gh-issue-number: gh-115999 -->
* Issue: gh-115999
<!-- /gh-issue-number -->
