### PR TITLE
link to the correct output method in documentation

### DIFF
--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -98,7 +98,7 @@ Cookie Objects
 .. method:: BaseCookie.output(attrs=None, header='Set-Cookie:', sep='\r\n')
 
    Return a string representation suitable to be sent as HTTP headers. *attrs* and
-   *header* are sent to each :class:`Morsel`'s :meth:`output` method. *sep* is used
+   *header* are sent to each :class:`Morsel`'s :meth:`~Morsel.output` method. *sep* is used
    to join the headers together, and is by default the combination ``'\r\n'``
    (CRLF).
 


### PR DESCRIPTION
`BaseCookie` also had an `output` method so the link linked to that, instead of `Morsel`'s output at https://docs.python.org/3/library/http.cookies.html#http.cookies.BaseCookie.output

In theory this can be backported until 3.6 https://docs.python.org/3.6/library/http.cookies.html#http.cookies.BaseCookie.output but not sure if that is needed here.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127857.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->