### PR TITLE
gh-58956: Fix a frame refleak in bdb

### DIFF
--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -404,6 +404,7 @@ class Bdb:
             frame.f_trace_lines = True
             frame = frame.f_back
         self.set_stepinstr()
+        self.enterframe = None
         sys.settrace(self.trace_dispatch)
 
     def set_continue(self):
@@ -423,6 +424,7 @@ class Bdb:
             for frame, (trace_lines, trace_opcodes) in self.frame_trace_lines_opcodes.items():
                 frame.f_trace_lines, frame.f_trace_opcodes = trace_lines, trace_opcodes
             self.frame_trace_lines_opcodes = {}
+            self.enterframe = None
 
     def set_quit(self):
         """Set quitting attribute to True.

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -3022,6 +3022,57 @@ def test_pdb_f_trace_lines():
     (Pdb) continue
     """
 
+def test_pdb_frame_refleak():
+    """
+    pdb should not leak reference to frames
+
+    >>> def frame_leaker(container):
+    ...     import sys
+    ...     container.append(sys._getframe())
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     pass
+
+    >>> def test_function():
+    ...     import gc
+    ...     container = []
+    ...     frame_leaker(container)  # c
+    ...     print(len(gc.get_referrers(container[0])))
+    ...     container = []
+    ...     frame_leaker(container)  # n c
+    ...     print(len(gc.get_referrers(container[0])))
+    ...     container = []
+    ...     frame_leaker(container)  # r c
+    ...     print(len(gc.get_referrers(container[0])))
+
+    >>> with PdbTestInput([  # doctest: +NORMALIZE_WHITESPACE
+    ...     'continue',
+    ...     'next',
+    ...     'continue',
+    ...     'return',
+    ...     'continue',
+    ... ]):
+    ...    test_function()
+    > <doctest test.test_pdb.test_pdb_frame_refleak[0]>(4)frame_leaker()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) continue
+    1
+    > <doctest test.test_pdb.test_pdb_frame_refleak[0]>(4)frame_leaker()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) next
+    > <doctest test.test_pdb.test_pdb_frame_refleak[0]>(5)frame_leaker()
+    -> pass
+    (Pdb) continue
+    1
+    > <doctest test.test_pdb.test_pdb_frame_refleak[0]>(4)frame_leaker()
+    -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    (Pdb) return
+    --Return--
+    > <doctest test.test_pdb.test_pdb_frame_refleak[0]>(5)frame_leaker()->None
+    -> pass
+    (Pdb) continue
+    1
+    """
+
 def test_pdb_function_break():
     """Testing the line number of break on function
 

--- a/Misc/NEWS.d/next/Library/2024-12-23-02-09-44.gh-issue-58956.4OdMdT.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-23-02-09-44.gh-issue-58956.4OdMdT.rst
@@ -1,0 +1,1 @@
+Fixed a frame reference leak in :mod:`bdb`.


### PR DESCRIPTION
We added `self.enterframe` in `bdb.Bdb`, but that will leak the frame reference of the enterframe until the next time the debugger is triggered. As the frame is a linked list, one leaked frame will also leak many others. We should fix this.

This is not a bug fix per se, but this blocks #125549, which is a backport for a bug fix. So we should backport this to 3.12 and 3.13, then merge the bug fix in #125549 to avoid leaking frames.

<!-- gh-issue-number: gh-58956 -->
* Issue: gh-58956
<!-- /gh-issue-number -->
