### PR TITLE
Revert "Doc: Show object descriptions in the table of contents (#125757)"

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -101,9 +101,7 @@ needs_sphinx = '7.2.6'
 
 # Create table of contents entries for domain objects (e.g. functions, classes,
 # attributes, etc.). Default is True.
-toc_object_entries = True
-# Hide parents to tidy up long entries in sidebar
-toc_object_entries_show_parents = 'hide'
+toc_object_entries = False
 
 # Ignore any .rst files in the includes/ directory;
 # they're embedded in pages but not rendered as individual pages.

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -434,6 +434,5 @@ def setup(app):
     app.add_directive_to_domain('py', 'awaitablemethod', PyAwaitableMethod)
     app.add_directive_to_domain('py', 'abstractmethod', PyAbstractMethod)
     app.add_directive('miscnews', MiscNews)
-    app.add_css_file('sidebar-wrap.css')
     app.connect('env-check-consistency', patch_pairindextypes)
     return {'version': '1.0', 'parallel_read_safe': True}

--- a/Doc/tools/static/sidebar-wrap.css
+++ b/Doc/tools/static/sidebar-wrap.css
@@ -1,6 +1,0 @@
-div.sphinxsidebarwrapper {
-    overflow-x: scroll;
-}
-div.sphinxsidebarwrapper li code {
-    overflow-wrap: normal;
-}


### PR DESCRIPTION
This reverts commit 91ddde4af0c3031c84a967bcf59f6fb4f8a48c0d.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Revert PR https://github.com/python/cpython/pull/125757 from October.

Re: https://discuss.python.org/t/summary-tables-as-an-api-overview/68474/37, https://discuss.python.org/t/summary-tables-as-an-api-overview/68474/53 etc.

The changes are a bit too extensive, so let's revert so this can be reworked later.

Before:
* https://docs.python.org/3.14/library/index.html
* https://docs.python.org/3.14/library/datetime.html

After:
* https://cpython-previews--128406.org.readthedocs.build/en/128406/library/index.html
* https://cpython-previews--128406.org.readthedocs.build/en/128406/library/datetime.html

cc @AA-Turner @willingc @pfmoore 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128406.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->