### PR TITLE
gh-127879: Fix data race in `_PyFreeList_Push`

### DIFF
--- a/Include/internal/pycore_freelist.h
+++ b/Include/internal/pycore_freelist.h
@@ -51,7 +51,7 @@ static inline int
 _PyFreeList_Push(struct _Py_freelist *fl, void *obj, Py_ssize_t maxsize)
 {
     if (fl->size < maxsize && fl->size >= 0) {
-        *(void **)obj = fl->freelist;
+        FT_ATOMIC_STORE_PTR_RELAXED(*(void **)obj, fl->freelist);
         fl->freelist = obj;
         fl->size++;
         OBJECT_STAT_INC(to_freelist);


### PR DESCRIPTION
Writes to the `ob_tid` field need to use atomics because it may be concurrently read by a non-locking dictionary, list, or structmember read.


<!-- gh-issue-number: gh-127879 -->
* Issue: gh-127879
<!-- /gh-issue-number -->
