### PR TITLE
[3.11] gh-121277: Allow .. versionadded:: next in docs (GH-121278) (#124718)

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -446,15 +446,15 @@ class DeprecatedRemoved(Directive):
         node = addnodes.versionmodified()
         node.document = self.state.document
         node['type'] = 'deprecated-removed'
+        env = self.state.document.settings.env
         version = (
-            expand_version_arg(self.arguments[0], self.config.release),
+            expand_version_arg(self.arguments[0], env.config.release),
             self.arguments[1],
         )
         if version[1] == 'next':
             raise ValueError(
                 'deprecated-removed:: second argument cannot be `next`')
         node['version'] = version
-        env = self.state.document.settings.env
         current_version = tuple(int(e) for e in env.config.version.split('.'))
         removed_version = tuple(int(e) for e in self.arguments[1].split('.'))
         if current_version < removed_version:

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -22,6 +22,7 @@ from docutils.utils import new_document
 from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.domains.python import PyFunction, PyMethod
+from sphinx.domains.changeset import VersionChange
 from sphinx.errors import NoUri
 from sphinx.locale import _ as sphinx_gettext
 from sphinx.util import logging

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -456,13 +456,13 @@ class DeprecatedRemoved(Directive):
                 'deprecated-removed:: second argument cannot be `next`')
         node['version'] = version
         current_version = tuple(int(e) for e in env.config.version.split('.'))
-        removed_version = tuple(int(e) for e in self.arguments[1].split('.'))
+        removed_version = tuple(int(e) for e in version[1].split('.'))
         if current_version < removed_version:
             label = self._deprecated_label
         else:
             label = self._removed_label
 
-        text = label.format(deprecated=self.arguments[0], removed=self.arguments[1])
+        text = label.format(deprecated=version[0], removed=version[1])
         if len(self.arguments) == 3:
             inodes, messages = self.state.inline_text(self.arguments[2],
                                                       self.lineno+1)

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -414,7 +414,22 @@ class PyAbstractMethod(PyMethod):
         return PyMethod.run(self)
 
 
-# Support for documenting version of removal in deprecations
+# Support for documenting version of changes, additions, deprecations
+
+def expand_version_arg(argument, release):
+    """Expand "next" to the current version"""
+    if argument == 'next':
+        return sphinx_gettext('{} (unreleased)').format(release)
+    return argument
+
+
+class PyVersionChange(VersionChange):
+    def run(self):
+        # Replace the 'next' special token with the current development version
+        self.arguments[0] = expand_version_arg(self.arguments[0],
+                                               self.config.release)
+        return super().run()
+
 
 class DeprecatedRemoved(Directive):
     has_content = True
@@ -430,7 +445,13 @@ class DeprecatedRemoved(Directive):
         node = addnodes.versionmodified()
         node.document = self.state.document
         node['type'] = 'deprecated-removed'
-        version = (self.arguments[0], self.arguments[1])
+        version = (
+            expand_version_arg(self.arguments[0], self.config.release),
+            self.arguments[1],
+        )
+        if version[1] == 'next':
+            raise ValueError(
+                'deprecated-removed:: second argument cannot be `next`')
         node['version'] = version
         env = self.state.document.settings.env
         current_version = tuple(int(e) for e in env.config.version.split('.'))
@@ -713,6 +734,10 @@ def setup(app):
     app.add_directive('availability', Availability)
     app.add_directive('audit-event', AuditEvent)
     app.add_directive('audit-event-table', AuditEventListDirective)
+    app.add_directive('versionadded', PyVersionChange, override=True)
+    app.add_directive('versionchanged', PyVersionChange, override=True)
+    app.add_directive('versionremoved', PyVersionChange, override=True)
+    app.add_directive('deprecated', PyVersionChange, override=True)
     app.add_directive('deprecated-removed', DeprecatedRemoved)
     app.add_builder(PydocTopicsBuilder)
     app.add_builder(suspicious.CheckSuspiciousMarkupBuilder)

--- a/Misc/NEWS.d/next/Documentation/2024-07-19-12-22-48.gh-issue-121277.wF_zKd.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-07-19-12-22-48.gh-issue-121277.wF_zKd.rst
@@ -1,0 +1,2 @@
+Writers of CPython's documentation can now use ``next`` as the version for
+the ``versionchanged``, ``versionadded``, ``deprecated`` directives.


### PR DESCRIPTION
Make ``versionchanged:: next`` expand to current (unreleased) version.

When a new CPython release is cut, the release manager will replace
all such occurences of "next" with the just-released version.
(See the issue for release-tools and devguide PRs.)

Obviously, this is not a security fix. It's an internal feature meant to make backporting easier.
@pablogsal, do you want this in 3.11?

The cherry-pick had conflicts that needed some rework.

---

I tested locally by adding this to docs:

```rest
   .. versionadded:: next

   .. deprecated-removed:: next 3.20

   .. versionadded:: 3.18

   .. deprecated-removed:: 3.18 3.20
```

With Sphinx 7.3.7:

![image](https://github.com/user-attachments/assets/49e99349-8991-483c-ba29-0850a52705d4)

With Sphinx 4.2.0 & other old reqs pinned in https://github.com/python/cpython/blob/3.11/Doc/requirements-oldest-sphinx.txt:

![image](https://github.com/user-attachments/assets/358733b8-02ac-4dda-80c6-9dcf94ee4123)


----

Co-authored-by: Adam Turner <9087854+AA-Turner@users.noreply.github.com>
Co-authored-by: Hugo van Kemenade <1324225+hugovk@users.noreply.github.com>
(cherry picked from commit https://github.com/python/cpython/commit/7d24ea9db3e8fdca52058629c9ba577aba3d8e5c)

Also backports follow-up GH-124623: Raise nice error on `next` as second argument to deprecated-removed

(cherry-picked from https://github.com/python/cpython/commit/e349f73a5ad2856b0a7cbe4aef7cc081c7aed777)


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121277 -->
* Issue: gh-121277
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127827.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->