### PR TITLE
gh-59705: Implement _thread.set_name() on Windows

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -2135,6 +2135,10 @@ class MiscTestCase(unittest.TestCase):
             # on Windows
             "x" * (limit - 1) + "\U0010FFFF",
             "x" * (limit - 2) + "\U0010FFFF" * 2,
+            "x" + "\U0001f40d" * limit,
+            "xx" + "\U0001f40d" * limit,
+            "xxx" + "\U0001f40d" * limit,
+            "xxxx" + "\U0001f40d" * limit,
         ]
         if os_helper.FS_NONASCII:
             tests.append(f"nonascii:{os_helper.FS_NONASCII}")
@@ -2162,11 +2166,18 @@ class MiscTestCase(unittest.TestCase):
                 else:
                     expected = os.fsdecode(encoded)
             else:
-                expected = name[:truncate]
-                if ord(expected[-1]) > 0xFFFF:
-                    # truncate the last non-BMP character to omit a lone
-                    # surrogate character
-                    expected = expected[:-1]
+                size = 0
+                chars = []
+                for ch in name:
+                    if ord(ch) > 0xFFFF:
+                        size += 2
+                    else:
+                        size += 1
+                    if size > truncate:
+                        break
+                    chars.append(ch)
+                expected = ''.join(chars)
+
                 if '\0' in expected:
                     expected = expected.split('\0', 1)[0]
 

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -2130,6 +2130,11 @@ class MiscTestCase(unittest.TestCase):
 
             # Test long non-ASCII name (truncated)
             "x" * (limit - 1) + "é€",
+
+            # Test long non-BMP names (truncated) creating surrogate pairs
+            # on Windows
+            "x" * (limit - 1) + "\U0010FFFF",
+            "x" * (limit - 2) + "\U0010FFFF" * 2,
         ]
         if os_helper.FS_NONASCII:
             tests.append(f"nonascii:{os_helper.FS_NONASCII}")
@@ -2158,6 +2163,10 @@ class MiscTestCase(unittest.TestCase):
                     expected = os.fsdecode(encoded)
             else:
                 expected = name[:truncate]
+                if ord(expected[-1]) > 0xFFFF:
+                    # truncate the last non-BMP character to omit a lone
+                    # surrogate character
+                    expected = expected[:-1]
                 if '\0' in expected:
                     expected = expected.split('\0', 1)[0]
 

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -2118,6 +2118,10 @@ class MiscTestCase(unittest.TestCase):
             # test short non-ASCII name
             "namé€",
 
+            # embedded null character: name is truncated
+            # at the first null character
+            "embed\0null",
+
             # Test long ASCII names (not truncated)
             "x" * limit,
 
@@ -2127,13 +2131,6 @@ class MiscTestCase(unittest.TestCase):
             # Test long non-ASCII name (truncated)
             "x" * (limit - 1) + "é€",
         ]
-        # set_name() raises ValueError on Windows if the name contains an
-        # embedded null character, error ignored silently by the threading
-        # module.
-        if not support.MS_WINDOWS:
-            # embedded null character: name is truncated
-            # at the first null character
-            tests.append("embed\0null")
         if os_helper.FS_NONASCII:
             tests.append(f"nonascii:{os_helper.FS_NONASCII}")
         if os_helper.TESTFN_UNENCODABLE:
@@ -2161,6 +2158,8 @@ class MiscTestCase(unittest.TestCase):
                     expected = os.fsdecode(encoded)
             else:
                 expected = name[:truncate]
+                if '\0' in expected:
+                    expected = expected.split('\0', 1)[0]
 
             with self.subTest(name=name, expected=expected):
                 work_name = None

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1031,9 +1031,7 @@ class Thread:
             return
         try:
             _set_name(self._name)
-        except (OSError, ValueError):
-            # On Windows, ValueError is raised if name contains an embedded
-            # null character.
+        except OSError:
             pass
 
     def _bootstrap_inner(self):

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1031,7 +1031,9 @@ class Thread:
             return
         try:
             _set_name(self._name)
-        except OSError:
+        except (OSError, ValueError):
+            # On Windows, ValueError is raised if name contains an embedded
+            # null character.
             pass
 
     def _bootstrap_inner(self):

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -2500,7 +2500,7 @@ _thread_set_name_impl(PyObject *module, PyObject *name_obj)
     HRESULT hr = pSetThreadDescription(GetCurrentThread(), name);
     PyMem_Free(name);
     if (FAILED(hr)) {
-        PyErr_SetFromWindowsErr(0);
+        PyErr_SetFromWindowsErr((int)hr);
         return NULL;
     }
     Py_RETURN_NONE;

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -2488,7 +2488,13 @@ _thread_set_name_impl(PyObject *module, PyObject *name_obj)
 
     if (len > PYTHREAD_NAME_MAXLEN) {
         // Truncate the name
-        name[PYTHREAD_NAME_MAXLEN] = 0;
+        Py_UCS4 ch = name[PYTHREAD_NAME_MAXLEN-1];
+        if (Py_UNICODE_IS_HIGH_SURROGATE(ch)) {
+            name[PYTHREAD_NAME_MAXLEN-1] = 0;
+        }
+        else {
+            name[PYTHREAD_NAME_MAXLEN] = 0;
+        }
     }
 
     HRESULT hr = pSetThreadDescription(GetCurrentThread(), name);

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -2659,16 +2659,16 @@ thread_module_exec(PyObject *module)
             pSetThreadDescription = (PF_SET_THREAD_DESCRIPTION)GetProcAddress(
                                         kernelbase, "SetThreadDescription");
         }
