### PR TITLE
gh-128182: Add per-object memory access synchronization to `ctypes`

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -900,9 +900,6 @@ to synchronize access to memory:
       >>> with lock:
       ...    pointer_b.contents = 42
 
-.. seealso::
-
-    Use :func:`sys._is_gil_enabled` to dynamically synchronize your application.
 
 .. _ctypes-type-conversions:
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -870,6 +870,35 @@ invalid non-\ ``NULL`` pointers would crash Python)::
    ValueError: NULL pointer access
    >>>
 
+.. _ctypes-thread-safety:
+
+Thread Safety Without The GIL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In Python 3.13, the :term:`GIL` may be disabled on :term:`experimental free threaded <free threading>` builds.
+In ctypes, reads and writes to a single object concurrently is safe, but not across multiple objects.::
+
+   >>> number = c_int(42)
+   >>> pointer_a = pointer(number)
+   >>> pointer_b = pointer(number)
+
+In the above, it's only safe for one object to read and write to the address at once if the :term:`GIL` is disabled.
+So, ``pointer_a`` can be shared and written to across multiple threads, but only if ``pointer_b``
+is not also attempting to do the same. If this is an issue, consider using a :class:`threading.Lock`
+to synchronize access to memory.::
+
+   >>> import threading
+   >>> lock = threading.Lock()
+   >>> # Thread 1
+   >>> with lock:
+   ...    pointer_a.contents = 24
+   >>> # Thread 2
+   >>> with lock:
+   ...    pointer_b.contents = 42
+
+.. seealso::
+
+    :func:`sys._is_gil_enabled` if you would like to dynamically synchronize your application.
 
 .. _ctypes-type-conversions:
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -887,16 +887,18 @@ In ctypes, reads and writes to a single object concurrently is safe, but not acr
 In the above, it's only safe for one object to read and write to the address at once if the :term:`GIL` is disabled.
 So, ``pointer_a`` can be shared and written to across multiple threads, but only if ``pointer_b``
 is not also attempting to do the same. If this is an issue, consider using a :class:`threading.Lock`
-to synchronize access to memory.::
+to synchronize access to memory:
 
-   >>> import threading
-   >>> lock = threading.Lock()
-   >>> # Thread 1
-   >>> with lock:
-   ...    pointer_a.contents = 24
-   >>> # Thread 2
-   >>> with lock:
-   ...    pointer_b.contents = 42
+   .. code-block:: pycon
+
+      >>> import threading
+      >>> lock = threading.Lock()
+      >>> # Thread 1
+      >>> with lock:
+      ...    pointer_a.contents = 24
+      >>> # Thread 2
+      >>> with lock:
+      ...    pointer_b.contents = 42
 
 .. seealso::
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -872,15 +872,17 @@ invalid non-\ ``NULL`` pointers would crash Python)::
 
 .. _ctypes-thread-safety:
 
-Thread Safety Without The GIL
+Thread safety without the GIL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In Python 3.13, the :term:`GIL` may be disabled on :term:`experimental free threaded <free threading>` builds.
-In ctypes, reads and writes to a single object concurrently is safe, but not across multiple objects.::
+In ctypes, reads and writes to a single object concurrently is safe, but not across multiple objects:
 
-   >>> number = c_int(42)
-   >>> pointer_a = pointer(number)
-   >>> pointer_b = pointer(number)
+   .. code-block:: pycon
+
+      >>> number = c_int(42)
+      >>> pointer_a = pointer(number)
+      >>> pointer_b = pointer(number)
 
 In the above, it's only safe for one object to read and write to the address at once if the :term:`GIL` is disabled.
 So, ``pointer_a`` can be shared and written to across multiple threads, but only if ``pointer_b``
@@ -898,7 +900,7 @@ to synchronize access to memory.::
 
 .. seealso::
 
