### PR TITLE
[3.13] gh-126890: Restore stripped `ssl` docstrings (GH-127281)

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2155,11 +2155,17 @@ _ssl__SSLSocket_compression_impl(PySSLSocket *self)
 @critical_section
 @getter
 _ssl._SSLSocket.context
+
+This changes the context associated with the SSLSocket.
+
+This is typically used from within a callback function set by the sni_callback
+on the SSLContext to change the certificate information associated with the
+SSLSocket before the cryptographic exchange handshake messages.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_context_get_impl(PySSLSocket *self)
-/*[clinic end generated code: output=d23e82f72f32e3d7 input=25aa82e4d9fa344a]*/
+/*[clinic end generated code: output=d23e82f72f32e3d7 input=7cbb97407c2ace30]*/
 {
     return Py_NewRef(self->ctx);
 }
@@ -2226,11 +2232,15 @@ _ssl__SSLSocket_server_hostname_get_impl(PySSLSocket *self)
 @critical_section
 @getter
 _ssl._SSLSocket.owner
+
+The Python-level owner of this object.
+
+Passed as "self" in servername callback.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_owner_get_impl(PySSLSocket *self)
-/*[clinic end generated code: output=1f278cb930382927 input=bc2861ff3cf1402e]*/
+/*[clinic end generated code: output=1f278cb930382927 input=978a8382d9c25c92]*/
 {
     if (self->owner == NULL) {
         Py_RETURN_NONE;
@@ -2844,11 +2854,13 @@ _ssl__SSLSocket_verify_client_post_handshake_impl(PySSLSocket *self)
 @critical_section
 @getter
 _ssl._SSLSocket.session
+
+The underlying SSLSession object.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLSocket_session_get_impl(PySSLSocket *self)
-/*[clinic end generated code: output=a5cd5755b35da670 input=b9792df9255a9f63]*/
+/*[clinic end generated code: output=a5cd5755b35da670 input=d427318604244bf8]*/
 {
     /* get_session can return sessions from a server-side connection,
      * it does not check for handshake done or client socket. */
@@ -3650,11 +3662,13 @@ _ssl__SSLContext_maximum_version_set_impl(PySSLContext *self,
 @critical_section
 @getter
 _ssl._SSLContext.num_tickets
+
+Control the number of TLSv1.3 session tickets.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLContext_num_tickets_get_impl(PySSLContext *self)
-/*[clinic end generated code: output=3d06d016318846c9 input=1dee26d75163c073]*/
+/*[clinic end generated code: output=3d06d016318846c9 input=1e2599a2e22564ff]*/
 {
     // Clinic seems to be misbehaving when the comment is wrapped with in directive
 #if defined(TLS1_3_VERSION) && !defined(OPENSSL_NO_TLS1_3)
@@ -3698,11 +3712,13 @@ _ssl__SSLContext_num_tickets_set_impl(PySSLContext *self, PyObject *value)
 @critical_section
 @getter
 _ssl._SSLContext.security_level
+
+The current security level.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLContext_security_level_get_impl(PySSLContext *self)
-/*[clinic end generated code: output=56ece09e6a9572d0 input=a0416598e07c3183]*/
+/*[clinic end generated code: output=56ece09e6a9572d0 input=2bdeecb57bb86e3f]*/
 {
     PyObject *res = PyLong_FromLong(SSL_CTX_get_security_level(self->ctx));
     return res;
@@ -4659,11 +4675,18 @@ error:
 @critical_section
 @getter
 _ssl._SSLContext.sni_callback
+
+Set a callback that will be called when a server name is provided by the SSL/TLS client in the SNI extension.
+
+If the argument is None then the callback is disabled. The method is called
+with the SSLSocket, the server name as a string, and the SSLContext object.
+
+See RFC 6066 for details of the SNI extension.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl__SSLContext_sni_callback_get_impl(PySSLContext *self)
-/*[clinic end generated code: output=961e6575cdfaf036 input=22dd28c31fdc4318]*/
+/*[clinic end generated code: output=961e6575cdfaf036 input=9b2473c5e984cfe6]*/
 {
     PyObject *cb = self->set_sni_cb;
     if (cb == NULL) {
@@ -5236,11 +5259,13 @@ memory_bio_dealloc(PySSLMemoryBIO *self)
 @critical_section
 @getter
 _ssl.MemoryBIO.pending
+
+The number of bytes pending in the memory BIO.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl_MemoryBIO_pending_get_impl(PySSLMemoryBIO *self)
-/*[clinic end generated code: output=19236a32a51ac8ff input=c0b6d14eba107f6a]*/
+/*[clinic end generated code: output=19236a32a51ac8ff input=02d9063d8ac31732]*/
 {
     size_t res = BIO_ctrl_pending(self->bio);
     return PyLong_FromSize_t(res);
@@ -5250,11 +5275,13 @@ _ssl_MemoryBIO_pending_get_impl(PySSLMemoryBIO *self)
 @critical_section
 @getter
 _ssl.MemoryBIO.eof
+
+Whether the memory BIO is at EOF.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl_MemoryBIO_eof_get_impl(PySSLMemoryBIO *self)
-/*[clinic end generated code: output=c255a9ea16e31b92 input=0f5c6be69752e04c]*/
+/*[clinic end generated code: output=c255a9ea16e31b92 input=c6ecc12c4509de1f]*/
 {
     size_t pending = BIO_ctrl_pending(self->bio);
     return PyBool_FromLong((pending == 0) && self->eof_written);
@@ -5495,11 +5522,13 @@ PySSLSession_clear(PySSLSession *self)
 @critical_section
 @getter
 _ssl.SSLSession.time
+
+Session creation time (seconds since epoch).
 [clinic start generated code]*/
 
 static PyObject *
 _ssl_SSLSession_time_get_impl(PySSLSession *self)
-/*[clinic end generated code: output=4b887b9299de9be4 input=8d1e4afd09103279]*/
+/*[clinic end generated code: output=4b887b9299de9be4 input=67f2325284450ae2]*/
 {
 #if OPENSSL_VERSION_NUMBER >= 0x30300000L
     return _PyLong_FromTime_t(SSL_SESSION_get_time_ex(self->session));
@@ -5512,11 +5541,13 @@ _ssl_SSLSession_time_get_impl(PySSLSession *self)
 @critical_section
 @getter
 _ssl.SSLSession.timeout
+
+Session timeout (delta in seconds).
 [clinic start generated code]*/
 
 static PyObject *
 _ssl_SSLSession_timeout_get_impl(PySSLSession *self)
-/*[clinic end generated code: output=82339c148ab2f7d1 input=ae5e84a9d85df60d]*/
+/*[clinic end generated code: output=82339c148ab2f7d1 input=cd17c2b087c442f2]*/
 {
     long timeout = SSL_SESSION_get_timeout(self->session);
     PyObject *res = PyLong_FromLong(timeout);
@@ -5527,11 +5558,13 @@ _ssl_SSLSession_timeout_get_impl(PySSLSession *self)
 @critical_section
 @getter
 _ssl.SSLSession.ticket_lifetime_hint
+
+Ticket life time hint.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl_SSLSession_ticket_lifetime_hint_get_impl(PySSLSession *self)
-/*[clinic end generated code: output=c8b6db498136c275 input=d0e06942ddd8d07f]*/
+/*[clinic end generated code: output=c8b6db498136c275 input=f0e2df50961a7806]*/
 {
     unsigned long hint = SSL_SESSION_get_ticket_lifetime_hint(self->session);
     return PyLong_FromUnsignedLong(hint);
@@ -5541,11 +5574,13 @@ _ssl_SSLSession_ticket_lifetime_hint_get_impl(PySSLSession *self)
 @critical_section
 @getter
 _ssl.SSLSession.id
+
+Session ID.
 [clinic start generated code]*/
 
 static PyObject *
 _ssl_SSLSession_id_get_impl(PySSLSession *self)
-/*[clinic end generated code: output=c532fb96b10c5adf input=e7322372cf6325dd]*/
+/*[clinic end generated code: output=c532fb96b10c5adf input=0a379e64312b776d]*/
 
 {
     const unsigned char *id;
@@ -5558,11 +5593,13 @@ _ssl_SSLSession_id_get_impl(PySSLSession *self)
 @critical_section
 @getter
 _ssl.SSLSession.has_ticket
+
+Does the session contain a ticket?
 [clinic start generated code]*/
 
 static PyObject *
 _ssl_SSLSession_has_ticket_get_impl(PySSLSession *self)
-/*[clinic end generated code: output=aa3ccfc40b10b96d input=1a48ae8955fa9601]*/
+/*[clinic end generated code: output=aa3ccfc40b10b96d input=fa475555f53a5086]*/
 {
     int res = SSL_SESSION_has_ticket(self->session);
     return res ? Py_True : Py_False;

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -258,9 +258,15 @@ _ssl__SSLSocket_compression(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
     return _ssl__SSLSocket_compression_impl(self);
 }
 
-#if defined(_ssl__SSLSocket_context_HAS_DOCSTR)
-#  define _ssl__SSLSocket_context_DOCSTR _ssl__SSLSocket_context__doc__
-#else
+PyDoc_STRVAR(_ssl__SSLSocket_context__doc__,
+"This changes the context associated with the SSLSocket.\n"
+"\n"
+"This is typically used from within a callback function set by the sni_callback\n"
+"on the SSLContext to change the certificate information associated with the\n"
+"SSLSocket before the cryptographic exchange handshake messages.");
+#define _ssl__SSLSocket_context_DOCSTR _ssl__SSLSocket_context__doc__
+
+#if !defined(_ssl__SSLSocket_context_DOCSTR)
 #  define _ssl__SSLSocket_context_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLSOCKET_CONTEXT_GETSETDEF)
@@ -285,9 +291,7 @@ _ssl__SSLSocket_context_get(PySSLSocket *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_SSL__SSLSOCKET_CONTEXT_HAS_DOCSTR)
-#  define _ssl__SSLSocket_context_DOCSTR _ssl__SSLSocket_context__doc__
-#else
+#if !defined(_ssl__SSLSocket_context_DOCSTR)
 #  define _ssl__SSLSocket_context_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLSOCKET_CONTEXT_GETSETDEF)
@@ -314,11 +318,9 @@ _ssl__SSLSocket_context_set(PySSLSocket *self, PyObject *value, void *Py_UNUSED(
 
 PyDoc_STRVAR(_ssl__SSLSocket_server_side__doc__,
 "Whether this is a server-side socket.");
-#define _ssl__SSLSocket_server_side_HAS_DOCSTR
+#define _ssl__SSLSocket_server_side_DOCSTR _ssl__SSLSocket_server_side__doc__
 
-#if defined(_ssl__SSLSocket_server_side_HAS_DOCSTR)
-#  define _ssl__SSLSocket_server_side_DOCSTR _ssl__SSLSocket_server_side__doc__
-#else
+#if !defined(_ssl__SSLSocket_server_side_DOCSTR)
 #  define _ssl__SSLSocket_server_side_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLSOCKET_SERVER_SIDE_GETSETDEF)
@@ -345,11 +347,9 @@ _ssl__SSLSocket_server_side_get(PySSLSocket *self, void *Py_UNUSED(context))
 
 PyDoc_STRVAR(_ssl__SSLSocket_server_hostname__doc__,
 "The currently set server hostname (for SNI).");
-#define _ssl__SSLSocket_server_hostname_HAS_DOCSTR
+#define _ssl__SSLSocket_server_hostname_DOCSTR _ssl__SSLSocket_server_hostname__doc__
 
-#if defined(_ssl__SSLSocket_server_hostname_HAS_DOCSTR)
-#  define _ssl__SSLSocket_server_hostname_DOCSTR _ssl__SSLSocket_server_hostname__doc__
-#else
+#if !defined(_ssl__SSLSocket_server_hostname_DOCSTR)
 #  define _ssl__SSLSocket_server_hostname_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLSOCKET_SERVER_HOSTNAME_GETSETDEF)
@@ -374,9 +374,13 @@ _ssl__SSLSocket_server_hostname_get(PySSLSocket *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_ssl__SSLSocket_owner_HAS_DOCSTR)
-#  define _ssl__SSLSocket_owner_DOCSTR _ssl__SSLSocket_owner__doc__
-#else
+PyDoc_STRVAR(_ssl__SSLSocket_owner__doc__,
+"The Python-level owner of this object.\n"
+"\n"
+"Passed as \"self\" in servername callback.");
+#define _ssl__SSLSocket_owner_DOCSTR _ssl__SSLSocket_owner__doc__
+
+#if !defined(_ssl__SSLSocket_owner_DOCSTR)
 #  define _ssl__SSLSocket_owner_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLSOCKET_OWNER_GETSETDEF)
@@ -401,9 +405,7 @@ _ssl__SSLSocket_owner_get(PySSLSocket *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_SSL__SSLSOCKET_OWNER_HAS_DOCSTR)
-#  define _ssl__SSLSocket_owner_DOCSTR _ssl__SSLSocket_owner__doc__
-#else
+#if !defined(_ssl__SSLSocket_owner_DOCSTR)
 #  define _ssl__SSLSocket_owner_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLSOCKET_OWNER_GETSETDEF)
@@ -663,9 +665,11 @@ _ssl__SSLSocket_verify_client_post_handshake(PySSLSocket *self, PyObject *Py_UNU
     return return_value;
 }
 
-#if defined(_ssl__SSLSocket_session_HAS_DOCSTR)
-#  define _ssl__SSLSocket_session_DOCSTR _ssl__SSLSocket_session__doc__
-#else
+PyDoc_STRVAR(_ssl__SSLSocket_session__doc__,
+"The underlying SSLSession object.");
+#define _ssl__SSLSocket_session_DOCSTR _ssl__SSLSocket_session__doc__
+
+#if !defined(_ssl__SSLSocket_session_DOCSTR)
 #  define _ssl__SSLSocket_session_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLSOCKET_SESSION_GETSETDEF)
@@ -690,9 +694,7 @@ _ssl__SSLSocket_session_get(PySSLSocket *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_SSL__SSLSOCKET_SESSION_HAS_DOCSTR)
-#  define _ssl__SSLSocket_session_DOCSTR _ssl__SSLSocket_session__doc__
-#else
+#if !defined(_ssl__SSLSocket_session_DOCSTR)
 #  define _ssl__SSLSocket_session_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLSOCKET_SESSION_GETSETDEF)
@@ -719,11 +721,9 @@ _ssl__SSLSocket_session_set(PySSLSocket *self, PyObject *value, void *Py_UNUSED(
 
 PyDoc_STRVAR(_ssl__SSLSocket_session_reused__doc__,
 "Was the client session reused during handshake?");
-#define _ssl__SSLSocket_session_reused_HAS_DOCSTR
+#define _ssl__SSLSocket_session_reused_DOCSTR _ssl__SSLSocket_session_reused__doc__
 
-#if defined(_ssl__SSLSocket_session_reused_HAS_DOCSTR)
-#  define _ssl__SSLSocket_session_reused_DOCSTR _ssl__SSLSocket_session_reused__doc__
-#else
+#if !defined(_ssl__SSLSocket_session_reused_DOCSTR)
 #  define _ssl__SSLSocket_session_reused_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLSOCKET_SESSION_REUSED_GETSETDEF)
@@ -872,9 +872,7 @@ exit:
     return return_value;
 }
 
-#if defined(_ssl__SSLContext_verify_mode_HAS_DOCSTR)
-#  define _ssl__SSLContext_verify_mode_DOCSTR _ssl__SSLContext_verify_mode__doc__
-#else
+#if !defined(_ssl__SSLContext_verify_mode_DOCSTR)
 #  define _ssl__SSLContext_verify_mode_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF)
@@ -899,9 +897,7 @@ _ssl__SSLContext_verify_mode_get(PySSLContext *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_SSL__SSLCONTEXT_VERIFY_MODE_HAS_DOCSTR)
-#  define _ssl__SSLContext_verify_mode_DOCSTR _ssl__SSLContext_verify_mode__doc__
-#else
+#if !defined(_ssl__SSLContext_verify_mode_DOCSTR)
 #  define _ssl__SSLContext_verify_mode_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_VERIFY_MODE_GETSETDEF)
@@ -926,9 +922,7 @@ _ssl__SSLContext_verify_mode_set(PySSLContext *self, PyObject *value, void *Py_U
     return return_value;
 }
 
-#if defined(_ssl__SSLContext_verify_flags_HAS_DOCSTR)
-#  define _ssl__SSLContext_verify_flags_DOCSTR _ssl__SSLContext_verify_flags__doc__
-#else
+#if !defined(_ssl__SSLContext_verify_flags_DOCSTR)
 #  define _ssl__SSLContext_verify_flags_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF)
@@ -953,9 +947,7 @@ _ssl__SSLContext_verify_flags_get(PySSLContext *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_SSL__SSLCONTEXT_VERIFY_FLAGS_HAS_DOCSTR)
-#  define _ssl__SSLContext_verify_flags_DOCSTR _ssl__SSLContext_verify_flags__doc__
-#else
+#if !defined(_ssl__SSLContext_verify_flags_DOCSTR)
 #  define _ssl__SSLContext_verify_flags_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_VERIFY_FLAGS_GETSETDEF)
@@ -980,9 +972,7 @@ _ssl__SSLContext_verify_flags_set(PySSLContext *self, PyObject *value, void *Py_
     return return_value;
 }
 
-#if defined(_ssl__SSLContext_minimum_version_HAS_DOCSTR)
-#  define _ssl__SSLContext_minimum_version_DOCSTR _ssl__SSLContext_minimum_version__doc__
-#else
+#if !defined(_ssl__SSLContext_minimum_version_DOCSTR)
 #  define _ssl__SSLContext_minimum_version_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF)
@@ -1007,9 +997,7 @@ _ssl__SSLContext_minimum_version_get(PySSLContext *self, void *Py_UNUSED(context
     return return_value;
 }
 
-#if defined(_SSL__SSLCONTEXT_MINIMUM_VERSION_HAS_DOCSTR)
-#  define _ssl__SSLContext_minimum_version_DOCSTR _ssl__SSLContext_minimum_version__doc__
-#else
+#if !defined(_ssl__SSLContext_minimum_version_DOCSTR)
 #  define _ssl__SSLContext_minimum_version_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_MINIMUM_VERSION_GETSETDEF)
@@ -1035,9 +1023,7 @@ _ssl__SSLContext_minimum_version_set(PySSLContext *self, PyObject *value, void *
     return return_value;
 }
 
-#if defined(_ssl__SSLContext_maximum_version_HAS_DOCSTR)
-#  define _ssl__SSLContext_maximum_version_DOCSTR _ssl__SSLContext_maximum_version__doc__
-#else
+#if !defined(_ssl__SSLContext_maximum_version_DOCSTR)
 #  define _ssl__SSLContext_maximum_version_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_MAXIMUM_VERSION_GETSETDEF)
@@ -1062,9 +1048,7 @@ _ssl__SSLContext_maximum_version_get(PySSLContext *self, void *Py_UNUSED(context
     return return_value;
 }
 
-#if defined(_SSL__SSLCONTEXT_MAXIMUM_VERSION_HAS_DOCSTR)
-#  define _ssl__SSLContext_maximum_version_DOCSTR _ssl__SSLContext_maximum_version__doc__
-#else
+#if !defined(_ssl__SSLContext_maximum_version_DOCSTR)
 #  define _ssl__SSLContext_maximum_version_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_MAXIMUM_VERSION_GETSETDEF)
@@ -1090,9 +1074,11 @@ _ssl__SSLContext_maximum_version_set(PySSLContext *self, PyObject *value, void *
     return return_value;
 }
 
-#if defined(_ssl__SSLContext_num_tickets_HAS_DOCSTR)
-#  define _ssl__SSLContext_num_tickets_DOCSTR _ssl__SSLContext_num_tickets__doc__
-#else
+PyDoc_STRVAR(_ssl__SSLContext_num_tickets__doc__,
+"Control the number of TLSv1.3 session tickets.");
+#define _ssl__SSLContext_num_tickets_DOCSTR _ssl__SSLContext_num_tickets__doc__
+
+#if !defined(_ssl__SSLContext_num_tickets_DOCSTR)
 #  define _ssl__SSLContext_num_tickets_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF)
@@ -1117,9 +1103,7 @@ _ssl__SSLContext_num_tickets_get(PySSLContext *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_SSL__SSLCONTEXT_NUM_TICKETS_HAS_DOCSTR)
-#  define _ssl__SSLContext_num_tickets_DOCSTR _ssl__SSLContext_num_tickets__doc__
-#else
+#if !defined(_ssl__SSLContext_num_tickets_DOCSTR)
 #  define _ssl__SSLContext_num_tickets_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_NUM_TICKETS_GETSETDEF)
@@ -1144,9 +1128,11 @@ _ssl__SSLContext_num_tickets_set(PySSLContext *self, PyObject *value, void *Py_U
     return return_value;
 }
 
-#if defined(_ssl__SSLContext_security_level_HAS_DOCSTR)
-#  define _ssl__SSLContext_security_level_DOCSTR _ssl__SSLContext_security_level__doc__
-#else
+PyDoc_STRVAR(_ssl__SSLContext_security_level__doc__,
+"The current security level.");
+#define _ssl__SSLContext_security_level_DOCSTR _ssl__SSLContext_security_level__doc__
+
+#if !defined(_ssl__SSLContext_security_level_DOCSTR)
 #  define _ssl__SSLContext_security_level_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_SECURITY_LEVEL_GETSETDEF)
@@ -1171,9 +1157,7 @@ _ssl__SSLContext_security_level_get(PySSLContext *self, void *Py_UNUSED(context)
     return return_value;
 }
 
-#if defined(_ssl__SSLContext_options_HAS_DOCSTR)
-#  define _ssl__SSLContext_options_DOCSTR _ssl__SSLContext_options__doc__
-#else
+#if !defined(_ssl__SSLContext_options_DOCSTR)
 #  define _ssl__SSLContext_options_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_OPTIONS_GETSETDEF)
@@ -1198,9 +1182,7 @@ _ssl__SSLContext_options_get(PySSLContext *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_SSL__SSLCONTEXT_OPTIONS_HAS_DOCSTR)
-#  define _ssl__SSLContext_options_DOCSTR _ssl__SSLContext_options__doc__
-#else
+#if !defined(_ssl__SSLContext_options_DOCSTR)
 #  define _ssl__SSLContext_options_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_OPTIONS_GETSETDEF)
@@ -1225,9 +1207,7 @@ _ssl__SSLContext_options_set(PySSLContext *self, PyObject *value, void *Py_UNUSE
     return return_value;
 }
 
-#if defined(_ssl__SSLContext__host_flags_HAS_DOCSTR)
-#  define _ssl__SSLContext__host_flags_DOCSTR _ssl__SSLContext__host_flags__doc__
-#else
+#if !defined(_ssl__SSLContext__host_flags_DOCSTR)
 #  define _ssl__SSLContext__host_flags_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF)
@@ -1252,9 +1232,7 @@ _ssl__SSLContext__host_flags_get(PySSLContext *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_SSL__SSLCONTEXT__HOST_FLAGS_HAS_DOCSTR)
-#  define _ssl__SSLContext__host_flags_DOCSTR _ssl__SSLContext__host_flags__doc__
-#else
+#if !defined(_ssl__SSLContext__host_flags_DOCSTR)
 #  define _ssl__SSLContext__host_flags_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT__HOST_FLAGS_GETSETDEF)
@@ -1279,9 +1257,7 @@ _ssl__SSLContext__host_flags_set(PySSLContext *self, PyObject *value, void *Py_U
     return return_value;
 }
 
-#if defined(_ssl__SSLContext_check_hostname_HAS_DOCSTR)
-#  define _ssl__SSLContext_check_hostname_DOCSTR _ssl__SSLContext_check_hostname__doc__
-#else
+#if !defined(_ssl__SSLContext_check_hostname_DOCSTR)
 #  define _ssl__SSLContext_check_hostname_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF)
@@ -1306,9 +1282,7 @@ _ssl__SSLContext_check_hostname_get(PySSLContext *self, void *Py_UNUSED(context)
     return return_value;
 }
 
-#if defined(_SSL__SSLCONTEXT_CHECK_HOSTNAME_HAS_DOCSTR)
-#  define _ssl__SSLContext_check_hostname_DOCSTR _ssl__SSLContext_check_hostname__doc__
-#else
+#if !defined(_ssl__SSLContext_check_hostname_DOCSTR)
 #  define _ssl__SSLContext_check_hostname_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_CHECK_HOSTNAME_GETSETDEF)
@@ -1333,9 +1307,7 @@ _ssl__SSLContext_check_hostname_set(PySSLContext *self, PyObject *value, void *P
     return return_value;
 }
 
-#if defined(_ssl__SSLContext_protocol_HAS_DOCSTR)
-#  define _ssl__SSLContext_protocol_DOCSTR _ssl__SSLContext_protocol__doc__
-#else
+#if !defined(_ssl__SSLContext_protocol_DOCSTR)
 #  define _ssl__SSLContext_protocol_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_PROTOCOL_GETSETDEF)
@@ -1794,9 +1766,16 @@ _ssl__SSLContext_set_ecdh_curve(PySSLContext *self, PyObject *name)
     return return_value;
 }
 
-#if defined(_ssl__SSLContext_sni_callback_HAS_DOCSTR)
-#  define _ssl__SSLContext_sni_callback_DOCSTR _ssl__SSLContext_sni_callback__doc__
-#else
+PyDoc_STRVAR(_ssl__SSLContext_sni_callback__doc__,
+"Set a callback that will be called when a server name is provided by the SSL/TLS client in the SNI extension.\n"
+"\n"
+"If the argument is None then the callback is disabled. The method is called\n"
+"with the SSLSocket, the server name as a string, and the SSLContext object.\n"
+"\n"
+"See RFC 6066 for details of the SNI extension.");
+#define _ssl__SSLContext_sni_callback_DOCSTR _ssl__SSLContext_sni_callback__doc__
+
+#if !defined(_ssl__SSLContext_sni_callback_DOCSTR)
 #  define _ssl__SSLContext_sni_callback_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF)
@@ -1821,9 +1800,7 @@ _ssl__SSLContext_sni_callback_get(PySSLContext *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_SSL__SSLCONTEXT_SNI_CALLBACK_HAS_DOCSTR)
-#  define _ssl__SSLContext_sni_callback_DOCSTR _ssl__SSLContext_sni_callback__doc__
-#else
+#if !defined(_ssl__SSLContext_sni_callback_DOCSTR)
 #  define _ssl__SSLContext_sni_callback_DOCSTR NULL
 #endif
 #if defined(_SSL__SSLCONTEXT_SNI_CALLBACK_GETSETDEF)
@@ -2113,9 +2090,11 @@ exit:
     return return_value;
 }
 
-#if defined(_ssl_MemoryBIO_pending_HAS_DOCSTR)
-#  define _ssl_MemoryBIO_pending_DOCSTR _ssl_MemoryBIO_pending__doc__
-#else
+PyDoc_STRVAR(_ssl_MemoryBIO_pending__doc__,
+"The number of bytes pending in the memory BIO.");
+#define _ssl_MemoryBIO_pending_DOCSTR _ssl_MemoryBIO_pending__doc__
+
+#if !defined(_ssl_MemoryBIO_pending_DOCSTR)
 #  define _ssl_MemoryBIO_pending_DOCSTR NULL
 #endif
 #if defined(_SSL_MEMORYBIO_PENDING_GETSETDEF)
@@ -2140,9 +2119,11 @@ _ssl_MemoryBIO_pending_get(PySSLMemoryBIO *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_ssl_MemoryBIO_eof_HAS_DOCSTR)
-#  define _ssl_MemoryBIO_eof_DOCSTR _ssl_MemoryBIO_eof__doc__
-#else
+PyDoc_STRVAR(_ssl_MemoryBIO_eof__doc__,
+"Whether the memory BIO is at EOF.");
+#define _ssl_MemoryBIO_eof_DOCSTR _ssl_MemoryBIO_eof__doc__
+
+#if !defined(_ssl_MemoryBIO_eof_DOCSTR)
 #  define _ssl_MemoryBIO_eof_DOCSTR NULL
 #endif
 #if defined(_SSL_MEMORYBIO_EOF_GETSETDEF)
@@ -2271,9 +2252,11 @@ _ssl_MemoryBIO_write_eof(PySSLMemoryBIO *self, PyObject *Py_UNUSED(ignored))
     return return_value;
 }
 
-#if defined(_ssl_SSLSession_time_HAS_DOCSTR)
-#  define _ssl_SSLSession_time_DOCSTR _ssl_SSLSession_time__doc__
-#else
+PyDoc_STRVAR(_ssl_SSLSession_time__doc__,
+"Session creation time (seconds since epoch).");
+#define _ssl_SSLSession_time_DOCSTR _ssl_SSLSession_time__doc__
+
+#if !defined(_ssl_SSLSession_time_DOCSTR)
 #  define _ssl_SSLSession_time_DOCSTR NULL
 #endif
 #if defined(_SSL_SSLSESSION_TIME_GETSETDEF)
@@ -2298,9 +2281,11 @@ _ssl_SSLSession_time_get(PySSLSession *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_ssl_SSLSession_timeout_HAS_DOCSTR)
-#  define _ssl_SSLSession_timeout_DOCSTR _ssl_SSLSession_timeout__doc__
-#else
+PyDoc_STRVAR(_ssl_SSLSession_timeout__doc__,
+"Session timeout (delta in seconds).");
+#define _ssl_SSLSession_timeout_DOCSTR _ssl_SSLSession_timeout__doc__
+
+#if !defined(_ssl_SSLSession_timeout_DOCSTR)
 #  define _ssl_SSLSession_timeout_DOCSTR NULL
 #endif
 #if defined(_SSL_SSLSESSION_TIMEOUT_GETSETDEF)
@@ -2325,9 +2310,11 @@ _ssl_SSLSession_timeout_get(PySSLSession *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_ssl_SSLSession_ticket_lifetime_hint_HAS_DOCSTR)
-#  define _ssl_SSLSession_ticket_lifetime_hint_DOCSTR _ssl_SSLSession_ticket_lifetime_hint__doc__
-#else
+PyDoc_STRVAR(_ssl_SSLSession_ticket_lifetime_hint__doc__,
+"Ticket life time hint.");
+#define _ssl_SSLSession_ticket_lifetime_hint_DOCSTR _ssl_SSLSession_ticket_lifetime_hint__doc__
+
+#if !defined(_ssl_SSLSession_ticket_lifetime_hint_DOCSTR)
 #  define _ssl_SSLSession_ticket_lifetime_hint_DOCSTR NULL
 #endif
 #if defined(_SSL_SSLSESSION_TICKET_LIFETIME_HINT_GETSETDEF)
@@ -2352,9 +2339,11 @@ _ssl_SSLSession_ticket_lifetime_hint_get(PySSLSession *self, void *Py_UNUSED(con
     return return_value;
 }
 
-#if defined(_ssl_SSLSession_id_HAS_DOCSTR)
-#  define _ssl_SSLSession_id_DOCSTR _ssl_SSLSession_id__doc__
-#else
+PyDoc_STRVAR(_ssl_SSLSession_id__doc__,
+"Session ID.");
+#define _ssl_SSLSession_id_DOCSTR _ssl_SSLSession_id__doc__
+
+#if !defined(_ssl_SSLSession_id_DOCSTR)
 #  define _ssl_SSLSession_id_DOCSTR NULL
 #endif
 #if defined(_SSL_SSLSESSION_ID_GETSETDEF)
@@ -2379,9 +2368,11 @@ _ssl_SSLSession_id_get(PySSLSession *self, void *Py_UNUSED(context))
     return return_value;
 }
 
-#if defined(_ssl_SSLSession_has_ticket_HAS_DOCSTR)
-#  define _ssl_SSLSession_has_ticket_DOCSTR _ssl_SSLSession_has_ticket__doc__
-#else
+PyDoc_STRVAR(_ssl_SSLSession_has_ticket__doc__,
+"Does the session contain a ticket?");
+#define _ssl_SSLSession_has_ticket_DOCSTR _ssl_SSLSession_has_ticket__doc__
+
+#if !defined(_ssl_SSLSession_has_ticket_DOCSTR)
 #  define _ssl_SSLSession_has_ticket_DOCSTR NULL
 #endif
 #if defined(_SSL_SSLSESSION_HAS_TICKET_GETSETDEF)
@@ -2828,4 +2819,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=c1489122072a9f5e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1ed5d1c707ad352e input=a9049054013a1b77]*/


### PR DESCRIPTION
(cherry picked from commit c112de1da2d18e3b5c2ea30b0e409f18e574efd8)

<!-- gh-issue-number: gh-126890 -->
* Issue: gh-126890
<!-- /gh-issue-number -->
