### PR TITLE
Document that dict.get takes no keyword arguments

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4640,7 +4640,7 @@ can be used interchangeably to index the same dictionary entry.
       such as an empty list.  To get distinct values, use a :ref:`dict
       comprehension <dict>` instead.
 
-   .. method:: get(key, default=None)
+   .. method:: get(key, default=None, /)
 
       Return the value for *key* if *key* is in the dictionary, else *default*.
       If *default* is not given, it defaults to ``None``, so that this method


### PR DESCRIPTION
Running

```python
{}.get("a", default="b")
```

gives:

```
    {}.get("a", default="b")
    ~~~~~~^^^^^^^^^^^^^^^^^^
TypeError: dict.get() takes no keyword arguments
```

----

Relatedly, this means that `dict` does not implement `collections.abc.Mapping` which does allow keyword arguments:
 https://github.com/python/cpython/blob/6f3c2c8d04e4981bdc3aec54e14236119c1aedcc/Lib/_collections_abc.py#L808

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128207.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->