### PR TITLE
gh-127209: Clarify and clean up the separation between BaseServer and TCPServer

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -49,7 +49,7 @@ There are four basic concrete server classes:
 
    .. attribute:: socket
 
-      The socket object on which the server will listen for incoming requests.
+      The :class:`socket.socket` object on which the server will listen for incoming requests.
 
 
    .. attribute:: allow_reuse_address

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -24,6 +24,55 @@ There are four basic concrete server classes:
    :meth:`~BaseServer.server_activate`.  The other parameters are passed to
    the :class:`BaseServer` base class.
 
+   In addition to the methods and attributes inherited from :class:`BaseServer`,
+   :class:`TCPServer` provides:
+
+
+   .. method:: fileno()
+
+      Return an integer file descriptor for the socket on which the server is
+      listening.  This function is most commonly passed to :mod:`selectors`, to
+      allow monitoring multiple servers in the same process.
+
+
+   .. method:: server_bind()
+
+      Called by the server's constructor to bind the socket to the desired address.
+      May be overridden.
+
+
+   .. attribute:: address_family
+
+      The family of protocols to which the server's socket belongs.
+      Common examples are :const:`socket.AF_INET` and :const:`socket.AF_UNIX`.
+
+
+   .. attribute:: socket
+
+      The socket object on which the server will listen for incoming requests.
+
+
+   .. attribute:: allow_reuse_address
+
+      Whether the server will allow the reuse of an address.  This defaults to
+      :const:`False`, and can be set in subclasses to change the policy.
+
+
+   .. attribute:: request_queue_size
+
+      The size of the request queue.  If it takes a long time to process a single
+      request, any requests that arrive while the server is busy are placed into a
+      queue, up to :attr:`request_queue_size` requests.  Once the queue is full,
+      further requests from clients will get a "Connection denied" error.  The default
+      value is usually 5, but this can be overridden by subclasses.
+
+
+   .. attribute:: socket_type
+
+      The type of socket used by the server; :const:`socket.SOCK_STREAM` and
+      :const:`socket.SOCK_DGRAM` are two common values.
+
+
 
 .. class:: UDPServer(server_address, RequestHandlerClass, bind_and_activate=True)
 
@@ -211,13 +260,6 @@ Server Objects
    :attr:`server_address` and :attr:`RequestHandlerClass` attributes.
 
 
-   .. method:: fileno()
-
-      Return an integer file descriptor for the socket on which the server is
-      listening.  This function is most commonly passed to :mod:`selectors`, to
-      allow monitoring multiple servers in the same process.
-
-
    .. method:: handle_request()
 
       Process a single request.  This function calls the following methods in
@@ -264,12 +306,6 @@ Server Objects
       Clean up the server. May be overridden.
 
 
-   .. attribute:: address_family
-
-      The family of protocols to which the server's socket belongs.
-      Common examples are :const:`socket.AF_INET` and :const:`socket.AF_UNIX`.
-
-
    .. attribute:: RequestHandlerClass
 
       The user-provided request handler class; an instance of this class is created
@@ -285,35 +321,9 @@ Server Objects
       the address, and an integer port number: ``('127.0.0.1', 80)``, for example.
 
 
-   .. attribute:: socket
-
-      The socket object on which the server will listen for incoming requests.
-
-
    The server classes support the following class variables:
 
    .. XXX should class variables be covered before instance variables, or vice versa?
-
-   .. attribute:: allow_reuse_address
-
-      Whether the server will allow the reuse of an address.  This defaults to
-      :const:`False`, and can be set in subclasses to change the policy.
-
-
-   .. attribute:: request_queue_size
-
-      The size of the request queue.  If it takes a long time to process a single
-      request, any requests that arrive while the server is busy are placed into a
-      queue, up to :attr:`request_queue_size` requests.  Once the queue is full,
-      further requests from clients will get a "Connection denied" error.  The default
-      value is usually 5, but this can be overridden by subclasses.
-
-
-   .. attribute:: socket_type
-
-      The type of socket used by the server; :const:`socket.SOCK_STREAM` and
-      :const:`socket.SOCK_DGRAM` are two common values.
-
 
    .. attribute:: timeout
 
@@ -340,6 +350,10 @@ Server Objects
       Must accept a request from the socket, and return a 2-tuple containing the *new*
       socket object to be used to communicate with the client, and the client's
       address.
+
+      An implementation of :meth:`get_request` is provided by :class:`TCPServer`.
+      Other classes which inherit from :class:`BaseServer` directly must provide
+      their own implementation.
 
 
    .. method:: handle_error(request, client_address)
@@ -380,12 +394,6 @@ Server Objects
       Called by the server's constructor to activate the server.  The default behavior
       for a TCP server just invokes :meth:`~socket.socket.listen`
       on the server's socket.  May be overridden.
-
-
-   .. method:: server_bind()
-
-      Called by the server's constructor to bind the socket to the desired address.
-      May be overridden.
 
 
    .. method:: verify_request(request, client_address)
@@ -697,4 +705,3 @@ The output of the example should look something like this:
 The :class:`ForkingMixIn` class is used in the same way, except that the server
 will spawn a new process for each request.
 Available only on POSIX platforms that support :func:`~os.fork`.
