### PR TITLE
gh-128069: Do not manually brew link Tcl/Tk to fix macOS CI failure

### DIFF
--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -39,10 +39,7 @@ jobs:
         path: config.cache
         key: ${{ github.job }}-${{ inputs.os }}-${{ env.IMAGE_VERSION }}-${{ inputs.config_hash }}
     - name: Install Homebrew dependencies
-      run: |
-        brew install pkg-config openssl@3.0 xz gdbm tcl-tk@8 make
-        # Because alternate versions are not symlinked into place by default:
-        brew link tcl-tk@8
+      run: brew install pkg-config openssl@3.0 xz gdbm tcl-tk@8 make
     - name: Configure CPython
       run: |
         GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \


### PR DESCRIPTION
To me the [current macOS build failure](https://github.com/python/cpython/actions/runs/12396242149/job/34603835485#step:5:99) sounds like `tcl-tk@8` has already been linked during `brew install`. This removes the manual `brew link` step.
~~Let's see what CI thinks 🤞~~ Looks like this now [makes sonoma fail](https://github.com/python/cpython/actions/runs/12401971318/job/34622530396?pr=128082#step:5:112). I guess we should follow [this suggestion](https://github.com/python/cpython/issues/128069#issuecomment-2551539393).

Sorry for the noise.

<!-- gh-issue-number: gh-128069 -->
* Issue: gh-128069
<!-- /gh-issue-number -->
