### PR TITLE
gh-126862: Use `Py_ssize_t` instead of `int` when processing the number of super-classes 

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-02-18-15-37.gh-issue-126862.fdIK7T.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-02-18-15-37.gh-issue-126862.fdIK7T.rst
@@ -1,0 +1,2 @@
+Fix a possible overflow when a class inherits from an absurdly number of
+super-classes. Reported by Valery Fedorenko. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-02-18-15-37.gh-issue-126862.fdIK7T.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-02-18-15-37.gh-issue-126862.fdIK7T.rst
@@ -1,2 +1,2 @@
-Fix a possible overflow when a class inherits from an absurdly number of
+Fix a possible overflow when a class inherits from an absurd number of
 super-classes. Reported by Valery Fedorenko. Patch by Bénédikt Tran.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2859,7 +2859,7 @@ vectorcall_maybe(PyThreadState *tstate, PyObject *name,
  */
 
 static int
-tail_contains(PyObject *tuple, int whence, PyObject *o)
+tail_contains(PyObject *tuple, Py_ssize_t whence, PyObject *o)
 {
     Py_ssize_t j, size;
     size = PyTuple_GET_SIZE(tuple);
@@ -2922,7 +2922,7 @@ check_duplicates(PyObject *tuple)
 */
 
 static void
-set_mro_error(PyObject **to_merge, Py_ssize_t to_merge_size, int *remain)
+set_mro_error(PyObject **to_merge, Py_ssize_t to_merge_size, Py_ssize_t *remain)
 {
     Py_ssize_t i, n, off;
     char buf[1000];
@@ -2977,13 +2977,13 @@ pmerge(PyObject *acc, PyObject **to_merge, Py_ssize_t to_merge_size)
 {
     int res = 0;
     Py_ssize_t i, j, empty_cnt;
-    int *remain;
+    Py_ssize_t *remain;
 
     /* remain stores an index into each sublist of to_merge.
        remain[i] is the index of the next base in to_merge[i]
        that is not included in acc.
     */
-    remain = PyMem_New(int, to_merge_size);
+    remain = PyMem_New(Py_ssize_t, to_merge_size);
     if (remain == NULL) {
         PyErr_NoMemory();
         return -1;


### PR DESCRIPTION
cc @JelleZijlstra 

<!-- gh-issue-number: gh-126862 -->
* Issue: gh-126862
<!-- /gh-issue-number -->
