### PR TITLE
gh-128302: fix apparent bug in `xml.dom.xmlbuilder.DOMBuilder.parse()`

### DIFF
--- a/Lib/test/test_xml_dom_xmlbuilder.py
+++ b/Lib/test/test_xml_dom_xmlbuilder.py
@@ -1,0 +1,88 @@
+import io
+import unittest
+from http import client
+from test.test_httplib import FakeSocket
+from unittest import mock
+from xml.dom import getDOMImplementation, minidom, xmlbuilder
+
+SMALL_SAMPLE = b"""<?xml version="1.0"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:xdc="http://www.xml.com/books">
+<!-- A comment -->
+<title>Introduction to XSL</title>
+<hr/>
+<p><xdc:author xdc:attrib="prefixed attribute" attrib="other attrib">A. Namespace</xdc:author></p>
+</html>"""
+
+
+class XMLBuilderTest(unittest.TestCase):
+    def test_entity_resolver(self):
+        body = (
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/xml; charset=utf-8\r\n\r\n"
+            + SMALL_SAMPLE
+        )
+
+        sock = FakeSocket(body)
+        response = client.HTTPResponse(sock)
+        response.begin()
+        attrs = {"open.return_value": response}
+        opener = mock.Mock(**attrs)
+
+        resolver = xmlbuilder.DOMEntityResolver()
+
+        with mock.patch("urllib.request.build_opener") as mock_build:
+            mock_build.return_value = opener
+            source = resolver.resolveEntity(None, "http://example.com/2000/svg")
+
+        self.assertIsInstance(source, xmlbuilder.DOMInputSource)
+        self.assertIsNone(source.publicId)
+        self.assertEqual(source.systemId, "http://example.com/2000/svg")
+        self.assertEqual(source.baseURI, "http://example.com/2000/")
+        self.assertEqual(source.encoding, "utf-8")
+        self.assertIs(source.byteStream, response)
+
+        self.assertIsNone(source.characterStream)
+        self.assertIsNone(source.stringData)
+
+    def test_builder(self):
+        imp = getDOMImplementation()
+        self.assertIsInstance(imp, xmlbuilder.DOMImplementationLS)
+
+        builder = imp.createDOMBuilder(imp.MODE_SYNCHRONOUS, None)
+        self.assertIsInstance(builder, xmlbuilder.DOMBuilder)
+
+    def test_parse_uri(self):
+        body = (
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/xml; charset=utf-8\r\n\r\n"
+            + SMALL_SAMPLE
+        )
+
+        sock = FakeSocket(body)
+        response = client.HTTPResponse(sock)
+        response.begin()
+        attrs = {"open.return_value": response}
+        opener = mock.Mock(**attrs)
+
+        with mock.patch("urllib.request.build_opener") as mock_build:
+            mock_build.return_value = opener
+
+            imp = getDOMImplementation()
+            builder = imp.createDOMBuilder(imp.MODE_SYNCHRONOUS, None)
+            document = builder.parseURI("http://example.com/2000/svg")
+
+        self.assertIsInstance(document, minidom.Document)
+        self.assertEqual(len(document.childNodes), 1)
+
+    def test_parse_with_systemId(self):
+        response = io.BytesIO(SMALL_SAMPLE)
+
+        with mock.patch("urllib.request.urlopen") as mock_open:
+            mock_open.return_value = response
+
+            imp = getDOMImplementation()
+            source = imp.createDOMInputSource()
+            builder = imp.createDOMBuilder(imp.MODE_SYNCHRONOUS, None)
+            source.systemId = "http://example.com/2000/svg"
+            document = builder.parse(source)
+
+        self.assertIsInstance(document, minidom.Document)
+        self.assertEqual(len(document.childNodes), 1)

--- a/Lib/xml/dom/xmlbuilder.py
+++ b/Lib/xml/dom/xmlbuilder.py
@@ -248,9 +248,9 @@ class DOMEntityResolver(object):
     def _guess_media_encoding(self, source):
         info = source.byteStream.info()
         if "Content-Type" in info:
-            for param in info.getplist():
-                if param.startswith("charset="):
-                    return param.split("=", 1)[1].lower()
+            for param in info.get_params([]):
+                if param[0] == 'charset':
+                    return param[1].lower()
 
 
 class DOMInputSource(object):

--- a/Lib/xml/dom/xmlbuilder.py
+++ b/Lib/xml/dom/xmlbuilder.py
@@ -189,7 +189,7 @@ class DOMBuilder:
         options.filter = self.filter
         options.errorHandler = self.errorHandler
         fp = input.byteStream
