### PR TITLE
gh-128694: Fix `(env changed)` error in `test_inspect`

### DIFF
--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -1,4 +1,5 @@
 from annotationlib import Format, ForwardRef
+import asyncio
 import builtins
 import collections
 import copy
@@ -47,6 +48,10 @@ from test.test_inspect import inspect_fodder as mod
 from test.test_inspect import inspect_fodder2 as mod2
 from test.test_inspect import inspect_stringized_annotations
 from test.test_inspect import inspect_deferred_annotations
+
+
+def tearDownModule():
+    asyncio._set_event_loop_policy(None)
 
 
 # Functions tested in this suite:

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -50,10 +50,6 @@ from test.test_inspect import inspect_stringized_annotations
 from test.test_inspect import inspect_deferred_annotations
 
 
-def tearDownModule():
-    asyncio._set_event_loop_policy(None)
-
-
 # Functions tested in this suite:
 # ismodule, isclass, ismethod, isfunction, istraceback, isframe, iscode,
 # isbuiltin, isroutine, isgenerator, ispackage, isgeneratorfunction, getmembers,
@@ -2795,6 +2791,10 @@ class TestGetAsyncGenState(unittest.IsolatedAsyncioTestCase):
 
     async def asyncTearDown(self):
         await self.asyncgen.aclose()
+
+    @classmethod
+    def tearDownClass(cls):
+        asyncio._set_event_loop_policy(None)
 
     def _asyncgenstate(self):
         return inspect.getasyncgenstate(self.asyncgen)


### PR DESCRIPTION
Other modules do this as well, like `test_logging`.

But, I am not quite sure: maybe `IsolatedAsyncioTestCase` should do it instead?

<!-- gh-issue-number: gh-128694 -->
* Issue: gh-128694
<!-- /gh-issue-number -->
