### PR TITLE
Fix buggy `__slots__` example definition in `_threading_local` docstring

### DIFF
--- a/Lib/_threading_local.py
+++ b/Lib/_threading_local.py
@@ -108,7 +108,7 @@ Note that subclasses can define slots, but they are not thread
 local. They are shared across threads:
 
   >>> class MyLocal(local):
-  ...     __slots__ = 'number'
+  ...     __slots__ = ['number']
 
   >>> mydata = MyLocal()
   >>> mydata.number = 42


### PR DESCRIPTION
This appears to have existed in the docstring for 20 years without anybody noticing. It's a very minor issue, but the example `__slots__` definition in this docstring actually creates 6 distinct slot descriptors on the class: 'n', 'u', 'm', 'b', 'e' and 'r'. I think this is almost certainly not what the example means to show.

We do actually point to this docstring from the docs on docs.python.org: https://docs.python.org/3/library/threading.html#threading.local