### PR TITLE
gh-128083: Fix macro redefinition warning in clinic.

### DIFF
--- a/Lib/test/clinic.test.c
+++ b/Lib/test/clinic.test.c
@@ -5400,7 +5400,7 @@ my silly docstring
 PyDoc_STRVAR(Test_setter_first_with_docstr__doc__,
 "my silly docstring");
 #if defined(Test_setter_first_with_docstr_DOCSTR)
-    #undef Test_setter_first_with_docstr_DOCSTR
+#   undef Test_setter_first_with_docstr_DOCSTR
 #endif
 #define Test_setter_first_with_docstr_DOCSTR Test_setter_first_with_docstr__doc__
 
@@ -5425,7 +5425,7 @@ Test_setter_first_with_docstr_get(TestObj *self, void *Py_UNUSED(context))
 
 static PyObject *
 Test_setter_first_with_docstr_get_impl(TestObj *self)
-/*[clinic end generated code: output=af9c9b2fcd03c0de input=10af4e43b3cb34dc]*/
+/*[clinic end generated code: output=749a30266f9fb443 input=10af4e43b3cb34dc]*/
 
 /*[clinic input]
 output push

--- a/Lib/test/clinic.test.c
+++ b/Lib/test/clinic.test.c
@@ -5359,6 +5359,75 @@ Test_property_set_impl(TestObj *self, PyObject *value)
 /*[clinic end generated code: output=e4342fe9bb1d7817 input=3bc3f46a23c83a88]*/
 
 /*[clinic input]
+@setter
+Test.setter_first_with_docstr
+[clinic start generated code]*/
+
+#if !defined(Test_setter_first_with_docstr_DOCSTR)
+#  define Test_setter_first_with_docstr_DOCSTR NULL
+#endif
+#if defined(TEST_SETTER_FIRST_WITH_DOCSTR_GETSETDEF)
+#  undef TEST_SETTER_FIRST_WITH_DOCSTR_GETSETDEF
+#  define TEST_SETTER_FIRST_WITH_DOCSTR_GETSETDEF {"setter_first_with_docstr", (getter)Test_setter_first_with_docstr_get, (setter)Test_setter_first_with_docstr_set, Test_setter_first_with_docstr_DOCSTR},
+#else
+#  define TEST_SETTER_FIRST_WITH_DOCSTR_GETSETDEF {"setter_first_with_docstr", NULL, (setter)Test_setter_first_with_docstr_set, NULL},
+#endif
+
+static int
+Test_setter_first_with_docstr_set_impl(TestObj *self, PyObject *value);
+
+static int
+Test_setter_first_with_docstr_set(TestObj *self, PyObject *value, void *Py_UNUSED(context))
+{
+    int return_value;
+
+    return_value = Test_setter_first_with_docstr_set_impl(self, value);
+
+    return return_value;
+}
+
+static int
+Test_setter_first_with_docstr_set_impl(TestObj *self, PyObject *value)
+/*[clinic end generated code: output=e4d76b558a4061db input=31a045ce11bbe961]*/
+
+/*[clinic input]
+@getter
+Test.setter_first_with_docstr
+
+my silly docstring
+[clinic start generated code]*/
+
+PyDoc_STRVAR(Test_setter_first_with_docstr__doc__,
+"my silly docstring");
+#if defined(Test_setter_first_with_docstr_DOCSTR)
+    #undef Test_setter_first_with_docstr_DOCSTR
+#endif
+#define Test_setter_first_with_docstr_DOCSTR Test_setter_first_with_docstr__doc__
+
+#if !defined(Test_setter_first_with_docstr_DOCSTR)
+#  define Test_setter_first_with_docstr_DOCSTR NULL
+#endif
+#if defined(TEST_SETTER_FIRST_WITH_DOCSTR_GETSETDEF)
+#  undef TEST_SETTER_FIRST_WITH_DOCSTR_GETSETDEF
+#  define TEST_SETTER_FIRST_WITH_DOCSTR_GETSETDEF {"setter_first_with_docstr", (getter)Test_setter_first_with_docstr_get, (setter)Test_setter_first_with_docstr_set, Test_setter_first_with_docstr_DOCSTR},
+#else
+#  define TEST_SETTER_FIRST_WITH_DOCSTR_GETSETDEF {"setter_first_with_docstr", (getter)Test_setter_first_with_docstr_get, NULL, Test_setter_first_with_docstr_DOCSTR},
+#endif
+
+static PyObject *
+Test_setter_first_with_docstr_get_impl(TestObj *self);
+
+static PyObject *
+Test_setter_first_with_docstr_get(TestObj *self, void *Py_UNUSED(context))
+{
+    return Test_setter_first_with_docstr_get_impl(self);
+}
+
+static PyObject *
+Test_setter_first_with_docstr_get_impl(TestObj *self)
+/*[clinic end generated code: output=af9c9b2fcd03c0de input=10af4e43b3cb34dc]*/
+
+/*[clinic input]
 output push
 output preset buffer
 [clinic start generated code]*/

