### PR TITLE
gh-97850: Suggest `TraversableResources` as the alternative for `ResourceLoader`.

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -380,13 +380,15 @@ ABC hierarchy::
 
 .. class:: ResourceLoader
 
+   *Superseded by TraversableResources*
+
     An abstract base class for a :term:`loader` which implements the optional
     :pep:`302` protocol for loading arbitrary resources from the storage
     back-end.
 
     .. deprecated:: 3.7
        This ABC is deprecated in favour of supporting resource loading
-       through :class:`importlib.resources.abc.ResourceReader`.
+       through :class:`importlib.resources.abc.TraversableResources`.
 
     .. abstractmethod:: get_data(path)
 


### PR DESCRIPTION
Previously, `ResourceReader` was the suggested alternative, but it
is itself deprecated in favour of `TraversableResources`.

More discussion is here: https://github.com/python/cpython/issues/97850#issuecomment-2551304644

<!-- gh-issue-number: gh-97850 -->
* Issue: gh-97850
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128601.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->