### PR TITLE
gh-100991: fix email header `References` and `In-Reply-To` being treated as unstructured

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -863,6 +863,10 @@ class MessageID(MsgID):
     token_type = 'message-id'
 
 
+class MessageIDList(TokenList):
+    token_type = "message-id-list"
+
+
 class InvalidMessageID(MessageID):
     token_type = 'invalid-message-id'
 
@@ -2141,6 +2145,23 @@ def get_msg_id(value):
     return msg_id, value
 
 
+def get_invalid_msg_id(value, endchars):
+    """ Read everything up to one of the chars in endchars, return InvalidMessageID
+    and rest of the value
+
+    """
+    invalid_msg_id = InvalidMessageID()
+    while value and value[0] not in endchars:
+        if value[0] in PHRASE_ENDS:
+            invalid_msg_id.append(ValueTerminal(value[0],
+                                                 'misplaced-special'))
+            value = value[1:]
+        else:
+            token, value = get_phrase(value)
+            invalid_msg_id.append(token)
+    return invalid_msg_id, value
+
+
 def parse_message_id(value):
     """message-id      =   "Message-ID:" msg-id CRLF
     """
@@ -2160,6 +2181,26 @@ def parse_message_id(value):
                 "Unexpected {!r}".format(value)))
 
     return message_id
+
+def parse_message_id_list(value):
+    """ in-reply-to     =   "In-Reply-To:" 1*msg-id CRLF
+        references      =   "References:" 1*msg-id CRLF
+    """
+
+    message_id_list = MessageIDList()
+
+    while value:
+        try:
+            token, value = get_msg_id(value)
+            message_id_list.append(MessageID([token]))
+        except errors.HeaderParseError:
+            token, value = get_invalid_msg_id(value, "<")
+            message_id_list.append(token)
+            message_id_list.defects.append(
+                errors.InvalidHeaderDefect("Invalid msg-id: {!r}".format(str(token))))
+
+
+    return message_id_list
 
 #
 # XXX: As I begin to add additional header parsers, I'm realizing we probably

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2189,6 +2189,17 @@ def parse_message_id_list(value):
 
     message_id_list = MessageIDList()
 
+    # ignore initial CFWS
+    if value and value[0] in CFWS_LEADER:
+        _, value = get_cfws(value)
+
+    # required at least one msg-id
+    if not value:
+        message_id_list.defects.append(errors.InvalidHeaderDefect(
+            "Empty message-id-list"
+        ))
+        return message_id_list
+
     while value:
         try:
             token, value = get_msg_id(value)

--- a/Lib/email/headerregistry.py
+++ b/Lib/email/headerregistry.py
@@ -534,6 +534,18 @@ class MessageIDHeader:
         kwds['defects'].extend(parse_tree.all_defects)
 
 
+class MessageIDListHeader:
+
+    max_count = None
+    value_parser = staticmethod(parser.parse_message_id_list)
+
+    @classmethod
+    def parse(cls, value, kwds):
+        kwds['parse_tree'] = parse_tree = cls.value_parser(value)
+        kwds['decoded'] = str(parse_tree)
+        kwds['defects'].extend(parse_tree.all_defects)
+
+
 # The header factory #
 
 _default_header_map = {
@@ -557,6 +569,8 @@ _default_header_map = {
     'content-disposition':          ContentDispositionHeader,
     'content-transfer-encoding':    ContentTransferEncodingHeader,
     'message-id':                   MessageIDHeader,
+    'references':                   MessageIDListHeader,
+    'in-reply-to':                  MessageIDListHeader,
     }
 
 class HeaderRegistry:

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2810,6 +2810,16 @@ class TestParser(TestParserMixin, TestEmailBase):
             [],
         )
 
+    def test_parse_message_id_list_extra_white_spaces(self):
+        text = "<1@example.com> <2@example.com>    <3@example.com>"
+        self._test_parse_x(
+            parser.parse_message_id_list,
+            text,
+            text,
+            "<1@example.com> <2@example.com> <3@example.com>",
+            [],
+        )
+
     def test_parse_message_id_list_with_invalid_msg_id(self):
         text = "<1@example.com> <2@example.com> abc <3@example.com>"
         self._test_parse_x(

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2830,6 +2830,55 @@ class TestParser(TestParserMixin, TestEmailBase):
             [errors.InvalidHeaderDefect], # "Invalid msg-id: 'abc '"
         )
 
