### PR TITLE
gh-127655: Ensure `_SelectorSocketTransport.writelines` pauses the protocol if needed

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -1175,6 +1175,7 @@ class _SelectorSocketTransport(_SelectorTransport):
         # If the entire buffer couldn't be written, register a write handler
         if self._buffer:
             self._loop._add_writer(self._sock_fd, self._write_ready)
+            self._maybe_pause_protocol()
 
     def can_write_eof(self):
         return True

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -805,6 +805,18 @@ class SelectorSocketTransportTests(test_utils.TestCase):
         self.assertTrue(self.sock.send.called)
         self.assertTrue(self.loop.writers)
 
+    def test_writelines_pauses_protocol(self):
+        data = memoryview(b'data')
+        self.sock.send.return_value = 2
+        self.sock.send.fileno.return_value = 7
+
+        transport = self.socket_transport()
+        transport._high_water = 1
+        transport.writelines([data])
+        self.assertTrue(self.protocol.pause_writing.called)
+        self.assertTrue(self.sock.send.called)
+        self.assertTrue(self.loop.writers)
+
     @unittest.skipUnless(selector_events._HAS_SENDMSG, 'no sendmsg')
     def test_write_sendmsg_full(self):
         data = memoryview(b'data')

--- a/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
+++ b/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
@@ -1,1 +1,1 @@
-Fixed the :class:`asyncio.SelectorEventLoop` transport not pausing writes for the protocol when the buffer reaches the high water mark when using :meth:`asyncio.WriteTransport.writelines`.
+Fixed the :class:`!asyncio.selector_events._SelectorSocketTransport` transport not pausing writes for the protocol when the buffer reaches the high water mark when using :meth:`asyncio.WriteTransport.writelines`.

--- a/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
+++ b/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
@@ -1,1 +1,1 @@
-Fixed the :mod:`asyncio` selector transport not pausing writes for the protocol when the buffer reaches the high water mark when using ``writelines``.
+Fixed the :mod:`asyncio` selector transport not pausing writes for the protocol when the buffer reaches the high water mark when using :meth:`asyncio.StreamWriter.writelines`.

--- a/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
+++ b/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
@@ -1,1 +1,1 @@
-Fixed the :mod:`asyncio` selector transport not pausing writes for the protocol when the buffer reaches the high water mark when using `writelines`.
+Fixed the :mod:`asyncio` selector transport not pausing writes for the protocol when the buffer reaches the high water mark when using ``writelines``.

--- a/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
+++ b/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
@@ -1,1 +1,1 @@
-Fixed the :mod:`asyncio` selector transport not pausing writes for the protocol when the buffer reaches the high water mark.
+Fixed the :mod:`asyncio` selector transport not pausing writes for the protocol when the buffer reaches the high water mark when using `writelines`.

--- a/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
+++ b/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
@@ -1,1 +1,1 @@
-Fixed the :mod:`asyncio` selector transport not pausing writes for the protocol when the buffer reaches the high water mark when using :meth:`asyncio.StreamWriter.writelines`.
+Fixed the :mod:`asyncio` selector transport not pausing writes for the protocol when the buffer reaches the high water mark when using :meth:`asyncio.WriteTransport.writelines`.

--- a/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
+++ b/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
@@ -1,1 +1,1 @@
-Fixed the :mod:`asyncio` selector transport not pausing the protocol when the buffer reaches the high water mark.
+Fixed the :mod:`asyncio` selector transport not pausing writes for the protocol when the buffer reaches the high water mark.

--- a/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
+++ b/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
@@ -1,1 +1,1 @@
-Fixed the :mod:`asyncio` selector transport not pausing writes for the protocol when the buffer reaches the high water mark when using :meth:`asyncio.WriteTransport.writelines`.
+Fixed the :class:`asyncio.SelectorEventLoop` transport not pausing writes for the protocol when the buffer reaches the high water mark when using :meth:`asyncio.WriteTransport.writelines`.

--- a/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
+++ b/Misc/NEWS.d/next/Security/2024-12-05-21-35-19.gh-issue-127655.xpPoOf.rst
@@ -1,0 +1,1 @@
+Fixed the :mod:`asyncio` selector transport not pausing the protocol when the buffer reaches the high water mark.


### PR DESCRIPTION
gh-127655: Ensure writelines pauses the protocol if needed

Note for reviewers: 3.12+ only since writelines only exists since 3.12.