### PR TITLE
GH-127652: stop using `--wasi preview2` in `wasi.py`

### DIFF
--- a/Tools/wasm/wasi.py
+++ b/Tools/wasm/wasi.py
@@ -297,8 +297,6 @@ def main():
                         # build.
                         # Use 16 MiB stack.
                         "--wasm max-wasm-stack=16777216 "
-                        # Use WASI 0.2 primitives.
-                        "--wasi preview2 "
                         # Enable thread support; causes use of preview1.
                         #"--wasm threads=y --wasi threads=y "
                         # Map the checkout to / to load the stdlib from /Lib.


### PR DESCRIPTION
It's only to use WASI 0.2 code to back preview1 APIs and is considered experimental anyway.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127652 -->
* Issue: gh-127652
<!-- /gh-issue-number -->
