### PR TITLE
gh-128118: Improve performance of copy.copy by using a fast lookup for atomic and container types

### DIFF
--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -67,13 +67,15 @@ def copy(x):
 
     cls = type(x)
 
-    copier = _copy_dispatch.get(cls)
-    if copier:
-        return copier(x)
+    if cls in _copy_atomic_types:
+        return x
+    if cls in _copy_builtin_containers:
+        return cls.copy(x)
+
 
     if issubclass(cls, type):
         # treat it as a regular class:
-        return _copy_immutable(x)
+        return x
 
     copier = getattr(cls, "__copy__", None)
     if copier is not None:
@@ -98,23 +100,12 @@ def copy(x):
     return _reconstruct(x, None, *rv)
 
 
-_copy_dispatch = d = {}
-
-def _copy_immutable(x):
-    return x
-for t in (types.NoneType, int, float, bool, complex, str, tuple,
+_copy_atomic_types = (types.NoneType, int, float, bool, complex, str, tuple,
           bytes, frozenset, type, range, slice, property,
           types.BuiltinFunctionType, types.EllipsisType,
           types.NotImplementedType, types.FunctionType, types.CodeType,
-          weakref.ref, super):
-    d[t] = _copy_immutable
-
-d[list] = list.copy
-d[dict] = dict.copy
-d[set] = set.copy
-d[bytearray] = bytearray.copy
-
-del d, t
+          weakref.ref, super)
+_copy_builtin_containers = (list, dict, set, bytearray)
 
 def deepcopy(x, memo=None, _nil=[]):
     """Deep copy operation on arbitrary Python objects.

--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -100,12 +100,12 @@ def copy(x):
     return _reconstruct(x, None, *rv)
 
 
-_copy_atomic_types = (types.NoneType, int, float, bool, complex, str, tuple,
+_copy_atomic_types = {types.NoneType, int, float, bool, complex, str, tuple,
           bytes, frozenset, type, range, slice, property,
           types.BuiltinFunctionType, types.EllipsisType,
           types.NotImplementedType, types.FunctionType, types.CodeType,
-          weakref.ref, super)
-_copy_builtin_containers = (list, dict, set, bytearray)
+          weakref.ref, super}
+_copy_builtin_containers = {list, dict, set, bytearray}
 
 def deepcopy(x, memo=None, _nil=[]):
     """Deep copy operation on arbitrary Python objects.

--- a/Misc/NEWS.d/next/Library/2024-12-20-10-57-10.gh-issue-128118.mYak8i.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-20-10-57-10.gh-issue-128118.mYak8i.rst
@@ -1,0 +1,1 @@
+Improve performance of :func:`copy.copy` by adding a fast path for atomic types and container types.

--- a/Misc/NEWS.d/next/Library/2024-12-20-10-57-10.gh-issue-128118.mYak8i.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-20-10-57-10.gh-issue-128118.mYak8i.rst
@@ -1,1 +1,2 @@
-Improve performance of :func:`copy.copy` by adding a fast path for atomic types and container types.
+Improve performance of :func:`copy.copy` by 30% via
+a fast path for atomic types and container types.


### PR DESCRIPTION
Similar to the approached used for `copy.deepcopy` in #114266 we can simplifly the implementation of `copy.copy` and improve performance by checking on the type of the argument using a lookup. 

Results:
```
copy int: Mean +- std dev: [main] 159 ns +- 10 ns -> [pr_v2] 104 ns +- 7 ns: 1.54x faster
copy slice: Mean +- std dev: [main] 184 ns +- 44 ns -> [pr_v2] 109 ns +- 13 ns: 1.69x faster
copy dict: Mean +- std dev: [main] 196 ns +- 18 ns -> [pr_v2] 182 ns +- 16 ns: 1.07x faster
copy dataclass: Mean +- std dev: [main] 1.88 us +- 0.13 us -> [pr_v2] 1.82 us +- 0.11 us: 1.04x faster
copy small list: Mean +- std dev: [main] 179 ns +- 18 ns -> [pr_v2] 134 ns +- 7 ns: 1.33x faster
copy small tuple: Mean +- std dev: [main] 155 ns +- 12 ns -> [pr_v2] 80.3 ns +- 6.1 ns: 1.93x faster
copy list dataclasses: Mean +- std dev: [main] 151 ns +- 11 ns -> [pr_v2] 160 ns +- 25 ns: 1.05x slower

Geometric mean: 1.32x faster
```

Benchmark script:
```python
import pyperf

runner = pyperf.Runner()

setup = """
import copy

a={'list': [1,2,3,43], 't': (1,2,3), 'str': 'hello', 'subdict': {'a': True}}

from dataclasses import dataclass

lst = [1, 's']
tpl  =('a', 'b', 3)

i = 123123123
sl = slice(1,2,3)

@dataclass
class A:
    a : int
    
dc = A(123)
list_dc = [A(1), A(2), A(3), A(4)]
"""

runner.timeit(name="copy int", stmt="b=copy.copy(i)", setup=setup)
runner.timeit(name="copy slice", stmt="b=copy.copy(sl)", setup=setup)
runner.timeit(name="copy dict", stmt="b=copy.copy(a)", setup=setup)
runner.timeit(name="copy dataclass", stmt="b=copy.copy(dc)", setup=setup)
runner.timeit(name="copy small list", stmt="b=copy.copy(lst)", setup=setup)
runner.timeit(name="copy small tuple", stmt="b=copy.copy(tpl)", setup=setup)
runner.timeit(name="copy list dataclasses", stmt="b=copy.copy(list_dc)", setup=setup)
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128118 -->
* Issue: gh-128118
<!-- /gh-issue-number -->
