### PR TITLE
gh-128679: fix race condition in tracemalloc

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-01-09-23-25-42.gh-issue-128679.Uhblds.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-01-09-23-25-42.gh-issue-128679.Uhblds.rst
@@ -1,0 +1,1 @@
+Fix race condition in tracemalloc causing abort.


### PR DESCRIPTION
* Add emergency fallback in `tracemalloc_alloc()` to not add a trace if tracing was turned off while the GIL was being acquired.
* Add secondary check in `PyTraceMalloc_Track()` for tracing after acquiring GIL in case tracing was turned off while GIL was being acquired.
* Protect `tracemalloc_config.tracing = 0` in `_PyTraceMalloc_Stop()` using `table_lock` to avoid turning it off in the middle of critical operations.

<!-- gh-issue-number: gh-128679 -->
* Issue: gh-128679
<!-- /gh-issue-number -->
