### PR TITLE
Docs: correctly markup sys.monitoring "What's New" entry

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -614,8 +614,8 @@ sys
 sys.monitoring
 --------------
 
-Two new events are added: :monitoring-event:`BRANCH_LEFT` and
-:monitoring-event:`BRANCH_RIGHT`. The ``BRANCH`` event is deprecated.
+* Two new events are added: :monitoring-event:`BRANCH_LEFT` and
+  :monitoring-event:`BRANCH_RIGHT`. The ``BRANCH`` event is deprecated.
 
 tkinter
 -------


### PR DESCRIPTION
The sys.monitoring entry was added with commit d2f1d917e.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128346.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->