### PR TITLE
gh-128400: Only show the current thread in `faulthandler` if the GIL is disabled

### DIFF
--- a/Doc/library/faulthandler.rst
+++ b/Doc/library/faulthandler.rst
@@ -92,8 +92,8 @@ Fault handler state
       if *all_threads* is true.
 
    .. versionchanged:: next
-      Only the current thread is dumped if the :term:`GIL` is disabled and
-      other threads are running.
+      Only the current thread is dumped if the :term:`GIL` is disabled to
+      prevent the risk of data races.
 
 .. function:: disable()
 

--- a/Doc/library/faulthandler.rst
+++ b/Doc/library/faulthandler.rst
@@ -91,6 +91,10 @@ Fault handler state
       The dump now mentions if a garbage collector collection is running
       if *all_threads* is true.
 
+   .. versionchanged:: next
+      Only the current thread is dumped if the :term:`GIL` is disabled and
+      other threads are running.
+
 .. function:: disable()
 
    Disable the fault handler: uninstall the signal handlers installed by

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -100,7 +100,7 @@ class FaultHandlerTests(unittest.TestCase):
 
         Raise an error if the output doesn't match the expected format.
         """
-        if all_threads:
+        if all_threads and sys._is_gil_enabled():
             if know_current_thread:
                 header = 'Current thread 0x[0-9a-f]+'
             else:
@@ -111,6 +111,8 @@ class FaultHandlerTests(unittest.TestCase):
         if py_fatal_error:
             regex.append("Python runtime state: initialized")
         regex.append('')
+        if not sys._is_gil_enabled():
+            regex.append("<Cannot show all threads while the GIL is disabled>")
         regex.append(fr'{header} \(most recent call first\):')
         if garbage_collecting:
             regex.append('  Garbage-collecting')

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -100,7 +100,13 @@ class FaultHandlerTests(unittest.TestCase):
 
         Raise an error if the output doesn't match the expected format.
         """
-        if all_threads and sys._is_gil_enabled():
+        all_threads_disabled = (
+            (not py_fatal_error)
+            and all_threads
+            and (not sys._is_gil_enabled())
+            and (not garbage_collecting)
+        )
+        if all_threads and not all_threads_disabled:
             if know_current_thread:
                 header = 'Current thread 0x[0-9a-f]+'
             else:
@@ -111,7 +117,7 @@ class FaultHandlerTests(unittest.TestCase):
         if py_fatal_error:
             regex.append("Python runtime state: initialized")
         regex.append('')
-        if not sys._is_gil_enabled():
+        if all_threads_disabled:
             regex.append("<Cannot show all threads while the GIL is disabled>")
         regex.append(fr'{header} \(most recent call first\):')
         if garbage_collecting:

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -104,7 +104,6 @@ class FaultHandlerTests(unittest.TestCase):
             (not py_fatal_error)
             and all_threads
             and (not sys._is_gil_enabled())
-            and (not garbage_collecting)
         )
         if all_threads and not all_threads_disabled:
             if know_current_thread:
@@ -120,7 +119,7 @@ class FaultHandlerTests(unittest.TestCase):
         if all_threads_disabled:
             regex.append("<Cannot show all threads while the GIL is disabled>")
         regex.append(fr'{header} \(most recent call first\):')
-        if garbage_collecting:
+        if garbage_collecting and not all_threads_disabled:
             regex.append('  Garbage-collecting')
         regex.append(fr'  File "<string>", line {lineno} in {function}')
         regex = '\n'.join(regex)

--- a/Misc/NEWS.d/next/Library/2025-01-02-15-20-17.gh-issue-128400.UMiG4f.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-02-15-20-17.gh-issue-128400.UMiG4f.rst
@@ -1,0 +1,2 @@
+Only show the current thread in :mod:`faulthandler` on the :term:`free
+threaded <free threading>` build to prevent races.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -288,11 +288,6 @@ deduce_all_threads(void)
     {
         return 0;
     }
-    if (tstate->interp->gc.collecting)
-    {
-        // Yay! All threads are paused, it's safe to access them.
-        return 1;
-    }
 
     /* In theory, it's safe to dump all threads if the GIL is enabled */
     return _PyEval_IsGILEnabled(tstate)

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -283,8 +283,7 @@ deduce_all_threads(void)
     }
     // We can't use _PyThreadState_GET, so use the stored GILstate one
     PyThreadState *tstate = PyGILState_GetThisThreadState();
