### PR TITLE
add missing gc_collect() calls in sqlite3 tests

### DIFF
--- a/Lib/test/test_sqlite3/test_regression.py
+++ b/Lib/test/test_sqlite3/test_regression.py
@@ -433,6 +433,7 @@ class RegressionTests(MemoryDatabaseMixin, unittest.TestCase):
             con.commit()
             cur = con.execute("select t from t")
             del cur
+            support.gc_collect()
             con.execute("drop table t")
             con.commit()
 
@@ -448,6 +449,7 @@ class RegressionTests(MemoryDatabaseMixin, unittest.TestCase):
             con.create_function("dup", 1, dup)
             cur = con.execute("select dup(t) from t")
             del cur
+            support.gc_collect()
             con.execute("drop table t")
             con.commit()
 


### PR DESCRIPTION
PyPy needs a `gc_collect()` call after the `del cur` statements for the cursors' finalizers to execute.