### PR TITLE
gh-126024: fix UBSan failure in `unicodeobject.c:find_first_nonascii`

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -5068,14 +5068,17 @@ load_unaligned(const unsigned char *p, size_t size)
 #endif
 #  if defined(_M_AMD64) || defined(_M_IX86) || defined(__x86_64__) || defined(__i386__)
 // x86 and amd64 are little endian and can load unaligned memory.
-#    if defined(__clang__) && defined(__has_feature)    \
-        && __has_feature(undefined_behavior_sanitizer)
+#    if defined(__clang__) && defined(__has_feature)
+#      if __has_feature(undefined_behavior_sanitizer)
 static inline size_t
 __attribute__((no_sanitize("alignment")))
 load_unaligned_x86_amd64(const unsigned char *p)
 {
     return *(const size_t *)p;
 }
+#      else
+#        define load_unaligned_x86_amd64(p)   *(const size_t *)p
+#      endif
 #    else
 #      define load_unaligned_x86_amd64(p)   *(const size_t *)p
 #    endif

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -5019,7 +5019,7 @@ ctz(size_t v)
 #endif
 
 #if PY_LITTLE_ENDIAN
-#if HAVE_CTZ
+#  if HAVE_CTZ
 // load p[0]..p[size-1] as a size_t without unaligned access nor read ahead.
 static size_t
 load_unaligned(const unsigned char *p, size_t size)
@@ -5065,24 +5065,20 @@ load_unaligned(const unsigned char *p, size_t size)
     }
     return u.s;
 }
-#endif
+#  endif
 #  if defined(_M_AMD64) || defined(_M_IX86) || defined(__x86_64__) || defined(__i386__)
 // x86 and amd64 are little endian and can load unaligned memory.
-#    if defined(__clang__) && defined(__has_feature)
-#      if __has_feature(undefined_behavior_sanitizer)
+#    if defined(__clang__)
 static inline size_t
 __attribute__((no_sanitize("alignment")))
 load_unaligned_x86_amd64(const unsigned char *p)
 {
     return *(const size_t *)p;
 }
-#      else
-#        define load_unaligned_x86_amd64(p)   *(const size_t *)p
-#      endif
 #    else
 #      define load_unaligned_x86_amd64(p)   *(const size_t *)p
 #    endif
-#endif
+#  endif
 #endif // PY_LITTLE_ENDIAN
 
 /*

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -5084,13 +5084,8 @@ find_first_nonascii(const unsigned char *start, const unsigned char *end)
 #if PY_LITTLE_ENDIAN && HAVE_CTZ
         if (p < p2) {
             size_t u;
-#if defined(_M_AMD64) || defined(_M_IX86) || defined(__x86_64__) || defined(__i386__)
-            // x86 and amd64 are little endian and can load unaligned memory.
             memcpy(&u, p, sizeof(size_t));
             u &= ASCII_CHAR_MASK;
-#else
-            u = load_unaligned(p, p2 - p) & ASCII_CHAR_MASK;
-#endif
             if (u) {
                 return (ctz(u) - 7) / 8;
             }


### PR DESCRIPTION
Not sure we can do anything except wrapping the call in a function. Adding an allow list may seem too hard since the line would change everytime we change the code. Or we can just forget about the optimized unaligned load.

<!-- gh-issue-number: gh-126024 -->
* Issue: gh-126024
<!-- /gh-issue-number -->
