### PR TITLE
Make Sphinx generate a 404 page

### DIFF
--- a/Doc/404.rst
+++ b/Doc/404.rst
@@ -1,0 +1,7 @@
+******************
+404 Page Not Found
+******************
+
+It seems the page you are searching for is missing.
+
+`Click Here to return to the homepage. <docs.python.org>`_

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -401,6 +401,7 @@ html_sidebars = {
 html_additional_pages = {
     'download': 'download.html',
     'index': 'indexcontent.html',
+    '404': '404.html',
 }
 
 # Output an OpenSearch description file.

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -401,7 +401,7 @@ html_sidebars = {
 html_additional_pages = {
     'download': 'download.html',
     'index': 'indexcontent.html',
-    '404': '404.html',
+    '404': '404.rst',
 }
 
 # Output an OpenSearch description file.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


Currently the docs 404 page is just the standard nginx page which has little features and does not have the Python Docs Header and footer. Most websites have a custom 404 page that is more helpful than the default.

My changes will result in Spinx building the page with the footer and header however the nginx conf must also be modified however this is up to the sysadmin as a PR cannot be submitted for it. I think this is what is required from a google search but I am not too familiar with nginx.

```diff
+ error_page 404 /404.html;
+ location = /404.html {
+     internal;
+ }
```



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128333.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->