-    :func:`sys._is_gil_enabled` if you would like to dynamically synchronize your application.
+    Use :func:`sys._is_gil_enabled` to dynamically synchronize your application.
 
 .. _ctypes-type-conversions:
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -884,7 +884,7 @@ In ctypes, reads and writes to a single object concurrently is safe, but not acr
       >>> pointer_a = pointer(number)
       >>> pointer_b = pointer(number)
 
-In the above, it's only safe for one object to read and write to the address at once if the :term:`GIL` is disabled.
+In the above, it's only safe for one object to read and write to the address at once if the GIL is disabled.
 So, ``pointer_a`` can be shared and written to across multiple threads, but only if ``pointer_b``
 is not also attempting to do the same. If this is an issue, consider using a :class:`threading.Lock`
 to synchronize access to memory:

--- a/Lib/test/test_ctypes/test_arrays.py
+++ b/Lib/test/test_ctypes/test_arrays.py
@@ -284,7 +284,8 @@ class ArrayTestCase(unittest.TestCase):
             with threading_helper.start_threads(threads):
                 pass
 
-            self.assertIsNone(cm.exc_value)
+            if cm.exc_value:
+                raise cm.exc_value
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_ctypes/test_arrays.py
+++ b/Lib/test/test_ctypes/test_arrays.py
@@ -280,7 +280,8 @@ class ArrayTestCase(unittest.TestCase):
                 buffer[0] = b"j"
 
         with threading_helper.catch_threading_exception() as cm:
-            with threading_helper.start_threads((Thread(target=run) for _ in range(25))):
+            threads = (Thread(target=run) for _ in range(25))
+            with threading_helper.start_threads(threads):
                 pass
 
             self.assertIsNone(cm.exc_value)

--- a/Lib/test/test_ctypes/test_arrays.py
+++ b/Lib/test/test_ctypes/test_arrays.py
@@ -5,7 +5,7 @@ from ctypes import (Structure, Array, ARRAY, sizeof, addressof,
                     create_string_buffer, create_unicode_buffer,
                     c_char, c_wchar, c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint,
                     c_long, c_ulonglong, c_float, c_double, c_longdouble)
-from test.support import bigmemtest, _2G
+from test.support import bigmemtest, _2G, threading_helper
 from ._support import (_CData, PyCArrayType, Py_TPFLAGS_DISALLOW_INSTANTIATION,
                        Py_TPFLAGS_IMMUTABLETYPE)
 
@@ -266,6 +266,24 @@ class ArrayTestCase(unittest.TestCase):
     @bigmemtest(size=_2G, memuse=1, dry_run=False)
     def test_large_array(self, size):
         c_char * size
+
+    @threading_helper.requires_working_threading()
+    @unittest.skipUnless(support.Py_GIL_DISABLED, "only meaningful if the GIL is disabled")
+    def test_thread_safety(self):
+        from threading import Thread
+
+        buffer = (ctypes.c_char_p * 10)()
+
+        def run():
+            for i in range(100):
+                buffer.value = b"hello"
+                buffer[0] = b"j"
+
+        with threading_helper.catch_threading_exception() as cm:
+            with threading_helper.start_threads((run for _ in range(25))):
+                pass
+
+            self.assertIsNone(cm.exc_value)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_ctypes/test_arrays.py
+++ b/Lib/test/test_ctypes/test_arrays.py
@@ -5,7 +5,7 @@ from ctypes import (Structure, Array, ARRAY, sizeof, addressof,
                     create_string_buffer, create_unicode_buffer,
                     c_char, c_wchar, c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint,
                     c_long, c_ulonglong, c_float, c_double, c_longdouble)
-from test.support import bigmemtest, _2G, threading_helper
+from test.support import bigmemtest, _2G, threading_helper, Py_GIL_DISABLED
 from ._support import (_CData, PyCArrayType, Py_TPFLAGS_DISALLOW_INSTANTIATION,
                        Py_TPFLAGS_IMMUTABLETYPE)
 
@@ -268,7 +268,7 @@ class ArrayTestCase(unittest.TestCase):
         c_char * size
 
     @threading_helper.requires_working_threading()
