### PR TITLE
[3.13] gh-127341: Argument Clinic: fix compiler warnings for getters with docstrings (GH-127310)

### DIFF
--- a/Lib/test/clinic.test.c
+++ b/Lib/test/clinic.test.c
@@ -4956,9 +4956,7 @@ Test_meth_coexist_impl(TestObj *self)
 Test.property
 [clinic start generated code]*/
 
-#if defined(Test_property_HAS_DOCSTR)
-#  define Test_property_DOCSTR Test_property__doc__
-#else
+#if !defined(Test_property_DOCSTR)
 #  define Test_property_DOCSTR NULL
 #endif
 #if defined(TEST_PROPERTY_GETSETDEF)
@@ -4979,16 +4977,14 @@ Test_property_get(TestObj *self, void *Py_UNUSED(context))
 
 static PyObject *
 Test_property_get_impl(TestObj *self)
-/*[clinic end generated code: output=27b519719d992e03 input=2d92b3449fbc7d2b]*/
+/*[clinic end generated code: output=7cadd0f539805266 input=2d92b3449fbc7d2b]*/
 
 /*[clinic input]
 @setter
 Test.property
 [clinic start generated code]*/
 
-#if defined(TEST_PROPERTY_HAS_DOCSTR)
-#  define Test_property_DOCSTR Test_property__doc__
-#else
+#if !defined(Test_property_DOCSTR)
 #  define Test_property_DOCSTR NULL
 #endif
 #if defined(TEST_PROPERTY_GETSETDEF)
@@ -5013,7 +5009,7 @@ Test_property_set(TestObj *self, PyObject *value, void *Py_UNUSED(context))
 
 static int
 Test_property_set_impl(TestObj *self, PyObject *value)
