### PR TITLE
gh-128319: Add missing server class attributes to socketserver docs

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -264,12 +264,6 @@ Server Objects
       Clean up the server. May be overridden.
 
 
-   .. attribute:: address_family
-
-      The family of protocols to which the server's socket belongs.
-      Common examples are :const:`socket.AF_INET` and :const:`socket.AF_UNIX`.
-
-
    .. attribute:: RequestHandlerClass
 
       The user-provided request handler class; an instance of this class is created
@@ -294,14 +288,35 @@ Server Objects
 
    .. XXX should class variables be covered before instance variables, or vice versa?
 
+   .. attribute:: address_family
+
+      The family of protocols to which the server's socket belongs.
+      Common examples are :const:`socket.AF_INET` and :const:`socket.AF_UNIX`.
+
+
    .. attribute:: allow_reuse_address
 
       Whether the server will allow the reuse of an address.  This defaults to
       :const:`False`, and can be set in subclasses to change the policy.
 
 
+   .. attribute:: allow_reuse_port
+
+      Whether the server will allow the reuse of a port. This defaults to
+      :const:`False`, and can be set in subclasses to change the policy.
+
+   .. attribute:: max_packet_size
+
+      Only for datagram sockets, e.g. UDP.
+      The maximum amount of data (in bytes) to receive at once. If a packet is
+      too large for the buffer, then the excess bytes beyond :attr:`max_packet_size`
+      are discarded. The default value is usually 8192, but this can be
+      overridden by subclasses.
+
+
    .. attribute:: request_queue_size
 
+      Only for stream sockets, e.g. TCP.
       The size of the request queue.  If it takes a long time to process a single
       request, any requests that arrive while the server is busy are placed into a
       queue, up to :attr:`request_queue_size` requests.  Once the queue is full,

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -305,6 +305,7 @@ Server Objects
       Whether the server will allow the reuse of a port. This defaults to
       :const:`False`, and can be set in subclasses to change the policy.
 
+
    .. attribute:: max_packet_size
 
       Only for datagram sockets, e.g. UDP.

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -308,21 +308,27 @@ Server Objects
 
    .. attribute:: max_packet_size
 
-      Only for datagram sockets, e.g. UDP.
       The maximum amount of data (in bytes) to receive at once. If a packet is
       too large for the buffer, then the excess bytes beyond :attr:`max_packet_size`
-      are discarded. The default value is usually 8192, but this can be
+      are discarded. The default value is usually ``8192``, but this can be
       overridden by subclasses.
+
+      .. note::
+
+         Only for datagram sockets, i.e. UDP.
 
 
    .. attribute:: request_queue_size
 
-      Only for stream sockets, e.g. TCP.
       The size of the request queue.  If it takes a long time to process a single
       request, any requests that arrive while the server is busy are placed into a
       queue, up to :attr:`request_queue_size` requests.  Once the queue is full,
       further requests from clients will get a "Connection denied" error.  The default
-      value is usually 5, but this can be overridden by subclasses.
+      value is usually ``5``, but this can be overridden by subclasses.
+
+      .. note::
+
+         Only for stream sockets, i.e. TCP.
 
 
    .. attribute:: socket_type


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Just doing some cleanup of the socketserver docs regarding class attributes as mentioned in the linked issue.

- Move `address_family` attribute from instance attributes to class attributes.
- Document `allow_reuse_port`.
- Document `max_packet_size` (note UDP only).
- Add note to `request_queue_size` to denote TCP only.

<!-- gh-issue-number: gh-128319 -->
* Issue: gh-128319
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128320.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->