### PR TITLE
gh-128661: Fix `typing.evaluate_forward_ref` not showing deprecation

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -45,6 +45,7 @@ import abc
 import textwrap
 import typing
 import weakref
+import warnings
 import types
 
 from test.support import captured_stderr, cpython_only, infinite_recursion, requires_docstrings, import_helper, run_code
@@ -7252,6 +7253,51 @@ class GetUtilitiesTestCase(TestCase):
         self.assertEqual(get_args(tuple[Unpack[Ts]]), (Unpack[Ts],))
         self.assertEqual(get_args((*tuple[*Ts],)[0]), (*Ts,))
         self.assertEqual(get_args(Unpack[tuple[Unpack[Ts]]]), (tuple[Unpack[Ts]],))
+
+
+class EvaluateForwardRefTests(BaseTestCase):
+    def test_evaluate_forward_ref(self):
+        int_ref = ForwardRef('int')
+        missing = ForwardRef('missing')
+        self.assertIs(
+            typing.evaluate_forward_ref(int_ref, type_params=()),
+            int,
+        )
+        self.assertIs(
+            typing.evaluate_forward_ref(
+                int_ref, type_params=(), format=annotationlib.Format.FORWARDREF,
+            ),
+            int,
+        )
+        self.assertIs(
+            typing.evaluate_forward_ref(
+                missing, type_params=(), format=annotationlib.Format.FORWARDREF,
+            ),
+            missing,
+        )
+        self.assertEqual(
+            typing.evaluate_forward_ref(
+                int_ref, type_params=(), format=annotationlib.Format.STRING,
+            ),
+            'int',
+        )
+
+    def test_evaluate_forward_ref_no_type_params(self):
+        ref = ForwardRef('int')
+        with self.assertWarnsRegex(
+            DeprecationWarning,
+            (
+                "Failing to pass a value to the 'type_params' parameter "
+                "of 'typing.evaluate_forward_ref' is deprecated, "
+                "as it leads to incorrect behaviour"
+            ),
+        ):
+            typing.evaluate_forward_ref(ref)
+
+        # No warnings when `type_params` is passed:
+        with warnings.catch_warnings(record=True) as w:
+            typing.evaluate_forward_ref(ref, type_params=())
+        self.assertEqual(w, [])
 
 
 class CollectionsAbcTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1024,7 +1024,7 @@ def evaluate_forward_ref(
     owner=None,
     globals=None,
     locals=None,
-    type_params=None,
+    type_params=_sentinel,
     format=annotationlib.Format.VALUE,
     _recursive_guard=frozenset(),
 ):

--- a/Misc/NEWS.d/next/Library/2025-01-09-12-06-52.gh-issue-128661.ixx_0z.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-09-12-06-52.gh-issue-128661.ixx_0z.rst
@@ -1,0 +1,2 @@
+Fixes :func:`typing.evaluate_forward_ref` not showing deprecation when
+``type_params`` arg is not passed.


### PR DESCRIPTION
Now calling `typing.evaluate_forward_ref` without `type_params` raises a warning, as it should.
Calling `ForwardRef._evaluate` only raises 1 warning, as it should.

I've also covered all branches. After:
<img width="688" alt="Снимок экрана 2025-01-09 в 12 04 04" src="https://github.com/user-attachments/assets/a4c4b063-ce27-40b9-a03d-1f7b7fcbee3f" />

No backports are needed, this is 3.14 only feature.

<!-- gh-issue-number: gh-128661 -->
* Issue: gh-128661
<!-- /gh-issue-number -->
