### PR TITLE
gh-127545: Specify minimum PyGC_Head alignment to fix build failure

### DIFF
--- a/Include/internal/pycore_gc.h
+++ b/Include/internal/pycore_gc.h
@@ -133,7 +133,7 @@ static inline void _PyObject_GC_SET_SHARED(PyObject *op) {
 */
 #define _PyGC_NEXT_MASK_OLD_SPACE_1    1
 
-#define _PyGC_PREV_SHIFT           2
+#define _PyGC_PREV_SHIFT           _PyObject_ALIGNMENT_SHIFT
 #define _PyGC_PREV_MASK            (((uintptr_t) -1) << _PyGC_PREV_SHIFT)
 
 /* set for debugging information */

--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -163,8 +163,9 @@ typedef struct {
 
     // Tagged pointer to previous object in the list.
     // Lowest two bits are used for flags documented later.
+    // Those bits are made available by the struct's minimum alignment.
     uintptr_t _gc_prev;
-} PyGC_Head;
+} PyGC_Head Py_ALIGNED(1 << _PyObject_ALIGNMENT_SHIFT);
 
 #define _PyGC_Head_UNUSED PyGC_Head
 

--- a/Include/object.h
+++ b/Include/object.h
@@ -101,6 +101,11 @@ whose size is determined when the object is allocated.
 #define PyObject_VAR_HEAD      PyVarObject ob_base;
 #define Py_INVALID_SIZE (Py_ssize_t)-1
 
+/* PyObjects are given a minimum alignment so that the least significant bits
+ * of an object pointer become available for other purposes.
+ */
+#define _PyObject_ALIGNMENT_SHIFT       2
+
 /* Nothing is actually declared to be a PyObject, but every pointer to
  * a Python object can be cast to a PyObject*.  This is inheritance built
  * by hand.  Similarly every pointer to a variable-size Python object can,
@@ -142,7 +147,7 @@ struct _object {
 #endif
 
     PyTypeObject *ob_type;
-};
+} Py_ALIGNED(1 << _PyObject_ALIGNMENT_SHIFT);
 #else
 // Objects that are not owned by any thread use a thread id (tid) of zero.
 // This includes both immortal objects and objects whose reference count
@@ -160,7 +165,7 @@ struct _object {
     uint32_t ob_ref_local;      // local reference count
     Py_ssize_t ob_ref_shared;   // shared (atomic) reference count
     PyTypeObject *ob_type;
-};
+} Py_ALIGNED(1 << _PyObject_ALIGNMENT_SHIFT);
 #endif
 
 /* Cast argument to PyObject* type. */

--- a/Misc/NEWS.d/next/Build/2024-12-04-10-00-35.gh-issue-127545.t0THjE.rst
+++ b/Misc/NEWS.d/next/Build/2024-12-04-10-00-35.gh-issue-127545.t0THjE.rst
@@ -1,0 +1,1 @@
+Fix crash when building on Linux/m68k.


### PR DESCRIPTION
    As documented in InternalDocs/garbage_collector.md, the garbage collector
    stores flags in the least significant two bits of the _gc_prev pointer
    in struct PyGC_Head. Consequently, this pointer is only capable of storing
    a location that's aligned to a 4-byte boundary.
    
    This alignment requirement is documented but it's not actually encoded.
    The code works when python happens to run on a platform that has a large
    minimum alignment, but fails otherwise.
    
    Since we know that 2 bits are needed, we also know the minimum alignment
    that's needed. Let's make that explicit, so the compiler can then make
    sure those 2 bits are available.
    
    This patch fixes a segfault in _bootstrap_python. It also clarifies the
    code by making the actual requirement explicit.
    
    This bug was investigated by Adrian Glaubitz here:
    https://lists.debian.org/debian-68k/2024/11/msg00020.html
    https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1087600
    
    Although Adrian's patch isn't really correct (because natural alignment
    is not needed), he deserves full credit for finding the root cause.

#127545 

<!-- gh-issue-number: gh-127545 -->
* Issue: gh-127545
<!-- /gh-issue-number -->