-/*[clinic end generated code: output=d51023f17c4ac3a1 input=3bc3f46a23c83a88]*/
+/*[clinic end generated code: output=e4342fe9bb1d7817 input=3bc3f46a23c83a88]*/
 
 /*[clinic input]
 output push

--- a/Modules/_io/clinic/bufferedio.c.h
+++ b/Modules/_io/clinic/bufferedio.c.h
@@ -327,9 +327,7 @@ _io__Buffered_simple_flush(buffered *self, PyObject *Py_UNUSED(ignored))
     return return_value;
 }
 
-#if defined(_io__Buffered_closed_HAS_DOCSTR)
-#  define _io__Buffered_closed_DOCSTR _io__Buffered_closed__doc__
-#else
+#if !defined(_io__Buffered_closed_DOCSTR)
 #  define _io__Buffered_closed_DOCSTR NULL
 #endif
 #if defined(_IO__BUFFERED_CLOSED_GETSETDEF)
@@ -469,9 +467,7 @@ _io__Buffered_writable(buffered *self, PyObject *Py_UNUSED(ignored))
     return return_value;
 }
 
-#if defined(_io__Buffered_name_HAS_DOCSTR)
-#  define _io__Buffered_name_DOCSTR _io__Buffered_name__doc__
-#else
+#if !defined(_io__Buffered_name_DOCSTR)
 #  define _io__Buffered_name_DOCSTR NULL
 #endif
 #if defined(_IO__BUFFERED_NAME_GETSETDEF)
@@ -496,9 +492,7 @@ _io__Buffered_name_get(buffered *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_io__Buffered_mode_HAS_DOCSTR)
-#  define _io__Buffered_mode_DOCSTR _io__Buffered_mode__doc__
-#else
+#if !defined(_io__Buffered_mode_DOCSTR)
 #  define _io__Buffered_mode_DOCSTR NULL
 #endif
 #if defined(_IO__BUFFERED_MODE_GETSETDEF)
@@ -1245,4 +1239,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8eead000083dc5fa input=a9049054013a1b77]*/
+/*[clinic end generated code: output=985a70d6d7cd0154 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/stringio.c.h
+++ b/Modules/_io/clinic/stringio.c.h
@@ -475,9 +475,7 @@ _io_StringIO___setstate__(stringio *self, PyObject *state)
     return return_value;
 }
 
-#if defined(_io_StringIO_closed_HAS_DOCSTR)
-#  define _io_StringIO_closed_DOCSTR _io_StringIO_closed__doc__
-#else
+#if !defined(_io_StringIO_closed_DOCSTR)
 #  define _io_StringIO_closed_DOCSTR NULL
 #endif
 #if defined(_IO_STRINGIO_CLOSED_GETSETDEF)
@@ -502,9 +500,7 @@ _io_StringIO_closed_get(stringio *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_io_StringIO_line_buffering_HAS_DOCSTR)
-#  define _io_StringIO_line_buffering_DOCSTR _io_StringIO_line_buffering__doc__
-#else
+#if !defined(_io_StringIO_line_buffering_DOCSTR)
 #  define _io_StringIO_line_buffering_DOCSTR NULL
 #endif
 #if defined(_IO_STRINGIO_LINE_BUFFERING_GETSETDEF)
@@ -529,9 +525,7 @@ _io_StringIO_line_buffering_get(stringio *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_io_StringIO_newlines_HAS_DOCSTR)
-#  define _io_StringIO_newlines_DOCSTR _io_StringIO_newlines__doc__
-#else
+#if !defined(_io_StringIO_newlines_DOCSTR)
 #  define _io_StringIO_newlines_DOCSTR NULL
 #endif
 #if defined(_IO_STRINGIO_NEWLINES_GETSETDEF)
@@ -555,4 +549,4 @@ _io_StringIO_newlines_get(stringio *self, void *Py_UNUSED(context))
 
     return return_value;
 }
-/*[clinic end generated code: output=9ffea20cd32d4cd8 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b16edb931e4fa548 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/textio.c.h
+++ b/Modules/_io/clinic/textio.c.h
@@ -205,11 +205,9 @@ PyDoc_STRVAR(_io__TextIOBase_encoding__doc__,
 "Encoding of the text stream.\n"
 "\n"
 "Subclasses should override.");
-#define _io__TextIOBase_encoding_HAS_DOCSTR
+#define _io__TextIOBase_encoding_DOCSTR _io__TextIOBase_encoding__doc__
 
-#if defined(_io__TextIOBase_encoding_HAS_DOCSTR)
-#  define _io__TextIOBase_encoding_DOCSTR _io__TextIOBase_encoding__doc__
-#else
+#if !defined(_io__TextIOBase_encoding_DOCSTR)
 #  define _io__TextIOBase_encoding_DOCSTR NULL
 #endif
 #if defined(_IO__TEXTIOBASE_ENCODING_GETSETDEF)
@@ -234,11 +232,9 @@ PyDoc_STRVAR(_io__TextIOBase_newlines__doc__,
 "Only line endings translated during reading are considered.\n"
 "\n"
 "Subclasses should override.");
-#define _io__TextIOBase_newlines_HAS_DOCSTR
+#define _io__TextIOBase_newlines_DOCSTR _io__TextIOBase_newlines__doc__
 
-#if defined(_io__TextIOBase_newlines_HAS_DOCSTR)
-#  define _io__TextIOBase_newlines_DOCSTR _io__TextIOBase_newlines__doc__
-#else
+#if !defined(_io__TextIOBase_newlines_DOCSTR)
 #  define _io__TextIOBase_newlines_DOCSTR NULL
 #endif
 #if defined(_IO__TEXTIOBASE_NEWLINES_GETSETDEF)
@@ -261,11 +257,9 @@ PyDoc_STRVAR(_io__TextIOBase_errors__doc__,
 "The error setting of the decoder or encoder.\n"
 "\n"
 "Subclasses should override.");
-#define _io__TextIOBase_errors_HAS_DOCSTR
+#define _io__TextIOBase_errors_DOCSTR _io__TextIOBase_errors__doc__
 
-#if defined(_io__TextIOBase_errors_HAS_DOCSTR)
-#  define _io__TextIOBase_errors_DOCSTR _io__TextIOBase_errors__doc__
-#else
+#if !defined(_io__TextIOBase_errors_DOCSTR)
 #  define _io__TextIOBase_errors_DOCSTR NULL
 #endif
 #if defined(_IO__TEXTIOBASE_ERRORS_GETSETDEF)
@@ -1131,9 +1125,7 @@ _io_TextIOWrapper_close(textio *self, PyObject *Py_UNUSED(ignored))
     return return_value;
 }
 
-#if defined(_io_TextIOWrapper_name_HAS_DOCSTR)
-#  define _io_TextIOWrapper_name_DOCSTR _io_TextIOWrapper_name__doc__
-#else
+#if !defined(_io_TextIOWrapper_name_DOCSTR)
 #  define _io_TextIOWrapper_name_DOCSTR NULL
 #endif
 #if defined(_IO_TEXTIOWRAPPER_NAME_GETSETDEF)
@@ -1158,9 +1150,7 @@ _io_TextIOWrapper_name_get(textio *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_io_TextIOWrapper_closed_HAS_DOCSTR)
-#  define _io_TextIOWrapper_closed_DOCSTR _io_TextIOWrapper_closed__doc__
-#else
+#if !defined(_io_TextIOWrapper_closed_DOCSTR)
 #  define _io_TextIOWrapper_closed_DOCSTR NULL
 #endif
 #if defined(_IO_TEXTIOWRAPPER_CLOSED_GETSETDEF)
@@ -1185,9 +1175,7 @@ _io_TextIOWrapper_closed_get(textio *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_io_TextIOWrapper_newlines_HAS_DOCSTR)
-#  define _io_TextIOWrapper_newlines_DOCSTR _io_TextIOWrapper_newlines__doc__
-#else
+#if !defined(_io_TextIOWrapper_newlines_DOCSTR)
 #  define _io_TextIOWrapper_newlines_DOCSTR NULL
 #endif
 #if defined(_IO_TEXTIOWRAPPER_NEWLINES_GETSETDEF)
@@ -1212,9 +1200,7 @@ _io_TextIOWrapper_newlines_get(textio *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_io_TextIOWrapper_errors_HAS_DOCSTR)
-#  define _io_TextIOWrapper_errors_DOCSTR _io_TextIOWrapper_errors__doc__
-#else
+#if !defined(_io_TextIOWrapper_errors_DOCSTR)
 #  define _io_TextIOWrapper_errors_DOCSTR NULL
 #endif
 #if defined(_IO_TEXTIOWRAPPER_ERRORS_GETSETDEF)
@@ -1239,9 +1225,7 @@ _io_TextIOWrapper_errors_get(textio *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_io_TextIOWrapper__CHUNK_SIZE_HAS_DOCSTR)
-#  define _io_TextIOWrapper__CHUNK_SIZE_DOCSTR _io_TextIOWrapper__CHUNK_SIZE__doc__
-#else
+#if !defined(_io_TextIOWrapper__CHUNK_SIZE_DOCSTR)
 #  define _io_TextIOWrapper__CHUNK_SIZE_DOCSTR NULL
 #endif
 #if defined(_IO_TEXTIOWRAPPER__CHUNK_SIZE_GETSETDEF)
@@ -1266,9 +1250,7 @@ _io_TextIOWrapper__CHUNK_SIZE_get(textio *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_IO_TEXTIOWRAPPER__CHUNK_SIZE_HAS_DOCSTR)
-#  define _io_TextIOWrapper__CHUNK_SIZE_DOCSTR _io_TextIOWrapper__CHUNK_SIZE__doc__
-#else
+#if !defined(_io_TextIOWrapper__CHUNK_SIZE_DOCSTR)
 #  define _io_TextIOWrapper__CHUNK_SIZE_DOCSTR NULL
 #endif
 #if defined(_IO_TEXTIOWRAPPER__CHUNK_SIZE_GETSETDEF)
@@ -1292,4 +1274,4 @@ _io_TextIOWrapper__CHUNK_SIZE_set(textio *self, PyObject *value, void *Py_UNUSED
 
     return return_value;
 }
-/*[clinic end generated code: output=04cb7c67791a9ec1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8074cba93ae39cf7 input=a9049054013a1b77]*/

