### PR TITLE
gh-127787: refactor helpers for `PyUnicodeErrorObject` internal interface

### DIFF
--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -97,7 +97,7 @@ PyAPI_FUNC(void) _PyErr_ChainExceptions1(PyObject *);
 PyAPI_FUNC(int) _PyUnicodeError_GetParams(
     PyObject *self,
     PyObject **obj, Py_ssize_t *objlen,
-    Py_ssize_t *start, Py_ssize_t *end, int *consistent,
+    Py_ssize_t *start, Py_ssize_t *end,
     int as_bytes);
 
 PyAPI_FUNC(PyObject*) PyUnstable_Exc_PrepReraiseStar(

--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -94,6 +94,12 @@ PyAPI_FUNC(void) _PyErr_ChainExceptions1(PyObject *);
 
 /* In exceptions.c */
 
+PyAPI_FUNC(int) _PyUnicodeError_GetParams(
+    PyObject *self,
+    PyObject **obj, Py_ssize_t *objlen,
+    Py_ssize_t *start, Py_ssize_t *end, int *consistent,
+    int as_bytes);
+
 PyAPI_FUNC(PyObject*) PyUnstable_Exc_PrepReraiseStar(
      PyObject *orig,
      PyObject *excs);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2738,8 +2738,8 @@ check_unicode_error_type(PyObject *self, const char *expect_type)
 // --- PyUnicodeEncodeObject: internal helpers --------------------------------
 //
 // In the helpers below, the caller is responsible to ensure that 'self'
-// is a PyUnicodeErrorObject, although this condition is verified by this
-// function on DEBUG builds through PyUnicodeError_CAST().
+// is a PyUnicodeErrorObject, although this is verified on DEBUG builds
+// through PyUnicodeError_CAST().
 
 /*
  * Return the underlying (str) 'encoding' attribute of a UnicodeError object.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2947,33 +2947,40 @@ PyUnicodeTranslateError_GetObject(PyObject *self)
 
 // --- PyUnicodeEncodeObject: 'start' getters ---------------------------------
 
+/*
+ * Specialization of _PyUnicodeError_GetParams() for the 'start' attribute.
+ *
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject,
+ * although this condition is verified by this function on DEBUG builds.
+ */
+static inline int
+unicode_error_get_start_impl(PyObject *self, Py_ssize_t *start, int as_bytes)
+{
+    return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, as_bytes);
+}
+
+
 int
 PyUnicodeEncodeError_GetStart(PyObject *self, Py_ssize_t *start)
 {
-    if (check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME) < 0) {
-        return -1;
-    }
-    return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, false);
+    int rc = check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME);
+    return rc < 0 ? -1 : unicode_error_get_start_impl(self, start, false);
 }
 
 
 int
 PyUnicodeDecodeError_GetStart(PyObject *self, Py_ssize_t *start)
 {
-    if (check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME) < 0) {
-        return -1;
-    }
-    return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, true);
+    int rc = check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME);
+    return rc < 0 ? -1 : unicode_error_get_start_impl(self, start, true);
 }
 
 
 int
 PyUnicodeTranslateError_GetStart(PyObject *self, Py_ssize_t *start)
 {
-    if (check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME) < 0) {
-        return -1;
-    }
-    return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, false);
+    int rc = check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME);
+    return rc < 0 ? -1 : unicode_error_get_start_impl(self, start, false);
 }
 
 // --- PyUnicodeEncodeObject: 'start' setters ---------------------------------
@@ -3003,33 +3010,40 @@ PyUnicodeTranslateError_SetStart(PyObject *self, Py_ssize_t start)
 
 // --- PyUnicodeEncodeObject: 'end' getters -----------------------------------
 
+/*
+ * Specialization of _PyUnicodeError_GetParams() for the 'end' attribute.
+ *
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject,
+ * although this condition is verified by this function on DEBUG builds.
+ */
+static inline int
+unicode_error_get_end_impl(PyObject *self, Py_ssize_t *end, int as_bytes)
+{
+    return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, as_bytes);
+}
+
+
 int
 PyUnicodeEncodeError_GetEnd(PyObject *self, Py_ssize_t *end)
 {
-    if (check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME) < 0) {
-        return -1;
-    }
-    return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, false);
+    int rc = check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME);
+    return rc < 0 ? -1 : unicode_error_get_end_impl(self, end, false);
 }
 
 
 int
 PyUnicodeDecodeError_GetEnd(PyObject *self, Py_ssize_t *end)
 {
-    if (check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME) < 0) {
-        return -1;
-    }
-    return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, true);
+    int rc = check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME);
+    return rc < 0 ? -1 : unicode_error_get_end_impl(self, end, true);
 }
 
 
 int
 PyUnicodeTranslateError_GetEnd(PyObject *self, Py_ssize_t *end)
 {
-    if (check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME) < 0) {
-        return -1;
-    }
-    return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, false);
+    int rc = check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME);
+    return rc < 0 ? -1 : unicode_error_get_end_impl(self, end, false);
 }
 
 // --- PyUnicodeEncodeObject: 'end' setters -----------------------------------

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2696,6 +2696,11 @@ as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
 #define PyUnicodeError_CAST(PTR)    \
     (assert(PyUnicodeError_Check(PTR)), ((PyUnicodeErrorObject *)(PTR)))
 
