### PR TITLE
gh-127651: Use __file__ in diagnostics if origin is missing

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -15,7 +15,6 @@ import marshal
 import os
 import py_compile
 import random
-import re
 import shutil
 import stat
 import subprocess
@@ -811,9 +810,9 @@ class ImportTests(unittest.TestCase):
     def test_frozen_module_from_import_error(self):
         with self.assertRaises(ImportError) as cm:
             from os import this_will_never_exist
-        self.assertRegex(
+        self.assertIn(
+            f"cannot import name 'this_will_never_exist' from 'os' ({os.__file__})",
             str(cm.exception),
-            f"cannot import name 'this_will_never_exist' from 'os' \\({re.escape(os.__file__)}\\)"
         )
 
 

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -814,15 +814,12 @@ class ImportTests(unittest.TestCase):
             f"cannot import name 'this_will_never_exist' from 'os' ({os.__file__})",
             str(cm.exception),
         )
-
-        expected_error = (
-            b"cannot import name 'this_will_never_exist' "
-            b"from 'sys' (unknown location)"
+        with self.assertRaises(ImportError) as cm:
+            from sys import this_will_never_exist
+        self.assertIn(
+            "cannot import name 'this_will_never_exist' from 'sys' (unknown location)",
+            str(cm.exception),
         )
-        popen = script_helper.spawn_python("-c", "from sys import this_will_never_exist")
-        stdout, stderr = popen.communicate()
-        self.assertIn(expected_error, stdout)
-
 
         scripts = [
             """

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -831,15 +831,12 @@ from os import this_will_never_exist
 """
         ]
         for script in scripts:
-            with self.subTest(script=script), os_helper.temp_dir() as tmp:
-                with open(os.path.join(tmp, "main.py"), "w", encoding='utf-8') as f:
-                    f.write(script)
-
+            with self.subTest(script=script):
                 expected_error = (
                     b"cannot import name 'this_will_never_exist' "
                     b"from 'os' \\(unknown location\\)"
                 )
-                popen = script_helper.spawn_python(os.path.join(tmp, "main.py"), cwd=tmp)
+                popen = script_helper.spawn_python("-c", script)
                 stdout, stderr = popen.communicate()
                 self.assertRegex(stdout, expected_error)
 

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -807,6 +807,14 @@ class ImportTests(unittest.TestCase):
         self.assertIn("Frozen object named 'x' is invalid",
                       str(cm.exception))
 
+    def test_frozen_module_from_import_error(self):
+        with self.assertRaises(ImportError) as cm:
+            from os import this_will_never_exist
+        self.assertRegex(
+            str(cm.exception),
+            r"cannot import name 'this_will_never_exist' from 'os' \(.*Lib[\\/]os\.py\)"
+        )
+
     def test_script_shadowing_stdlib(self):
         script_errors = [
             (

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -821,7 +821,7 @@ class ImportTests(unittest.TestCase):
             """
 import os
 os.__spec__.has_location = False
-os.__file__ = 123
+os.__file__ = []
 from os import this_will_never_exist
 """,
             """
@@ -1105,7 +1105,7 @@ try:
 except AttributeError as e:
     print(str(e))
 
-fractions.__spec__.origin = 0
+fractions.__spec__.origin = []
 try:
     fractions.Fraction
 except AttributeError as e:
@@ -1129,7 +1129,7 @@ try:
 except ImportError as e:
     print(str(e))
 
-fractions.__spec__.origin = 0
+fractions.__spec__.origin = []
 try:
     from fractions import Fraction
 except ImportError as e:

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -833,6 +833,12 @@ import os
 os.__spec__.has_location = False
 del os.__file__
 from os import this_will_never_exist
+""",
+              """
+import os
+os.__spec__.origin = []
+os.__file__ = []
+from os import this_will_never_exist
 """
         ]
         for script in scripts:

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -15,6 +15,7 @@ import marshal
 import os
 import py_compile
 import random
+import re
 import shutil
 import stat
 import subprocess
@@ -812,7 +813,7 @@ class ImportTests(unittest.TestCase):
             from os import this_will_never_exist
         self.assertRegex(
             str(cm.exception),
-            r"cannot import name 'this_will_never_exist' from 'os' \(.*Lib[\\/]os\.py\)"
+            f"cannot import name 'this_will_never_exist' from 'os' \\({re.escape(os.__file__)}\\)"
         )
 
     def test_script_shadowing_stdlib(self):

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -815,6 +815,14 @@ class ImportTests(unittest.TestCase):
             str(cm.exception),
         )
 
+        expected_error = (
+            b"cannot import name 'this_will_never_exist' "
+            b"from 'sys' (unknown location)"
+        )
+        popen = script_helper.spawn_python("-c", "from sys import this_will_never_exist")
+        stdout, stderr = popen.communicate()
+        self.assertIn(expected_error, stdout)
+
 
         scripts = [
             """
@@ -834,11 +842,11 @@ from os import this_will_never_exist
             with self.subTest(script=script):
                 expected_error = (
                     b"cannot import name 'this_will_never_exist' "
-                    b"from 'os' \\(unknown location\\)"
+                    b"from 'os' (unknown location)"
                 )
                 popen = script_helper.spawn_python("-c", script)
                 stdout, stderr = popen.communicate()
-                self.assertRegex(stdout, expected_error)
+                self.assertIn(expected_error, stdout)
 
     def test_script_shadowing_stdlib(self):
         script_errors = [

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -816,22 +816,33 @@ class ImportTests(unittest.TestCase):
             f"cannot import name 'this_will_never_exist' from 'os' \\({re.escape(os.__file__)}\\)"
         )
 
-        with os_helper.temp_dir() as tmp:
-            with open(os.path.join(tmp, "main.py"), "w", encoding='utf-8') as f:
-                f.write("""
-import os
-os.__file__ = 123
-os.__spec__.has_location = False
-from os import this_will_never_exist
-""")
 
-            expected_error = (
-                b"cannot import name 'this_will_never_exist' "
-                b"from 'os' \\(unknown location\\)"
-            )
-            popen = script_helper.spawn_python(os.path.join(tmp, "main.py"), cwd=tmp)
-            stdout, stderr = popen.communicate()
-            self.assertRegex(stdout, expected_error)
+        scripts = [
+            """
+import os
+os.__spec__.has_location = False
+os.__file__ = 123
+from os import this_will_never_exist
+""",
+            """
+import os
+os.__spec__.has_location = False
+del os.__file__
+from os import this_will_never_exist
+"""
+        ]
+        for script in scripts:
+            with self.subTest(script=script), os_helper.temp_dir() as tmp:
+                with open(os.path.join(tmp, "main.py"), "w", encoding='utf-8') as f:
+                    f.write(script)
+
+                expected_error = (
+                    b"cannot import name 'this_will_never_exist' "
+                    b"from 'os' \\(unknown location\\)"
+                )
+                popen = script_helper.spawn_python(os.path.join(tmp, "main.py"), cwd=tmp)
+                stdout, stderr = popen.communicate()
+                self.assertRegex(stdout, expected_error)
 
     def test_script_shadowing_stdlib(self):
         script_errors = [

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-06-01-09-40.gh-issue-127651.80cm6j.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-06-01-09-40.gh-issue-127651.80cm6j.rst
@@ -1,1 +1,1 @@
-When raising ImportError for missing symbols in ``from`` imports, use ``__file__`` in the error message if `__spec__.origin` is not a location
+When raising :exc:`ImportError` for missing symbols in ``from`` imports, use ``__file__`` in the error message if ``__spec__.origin`` is not a location

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-06-01-09-40.gh-issue-127651.80cm6j.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-06-01-09-40.gh-issue-127651.80cm6j.rst
@@ -1,0 +1,1 @@
+When raising ImportError for missing symbols in ``from`` imports, use ``__file__`` in the error message if `__spec__.origin` is not a location

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2933,9 +2933,11 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
     }
 
 done_with_errmsg:
-    /* NULL checks for errmsg, mod_name, origin done by PyErr_SetImportError. */
-    _PyErr_SetImportErrorWithNameFrom(errmsg, mod_name, origin, name);
-    Py_DECREF(errmsg);
+    if (errmsg != NULL) {
+        /* NULL checks for errmsg, mod_name, origin done by _PyErr_SetImportErrorWithNameFrom */
+        _PyErr_SetImportErrorWithNameFrom(errmsg, mod_name, origin, name);
+        Py_DECREF(errmsg);
+    }
 
 done:
     Py_XDECREF(origin);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2934,7 +2934,7 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
 
 done_with_errmsg:
     if (errmsg != NULL) {
-        /* NULL checks for errmsg, mod_name, origin done by _PyErr_SetImportErrorWithNameFrom */
+        /* NULL checks for mod_name and origin done by _PyErr_SetImportErrorWithNameFrom */
         _PyErr_SetImportErrorWithNameFrom(errmsg, mod_name, origin, name);
         Py_DECREF(errmsg);
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2859,6 +2859,20 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
         }
     }
 
+    if (origin == NULL) {
+        // Fall back to __file__ for diagnostics if we don't have
+        // an origin that is a location
+        origin = PyModule_GetFilenameObject(v);
+        if (origin == NULL) {
+            if (!PyErr_ExceptionMatches(PyExc_SystemError)) {
+                goto done;
+            }
+            // PyModule_GetFilenameObject raised "module filename missing"
+            _PyErr_Clear(tstate);
+        }
+        assert(origin == NULL || PyUnicode_Check(origin));
+    }
+
     if (is_possibly_shadowing_stdlib) {
         assert(origin);
         errmsg = PyUnicode_FromFormat(
@@ -2903,19 +2917,6 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
         }
         else {
             assert(rc == 0);
-            if (origin == NULL) {
-                // Fall back to __file__ for diagnostics if we don't have
-                // an origin that is a location
-                origin = PyModule_GetFilenameObject(v);
-                if (origin == NULL) {
-                    if (!PyErr_ExceptionMatches(PyExc_SystemError)) {
-                        goto done;
-                    }
-                    // PyModule_GetFilenameObject raised "module filename missing"
-                    _PyErr_Clear(tstate);
-                }
-                assert(origin == NULL || PyUnicode_Check(origin));
-            }
             if (origin) {
                 errmsg = PyUnicode_FromFormat(
                     "cannot import name %R from %R (%S)",

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2903,6 +2903,19 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
         }
         else {
             assert(rc == 0);
+            if (origin == NULL) {
+                // Fall back to __file__ for diagnostics if we don't have
+                // an origin that is a location
+                origin = PyModule_GetFilenameObject(v);
+                if (origin == NULL) {
+                    if (!PyErr_ExceptionMatches(PyExc_SystemError)) {
+                        goto done;
+                    }
+                    // PyModule_GetFilenameObject raised "module filename missing"
+                    _PyErr_Clear(tstate);
+                }
+                assert(origin == NULL || PyUnicode_Check(origin));
+            }
             if (origin) {
                 errmsg = PyUnicode_FromFormat(
                     "cannot import name %R from %R (%S)",


### PR DESCRIPTION
See the left hand side in https://github.com/python/cpython/pull/123929/files#diff-c22186367cbe20233e843261998dc027ae5f1f8c0d2e778abfa454ae74cc59deL2840-L2849

I missed this in part because I use debug builds for dev which I think don't freeze modules

<!-- gh-issue-number: gh-127651 -->
* Issue: gh-127651
<!-- /gh-issue-number -->
