### PR TITLE
[3.12] gh-127614: Correctly check for ttyname_r() in configure (#128503)

### DIFF
--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -304,7 +304,7 @@ exit:
     return return_value;
 }
 
-#if defined(HAVE_TTYNAME)
+#if defined(HAVE_TTYNAME_R)
 
 PyDoc_STRVAR(os_ttyname__doc__,
 "ttyname($module, fd, /)\n"
@@ -337,7 +337,7 @@ exit:
     return return_value;
 }
 
-#endif /* defined(HAVE_TTYNAME) */
+#endif /* defined(HAVE_TTYNAME_R) */
 
 #if defined(HAVE_CTERMID)
 
@@ -12032,4 +12032,4 @@ exit:
 #ifndef OS_WAITSTATUS_TO_EXITCODE_METHODDEF
     #define OS_WAITSTATUS_TO_EXITCODE_METHODDEF
 #endif /* !defined(OS_WAITSTATUS_TO_EXITCODE_METHODDEF) */
-/*[clinic end generated code: output=6d34c4564aca7725 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=efe45f93561db8d3 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -3237,7 +3237,7 @@ os_access_impl(PyObject *module, path_t *path, int mode, int dir_fd,
 #endif
 
 
-#ifdef HAVE_TTYNAME
+#ifdef HAVE_TTYNAME_R
 /*[clinic input]
 os.ttyname
 

--- a/configure
+++ b/configure
@@ -18553,10 +18553,10 @@ then :
   printf "%s\n" "#define HAVE_TRUNCATE 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "ttyname" "ac_cv_func_ttyname"
-if test "x$ac_cv_func_ttyname" = xyes
+ac_fn_c_check_func "$LINENO" "ttyname_r" "ac_cv_func_ttyname_r"
+if test "x$ac_cv_func_ttyname_r" = xyes
 then :
-  printf "%s\n" "#define HAVE_TTYNAME 1" >>confdefs.h
+  printf "%s\n" "#define HAVE_TTYNAME_R 1" >>confdefs.h
 
 fi
 ac_fn_c_check_func "$LINENO" "umask" "ac_cv_func_umask"

--- a/configure.ac
+++ b/configure.ac
@@ -4941,7 +4941,7 @@ AC_CHECK_FUNCS([ \
   sigfillset siginterrupt sigpending sigrelse sigtimedwait sigwait \
   sigwaitinfo snprintf splice strftime strlcpy strsignal symlinkat sync \
   sysconf system tcgetpgrp tcsetpgrp tempnam timegm times tmpfile \
-  tmpnam tmpnam_r truncate ttyname umask uname unlinkat utimensat utimes vfork \
+  tmpnam tmpnam_r truncate ttyname_r umask uname unlinkat utimensat utimes vfork \
   wait wait3 wait4 waitid waitpid wcscoll wcsftime wcsxfrm wmemcmp writev \
 ])
 

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1435,8 +1435,8 @@
 /* Define to 1 if you have the `truncate' function. */
 #undef HAVE_TRUNCATE
 
-/* Define to 1 if you have the `ttyname' function. */
-#undef HAVE_TTYNAME
+/* Define to 1 if you have the `ttyname_r' function. */
+#undef HAVE_TTYNAME_R
 
 /* Define to 1 if you don't have `tm_zone' but do have the external array
    `tzname'. */


### PR DESCRIPTION
(cherry picked from commit e08b28235a863323ca3a7e444776bb7803e77caf)

PR #14868 replaced the ttyname() call with ttyname_r(), but the old
check remained.


<!-- gh-issue-number: gh-127614 -->
* Issue: gh-127614
<!-- /gh-issue-number -->
