### PR TITLE
gh-127949: fix resource warnings in test_tasks.py due to avoiding a call to get_event_loop()

### DIFF
--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2698,17 +2698,17 @@ class BaseTaskTests:
         initial_refcount = sys.getrefcount(obj)
 
         coro = coroutine_function()
-        loop = asyncio.new_event_loop()
-        task = asyncio.Task.__new__(asyncio.Task)
+        with contextlib.closing(asyncio.EventLoop()) as loop:
+            task = asyncio.Task.__new__(asyncio.Task)
 
-        for _ in range(5):
-            with self.assertRaisesRegex(RuntimeError, 'break'):
-                task.__init__(coro, loop=loop, context=obj, name=Break())
+            for _ in range(5):
+                with self.assertRaisesRegex(RuntimeError, 'break'):
+                    task.__init__(coro, loop=loop, context=obj, name=Break())
 
-        coro.close()
-        del task
+            coro.close()
+            del task
 
-        self.assertEqual(sys.getrefcount(obj), initial_refcount)
+            self.assertEqual(sys.getrefcount(obj), initial_refcount)
 
 
 def add_subclass_tests(cls):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127949 -->
* Issue: gh-127949
<!-- /gh-issue-number -->
