### PR TITLE
gh-127146: Fix test_sysconfigdata_json for Emscripten

### DIFF
--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -485,10 +485,10 @@ def _init_config_vars():
         _init_posix(_CONFIG_VARS)
         # If we are cross-compiling, load the prefixes from the Makefile instead.
         if '_PYTHON_PROJECT_BASE' in os.environ:
-            prefix = _CONFIG_VARS['prefix']
-            exec_prefix = _CONFIG_VARS['exec_prefix']
-            base_prefix = _CONFIG_VARS['prefix']
-            base_exec_prefix = _CONFIG_VARS['exec_prefix']
+            prefix = _CONFIG_VARS['host_prefix']
+            exec_prefix = _CONFIG_VARS['host_exec_prefix']
+            base_prefix = _CONFIG_VARS['host_prefix']
+            base_exec_prefix = _CONFIG_VARS['host_exec_prefix']
             abiflags = _CONFIG_VARS['ABIFLAGS']
 
     # Normalized versions of prefix and exec_prefix are handy to have;


### PR DESCRIPTION
We should set the value of prefix and exec_prefix in the host from host_prefix and host_exec_prefix.


<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
