### PR TITLE
gh-127527: Improve error handling in time_strftime1

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2638,11 +2638,15 @@ For :class:`date` objects, the format codes for hours, minutes, seconds, and
 microseconds should not be used, as :class:`date` objects have no such
 values. If they're used anyway, 0 is substituted for them.
 
-For the same reason, handling of format strings containing Unicode code points
-that can't be represented in the charset of the current locale is also
-platform-dependent. On some platforms such code points are preserved intact in
-the output, while on others ``strftime`` may raise :exc:`UnicodeError` or return
-an empty string instead.
+If a format directive is unrecognized, the behavior is platform-dependent. glibc
+will return the directive unmodified, Windows will raise a :exc:`ValueError`,
+and macOS, musl, and BSD will return an empty string.
+
+Handling of format strings containing Unicode code points that can't be
+represented in the charset of the current locale is also platform-dependent. On
+some platforms such code points are preserved intact in the output, while on
+others ``strftime`` may raise :exc:`UnicodeError` or return an empty string
+instead.
 
 Notes:
 

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -611,6 +611,7 @@ Functions
    glibc will return the format string unmodified, Windows will raise a
    :exc:`ValueError`, and macOS, musl, and BSD will return an empty string.
 
+
 .. class:: struct_time
 
    The type of the time value sequence returned by :func:`gmtime`,

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -608,7 +608,7 @@ Functions
    documented as supported.
 
    If a format directive is unrecognized, the behavior is platform-dependent.
-   glibc will return the format string unmodified, Windows will raise a
+   glibc will return the directive unmodified, Windows will raise a
    :exc:`ValueError`, and macOS, musl, and BSD will return an empty string.
 
 

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -607,6 +607,9 @@ Functions
    and thus does not necessarily support all directives available that are not
    documented as supported.
 
+   If a format directive is unrecognized, the behavior is platform-dependent.
+   glibc will return the format string unmodified, Windows will raise a
+   :exc:`ValueError`, and macOS, musl, and BSD will return an empty string.
 
 .. class:: struct_time
 

--- a/Misc/NEWS.d/next/Library/2024-12-03-11-53-56.gh-issue-127527.hoM7oD.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-03-11-53-56.gh-issue-127527.hoM7oD.rst
@@ -1,0 +1,2 @@
+Made minor improvements to the error handling in `time.strftime` and
+documented the behavior when an unknown directive is seen

--- a/Misc/NEWS.d/next/Library/2024-12-03-11-53-56.gh-issue-127527.hoM7oD.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-03-11-53-56.gh-issue-127527.hoM7oD.rst
@@ -1,2 +1,2 @@
-Made minor improvements to the error handling in `time.strftime` and
+Made minor improvements to the error handling in ``time.strftime`` and
 documented the behavior when an unknown directive is seen

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -813,7 +813,9 @@ time_strftime1(time_char **outbuf, size_t *bufsize,
     /* I hate these functions that presume you know how big the output
      * will be ahead of time...
      */
+    int attempts = 0;
     while (1) {
+        attempts ++;
         if (*bufsize > PY_SSIZE_T_MAX/sizeof(time_char)) {
             PyErr_NoMemory();
             return NULL;
@@ -854,7 +856,7 @@ time_strftime1(time_char **outbuf, size_t *bufsize,
                 format string. For instance we end up here with musl if the format
                 string ends with a '%'.
             */
-            PyErr_SetString(PyExc_ValueError, "Invalid format string");
+            PyErr_Format(PyExc_ValueError, "Invalid format string attempts: %d *outbuf: '%.8s'", attempts, *outbuf);
             return NULL;
         }
     }

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -813,9 +813,7 @@ time_strftime1(time_char **outbuf, size_t *bufsize,
     /* I hate these functions that presume you know how big the output
      * will be ahead of time...
      */
-    int attempts = 0;
     while (1) {
-        attempts ++;
         if (*bufsize > PY_SSIZE_T_MAX/sizeof(time_char)) {
             PyErr_NoMemory();
             return NULL;
@@ -851,13 +849,15 @@ time_strftime1(time_char **outbuf, size_t *bufsize,
             return NULL;
         }
         if (*bufsize >= 256 * fmtlen) {
-            /* If the buffer is 256 times as long as the format, it's probably not
-                failing for lack of room! More likely, `format_time` doesn't like the
-                format string. For instance we end up here with musl if the format
-                string ends with a '%'.
+            /* If the buffer is 256 times as long as the format, it's probably
+                not failing for lack of room! More likely, `format_time` doesn't
+                like the format string. For instance we end up here with musl if
+                the format string ends with a '%'.
+
+                Ideally we should raise ValueError("Invalid format string")
+                here. For backwards compatibility, return empty string instead.
             */
-            PyErr_Format(PyExc_ValueError, "Invalid format string attempts: %d *outbuf: '%.8s'", attempts, *outbuf);
-            return NULL;
+            return PyUnicode_FromStringAndSize(NULL, 0);
         }
         *bufsize += *bufsize;
     }

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -859,6 +859,7 @@ time_strftime1(time_char **outbuf, size_t *bufsize,
             PyErr_Format(PyExc_ValueError, "Invalid format string attempts: %d *outbuf: '%.8s'", attempts, *outbuf);
             return NULL;
         }
+        *bufsize += *bufsize;
     }
 }
 


### PR DESCRIPTION
This fixes `python  -m test test_datetime -mtest_strftime_trailing_percent` on Emscripten. On other musl platforms it will:
1. if `HAVE_WCSFTIME` is true, change `strftime("format string ending in %")` from returning empty string to raising `ValueError("Invalid format string")`
2. if `HAVE_WCSFTIME` is false, change `strftime("format string ending in %")` from raising `ValueError("embedded null byte")` to `ValueError("invalid format string")`.

It also should change the behavior for other unsupported behaviors from returning empty string to raising `Invalid format string`. Also, if the result is actually empty, the exit condition `(*outbuf)[buflen] == '\0'` is always true the first time and allows us to avoid resizing the buffer and calling `format_time` again.

<!-- gh-issue-number: gh-127527 -->
* Issue: gh-127527
<!-- /gh-issue-number -->
