### PR TITLE
gh-14187: Change to accept 229 Extended passive mode error as acceptible ouput with PASV command

### DIFF
--- a/Lib/ftplib.py
+++ b/Lib/ftplib.py
@@ -324,16 +324,11 @@ class FTP:
     def makepasv(self):
         """Internal: Does the PASV or EPSV handshake -> (address, port)"""
         if self.af == socket.AF_INET:
-            try:
-                untrusted_host, port = parse227(self.sendcmd('PASV'))
-                if self.trust_server_pasv_ipv4_address:
-                    host = untrusted_host
-                else:
-                    host = self.sock.getpeername()[0]
-            except error_reply as resp:
-                resp = str(resp)
-                if resp[:3] == '229':
-                    host, port = parse229(resp, self.sock.getpeername())
+            untrusted_host, port = parse227(self.sendcmd('PASV'))
+            if self.trust_server_pasv_ipv4_address:
+                host = untrusted_host
+            else:
+                host = self.sock.getpeername()[0]
         else:
             host, port = parse229(self.sendcmd('EPSV'), self.sock.getpeername())
         return host, port

--- a/Lib/ftplib.py
+++ b/Lib/ftplib.py
@@ -324,11 +324,16 @@ class FTP:
     def makepasv(self):
         """Internal: Does the PASV or EPSV handshake -> (address, port)"""
         if self.af == socket.AF_INET:
-            untrusted_host, port = parse227(self.sendcmd('PASV'))
-            if self.trust_server_pasv_ipv4_address:
-                host = untrusted_host
-            else:
-                host = self.sock.getpeername()[0]
+            try:
+                untrusted_host, port = parse227(self.sendcmd('PASV'))
+                if self.trust_server_pasv_ipv4_address:
+                    host = untrusted_host
+                else:
+                    host = self.sock.getpeername()[0]
+            except error_reply as resp:
+                resp = str(resp)
+                if resp[:3] == '229':
+                    host, port = parse229(resp, self.sock.getpeername())
         else:
             host, port = parse229(self.sendcmd('EPSV'), self.sock.getpeername())
         return host, port


### PR DESCRIPTION
New FTP servers are responding with 229 Entering Extended passive mode response when PASV command is sent over CLAT environment. Because of this sendcmd('PASV') is sending error though it's a accepted response. Tested with filezilla manually where it's accepting the same. So we need to make changes in ftplib to accept & parse Extended mode with 'PASV' command. Please help to review and merge.

Best Regards,
Yughandhar