### PR TITLE
[3.13] gh-127434: Fix iOS `xcrun --sdk` clang/ar scripts to allow arguments with spaces (GH-127575)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2024-12-04-09-52-08.gh-issue-127434.RjkGT_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-12-04-09-52-08.gh-issue-127434.RjkGT_.rst
@@ -1,0 +1,1 @@
+The iOS compiler shims can now accept arguments with spaces.

--- a/iOS/Resources/bin/arm64-apple-ios-ar
+++ b/iOS/Resources/bin/arm64-apple-ios-ar
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} ar $@
+xcrun --sdk iphoneos${IOS_SDK_VERSION} ar "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-clang
+++ b/iOS/Resources/bin/arm64-apple-ios-clang
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} clang -target arm64-apple-ios $@
+xcrun --sdk iphoneos${IOS_SDK_VERSION} clang -target arm64-apple-ios "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-clang++
+++ b/iOS/Resources/bin/arm64-apple-ios-clang++
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} clang++ -target arm64-apple-ios $@
+xcrun --sdk iphoneos${IOS_SDK_VERSION} clang++ -target arm64-apple-ios "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-cpp
+++ b/iOS/Resources/bin/arm64-apple-ios-cpp
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} clang -target arm64-apple-ios -E $@
+xcrun --sdk iphoneos${IOS_SDK_VERSION} clang -target arm64-apple-ios -E "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-ar
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-ar
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} ar $@
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} ar "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-clang
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-clang
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target arm64-apple-ios-simulator $@
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target arm64-apple-ios-simulator "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-clang++
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-clang++
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target arm64-apple-ios-simulator $@
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target arm64-apple-ios-simulator "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-cpp
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-cpp
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target arm64-apple-ios-simulator -E $@
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target arm64-apple-ios-simulator -E "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-ar
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-ar
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} ar $@
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} ar "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-clang
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-clang
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target x86_64-apple-ios-simulator $@
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target x86_64-apple-ios-simulator "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-clang++
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-clang++
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target x86_64-apple-ios-simulator $@
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target x86_64-apple-ios-simulator "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-cpp
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-cpp
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target x86_64-apple-ios-simulator -E $@
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target x86_64-apple-ios-simulator -E "$@"


### PR DESCRIPTION
Added shell escaping to ensure iOS compiler shims can accept arguments with spaces. (cherry picked from commit 6cf77949fba7b44f6885794b2028f091f42f5d6c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127434 -->
* Issue: gh-127434
<!-- /gh-issue-number -->