-        if fp is None and options.systemId:
+        if fp is None and input.systemId:
             import urllib.request
             fp = urllib.request.urlopen(input.systemId)
         return self._parse_bytestream(fp, options)

--- a/Lib/xml/dom/xmlbuilder.py
+++ b/Lib/xml/dom/xmlbuilder.py
@@ -247,10 +247,11 @@ class DOMEntityResolver(object):
 
     def _guess_media_encoding(self, source):
         info = source.byteStream.info()
-        if "Content-Type" in info:
-            for param in info.get_params([]):
-                if param[0] == 'charset':
-                    return param[1].lower()
+        # import email.message
+        # assert isinstance(info, email.message.Message)
+        for ctp_name, ctp_value in info.get_params(()):
+            if ctp_name == 'charset':
+                return ctp_value.lower()
 
 
 class DOMInputSource(object):

--- a/Lib/xml/dom/xmlbuilder.py
+++ b/Lib/xml/dom/xmlbuilder.py
@@ -249,9 +249,10 @@ class DOMEntityResolver(object):
         info = source.byteStream.info()
         # import email.message
         # assert isinstance(info, email.message.Message)
-        for ctp_name, ctp_value in info.get_params(()):
-            if ctp_name == 'charset':
-                return ctp_value.lower()
+        charset = info.get_param('charset')
+        if charset is not None:
+            return charset.lower()
+        return None
 
 
 class DOMInputSource(object):

--- a/Misc/NEWS.d/next/Library/2024-12-27-16-28-57.gh-issue-128302.2GMvyl.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-27-16-28-57.gh-issue-128302.2GMvyl.rst
@@ -1,0 +1,3 @@
+Allow :meth:`!xml.dom.xmlbuilder.DOMParser.parse` to correctly handle
+:class:`!xml.dom.xmlbuilder.DOMInputSource` instances that only have a
+:attr:`!systemId` attribute set.

--- a/Misc/NEWS.d/next/Library/2024-12-27-16-28-57.gh-issue-128302.2GMvyl.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-27-16-28-57.gh-issue-128302.2GMvyl.rst
@@ -1,3 +1,4 @@
 Allow :meth:`!xml.dom.xmlbuilder.DOMParser.parse` to correctly handle
 :class:`!xml.dom.xmlbuilder.DOMInputSource` instances that only have a
-:attr:`!systemId` attribute set.
+:attr:`!systemId` attribute set. Also, fix the broken
+:meth:`!xml.dom.xmlbuilder.DOMEntityResolver.resolveEntity` method.

--- a/Misc/NEWS.d/next/Library/2024-12-27-16-28-57.gh-issue-128302.2GMvyl.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-27-16-28-57.gh-issue-128302.2GMvyl.rst
@@ -1,4 +1,3 @@
 Allow :meth:`!xml.dom.xmlbuilder.DOMParser.parse` to correctly handle
 :class:`!xml.dom.xmlbuilder.DOMInputSource` instances that only have a
-:attr:`!systemId` attribute set. Also, fix the broken
-:meth:`!xml.dom.xmlbuilder.DOMEntityResolver.resolveEntity` method.
+:attr:`!systemId` attribute set.

--- a/Misc/NEWS.d/next/Library/2024-12-29-13-49-46.gh-issue-128302.psRpPN.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-29-13-49-46.gh-issue-128302.psRpPN.rst
@@ -1,0 +1,2 @@
+Fix :meth:`!xml.dom.xmlbuilder.DOMEntityResolver.resolveEntity`, which was
+broken by the Python 3.0 transition.


### PR DESCRIPTION
This looks like a bug. The `Options` class has no `systemId` attribute, but the input parameter, which seems to be an instance of `DOMInputSource`, does.

I don't really know how this is meant to be used, but given this code:

```python
from xml.dom.xmlbuilder import DOMBuilder, DOMInputSource

db = DOMBuilder()
source = DOMInputSource()
source.systemId = "http://www.w3.org/2000/svg"
print(db.parse(source))
```

As-is this raises an error:

```
  File "test.py", line 6, in <module>
    print(db.parse(source))
          ~~~~~~~~^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/xml/dom/xmlbuilder.py", line 192, in parse
    if fp is None and options.systemId:
                      ^^^^^^^^^^^^^^^^
AttributeError: 'Options' object has no attribute 'systemId'
```

With this change:

```
<xml.dom.minidom.Document object at 0x105438f50>
```

I'd consider adding a test, but there's no tests right now for any of this.

<!-- gh-issue-number: gh-128302 -->
* Issue: gh-128302
<!-- /gh-issue-number -->
