### PR TITLE
Reword `about.rst` to not limit Sphinx

### DIFF
--- a/Doc/about.rst
+++ b/Doc/about.rst
@@ -1,6 +1,6 @@
-=====================
+========================
 About this documentation
-=====================
+========================
 
 
 These documents are generated from `reStructuredText`_ sources using `Sphinx`_,

--- a/Doc/about.rst
+++ b/Doc/about.rst
@@ -27,7 +27,7 @@ Many thanks go to:
   got many good ideas.
 
 
-Contributors to the Python Documentation
+Contributors to the Python documentation
 ----------------------------------------
 
 Many people have contributed to the Python language, the Python standard

--- a/Doc/about.rst
+++ b/Doc/about.rst
@@ -3,8 +3,9 @@ About this documentation
 ========================
 
 
-These documents are generated from `reStructuredText`_ sources using `Sphinx`_,
-a documentation processor originally created for Python.
+Python's documentation is generated from `reStructuredText`_ sources
+using `Sphinx`_, a documentation generator originally created for Python
+and now maintained as an independent project.
 
 .. _reStructuredText: https://docutils.sourceforge.io/rst.html
 .. _Sphinx: https://www.sphinx-doc.org/

--- a/Doc/about.rst
+++ b/Doc/about.rst
@@ -1,10 +1,10 @@
 =====================
-About these documents
+About this documentation
 =====================
 
 
-These documents are generated from `reStructuredText`_ sources by `Sphinx`_, a
-document processor specifically written for the Python documentation.
+These documents are generated from `reStructuredText`_ sources using `Sphinx`_,
+a documentation processor originally created for Python.
 
 .. _reStructuredText: https://docutils.sourceforge.io/rst.html
 .. _Sphinx: https://www.sphinx-doc.org/
@@ -20,7 +20,7 @@ volunteers are always welcome!
 Many thanks go to:
 
 * Fred L. Drake, Jr., the creator of the original Python documentation toolset
-  and writer of much of the content;
+  and author of much of the content;
 * the `Docutils <https://docutils.sourceforge.io/>`_ project for creating
   reStructuredText and the Docutils suite;
 * Fredrik Lundh for his Alternative Python Reference project from which Sphinx


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Currently the documentation makes it sound like Sphinx is restricted for CPython documentation which is misleading as it is not.

I also propose a more formal title, which is more consistent with `about.rst` as `documentation` is preferred over `documents`.

Finally a small change, `writer` is replaced by `author` which again is also more consistent with the documentation overall as people are elsewhere referred to as "authors".

The page is linked as `About the Documentation` in the index.
![image](https://github.com/user-attachments/assets/0c4a745a-e6c9-4b9c-8236-78d4e84596ba)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128325.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->