### PR TITLE
gh-127529: Correct asyncio.selector_events.BaseSelectorEventLoop._accept_connection's behaviour for handling ConnectionAbortedError

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -180,9 +180,13 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
                     logger.debug("%r got a new connection from %r: %r",
                                  server, addr, conn)
                 conn.setblocking(False)
-            except (BlockingIOError, InterruptedError, ConnectionAbortedError):
-                # Early exit because the socket accept buffer is empty.
-                return None
+            except ConnectionAbortedError:
+                # Discard connections that were aborted before accept().
+                continue
+            except (BlockingIOError, InterruptedError):
+                # Early exit because of a signal or
+                # the socket accept buffer is empty.
+                return
             except OSError as exc:
                 # There's nowhere to send the error, so just log it.
                 if exc.errno in (errno.EMFILE, errno.ENFILE,

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -364,6 +364,31 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         self.loop.run_until_complete(asyncio.sleep(0))
         self.assertEqual(sock.accept.call_count, backlog)
 
+    def test_accept_connection_skip_connectionabortederror(self):
+        sock = mock.Mock()
+
+        def mock_sock_accept():
+            # mock accept(2) returning -ECONNABORTED every-other
+            # time that it's called. This applies most to OpenBSD
+            # whose sockets generate this errno more reproducibly than
+            # Linux and other OSs.
+            if sock.accept.call_count % 2 == 0:
+                raise ConnectionAbortedError
+            return (mock.Mock(), mock.Mock())
+
+        sock.accept.side_effect = mock_sock_accept
+        backlog = 100
+        # test that _accept_connection's loop calls sock.accept
+        # all 100 times, continuing past ConnectionAbortedError
+        # instead of unnecessarily returning early
+        mock_obj = mock.patch.object
+        with mock_obj(self.loop, '_accept_connection2') as accept2_mock:
+            self.loop._accept_connection(
+                mock.Mock(), sock, backlog=backlog)
+        # as in test_accept_connection_multiple avoid task pending
+        # warnings by using asyncio.sleep(0)
+        self.loop.run_until_complete(asyncio.sleep(0))
+        self.assertEqual(sock.accept.call_count, backlog)
 
 class SelectorTransportTests(test_utils.TestCase):
 

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -371,7 +371,7 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
             # mock accept(2) returning -ECONNABORTED every-other
             # time that it's called. This applies most to OpenBSD
             # whose sockets generate this errno more reproducibly than
-            # Linux and other OSs.
+            # Linux and other OS.
             if sock.accept.call_count % 2 == 0:
                 raise ConnectionAbortedError
             return (mock.Mock(), mock.Mock())

--- a/Misc/NEWS.d/next/Library/2024-12-02-19-13-19.gh-issue-127529.Pj1Xtf.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-02-19-13-19.gh-issue-127529.Pj1Xtf.rst
@@ -1,4 +1,4 @@
 Correct behavior of
 :func:`!asyncio.selector_events.BaseSelectorEventLoop._accept_connection`
 in handling :exc:`ConnectionAbortedError` in a loop. This improves
-performance on OpenBSD
+performance on OpenBSD.

--- a/Misc/NEWS.d/next/Library/2024-12-02-19-13-19.gh-issue-127529.Pj1Xtf.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-02-19-13-19.gh-issue-127529.Pj1Xtf.rst
@@ -1,4 +1,4 @@
 Correct behavior of
-asyncio.selector_events.BaseSelectorEventLoop._accept_connection
+:func:`!asyncio.selector_events.BaseSelectorEventLoop._accept_connection`
 in handling :exc:`ConnectionAbortedError` in a loop. This improves
 performance on OpenBSD

--- a/Misc/NEWS.d/next/Library/2024-12-02-19-13-19.gh-issue-127529.Pj1Xtf.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-02-19-13-19.gh-issue-127529.Pj1Xtf.rst
@@ -1,0 +1,4 @@
+Correct behavior of
+:meth:`asyncio.selector_events.BaseSelectorEventLoop._accept_connection`
+in handling :exc:`ConnectionAbortedError` in a loop. This improves
+performance on OpenBSD

--- a/Misc/NEWS.d/next/Library/2024-12-02-19-13-19.gh-issue-127529.Pj1Xtf.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-02-19-13-19.gh-issue-127529.Pj1Xtf.rst
@@ -1,4 +1,4 @@
 Correct behavior of
-:meth:`asyncio.selector_events.BaseSelectorEventLoop._accept_connection`
+asyncio.selector_events.BaseSelectorEventLoop._accept_connection
 in handling :exc:`ConnectionAbortedError` in a loop. This improves
 performance on OpenBSD


### PR DESCRIPTION
Closes #127529 

All good to go. `ConnectionAbortedError` now `continue`s instead of `return`ing. Improves OpenBSD performance. Full writeup in the issue.

I've left `InterruptedError` grouped with `BlockingIOError` to both `return` early, instead of `InterruptedError` `continue`ing and `BlockingIOError` `return`ing. [PEP-475](https://peps.python.org/pep-0475/) should make `InterruptedError` never appear right, but hey if it's not broken don't fix it. Best to play it safe with the urgency of signals, especially as asyncio uses them for a wakeup fd.


<!-- gh-issue-number: gh-127529 -->
* Issue: gh-127529
<!-- /gh-issue-number -->
