### PR TITLE
Add instructions for cloning the repository using GitHub CLI

### DIFF
--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -135,3 +135,29 @@ Bugs in the toolset should be reported to the tools themselves.
 
 To help with the documentation, or report any problems, please leave a message
 on `discuss.python.org <https://discuss.python.org/c/documentation>`_.
+
+
+Cloning the Repository
+======================
+
+To clone the `python/cpython` repository, you can use the GitHub CLI. Follow the steps below:
+
+Prerequisites
+-------------
+
+Before you can clone the repository, make sure you have the following prerequisites:
+
+1. **GitHub CLI**: You need to have the GitHub CLI installed on your machine. If you don't have it installed, you can download and install it from the [GitHub CLI website](https://cli.github.com/).
+
+2. **Git**: Ensure that you have Git installed on your machine. You can download and install Git from the [Git website](https://git-scm.com/).
+
+Cloning the Repository
+----------------------
+
+Once you have the prerequisites installed, you can clone the repository using the following command:
+
+```sh
+gh repo clone python/cpython
+```
+
+This command will clone the `python/cpython` repository to your local machine, including all files and directories.

--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -180,3 +180,29 @@ Custom OpenSSL
    Patch releases of OpenSSL have a backwards compatible ABI. You don't need
    to recompile Python to update OpenSSL. It's sufficient to replace the
    custom OpenSSL installation with a newer version.
+
+
+Cloning the Repository
+======================
+
+To clone the `python/cpython` repository, you can use the GitHub CLI. Follow the steps below:
+
+Prerequisites
+-------------
+
+Before you can clone the repository, make sure you have the following prerequisites:
+
+1. **GitHub CLI**: You need to have the GitHub CLI installed on your machine. If you don't have it installed, you can download and install it from the [GitHub CLI website](https://cli.github.com/).
+
+2. **Git**: Ensure that you have Git installed on your machine. You can download and install Git from the [Git website](https://git-scm.com/).
+
+Cloning the Repository
+----------------------
+
+Once you have the prerequisites installed, you can clone the repository using the following command:
+
+```sh
+gh repo clone python/cpython
+```
+
+This command will clone the `python/cpython` repository to your local machine, including all files and directories.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Cloning the Repository
+
+To clone the `python/cpython` repository, you can use the GitHub CLI. Follow the steps below:
+
+## Prerequisites
+
+Before you can clone the repository, make sure you have the following prerequisites:
+
+1. **GitHub CLI**: You need to have the GitHub CLI installed on your machine. If you don't have it installed, you can download and install it from the [GitHub CLI website](https://cli.github.com/).
+
+2. **Git**: Ensure that you have Git installed on your machine. You can download and install Git from the [Git website](https://git-scm.com/).
+
+## Cloning the Repository
+
+Once you have the prerequisites installed, you can clone the repository using the following command:
+
+```sh
+gh repo clone python/cpython
+```
+
+This command will clone the `python/cpython` repository to your local machine, including all files and directories.


### PR DESCRIPTION
Add instructions for cloning the repository using GitHub CLI.

* **README.md**: Add a section on how to clone the repository using `gh repo clone python/cpython`. Mention the prerequisites for using GitHub CLI.
* **Doc/README.rst**: Add instructions on cloning the repository using `gh repo clone python/cpython`. Include a note on installing GitHub CLI if not already installed.
* **Doc/using/unix.rst**: Add a section on cloning the repository using `gh repo clone python/cpython`. Mention the prerequisites for using GitHub CLI.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/python/cpython/pull/128471?shareId=bbbf513f-36a1-4210-a73f-7aa936bdd9e1).

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128471.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->