### PR TITLE
gh-111178: fix UBSan failures in `Python/hamt.c`

### DIFF
--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -2592,7 +2592,7 @@ static PyObject *
 hamt_dump(PyHamtObject *self);
 #endif
 
-#define _PyHamtObject_CAST(op)     ((PyHamtObject *)(op))
+#define _PyHamtObject_CAST(op)      ((PyHamtObject *)(op))
 
 
 static PyObject *


### PR DESCRIPTION
- fix UBSan failures for `PyHamtObject`
- fix UBSan failures for `PyHamtNode_Array`
- fix UBSan failures for `PyHamtNode_Collision`
- fix UBSan failures for `PyHamtNode_Bitmap`


<!-- gh-issue-number: gh-111178 -->
* Issue: gh-111178
<!-- /gh-issue-number -->
