### PR TITLE
gh-127750: Improve caching in singledispatchmethod

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-12-08-21-03-55.gh-issue-127750.94rNtr.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-08-21-03-55.gh-issue-127750.94rNtr.rst
@@ -1,0 +1,2 @@
+Improve caching of :class:`functools.singledispatchmethod` to fix issues
+where sometimes different object instances could collide with each other.


### PR DESCRIPTION
The problem with using a `WeakRefDictionary` is it's possible for distinct object instances to collide in the cache depending on their implementation of `__eq__`/`__hash__`. In particular, it prevents it from being used at all on Django models.

<!-- gh-issue-number: gh-127750 -->
* Issue: gh-127750
<!-- /gh-issue-number -->
