### PR TITLE
Speed-up lazy heapq import in collections

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -59,6 +59,8 @@ try:
 except ImportError:
     pass
 
+heapq = None  # Lazily imported
+
 
 ################################################################################
 ### OrderedDict
@@ -633,7 +635,10 @@ class Counter(dict):
             return sorted(self.items(), key=_itemgetter(1), reverse=True)
 
         # Lazy import to speedup Python startup time
-        import heapq
+        global heapq
+        if heapq is None:
+            import heapq
+
         return heapq.nlargest(n, self.items(), key=_itemgetter(1))
 
     def elements(self):


### PR DESCRIPTION
It is faster to test for `None` than to go through the `import` logic to check `sys.modules`.

Baseline:
```
$ ./python.exe -m timeit -s 'from collections import Counter' -s 'c=Counter("abc")' 'c.most_common(1)'
500000 loops, best of 5: 481 nsec per loop
```

Patched:
```
$ ./python.exe -m timeit -s 'from collections import Counter' -s 'c=Counter("abc")' 'c.most_common(1)'
500000 loops, best of 5: 400 nsec per loop
```
