### PR TITLE
Mention loop_factory argument in docstring for asyncio.run()

### DIFF
--- a/Lib/asyncio/runners.py
+++ b/Lib/asyncio/runners.py
@@ -177,6 +177,7 @@ def run(main, *, debug=None, loop_factory=None):
     running in the same thread.
 
     If debug is True, the event loop will be run in debug mode.
+    If loop_factory is passed, it is used for new event loop creation.
 
     This function always creates a new event loop and closes it at the end.
     It should be used as a main entry point for asyncio programs, and should


### PR DESCRIPTION
The change copies missing `loop_factory` argument description from `asyncio.Runner` to `asyncio.run` docstring.

The only docstring should be updated, sphinx docs are good already.