+    def test_parse_message_id_list_endswith_invalid_msg_id(self):
+        text = "<1@example.com> <2@example.com> abc"
+        self._test_parse_x(
+            parser.parse_message_id_list,
+            text,
+            text,
+            text,
+            [errors.InvalidHeaderDefect], # "Invalid msg-id: 'abc '"
+        )
+
+    def test_parse_message_id_list_with_no_value(self):
+        text = ""
+        self._test_parse_x(
+            parser.parse_message_id_list,
+            text,
+            text,
+            text,
+            [errors.InvalidHeaderDefect], # "Empty message-id-list"
+        )
+
+    def test_parse_message_id_list_with_invalid_id_only(self):
+        text = "abc"
+        self._test_parse_x(
+            parser.parse_message_id_list,
+            text,
+            text,
+            text,
+            [errors.InvalidHeaderDefect], # "Invalid msg-id: 'abc '"
+        )
+
+    def test_parse_message_id_list_startswith_invalid_id(self):
+        text = "abc <1@example.com> <2@example.com> abc"
+        self._test_parse_x(
+            parser.parse_message_id_list,
+            text,
+            text,
+            text,
+            [errors.InvalidHeaderDefect, errors.InvalidHeaderDefect], # "Invalid msg-id: 'abc '"
+        )
+
+    def test_parse_message_id_list_with_leading_whitespace(self):
+        text = "    <1@example.com> <2@example.com>"
+        self._test_parse_x(
+            parser.parse_message_id_list,
+            text,
+            text.strip(),
+            text.strip(),
+            [],
+        )
 
 
 @parameterize

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2789,6 +2789,37 @@ class TestParser(TestParserMixin, TestEmailBase):
         )
         self.assertEqual(msg_id.token_type, 'msg-id')
 
+    def test_parse_message_id_list_with_one_id(self):
+        text = "<1@example.com>"
+        msg_id_list = self._test_parse_x(
+            parser.parse_message_id_list,
+            text,
+            text,
+            text,
+            [],
+        )
+        self.assertEqual(msg_id_list.token_type, 'message-id-list')
+
+    def test_parse_message_id_list(self):
+        text = "<1@example.com> <2@example.com> <3@example.com>"
+        self._test_parse_x(
+            parser.parse_message_id_list,
+            text,
+            text,
+            text,
+            [],
+        )
+
+    def test_parse_message_id_list_with_invalid_msg_id(self):
+        text = "<1@example.com> <2@example.com> abc <3@example.com>"
+        self._test_parse_x(
+            parser.parse_message_id_list,
+            text,
+            text,
+            text,
+            [errors.InvalidHeaderDefect], # "Invalid msg-id: 'abc '"
+        )
+
 
 
 @parameterize

--- a/Lib/test/test_email/test_message.py
+++ b/Lib/test/test_email/test_message.py
@@ -1091,6 +1091,22 @@ class TestEmailMessage(TestEmailMessageBase, TestEmailBase):
                      b'From: Foo Bar <email@email.au>\n\nNo content\n')
         self.assertEqual(m.as_bytes(), msg_bytes)
 
+    def test_no_references_value(self):
+        msg = textwrap.dedent("""\
+            Message-ID: <long-but-perfectly-valid-message-id-that-does-not-end-up-qp-encoded@example.com>
+            References:
+            From: Foo Bar <email@email.au>
+
+            No content
+            """)
+        m = self._str_msg(msg)
+        msg_bytes = (b'Message-ID:'
+                     b' <long-but-perfectly-valid-message-id-that-does-not-end-up-qp-encoded@example.com>\n'
+                     b'References: \n'
+                     b'From: Foo Bar <email@email.au>\n\nNo content\n')
+        self.assertEqual(m.as_bytes(), msg_bytes)
+
+
 class TestMIMEPart(TestEmailMessageBase, TestEmailBase):
     # Doing the full test run here may seem a bit redundant, since the two
     # classes are almost identical.  But what if they drift apart?  So we do

--- a/Lib/test/test_email/test_message.py
+++ b/Lib/test/test_email/test_message.py
@@ -1031,6 +1031,65 @@ class TestEmailMessage(TestEmailMessageBase, TestEmailBase):
         # AttributeError: 'str' object has no attribute 'is_attachment'
         m.get_body()
 
