### PR TITLE
gh-100384: Error on `unguarded-availability` in Darwin builds

### DIFF
--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -45,7 +45,7 @@ jobs:
         brew link --overwrite tcl-tk@8
     - name: Configure CPython
       run: |
-        MACOSX_DEPLOYMENT_TARGET=10.9 \
+        MACOSX_DEPLOYMENT_TARGET=10.13 \
         GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \
         GDBM_LIBS="-L$(brew --prefix gdbm)/lib -lgdbm" \
         ./configure \

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -45,7 +45,7 @@ jobs:
         brew link --overwrite tcl-tk@8
     - name: Configure CPython
       run: |
-        MACOSX_DEPLOYMENT_TARGET=10.13 \
+        MACOSX_DEPLOYMENT_TARGET=10.15 \
         GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \
         GDBM_LIBS="-L$(brew --prefix gdbm)/lib -lgdbm" \
         ./configure \

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -45,6 +45,7 @@ jobs:
         brew link --overwrite tcl-tk@8
     - name: Configure CPython
       run: |
+        MACOSX_DEPLOYMENT_TARGET=10.9 \
         GDBM_CFLAGS="-I$(brew --prefix gdbm)/include" \
         GDBM_LIBS="-L$(brew --prefix gdbm)/lib -lgdbm" \
         ./configure \

--- a/Misc/NEWS.d/next/Build/2024-12-21-09-56-37.gh-issue-100384.Ib-XrN.rst
+++ b/Misc/NEWS.d/next/Build/2024-12-21-09-56-37.gh-issue-100384.Ib-XrN.rst
@@ -1,2 +1,2 @@
-Error on ``unguarded-availability-new`` in Darwin builds, preventing invalid
+Error on ``unguarded-availability`` in macOS builds, preventing invalid
 use of symbols that are not available in older versions of the OS.

--- a/Misc/NEWS.d/next/Build/2024-12-21-09-56-37.gh-issue-100384.Ib-XrN.rst
+++ b/Misc/NEWS.d/next/Build/2024-12-21-09-56-37.gh-issue-100384.Ib-XrN.rst
@@ -1,0 +1,2 @@
+Error on ``unguarded-availability-new`` in Darwin builds, preventing invalid
+use of symbols that are not available in older versions of the OS.

--- a/configure
+++ b/configure
@@ -10406,6 +10406,47 @@ printf %s "checking which compiler should be used... " >&6; }
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
 printf "%s\n" "$CC" >&6; }
 
+        # Error on unguarded use of new symbols, which will fail at runtime for
+        # users on older versions of macOS
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -Wunguarded-availability-new" >&5
+printf %s "checking whether C compiler accepts -Wunguarded-availability-new... " >&6; }
+if test ${ax_cv_check_cflags__Werror__Wunguarded_availability_new+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS -Werror -Wunguarded-availability-new"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags__Werror__Wunguarded_availability_new=yes
+else $as_nop
+  ax_cv_check_cflags__Werror__Wunguarded_availability_new=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags__Werror__Wunguarded_availability_new" >&5
+printf "%s\n" "$ax_cv_check_cflags__Werror__Wunguarded_availability_new" >&6; }
+if test "x$ax_cv_check_cflags__Werror__Wunguarded_availability_new" = xyes
+then :
+  as_fn_append CFLAGS_NODIST " -Werror=unguarded-availability-new"
+else $as_nop
+  :
+fi
+
+
         LIPO_INTEL64_FLAGS=""
         if test "${enable_universalsdk}"
         then

--- a/configure
+++ b/configure
@@ -10408,15 +10408,15 @@ printf "%s\n" "$CC" >&6; }
 
         # Error on unguarded use of new symbols, which will fail at runtime for
         # users on older versions of macOS
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -Wunguarded-availability-new" >&5
-printf %s "checking whether C compiler accepts -Wunguarded-availability-new... " >&6; }
-if test ${ax_cv_check_cflags__Werror__Wunguarded_availability_new+y}
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -Wunguarded-availability" >&5
+printf %s "checking whether C compiler accepts -Wunguarded-availability... " >&6; }
+if test ${ax_cv_check_cflags__Werror__Wunguarded_availability+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
 
   ax_check_save_flags=$CFLAGS
-  CFLAGS="$CFLAGS -Werror -Wunguarded-availability-new"
+  CFLAGS="$CFLAGS -Werror -Wunguarded-availability"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -10430,18 +10430,18 @@ main (void)
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"
 then :
-  ax_cv_check_cflags__Werror__Wunguarded_availability_new=yes
+  ax_cv_check_cflags__Werror__Wunguarded_availability=yes
 else $as_nop
-  ax_cv_check_cflags__Werror__Wunguarded_availability_new=no
+  ax_cv_check_cflags__Werror__Wunguarded_availability=no
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
   CFLAGS=$ax_check_save_flags
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags__Werror__Wunguarded_availability_new" >&5
-printf "%s\n" "$ax_cv_check_cflags__Werror__Wunguarded_availability_new" >&6; }
-if test "x$ax_cv_check_cflags__Werror__Wunguarded_availability_new" = xyes
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags__Werror__Wunguarded_availability" >&5
+printf "%s\n" "$ax_cv_check_cflags__Werror__Wunguarded_availability" >&6; }
+if test "x$ax_cv_check_cflags__Werror__Wunguarded_availability" = xyes
 then :
-  as_fn_append CFLAGS_NODIST " -Werror=unguarded-availability-new"
+  as_fn_append CFLAGS_NODIST " -Werror=unguarded-availability"
 else $as_nop
   :
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -2605,8 +2605,8 @@ AS_VAR_IF([ac_cv_gcc_compat], [yes], [
 
         # Error on unguarded use of new symbols, which will fail at runtime for
         # users on older versions of macOS
-        AX_CHECK_COMPILE_FLAG([-Wunguarded-availability-new],
-            [AS_VAR_APPEND([CFLAGS_NODIST], [" -Werror=unguarded-availability-new"])],
+        AX_CHECK_COMPILE_FLAG([-Wunguarded-availability],
+            [AS_VAR_APPEND([CFLAGS_NODIST], [" -Werror=unguarded-availability"])],
             [],
             [-Werror])
 

--- a/configure.ac
+++ b/configure.ac
@@ -2603,6 +2603,13 @@ AS_VAR_IF([ac_cv_gcc_compat], [yes], [
         esac
         AC_MSG_RESULT([$CC])
 
+        # Error on unguarded use of new symbols, which will fail at runtime for
+        # users on older versions of macOS
+        AX_CHECK_COMPILE_FLAG([-Wunguarded-availability-new],
+            [AS_VAR_APPEND([CFLAGS_NODIST], [" -Werror=unguarded-availability-new"])],
+            [],
+            [-Werror])
+
         LIPO_INTEL64_FLAGS=""
         if test "${enable_universalsdk}"
         then


### PR DESCRIPTION
Closes https://github.com/python/cpython/issues/100384

This prevents introduction of unguarded use of  symbols that would fail on older systems.

The build system purports to support macOS 10.3+, but the GitHub runners default Xcode version only supports 10.13+ and https://github.com/python/cpython/issues/128156 means 10.15+ is required. Here, we set that as the target in CI.

<!-- gh-issue-number: gh-100384 -->
* Issue: gh-100384
<!-- /gh-issue-number -->
