### PR TITLE
gh-128192: support HTTP sha-256 digest authentication as per RFC-7617

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -411,6 +411,9 @@ The following classes are provided:
    :ref:`http-password-mgr` for information on the interface that must be
    supported.
 
+   .. versionchanged:: 3.14
+      Added support for HTTP digest authentication algorithm ``SHA-256``.
+
 
 .. class:: HTTPDigestAuthHandler(password_mgr=None)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -643,7 +643,8 @@ urllib
 
 * Upgrade HTTP digest authentication algorithm for :mod:`urllib.request` by
   supporting SHA-256 digest authentication as specified in :rfc:`7616`.
-  (Contributed by Calvin Bui in :gh:`128193`)
+  (Contributed by Calvin Bui in :gh:`128193`.)
+
 
 uuid
 ----

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -638,6 +638,13 @@ unittest
   (Contributed by Jacob Walls in :gh:`80958`.)
 
 
+urllib
+------
+
+* Upgrade HTTP digest authentication algorithm for :mod:`urllib.request` by
+  supporting SHA-256 digest authentication as specified in :rfc:`7616`.
+  (Contributed by Calvin Bui in :gh:`128193`)
+
 uuid
 ----
 

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1970,17 +1970,17 @@ class TestDigestAlgorithms(unittest.TestCase):
         H, KD = self.handler.get_algorithm_impls('MD5')
         self.assertEqual(H("foo"), "acbd18db4cc2f85cedef654fccc4a4d8")
         self.assertEqual(KD("foo", "bar"), "4e99e8c12de7e01535248d2bac85e732")
