### PR TITLE
GH-126367: Fix urllib.request.url2pathname() colon handling in URLs on Windows

### DIFF
--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -26,8 +26,13 @@ def url2pathname(url):
         # Skip past extra slash before UNC drive in URL path.
         url = url[1:]
     # Windows itself uses ":" even in URLs.
-    url = url.replace(':', '|')
-    if not '|' in url:
+    url = url.replace(':', '|', 1)
+    if not '|' in url or ('|' in url and not (
+        url.startswith('|') or 
+        '/|' in url or 
+        (len(url) > 2 and url[0] == '/' and url[2] == '|' and url[1].isalpha()))
+    ):
+        url = url.replace('|', ':', 1)
         # No drive specifier, just convert slashes
         # make sure not to convert quoted slashes :-)
         return urllib.parse.unquote(url.replace('/', '\\'))

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1509,6 +1509,9 @@ class Pathname_Tests(unittest.TestCase):
         # Percent-encoded forward slashes are preserved for backwards compatibility
         self.assertEqual(fn('C:/foo%2fbar'), 'C:\\foo/bar')
         self.assertEqual(fn('//server/share/foo%2fbar'), '\\\\server\\share\\foo/bar')
+        # Colon in filenames, both with drive specifier and without
+        self.assertEqual(fn('//host/path/spam.foo:bar'), '\\\\host\\path\\spam.foo:bar')
+        self.assertEqual(fn('///c:/path/spam.foo:bar'), 'c:\\path\\spam.foo:bar')
         # Round-tripping
         paths = ['C:',
                  r'\C\test\\',

--- a/Misc/NEWS.d/next/Library/2024-12-09-04-02-41.gh-issue-126367.OsTibm.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-09-04-02-41.gh-issue-126367.OsTibm.rst
@@ -1,0 +1,1 @@
+Modified the :func:`~urllib.request.url2pathname` function in :mod:`urllib.request` to correctly handle DOS drive paths in URLs on Windows. Previously, the function produced incorrect results for UNC paths and raised OS errors for some paths.


### PR DESCRIPTION


<!-- gh-issue-number: gh-126367 -->
* Issue: gh-126367
<!-- /gh-issue-number -->
