### PR TITLE
Clarify ast docs to use a less confusing example for `ast.ParamSpec`

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1807,7 +1807,7 @@ aliases.
 
    .. doctest::
 
-        >>> print(ast.dump(ast.parse("type Alias[**P = (int, str)] = Callable[P, int]"), indent=4))
+        >>> print(ast.dump(ast.parse("type Alias[**P = [int, str]] = Callable[P, int]"), indent=4))
         Module(
             body=[
                 TypeAlias(
@@ -1815,7 +1815,7 @@ aliases.
                     type_params=[
                         ParamSpec(
                             name='P',
-                            default_value=Tuple(
+                            default_value=List(
                                 elts=[
                                     Name(id='int', ctx=Load()),
                                     Name(id='str', ctx=Load())],


### PR DESCRIPTION
Fixes a syntactical typo. The syntax is _valid_ and works fine at runtime, but I noticed that pyright was nitpicky about it.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127955.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->