### PR TITLE
gh-128152: Update Argument Clinic to support empty lines

### DIFF
--- a/Tools/clinic/libclinic/cpp.py
+++ b/Tools/clinic/libclinic/cpp.py
@@ -136,7 +136,8 @@ class Monitor:
             return
 
         line = line[1:].lstrip()
-        assert line
+        if not line:
+            return
 
         fields = line.split()
         token = fields[0].lower()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This will skip the logic that follows after for empty lines so there should be no error. Assert is now no longer needed.

I don't this a NEWS worthy PR? If it is I can add an entry but I think a Skip NEWS label is just fine.

<!-- gh-issue-number: gh-128152 -->
* Issue: gh-128152
<!-- /gh-issue-number -->
