### PR TITLE
gh-127553: Remove `TODO` comment in `_pydatetime._isoweek1monday`

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -2392,7 +2392,6 @@ datetime.resolution = timedelta(microseconds=1)
 
 def _isoweek1monday(year):
     # Helper to calculate the day number of the Monday starting week 1
-    # XXX This could be done more efficiently
     THURSDAY = 3
     firstday = _ymd2ord(year, 1, 1)
     firstweekday = (firstday + 6) % 7  # See weekday() above

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -2395,8 +2395,6 @@ def _isoweek1monday(year):
     THURSDAY = 3
     firstday = _ymd2ord(year, 1, 1)
     firstweekday = (firstday + 6) % 7  # See weekday() above
-    # If the first weekday is after Thursday,
-    # ISO week 1 doesn't start until the next Monday
     week1monday = firstday - firstweekday
     if firstweekday > THURSDAY:
         week1monday += 7

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -2395,6 +2395,8 @@ def _isoweek1monday(year):
     THURSDAY = 3
     firstday = _ymd2ord(year, 1, 1)
     firstweekday = (firstday + 6) % 7  # See weekday() above
+    # If the first weekday is after Thursday,
+    # ISO week 1 doesn't start until the next Monday
     week1monday = firstday - firstweekday
     if firstweekday > THURSDAY:
         week1monday += 7


### PR DESCRIPTION
*  Removes the unnecessary TODO comment
    * In #127553 a optimization has been tried, but it seems that the existing code is nearly optimal
* Adds a comment about the need for the one week addition

<!-- gh-issue-number: gh-127553 -->
* Issue: gh-127553
<!-- /gh-issue-number -->
