### PR TITLE
Fix while statements with non-bool conditions in `_pyrepl`

### DIFF
--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -138,7 +138,7 @@ def run_multiline_interactive_console(
 
         return False
 
-    while 1:
+    while True:
         try:
             try:
                 sys.stdout.flush()

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -786,7 +786,7 @@ class UnixConsole(Console):
         # only if the bps is actually needed (which I'm
         # betting is pretty unlkely)
         bps = ratedict.get(self.__svtermstate.ospeed)
-        while 1:
+        while True:
             m = prog.search(fmt)
             if not m:
                 os.write(self.output_fd, fmt)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

In Python, it is recommended to use bool values ​​as conditions, but there are still scenarios where integers are used in pyrepl, and we use `while True` instead of `while 1`.
(I hope this is not considered a cosmetic change. They were discovered when I was learning pyrepl.)