### PR TITLE
gh-128146: Exclude os/log.h import on older macOS versions.

### DIFF
--- a/Misc/NEWS.d/next/macOS/2024-12-22-08-54-30.gh-issue-127592.iyuFCC.rst
+++ b/Misc/NEWS.d/next/macOS/2024-12-22-08-54-30.gh-issue-127592.iyuFCC.rst
@@ -1,0 +1,2 @@
+Usage of the unified Apple System Log APIs was disabled when the minimum
+macOS version is earlier than 10.12.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -49,7 +49,7 @@
 #  include <mach-o/loader.h>
 // The os_log unified logging APIs were introduced in macOS 10.12, iOS 10.0,
 // tvOS 10.0, and watchOS 3.0;
-#  if TARGET_OS_IPHONE || (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12)
+#  if TARGET_OS_IPHONE || (TARGET_OS_OSX && defined(MAC_OS_X_VERSION_10_12) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12)
 #    include <os/log.h>
 #  endif
 #endif
@@ -2964,7 +2964,7 @@ apple_log_write_impl(PyObject *self, PyObject *args)
     // Call the underlying Apple logging API. The os_log unified logging APIs
     // were introduced in macOS 10.12, iOS 10.0, tvOS 10.0, and watchOS 3.0;
     // this call is a no-op on older versions.
-    #if TARGET_OS_IPHONE || (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12)
+    #if TARGET_OS_IPHONE || (TARGET_OS_OSX && defined(MAC_OS_X_VERSION_10_12) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12)
     // Pass the user-provided text through explicit %s formatting
     // to avoid % literals being interpreted as a formatting directive.
     os_log_with_type(OS_LOG_DEFAULT, logtype, "%s", text);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -50,7 +50,7 @@
 #  include <mach-o/loader.h>
 // The os_log unified logging APIs were introduced in macOS 10.12, iOS 10.0,
 // tvOS 10.0, and watchOS 3.0;
-#  if defined(TARGET_OS_IPHONE) && TARGET_IOS_IPHONE
+#  if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 #    define HAS_APPLE_SYSTEM_LOG 1
 #  elif defined(TARGET_OS_OSX) && TARGET_OS_OSX
 #    if defined(MAC_OS_X_VERSION_10_12) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
@@ -94,7 +94,7 @@ static PyStatus init_sys_streams(PyThreadState *tstate);
 #ifdef __ANDROID__
 static PyStatus init_android_streams(PyThreadState *tstate);
 #endif
-#if defined(__APPLE__)
+#if defined(__APPLE__) && HAS_APPLE_SYSTEM_LOG
 static PyStatus init_apple_streams(PyThreadState *tstate);
 #endif
 static void wait_for_thread_shutdown(PyThreadState *tstate);
@@ -1279,7 +1279,7 @@ init_interp_main(PyThreadState *tstate)
         return status;
     }
 #endif
-#if defined(__APPLE__)
+#if defined(__APPLE__) && HAS_APPLE_SYSTEM_LOG
     if (config->use_system_logger) {
         status = init_apple_streams(tstate);
         if (_PyStatus_EXCEPTION(status)) {
@@ -2963,7 +2963,7 @@ done:
 
 #endif  // __ANDROID__
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && HAS_APPLE_SYSTEM_LOG
 
 static PyObject *
 apple_log_write_impl(PyObject *self, PyObject *args)
@@ -2974,14 +2974,9 @@ apple_log_write_impl(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    // Call the underlying Apple logging API. The os_log unified logging APIs
-    // were introduced in macOS 10.12, iOS 10.0, tvOS 10.0, and watchOS 3.0;
-    // this call is a no-op on older versions.
-    #if HAS_APPLE_SYSTEM_LOG
     // Pass the user-provided text through explicit %s formatting
     // to avoid % literals being interpreted as a formatting directive.
     os_log_with_type(OS_LOG_DEFAULT, logtype, "%s", text);
-    #endif
     Py_RETURN_NONE;
 }
 
@@ -3016,7 +3011,6 @@ init_apple_streams(PyThreadState *tstate)
     if (result == NULL) {
         goto error;
     }
-
     goto done;
 
 error:
@@ -3030,7 +3024,7 @@ done:
     return status;
 }
 
-#endif  // __APPLE__
+#endif  // __APPLE__ && HAS_APPLE_SYSTEM_LOG
 
 
 static void

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -47,7 +47,11 @@
 #if defined(__APPLE__)
 #  include <AvailabilityMacros.h>
 #  include <mach-o/loader.h>
-#  include <os/log.h>
+// The os_log unified logging APIs were introduced in macOS 10.12, iOS 10.0,
+// tvOS 10.0, and watchOS 3.0;
+#  if TARGET_OS_IPHONE || (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12)
+#    include <os/log.h>
+#  endif
 #endif
 
 #ifdef HAVE_SIGNAL_H


### PR DESCRIPTION
#127592 recently added support for redirecting stdout/err to the Apple System logs, using the os_log API. This API was added in macOS 10.12; and while the *usage* of the API was gated with a preprocessor directive, the header declaration was not. This adds preprocessor gating on the header definition.

/cc @barracuda156

<!-- gh-issue-number: gh-128146 -->
* Issue: gh-128146
<!-- /gh-issue-number -->
