### PR TITLE
Revert "gh-127586: properly restore blocked signals in resource_tracker.py (GH-127587)"

### DIFF
--- a/Lib/multiprocessing/resource_tracker.py
+++ b/Lib/multiprocessing/resource_tracker.py
@@ -155,14 +155,13 @@ class ResourceTracker(object):
                 # that can make the child die before it registers signal handlers
                 # for SIGINT and SIGTERM. The mask is unregistered after spawning
                 # the child.
-                prev_sigmask = None
                 try:
                     if _HAVE_SIGMASK:
-                        prev_sigmask = signal.pthread_sigmask(signal.SIG_BLOCK, _IGNORED_SIGNALS)
+                        signal.pthread_sigmask(signal.SIG_BLOCK, _IGNORED_SIGNALS)
                     pid = util.spawnv_passfds(exe, args, fds_to_pass)
                 finally:
-                    if prev_sigmask is not None:
-                        signal.pthread_sigmask(signal.SIG_SETMASK, prev_sigmask)
+                    if _HAVE_SIGMASK:
+                        signal.pthread_sigmask(signal.SIG_UNBLOCK, _IGNORED_SIGNALS)
             except:
                 os.close(w)
                 raise

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6044,21 +6044,6 @@ class TestResourceTracker(unittest.TestCase):
                 self._test_resource_tracker_leak_resources(
                     cleanup=cleanup,
                 )
-    @unittest.skipUnless(hasattr(signal, "pthread_sigmask"), "pthread_sigmask is not available")
-    def test_resource_tracker_blocked_signals(self):
-        #
-        # gh-127586: Check that resource_tracker does not override blocked signals of caller.
-        #
-        from multiprocessing.resource_tracker import ResourceTracker
-        signals = {signal.SIGTERM, signal.SIGINT, signal.SIGUSR1}
-
-        for sig in signals:
-            signal.pthread_sigmask(signal.SIG_SETMASK, {sig})
-            self.assertEqual(signal.pthread_sigmask(signal.SIG_BLOCK, set()), {sig})
-            tracker = ResourceTracker()
-            tracker.ensure_running()
-            self.assertEqual(signal.pthread_sigmask(signal.SIG_BLOCK, set()), {sig})
-            tracker._stop()
 
 class TestSimpleQueue(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2024-12-03-20-28-08.gh-issue-127586.zgotYF.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-03-20-28-08.gh-issue-127586.zgotYF.rst
@@ -1,3 +1,0 @@
-:class:`multiprocessing.pool.Pool` now properly restores blocked signal handlers
-of the parent thread when creating processes via either *spawn* or
-*forkserver*.


### PR DESCRIPTION
This reverts commit 46006a1b355f75d06c10e7b8086912c483b34487.

PR https://github.com/python/cpython/pull/127587 fails on some tier 1 and 2 buildbots which is blocking tomorrow's 3.14 alpha, here's a revert PR in case we need it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127586 -->
* Issue: gh-127586
<!-- /gh-issue-number -->
