### PR TITLE
gh-127552: Remove comment questioning 4-digit restriction for ‘Y’ in datetime.strptime patterns

### DIFF
--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -301,8 +301,6 @@ class TimeRE(dict):
             'V': r"(?P<V>5[0-3]|0[1-9]|[1-4]\d|\d)",
             # W is set below by using 'U'
             'y': r"(?P<y>\d\d)",
-            #XXX: Does 'Y' need to worry about having less or more than
-            #     4 digits?
             'Y': r"(?P<Y>\d\d\d\d)",
             'z': r"(?P<z>[+-]\d\d:?[0-5]\d(:?[0-5]\d(\.\d{1,6})?)?|(?-i:Z))",
             'A': self.__seqToRE(self.locale_time.f_weekday, 'A'),


### PR DESCRIPTION
This PR removes the comment questioning 4-digit restriction for ‘Y’ in `datetime.strptime` patterns. The comment is more than 20 years old and practically obsolete at this point.

<!-- gh-issue-number: gh-127552 -->
* Issue: gh-127552
<!-- /gh-issue-number -->
