### PR TITLE
[3.9] gh-121277: Allow .. versionadded:: next in docs (GH-121278)

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -22,6 +22,7 @@ from docutils import nodes, utils
 
 from sphinx import addnodes
 from sphinx.builders import Builder
+from sphinx.domains.changeset import VersionChange
 try:
     from sphinx.errors import NoUri
 except ImportError:
@@ -332,7 +333,22 @@ class PyAbstractMethod(PyMethod):
         return PyMethod.run(self)
 
 
-# Support for documenting version of removal in deprecations
+# Support for documenting version of changes, additions, deprecations
+
+def expand_version_arg(argument, release):
+    """Expand "next" to the current version"""
+    if argument == 'next':
+        return sphinx_gettext('{} (unreleased)').format(release)
+    return argument
+
+
+class PyVersionChange(VersionChange):
+    def run(self):
+        # Replace the 'next' special token with the current development version
+        self.arguments[0] = expand_version_arg(self.arguments[0],
+                                               self.config.release)
+        return super().run()
+
 
 class DeprecatedRemoved(Directive):
     has_content = True
@@ -348,18 +364,24 @@ class DeprecatedRemoved(Directive):
         node = addnodes.versionmodified()
         node.document = self.state.document
         node['type'] = 'deprecated-removed'
-        version = (self.arguments[0], self.arguments[1])
-        node['version'] = version
         env = self.state.document.settings.env
+        version = (
+            expand_version_arg(self.arguments[0], env.config.release),
+            self.arguments[1],
+        )
+        if version[1] == 'next':
+            raise ValueError(
+                'deprecated-removed:: second argument cannot be `next`')
+        node['version'] = version
         current_version = tuple(int(e) for e in env.config.version.split('.'))
-        removed_version = tuple(int(e) for e in self.arguments[1].split('.'))
+        removed_version = tuple(int(e) for e in version[1].split('.'))
         if current_version < removed_version:
             label = self._deprecated_label
         else:
             label = self._removed_label
 
         label = translators['sphinx'].gettext(label)
-        text = label.format(deprecated=self.arguments[0], removed=self.arguments[1])
+        text = label.format(deprecated=version[0], removed=version[1])
         if len(self.arguments) == 3:
             inodes, messages = self.state.inline_text(self.arguments[2],
                                                       self.lineno+1)
@@ -607,6 +629,10 @@ def setup(app):
     app.add_directive('availability', Availability)
     app.add_directive('audit-event', AuditEvent)
     app.add_directive('audit-event-table', AuditEventListDirective)
+    app.add_directive('versionadded', PyVersionChange, override=True)
+    app.add_directive('versionchanged', PyVersionChange, override=True)
+    app.add_directive('versionremoved', PyVersionChange, override=True)
+    app.add_directive('deprecated', PyVersionChange, override=True)
     app.add_directive('deprecated-removed', DeprecatedRemoved)
     app.add_builder(PydocTopicsBuilder)
     app.add_builder(suspicious.CheckSuspiciousMarkupBuilder)

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -338,7 +338,7 @@ class PyAbstractMethod(PyMethod):
 def expand_version_arg(argument, release):
     """Expand "next" to the current version"""
     if argument == 'next':
-        return sphinx_gettext('{} (unreleased)').format(release)
+        return translators['sphinx'].gettext('{} (unreleased)').format(release)
     return argument
 
 

--- a/Misc/NEWS.d/next/Documentation/2024-07-19-12-22-48.gh-issue-121277.wF_zKd.rst
+++ b/Misc/NEWS.d/next/Documentation/2024-07-19-12-22-48.gh-issue-121277.wF_zKd.rst
@@ -1,0 +1,2 @@
+Writers of CPython's documentation can now use ``next`` as the version for
+the ``versionchanged``, ``versionadded``, ``deprecated`` directives.


### PR DESCRIPTION
Make `versionchanged:: next`` expand to current (unreleased) version.

When a new CPython release is cut, the release manager will replace all such occurences of "next" with the just-released version. (See the issue for release-tools and devguide PRs.)

This is not a security fix, but an internal feature meant to make backporting easier. Pablo allowed it in 3.10-3.11 though. @ambv, do you want it in 3.9?

Tested on Sphinx 2.4 & 4.5 with a local change (like in GH-127827).
(On Sphinx 5 the build fails for an unrelated reason: #98366.)

---

Co-authored-by: Adam Turner <9087854+AA-Turner@users.noreply.github.com>
Co-authored-by: Hugo van Kemenade <1324225+hugovk@users.noreply.github.com>
(cherry picked from commit 7d24ea9db3e8fdca52058629c9ba577aba3d8e5c)

gh-121277: Raise nice error on `next` as second argument to deprecated-removed (GH-124623)

(cherry-picked from e349f73a5ad2856b0a7cbe4aef7cc081c7aed777)

Updates for 3.9: avoid the new `sphinx_gettext`

(cherry-picked from 3.10: 8773554b717cfb08b4bd11a927813f4ed74762c7)
