### PR TITLE
gh-127637: add tests for `dis` command-line interface

### DIFF
--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -1115,7 +1115,7 @@ class Bytecode:
             return output.getvalue()
 
 
-def main():
+def main(args=None):
     import argparse
 
     parser = argparse.ArgumentParser()
@@ -1128,7 +1128,7 @@ def main():
     parser.add_argument('-S', '--specialized', action='store_true',
                         help='show specialized bytecode')
     parser.add_argument('infile', nargs='?', default='-')
-    args = parser.parse_args()
+    args = parser.parse_args(args=args)
     if args.infile == '-':
         name = '<stdin>'
         source = sys.stdin.buffer.read()

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -5,15 +5,19 @@ import contextlib
 import dis
 import functools
 import io
+import itertools
+import opcode
 import re
 import sys
+import tempfile
+import textwrap
 import types
 import unittest
 from test.support import (captured_stdout, requires_debug_ranges,
-                          requires_specialization, cpython_only)
+                          requires_specialization, cpython_only,
+                          os_helper)
 from test.support.bytecode_helper import BytecodeTestCase
 
-import opcode
 
 CACHE = dis.opmap["CACHE"]
 
@@ -2424,6 +2428,102 @@ def _unroll_caches_as_Instructions(instrs, show_caches=False):
 
                 yield Instruction("CACHE", CACHE, 0, None, argrepr, offset, offset,
                                   False, None, None, instr.positions)
+
+
+class TestDisCLI(unittest.TestCase):
+
+    def infile(self, content):
+        filename = tempfile.mktemp()
+        self.addCleanup(os_helper.unlink, filename)
+        with open(filename, 'w') as fp:
+            fp.write(content)
+        return filename
+
+    def invoke_dis(self, infile, *flags):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            dis.main(args=[*flags, infile])
+        return output.getvalue()
+
+    def check_output(self, source, expect, *flags):
+        with self.subTest(flags):
+            infile = self.infile(source)
+            res = self.invoke_dis(infile, *flags)
+            res = textwrap.dedent(res)
+            expect = textwrap.dedent(expect)
+            self.assertListEqual(res.splitlines(), expect.splitlines())
+
+    def test_invokation(self):
+        # test various combinations of parameters
+        base_flags = [
+            ('-C', '--show-caches'),
+            ('-O', '--show-offsets'),
+            ('-P', '--show-positions'),
+            ('-S', '--specialized'),
+        ]
+
+        infile = self.infile('def f():\n\tprint(x)\n\treturn None')
+
+        for r in range(1, len(base_flags) + 1):
+            for choices in itertools.combinations(base_flags, r=r):
+                for args in itertools.product(*choices):
+                    with self.subTest(args=args[1:]):
+                        _ = self.invoke_dis(infile, *args)
+
+    def test_show_cache(self):
+        # test 'python -m dis -C/--show-caches'
+        source = 'print()'
+        expect = '''\
+0           RESUME                   0
+
+1           LOAD_NAME                0 (print)
+            PUSH_NULL
+            CALL                     0
+            CACHE                    0 (counter: 0)
+            CACHE                    0 (func_version: 0)
+            CACHE                    0
+            POP_TOP
+            LOAD_CONST               0 (None)
+            RETURN_VALUE
+'''
+        for flag in ['-C', '--show-caches']:
+            self.check_output(source, expect, flag)
+
+    def test_show_offsets(self):
+        # test 'python -m dis -O/--show-offsets'
+        source = 'pass'
+        expect = '''\
+0          0       RESUME                   0
+
+1          2       LOAD_CONST               0 (None)
+           4       RETURN_VALUE
+ '''
+        for flag in ['-O', '--show-offsets']:
+            self.check_output(source, expect, flag)
+
+    def test_show_positions(self):
+        # test 'python -m dis -P/--show-positions'
+        source = 'pass'
+        expect = '''\
+0:0-1:0            RESUME                   0
+
+1:0-1:4            LOAD_CONST               0 (None)
+1:0-1:4            RETURN_VALUE
+'''
+        for flag in ['-P', '--show-positions']:
+            self.check_output(source, expect, flag)
+
+    def test_specialized_code(self):
+        # test 'python -m dis -S/--specialized'
+        source = 'pass'
+        expect = '''\
+0           RESUME                   0
+
+1           LOAD_CONST_IMMORTAL      0 (None)
+            RETURN_VALUE
+'''
+        for flag in ['-S', '--specialized']:
+            self.check_output(source, expect, flag)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -2436,21 +2436,30 @@ class TestDisCLI(unittest.TestCase):
         self.filename = tempfile.mktemp()
         self.addCleanup(os_helper.unlink, self.filename)
 
