### PR TITLE
pathlib tests: create test hierarchy without using class under test

### DIFF
--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -578,10 +578,44 @@ class PathTest(test_pathlib_abc.DummyPathTest, PurePathTest):
         if name in _tests_needing_symlinks and not self.can_symlink:
             self.skipTest('requires symlinks')
         super().setUp()
-        os.chmod(self.parser.join(self.base, 'dirE'), 0)
+
+    def createTestHierarchy(self):
+        os.mkdir(self.base)
+        os.mkdir(os.path.join(self.base, 'dirA'))
+        os.mkdir(os.path.join(self.base, 'dirB'))
+        os.mkdir(os.path.join(self.base, 'dirC'))
+        os.mkdir(os.path.join(self.base, 'dirC', 'dirD'))
+        os.mkdir(os.path.join(self.base, 'dirE'))
+        with open(os.path.join(self.base, 'fileA'), 'wb') as f:
+            f.write(b"this is file A\n")
+        with open(os.path.join(self.base, 'dirB', 'fileB'), 'wb') as f:
+            f.write(b"this is file B\n")
+        with open(os.path.join(self.base, 'dirC', 'fileC'), 'wb') as f:
+            f.write(b"this is file C\n")
+        with open(os.path.join(self.base, 'dirC', 'novel.txt'), 'wb') as f:
+            f.write(b"this is a novel\n")
+        with open(os.path.join(self.base, 'dirC', 'dirD', 'fileD'), 'wb') as f:
+            f.write(b"this is file D\n")
+        os.chmod(os.path.join(self.base, 'dirE'), 0)
+        if self.can_symlink:
+            # Relative symlinks.
+            os.symlink('fileA', os.path.join(self.base, 'linkA'))
+            os.symlink('non-existing', os.path.join(self.base, 'brokenLink'))
+            os.symlink('dirB',
+                       os.path.join(self.base, 'linkB'),
+                       target_is_directory=True)
+            os.symlink(os.path.join('..', 'dirB'),
+                       os.path.join(self.base, 'dirA', 'linkC'),
+                       target_is_directory=True)
+            # This one goes upwards, creating a loop.
+            os.symlink(os.path.join('..', 'dirB'),
+                       os.path.join(self.base, 'dirB', 'linkD'),
+                       target_is_directory=True)
+            # Broken symlink (pointing to itself).
+            os.symlink('brokenLinkLoop', os.path.join(self.base, 'brokenLinkLoop'))
 
     def tearDown(self):
-        os.chmod(self.parser.join(self.base, 'dirE'), 0o777)
+        os.chmod(os.path.join(self.base, 'dirE'), 0o777)
         os_helper.rmtree(self.base)
 
     def tempdir(self):

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1437,33 +1437,25 @@ class DummyPathTest(DummyPurePathTest):
 
     def setUp(self):
         super().setUp()
-        parser = self.cls.parser
-        p = self.cls(self.base)
-        p.mkdir(parents=True)
-        p.joinpath('dirA').mkdir()
-        p.joinpath('dirB').mkdir()
-        p.joinpath('dirC').mkdir()
-        p.joinpath('dirC', 'dirD').mkdir()
-        p.joinpath('dirE').mkdir()
-        with p.joinpath('fileA').open('wb') as f:
-            f.write(b"this is file A\n")
-        with p.joinpath('dirB', 'fileB').open('wb') as f:
-            f.write(b"this is file B\n")
-        with p.joinpath('dirC', 'fileC').open('wb') as f:
-            f.write(b"this is file C\n")
-        with p.joinpath('dirC', 'novel.txt').open('wb') as f:
-            f.write(b"this is a novel\n")
-        with p.joinpath('dirC', 'dirD', 'fileD').open('wb') as f:
-            f.write(b"this is file D\n")
-        if self.can_symlink:
-            p.joinpath('linkA').symlink_to('fileA')
-            p.joinpath('brokenLink').symlink_to('non-existing')
-            p.joinpath('linkB').symlink_to('dirB', target_is_directory=True)
-            p.joinpath('dirA', 'linkC').symlink_to(
-                parser.join('..', 'dirB'), target_is_directory=True)
-            p.joinpath('dirB', 'linkD').symlink_to(
-                parser.join('..', 'dirB'), target_is_directory=True)
-            p.joinpath('brokenLinkLoop').symlink_to('brokenLinkLoop')
+        self.createTestHierarchy()
+
+    def createTestHierarchy(self):
+        cls = self.cls
+        cls._files = {
+            f'{self.base}/fileA': b'this is file A\n',
+            f'{self.base}/dirB/fileB': b'this is file B\n',
+            f'{self.base}/dirC/fileC': b'this is file C\n',
+            f'{self.base}/dirC/dirD/fileD': b'this is file D\n',
+            f'{self.base}/dirC/novel.txt': b'this is a novel\n',
+        }
+        cls._directories = {
+            f'{self.base}': {'dirA', 'dirB','dirC', 'dirE', 'fileA'},
+            f'{self.base}/dirA': set(),
+            f'{self.base}/dirB': {'fileB'},
+            f'{self.base}/dirC': {'dirD', 'fileC', 'novel.txt'},
+            f'{self.base}/dirC/dirD': {'fileD'},
+            f'{self.base}/dirE': set(),
+        }
 
     def tearDown(self):
         cls = self.cls

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1449,10 +1449,10 @@ class DummyPathTest(DummyPurePathTest):
             f'{self.base}/dirC/novel.txt': b'this is a novel\n',
         }
         cls._directories = {
-            f'{self.base}': {'dirA', 'dirB','dirC', 'dirE', 'fileA'},
+            f'{self.base}': {'fileA', 'dirA', 'dirB', 'dirC', 'dirE'},
             f'{self.base}/dirA': set(),
             f'{self.base}/dirB': {'fileB'},
-            f'{self.base}/dirC': {'dirD', 'fileC', 'novel.txt'},
+            f'{self.base}/dirC': {'fileC', 'dirD', 'novel.txt'},
             f'{self.base}/dirC/dirD': {'fileD'},
             f'{self.base}/dirE': set(),
         }


### PR DESCRIPTION
In the pathlib tests, avoid using the path class under test (`self.cls`) in test setup. Instead we use `os` functions in `test_pathlib`, and direct manipulation of `DummyPath` internal data in `test_pathlib_abc`.
