### PR TITLE
add __class_getitem__ to the python implementation of functools.partial

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -433,6 +433,9 @@ class partial:
         self._phcount = phcount
         self._merger = merger
 
+    __class_getitem__ = classmethod(GenericAlias)
+
+
 try:
     from _functools import partial, Placeholder, _PlaceholderType
 except ImportError:

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -472,6 +472,12 @@ class TestPartial:
         self.assertEqual(a.cmeth(3, b=4), ((1, A, 3), {'a': 2, 'b': 4}))
         self.assertEqual(a.smeth(3, b=4), ((1, 3), {'a': 2, 'b': 4}))
 
+    def test_partial_genericalias(self):
+        alias = self.partial[int]
+        self.assertIs(alias.__origin__, self.partial)
+        self.assertEqual(alias.__args__, (int,))
+        self.assertEqual(alias.__parameters__, ())
+
 
 @unittest.skipUnless(c_functools, 'requires the C _functools module')
 class TestPartialC(TestPartial, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2024-12-04-10-39-29.gh-issue-83662.CG1s3m.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-04-10-39-29.gh-issue-83662.CG1s3m.rst
@@ -1,0 +1,5 @@
+Add missing `__class_getitem__` method to the Python implementation of
+:func:`functools.partial`, to make it compatible with the C version. This is
+mainly relevant for alternative Python implementations like PyPy and
+GraalPy, because CPython will usually use the C-implementation of that
+function.

--- a/Misc/NEWS.d/next/Library/2024-12-04-10-39-29.gh-issue-83662.CG1s3m.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-04-10-39-29.gh-issue-83662.CG1s3m.rst
@@ -1,4 +1,4 @@
-Add missing `__class_getitem__` method to the Python implementation of
+Add missing ``__class_getitem__`` method to the Python implementation of
 :func:`functools.partial`, to make it compatible with the C version. This is
 mainly relevant for alternative Python implementations like PyPy and
 GraalPy, because CPython will usually use the C-implementation of that


### PR DESCRIPTION
The Python version of `functools.partial` is missing the `__class_getitem__` that would make it usable as a generic alias. This never matters for CPython, because it always uses the C-implementation of that class. However, in PyPy we always use the Python version.

The problem went unnoticed because the tests for this behaviour got added to `test_genericalias.py`, which is only testing the C version (unlike `test_functools.py`).