### PR TITLE
gh-128615: Cover pickling of `ParamSpecArgs` and `ParamSpecKwargs`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5182,6 +5182,18 @@ class GenericTests(BaseTestCase):
                 x = pickle.loads(z)
                 self.assertEqual(s, x)
 
+        # Test ParamSpec args and kwargs
+        global PP
+        PP = ParamSpec('PP')
+        for thing in [PP.args, PP.kwargs]:
+            for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+                with self.subTest(thing=thing, proto=proto):
+                    self.assertEqual(
+                        pickle.loads(pickle.dumps(thing, proto)),
+                        thing,
+                    )
+        del PP
+
     def test_copy_and_deepcopy(self):
         T = TypeVar('T')
         class Node(Generic[T]): ...


### PR DESCRIPTION
Refs https://github.com/python/cpython/commit/24d8b88420b81fc60aeb0cbcacef1e72d633824a

<!-- gh-issue-number: gh-128615 -->
* Issue: gh-128615
<!-- /gh-issue-number -->
