### PR TITLE
gh-128330: Terminal control characters should be restored on repl exit

### DIFF
--- a/Lib/_pyrepl/fancy_termios.py
+++ b/Lib/_pyrepl/fancy_termios.py
@@ -40,7 +40,7 @@ class TermState:
             self.lflag,
             self.ispeed,
             self.ospeed,
-            self.cc,
+            self.cc[:],
         ]
 
     def copy(self):

--- a/Lib/_pyrepl/fancy_termios.py
+++ b/Lib/_pyrepl/fancy_termios.py
@@ -40,6 +40,8 @@ class TermState:
             self.lflag,
             self.ispeed,
             self.ospeed,
+            # Always return a copy of the control characters list to ensure
+            # there are not any additional references to self.cc
             self.cc[:],
         ]
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-29-15-09-21.gh-issue-128330.IaYL7G.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-29-15-09-21.gh-issue-128330.IaYL7G.rst
@@ -1,0 +1,1 @@
+Terminal control characters should be restored on repl exit

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-29-15-09-21.gh-issue-128330.IaYL7G.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-29-15-09-21.gh-issue-128330.IaYL7G.rst
@@ -1,1 +1,1 @@
-Terminal control characters should be restored on repl exit
+Restore terminal control characters on REPL exit.


### PR DESCRIPTION


<!-- gh-issue-number: gh-128330 -->
* Issue: gh-128330
<!-- /gh-issue-number -->
