### PR TITLE
gh-128030: Avoid error from PyModule_GetFilenameObject for non-module

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-17-22-28-15.gh-issue-128030.H1ptOD.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-17-22-28-15.gh-issue-128030.H1ptOD.rst
@@ -1,0 +1,1 @@
+Avoid error from calling ``PyModule_GetFilenameObject`` on a non-module object when importing a non-existent symbol from a non-module object.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2863,13 +2863,15 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
     if (origin == NULL) {
         // Fall back to __file__ for diagnostics if we don't have
         // an origin that is a location
-        origin = PyModule_GetFilenameObject(v);
-        if (origin == NULL) {
-            if (!PyErr_ExceptionMatches(PyExc_SystemError)) {
-                goto done;
+        if (PyModule_Check(v)) {
+            origin = PyModule_GetFilenameObject(v);
+            if (origin == NULL) {
+                if (!PyErr_ExceptionMatches(PyExc_SystemError)) {
+                    goto done;
+                }
+                // PyModule_GetFilenameObject raised "module filename missing"
+                _PyErr_Clear(tstate);
             }
-            // PyModule_GetFilenameObject raised "module filename missing"
-            _PyErr_Clear(tstate);
         }
         assert(origin == NULL || PyUnicode_Check(origin));
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2860,18 +2860,16 @@ _PyEval_ImportFrom(PyThreadState *tstate, PyObject *v, PyObject *name)
         }
     }
 
-    if (origin == NULL) {
+    if (origin == NULL && PyModule_Check(v)) {
         // Fall back to __file__ for diagnostics if we don't have
         // an origin that is a location
-        if (PyModule_Check(v)) {
-            origin = PyModule_GetFilenameObject(v);
-            if (origin == NULL) {
-                if (!PyErr_ExceptionMatches(PyExc_SystemError)) {
-                    goto done;
-                }
-                // PyModule_GetFilenameObject raised "module filename missing"
-                _PyErr_Clear(tstate);
+        origin = PyModule_GetFilenameObject(v);
+        if (origin == NULL) {
+            if (!PyErr_ExceptionMatches(PyExc_SystemError)) {
+                goto done;
             }
+            // PyModule_GetFilenameObject raised "module filename missing"
+            _PyErr_Clear(tstate);
         }
         assert(origin == NULL || PyUnicode_Check(origin));
     }


### PR DESCRIPTION
I missed the extra `PyModule_Check` in #127660 because I was looking at 3.12 as the base implementation for import from. This meant that I missed the `PyModuleCheck` introduced in #112661 (see [here](https://github.com/python/cpython/pull/112661/files#diff-c22186367cbe20233e843261998dc027ae5f1f8c0d2e778abfa454ae74cc59deR2647)).

<!-- gh-issue-number: gh-128030 -->
* Issue: gh-128030
<!-- /gh-issue-number -->
