### PR TITLE
gh-108202: Document calendar.Calendar.firstweekday

### DIFF
--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -52,13 +52,13 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
 
       Return an :class:`int` for the current first weekday (0--6).
 
-      Identical to reading the :attr:`firstweekday` property.
+      Identical to reading the :attr:`~Calendar.firstweekday` property.
 
    .. method:: setfirstweekday(firstweekday)
 
       Set the first weekday to *firstweekday*, passed as an :class:`int` (0--6)
 
-      Identical to setting the :attr:`firstweekday` property.
+      Identical to setting the :attr:`~Calendar.firstweekday` property.
 
    .. method:: iterweekdays()
 

--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -38,15 +38,27 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
    itself. This is the job of subclasses.
 
 
-   :class:`Calendar` instances have the following methods:
+   :class:`Calendar` instances have the following methods and attributes:
+
+   .. attribute:: firstweekday
+
+      The first weekday as an integer (0--6).
+
+      This property can also be set and read using
+      :meth:`~Calendar.setfirstweekday` and
+      :meth:`~Calendar.getfirstweekday` respectively.
 
    .. method:: getfirstweekday()
 
-      Return an :class:`int` for the current first weekday (0-6).
+      Return an :class:`int` for the current first weekday (0--6).
+
+      Identical to the reading the :attr:`firstweekday` property.
 
    .. method:: setfirstweekday(firstweekday)
 
-      Set the first weekday to *firstweekday*, passed as an :class:`int` where Monday is 0 and Sunday is 6.
+      Set the first weekday to *firstweekday*, passed as an :class:`int` (0--6)
+
+      Identical to the setting the :attr:`firstweekday` property.
 
    .. method:: iterweekdays()
 

--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -52,13 +52,13 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
 
       Return an :class:`int` for the current first weekday (0--6).
 
-      Identical to the reading the :attr:`firstweekday` property.
+      Identical to reading the :attr:`firstweekday` property.
 
    .. method:: setfirstweekday(firstweekday)
 
       Set the first weekday to *firstweekday*, passed as an :class:`int` (0--6)
 
-      Identical to the setting the :attr:`firstweekday` property.
+      Identical to setting the :attr:`firstweekday` property.
 
    .. method:: iterweekdays()
 

--- a/Doc/library/calendar.rst
+++ b/Doc/library/calendar.rst
@@ -64,7 +64,7 @@ interpreted as prescribed by the ISO 8601 standard.  Year 0 is 1 BC, year -1 is
 
       Return an iterator for the week day numbers that will be used for one
       week.  The first value from the iterator will be the same as the value of
-      the :attr:`firstweekday` property.
+      the :attr:`~Calendar.firstweekday` property.
 
 
    .. method:: itermonthdates(year, month)


### PR DESCRIPTION
Follow-up to #127579. I think we should promote the more pythonic property API, rather than the setter/getter pair.

<!-- gh-issue-number: gh-108202 -->
* Issue: gh-108202
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128566.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->