### PR TITLE
gh-76023: WinFSP giving WinError 1005 fix

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -638,9 +638,10 @@ else:
         # 87: ERROR_INVALID_PARAMETER
         # 123: ERROR_INVALID_NAME
         # 161: ERROR_BAD_PATHNAME
+        # 1005: ERROR_UNRECOGNIZED_VOLUME
         # 1920: ERROR_CANT_ACCESS_FILE
         # 1921: ERROR_CANT_RESOLVE_FILENAME (implies unfollowable symlink)
-        allowed_winerror = 1, 2, 3, 5, 21, 32, 50, 53, 65, 67, 87, 123, 161, 1920, 1921
+        allowed_winerror = 1, 2, 3, 5, 21, 32, 50, 53, 65, 67, 87, 123, 161, 1005, 1920, 1921
 
         # Non-strict algorithm is to find as much of the target directory
         # as we can and join the rest.


### PR DESCRIPTION
Make os.path.realpath to ignore WinError 1005 in non-strict mode. (Tested on OS Windows 11)

[Cryptomator issue](https://github.com/cryptomator/cryptomator/issues/2359)
[python related issue](https://github.com/python/cpython/issues/76023)

In cryptomator running WinFSP volume as administrator and make encrypted volumes available to all users, is not recommended.


<!-- gh-issue-number: gh-76023 -->
* Issue: gh-76023
<!-- /gh-issue-number -->
