### PR TITLE
gh-128472: Add `-skip-funcs` to BOLT options to fix computed goto errors

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-01-04-22-39-10.gh-issue-128472.Wt5E6M.rst
+++ b/Misc/NEWS.d/next/Build/2025-01-04-22-39-10.gh-issue-128472.Wt5E6M.rst
@@ -1,0 +1,2 @@
+Skip BOLT optimization of functions using computed gotos, fixing errors on
+build with LLVM 19.

--- a/configure
+++ b/configure
@@ -9398,7 +9398,7 @@ fi
 printf %s "checking BOLT_COMMON_FLAGS... " >&6; }
 if test -z "${BOLT_COMMON_FLAGS}"
 then
-  BOLT_COMMON_FLAGS=-update-debug-sections
+  BOLT_COMMON_FLAGS=" -update-debug-sections -skip-funcs=_PyEval_EvalFrameDefault,sre_ucs1_match/1,sre_ucs2_match/1,sre_ucs4_match/1 "
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -2170,7 +2170,14 @@ if test -z "${BOLT_COMMON_FLAGS}"
 then
   AS_VAR_SET(
     [BOLT_COMMON_FLAGS],
-    [-update-debug-sections]
+    [m4_normalize("
+      [-update-debug-sections]
+
+      dnl At least LLVM 19.x doesn't support computed gotos in PIC compiled code.
+      dnl Exclude functions containing computed gotos.
+      dnl TODO this may be fixed in LLVM 20.x via https://github.com/llvm/llvm-project/pull/120267.
+      [-skip-funcs=_PyEval_EvalFrameDefault,sre_ucs1_match/1,sre_ucs2_match/1,sre_ucs4_match/1]
+    ")]
   )
 fi
 


### PR DESCRIPTION
This patch was originally authored as part of https://github.com/astral-sh/python-build-standalone/pull/463

Makes use of the common options added in #128455

Closes https://github.com/python/cpython/issues/128472
Backport needed for https://github.com/python/cpython/issues/124948

<!-- gh-issue-number: gh-128472 -->
* Issue: gh-128472
<!-- /gh-issue-number -->
