### PR TITLE
gh-127085: Add a test skip if multiprocessing isn't available

### DIFF
--- a/Lib/test/test_memoryview.py
+++ b/Lib/test/test_memoryview.py
@@ -739,7 +739,10 @@ class OtherTest(unittest.TestCase):
 class RacingTest(unittest.TestCase):
     def test_racing_getbuf_and_releasebuf(self):
         """Repeatly access the memoryview for racing."""
-        from multiprocessing.managers import SharedMemoryManager
+        try:
+            from multiprocessing.managers import SharedMemoryManager
+        except ImportError:
+            self.skipTest("Test requires multiprocessing")
         from threading import Thread
 
         n = 100


### PR DESCRIPTION
#127412 added a test that requires the existence of `multiprocessing`. This test fails on iOS and Android because those platforms *have* threads, but don't have a multiprocessing module (because they don't support *processes*).

This PR skips the test on those platforms, so that the buildbots are no longer broken. There may be a better fix that involves re-writing the test to avoid the use of SharedMemoryManager.

/cc @LindaSummer @kumaraditya303 @ZeroIntensity @mhsmith 


<!-- gh-issue-number: gh-127085 -->
* Issue: gh-127085
<!-- /gh-issue-number -->
