### PR TITLE
gh-127146: Emscripten clean up test suite

### DIFF
--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -11,7 +11,7 @@ from test.support.os_helper import TESTFN_UNDECODABLE, FS_NONASCII
 from .filter import set_match_tests
 from .runtests import RunTests
 from .utils import (
-    setup_unraisable_hook, setup_threading_excepthook, fix_umask,
+    setup_unraisable_hook, setup_threading_excepthook,
     adjust_rlimit_nofile)
 
 
@@ -26,8 +26,6 @@ def setup_test_dir(testdir: str | None) -> None:
 
 
 def setup_process() -> None:
-    fix_umask()
-
     assert sys.__stderr__ is not None, "sys.__stderr__ is None"
     try:
         stderr_fd = sys.__stderr__.fileno()

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -478,17 +478,6 @@ def get_temp_dir(tmp_dir: StrPath | None = None) -> StrPath:
     return os.path.abspath(tmp_dir)
 
 
-def fix_umask() -> None:
-    if support.is_emscripten:
-        # Emscripten has default umask 0o777, which breaks some tests.
-        # see https://github.com/emscripten-core/emscripten/issues/17269
-        old_mask = os.umask(0)
-        if old_mask == 0o777:
-            os.umask(0o027)
-        else:
-            os.umask(old_mask)
-
-
 def get_work_dir(parent_dir: StrPath, worker: bool = False) -> StrPath:
     # Define a writable temp dir that will be used as cwd while running
     # the tests. The name of the dir includes the pid to allow parallel

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -10,7 +10,7 @@ from weakref import proxy
 from functools import wraps
 
 from test.support import (
-    cpython_only, swap_attr, gc_collect, is_emscripten, is_wasi,
+    cpython_only, swap_attr, gc_collect, is_wasi,
     infinite_recursion, strace_helper
 )
 from test.support.os_helper import (
@@ -531,7 +531,7 @@ class OtherFileTests:
             self.assertEqual(f.isatty(), False)
             f.close()
 
-            if sys.platform != "win32" and not is_emscripten:
+            if sys.platform != "win32":
                 try:
                     f = self.FileIO("/dev/tty", "a")
                 except OSError:

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -680,9 +680,6 @@ class HandlerTest(BaseTest):
             os.unlink(fn)
 
     @unittest.skipIf(os.name == 'nt', 'WatchedFileHandler not appropriate for Windows.')
-    @unittest.skipIf(
-        support.is_emscripten, "Emscripten cannot fstat unlinked files."
-    )
     @threading_helper.requires_working_threading()
     @support.requires_resource('walltime')
     def test_race(self):

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -1665,7 +1665,6 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         self.assertTrue(p.exists())
         self.assertEqual(p.stat().st_ctime, st_ctime_first)
 
-    @unittest.skipIf(is_emscripten, "FS root cannot be modified on Emscripten.")
     def test_mkdir_exist_ok_root(self):
         # Issue #25803: A drive root could raise PermissionError on Windows.
         self.cls('/').resolve().mkdir(exist_ok=True)
@@ -2031,7 +2030,6 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         self.assertEqual(expect, set(p.rglob(FakePath(pattern))))
 
     @needs_symlinks
-    @unittest.skipIf(is_emscripten, "Hangs")
     def test_glob_recurse_symlinks_common(self):
         def _check(path, glob, expected):
             actual = {path for path in path.glob(glob, recurse_symlinks=True)
@@ -2069,7 +2067,6 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         _check(p, "*/dirD/**/", ["dirC/dirD/"])
 
     @needs_symlinks
-    @unittest.skipIf(is_emscripten, "Hangs")
     def test_rglob_recurse_symlinks_common(self):
         def _check(path, glob, expected):
             actual = {path for path in path.rglob(glob, recurse_symlinks=True)
@@ -2476,9 +2473,7 @@ class PathWalkTest(test_pathlib_abc.DummyPathWalkTest):
             os.symlink(tmp5_path, broken_link3_path)
             self.sub2_tree[2].append('broken_link3')
             self.sub2_tree[2].sort()
-        if not is_emscripten:
-            # Emscripten fails with inaccessible directories.
-            os.chmod(sub21_path, 0)
+        os.chmod(sub21_path, 0)
         try:
             os.listdir(sub21_path)
         except PermissionError:

--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -1224,7 +1224,6 @@ class PydocImportTest(PydocBaseTest):
         self.assertEqual(err.getvalue(), '')
 
     @os_helper.skip_unless_working_chmod
-    @unittest.skipIf(is_emscripten, "cannot remove x bit")
     def test_apropos_empty_doc(self):
         pkgdir = os.path.join(TESTFN, 'walkpkg')
         os.mkdir(pkgdir)

--- a/Lib/test/test_strptime.py
+++ b/Lib/test/test_strptime.py
@@ -79,9 +79,6 @@ class LocaleTime_Tests(unittest.TestCase):
         self.assertEqual(self.LT_ins.am_pm[position], strftime_output,
                          "AM/PM representation in the wrong position within the tuple")
 
-    @unittest.skipIf(
-        support.is_emscripten, "musl libc issue on Emscripten, bpo-46390"
-    )
     def test_timezone(self):
         # Make sure timezone is correct
         timezone = time.strftime("%Z", self.time_tuple).lower()
@@ -431,9 +428,6 @@ class StrptimeTests(unittest.TestCase):
         self.assertEqual("Inconsistent use of : in -01:3030", str(err.exception))
 
     @skip_if_buggy_ucrt_strfptime
-    @unittest.skipIf(
-        support.is_emscripten, "musl libc issue on Emscripten, bpo-46390"
-    )
     def test_timezone(self):
         # Test timezone directives.
         # When gmtime() is used with %Z, entire result of strftime() is empty.

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -549,7 +549,6 @@ class TestSupport(unittest.TestCase):
                 self.check_options(opts, 'optim_args_from_interpreter_flags')
 
     @unittest.skipIf(support.is_apple_mobile, "Unstable on Apple Mobile")
-    @unittest.skipIf(support.is_emscripten, "Unstable in Emscripten")
     @unittest.skipIf(support.is_wasi, "Unavailable on WASI")
     def test_fd_count(self):
         # We cannot test the absolute value of fd_count(): on old Linux kernel

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -328,10 +328,6 @@ def _mock_candidate_names(*names):
 
 
 class TestBadTempdir:
-
-    @unittest.skipIf(
-        support.is_emscripten, "Emscripten cannot remove write bits."
-    )
     def test_read_only_directory(self):
         with _inside_empty_temp_dir():
             oldmode = mode = os.stat(tempfile.tempdir).st_mode
@@ -1240,9 +1236,6 @@ class TestSpooledTemporaryFile(BaseTestCase):
         with self.assertWarns(ResourceWarning):
             f.__del__()
 
-    @unittest.skipIf(
-        support.is_emscripten, "Emscripten cannot fstat renamed files."
-    )
     def test_del_rolled_file(self):
         # The rolled file should be deleted when the SpooledTemporaryFile
         # object is deleted. This should raise a ResourceWarning since the file
@@ -1468,9 +1461,6 @@ class TestSpooledTemporaryFile(BaseTestCase):
                 pass
         self.assertRaises(ValueError, use_closed)
 
-    @unittest.skipIf(
-        support.is_emscripten, "Emscripten cannot fstat renamed files."
-    )
     def test_truncate_with_size_parameter(self):
         # A SpooledTemporaryFile can be truncated to zero size
         f = tempfile.SpooledTemporaryFile(max_size=10)

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -361,9 +361,6 @@ class TimeTestCase(unittest.TestCase):
     def test_asctime_bounding_check(self):
         self._bounds_checking(time.asctime)
 
-    @unittest.skipIf(
-        support.is_emscripten, "musl libc issue on Emscripten, bpo-46390"
-    )
     def test_ctime(self):
         t = time.mktime((1973, 9, 16, 1, 3, 52, 0, 0, -1))
         self.assertEqual(time.ctime(t), 'Sun Sep 16 01:03:52 1973')
@@ -746,9 +743,6 @@ class TestStrftime4dyear(_TestStrftimeYear, _Test4dYear, unittest.TestCase):
 class TestPytime(unittest.TestCase):
     @skip_if_buggy_ucrt_strfptime
     @unittest.skipUnless(time._STRUCT_TM_ITEMS == 11, "needs tm_zone support")
-    @unittest.skipIf(
-        support.is_emscripten, "musl libc issue on Emscripten, bpo-46390"
-    )
     def test_localtime_timezone(self):
 
         # Get the localtime and examine it for the offset and zone.

--- a/Lib/test/test_unicode_file_functions.py
+++ b/Lib/test/test_unicode_file_functions.py
@@ -126,7 +126,7 @@ class UnicodeFileTests(unittest.TestCase):
     @unittest.skipIf(is_apple, 'irrelevant test on Apple platforms')
     @unittest.skipIf(
         support.is_wasi,
-        "test fails on Emscripten/WASI when host platform is macOS."
+        "test fails on WASI when host platform is macOS."
     )
     def test_normalize(self):
         files = set(self.files)

--- a/Lib/test/test_unicode_file_functions.py
+++ b/Lib/test/test_unicode_file_functions.py
@@ -125,7 +125,7 @@ class UnicodeFileTests(unittest.TestCase):
     # open(), os.stat(), etc. don't raise any exception.
     @unittest.skipIf(is_apple, 'irrelevant test on Apple platforms')
     @unittest.skipIf(
-        support.is_emscripten or support.is_wasi,
+        support.is_wasi,
         "test fails on Emscripten/WASI when host platform is macOS."
     )
     def test_normalize(self):


### PR DESCRIPTION
A lot of these skips are no longer necessary on Emscripten 3.1.74.

<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
