### PR TITLE
gh-126868: Add freelist for compact ints to _PyLong_New

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-22-15-47-44.gh-issue-126868.RpjKez.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-22-15-47-44.gh-issue-126868.RpjKez.rst
@@ -1,0 +1,1 @@
+Increase usage of freelist for :class:`int` allocation.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3641,13 +3641,11 @@ _PyLong_ExactDealloc(PyObject *self)
 {
     assert(PyLong_CheckExact(self));
     if (_PyLong_IsCompact((PyLongObject *)self)) {
-        #ifndef Py_GIL_DISABLED
         if (compact_int_is_small(self)) {
             // See PEP 683, section Accidental De-Immortalizing for details
             _Py_SetImmortal(self);
             return;
         }
-        #endif
         _Py_FREELIST_FREE(ints, self, PyObject_Free);
         return;
     }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -156,7 +156,7 @@ PyLongObject *
 _PyLong_New(Py_ssize_t size)
 {
     assert(size >= 0);
-    PyLongObject *result;
+    PyLongObject *result = NULL;
     if (size > (Py_ssize_t)MAX_LONG_DIGITS) {
         PyErr_SetString(PyExc_OverflowError,
                         "too many digits in integer");
@@ -165,19 +165,25 @@ _PyLong_New(Py_ssize_t size)
     /* Fast operations for single digit integers (including zero)
      * assume that there is always at least one digit present. */
     Py_ssize_t ndigits = size ? size : 1;
-    /* Number of bytes needed is: offsetof(PyLongObject, ob_digit) +
-       sizeof(digit)*size.  Previous incarnations of this code used
-       sizeof() instead of the offsetof, but this risks being
-       incorrect in the presence of padding between the header
-       and the digits. */
-    result = PyObject_Malloc(offsetof(PyLongObject, long_value.ob_digit) +
-                             ndigits*sizeof(digit));
-    if (!result) {
-        PyErr_NoMemory();
-        return NULL;
+
+    if (ndigits==1) {
+        result = (PyLongObject *)_Py_FREELIST_POP(PyLongObject, ints);
+    }
+    if (result == NULL) {
+        /* Number of bytes needed is: offsetof(PyLongObject, ob_digit) +
+        sizeof(digit)*size.  Previous incarnations of this code used
+        sizeof() instead of the offsetof, but this risks being
+        incorrect in the presence of padding between the header
+        and the digits. */
+        result = PyObject_Malloc(offsetof(PyLongObject, long_value.ob_digit) +
+                                ndigits*sizeof(digit));
+        if (!result) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+        _PyObject_Init((PyObject*)result, &PyLong_Type);
     }
     _PyLong_SetSignAndDigitCount(result, size != 0, size);
-    _PyObject_Init((PyObject*)result, &PyLong_Type);
     /* The digit has to be initialized explicitly to avoid
      * use-of-uninitialized-value. */
     result->long_value.ob_digit[0] = 0;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -166,7 +166,7 @@ _PyLong_New(Py_ssize_t size)
      * assume that there is always at least one digit present. */
     Py_ssize_t ndigits = size ? size : 1;
 
-    if (ndigits==1) {
+    if (ndigits == 1) {
         result = (PyLongObject *)_Py_FREELIST_POP(PyLongObject, ints);
     }
     if (result == NULL) {

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -3641,11 +3641,13 @@ _PyLong_ExactDealloc(PyObject *self)
 {
     assert(PyLong_CheckExact(self));
     if (_PyLong_IsCompact((PyLongObject *)self)) {
+        #ifndef Py_GIL_DISABLED
         if (compact_int_is_small(self)) {
             // See PEP 683, section Accidental De-Immortalizing for details
             _Py_SetImmortal(self);
             return;
         }
+        #endif
         _Py_FREELIST_FREE(ints, self, PyObject_Free);
         return;
     }


### PR DESCRIPTION
We add freelist support to `_PyLong_New` (this was missed/left out in #126868). On the pyperformance suite this increases the percentage of allocations from freelist by roughly 1%. For comparison, the addition of the freelist to `_PyLong_FromMedium` increased the percentage by roughly 20%. Also note that `_PyLong_New` is used in the new `PyLongWriter_Create` (see https://peps.python.org/pep-0757/), so usage with external packages might be a bit higher.

Microbenchmark:
```
import pyperf

def bench_lshift(loops):
    range_it = range(loops)
    t0 = pyperf.perf_counter()
    for ii in range_it:
        _ = ii << 2
    return pyperf.perf_counter() - t0

if __name__ == "__main__":
    runner = pyperf.Runner()
    runner.bench_time_func("bench_lshift", bench_lshift)

```
results in:
```
Mean +- std dev: [main] 44.7 ns +- 3.0 ns -> [pr] 40.9 ns +- 2.3 ns: 1.09x faster
``` 
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-126868 -->
* Issue: gh-126868
<!-- /gh-issue-number -->
