### PR TITLE
gh-128519: Update the docstring of `untokenize()` to match the docs

### DIFF
--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -318,16 +318,10 @@ def untokenize(iterable):
     with at least two elements, a token number and token value.  If
     only two tokens are passed, the resulting output is poor.
 
-    Round-trip invariant for full input:
-        Untokenized source will match input source exactly
-
-    Round-trip invariant for limited input:
-        # Output bytes will tokenize back to the input
-        t1 = [tok[:2] for tok in tokenize(f.readline)]
-        newcode = untokenize(t1)
-        readline = BytesIO(newcode).readline
-        t2 = [tok[:2] for tok in tokenize(readline)]
-        assert t1 == t2
+    The result is guaranteed to tokenize back to match the input so
+    that the conversion is lossless and round-trips are assured.
+    The guarantee applies only to the token type and token string as
+    the spacing between tokens (column positions) may change.
     """
     ut = Untokenizer()
     out = ut.untokenize(iterable)

--- a/Misc/NEWS.d/next/Library/2025-01-05-18-41-27.gh-issue-128519.DfI2M2.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-05-18-41-27.gh-issue-128519.DfI2M2.rst
@@ -1,2 +1,0 @@
-Update the docstring of :func:`tokenize.untokenize` to match the
-documentation.

--- a/Misc/NEWS.d/next/Library/2025-01-05-18-41-27.gh-issue-128519.DfI2M2.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-05-18-41-27.gh-issue-128519.DfI2M2.rst
@@ -1,0 +1,2 @@
+Update the docstring of :func:`tokenize.untokenize` to match the
+documentation.


### PR DESCRIPTION
Synchronizes the docstring of `untokenize` with the docs regarding roundtrip invariance guarantees.
See the linked issue for details :)

<!-- gh-issue-number: gh-128519 -->
* Issue: gh-128519
<!-- /gh-issue-number -->