-    if (tstate == NULL)
-    {
+    if (tstate == NULL) {
         return 0;
     }
 

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -208,8 +208,7 @@ faulthandler_dump_traceback(int fd, int all_threads,
         (void)_Py_DumpTracebackThreads(fd, NULL, tstate);
     }
     else {
-        if (all_threads == FT_IGNORE_ALL_THREADS)
-        {
+        if (all_threads == FT_IGNORE_ALL_THREADS) {
             PUTS(fd, "<Cannot show all threads while the GIL is disabled>\n");
         }
         if (tstate != NULL)

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -279,8 +279,17 @@ deduce_all_threads(void)
 #ifndef Py_GIL_DISABLED
     return fatal_error.all_threads;
 #else
+    if (fatal_error.all_threads == 0) {
+        return 0;
+    }
+    // We can't use _PyThreadState_GET
+    PyThreadState *tstate = PyGILState_GetThisThreadState();
+    if (tstate == NULL)
+    {
+        return 0;
+    }
     /* In theory, it's safe to dump all threads if the GIL is enabled */
-    return _PyEval_IsGILEnabled(_PyThreadState_GET())
+    return _PyEval_IsGILEnabled(tstate)
         ? fatal_error.all_threads
         : FT_IGNORE_ALL_THREADS;
 #endif

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "pycore_ceval.h"         // _PyEval_IsGILEnabled
 #include "pycore_initconfig.h"    // _PyStatus_ERR
 #include "pycore_pyerrors.h"      // _Py_DumpExtensionModules
 #include "pycore_pystate.h"       // _PyThreadState_GET()
@@ -27,6 +28,8 @@
 #  include <sys/auxv.h>           // getauxval()
 #endif
 
+/* Sentinel to ignore all_threads on free-threading */
+#define FT_IGNORE_ALL_THREADS 2
 
 /* Allocate at maximum 100 MiB of the stack to raise the stack overflow */
 #define STACK_OVERFLOW_MAX_SIZE (100 * 1024 * 1024)
@@ -201,10 +204,14 @@ faulthandler_dump_traceback(int fd, int all_threads,
        PyGILState_GetThisThreadState(). */
     PyThreadState *tstate = PyGILState_GetThisThreadState();
 
-    if (all_threads) {
+    if (all_threads == 1) {
         (void)_Py_DumpTracebackThreads(fd, NULL, tstate);
     }
     else {
+        if (all_threads == FT_IGNORE_ALL_THREADS)
+        {
+            PUTS(fd, "<Only the current thread is shown while the GIL is disabled>\n");
+        }
         if (tstate != NULL)
             _Py_DumpTraceback(fd, tstate);
     }
@@ -266,6 +273,18 @@ faulthandler_disable_fatal_handler(fault_handler_t *handler)
 #endif
 }
 
+static int
+deduce_all_threads(void)
+{
+#ifndef Py_GIL_DISABLED
+    return fatal_error.all_threads;
+#else
+    /* In theory, it's safe to dump all threads if the GIL is enabled */
+    return _PyEval_IsGILEnabled(_PyThreadState_GET())
+        ? fatal_error.all_threads
+        : FT_IGNORE_ALL_THREADS;
+#endif
+}
 
 /* Handler for SIGSEGV, SIGFPE, SIGABRT, SIGBUS and SIGILL signals.
 
@@ -320,7 +339,7 @@ faulthandler_fatal_error(int signum)
         PUTS(fd, "\n\n");
     }
 
-    faulthandler_dump_traceback(fd, fatal_error.all_threads,
+    faulthandler_dump_traceback(fd, deduce_all_threads(),
                                 fatal_error.interp);
 
     _Py_DumpExtensionModules(fd, fatal_error.interp);
@@ -396,7 +415,7 @@ faulthandler_exc_handler(struct _EXCEPTION_POINTERS *exc_info)
         }
     }
 
-    faulthandler_dump_traceback(fd, fatal_error.all_threads,
+    faulthandler_dump_traceback(fd, deduce_all_threads(),
                                 fatal_error.interp);
 
     /* call the next exception handler */

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -210,7 +210,7 @@ faulthandler_dump_traceback(int fd, int all_threads,
     else {
         if (all_threads == FT_IGNORE_ALL_THREADS)
         {
-            PUTS(fd, "<Only the current thread is shown while the GIL is disabled>\n");
+            PUTS(fd, "<Cannot show all threads while the GIL is disabled>\n");
         }
         if (tstate != NULL)
             _Py_DumpTraceback(fd, tstate);


### PR DESCRIPTION
A few notes here:

- Displaying other threads is useful for debugging, so some cases such as where the GIL is re-enabled or during a garbage collection (and therefore threads are stopped) still show all threads.
- `Py_FatalError` still displays all threads, but that's a seperate bug--is it safe to stop-the-world during a fatal error?
- Should this get backported?

<!-- gh-issue-number: gh-128400 -->
* Issue: gh-128400
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128425.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->