### PR TITLE
gh-126821: Add versionadded annotation to use_system_logger feature.

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -1290,6 +1290,8 @@ PyConfig
 
       Default: ``0`` (don't use system log).
 
+      .. versionadded:: 3.13.2
+
    .. c:member:: int user_site_directory
 
       If non-zero, add the user site directory to :data:`sys.path`.

--- a/iOS/README.rst
+++ b/iOS/README.rst
@@ -286,7 +286,7 @@ This will:
 * Run the test suite on an "iPhone SE (3rd generation)" simulator.
 
 On success, the test suite will exit and report successful completion of the
-test suite. On a 2022 M1 MacBook Pro, the test suite takes approximately 12
+test suite. On a 2022 M1 MacBook Pro, the test suite takes approximately 15
 minutes to run; a couple of extra minutes is required to compile the testbed
 project, and then boot and prepare the iOS simulator.
 


### PR DESCRIPTION
In the process of backporting #127592 (see #127754), I realised that I didn't add a ``versionadded`` annotation in the docs for the new `use_system_logger` config option. This PR addresses that change.

It also makes a small tweak to the claim about iOS test times, as some recent changes have significantly increased the expected test time.


<!-- gh-issue-number: gh-126821 -->
* Issue: gh-126821
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127755.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->