### PR TITLE
gh-127747: Resolve BytesWarning in test.support.strace_helper

### DIFF
--- a/Lib/test/support/strace_helper.py
+++ b/Lib/test/support/strace_helper.py
@@ -104,7 +104,8 @@ def strace_python(code, strace_flags, check=True):
         return StraceResult(
             strace_returncode=-1,
             python_returncode=-1,
-            event_bytes=f"error({reason},details={details}) = -1".encode('utf-8'),
+            event_bytes= \
+                f"error({reason},details={details!r}) = -1".encode('utf-8'),
             stdout=res.out if res else b"",
             stderr=res.err if res else b"")
 

--- a/Lib/test/support/strace_helper.py
+++ b/Lib/test/support/strace_helper.py
@@ -180,9 +180,10 @@ def get_syscalls(code, strace_flags, prelude="", cleanup="",
 @cache
 def _can_strace():
     res = strace_python("import sys; sys.exit(0)", [], check=False)
-    assert res.events(), "Should have parsed multiple calls"
-
-    return res.strace_returncode == 0 and res.python_returncode == 0
+    if res.strace_returncode == 0 and res.python_returncode == 0:
+        assert res.events(), "Should have parsed multiple calls"
+        return True
+    return False
 
 
 def requires_strace():

--- a/Lib/test/support/strace_helper.py
+++ b/Lib/test/support/strace_helper.py
@@ -104,8 +104,7 @@ def strace_python(code, strace_flags, check=True):
         return StraceResult(
             strace_returncode=-1,
             python_returncode=-1,
-            event_bytes= \
-                f"error({reason},details={details!r}) = -1".encode('utf-8'),
+            event_bytes= f"error({reason},details={details!r}) = -1".encode('utf-8'),
             stdout=res.out if res else b"",
             stderr=res.err if res else b"")
 


### PR DESCRIPTION
## Validation Steps:
1. Update `Lib/test/support/strace_helper.py` to set `_strace_binary` to `/usr/bin/false` (or don't have strace installed)
2. Run `./python -Werror -I -bb -m test.test_subprocess -vv POSIXProcessTestCase.test_vfork_used_when_expected`

## Description

The strace_helper code has a _make_error function to simplify making StraceResult objects in error cases. That takes a details parameter which is either a caught OSError or bytes. If it's bytes, _make_error would implicitly coerce that to a str inside of a f-string, resulting in a BytesWarning when the python test is invoked with [-b](https://docs.python.org/3.14/using/cmdline.html#cmdoption-b).

It is useful to distinguish between an OSError or bytes when debugging the test, so eliminate the BytesWarning and show both by changing to format with repr().

After fixing the implicing bytes-> str conversion, if `/usr/bin/strace` is uninstalled/doesn't exist, get a new error running the test:
```
  File "<source_dir>/cpython/Lib/test/support/strace_helper.py", line 183, in _can_strace
    assert res.events(), "Should have parsed multiple calls"
           ~~~~~~~~~~^^
AssertionError: Should have parsed multiple calls
```

Resolved by checking the exit code of the subprocess before asserting there should be events. Reason for asserting there are events, rather than returning False from `_can_strace`, is to try and ensure that if strace runs successfully and produces an output that can't be parsed that is a test error rather than silently disabling all strace tests (See: gh-121381 where a feature working was tested with strace but the strace tests stopped running, leading to this infrastructure in https://github.com/python/cpython/pull/123413).


skip news: This is a fix to an error message on a python test suite internal helper.

<!-- gh-issue-number: gh-127747 -->
* Issue: gh-127747
<!-- /gh-issue-number -->
