### PR TITLE
gh-97850: Remove the mention of removal from `ResourceReader` docs

### DIFF
--- a/Doc/library/importlib.resources.abc.rst
+++ b/Doc/library/importlib.resources.abc.rst
@@ -43,7 +43,7 @@
     :const:`None`. An object compatible with this ABC should only be
     returned when the specified module is a package.
 
-    .. deprecated-removed:: 3.12 3.14
+    .. deprecated:: 3.12
        Use :class:`importlib.resources.abc.TraversableResources` instead.
 
     .. abstractmethod:: open_resource(resource)


### PR DESCRIPTION
There is currently no plan to remove `ResourceReader`, especially given that the suggested alternative `TraversableResources` inherits from `ResourceReader`. Let's remove the mention of a removal for now.

Related discussion: https://github.com/python/cpython/issues/97850#issuecomment-2561234688

<!-- gh-issue-number: gh-97850 -->
* Issue: gh-97850
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128602.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->