### PR TITLE
gh-127610: Added validation for more than one var positional and var keyword parameters in inspect.Signature

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2943,12 +2943,19 @@ class Signature:
                 params = OrderedDict()
                 top_kind = _POSITIONAL_ONLY
                 seen_default = False
-                seen_var_positional = False
-                seen_var_keyword = False
+                seen_var_parameters = set()
 
                 for param in parameters:
                     kind = param.kind
                     name = param.name
+
+                    if kind in (_VAR_POSITIONAL, _VAR_KEYWORD):
+                        if kind in seen_var_parameters:
+                            msg = 'more than one {} parameter'
+                            msg = msg.format(kind.description)
+                            raise ValueError(msg)
+
+                        seen_var_parameters.add(kind)
 
                     if kind < top_kind:
                         msg = (
@@ -2972,20 +2979,6 @@ class Signature:
                         else:
                             # There is a default for this parameter.
                             seen_default = True
-
-                    if kind == _VAR_POSITIONAL:
-                        if seen_var_positional:
-                            msg = 'more than one var-positional parameter'
-                            raise ValueError(msg)
-
-                        seen_var_positional = True
-
-                    if kind == _VAR_KEYWORD:
-                        if seen_var_keyword:
-                            msg = 'more than one var-keyword parameter'
-                            raise ValueError(msg)
-
-                        seen_var_keyword = True
 
                     if name in params:
                         msg = 'duplicate parameter name: {!r}'.format(name)

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2943,6 +2943,8 @@ class Signature:
                 params = OrderedDict()
                 top_kind = _POSITIONAL_ONLY
                 seen_default = False
+                var_positional_count = 0
+                var_keyword_count = 0
 
                 for param in parameters:
                     kind = param.kind
@@ -2970,6 +2972,18 @@ class Signature:
                         else:
                             # There is a default for this parameter.
                             seen_default = True
+
+                    if kind == _VAR_POSITIONAL:
+                        var_positional_count += 1
+                        if var_positional_count > 1:
+                            msg = 'more than one var positional parameter'
+                            raise ValueError(msg)
+
+                    if kind == _VAR_KEYWORD:
+                        var_keyword_count += 1
+                        if var_keyword_count > 1:
+                            msg = 'more than one var keyword parameter'
+                            raise ValueError(msg)
 
                     if name in params:
                         msg = 'duplicate parameter name: {!r}'.format(name)

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2951,8 +2951,7 @@ class Signature:
 
                     if kind in (_VAR_POSITIONAL, _VAR_KEYWORD):
                         if kind in seen_var_parameters:
-                            msg = 'more than one {} parameter'
-                            msg = msg.format(kind.description)
+                            msg = f'more than one {kind.description} parameter'
                             raise ValueError(msg)
 
                         seen_var_parameters.add(kind)

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2943,8 +2943,8 @@ class Signature:
                 params = OrderedDict()
                 top_kind = _POSITIONAL_ONLY
                 seen_default = False
-                var_positional_count = 0
-                var_keyword_count = 0
+                seen_var_positional = False
+                seen_var_keyword = False
 
                 for param in parameters:
                     kind = param.kind
@@ -2974,16 +2974,18 @@ class Signature:
                             seen_default = True
 
                     if kind == _VAR_POSITIONAL:
-                        var_positional_count += 1
-                        if var_positional_count > 1:
-                            msg = 'more than one var positional parameter'
+                        if seen_var_positional:
+                            msg = 'more than one var-positional parameter'
                             raise ValueError(msg)
 
+                        seen_var_positional = True
+
                     if kind == _VAR_KEYWORD:
-                        var_keyword_count += 1
-                        if var_keyword_count > 1:
-                            msg = 'more than one var keyword parameter'
+                        if seen_var_keyword:
+                            msg = 'more than one var-keyword parameter'
                             raise ValueError(msg)
+
+                        seen_var_keyword = True
 
                     if name in params:
                         msg = 'duplicate parameter name: {!r}'.format(name)

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -2992,6 +2992,14 @@ class TestSignatureObject(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'follows default argument'):
             S((pkd, pk))
 
+        second_args = args.replace(name="second_args")
+        with self.assertRaisesRegex(ValueError, 'more than one var positional parameter'):
+            S((args, second_args))
+
+        second_kwargs = kwargs.replace(name="second_kwargs")
+        with self.assertRaisesRegex(ValueError, 'more than one var keyword parameter'):
+            S((kwargs, second_kwargs))
+
     def test_signature_object_pickle(self):
         def foo(a, b, *, c:1={}, **kw) -> {42:'ham'}: pass
         foo_partial = functools.partial(foo, a=1)

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -2993,11 +2993,14 @@ class TestSignatureObject(unittest.TestCase):
             S((pkd, pk))
 
         second_args = args.replace(name="second_args")
-        with self.assertRaisesRegex(ValueError, 'more than one var-positional parameter'):
+        with self.assertRaisesRegex(ValueError, 'more than one variadic positional parameter'):
             S((args, second_args))
 
+        with self.assertRaisesRegex(ValueError, 'more than one variadic positional parameter'):
+            S((args, ko, second_args))
+
         second_kwargs = kwargs.replace(name="second_kwargs")
-        with self.assertRaisesRegex(ValueError, 'more than one var-keyword parameter'):
+        with self.assertRaisesRegex(ValueError, 'more than one variadic keyword parameter'):
             S((kwargs, second_kwargs))
 
     def test_signature_object_pickle(self):

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -2993,11 +2993,11 @@ class TestSignatureObject(unittest.TestCase):
             S((pkd, pk))
 
         second_args = args.replace(name="second_args")
-        with self.assertRaisesRegex(ValueError, 'more than one var positional parameter'):
+        with self.assertRaisesRegex(ValueError, 'more than one var-positional parameter'):
             S((args, second_args))
 
         second_kwargs = kwargs.replace(name="second_kwargs")
-        with self.assertRaisesRegex(ValueError, 'more than one var keyword parameter'):
+        with self.assertRaisesRegex(ValueError, 'more than one var-keyword parameter'):
             S((kwargs, second_kwargs))
 
     def test_signature_object_pickle(self):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -24,6 +24,7 @@ Eitan Adler
 Anton Afanasyev
 Ali Afshar
 Nitika Agarwal
+Maxim Ageev
 Anjani Agrawal
 Pablo S. Blum de Aguiar
 Jim Ahlstrom

--- a/Misc/NEWS.d/next/Library/2024-12-06-17-28-55.gh-issue-127610.ctv_NP.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-06-17-28-55.gh-issue-127610.ctv_NP.rst
@@ -1,2 +1,3 @@
 Added validation for more than one var-positional or
 var-keyword parameters in :class:`inspect.Signature`.
+Patch by Maxim Ageev.

--- a/Misc/NEWS.d/next/Library/2024-12-06-17-28-55.gh-issue-127610.ctv_NP.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-06-17-28-55.gh-issue-127610.ctv_NP.rst
@@ -1,2 +1,2 @@
-Added validation for more than one var positional and var
-keyword parameters in :class:`inspect.Signature`.
+Added validation for more than one var-positional or
+var-keyword parameters in :class:`inspect.Signature`.

--- a/Misc/NEWS.d/next/Library/2024-12-06-17-28-55.gh-issue-127610.ctv_NP.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-06-17-28-55.gh-issue-127610.ctv_NP.rst
@@ -1,1 +1,2 @@
-Added validation for more than one var positional and var keyword parameters in ``inspect.Signature.__init__``
+Added validation for more than one var positional and var
+keyword parameters in :class:`inspect.Signature`.

--- a/Misc/NEWS.d/next/Library/2024-12-06-17-28-55.gh-issue-127610.ctv_NP.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-06-17-28-55.gh-issue-127610.ctv_NP.rst
@@ -1,0 +1,1 @@
+Added validation for more than one var positional and var keyword parameters in ``inspect.Signature.__init__``


### PR DESCRIPTION
Added flags for var positional and var keyword parameters.
Raise ValueError if arguments are more than one. 
Added corresponding tests

<!-- gh-issue-number: gh-127610 -->
* Issue: gh-127610
<!-- /gh-issue-number -->
