### PR TITLE
Add zizmor to pre-commit and fix most findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: Runner image version
         run: echo "IMAGE_VERSION=${ImageVersion}" >> "$GITHUB_ENV"
       - name: Check Autoconf and aclocal versions
@@ -94,6 +95,8 @@ jobs:
     if: needs.check_source.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
@@ -268,6 +271,8 @@ jobs:
       LD_LIBRARY_PATH: ${{ github.workspace }}/multissl/openssl/${{ matrix.openssl_ver }}/lib
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Runner image version
       run: echo "IMAGE_VERSION=${ImageVersion}" >> "$GITHUB_ENV"
     - name: Restore config.cache
@@ -328,6 +333,8 @@ jobs:
       PYTHONSTRICTEXTENSIONBUILD: 1
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
     - name: Install Dependencies
@@ -446,6 +453,8 @@ jobs:
       ASAN_OPTIONS: detect_leaks=0:allocator_may_return_null=1:handle_segv=0
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Runner image version
       run: echo "IMAGE_VERSION=${ImageVersion}" >> "$GITHUB_ENV"
     - name: Restore config.cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,7 +418,7 @@ jobs:
         #
         # (GH-104097) test_sysconfig is skipped because it has tests that are
         # failing when executed from inside a virtual environment.
-        ${{ env.VENV_PYTHON }} -m test \
+        "${VENV_PYTHON}" -m test \
           -W \
           -o \
           -j4 \

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -10,9 +10,6 @@ on:
     - 'Doc/**'
     - '.github/workflows/doc.yml'
 
-permissions:
-  pull-requests: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -20,6 +17,9 @@ concurrency:
 jobs:
   documentation-links:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
     steps:
       - uses: readthedocs/actions/preview@v1
         with:

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -32,6 +32,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build tier two interpreter
         run: |
           ./configure --enable-experimental-jit=interpreter --with-pydebug
