### PR TITLE
gh-111609: Test `end_offset` in SyntaxError subclass

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2274,6 +2274,21 @@ class SyntaxErrorTests(unittest.TestCase):
                     self.assertIn(expected, err.getvalue())
                     the_exception = exc
 
+    def test_subclass(self):
+        class MySyntaxError(SyntaxError):
+            pass
+
+        try:
+            raise MySyntaxError("bad bad", ("bad.py", 1, 2, "abcdefg", 1, 7))
+        except SyntaxError as exc:
+            with support.captured_stderr() as err:
+                sys.__excepthook__(*sys.exc_info())
+            self.assertIn("""
+  File "bad.py", line 1
+    abcdefg
+     ^^^^^
+""", err.getvalue())
+
     def test_encodings(self):
         self.addCleanup(unlink, TESTFN)
         source = (


### PR DESCRIPTION
This was fixed as a side effect of #110702, but wasn't tested.

```python
class CustomSyntaxError(SyntaxError):
    pass

raise CustomSyntaxError("Error message", (None, 1, 5, 'a = sin(3)', 1, 9))
```

Output:

```pytb
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1
    a = sin(3)
        ^^^^
CustomSyntaxError: Error message
```


<!-- gh-issue-number: gh-111609 -->
* Issue: gh-111609
<!-- /gh-issue-number -->
