### PR TITLE
gh-127681: add overflow checks when using  `PyMem_Malloc`

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -376,7 +376,7 @@ _ctypes_alloc_format_string_with_shape(int ndim, const Py_ssize_t *shape,
     prefix_len = 32 * ndim + 3;
     if (prefix) {
         size_t l = strlen(prefix);
-        if (prefix < PY_SIZE_MAX - l) {
+        if ((size_t)prefix < (size_t)PY_SSIZE_T_MAX - l) {
             goto oom;
         }
         prefix_len += l;

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -376,7 +376,7 @@ _ctypes_alloc_format_string_with_shape(int ndim, const Py_ssize_t *shape,
     prefix_len = 32 * ndim + 3;
     if (prefix) {
         size_t l = strlen(prefix);
-        if ((size_t)prefix < (size_t)PY_SSIZE_T_MAX - l) {
+        if ((size_t)prefix > (size_t)PY_SSIZE_T_MAX - l) {
             goto oom;
         }
         prefix_len += l;

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -62,7 +62,7 @@ PyCStgInfo_clone(StgInfo *dst_info, StgInfo *src_info)
 
     if (src_info->ffi_type_pointer.elements == NULL)
         return 0;
-    if (src_info->length > PY_SSIZE_T_MAX / sizeof(ffi_type *) - 1) {
+    if ((size_t)src_info->length > (size_t)PY_SSIZE_T_MAX / sizeof(ffi_type *) - 1) {
         goto oom;
     }
     Py_ssize_t size = sizeof(ffi_type *) * (src_info->length + 1);

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -42,7 +42,7 @@ PyCStgInfo_clone(StgInfo *dst_info, StgInfo *src_info)
 
     if (src_info->format) {
         size_t s = strlen(src_info->format);
-        if (s > (size_t)PY_SSIZE_T_MAX - 1) {
+        if (s >= (size_t)PY_SSIZE_T_MAX) {
             goto oom;
         }
         dst_info->format = PyMem_Malloc(s + 1);

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -5186,6 +5186,7 @@ cursesmodule_exec(PyObject *module)
             continue;
         }
         if (strncmp(key_name, "KEY_F(", 6) == 0) {
+            // We may assume that the name has a small enough length.
             char *fn_key_name = PyMem_Malloc(strlen(key_name) + 1);
             if (!fn_key_name) {
                 PyErr_NoMemory();

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -2116,10 +2116,10 @@ numeric_as_ascii(PyObject *u, int strip_ws, int ignore_underscores)
     data = PyUnicode_DATA(u);
     len =  PyUnicode_GET_LENGTH(u);
 
+    // Note: this should not overflow since the number of digits is << 2^32.
     cp = res = PyMem_Malloc(len+1);
     if (res == NULL) {
-        PyErr_NoMemory();
-        return NULL;
+        goto oom;
     }
 
     j = 0;
@@ -2155,6 +2155,10 @@ numeric_as_ascii(PyObject *u, int strip_ws, int ignore_underscores)
     }
     *cp = '\0';
     return res;
+
+oom:
+    PyErr_NoMemory();
+    return NULL;
 }
 
 /* Return a new PyDecObject or a subtype from a C string. Use the context
@@ -2689,6 +2693,7 @@ dectuple_as_str(PyObject *dectuple)
 
     tsize = PyTuple_Size(digits);
     /* [sign][coeffdigits+1][E][-][expdigits+1]['\0'] */
+    // TODO: this should not overflow since we would be below the digits limit
     mem = 1 + tsize + 3 + MPD_EXPDIGITS + 2;
     cp = decstring = PyMem_Malloc(mem);
     if (decstring == NULL) {
@@ -3377,6 +3382,7 @@ dec_repr(PyObject *dec)
 static char *
 dec_strdup(const char *src, Py_ssize_t size)
 {
+    // Note: this should not overflow since the number of digits is << 2^32.
     char *dest = PyMem_Malloc(size+1);
     if (dest == NULL) {
         PyErr_NoMemory();

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -465,6 +465,10 @@ _PyIncrementalNewlineDecoder_decode(PyObject *myself,
                when there is something to translate. On the other hand,
                we already know there is a \r byte, so chances are high
                that something needs to be done. */
+            if (len > PY_SSIZE_T_MAX / kind) {
+                PyErr_NoMemory();
+                goto error;
+            }
             translated = PyMem_Malloc(kind * len);
             if (translated == NULL) {
                 PyErr_NoMemory();

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -610,7 +610,7 @@ static wchar_t *
 read_console_w(HANDLE handle, DWORD maxlen, DWORD *readlen) {
     int err = 0, sig = 0;
 
-    wchar_t *buf = (wchar_t*)PyMem_Malloc(maxlen * sizeof(wchar_t));
+    wchar_t *buf = PyMem_New(wchar_t, maxlen);
     if (!buf) {
         PyErr_NoMemory();
         goto error;
@@ -875,8 +875,8 @@ _io__WindowsConsoleIO_readall_impl(winconsoleio *self)
         return NULL;
 
     bufsize = BUFSIZ;
-
-    buf = (wchar_t*)PyMem_Malloc((bufsize + 1) * sizeof(wchar_t));
+    // BUFSIZ is small enough not to overflow, so no need for checks
+    buf = (wchar_t*)PyMem_New((bufsize + 1) * sizeof(wchar_t));
     if (buf == NULL) {
         PyErr_NoMemory();
         return NULL;

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -875,8 +875,10 @@ _io__WindowsConsoleIO_readall_impl(winconsoleio *self)
         return NULL;
 
     bufsize = BUFSIZ;
-    // BUFSIZ is small enough not to overflow, so no need for checks
-    buf = (wchar_t*)PyMem_Malloc((bufsize + 1) * sizeof(wchar_t));
+    // Note: BUFSIZ is small enough not to overflow, so no need
+    //       to check that 'bufsize + 1' overflows. However, we
+    //       still need to check (bufsize + 1) * sizeof(wchar_t).
+    buf = PyMem_New(wchar_t, bufsize);
     if (buf == NULL) {
         PyErr_NoMemory();
         return NULL;

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -876,7 +876,7 @@ _io__WindowsConsoleIO_readall_impl(winconsoleio *self)
 
     bufsize = BUFSIZ;
     // BUFSIZ is small enough not to overflow, so no need for checks
-    buf = (wchar_t*)PyMem_New((bufsize + 1) * sizeof(wchar_t));
+    buf = (wchar_t*)PyMem_Malloc((bufsize + 1) * sizeof(wchar_t));
     if (buf == NULL) {
         PyErr_NoMemory();
         return NULL;

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -642,7 +642,11 @@ static PyObject *
 decode_strings(const char *result, size_t max_count)
 {
     /* Convert a sequence of NUL-separated C strings to a Python string
-     * containing semicolon separated items. */
+     * containing semicolon separated items.
+     *
+     * For efficiency purposes, we assume that messages to be translated
+     * are not absurdly large so that 'i' never overflows.
+     */
     size_t i = 0;
     size_t count = 0;
     for (; count < max_count && result[i]; count++) {

--- a/Modules/_multiprocessing/semaphore.c
+++ b/Modules/_multiprocessing/semaphore.c
@@ -502,6 +502,7 @@ _multiprocessing_SemLock_impl(PyTypeObject *type, int kind, int value,
     }
 
     if (!unlink) {
+        // We may assume that the name has a small enough length.
         name_copy = PyMem_Malloc(strlen(name) + 1);
         if (name_copy == NULL) {
             return PyErr_NoMemory();
@@ -555,6 +556,7 @@ _multiprocessing_SemLock__rebuild_impl(PyTypeObject *type, SEM_HANDLE handle,
     char *name_copy = NULL;
 
     if (name != NULL) {
+        // We may assume that the name has a small enough length.
         name_copy = PyMem_Malloc(strlen(name) + 1);
         if (name_copy == NULL)
             return PyErr_NoMemory();

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -1126,7 +1126,7 @@ subprocess_fork_exec_impl(PyObject *module, PyObject *process_args,
             goto cleanup;
 
         if (extra_group_size > MAX_GROUPS
-            || extra_group_size > PY_SSIZE_T_MAX / sizeof(gid_t))
+            || (size_t)extra_group_size > (size_t)PY_SSIZE_T_MAX / sizeof(gid_t))
         {
             PyErr_SetString(PyExc_ValueError, "too many extra_groups");
             goto cleanup;

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -524,10 +524,10 @@ _random_Random_getrandbits_impl(RandomObject *self, int k)
         return PyLong_FromUnsignedLong(genrand_uint32(self) >> (32 - k));
 
     words = (k - 1) / 32 + 1;
+    // words * 4 always fits on int if k fits on ints (and thus fits on size_t)
     wordarray = (uint32_t *)PyMem_Malloc(words * 4);
     if (wordarray == NULL) {
-        PyErr_NoMemory();
-        return NULL;
+        goto oom;
     }
 
     /* Fill-out bits of long integer, by 32-bit words, from least significant
@@ -548,6 +548,10 @@ _random_Random_getrandbits_impl(RandomObject *self, int k)
                                    PY_LITTLE_ENDIAN, 0 /* unsigned */);
     PyMem_Free(wordarray);
     return result;
+
+oom:
+    PyErr_NoMemory();
+    return NULL;
 }
 
 static int

--- a/Modules/_scproxy.c
+++ b/Modules/_scproxy.c
@@ -36,6 +36,7 @@ cfstring_to_pystring(CFStringRef ref)
         PyObject* result;
         char* buf;
 
+        // TODO: can this overflow?
         buf = PyMem_Malloc(len*4);
         if (buf == NULL) {
             PyErr_NoMemory();

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1725,7 +1725,7 @@ prepare_s(PyStructObject *self)
     }
 
     /* check for overflow */
-    if ((ncodes + 1) > ((size_t)PY_SSIZE_T_MAX / sizeof(formatcode))) {
+    if (ncodes > ((size_t)PY_SSIZE_T_MAX / sizeof(formatcode)) - 1) {
         PyErr_NoMemory();
         return -1;
     }

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1653,6 +1653,7 @@ _winapi_GetShortPathName_impl(PyObject *module, LPCWSTR path)
     cchBuffer = GetShortPathNameW(path, NULL, 0);
     Py_END_ALLOW_THREADS
     if (cchBuffer) {
+        // Note: the path length is way smaller than the max alloc. size.
         WCHAR *buffer = (WCHAR *)PyMem_Malloc(cchBuffer * sizeof(WCHAR));
         if (buffer) {
             Py_BEGIN_ALLOW_THREADS

--- a/Modules/_zoneinfo.c
+++ b/Modules/_zoneinfo.c
@@ -1021,12 +1021,14 @@ load_data(zoneinfo_state *state, PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
     self->num_transitions = (size_t)num_transitions;
     self->num_ttinfos = (size_t)num_ttinfos;
 
+    // TODO: can this overflow?
     // Load the transition indices and list
     self->trans_list_utc =
         PyMem_Malloc(self->num_transitions * sizeof(int64_t));
     if (self->trans_list_utc == NULL) {
         goto error;
     }
+    // TODO: can this overflow?
     trans_idx = PyMem_Malloc(self->num_transitions * sizeof(Py_ssize_t));
     if (trans_idx == NULL) {
         goto error;
@@ -1064,6 +1066,7 @@ load_data(zoneinfo_state *state, PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
     }
 
     // Load UTC offsets and isdst (size num_ttinfos)
+    // TODO: can this overflow?
     utcoff = PyMem_Malloc(self->num_ttinfos * sizeof(long));
     isdst = PyMem_Malloc(self->num_ttinfos * sizeof(unsigned char));
 
@@ -1111,6 +1114,7 @@ load_data(zoneinfo_state *state, PyZoneInfo_ZoneInfo *self, PyObject *file_obj)
     }
 
     // Build _ttinfo objects from utcoff, dstoff and abbr
+    // TODO: can this overflow?
     self->_ttinfos = PyMem_Malloc(self->num_ttinfos * sizeof(_ttinfo));
     if (self->_ttinfos == NULL) {
         goto error;
@@ -2115,6 +2119,7 @@ ts_to_local(size_t *trans_idx, int64_t *trans_utc, long *utcoff,
 
     // Copy the UTC transitions into each array to be modified in place later
     for (size_t i = 0; i < 2; ++i) {
+        // TODO: can this overflow?
         trans_local[i] = PyMem_Malloc(num_transitions * sizeof(int64_t));
         if (trans_local[i] == NULL) {
             return -1;

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -261,6 +261,7 @@ getpath_joinpath(PyObject *Py_UNUSED(self), PyObject *args)
         return Py_GetConstant(Py_CONSTANT_EMPTY_STR);
     }
     /* Convert all parts to wchar and accumulate max final length */
+    // TODO: can this overflow?
     wchar_t **parts = (wchar_t **)PyMem_Malloc(n * sizeof(wchar_t *));
     if (parts == NULL) {
         PyErr_NoMemory();
@@ -292,6 +293,7 @@ getpath_joinpath(PyObject *Py_UNUSED(self), PyObject *args)
         cchFinal += cch + 1;
     }
 
+    // TODO: can this overflow?
     wchar_t *final = cchFinal > 0 ? (wchar_t *)PyMem_Malloc(cchFinal * sizeof(wchar_t)) : NULL;
     if (!final) {
         for (Py_ssize_t i = 0; i < n; ++i) {

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2661,6 +2661,7 @@ math_hypot_impl(PyObject *module, PyObject * const *args,
     double *coordinates = coord_on_stack;
 
     if (args_length > NUM_STACK_ELEMS) {
+        // Number of coordinates should be way smaller than the max alloc. size.
         coordinates = (double *) PyMem_Malloc(args_length * sizeof(double));
         if (coordinates == NULL) {
             return PyErr_NoMemory();

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -705,8 +705,7 @@ int PyObject_CopyData(PyObject *dest, PyObject *src)
 
     /* Otherwise a more elaborate copy scheme is needed */
 
-    /* XXX(nnorwitz): need to check for overflow! */
-    indices = (Py_ssize_t *)PyMem_Malloc(sizeof(Py_ssize_t)*view_src.ndim);
+    indices = PyMem_New(Py_ssize_t, view_src.ndim);
     if (indices == NULL) {
         PyErr_NoMemory();
         PyBuffer_Release(&view_dest);

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -484,10 +484,13 @@ _PyObject_Call_Prepend(PyThreadState *tstate, PyObject *callable,
     PyObject **stack;
 
     Py_ssize_t argcount = PyTuple_GET_SIZE(args);
-    if (argcount + 1 <= (Py_ssize_t)Py_ARRAY_LENGTH(small_stack)) {
+    if (argcount <= (Py_ssize_t)Py_ARRAY_LENGTH(small_stack) - 1) {
         stack = small_stack;
     }
     else {
+        // Note: argcount + 1 is likely small enough not to overflow
+        //       and we don't want to hurt performances by adding an
+        //       additional check.
         stack = PyMem_Malloc((argcount + 1) * sizeof(PyObject *));
         if (stack == NULL) {
             PyErr_NoMemory();
@@ -794,6 +797,9 @@ object_vacall(PyThreadState *tstate, PyObject *base,
         stack = small_stack;
     }
     else {
+        // Note: nargs is likely small enough not to overflow and
+        //       we don't want to hurt performances by adding an
+        //       additional check.
         stack = PyMem_Malloc(nargs * sizeof(stack[0]));
         if (stack == NULL) {
             PyErr_NoMemory();

--- a/Objects/capsule.c
+++ b/Objects/capsule.c
@@ -230,6 +230,7 @@ PyCapsule_Import(const char *name, int no_block)
     PyObject *object = NULL;
     void *return_value = NULL;
     char *trace;
+    // Note: strlen(name) is likely smaller than the max alloc. size.
     size_t name_length = (strlen(name) + 1) * sizeof(char);
     char *name_dup = (char *)PyMem_Malloc(name_length);
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -776,6 +776,7 @@ new_keys_object(PyInterpreterState *interp, uint8_t log2_size, bool unicode)
         dk = _Py_FREELIST_POP_MEM(dictkeys);
     }
     if (dk == NULL) {
+        // TODO: should we check for an overflow?
         dk = PyMem_Malloc(sizeof(PyDictKeysObject)
                           + ((size_t)1 << log2_bytes)
                           + entry_size * usable);
@@ -826,6 +827,7 @@ values_size_from_count(size_t count)
     size_t suffix_size = _Py_SIZE_ROUND_UP(count, sizeof(PyObject *));
     assert(suffix_size < 128);
     assert(suffix_size % sizeof(PyObject *) == 0);
+    // TODO: should we check for an overflow?
     return (count + 1) * sizeof(PyObject *) + suffix_size;
 }
 

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -968,6 +968,8 @@ double_round(double x, int ndigits) {
     buflen = buf_end - buf;
     if (buflen + 8 > mybuflen) {
         mybuflen = buflen+8;
+        // Note: the number of digits to round is likely
+        //       way smaller than the max alloc. size.
         mybuf = (char *)PyMem_Malloc(mybuflen);
         if (mybuf == NULL) {
             PyErr_NoMemory();

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3637,7 +3637,7 @@ list_ass_subscript_lock_held(PyObject *_self, PyObject *item, PyObject *value)
                 step = -step;
             }
 
-            garbage = PyMem_New(PyObject, slicelength);
+            garbage = PyMem_New(PyObject *, slicelength);
             if (!garbage) {
                 PyErr_NoMemory();
                 return -1;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -3637,8 +3637,7 @@ list_ass_subscript_lock_held(PyObject *_self, PyObject *item, PyObject *value)
                 step = -step;
             }
 
-            garbage = (PyObject**)
-                PyMem_Malloc(slicelength*sizeof(PyObject*));
+            garbage = PyMem_New(PyObject, slicelength);
             if (!garbage) {
                 PyErr_NoMemory();
                 return -1;

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -413,6 +413,7 @@ copy_single(PyMemoryViewObject *self, const Py_buffer *dest, const Py_buffer *sr
         return -1;
 
     if (!last_dim_is_contiguous(dest, src)) {
+        // TODO: should we check for an overflow?
         mem = PyMem_Malloc(dest->shape[0] * dest->itemsize);
         if (mem == NULL) {
             PyErr_NoMemory();
@@ -445,6 +446,7 @@ copy_buffer(const Py_buffer *dest, const Py_buffer *src)
         return -1;
 
     if (!last_dim_is_contiguous(dest, src)) {
+        // TODO: should we check for an overflow?
         mem = PyMem_Malloc(dest->shape[dest->ndim-1] * dest->itemsize);
         if (mem == NULL) {
             PyErr_NoMemory();
@@ -503,6 +505,7 @@ buffer_to_contiguous(char *mem, const Py_buffer *src, char order)
     assert(src->shape != NULL);
     assert(src->strides != NULL);
 
+    // TODO: should we check for an overflow?
     strides = PyMem_Malloc(src->ndim * (sizeof *src->strides));
     if (strides == NULL) {
         PyErr_NoMemory();
@@ -861,6 +864,7 @@ static int
 mbuf_copy_format(_PyManagedBufferObject *mbuf, const char *fmt)
 {
     if (fmt != NULL) {
+        // TODO: should we check for an overflow?
         char *cp = PyMem_Malloc(strlen(fmt)+1);
         if (cp == NULL) {
             PyErr_NoMemory();
@@ -1065,6 +1069,7 @@ PyBuffer_ToContiguous(void *buf, const Py_buffer *src, Py_ssize_t len, char orde
     }
 
     /* buffer_to_contiguous() assumes PyBUF_FULL */
+    // TODO: should we check for an overflow?
     fb = PyMem_Malloc(sizeof *fb + 3 * src->ndim * (sizeof *fb->array));
     if (fb == NULL) {
         PyErr_NoMemory();

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1060,6 +1060,7 @@ char *
 _PyMem_Strdup(const char *str)
 {
     assert(str != NULL);
+    // TODO: should we check for an overflow?
     size_t size = strlen(str) + 1;
     char *copy = PyMem_Malloc(size);
     if (copy == NULL) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4041,7 +4041,9 @@ type_new_set_doc(PyTypeObject *type)
         return -1;
     }
 
-    // Silently truncate the docstring if it contains a null byte
+    // Silently truncate the docstring if it contains a null byte.
+    // Note: the docstring length is likely smaller than the max
+    //       alloc. size.
     Py_ssize_t size = strlen(doc_str) + 1;
     char *tp_doc = (char *)PyMem_Malloc(size);
     if (tp_doc == NULL) {
@@ -4825,6 +4827,8 @@ PyType_FromMetaclass(
     * of any such flag.
     * So, we use a separate buffer, _ht_tpname, that's always
     * deallocated with the type (if it's non-NULL).
+    *
+    * Note: the type name length is way smaller than the max alloc. size.
     */
     Py_ssize_t name_buf_len = strlen(spec->name) + 1;
     _ht_tpname = PyMem_Malloc(name_buf_len);


### PR DESCRIPTION
For now, this only adds checks in `Modules` and `Objects`.

<!-- gh-issue-number: gh-127681 -->
* Issue: gh-127681
<!-- /gh-issue-number -->
