### PR TITLE
gh-128185: Align the grammar of the `Decimal` string constructor with `float`'s

### DIFF
--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -358,7 +358,7 @@ Decimal objects
       indicator: "e" | "E"
       digits: (`digit` | "_")* `digit` (`digit` | "_")*
       decimalpart: `digits` "." [`digits`] | ["."] `digits`
-      exponentpart: indicator [sign] digits
+      exponentpart: `indicator` [`sign`] `digits`
       infinity: "Infinity" | "Inf"
       nan: "NaN" [`digits`] | "sNaN" [`digits`]
       numericvalue: `decimalpart` [`exponentpart`] | `infinity`

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -357,12 +357,12 @@ Decimal objects
       digit: "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
       indicator: "e" | "E"
       digits: (`digit` | "_")* `digit` (`digit` | "_")*
-      decimalpart: `digits` "." [`digits`] | ["."] `digits`
-      exponentpart: `indicator` [`sign`] `digits`
+      decimal_part: `digits` "." [`digits`] | ["."] `digits`
+      exponent_part: `indicator` [`sign`] `digits`
       infinity: "Infinity" | "Inf"
       nan: "NaN" [`digits`] | "sNaN" [`digits`]
-      numericvalue: `decimalpart` [`exponentpart`] | `infinity`
-      numericstring: [`sign`] `numericvalue` | [`sign`] `nan`
+      numeric_value: `decimal_part` [`exponent_part`] | `infinity`
+      numeric_string: [`sign`] `numeric_value` | [`sign`] `nan`
 
    Other Unicode decimal digits are also permitted where ``digit``
    appears above.  These include decimal digits from various other

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -350,18 +350,19 @@ Decimal objects
    *value* can be an integer, string, tuple, :class:`float`, or another :class:`Decimal`
    object. If no *value* is given, returns ``Decimal('0')``.  If *value* is a
    string, it should conform to the decimal numeric string syntax after leading
-   and trailing whitespace characters are removed::
+   and trailing whitespace characters are removed:
 
-      sign           ::=  '+' | '-'
-      digit          ::=  '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
-      indicator      ::=  'e' | 'E'
-      digits         ::=  (digit | '_')* digit (digit | '_')*
-      decimal-part   ::=  digits '.' [digits] | ['.'] digits
-      exponent-part  ::=  indicator [sign] digits
-      infinity       ::=  'Infinity' | 'Inf'
-      nan            ::=  'NaN' [digits] | 'sNaN' [digits]
-      numeric-value  ::=  decimal-part [exponent-part] | infinity
-      numeric-string ::=  [sign] numeric-value | [sign] nan
+   .. productionlist:: decimal
+      sign: "+" | "-"
+      digit: "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+      indicator: "e" | "E"
+      digits: (`digit` | "_")* `digit` (`digit` | "_")*
+      decimalpart: `digits` "." [`digits`] | ["."] `digits`
+      exponentpart: indicator [sign] digits
+      infinity: "Infinity" | "Inf"
+      nan: "NaN" [`digits`] | "sNaN" [`digits`]
+      numericvalue: `decimalpart` [`exponentpart`] | `infinity`
+      numericstring: [`sign`] `numericvalue` | [`sign`] `nan`
 
    Other Unicode decimal digits are also permitted where ``digit``
    appears above.  These include decimal digits from various other

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -356,7 +356,7 @@ Decimal objects
       sign: "+" | "-"
       digit: "0"..."9"
       indicator: "e" | "E"
-      digits: `digit` [`digit`]...
+      digits: (`digit`)+
       decimal_part: `digits` "." [`digits`] | ["."] `digits`
       exponent_part: `indicator` [`sign`] `digits`
       infinity: "Infinity" | "Inf"

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -356,7 +356,7 @@ Decimal objects
       sign: "+" | "-"
       digit: "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
       indicator: "e" | "E"
-      digits: (`digit` | "_")* `digit` (`digit` | "_")*
+      digits: `digit` [`digit`]...
       decimal_part: `digits` "." [`digits`] | ["."] `digits`
       exponent_part: `indicator` [`sign`] `digits`
       infinity: "Infinity" | "Inf"

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -354,7 +354,7 @@ Decimal objects
 
    .. productionlist:: decimal
       sign: "+" | "-"
-      digit: "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+      digit: "0"..."9"
       indicator: "e" | "E"
       digits: `digit` [`digit`]...
       decimal_part: `digits` "." [`digits`] | ["."] `digits`

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -350,12 +350,12 @@ Decimal objects
    *value* can be an integer, string, tuple, :class:`float`, or another :class:`Decimal`
    object. If no *value* is given, returns ``Decimal('0')``.  If *value* is a
    string, it should conform to the decimal numeric string syntax after leading
-   and trailing whitespace characters, as well as underscores throughout, are removed::
+   and trailing whitespace characters are removed::
 
       sign           ::=  '+' | '-'
       digit          ::=  '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
       indicator      ::=  'e' | 'E'
-      digits         ::=  digit [digit]...
+      digits         ::=  (digit | '_')* digit (digit | '_')*
       decimal-part   ::=  digits '.' [digits] | ['.'] digits
       exponent-part  ::=  indicator [sign] digits
       infinity       ::=  'Infinity' | 'Inf'

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -350,7 +350,7 @@ Decimal objects
    *value* can be an integer, string, tuple, :class:`float`, or another :class:`Decimal`
    object. If no *value* is given, returns ``Decimal('0')``.  If *value* is a
    string, it should conform to the decimal numeric string syntax after leading
-   and trailing whitespace characters are removed:
+   and trailing whitespace characters, as well as underscores throughout, are removed:
 
    .. productionlist:: decimal
       sign: "+" | "-"


### PR DESCRIPTION
This PR
- removes the mention of underscores in the text
- changes `digits` from `digit [digit]...` to `(digit | "_")* digit (digit | "_")*`
- makes it a `.. productionlist::`

<!-- gh-issue-number: gh-128185 -->
* Issue: gh-128185
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128315.org.readthedocs.build/en/128315/library/decimal.html#decimal.Decimal

<!-- readthedocs-preview cpython-previews end -->