@@ -85,6 +87,8 @@ jobs:
             runner: ${{ github.repository_owner == 'python' && 'ubuntu-24.04-aarch64' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -138,6 +142,8 @@ jobs:
           - 19
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -51,6 +51,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -4,15 +4,14 @@ on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, synchronize]
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   label-dnm:
     name: DO-NOT-MERGE
     if: github.repository_owner == 'python'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -27,6 +27,9 @@ jobs:
     name: Unresolved review
     if: github.repository_owner == 'python'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -61,6 +61,8 @@ jobs:
     - run: >-
         echo '${{ github.event_name }}'
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Check for source changes
       id: check
       run: |

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       branch_base: 'origin/${{ github.event.pull_request.base.ref }}'
       branch_pr: 'origin/${{ github.event.pull_request.head.ref }}'
+      commits: ${{ github.event.pull_request.commits }}
       refspec_base: '+${{ github.event.pull_request.base.sha }}:remotes/origin/${{ github.event.pull_request.base.ref }}'
       refspec_pr: '+${{ github.event.pull_request.head.sha }}:remotes/origin/${{ github.event.pull_request.head.ref }}'
     steps:
@@ -40,7 +41,7 @@ jobs:
       if: github.event_name == 'pull_request'
       run: |
         # Fetch enough history to find a common ancestor commit (aka merge-base):
-        git fetch origin ${{ env.refspec_pr }} --depth=$(( ${{ github.event.pull_request.commits }} + 1 )) \
+        git fetch origin ${{ env.refspec_pr }} --depth=$(( ${{ env.commits }} + 1 )) \
           --no-tags --prune --no-recurse-submodules
 
         # This should get the oldest commit in the local fetched history (which may not be the commit the PR branched from):

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -41,15 +41,15 @@ jobs:
       if: github.event_name == 'pull_request'
       run: |
         # Fetch enough history to find a common ancestor commit (aka merge-base):
-        git fetch origin ${{ env.refspec_pr }} --depth=$(( ${{ env.commits }} + 1 )) \
+        git fetch origin "${refspec_pr}" --depth=$(( commits + 1 )) \
           --no-tags --prune --no-recurse-submodules
 
         # This should get the oldest commit in the local fetched history (which may not be the commit the PR branched from):
-        COMMON_ANCESTOR=$( git rev-list --first-parent --max-parents=0 --max-count=1 ${{ env.branch_pr }} )
+        COMMON_ANCESTOR=$( git rev-list --first-parent --max-parents=0 --max-count=1 "${branch_pr}" )
         DATE=$( git log --date=iso8601 --format=%cd "${COMMON_ANCESTOR}" )
 
         # Get all commits since that commit date from the base branch (eg: master or main):
-        git fetch origin ${{ env.refspec_base }} --shallow-since="${DATE}" \
+        git fetch origin "${refspec_base}" --shallow-since="${DATE}" \
           --no-tags --prune --no-recurse-submodules
     - name: 'Set up Python'
       uses: actions/setup-python@v5
@@ -71,7 +71,7 @@ jobs:
       if: github.event_name == 'pull_request'
       run: |
         python Doc/tools/check-warnings.py \
-          --annotate-diff '${{ env.branch_base }}' '${{ env.branch_pr }}' \
+          --annotate-diff "${branch_base}" "${branch_pr}" \
           --fail-if-regression \
           --fail-if-improved \
           --fail-if-new-news-nit

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -28,6 +28,7 @@ jobs:
     - name: 'Check out latest PR branch commit'
       uses: actions/checkout@v4
       with:
+        persist-credentials: false
         ref: >-
           ${{
             github.event_name == 'pull_request'
@@ -81,6 +82,8 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: 'Set up Python'
       uses: actions/setup-python@v5
       with:
@@ -99,6 +102,8 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: actions/cache@v4
       with:
         path: ~/.cache/pip

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Runner image version
       run: echo "IMAGE_VERSION=${ImageVersion}" >> "$GITHUB_ENV"
     - name: Restore config.cache

--- a/.github/workflows/reusable-tsan.yml
+++ b/.github/workflows/reusable-tsan.yml
@@ -23,6 +23,9 @@ jobs:
     name: 'Thread sanitizer'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    env:
+      OPTIONS: ${{ inputs.options }}
+      SUPPRESSIONS_PATH: ${{ inputs.suppressions_path }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -49,7 +52,7 @@ jobs:
         sudo sysctl -w vm.mmap_rnd_bits=28
     - name: TSAN Option Setup
       run: |
-        echo "TSAN_OPTIONS=log_path=${GITHUB_WORKSPACE}/tsan_log suppressions=${GITHUB_WORKSPACE}/${{ inputs.suppressions_path }} handle_segv=0" >> "$GITHUB_ENV"
+        echo "TSAN_OPTIONS=log_path=${GITHUB_WORKSPACE}/tsan_log suppressions=${GITHUB_WORKSPACE}/${{ env.SUPPRESSIONS_PATH }} handle_segv=0" >> "$GITHUB_ENV"
         echo "CC=clang" >> "$GITHUB_ENV"
         echo "CXX=clang++" >> "$GITHUB_ENV"
     - name: Add ccache to PATH
@@ -61,7 +64,7 @@ jobs:
         save: ${{ github.event_name == 'push' }}
         max-size: "200M"
     - name: Configure CPython
-      run: ${{ inputs.options }}
+      run: ${{ env.OPTIONS }}
     - name: Build CPython
       run: make -j4
     - name: Display build info

--- a/.github/workflows/reusable-tsan.yml
+++ b/.github/workflows/reusable-tsan.yml
@@ -25,6 +25,8 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Runner image version
       run: echo "IMAGE_VERSION=${ImageVersion}" >> "$GITHUB_ENV"
     - name: Restore config.cache

--- a/.github/workflows/reusable-tsan.yml
+++ b/.github/workflows/reusable-tsan.yml
@@ -52,7 +52,7 @@ jobs:
         sudo sysctl -w vm.mmap_rnd_bits=28
     - name: TSAN Option Setup
       run: |
-        echo "TSAN_OPTIONS=log_path=${GITHUB_WORKSPACE}/tsan_log suppressions=${GITHUB_WORKSPACE}/${{ env.SUPPRESSIONS_PATH }} handle_segv=0" >> "$GITHUB_ENV"
+        echo "TSAN_OPTIONS=log_path=${GITHUB_WORKSPACE}/tsan_log suppressions=${GITHUB_WORKSPACE}/${SUPPRESSIONS_PATH} handle_segv=0" >> "$GITHUB_ENV"
         echo "CC=clang" >> "$GITHUB_ENV"
         echo "CXX=clang++" >> "$GITHUB_ENV"
     - name: Add ccache to PATH
@@ -64,7 +64,7 @@ jobs:
         save: ${{ github.event_name == 'push' }}
         max-size: "200M"
     - name: Configure CPython
-      run: ${{ env.OPTIONS }}
+      run: "${OPTIONS}"
     - name: Build CPython
       run: make -j4
     - name: Display build info

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -28,6 +28,8 @@ jobs:
       TERM: linux
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
     - name: Install dependencies

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -96,7 +96,7 @@ jobs:
       if: ${{ !inputs.free-threading }}
       run: >-
         python Tools/build/check_warnings.py
-        --compiler-output-file-path=${{ env.CPYTHON_BUILDDIR }}/compiler_output_ubuntu.txt
+        --compiler-output-file-path="${CPYTHON_BUILDDIR}/compiler_output_ubuntu.txt"
         --warning-ignore-file-path "${GITHUB_WORKSPACE}/Tools/build/.warningignore_ubuntu"
         --compiler-output-type=gcc
         --fail-on-regression

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -20,6 +20,8 @@ jobs:
       CROSS_BUILD_WASI: cross-build/wasm32-wasip1
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     # No problem resolver registered as one doesn't currently exist for Clang.
     - name: "Install wasmtime"
       uses: bytecodealliance/actions/wasmtime/setup@v1

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -36,9 +36,9 @@ jobs:
     - name: "Install WASI SDK"  # Hard-coded to x64.
       if: steps.cache-wasi-sdk.outputs.cache-hit != 'true'
       run: |
-        mkdir ${{ env.WASI_SDK_PATH }} && \
-        curl -s -S --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ env.WASI_SDK_VERSION }}/wasi-sdk-${{ env.WASI_SDK_VERSION }}.0-x86_64-linux.tar.gz | \
-        tar --strip-components 1 --directory ${{ env.WASI_SDK_PATH }} --extract --gunzip
+        mkdir "${WASI_SDK_PATH}" && \
+        curl -s -S --location "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_VERSION}.0-x86_64-linux.tar.gz" | \
+        tar --strip-components 1 --directory "${WASI_SDK_PATH}" --extract --gunzip
     - name: "Configure ccache action"
       uses: hendrikmuhs/ccache-action@v1.2
       with:
@@ -74,6 +74,6 @@ jobs:
     - name: "Make host"
       run: python3 Tools/wasm/wasi.py make-host
     - name: "Display build info"
-      run: make --directory ${{ env.CROSS_BUILD_WASI }} pythoninfo
+      run: make --directory "${CROSS_BUILD_WASI}" pythoninfo
     - name: "Test"
-      run: make --directory ${{ env.CROSS_BUILD_WASI }} test
+      run: make --directory "${CROSS_BUILD_WASI}" test

--- a/.github/workflows/reusable-windows-msi.yml
+++ b/.github/workflows/reusable-windows-msi.yml
@@ -17,10 +17,11 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 60
     env:
+      ARCH: ${{ inputs.arch }}
       IncludeFreethreaded: true
     steps:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
     - name: Build CPython installer
-      run: .\Tools\msi\build.bat --doc -${{ inputs.arch }}
+      run: .\Tools\msi\build.bat --doc -${{ env.ARCH }}

--- a/.github/workflows/reusable-windows-msi.yml
+++ b/.github/workflows/reusable-windows-msi.yml
@@ -24,4 +24,4 @@ jobs:
       with:
         persist-credentials: false
     - name: Build CPython installer
-      run: .\Tools\msi\build.bat --doc -${{ env.ARCH }}
+      run: .\Tools\msi\build.bat --doc -"${ARCH}"

--- a/.github/workflows/reusable-windows-msi.yml
+++ b/.github/workflows/reusable-windows-msi.yml
@@ -20,5 +20,7 @@ jobs:
       IncludeFreethreaded: true
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Build CPython installer
       run: .\Tools\msi\build.bat --doc -${{ inputs.arch }}

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -39,7 +39,7 @@ jobs:
       run: >-
         .\\PCbuild\\build.bat
         -e -d -v
-        -p ${{ env.ARCH }}
+        -p "${ARCH}"
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
     - name: Display build info  # FIXME(diegorusso): remove the `if`
       if: inputs.arch != 'arm64'
@@ -48,6 +48,6 @@ jobs:
       if: inputs.arch != 'arm64'
       run: >-
         .\\PCbuild\\rt.bat
-        -p ${{ env.ARCH }}
+        -p "${ARCH}"
         -d -q --fast-ci
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -26,6 +26,8 @@ jobs:
     name: 'build and test (${{ inputs.arch }})'
     runs-on: ${{ inputs.os }}
     timeout-minutes: 60
+    env:
+      ARCH: ${{ inputs.arch }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -37,7 +39,7 @@ jobs:
       run: >-
         .\\PCbuild\\build.bat
         -e -d -v
-        -p ${{ inputs.arch }}
+        -p ${{ env.ARCH }}
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
     - name: Display build info  # FIXME(diegorusso): remove the `if`
       if: inputs.arch != 'arm64'
@@ -46,6 +48,6 @@ jobs:
       if: inputs.arch != 'arm64'
       run: >-
         .\\PCbuild\\rt.bat
-        -p ${{ inputs.arch }}
+        -p ${{ env.ARCH }}
         -d -q --fast-ci
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -28,6 +28,8 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Register MSVC problem matcher
       if: inputs.arch != 'Win32'
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -41,6 +41,7 @@ jobs:
         -e -d -v
         -p "${ARCH}"
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
+      shell: bash
     - name: Display build info  # FIXME(diegorusso): remove the `if`
       if: inputs.arch != 'arm64'
       run: .\\python.bat -m test.pythoninfo
@@ -51,3 +52,4 @@ jobs:
         -p "${ARCH}"
         -d -q --fast-ci
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
+      shell: bash

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,14 +4,13 @@ on:
   schedule:
   - cron: "0 */6 * * *"
 
-permissions:
-  pull-requests: write
-
 jobs:
   stale:
     if: github.repository_owner == 'python'
 
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/verify-ensurepip-wheels.yml
+++ b/.github/workflows/verify-ensurepip-wheels.yml
@@ -26,6 +26,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,3 +1,5 @@
+# Configuration for the zizmor static analysis tool, ran from pre-commit
+# https://woodruffw.github.io/zizmor/configuration/
 rules:
   dangerous-triggers:
     ignore:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,4 +1,4 @@
-# Configuration for the zizmor static analysis tool, ran from pre-commit
+# Configuration for the zizmor static analysis tool, run via pre-commit in CI
 # https://woodruffw.github.io/zizmor/configuration/
 rules:
   dangerous-triggers:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      - documentation-links.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.1
+    rev: v0.8.2
     hooks:
       - id: ruff
         name: Run Ruff (lint) on Doc/
@@ -51,7 +51,7 @@ repos:
         types_or: [c, inc, python, rst]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.29.4
+    rev: 0.30.0
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
@@ -60,6 +60,12 @@ repos:
     rev: v1.7.4
     hooks:
       - id: actionlint
+
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: zizmor
+        args: [--min-severity=medium]
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
     rev: v1.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,6 @@ repos:
     rev: v0.8.0
     hooks:
       - id: zizmor
-        args: [--min-severity=medium]
 
   - repo: https://github.com/sphinx-contrib/sphinx-lint
     rev: v1.0.0


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

> zizmor is a static analysis tool for GitHub Actions. It can find many common security issues in typical GitHub Actions CI/CD setups.

https://woodruffw.github.io/zizmor/

This PR adds zizmor to pre-commit, which runs it on the CI.

Here are all the findings currently on `main`:

<details>
<summary>134 findings (89 suppressed): 0 unknown, 0 informational, 13 low, 21 medium, 11 high</summary>

```
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/reusable-windows.yml:30:7
   |
30 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-windows.yml:34:7
   |
34 |       - name: Build CPython
   |         ^^^^^^^^^^^^^^^^^^^ this step
35 |         run: >-
   |  _______^
36 | |         .\\PCbuild\\build.bat
37 | |         -e -d -v
38 | |         -p ${{ inputs.arch }}
39 | |         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
   | |_______________________________________________________________________^ inputs.arch may expand into attacker-controllable code
   |
   = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-windows.yml:43:7
   |
43 |       - name: Tests  # FIXME(diegorusso): remove the `if`
   |         ^^^^^^^^^^^ this step
44 |         if: inputs.arch != 'arm64'
45 |         run: >-
   |  _______^
46 | |         .\\PCbuild\\rt.bat
47 | |         -p ${{ inputs.arch }}
48 | |         -d -q --fast-ci
49 | |         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
   | |________________________________________________________________________^ inputs.arch may expand into attacker-controllable code
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/reusable-ubuntu.yml:30:7
   |
30 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

help[template-injection]: code injection via template expansion
   --> .github/workflows/reusable-ubuntu.yml:93:7
    |
 93 |       - name: Check compiler warnings
    |         ----------------------------- help: this step
 94 |         if: ${{ !inputs.free-threading }}
 95 |         run: >-
    |  _______-
 96 | |         python Tools/build/check_warnings.py
...   |
101 | |         --fail-on-improvement
102 | |         --path-prefix="../cpython-ro-srcdir/"
    | |_____________________________________________- help: env.CPYTHON_BUILDDIR may expand into attacker-controllable code
    |
    = note: audit confidence → High

error[excessive-permissions]: overly broad workflow or job-level permissions
 --> .github/workflows/require-pr-label.yml:7:1
  |
7 | / permissions:
8 | |   issues: write
9 | |   pull-requests: write
  | |______________________^ issues: write is overly broad at the workflow level
  |
  = note: audit confidence → High

error[excessive-permissions]: overly broad workflow or job-level permissions
 --> .github/workflows/require-pr-label.yml:7:1
  |
7 | / permissions:
8 | |   issues: write
9 | |   pull-requests: write
  | |______________________^ pull-requests: write is overly broad at the workflow level
  |
  = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/lint.yml:22:9
   |
22 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/verify-ensurepip-wheels.yml:28:9
   |
28 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/jit.yml:34:9
   |
34 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/jit.yml:87:9
   |
87 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/jit.yml:140:9
    |
140 |       - uses: actions/checkout@v4
    |         ------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/reusable-macos.yml:31:7
   |
31 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[excessive-permissions]: overly broad workflow or job-level permissions
 --> .github/workflows/stale.yml:7:1
  |
7 | / permissions:
8 | |   pull-requests: write
  | |______________________^ pull-requests: write is overly broad at the workflow level
  |
  = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/reusable-change-detection.yml:63:7
   |
63 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/reusable-docs.yml:28:7
   |
28 |       - name: 'Check out latest PR branch commit'
   |  _______-
29 | |       uses: actions/checkout@v4
...  |
36 | |           }}
37 | |     # Adapted from https://github.com/actions/checkout/issues/520#issuecomment-1167205721
   | |_________________________________________________________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/reusable-docs.yml:83:7
   |
83 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/reusable-docs.yml:101:7
    |
101 |     - uses: actions/checkout@v4
    |       ------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:38:7
   |
38 |       - name: 'Fetch commits to get branch diff'
   |         ---------------------------------------- help: this step
39 |         if: github.event_name == 'pull_request'
40 |         run: |
   |  _______-
41 | |         # Fetch enough history to find a common ancestor commit (aka merge-base):
...  |
50 | |         git fetch origin ${{ env.refspec_base }} --shallow-since="${DATE}" \
51 | |           --no-tags --prune --no-recurse-submodules
   | |___________________________________________________- help: env.refspec_pr may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:38:7
   |
38 |       - name: 'Fetch commits to get branch diff'
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
39 |         if: github.event_name == 'pull_request'
40 |         run: |
   |  _______^
41 | |         # Fetch enough history to find a common ancestor commit (aka merge-base):
...  |
50 | |         git fetch origin ${{ env.refspec_base }} --shallow-since="${DATE}" \
51 | |           --no-tags --prune --no-recurse-submodules
   | |___________________________________________________^ github.event.pull_request.commits may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:38:7
   |
38 |       - name: 'Fetch commits to get branch diff'
   |         ---------------------------------------- help: this step
39 |         if: github.event_name == 'pull_request'
40 |         run: |
   |  _______-
41 | |         # Fetch enough history to find a common ancestor commit (aka merge-base):
...  |
50 | |         git fetch origin ${{ env.refspec_base }} --shallow-since="${DATE}" \
51 | |           --no-tags --prune --no-recurse-submodules
   | |___________________________________________________- help: env.branch_pr may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:38:7
   |
38 |       - name: 'Fetch commits to get branch diff'
   |         ---------------------------------------- help: this step
39 |         if: github.event_name == 'pull_request'
40 |         run: |
   |  _______-
41 | |         # Fetch enough history to find a common ancestor commit (aka merge-base):
...  |
50 | |         git fetch origin ${{ env.refspec_base }} --shallow-since="${DATE}" \
51 | |           --no-tags --prune --no-recurse-submodules
   | |___________________________________________________- help: env.refspec_base may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:68:7
   |
68 |       - name: 'Check warnings'
   |         ---------------------- help: this step
69 |         if: github.event_name == 'pull_request'
70 |         run: |
   |  _______-
71 | |         python Doc/tools/check-warnings.py \
...  |
74 | |           --fail-if-improved \
75 | |           --fail-if-new-news-nit
   | |________________________________- help: env.branch_base may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:68:7
   |
68 |       - name: 'Check warnings'
   |         ---------------------- help: this step
69 |         if: github.event_name == 'pull_request'
70 |         run: |
   |  _______-
71 | |         python Doc/tools/check-warnings.py \
...  |
74 | |           --fail-if-improved \
75 | |           --fail-if-new-news-nit
   | |________________________________- help: env.branch_pr may expand into attacker-controllable code
   |
   = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/reusable-tsan.yml:27:7
   |
27 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-tsan.yml:48:7
   |
48 |       - name: TSAN Option Setup
   |         ^^^^^^^^^^^^^^^^^^^^^^^ this step
49 |         run: |
   |  _______^
50 | |         echo "TSAN_OPTIONS=log_path=${GITHUB_WORKSPACE}/tsan_log suppressions=${GITHUB_WORKSPACE}/${{ inputs.suppressions_path }} ha...
51 | |         echo "CC=clang" >> "$GITHUB_ENV"
52 | |         echo "CXX=clang++" >> "$GITHUB_ENV"
   | |___________________________________________^ inputs.suppressions_path may expand into attacker-controllable code
   |
   = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-tsan.yml:61:7
   |
61 |     - name: Configure CPython
   |       ^^^^^^^^^^^^^^^^^^^^^^^ this step
62 |       run: ${{ inputs.options }}
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^ inputs.options may expand into attacker-controllable code
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/mypy.yml:53:9
   |
53 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/reusable-windows-msi.yml:22:7
   |
22 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-windows-msi.yml:23:7
   |
23 |     - name: Build CPython installer
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
24 |       run: .\Tools\msi\build.bat --doc -${{ inputs.arch }}
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inputs.arch may expand into attacker-controllable code
   |
   = note: audit confidence → Low

error[excessive-permissions]: overly broad workflow or job-level permissions
  --> .github/workflows/documentation-links.yml:13:1
   |
13 | / permissions:
14 | |   pull-requests: write
   | |______________________^ pull-requests: write is overly broad at the workflow level
   |
   = note: audit confidence → High

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
  --> .github/workflows/documentation-links.yml:5:1
   |
 5 | / on:
 6 | |   pull_request_target:
...  |
10 | |     - 'Doc/**'
11 | |     - '.github/workflows/doc.yml'
   | |_________________________________^ pull_request_target is almost always used insecurely
   |
   = note: audit confidence → Medium

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/reusable-wasi.yml:22:7
   |
22 |       - uses: actions/checkout@v4
   |  _______-
23 | |     # No problem resolver registered as one doesn't currently exist for Clang.
   | |______________________________________________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:34:7
   |
34 |       - name: "Install WASI SDK"  # Hard-coded to x64.
   |         ------------------------ help: this step
35 |         if: steps.cache-wasi-sdk.outputs.cache-hit != 'true'
36 |         run: |
   |  _______-
37 | |         mkdir ${{ env.WASI_SDK_PATH }} && \
38 | |         curl -s -S --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ env.WASI_SDK_VERSION }}/wasi-sd...
39 | |         tar --strip-components 1 --directory ${{ env.WASI_SDK_PATH }} --extract --gunzip
   | |________________________________________________________________________________________- help: env.WASI_SDK_PATH may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:34:7
   |
34 |       - name: "Install WASI SDK"  # Hard-coded to x64.
   |         ------------------------ help: this step
35 |         if: steps.cache-wasi-sdk.outputs.cache-hit != 'true'
36 |         run: |
   |  _______-
37 | |         mkdir ${{ env.WASI_SDK_PATH }} && \
38 | |         curl -s -S --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ env.WASI_SDK_VERSION }}/wasi-sd...
39 | |         tar --strip-components 1 --directory ${{ env.WASI_SDK_PATH }} --extract --gunzip
   | |________________________________________________________________________________________- help: env.WASI_SDK_VERSION may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:34:7
   |
34 |       - name: "Install WASI SDK"  # Hard-coded to x64.
   |         ------------------------ help: this step
35 |         if: steps.cache-wasi-sdk.outputs.cache-hit != 'true'
36 |         run: |
   |  _______-
37 | |         mkdir ${{ env.WASI_SDK_PATH }} && \
38 | |         curl -s -S --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ env.WASI_SDK_VERSION }}/wasi-sd...
39 | |         tar --strip-components 1 --directory ${{ env.WASI_SDK_PATH }} --extract --gunzip
   | |________________________________________________________________________________________- help: env.WASI_SDK_VERSION may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:34:7
   |
34 |       - name: "Install WASI SDK"  # Hard-coded to x64.
   |         ------------------------ help: this step
35 |         if: steps.cache-wasi-sdk.outputs.cache-hit != 'true'
36 |         run: |
   |  _______-
37 | |         mkdir ${{ env.WASI_SDK_PATH }} && \
38 | |         curl -s -S --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ env.WASI_SDK_VERSION }}/wasi-sd...
39 | |         tar --strip-components 1 --directory ${{ env.WASI_SDK_PATH }} --extract --gunzip
   | |________________________________________________________________________________________- help: env.WASI_SDK_PATH may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:74:7
   |
74 |     - name: "Display build info"
   |       -------------------------- help: this step
75 |       run: make --directory ${{ env.CROSS_BUILD_WASI }} pythoninfo
   |       ------------------------------------------------------------ help: env.CROSS_BUILD_WASI may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:76:7
   |
76 |     - name: "Test"
   |       ------------ help: this step
77 |       run: make --directory ${{ env.CROSS_BUILD_WASI }} test
   |       ------------------------------------------------------ help: env.CROSS_BUILD_WASI may expand into attacker-controllable code
   |
   = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/build.yml:58:9
   |
58 |         - uses: actions/checkout@v4
   |  _________-
59 | |         with:
60 | |           fetch-depth: 1
   | |________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/build.yml:96:9
   |
96 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/build.yml:270:7
    |
270 |     - uses: actions/checkout@v4
    |       ------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/build.yml:330:7
    |
330 |     - uses: actions/checkout@v4
    |       ------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/build.yml:448:7
    |
448 |     - uses: actions/checkout@v4
    |       ------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low

help[template-injection]: code injection via template expansion
   --> .github/workflows/build.yml:407:7
    |
407 |       - name: "Run tests"
    |         ----------------- help: this step
408 |         working-directory: ${{ env.CPYTHON_BUILDDIR }}
409 |         run: |
    |  _______-
410 | |         # Most of the excluded tests are slow test suites with no property tests
...   |
425 | |           -x test_signal \
426 | |           -x test_sysconfig
    | |___________________________- help: env.VENV_PYTHON may expand into attacker-controllable code
    |
    = note: audit confidence → High

134 findings (89 suppressed): 0 unknown, 0 informational, 13 low, 21 medium, 11 high
```

</details>

This PR fixes all errors except this one:

```
error[dangerous-triggers]: use of fundamentally insecure workflow trigger
  --> .github/workflows/documentation-links.yml:5:1
   |
 5 | / on:
 6 | |   pull_request_target:
...  |
10 | |     - 'Doc/**'
11 | |     - '.github/workflows/doc.yml'
   | |_________________________________^ pull_request_target is almost always used insecurely
   |
   = note: audit confidence → Medium
```
Let's tackle that another time. For now it's added to the ignore list in `.github/zizmor.yml`.


Also, these high-severity errors are fixed:

```
error[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-windows.yml:34:7
   |
34 |       - name: Build CPython
   |         ^^^^^^^^^^^^^^^^^^^ this step
35 |         run: >-
   |  _______^
36 | |         .\\PCbuild\\build.bat
37 | |         -e -d -v
38 | |         -p ${{ inputs.arch }}
39 | |         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
   | |_______________________________________________________________________^ inputs.arch may expand into attacker-controllable code
   |
   = note: audit confidence → Low
```

And turned into these low-severity findings:

```
help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-windows.yml:38:7
   |
38 |       - name: Build CPython
   |         ------------------- help: this step
39 |         run: >-
   |  _______-
40 | |         .\\PCbuild\\build.bat
41 | |         -e -d -v
42 | |         -p ${{ env.ARCH }}
43 | |         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
   | |_______________________________________________________________________- help: env.ARCH may expand into attacker-controllable code
   |
   = note: audit confidence → High
```

There's also some other low-severity ones like this. So this PR runs zizmor with `--min-severity=medium` to ignore those low-severity ones for now.

Here's all the findings on this branch, without ignoring anything:

<details>
<summary>109 findings (89 suppressed): 0 unknown, 0 informational, 19 low, 0 medium, 1 high</summary>

```
help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-windows.yml:38:7
   |
38 |       - name: Build CPython
   |         ------------------- help: this step
39 |         run: >-
   |  _______-
40 | |         .\\PCbuild\\build.bat
41 | |         -e -d -v
42 | |         -p ${{ env.ARCH }}
43 | |         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
   | |_______________________________________________________________________- help: env.ARCH may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-windows.yml:47:7
   |
47 |       - name: Tests  # FIXME(diegorusso): remove the `if`
   |         ----------- help: this step
48 |         if: inputs.arch != 'arm64'
49 |         run: >-
   |  _______-
50 | |         .\\PCbuild\\rt.bat
51 | |         -p ${{ env.ARCH }}
52 | |         -d -q --fast-ci
53 | |         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
   | |________________________________________________________________________- help: env.ARCH may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
   --> .github/workflows/reusable-ubuntu.yml:95:7
    |
 95 |       - name: Check compiler warnings
    |         ----------------------------- help: this step
 96 |         if: ${{ !inputs.free-threading }}
 97 |         run: >-
    |  _______-
 98 | |         python Tools/build/check_warnings.py
...   |
103 | |         --fail-on-improvement
104 | |         --path-prefix="../cpython-ro-srcdir/"
    | |_____________________________________________- help: env.CPYTHON_BUILDDIR may expand into attacker-controllable code
    |
    = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:40:7
   |
40 |       - name: 'Fetch commits to get branch diff'
   |         ---------------------------------------- help: this step
41 |         if: github.event_name == 'pull_request'
42 |         run: |
   |  _______-
43 | |         # Fetch enough history to find a common ancestor commit (aka merge-base):
...  |
52 | |         git fetch origin ${{ env.refspec_base }} --shallow-since="${DATE}" \
53 | |           --no-tags --prune --no-recurse-submodules
   | |___________________________________________________- help: env.refspec_pr may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:40:7
   |
40 |       - name: 'Fetch commits to get branch diff'
   |         ---------------------------------------- help: this step
41 |         if: github.event_name == 'pull_request'
42 |         run: |
   |  _______-
43 | |         # Fetch enough history to find a common ancestor commit (aka merge-base):
...  |
52 | |         git fetch origin ${{ env.refspec_base }} --shallow-since="${DATE}" \
53 | |           --no-tags --prune --no-recurse-submodules
   | |___________________________________________________- help: env.commits may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:40:7
   |
40 |       - name: 'Fetch commits to get branch diff'
   |         ---------------------------------------- help: this step
41 |         if: github.event_name == 'pull_request'
42 |         run: |
   |  _______-
43 | |         # Fetch enough history to find a common ancestor commit (aka merge-base):
...  |
52 | |         git fetch origin ${{ env.refspec_base }} --shallow-since="${DATE}" \
53 | |           --no-tags --prune --no-recurse-submodules
   | |___________________________________________________- help: env.branch_pr may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:40:7
   |
40 |       - name: 'Fetch commits to get branch diff'
   |         ---------------------------------------- help: this step
41 |         if: github.event_name == 'pull_request'
42 |         run: |
   |  _______-
43 | |         # Fetch enough history to find a common ancestor commit (aka merge-base):
...  |
52 | |         git fetch origin ${{ env.refspec_base }} --shallow-since="${DATE}" \
53 | |           --no-tags --prune --no-recurse-submodules
   | |___________________________________________________- help: env.refspec_base may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:70:7
   |
70 |       - name: 'Check warnings'
   |         ---------------------- help: this step
71 |         if: github.event_name == 'pull_request'
72 |         run: |
   |  _______-
73 | |         python Doc/tools/check-warnings.py \
...  |
76 | |           --fail-if-improved \
77 | |           --fail-if-new-news-nit
   | |________________________________- help: env.branch_base may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-docs.yml:70:7
   |
70 |       - name: 'Check warnings'
   |         ---------------------- help: this step
71 |         if: github.event_name == 'pull_request'
72 |         run: |
   |  _______-
73 | |         python Doc/tools/check-warnings.py \
...  |
76 | |           --fail-if-improved \
77 | |           --fail-if-new-news-nit
   | |________________________________- help: env.branch_pr may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-tsan.yml:53:7
   |
53 |       - name: TSAN Option Setup
   |         ----------------------- help: this step
54 |         run: |
   |  _______-
55 | |         echo "TSAN_OPTIONS=log_path=${GITHUB_WORKSPACE}/tsan_log suppressions=${GITHUB_WORKSPACE}/${{ env.SUPPRESSIONS_PATH }} handl...
56 | |         echo "CC=clang" >> "$GITHUB_ENV"
57 | |         echo "CXX=clang++" >> "$GITHUB_ENV"
   | |___________________________________________- help: env.SUPPRESSIONS_PATH may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-tsan.yml:66:7
   |
66 |     - name: Configure CPython
   |       ----------------------- help: this step
67 |       run: ${{ env.OPTIONS }}
   |       ----------------------- help: env.OPTIONS may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-windows-msi.yml:26:7
   |
26 |     - name: Build CPython installer
   |       ----------------------------- help: this step
27 |       run: .\Tools\msi\build.bat --doc -${{ env.ARCH }}
   |       ------------------------------------------------- help: env.ARCH may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
  --> .github/workflows/documentation-links.yml:5:1
   |
 5 | / on:
 6 | |   pull_request_target:
...  |
10 | |     - 'Doc/**'
11 | |     - '.github/workflows/doc.yml'
   | |_________________________________^ pull_request_target is almost always used insecurely
   |
   = note: audit confidence → Medium

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:36:7
   |
36 |       - name: "Install WASI SDK"  # Hard-coded to x64.
   |         ------------------------ help: this step
37 |         if: steps.cache-wasi-sdk.outputs.cache-hit != 'true'
38 |         run: |
   |  _______-
39 | |         mkdir ${{ env.WASI_SDK_PATH }} && \
40 | |         curl -s -S --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ env.WASI_SDK_VERSION }}/wasi-sd...
41 | |         tar --strip-components 1 --directory ${{ env.WASI_SDK_PATH }} --extract --gunzip
   | |________________________________________________________________________________________- help: env.WASI_SDK_PATH may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:36:7
   |
36 |       - name: "Install WASI SDK"  # Hard-coded to x64.
   |         ------------------------ help: this step
37 |         if: steps.cache-wasi-sdk.outputs.cache-hit != 'true'
38 |         run: |
   |  _______-
39 | |         mkdir ${{ env.WASI_SDK_PATH }} && \
40 | |         curl -s -S --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ env.WASI_SDK_VERSION }}/wasi-sd...
41 | |         tar --strip-components 1 --directory ${{ env.WASI_SDK_PATH }} --extract --gunzip
   | |________________________________________________________________________________________- help: env.WASI_SDK_VERSION may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:36:7
   |
36 |       - name: "Install WASI SDK"  # Hard-coded to x64.
   |         ------------------------ help: this step
37 |         if: steps.cache-wasi-sdk.outputs.cache-hit != 'true'
38 |         run: |
   |  _______-
39 | |         mkdir ${{ env.WASI_SDK_PATH }} && \
40 | |         curl -s -S --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ env.WASI_SDK_VERSION }}/wasi-sd...
41 | |         tar --strip-components 1 --directory ${{ env.WASI_SDK_PATH }} --extract --gunzip
   | |________________________________________________________________________________________- help: env.WASI_SDK_VERSION may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:36:7
   |
36 |       - name: "Install WASI SDK"  # Hard-coded to x64.
   |         ------------------------ help: this step
37 |         if: steps.cache-wasi-sdk.outputs.cache-hit != 'true'
38 |         run: |
   |  _______-
39 | |         mkdir ${{ env.WASI_SDK_PATH }} && \
40 | |         curl -s -S --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ env.WASI_SDK_VERSION }}/wasi-sd...
41 | |         tar --strip-components 1 --directory ${{ env.WASI_SDK_PATH }} --extract --gunzip
   | |________________________________________________________________________________________- help: env.WASI_SDK_PATH may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:76:7
   |
76 |     - name: "Display build info"
   |       -------------------------- help: this step
77 |       run: make --directory ${{ env.CROSS_BUILD_WASI }} pythoninfo
   |       ------------------------------------------------------------ help: env.CROSS_BUILD_WASI may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
  --> .github/workflows/reusable-wasi.yml:78:7
   |
78 |     - name: "Test"
   |       ------------ help: this step
79 |       run: make --directory ${{ env.CROSS_BUILD_WASI }} test
   |       ------------------------------------------------------ help: env.CROSS_BUILD_WASI may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[template-injection]: code injection via template expansion
   --> .github/workflows/build.yml:414:7
    |
414 |       - name: "Run tests"
    |         ----------------- help: this step
415 |         working-directory: ${{ env.CPYTHON_BUILDDIR }}
416 |         run: |
    |  _______-
417 | |         # Most of the excluded tests are slow test suites with no property tests
...   |
432 | |           -x test_signal \
433 | |           -x test_sysconfig
    | |___________________________- help: env.VENV_PYTHON may expand into attacker-controllable code
    |
    = note: audit confidence → High

109 findings (89 suppressed): 0 unknown, 0 informational, 19 low, 0 medium, 1 high
```

</details>


Summary:

* Before: `134 findings (89 suppressed): 0 unknown, 0 informational, 13 low, 21 medium, 11 high`
* After: `No findings to report. Good job! (20 ignored, 89 suppressed)`

cc @sethmlarson and zizmor author @woodruffw.