### PR TITLE
gh-127321: Avoid stopping at an opcode without an associated line number for breakpoint()

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -438,6 +438,13 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             if (self.mainpyfile != self.canonic(frame.f_code.co_filename)):
                 return
             self._wait_for_mainpyfile = False
+        if self.trace_opcodes:
+            # GH-127321
+            # We want to avoid stopping at an opcode that does not have
+            # an associated line number because pdb does not like it
+            if frame.f_lineno is None:
+                self.set_stepinstr()
+                return
         self.bp_commands(frame)
         self.interaction(frame, None)
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2931,6 +2931,22 @@ def test_pdb_issue_gh_108976():
     (Pdb) continue
     """
 
+def test_pdb_issue_gh_127321():
+    """See GH-127321
+    breakpoint() should stop at a opcode that has a line number
+    >>> def test_function():
+    ...     import pdb; pdb_instance = pdb.Pdb(nosigint=True, readrc=False)
+    ...     [1, 2] and pdb_instance.set_trace()
+    ...     a = 1
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'continue'
+    ... ]):
+    ...    test_function()
+    > <doctest test.test_pdb.test_pdb_issue_gh_127321[0]>(4)test_function()
+    -> a = 1
+    (Pdb) continue
+    """
+
 
 def test_pdb_issue_gh_80731():
     """See GH-80731

--- a/Misc/NEWS.d/next/Library/2024-11-30-21-46-15.gh-issue-127321.M78fBv.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-30-21-46-15.gh-issue-127321.M78fBv.rst
@@ -1,1 +1,1 @@
-:func:`pdb.set_trace()` will not stop at an opcode that does not have an associated line number anymore.
+:func:`pdb.set_trace` will not stop at an opcode that does not have an associated line number anymore.

--- a/Misc/NEWS.d/next/Library/2024-11-30-21-46-15.gh-issue-127321.M78fBv.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-30-21-46-15.gh-issue-127321.M78fBv.rst
@@ -1,0 +1,1 @@
+:func:`pdb.set_trace()` will not stop at an opcode that does not have an associated line number anymore.


### PR DESCRIPTION
If we are tracing opcodes (which only happen when we do `set_trace()` for now), we just step instr again if there's no line number.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127321 -->
* Issue: gh-127321
<!-- /gh-issue-number -->
