### PR TITLE
gh-127734: improve signature of `urllib.request.HTTPPasswordMgrWithPriorAuth.__init__`

### DIFF
--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -876,9 +876,9 @@ class HTTPPasswordMgrWithDefaultRealm(HTTPPasswordMgr):
 
 class HTTPPasswordMgrWithPriorAuth(HTTPPasswordMgrWithDefaultRealm):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self):
         self.authenticated = {}
-        super().__init__(*args, **kwargs)
+        super().__init__()
 
     def add_password(self, realm, uri, user, passwd, is_authenticated=False):
         self.update_authenticated(uri, is_authenticated)


### PR DESCRIPTION
A small MR to improve signature introspection of `urllib.request.HTTPPasswordMgrWithPriorAuth.__init__`. The parent class takes no arguments, so the pass-through serves no purpose.  Currently, typeshed needs to have `urllib.request.HTTPPasswordMgrWithPriorAuth.__init__` on its allowlist for stubtest errors as a result of the poor introspection.

<!-- gh-issue-number: gh-127734 -->
* Issue: gh-127734
<!-- /gh-issue-number -->
