### PR TITLE
GH-125174: Mark objects as statically allocated.

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -73,14 +73,24 @@ PyAPI_FUNC(int) _PyObject_IsFreed(PyObject *);
 #define _PyObject_HEAD_INIT(type)                   \
     {                                               \
         .ob_ref_local = _Py_IMMORTAL_REFCNT_LOCAL,  \
+        .ob_flags = _Py_STATICALLY_ALLOCATED_FLAG,  \
         .ob_type = (type)                           \
+    }
+#else
+#if SIZEOF_VOID_P > 4
+#define _PyObject_HEAD_INIT(type)         \
+    {                                     \
+        .ob_refcnt = _Py_IMMORTAL_INITIAL_REFCNT,  \
+        .ob_flags = _Py_STATICALLY_ALLOCATED_FLAG, \
+        .ob_type = (type)                 \
     }
 #else
 #define _PyObject_HEAD_INIT(type)         \
     {                                     \
-        .ob_refcnt = _Py_IMMORTAL_INITIAL_REFCNT, \
+        .ob_refcnt = _Py_STATIC_IMMORTAL_INITIAL_REFCNT, \
         .ob_type = (type)                 \
     }
+#endif
 #endif
 #define _PyVarObject_HEAD_INIT(type, size)    \
     {                                         \

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -137,7 +137,11 @@ static inline void _Py_RefcntAdd(PyObject* op, Py_ssize_t n)
     _Py_AddRefTotal(_PyThreadState_GET(), n);
 #endif
 #if !defined(Py_GIL_DISABLED)
+#if SIZEOF_VOID_P > 4
+    op->ob_refcnt += (PY_UINT32_T)n;
+#else
     op->ob_refcnt += n;
+#endif
 #else
     if (_Py_IsOwnedByCurrentThread(op)) {
         uint32_t local = op->ob_ref_local;

--- a/Include/object.h
+++ b/Include/object.h
@@ -71,7 +71,7 @@ whose size is determined when the object is allocated.
 #define PyObject_HEAD_INIT(type)    \
     {                               \
         0,                          \
-        0,                          \
+        _Py_STATICALLY_ALLOCATED_FLAG, \
         { 0 },                      \
         0,                          \
         _Py_IMMORTAL_REFCNT_LOCAL,  \

--- a/Include/object.h
+++ b/Include/object.h
@@ -152,7 +152,7 @@ struct _object {
     // trashcan mechanism as a linked list pointer and by the GC to store the
     // computed "gc_refs" refcount.
     uintptr_t ob_tid;
-    uint16_t _padding;
+    uint16_t ob_flags;
     PyMutex ob_mutex;           // per-object lock
     uint8_t ob_gc_bits;         // gc-related state
     uint32_t ob_ref_local;      // local reference count

--- a/Include/object.h
+++ b/Include/object.h
@@ -120,9 +120,19 @@ struct _object {
     __pragma(warning(disable: 4201))
 #endif
     union {
-       Py_ssize_t ob_refcnt;
 #if SIZEOF_VOID_P > 4
-       PY_UINT32_T ob_refcnt_split[2];
+        PY_INT64_T ob_refcnt_full; /* This field is needed for efficient initialization with Clang on ARM */
+        struct {
+#  if PY_BIG_ENDIAN
+            PY_UINT32_T ob_flags;
+            PY_UINT32_T ob_refcnt;
+#  else
+            PY_UINT32_T ob_refcnt;
+            PY_UINT32_T ob_flags;
+#  endif
+        };
+#else
+        Py_ssize_t ob_refcnt;
 #endif
     };
 #ifdef _MSC_VER

--- a/Include/object.h
+++ b/Include/object.h
@@ -81,7 +81,7 @@ whose size is determined when the object is allocated.
 #else
 #define PyObject_HEAD_INIT(type)    \
     {                               \
-        { _Py_IMMORTAL_INITIAL_REFCNT },    \
+        { _Py_STATIC_IMMORTAL_INITIAL_REFCNT },    \
         (type)                      \
     },
 #endif

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -19,6 +19,9 @@ immortal. The latter should be the only instances that require
 cleanup during runtime finalization.
 */
 
+/* Leave the low bits for refcount overflow for old stable ABI code */
+#define _Py_STATICALLY_ALLOCATED_FLAG (1 << 7)
+
 #if SIZEOF_VOID_P > 4
 /*
 In 64+ bit systems, any object whose 32 bit reference count is >= 2**31
@@ -39,7 +42,8 @@ beyond the refcount limit. Immortality checks for reference count decreases will
 be done by checking the bit sign flag in the lower 32 bits.
 
 */
-#define _Py_IMMORTAL_INITIAL_REFCNT ((Py_ssize_t)(3UL << 30))
+#define _Py_IMMORTAL_INITIAL_REFCNT (3UL << 30)
+#define _Py_STATIC_IMMORTAL_INITIAL_REFCNT ((Py_ssize_t)(_Py_IMMORTAL_INITIAL_REFCNT | (((Py_ssize_t)_Py_STATICALLY_ALLOCATED_FLAG) << 32)))
 
 #else
 /*
@@ -59,9 +63,6 @@ check by comparing the reference count field to the minimum immortality refcount
 #define _Py_STATIC_IMMORTAL_INITIAL_REFCNT ((Py_ssize_t)(7L << 28))
 #define _Py_STATIC_IMMORTAL_MINIMUM_REFCNT ((Py_ssize_t)(6L << 28))
 #endif
-
-/* Leave the low bits for refcount overflow for old stable ABI code */
-#define _Py_STATICALLY_ALLOCATED_FLAG (1 << 7)
 
 // Py_GIL_DISABLED builds indicate immortal objects using `ob_ref_local`, which is
 // always 32-bits.

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -2691,7 +2691,7 @@ class ShutdownTest(unittest.TestCase):
 class ImmortalTests(unittest.TestCase):
 
     if sys.maxsize < (1 << 32):
-        IMMORTAL_REFCOUNT = 3 << 29
+        IMMORTAL_REFCOUNT = 7 << 28
     else:
         IMMORTAL_REFCOUNT = 3 << 30
 

--- a/Lib/test/test_capi/test_immortal.py
+++ b/Lib/test/test_capi/test_immortal.py
@@ -17,11 +17,11 @@ class TestInternalCAPI(unittest.TestCase):
     def test_immortal_builtins(self):
         for obj in range(-5, 256):
             self.assertTrue(_testinternalcapi.is_static_immortal(obj))
-        self.assertTrue(_testinternalcapi.is_static_immortal(None)
-        self.assertTrue(_testinternalcapi.is_static_immortal(False)
-        self.assertTrue(_testinternalcapi.is_static_immortal(True)
-        self.assertTrue(_testinternalcapi.is_static_immortal(...)
-        self.assertTrue(_testinternalcapi.is_static_immortal(())
+        self.assertTrue(_testinternalcapi.is_static_immortal(None))
+        self.assertTrue(_testinternalcapi.is_static_immortal(False))
+        self.assertTrue(_testinternalcapi.is_static_immortal(True))
+        self.assertTrue(_testinternalcapi.is_static_immortal(...))
+        self.assertTrue(_testinternalcapi.is_static_immortal(()))
         for obj in range(300, 400):
             self.assertFalse(_testinternalcapi.is_static_immortal(obj))
         for obj in ([], {}, set()):

--- a/Lib/test/test_capi/test_immortal.py
+++ b/Lib/test/test_capi/test_immortal.py
@@ -2,6 +2,7 @@ import unittest
 from test.support import import_helper
 
 _testcapi = import_helper.import_module('_testcapi')
+_testinternalcapi = import_helper.import_module('_testinternalcapi')
 
 
 class TestCAPI(unittest.TestCase):
@@ -10,6 +11,18 @@ class TestCAPI(unittest.TestCase):
 
     def test_immortal_small_ints(self):
         _testcapi.test_immortal_small_ints()
+
+class TestInternalCAPI(unittest.TestCase):
+
+    def test_immortal_builtins(self):
+        for obj in range(-5, 256):
+            self.assertTrue(_testinternalcapi.is_static_immortal(obj))
+        for obj in (None, True, False, ..., NotImplemented, ()):
+            self.assertTrue(_testinternalcapi.is_static_immortal(obj))
+        for obj in range(300, 400):
+            self.assertFalse(_testinternalcapi.is_static_immortal(obj))
+        for obj in ([], {}, set()):
+            self.assertFalse(_testinternalcapi.is_static_immortal(obj))
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_capi/test_immortal.py
+++ b/Lib/test/test_capi/test_immortal.py
@@ -17,8 +17,11 @@ class TestInternalCAPI(unittest.TestCase):
     def test_immortal_builtins(self):
         for obj in range(-5, 256):
             self.assertTrue(_testinternalcapi.is_static_immortal(obj))
-        for obj in (None, True, False, ..., NotImplemented, ()):
-            self.assertTrue(_testinternalcapi.is_static_immortal(obj))
+        self.assertTrue(_testinternalcapi.is_static_immortal(None)
+        self.assertTrue(_testinternalcapi.is_static_immortal(False)
+        self.assertTrue(_testinternalcapi.is_static_immortal(True)
+        self.assertTrue(_testinternalcapi.is_static_immortal(...)
+        self.assertTrue(_testinternalcapi.is_static_immortal(())
         for obj in range(300, 400):
             self.assertFalse(_testinternalcapi.is_static_immortal(obj))
         for obj in ([], {}, set()):

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -2082,6 +2082,15 @@ get_tracked_heap_size(PyObject *self, PyObject *Py_UNUSED(ignored))
     return PyLong_FromInt64(PyInterpreterState_Get()->gc.heap_size);
 }
 
+static PyObject *
+is_static_immortal(PyObject *self, PyObject *op)
+{
+    if (_Py_IsStaticImmortal(op)) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+
 static PyMethodDef module_functions[] = {
     {"get_configs", get_configs, METH_NOARGS},
     {"get_recursion_depth", get_recursion_depth, METH_NOARGS},
@@ -2180,6 +2189,7 @@ static PyMethodDef module_functions[] = {
     {"identify_type_slot_wrappers", identify_type_slot_wrappers, METH_NOARGS},
     {"has_deferred_refcount", has_deferred_refcount, METH_O},
     {"get_tracked_heap_size", get_tracked_heap_size, METH_NOARGS},
+    {"is_static_immortal", is_static_immortal, METH_O},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2475,12 +2475,16 @@ new_reference(PyObject *op)
 {
     // Skip the immortal object check in Py_SET_REFCNT; always set refcnt to 1
 #if !defined(Py_GIL_DISABLED)
+#if SIZEOF_VOID_P > 4
     op->ob_refcnt_full = 1;
     assert(op->ob_refcnt == 1);
     assert(op->ob_flags == 0);
 #else
+    op->ob_refcnt = 1;
+#endif
+#else
     op->ob_tid = _Py_ThreadId();
-    op->_padding = 0;
+    op->ob_flags = 0;
     op->ob_mutex = (PyMutex){ 0 };
     op->ob_gc_bits = 0;
     op->ob_ref_local = 1;

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2475,7 +2475,9 @@ new_reference(PyObject *op)
 {
     // Skip the immortal object check in Py_SET_REFCNT; always set refcnt to 1
 #if !defined(Py_GIL_DISABLED)
-    op->ob_refcnt = 1;
+    op->ob_refcnt_full = 1;
+    assert(op->ob_refcnt == 1);
+    assert(op->ob_flags == 0);
 #else
     op->ob_tid = _Py_ThreadId();
     op->_padding = 0;

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2521,6 +2521,10 @@ _Py_SetImmortalUntracked(PyObject *op)
             || PyUnicode_CHECK_INTERNED(op) == SSTATE_INTERNED_IMMORTAL_STATIC);
     }
 #endif
+    // Check if already immortal to avoid degrading from static immortal to plain immortal
+    if (_Py_IsImmortal(op)) {
+        return;
+    }
 #ifdef Py_GIL_DISABLED
     op->ob_tid = _Py_UNOWNED_TID;
     op->ob_ref_local = _Py_IMMORTAL_REFCNT_LOCAL;


### PR DESCRIPTION
This PR is a follow up to https://github.com/python/cpython/pull/125251 which made checking for immortal objects more robust.

This adds the ability to check whether objects are statically allocated or not, which should assist finalization and safety checks.

<!-- gh-issue-number: gh-125174 -->
* Issue: gh-125174
<!-- /gh-issue-number -->
