### PR TITLE
gh-127845: Minor improvements to iOS test runner script

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2169,7 +2169,7 @@ testios:
 	$(PYTHON_FOR_BUILD) $(srcdir)/iOS/testbed clone --framework $(PYTHONFRAMEWORKPREFIX) "$(XCFOLDER)"
 
 	# Run the testbed project
-	$(PYTHON_FOR_BUILD) "$(XCFOLDER)" run -- test -uall --single-process --rerun -W
+	$(PYTHON_FOR_BUILD) "$(XCFOLDER)" run --verbose -- test -uall --single-process --rerun -W
 
 # Like test, but using --slow-ci which enables all test resources and use
 # longer timeout. Run an optional pybuildbot.identify script to include

--- a/iOS/testbed/__main__.py
+++ b/iOS/testbed/__main__.py
@@ -186,7 +186,9 @@ def clone_testbed(
         sys.exit(10)
 
     if framework is None:
-        if not (source / "Python.xcframework/ios-arm64_x86_64-simulator/bin").is_dir():
+        if not (
+            source / "Python.xcframework/ios-arm64_x86_64-simulator/bin"
+        ).is_dir():
             print(
                 f"The testbed being cloned ({source}) does not contain "
                 f"a simulator framework. Re-run with --framework"
@@ -214,23 +216,27 @@ def clone_testbed(
     if framework is not None:
         if framework.suffix == ".xcframework":
             print("  Installing XCFramework...", end="", flush=True)
-            xc_framework_path = target / "Python.xcframework"
+            xc_framework_path = (target / "Python.xcframework").resolve()
             if xc_framework_path.is_dir():
                 shutil.rmtree(xc_framework_path)
             else:
                 xc_framework_path.unlink()
-            xc_framework_path.symlink_to(framework)
+            xc_framework_path.symlink_to(
+                framework.relative_to(xc_framework_path.parent, walk_up=True)
+            )
             print(" done")
         else:
             print("  Installing simulator framework...", end="", flush=True)
             sim_framework_path = (
                 target / "Python.xcframework" / "ios-arm64_x86_64-simulator"
-            )
+            ).resolve()
             if sim_framework_path.is_dir():
                 shutil.rmtree(sim_framework_path)
             else:
                 sim_framework_path.unlink()
-            sim_framework_path.symlink_to(framework)
+            sim_framework_path.symlink_to(
+                framework.relative_to(sim_framework_path.parent, walk_up=True)
+            )
             print(" done")
     else:
         print("  Using pre-existing iOS framework.")
@@ -351,7 +357,7 @@ def main():
         clone_testbed(
             source=Path(__file__).parent,
             target=Path(context.location),
-            framework=Path(context.framework) if context.framework else None,
+            framework=Path(context.framework).resolve() if context.framework else None,
             apps=[Path(app) for app in context.apps],
         )
     elif context.subcommand == "run":

--- a/iOS/testbed/__main__.py
+++ b/iOS/testbed/__main__.py
@@ -141,6 +141,7 @@ async def log_stream_task(initial_devices):
             else:
                 suppress_dupes = False
                 sys.stdout.write(line)
+            sys.stdout.flush()
 
 
 async def xcode_test(location, simulator, verbose):
@@ -170,6 +171,7 @@ async def xcode_test(location, simulator, verbose):
     ) as process:
         while line := (await process.stdout.readline()).decode(*DECODE_ARGS):
             sys.stdout.write(line)
+            sys.stdout.flush()
 
         status = await asyncio.wait_for(process.wait(), timeout=1)
         exit(status)

--- a/iOS/testbed/__main__.py
+++ b/iOS/testbed/__main__.py
@@ -202,33 +202,44 @@ def clone_testbed(
             )
             sys.exit(13)
 
-    print("Cloning testbed project...")
-    shutil.copytree(source, target)
+    print("Cloning testbed project:")
+    print(f"  Cloning {source}...", end="", flush=True)
+    shutil.copytree(source, target, symlinks=True)
+    print(" done")
 
     if framework is not None:
         if framework.suffix == ".xcframework":
-            print("Installing XCFramework...")
+            print("  Installing XCFramework...", end="", flush=True)
             xc_framework_path = target / "Python.xcframework"
-            shutil.rmtree(xc_framework_path)
-            shutil.copytree(framework, xc_framework_path)
+            if xc_framework_path.is_dir():
+                shutil.rmtree(xc_framework_path)
+            else:
+                xc_framework_path.unlink()
+            xc_framework_path.symlink_to(framework)
+            print(" done")
         else:
-            print("Installing simulator Framework...")
+            print("  Installing simulator framework...", end="", flush=True)
             sim_framework_path = (
                 target / "Python.xcframework" / "ios-arm64_x86_64-simulator"
             )
-            shutil.rmtree(sim_framework_path)
-            shutil.copytree(framework, sim_framework_path)
+            if sim_framework_path.is_dir():
+                shutil.rmtree(sim_framework_path)
+            else:
+                sim_framework_path.unlink()
+            sim_framework_path.symlink_to(framework)
+            print(" done")
     else:
-        print("Using pre-existing iOS framework.")
+        print("  Using pre-existing iOS framework.")
 
     for app_src in apps:
-        print(f"Installing app {app_src.name!r}...")
+        print(f"  Installing app {app_src.name!r}...", end="", flush=True)
         app_target = target / f"iOSTestbed/app/{app_src.name}"
         if app_target.is_dir():
             shutil.rmtree(app_target)
         shutil.copytree(app_src, app_target)
+        print(" done")
 
-    print(f"Testbed project created in {target}")
+    print(f"Successfully cloned testbed: {target.resolve()}")
 
 
 def update_plist(testbed_path, args):

--- a/iOS/testbed/__main__.py
+++ b/iOS/testbed/__main__.py
@@ -145,6 +145,7 @@ async def log_stream_task(initial_devices):
 
 async def xcode_test(location, simulator, verbose):
     # Run the test suite on the named simulator
+    print("Starting xcodebuild...")
     args = [
         "xcodebuild",
         "test",
@@ -259,8 +260,9 @@ def update_plist(testbed_path, args):
 
 async def run_testbed(simulator: str, args: list[str], verbose: bool=False):
     location = Path(__file__).parent
-    print("Updating plist...")
+    print("Updating plist...", end="", flush=True)
     update_plist(location, args)
+    print(" done.")
 
     # Get the list of devices that are booted at the start of the test run.
     # The simulator started by the test suite will be detected as the new

--- a/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
+++ b/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
@@ -24,8 +24,11 @@
 
     NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
 
-    // Disable all color, as the Xcode log can't display color
+    // Set some other common environment indicators to disable color, as the
+    // Xcode log can't display color. Stdout will report that it is *not* a
+    // TTY.
     setenv("NO_COLOR", "1", true);
+    setenv("PY_COLORS", "0", true);
 
     // Arguments to pass into the test suite runner.
     // argv[0] must identify the process; any subsequent arg


### PR DESCRIPTION
Implements some minor quality of life improvements to the iOS test runner, exposed through use on other projects.

* Adds a `--verbose` option to reduce the amount of output from Xcode builds (which will be mostly boilerplate)
* Uses symlinks instead of a copy when installing the iOS framework into the testbed
* Includes `PY_COLORS=0` in the list of environmental markers to disable colors
* Flushes stdout after every write, ensuring there's no internal buffering of log content.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127845 -->
* Issue: gh-127845
<!-- /gh-issue-number -->
