### PR TITLE
[3.12] Add `extern "C"` around `PyTraceMalloc_` functions. (#127772)

### DIFF
--- a/Include/tracemalloc.h
+++ b/Include/tracemalloc.h
@@ -1,5 +1,8 @@
 #ifndef Py_TRACEMALLOC_H
 #define Py_TRACEMALLOC_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef Py_LIMITED_API
 /* Track an allocated memory block in the tracemalloc module.
@@ -67,6 +70,8 @@ PyAPI_FUNC(PyObject *) _PyTraceMalloc_GetTracedMemory(void);
 /* Set the peak size of traced memory blocks to the current size */
 PyAPI_FUNC(void) _PyTraceMalloc_ResetPeak(void);
 
+#ifdef __cplusplus
+}
 #endif
-
+#endif /* !Py_LIMITED_API */
 #endif /* !Py_TRACEMALLOC_H */


### PR DESCRIPTION
Pretty much everything else exported by Python.h has an extern "C" annotation, yet this header appears to be missing one.

(cherry picked from commit 2cdeb61b57e638ae46a04386330a12abe9cddf2c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
