### PR TITLE
[3.12] gh-127906: Declare timeval struct in pytime.h on Windows

### DIFF
--- a/Include/cpython/pytime.h
+++ b/Include/cpython/pytime.h
@@ -53,7 +53,7 @@ functions and constants
 extern "C" {
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) || defined(_MSC_VER)
 struct timeval;
 #endif
 


### PR DESCRIPTION
Fix the following MSVC compiler warning:

    include\cpython\pytime.h(192): warning C4115: 'timeval':
    named type definition in parentheses

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127906 -->
* Issue: gh-127906
<!-- /gh-issue-number -->