-    @unittest.skipUnless(support.Py_GIL_DISABLED, "only meaningful if the GIL is disabled")
+    @unittest.skipUnless(Py_GIL_DISABLED, "only meaningful if the GIL is disabled")
     def test_thread_safety(self):
         from threading import Thread
 
@@ -280,7 +280,7 @@ class ArrayTestCase(unittest.TestCase):
                 buffer[0] = b"j"
 
         with threading_helper.catch_threading_exception() as cm:
-            with threading_helper.start_threads((run for _ in range(25))):
+            with threading_helper.start_threads((Thread(target=run) for _ in range(25))):
                 pass
 
             self.assertIsNone(cm.exc_value)

--- a/Misc/NEWS.d/next/Library/2025-01-04-11-32-46.gh-issue-128182.SJ2Zsa.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-04-11-32-46.gh-issue-128182.SJ2Zsa.rst
@@ -1,0 +1,2 @@
+Fix crash when using :mod:`ctypes` pointers concurrently on the :term:`free
+threaded <free threading>` build.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3117,8 +3117,11 @@ static int
 PyCData_MallocBuffer(CDataObject *obj, StgInfo *info)
 {
     /* We don't have to lock in this function, because it's only
-       used in constructors and therefore does not have concurrent
-       access. */
+     * used in constructors and therefore does not have concurrent
+     * access.
+     */
+   assert (Py_REFCNT(obj) == 1);
+
     if ((size_t)info->size <= sizeof(obj->b_value)) {
         /* No need to call malloc, can use the default buffer */
         obj->b_ptr = (char *)&obj->b_value;

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -4865,7 +4865,7 @@ Array_subscript(PyObject *myself, PyObject *item)
             if (step == 1) {
                 LOCK_PTR(self);
                 PyObject *res = PyBytes_FromStringAndSize(ptr + start,
-                                                 slicelen);
+                                                          slicelen);
                 UNLOCK_PTR(self);
                 return res;
             }
@@ -4894,7 +4894,7 @@ Array_subscript(PyObject *myself, PyObject *item)
             if (step == 1) {
                 LOCK_PTR(self);
                 PyObject *res = PyUnicode_FromWideChar(ptr + start,
-                                              slicelen);
+                                                       slicelen);
                 UNLOCK_PTR(self);
                 return res;
             }
@@ -5371,7 +5371,7 @@ Pointer_ass_item(PyObject *myself, Py_ssize_t index, PyObject *value)
     offset = index * iteminfo->size;
 
     return PyCData_set(st, (PyObject *)self, proto, stginfo->setfunc, value,
-                     index, size, ((char *)deref + offset));
+                       index, size, ((char *)deref + offset));
 }
 
 static PyObject *
@@ -5571,7 +5571,7 @@ Pointer_subscript(PyObject *myself, PyObject *item)
             if (step == 1) {
                 LOCK_PTR(self);
                 PyObject *res = PyBytes_FromStringAndSize(ptr + start,
-                                                 len);
+                                                          len);
                 UNLOCK_PTR(self);
                 return res;
             }
