### PR TITLE
[3.12] gh-123085: Remove double 'import os' added by PR #124021

### DIFF
--- a/Lib/test/test_importlib/resources/test_files.py
+++ b/Lib/test/test_importlib/resources/test_files.py
@@ -115,7 +115,6 @@ class ImplicitContextFilesTests(SiteDir, unittest.TestCase):
         """
         Special test for gh-121735 for Python 3.12.
         """
-        import os
         import zipfile
 
         def create_zip_from_directory(source_dir, zip_filename):


### PR DESCRIPTION


<!-- gh-issue-number: gh-123085 -->
* Issue: gh-123085
<!-- /gh-issue-number -->
