### PR TITLE
[3.12] Link to correct class methods in asyncio primitives docs (GH-127270)

### DIFF
--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -257,11 +257,6 @@ Condition
       Once awakened, the Condition re-acquires its lock and this method
       returns ``True``.
 
-      Note that a task *may* return from this call spuriously,
-      which is why the caller should always re-check the state
-      and be prepared to :meth:`~Condition.wait` again. For this reason, you may
-      prefer to use :meth:`~Condition.wait_for` instead.
-
    .. coroutinemethod:: wait_for(predicate)
 
       Wait until a predicate becomes *true*.

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -257,13 +257,19 @@ Condition
       Once awakened, the Condition re-acquires its lock and this method
       returns ``True``.
 
+      Note that a task *may* return from this call spuriously,
+      which is why the caller should always re-check the state
+      and be prepared to :meth:`~Condition.wait` again. For this reason, you may
+      prefer to use :meth:`~Condition.wait_for` instead.
+
    .. coroutinemethod:: wait_for(predicate)
 
       Wait until a predicate becomes *true*.
 
       The predicate must be a callable which result will be
-      interpreted as a boolean value.  The final value is the
-      return value.
+      interpreted as a boolean value.  The method will repeatedly
+      :meth:`~Condition.wait` until the predicate evaluates to *true*.
+      The final value is the return value.
 
 
 Semaphore
@@ -428,7 +434,7 @@ Barrier
    .. coroutinemethod:: abort()
 
       Put the barrier into a broken state.  This causes any active or future
-      calls to :meth:`wait` to fail with the :class:`BrokenBarrierError`.
+      calls to :meth:`~Barrier.wait` to fail with the :class:`BrokenBarrierError`.
       Use this for example if one of the tasks needs to abort, to avoid infinite
       waiting tasks.
 


### PR DESCRIPTION
(cherry picked from commit 15d6506d175780bb29e5fcde654e3860408aa93e)

Co-authored-by: Ollanta Cuba Gyllensten <ollantaster@gmail.com>

@kumaraditya303 
I've checked that `wait_for` does indeed call `wait()` before checking the predicate but I'd like to know whether this additional paragraph for `wait` is needed or not:

> [!NOTE]
> Note that a task *may* return from this call spuriously,
which is why the caller should always re-check the state
and be prepared to :meth:`~Condition.wait` again. For this reason, you may
prefer to use :meth:`~Condition.wait_for` instead.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127438.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->