+/* class names to use when reporting errors */
+#define Py_UNICODE_ENCODE_ERROR_NAME        "UnicodeEncodeError"
+#define Py_UNICODE_DECODE_ERROR_NAME        "UnicodeDecodeError"
+#define Py_UNICODE_TRANSLATE_ERROR_NAME     "UnicodeTranslateError"
+
 
 static inline int
 check_unicode_error_type(PyObject *self, const char *expect_type)
@@ -2903,7 +2908,7 @@ _PyUnicodeError_GetParams(PyObject *self,
 PyObject *
 PyUnicodeEncodeError_GetEncoding(PyObject *self)
 {
-    int rc = check_unicode_error_type(self, "UnicodeEncodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME);
     return rc < 0 ? NULL : unicode_error_get_encoding_impl(self);
 }
 
@@ -2911,7 +2916,7 @@ PyUnicodeEncodeError_GetEncoding(PyObject *self)
 PyObject *
 PyUnicodeDecodeError_GetEncoding(PyObject *self)
 {
-    int rc = check_unicode_error_type(self, "UnicodeDecodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME);
     return rc < 0 ? NULL : unicode_error_get_encoding_impl(self);
 }
 
@@ -2920,7 +2925,7 @@ PyUnicodeDecodeError_GetEncoding(PyObject *self)
 PyObject *
 PyUnicodeEncodeError_GetObject(PyObject *self)
 {
-    int rc = check_unicode_error_type(self, "UnicodeEncodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME);
     return rc < 0 ? NULL : unicode_error_get_object_impl(self, false);
 }
 
@@ -2928,7 +2933,7 @@ PyUnicodeEncodeError_GetObject(PyObject *self)
 PyObject *
 PyUnicodeDecodeError_GetObject(PyObject *self)
 {
-    int rc = check_unicode_error_type(self, "UnicodeDecodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME);
     return rc < 0 ? NULL : unicode_error_get_object_impl(self, true);
 }
 
@@ -2936,7 +2941,7 @@ PyUnicodeDecodeError_GetObject(PyObject *self)
 PyObject *
 PyUnicodeTranslateError_GetObject(PyObject *self)
 {
-    int rc = check_unicode_error_type(self, "UnicodeTranslateError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME);
     return rc < 0 ? NULL : unicode_error_get_object_impl(self, false);
 }
 
@@ -2945,7 +2950,7 @@ PyUnicodeTranslateError_GetObject(PyObject *self)
 int
 PyUnicodeEncodeError_GetStart(PyObject *self, Py_ssize_t *start)
 {
-    if (check_unicode_error_type(self, "UnicodeEncodeError") < 0) {
+    if (check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME) < 0) {
         return -1;
     }
     return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, false);
@@ -2955,7 +2960,7 @@ PyUnicodeEncodeError_GetStart(PyObject *self, Py_ssize_t *start)
 int
 PyUnicodeDecodeError_GetStart(PyObject *self, Py_ssize_t *start)
 {
-    if (check_unicode_error_type(self, "UnicodeDecodeError") < 0) {
+    if (check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME) < 0) {
         return -1;
     }
     return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, true);
@@ -2965,7 +2970,7 @@ PyUnicodeDecodeError_GetStart(PyObject *self, Py_ssize_t *start)
 int
 PyUnicodeTranslateError_GetStart(PyObject *self, Py_ssize_t *start)
 {
-    if (check_unicode_error_type(self, "UnicodeTranslateError") < 0) {
+    if (check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME) < 0) {
         return -1;
     }
     return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, false);
@@ -2976,7 +2981,7 @@ PyUnicodeTranslateError_GetStart(PyObject *self, Py_ssize_t *start)
 int
 PyUnicodeEncodeError_SetStart(PyObject *self, Py_ssize_t start)
 {
-    int rc = check_unicode_error_type(self, "UnicodeEncodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME);
     return rc < 0 ? -1 : unicode_error_set_start_impl(self, start);
 }
 
@@ -2984,7 +2989,7 @@ PyUnicodeEncodeError_SetStart(PyObject *self, Py_ssize_t start)
 int
 PyUnicodeDecodeError_SetStart(PyObject *self, Py_ssize_t start)
 {
-    int rc = check_unicode_error_type(self, "UnicodeDecodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME);
     return rc < 0 ? -1 : unicode_error_set_start_impl(self, start);
 }
 
@@ -2992,7 +2997,7 @@ PyUnicodeDecodeError_SetStart(PyObject *self, Py_ssize_t start)
 int
 PyUnicodeTranslateError_SetStart(PyObject *self, Py_ssize_t start)
 {
-    int rc = check_unicode_error_type(self, "UnicodeTranslateError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME);
     return rc < 0 ? -1 : unicode_error_set_start_impl(self, start);
 }
 
@@ -3001,7 +3006,7 @@ PyUnicodeTranslateError_SetStart(PyObject *self, Py_ssize_t start)
 int
 PyUnicodeEncodeError_GetEnd(PyObject *self, Py_ssize_t *end)
 {
-    if (check_unicode_error_type(self, "UnicodeEncodeError") < 0) {
+    if (check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME) < 0) {
         return -1;
     }
     return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, false);
@@ -3011,7 +3016,7 @@ PyUnicodeEncodeError_GetEnd(PyObject *self, Py_ssize_t *end)
 int
 PyUnicodeDecodeError_GetEnd(PyObject *self, Py_ssize_t *end)
 {
-    if (check_unicode_error_type(self, "UnicodeDecodeError") < 0) {
+    if (check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME) < 0) {
         return -1;
     }
     return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, true);
@@ -3021,7 +3026,7 @@ PyUnicodeDecodeError_GetEnd(PyObject *self, Py_ssize_t *end)
 int
 PyUnicodeTranslateError_GetEnd(PyObject *self, Py_ssize_t *end)
 {
-    if (check_unicode_error_type(self, "UnicodeTranslateError") < 0) {
+    if (check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME) < 0) {
         return -1;
     }
     return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, false);
@@ -3032,7 +3037,7 @@ PyUnicodeTranslateError_GetEnd(PyObject *self, Py_ssize_t *end)
 int
 PyUnicodeEncodeError_SetEnd(PyObject *self, Py_ssize_t end)
 {
-    int rc = check_unicode_error_type(self, "UnicodeEncodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME);
     return rc < 0 ? -1 : unicode_error_set_end_impl(self, end);
 }
 
@@ -3040,7 +3045,7 @@ PyUnicodeEncodeError_SetEnd(PyObject *self, Py_ssize_t end)
 int
 PyUnicodeDecodeError_SetEnd(PyObject *self, Py_ssize_t end)
 {
-    int rc = check_unicode_error_type(self, "UnicodeDecodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME);
     return rc < 0 ? -1 : unicode_error_set_end_impl(self, end);
 }
 
@@ -3048,7 +3053,7 @@ PyUnicodeDecodeError_SetEnd(PyObject *self, Py_ssize_t end)
 int
 PyUnicodeTranslateError_SetEnd(PyObject *self, Py_ssize_t end)
 {
-    int rc = check_unicode_error_type(self, "UnicodeTranslateError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME);
     return rc < 0 ? -1 : unicode_error_set_end_impl(self, end);
 }
 
@@ -3057,7 +3062,7 @@ PyUnicodeTranslateError_SetEnd(PyObject *self, Py_ssize_t end)
 PyObject *
 PyUnicodeEncodeError_GetReason(PyObject *self)
 {
-    int rc = check_unicode_error_type(self, "UnicodeEncodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME);
     return rc < 0 ? NULL : unicode_error_get_reason_impl(self);
 }
 
@@ -3065,7 +3070,7 @@ PyUnicodeEncodeError_GetReason(PyObject *self)
 PyObject *
 PyUnicodeDecodeError_GetReason(PyObject *self)
 {
-    int rc = check_unicode_error_type(self, "UnicodeDecodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME);
     return rc < 0 ? NULL : unicode_error_get_reason_impl(self);
 }
 
@@ -3073,7 +3078,7 @@ PyUnicodeDecodeError_GetReason(PyObject *self)
 PyObject *
 PyUnicodeTranslateError_GetReason(PyObject *self)
 {
-    int rc = check_unicode_error_type(self, "UnicodeTranslateError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME);
     return rc < 0 ? NULL : unicode_error_get_reason_impl(self);
 }
 
@@ -3082,7 +3087,7 @@ PyUnicodeTranslateError_GetReason(PyObject *self)
 int
 PyUnicodeEncodeError_SetReason(PyObject *self, const char *reason)
 {
-    int rc = check_unicode_error_type(self, "UnicodeEncodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_ENCODE_ERROR_NAME);
     return rc < 0 ? -1 : unicode_error_set_reason_impl(self, reason);
 }
 
@@ -3090,7 +3095,7 @@ PyUnicodeEncodeError_SetReason(PyObject *self, const char *reason)
 int
 PyUnicodeDecodeError_SetReason(PyObject *self, const char *reason)
 {
-    int rc = check_unicode_error_type(self, "UnicodeDecodeError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME);
     return rc < 0 ? -1 : unicode_error_set_reason_impl(self, reason);
 }
 
@@ -3098,7 +3103,7 @@ PyUnicodeDecodeError_SetReason(PyObject *self, const char *reason)
 int
 PyUnicodeTranslateError_SetReason(PyObject *self, const char *reason)
 {
-    int rc = check_unicode_error_type(self, "UnicodeTranslateError");
+    int rc = check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME);
     return rc < 0 ? -1 : unicode_error_set_reason_impl(self, reason);
 }
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2671,6 +2671,11 @@ SimpleExtendsException(PyExc_ValueError, UnicodeError,
 /*
  * Check the validity of 'attr' as a unicode or bytes object depending
  * on 'as_bytes' and return a new reference on it if it is the case.
+ *
+ * The 'name' is the attribute name and is only used for error reporting.
+ *
+ * On success, this returns a strong reference on 'attr'.
+ * On failure, this sets an exception and returns NULL.
  */
 static PyObject *
 as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
@@ -2702,6 +2707,12 @@ as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
 #define Py_UNICODE_TRANSLATE_ERROR_NAME     "UnicodeTranslateError"
 
 
+/*
+ * Check that 'self' is of a Unicode Error object.
+ *
+ * On success, this returns 0.
+ * On failure, this sets a TypeError exception and returns -1.
+ */
 static inline int
 check_unicode_error_type(PyObject *self, const char *expect_type)
 {
@@ -2717,7 +2728,8 @@ check_unicode_error_type(PyObject *self, const char *expect_type)
 /*
  * Return the underlying (str) 'encoding' attribute of a Unicode Error object.
  *
- * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject,
+ * although this condition is verified by this function on DEBUG builds.
  */
 static inline PyObject *
 unicode_error_get_encoding_impl(PyObject *self)
@@ -2731,7 +2743,8 @@ unicode_error_get_encoding_impl(PyObject *self)
  * Return the underlying 'object' attribute of a Unicode Error object
  * as a bytes or a string instance, depending on the 'as_bytes' flag.
  *
- * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject,
+ * although this condition is verified by this function on DEBUG builds.
  */
 static inline PyObject *
 unicode_error_get_object_impl(PyObject *self, int as_bytes)
@@ -2757,7 +2770,8 @@ unicode_error_get_reason_impl(PyObject *self)
 /*
  * Set the underlying (str) 'reason' attribute of a Unicode Error object.
  *
- * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject,
+ * although this condition is verified by this function on DEBUG builds.
  *
  * Return 0 on success and -1 on failure.
  */
@@ -2777,7 +2791,8 @@ unicode_error_set_reason_impl(PyObject *self, const char *reason)
 /*
  * Set the 'start' attribute of a Unicode Error object.
  *
- * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject,
+ * although this condition is verified by this function on DEBUG builds.
  *
  * Return 0 on success and -1 on failure.
  */
@@ -2793,7 +2808,8 @@ unicode_error_set_start_impl(PyObject *self, Py_ssize_t start)
 /*
  * Set the 'end' attribute of a Unicode Error object.
  *
- * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject,
+ * although this condition is verified by this function on DEBUG builds.
  *
  * Return 0 on success and -1 on failure.
  */
@@ -2852,7 +2868,8 @@ unicode_error_adjust_end(Py_ssize_t end, Py_ssize_t objlen)
 /*
  * Get various common parameters of a Unicode Error object.
  *
- * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject,
+ * although this condition is verified by this function on DEBUG builds.
  *
  * Return 0 on success and -1 on failure.
  *
@@ -2904,6 +2921,7 @@ _PyUnicodeError_GetParams(PyObject *self,
 }
 
 // --- PyUnicodeEncodeObject: 'encoding' getters ------------------------------
+// Note: PyUnicodeTranslateError does not have an 'encoding' attribute.
 
 PyObject *
 PyUnicodeEncodeError_GetEncoding(PyObject *self)

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2676,14 +2676,15 @@ static PyObject *
 as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
 {
     assert(as_bytes == 0 || as_bytes == 1);
-    if (!attr) {
-        PyErr_Format(PyExc_TypeError, "%.200s attribute not set", name);
+    if (attr == NULL) {
+        PyErr_Format(PyExc_TypeError, "%s attribute not set", name);
         return NULL;
     }
     if (!(as_bytes ? PyBytes_Check(attr) : PyUnicode_Check(attr))) {
         PyErr_Format(PyExc_TypeError,
                      "%s attribute must be %s",
-                     name, as_bytes ? "bytes" : "unicode");
+                     name,
+                     as_bytes ? "bytes" : "unicode");
         return NULL;
     }
     return Py_NewRef(attr);
@@ -2759,7 +2760,7 @@ static inline int
 unicode_error_set_reason_impl(PyObject *self, const char *reason)
 {
     PyObject *value = PyUnicode_FromString(reason);
-    if (!value) {
+    if (value == NULL) {
         return -1;
     }
     PyUnicodeErrorObject *exc = PyUnicodeError_CAST(self);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2717,6 +2717,7 @@ as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
 static inline int
 check_unicode_error_type(PyObject *self, const char *expect_type)
 {
+    assert(self != NULL);
     if (!PyUnicodeError_Check(self)) {
         PyErr_Format(PyExc_TypeError,
                      "expecting a %s object, got %T", expect_type, self);
@@ -2735,6 +2736,7 @@ check_unicode_error_type(PyObject *self, const char *expect_type)
 static inline PyObject *
 unicode_error_get_encoding_impl(PyObject *self)
 {
+    assert(self != NULL);
     PyUnicodeErrorObject *exc = PyUnicodeError_CAST(self);
     return as_unicode_error_attribute(exc->encoding, "encoding", false);
 }
@@ -2750,6 +2752,7 @@ unicode_error_get_encoding_impl(PyObject *self)
 static inline PyObject *
 unicode_error_get_object_impl(PyObject *self, int as_bytes)
 {
+    assert(self != NULL);
     PyUnicodeErrorObject *exc = PyUnicodeError_CAST(self);
     return as_unicode_error_attribute(exc->object, "object", as_bytes);
 }
@@ -2763,6 +2766,7 @@ unicode_error_get_object_impl(PyObject *self, int as_bytes)
 static inline PyObject *
 unicode_error_get_reason_impl(PyObject *self)
 {
+    assert(self != NULL);
     PyUnicodeErrorObject *exc = PyUnicodeError_CAST(self);
     return as_unicode_error_attribute(exc->reason, "reason", false);
 }
@@ -2779,6 +2783,7 @@ unicode_error_get_reason_impl(PyObject *self)
 static inline int
 unicode_error_set_reason_impl(PyObject *self, const char *reason)
 {
+    assert(self != NULL);
     PyObject *value = PyUnicode_FromString(reason);
     if (value == NULL) {
         return -1;
@@ -2800,6 +2805,7 @@ unicode_error_set_reason_impl(PyObject *self, const char *reason)
 static inline int
 unicode_error_set_start_impl(PyObject *self, Py_ssize_t start)
 {
+    assert(self != NULL);
     PyUnicodeErrorObject *exc = PyUnicodeError_CAST(self);
     exc->start = start;
     return 0;
@@ -2817,6 +2823,7 @@ unicode_error_set_start_impl(PyObject *self, Py_ssize_t start)
 static inline int
 unicode_error_set_end_impl(PyObject *self, Py_ssize_t end)
 {
+    assert(self != NULL);
     PyUnicodeErrorObject *exc = PyUnicodeError_CAST(self);
     exc->end = end;
     return 0;
@@ -2891,6 +2898,7 @@ _PyUnicodeError_GetParams(PyObject *self,
                           Py_ssize_t *start, Py_ssize_t *end,
                           int as_bytes)
 {
+    assert(self != NULL);
     assert(as_bytes == 0 || as_bytes == 1);
     PyUnicodeErrorObject *exc = PyUnicodeError_CAST(self);
     PyObject *r = as_unicode_error_attribute(exc->object, "object", as_bytes);
@@ -2978,6 +2986,7 @@ PyUnicodeTranslateError_GetObject(PyObject *self)
 static inline int
 unicode_error_get_start_impl(PyObject *self, Py_ssize_t *start, int as_bytes)
 {
+    assert(self != NULL);
     return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, as_bytes);
 }
 
@@ -3043,6 +3052,7 @@ PyUnicodeTranslateError_SetStart(PyObject *self, Py_ssize_t start)
 static inline int
 unicode_error_get_end_impl(PyObject *self, Py_ssize_t *end, int as_bytes)
 {
+    assert(self != NULL);
     return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, as_bytes);
 }
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2682,7 +2682,7 @@ as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
     }
     if (!(as_bytes ? PyBytes_Check(attr) : PyUnicode_Check(attr))) {
         PyErr_Format(PyExc_TypeError,
-                     "%.200s attribute must be %s, not %T",
+                     "%.200s attribute must be %s",
                      name, as_bytes ? "bytes" : "unicode");
         return NULL;
     }

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2709,14 +2709,6 @@ check_unicode_error_type(PyObject *self, const char *expect_type)
 }
 
 
-static inline PyUnicodeErrorObject *
-as_unicode_error(PyObject *self, const char *expect_type)
-{
-    int rc = check_unicode_error_type(self, expect_type);
-    return rc < 0 ? NULL : _PyUnicodeError_CAST(self);
-}
-
-
 /*
  * Return the underlying (str) 'encoding' attribute of a Unicode Error object.
  *

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2690,11 +2690,10 @@ as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
 }
 
 
-#define _PyUnicodeError_CAST(PTR)   ((PyUnicodeErrorObject *)(PTR))
 #define PyUnicodeError_Check(PTR)   \
     PyObject_TypeCheck((PTR), (PyTypeObject *)PyExc_UnicodeError)
 #define PyUnicodeError_CAST(PTR)    \
-    (assert(PyUnicodeError_Check(PTR)), _PyUnicodeError_CAST(PTR))
+    (assert(PyUnicodeError_Check(PTR)), ((PyUnicodeErrorObject *)(PTR)))
 
 
 static inline int

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2668,6 +2668,10 @@ SimpleExtendsException(PyExc_ValueError, UnicodeError,
                        "Unicode related error.");
 
 
+/*
+ * Check the validity of 'attr' as a unicode or bytes object depending
+ * on 'as_bytes' and return a new reference on it if it is the case.
+ */
 static PyObject *
 as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
 {
@@ -2689,6 +2693,11 @@ as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
 }
 
 
+/*
+ * Return the underlying (str) 'encoding' attribute of a Unicode Error object.
+ *
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ */
 static inline PyObject *
 unicode_error_get_encoding_impl(PyObject *self)
 {
@@ -2699,6 +2708,12 @@ unicode_error_get_encoding_impl(PyObject *self)
 }
 
 
+/*
+ * Return the underlying 'object' attribute of a Unicode Error object
+ * as a bytes or a string instance, depending on the 'as_bytes' flag.
+ *
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ */
 static inline PyObject *
 unicode_error_get_object_impl(PyObject *self, int as_bytes)
 {
@@ -2709,6 +2724,11 @@ unicode_error_get_object_impl(PyObject *self, int as_bytes)
 }
 
 
+/*
+ * Return the underlying (str) 'reason' attribute of a Unicode Error object.
+ *
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ */
 static inline PyObject *
 unicode_error_get_reason_impl(PyObject *self)
 {
@@ -2719,6 +2739,13 @@ unicode_error_get_reason_impl(PyObject *self)
 }
 
 
+/*
+ * Set the underlying (str) 'reason' attribute of a Unicode Error object.
+ *
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ *
+ * Return 0 on success and -1 on failure.
+ */
 static inline int
 unicode_error_set_reason_impl(PyObject *self, const char *reason)
 {
@@ -2734,7 +2761,19 @@ unicode_error_set_reason_impl(PyObject *self, const char *reason)
 }
 
 
-static inline int
+/*
+ * Get the underlying 'object' attribute of a Unicode Error object
+ * as a bytes or a string instance, depending on the 'as_bytes' flag.
+ *
+ * The result is stored in 'result' and its size in 'size',
+ * which can be NULL to indicate that the value would be
+ * discarded after the call.
+ *
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ *
+ * Return 0 on success and -1 on failure.
+ */
+static int
 unicode_error_get_object_and_size(PyObject *self,
                                   PyObject **result, Py_ssize_t *size,
                                   int as_bytes)
@@ -2808,6 +2847,13 @@ unicode_error_adjust_end(Py_ssize_t end, Py_ssize_t objlen)
 }
 
 
+/*
+ * Retrieve and adjust the 'start' attribute of a Unicode Error object.
+ *
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ *
+ * Return 0 on success and -1 on failure.
+ */
 static inline int
 unicode_error_get_start_impl(PyObject *self, Py_ssize_t *start, int as_bytes)
 {
@@ -2825,6 +2871,13 @@ unicode_error_get_start_impl(PyObject *self, Py_ssize_t *start, int as_bytes)
 }
 
 
+/*
+ * Set the 'start' attribute of a Unicode Error object.
+ *
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ *
+ * Return 0 on success and -1 on failure.
+ */
 static inline int
 unicode_error_set_start_impl(PyObject *self, Py_ssize_t start)
 {
@@ -2836,6 +2889,13 @@ unicode_error_set_start_impl(PyObject *self, Py_ssize_t start)
 }
 
 
+/*
+ * Retrieve and adjust the 'end' attribute of a Unicode Error object.
+ *
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ *
+ * Return 0 on success and -1 on failure.
+ */
 static inline int
 unicode_error_get_end_impl(PyObject *self, Py_ssize_t *end, int as_bytes)
 {
@@ -2853,6 +2913,13 @@ unicode_error_get_end_impl(PyObject *self, Py_ssize_t *end, int as_bytes)
 }
 
 
+/*
+ * Set the 'end' attribute of a Unicode Error object.
+ *
+ * The caller is responsible to ensure that 'self' is a PyUnicodeErrorObject.
+ *
+ * Return 0 on success and -1 on failure.
+ */
 static inline int
 unicode_error_set_end_impl(PyObject *self, Py_ssize_t end)
 {

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2863,6 +2863,7 @@ unicode_error_set_end_impl(PyObject *self, Py_ssize_t end)
     return 0;
 }
 
+// --- PyUnicodeEncodeObject: 'encoding' getters ------------------------------
 
 PyObject *
 PyUnicodeEncodeError_GetEncoding(PyObject *self)
@@ -2870,11 +2871,14 @@ PyUnicodeEncodeError_GetEncoding(PyObject *self)
     return unicode_error_get_encoding_impl(self);
 }
 
+
 PyObject *
 PyUnicodeDecodeError_GetEncoding(PyObject *self)
 {
     return unicode_error_get_encoding_impl(self);
 }
+
+// --- PyUnicodeEncodeObject: 'object' getters --------------------------------
 
 PyObject *
 PyUnicodeEncodeError_GetObject(PyObject *self)
@@ -2882,17 +2886,21 @@ PyUnicodeEncodeError_GetObject(PyObject *self)
     return unicode_error_get_object_impl(self, false);
 }
 
+
 PyObject *
 PyUnicodeDecodeError_GetObject(PyObject *self)
 {
     return unicode_error_get_object_impl(self, true);
 }
 
+
 PyObject *
 PyUnicodeTranslateError_GetObject(PyObject *self)
 {
     return unicode_error_get_object_impl(self, false);
 }
+
+// --- PyUnicodeEncodeObject: 'start' getters ---------------------------------
 
 int
 PyUnicodeEncodeError_GetStart(PyObject *self, Py_ssize_t *start)
@@ -2914,6 +2922,7 @@ PyUnicodeTranslateError_GetStart(PyObject *self, Py_ssize_t *start)
     return unicode_error_get_start_impl(self, start, false);
 }
 
+// --- PyUnicodeEncodeObject: 'start' setters ---------------------------------
 
 int
 PyUnicodeEncodeError_SetStart(PyObject *self, Py_ssize_t start)
@@ -2935,6 +2944,7 @@ PyUnicodeTranslateError_SetStart(PyObject *self, Py_ssize_t start)
     return unicode_error_set_start_impl(self, start);
 }
 
+// --- PyUnicodeEncodeObject: 'end' getters -----------------------------------
 
 int
 PyUnicodeEncodeError_GetEnd(PyObject *self, Py_ssize_t *end)
@@ -2956,6 +2966,7 @@ PyUnicodeTranslateError_GetEnd(PyObject *self, Py_ssize_t *end)
     return unicode_error_get_end_impl(self, end, false);
 }
 
+// --- PyUnicodeEncodeObject: 'end' setters -----------------------------------
 
 int
 PyUnicodeEncodeError_SetEnd(PyObject *self, Py_ssize_t end)
@@ -2977,6 +2988,7 @@ PyUnicodeTranslateError_SetEnd(PyObject *self, Py_ssize_t end)
     return unicode_error_set_end_impl(self, end);
 }
 
+// --- PyUnicodeEncodeObject: 'reason' getters --------------------------------
 
 PyObject *
 PyUnicodeEncodeError_GetReason(PyObject *self)
@@ -2998,6 +3010,7 @@ PyUnicodeTranslateError_GetReason(PyObject *self)
     return unicode_error_get_reason_impl(self);
 }
 
+// --- PyUnicodeEncodeObject: 'reason' setters --------------------------------
 
 int
 PyUnicodeEncodeError_SetReason(PyObject *self, const char *reason)

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2701,6 +2701,7 @@ as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
 #define PyUnicodeError_CAST(PTR)    \
     (assert(PyUnicodeError_Check(PTR)), ((PyUnicodeErrorObject *)(PTR)))
 
+
 /* class names to use when reporting errors */
 #define Py_UNICODE_ENCODE_ERROR_NAME        "UnicodeEncodeError"
 #define Py_UNICODE_DECODE_ERROR_NAME        "UnicodeDecodeError"
@@ -2920,6 +2921,7 @@ _PyUnicodeError_GetParams(PyObject *self,
     return 0;
 }
 
+
 // --- PyUnicodeEncodeObject: 'encoding' getters ------------------------------
 // Note: PyUnicodeTranslateError does not have an 'encoding' attribute.
 
@@ -2937,6 +2939,7 @@ PyUnicodeDecodeError_GetEncoding(PyObject *self)
     int rc = check_unicode_error_type(self, Py_UNICODE_DECODE_ERROR_NAME);
     return rc < 0 ? NULL : unicode_error_get_encoding_impl(self);
 }
+
 
 // --- PyUnicodeEncodeObject: 'object' getters --------------------------------
 
@@ -2962,6 +2965,7 @@ PyUnicodeTranslateError_GetObject(PyObject *self)
     int rc = check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME);
     return rc < 0 ? NULL : unicode_error_get_object_impl(self, false);
 }
+
 
 // --- PyUnicodeEncodeObject: 'start' getters ---------------------------------
 
@@ -3001,6 +3005,7 @@ PyUnicodeTranslateError_GetStart(PyObject *self, Py_ssize_t *start)
     return rc < 0 ? -1 : unicode_error_get_start_impl(self, start, false);
 }
 
+
 // --- PyUnicodeEncodeObject: 'start' setters ---------------------------------
 
 int
@@ -3025,6 +3030,7 @@ PyUnicodeTranslateError_SetStart(PyObject *self, Py_ssize_t start)
     int rc = check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME);
     return rc < 0 ? -1 : unicode_error_set_start_impl(self, start);
 }
+
 
 // --- PyUnicodeEncodeObject: 'end' getters -----------------------------------
 
@@ -3064,6 +3070,7 @@ PyUnicodeTranslateError_GetEnd(PyObject *self, Py_ssize_t *end)
     return rc < 0 ? -1 : unicode_error_get_end_impl(self, end, false);
 }
 
+
 // --- PyUnicodeEncodeObject: 'end' setters -----------------------------------
 
 int
@@ -3089,6 +3096,7 @@ PyUnicodeTranslateError_SetEnd(PyObject *self, Py_ssize_t end)
     return rc < 0 ? -1 : unicode_error_set_end_impl(self, end);
 }
 
+
 // --- PyUnicodeEncodeObject: 'reason' getters --------------------------------
 
 PyObject *
@@ -3113,6 +3121,7 @@ PyUnicodeTranslateError_GetReason(PyObject *self)
     int rc = check_unicode_error_type(self, Py_UNICODE_TRANSLATE_ERROR_NAME);
     return rc < 0 ? NULL : unicode_error_get_reason_impl(self);
 }
+
 
 // --- PyUnicodeEncodeObject: 'reason' setters --------------------------------
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2682,7 +2682,7 @@ as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
     }
     if (!(as_bytes ? PyBytes_Check(attr) : PyUnicode_Check(attr))) {
         PyErr_Format(PyExc_TypeError,
-                     "%.200s attribute must be %s",
+                     "%s attribute must be %s",
                      name, as_bytes ? "bytes" : "unicode");
         return NULL;
     }

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2680,10 +2680,7 @@ as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
         PyErr_Format(PyExc_TypeError, "%.200s attribute not set", name);
         return NULL;
     }
