### PR TITLE
Free arena on _PyCompile_AstOptimize failure in Py_CompileStringObject

### DIFF
--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1486,6 +1486,7 @@ Py_CompileStringObject(const char *str, PyObject *filename, int start,
     if (flags && (flags->cf_flags & PyCF_ONLY_AST)) {
         if ((flags->cf_flags & PyCF_OPTIMIZED_AST) == PyCF_OPTIMIZED_AST) {
             if (_PyCompile_AstOptimize(mod, filename, flags, optimize, arena) < 0) {
+                _PyArena_Free(arena);
                 return NULL;
             }
         }


### PR DESCRIPTION
After commit 10a91d7e9 introduced arena cleanup, commit 2dfbd4f36 removed the free call when _PyCompile_AstOptimize fails.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
