### PR TITLE
[doc] Using windows: Fix typo in `windows.rst`

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -852,7 +852,7 @@ Virtual environments
 
 If the launcher is run with no explicit Python version specification, and a
 virtual environment (created with the standard library :mod:`venv` module or
-the external ``virtualenv`` tool) active, the launcher will run the virtual
+the external ``virtualenv`` tool) is active, the launcher will run the virtual
 environment's interpreter rather than the global one.  To run the global
 interpreter, either deactivate the virtual environment, or explicitly specify
 the global Python version.


### PR DESCRIPTION
Fixed minor typo in `Doc/using/windows.rst`, there was a missing `is`.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127768.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->