### PR TITLE
gh-127146: Strip dash from Emscripten compiler version

### DIFF
--- a/configure
+++ b/configure
@@ -4595,7 +4595,7 @@ printf "%s\n" "$IPHONEOS_DEPLOYMENT_TARGET" >&6; }
 		_host_ident=$host_cpu
 		;;
 	*-*-emscripten)
-		_host_ident=$(emcc -dumpversion)-$host_cpu
+		_host_ident=$(emcc -dumpversion | cut -f1 -d-)-$host_cpu
 		;;
 	wasm32-*-* | wasm64-*-*)
 		_host_ident=$host_cpu

--- a/configure.ac
+++ b/configure.ac
@@ -794,7 +794,7 @@ if test "$cross_compiling" = yes; then
 		_host_ident=$host_cpu
 		;;
 	*-*-emscripten)
-		_host_ident=$(emcc -dumpversion)-$host_cpu
+		_host_ident=$(emcc -dumpversion | cut -f1 -d-)-$host_cpu
 		;;
 	wasm32-*-* | wasm64-*-*)
 		_host_ident=$host_cpu


### PR DESCRIPTION
`emcc -dumpversion` will sometimes say e.g., `4.0.0-git` but in this case uname does not include `-git` in the version string. Use cut to delete everything after the dash.
cc @kleisauke

<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
