### PR TITLE
gh-128673: Increase coverage of `typing.get_type_hints`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -7152,6 +7152,25 @@ class GetTypeHintTests(BaseTestCase):
         self.assertEqual(get_type_hints(C, format=annotationlib.Format.STRING),
                          {'x': 'undefined'})
 
+    def test_get_type_hints_format_function(self):
+        def func(x: undefined) -> undefined: ...
+
+        # VALUE
+        with self.assertRaises(NameError):
+            get_type_hints(func)
+        with self.assertRaises(NameError):
+            get_type_hints(func, format=annotationlib.Format.VALUE)
+
+        # FORWARDREF
+        self.assertEqual(
+            get_type_hints(func, format=annotationlib.Format.FORWARDREF),
+            {'x': ForwardRef('undefined'), 'return': ForwardRef('undefined')},
+        )
+
+        # STRING
+        self.assertEqual(get_type_hints(func, format=annotationlib.Format.STRING),
+                         {'x': 'undefined', 'return': 'undefined'})
+
 
 class GetUtilitiesTestCase(TestCase):
     def test_get_origin(self):


### PR DESCRIPTION
After: 
<img width="591" alt="Снимок экрана 2025-01-09 в 15 24 56" src="https://github.com/user-attachments/assets/9a69f402-cdce-4fdd-a8a8-9cb9786780d0" />

No backports are needed.

<!-- gh-issue-number: gh-128673 -->
* Issue: gh-128673
<!-- /gh-issue-number -->
