### PR TITLE
gh-126742: add missing NEWS entry

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-12-17-12-41-07.gh-issue-126742.l07qvT.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-17-12-41-07.gh-issue-126742.l07qvT.rst
@@ -1,0 +1,3 @@
+Fix localization of error messages reported by :manpage:`dlerror(3)` and
+:manpage:`gdbm_strerror <gdbm(3)>` in :mod:`ctypes` and :mod:`dbm.gnu`
+functions respectively. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2024-12-17-12-41-07.gh-issue-126742.l07qvT.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-17-12-41-07.gh-issue-126742.l07qvT.rst
@@ -1,3 +1,3 @@
-Fix localization of error messages reported by :manpage:`dlerror(3)` and
+Fix support of localized error messages reported by :manpage:`dlerror(3)` and
 :manpage:`gdbm_strerror <gdbm(3)>` in :mod:`ctypes` and :mod:`dbm.gnu`
 functions respectively. Patch by Bénédikt Tran.


### PR DESCRIPTION
Since Serhiy categorized the previous PR as a bug fix, and since the changes may be non-trivial, I suggest adding this NEWS entry. I don't know whether it's better to talk about localization or non-UTF8 messages though.

<!-- gh-issue-number: gh-126742 -->
* Issue: gh-126742
<!-- /gh-issue-number -->