--- a/Modules/_io/clinic/textio.c.h
+++ b/Modules/_io/clinic/textio.c.h
@@ -209,7 +209,7 @@ PyDoc_STRVAR(_io__TextIOBase_encoding__doc__,
 "\n"
 "Subclasses should override.");
 #if defined(_io__TextIOBase_encoding_DOCSTR)
-    #undef _io__TextIOBase_encoding_DOCSTR
+#   undef _io__TextIOBase_encoding_DOCSTR
 #endif
 #define _io__TextIOBase_encoding_DOCSTR _io__TextIOBase_encoding__doc__
 
@@ -239,7 +239,7 @@ PyDoc_STRVAR(_io__TextIOBase_newlines__doc__,
 "\n"
 "Subclasses should override.");
 #if defined(_io__TextIOBase_newlines_DOCSTR)
-    #undef _io__TextIOBase_newlines_DOCSTR
+#   undef _io__TextIOBase_newlines_DOCSTR
 #endif
 #define _io__TextIOBase_newlines_DOCSTR _io__TextIOBase_newlines__doc__
 
@@ -267,7 +267,7 @@ PyDoc_STRVAR(_io__TextIOBase_errors__doc__,
 "\n"
 "Subclasses should override.");
 #if defined(_io__TextIOBase_errors_DOCSTR)
-    #undef _io__TextIOBase_errors_DOCSTR
+#   undef _io__TextIOBase_errors_DOCSTR
 #endif
 #define _io__TextIOBase_errors_DOCSTR _io__TextIOBase_errors__doc__
 
@@ -1290,4 +1290,4 @@ _io_TextIOWrapper__CHUNK_SIZE_set(textio *self, PyObject *value, void *Py_UNUSED
 
     return return_value;
 }
