### PR TITLE
gh-80192: Use windows api if ssl cert verification fails

### DIFF
--- a/Misc/NEWS.d/next/Windows/2024-12-05-00-21-11.gh-issue-80192.28PTj4.rst
+++ b/Misc/NEWS.d/next/Windows/2024-12-05-00-21-11.gh-issue-80192.28PTj4.rst
@@ -1,0 +1,1 @@
+Fixed valid ssl certificates being rejected.

--- a/Misc/NEWS.d/next/Windows/2024-12-05-00-21-11.gh-issue-80192.28PTj4.rst
+++ b/Misc/NEWS.d/next/Windows/2024-12-05-00-21-11.gh-issue-80192.28PTj4.rst
@@ -1,1 +1,1 @@
-Fixed valid ssl certificates being rejected.
+Fixed valid :mod:`ssl` certificates being rejected.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3029,7 +3029,7 @@ _translate_policy_status_error(int error)
     case TRUST_E_CERT_SIGNATURE:
         return X509_V_ERR_CERT_SIGNATURE_FAILURE;
     case CERT_E_UNTRUSTEDROOT:
-        return X509_V_ERR_CERT_UNTRUSTED;
+        return X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY;
     case CERT_E_CHAINING:
         return X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT;
     case CERT_E_EXPIRED:

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2997,8 +2997,8 @@ static PyType_Spec PySSLSocket_spec = {
 };
 
 #ifdef _MSC_VER
-static unsigned char *
-_get_cert_bytes(X509 *cert, int *length)
+static const unsigned char *
+_get_cert_bytes(const X509 *cert, int *length)
 {
     unsigned char *cert_bytes;
     int cert_bytes_length = i2d_X509(cert, NULL);
@@ -3042,7 +3042,7 @@ _verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
     }
 
     int cert_bytes_length;
-    unsigned char *cert_bytes = _get_cert_bytes(X509_STORE_CTX_get_current_cert(ctx), &cert_bytes_length);
+    const unsigned char *cert_bytes = _get_cert_bytes(X509_STORE_CTX_get_current_cert(ctx), &cert_bytes_length);
     if (cert_bytes == NULL)
     {
         goto error_1;
@@ -3100,7 +3100,7 @@ error_4:
 error_3:
     CertFreeCertificateContext(primary_context);
 error_2:
-    PyMem_RawFree(cert_bytes);
+    PyMem_RawFree((void *)cert_bytes);
 error_1:
     CertCloseStore(store, 0);
     return ret;


### PR DESCRIPTION
This avoids rejecting certificates that should be accepted, see #80192.

Here is the relevant openssl documentation: https://docs.openssl.org/master/man3/SSL_CTX_set_verify/.

Also, here are the windows api docs:
- https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certverifycertificatechainpolicy
- https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-cert_chain_policy_status for error status.

I've been testing manually by deleting `DigiCert Global Root G2` from `Third Party Root Certificates` in the user certificate store (this is safe, the certificate will be added back automatically), and running the following code:

```python
import http.client
conn = http.client.HTTPSConnection("www.verisign.com")
conn.request("GET", "/")
conn.close()
```

The main branch errors with:
```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1025)
```
Whereas with this patch, the certificate is verified and the connection is established.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-80192 -->
* Issue: gh-80192
<!-- /gh-issue-number -->