-    if (!PyType_FastSubclass(
-            Py_TYPE(attr),
-            as_bytes ? Py_TPFLAGS_BYTES_SUBCLASS : Py_TPFLAGS_UNICODE_SUBCLASS
-    )) {
+    if (!(as_bytes ? PyBytes_Check(attr) : PyUnicode_Check(attr))) {
         PyErr_Format(PyExc_TypeError,
                      "%.200s attribute must be %s, not %T",
                      name, as_bytes ? "bytes" : "unicode");
@@ -2793,7 +2790,7 @@ unicode_error_get_object_and_size(PyObject *self,
         return -1;
     }
     if (size != NULL) {
-        *size = as_bytes ? PyBytes_GET_SIZE(obj) : PyUnicode_GetLength(obj);
+        *size = as_bytes ? PyBytes_GET_SIZE(obj) : PyUnicode_GET_LENGTH(obj);
     }
     if (result != NULL) {
         *result = obj;

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2753,7 +2753,7 @@ unicode_error_set_reason_impl(PyObject *self, const char *reason)
     // TODO(picnixz): do an assert-only type-check when gh-127694 is merged
     //                (the caller function must do an eager type-check)
     PyUnicodeErrorObject *exc = (PyUnicodeErrorObject *)self;
-    Py_XSETREF(*&exc->reason, value);
+    Py_XSETREF(exc->reason, value);
     return 0;
 }
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2709,7 +2709,7 @@ as_unicode_error_attribute(PyObject *attr, const char *name, int as_bytes)
 
 
 /*
- * Check that 'self' is of a UnicodeError object.
+ * Check that 'self' is a UnicodeError object.
  *
  * On success, this returns 0.
  * On failure, this sets a TypeError exception and returns -1.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2850,18 +2850,15 @@ unicode_error_adjust_end(Py_ssize_t end, Py_ssize_t objlen)
  *     objlen       The 'object' length.
  *     start        The clipped 'start' attribute.
  *     end          The clipped 'end' attribute.
- *     consistent   Indicate whetehr 'start' and 'end' are consistent.
  *     as_bytes     Indicate whether the underlying 'object' is a bytes object.
  *
- * The 'obj', 'objlen', 'start', 'end' and 'consistent' parameters may
- * be NULL to indicate that the parameter does not need to be stored.
- *
- * The 'consistent' value is only set if 'start', and 'end' are retrieved.
+ * The 'obj', 'objlen', 'start' and 'end' parameters may be NULL
+ * to indicate that the parameter does not need to be stored.
  */
 int
 _PyUnicodeError_GetParams(PyObject *self,
                           PyObject **obj, Py_ssize_t *objlen,
-                          Py_ssize_t *start, Py_ssize_t *end, int *consistent,
+                          Py_ssize_t *start, Py_ssize_t *end,
                           int as_bytes)
 {
     assert(as_bytes == 0 || as_bytes == 1);
@@ -2877,7 +2874,6 @@ _PyUnicodeError_GetParams(PyObject *self,
     if (objlen != NULL) {
         *objlen = n;
     }
-
     if (start != NULL) {
         *start = unicode_error_adjust_start(exc->start, n);
         assert(*start >= 0);
@@ -2888,11 +2884,6 @@ _PyUnicodeError_GetParams(PyObject *self,
         assert(*end >= 0);
         assert(*end <= n);
     }
-
-    if (start != NULL && end != NULL && consistent != NULL) {
-        *consistent = *start < *end ? 1 : 0;
-    }
-
     if (obj != NULL) {
         *obj = r;
     }
@@ -2944,21 +2935,21 @@ PyUnicodeTranslateError_GetObject(PyObject *self)
 int
 PyUnicodeEncodeError_GetStart(PyObject *self, Py_ssize_t *start)
 {
-    return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, NULL, false);
+    return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, false);
 }
 
 
 int
 PyUnicodeDecodeError_GetStart(PyObject *self, Py_ssize_t *start)
 {
-    return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, NULL, true);
+    return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, true);
 }
 
 
 int
 PyUnicodeTranslateError_GetStart(PyObject *self, Py_ssize_t *start)
 {
-    return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, NULL, false);
+    return _PyUnicodeError_GetParams(self, NULL, NULL, start, NULL, false);
 }
 
 // --- PyUnicodeEncodeObject: 'start' setters ---------------------------------