+    }
 
-        if (pGetThreadDescription == NULL) {
-            if (PyObject_DelAttrString(module, "_get_name") < 0) {
-                return -1;
-            }
+    if (pGetThreadDescription == NULL) {
+        if (PyObject_DelAttrString(module, "_get_name") < 0) {
+            return -1;
         }
-        if (pSetThreadDescription == NULL) {
-            if (PyObject_DelAttrString(module, "set_name") < 0) {
-                return -1;
-            }
+    }
+    if (pSetThreadDescription == NULL) {
+        if (PyObject_DelAttrString(module, "set_name") < 0) {
+            return -1;
         }
     }
 #endif

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -47,6 +47,14 @@ get_thread_state(PyObject *module)
 }
 
 
+#ifdef MS_WINDOWS
+typedef HRESULT (WINAPI *PF_GET_THREAD_DESCRIPTION)(HANDLE, PCWSTR*);
+typedef HRESULT (WINAPI *PF_SET_THREAD_DESCRIPTION)(HANDLE, PCWSTR);
+static PF_GET_THREAD_DESCRIPTION pGetThreadDescription = NULL;
+static PF_SET_THREAD_DESCRIPTION pSetThreadDescription = NULL;
+#endif
+
+
 /*[clinic input]
 module _thread
 [clinic start generated code]*/
@@ -2364,7 +2372,7 @@ Internal only. Return a non-zero integer that uniquely identifies the main threa
 of the main interpreter.");
 
 
-#ifdef HAVE_PTHREAD_GETNAME_NP
+#if defined(HAVE_PTHREAD_GETNAME_NP) || defined(MS_WINDOWS)
 /*[clinic input]
 _thread._get_name
 
@@ -2375,6 +2383,7 @@ static PyObject *
 _thread__get_name_impl(PyObject *module)
 /*[clinic end generated code: output=20026e7ee3da3dd7 input=35cec676833d04c8]*/
 {
+#ifndef MS_WINDOWS
     // Linux and macOS are limited to respectively 16 and 64 bytes
     char name[100];
     pthread_t thread = pthread_self();
@@ -2389,11 +2398,26 @@ _thread__get_name_impl(PyObject *module)
 #else
     return PyUnicode_DecodeFSDefault(name);
 #endif
+#else
+    // Windows implementation
+    assert(pGetThreadDescription != NULL);
+
+    wchar_t *name;
+    HRESULT hr = pGetThreadDescription(GetCurrentThread(), &name);
+    if (FAILED(hr)) {
+        PyErr_SetFromWindowsErr(0);
+        return NULL;
+    }
+
+    PyObject *name_obj = PyUnicode_FromWideChar(name, -1);
+    LocalFree(name);
+    return name_obj;
+#endif
 }
 #endif  // HAVE_PTHREAD_GETNAME_NP
 
 
-#ifdef HAVE_PTHREAD_SETNAME_NP
+#if defined(HAVE_PTHREAD_SETNAME_NP) || defined(MS_WINDOWS)
 /*[clinic input]
 _thread.set_name
 
@@ -2406,6 +2430,7 @@ static PyObject *
 _thread_set_name_impl(PyObject *module, PyObject *name_obj)
 /*[clinic end generated code: output=402b0c68e0c0daed input=7e7acd98261be82f]*/
 {
+#ifndef MS_WINDOWS
 #ifdef __sun
     // Solaris always uses UTF-8
     const char *encoding = "utf-8";
@@ -2451,6 +2476,29 @@ _thread_set_name_impl(PyObject *module, PyObject *name_obj)
         return PyErr_SetFromErrno(PyExc_OSError);
     }
     Py_RETURN_NONE;
+#else
+    // Windows implementation
+    assert(pSetThreadDescription != NULL);
+
+    Py_ssize_t len;
+    wchar_t *name = PyUnicode_AsWideCharString(name_obj, &len);
+    if (name == NULL) {
+        return NULL;
+    }
+
+    if (len > PYTHREAD_NAME_MAXLEN) {
+        // Truncate the name
+        name[PYTHREAD_NAME_MAXLEN] = 0;
+    }
+
+    HRESULT hr = pSetThreadDescription(GetCurrentThread(), name);
+    PyMem_Free(name);
+    if (FAILED(hr)) {
+        PyErr_SetFromWindowsErr(0);
+        return NULL;
+    }
+    Py_RETURN_NONE;
+#endif
 }
 #endif  // HAVE_PTHREAD_SETNAME_NP
 
