### PR TITLE
GH-127903: Fix a crash on DEBUG builds when calling `_copy_characters`

### DIFF
--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -1910,7 +1910,7 @@ class StrTest(string_tests.StringLikeTest,
                               (b'\xF4'+cb+b'\xBF\xBF').decode, 'utf-8')
 
     def test_issue127903(self):
-        # Issue #127903: ``_copy_characters`` crashes on DEBUG builds when
+        # gh-127903: ``_copy_characters`` crashes on DEBUG builds when
         # there is nothing to copy.
         d = datetime.datetime(2013, 11, 10, 14, 20, 59)
         self.assertEqual(d.strftime('%z'), '')

--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -1910,9 +1910,10 @@ class StrTest(string_tests.StringLikeTest,
                               (b'\xF4'+cb+b'\xBF\xBF').decode, 'utf-8')
 
     def test_issue127903(self):
-        # Issue #127903: segmentation fault in debug mode in ``_copy_characters``
-        # when there is nothing to copy.
-        self.assertEqual(datetime.datetime(2013, 11, 10, 14, 20, 59).strftime('%z'), '')
+        # Issue #127903: ``_copy_characters`` crashes on DEBUG builds when
+        # there is nothing to copy.
+        d = datetime.datetime(2013, 11, 10, 14, 20, 59)
+        self.assertEqual(d.strftime('%z'), '')
 
     def test_issue8271(self):
         # Issue #8271: during the decoding of an invalid UTF-8 byte sequence,

--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -7,6 +7,7 @@ Written by Marc-Andre Lemburg (mal@lemburg.com).
 """
 import _string
 import codecs
+import datetime
 import itertools
 import operator
 import pickle
@@ -1907,6 +1908,11 @@ class StrTest(string_tests.StringLikeTest,
                               (b'\xF4'+cb+b'\x80\x80').decode, 'utf-8')
             self.assertRaises(UnicodeDecodeError,
                               (b'\xF4'+cb+b'\xBF\xBF').decode, 'utf-8')
+
+    def test_issue127903(self):
+        # Issue #127903: segmentation fault in debug mode in ``_copy_characters``
+        # when there is nothing to copy.
+        self.assertEqual(datetime.datetime(2013, 11, 10, 14, 20, 59).strftime('%z'), '')
 
     def test_issue8271(self):
         # Issue #8271: during the decoding of an invalid UTF-8 byte sequence,

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-13-14-17-24.gh-issue-127903.vemHSl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-13-14-17-24.gh-issue-127903.vemHSl.rst
@@ -1,0 +1,2 @@
+Fix segmentation fault in debug mode in ``_copy_characters`` when there is
+nothing to copy.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-13-14-17-24.gh-issue-127903.vemHSl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-13-14-17-24.gh-issue-127903.vemHSl.rst
@@ -1,2 +1,2 @@
-Fix segmentation fault in debug mode in ``_copy_characters`` when there is
-nothing to copy.
+``Objects/unicodeobject.c``: fix a crash on DEBUG builds in ``_copy_characters``
+when there is nothing to copy.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -1429,8 +1429,8 @@ _copy_characters(PyObject *to, Py_ssize_t to_start,
     assert(PyUnicode_Check(from));
     assert(from_start + how_many <= PyUnicode_GET_LENGTH(from));
 
-    assert((to == NULL && how_many == 0) || PyUnicode_Check(to));
-    assert((to == NULL && how_many == 0) || (to_start + how_many <= PyUnicode_GET_LENGTH(to)));
+    assert(to == NULL || PyUnicode_Check(to));
+    assert(how_many == 0 || (to_start + how_many <= PyUnicode_GET_LENGTH(to)));
 
     if (how_many == 0)
         return 0;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -1430,10 +1430,13 @@ _copy_characters(PyObject *to, Py_ssize_t to_start,
     assert(from_start + how_many <= PyUnicode_GET_LENGTH(from));
 
     assert(to == NULL || PyUnicode_Check(to));
-    assert(how_many == 0 || (to_start + how_many <= PyUnicode_GET_LENGTH(to)));
 
-    if (how_many == 0)
+    if (how_many == 0) {
         return 0;
+    }
+
+    assert(to != NULL);
+    assert(to_start + how_many <= PyUnicode_GET_LENGTH(to));
 
     from_kind = PyUnicode_KIND(from);
     from_data = PyUnicode_DATA(from);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -1429,11 +1429,11 @@ _copy_characters(PyObject *to, Py_ssize_t to_start,
     assert(PyUnicode_Check(from));
     assert(from_start + how_many <= PyUnicode_GET_LENGTH(from));
 
-    assert(PyUnicode_Check(to));
-    assert(to_start + how_many <= PyUnicode_GET_LENGTH(to));
-
     if (how_many == 0)
         return 0;
+
+    assert(PyUnicode_Check(to));
+    assert(to_start + how_many <= PyUnicode_GET_LENGTH(to));
 
     from_kind = PyUnicode_KIND(from);
     from_data = PyUnicode_DATA(from);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -1429,11 +1429,11 @@ _copy_characters(PyObject *to, Py_ssize_t to_start,
     assert(PyUnicode_Check(from));
     assert(from_start + how_many <= PyUnicode_GET_LENGTH(from));
 
+    assert((to == NULL && how_many == 0) || PyUnicode_Check(to));
+    assert((to == NULL && how_many == 0) || (to_start + how_many <= PyUnicode_GET_LENGTH(to)));
+
     if (how_many == 0)
         return 0;
-
-    assert(PyUnicode_Check(to));
-    assert(to_start + how_many <= PyUnicode_GET_LENGTH(to));
 
     from_kind = PyUnicode_KIND(from);
     from_data = PyUnicode_DATA(from);


### PR DESCRIPTION
Reproduce on Python 3.12.8+ or 3.13.1+, `main` work fine, but there is a problem there too:
```bash
./configure --with-pydebug
make
./python --version
Python 3.13.1+
./python -c 'import datetime as dt; dt.datetime(2013, 11, 10, 14, 20, 59).strftime("%z")'
Segmentation fault
```

No need to check `to` if we don't write there

<!-- gh-issue-number: gh-127903 -->
* Issue: gh-127903
<!-- /gh-issue-number -->