-

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -20,7 +20,7 @@ There are four basic concrete server classes:
    This uses the internet TCP protocol, which provides for
    continuous streams of data between the client and server.
    If *bind_and_activate* is true, the constructor automatically attempts to
-   invoke :meth:`~BaseServer.server_bind` and
+   invoke :meth:`~TCPServer.server_bind` and
    :meth:`~BaseServer.server_activate`.  The other parameters are passed to
    the :class:`BaseServer` base class.
 

--- a/Misc/NEWS.d/next/Documentation/2024-12-15-14-08-40.gh-issue-127209.17oPD0.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-12-15-14-08-40.gh-issue-127209.17oPD0.rst
@@ -1,7 +1,0 @@
-Updated documentation for :mod:`socketserver` to clarify the differences
-between :class:`socketserver.BaseServer` and
-:class:`socketserver.TCPServer`. Additionally, :class:`socketserver.BaseServer`
-no longer assumes that all subclasses will add a ``socket`` attribute, and
-:method:`socketserver.BaseServer.get_request` now raises ``NotImplementedError``.
-It was previously absent and attempting to use it would generate an
-``AttributeError``.

--- a/Misc/NEWS.d/next/Documentation/2024-12-15-14-08-40.gh-issue-127209.17oPD0.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-12-15-14-08-40.gh-issue-127209.17oPD0.rst
@@ -1,3 +1,7 @@
 Updated documentation for :mod:`socketserver` to clarify the differences
 between :class:`socketserver.BaseServer` and
-:class:`socketserver.TCPServer`.
+:class:`socketserver.TCPServer`. Additionally, :class:`socketserver.BaseServer`
+no longer assumes that all subclasses will add a ``socket`` attribute, and
+:method:`socketserver.BaseServer.get_request` now raises ``NotImplementedError``.
+It was previously absent and attempting to use it would generate an
+``AttributeError``.

--- a/Misc/NEWS.d/next/Documentation/2024-12-15-14-08-40.gh-issue-127209.17oPD0.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-12-15-14-08-40.gh-issue-127209.17oPD0.rst
@@ -1,0 +1,3 @@
+Updated documentation for :mod:`socketserver` to clarify the differences
+between :class:`socketserver.BaseServer` and
+:class:`socketserver.TCPServer`.

--- a/Misc/NEWS.d/next/Library/2024-12-15-14-08-40.gh-issue-127209.17oPD0.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-15-14-08-40.gh-issue-127209.17oPD0.rst
@@ -1,4 +1,4 @@
-:method:`socketserver.BaseServer.get_request` now raises ``NotImplementedError``.
+:meth:`socketserver.BaseServer.get_request` now raises ``NotImplementedError``.
 It was previously absent and attempting to use it would generate an
 ``AttributeError``. :class:`socketserver.BaseServer` no longer assumes that
 all subclasses will add a ``socket`` attribute. Updated documentation to

--- a/Misc/NEWS.d/next/Library/2024-12-15-14-08-40.gh-issue-127209.17oPD0.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-15-14-08-40.gh-issue-127209.17oPD0.rst
@@ -1,0 +1,6 @@
+:method:`socketserver.BaseServer.get_request` now raises ``NotImplementedError``.
+It was previously absent and attempting to use it would generate an
+``AttributeError``. :class:`socketserver.BaseServer` no longer assumes that
+all subclasses will add a ``socket`` attribute. Updated documentation to
+clarify the differences between :class:`socketserver.BaseServer` and
+:class:`socketserver.TCPServer`.


### PR DESCRIPTION
This turned out to *mostly* be a documentation change. I updated the documentation and docstrings to clarify what's from `BaseServer` and what's added by `TCPServer`. For code changes, I added a stub method for `BaseServer.get_request` which just raises `NotImplementedError`.

While examining the history of the module, it's clear to me that `BaseServer` was intended to not reference the socket used by `TCPServer` and it's subclasses. You can see the original commit which created `BaseServer` here: https://github.com/python/cpython/commit/90cb9067b82509ed4917084ffa85abc150509ff5

The use of `self.socket` in `BaseServer.handle_request` was introduced much later, and seems to me like it broke the expected separation. I added the private method `BaseSever._get_timeout` so that `TCPServer` can handle `socket.settimeout()` without requiring alternate implementations of `BaseServer` to have a `self.socket` attribute.

Unlike `get_request`, nothing in `BaseServer` uses `fileno` or `server_bind`, so I documented those two as being introduced by `TCPServer` rather than create a stub method for them.

I think it's also worth noting that `TCPServer` also adds a `allow_reuse_port` attribute which is not currently documented. I wasn't sure if there was a reason for that, so I didn't try to add it.

As suggested by @picnixz in the issue, this MR leaves the question of whether `BaseServer.get_request` should be marked as abstract for another time. It would make sense to do so, but I haven't checked any possible performance implications, so this is the conservative approach.

<!-- gh-issue-number: gh-127209 -->
* Issue: gh-127209
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127976.org.readthedocs.build/en/127976/library/socketserver.html#module-socketserver

<!-- readthedocs-preview cpython-previews end -->