### PR TITLE
gh-127840: pass flags and address from send_fds

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -563,7 +563,7 @@ if hasattr(_socket.socket, "sendmsg"):
         import array
 
         return sock.sendmsg(buffers, [(_socket.SOL_SOCKET,
-            _socket.SCM_RIGHTS, array.array("i", fds))])
+            _socket.SCM_RIGHTS, array.array("i", fds))], flags, address)
     __all__.append("send_fds")
 
 if hasattr(_socket.socket, "recvmsg"):

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -7071,6 +7071,45 @@ class SendRecvFdsTests(unittest.TestCase):
             data = os.read(rfd, 100)
             self.assertEqual(data,  str(index).encode())
 
+    def testSendAndRecvFdsByAddress(self):
+        def close_pipes(pipes):
+            for fd1, fd2 in pipes:
+                os.close(fd1)
+                os.close(fd2)
+
+        def close_fds(fds):
+            for fd in fds:
+                os.close(fd)
+
+        # send 10 file descriptors
+        pipes = [os.pipe() for _ in range(10)]
+        self.addCleanup(close_pipes, pipes)
+        fds = [rfd for rfd, wfd in pipes]
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        address = socket_helper.create_unix_domain_name()
+        self.addCleanup(os_helper.unlink, address)
+        socket_helper.bind_unix_socket(sock, address)
+
+        socket.send_fds(sock, [MSG], fds, 0, address)
+
+        # request more data and file descriptors than expected
+        msg, fds2, flags, addr = socket.recv_fds(sock, len(MSG) * 2, len(fds) * 2)
+        self.addCleanup(close_fds, fds2)
+
+        self.assertEqual(msg, MSG)
+        self.assertEqual(len(fds2), len(fds))
+        self.assertEqual(flags, 0)
+
+        # test that file descriptors are connected
+        for index, fds in enumerate(pipes):
+            rfd, wfd = fds
+            os.write(wfd, str(index).encode())
+
+        for index, rfd in enumerate(fds2):
+            data = os.read(rfd, 100)
+            self.assertEqual(data,  str(index).encode())
+
 
 def setUpModule():
     thread_info = threading_helper.threading_setup()

--- a/Misc/NEWS.d/next/Library/2024-12-11-20-15-00.gh-issue-127840.pt8fiQ.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-11-20-15-00.gh-issue-127840.pt8fiQ.rst
@@ -1,1 +1,1 @@
-Fix ``socket.send_fds`` ignoring flags and address parameters
+Fix :func:`socket.send_fds` ignoring flags and address parameters.

--- a/Misc/NEWS.d/next/Library/2024-12-11-20-15-00.gh-issue-127840.pt8fiQ.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-11-20-15-00.gh-issue-127840.pt8fiQ.rst
@@ -1,0 +1,1 @@
+Fix ``socket.send_fds`` ignoring flags and address parameters


### PR DESCRIPTION
The new test is a copy of the existing test using `socketpair`. Let me know if I should refactor and merge these two somehow.

<!-- gh-issue-number: gh-127840 -->
* Issue: gh-127840
<!-- /gh-issue-number -->
