### PR TITLE
gh-128152: Argument Clinic: don't parse CPP directives inside C comments

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -740,6 +740,16 @@ class ClinicWholeFileTest(TestCase):
         err = "Cannot use @text_signature when cloning a function"
         self.expect_failure(block, err, lineno=11)
 
+    def test_ignore_preprocessor_in_comments(self):
+        for dsl in "clinic", "python":
+            raw = dedent(f"""\
+                /*[{dsl} input]
+                # CPP directives, valid or not, should be ignored in C comments.
+                #
+                [{dsl} start generated code]*/
+            """)
+            self.clinic.parse(raw)
+
 
 class ParseFileUnitTest(TestCase):
     def expect_parsing_failure(

--- a/Misc/NEWS.d/next/Tools-Demos/2025-01-03-23-51-07.gh-issue-128152.IhzElS.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-01-03-23-51-07.gh-issue-128152.IhzElS.rst
@@ -1,0 +1,2 @@
+Fix a bug where Argument Clinic's C pre-processor parser tried to parse
+pre-processor directives inside C comments. Patch by Erlend Aasland.

--- a/Tools/clinic/libclinic/cpp.py
+++ b/Tools/clinic/libclinic/cpp.py
@@ -132,6 +132,9 @@ class Monitor:
         if line_comment:
             line = before.rstrip()
 
+        if self.in_comment:
+            return
+
         if not line.startswith('#'):
             return
 


### PR DESCRIPTION
Resolves #128152