### PR TITLE
Remove incorrect imports rationale comment in `http.server`

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -99,7 +99,7 @@ import os
 import posixpath
 import select
 import shutil
-import socket # For gethostbyaddr()
+import socket
 import socketserver
 import sys
 import time


### PR DESCRIPTION
Remove reference to gethostbyaddr(), because gethostbyaddr() is not actually used within this file.