### PR TITLE
gh-119786: Mention `InternalDocs/interpreter.md` instead of non-existing `adaptive.md`

### DIFF
--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -21,7 +21,7 @@
 extern const char *_PyUOpName(int index);
 
 /* For guidance on adding or extending families of instructions see
- * ./adaptive.md
+ * ../InternalDocs/interpreter.md `Specialization` section.
  */
 
 #ifdef Py_STATS

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -21,7 +21,7 @@
 extern const char *_PyUOpName(int index);
 
 /* For guidance on adding or extending families of instructions see
- * ../InternalDocs/interpreter.md `Specialization` section.
+ * InternalDocs/interpreter.md `Specialization` section.
  */
 
 #ifdef Py_STATS


### PR DESCRIPTION
`adaptive.md` was [moved](https://github.com/python/cpython/pull/127175) to a section in `InternalDocs/interpreter.md` but comment pointing there was not updated.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119786 -->
* Issue: gh-119786
<!-- /gh-issue-number -->
