### PR TITLE
[3.12] gh-128198: Add missing error checks for usages of PyIter_Next() (GH-128199)

### DIFF
--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -121,6 +121,10 @@ namespace_repr(PyObject *ns)
             goto error;
     }
 
+    if (PyErr_Occurred()) {
+        goto error;
+    }
+
     separator = PyUnicode_FromString(", ");
     if (separator == NULL)
         goto error;


### PR DESCRIPTION


(cherry picked from commit 5c814c83cdd3dc42bd9682106ffb7ade7ce6b5b3)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128198 -->
* Issue: gh-128198
<!-- /gh-issue-number -->
