### PR TITLE
[3.12] gh-127902: Make sure `extern "C"` is closed when using Py_LIMITED_API

### DIFF
--- a/Include/tracemalloc.h
+++ b/Include/tracemalloc.h
@@ -1,10 +1,10 @@
 #ifndef Py_TRACEMALLOC_H
 #define Py_TRACEMALLOC_H
+#ifndef Py_LIMITED_API
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#ifndef Py_LIMITED_API
 /* Track an allocated memory block in the tracemalloc module.
    Return 0 on success, return -1 on error (failed to allocate memory to store
    the trace).


### PR DESCRIPTION
This issue does not affect 3.13 or newer branches, so it is a direct fix in 3.12 branch, not a backport.

With this change, the `extern "C"` block is the inner-most like it is in Python 3.13, although the order of two `#ifndefs` is still different from 3.13 (but it does not matter).

Fixes #127902.

<!-- gh-issue-number: gh-127902 -->
* Issue: gh-127902
<!-- /gh-issue-number -->
