### PR TITLE
gh-127146: skip Emscripten tests with pending fixes

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3933,6 +3933,7 @@ class TextIOWrapperTest(unittest.TestCase):
         self.assertEqual(res + f.readline(), 'foo\nbar\n')
 
     @unittest.skipUnless(hasattr(os, "pipe"), "requires os.pipe()")
+    @unittest.skipIf(support.is_emscripten, "Would be fixed by emscripten-core/emscripten#23306")
     def test_read_non_blocking(self):
         import os
         r, w = os.pipe()

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3933,6 +3933,7 @@ class TextIOWrapperTest(unittest.TestCase):
         self.assertEqual(res + f.readline(), 'foo\nbar\n')
 
     @unittest.skipUnless(hasattr(os, "pipe"), "requires os.pipe()")
+    @unittest.skipIf(support.is_emscripten, "Would be fixed by emscripten-core/emscripten#23058")
     def test_read_non_blocking(self):
         import os
         r, w = os.pipe()

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3933,7 +3933,6 @@ class TextIOWrapperTest(unittest.TestCase):
         self.assertEqual(res + f.readline(), 'foo\nbar\n')
 
     @unittest.skipUnless(hasattr(os, "pipe"), "requires os.pipe()")
-    @unittest.skipIf(support.is_emscripten, "Would be fixed by emscripten-core/emscripten#23058")
     def test_read_non_blocking(self):
         import os
         r, w = os.pipe()

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4979,6 +4979,7 @@ class TestScandir(unittest.TestCase):
         self.assertRaises(TypeError, pickle.dumps, scandir_iter, filename)
         scandir_iter.close()
 
+    @unittest.skipIf(support.is_emscripten, "Fixed by emscripten-core/emscripten#23139, remove when next Emscripten release comes out")
     def check_entry(self, entry, name, is_dir, is_file, is_symlink):
         self.assertIsInstance(entry, os.DirEntry)
         self.assertEqual(entry.name, name)

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1587,6 +1587,7 @@ class TestCopy(BaseTest, unittest.TestCase):
     # the path as a directory, but on AIX the trailing slash has no effect
     # and is considered as a file.
     @unittest.skipIf(AIX, 'Not valid on AIX, see gh-92670')
+    @unittest.skipIf(support.is_emscripten, 'Fixed by emscripten-core/emscripten#23218, remove when next Emscripten release comes out')
     def test_copyfile_nonexistent_dir(self):
         # Issue 43219
         src_dir = self.mkdtemp()

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3800,6 +3800,7 @@ class TestExtractionFilters(unittest.TestCase):
                 "'parent' is a link to an absolute path")
 
     @symlink_test
+    @unittest.skipIf(support.is_emscripten, "Fixed by emscripten-core/emscripten#23136, remove when next Emscripten release comes out")
     def test_sly_relative0(self):
         # Inspired by 'relative0' in jwilk/traversal-archives
         with ArchiveMaker() as arc:

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -22,7 +22,8 @@ from test import archiver_tests
 from test.support import script_helper
 from test.support import (
     findfile, requires_zlib, requires_bz2, requires_lzma,
-    captured_stdout, captured_stderr, requires_subprocess
+    captured_stdout, captured_stderr, requires_subprocess,
+    is_emscripten
 )
 from test.support.os_helper import (
     TESTFN, unlink, rmtree, temp_dir, temp_cwd, fd_count, FakePath
@@ -622,6 +623,7 @@ class StoredTestsWithSourceFile(AbstractTestsWithSourceFile,
             with self.assertRaises(ValueError):
                 zipfp.open(TESTFN, mode='w')
 
+    @unittest.skipIf(is_emscripten, "Fixed by emscripten-core/emscripten#23310")
     def test_add_file_before_1980(self):
         # Set atime and mtime to 1970-01-01
         os.utime(TESTFN, (0, 0))

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -22,7 +22,8 @@ from test import archiver_tests
 from test.support import script_helper
 from test.support import (
     findfile, requires_zlib, requires_bz2, requires_lzma,
-    captured_stdout, captured_stderr, requires_subprocess
+    captured_stdout, captured_stderr, requires_subprocess,
+    is_emscripten
 )
 from test.support.os_helper import (
     TESTFN, unlink, rmtree, temp_dir, temp_cwd, fd_count, FakePath
@@ -622,6 +623,7 @@ class StoredTestsWithSourceFile(AbstractTestsWithSourceFile,
             with self.assertRaises(ValueError):
                 zipfp.open(TESTFN, mode='w')
 
+    @unittest.skipIf(support.is_emscripten, "Would be fixed by emscripten-core/emscripten#23058")
     def test_add_file_before_1980(self):
         # Set atime and mtime to 1970-01-01
         os.utime(TESTFN, (0, 0))

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -22,8 +22,7 @@ from test import archiver_tests
 from test.support import script_helper
 from test.support import (
     findfile, requires_zlib, requires_bz2, requires_lzma,
-    captured_stdout, captured_stderr, requires_subprocess,
-    is_emscripten
+    captured_stdout, captured_stderr, requires_subprocess
 )
 from test.support.os_helper import (
     TESTFN, unlink, rmtree, temp_dir, temp_cwd, fd_count, FakePath
@@ -623,7 +622,6 @@ class StoredTestsWithSourceFile(AbstractTestsWithSourceFile,
             with self.assertRaises(ValueError):
                 zipfp.open(TESTFN, mode='w')
 
-    @unittest.skipIf(support.is_emscripten, "Would be fixed by emscripten-core/emscripten#23058")
     def test_add_file_before_1980(self):
         # Set atime and mtime to 1970-01-01
         os.utime(TESTFN, (0, 0))

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -1038,6 +1038,7 @@ class BadFileZipImportTestCase(unittest.TestCase):
         self.assertZipFailure(TESTMOD)
 
     @unittest.skipIf(support.is_wasi, "mode 000 not supported.")
+    @unittest.skipIf(support.is_emscripten, "Fixed by emscripten-core/emscripten#23137, remove when next Emscripten release comes out")
     def testFileUnreadable(self):
         os_helper.unlink(TESTMOD)
         fd = os.open(TESTMOD, os.O_CREAT, 000)


### PR DESCRIPTION
Skip some tests failures that are either fixed on the main branch of Emscripten or by an open PR.

<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