+    @staticmethod
+    def text_normalize(string):
+        """Dedent *string* and strip it from its surrounding whitespaces.
+
+        This method is used by the other utility functions so that any
+        string to write or to match against can be freely indented.
+        """
+        return textwrap.dedent(string).strip()
+
     def set_source(self, content):
         with open(self.filename, 'w') as fp:
-            fp.write(textwrap.dedent(content).strip())
+            fp.write(self.text_normalize(content))
 
     def invoke_dis(self, *flags):
         output = io.StringIO()
         with contextlib.redirect_stdout(output):
             dis.main(args=[*flags, self.filename])
-        return output.getvalue()
+        return self.text_normalize(output.getvalue())
 
     def check_output(self, source, expect, *flags):
-        with self.subTest(flags):
+        with self.subTest(source=source, flags=flags):
             self.set_source(source)
             res = self.invoke_dis(*flags)
-            res = textwrap.dedent(res)
+            expect = self.text_normalize(expect)
             self.assertListEqual(res.splitlines(), expect.splitlines())
 
     def test_invokation(self):
@@ -2477,7 +2486,7 @@ class TestDisCLI(unittest.TestCase):
     def test_show_cache(self):
         # test 'python -m dis -C/--show-caches'
         source = 'print()'
-        expect = textwrap.dedent('''
+        expect = '''
             0           RESUME                   0
 
             1           LOAD_NAME                0 (print)
@@ -2489,43 +2498,43 @@ class TestDisCLI(unittest.TestCase):
                         POP_TOP
                         LOAD_CONST               0 (None)
                         RETURN_VALUE
-        ''').strip()
+        '''
         for flag in ['-C', '--show-caches']:
             self.check_output(source, expect, flag)
 
     def test_show_offsets(self):
         # test 'python -m dis -O/--show-offsets'
         source = 'pass'
-        expect = textwrap.dedent('''
+        expect = '''
             0          0       RESUME                   0
 
             1          2       LOAD_CONST               0 (None)
                        4       RETURN_VALUE
-        ''').strip()
+        '''
         for flag in ['-O', '--show-offsets']:
             self.check_output(source, expect, flag)
 
     def test_show_positions(self):
         # test 'python -m dis -P/--show-positions'
         source = 'pass'
-        expect = textwrap.dedent('''
+        expect = '''
             0:0-1:0            RESUME                   0
 
             1:0-1:4            LOAD_CONST               0 (None)
             1:0-1:4            RETURN_VALUE
-        ''').strip()
+        '''
         for flag in ['-P', '--show-positions']:
             self.check_output(source, expect, flag)
 
     def test_specialized_code(self):
         # test 'python -m dis -S/--specialized'
         source = 'pass'
-        expect = textwrap.dedent('''
+        expect = '''
             0           RESUME                   0
 
             1           LOAD_CONST_IMMORTAL      0 (None)
                         RETURN_VALUE
-        ''').strip()
+        '''
         for flag in ['-S', '--specialized']:
             self.check_output(source, expect, flag)
 

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -2462,7 +2462,7 @@ class TestDisCLI(unittest.TestCase):
             expect = self.text_normalize(expect)
             self.assertListEqual(res.splitlines(), expect.splitlines())
 
-    def test_invokation(self):
+    def test_invocation(self):
         # test various combinations of parameters
         base_flags = [
             ('-C', '--show-caches'),
@@ -2482,6 +2482,11 @@ class TestDisCLI(unittest.TestCase):
                 for args in itertools.product(*choices):
                     with self.subTest(args=args[1:]):
                         _ = self.invoke_dis(*args)
+
+        with self.assertRaises(SystemExit):
+            # suppress argparse error message
+            with contextlib.redirect_stderr(io.StringIO()):
+                _ = self.invoke_dis('--unknown')
 
     def test_show_cache(self):
         # test 'python -m dis -C/--show-caches'

--- a/Misc/NEWS.d/next/Tests/2024-12-09-12-35-44.gh-issue-127637.KLx-9I.rst
+++ b/Misc/NEWS.d/next/Tests/2024-12-09-12-35-44.gh-issue-127637.KLx-9I.rst
@@ -1,0 +1,1 @@
+Add tests for the :mod:`dis` command-line interface. Patch by Bénédikt Tran.


### PR DESCRIPTION
We can decide to backport it or not.

<!-- gh-issue-number: gh-127637 -->
* Issue: gh-127637
<!-- /gh-issue-number -->
