### PR TITLE
gh-128427: Add `uuid.NIL` and `uuid.MAX`

### DIFF
--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -288,6 +288,24 @@ of the :attr:`~UUID.variant` attribute:
 
    Reserved for future definition.
 
+The :mod:`uuid` module defines the special Nil and Max UUID values:
+
+
+.. data:: NIL
+
+   A special form of UUID that is specified to have all 128 bits set to zero
+   according to :rfc:`RFC 9562, §5.9 <9562#section-5.9>`.
+
+   .. versionadded:: 3.14
+
+
+.. data:: MAX
+
+   A special form of UUID that is specified to have all 128 bits set to one
+   according to :rfc:`RFC 9562, §5.10 <9562#section-5.10>`.
+
+   .. versionadded:: 3.14
+
 
 .. seealso::
 
@@ -380,6 +398,13 @@ Here are some examples of typical usage of the :mod:`uuid` module::
    >>> uuid.UUID(bytes=x.bytes)
    UUID('00010203-0405-0607-0809-0a0b0c0d0e0f')
 
+   >>> # get the Nil UUID
+   >>> uuid.NIL
+   UUID('00000000-0000-0000-0000-000000000000')
+
+   >>> # get the Max UUID
+   >>> uuid.MAX
+   UUID('ffffffff-ffff-ffff-ffff-ffffffffffff')
 
 .. _uuid-cli-example:
 

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -288,6 +288,7 @@ of the :attr:`~UUID.variant` attribute:
 
    Reserved for future definition.
 
+
 The :mod:`uuid` module defines the special Nil and Max UUID values:
 
 
@@ -296,7 +297,7 @@ The :mod:`uuid` module defines the special Nil and Max UUID values:
    A special form of UUID that is specified to have all 128 bits set to zero
    according to :rfc:`RFC 9562, §5.9 <9562#section-5.9>`.
 
-   .. versionadded:: 3.14
+   .. versionadded:: next
 
 
 .. data:: MAX
@@ -304,7 +305,7 @@ The :mod:`uuid` module defines the special Nil and Max UUID values:
    A special form of UUID that is specified to have all 128 bits set to one
    according to :rfc:`RFC 9562, §5.10 <9562#section-5.10>`.
 
-   .. versionadded:: 3.14
+   .. versionadded:: next
 
 
 .. seealso::
@@ -405,6 +406,7 @@ Here are some examples of typical usage of the :mod:`uuid` module::
    >>> # get the Max UUID
    >>> uuid.MAX
    UUID('ffffffff-ffff-ffff-ffff-ffffffffffff')
+
 
 .. _uuid-cli-example:
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -665,9 +665,10 @@ uuid
   in :rfc:`9562`.
   (Contributed by Bénédikt Tran in :gh:`89083`.)
 
-* :data:`uuid.NIL` and :data:`uuid.MAX` are now available to represent the Nil
-  and Max UUID formats as defined by :rfc:`9562`. (Contributed by Nick Pope in
-  :gh:`128427`.)
+* :const:`uuid.NIL` and :const:`uuid.MAX` are now available to represent the
+  Nil and Max UUID formats as defined by :rfc:`9562`.
+  (Contributed by Nick Pope in :gh:`128427`.)
+
 
 zipinfo
 -------

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -665,6 +665,10 @@ uuid
   in :rfc:`9562`.
   (Contributed by Bénédikt Tran in :gh:`89083`.)
 
+* :data:`uuid.NIL` and :data:`uuid.MAX` are now available to represent the Nil
+  and Max UUID formats as defined by :rfc:`9562`. (Contributed by Nick Pope in
+  :gh:`128427`.)
+
 zipinfo
 -------
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -43,8 +43,17 @@ class BaseTestUUID:
         self.assertEqual(nil_uuid, self.uuid.UUID(int=i))
         self.assertEqual(nil_uuid.int, i)
         self.assertEqual(str(nil_uuid), s)
-        self.assertIsNone(nil_uuid.version)
+        # The Nil UUID falls within the range of the Apollo NCS variant as per
+        # RFC 9562.
+        # See https://www.rfc-editor.org/rfc/rfc9562.html#table1
+        # See https://www.rfc-editor.org/rfc/rfc9562.html#section-5.9-4
         self.assertEqual(nil_uuid.variant, self.uuid.RESERVED_NCS)
