### PR TITLE
gh-126664: revert: Use `else` instead of `finally` in docs explaining "with"

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -534,15 +534,18 @@ is semantically equivalent to::
     enter = type(manager).__enter__
     exit = type(manager).__exit__
     value = enter(manager)
+    hit_except = False
 
     try:
         TARGET = value
         SUITE
     except:
+        hit_except = True
         if not exit(manager, *sys.exc_info()):
             raise
-    else:
-        exit(manager, None, None, None)
+    finally:
+        if not hit_except:
+            exit(manager, None, None, None)
 
 With more than one item, the context managers are processed as if multiple
 :keyword:`with` statements were nested::


### PR DESCRIPTION
This reverts docs commit 25257d61cfccc3b4189f96390a5c4db73fd5302c.

See https://github.com/python/cpython/pull/126665#issuecomment-2558386359


<!-- gh-issue-number: gh-126664 -->
* Issue: gh-126664
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128169.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->