### PR TITLE
gh-127572: Fix `test_structmembers` initialization

### DIFF
--- a/Lib/test/test_capi/test_structmembers.py
+++ b/Lib/test/test_capi/test_structmembers.py
@@ -39,7 +39,7 @@ def _make_test_object(cls):
                "hi",   # T_STRING_INPLACE
                12,     # T_LONGLONG
                13,     # T_ULONGLONG
-               "c",    # T_CHAR
+               b"c",   # T_CHAR
                )
 
 

--- a/Modules/_testcapi/structmember.c
+++ b/Modules/_testcapi/structmember.c
@@ -60,7 +60,7 @@ test_structmembers_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         "T_FLOAT", "T_DOUBLE", "T_STRING_INPLACE",
         "T_LONGLONG", "T_ULONGLONG", "T_CHAR",
         NULL};
-    static const char fmt[] = "|bbBhHiIlknfds#LKC";
+    static const char fmt[] = "|bbBhHiIlknfds#LKc";
     test_structmembers *ob;
     const char *s = NULL;
     Py_ssize_t string_len = 0;


### PR DESCRIPTION
The 'C' format code expects an `int` as a destination (not a `char`). This led to test failures on big-endian platforms like s390x. Use the 'c' format code, which expects a `char` as the destination (but requires a Python byte objects instead of a str).

<!-- gh-issue-number: gh-127572 -->
* Issue: gh-127572
<!-- /gh-issue-number -->
