### PR TITLE
gh-127949: deprecate `asyncio.set_event_loop_policy`

### DIFF
--- a/Doc/library/asyncio-policy.rst
+++ b/Doc/library/asyncio-policy.rst
@@ -46,6 +46,10 @@ for the current process:
 
    If *policy* is set to ``None``, the default policy is restored.
 
+   .. deprecated:: 3.14
+      The :func:`set_event_loop_policy` function is deprecated and
+      will be removed in Python 3.16.
+
 
 .. _asyncio-policy-objects:
 

--- a/Doc/library/asyncio-policy.rst
+++ b/Doc/library/asyncio-policy.rst
@@ -46,7 +46,7 @@ for the current process:
 
    If *policy* is set to ``None``, the default policy is restored.
 
-   .. deprecated:: 3.14
+   .. deprecated:: next
       The :func:`set_event_loop_policy` function is deprecated and
       will be removed in Python 3.16.
 

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -8,7 +8,9 @@ __all__ = (
     'AbstractEventLoopPolicy',
     'AbstractEventLoop', 'AbstractServer',
     'Handle', 'TimerHandle',
-    'get_event_loop_policy', 'set_event_loop_policy',
+    'get_event_loop_policy',
+    '_set_event_loop_policy',
+    'set_event_loop_policy',
     'get_event_loop', 'set_event_loop', 'new_event_loop',
     '_set_running_loop', 'get_running_loop',
     '_get_running_loop',
@@ -21,6 +23,7 @@ import socket
 import subprocess
 import sys
 import threading
+import warnings
 
 from . import format_helpers
 
@@ -765,7 +768,7 @@ def get_event_loop_policy():
     return _event_loop_policy
 
 
-def set_event_loop_policy(policy):
+def _set_event_loop_policy(policy):
     """Set the current event loop policy.
 
     If policy is None, the default policy is restored."""
@@ -774,6 +777,9 @@ def set_event_loop_policy(policy):
         raise TypeError(f"policy must be an instance of AbstractEventLoopPolicy or None, not '{type(policy).__name__}'")
     _event_loop_policy = policy
 
+def set_event_loop_policy(policy):
+    warnings._deprecated('set_event_loop_policy', remove=(3,16))
+    _set_event_loop_policy(policy)
 
 def get_event_loop():
     """Return an asyncio event loop.

--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -97,7 +97,7 @@ class saved_test_environment:
         return support.maybe_get_event_loop_policy()
     def restore_asyncio_events__event_loop_policy(self, policy):
         asyncio = self.get_module('asyncio')
-        asyncio.set_event_loop_policy(policy)
+        asyncio._set_event_loop_policy(policy)
 
     def get_sys_argv(self):
         return id(sys.argv), sys.argv, sys.argv[:]

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -629,7 +629,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
     def tearDown(self):
         self.loop.close()
         self.loop = None
-        asyncio.set_event_loop_policy(None)
+        asyncio._set_event_loop_policy(None)
 
     def check_async_iterator_anext(self, ait_class):
         with self.subTest(anext="pure-Python"):

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -25,7 +25,7 @@ MOCK_ANY = mock.ANY
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 def mock_socket_module():

--- a/Lib/test/test_asyncio/test_buffered_proto.py
+++ b/Lib/test/test_asyncio/test_buffered_proto.py
@@ -5,7 +5,7 @@ from test.test_asyncio import functional as func_tests
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class ReceiveStuffProto(asyncio.BufferedProtocol):

--- a/Lib/test/test_asyncio/test_context.py
+++ b/Lib/test/test_asyncio/test_context.py
@@ -4,7 +4,7 @@ import unittest
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 @unittest.skipUnless(decimal.HAVE_CONTEXTVAR, "decimal is built with a thread-local context")

--- a/Lib/test/test_asyncio/test_eager_task_factory.py
+++ b/Lib/test/test_asyncio/test_eager_task_factory.py
@@ -13,7 +13,7 @@ MOCK_ANY = mock.ANY
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class EagerTaskFactoryLoopTests:

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -36,10 +36,10 @@ from test import support
 from test.support import socket_helper
 from test.support import threading_helper
 from test.support import ALWAYS_EQ, LARGEST, SMALLEST
-
+from test.support import warnings_helper
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 def broken_unix_getsockname():
@@ -2764,13 +2764,17 @@ class PolicyTests(unittest.TestCase):
         self.assertIs(policy, asyncio.get_event_loop_policy())
 
     def test_set_event_loop_policy(self):
-        self.assertRaises(
-            TypeError, asyncio.set_event_loop_policy, object())
+        with self.assertWarnsRegex(
+                DeprecationWarning, "'set_event_loop_policy' is deprecated"):
+            self.assertRaises(
+                TypeError, asyncio.set_event_loop_policy, object())
 
         old_policy = asyncio.get_event_loop_policy()
 
         policy = asyncio.DefaultEventLoopPolicy()
-        asyncio.set_event_loop_policy(policy)
+        with self.assertWarnsRegex(
+                DeprecationWarning, "'set_event_loop_policy' is deprecated"):
+            asyncio.set_event_loop_policy(policy)
         self.assertIs(policy, asyncio.get_event_loop_policy())
         self.assertIsNot(policy, old_policy)
 
@@ -2857,7 +2861,7 @@ class GetEventLoopTestsMixin:
 
         old_policy = asyncio.get_event_loop_policy()
         try:
-            asyncio.set_event_loop_policy(Policy())
+            asyncio._set_event_loop_policy(Policy())
             loop = asyncio.new_event_loop()
 
             with self.assertRaises(TestError):
@@ -2885,7 +2889,7 @@ class GetEventLoopTestsMixin:
                 asyncio.get_event_loop()
 
         finally:
-            asyncio.set_event_loop_policy(old_policy)
+            asyncio._set_event_loop_policy(old_policy)
             if loop is not None:
                 loop.close()
 
@@ -2897,7 +2901,7 @@ class GetEventLoopTestsMixin:
     def test_get_event_loop_returns_running_loop2(self):
         old_policy = asyncio.get_event_loop_policy()
         try:
-            asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
+            asyncio._set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
             loop = asyncio.new_event_loop()
             self.addCleanup(loop.close)
 
@@ -2923,7 +2927,7 @@ class GetEventLoopTestsMixin:
                 asyncio.get_event_loop()
 
         finally:
-            asyncio.set_event_loop_policy(old_policy)
+            asyncio._set_event_loop_policy(old_policy)
             if loop is not None:
                 loop.close()
 

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -17,7 +17,7 @@ from test import support
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 def _fakefunc(f):

--- a/Lib/test/test_asyncio/test_futures2.py
+++ b/Lib/test/test_asyncio/test_futures2.py
@@ -7,7 +7,7 @@ from asyncio import tasks
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class FutureTests:

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -20,7 +20,7 @@ RGX_REPR = re.compile(STR_RGX_REPR)
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class LockTests(unittest.IsolatedAsyncioTestCase):

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -11,7 +11,7 @@ from test.test_asyncio import utils as test_utils
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 # Test that asyncio.iscoroutine() uses collections.abc.Coroutine

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -18,7 +18,7 @@ from test.test_asyncio import utils as test_utils
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 def close_transport(transport):

--- a/Lib/test/test_asyncio/test_protocols.py
+++ b/Lib/test/test_asyncio/test_protocols.py
@@ -7,7 +7,7 @@ import asyncio
 def tearDownModule():
     # not needed for the test file but added for uniformness with all other
     # asyncio test files for the sake of unified cleanup
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class ProtocolsAbsTests(unittest.TestCase):

--- a/Lib/test/test_asyncio/test_queues.py
+++ b/Lib/test/test_asyncio/test_queues.py
@@ -6,7 +6,7 @@ from types import GenericAlias
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class QueueBasicTests(unittest.IsolatedAsyncioTestCase):

--- a/Lib/test/test_asyncio/test_runners.py
+++ b/Lib/test/test_asyncio/test_runners.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 def interrupt_self():
@@ -61,7 +61,7 @@ class BaseTest(unittest.TestCase):
         super().setUp()
 
         policy = TestPolicy(self.new_loop)
-        asyncio.set_event_loop_policy(policy)
+        asyncio._set_event_loop_policy(policy)
 
     def tearDown(self):
         policy = asyncio.get_event_loop_policy()
@@ -69,7 +69,7 @@ class BaseTest(unittest.TestCase):
             self.assertTrue(policy.loop.is_closed())
             self.assertTrue(policy.loop.shutdown_ag_run)
 
-        asyncio.set_event_loop_policy(None)
+        asyncio._set_event_loop_policy(None)
         super().tearDown()
 
 
@@ -259,7 +259,7 @@ class RunTests(BaseTest):
             loop.set_task_factory(Task)
             return loop
 
-        asyncio.set_event_loop_policy(TestPolicy(new_event_loop))
+        asyncio._set_event_loop_policy(TestPolicy(new_event_loop))
         with self.assertRaises(asyncio.CancelledError):
             asyncio.run(main())
 

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -24,7 +24,7 @@ MOCK_ANY = mock.ANY
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class TestBaseSelectorEventLoop(BaseSelectorEventLoop):

--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -22,7 +22,7 @@ except ImportError:
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class MySendfileProto(asyncio.Protocol):

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -11,7 +11,7 @@ from test.test_asyncio import functional as func_tests
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class BaseStartServer(func_tests.FunctionalTestCaseMixin):

--- a/Lib/test/test_asyncio/test_sock_lowlevel.py
+++ b/Lib/test/test_asyncio/test_sock_lowlevel.py
@@ -15,7 +15,7 @@ if socket_helper.tcp_blackhole():
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class MyProto(asyncio.Protocol):

--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -29,7 +29,7 @@ BUF_MULTIPLIER = 1024 if not MACOS else 64
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class MyBaseProto(asyncio.Protocol):

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -21,7 +21,7 @@ from test.test_asyncio import functional as func_tests
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 @unittest.skipIf(ssl is None, 'No ssl module')

--- a/Lib/test/test_asyncio/test_staggered.py
+++ b/Lib/test/test_asyncio/test_staggered.py
@@ -8,7 +8,7 @@ support.requires_working_socket(module=True)
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class StaggeredTests(unittest.IsolatedAsyncioTestCase):

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -21,7 +21,7 @@ from test.support import requires_subprocess, socket_helper
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class StreamTests(test_utils.TestCase):

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -37,7 +37,7 @@ PROGRAM_CAT = [
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class TestSubprocessTransport(base_subprocess.BaseSubprocessTransport):

--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -14,7 +14,7 @@ from test.test_asyncio.utils import await_without_task
 
 # To prevent a warning "test altered the execution environment"
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class MyExc(Exception):

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -24,7 +24,7 @@ from test.support.warnings_helper import ignore_warnings
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 async def coroutine_function():

--- a/Lib/test/test_asyncio/test_threads.py
+++ b/Lib/test/test_asyncio/test_threads.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class ToThreadTests(unittest.IsolatedAsyncioTestCase):

--- a/Lib/test/test_asyncio/test_timeouts.py
+++ b/Lib/test/test_asyncio/test_timeouts.py
@@ -9,7 +9,7 @@ from test.test_asyncio.utils import await_without_task
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 class TimeoutTests(unittest.IsolatedAsyncioTestCase):
 

--- a/Lib/test/test_asyncio/test_transports.py
+++ b/Lib/test/test_asyncio/test_transports.py
@@ -10,7 +10,7 @@ from asyncio import transports
 def tearDownModule():
     # not needed for the test file but added for uniformness with all other
     # asyncio test files for the sake of unified cleanup
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class TransportTests(unittest.TestCase):

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -33,7 +33,7 @@ from test.test_asyncio import utils as test_utils
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 MOCK_ANY = mock.ANY

--- a/Lib/test/test_asyncio/test_waitfor.py
+++ b/Lib/test/test_asyncio/test_waitfor.py
@@ -5,7 +5,7 @@ from test import support
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 # The following value can be used as a very small timeout:

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -19,7 +19,7 @@ from test.test_asyncio import utils as test_utils
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class UpperProto(asyncio.Protocol):
@@ -334,11 +334,11 @@ class WinPolicyTests(WindowsEventsTestCase):
 
         old_policy = asyncio.get_event_loop_policy()
         try:
-            asyncio.set_event_loop_policy(
+            asyncio._set_event_loop_policy(
                 asyncio.WindowsSelectorEventLoopPolicy())
             asyncio.run(main())
         finally:
-            asyncio.set_event_loop_policy(old_policy)
+            asyncio._set_event_loop_policy(old_policy)
 
     def test_proactor_win_policy(self):
         async def main():
@@ -348,11 +348,11 @@ class WinPolicyTests(WindowsEventsTestCase):
 
         old_policy = asyncio.get_event_loop_policy()
         try:
-            asyncio.set_event_loop_policy(
+            asyncio._set_event_loop_policy(
                 asyncio.WindowsProactorEventLoopPolicy())
             asyncio.run(main())
         finally:
-            asyncio.set_event_loop_policy(old_policy)
+            asyncio._set_event_loop_policy(old_policy)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_asyncio/test_windows_utils.py
+++ b/Lib/test/test_asyncio/test_windows_utils.py
@@ -16,7 +16,7 @@ from test import support
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class PipeTests(unittest.TestCase):

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -493,7 +493,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
                     asyncio.run(eval(co, globals_))
                     self.assertEqual(globals_['a'], 1)
         finally:
-            asyncio.set_event_loop_policy(policy)
+            asyncio._set_event_loop_policy(policy)
 
     def test_compile_top_level_await_invalid_cases(self):
          # helper function just to check we can run top=level async-for
@@ -530,7 +530,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
                              mode,
                              flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
         finally:
-            asyncio.set_event_loop_policy(policy)
+            asyncio._set_event_loop_policy(policy)
 
 
     def test_compile_async_generator(self):

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -311,7 +311,7 @@ class AsyncioTest(InterpretersMixin, testasyncio_utils.TestCase):
         # tests left a policy in place, just in case.
         policy = support.maybe_get_event_loop_policy()
         assert policy is None, policy
-        cls.addClassCleanup(lambda: asyncio.set_event_loop_policy(None))
+        cls.addClassCleanup(lambda: asyncio._set_event_loop_policy(None))
 
     def setUp(self):
         super().setUp()

--- a/Lib/test/test_contextlib_async.py
+++ b/Lib/test/test_contextlib_async.py
@@ -11,7 +11,7 @@ from test.test_contextlib import TestBaseExitStack
 support.requires_working_socket(module=True)
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class TestAbstractAsyncContextManager(unittest.IsolatedAsyncioTestCase):

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2294,7 +2294,7 @@ class CoroAsyncIOCompatTest(unittest.TestCase):
             pass
         finally:
             loop.close()
-            asyncio.set_event_loop_policy(None)
+            asyncio._set_event_loop_policy(None)
 
         self.assertEqual(buffer, [1, 2, 'MyException'])
 

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -75,7 +75,7 @@ git = mod.StupidGit()
 
 def tearDownModule():
     if support.has_socket_support:
-        asyncio.set_event_loop_policy(None)
+        asyncio._set_event_loop_policy(None)
 
 
 def signatures_with_lexicographic_keyword_only_parameters():

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5352,7 +5352,7 @@ class LogRecordTest(BaseTest):
                 logging.logAsyncioTasks = False
                 runner.run(make_record(self.assertIsNone))
         finally:
-            asyncio.set_event_loop_policy(None)
+            asyncio._set_event_loop_policy(None)
 
     @support.requires_working_socket()
     def test_taskName_without_asyncio_imported(self):
@@ -5364,7 +5364,7 @@ class LogRecordTest(BaseTest):
                 logging.logAsyncioTasks = False
                 runner.run(make_record(self.assertIsNone))
         finally:
-            asyncio.set_event_loop_policy(None)
+            asyncio._set_event_loop_policy(None)
 
 
 class BasicConfigTest(unittest.TestCase):
@@ -5668,7 +5668,7 @@ class BasicConfigTest(unittest.TestCase):
                 data = f.read().strip()
             self.assertRegex(data, r'Task-\d+ - hello world')
         finally:
-            asyncio.set_event_loop_policy(None)
+            asyncio._set_event_loop_policy(None)
             if handler:
                 handler.close()
 

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -105,7 +105,7 @@ requires_splice_pipe = unittest.skipIf(sys.platform.startswith("aix"),
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class MiscTests(unittest.TestCase):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2132,7 +2132,7 @@ if not SKIP_ASYNCIO_TESTS:
         ...     loop = asyncio.new_event_loop()
         ...     loop.run_until_complete(test_main())
         ...     loop.close()
-        ...     asyncio.set_event_loop_policy(None)
+        ...     asyncio._set_event_loop_policy(None)
         ...     print("finished")
 
         >>> with PdbTestInput(['step',
@@ -2253,7 +2253,7 @@ if not SKIP_ASYNCIO_TESTS:
         ...     loop = asyncio.new_event_loop()
         ...     loop.run_until_complete(test_main())
         ...     loop.close()
-        ...     asyncio.set_event_loop_policy(None)
+        ...     asyncio._set_event_loop_policy(None)
         ...     print("finished")
 
         >>> with PdbTestInput(['step',
@@ -2353,7 +2353,7 @@ if not SKIP_ASYNCIO_TESTS:
         ...     loop = asyncio.new_event_loop()
         ...     loop.run_until_complete(test_main())
         ...     loop.close()
-        ...     asyncio.set_event_loop_policy(None)
+        ...     asyncio._set_event_loop_policy(None)
         ...     print("finished")
 
         >>> with PdbTestInput(['step',

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -2070,7 +2070,7 @@ class JumpTestCase(unittest.TestCase):
             asyncio.run(func(output))
 
         sys.settrace(None)
-        asyncio.set_event_loop_policy(None)
+        asyncio._set_event_loop_policy(None)
         self.compare_jump_output(expected, output)
 
     def jump_test(jumpFrom, jumpTo, expected, error=None, event='line', warning=None):

--- a/Lib/test/test_unittest/test_async_case.py
+++ b/Lib/test/test_unittest/test_async_case.py
@@ -12,7 +12,7 @@ class MyException(Exception):
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class TestCM:
@@ -490,7 +490,7 @@ class TestAsyncCase(unittest.TestCase):
         self.assertTrue(result.wasSuccessful())
 
     def test_loop_factory(self):
-        asyncio.set_event_loop_policy(None)
+        asyncio._set_event_loop_policy(None)
 
         class TestCase1(unittest.IsolatedAsyncioTestCase):
             loop_factory = asyncio.EventLoop

--- a/Lib/test/test_unittest/testmock/testasync.py
+++ b/Lib/test/test_unittest/testmock/testasync.py
@@ -15,7 +15,7 @@ from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock, Mock,
 
 
 def tearDownModule():
-    asyncio.set_event_loop_policy(None)
+    asyncio._set_event_loop_policy(None)
 
 
 class AsyncClass:


### PR DESCRIPTION
I am skipping news for now, I'll add docs and what's new when all the work is completed at the end to avoid having many news entry for the same. 

<!-- gh-issue-number: gh-127949 -->
* Issue: gh-127949
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128024.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->