### PR TITLE
[3.12] gh-128014:  Fix passing default='' to the tkinter method wm_iconbitmap() (GH-128015)

### DIFF
--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -3,7 +3,8 @@ import unittest
 import tkinter
 import enum
 from test import support
-from test.test_tkinter.support import AbstractTkTest, AbstractDefaultRootTest
+from test.test_tkinter.support import (AbstractTkTest, AbstractDefaultRootTest,
+                                       requires_tk, get_tk_patchlevel)
 
 support.requires('gui')
 
@@ -390,6 +391,34 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         widget.insert(0, '\u20ac\0')  # non-ASCII
         widget.selection_range(0, 'end')
         self.assertEqual(widget.selection_get(), '\u20ac\0abc\x00def')
+
+
+class WmTest(AbstractTkTest, unittest.TestCase):
+
+    def test_wm_iconbitmap(self):
+        t = tkinter.Toplevel(self.root)
+        self.assertEqual(t.wm_iconbitmap(), '')
+        t.wm_iconbitmap('hourglass')
+        bug = False
+        if t._windowingsystem == 'aqua':
+            # Tk bug 13ac26b35dc55f7c37f70b39d59d7ef3e63017c8.
+            patchlevel = get_tk_patchlevel(t)
+            if patchlevel < (8, 6, 17) or (9, 0) <= patchlevel < (9, 0, 2):
+                bug = True
+        if not bug:
+            self.assertEqual(t.wm_iconbitmap(), 'hourglass')
+        self.assertEqual(self.root.wm_iconbitmap(), '')
+        t.wm_iconbitmap('')
+        self.assertEqual(t.wm_iconbitmap(), '')
+
+        if t._windowingsystem == 'win32':
+            t.wm_iconbitmap(default='hourglass')
+            self.assertEqual(t.wm_iconbitmap(), 'hourglass')
+            self.assertEqual(self.root.wm_iconbitmap(), '')
+            t.wm_iconbitmap(default='')
+            self.assertEqual(t.wm_iconbitmap(), '')
+
+        t.destroy()
 
 
 class EventTest(AbstractTkTest, unittest.TestCase):

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -2150,7 +2150,7 @@ class Wm:
         explicitly.  DEFAULT can be the relative path to a .ico file
         (example: root.iconbitmap(default='myicon.ico') ).  See Tk
         documentation for more information."""
-        if default:
+        if default is not None:
             return self.tk.call('wm', 'iconbitmap', self._w, '-default', default)
         else:
             return self.tk.call('wm', 'iconbitmap', self._w, bitmap)

--- a/Misc/NEWS.d/next/Library/2024-12-18-00-07-50.gh-issue-128014.F3aUbz.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-18-00-07-50.gh-issue-128014.F3aUbz.rst
@@ -1,0 +1,2 @@
+Fix resetting the default window icon by passing ``default=''`` to the
+:mod:`tkinter` method :meth:`!wm_iconbitmap`.


### PR DESCRIPTION
(cherry picked from commit 58e9f95c4aa970db32a94b9152b51ede22f823bd)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128014 -->
* Issue: gh-128014
<!-- /gh-issue-number -->
