### PR TITLE
Add Windows version comments to the python manifest.

### DIFF
--- a/PC/python.manifest
+++ b/PC/python.manifest
@@ -10,7 +10,7 @@
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- Windows Vista -->
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
       <!-- Windows 7 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <!-- Windows 8 -->

--- a/PC/python.manifest
+++ b/PC/python.manifest
@@ -9,10 +9,15 @@
   </trustInfo>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+      <!-- Windows 7 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows 8 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 8.1 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 / Windows 11 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>


### PR DESCRIPTION
This is so it becomes easier to add or remove future values as time passes and when support for older versions of Windows gets dropped from python. MSVC's vNEXT (V18) will soon drop all but Windows 8.1 so if and when Python migrates to that version of MSVC that means support for Windows older than 8.1 would need to be dropped then.

This is a followup PR to the change from 7 years ago (https://github.com/python/cpython/pull/2328) as I felt that leaving comments for the versions of windows for each specific compatibility entry is needed. It is also a trivial change as well.