### PR TITLE
GH-115776: Rename `Py_TPFLAGS_INLINE_VALUES` as `_Py_TPFLAGS_INLINE_VALUES`

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -944,7 +944,7 @@ _PyObject_InlineValues(PyObject *obj)
 {
     PyTypeObject *tp = Py_TYPE(obj);
     assert(tp->tp_basicsize > 0 && (size_t)tp->tp_basicsize % sizeof(PyObject *) == 0);
-    assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+    assert(Py_TYPE(obj)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
     assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
     return (PyDictValues *)((char *)obj + tp->tp_basicsize);
 }

--- a/Include/object.h
+++ b/Include/object.h
@@ -513,7 +513,7 @@ given type object has a specified feature.
 /* The values array is placed inline directly after the rest of
  * the object. Implies Py_TPFLAGS_HAVE_GC.
  */
-#define Py_TPFLAGS_INLINE_VALUES (1 << 2)
+#define _Py_TPFLAGS_INLINE_VALUES (1 << 2)
 
 /* Placement of weakref pointers are managed by the VM, not by the type.
  * The VM will automatically set tp_weaklistoffset.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-01-08-15-56-36.gh-issue-128635.ODIPtl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-01-08-15-56-36.gh-issue-128635.ODIPtl.rst
@@ -1,0 +1,3 @@
+The ``Py_TPFLAGS_INLINE_VALUES`` has been renamed
+``_Py_TPFLAGS_INLINE_VALUES`` to clarify that it is internal and should not
+be used.

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -1322,7 +1322,7 @@ static PyObject *
 get_object_dict_values(PyObject *self, PyObject *obj)
 {
     PyTypeObject *type = Py_TYPE(obj);
-    if (!_PyType_HasFeature(type, Py_TPFLAGS_INLINE_VALUES)) {
+    if (!_PyType_HasFeature(type, _Py_TPFLAGS_INLINE_VALUES)) {
         Py_RETURN_NONE;
     }
     PyDictValues *values = _PyObject_InlineValues(obj);
@@ -1982,7 +1982,7 @@ get_tlbc_id(PyObject *Py_UNUSED(module), PyObject *obj)
 static PyObject *
 has_inline_values(PyObject *self, PyObject *obj)
 {
-    if ((Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES) &&
+    if ((Py_TYPE(obj)->tp_flags & _Py_TPFLAGS_INLINE_VALUES) &&
         _PyObject_InlineValues(obj)->valid) {
         Py_RETURN_TRUE;
     }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -6677,7 +6677,7 @@ void
 _PyObject_InitInlineValues(PyObject *obj, PyTypeObject *tp)
 {
     assert(tp->tp_flags & Py_TPFLAGS_HEAPTYPE);
-    assert(tp->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+    assert(tp->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
     assert(tp->tp_flags & Py_TPFLAGS_MANAGED_DICT);
     PyDictKeysObject *keys = CACHED_KEYS(tp);
     assert(keys != NULL);
@@ -6798,7 +6798,7 @@ store_instance_attr_lock_held(PyObject *obj, PyDictValues *values,
     PyDictKeysObject *keys = CACHED_KEYS(Py_TYPE(obj));
     assert(keys != NULL);
     assert(values != NULL);
-    assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+    assert(Py_TYPE(obj)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
     Py_ssize_t ix = DKIX_EMPTY;
     PyDictObject *dict = _PyObject_GetManagedDict(obj);
     assert(dict == NULL || ((PyDictObject *)dict)->ma_values == values);
@@ -7069,7 +7069,7 @@ _PyObject_IsInstanceDictEmpty(PyObject *obj)
         return 1;
     }
     PyDictObject *dict;
-    if (tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (tp->tp_flags & _Py_TPFLAGS_INLINE_VALUES) {
         PyDictValues *values = _PyObject_InlineValues(obj);
         if (FT_ATOMIC_LOAD_UINT8(values->valid)) {
             PyDictKeysObject *keys = CACHED_KEYS(tp);
@@ -7102,7 +7102,7 @@ PyObject_VisitManagedDict(PyObject *obj, visitproc visit, void *arg)
     if((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0) {
         return 0;
     }
-    if (tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (tp->tp_flags & _Py_TPFLAGS_INLINE_VALUES) {
         PyDictValues *values = _PyObject_InlineValues(obj);
         if (values->valid) {
             for (Py_ssize_t i = 0; i < values->capacity; i++) {
@@ -7219,7 +7219,7 @@ set_or_clear_managed_dict(PyObject *obj, PyObject *new_dict, bool clear)
 #endif
     int err = 0;
     PyTypeObject *tp = Py_TYPE(obj);
-    if (tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (tp->tp_flags & _Py_TPFLAGS_INLINE_VALUES) {
 #ifdef Py_GIL_DISABLED
         PyDictObject *prev_dict;
         if (!try_set_dict_inline_only_or_other_dict(obj, new_dict, &prev_dict)) {
@@ -7335,7 +7335,7 @@ _PyDict_DetachFromObject(PyDictObject *mp, PyObject *obj)
     ASSERT_WORLD_STOPPED_OR_OBJ_LOCKED(mp);
     assert(mp->ma_values->embedded == 1);
     assert(mp->ma_values->valid == 1);
-    assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+    assert(Py_TYPE(obj)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
 
     PyDictValues *values = copy_values(mp->ma_values);
 
@@ -7358,7 +7358,7 @@ ensure_managed_dict(PyObject *obj)
     PyDictObject *dict = _PyObject_GetManagedDict(obj);
     if (dict == NULL) {
         PyTypeObject *tp = Py_TYPE(obj);
-        if ((tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) &&
+        if ((tp->tp_flags & _Py_TPFLAGS_INLINE_VALUES) &&
             FT_ATOMIC_LOAD_UINT8(_PyObject_InlineValues(obj)->valid)) {
             dict = _PyObject_MaterializeManagedDict(obj);
         }
@@ -7402,7 +7402,7 @@ ensure_nonmanaged_dict(PyObject *obj, PyObject **dictptr)
         PyTypeObject *tp = Py_TYPE(obj);
         if (_PyType_HasFeature(tp, Py_TPFLAGS_HEAPTYPE) && (cached = CACHED_KEYS(tp))) {
             PyInterpreterState *interp = _PyInterpreterState_GET();
-            assert(!_PyType_HasFeature(tp, Py_TPFLAGS_INLINE_VALUES));
+            assert(!_PyType_HasFeature(tp, _Py_TPFLAGS_INLINE_VALUES));
             dict = new_dict_with_shared_keys(interp, cached);
         }
         else {
@@ -7624,7 +7624,7 @@ _PyDict_SendEvent(int watcher_bits,
 static int
 _PyObject_InlineValuesConsistencyCheck(PyObject *obj)
 {
-    if ((Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES) == 0) {
+    if ((Py_TYPE(obj)->tp_flags & _Py_TPFLAGS_INLINE_VALUES) == 0) {
         return 1;
     }
     assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_MANAGED_DICT);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1518,7 +1518,7 @@ _PyObject_GetDictPtr(PyObject *obj)
         return _PyObject_ComputedDictPointer(obj);
     }
     PyDictObject *dict = _PyObject_GetManagedDict(obj);
-    if (dict == NULL && Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (dict == NULL && Py_TYPE(obj)->tp_flags & _Py_TPFLAGS_INLINE_VALUES) {
         dict = _PyObject_MaterializeManagedDict(obj);
         if (dict == NULL) {
             PyErr_Clear();
@@ -1594,7 +1594,7 @@ _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
         }
     }
     PyObject *dict, *attr;
-    if ((tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) &&
+    if ((tp->tp_flags & _Py_TPFLAGS_INLINE_VALUES) &&
          _PyObject_TryGetInstanceAttribute(obj, name, &attr)) {
         if (attr != NULL) {
             *method = attr;
@@ -1696,7 +1696,7 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
         }
     }
     if (dict == NULL) {
-        if ((tp->tp_flags & Py_TPFLAGS_INLINE_VALUES)) {
+        if ((tp->tp_flags & _Py_TPFLAGS_INLINE_VALUES)) {
             if (PyUnicode_CheckExact(name) &&
                 _PyObject_TryGetInstanceAttribute(obj, name, &res)) {
                 if (res != NULL) {
@@ -1812,7 +1812,7 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
     if (dict == NULL) {
         PyObject **dictptr;
 
-        if ((tp->tp_flags & Py_TPFLAGS_INLINE_VALUES)) {
+        if ((tp->tp_flags & _Py_TPFLAGS_INLINE_VALUES)) {
             res = _PyObject_StoreInstanceAttribute(obj, name, value);
             goto error_check;
         }
@@ -1883,7 +1883,7 @@ PyObject_GenericSetDict(PyObject *obj, PyObject *value, void *context)
 {
     PyObject **dictptr = _PyObject_GetDictPtr(obj);
     if (dictptr == NULL) {
-        if (_PyType_HasFeature(Py_TYPE(obj), Py_TPFLAGS_INLINE_VALUES) &&
+        if (_PyType_HasFeature(Py_TYPE(obj), _Py_TPFLAGS_INLINE_VALUES) &&
             _PyObject_GetManagedDict(obj) == NULL
         ) {
             /* Was unable to convert to dict */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2197,7 +2197,7 @@ type_call(PyObject *self, PyObject *args, PyObject *kwds)
 PyObject *
 _PyType_NewManagedObject(PyTypeObject *type)
 {
-    assert(type->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+    assert(type->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
     assert(_PyType_IS_GC(type));
     assert(type->tp_new == PyBaseObject_Type.tp_new);
     assert(type->tp_alloc == PyType_GenericAlloc);
@@ -2222,7 +2222,7 @@ _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems)
     size_t size = _PyObject_VAR_SIZE(type, nitems+1);
 
     const size_t presize = _PyType_PreHeaderSize(type);
-    if (type->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (type->tp_flags & _Py_TPFLAGS_INLINE_VALUES) {
         assert(type->tp_itemsize == 0);
         size += _PyInlineValuesSize(type);
     }
@@ -2246,7 +2246,7 @@ _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems)
     else {
         _PyObject_InitVar((PyVarObject *)obj, type, nitems);
     }
-    if (type->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (type->tp_flags & _Py_TPFLAGS_INLINE_VALUES) {
         _PyObject_InitInlineValues(obj, type);
     }
     return obj;
@@ -2399,8 +2399,8 @@ subtype_clear(PyObject *self)
             PyObject_ClearManagedDict(self);
         }
         else {
-            assert((base->tp_flags & Py_TPFLAGS_INLINE_VALUES) ==
-                   (type->tp_flags & Py_TPFLAGS_INLINE_VALUES));
+            assert((base->tp_flags & _Py_TPFLAGS_INLINE_VALUES) ==
+                   (type->tp_flags & _Py_TPFLAGS_INLINE_VALUES));
         }
     }
     else if (type->tp_dictoffset != base->tp_dictoffset) {
@@ -5953,7 +5953,7 @@ type_setattro(PyObject *self, PyObject *name, PyObject *value)
     }
 
     PyTypeObject *metatype = Py_TYPE(type);
-    assert(!_PyType_HasFeature(metatype, Py_TPFLAGS_INLINE_VALUES));
+    assert(!_PyType_HasFeature(metatype, _Py_TPFLAGS_INLINE_VALUES));
     assert(!_PyType_HasFeature(metatype, Py_TPFLAGS_MANAGED_DICT));
 
     PyObject *old_value = NULL;
@@ -6769,8 +6769,8 @@ compatible_for_assignment(PyTypeObject* oldto, PyTypeObject* newto, const char* 
          !same_slots_added(newbase, oldbase))) {
         goto differs;
     }
-    if ((oldto->tp_flags & Py_TPFLAGS_INLINE_VALUES) !=
-        ((newto->tp_flags & Py_TPFLAGS_INLINE_VALUES)))
+    if ((oldto->tp_flags & _Py_TPFLAGS_INLINE_VALUES) !=
+        ((newto->tp_flags & _Py_TPFLAGS_INLINE_VALUES)))
     {
         goto differs;
     }
@@ -6859,7 +6859,7 @@ object_set_class_world_stopped(PyObject *self, PyTypeObject *newto)
     if (compatible_for_assignment(oldto, newto, "__class__")) {
         /* Changing the class will change the implicit dict keys,
          * so we must materialize the dictionary first. */
-        if (oldto->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+        if (oldto->tp_flags & _Py_TPFLAGS_INLINE_VALUES) {
             PyDictObject *dict = _PyObject_GetManagedDict(self);
             if (dict == NULL) {
                 dict = _PyObject_MaterializeManagedDict_LockHeld(self);
@@ -8543,7 +8543,7 @@ type_ready_managed_dict(PyTypeObject *type)
         }
     }
     if (type->tp_itemsize == 0) {
-        type->tp_flags |= Py_TPFLAGS_INLINE_VALUES;
+        type->tp_flags |= _Py_TPFLAGS_INLINE_VALUES;
     }
     return 0;
 }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2162,7 +2162,7 @@ dummy_func(
         op(_CHECK_MANAGED_OBJECT_HAS_VALUES, (owner -- owner)) {
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
             assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(Py_TYPE(owner_o)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
             DEOPT_IF(!_PyObject_InlineValues(owner_o)->valid);
         }
 
@@ -2362,7 +2362,7 @@ dummy_func(
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
 
             assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(Py_TYPE(owner_o)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
             if (_PyObject_GetManagedDict(owner_o) ||
                     !FT_ATOMIC_LOAD_UINT8(_PyObject_InlineValues(owner_o)->valid)) {
                 UNLOCK_OBJECT(owner_o);
@@ -3254,7 +3254,7 @@ dummy_func(
 
         op(_GUARD_DORV_VALUES_INST_ATTR_FROM_DICT, (owner -- owner)) {
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(Py_TYPE(owner_o)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
             DEOPT_IF(!_PyObject_InlineValues(owner_o)->valid);
         }
 

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -2621,7 +2621,7 @@
             owner = stack_pointer[-1];
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
             assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(Py_TYPE(owner_o)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
             if (!_PyObject_InlineValues(owner_o)->valid) {
                 UOP_STAT_INC(uopcode, miss);
                 JUMP_TO_JUMP_TARGET();
@@ -2944,7 +2944,7 @@
             owner = stack_pointer[-1];
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
             assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(Py_TYPE(owner_o)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
             if (_PyObject_GetManagedDict(owner_o) ||
                 !FT_ATOMIC_LOAD_UINT8(_PyObject_InlineValues(owner_o)->valid)) {
                 UNLOCK_OBJECT(owner_o);
@@ -3885,7 +3885,7 @@
             _PyStackRef owner;
             owner = stack_pointer[-1];
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(Py_TYPE(owner_o)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
             if (!_PyObject_InlineValues(owner_o)->valid) {
                 UOP_STAT_INC(uopcode, miss);
                 JUMP_TO_JUMP_TARGET();

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -2269,7 +2269,7 @@ _PyObject_GC_New(PyTypeObject *tp)
 {
     size_t presize = _PyType_PreHeaderSize(tp);
     size_t size = _PyObject_SIZE(tp);
-    if (_PyType_HasFeature(tp, Py_TPFLAGS_INLINE_VALUES)) {
+    if (_PyType_HasFeature(tp, _Py_TPFLAGS_INLINE_VALUES)) {
         size += _PyInlineValuesSize(tp);
     }
     PyObject *op = gc_alloc(tp, size, presize);
@@ -2277,7 +2277,7 @@ _PyObject_GC_New(PyTypeObject *tp)
         return NULL;
     }
     _PyObject_Init(op, tp);
-    if (tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (tp->tp_flags & _Py_TPFLAGS_INLINE_VALUES) {
         _PyObject_InitInlineValues(op, tp);
     }
     return op;

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1839,7 +1839,7 @@ _PyObject_GC_New(PyTypeObject *tp)
 {
     size_t presize = _PyType_PreHeaderSize(tp);
     size_t size = _PyObject_SIZE(tp);
-    if (_PyType_HasFeature(tp, Py_TPFLAGS_INLINE_VALUES)) {
+    if (_PyType_HasFeature(tp, _Py_TPFLAGS_INLINE_VALUES)) {
         size += _PyInlineValuesSize(tp);
     }
     PyObject *op = gc_alloc(tp, size, presize);
@@ -1847,7 +1847,7 @@ _PyObject_GC_New(PyTypeObject *tp)
         return NULL;
     }
     _PyObject_Init(op, tp);
-    if (tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (tp->tp_flags & _Py_TPFLAGS_INLINE_VALUES) {
         _PyObject_InitInlineValues(op, tp);
     }
     return op;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -5416,7 +5416,7 @@
             {
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
                 assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-                assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+                assert(Py_TYPE(owner_o)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
                 DEOPT_IF(!_PyObject_InlineValues(owner_o)->valid, LOAD_ATTR);
             }
             // _LOAD_ATTR_INSTANCE_VALUE
@@ -5539,7 +5539,7 @@
             // _GUARD_DORV_VALUES_INST_ATTR_FROM_DICT
             {
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-                assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+                assert(Py_TYPE(owner_o)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
                 DEOPT_IF(!_PyObject_InlineValues(owner_o)->valid, LOAD_ATTR);
             }
             // _GUARD_KEYS_VERSION
@@ -5669,7 +5669,7 @@
             // _GUARD_DORV_VALUES_INST_ATTR_FROM_DICT
             {
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-                assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+                assert(Py_TYPE(owner_o)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
                 DEOPT_IF(!_PyObject_InlineValues(owner_o)->valid, LOAD_ATTR);
             }
             // _GUARD_KEYS_VERSION
@@ -7404,7 +7404,7 @@
             {
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
                 assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-                assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+                assert(Py_TYPE(owner_o)->tp_flags & _Py_TPFLAGS_INLINE_VALUES);
                 if (_PyObject_GetManagedDict(owner_o) ||
                     !FT_ATOMIC_LOAD_UINT8(_PyObject_InlineValues(owner_o)->valid)) {
                     UNLOCK_OBJECT(owner_o);

--- a/Python/specialize.c
+++ b/Python/specialize.c
@@ -1027,7 +1027,7 @@ specialize_dict_access(
         SPECIALIZATION_FAIL(base_op, SPEC_FAIL_ATTR_NOT_MANAGED_DICT);
         return 0;
     }
-    if (type->tp_flags & Py_TPFLAGS_INLINE_VALUES &&
+    if (type->tp_flags & _Py_TPFLAGS_INLINE_VALUES &&
         FT_ATOMIC_LOAD_UINT8(_PyObject_InlineValues(owner)->valid) &&
         !(base_op == STORE_ATTR && _PyObject_GetManagedDict(owner) != NULL))
     {
@@ -1080,7 +1080,7 @@ instance_has_key(PyObject *obj, PyObject* name)
     if ((cls->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0) {
         return false;
     }
-    if (cls->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (cls->tp_flags & _Py_TPFLAGS_INLINE_VALUES) {
         PyDictKeysObject *keys = ((PyHeapTypeObject *)cls)->ht_cached_keys;
         Py_ssize_t index = _PyDictKeys_StringLookup(keys, name);
         return index >= 0;
@@ -1525,7 +1525,7 @@ PyObject *descr, DescriptorClassification kind, bool is_method)
 
     assert(descr != NULL);
     assert((is_method && kind == METHOD) || (!is_method && kind == NON_DESCRIPTOR));
-    if (owner_cls->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (owner_cls->tp_flags & _Py_TPFLAGS_INLINE_VALUES) {
         PyDictKeysObject *keys = ((PyHeapTypeObject *)owner_cls)->ht_cached_keys;
         assert(_PyDictKeys_StringLookup(keys, name) < 0);
         uint32_t keys_version = _PyDictKeys_GetVersionForCurrentState(

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -86,7 +86,7 @@ def interp_frame_has_tlbc_index():
                                            for field in interp_frame.fields())
     return _INTERP_FRAME_HAS_TLBC_INDEX
 
-Py_TPFLAGS_INLINE_VALUES     = (1 << 2)
+_Py_TPFLAGS_INLINE_VALUES     = (1 << 2)
 Py_TPFLAGS_MANAGED_DICT      = (1 << 4)
 Py_TPFLAGS_HEAPTYPE          = (1 << 9)
 Py_TPFLAGS_LONG_SUBCLASS     = (1 << 24)


### PR DESCRIPTION
The `Py_TPFLAGS_INLINE_VALUES` should not be used when declaring a static `PyTypeObject`. It can only be used by the VM when creating a class.  It is undocumented, but is exposed in `object.h`.
This PR adds an underscore prefix to the name to make it clearer that this flag is internal.


<!-- gh-issue-number: gh-115776 -->
* Issue: gh-115776
<!-- /gh-issue-number -->
