### PR TITLE
Revert "gh-127353: Allow to force color output on Windows (#127354)"

### DIFF
--- a/Lib/_colorize.py
+++ b/Lib/_colorize.py
@@ -32,6 +32,14 @@ def get_colors(colorize: bool = False) -> ANSIColors:
 
 
 def can_colorize() -> bool:
+    if sys.platform == "win32":
+        try:
+            import nt
+
+            if not nt._supports_virtual_terminal():
+                return False
+        except (ImportError, AttributeError):
+            return False
     if not sys.flags.ignore_environment:
         if os.environ.get("PYTHON_COLORS") == "0":
             return False
@@ -49,15 +57,6 @@ def can_colorize() -> bool:
 
     if not hasattr(sys.stderr, "fileno"):
         return False
-
-    if sys.platform == "win32":
-        try:
-            import nt
-
-            if not nt._supports_virtual_terminal():
-                return False
-        except (ImportError, AttributeError):
-            return False
 
     try:
         return os.isatty(sys.stderr.fileno())

--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -50,46 +50,9 @@ class TestColorizeFunction(unittest.TestCase):
                 with unittest.mock.patch("os.environ",
                                          {'FORCE_COLOR': '1', "PYTHON_COLORS": '0'}):
                     self.assertEqual(_colorize.can_colorize(), False)
-                with unittest.mock.patch("os.environ", {}):
-                    self.assertEqual(_colorize.can_colorize(), True)
-
                 isatty_mock.return_value = False
                 with unittest.mock.patch("os.environ", {}):
                     self.assertEqual(_colorize.can_colorize(), False)
-
-    @force_not_colorized
-    @unittest.skipUnless(sys.platform == "win32", "Windows only")
-    def test_colorized_detection_checks_for_environment_variables_no_vt(self):
-        with (unittest.mock.patch("nt._supports_virtual_terminal", return_value=False),
-              unittest.mock.patch("os.isatty") as isatty_mock,
-              unittest.mock.patch("sys.flags", unittest.mock.MagicMock(ignore_environment=False)),
-              unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE)):
-            isatty_mock.return_value = True
-            with unittest.mock.patch("os.environ", {'TERM': 'dumb'}):
-                self.assertEqual(_colorize.can_colorize(), False)
-            with unittest.mock.patch("os.environ", {'PYTHON_COLORS': '1'}):
-                self.assertEqual(_colorize.can_colorize(), True)
-            with unittest.mock.patch("os.environ", {'PYTHON_COLORS': '0'}):
-                self.assertEqual(_colorize.can_colorize(), False)
-            with unittest.mock.patch("os.environ", {'NO_COLOR': '1'}):
-                self.assertEqual(_colorize.can_colorize(), False)
-            with unittest.mock.patch("os.environ",
-                                     {'NO_COLOR': '1', "PYTHON_COLORS": '1'}):
-                self.assertEqual(_colorize.can_colorize(), True)
-            with unittest.mock.patch("os.environ", {'FORCE_COLOR': '1'}):
-                self.assertEqual(_colorize.can_colorize(), True)
-            with unittest.mock.patch("os.environ",
-                                     {'FORCE_COLOR': '1', 'NO_COLOR': '1'}):
-                self.assertEqual(_colorize.can_colorize(), False)
-            with unittest.mock.patch("os.environ",
-                                     {'FORCE_COLOR': '1', "PYTHON_COLORS": '0'}):
-                self.assertEqual(_colorize.can_colorize(), False)
-            with unittest.mock.patch("os.environ", {}):
-                self.assertEqual(_colorize.can_colorize(), False)
-
-            isatty_mock.return_value = False
-            with unittest.mock.patch("os.environ", {}):
-                self.assertEqual(_colorize.can_colorize(), False)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Windows/2024-11-28-15-55-48.gh-issue-127353.i-XOXg.rst
+++ b/Misc/NEWS.d/next/Windows/2024-11-28-15-55-48.gh-issue-127353.i-XOXg.rst
@@ -1,2 +1,0 @@
-Allow to force color output on Windows using environment variables. Patch by
-Andrey Efremov.


### PR DESCRIPTION
This reverts commit 365451e28368db46ae89a3a990d85c10c2284aa2 because it broke the buildbots: https://github.com/python/cpython/pull/127354#issuecomment-2539946997.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127353 -->
* Issue: gh-127353
<!-- /gh-issue-number -->
