### PR TITLE
gh-127740: For odd-length input to bytes.fromhex(...) change the error message to  ValueError: fromhex() arg must be of even length

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -460,9 +460,10 @@ class BaseBytesTest:
         self.assertRaises(ValueError, self.type2test.fromhex, '12   \x00   34')
 
         # For odd number of character(s)
-        with self.assertRaises(ValueError) as cm:
-            self.type2test.fromhex("a")
-        self.assertIn("fromhex() arg must be of even length", str(cm.exception))
+        for value in ("a", "a ", " a"," a ", "aaa", "aaa   ", "   aaa", "   aaa   "):
+            with self.assertRaises(ValueError) as cm:
+                self.type2test.fromhex(value)
+            self.assertIn("fromhex() arg must be of even length", str(cm.exception))
 
         for data, pos in (
             # invalid first hexadecimal character

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -460,7 +460,7 @@ class BaseBytesTest:
         self.assertRaises(ValueError, self.type2test.fromhex, '12   \x00   34')
 
         # For odd number of character(s)
-        for value in ("a", "a ", " a"," a ", "aaa", "aaa   ", "   aaa", "   aaa   "):
+        for value in ("a", "a ", " a"," a ", "a a a", "a a a   ", "   a a a", "   a a a   "):
             with self.assertRaises(ValueError) as cm:
                 self.type2test.fromhex(value)
             self.assertIn("fromhex() arg must be of even length", str(cm.exception))

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -459,6 +459,11 @@ class BaseBytesTest:
         self.assertRaises(ValueError, self.type2test.fromhex, '\x00')
         self.assertRaises(ValueError, self.type2test.fromhex, '12   \x00   34')
 
+        # For odd number of character(s)
+        with self.assertRaises(ValueError) as cm:
+            self.type2test.fromhex("a")
+        self.assertIn("fromhex() arg must be of even length", str(cm.exception))
+
         for data, pos in (
             # invalid first hexadecimal character
             ('12 x4 56', 3),

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -460,7 +460,7 @@ class BaseBytesTest:
         self.assertRaises(ValueError, self.type2test.fromhex, '12   \x00   34')
 
         # For odd number of character(s)
-        for value in ("a", "a ", " a"," a ", "aaa", "aaa ", " aaa", " aaa "):
+        for value in ("a", "a ", " a"," a ", "aaa", "aaa ", " aaa", " aaa ",  " aa a "):
             with self.assertRaises(ValueError) as cm:
                 self.type2test.fromhex(value)
             self.assertIn("fromhex() arg must be of even length", str(cm.exception))

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -460,7 +460,7 @@ class BaseBytesTest:
         self.assertRaises(ValueError, self.type2test.fromhex, '12   \x00   34')
 
         # For odd number of character(s)
-        for value in ("a", "a ", " a"," a ", "a a a", "aa a ", " aa a", " aaa "):
+        for value in ("a", "a ", " a"," a ", "aaa", "aaa ", " aaa", " aaa "):
             with self.assertRaises(ValueError) as cm:
                 self.type2test.fromhex(value)
             self.assertIn("fromhex() arg must be of even length", str(cm.exception))

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -460,10 +460,10 @@ class BaseBytesTest:
         self.assertRaises(ValueError, self.type2test.fromhex, '12   \x00   34')
 
         # For odd number of character(s)
-        for value in ("a", "a ", " a"," a ", "aaa", "aaa ", " aaa", " aaa ",  " aa a "):
+        for value in ("a", "a ", " a"," a ", "aaa", "aaa ", " aaa", " aaa "):
             with self.assertRaises(ValueError) as cm:
                 self.type2test.fromhex(value)
-            self.assertIn("fromhex() arg must be of even length", str(cm.exception))
+            self.assertIn("fromhex() arg must contain an even number of hexadecimal digits", str(cm.exception))
 
         for data, pos in (
             # invalid first hexadecimal character

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -460,7 +460,7 @@ class BaseBytesTest:
         self.assertRaises(ValueError, self.type2test.fromhex, '12   \x00   34')
 
         # For odd number of character(s)
-        for value in ("a", "a ", " a"," a ", "aaa", "aaa ", " aaa", " aaa "):
+        for value in ("a", "aaa", "deadbee"):
             with self.assertRaises(ValueError) as cm:
                 self.type2test.fromhex(value)
             self.assertIn("fromhex() arg must contain an even number of hexadecimal digits", str(cm.exception))

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -460,7 +460,7 @@ class BaseBytesTest:
         self.assertRaises(ValueError, self.type2test.fromhex, '12   \x00   34')
 
         # For odd number of character(s)
-        for value in ("a", "a ", " a"," a ", "a a a", "a a a   ", "   a a a", "   a a a   "):
+        for value in ("a", "a ", " a"," a ", "a a a", "aa a ", " aa a", " aaa "):
             with self.assertRaises(ValueError) as cm:
                 self.type2test.fromhex(value)
             self.assertIn("fromhex() arg must be of even length", str(cm.exception))

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-10-21-08-05.gh-issue-127740.0tWC9h.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-10-21-08-05.gh-issue-127740.0tWC9h.rst
@@ -1,3 +1,3 @@
-Fix error message in :func:`bytes.fromhex()` when given an odd number of
+Fix error message in :func:`bytes.fromhex` when given an odd number of
 digits to properly indicate that an even number of hexadecimal digits is
 required.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-10-21-08-05.gh-issue-127740.0tWC9h.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-10-21-08-05.gh-issue-127740.0tWC9h.rst
@@ -1,0 +1,3 @@
+Fix error message in :func:`bytes.fromhex()` when given an odd number of
+digits to properly indicate that an even number of hexadecimal digits is
+required.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2490,7 +2490,7 @@ PyObject*
 _PyBytes_FromHex(PyObject *string, int use_bytearray)
 {
     char *buf;
-    Py_ssize_t hexlen, invalid_char, real_len=0;
+    Py_ssize_t hexlen, invalid_char;
     unsigned int top, bot;
     const Py_UCS1 *str, *end;
     _PyBytesWriter writer;

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2541,6 +2541,14 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
         }
         str++;
 
+        /* Check if we have a second digit*/
+        if (str >= end) {
+            PyErr_SetString(PyExc_ValueError,
+                           "fromhex() arg must be of even length");
+            _PyBytesWriter_Dealloc(&writer);
+            return NULL;
+        }
+
         bot = _PyLong_DigitValue[*str];
         if (bot >= 16) {
             invalid_char = str - PyUnicode_1BYTE_DATA(string);
@@ -2554,15 +2562,9 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
     return _PyBytesWriter_Finish(&writer, buf);
 
   error:
-    if (str >= end) {
-        PyErr_SetString(PyExc_ValueError,
-                        "fromhex() arg must be of even length");
-    }
-    else {
-        PyErr_Format(PyExc_ValueError,
-                     "non-hexadecimal number found in "
-                     "fromhex() arg at position %zd", invalid_char);
-    }
+    PyErr_Format(PyExc_ValueError,
+                 "non-hexadecimal number found in "
+                 "fromhex() arg at position %zd", invalid_char);
     _PyBytesWriter_Dealloc(&writer);
     return NULL;
 }

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2542,19 +2542,6 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
         }
         str++;
 
-        /* Skip spaces after first digit */
-        while (str < end && Py_ISSPACE(*str)) {
-            str++;
-        }
-
-        /* Check if we have a second digit*/
-        if (str >= end) {
-            PyErr_SetString(PyExc_ValueError,
-                           "fromhex() arg must be of even length");
-            _PyBytesWriter_Dealloc(&writer);
-            return NULL;
-        }
-
         /* Check second hex digit */
         bot = _PyLong_DigitValue[*str];
         if (bot >= 16) {
@@ -2569,9 +2556,15 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
     return _PyBytesWriter_Finish(&writer, buf);
 
   error:
-    PyErr_Format(PyExc_ValueError,
-                 "non-hexadecimal number found in "
-                 "fromhex() arg at position %zd", invalid_char);
+    if (str >= end) {
+        PyErr_SetString(PyExc_ValueError,
+                        "fromhex() arg must be of even length");
+    }
+    else {
+        PyErr_Format(PyExc_ValueError,
+                     "non-hexadecimal number found in "
+                     "fromhex() arg at position %zd", invalid_char);
+    }
     _PyBytesWriter_Dealloc(&writer);
     return NULL;
 }

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2490,7 +2490,7 @@ PyObject*
 _PyBytes_FromHex(PyObject *string, int use_bytearray)
 {
     char *buf;
-    Py_ssize_t hexlen, invalid_char;
+    Py_ssize_t hexlen, invalid_char,real_len=0;
     unsigned int top, bot;
     const Py_UCS1 *str, *end;
     _PyBytesWriter writer;
@@ -2516,6 +2516,19 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
     }
 
     assert(PyUnicode_KIND(string) == PyUnicode_1BYTE_KIND);
+
+    const Py_UCS1 *s = PyUnicode_1BYTE_DATA(string);
+    for (Py_ssize_t i = 0; i < hexlen; i++) {
+        if (!Py_ISSPACE(s[i])) {
+            real_len++;
+        }
+    }
+    if (real_len % 2 != 0) {
+        PyErr_SetString(PyExc_ValueError,
+                       "fromhex() arg must be of even length");
+        _PyBytesWriter_Dealloc(&writer);
+        return NULL;
+    }
     str = PyUnicode_1BYTE_DATA(string);
 
     /* This overestimates if there are spaces */

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2540,8 +2540,13 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
         }
         str++;
 
+        /* Skip spaces after first digit */
+        while (str < end && Py_ISSPACE(*str)) {
+            str++;
+        }
+
         /* Check if we have a second digit*/
-        if (str >= end || Py_ISSPACE(*str)) {
+        if (str >= end) {
             PyErr_SetString(PyExc_ValueError,
                            "fromhex() arg must be of even length");
             _PyBytesWriter_Dealloc(&writer);

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2543,7 +2543,7 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
 
         /* Check if we have a second digit */
         if (str >= end) {
-            invalid_char = -2;
+            invalid_char = -1;
             goto error;
         }
 
@@ -2560,7 +2560,7 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
     return _PyBytesWriter_Finish(&writer, buf);
 
   error:
-    if (invalid_char == -2) {
+    if (invalid_char == -1) {
         PyErr_SetString(PyExc_ValueError,
                         "fromhex() arg must be of even length");
     } else {

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2516,10 +2516,9 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
     }
 
     assert(PyUnicode_KIND(string) == PyUnicode_1BYTE_KIND);
-
-    const Py_UCS1 *s = PyUnicode_1BYTE_DATA(string);
+    str = PyUnicode_1BYTE_DATA(string);
     for (Py_ssize_t i = 0; i < hexlen; i++) {
-        if (!Py_ISSPACE(s[i])) {
+        if (!Py_ISSPACE(str[i])) {
             real_len++;
         }
     }
@@ -2529,7 +2528,6 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
         _PyBytesWriter_Dealloc(&writer);
         return NULL;
     }
-    str = PyUnicode_1BYTE_DATA(string);
 
     /* This overestimates if there are spaces */
     buf = _PyBytesWriter_Alloc(&writer, hexlen / 2);

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2526,11 +2526,13 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
     end = str + hexlen;
     while (str < end) {
         /* skip over spaces in the input */
-        while (str < end && Py_ISSPACE(*str)) {
-            str++;
+        if (Py_ISSPACE(*str)) {
+            do {
+                str++;
+            } while (Py_ISSPACE(*str));
+            if (str >= end)
+                break;
         }
-        if (str >= end)
-            break;
 
         /* Check first hex digit */
         top = _PyLong_DigitValue[*str];

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2540,6 +2540,7 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
             goto error;
         }
         str++;
+
         bot = _PyLong_DigitValue[*str];
         if (bot >= 16) {
             /* NULL at the end of the string */

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2543,8 +2543,8 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
 
         bot = _PyLong_DigitValue[*str];
         if (bot >= 16) {
-            /* NULL at the end of the string */
-            if (bot == 37){
+            /* Check if we had a second digit */
+            if (str >= end){
                 invalid_char = -1;
             } else {
                 invalid_char = str - PyUnicode_1BYTE_DATA(string);

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2562,7 +2562,7 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
   error:
     if (invalid_char == -1) {
         PyErr_SetString(PyExc_ValueError,
-                        "fromhex() arg must be of even length");
+                        "fromhex() arg must contain an even number of hexadecimal digits");
     } else {
         PyErr_Format(PyExc_ValueError,
                      "non-hexadecimal number found in "

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2490,7 +2490,7 @@ PyObject*
 _PyBytes_FromHex(PyObject *string, int use_bytearray)
 {
     char *buf;
-    Py_ssize_t hexlen, invalid_char,real_len=0;
+    Py_ssize_t hexlen, invalid_char, real_len=0;
     unsigned int top, bot;
     const Py_UCS1 *str, *end;
     _PyBytesWriter writer;

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2541,12 +2541,10 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
         }
         str++;
 
-        /* Check if we have a second digit*/
+        /* Check if we have a second digit */
         if (str >= end) {
-            PyErr_SetString(PyExc_ValueError,
-                           "fromhex() arg must be of even length");
-            _PyBytesWriter_Dealloc(&writer);
-            return NULL;
+            invalid_char = -2;
+            goto error;
         }
 
         bot = _PyLong_DigitValue[*str];
@@ -2562,9 +2560,14 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
     return _PyBytesWriter_Finish(&writer, buf);
 
   error:
-    PyErr_Format(PyExc_ValueError,
-                 "non-hexadecimal number found in "
-                 "fromhex() arg at position %zd", invalid_char);
+    if (invalid_char == -2) {
+        PyErr_SetString(PyExc_ValueError,
+                        "fromhex() arg must be of even length");
+    } else {
+        PyErr_Format(PyExc_ValueError,
+                     "non-hexadecimal number found in "
+                     "fromhex() arg at position %zd", invalid_char);
+    }
     _PyBytesWriter_Dealloc(&writer);
     return NULL;
 }

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2540,16 +2540,14 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
             goto error;
         }
         str++;
-
-        /* Check if we have a second digit */
-        if (str >= end) {
-            invalid_char = -1;
-            goto error;
-        }
-
         bot = _PyLong_DigitValue[*str];
         if (bot >= 16) {
-            invalid_char = str - PyUnicode_1BYTE_DATA(string);
+            /* NULL at the end of the string */
+            if (bot == 37){
+                invalid_char = -1;
+            } else {
+                invalid_char = str - PyUnicode_1BYTE_DATA(string);
+            }
             goto error;
         }
         str++;

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2534,7 +2534,6 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
                 break;
         }
 
-        /* Check first hex digit */
         top = _PyLong_DigitValue[*str];
         if (top >= 16) {
             invalid_char = str - PyUnicode_1BYTE_DATA(string);
@@ -2542,7 +2541,6 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
         }
         str++;
 
-        /* Check second hex digit */
         bot = _PyLong_DigitValue[*str];
         if (bot >= 16) {
             invalid_char = str - PyUnicode_1BYTE_DATA(string);


### PR DESCRIPTION


<!-- gh-issue-number: gh-127740 -->
* Issue: gh-127740
<!-- /gh-issue-number -->
