### PR TITLE
Add `extern "C"` around `PyTraceMalloc_` functions.

### DIFF
--- a/Include/cpython/tracemalloc.h
+++ b/Include/cpython/tracemalloc.h
@@ -1,6 +1,9 @@
 #ifndef Py_LIMITED_API
 #ifndef Py_TRACEMALLOC_H
 #define Py_TRACEMALLOC_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Track an allocated memory block in the tracemalloc module.
    Return 0 on success, return -1 on error (failed to allocate memory to store
@@ -22,5 +25,8 @@ PyAPI_FUNC(int) PyTraceMalloc_Untrack(
     unsigned int domain,
     uintptr_t ptr);
 
+#ifdef __cplusplus
+}
+#endif
 #endif  // !Py_TRACEMALLOC_H
 #endif  // !Py_LIMITED_API


### PR DESCRIPTION
Pretty much everything else exported by `Python.h` has an `extern "C"` annotation, yet this header appears to be missing one.

(Noticed because https://github.com/numpy/numpy/commit/71240911fafb2c82198701de1bf3b48796c456eb added an `extern "C"` around its include of `<Python.h>`, which should have been a no-op but wasn't in all cases.)