### PR TITLE
gh-123925: Fix building curses on platforms without libncursesw

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-01-02-11-02-45.gh-issue-123925.TLlyUi.rst
+++ b/Misc/NEWS.d/next/Build/2025-01-02-11-02-45.gh-issue-123925.TLlyUi.rst
@@ -1,0 +1,2 @@
+Fix building the :mod:`curses` module on platforms with libncurses but
+without libncursesw.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -138,7 +138,7 @@ typedef chtype attr_t;           /* No attr_t type is available */
 #define STRICT_SYSV_CURSES
 #endif
 
-#if NCURSES_EXT_FUNCS+0 >= 20170401 && NCURSES_EXT_COLORS+0 >= 20170401
+#if defined(HAVE_NCURSESW) && NCURSES_EXT_FUNCS+0 >= 20170401 && NCURSES_EXT_COLORS+0 >= 20170401
 #define _NCURSES_EXTENDED_COLOR_FUNCS   1
 #else
 #define _NCURSES_EXTENDED_COLOR_FUNCS   0


### PR DESCRIPTION


<!-- gh-issue-number: gh-123925 -->
* Issue: gh-123925
<!-- /gh-issue-number -->