@@ -2591,6 +2639,31 @@ thread_module_exec(PyObject *module)
     if (PyModule_AddIntConstant(module, "_NAME_MAXLEN",
                                 PYTHREAD_NAME_MAXLEN) < 0) {
         return -1;
+    }
+#endif
+
+#ifdef MS_WINDOWS
+    HMODULE kernelbase = GetModuleHandleW(L"kernelbase.dll");
+    if (kernelbase != NULL) {
+        if (pGetThreadDescription == NULL) {
+            pGetThreadDescription = (PF_GET_THREAD_DESCRIPTION)GetProcAddress(
+                                        kernelbase, "GetThreadDescription");
+        }
+        if (pSetThreadDescription == NULL) {
+            pSetThreadDescription = (PF_SET_THREAD_DESCRIPTION)GetProcAddress(
+                                        kernelbase, "SetThreadDescription");
+        }
+
+        if (pGetThreadDescription == NULL) {
+            if (PyObject_DelAttrString(module, "_get_name") < 0) {
+                return -1;
+            }
+        }
+        if (pSetThreadDescription == NULL) {
+            if (PyObject_DelAttrString(module, "set_name") < 0) {
+                return -1;
+            }
+        }
     }
 #endif
 

--- a/Modules/clinic/_threadmodule.c.h
+++ b/Modules/clinic/_threadmodule.c.h
@@ -8,7 +8,7 @@ preserve
 #endif
 #include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
-#if defined(HAVE_PTHREAD_GETNAME_NP)
+#if (defined(HAVE_PTHREAD_GETNAME_NP) || defined(MS_WINDOWS))
 
 PyDoc_STRVAR(_thread__get_name__doc__,
 "_get_name($module, /)\n"
@@ -28,9 +28,9 @@ _thread__get_name(PyObject *module, PyObject *Py_UNUSED(ignored))
     return _thread__get_name_impl(module);
 }
 
-#endif /* defined(HAVE_PTHREAD_GETNAME_NP) */
+#endif /* (defined(HAVE_PTHREAD_GETNAME_NP) || defined(MS_WINDOWS)) */
 
-#if defined(HAVE_PTHREAD_SETNAME_NP)
+#if (defined(HAVE_PTHREAD_SETNAME_NP) || defined(MS_WINDOWS))
 
 PyDoc_STRVAR(_thread_set_name__doc__,
 "set_name($module, /, name)\n"
@@ -92,7 +92,7 @@ exit:
     return return_value;
 }
 
-#endif /* defined(HAVE_PTHREAD_SETNAME_NP) */
+#endif /* (defined(HAVE_PTHREAD_SETNAME_NP) || defined(MS_WINDOWS)) */
 
 #ifndef _THREAD__GET_NAME_METHODDEF
     #define _THREAD__GET_NAME_METHODDEF
@@ -101,4 +101,4 @@ exit:
 #ifndef _THREAD_SET_NAME_METHODDEF
     #define _THREAD_SET_NAME_METHODDEF
 #endif /* !defined(_THREAD_SET_NAME_METHODDEF) */
-/*[clinic end generated code: output=b5cb85aaccc45bf6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6e88ef6b126cece8 input=a9049054013a1b77]*/

--- a/PC/pyconfig.h.in
+++ b/PC/pyconfig.h.in
@@ -755,6 +755,6 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 
 // Truncate the thread name to 64 characters. The OS limit is 32766 wide
 // characters, but long names aren't of practical use.
-#define PYTHREAD_NAME_MAXLEN 64
+#define PYTHREAD_NAME_MAXLEN 32766
 
 #endif /* !Py_CONFIG_H */

--- a/PC/pyconfig.h.in
+++ b/PC/pyconfig.h.in
@@ -753,4 +753,8 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 /* Define if libssl has X509_VERIFY_PARAM_set1_host and related function */
 #define HAVE_X509_VERIFY_PARAM_SET1_HOST 1
 
+// Truncate the thread name to 64 characters. The OS limit is 32766 wide
+// characters, but long names aren't of practical use.
+#define PYTHREAD_NAME_MAXLEN 64
+
 #endif /* !Py_CONFIG_H */


### PR DESCRIPTION
Implement set_name() with SetThreadDescription() and _get_name() with GetThreadDescription(). If SetThreadDescription() or GetThreadDescription() is not available in kernelbase.dll, delete the method when the _thread module is imported.

Truncate the thread name to 32766 characters.

~~set_name() raises ValueError if the name contains an embedded null character.~~

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-59705 -->
* Issue: gh-59705
<!-- /gh-issue-number -->
