### PR TITLE
gh-127146: Resolve some minor problems in Emscripten tests

### DIFF
--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -1,5 +1,5 @@
 from test import support
-from test.support import is_apple_mobile, os_helper, requires_debug_ranges
+from test.support import is_apple_mobile, os_helper, requires_debug_ranges, is_emscripten
 from test.support.script_helper import assert_python_ok
 import array
 import io
@@ -294,7 +294,7 @@ class BugsTestCase(unittest.TestCase):
         #if os.name == 'nt' and support.Py_DEBUG:
         if os.name == 'nt':
             MAX_MARSHAL_STACK_DEPTH = 1000
-        elif sys.platform == 'wasi' or is_apple_mobile:
+        elif sys.platform == 'wasi' or is_emscripten or is_apple_mobile:
             MAX_MARSHAL_STACK_DEPTH = 1500
         else:
             MAX_MARSHAL_STACK_DEPTH = 2000

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -2722,7 +2722,7 @@ class FMATests(unittest.TestCase):
     # gh-73468: On some platforms, libc fma() doesn't implement IEE 754-2008
     # properly: it doesn't use the right sign when the result is zero.
     @unittest.skipIf(
-        sys.platform.startswith(("freebsd", "wasi", "netbsd"))
+        sys.platform.startswith(("freebsd", "wasi", "netbsd", "emscripten"))
         or (sys.platform == "android" and platform.machine() == "x86_64"),
         f"this platform doesn't implement IEE 754-2008 properly")
     def test_fma_zero_result(self):

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -578,7 +578,7 @@ class TestSupport(unittest.TestCase):
                                  'Warning -- a\nWarning -- b\n')
 
     def test_has_strftime_extensions(self):
-        if support.is_emscripten or sys.platform == "win32":
+        if sys.platform == "win32":
             self.assertFalse(support.has_strftime_extensions)
         else:
             self.assertTrue(support.has_strftime_extensions)


### PR DESCRIPTION
* Emscripten has_strftime_extensions
* fma doesn't handle negative zero correctly in Emscripten
* Emscripten has similar limited stack depth to wasi and apple in test_marshall


<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
