### PR TITLE
gh-128260: move getopt back into command line modules section

### DIFF
--- a/Doc/library/cmdlinelibs.rst
+++ b/Doc/library/cmdlinelibs.rst
@@ -14,6 +14,7 @@ Here's an overview:
 
    argparse.rst
    optparse.rst
+   getopt.rst
    getpass.rst
    fileinput.rst
    curses.rst

--- a/Doc/library/superseded.rst
+++ b/Doc/library/superseded.rst
@@ -22,5 +22,3 @@ currently no modules in this latter category.
 
 .. toctree::
    :maxdepth: 1
-
-   getopt.rst


### PR DESCRIPTION
This PR moves the `getopt` module back to most favored module status.

<!-- gh-issue-number: gh-128260 -->
* Issue: gh-128260
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128261.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->