### PR TITLE
Revert "gh-127864: Fix compiler warning (-Wstringop-truncation) (GH-127878)"

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -1176,10 +1176,9 @@ hashtable_key_from_2_strings(PyObject *str1, PyObject *str2, const char sep)
         return NULL;
     }
 
-    memcpy(key, str1_data, str1_len);
+    strncpy(key, str1_data, str1_len);
     key[str1_len] = sep;
-    memcpy(key + str1_len + 1, str2_data, str2_len);
-    key[size - 1] = '\0';
+    strncpy(key + str1_len + 1, str2_data, str2_len + 1);
     assert(strlen(key) == size - 1);
     return key;
 }


### PR DESCRIPTION
This reverts commit 081673801e3d47d931d2e2b6a4a1515e1207d938.

This may have caused a buildbot failure: [ARM64 MacOS M1 NoGIL 3.x](https://buildbot.python.org/#/builders/1270/builds/3247)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127864 -->
* Issue: gh-127864
<!-- /gh-issue-number -->
