### PR TITLE
gh-128562: Fix tkinter widget instance name sometimes duplicated on inherited class

### DIFF
--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -37,11 +37,15 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         t = tkinter.Toplevel(self.root)
         f = tkinter.Frame(t)
         f2 = tkinter.Frame(t)
+        self.assertNotEqual(str(f), str(f2))
         b = tkinter.Button(f2)
         b2 = Button2(f2)
         for name in str(b).split('.') + str(b2).split('.'):
             self.assertFalse(name.isidentifier(), msg=repr(name))
         self.assertEqual(str(b2)[-1], "!")
+        b3 = tkinter.Button(f2)
+        b4 = Button2(f2)
+        self.assertEqual(len(set([str(b), str(b2), str(b3), str(b4)])), 4)
 
     @requires_tk(8, 6, 6)
     def test_tk_busy(self):

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -45,7 +45,7 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(str(b2)[-1], "!")
         b3 = tkinter.Button(f2)
         b4 = Button2(f2)
-        self.assertEqual(len(set([str(b), str(b2), str(b3), str(b4)])), 4)
+        self.assertEqual(len({str(b), str(b2), str(b3), str(b4)}), 4)
 
     @requires_tk(8, 6, 6)
     def test_tk_busy(self):

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -42,7 +42,6 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         b2 = Button2(f2)
         for name in str(b).split('.') + str(b2).split('.'):
             self.assertFalse(name.isidentifier(), msg=repr(name))
-        self.assertEqual(str(b2)[-1], "!")
         b3 = tkinter.Button(f2)
         b4 = Button2(f2)
         self.assertEqual(len({str(b), str(b2), str(b3), str(b4)}), 4)

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -41,7 +41,7 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         b2 = Button2(f2)
         for name in str(b).split('.') + str(b2).split('.'):
             self.assertFalse(name.isidentifier(), msg=repr(name))
-        self.assertEqual(str(b2)[-1], "$")
+        self.assertEqual(str(b2)[-1], "!")
 
     @requires_tk(8, 6, 6)
     def test_tk_busy(self):

--- a/Lib/test/test_tkinter/test_misc.py
+++ b/Lib/test/test_tkinter/test_misc.py
@@ -31,12 +31,17 @@ class MiscTest(AbstractTkTest, unittest.TestCase):
         self.assertEqual(repr(f), '<tkinter.Frame object .top.child>')
 
     def test_generated_names(self):
+        class Button2(tkinter.Button):
+            pass
+
         t = tkinter.Toplevel(self.root)
         f = tkinter.Frame(t)
         f2 = tkinter.Frame(t)
         b = tkinter.Button(f2)
-        for name in str(b).split('.'):
+        b2 = Button2(f2)
+        for name in str(b).split('.') + str(b2).split('.'):
             self.assertFalse(name.isidentifier(), msg=repr(name))
+        self.assertEqual(str(b2)[-1], "$")
 
     @requires_tk(8, 6, 6)
     def test_tk_busy(self):

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -2742,7 +2742,7 @@ class BaseWidget(Misc):
         if not name:
             name = cls.__name__.lower()
             if name[-1].isdigit():
-                name += "$"  # Avoid duplication when calculating names below
+                name += "_0"  # Avoid duplication when calculating names below
             if master._last_child_ids is None:
                 master._last_child_ids = {}
             count = master._last_child_ids.get(name, 0) + 1

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -2742,7 +2742,7 @@ class BaseWidget(Misc):
         if not name:
             name = cls.__name__.lower()
             if name[-1].isdigit():
-                name += "_0"  # Avoid duplication when calculating names below
+                name += "$"  # Avoid duplication when calculating names below
             if master._last_child_ids is None:
                 master._last_child_ids = {}
             count = master._last_child_ids.get(name, 0) + 1

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -2742,7 +2742,7 @@ class BaseWidget(Misc):
         if not name:
             name = self.__class__.__name__.lower()
             if name[-1].isdigit():
-                name += "$"  # Avoid duplication when calculating names below
+                name += "!"  # Avoid duplication when calculating names below
             if master._last_child_ids is None:
                 master._last_child_ids = {}
             count = master._last_child_ids.get(name, 0) + 1

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -2740,7 +2740,7 @@ class BaseWidget(Misc):
             name = cnf['name']
             del cnf['name']
         if not name:
-            name = cls.__name__.lower()
+            name = self.__class__.__name__.lower()
             if name[-1].isdigit():
                 name += "$"  # Avoid duplication when calculating names below
             if master._last_child_ids is None:

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -2740,10 +2740,9 @@ class BaseWidget(Misc):
             name = cnf['name']
             del cnf['name']
         if not name:
-            cls = self.__class__
-            while cls.__module__ not in ("tkinter", "tkinter.ttk"):
-                cls = cls.__base__
             name = cls.__name__.lower()
+            if name[-1].isdigit():
+                name += "$"  # Avoid duplication when calculating names below
             if master._last_child_ids is None:
                 master._last_child_ids = {}
             count = master._last_child_ids.get(name, 0) + 1

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -2740,7 +2740,10 @@ class BaseWidget(Misc):
             name = cnf['name']
             del cnf['name']
         if not name:
-            name = self.__class__.__name__.lower()
+            cls = self.__class__
+            while cls.__module__ not in ("tkinter", "tkinter.ttk"):
+                cls = cls.__base__
+            name = cls.__name__.lower()
             if master._last_child_ids is None:
                 master._last_child_ids = {}
             count = master._last_child_ids.get(name, 0) + 1

--- a/Misc/NEWS.d/next/Library/2025-01-08-03-09-29.gh-issue-128562.Mlv-yO.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-08-03-09-29.gh-issue-128562.Mlv-yO.rst
@@ -1,1 +1,1 @@
-Fix the bug that the widgets of :mod:`tkinter` are named inaccurately.
+Fix possible conflicts in generated :mod:`tkinter` widget names if the widget class name ends with a digit.

--- a/Misc/NEWS.d/next/Library/2025-01-08-03-09-29.gh-issue-128562.Mlv-yO.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-08-03-09-29.gh-issue-128562.Mlv-yO.rst
@@ -1,0 +1,1 @@
+Fix the bug that the widgets of :mod:`tkinter` are named inaccurately.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128562 -->
* Issue: gh-128562
<!-- /gh-issue-number -->