@@ -5596,7 +5596,7 @@ Pointer_subscript(PyObject *myself, PyObject *item)
             if (step == 1) {
                 LOCK_PTR(self);
                 PyObject *res = PyUnicode_FromWideChar(ptr + start,
-                                              len);
+                                                       len);
                 UNLOCK_PTR(self);
                 return res;
             }

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3112,7 +3112,9 @@ static PyType_Spec pycdata_spec = {
 static int
 PyCData_MallocBuffer(CDataObject *obj, StgInfo *info)
 {
-    // We don't have to lock in this function
+    /* We don't have to lock in this function, because it's only
+       used in constructors and therefore does not have concurrent
+       access. */
     if ((size_t)info->size <= sizeof(obj->b_value)) {
         /* No need to call malloc, can use the default buffer */
         obj->b_ptr = (char *)&obj->b_value;

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1553,7 +1553,7 @@ WCharArray_set_value(CDataObject *self, PyObject *value, void *Py_UNUSED(ignored
         PyErr_SetString(PyExc_ValueError, "string too long");
         return -1;
     }
-    int rc;
+    Py_ssize_t rc;
     LOCK_PTR(self);
     rc = PyUnicode_AsWideChar(value, (wchar_t *)self->b_ptr, size);
     UNLOCK_PTR(self);

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -907,7 +907,7 @@ CDataType_from_buffer_copy_impl(PyObject *type, PyTypeObject *cls,
 
     result = generic_pycdata_new(st, (PyTypeObject *)type, NULL, NULL);
     if (result != NULL) {
-        locked_memcpy_to((CDataObject *) result, buffer->buf + offset, info->size);
+        locked_memcpy_to((CDataObject *) result, (char *)buffer->buf + offset, info->size);
     }
     return result;
 }
@@ -5329,7 +5329,7 @@ Pointer_item(PyObject *myself, Py_ssize_t index)
     offset = index * iteminfo->size;
 
     return PyCData_get(st, proto, stginfo->getfunc, (PyObject *)self,
-                     index, size, (deref + offset));
+                     index, size, (char *)(deref + offset));
 }
 
 static int
@@ -5374,7 +5374,7 @@ Pointer_ass_item(PyObject *myself, Py_ssize_t index, PyObject *value)
     offset = index * iteminfo->size;
 
     return PyCData_set(st, (PyObject *)self, proto, stginfo->setfunc, value,
-                     index, size, (deref + offset));
+                     index, size, (char *)(deref + offset));
 }
 
 static PyObject *

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1552,12 +1552,9 @@ WCharArray_set_value(CDataObject *self, PyObject *value, void *Py_UNUSED(ignored
         return -1;
     }
     LOCK_PTR(self);
-    if (PyUnicode_AsWideChar(value, (wchar_t *)self->b_ptr, size) < 0) {
-        UNLOCK_PTR(self);
-        return -1;
-    }
+    int rc = PyUnicode_AsWideChar(value, (wchar_t *)self->b_ptr, size);
     UNLOCK_PTR(self);
-    return 0;
+    return rc < 0 ? -1 : 0;
 }
 
 static PyGetSetDef WCharArray_getsets[] = {

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5326,7 +5326,7 @@ Pointer_item(PyObject *myself, Py_ssize_t index)
     offset = index * iteminfo->size;
 
     return PyCData_get(st, proto, stginfo->getfunc, (PyObject *)self,
-                     index, size, (char *)((char *)deref + offset));
+                       index, size, (char *)((char *)deref + offset));
 }
 
 static int

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5329,7 +5329,7 @@ Pointer_item(PyObject *myself, Py_ssize_t index)
     offset = index * iteminfo->size;
 
     return PyCData_get(st, proto, stginfo->getfunc, (PyObject *)self,
-                     index, size, (char *)(deref + offset));
+                     index, size, (char *)((char *)deref + offset));
 }
 
 static int
@@ -5374,7 +5374,7 @@ Pointer_ass_item(PyObject *myself, Py_ssize_t index, PyObject *value)
     offset = index * iteminfo->size;
 
     return PyCData_set(st, (PyObject *)self, proto, stginfo->setfunc, value,
-                     index, size, (char *)(deref + offset));
+                     index, size, ((char *)deref + offset));
 }
 
 static PyObject *

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3361,9 +3361,9 @@ _PyCData_set(ctypes_state *st,
                          ((PyTypeObject *)type)->tp_name);
             return NULL;
         }
-        LOCK_PTR(dst);
+        LOCK_PTR(src);
         *(void **)ptr = src->b_ptr;
