### PR TITLE
gh-127750: Fix singledispatchmethod caching (v2)

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1037,14 +1037,13 @@ class singledispatchmethod:
         return self.dispatcher.register(cls, func=method)
 
     def __get__(self, obj, cls=None):
-        try:
+        if hasattr(obj, '__dict__'):
             cache = obj.__dict__
-        except AttributeError:
-            cache = None
-        else:
             method = cache.get(self.attrname)
             if method is not None:
                     return method
+        else:
+            cache = None
 
         dispatch = self.dispatcher.dispatch
         funcname = getattr(self.func, '__name__', 'singledispatchmethod method')

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1047,12 +1047,12 @@ class singledispatchmethod:
 
         dispatch = self.dispatcher.dispatch
         funcname = getattr(self.func, '__name__', 'singledispatchmethod method')
-
         def _method(*args, **kwargs):
             if not args:
                 raise TypeError(f'{funcname} requires at least '
                                 '1 positional argument')
             return dispatch(args[0].__class__).__get__(obj, cls)(*args, **kwargs)
+
         _method.__isabstractmethod__ = self.__isabstractmethod__
         _method.register = self.register
         update_wrapper(_method, self.func)

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1026,9 +1026,6 @@ class singledispatchmethod:
         self.dispatcher = singledispatch(func)
         self.func = func
 
-        import weakref # see comment in singledispatch function
-        self._method_cache = weakref.WeakValueDictionary()
-
     def __set_name__(self, obj, name):
         self.attrname = name
 
@@ -1040,16 +1037,10 @@ class singledispatchmethod:
         return self.dispatcher.register(cls, func=method)
 
     def __get__(self, obj, cls=None):
-
         try:
             cache = obj.__dict__
         except AttributeError:
-            # how to disable caching for next invocation? )
-            # 1) do not disable, but accept the AttributeError on each invocation or use hasattr. makes the operation (a bit) slower for slotted classes
-            # 2) remember in a WeakValueDictionary: self.no_cache with key id(obj) and value obj
-            # picking first option for now
             cache = None
-            pass
         else:
             method = cache.get(self.attrname)
             if method is not None:

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1041,7 +1041,7 @@ class singledispatchmethod:
             cache = obj.__dict__
             method = cache.get(self.attrname)
             if method is not None:
-                    return method
+                return method
         else:
             cache = None
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -3240,6 +3240,25 @@ class TestSingleDispatch(unittest.TestCase):
             def _(arg: undefined):
                 return "forward reference"
 
+    def test_singledispatchmethod_hash_comparision_equal(self):
+        from dataclasses import dataclass
+
+        @dataclass(frozen=True)
+        class A:
+            value: int
+
+            @functools.singledispatchmethod
+            def dispatch(self, x):
+                return id(self)
+
+        t1 = A(1)
+        t2 = A(1)
+
+        assert t1 == t2
+        assert id(t1) == t1.dispatch(2)
+        assert id(t2) == t2.dispatch(2) # gh-127750
+
+
 class CachedCostItem:
     _cost = 1
 

--- a/Misc/NEWS.d/next/Library/2024-12-11-20-26-44.gh-issue-127750.8witaH.rst
+++ b/Misc/NEWS.d/next/Library/2024-12-11-20-26-44.gh-issue-127750.8witaH.rst
@@ -1,0 +1,1 @@
+Update caching of :class:`functools.singledispatchmethod` to avoid collisions of objects which compare equal.


### PR DESCRIPTION
Version based on idea from @dg-pb in #127839. This version

* Fixes the issue of collisions between different objects with equal `__hash__`/`__eq__` #127750
* Fixes the issue of keeping object instances alive
* Adds two regression tests

There is still a cache (stored on the object instances). Quick benchmark (windows, non-pgo):
```
bench singledispatchmethod: Mean +- std dev: [main] 798 ns +- 64 ns -> [prx] 495 ns +- 38 ns: 1.61x faster

Benchmark hidden because not significant (1): bench singledispatchmethod slots

Geometric mean: 1.26x faster
```

(note that the alternative to this PR is not to keep main, but to revert #107148)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127750 -->
* Issue: gh-127750
<!-- /gh-issue-number -->
