### PR TITLE
gh-128167: Document another difference between RLock and Lock

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -613,6 +613,13 @@ and "recursion level" in addition to the locked/unlocked state used by primitive
 locks.  In the locked state, some thread owns the lock; in the unlocked state,
 no thread owns it.
 
+.. note::
+
+  Reentrant locks are "owned" by the acquiring thread only throughout the
+  thread's life cycle. In particular, an RLock is silently and fully released
+  when the acquiring thread returns. This is different from Lock, which remains
+  locked after its acquiring thread returns.
+
 Threads call a lock's :meth:`~RLock.acquire` method to lock it,
 and its :meth:`~Lock.release` method to unlock it.
 


### PR DESCRIPTION
RLock is fully released when the acquiring thread returns while Lock remains locked when its acquiring thread returns.

<!-- gh-issue-number: gh-128167 -->
* Issue: gh-128167
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128168.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->