### PR TITLE
Fix typo in itertools docs

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -681,7 +681,7 @@ loops that truncate the stream.
    consumed from the input iterator and there is no way to access it.
    This could be an issue if an application wants to further consume the
    input iterator after *takewhile* has been run to exhaustion.  To work
-   around this problem, consider using `more-iterools before_and_after()
+   around this problem, consider using `more-itertools before_and_after()
    <https://more-itertools.readthedocs.io/en/stable/api.html#more_itertools.before_and_after>`_
    instead.
 


### PR DESCRIPTION
"more-iterools" to "more-itertools"

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--127995.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->