-/*[clinic end generated code: output=a5fb7aa35e510524 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=423a320f087792b9 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/textio.c.h
+++ b/Modules/_io/clinic/textio.c.h
@@ -208,6 +208,9 @@ PyDoc_STRVAR(_io__TextIOBase_encoding__doc__,
 "Encoding of the text stream.\n"
 "\n"
 "Subclasses should override.");
+#if defined(_io__TextIOBase_encoding_DOCSTR)
+    #undef _io__TextIOBase_encoding_DOCSTR
+#endif
 #define _io__TextIOBase_encoding_DOCSTR _io__TextIOBase_encoding__doc__
 
 #if !defined(_io__TextIOBase_encoding_DOCSTR)
@@ -235,6 +238,9 @@ PyDoc_STRVAR(_io__TextIOBase_newlines__doc__,
 "Only line endings translated during reading are considered.\n"
 "\n"
 "Subclasses should override.");
+#if defined(_io__TextIOBase_newlines_DOCSTR)
+    #undef _io__TextIOBase_newlines_DOCSTR
+#endif
 #define _io__TextIOBase_newlines_DOCSTR _io__TextIOBase_newlines__doc__
 
 #if !defined(_io__TextIOBase_newlines_DOCSTR)
@@ -260,6 +266,9 @@ PyDoc_STRVAR(_io__TextIOBase_errors__doc__,
 "The error setting of the decoder or encoder.\n"
 "\n"
 "Subclasses should override.");
+#if defined(_io__TextIOBase_errors_DOCSTR)
+    #undef _io__TextIOBase_errors_DOCSTR
+#endif
 #define _io__TextIOBase_errors_DOCSTR _io__TextIOBase_errors__doc__
 
 #if !defined(_io__TextIOBase_errors_DOCSTR)
@@ -1281,4 +1290,4 @@ _io_TextIOWrapper__CHUNK_SIZE_set(textio *self, PyObject *value, void *Py_UNUSED
 
     return return_value;
 }
-/*[clinic end generated code: output=1172c500a022c65d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a5fb7aa35e510524 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -264,6 +264,9 @@ PyDoc_STRVAR(_ssl__SSLSocket_context__doc__,
 "This is typically used from within a callback function set by the sni_callback\n"
 "on the SSLContext to change the certificate information associated with the\n"
 "SSLSocket before the cryptographic exchange handshake messages.");
+#if defined(_ssl__SSLSocket_context_DOCSTR)
+    #undef _ssl__SSLSocket_context_DOCSTR
+#endif
 #define _ssl__SSLSocket_context_DOCSTR _ssl__SSLSocket_context__doc__
 
 #if !defined(_ssl__SSLSocket_context_DOCSTR)
@@ -318,6 +321,9 @@ _ssl__SSLSocket_context_set(PySSLSocket *self, PyObject *value, void *Py_UNUSED(
 
 PyDoc_STRVAR(_ssl__SSLSocket_server_side__doc__,
 "Whether this is a server-side socket.");
+#if defined(_ssl__SSLSocket_server_side_DOCSTR)
+    #undef _ssl__SSLSocket_server_side_DOCSTR
+#endif
 #define _ssl__SSLSocket_server_side_DOCSTR _ssl__SSLSocket_server_side__doc__
 
 #if !defined(_ssl__SSLSocket_server_side_DOCSTR)
@@ -347,6 +353,9 @@ _ssl__SSLSocket_server_side_get(PySSLSocket *self, void *Py_UNUSED(context))
 
 PyDoc_STRVAR(_ssl__SSLSocket_server_hostname__doc__,
 "The currently set server hostname (for SNI).");
+#if defined(_ssl__SSLSocket_server_hostname_DOCSTR)
+    #undef _ssl__SSLSocket_server_hostname_DOCSTR
+#endif
 #define _ssl__SSLSocket_server_hostname_DOCSTR _ssl__SSLSocket_server_hostname__doc__
 
 #if !defined(_ssl__SSLSocket_server_hostname_DOCSTR)
@@ -378,6 +387,9 @@ PyDoc_STRVAR(_ssl__SSLSocket_owner__doc__,
 "The Python-level owner of this object.\n"
 "\n"
 "Passed as \"self\" in servername callback.");
+#if defined(_ssl__SSLSocket_owner_DOCSTR)
+    #undef _ssl__SSLSocket_owner_DOCSTR
+#endif
 #define _ssl__SSLSocket_owner_DOCSTR _ssl__SSLSocket_owner__doc__
 
 #if !defined(_ssl__SSLSocket_owner_DOCSTR)
@@ -668,6 +680,9 @@ _ssl__SSLSocket_verify_client_post_handshake(PySSLSocket *self, PyObject *Py_UNU
 
 PyDoc_STRVAR(_ssl__SSLSocket_session__doc__,
 "The underlying SSLSession object.");
+#if defined(_ssl__SSLSocket_session_DOCSTR)
+    #undef _ssl__SSLSocket_session_DOCSTR
+#endif
 #define _ssl__SSLSocket_session_DOCSTR _ssl__SSLSocket_session__doc__
 
 #if !defined(_ssl__SSLSocket_session_DOCSTR)
@@ -722,6 +737,9 @@ _ssl__SSLSocket_session_set(PySSLSocket *self, PyObject *value, void *Py_UNUSED(
 
 PyDoc_STRVAR(_ssl__SSLSocket_session_reused__doc__,
 "Was the client session reused during handshake?");
+#if defined(_ssl__SSLSocket_session_reused_DOCSTR)
+    #undef _ssl__SSLSocket_session_reused_DOCSTR
+#endif
 #define _ssl__SSLSocket_session_reused_DOCSTR _ssl__SSLSocket_session_reused__doc__
 
 #if !defined(_ssl__SSLSocket_session_reused_DOCSTR)
@@ -1077,6 +1095,9 @@ _ssl__SSLContext_maximum_version_set(PySSLContext *self, PyObject *value, void *
 
 PyDoc_STRVAR(_ssl__SSLContext_num_tickets__doc__,
 "Control the number of TLSv1.3 session tickets.");
+#if defined(_ssl__SSLContext_num_tickets_DOCSTR)
+    #undef _ssl__SSLContext_num_tickets_DOCSTR
+#endif
 #define _ssl__SSLContext_num_tickets_DOCSTR _ssl__SSLContext_num_tickets__doc__
 
 #if !defined(_ssl__SSLContext_num_tickets_DOCSTR)
@@ -1131,6 +1152,9 @@ _ssl__SSLContext_num_tickets_set(PySSLContext *self, PyObject *value, void *Py_U
 
 PyDoc_STRVAR(_ssl__SSLContext_security_level__doc__,
 "The current security level.");
+#if defined(_ssl__SSLContext_security_level_DOCSTR)
+    #undef _ssl__SSLContext_security_level_DOCSTR
+#endif
 #define _ssl__SSLContext_security_level_DOCSTR _ssl__SSLContext_security_level__doc__
 
 #if !defined(_ssl__SSLContext_security_level_DOCSTR)
@@ -1778,6 +1802,9 @@ PyDoc_STRVAR(_ssl__SSLContext_sni_callback__doc__,
 "with the SSLSocket, the server name as a string, and the SSLContext object.\n"
 "\n"
 "See RFC 6066 for details of the SNI extension.");
+#if defined(_ssl__SSLContext_sni_callback_DOCSTR)
+    #undef _ssl__SSLContext_sni_callback_DOCSTR
+#endif
 #define _ssl__SSLContext_sni_callback_DOCSTR _ssl__SSLContext_sni_callback__doc__
 
 #if !defined(_ssl__SSLContext_sni_callback_DOCSTR)
@@ -2100,6 +2127,9 @@ exit:
 
 PyDoc_STRVAR(_ssl_MemoryBIO_pending__doc__,
 "The number of bytes pending in the memory BIO.");
+#if defined(_ssl_MemoryBIO_pending_DOCSTR)
+    #undef _ssl_MemoryBIO_pending_DOCSTR
+#endif
 #define _ssl_MemoryBIO_pending_DOCSTR _ssl_MemoryBIO_pending__doc__
 
 #if !defined(_ssl_MemoryBIO_pending_DOCSTR)
@@ -2129,6 +2159,9 @@ _ssl_MemoryBIO_pending_get(PySSLMemoryBIO *self, void *Py_UNUSED(context))
 
 PyDoc_STRVAR(_ssl_MemoryBIO_eof__doc__,
 "Whether the memory BIO is at EOF.");
+#if defined(_ssl_MemoryBIO_eof_DOCSTR)
+    #undef _ssl_MemoryBIO_eof_DOCSTR
+#endif
 #define _ssl_MemoryBIO_eof_DOCSTR _ssl_MemoryBIO_eof__doc__
 
 #if !defined(_ssl_MemoryBIO_eof_DOCSTR)
@@ -2262,6 +2295,9 @@ _ssl_MemoryBIO_write_eof(PySSLMemoryBIO *self, PyObject *Py_UNUSED(ignored))
 
 PyDoc_STRVAR(_ssl_SSLSession_time__doc__,
 "Session creation time (seconds since epoch).");
+#if defined(_ssl_SSLSession_time_DOCSTR)
+    #undef _ssl_SSLSession_time_DOCSTR
+#endif
 #define _ssl_SSLSession_time_DOCSTR _ssl_SSLSession_time__doc__
 
 #if !defined(_ssl_SSLSession_time_DOCSTR)
@@ -2291,6 +2327,9 @@ _ssl_SSLSession_time_get(PySSLSession *self, void *Py_UNUSED(context))
 
 PyDoc_STRVAR(_ssl_SSLSession_timeout__doc__,
 "Session timeout (delta in seconds).");
+#if defined(_ssl_SSLSession_timeout_DOCSTR)
+    #undef _ssl_SSLSession_timeout_DOCSTR
+#endif
 #define _ssl_SSLSession_timeout_DOCSTR _ssl_SSLSession_timeout__doc__
 
 #if !defined(_ssl_SSLSession_timeout_DOCSTR)
@@ -2320,6 +2359,9 @@ _ssl_SSLSession_timeout_get(PySSLSession *self, void *Py_UNUSED(context))
 
 PyDoc_STRVAR(_ssl_SSLSession_ticket_lifetime_hint__doc__,
 "Ticket life time hint.");
+#if defined(_ssl_SSLSession_ticket_lifetime_hint_DOCSTR)
+    #undef _ssl_SSLSession_ticket_lifetime_hint_DOCSTR
+#endif
 #define _ssl_SSLSession_ticket_lifetime_hint_DOCSTR _ssl_SSLSession_ticket_lifetime_hint__doc__
 
 #if !defined(_ssl_SSLSession_ticket_lifetime_hint_DOCSTR)
@@ -2349,6 +2391,9 @@ _ssl_SSLSession_ticket_lifetime_hint_get(PySSLSession *self, void *Py_UNUSED(con
 
 PyDoc_STRVAR(_ssl_SSLSession_id__doc__,
 "Session ID.");
+#if defined(_ssl_SSLSession_id_DOCSTR)
+    #undef _ssl_SSLSession_id_DOCSTR
+#endif
 #define _ssl_SSLSession_id_DOCSTR _ssl_SSLSession_id__doc__
 
 #if !defined(_ssl_SSLSession_id_DOCSTR)
@@ -2378,6 +2423,9 @@ _ssl_SSLSession_id_get(PySSLSession *self, void *Py_UNUSED(context))
 
 PyDoc_STRVAR(_ssl_SSLSession_has_ticket__doc__,
 "Does the session contain a ticket?");
+#if defined(_ssl_SSLSession_has_ticket_DOCSTR)
+    #undef _ssl_SSLSession_has_ticket_DOCSTR
+#endif
 #define _ssl_SSLSession_has_ticket_DOCSTR _ssl_SSLSession_has_ticket__doc__
 
 #if !defined(_ssl_SSLSession_has_ticket_DOCSTR)
@@ -2830,4 +2878,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=654d6d7af659f6cd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a79f84b6051085e1 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -265,7 +265,7 @@ PyDoc_STRVAR(_ssl__SSLSocket_context__doc__,
 "on the SSLContext to change the certificate information associated with the\n"
 "SSLSocket before the cryptographic exchange handshake messages.");
 #if defined(_ssl__SSLSocket_context_DOCSTR)
-    #undef _ssl__SSLSocket_context_DOCSTR
+#   undef _ssl__SSLSocket_context_DOCSTR
 #endif
 #define _ssl__SSLSocket_context_DOCSTR _ssl__SSLSocket_context__doc__
 
@@ -322,7 +322,7 @@ _ssl__SSLSocket_context_set(PySSLSocket *self, PyObject *value, void *Py_UNUSED(
 PyDoc_STRVAR(_ssl__SSLSocket_server_side__doc__,
 "Whether this is a server-side socket.");
 #if defined(_ssl__SSLSocket_server_side_DOCSTR)
-    #undef _ssl__SSLSocket_server_side_DOCSTR
+#   undef _ssl__SSLSocket_server_side_DOCSTR
 #endif
 #define _ssl__SSLSocket_server_side_DOCSTR _ssl__SSLSocket_server_side__doc__
 
@@ -354,7 +354,7 @@ _ssl__SSLSocket_server_side_get(PySSLSocket *self, void *Py_UNUSED(context))
 PyDoc_STRVAR(_ssl__SSLSocket_server_hostname__doc__,
 "The currently set server hostname (for SNI).");
 #if defined(_ssl__SSLSocket_server_hostname_DOCSTR)
-    #undef _ssl__SSLSocket_server_hostname_DOCSTR
+#   undef _ssl__SSLSocket_server_hostname_DOCSTR
 #endif
 #define _ssl__SSLSocket_server_hostname_DOCSTR _ssl__SSLSocket_server_hostname__doc__
 
@@ -388,7 +388,7 @@ PyDoc_STRVAR(_ssl__SSLSocket_owner__doc__,
 "\n"
 "Passed as \"self\" in servername callback.");
 #if defined(_ssl__SSLSocket_owner_DOCSTR)
-    #undef _ssl__SSLSocket_owner_DOCSTR
+#   undef _ssl__SSLSocket_owner_DOCSTR
 #endif
 #define _ssl__SSLSocket_owner_DOCSTR _ssl__SSLSocket_owner__doc__
 
@@ -681,7 +681,7 @@ _ssl__SSLSocket_verify_client_post_handshake(PySSLSocket *self, PyObject *Py_UNU
 PyDoc_STRVAR(_ssl__SSLSocket_session__doc__,
 "The underlying SSLSession object.");
 #if defined(_ssl__SSLSocket_session_DOCSTR)
-    #undef _ssl__SSLSocket_session_DOCSTR
+#   undef _ssl__SSLSocket_session_DOCSTR
 #endif
 #define _ssl__SSLSocket_session_DOCSTR _ssl__SSLSocket_session__doc__
 
@@ -738,7 +738,7 @@ _ssl__SSLSocket_session_set(PySSLSocket *self, PyObject *value, void *Py_UNUSED(
 PyDoc_STRVAR(_ssl__SSLSocket_session_reused__doc__,
 "Was the client session reused during handshake?");
 #if defined(_ssl__SSLSocket_session_reused_DOCSTR)
-    #undef _ssl__SSLSocket_session_reused_DOCSTR
+#   undef _ssl__SSLSocket_session_reused_DOCSTR
 #endif
 #define _ssl__SSLSocket_session_reused_DOCSTR _ssl__SSLSocket_session_reused__doc__
 
@@ -1096,7 +1096,7 @@ _ssl__SSLContext_maximum_version_set(PySSLContext *self, PyObject *value, void *
 PyDoc_STRVAR(_ssl__SSLContext_num_tickets__doc__,
 "Control the number of TLSv1.3 session tickets.");
 #if defined(_ssl__SSLContext_num_tickets_DOCSTR)
-    #undef _ssl__SSLContext_num_tickets_DOCSTR
+#   undef _ssl__SSLContext_num_tickets_DOCSTR
 #endif
 #define _ssl__SSLContext_num_tickets_DOCSTR _ssl__SSLContext_num_tickets__doc__
 
@@ -1153,7 +1153,7 @@ _ssl__SSLContext_num_tickets_set(PySSLContext *self, PyObject *value, void *Py_U
 PyDoc_STRVAR(_ssl__SSLContext_security_level__doc__,
 "The current security level.");
 #if defined(_ssl__SSLContext_security_level_DOCSTR)
-    #undef _ssl__SSLContext_security_level_DOCSTR
+#   undef _ssl__SSLContext_security_level_DOCSTR
 #endif
 #define _ssl__SSLContext_security_level_DOCSTR _ssl__SSLContext_security_level__doc__
 
@@ -1803,7 +1803,7 @@ PyDoc_STRVAR(_ssl__SSLContext_sni_callback__doc__,
 "\n"
 "See RFC 6066 for details of the SNI extension.");
 #if defined(_ssl__SSLContext_sni_callback_DOCSTR)
-    #undef _ssl__SSLContext_sni_callback_DOCSTR
+#   undef _ssl__SSLContext_sni_callback_DOCSTR
 #endif
 #define _ssl__SSLContext_sni_callback_DOCSTR _ssl__SSLContext_sni_callback__doc__
 
@@ -2128,7 +2128,7 @@ exit:
 PyDoc_STRVAR(_ssl_MemoryBIO_pending__doc__,
 "The number of bytes pending in the memory BIO.");
 #if defined(_ssl_MemoryBIO_pending_DOCSTR)
-    #undef _ssl_MemoryBIO_pending_DOCSTR
+#   undef _ssl_MemoryBIO_pending_DOCSTR
 #endif
 #define _ssl_MemoryBIO_pending_DOCSTR _ssl_MemoryBIO_pending__doc__
 
@@ -2160,7 +2160,7 @@ _ssl_MemoryBIO_pending_get(PySSLMemoryBIO *self, void *Py_UNUSED(context))
 PyDoc_STRVAR(_ssl_MemoryBIO_eof__doc__,
 "Whether the memory BIO is at EOF.");
 #if defined(_ssl_MemoryBIO_eof_DOCSTR)
-    #undef _ssl_MemoryBIO_eof_DOCSTR
+#   undef _ssl_MemoryBIO_eof_DOCSTR
 #endif
 #define _ssl_MemoryBIO_eof_DOCSTR _ssl_MemoryBIO_eof__doc__
 
@@ -2296,7 +2296,7 @@ _ssl_MemoryBIO_write_eof(PySSLMemoryBIO *self, PyObject *Py_UNUSED(ignored))
 PyDoc_STRVAR(_ssl_SSLSession_time__doc__,
 "Session creation time (seconds since epoch).");
 #if defined(_ssl_SSLSession_time_DOCSTR)
-    #undef _ssl_SSLSession_time_DOCSTR
+#   undef _ssl_SSLSession_time_DOCSTR
 #endif
 #define _ssl_SSLSession_time_DOCSTR _ssl_SSLSession_time__doc__
 
@@ -2328,7 +2328,7 @@ _ssl_SSLSession_time_get(PySSLSession *self, void *Py_UNUSED(context))
 PyDoc_STRVAR(_ssl_SSLSession_timeout__doc__,
 "Session timeout (delta in seconds).");
 #if defined(_ssl_SSLSession_timeout_DOCSTR)
-    #undef _ssl_SSLSession_timeout_DOCSTR
+#   undef _ssl_SSLSession_timeout_DOCSTR
 #endif
 #define _ssl_SSLSession_timeout_DOCSTR _ssl_SSLSession_timeout__doc__
 
@@ -2360,7 +2360,7 @@ _ssl_SSLSession_timeout_get(PySSLSession *self, void *Py_UNUSED(context))
 PyDoc_STRVAR(_ssl_SSLSession_ticket_lifetime_hint__doc__,
 "Ticket life time hint.");
 #if defined(_ssl_SSLSession_ticket_lifetime_hint_DOCSTR)
-    #undef _ssl_SSLSession_ticket_lifetime_hint_DOCSTR
+#   undef _ssl_SSLSession_ticket_lifetime_hint_DOCSTR
 #endif
 #define _ssl_SSLSession_ticket_lifetime_hint_DOCSTR _ssl_SSLSession_ticket_lifetime_hint__doc__
 
@@ -2392,7 +2392,7 @@ _ssl_SSLSession_ticket_lifetime_hint_get(PySSLSession *self, void *Py_UNUSED(con
 PyDoc_STRVAR(_ssl_SSLSession_id__doc__,
 "Session ID.");
 #if defined(_ssl_SSLSession_id_DOCSTR)
-    #undef _ssl_SSLSession_id_DOCSTR
+#   undef _ssl_SSLSession_id_DOCSTR
 #endif
 #define _ssl_SSLSession_id_DOCSTR _ssl_SSLSession_id__doc__
 
@@ -2424,7 +2424,7 @@ _ssl_SSLSession_id_get(PySSLSession *self, void *Py_UNUSED(context))
 PyDoc_STRVAR(_ssl_SSLSession_has_ticket__doc__,
 "Does the session contain a ticket?");
 #if defined(_ssl_SSLSession_has_ticket_DOCSTR)
-    #undef _ssl_SSLSession_has_ticket_DOCSTR
+#   undef _ssl_SSLSession_has_ticket_DOCSTR
 #endif
 #define _ssl_SSLSession_has_ticket_DOCSTR _ssl_SSLSession_has_ticket__doc__
 
@@ -2878,4 +2878,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=a79f84b6051085e1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e71f1ef621aead08 input=a9049054013a1b77]*/

