### PR TITLE
gh-127146: Emscripten Include compiler version in _PYTHON_HOST_PLATFORM

### DIFF
--- a/configure
+++ b/configure
@@ -4545,9 +4545,9 @@ printf "%s\n" "$IPHONEOS_DEPLOYMENT_TARGET" >&6; }
 	*-*-vxworks*)
 		_host_ident=$host_cpu
 		;;
-  *-*-emscripten)
-    _host_ident=$(cat $(dirname $(which emcc))/emscripten-version.txt | cut -d- -f1)-$host_cpu
-    ;;
+	*-*-emscripten)
+		_host_ident=$(emcc -dumpversion)-$host_cpu
+		;;
 	wasm32-*-* | wasm64-*-*)
 		_host_ident=$host_cpu
 		;;

--- a/configure
+++ b/configure
@@ -4545,6 +4545,9 @@ printf "%s\n" "$IPHONEOS_DEPLOYMENT_TARGET" >&6; }
 	*-*-vxworks*)
 		_host_ident=$host_cpu
 		;;
+  *-*-emscripten)
+    _host_ident=$(cat $(dirname $(which emcc))/emscripten-version.txt | cut -d- -f1)-$host_cpu
+    ;;
 	wasm32-*-* | wasm64-*-*)
 		_host_ident=$host_cpu
 		;;

--- a/configure.ac
+++ b/configure.ac
@@ -793,6 +793,9 @@ if test "$cross_compiling" = yes; then
 	*-*-vxworks*)
 		_host_ident=$host_cpu
 		;;
+  *-*-emscripten)
+    _host_ident=$(cat $(dirname $(which emcc))/emscripten-version.txt | cut -d- -f1)-$host_cpu
+    ;;
 	wasm32-*-* | wasm64-*-*)
 		_host_ident=$host_cpu
 		;;

--- a/configure.ac
+++ b/configure.ac
@@ -793,9 +793,9 @@ if test "$cross_compiling" = yes; then
 	*-*-vxworks*)
 		_host_ident=$host_cpu
 		;;
-  *-*-emscripten)
-    _host_ident=$(emcc -dumpversion)-$host_cpu
-    ;;
+	*-*-emscripten)
+		_host_ident=$(emcc -dumpversion)-$host_cpu
+		;;
 	wasm32-*-* | wasm64-*-*)
 		_host_ident=$host_cpu
 		;;

--- a/configure.ac
+++ b/configure.ac
@@ -794,7 +794,7 @@ if test "$cross_compiling" = yes; then
 		_host_ident=$host_cpu
 		;;
   *-*-emscripten)
-    _host_ident=$(cat $(dirname $(which emcc))/emscripten-version.txt | cut -d- -f1)-$host_cpu
+    _host_ident=$(emcc -dumpversion)-$host_cpu
     ;;
 	wasm32-*-* | wasm64-*-*)
 		_host_ident=$host_cpu


### PR DESCRIPTION
`test_sysconfigdata_json` is failing. This doesn't entirely fix it but it moves the failure later -- before this change it doesn't even find the sysconfigdata file because of a descrepancy between what `uname()` returns and what `configure.ac` sets `_PYTHON_HOST_PLATFORM` to. After, there are some small differences.

<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