@@ -2988,21 +2979,21 @@ PyUnicodeTranslateError_SetStart(PyObject *self, Py_ssize_t start)
 int
 PyUnicodeEncodeError_GetEnd(PyObject *self, Py_ssize_t *end)
 {
-    return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, NULL, false);
+    return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, false);
 }
 
 
 int
 PyUnicodeDecodeError_GetEnd(PyObject *self, Py_ssize_t *end)
 {
-    return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, NULL, true);
+    return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, true);
 }
 
 
 int
 PyUnicodeTranslateError_GetEnd(PyObject *self, Py_ssize_t *end)
 {
-    return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, NULL, false);
+    return _PyUnicodeError_GetParams(self, NULL, NULL, NULL, end, false);
 }
 
 // --- PyUnicodeEncodeObject: 'end' setters -----------------------------------


### PR DESCRIPTION
- Unify `get_unicode` and `get_string` in a single function.
- Allow to retrieve the underlying `object` attribute, its size and its start and end indices in one round.
- Use a common implementation for the following functions:

  - `PyUnicode{Decode,Encode}Error_GetEncoding`
  - `PyUnicode{Decode,Encode,Translate}Error_GetObject`
  - `PyUnicode{Decode,Encode,Translate}Error_{Get,Set}Reason`
  - `PyUnicode{Decode,Encode,Translate}Error_{Get,Set}{Start,End}`

Note that there are some cosmetic changes here and there (in the naming of parameters) but these are essentially in prevision of https://github.com/python/cpython/pull/127694 in order to reduce the conflicts I'll need to solve (there will be conflicts probably but ideally, I want them to be minimal).

I've moved all helpers before the public API. I could move them inbetween but I felt that it's cleaner that way (it also allowed me to put double blank lines between functions a bit more easily).


<!-- gh-issue-number: gh-127787 -->
* Issue: gh-127787
<!-- /gh-issue-number -->
