### PR TITLE
gh-127712: Fix `secure` argument of `logging.handlers.SMTPHandler`

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1040,7 +1040,8 @@ class SMTPHandler(logging.Handler):
         only be used when authentication credentials are supplied. The tuple
         will be either an empty tuple, or a single-value tuple with the name
         of a keyfile, or a 2-value tuple with the names of the keyfile and
-        certificate file. (This tuple is passed to the `starttls` method).
+        certificate file. (This tuple is passed to the
+        `ssl.SSLContext.load_cert_chain` method).
         A timeout in seconds can be specified for the SMTP connection (the
         default is one second).
         """
@@ -1093,8 +1094,23 @@ class SMTPHandler(logging.Handler):
             msg.set_content(self.format(record))
             if self.username:
                 if self.secure is not None:
+                    import ssl
+
+                    try:
+                        keyfile = self.secure[0]
+                    except IndexError:
+                        keyfile = None
+
+                    try:
+                        certfile = self.secure[1]
+                    except IndexError:
+                        certfile = None
+
+                    context = ssl._create_stdlib_context(
+                        certfile=certfile, keyfile=keyfile
+                    )
                     smtp.ehlo()
-                    smtp.starttls(*self.secure)
+                    smtp.starttls(context=context)
                     smtp.ehlo()
                 smtp.login(self.username, self.password)
             smtp.send_message(msg)

--- a/Misc/NEWS.d/next/Library/2024-12-07-20-33-43.gh-issue-127712.Uzsij4.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-07-20-33-43.gh-issue-127712.Uzsij4.rst
@@ -1,0 +1,1 @@
+Fix handling of the ``secure`` argument of :class:`logging.handlers.SMTPHandler`.


### PR DESCRIPTION
Python 3.12 removed support for the `keyfile` and `certfile` parameters in `smtplib.SMTP.starttls()`, requiring a `ssl.SSLContext` instead. `SMTPHandler` now creates a context from the `secure` tuple and passes that to `starttls`.

This PR basically restores `SMTPHandler` functionality as it was in Python 3.11.
It is to note that, contrary to the documentation, using a single-value tuple for `secure` does not work. Instead, `ssl._create_unverified_context` raises `ValueError: certfile must be specified`.
However, this also happened with Python 3.11, so I did not change it. The only difference is, with Python 3.11 the target SMTP server needed to actually support STARTTLS to encounter the exception. Now it is raised before checking the server for STARTTLS support.
This is simply because the `ssl.SSLContext` is created earlier.

Off topic: Personally, I believe the `secure` argument to `SMTPHandler` is confusing and somewhat limiting. I suggest deprecating it in favour of something more versatile. Allow passing a context, maybe?

<!-- gh-issue-number: gh-127712 -->
* Issue: gh-127712
<!-- /gh-issue-number -->
