### PR TITLE
Add the `.. availability:: Windows` directive to the function prototype that "returns a foreign function that will call a COM method".

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1812,6 +1812,8 @@ different ways, depending on the type and number of the parameters in the call:
    the COM interface as first argument, in addition to those parameters that
    are specified in the :attr:`!argtypes` tuple.
 
+   .. availability:: Windows
+
 
 The optional *paramflags* parameter creates foreign function wrappers with much
 more functionality than the features described above.


### PR DESCRIPTION
During my investigation of a `ctypes`-related issue, I noticed a section on COM that was missing the `.. availability:: Windows` directive.

I initially planned to address this along with improvements to other sections after completing my investigation, but I might forget by then, so I am submitting a PR for just this part now.

Since this change only adds a directive, I believe it does not require re-translating the documentation for languages other than the English version.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127436.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->