+        # A version field of all zeros is "Unused" in RFC 9562, but the version
+        # field also only applies to the 10xx variant, i.e. the variant
+        # specified in RFC 9562. As such, because the Nil UUID falls under a
+        # different variant, its version is considered undefined.
+        # See https://www.rfc-editor.org/rfc/rfc9562.html#table2
+        self.assertIsNone(nil_uuid.version)
 
     def test_max_uuid(self):
         max_uuid = self.uuid.MAX
@@ -55,8 +64,18 @@ class BaseTestUUID:
         self.assertEqual(max_uuid, self.uuid.UUID(int=i))
         self.assertEqual(max_uuid.int, i)
         self.assertEqual(str(max_uuid), s)
-        self.assertIsNone(max_uuid.version)
+        # The Max UUID falls within the range of the "yet-to-be defined" future
+        # UUID variant as per RFC 9562.
+        # See https://www.rfc-editor.org/rfc/rfc9562.html#table1
+        # See https://www.rfc-editor.org/rfc/rfc9562.html#section-5.10-4
         self.assertEqual(max_uuid.variant, self.uuid.RESERVED_FUTURE)
+        # A version field of all ones is "Reserved for future definition" in
+        # RFC 9562, but the version field also only applies to the 10xx
+        # variant, i.e. the variant specified in RFC 9562. As such, because the
+        # Max UUID falls under a different variant, its version is considered
+        # undefined.
+        # See https://www.rfc-editor.org/rfc/rfc9562.html#table2
+        self.assertIsNone(max_uuid.version)
 
     def test_safe_uuid_enum(self):
         class CheckedSafeUUID(enum.Enum):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -38,21 +38,25 @@ class BaseTestUUID:
         nil_uuid = self.uuid.NIL
 
         s = '00000000-0000-0000-0000-000000000000'
-        i = 0x00000000000000000000000000000000
+        i = 0
         self.assertEqual(nil_uuid, self.uuid.UUID(s))
         self.assertEqual(nil_uuid, self.uuid.UUID(int=i))
         self.assertEqual(nil_uuid.int, i)
         self.assertEqual(str(nil_uuid), s)
+        self.assertIsNone(nil_uuid.version)
+        self.assertEqual(nil_uuid.variant, self.uuid.RESERVED_NCS)
 
     def test_max_uuid(self):
         max_uuid = self.uuid.MAX
 
         s = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
-        i = 0xffffffffffffffffffffffffffffffff
+        i = (1 << 128) - 1
         self.assertEqual(max_uuid, self.uuid.UUID(s))
         self.assertEqual(max_uuid, self.uuid.UUID(int=i))
         self.assertEqual(max_uuid.int, i)
         self.assertEqual(str(max_uuid), s)
+        self.assertIsNone(max_uuid.version)
+        self.assertEqual(max_uuid.variant, self.uuid.RESERVED_FUTURE)
 
     def test_safe_uuid_enum(self):
         class CheckedSafeUUID(enum.Enum):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -34,6 +34,18 @@ def mock_get_command_stdout(data):
 class BaseTestUUID:
     uuid = None
 
+    def test_nil_uuid(self):
+        self.assertEqual(
+            self.uuid.NIL,
+            self.uuid.UUID('00000000-0000-0000-0000-000000000000'),
+        )
+
+    def test_max_uuid(self):
+        self.assertEqual(
+            self.uuid.MAX,
+            self.uuid.UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),
+        )
+
     def test_safe_uuid_enum(self):
         class CheckedSafeUUID(enum.Enum):
             safe = 0

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -45,7 +45,6 @@ class BaseTestUUID:
         self.assertEqual(str(nil_uuid), s)
         # The Nil UUID falls within the range of the Apollo NCS variant as per
         # RFC 9562.
-        # See https://www.rfc-editor.org/rfc/rfc9562.html#table1
         # See https://www.rfc-editor.org/rfc/rfc9562.html#section-5.9-4
         self.assertEqual(nil_uuid.variant, self.uuid.RESERVED_NCS)
         # A version field of all zeros is "Unused" in RFC 9562, but the version
@@ -66,7 +65,6 @@ class BaseTestUUID:
         self.assertEqual(str(max_uuid), s)
         # The Max UUID falls within the range of the "yet-to-be defined" future
         # UUID variant as per RFC 9562.
