### PR TITLE
[3.12] gh-126937: ctypes: add test for maximum size of a struct field (GH-126938) (GH-127825)

### DIFF
--- a/Lib/test/test_ctypes/test_struct_fields.py
+++ b/Lib/test/test_ctypes/test_struct_fields.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 from ctypes import *
 
 class StructFieldsTestCase(unittest.TestCase):
@@ -68,6 +69,27 @@ class StructFieldsTestCase(unittest.TestCase):
         with self.assertRaisesRegex(TypeError,
                                     'ctypes state is not initialized'):
             class Subclass(BrokenStructure): ...
+
+    def test_max_field_size_gh126937(self):
+        # Classes for big structs should be created successfully.
+        # (But they most likely can't be instantiated.)
+        # The size must fit in Py_ssize_t.
+
+        class X(Structure):
+            _fields_ = [('char', c_char),]
+        max_field_size = sys.maxsize
+
+        class Y(Structure):
+            _fields_ = [('largeField', X * max_field_size)]
+        class Z(Structure):
+            _fields_ = [('largeField', c_char * max_field_size)]
+
+        with self.assertRaises(OverflowError):
+            class TooBig(Structure):
+                _fields_ = [('largeField', X * (max_field_size + 1))]
+        with self.assertRaises(OverflowError):
+            class TooBig(Structure):
+                _fields_ = [('largeField', c_char * (max_field_size + 1))]
 
     # __set__ and __get__ should raise a TypeError in case their self
     # argument is not a ctype instance.


### PR DESCRIPTION
This backports the *test* from GH-126938, with changed limit and exception class.

Co-authored-by: Melissa0x1f992 <70096546+Melissa0x1f992@users.noreply.github.com>
Co-authored-by: Peter Bierma <zintensitydev@gmail.com>
Co-authored-by: Terry Jan Reedy <tjreedy@udel.edu>

(cherry-picked from d51c1444e36e2cfdb33087f165819a7cd6774a9e)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-126937 -->
* Issue: gh-126937
<!-- /gh-issue-number -->