--- a/Tools/clinic/libclinic/parse_args.py
+++ b/Tools/clinic/libclinic/parse_args.py
@@ -146,6 +146,9 @@ DOCSTRING_PROTOTYPE_STRVAR: Final[str] = libclinic.normalize_snippet("""
 GETSET_DOCSTRING_PROTOTYPE_STRVAR: Final[str] = libclinic.normalize_snippet("""
     PyDoc_STRVAR({getset_basename}__doc__,
     {docstring});
+    #if defined({getset_basename}_DOCSTR)
+        #undef {getset_basename}_DOCSTR
+    #endif
     #define {getset_basename}_DOCSTR {getset_basename}__doc__
 """)
 IMPL_DEFINITION_PROTOTYPE: Final[str] = libclinic.normalize_snippet("""

--- a/Tools/clinic/libclinic/parse_args.py
+++ b/Tools/clinic/libclinic/parse_args.py
@@ -147,7 +147,7 @@ GETSET_DOCSTRING_PROTOTYPE_STRVAR: Final[str] = libclinic.normalize_snippet("""
     PyDoc_STRVAR({getset_basename}__doc__,
     {docstring});
     #if defined({getset_basename}_DOCSTR)
-        #undef {getset_basename}_DOCSTR
+    #   undef {getset_basename}_DOCSTR
     #endif
     #define {getset_basename}_DOCSTR {getset_basename}__doc__
 """)


### PR DESCRIPTION
Apparently, gh-127341 wasn't the only issue with getters and setters in clinic. If you define a setter first, then the getter doesn't `#undef` the docstring accordingly.

<!-- gh-issue-number: gh-128083 -->
* Issue: gh-128083
<!-- /gh-issue-number -->
