### PR TITLE
gh-127073: Clear completion list when KeyboardInterrupt occurs

### DIFF
--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -164,6 +164,8 @@ def run_multiline_interactive_console(
             r = _get_reader()
             if r.input_trans is r.isearch_trans:
                 r.do_cmd(("isearch-end", [""]))
+            if r.cmpltn_menu_choices:
+                r.cmpltn_reset()
             r.pos = len(r.get_unicode())
             r.dirty = True
             r.refresh()

--- a/Misc/NEWS.d/next/Tools-Demos/2025-01-03-10-28-31.gh-issue-127073.r8-flH.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-01-03-10-28-31.gh-issue-127073.r8-flH.rst
@@ -1,0 +1,4 @@
+Previously in the REPL, when a completion list was displayed and KeyboardInterrupt
+was triggered using Ctrl+C, the completion list would persist and duplicate with
+each KeyboardInterrupt. Now, when KeyboardInterrupt occurs, the completion list
+is properly cleared, consistent with the behavior of other errors.


### PR DESCRIPTION
Closes 127073

Issue: https://github.com/python/cpython/issues/127073

**Previous behavior:**
- The completion list persisted after KeyboardInterrupt and always there.

`int.<TAB><TAB>`
```python
int.as_integer_ratio(  int.bit_length(        int.denominator        int.imag               int.mro()              int.real
int.bit_count(         int.conjugate(         int.from_bytes(        int.is_integer(        int.numerator          int.to_bytes(
>>> int.
```
`<Ctrl+C>`
```python
int.as_integer_ratio(  int.bit_length(        int.denominator        int.imag               int.mro()              int.real
int.bit_count(         int.conjugate(         int.from_bytes(        int.is_integer(        int.numerator          int.to_bytes(
>>> int.
KeyboardInterrupt
int.as_integer_ratio(  int.bit_length(        int.denominator        int.imag               int.mro()              int.real
int.bit_count(         int.conjugate(         int.from_bytes(        int.is_integer(        int.numerator          int.to_bytes(
>>>
```
`<Ctrl+C>` again
```python
int.as_integer_ratio(  int.bit_length(        int.denominator        int.imag               int.mro()              int.real
int.bit_count(         int.conjugate(         int.from_bytes(        int.is_integer(        int.numerator          int.to_bytes(
>>> int.
KeyboardInterrupt
int.as_integer_ratio(  int.bit_length(        int.denominator        int.imag               int.mro()              int.real
int.bit_count(         int.conjugate(         int.from_bytes(        int.is_integer(        int.numerator          int.to_bytes(
>>>
KeyboardInterrupt
int.as_integer_ratio(  int.bit_length(        int.denominator        int.imag               int.mro()              int.real
int.bit_count(         int.conjugate(         int.from_bytes(        int.is_integer(        int.numerator          int.to_bytes(
>>>
```



**New behavior:**
- The completion list is properly cleared on KeyboardInterrupt just consistent with the behavior of other errors 

`int.<TAB><TAB>`
```python
int.as_integer_ratio(  int.bit_length(        int.denominator        int.imag               int.mro()              int.real
int.bit_count(         int.conjugate(         int.from_bytes(        int.is_integer(        int.numerator          int.to_bytes(
>>> int.
```
`<Ctrl+C>`
```python
>>> int.
KeyboardInterrupt
>>> 
```




<!-- gh-issue-number: gh-127073 -->
* Issue: gh-127073
<!-- /gh-issue-number -->
