### PR TITLE
GDB helpers docs: fix block type of a cast example

### DIFF
--- a/Doc/howto/gdb_helpers.rst
+++ b/Doc/howto/gdb_helpers.rst
@@ -180,7 +180,7 @@ regular machine-level integer::
     (gdb) p some_python_integer
     $4 = 42
 
-The internal structure can be revealed with a cast to :c:expr:`PyLongObject *`:
+The internal structure can be revealed with a cast to :c:expr:`PyLongObject *`::
 
     (gdb) p *(PyLongObject*)some_python_integer
     $5 = {ob_base = {ob_base = {ob_refcnt = 8, ob_type = 0x3dad39f5e0}, ob_size = 1},


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.


-->
Rendering of the code block example in broken now. This change is fixing it.

<img width="823" alt="Zrzut ekranu 2024-12-5 o 00 14 55" src="https://github.com/user-attachments/assets/4d540d4b-3557-44eb-b407-4f9bd3786ee4">

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127621.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->