### PR TITLE
GH-127705: Add debug mode for `_PyStackRef`s inspired by HPy debug mode

### DIFF
--- a/Include/internal/pycore_interp.h
+++ b/Include/internal/pycore_interp.h
@@ -34,6 +34,7 @@ extern "C" {
 #include "pycore_optimizer.h"     // _PyOptimizerObject
 #include "pycore_obmalloc.h"      // struct _obmalloc_state
 #include "pycore_qsbr.h"          // struct _qsbr_state
+#include "pycore_stackref.h"      // Py_STACKREF_DEBUG
 #include "pycore_tstate.h"        // _PyThreadStateImpl
 #include "pycore_tuple.h"         // struct _Py_tuple_state
 #include "pycore_uniqueid.h"      // struct _Py_unique_id_pool
@@ -285,6 +286,11 @@ struct _is {
     _PyThreadStateImpl _initial_thread;
     // _initial_thread should be the last field of PyInterpreterState.
     // See https://github.com/python/cpython/issues/127117.
+
+#if !defined(Py_GIL_DISABLED) && defined(Py_STACKREF_DEBUG)
+    uint64_t next_stackref;
+    _Py_hashtable_t *stackref_debug_table;
+#endif
 };
 
 

--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -5,7 +5,7 @@ extern "C" {
 #endif
 
 // Define this to get precise tracking of stackrefs.
-#define Py_STACKREF_DEBUG 1
+// #define Py_STACKREF_DEBUG 1
 
 #ifndef Py_BUILD_CORE
 #  error "this header requires Py_BUILD_CORE define"

--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -75,6 +75,8 @@ static const _PyStackRef PyStackRef_NULL = { .index = 0 };
 #define PyStackRef_False ((_PyStackRef){ .index = 2 })
 #define PyStackRef_True ((_PyStackRef){ .index = 3 })
 
+#define LAST_PREDEFINED_STACKREF_INDEX 3
+
 static inline int
 PyStackRef_IsNull(_PyStackRef ref)
 {

--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -4,6 +4,9 @@
 extern "C" {
 #endif
 
+// Define this to get precise tracking of stackrefs.
+#define Py_STACKREF_DEBUG 1
+
 #ifndef Py_BUILD_CORE
 #  error "this header requires Py_BUILD_CORE define"
 #endif
@@ -48,6 +51,105 @@ extern "C" {
    Note that it is unsafe to borrow a _PyStackRef and then do normal
    CPython refcounting operations on it!
 */
+
+
+#if !defined(Py_GIL_DISABLED) && defined(Py_STACKREF_DEBUG)
+
+typedef union _PyStackRef {
+    uint64_t index;
+} _PyStackRef;
+
+#define Py_TAG_BITS 0
+
+PyAPI_FUNC(PyObject *) _Py_stackref_get_object(_PyStackRef ref);
+PyAPI_FUNC(PyObject *) _Py_stackref_close(_PyStackRef ref);
+PyAPI_FUNC(_PyStackRef) _Py_stackref_create(PyObject *obj, const char *filename, int linenumber);
+extern void _Py_stackref_associate(PyInterpreterState *interp, PyObject *obj, _PyStackRef ref);
+
+static const _PyStackRef PyStackRef_NULL = { .index = 0 };
+
+#define PyStackRef_None ((_PyStackRef){ .index = 1 } )
+#define PyStackRef_False ((_PyStackRef){ .index = 2 })
+#define PyStackRef_True ((_PyStackRef){ .index = 3 })
+
+static inline int
+PyStackRef_IsNull(_PyStackRef ref)
+{
+    return ref.index == 0;
+}
+
+static inline int
+PyStackRef_IsTrue(_PyStackRef ref)
+{
+    return _Py_stackref_get_object(ref) == Py_True;
+}
+
+static inline int
+PyStackRef_IsFalse(_PyStackRef ref)
+{
+    return _Py_stackref_get_object(ref) == Py_False;
+}
+
+static inline int
+PyStackRef_IsNone(_PyStackRef ref)
+{
+    return _Py_stackref_get_object(ref) == Py_None;
+}
+
+static inline PyObject *
+PyStackRef_AsPyObjectBorrow(_PyStackRef ref)
+{
+    return _Py_stackref_get_object(ref);
+}
+
+static inline PyObject *
+PyStackRef_AsPyObjectSteal(_PyStackRef ref)
+{
+    return _Py_stackref_close(ref);
+}
+
+static inline _PyStackRef
+_PyStackRef_FromPyObjectNew(PyObject *obj, const char *filename, int linenumber)
+{
+    Py_INCREF(obj);
+    return _Py_stackref_create(obj, filename, linenumber);
+}
+#define PyStackRef_FromPyObjectNew(obj) _PyStackRef_FromPyObjectNew(_PyObject_CAST(obj), __FILE__, __LINE__)
+
+static inline _PyStackRef
+_PyStackRef_FromPyObjectSteal(PyObject *obj, const char *filename, int linenumber)
+{
+    return _Py_stackref_create(obj, filename, linenumber);
+}
+#define PyStackRef_FromPyObjectSteal(obj) _PyStackRef_FromPyObjectSteal(_PyObject_CAST(obj), __FILE__, __LINE__)
+
+static inline _PyStackRef
+_PyStackRef_FromPyObjectImmortal(PyObject *obj, const char *filename, int linenumber)
+{
+    assert(_Py_IsImmortal(obj));
+    return _Py_stackref_create(obj, filename, linenumber);
+}
+#define PyStackRef_FromPyObjectImmortal(obj) _PyStackRef_FromPyObjectImmortal(_PyObject_CAST(obj), __FILE__, __LINE__)
+
+static inline void
+PyStackRef_CLOSE(_PyStackRef ref)
+{
+    PyObject *obj = _Py_stackref_close(ref);
+    Py_DECREF(obj);
+}
+
+static inline _PyStackRef
+_PyStackRef_DUP(_PyStackRef ref, const char *filename, int linenumber)
+{
+    PyObject *obj = _Py_stackref_get_object(ref);
+    Py_INCREF(obj);
+    return _Py_stackref_create(obj, filename, linenumber);
+}
+#define PyStackRef_DUP(REF) _PyStackRef_DUP(REF, __FILE__, __LINE__)
+
+#define PyStackRef_CLOSE_SPECIALIZED(stackref, dealloc) PyStackRef_CLOSE(stackref)
+
+#else
 
 typedef union _PyStackRef {
     uintptr_t bits;
@@ -200,11 +302,14 @@ static const _PyStackRef PyStackRef_NULL = { .bits = 0 };
 #define PyStackRef_IsTrue(ref) (PyStackRef_AsPyObjectBorrow(ref) == Py_True)
 #define PyStackRef_IsFalse(ref) (PyStackRef_AsPyObjectBorrow(ref) == Py_False)
 
+#endif
+
 // Converts a PyStackRef back to a PyObject *, converting the
 // stackref to a new reference.
 #define PyStackRef_AsPyObjectNew(stackref) Py_NewRef(PyStackRef_AsPyObjectBorrow(stackref))
 
 #define PyStackRef_TYPE(stackref) Py_TYPE(PyStackRef_AsPyObjectBorrow(stackref))
+
 
 #define PyStackRef_CLEAR(op) \
     do { \

--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -153,19 +153,9 @@ _PyStackRef_DUP(_PyStackRef ref, const char *filename, int linenumber)
 }
 #define PyStackRef_DUP(REF) _PyStackRef_DUP(REF, __FILE__, __LINE__)
 
-static inline _PyStackRef
-_PyStackRef_Transfer(_PyStackRef ref, const char *filename, int linenumber)
-{
-    PyObject *obj = _Py_stackref_close(ref);
-    return _Py_stackref_create(obj, filename, linenumber);
-}
-#define PyStackRef_Transfer(REF) _PyStackRef_Transfer(REF, __FILE__, __LINE__)
-
 #define PyStackRef_CLOSE_SPECIALIZED(stackref, dealloc) PyStackRef_CLOSE(stackref)
 
 #else
-
-#define PyStackRef_Transfer(REF) (REF)
 
 typedef union _PyStackRef {
     uintptr_t bits;

--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -55,6 +55,8 @@ extern "C" {
 
 #if !defined(Py_GIL_DISABLED) && defined(Py_STACKREF_DEBUG)
 
+
+
 typedef union _PyStackRef {
     uint64_t index;
 } _PyStackRef;
@@ -147,9 +149,19 @@ _PyStackRef_DUP(_PyStackRef ref, const char *filename, int linenumber)
 }
 #define PyStackRef_DUP(REF) _PyStackRef_DUP(REF, __FILE__, __LINE__)
 
+static inline _PyStackRef
+_PyStackRef_Transfer(_PyStackRef ref, const char *filename, int linenumber)
+{
+    PyObject *obj = _Py_stackref_close(ref);
+    return _Py_stackref_create(obj, filename, linenumber);
+}
+#define PyStackRef_Transfer(REF) _PyStackRef_Transfer(REF, __FILE__, __LINE__)
+
 #define PyStackRef_CLOSE_SPECIALIZED(stackref, dealloc) PyStackRef_CLOSE(stackref)
 
 #else
+
+#define PyStackRef_Transfer(REF) (REF)
 
 typedef union _PyStackRef {
     uintptr_t bits;

--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -66,6 +66,7 @@ typedef union _PyStackRef {
 PyAPI_FUNC(PyObject *) _Py_stackref_get_object(_PyStackRef ref);
 PyAPI_FUNC(PyObject *) _Py_stackref_close(_PyStackRef ref);
 PyAPI_FUNC(_PyStackRef) _Py_stackref_create(PyObject *obj, const char *filename, int linenumber);
+PyAPI_FUNC(void) _Py_stackref_record_borrow(_PyStackRef ref, const char *filename, int linenumber);
 extern void _Py_stackref_associate(PyInterpreterState *interp, PyObject *obj, _PyStackRef ref);
 
 static const _PyStackRef PyStackRef_NULL = { .index = 0 };
@@ -99,10 +100,13 @@ PyStackRef_IsNone(_PyStackRef ref)
 }
 
 static inline PyObject *
-PyStackRef_AsPyObjectBorrow(_PyStackRef ref)
+_PyStackRef_AsPyObjectBorrow(_PyStackRef ref, const char *filename, int linenumber)
 {
+    _Py_stackref_record_borrow(ref, filename, linenumber);
     return _Py_stackref_get_object(ref);
 }
+
+#define PyStackRef_AsPyObjectBorrow(REF) _PyStackRef_AsPyObjectBorrow((REF), __FILE__, __LINE__)
 
 static inline PyObject *
 PyStackRef_AsPyObjectSteal(_PyStackRef ref)

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -488,6 +488,7 @@ PYTHON_OBJS=	\
 		Python/qsbr.o \
 		Python/bootstrap_hash.o \
 		Python/specialize.o \
+		Python/stackrefs.o \
 		Python/structmember.o \
 		Python/symtable.o \
 		Python/sysmodule.o \

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-20-12-25-16.gh-issue-127705.WmCz1z.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-20-12-25-16.gh-issue-127705.WmCz1z.rst
@@ -1,0 +1,2 @@
+Adds stackref debugging when ``Py_STACKREF_DEBUG`` is set. Finds all
+double-closes and leaks, logging the origin and last borrow.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-20-12-25-16.gh-issue-127705.WmCz1z.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-20-12-25-16.gh-issue-127705.WmCz1z.rst
@@ -1,2 +1,4 @@
 Adds stackref debugging when ``Py_STACKREF_DEBUG`` is set. Finds all
 double-closes and leaks, logging the origin and last borrow.
+
+Inspired by HPy's debug mode. https://docs.hpyproject.org/en/latest/debug-mode.html

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -179,9 +179,9 @@ framelocalsproxy_setitem(PyObject *self, PyObject *key, PyObject *value)
         if (kind == CO_FAST_FREE) {
             // The cell was set when the frame was created from
             // the function's closure.
-            assert(oldvalue.bits != 0 && PyCell_Check(PyStackRef_AsPyObjectBorrow(oldvalue)));
+            assert(!PyStackRef_IsNull(oldvalue) && PyCell_Check(PyStackRef_AsPyObjectBorrow(oldvalue)));
             cell = PyStackRef_AsPyObjectBorrow(oldvalue);
-        } else if (kind & CO_FAST_CELL && oldvalue.bits != 0) {
+        } else if (kind & CO_FAST_CELL && !PyStackRef_IsNull(oldvalue)) {
             PyObject *as_obj = PyStackRef_AsPyObjectBorrow(oldvalue);
             if (PyCell_Check(as_obj)) {
                 cell = as_obj;

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -679,7 +679,7 @@ dummy_func(
             assert(Py_REFCNT(left_o) >= 2);
             PyStackRef_CLOSE(left);
             DEAD(left);
-            PyObject *temp = PyStackRef_AsPyObjectBorrow(*target_local);
+            PyObject *temp = PyStackRef_AsPyObjectSteal(*target_local);
             PyUnicode_Append(&temp, right_o);
             *target_local = PyStackRef_FromPyObjectSteal(temp);
             PyStackRef_CLOSE_SPECIALIZED(right, _PyUnicode_ExactDealloc);
@@ -4476,17 +4476,17 @@ dummy_func(
 
         op(_DO_CALL_FUNCTION_EX, (func_st, unused, callargs_st, kwargs_st if (oparg & 1) -- result)) {
             PyObject *func = PyStackRef_AsPyObjectBorrow(func_st);
-            PyObject *callargs = PyStackRef_AsPyObjectBorrow(callargs_st);
-            PyObject *kwargs = PyStackRef_AsPyObjectBorrow(kwargs_st);
 
             // DICT_MERGE is called before this opcode if there are kwargs.
             // It converts all dict subtypes in kwargs into regular dicts.
-            assert(kwargs == NULL || PyDict_CheckExact(kwargs));
-            assert(PyTuple_CheckExact(callargs));
             EVAL_CALL_STAT_INC_IF_FUNCTION(EVAL_CALL_FUNCTION_EX, func);
             PyObject *result_o;
             assert(!_PyErr_Occurred(tstate));
             if (opcode == INSTRUMENTED_CALL_FUNCTION_EX) {
+                PyObject *callargs = PyStackRef_AsPyObjectBorrow(callargs_st);
+                PyObject *kwargs = PyStackRef_AsPyObjectBorrow(kwargs_st);
+                assert(kwargs == NULL || PyDict_CheckExact(kwargs));
+                assert(PyTuple_CheckExact(callargs));
                 PyObject *arg = PyTuple_GET_SIZE(callargs) > 0 ?
                     PyTuple_GET_ITEM(callargs, 0) : &_PyInstrumentation_MISSING;
                 int err = _Py_call_instrumentation_2args(
@@ -4517,7 +4517,10 @@ dummy_func(
                 if (Py_TYPE(func) == &PyFunction_Type &&
                     tstate->interp->eval_frame == NULL &&
                     ((PyFunctionObject *)func)->vectorcall == _PyFunction_Vectorcall) {
+                    PyObject *callargs = PyStackRef_AsPyObjectSteal(callargs_st);
                     assert(PyTuple_CheckExact(callargs));
+                    PyObject *kwargs = PyStackRef_IsNull(kwargs_st) ? NULL : PyStackRef_AsPyObjectSteal(kwargs_st);
+                    assert(kwargs == NULL || PyDict_CheckExact(kwargs));
                     Py_ssize_t nargs = PyTuple_GET_SIZE(callargs);
                     int code_flags = ((PyCodeObject *)PyFunction_GET_CODE(func))->co_flags;
                     PyObject *locals = code_flags & CO_OPTIMIZED ? NULL : Py_NewRef(PyFunction_GET_GLOBALS(func));
@@ -4535,6 +4538,10 @@ dummy_func(
                     frame->return_offset = 1;
                     DISPATCH_INLINED(new_frame);
                 }
+                PyObject *callargs = PyStackRef_AsPyObjectBorrow(callargs_st);
+                assert(PyTuple_CheckExact(callargs));
+                PyObject *kwargs = PyStackRef_AsPyObjectBorrow(kwargs_st);
+                assert(kwargs == NULL || PyDict_CheckExact(kwargs));
                 result_o = PyObject_Call(func, callargs, kwargs);
             }
             PyStackRef_XCLOSE(kwargs_st);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1811,7 +1811,7 @@ _PyEvalFramePushAndInit_Ex(PyThreadState *tstate, _PyStackRef func,
     bool has_dict = (kwargs != NULL && PyDict_GET_SIZE(kwargs) > 0);
     PyObject *kwnames = NULL;
     _PyStackRef *newargs;
-    PyObject *const *object_array;
+    PyObject *const *object_array = NULL;
     _PyStackRef stack_array[8];
     if (has_dict) {
         object_array = _PyStack_UnpackDict(tstate, _PyTuple_ITEMS(callargs), nargs, kwargs, &kwnames);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1811,6 +1811,7 @@ _PyEvalFramePushAndInit_Ex(PyThreadState *tstate, _PyStackRef func,
     bool has_dict = (kwargs != NULL && PyDict_GET_SIZE(kwargs) > 0);
     PyObject *kwnames = NULL;
     PyObject *const *newargs;
+    PyObject *stack_array[8];
     if (has_dict) {
         newargs = _PyStack_UnpackDict(tstate, _PyTuple_ITEMS(callargs), nargs, kwargs, &kwnames);
         if (newargs == NULL) {
@@ -1824,7 +1825,6 @@ _PyEvalFramePushAndInit_Ex(PyThreadState *tstate, _PyStackRef func,
     }
     else {
         if (nargs <= 8) {
-            PyObject *stack_array[8];
             newargs = stack_array;
         }
         else {

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -450,7 +450,7 @@ do { \
 /* How much scratch space to give stackref to PyObject* conversion. */
 #define MAX_STACKREF_SCRATCH 10
 
-#ifdef Py_GIL_DISABLED
+#if defined(Py_GIL_DISABLED) || defined(Py_STACKREF_DEBUG)
 #define STACKREFS_TO_PYOBJECTS(ARGS, ARG_COUNT, NAME) \
     /* +1 because vectorcall might use -1 to write self */ \
     PyObject *NAME##_temp[MAX_STACKREF_SCRATCH+1]; \
@@ -461,7 +461,7 @@ do { \
     assert(NAME != NULL);
 #endif
 
-#ifdef Py_GIL_DISABLED
+#if defined(Py_GIL_DISABLED) || defined(Py_STACKREF_DEBUG)
 #define STACKREFS_TO_PYOBJECTS_CLEANUP(NAME) \
     /* +1 because we +1 previously */ \
     _PyObjectArray_Free(NAME - 1, NAME##_temp);
@@ -470,7 +470,7 @@ do { \
     (void)(NAME);
 #endif
 
-#ifdef Py_GIL_DISABLED
+#if defined(Py_GIL_DISABLED) || defined(Py_STACKREF_DEBUG)
 #define CONVERSION_FAILED(NAME) ((NAME) == NULL)
 #else
 #define CONVERSION_FAILED(NAME) (0)

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -850,7 +850,7 @@
              */
             assert(Py_REFCNT(left_o) >= 2);
             PyStackRef_CLOSE(left);
-            PyObject *temp = PyStackRef_AsPyObjectBorrow(*target_local);
+            PyObject *temp = PyStackRef_AsPyObjectSteal(*target_local);
             PyUnicode_Append(&temp, right_o);
             *target_local = PyStackRef_FromPyObjectSteal(temp);
             PyStackRef_CLOSE_SPECIALIZED(right, _PyUnicode_ExactDealloc);

--- a/Python/stackrefs.c
+++ b/Python/stackrefs.c
@@ -54,14 +54,15 @@ _Py_stackref_get_object(_PyStackRef ref)
     return entry->obj;
 }
 
-PyObject *_Py_stackref_close(_PyStackRef ref)
+PyObject *
+_Py_stackref_close(_PyStackRef ref)
 {
     PyInterpreterState *interp = PyInterpreterState_Get();
     if (ref.index >= interp->next_stackref) {
         _Py_FatalErrorFormat(__func__, "Garbled stack ref with ID %" PRIu64 "\n", ref.index);
     }
     PyObject *obj;
-    if (ref.index <= 3) {
+    if (ref.index <= LAST_PREDEFINED_STACKREF_INDEX) {
         // Pre-allocated reference to None, False or True -- Do not clear
         TableEntry *entry = _Py_hashtable_get(interp->stackref_debug_table, (void *)ref.index);
         obj = entry->obj;
@@ -98,7 +99,7 @@ _Py_stackref_create(PyObject *obj, const char *filename, int linenumber)
 void
 _Py_stackref_record_borrow(_PyStackRef ref, const char *filename, int linenumber)
 {
-    if (ref.index <= 3) {
+    if (ref.index <= LAST_PREDEFINED_STACKREF_INDEX) {
         return;
     }
     PyInterpreterState *interp = PyInterpreterState_Get();

--- a/Python/stackrefs.c
+++ b/Python/stackrefs.c
@@ -1,0 +1,127 @@
+
+#include "Python.h"
+
+#include "pycore_stackref.h"
+
+#if !defined(Py_GIL_DISABLED) && defined(Py_STACKREF_DEBUG)
+
+#if SIZEOF_VOID_P < 8
+#error "Py_STACKREF_DEBUG requires 64 bit machine"
+#endif
+
+#include "pycore_interp.h"
+#include "pycore_hashtable.h"
+
+typedef struct _table_entry {
+    PyObject *obj;
+    const char *classname;
+    const char *filename;
+    int linenumber;
+} TableEntry;
+
+TableEntry *
+make_table_entry(PyObject *obj, const char *filename, int linenumber)
+{
+    TableEntry *result = malloc(sizeof(TableEntry));
+    if (result == NULL) {
+        return NULL;
+    }
+    result->obj = obj;
+    result->classname = Py_TYPE(obj)->tp_name;
+    result->filename = filename;
+    result->linenumber = linenumber;
+    return result;
+}
+
+PyObject *
+_Py_stackref_get_object(_PyStackRef ref)
+{
+    if (ref.index == 0) {
+        return NULL;
+    }
+    PyInterpreterState *interp = PyInterpreterState_Get();
+    assert(interp != NULL);
+    if (ref.index >= interp->next_stackref) {
+        _Py_FatalErrorFormat(__func__, "Garbled stack ref with ID %" PRIu64 "\n", ref.index);
+    }
+    TableEntry *entry = _Py_hashtable_get(interp->stackref_debug_table, (void *)ref.index);
+    if (entry == NULL) {
+        _Py_FatalErrorFormat(__func__, "Accessing closed stack ref with ID %" PRIu64 "\n", ref.index);
+    }
+    return entry->obj;
+}
+
+PyObject *_Py_stackref_close(_PyStackRef ref)
+{
+    PyInterpreterState *interp = PyInterpreterState_Get();
+    if (ref.index >= interp->next_stackref) {
+        _Py_FatalErrorFormat(__func__, "Garbled stack ref with ID %" PRIu64 "\n", ref.index);
+    }
+    PyObject *obj;
+    if (ref.index <= 3) {
+        // Pre-allocated reference to None, False or True -- Do not clear
+        TableEntry *entry = _Py_hashtable_get(interp->stackref_debug_table, (void *)ref.index);
+        obj = entry->obj;
+    }
+    else {
+        TableEntry *entry = _Py_hashtable_steal(interp->stackref_debug_table, (void *)ref.index);
+        if (entry == NULL) {
+            _Py_FatalErrorFormat(__func__, "Invalid StackRef with ID %" PRIu64 "\n", (void *)ref.index);
+        }
+        obj = entry->obj;
+        free(entry);
+    }
+    return obj;
+}
+
+_PyStackRef
+_Py_stackref_create(PyObject *obj, const char *filename, int linenumber)
+{
+    if (obj == NULL) {
+        Py_FatalError("Cannot create a stackref for NULL");
+    }
+    PyInterpreterState *interp = PyInterpreterState_Get();
+    uint64_t new_id = interp->next_stackref++;
+    TableEntry *entry = make_table_entry(obj, filename, linenumber);
+    if (entry == NULL) {
+        Py_FatalError("No memory left for stackref debug table");
+    }
+    if (_Py_hashtable_set(interp->stackref_debug_table, (void *)new_id, entry) < 0) {
+        Py_FatalError("No memory left for stackref debug table");
+    }
+    return (_PyStackRef){ .index = new_id };
+}
+
+void
+_Py_stackref_associate(PyInterpreterState *interp, PyObject *obj, _PyStackRef ref)
+{
+    assert(interp->next_stackref >= ref.index);
+    interp->next_stackref = ref.index+1;
+    TableEntry *entry = make_table_entry(obj, "builtin-object", 0);
+    if (entry == NULL) {
+        Py_FatalError("No memory left for stackref debug table");
+    }
+    if (_Py_hashtable_set(interp->stackref_debug_table, (void *)ref.index, (void *)entry) < 0) {
+        Py_FatalError("No memory left for stackref debug table");
+    }
+}
+
+
+static int
+report_leak(_Py_hashtable_t *ht, const void *key, const void *value, void *user_data)
+{
+    TableEntry *entry = (TableEntry *)value;
+    if (!_Py_IsStaticImmortal(entry->obj)) {
+        printf("Stackref leak. Refers to instance of %s at %p. Created at %s:%d\n",
+               entry->classname, entry->obj, entry->filename, entry->linenumber);
+    }
+    return 0;
+}
+
+void
+_Py_stackref_report_leaks(PyInterpreterState *interp)
+{
+    _Py_hashtable_foreach(interp->stackref_debug_table, report_leak, NULL);
+}
+
+#endif


### PR DESCRIPTION
This PR:
*  Adds a hashtable to track `_PyStackRefs` if `Py_STACKREF_DEBUG` is set.
* Aborts and reports any double-close or leaks of stack refs
* Fixes the leaks found in bytecodes.c by the above

When reporting leaks, both the origin of the `_PyStackRef` and the last call to `PyStackRef_AsPyObjectBorrow` are reported.

Only supports the default build for now. It shouldn't be too hard to support free-threading in the future.

------------------

Running on the full test suite passes all but these tests:

#### Expecting a `_PyStackRef` to look like a tagged pointer, not an index. Mostly segfaults
test.test_gdb.test_backtrace 
test.test_gdb.test_misc
test.test_gdb.test_pretty_print
test_external_inspection

#### Calling a `_PyStackRef...` function without holding the GIL at shutdown.
test_faulthandler
test_regrtest
    
#### Actual leaks
test.test_multiprocessing_spawn.test_manager
test_repl
test_threading


<!-- gh-issue-number: gh-127705 -->
* Issue: gh-127705
<!-- /gh-issue-number -->
