### PR TITLE
gh-109975: Add list of 3.13 removed library replacements

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1492,8 +1492,20 @@ All of the following modules were deprecated in Python 3.11,
 and are now removed:
 
 * :mod:`!aifc`
+
+  * :pypi:`standard-aifc`:
+    Use the redistribution of ``aifc`` library from PyPI.
+
 * :mod:`!audioop`
+
+  * :pypi:`audioop-lts`:
+    Use ``audioop-lts`` library from PyPI.
+
 * :mod:`!chunk`
+
+  * :pypi:`standard-chunk`:
+    Use the redistribution of ``chunk`` library from PyPI.
+
 * :mod:`!cgi` and :mod:`!cgitb`
 
   * :class:`!cgi.FieldStorage` can typically be replaced with
@@ -1524,6 +1536,9 @@ and are now removed:
     For example, the :class:`email.message.EmailMessage`
     and :class:`email.message.Message` classes.
 
+  * :pypi:`standard-cgi`: and :pypi:`standard-cgitb`:
+    Use the redistribution of ``cgi`` and ``cgitb`` library from PyPI.
+
 * :mod:`!crypt` and the private :mod:`!_crypt` extension.
   The :mod:`hashlib` module may be an appropriate replacement
   when simply hashing a value is required.
@@ -1542,6 +1557,8 @@ and are now removed:
     Fork of the :mod:`!crypt` module,
     wrapper to the :manpage:`crypt_r(3)` library call
     and associated functionality.
+  * :pypi:`standard-crypt` and :pypi:`deprecated-crypt-alternative`:
+    Use the redistribution of ``crypt`` and reimplementation of ``_crypt`` libraries from PyPI.
 
 * :mod:`!imghdr`:
   The :pypi:`filetype`, :pypi:`puremagic`, or :pypi:`python-magic` libraries
@@ -1549,29 +1566,64 @@ and are now removed:
   For example, the :func:`!puremagic.what` function can be used
   to replace the :func:`!imghdr.what` function for all file formats
   that were supported by :mod:`!imghdr`.
+
+  * :pypi:`standard-imghdr`:
+    Use the redistribution of ``imghdr`` library from PyPI.
+
 * :mod:`!mailcap`:
   Use the :mod:`mimetypes` module instead.
+
+  * :pypi:`standard-mailcap`:
+    Use the redistribution of ``mailcap`` library from PyPI.
+
 * :mod:`!msilib`
 * :mod:`!nis`
 * :mod:`!nntplib`:
   Use the :pypi:`pynntp` library from PyPI instead.
+
+  * :pypi:`standard-nntplib`:
+    Use the redistribution of ``nntplib`` library from PyPI.
+
 * :mod:`!ossaudiodev`:
   For audio playback, use the :pypi:`pygame` library from PyPI instead.
 * :mod:`!pipes`:
   Use the :mod:`subprocess` module instead.
   Use :func:`shlex.quote` to replace the undocumented ``pipes.quote``
   function.
+
+  * :pypi:`standard-pipes`:
+    Use the redistribution of ``pipes`` library from PyPI.
+
 * :mod:`!sndhdr`:
   The :pypi:`filetype`, :pypi:`puremagic`, or :pypi:`python-magic` libraries
   should be used as replacements.
+
+  * :pypi:`standard-sndhdr`:
+    Use the redistribution of ``sndhdr`` library from PyPI.
+
 * :mod:`!spwd`:
   Use the :pypi:`python-pam` library from PyPI instead.
 * :mod:`!sunau`
+
+  * :pypi:`standard-sunau`:
+    Use the redistribution of ``sunau`` library from PyPI.
+
 * :mod:`!telnetlib`,
   Use the :pypi:`telnetlib3` or :pypi:`Exscript` libraries from PyPI instead.
+
+  * :pypi:`standard-telnetlib`:
+    Use the redistribution of ``telnetlib`` library from PyPI.
+
 * :mod:`!uu`:
   Use the :mod:`base64` module instead, as a modern alternative.
+
+  * :pypi:`standard-uu`:
+    Use the redistribution of ``uu`` library from PyPI.
+
 * :mod:`!xdrlib`
+
+  * :pypi:`standard-xdrlib`:
+    Use the redistribution of ``xdrlib`` library from PyPI.
 
 (Contributed by Victor Stinner and Zachary Ware in :gh:`104773` and :gh:`104780`.)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The changes need to be backported to 3.13.

This is not an actual code change. I referred a closed issue. Please let me know if I need to open another issue for this chagne.

Disclaimer: Most of added libraries with `standard-` prefixed ones are distributed by me, from [python-deadlib](https://github.com/youknowone/python-deadlib) project. I wish it is not conflict of interests. `audioop-lts` is not related to me.

The below is not strictly related to the patch. But for fun.
While most of the dead batteries looks like not having a high demand of drop-in-replacement, the others are quickly getting users.

- chunk: https://pypistats.org/packages/standard-chunk
- telnetlib: https://pypistats.org/packages/standard-telnetlib
- imghdr: https://pypistats.org/packages/standard-imghdr
- aifc: https://pypistats.org/packages/standard-aifc
- audioop: https://pypistats.org/packages/audioop-lts



<!-- gh-issue-number: gh-109975 -->
* Issue: gh-109975
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127816.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->