### PR TITLE
gh-128613: Increase `typing.Concatenate` coverage

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -10129,6 +10129,18 @@ class ConcatenateTests(BaseTestCase):
         self.assertEqual(C4.__args__, (Concatenate[int, T, P], T))
         self.assertEqual(C4.__parameters__, (T, P))
 
+    def test_invalid_uses(self):
+        with self.assertRaisesRegex(TypeError, 'Concatenate of no types'):
+            Concatenate[()]
+        with self.assertRaisesRegex(
+            TypeError,
+            (
+                'The last parameter to Concatenate should be a '
+                'ParamSpec variable or ellipsis'
+            ),
+        ):
+            Concatenate[int]
+
     def test_var_substitution(self):
         T = TypeVar('T')
         P = ParamSpec('P')


### PR DESCRIPTION
After:
<img width="766" alt="Снимок экрана 2025-01-08 в 11 58 55" src="https://github.com/user-attachments/assets/70f01d45-17b1-4df1-b214-1b56434a7913" />


<!-- gh-issue-number: gh-128613 -->
* Issue: gh-128613
<!-- /gh-issue-number -->
