### PR TITLE
Docs: C API: Clarify what happens when null bytes are passed to `PyUnicode_AsUTF8`

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1037,10 +1037,12 @@ These are the UTF-8 codec APIs:
 
    .. warning::
 
-      This function does not handle null bytes within the unicode object.
-      As a result, the length of the returned string could be interpreted as
-      smaller than the length of *unicode*. When handling user input,
-      it is recommended to use :c:func:`PyUnicode_AsUTF8AndSize` instead.
+      This function does not have any special behavior for
+      `null bytes <https://en.wikipedia.org/wiki/Null_character>`_ embedded within
+      *unicode*. As a result, strings containing null bytes will remain in the returned
+      string, which some C functions might interpret as the end of the string, leading to
+      truncation. When handling user input, it is recommended to use :c:func:`PyUnicode_AsUTF8AndSize`
+      instead.
 
    .. versionadded:: 3.3
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1038,8 +1038,8 @@ These are the UTF-8 codec APIs:
    .. warning::
 
       This function does not have any special behavior for
-      `null bytes <https://en.wikipedia.org/wiki/Null_character>`_ embedded within
-      *unicode*. As a result, strings containing null bytes will remain in the returned
+      `null characters <https://en.wikipedia.org/wiki/Null_character>`_ embedded within
+      *unicode*. As a result, strings containing null characters will remain in the returned
       string, which some C functions might interpret as the end of the string, leading to
       truncation. When handling user input, it is recommended to use :c:func:`PyUnicode_AsUTF8AndSize`
       instead.

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1041,7 +1041,7 @@ These are the UTF-8 codec APIs:
       `null characters <https://en.wikipedia.org/wiki/Null_character>`_ embedded within
       *unicode*. As a result, strings containing null characters will remain in the returned
       string, which some C functions might interpret as the end of the string, leading to
-      truncation. When handling user input, it is recommended to use :c:func:`PyUnicode_AsUTF8AndSize`
+      truncation. If truncation is an issue, it is recommended to use :c:func:`PyUnicode_AsUTF8AndSize`
       instead.
 
    .. versionadded:: 3.3

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1039,7 +1039,8 @@ These are the UTF-8 codec APIs:
 
       This function does not strip null bytes from *unicode*, so the length of the
       returned string (from ``strlen()``) is possibly smaller than the length of the
-      passed unicode object.
+      passed unicode object. Prefer :c:func:`PyUnicode_AsUTF8AndSize` when dealing with
+      user input.
 
    .. versionadded:: 3.3
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1037,10 +1037,10 @@ These are the UTF-8 codec APIs:
 
    .. note::
 
-      This function does not handle null bytes inside of *unicode*, so the length of the
+      This function does not handle null bytes within the unicode object. As a result, the length of the
       returned string (from ``strlen()``) could be smaller than the length of the
-      passed unicode object, if the string contained embedded null characters. Prefer
-      :c:func:`PyUnicode_AsUTF8AndSize` when dealing with user input.
+      passed unicode object, if the string contained embedded null characters. When handling user input, 
+      it is recommended to use :c:func:`PyUnicode_AsUTF8AndSize` instead.
 
    .. versionadded:: 3.3
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1035,11 +1035,11 @@ These are the UTF-8 codec APIs:
 
    As :c:func:`PyUnicode_AsUTF8AndSize`, but does not store the size.
 
-   .. note::
+   .. warning::
 
-      This function does not handle null bytes within the unicode object. As a result, the length of the
-      returned string (from ``strlen()``) could be smaller than the length of the
-      passed unicode object, if the string contained embedded null characters. When handling user input,
+      This function does not handle null bytes within the unicode object.
+      As a result, the length of the returned string could be interpreted as
+      smaller than the length of *unicode*. When handling user input,
       it is recommended to use :c:func:`PyUnicode_AsUTF8AndSize` instead.
 
    .. versionadded:: 3.3

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1035,12 +1035,12 @@ These are the UTF-8 codec APIs:
 
    As :c:func:`PyUnicode_AsUTF8AndSize`, but does not store the size.
 
-   .. warning::
+   .. note::
 
-      This function does not strip null bytes from *unicode*, so the length of the
-      returned string (from ``strlen()``) is possibly smaller than the length of the
-      passed unicode object. Prefer :c:func:`PyUnicode_AsUTF8AndSize` when dealing with
-      user input.
+      This function does not handle null bytes inside of *unicode*, so the length of the
+      returned string (from ``strlen()``) could be smaller than the length of the
+      passed unicode object, if the string contained embedded null characters. Prefer
+      :c:func:`PyUnicode_AsUTF8AndSize` when dealing with user input.
 
    .. versionadded:: 3.3
 

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1039,7 +1039,7 @@ These are the UTF-8 codec APIs:
 
       This function does not handle null bytes within the unicode object. As a result, the length of the
       returned string (from ``strlen()``) could be smaller than the length of the
-      passed unicode object, if the string contained embedded null characters. When handling user input, 
+      passed unicode object, if the string contained embedded null characters. When handling user input,
       it is recommended to use :c:func:`PyUnicode_AsUTF8AndSize` instead.
 
    .. versionadded:: 3.3

--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -1035,6 +1035,12 @@ These are the UTF-8 codec APIs:
 
    As :c:func:`PyUnicode_AsUTF8AndSize`, but does not store the size.
 
+   .. warning::
+
+      This function does not strip null bytes from *unicode*, so the length of the
+      returned string (from ``strlen()``) is possibly smaller than the length of the
+      passed unicode object.
+
    .. versionadded:: 3.3
 
    .. versionchanged:: 3.7


### PR DESCRIPTION
Per discussion from a few days ago, `PyUnicode_AsUTF8` is missing documentation for the embedded null character gotcha. There was some pushback about marking it as a warning, so I've left it as a note for now.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127458.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->