### PR TITLE
gh-127421: Fix race in test_start_new_thread_failed

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1192,11 +1192,12 @@ class ThreadTests(BaseTestCase):
             resource.setrlimit(resource.RLIMIT_NPROC, (0, hard))
 
             try:
-                _thread.start_new_thread(f, ())
+                handle = _thread.start_joinable_thread(f)
             except RuntimeError:
                 print('ok')
             else:
                 print('!skip!')
+                handle.join()
         """
         _, out, err = assert_python_ok("-u", "-c", code)
         out = out.strip()


### PR DESCRIPTION
When we succeed in starting a new thread, for example if setrlimit was ineffective, we must wait for the newly spawned thread to exit. Otherwise, we run the risk that the newly spawned thread will race with runtime finalization and access memory that has already been freed. In this case, this assertion tends to fire:

https://github.com/python/cpython/blob/dffb90911a585a0921664c8b1c229d0883e65ee7/Python/pystate.c#L322

when the newly created thread attempts to bind the state after the runtime has been finalized, because all thread states are cleared and deleted as part of finalization.

The use of `_thread.start_new_thread()` is problematic here. It only spawns daemon threads, which the runtime does not wait for during finalization, and does not return a joinable handle. Instead, use `_thread.start_joinable_thread()` and join the resulting handle when the thread is started successfully.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127421 -->
* Issue: gh-127421
<!-- /gh-issue-number -->
