### PR TITLE
[3.13] gh-126937: ctypes: add test for maximum size of a struct field (GH-126938)

### DIFF
--- a/Lib/test/test_ctypes/test_struct_fields.py
+++ b/Lib/test/test_ctypes/test_struct_fields.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 from ctypes import Structure, Union, sizeof, c_char, c_int
 from ._support import (CField, Py_TPFLAGS_DISALLOW_INSTANTIATION,
                        Py_TPFLAGS_IMMUTABLETYPE)
@@ -74,6 +75,27 @@ class StructFieldsTestCase(unittest.TestCase):
         with self.assertRaisesRegex(TypeError,
                                     'ctypes state is not initialized'):
             class Subclass(BrokenStructure): ...
+
+    def test_max_field_size_gh126937(self):
+        # Classes for big structs should be created successfully.
+        # (But they most likely can't be instantiated.)
+        # The size must fit in Py_ssize_t.
+
+        class X(Structure):
+            _fields_ = [('char', c_char),]
+        max_field_size = sys.maxsize
+
+        class Y(Structure):
+            _fields_ = [('largeField', X * max_field_size)]
+        class Z(Structure):
+            _fields_ = [('largeField', c_char * max_field_size)]
+
+        with self.assertRaises(OverflowError):
+            class TooBig(Structure):
+                _fields_ = [('largeField', X * (max_field_size + 1))]
+        with self.assertRaises(OverflowError):
+            class TooBig(Structure):
+                _fields_ = [('largeField', c_char * (max_field_size + 1))]
 
     # __set__ and __get__ should raise a TypeError in case their self
     # argument is not a ctype instance.


### PR DESCRIPTION
This backports the test from GH-126938, with changed limit and exception class.

@serhiy-storchaka, thanks for the push to add the test. After #127297 I plan to relax the limit in `main` to match this test.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-126937 -->
* Issue: gh-126937
<!-- /gh-issue-number -->
