### PR TITLE
gh-128213: fast path for bytes creation from list and tuple

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-24-08-44-49.gh-issue-128213.Y71jDi.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-24-08-44-49.gh-issue-128213.Y71jDi.rst
@@ -1,0 +1,2 @@
+Speed up :class:`bytes` creation from :class:`list` and :class:`tuple` by around 62%.
+Patch by Ben Hsing

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-24-08-44-49.gh-issue-128213.Y71jDi.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-24-08-44-49.gh-issue-128213.Y71jDi.rst
@@ -1,2 +1,3 @@
-Speed up :class:`bytes` creation from :class:`list` and :class:`tuple` by around 81%.
+Speed up :class:`bytes` creation from :class:`list` and :class:`tuple` of integers. Benchmarks show that from a list with 1000000 random numbers the time to create a bytes object is reduced by around 31%, or 30% with 10000 numbers, or 27% with 100 numbers.
+
 Patch by Ben Hsing

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-24-08-44-49.gh-issue-128213.Y71jDi.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-24-08-44-49.gh-issue-128213.Y71jDi.rst
@@ -1,2 +1,2 @@
-Speed up :class:`bytes` creation from :class:`list` and :class:`tuple` by around 62%.
+Speed up :class:`bytes` creation from :class:`list` and :class:`tuple` by around 81%.
 Patch by Ben Hsing

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2828,7 +2828,8 @@ _PyBytes_FromSequence(PyObject *x)
             bytes = Py_None;
 	    goto done;
         }
-        int value = PyLong_AsInt(items[i]);
+        int overflow;
+        long value = PyLong_AsLongAndOverflow(items[i], &overflow);
         if (value == -1 && PyErr_Occurred()) {
             goto error;
         }

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2834,7 +2834,7 @@ _PyBytes_FromSequence(PyObject *x)
                             "bytes must be in range(0, 256)");
             goto error;
         }
-        s[i] = value;
+        s[i] = (char)value;
     }
     return bytes;
   error:

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2826,15 +2826,13 @@ _PyBytes_FromSequence(PyObject *x)
             Py_DECREF(bytes);
             /* Py_None as a fallback sentinel to the slow path */
             bytes = Py_None;
-	    goto done;
+            goto done;
         }
-        int overflow;
-        long value = PyLong_AsLongAndOverflow(items[i], &overflow);
+        Py_ssize_t value = PyNumber_AsSsize_t(items[i], NULL);
         if (value == -1 && PyErr_Occurred()) {
             goto error;
         }
         if (value < 0 || value >= 256) {
-            /* this includes an overflow in converting to C long */
             PyErr_SetString(PyExc_ValueError,
                             "bytes must be in range(0, 256)");
             goto error;
@@ -2846,6 +2844,10 @@ _PyBytes_FromSequence(PyObject *x)
     Py_DECREF(bytes);
     bytes = NULL;
   done:
+    /* some C parsers require a label not to be at the end of a compound
+       statement, which the ending macro of a critical section introduces, so
+       we need an empty statement here to satisfy that syntax rule */
+    ;
     /* both success and failure need to end the critical section */
     Py_END_CRITICAL_SECTION_SEQUENCE_FAST();
     return bytes;


### PR DESCRIPTION
<!-- gh-issue-number: gh-128213 -->
* Issue: gh-128213
<!-- /gh-issue-number -->
Benchmark using `python -m timeit -n 100 -s 'a = __import__("random").choices(range(256), k=1000000)' 'bytes(a)'` showing a ~31% reduction in time consumed:
```
100 loops, best of 5: 3.21 msec per loop # current
100 loops, best of 5: 2.23 msec per loop # this PR
```
With `k=10000`, a ~30% time reduction:
```
100 loops, best of 5: 31.7 usec per loop # current
100 loops, best of 5: 22.3 usec per loop # this PR
```
With `k=100`, a ~27% time reduction:
```
100 loops, best of 5: 410 nsec per loop # current
100 loops, best of 5: 299 nsec per loop # this PR
```