### PR TITLE
[3.12] gh-127906: Skip limited C API test_cext tests if Py_TRACE_REFS

### DIFF
--- a/Lib/test/test_cext/__init__.py
+++ b/Lib/test/test_cext/__init__.py
@@ -8,12 +8,14 @@ import os.path
 import shlex
 import shutil
 import subprocess
+import sys
 import unittest
 from test import support
 
 
 SOURCE = os.path.join(os.path.dirname(__file__), 'extension.c')
 SETUP = os.path.join(os.path.dirname(__file__), 'setup.py')
+Py_TRACE_REFS = hasattr(sys, 'getobjects')
 
 
 # With MSVC on a debug build, the linker fails with: cannot open file
@@ -47,6 +49,9 @@ class TestExt(unittest.TestCase):
         self.check_build('_test_limited_c11_cext', limited=True, std='c11')
 
     def check_build(self, extension_name, std=None, limited=False):
+        if limited and Py_TRACE_REFS:
+            self.skipTest('Py_LIMITED_API is incompatible with Py_TRACE_REFS')
+
         venv_dir = 'env'
         with support.setup_venv_with_pip_setuptools_wheel(venv_dir) as python_exe:
             self._check_build(extension_name, python_exe,

--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -4,12 +4,14 @@ import os.path
 import shlex
 import shutil
 import subprocess
+import sys
 import unittest
 from test import support
 
 
 SOURCE = os.path.join(os.path.dirname(__file__), 'extension.cpp')
 SETUP = os.path.join(os.path.dirname(__file__), 'setup.py')
+Py_TRACE_REFS = hasattr(sys, 'getobjects')
 
 
 # With MSVC on a debug build, the linker fails with: cannot open file
@@ -45,6 +47,9 @@ class TestCPPExt(unittest.TestCase):
         self.check_build('_testcppext_limited', limited=True)
 
     def check_build(self, extension_name, std=None, limited=False):
+        if limited and Py_TRACE_REFS:
+            self.skipTest('Py_LIMITED_API is incompatible with Py_TRACE_REFS')
+
         venv_dir = 'env'
         with support.setup_venv_with_pip_setuptools_wheel(venv_dir) as python_exe:
             self._check_build(extension_name, python_exe,


### PR DESCRIPTION
Skip limited C API tests in test_cext and test_cppext if Python is configured with --with-trace-refs (if the Py_TRACE_REFS macro is defined).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127906 -->
* Issue: gh-127906
<!-- /gh-issue-number -->