+    def test_long_references_header(self):
+        msg = textwrap.dedent("""\
+            Message-ID: <long-but-perfectly-valid-message-id-that-does-not-end-up-qp-encoded@example.com>
+            References: <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>
+            From: Foo Bar <email@email.au>
+
+            No content
+            """)
+        m = self._str_msg(msg)
+        msg_bytes = (b'Message-ID:'
+                     b' <long-but-perfectly-valid-message-id-that-does-not-end-up-qp-encoded@example.com>\n'
+                     b'References:'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b'From: Foo Bar <email@email.au>\n\nNo content\n')
+        self.assertEqual(m.as_bytes(), msg_bytes)
+
+    def test_long_in_reply_to_header(self):
+        msg = textwrap.dedent("""\
+            Message-ID: <long-but-perfectly-valid-message-id-that-does-not-end-up-qp-encoded@example.com>
+            In-Reply-To: <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>
+            From: Foo Bar <email@email.au>
+
+            No content
+            """)
+        m = self._str_msg(msg)
+        msg_bytes = (b'Message-ID:'
+                     b' <long-but-perfectly-valid-message-id-that-does-not-end-up-qp-encoded@example.com>\n'
+                     b'In-Reply-To:'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b'From: Foo Bar <email@email.au>\n\nNo content\n')
+        self.assertEqual(m.as_bytes(), msg_bytes)
+
+    def test_msg_id_list_in_header(self):
+        msg_ids = " ".join(["<reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>"] * 5)
+        msg = textwrap.dedent(f"""\
+            Message-ID: <long-but-perfectly-valid-message-id-that-does-not-end-up-qp-encoded@example.com>
+            In-Reply-To: {msg_ids}
+            References: {msg_ids}
+            From: Foo Bar <email@email.au>
+
+            No content
+            """)
+        m = self._str_msg(msg)
+        msg_bytes = (b'Message-ID:'
+                     b' <long-but-perfectly-valid-message-id-that-does-not-end-up-qp-encoded@example.com>\n'
+                     b'In-Reply-To:'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b'References:'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b' <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>\n'
+                     b'From: Foo Bar <email@email.au>\n\nNo content\n')
+        self.assertEqual(m.as_bytes(), msg_bytes)
 
 class TestMIMEPart(TestEmailMessageBase, TestEmailBase):
     # Doing the full test run here may seem a bit redundant, since the two

--- a/Misc/NEWS.d/next/Library/2025-01-08-13-16-37.gh-issue-100911.IzrEkV.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-08-13-16-37.gh-issue-100911.IzrEkV.rst
@@ -1,0 +1,2 @@
+Fixed email headers ``References`` and ``In-Reply-To`` being treated as
+unstructured.


### PR DESCRIPTION
According to [RFC 5322#3.6.4](https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.4), both `References` and `In-Reply-To` are not unstructured fields and should have similar behaviour to `Message-ID`.


```
message-id      =   "Message-ID:" msg-id CRLF
in-reply-to     =   "In-Reply-To:" 1*msg-id CRLF
references      =   "References:" 1*msg-id CRLF
```

---

**Sample Code**

```python
msg = textwrap.dedent(f"""\
            Message-ID: <long-but-perfectly-valid-message-id-that-does-not-end-up-qp-encoded@example.com>
            In-Reply-To: <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>
            References: <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com> <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>
            """)
msg = email.message_from_string(msg, policy=email.policy.default)
```

**Before this patch**
```python
Message-ID: <long-but-perfectly-valid-message-id-that-does-not-end-up-qp-encoded@example.com>
In-Reply-To: =?utf-8?q?=3Creference-to-long-but-perfectly-valid-message-id-t?=
 =?utf-8?q?hat-gets-qp-encoded=40example=2Ecom=3E?=
References: =?utf-8?q?=3Creference-to-long-but-perfectly-valid-message-id-th?=
 =?utf-8?q?at-gets-qp-encoded=40example=2Ecom=3E_=3Creference-to-long-but-pe?=
 =?utf-8?q?rfectly-valid-message-id-that-gets-qp-encoded=40example=2Ecom=3E?=
```


**After this patch**
```python
Message-ID: <long-but-perfectly-valid-message-id-that-does-not-end-up-qp-encoded@example.com>
In-Reply-To: <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>
References: <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>
 <reference-to-long-but-perfectly-valid-message-id-that-gets-qp-encoded@example.com>
```

<!-- gh-issue-number: gh-100991 -->
* Issue: gh-100991
<!-- /gh-issue-number -->
