### PR TITLE
gh-128349: use `.. data::` instead of `.. class::` for pre-defined decimal `Context` objects

### DIFF
--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -1035,7 +1035,7 @@ described below. In addition, the module provides three pre-made contexts:
 
 .. data:: BasicContext
 
-   This is a predefined context object defined by the General Decimal Arithmetic Specification.
+   This is a standard context object defined by the General Decimal Arithmetic Specification.
    Precision is set to nine.  Rounding is set to
    :const:`ROUND_HALF_UP`.  All flags are cleared.  All traps are enabled (treated
    as exceptions) except :const:`Inexact`, :const:`Rounded`, and
@@ -1044,7 +1044,7 @@ described below. In addition, the module provides three pre-made contexts:
    Because many of the traps are enabled, this context is useful for debugging.
 
 
-.. class:: ExtendedContext
+.. data:: ExtendedContext
 
    This is a standard context defined by the General Decimal Arithmetic
    Specification.  Precision is set to nine.  Rounding is set to
@@ -1057,7 +1057,7 @@ described below. In addition, the module provides three pre-made contexts:
    presence of conditions that would otherwise halt the program.
 
 
-.. class:: DefaultContext
+.. data:: DefaultContext
 
    This context is used by the :class:`Context` constructor as a prototype for new
    contexts.  Changing a field (such a precision) has the effect of changing the

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -1035,7 +1035,7 @@ described below. In addition, the module provides three pre-made contexts:
 
 .. data:: BasicContext
 
-   This is a standard context object defined by the General Decimal Arithmetic Specification.
+   This is a standard context defined by the General Decimal Arithmetic Specification.
    Precision is set to nine.  Rounding is set to
    :const:`ROUND_HALF_UP`.  All flags are cleared.  All traps are enabled (treated
    as exceptions) except :const:`Inexact`, :const:`Rounded`, and

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -1033,10 +1033,10 @@ New contexts can also be created using the :class:`Context` constructor
 described below. In addition, the module provides three pre-made contexts:
 
 
-.. class:: BasicContext
+.. data:: BasicContext
 
-   This is a standard context defined by the General Decimal Arithmetic
-   Specification.  Precision is set to nine.  Rounding is set to
+   This is a predefined context object defined by the General Decimal Arithmetic Specification.
+   Precision is set to nine.  Rounding is set to
    :const:`ROUND_HALF_UP`.  All flags are cleared.  All traps are enabled (treated
    as exceptions) except :const:`Inexact`, :const:`Rounded`, and
    :const:`Subnormal`.

--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -1035,8 +1035,8 @@ described below. In addition, the module provides three pre-made contexts:
 
 .. data:: BasicContext
 
-   This is a standard context defined by the General Decimal Arithmetic Specification.
-   Precision is set to nine.  Rounding is set to
+   This is a standard context defined by the General Decimal Arithmetic
+   Specification.  Precision is set to nine.  Rounding is set to
    :const:`ROUND_HALF_UP`.  All flags are cleared.  All traps are enabled (treated
    as exceptions) except :const:`Inexact`, :const:`Rounded`, and
    :const:`Subnormal`.

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -1147,8 +1147,8 @@ API changes
    | :const:`MIN_EMIN` | ``-425000000`` | ``-999999999999999999`` |
    +-------------------+----------------+-------------------------+
 
-* In the context templates (:class:`~decimal.DefaultContext`,
-  :class:`~decimal.BasicContext` and :class:`~decimal.ExtendedContext`)
+* In the context templates (:data:`~decimal.DefaultContext`,
+  :data:`~decimal.BasicContext` and :data:`~decimal.ExtendedContext`)
   the magnitude of :attr:`~decimal.Context.Emax` and
   :attr:`~decimal.Context.Emin` has changed to ``999999``.
 

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -1147,8 +1147,8 @@ API changes
    | :const:`MIN_EMIN` | ``-425000000`` | ``-999999999999999999`` |
    +-------------------+----------------+-------------------------+
 
-* In the context templates (:data:`~decimal.DefaultContext`,
-  :data:`~decimal.BasicContext` and :data:`~decimal.ExtendedContext`)
+* In the context templates (:const:`~decimal.DefaultContext`,
+  :const:`~decimal.BasicContext` and :const:`~decimal.ExtendedContext`)
   the magnitude of :attr:`~decimal.Context.Emax` and
   :attr:`~decimal.Context.Emin` has changed to ``999999``.
 


### PR DESCRIPTION
Closes gh-128349.

Updated `.. class:: BasicContext` to `.. data:: BasicContext` to correctly represent it as a predefined context object, not a class.

This ensures accurate documentation of the `decimal` module.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128379.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->