### PR TITLE
gh-127503: Fix realpath handling in emscripten cli

### DIFF
--- a/Tools/wasm/emscripten/__main__.py
+++ b/Tools/wasm/emscripten/__main__.py
@@ -223,7 +223,7 @@ def configure_emscripten_python(context, working_dir):
             if which grealpath > /dev/null; then
                 # It has brew installed gnu core utils, use that
                 REALPATH="grealpath -s"
-            elif which realpath > /dev/null && realpath --version 2&>1 | grep GNU > /dev/null; then
+            elif which realpath > /dev/null && realpath --version > /dev/null 2> /dev/null && realpath --version | grep GNU > /dev/null; then
                 # realpath points to GNU realpath so use it.
                 REALPATH="realpath -s"
             else


### PR DESCRIPTION
I believe @freakboy3742 checked that the previous version works on macs but I didn't test it correctly locally and it does not seem to work on linux. 


<!-- gh-issue-number: gh-127503 -->
* Issue: gh-127503
<!-- /gh-issue-number -->