-        
+
     def test_sha_algorithm(self):
         H, KD = self.handler.get_algorithm_impls('SHA')
         self.assertEqual(H("foo"), "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
         self.assertEqual(KD("foo", "bar"), "54dcbe67d21d5eb39493d46d89ae1f412d3bd6de")
-        
+
     def test_sha256_algorithm(self):
         H, KD = self.handler.get_algorithm_impls('SHA-256')
         self.assertEqual(H("foo"), "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
         self.assertEqual(KD("foo", "bar"), "a765a8beaa9d561d4c5cbed29d8f4e30870297fdfa9cb7d6e9848a95fec9f937")
-        
+
     def test_invalid_algorithm(self):
         with self.assertRaises(ValueError) as exc:
             self.handler.get_algorithm_impls('invalid')

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1962,6 +1962,7 @@ class MiscTests(unittest.TestCase):
 
         self.assertRaises(ValueError, _parse_proxy, 'file:/ftp.example.com'),
 
+
 class TestDigestAlgorithms(unittest.TestCase):
     def setUp(self):
         self.handler = AbstractDigestAuthHandler()

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1962,10 +1962,28 @@ class MiscTests(unittest.TestCase):
 
         self.assertRaises(ValueError, _parse_proxy, 'file:/ftp.example.com'),
 
-    def test_unsupported_algorithm(self):
-        handler = AbstractDigestAuthHandler()
+class TestDigestAlgorithms(unittest.TestCase):
+    def setUp(self):
+        self.handler = AbstractDigestAuthHandler()
+
+    def test_md5_algorithm(self):
+        H, KD = self.handler.get_algorithm_impls('MD5')
+        self.assertEqual(H("foo"), "acbd18db4cc2f85cedef654fccc4a4d8")
+        self.assertEqual(KD("foo", "bar"), "4e99e8c12de7e01535248d2bac85e732")
+        
+    def test_sha_algorithm(self):
+        H, KD = self.handler.get_algorithm_impls('SHA')
+        self.assertEqual(H("foo"), "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
+        self.assertEqual(KD("foo", "bar"), "54dcbe67d21d5eb39493d46d89ae1f412d3bd6de")
+        
+    def test_sha256_algorithm(self):
+        H, KD = self.handler.get_algorithm_impls('SHA-256')
+        self.assertEqual(H("foo"), "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+        self.assertEqual(KD("foo", "bar"), "a765a8beaa9d561d4c5cbed29d8f4e30870297fdfa9cb7d6e9848a95fec9f937")
+        
+    def test_invalid_algorithm(self):
         with self.assertRaises(ValueError) as exc:
-            handler.get_algorithm_impls('invalid')
+            self.handler.get_algorithm_impls('invalid')
         self.assertEqual(
             str(exc.exception),
             "Unsupported digest authentication algorithm 'invalid'"

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1180,7 +1180,7 @@ class AbstractDigestAuthHandler:
         # lambdas assume digest modules are imported at the top level
         if algorithm == 'MD5':
             H = lambda x: hashlib.md5(x.encode("ascii")).hexdigest()
-        elif algorithm == 'SHA':
+        elif algorithm == 'SHA':  # non-standard, retained for compatibility.
             H = lambda x: hashlib.sha1(x.encode("ascii")).hexdigest()
         elif algorithm == 'SHA-256':
             H = lambda x: hashlib.sha256(x.encode("ascii")).hexdigest()

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1048,7 +1048,7 @@ _randombytes = os.urandom
 
 
 class AbstractDigestAuthHandler:
-    # Digest authentication is specified in RFC 2617.
+    # Digest authentication is specified in RFC 2617/7616.
 
     # XXX The client does not inspect the Authentication-Info header
     # in a successful response.
@@ -1176,6 +1176,7 @@ class AbstractDigestAuthHandler:
         return base
 
     def get_algorithm_impls(self, algorithm):
+        # algorithm names taken from RFC 7616 Section 6.1
         # lambdas assume digest modules are imported at the top level
         if algorithm == 'MD5':
             H = lambda x: hashlib.md5(x.encode("ascii")).hexdigest()

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1182,9 +1182,9 @@ class AbstractDigestAuthHandler:
             H = lambda x: hashlib.md5(x.encode("ascii")).hexdigest()
         elif algorithm == 'SHA':
             H = lambda x: hashlib.sha1(x.encode("ascii")).hexdigest()
-        # XXX MD5-sess
         elif algorithm == 'SHA-256':
             H = lambda x: hashlib.sha256(x.encode("ascii")).hexdigest()
+        # XXX MD5-sess
         else:
             raise ValueError("Unsupported digest authentication "
                              "algorithm %r" % algorithm)

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1182,6 +1182,8 @@ class AbstractDigestAuthHandler:
         elif algorithm == 'SHA':
             H = lambda x: hashlib.sha1(x.encode("ascii")).hexdigest()
         # XXX MD5-sess
+        elif algorithm == 'SHA-256':
+            H = lambda x: hashlib.sha256(x.encode("ascii")).hexdigest()
         else:
             raise ValueError("Unsupported digest authentication "
                              "algorithm %r" % algorithm)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -258,6 +258,7 @@ Colm Buckley
 Erik de Bueger
 Jan-Hein Bührman
 Marc Bürg
+Calvin Bui
 Lars Buitinck
 Artem Bulgakov
 Dick Bulterman

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-23-11-14-07.gh-issue-128192.02mEhD.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-23-11-14-07.gh-issue-128192.02mEhD.rst
@@ -1,1 +1,1 @@
-Support digest authentication algorithm SHA-256
+Support digest authentication algorithm SHA-256 in :mod:`urllib.request`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-23-11-14-07.gh-issue-128192.02mEhD.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-23-11-14-07.gh-issue-128192.02mEhD.rst
@@ -1,1 +1,2 @@
-Support digest authentication algorithm SHA-256 in :mod:`urllib.request`.
+Upgrade HTTP digest authentication algorithm for :mod:`urllib.request` by
+supporting SHA-256 digest authentication as specified in :rfc:`7616`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-23-11-14-07.gh-issue-128192.02mEhD.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-23-11-14-07.gh-issue-128192.02mEhD.rst
@@ -1,0 +1,1 @@
+Support digest authentication algorithm SHA-256


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

as mentioned in the issue, other authentication exist, but i don't see them supported out of the box in hashlib.

this all depends if python wishes to support rfc7616

<!-- gh-issue-number: gh-128192 -->
* Issue: gh-128192
<!-- /gh-issue-number -->
