### PR TITLE
lib/logging: Initialize handlers as Set instead of List

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1483,7 +1483,7 @@ class Logger(Filterer):
         self.level = _checkLevel(level)
         self.parent = None
         self.propagate = True
-        self.handlers = []
+        self.handlers = set()
         self.disabled = False
         self._cache = {}
 
@@ -1685,7 +1685,7 @@ class Logger(Filterer):
         """
         with _lock:
             if not (hdlr in self.handlers):
-                self.handlers.append(hdlr)
+                self.handlers.add(hdlr)
 
     def removeHandler(self, hdlr):
         """


### PR DESCRIPTION
Handlers is currently initialized as empty list. The operation most performed is __contains__. Set performs faster for this and ordering of handler is not a concern. Hence replace the list initialization with set.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