--- a/Tools/clinic/libclinic/parse_args.py
+++ b/Tools/clinic/libclinic/parse_args.py
@@ -146,7 +146,7 @@ DOCSTRING_PROTOTYPE_STRVAR: Final[str] = libclinic.normalize_snippet("""
 GETSET_DOCSTRING_PROTOTYPE_STRVAR: Final[str] = libclinic.normalize_snippet("""
     PyDoc_STRVAR({getset_basename}__doc__,
     {docstring});
-    #define {getset_basename}_HAS_DOCSTR
+    #define {getset_basename}_DOCSTR {getset_basename}__doc__
 """)
 IMPL_DEFINITION_PROTOTYPE: Final[str] = libclinic.normalize_snippet("""
     static {impl_return_type}
@@ -157,9 +157,7 @@ METHODDEF_PROTOTYPE_DEFINE: Final[str] = libclinic.normalize_snippet(r"""
         {{"{name}", {methoddef_cast}{c_basename}{methoddef_cast_end}, {methoddef_flags}, {c_basename}__doc__}},
 """)
 GETTERDEF_PROTOTYPE_DEFINE: Final[str] = libclinic.normalize_snippet(r"""
-    #if defined({getset_basename}_HAS_DOCSTR)
-    #  define {getset_basename}_DOCSTR {getset_basename}__doc__
-    #else
+    #if !defined({getset_basename}_DOCSTR)
     #  define {getset_basename}_DOCSTR NULL
     #endif
     #if defined({getset_name}_GETSETDEF)
@@ -170,9 +168,7 @@ GETTERDEF_PROTOTYPE_DEFINE: Final[str] = libclinic.normalize_snippet(r"""
     #endif
 """)
 SETTERDEF_PROTOTYPE_DEFINE: Final[str] = libclinic.normalize_snippet(r"""
-    #if defined({getset_name}_HAS_DOCSTR)
-    #  define {getset_basename}_DOCSTR {getset_basename}__doc__
-    #else
+    #if !defined({getset_basename}_DOCSTR)
     #  define {getset_basename}_DOCSTR NULL
     #endif
     #if defined({getset_name}_GETSETDEF)


### PR DESCRIPTION
(cherry picked from commit 99490913a08adcf2fe5e69b82772a829ec462275)

Co-authored-by: Erlend E. Aasland <erlend@python.org>

<!-- gh-issue-number: gh-127341 -->
* Issue: gh-127341
<!-- /gh-issue-number -->
