### PR TITLE
gh-128127: add feature for ast.NodeVisitor generic_visit to return list of all return values of calls to `visit_`

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-12-20-20-57-43.gh-issue-128127.qqkW3b.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-20-20-57-43.gh-issue-128127.qqkW3b.rst
@@ -1,0 +1,4 @@
+Change behaviour of NodeVisitor's generic_visit to return list of return
+values of calls to visit_x method instead of None. For new functionailty to
+work derived classes need to call NodeVisitors constructor otherwise, it
+behaves same as before(returns None).


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This implementation tries to ensure that previous behaviour of visit is not disturbed. For visit's new behaviour to work, derived classes need to call supers constructor, otherwise it behaves same as before.

<!-- gh-issue-number: gh-128127 -->
* Issue: gh-128127
<!-- /gh-issue-number -->
