### PR TITLE
gh-125985: Fix `cmodule_function()` scaling benchmark

### DIFF
--- a/Tools/ftscalingbench/ftscalingbench.py
+++ b/Tools/ftscalingbench/ftscalingbench.py
@@ -62,7 +62,7 @@ def cmodule_function():
 def object_lookup_special():
     # round() uses `_PyObject_LookupSpecial()` internally.
     N = 1000 * WORK_SCALE
-    for i in range(1000 * WORK_SCALE):
+    for i in range(N):
         round(i / N)
 
 @register_benchmark

--- a/Tools/ftscalingbench/ftscalingbench.py
+++ b/Tools/ftscalingbench/ftscalingbench.py
@@ -54,8 +54,16 @@ def object_cfunction():
 
 @register_benchmark
 def cmodule_function():
+    N = 1000 * WORK_SCALE
+    for i in range(N):
+        math.cos(i / N)
+
+@register_benchmark
+def object_lookup_special():
+    # round() uses `_PyObject_LookupSpecial()` internally.
+    N = 1000 * WORK_SCALE
     for i in range(1000 * WORK_SCALE):
-        math.floor(i * i)
+        round(i / N)
 
 @register_benchmark
 def mult_constant():
@@ -206,7 +214,7 @@ def benchmark(func):
             color = "\x1b[33m"  # yellow
         reset_color = "\x1b[0m"
 
-    print(f"{color}{func.__name__:<18} {round(factor, 1):>4}x {direction}{reset_color}")
+    print(f"{color}{func.__name__:<25} {round(factor, 1):>4}x {direction}{reset_color}")
 
 def determine_num_threads_and_affinity():
     if sys.platform != "linux":


### PR DESCRIPTION
Add a separate benchmark that measures the effect of `_PyObject_LookupSpecial()` on scaling.

In the process of cleaning up the scaling benchmarks for inclusion, I unintentionally changed the `cmodule_function` benchmark to pass an `int` to `math.floor()`, which causes it to use the `_PyObject_LookupSpecial()` code path. `_PyObject_LookupSpecial()` has its own scaling issues that we want to measure separately.

<!-- gh-issue-number: gh-125985 -->
* Issue: gh-125985
<!-- /gh-issue-number -->
