### PR TITLE
Docs: Built-in Functions: Make missing functions appear in side nav

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -185,7 +185,7 @@ are always available.  They are listed here in alphabetical order.
 .. class:: bytearray(source=b'')
            bytearray(source, encoding)
            bytearray(source, encoding, errors)
-   :noindex:
+   :no-index-entry:
 
    Return a new array of bytes.  The :class:`bytearray` class is a mutable
    sequence of integers in the range 0 <= x < 256.  It has most of the usual
@@ -217,7 +217,7 @@ are always available.  They are listed here in alphabetical order.
 .. class:: bytes(source=b'')
            bytes(source, encoding)
            bytes(source, encoding, errors)
-   :noindex:
+   :no-index-entry:
 
    Return a new "bytes" object which is an immutable sequence of integers in
    the range ``0 <= x < 256``.  :class:`bytes` is an immutable version of
@@ -471,7 +471,7 @@ are always available.  They are listed here in alphabetical order.
 .. class:: dict(**kwarg)
            dict(mapping, **kwarg)
            dict(iterable, **kwarg)
-   :noindex:
+   :no-index-entry:
 
    Create a new dictionary.  The :class:`dict` object is the dictionary class.
    See :class:`dict` and :ref:`typesmapping` for documentation about this class.
@@ -847,7 +847,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. _func-frozenset:
 .. class:: frozenset(iterable=set())
-   :noindex:
+   :no-index-entry:
 
    Return a new :class:`frozenset` object, optionally with elements taken from
    *iterable*.  ``frozenset`` is a built-in class.  See :class:`frozenset` and
@@ -1146,7 +1146,7 @@ are always available.  They are listed here in alphabetical order.
 .. _func-list:
 .. class:: list()
            list(iterable)
-   :noindex:
+   :no-index-entry:
 
    Rather than being a function, :class:`list` is actually a mutable
    sequence type, as documented in :ref:`typesseq-list` and :ref:`typesseq`.
@@ -1252,7 +1252,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. _func-memoryview:
 .. class:: memoryview(object)
-   :noindex:
+   :no-index-entry:
 
    Return a "memory view" object created from the given argument.  See
    :ref:`typememoryview` for more information.
@@ -1731,7 +1731,7 @@ are always available.  They are listed here in alphabetical order.
 .. _func-range:
 .. class:: range(stop)
            range(start, stop, step=1)
-   :noindex:
+   :no-index-entry:
 
    Rather than being a function, :class:`range` is actually an immutable
    sequence type, as documented in :ref:`typesseq-range` and :ref:`typesseq`.
@@ -1799,7 +1799,7 @@ are always available.  They are listed here in alphabetical order.
 .. _func-set:
 .. class:: set()
            set(iterable)
-   :noindex:
+   :no-index-entry:
 
    Return a new :class:`set` object, optionally with elements taken from
    *iterable*.  ``set`` is a built-in class.  See :class:`set` and
@@ -1940,7 +1940,7 @@ are always available.  They are listed here in alphabetical order.
 .. _func-str:
 .. class:: str(object='')
            str(object=b'', encoding='utf-8', errors='strict')
-   :noindex:
+   :no-index-entry:
 
    Return a :class:`str` version of *object*.  See :func:`str` for details.
 
@@ -2056,7 +2056,7 @@ are always available.  They are listed here in alphabetical order.
 .. _func-tuple:
 .. class:: tuple()
            tuple(iterable)
-   :noindex:
+   :no-index-entry:
 
    Rather than being a function, :class:`tuple` is actually an immutable
    sequence type, as documented in :ref:`typesseq-tuple` and :ref:`typesseq`.


### PR DESCRIPTION
On the left side of https://docs.python.org/3/library/functions.html there is a gray side nav with a title at the top that says "Table of Contents". In that side nav there are many links to sections of that same page, but I noticed that there is no link to `list()` even though there is an entry for `list()` in the page.

This PR fixes that problem, but causes other problems. I don't know what the best solution is.

When I looked at the entry for `list()` in `Doc/library/functions.rst` I saw that there is a `:noindex:` directive on that entry. I also noticed that there are `:noindex:` directives on several other entries in that doc page. I tried removing them all and ran `make htmlview`, but then I noticed warning messages in the output of `make htmlview` that said, for example:

> WARNING: duplicate object description of bytearray, other instance in library/stdtypes, use :no-index: for one of them

I found [this Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/domains/index.html#basic-markup) that talks about directives that are similar to `:noindex:`. I don't fully understand it. I tried replacing all the `:noindex:` directives in `functions.rst` with `:no-index-entry:` directives. I noticed two effects from doing that:

1. ~~(Good) It silenced the warnings and the entries appeared in the side nav.~~ (Actually I can't get those warnings to show up anymore no matter what I do, even if I delete the `Doc/build/` directory and run `make htmlview` again.)
2. (Bad) When I use the docs search page to search all the docs for "list", the results are different when `:noindex:` and `:no-index-entry:` are used on the `list()` entry in `Doc/library/functions.rst`:
    - With `:noindex:`, the fifth search result for "list" is "list (Python class, in Built-in Types)" and links to `Doc/library/stdtypes.rst#list`.
    - But with `:no-index-entry:`, the fifth search result for "list" is "list (Python class, in Built-in Functions)" and links to `Doc/library/functions.rst#list`. (Also, the entry for `list()` in `functions.rst` attempts to link to the entry in `stdtypes.rst`, but the link instead now links back to the same entry in `functions.rst`.)

Since the definition in `stdtypes.rst` is more complete, changing the search result for `list()` is undesirable.

Does anyone know a way to make these entries show up in the side nav on the `functions.rst` page without changing other behaviors? Maybe instead of auto-generating the side nav content it could be manually, explicitly defined?

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128010.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->