### PR TITLE
gh-127353: Allow to force color output on Windows V2

### DIFF
--- a/Lib/_colorize.py
+++ b/Lib/_colorize.py
@@ -32,14 +32,6 @@ def get_colors(colorize: bool = False) -> ANSIColors:
 
 
 def can_colorize() -> bool:
-    if sys.platform == "win32":
-        try:
-            import nt
-
-            if not nt._supports_virtual_terminal():
-                return False
-        except (ImportError, AttributeError):
-            return False
     if not sys.flags.ignore_environment:
         if os.environ.get("PYTHON_COLORS") == "0":
             return False
@@ -57,6 +49,15 @@ def can_colorize() -> bool:
 
     if not hasattr(sys.stderr, "fileno"):
         return False
+
+    if sys.platform == "win32":
+        try:
+            import nt
+
+            if not nt._supports_virtual_terminal():
+                return False
+        except (ImportError, AttributeError):
+            return False
 
     try:
         return os.isatty(sys.stderr.fileno())

--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -28,9 +28,12 @@ class TestColorizeFunction(unittest.TestCase):
 
             flags = unittest.mock.MagicMock(ignore_environment=False)
             with (unittest.mock.patch("os.isatty") as isatty_mock,
+                  unittest.mock.patch("sys.stderr") as stderr_mock,
                   unittest.mock.patch("sys.flags", flags),
                   unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE)):
                 isatty_mock.return_value = True
+                stderr_mock.fileno.return_value = 2
+                stderr_mock.isatty.return_value = True
                 with unittest.mock.patch("os.environ", {'TERM': 'dumb'}):
                     self.assertEqual(_colorize.can_colorize(), False)
                 with unittest.mock.patch("os.environ", {'PYTHON_COLORS': '1'}):
@@ -50,9 +53,52 @@ class TestColorizeFunction(unittest.TestCase):
                 with unittest.mock.patch("os.environ",
                                          {'FORCE_COLOR': '1', "PYTHON_COLORS": '0'}):
                     self.assertEqual(_colorize.can_colorize(), False)
+                with unittest.mock.patch("os.environ", {}):
+                    self.assertEqual(_colorize.can_colorize(), True)
+
                 isatty_mock.return_value = False
+                stderr_mock.isatty.return_value = False
                 with unittest.mock.patch("os.environ", {}):
                     self.assertEqual(_colorize.can_colorize(), False)
+
+    @force_not_colorized
+    @unittest.skipUnless(sys.platform == "win32", "Windows only")
+    def test_colorized_detection_checks_for_environment_variables_no_vt(self):
+        flags = unittest.mock.MagicMock(ignore_environment=False)
+        with (unittest.mock.patch("nt._supports_virtual_terminal", return_value=False),
+              unittest.mock.patch("os.isatty") as isatty_mock,
+              unittest.mock.patch("sys.stderr") as stderr_mock,
+              unittest.mock.patch("sys.flags", flags),
+              unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE)):
+            isatty_mock.return_value = True
+            stderr_mock.fileno.return_value = 2
+            stderr_mock.isatty.return_value = True
+            with unittest.mock.patch("os.environ", {'TERM': 'dumb'}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ", {'PYTHON_COLORS': '1'}):
+                self.assertEqual(_colorize.can_colorize(), True)
+            with unittest.mock.patch("os.environ", {'PYTHON_COLORS': '0'}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ", {'NO_COLOR': '1'}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ",
+                                     {'NO_COLOR': '1', "PYTHON_COLORS": '1'}):
+                self.assertEqual(_colorize.can_colorize(), True)
+            with unittest.mock.patch("os.environ", {'FORCE_COLOR': '1'}):
+                self.assertEqual(_colorize.can_colorize(), True)
+            with unittest.mock.patch("os.environ",
+                                     {'FORCE_COLOR': '1', 'NO_COLOR': '1'}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ",
+                                     {'FORCE_COLOR': '1', "PYTHON_COLORS": '0'}):
+                self.assertEqual(_colorize.can_colorize(), False)
+            with unittest.mock.patch("os.environ", {}):
+                self.assertEqual(_colorize.can_colorize(), False)
+
+            isatty_mock.return_value = False
+            stderr_mock.isatty.return_value = False
+            with unittest.mock.patch("os.environ", {}):
+                self.assertEqual(_colorize.can_colorize(), False)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Windows/2024-11-28-15-55-48.gh-issue-127353.i-XOXg.rst
+++ b/Misc/NEWS.d/next/Windows/2024-11-28-15-55-48.gh-issue-127353.i-XOXg.rst
@@ -1,0 +1,2 @@
+Allow to force color output on Windows using environment variables. Patch by
+Andrey Efremov.


### PR DESCRIPTION
This PR allows to force color output on Windows and brings the behavior of can_colorize function into compliance with POSIX. Second version of #127354 with fixed tests.

<!-- gh-issue-number: gh-127353 -->
* Issue: gh-127353
<!-- /gh-issue-number -->