-        # See https://www.rfc-editor.org/rfc/rfc9562.html#table1
         # See https://www.rfc-editor.org/rfc/rfc9562.html#section-5.10-4
         self.assertEqual(max_uuid.variant, self.uuid.RESERVED_FUTURE)
         # A version field of all ones is "Reserved for future definition" in

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -35,16 +35,24 @@ class BaseTestUUID:
     uuid = None
 
     def test_nil_uuid(self):
-        self.assertEqual(
-            self.uuid.NIL,
-            self.uuid.UUID('00000000-0000-0000-0000-000000000000'),
-        )
+        nil_uuid = self.uuid.NIL
+
+        s = '00000000-0000-0000-0000-000000000000'
+        i = 0x00000000000000000000000000000000
+        self.assertEqual(nil_uuid, self.uuid.UUID(s))
+        self.assertEqual(nil_uuid, self.uuid.UUID(int=i))
+        self.assertEqual(nil_uuid.int, i)
+        self.assertEqual(str(nil_uuid), s)
 
     def test_max_uuid(self):
-        self.assertEqual(
-            self.uuid.MAX,
-            self.uuid.UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),
-        )
+        max_uuid = self.uuid.MAX
+
+        s = 'ffffffff-ffff-ffff-ffff-ffffffffffff'
+        i = 0xffffffffffffffffffffffffffffffff
+        self.assertEqual(max_uuid, self.uuid.UUID(s))
+        self.assertEqual(max_uuid, self.uuid.UUID(int=i))
+        self.assertEqual(max_uuid.int, i)
+        self.assertEqual(str(max_uuid), s)
 
     def test_safe_uuid_enum(self):
         class CheckedSafeUUID(enum.Enum):

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -42,6 +42,14 @@ Typical usage:
     # make a UUID from a 16-byte string
     >>> uuid.UUID(bytes=x.bytes)
     UUID('00010203-0405-0607-0809-0a0b0c0d0e0f')
+
+    # get the Nil UUID
+    >>> uuid.NIL
+    UUID('00000000-0000-0000-0000-000000000000')
+
+    # get the Max UUID
+    >>> uuid.MAX
+    UUID('ffffffff-ffff-ffff-ffff-ffffffffffff')
 """
 
 import os
@@ -798,6 +806,11 @@ NAMESPACE_DNS = UUID('6ba7b810-9dad-11d1-80b4-00c04fd430c8')
 NAMESPACE_URL = UUID('6ba7b811-9dad-11d1-80b4-00c04fd430c8')
 NAMESPACE_OID = UUID('6ba7b812-9dad-11d1-80b4-00c04fd430c8')
 NAMESPACE_X500 = UUID('6ba7b814-9dad-11d1-80b4-00c04fd430c8')
+
+# RFC 9562 Sections 5.9 and 5.10 define the special Nil and Max UUID formats.
+
+NIL = UUID('00000000-0000-0000-0000-000000000000')
+MAX = UUID('ffffffff-ffff-ffff-ffff-ffffffffffff')
 
 if __name__ == "__main__":
     main()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1473,6 +1473,7 @@ Michael Pomraning
 Martin Pool
 Iustin Pop
 Claudiu Popa
+Nick Pope
 John Popplewell
 Matheus Vieira Portela
 Davin Potts

--- a/Misc/NEWS.d/next/Library/2025-01-02-20-34-04.gh-issue-128427.onPoQZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-02-20-34-04.gh-issue-128427.onPoQZ.rst
@@ -1,0 +1,2 @@
+:data:`uuid.NIL` and :data:`uuid.MAX` are now available to represent the Nil
+and Max UUID formats as defined by :rfc:`9562`.

--- a/Misc/NEWS.d/next/Library/2025-01-02-20-34-04.gh-issue-128427.onPoQZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-02-20-34-04.gh-issue-128427.onPoQZ.rst
@@ -1,2 +1,2 @@
-:data:`uuid.NIL` and :data:`uuid.MAX` are now available to represent the Nil
+:const:`uuid.NIL` and :const:`uuid.MAX` are now available to represent the Nil
 and Max UUID formats as defined by :rfc:`9562`.


### PR DESCRIPTION
Adds constants for Nil and Max UUID formats as per RFC 9562.

<!-- gh-issue-number: gh-128427 -->
* Issue: gh-128427
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128429.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->