-        UNLOCK_PTR(dst);
+        UNLOCK_PTR(src);
 
         keep = GetKeepedObjects(src);
         if (keep == NULL)

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1552,12 +1552,9 @@ WCharArray_set_value(CDataObject *self, PyObject *value, void *Py_UNUSED(ignored
         return -1;
     }
     LOCK_PTR(self);
-    if (PyUnicode_AsWideChar(value, (wchar_t *)self->b_ptr, size) < 0) {
-        UNLOCK_PTR(self);
-        return -1;
-    }
+    int rc = PyUnicode_AsWideChar(value, (wchar_t *)self->b_ptr, size);
     UNLOCK_PTR(self);
-    return 0;
+    return rc;
 }
 
 static PyGetSetDef WCharArray_getsets[] = {

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1552,9 +1552,12 @@ WCharArray_set_value(CDataObject *self, PyObject *value, void *Py_UNUSED(ignored
         return -1;
     }
     LOCK_PTR(self);
-    int rc = PyUnicode_AsWideChar(value, (wchar_t *)self->b_ptr, size);
+    if (PyUnicode_AsWideChar(value, (wchar_t *)self->b_ptr, size) < 0) {
+        UNLOCK_PTR(self);
+        return -1;
+    }
     UNLOCK_PTR(self);
-    return rc;
+    return 0;
 }
 
 static PyGetSetDef WCharArray_getsets[] = {

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3241,7 +3241,10 @@ PyObject *
 PyCData_get(ctypes_state *st, PyObject *type, GETFUNC getfunc, PyObject *src,
           Py_ssize_t index, Py_ssize_t size, char *adr)
 {
+#ifdef Py_GIL_DISABLED
+    // This isn't used if the GIL is enabled, so it causes a compiler warning.
     CDataObject *cdata = (CDataObject *)src;
+#endif
     if (getfunc) {
         LOCK_PTR(cdata);
         PyObject *res = getfunc(adr, size);

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -562,7 +562,7 @@ static inline void
 locked_memcpy_to(CDataObject *self, void *buf, Py_ssize_t size)
 {
     LOCK_PTR(self);
-    memcpy(self->b_ptr, buf, size);
+    (void)memcpy(self->b_ptr, buf, size);
     UNLOCK_PTR(self);
 }
 
@@ -570,7 +570,7 @@ static inline void
 locked_memcpy_from(void *buf, CDataObject *self, Py_ssize_t size)
 {
     LOCK_PTR(self);
-    memcpy(buf, self->b_ptr, size);
+    (void)memcpy(buf, self->b_ptr, size);
     UNLOCK_PTR(self);
 }
 

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -587,6 +587,6 @@ static inline void
 locked_deref_assign(CDataObject *self, void *new_ptr)
 {
     LOCK_PTR(self);
-    *self->b_ptr = new_ptr;
+    *(void **)self->b_ptr = new_ptr;
     UNLOCK_PTR(self);
 }


### PR DESCRIPTION
I say "per-object" as in, using a single ctypes object is thread-safe if that's the only object accessing the memory. IMO, access to arbitrary memory across different pointer objects shouldn't (or can't?) be thread safe--ctypes should remain pretty low level, and that kind of synchronization might do bad things to applications that don't want it. I've clarified this in the docs. That said, I could see use in some sort of wrapper that ensures only one thread accesses memory using a table of addresses, but that should go to DPO first.

A few notes about the implementation here:

- I'm making some assumptions about ctypes casting `getfunc` and `setfunc` functions being non-reentrant. In practice, they really shouldn't be, but of course I'm not absolutely certain. We might want to go with a recursive mutex if that turns out to be an issue.
- I'm also assuming that the `PyFoo_FromBar` functions don't have a chance to re-enter. The cases I could think of that could maybe cause re-entrancy are: an embedder could hijack the allocator and run the interpreter from it, or audit events. (Let me know if this is a deal-breaker!)

<!-- gh-issue-number: gh-128182 -->
* Issue: gh-128182
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128490.org.readthedocs.build/en/128490/library/ctypes.html#thread-safety-without-the-gil

<!-- readthedocs-preview cpython-previews end -->