### PR TITLE
gh-128192: mark new tests with skips based on hashlib algorithm availability

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2969,3 +2969,11 @@ def run_yielding_async_fn(async_fn, /, *args, **kwargs):
                 return e.value
     finally:
         coro.close()
+
+
+def is_libssl_fips_mode():
+    try:
+        from _hashlib import get_fips_mode  # ask _hashopenssl.c
+    except ImportError:
+        return False  # more of a maybe, unless we add this to the _ssl module.
+    return get_fips_mode() != 0

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -27,11 +27,6 @@ from urllib.parse import urlsplit
 import urllib.error
 import http.client
 
-try:
-    from _hashlib import get_fips_mode
-except ImportError:
-    def get_fips_mode():
-        return 0
 
 support.requires_working_socket(module=True)
 
@@ -1969,23 +1964,29 @@ class MiscTests(unittest.TestCase):
         self.assertRaises(ValueError, _parse_proxy, 'file:/ftp.example.com'),
 
 
+skip_libssl_fips_mode = unittest.skipIf(
+    support.is_libssl_fips_mode(),
+    "conservative skip due to OpenSSL FIPS mode possible algorithm nerfing",
+)
+
+
 class TestDigestAuthAlgorithms(unittest.TestCase):
     def setUp(self):
         self.handler = AbstractDigestAuthHandler()
 
-    @unittest.skipIf(get_fips_mode(), "fips mode; requires hashlib.md5")
+    @skip_libssl_fips_mode
     def test_md5_algorithm(self):
         H, KD = self.handler.get_algorithm_impls('MD5')
         self.assertEqual(H("foo"), "acbd18db4cc2f85cedef654fccc4a4d8")
         self.assertEqual(KD("foo", "bar"), "4e99e8c12de7e01535248d2bac85e732")
 
-    @unittest.skipIf(get_fips_mode(), "fips mode; requires hashlib.sha1")
+    @skip_libssl_fips_mode
     def test_sha_algorithm(self):
         H, KD = self.handler.get_algorithm_impls('SHA')
         self.assertEqual(H("foo"), "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
         self.assertEqual(KD("foo", "bar"), "54dcbe67d21d5eb39493d46d89ae1f412d3bd6de")
 
-    @unittest.skipIf(get_fips_mode(), "fips mode; requires hashlib.sha256")
+    @skip_libssl_fips_mode
     def test_sha256_algorithm(self):
         H, KD = self.handler.get_algorithm_impls('SHA-256')
         self.assertEqual(H("foo"), "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -9,6 +9,7 @@ from unittest import mock
 import os
 import io
 import ftplib
+import hashlib
 import socket
 import array
 import sys
@@ -1963,20 +1964,23 @@ class MiscTests(unittest.TestCase):
         self.assertRaises(ValueError, _parse_proxy, 'file:/ftp.example.com'),
 
 
-class TestDigestAlgorithms(unittest.TestCase):
+class TestDigestAuthAlgorithms(unittest.TestCase):
     def setUp(self):
         self.handler = AbstractDigestAuthHandler()
 
+    @unittest.skipUnless(hasattr(hashlib, 'md5'), "required hashlib.md5")
     def test_md5_algorithm(self):
         H, KD = self.handler.get_algorithm_impls('MD5')
         self.assertEqual(H("foo"), "acbd18db4cc2f85cedef654fccc4a4d8")
         self.assertEqual(KD("foo", "bar"), "4e99e8c12de7e01535248d2bac85e732")
 
+    @unittest.skipUnless(hasattr(hashlib, 'sha1'), "required hashlib.sha1")
     def test_sha_algorithm(self):
         H, KD = self.handler.get_algorithm_impls('SHA')
         self.assertEqual(H("foo"), "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
         self.assertEqual(KD("foo", "bar"), "54dcbe67d21d5eb39493d46d89ae1f412d3bd6de")
 
+    @unittest.skipUnless(hasattr(hashlib, 'sha256'), "required hashlib.sha256")
     def test_sha256_algorithm(self):
         H, KD = self.handler.get_algorithm_impls('SHA-256')
         self.assertEqual(H("foo"), "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -9,7 +9,6 @@ from unittest import mock
 import os
 import io
 import ftplib
-import hashlib
 import socket
 import array
 import sys
@@ -27,6 +26,12 @@ from urllib.request import (Request, OpenerDirector, HTTPBasicAuthHandler,
 from urllib.parse import urlsplit
 import urllib.error
 import http.client
+
+try:
+    from _hashlib import get_fips_mode
+except ImportError:
+    def get_fips_mode():
+        return 0
 
 support.requires_working_socket(module=True)
 
@@ -1968,19 +1973,19 @@ class TestDigestAuthAlgorithms(unittest.TestCase):
     def setUp(self):
         self.handler = AbstractDigestAuthHandler()
 
-    @unittest.skipUnless(hasattr(hashlib, 'md5'), "required hashlib.md5")
+    @unittest.skipIf(get_fips_mode(), "fips mode; requires hashlib.md5")
     def test_md5_algorithm(self):
         H, KD = self.handler.get_algorithm_impls('MD5')
         self.assertEqual(H("foo"), "acbd18db4cc2f85cedef654fccc4a4d8")
         self.assertEqual(KD("foo", "bar"), "4e99e8c12de7e01535248d2bac85e732")
 
-    @unittest.skipUnless(hasattr(hashlib, 'sha1'), "required hashlib.sha1")
+    @unittest.skipIf(get_fips_mode(), "fips mode; requires hashlib.sha1")
     def test_sha_algorithm(self):
         H, KD = self.handler.get_algorithm_impls('SHA')
         self.assertEqual(H("foo"), "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
         self.assertEqual(KD("foo", "bar"), "54dcbe67d21d5eb39493d46d89ae1f412d3bd6de")
 
-    @unittest.skipUnless(hasattr(hashlib, 'sha256'), "required hashlib.sha256")
+    @unittest.skipIf(get_fips_mode(), "fips mode; requires hashlib.sha256")
     def test_sha256_algorithm(self):
         H, KD = self.handler.get_algorithm_impls('SHA-256')
         self.assertEqual(H("foo"), "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")


### PR DESCRIPTION
This is not _important_. The buildbot this is ameliorating is a crazy configuration that we don't support, primarily for testing purposes. This just tries to maintain pairity with which oddball bots were failing before the issues main change rather than regressing one.

<!-- gh-issue-number: gh-128192 -->
* Issue: gh-128192
<!-- /gh-issue-number -->
