### PR TITLE
gh-128691: Use deferred reference counting on `_thread._local`

### DIFF
--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1435,6 +1435,7 @@ local_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     Py_DECREF(localsdict);
     Py_DECREF(sentinel_wr);
 
+    _PyObject_SetDeferredRefcount((PyObject *)self);
     return (PyObject *)self;
 
   err:

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1414,6 +1414,10 @@ local_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         return NULL;
     }
 
+    // gh-128691: Use deferred reference counting for thread-locals to avoid
+    // contention on the shared object.
+    _PyObject_SetDeferredRefcount((PyObject *)self);
+
     self->args = Py_XNewRef(args);
     self->kw = Py_XNewRef(kw);
 
@@ -1435,7 +1439,6 @@ local_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     Py_DECREF(localsdict);
     Py_DECREF(sentinel_wr);
 
-    _PyObject_SetDeferredRefcount((PyObject *)self);
     return (PyObject *)self;
 
   err:


### PR DESCRIPTION
This change, along with the LOAD_ATTR specializations, makes the "thread_local_read" micro benchmark in Tools/ftscalingbench/ftscalingbench.py scale well to multiple threads.

<!-- gh-issue-number: gh-128691 -->
* Issue: gh-128691
<!-- /gh-issue-number -->
