### PR TITLE
gh-71339: Add additional assertion methods for unittest

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -883,6 +883,12 @@ Test cases
    | :meth:`assertNotIsInstance(a, b)        | ``not isinstance(a, b)``    | 3.2           |
    | <TestCase.assertNotIsInstance>`         |                             |               |
    +-----------------------------------------+-----------------------------+---------------+
+   | :meth:`assertIsSubclass(a, b)           | ``issubclass(a, b)``        | 3.14          |
+   | <TestCase.assertIsSubclass>`            |                             |               |
+   +-----------------------------------------+-----------------------------+---------------+
+   | :meth:`assertNotIsSubclass(a, b)        | ``not issubclass(a, b)``    | 3.14          |
+   | <TestCase.assertNotIsSubclass>`         |                             |               |
+   +-----------------------------------------+-----------------------------+---------------+
 
    All the assert methods accept a *msg* argument that, if specified, is used
    as the error message on failure (see also :data:`longMessage`).
@@ -960,6 +966,14 @@ Test cases
 
       .. versionadded:: 3.2
 
+   .. method:: assertIsSubclass(cls, superclass, msg=None)
+               assertNotIsSubclass(cls, superclass, msg=None)
+
+      Test that *cls* is (or is not) a subclass of *superclass* (which can be a
+      class or a tuple of classes, as supported by :func:`issubclass`).
+      To check for the exact type, use :func:`assertIs(cls, superclass) <assertIs>`.
+
+      .. versionadded:: next
 
 
    It is also possible to check the production of exceptions, warnings, and
@@ -1210,6 +1224,24 @@ Test cases
    | <TestCase.assertCountEqual>`          | elements in the same number,   |              |
    |                                       | regardless of their order.     |              |
    +---------------------------------------+--------------------------------+--------------+
+   | :meth:`assertStartswith(a, b)         | ``a.startswith(b)``            | 3.14         |
+   | <TestCase.assertStartswith>`          |                                |              |
+   +---------------------------------------+--------------------------------+--------------+
+   | :meth:`assertNotStartswith(a, b)      | ``not a.startswith(b)``        | 3.14         |
+   | <TestCase.assertNotStartswith>`       |                                |              |
+   +---------------------------------------+--------------------------------+--------------+
+   | :meth:`assertEndswith(a, b)           | ``a.endswith(b)``              | 3.14         |
+   | <TestCase.assertEndswith>`            |                                |              |
+   +---------------------------------------+--------------------------------+--------------+
+   | :meth:`assertNotEndswith(a, b)        | ``not a.endswith(b)``          | 3.14         |
+   | <TestCase.assertNotEndswith>`         |                                |              |
+   +---------------------------------------+--------------------------------+--------------+
+   | :meth:`assertHasAttr(a, b)            | ``hastattr(a, b)``             | 3.14         |
+   | <TestCase.assertHasAttr>`             |                                |              |
+   +---------------------------------------+--------------------------------+--------------+
+   | :meth:`assertNotHasAttr(a, b)         | ``not hastattr(a, b)``         | 3.14         |
+   | <TestCase.assertNotHasAttr>`          |                                |              |
+   +---------------------------------------+--------------------------------+--------------+
 
 
    .. method:: assertAlmostEqual(first, second, places=7, msg=None, delta=None)
@@ -1277,6 +1309,31 @@ Test cases
       but works with sequences of unhashable objects as well.
 
       .. versionadded:: 3.2
+
+   .. method:: assertStartswith(s, prefix, msg=None)
+   .. method:: assertNotStartswith(s, prefix, msg=None)
+
+      Test that the unicode or byte string *s* starts (or does not start)
+      with a *prefix*.
+      *prefix* can also be a tuple of strings to try.
+
+      .. versionadded:: next
+
+   .. method:: assertEndswith(s, suffix, msg=None)
+   .. method:: assertNotEndswith(s, suffix, msg=None)
+
+      Test that the unicode or byte string *s* ends (or does not end)
+      with a *suffix*.
+      *suffix* can also be a tuple of strings to try.
+
+      .. versionadded:: next
+
+   .. method:: assertHasAttr(obj, name, msg=None)
+   .. method:: assertNotHasAttr(obj, name, msg=None)
+
+      Test that the object *obj* has (or has not) an attribute *name*.
+
+      .. versionadded:: next
 
 
    .. _type-specific-methods:

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -966,6 +966,7 @@ Test cases
 
       .. versionadded:: 3.2
 
+
    .. method:: assertIsSubclass(cls, superclass, msg=None)
                assertNotIsSubclass(cls, superclass, msg=None)
 
@@ -1310,6 +1311,7 @@ Test cases
 
       .. versionadded:: 3.2
 
+
    .. method:: assertStartsWith(s, prefix, msg=None)
    .. method:: assertNotStartsWith(s, prefix, msg=None)
 
@@ -1319,6 +1321,7 @@ Test cases
 
       .. versionadded:: next
 
+
    .. method:: assertEndsWith(s, suffix, msg=None)
    .. method:: assertNotEndsWith(s, suffix, msg=None)
 
@@ -1327,6 +1330,7 @@ Test cases
       *suffix* can also be a tuple of strings to try.
 
       .. versionadded:: next
+
 
    .. method:: assertHasAttr(obj, name, msg=None)
    .. method:: assertNotHasAttr(obj, name, msg=None)

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1224,17 +1224,17 @@ Test cases
    | <TestCase.assertCountEqual>`          | elements in the same number,   |              |
    |                                       | regardless of their order.     |              |
    +---------------------------------------+--------------------------------+--------------+
-   | :meth:`assertStartswith(a, b)         | ``a.startswith(b)``            | 3.14         |
-   | <TestCase.assertStartswith>`          |                                |              |
+   | :meth:`assertStartsWith(a, b)         | ``a.startswith(b)``            | 3.14         |
+   | <TestCase.assertStartsWith>`          |                                |              |
    +---------------------------------------+--------------------------------+--------------+
-   | :meth:`assertNotStartswith(a, b)      | ``not a.startswith(b)``        | 3.14         |
-   | <TestCase.assertNotStartswith>`       |                                |              |
+   | :meth:`assertNotStartsWith(a, b)      | ``not a.startswith(b)``        | 3.14         |
+   | <TestCase.assertNotStartsWith>`       |                                |              |
    +---------------------------------------+--------------------------------+--------------+
-   | :meth:`assertEndswith(a, b)           | ``a.endswith(b)``              | 3.14         |
-   | <TestCase.assertEndswith>`            |                                |              |
+   | :meth:`assertEndsWith(a, b)           | ``a.endswith(b)``              | 3.14         |
+   | <TestCase.assertEndsWith>`            |                                |              |
    +---------------------------------------+--------------------------------+--------------+
-   | :meth:`assertNotEndswith(a, b)        | ``not a.endswith(b)``          | 3.14         |
-   | <TestCase.assertNotEndswith>`         |                                |              |
+   | :meth:`assertNotEndsWith(a, b)        | ``not a.endswith(b)``          | 3.14         |
+   | <TestCase.assertNotEndsWith>`         |                                |              |
    +---------------------------------------+--------------------------------+--------------+
    | :meth:`assertHasAttr(a, b)            | ``hastattr(a, b)``             | 3.14         |
    | <TestCase.assertHasAttr>`             |                                |              |
@@ -1310,8 +1310,8 @@ Test cases
 
       .. versionadded:: 3.2
 
-   .. method:: assertStartswith(s, prefix, msg=None)
-   .. method:: assertNotStartswith(s, prefix, msg=None)
+   .. method:: assertStartsWith(s, prefix, msg=None)
+   .. method:: assertNotStartsWith(s, prefix, msg=None)
 
       Test that the unicode or byte string *s* starts (or does not start)
       with a *prefix*.
@@ -1319,8 +1319,8 @@ Test cases
 
       .. versionadded:: next
 
-   .. method:: assertEndswith(s, suffix, msg=None)
-   .. method:: assertNotEndswith(s, suffix, msg=None)
+   .. method:: assertEndsWith(s, suffix, msg=None)
+   .. method:: assertNotEndsWith(s, suffix, msg=None)
 
       Test that the unicode or byte string *s* ends (or does not end)
       with a *suffix*.

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1313,7 +1313,7 @@ Test cases
    .. method:: assertStartsWith(s, prefix, msg=None)
    .. method:: assertNotStartsWith(s, prefix, msg=None)
 
-      Test that the unicode or byte string *s* starts (or does not start)
+      Test that the Unicode or byte string *s* starts (or does not start)
       with a *prefix*.
       *prefix* can also be a tuple of strings to try.
 
@@ -1322,7 +1322,7 @@ Test cases
    .. method:: assertEndsWith(s, suffix, msg=None)
    .. method:: assertNotEndsWith(s, suffix, msg=None)
 
-      Test that the unicode or byte string *s* ends (or does not end)
+      Test that the Unicode or byte string *s* ends (or does not end)
       with a *suffix*.
       *suffix* can also be a tuple of strings to try.
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -679,10 +679,10 @@ unittest
   - :meth:`~unittest.TestCase.assertIsSubclass` and
     :meth:`~unittest.TestCase.assertNotIsSubclass` check whether the object
     is a subclass of a particular class, or of one of a tuple of classes.
-  - :meth:`~unittest.TestCase.assertStartswith`,
-    :meth:`~unittest.TestCase.assertNotStartswith`,
-    :meth:`~unittest.TestCase.assertEndswith` and
-    :meth:`~unittest.TestCase.assertNotEndswith` check whether the unicode
+  - :meth:`~unittest.TestCase.assertStartsWith`,
+    :meth:`~unittest.TestCase.assertNotStartsWith`,
+    :meth:`~unittest.TestCase.assertEndsWith` and
+    :meth:`~unittest.TestCase.assertNotEndsWith` check whether the unicode
     or byte string starts or ends with particular string(s).
 
   (Contributed by Serhiy Storchaka in :gh:`71339`.)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -670,6 +670,23 @@ unittest
   directory again. It was removed in Python 3.11.
   (Contributed by Jacob Walls in :gh:`80958`.)
 
+* A number of new methods were added in the :class:`~unittest.TestCase` class
+  that provide more specialized tests.
+
+  - :meth:`~unittest.TestCase.assertHasAttr` and
+    :meth:`~unittest.TestCase.assertNotHasAttr` check whether the object
+    has a particular attribute.
+  - :meth:`~unittest.TestCase.assertIsSubclass` and
+    :meth:`~unittest.TestCase.assertNotIsSubclass` check whether the object
+    is a subclass of a particular class, or of one of a tuple of classes.
+  - :meth:`~unittest.TestCase.assertStartsWith`,
+    :meth:`~unittest.TestCase.assertNotStartsWith`,
+    :meth:`~unittest.TestCase.assertEndsWith` and
+    :meth:`~unittest.TestCase.assertNotEndsWith` check whether the unicode
+    or byte string starts or ends with particular string(s).
+
+  (Contributed by Serhiy Storchaka in :gh:`71339`.)
+
 
 urllib
 ------

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -682,7 +682,7 @@ unittest
   - :meth:`~unittest.TestCase.assertStartsWith`,
     :meth:`~unittest.TestCase.assertNotStartsWith`,
     :meth:`~unittest.TestCase.assertEndsWith` and
-    :meth:`~unittest.TestCase.assertNotEndsWith` check whether the unicode
+    :meth:`~unittest.TestCase.assertNotEndsWith` check whether the Unicode
     or byte string starts or ends with particular string(s).
 
   (Contributed by Serhiy Storchaka in :gh:`71339`.)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -679,10 +679,10 @@ unittest
   - :meth:`~unittest.TestCase.assertIsSubclass` and
     :meth:`~unittest.TestCase.assertNotIsSubclass` check whether the object
     is a subclass of a particular class, or of one of a tuple of classes.
-  - :meth:`~unittest.TestCase.assertStartsWith`,
-    :meth:`~unittest.TestCase.assertNotStartsWith`,
-    :meth:`~unittest.TestCase.assertEndsWith` and
-    :meth:`~unittest.TestCase.assertNotEndsWith` check whether the unicode
+  - :meth:`~unittest.TestCase.assertStartswith`,
+    :meth:`~unittest.TestCase.assertNotStartswith`,
+    :meth:`~unittest.TestCase.assertEndswith` and
+    :meth:`~unittest.TestCase.assertNotEndswith` check whether the unicode
     or byte string starts or ends with particular string(s).
 
   (Contributed by Serhiy Storchaka in :gh:`71339`.)

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -405,14 +405,6 @@ class OperatorsTest(unittest.TestCase):
 
 class ClassPropertiesAndMethods(unittest.TestCase):
 
-    def assertHasAttr(self, obj, name):
-        self.assertTrue(hasattr(obj, name),
-                        '%r has no attribute %r' % (obj, name))
-
-    def assertNotHasAttr(self, obj, name):
-        self.assertFalse(hasattr(obj, name),
-                         '%r has unexpected attribute %r' % (obj, name))
-
     def test_python_dicts(self):
         # Testing Python subclass of dict...
         self.assertTrue(issubclass(dict, dict))

--- a/Lib/test/test_gdb/test_misc.py
+++ b/Lib/test/test_gdb/test_misc.py
@@ -28,7 +28,7 @@ HAS_PYUP_PYDOWN = gdb_has_frame_select()
                  "Python was compiled with optimizations")
 class PyListTests(DebuggerTests):
     def assertListing(self, expected, actual):
-        self.assertEndsWith(actual, expected)
+        self.assertEndswith(actual, expected)
 
     def test_basic_command(self):
         'Verify that the "py-list" command works'
@@ -103,7 +103,7 @@ $''')
         'Verify handling of "py-down" at the bottom of the stack'
         bt = self.get_stack_trace(script=SAMPLE_SCRIPT,
                                   cmds_after_breakpoint=['py-down'])
-        self.assertEndsWith(bt,
+        self.assertEndswith(bt,
                             'Unable to find a newer python frame\n')
 
     @unittest.skipUnless(HAS_PYUP_PYDOWN, "test requires py-up/py-down commands")
@@ -111,7 +111,7 @@ $''')
         'Verify handling of "py-up" at the top of the stack'
         bt = self.get_stack_trace(script=SAMPLE_SCRIPT,
                                   cmds_after_breakpoint=['py-up'] * 5)
-        self.assertEndsWith(bt,
+        self.assertEndswith(bt,
                             'Unable to find an older python frame\n')
 
     @unittest.skipUnless(HAS_PYUP_PYDOWN, "test requires py-up/py-down commands")

--- a/Lib/test/test_gdb/test_misc.py
+++ b/Lib/test/test_gdb/test_misc.py
@@ -28,7 +28,7 @@ HAS_PYUP_PYDOWN = gdb_has_frame_select()
                  "Python was compiled with optimizations")
 class PyListTests(DebuggerTests):
     def assertListing(self, expected, actual):
-        self.assertEndswith(actual, expected)
+        self.assertEndsWith(actual, expected)
 
     def test_basic_command(self):
         'Verify that the "py-list" command works'
@@ -103,7 +103,7 @@ $''')
         'Verify handling of "py-down" at the bottom of the stack'
         bt = self.get_stack_trace(script=SAMPLE_SCRIPT,
                                   cmds_after_breakpoint=['py-down'])
-        self.assertEndswith(bt,
+        self.assertEndsWith(bt,
                             'Unable to find a newer python frame\n')
 
     @unittest.skipUnless(HAS_PYUP_PYDOWN, "test requires py-up/py-down commands")
@@ -111,7 +111,7 @@ $''')
         'Verify handling of "py-up" at the top of the stack'
         bt = self.get_stack_trace(script=SAMPLE_SCRIPT,
                                   cmds_after_breakpoint=['py-up'] * 5)
-        self.assertEndswith(bt,
+        self.assertEndsWith(bt,
                             'Unable to find an older python frame\n')
 
     @unittest.skipUnless(HAS_PYUP_PYDOWN, "test requires py-up/py-down commands")

--- a/Lib/test/test_gdb/util.py
+++ b/Lib/test/test_gdb/util.py
@@ -280,11 +280,6 @@ class DebuggerTests(unittest.TestCase):
 
         return out
 
-    def assertEndsWith(self, actual, exp_end):
-        '''Ensure that the given "actual" string ends with "exp_end"'''
-        self.assertTrue(actual.endswith(exp_end),
-                        msg='%r did not end with %r' % (actual, exp_end))
-
     def assertMultilineMatches(self, actual, pattern):
         m = re.match(pattern, actual, re.DOTALL)
         if not m:

--- a/Lib/test/test_importlib/resources/test_functional.py
+++ b/Lib/test/test_importlib/resources/test_functional.py
@@ -83,7 +83,7 @@ class FunctionalAPIBase(util.DiskSetup):
             ),
             '\x00\x01\x02\x03',
         )
-        self.assertEndswith(  # ignore the BOM
+        self.assertEndsWith(  # ignore the BOM
             resources.read_text(
                 self.anchor01,
                 'utf-16.file',
@@ -135,7 +135,7 @@ class FunctionalAPIBase(util.DiskSetup):
             'utf-16.file',
             errors='backslashreplace',
         ) as f:
-            self.assertEndswith(  # ignore the BOM
+            self.assertEndsWith(  # ignore the BOM
                 f.read(),
                 'Hello, UTF-16 world!\n'.encode('utf-16-le').decode(
                     errors='backslashreplace',

--- a/Lib/test/test_importlib/resources/test_functional.py
+++ b/Lib/test/test_importlib/resources/test_functional.py
@@ -43,12 +43,6 @@ class FunctionalAPIBase(util.DiskSetup):
             with self.subTest(path_parts=path_parts):
                 yield path_parts
 
-    def assertEndsWith(self, string, suffix):
-        """Assert that `string` ends with `suffix`.
-
-        Used to ignore an architecture-specific UTF-16 byte-order mark."""
-        self.assertEqual(string[-len(suffix) :], suffix)
-
     def test_read_text(self):
         self.assertEqual(
             resources.read_text(self.anchor01, 'utf-8.file'),
@@ -89,7 +83,7 @@ class FunctionalAPIBase(util.DiskSetup):
             ),
             '\x00\x01\x02\x03',
         )
-        self.assertEndsWith(  # ignore the BOM
+        self.assertEndswith(  # ignore the BOM
             resources.read_text(
                 self.anchor01,
                 'utf-16.file',
@@ -141,7 +135,7 @@ class FunctionalAPIBase(util.DiskSetup):
             'utf-16.file',
             errors='backslashreplace',
         ) as f:
-            self.assertEndsWith(  # ignore the BOM
+            self.assertEndswith(  # ignore the BOM
                 f.read(),
                 'Hello, UTF-16 world!\n'.encode('utf-16-le').decode(
                     errors='backslashreplace',

--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -31,14 +31,6 @@ class PyclbrTest(TestCase):
             print("l1=%r\nl2=%r\nignore=%r" % (l1, l2, ignore), file=sys.stderr)
             self.fail("%r missing" % missing.pop())
 
-    def assertHasattr(self, obj, attr, ignore):
-        ''' succeed iff hasattr(obj,attr) or attr in ignore. '''
-        if attr in ignore: return
-        if not hasattr(obj, attr): print("???", attr)
-        self.assertTrue(hasattr(obj, attr),
-                        'expected hasattr(%r, %r)' % (obj, attr))
-
-
     def assertHaskey(self, obj, key, ignore):
         ''' succeed iff key in obj or key in ignore. '''
         if key in ignore: return
@@ -86,7 +78,7 @@ class PyclbrTest(TestCase):
         for name, value in dict.items():
             if name in ignore:
                 continue
-            self.assertHasattr(module, name, ignore)
+            self.assertHasAttr(module, name, ignore)
             py_item = getattr(module, name)
             if isinstance(value, pyclbr.Function):
                 self.assertIsInstance(py_item, (FunctionType, BuiltinFunctionType))

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1426,31 +1426,31 @@ class TypeVarTupleTests(BaseTestCase):
         class A(Generic[*Ts]): pass
         class B(Generic[Unpack[Ts]]): pass
 
-        self.assertEndswith(repr(A[()]), 'A[()]')
-        self.assertEndswith(repr(B[()]), 'B[()]')
-        self.assertEndswith(repr(A[float]), 'A[float]')
-        self.assertEndswith(repr(B[float]), 'B[float]')
-        self.assertEndswith(repr(A[float, str]), 'A[float, str]')
-        self.assertEndswith(repr(B[float, str]), 'B[float, str]')
+        self.assertEndsWith(repr(A[()]), 'A[()]')
+        self.assertEndsWith(repr(B[()]), 'B[()]')
+        self.assertEndsWith(repr(A[float]), 'A[float]')
+        self.assertEndsWith(repr(B[float]), 'B[float]')
+        self.assertEndsWith(repr(A[float, str]), 'A[float, str]')
+        self.assertEndsWith(repr(B[float, str]), 'B[float, str]')
 
-        self.assertEndswith(repr(A[*tuple[int, ...]]),
+        self.assertEndsWith(repr(A[*tuple[int, ...]]),
                             'A[*tuple[int, ...]]')
-        self.assertEndswith(repr(B[Unpack[Tuple[int, ...]]]),
+        self.assertEndsWith(repr(B[Unpack[Tuple[int, ...]]]),
                             'B[typing.Unpack[typing.Tuple[int, ...]]]')
 
-        self.assertEndswith(repr(A[float, *tuple[int, ...]]),
+        self.assertEndsWith(repr(A[float, *tuple[int, ...]]),
                             'A[float, *tuple[int, ...]]')
-        self.assertEndswith(repr(A[float, Unpack[Tuple[int, ...]]]),
+        self.assertEndsWith(repr(A[float, Unpack[Tuple[int, ...]]]),
                             'A[float, typing.Unpack[typing.Tuple[int, ...]]]')
 
-        self.assertEndswith(repr(A[*tuple[int, ...], str]),
+        self.assertEndsWith(repr(A[*tuple[int, ...], str]),
                             'A[*tuple[int, ...], str]')
-        self.assertEndswith(repr(B[Unpack[Tuple[int, ...]], str]),
+        self.assertEndsWith(repr(B[Unpack[Tuple[int, ...]], str]),
                             'B[typing.Unpack[typing.Tuple[int, ...]], str]')
 
-        self.assertEndswith(repr(A[float, *tuple[int, ...], str]),
+        self.assertEndsWith(repr(A[float, *tuple[int, ...], str]),
                             'A[float, *tuple[int, ...], str]')
-        self.assertEndswith(repr(B[float, Unpack[Tuple[int, ...]], str]),
+        self.assertEndsWith(repr(B[float, Unpack[Tuple[int, ...]], str]),
                             'B[float, typing.Unpack[typing.Tuple[int, ...]], str]')
 
     def test_variadic_class_alias_repr_is_correct(self):
@@ -1458,64 +1458,64 @@ class TypeVarTupleTests(BaseTestCase):
         class A(Generic[Unpack[Ts]]): pass
 
         B = A[*Ts]
-        self.assertEndswith(repr(B), 'A[typing.Unpack[Ts]]')
-        self.assertEndswith(repr(B[()]), 'A[()]')
-        self.assertEndswith(repr(B[float]), 'A[float]')
-        self.assertEndswith(repr(B[float, str]), 'A[float, str]')
+        self.assertEndsWith(repr(B), 'A[typing.Unpack[Ts]]')
+        self.assertEndsWith(repr(B[()]), 'A[()]')
+        self.assertEndsWith(repr(B[float]), 'A[float]')
+        self.assertEndsWith(repr(B[float, str]), 'A[float, str]')
 
         C = A[Unpack[Ts]]
-        self.assertEndswith(repr(C), 'A[typing.Unpack[Ts]]')
-        self.assertEndswith(repr(C[()]), 'A[()]')
-        self.assertEndswith(repr(C[float]), 'A[float]')
-        self.assertEndswith(repr(C[float, str]), 'A[float, str]')
+        self.assertEndsWith(repr(C), 'A[typing.Unpack[Ts]]')
+        self.assertEndsWith(repr(C[()]), 'A[()]')
+        self.assertEndsWith(repr(C[float]), 'A[float]')
+        self.assertEndsWith(repr(C[float, str]), 'A[float, str]')
 
         D = A[*Ts, int]
-        self.assertEndswith(repr(D), 'A[typing.Unpack[Ts], int]')
-        self.assertEndswith(repr(D[()]), 'A[int]')
-        self.assertEndswith(repr(D[float]), 'A[float, int]')
-        self.assertEndswith(repr(D[float, str]), 'A[float, str, int]')
+        self.assertEndsWith(repr(D), 'A[typing.Unpack[Ts], int]')
+        self.assertEndsWith(repr(D[()]), 'A[int]')
+        self.assertEndsWith(repr(D[float]), 'A[float, int]')
+        self.assertEndsWith(repr(D[float, str]), 'A[float, str, int]')
 
         E = A[Unpack[Ts], int]
-        self.assertEndswith(repr(E), 'A[typing.Unpack[Ts], int]')
-        self.assertEndswith(repr(E[()]), 'A[int]')
-        self.assertEndswith(repr(E[float]), 'A[float, int]')
-        self.assertEndswith(repr(E[float, str]), 'A[float, str, int]')
+        self.assertEndsWith(repr(E), 'A[typing.Unpack[Ts], int]')
+        self.assertEndsWith(repr(E[()]), 'A[int]')
+        self.assertEndsWith(repr(E[float]), 'A[float, int]')
+        self.assertEndsWith(repr(E[float, str]), 'A[float, str, int]')
 
         F = A[int, *Ts]
-        self.assertEndswith(repr(F), 'A[int, typing.Unpack[Ts]]')
-        self.assertEndswith(repr(F[()]), 'A[int]')
-        self.assertEndswith(repr(F[float]), 'A[int, float]')
-        self.assertEndswith(repr(F[float, str]), 'A[int, float, str]')
+        self.assertEndsWith(repr(F), 'A[int, typing.Unpack[Ts]]')
+        self.assertEndsWith(repr(F[()]), 'A[int]')
+        self.assertEndsWith(repr(F[float]), 'A[int, float]')
+        self.assertEndsWith(repr(F[float, str]), 'A[int, float, str]')
 
         G = A[int, Unpack[Ts]]
-        self.assertEndswith(repr(G), 'A[int, typing.Unpack[Ts]]')
-        self.assertEndswith(repr(G[()]), 'A[int]')
-        self.assertEndswith(repr(G[float]), 'A[int, float]')
-        self.assertEndswith(repr(G[float, str]), 'A[int, float, str]')
+        self.assertEndsWith(repr(G), 'A[int, typing.Unpack[Ts]]')
+        self.assertEndsWith(repr(G[()]), 'A[int]')
+        self.assertEndsWith(repr(G[float]), 'A[int, float]')
+        self.assertEndsWith(repr(G[float, str]), 'A[int, float, str]')
 
         H = A[int, *Ts, str]
-        self.assertEndswith(repr(H), 'A[int, typing.Unpack[Ts], str]')
-        self.assertEndswith(repr(H[()]), 'A[int, str]')
-        self.assertEndswith(repr(H[float]), 'A[int, float, str]')
-        self.assertEndswith(repr(H[float, str]), 'A[int, float, str, str]')
+        self.assertEndsWith(repr(H), 'A[int, typing.Unpack[Ts], str]')
+        self.assertEndsWith(repr(H[()]), 'A[int, str]')
+        self.assertEndsWith(repr(H[float]), 'A[int, float, str]')
+        self.assertEndsWith(repr(H[float, str]), 'A[int, float, str, str]')
 
         I = A[int, Unpack[Ts], str]
-        self.assertEndswith(repr(I), 'A[int, typing.Unpack[Ts], str]')
-        self.assertEndswith(repr(I[()]), 'A[int, str]')
-        self.assertEndswith(repr(I[float]), 'A[int, float, str]')
-        self.assertEndswith(repr(I[float, str]), 'A[int, float, str, str]')
+        self.assertEndsWith(repr(I), 'A[int, typing.Unpack[Ts], str]')
+        self.assertEndsWith(repr(I[()]), 'A[int, str]')
+        self.assertEndsWith(repr(I[float]), 'A[int, float, str]')
+        self.assertEndsWith(repr(I[float, str]), 'A[int, float, str, str]')
 
         J = A[*Ts, *tuple[str, ...]]
-        self.assertEndswith(repr(J), 'A[typing.Unpack[Ts], *tuple[str, ...]]')
-        self.assertEndswith(repr(J[()]), 'A[*tuple[str, ...]]')
-        self.assertEndswith(repr(J[float]), 'A[float, *tuple[str, ...]]')
-        self.assertEndswith(repr(J[float, str]), 'A[float, str, *tuple[str, ...]]')
+        self.assertEndsWith(repr(J), 'A[typing.Unpack[Ts], *tuple[str, ...]]')
+        self.assertEndsWith(repr(J[()]), 'A[*tuple[str, ...]]')
+        self.assertEndsWith(repr(J[float]), 'A[float, *tuple[str, ...]]')
+        self.assertEndsWith(repr(J[float, str]), 'A[float, str, *tuple[str, ...]]')
 
         K = A[Unpack[Ts], Unpack[Tuple[str, ...]]]
-        self.assertEndswith(repr(K), 'A[typing.Unpack[Ts], typing.Unpack[typing.Tuple[str, ...]]]')
-        self.assertEndswith(repr(K[()]), 'A[typing.Unpack[typing.Tuple[str, ...]]]')
-        self.assertEndswith(repr(K[float]), 'A[float, typing.Unpack[typing.Tuple[str, ...]]]')
-        self.assertEndswith(repr(K[float, str]), 'A[float, str, typing.Unpack[typing.Tuple[str, ...]]]')
+        self.assertEndsWith(repr(K), 'A[typing.Unpack[Ts], typing.Unpack[typing.Tuple[str, ...]]]')
+        self.assertEndsWith(repr(K[()]), 'A[typing.Unpack[typing.Tuple[str, ...]]]')
+        self.assertEndsWith(repr(K[float]), 'A[float, typing.Unpack[typing.Tuple[str, ...]]]')
+        self.assertEndsWith(repr(K[float, str]), 'A[float, str, typing.Unpack[typing.Tuple[str, ...]]]')
 
     def test_cannot_subclass(self):
         with self.assertRaisesRegex(TypeError, NOT_A_BASE_TYPE % 'TypeVarTuple'):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -59,20 +59,6 @@ CANNOT_SUBCLASS_INSTANCE = 'Cannot subclass an instance of %s'
 
 class BaseTestCase(TestCase):
 
-    def assertIsSubclass(self, cls, class_or_tuple, msg=None):
-        if not issubclass(cls, class_or_tuple):
-            message = '%r is not a subclass of %r' % (cls, class_or_tuple)
-            if msg is not None:
-                message += ' : %s' % msg
-            raise self.failureException(message)
-
-    def assertNotIsSubclass(self, cls, class_or_tuple, msg=None):
-        if issubclass(cls, class_or_tuple):
-            message = '%r is a subclass of %r' % (cls, class_or_tuple)
-            if msg is not None:
-                message += ' : %s' % msg
-            raise self.failureException(message)
-
     def clear_caches(self):
         for f in typing._cleanups:
             f()
@@ -1252,10 +1238,6 @@ class UnpackTests(BaseTestCase):
 
 class TypeVarTupleTests(BaseTestCase):
 
-    def assertEndsWith(self, string, tail):
-        if not string.endswith(tail):
-            self.fail(f"String {string!r} does not end with {tail!r}")
-
     def test_name(self):
         Ts = TypeVarTuple('Ts')
         self.assertEqual(Ts.__name__, 'Ts')
@@ -1444,31 +1426,31 @@ class TypeVarTupleTests(BaseTestCase):
         class A(Generic[*Ts]): pass
         class B(Generic[Unpack[Ts]]): pass
 
-        self.assertEndsWith(repr(A[()]), 'A[()]')
-        self.assertEndsWith(repr(B[()]), 'B[()]')
-        self.assertEndsWith(repr(A[float]), 'A[float]')
-        self.assertEndsWith(repr(B[float]), 'B[float]')
-        self.assertEndsWith(repr(A[float, str]), 'A[float, str]')
-        self.assertEndsWith(repr(B[float, str]), 'B[float, str]')
+        self.assertEndswith(repr(A[()]), 'A[()]')
+        self.assertEndswith(repr(B[()]), 'B[()]')
+        self.assertEndswith(repr(A[float]), 'A[float]')
+        self.assertEndswith(repr(B[float]), 'B[float]')
+        self.assertEndswith(repr(A[float, str]), 'A[float, str]')
+        self.assertEndswith(repr(B[float, str]), 'B[float, str]')
 
-        self.assertEndsWith(repr(A[*tuple[int, ...]]),
+        self.assertEndswith(repr(A[*tuple[int, ...]]),
                             'A[*tuple[int, ...]]')
-        self.assertEndsWith(repr(B[Unpack[Tuple[int, ...]]]),
+        self.assertEndswith(repr(B[Unpack[Tuple[int, ...]]]),
                             'B[typing.Unpack[typing.Tuple[int, ...]]]')
 
-        self.assertEndsWith(repr(A[float, *tuple[int, ...]]),
+        self.assertEndswith(repr(A[float, *tuple[int, ...]]),
                             'A[float, *tuple[int, ...]]')
-        self.assertEndsWith(repr(A[float, Unpack[Tuple[int, ...]]]),
+        self.assertEndswith(repr(A[float, Unpack[Tuple[int, ...]]]),
                             'A[float, typing.Unpack[typing.Tuple[int, ...]]]')
 
-        self.assertEndsWith(repr(A[*tuple[int, ...], str]),
+        self.assertEndswith(repr(A[*tuple[int, ...], str]),
                             'A[*tuple[int, ...], str]')
-        self.assertEndsWith(repr(B[Unpack[Tuple[int, ...]], str]),
+        self.assertEndswith(repr(B[Unpack[Tuple[int, ...]], str]),
                             'B[typing.Unpack[typing.Tuple[int, ...]], str]')
 
-        self.assertEndsWith(repr(A[float, *tuple[int, ...], str]),
+        self.assertEndswith(repr(A[float, *tuple[int, ...], str]),
                             'A[float, *tuple[int, ...], str]')
-        self.assertEndsWith(repr(B[float, Unpack[Tuple[int, ...]], str]),
+        self.assertEndswith(repr(B[float, Unpack[Tuple[int, ...]], str]),
                             'B[float, typing.Unpack[typing.Tuple[int, ...]], str]')
 
     def test_variadic_class_alias_repr_is_correct(self):
@@ -1476,64 +1458,64 @@ class TypeVarTupleTests(BaseTestCase):
         class A(Generic[Unpack[Ts]]): pass
 
         B = A[*Ts]
-        self.assertEndsWith(repr(B), 'A[typing.Unpack[Ts]]')
-        self.assertEndsWith(repr(B[()]), 'A[()]')
-        self.assertEndsWith(repr(B[float]), 'A[float]')
-        self.assertEndsWith(repr(B[float, str]), 'A[float, str]')
+        self.assertEndswith(repr(B), 'A[typing.Unpack[Ts]]')
+        self.assertEndswith(repr(B[()]), 'A[()]')
+        self.assertEndswith(repr(B[float]), 'A[float]')
+        self.assertEndswith(repr(B[float, str]), 'A[float, str]')
 
         C = A[Unpack[Ts]]
-        self.assertEndsWith(repr(C), 'A[typing.Unpack[Ts]]')
-        self.assertEndsWith(repr(C[()]), 'A[()]')
-        self.assertEndsWith(repr(C[float]), 'A[float]')
-        self.assertEndsWith(repr(C[float, str]), 'A[float, str]')
+        self.assertEndswith(repr(C), 'A[typing.Unpack[Ts]]')
+        self.assertEndswith(repr(C[()]), 'A[()]')
+        self.assertEndswith(repr(C[float]), 'A[float]')
+        self.assertEndswith(repr(C[float, str]), 'A[float, str]')
 
         D = A[*Ts, int]
-        self.assertEndsWith(repr(D), 'A[typing.Unpack[Ts], int]')
-        self.assertEndsWith(repr(D[()]), 'A[int]')
-        self.assertEndsWith(repr(D[float]), 'A[float, int]')
-        self.assertEndsWith(repr(D[float, str]), 'A[float, str, int]')
+        self.assertEndswith(repr(D), 'A[typing.Unpack[Ts], int]')
+        self.assertEndswith(repr(D[()]), 'A[int]')
+        self.assertEndswith(repr(D[float]), 'A[float, int]')
+        self.assertEndswith(repr(D[float, str]), 'A[float, str, int]')
 
         E = A[Unpack[Ts], int]
-        self.assertEndsWith(repr(E), 'A[typing.Unpack[Ts], int]')
-        self.assertEndsWith(repr(E[()]), 'A[int]')
-        self.assertEndsWith(repr(E[float]), 'A[float, int]')
-        self.assertEndsWith(repr(E[float, str]), 'A[float, str, int]')
+        self.assertEndswith(repr(E), 'A[typing.Unpack[Ts], int]')
+        self.assertEndswith(repr(E[()]), 'A[int]')
+        self.assertEndswith(repr(E[float]), 'A[float, int]')
+        self.assertEndswith(repr(E[float, str]), 'A[float, str, int]')
 
         F = A[int, *Ts]
-        self.assertEndsWith(repr(F), 'A[int, typing.Unpack[Ts]]')
-        self.assertEndsWith(repr(F[()]), 'A[int]')
-        self.assertEndsWith(repr(F[float]), 'A[int, float]')
-        self.assertEndsWith(repr(F[float, str]), 'A[int, float, str]')
+        self.assertEndswith(repr(F), 'A[int, typing.Unpack[Ts]]')
+        self.assertEndswith(repr(F[()]), 'A[int]')
+        self.assertEndswith(repr(F[float]), 'A[int, float]')
+        self.assertEndswith(repr(F[float, str]), 'A[int, float, str]')
 
         G = A[int, Unpack[Ts]]
-        self.assertEndsWith(repr(G), 'A[int, typing.Unpack[Ts]]')
-        self.assertEndsWith(repr(G[()]), 'A[int]')
-        self.assertEndsWith(repr(G[float]), 'A[int, float]')
-        self.assertEndsWith(repr(G[float, str]), 'A[int, float, str]')
+        self.assertEndswith(repr(G), 'A[int, typing.Unpack[Ts]]')
+        self.assertEndswith(repr(G[()]), 'A[int]')
+        self.assertEndswith(repr(G[float]), 'A[int, float]')
+        self.assertEndswith(repr(G[float, str]), 'A[int, float, str]')
 
         H = A[int, *Ts, str]
-        self.assertEndsWith(repr(H), 'A[int, typing.Unpack[Ts], str]')
-        self.assertEndsWith(repr(H[()]), 'A[int, str]')
-        self.assertEndsWith(repr(H[float]), 'A[int, float, str]')
-        self.assertEndsWith(repr(H[float, str]), 'A[int, float, str, str]')
+        self.assertEndswith(repr(H), 'A[int, typing.Unpack[Ts], str]')
+        self.assertEndswith(repr(H[()]), 'A[int, str]')
+        self.assertEndswith(repr(H[float]), 'A[int, float, str]')
+        self.assertEndswith(repr(H[float, str]), 'A[int, float, str, str]')
 
         I = A[int, Unpack[Ts], str]
-        self.assertEndsWith(repr(I), 'A[int, typing.Unpack[Ts], str]')
-        self.assertEndsWith(repr(I[()]), 'A[int, str]')
-        self.assertEndsWith(repr(I[float]), 'A[int, float, str]')
-        self.assertEndsWith(repr(I[float, str]), 'A[int, float, str, str]')
+        self.assertEndswith(repr(I), 'A[int, typing.Unpack[Ts], str]')
+        self.assertEndswith(repr(I[()]), 'A[int, str]')
+        self.assertEndswith(repr(I[float]), 'A[int, float, str]')
+        self.assertEndswith(repr(I[float, str]), 'A[int, float, str, str]')
 
         J = A[*Ts, *tuple[str, ...]]
-        self.assertEndsWith(repr(J), 'A[typing.Unpack[Ts], *tuple[str, ...]]')
-        self.assertEndsWith(repr(J[()]), 'A[*tuple[str, ...]]')
-        self.assertEndsWith(repr(J[float]), 'A[float, *tuple[str, ...]]')
-        self.assertEndsWith(repr(J[float, str]), 'A[float, str, *tuple[str, ...]]')
+        self.assertEndswith(repr(J), 'A[typing.Unpack[Ts], *tuple[str, ...]]')
+        self.assertEndswith(repr(J[()]), 'A[*tuple[str, ...]]')
+        self.assertEndswith(repr(J[float]), 'A[float, *tuple[str, ...]]')
+        self.assertEndswith(repr(J[float, str]), 'A[float, str, *tuple[str, ...]]')
 
         K = A[Unpack[Ts], Unpack[Tuple[str, ...]]]
-        self.assertEndsWith(repr(K), 'A[typing.Unpack[Ts], typing.Unpack[typing.Tuple[str, ...]]]')
-        self.assertEndsWith(repr(K[()]), 'A[typing.Unpack[typing.Tuple[str, ...]]]')
-        self.assertEndsWith(repr(K[float]), 'A[float, typing.Unpack[typing.Tuple[str, ...]]]')
-        self.assertEndsWith(repr(K[float, str]), 'A[float, str, typing.Unpack[typing.Tuple[str, ...]]]')
+        self.assertEndswith(repr(K), 'A[typing.Unpack[Ts], typing.Unpack[typing.Tuple[str, ...]]]')
+        self.assertEndswith(repr(K[()]), 'A[typing.Unpack[typing.Tuple[str, ...]]]')
+        self.assertEndswith(repr(K[float]), 'A[float, typing.Unpack[typing.Tuple[str, ...]]]')
+        self.assertEndswith(repr(K[float, str]), 'A[float, str, typing.Unpack[typing.Tuple[str, ...]]]')
 
     def test_cannot_subclass(self):
         with self.assertRaisesRegex(TypeError, NOT_A_BASE_TYPE % 'TypeVarTuple'):

--- a/Lib/test/test_unittest/test_case.py
+++ b/Lib/test/test_unittest/test_case.py
@@ -90,7 +90,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
             def runTest(self): raise MyException()
             def test(self): pass
 
-        self.assertEndswith(Test().id(), '.Test.runTest')
+        self.assertEndsWith(Test().id(), '.Test.runTest')
 
         # test that TestCase can be instantiated with no args
         # primarily for use at the interactive interpreter
@@ -111,7 +111,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
             def runTest(self): raise MyException()
             def test(self): pass
 
-        self.assertEndswith(Test('test').id(), '.Test.test')
+        self.assertEndsWith(Test('test').id(), '.Test.test')
 
     # "class TestCase([methodName])"
     # ...
@@ -1971,183 +1971,183 @@ test case
         self.assertIsNone(value)
 
     def testAssertStartswith(self):
-        self.assertStartswith('ababahalamaha', 'ababa')
-        self.assertStartswith('ababahalamaha', ('x', 'ababa', 'y'))
-        self.assertStartswith(UserString('ababahalamaha'), 'ababa')
-        self.assertStartswith(UserString('ababahalamaha'), ('x', 'ababa', 'y'))
-        self.assertStartswith(bytearray(b'ababahalamaha'), b'ababa')
-        self.assertStartswith(bytearray(b'ababahalamaha'), (b'x', b'ababa', b'y'))
-        self.assertStartswith(b'ababahalamaha', bytearray(b'ababa'))
-        self.assertStartswith(b'ababahalamaha',
+        self.assertStartsWith('ababahalamaha', 'ababa')
+        self.assertStartsWith('ababahalamaha', ('x', 'ababa', 'y'))
+        self.assertStartsWith(UserString('ababahalamaha'), 'ababa')
+        self.assertStartsWith(UserString('ababahalamaha'), ('x', 'ababa', 'y'))
+        self.assertStartsWith(bytearray(b'ababahalamaha'), b'ababa')
+        self.assertStartsWith(bytearray(b'ababahalamaha'), (b'x', b'ababa', b'y'))
+        self.assertStartsWith(b'ababahalamaha', bytearray(b'ababa'))
+        self.assertStartsWith(b'ababahalamaha',
                 (bytearray(b'x'), bytearray(b'ababa'), bytearray(b'y')))
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertStartswith('ababahalamaha', 'amaha')
+            self.assertStartsWith('ababahalamaha', 'amaha')
         self.assertEqual(str(cm.exception),
                 "'ababahalamaha' doesn't start with 'amaha'")
         with self.assertRaises(self.failureException) as cm:
-            self.assertStartswith('ababahalamaha', ('x', 'y'))
+            self.assertStartsWith('ababahalamaha', ('x', 'y'))
         self.assertEqual(str(cm.exception),
                 "'ababahalamaha' doesn't start with any of ('x', 'y')")
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertStartswith(b'ababahalamaha', 'ababa')
+            self.assertStartsWith(b'ababahalamaha', 'ababa')
         self.assertEqual(str(cm.exception), 'Expected str, not bytes')
         with self.assertRaises(self.failureException) as cm:
-            self.assertStartswith(b'ababahalamaha', ('amaha', 'ababa'))
+            self.assertStartsWith(b'ababahalamaha', ('amaha', 'ababa'))
         self.assertEqual(str(cm.exception), 'Expected str, not bytes')
         with self.assertRaises(self.failureException) as cm:
-            self.assertStartswith([], 'ababa')
+            self.assertStartsWith([], 'ababa')
         self.assertEqual(str(cm.exception), 'Expected str, not list')
         with self.assertRaises(self.failureException) as cm:
-            self.assertStartswith('ababahalamaha', b'ababa')
+            self.assertStartsWith('ababahalamaha', b'ababa')
         self.assertEqual(str(cm.exception), 'Expected bytes, not str')
         with self.assertRaises(self.failureException) as cm:
-            self.assertStartswith('ababahalamaha', (b'amaha', b'ababa'))
+            self.assertStartsWith('ababahalamaha', (b'amaha', b'ababa'))
         self.assertEqual(str(cm.exception), 'Expected bytes, not str')
         with self.assertRaises(TypeError):
-            self.assertStartswith('ababahalamaha', ord('a'))
+            self.assertStartsWith('ababahalamaha', ord('a'))
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertStartswith('ababahalamaha', 'amaha', 'abracadabra')
+            self.assertStartsWith('ababahalamaha', 'amaha', 'abracadabra')
         self.assertIn('ababahalamaha', str(cm.exception))
         with self.assertRaises(self.failureException) as cm:
-            self.assertStartswith('ababahalamaha', 'amaha', msg='abracadabra')
+            self.assertStartsWith('ababahalamaha', 'amaha', msg='abracadabra')
         self.assertIn('ababahalamaha', str(cm.exception))
 
     def testAssertNotStartswith(self):
-        self.assertNotStartswith('ababahalamaha', 'amaha')
-        self.assertNotStartswith('ababahalamaha', ('x', 'amaha', 'y'))
-        self.assertNotStartswith(UserString('ababahalamaha'), 'amaha')
-        self.assertNotStartswith(UserString('ababahalamaha'), ('x', 'amaha', 'y'))
-        self.assertNotStartswith(bytearray(b'ababahalamaha'), b'amaha')
-        self.assertNotStartswith(bytearray(b'ababahalamaha'), (b'x', b'amaha', b'y'))
-        self.assertNotStartswith(b'ababahalamaha', bytearray(b'amaha'))
-        self.assertNotStartswith(b'ababahalamaha',
+        self.assertNotStartsWith('ababahalamaha', 'amaha')
+        self.assertNotStartsWith('ababahalamaha', ('x', 'amaha', 'y'))
+        self.assertNotStartsWith(UserString('ababahalamaha'), 'amaha')
+        self.assertNotStartsWith(UserString('ababahalamaha'), ('x', 'amaha', 'y'))
+        self.assertNotStartsWith(bytearray(b'ababahalamaha'), b'amaha')
+        self.assertNotStartsWith(bytearray(b'ababahalamaha'), (b'x', b'amaha', b'y'))
+        self.assertNotStartsWith(b'ababahalamaha', bytearray(b'amaha'))
+        self.assertNotStartsWith(b'ababahalamaha',
                 (bytearray(b'x'), bytearray(b'amaha'), bytearray(b'y')))
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotStartswith('ababahalamaha', 'ababa')
+            self.assertNotStartsWith('ababahalamaha', 'ababa')
         self.assertEqual(str(cm.exception),
                 "'ababahalamaha' starts with 'ababa'")
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotStartswith('ababahalamaha', ('x', 'ababa', 'y'))
+            self.assertNotStartsWith('ababahalamaha', ('x', 'ababa', 'y'))
         self.assertEqual(str(cm.exception),
                 "'ababahalamaha' starts with 'ababa'")
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotStartswith(b'ababahalamaha', 'ababa')
+            self.assertNotStartsWith(b'ababahalamaha', 'ababa')
         self.assertEqual(str(cm.exception), 'Expected str, not bytes')
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotStartswith(b'ababahalamaha', ('amaha', 'ababa'))
+            self.assertNotStartsWith(b'ababahalamaha', ('amaha', 'ababa'))
         self.assertEqual(str(cm.exception), 'Expected str, not bytes')
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotStartswith([], 'ababa')
+            self.assertNotStartsWith([], 'ababa')
         self.assertEqual(str(cm.exception), 'Expected str, not list')
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotStartswith('ababahalamaha', b'ababa')
+            self.assertNotStartsWith('ababahalamaha', b'ababa')
         self.assertEqual(str(cm.exception), 'Expected bytes, not str')
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotStartswith('ababahalamaha', (b'amaha', b'ababa'))
+            self.assertNotStartsWith('ababahalamaha', (b'amaha', b'ababa'))
         self.assertEqual(str(cm.exception), 'Expected bytes, not str')
         with self.assertRaises(TypeError):
-            self.assertNotStartswith('ababahalamaha', ord('a'))
+            self.assertNotStartsWith('ababahalamaha', ord('a'))
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotStartswith('ababahalamaha', 'ababa', 'abracadabra')
+            self.assertNotStartsWith('ababahalamaha', 'ababa', 'abracadabra')
         self.assertIn('ababahalamaha', str(cm.exception))
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotStartswith('ababahalamaha', 'ababa', msg='abracadabra')
+            self.assertNotStartsWith('ababahalamaha', 'ababa', msg='abracadabra')
         self.assertIn('ababahalamaha', str(cm.exception))
 
     def testAssertEndswith(self):
-        self.assertEndswith('ababahalamaha', 'amaha')
-        self.assertEndswith('ababahalamaha', ('x', 'amaha', 'y'))
-        self.assertEndswith(UserString('ababahalamaha'), 'amaha')
-        self.assertEndswith(UserString('ababahalamaha'), ('x', 'amaha', 'y'))
-        self.assertEndswith(bytearray(b'ababahalamaha'), b'amaha')
-        self.assertEndswith(bytearray(b'ababahalamaha'), (b'x', b'amaha', b'y'))
-        self.assertEndswith(b'ababahalamaha', bytearray(b'amaha'))
-        self.assertEndswith(b'ababahalamaha',
+        self.assertEndsWith('ababahalamaha', 'amaha')
+        self.assertEndsWith('ababahalamaha', ('x', 'amaha', 'y'))
+        self.assertEndsWith(UserString('ababahalamaha'), 'amaha')
+        self.assertEndsWith(UserString('ababahalamaha'), ('x', 'amaha', 'y'))
+        self.assertEndsWith(bytearray(b'ababahalamaha'), b'amaha')
+        self.assertEndsWith(bytearray(b'ababahalamaha'), (b'x', b'amaha', b'y'))
+        self.assertEndsWith(b'ababahalamaha', bytearray(b'amaha'))
+        self.assertEndsWith(b'ababahalamaha',
                 (bytearray(b'x'), bytearray(b'amaha'), bytearray(b'y')))
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertEndswith('ababahalamaha', 'ababa')
+            self.assertEndsWith('ababahalamaha', 'ababa')
         self.assertEqual(str(cm.exception),
                 "'ababahalamaha' doesn't end with 'ababa'")
         with self.assertRaises(self.failureException) as cm:
-            self.assertEndswith('ababahalamaha', ('x', 'y'))
+            self.assertEndsWith('ababahalamaha', ('x', 'y'))
         self.assertEqual(str(cm.exception),
                 "'ababahalamaha' doesn't end with any of ('x', 'y')")
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertEndswith(b'ababahalamaha', 'amaha')
+            self.assertEndsWith(b'ababahalamaha', 'amaha')
         self.assertEqual(str(cm.exception), 'Expected str, not bytes')
         with self.assertRaises(self.failureException) as cm:
-            self.assertEndswith(b'ababahalamaha', ('ababa', 'amaha'))
+            self.assertEndsWith(b'ababahalamaha', ('ababa', 'amaha'))
         self.assertEqual(str(cm.exception), 'Expected str, not bytes')
         with self.assertRaises(self.failureException) as cm:
-            self.assertEndswith([], 'amaha')
+            self.assertEndsWith([], 'amaha')
         self.assertEqual(str(cm.exception), 'Expected str, not list')
         with self.assertRaises(self.failureException) as cm:
-            self.assertEndswith('ababahalamaha', b'amaha')
+            self.assertEndsWith('ababahalamaha', b'amaha')
         self.assertEqual(str(cm.exception), 'Expected bytes, not str')
         with self.assertRaises(self.failureException) as cm:
-            self.assertEndswith('ababahalamaha', (b'ababa', b'amaha'))
+            self.assertEndsWith('ababahalamaha', (b'ababa', b'amaha'))
         self.assertEqual(str(cm.exception), 'Expected bytes, not str')
         with self.assertRaises(TypeError):
-            self.assertEndswith('ababahalamaha', ord('a'))
+            self.assertEndsWith('ababahalamaha', ord('a'))
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertEndswith('ababahalamaha', 'ababa', 'abracadabra')
+            self.assertEndsWith('ababahalamaha', 'ababa', 'abracadabra')
         self.assertIn('ababahalamaha', str(cm.exception))
         with self.assertRaises(self.failureException) as cm:
-            self.assertEndswith('ababahalamaha', 'ababa', msg='abracadabra')
+            self.assertEndsWith('ababahalamaha', 'ababa', msg='abracadabra')
         self.assertIn('ababahalamaha', str(cm.exception))
 
     def testAssertNotEndswith(self):
-        self.assertNotEndswith('ababahalamaha', 'ababa')
-        self.assertNotEndswith('ababahalamaha', ('x', 'ababa', 'y'))
-        self.assertNotEndswith(UserString('ababahalamaha'), 'ababa')
-        self.assertNotEndswith(UserString('ababahalamaha'), ('x', 'ababa', 'y'))
-        self.assertNotEndswith(bytearray(b'ababahalamaha'), b'ababa')
-        self.assertNotEndswith(bytearray(b'ababahalamaha'), (b'x', b'ababa', b'y'))
-        self.assertNotEndswith(b'ababahalamaha', bytearray(b'ababa'))
-        self.assertNotEndswith(b'ababahalamaha',
+        self.assertNotEndsWith('ababahalamaha', 'ababa')
+        self.assertNotEndsWith('ababahalamaha', ('x', 'ababa', 'y'))
+        self.assertNotEndsWith(UserString('ababahalamaha'), 'ababa')
+        self.assertNotEndsWith(UserString('ababahalamaha'), ('x', 'ababa', 'y'))
+        self.assertNotEndsWith(bytearray(b'ababahalamaha'), b'ababa')
+        self.assertNotEndsWith(bytearray(b'ababahalamaha'), (b'x', b'ababa', b'y'))
+        self.assertNotEndsWith(b'ababahalamaha', bytearray(b'ababa'))
+        self.assertNotEndsWith(b'ababahalamaha',
                 (bytearray(b'x'), bytearray(b'ababa'), bytearray(b'y')))
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotEndswith('ababahalamaha', 'amaha')
+            self.assertNotEndsWith('ababahalamaha', 'amaha')
         self.assertEqual(str(cm.exception),
                 "'ababahalamaha' ends with 'amaha'")
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotEndswith('ababahalamaha', ('x', 'amaha', 'y'))
+            self.assertNotEndsWith('ababahalamaha', ('x', 'amaha', 'y'))
         self.assertEqual(str(cm.exception),
                 "'ababahalamaha' ends with 'amaha'")
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotEndswith(b'ababahalamaha', 'amaha')
+            self.assertNotEndsWith(b'ababahalamaha', 'amaha')
         self.assertEqual(str(cm.exception), 'Expected str, not bytes')
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotEndswith(b'ababahalamaha', ('ababa', 'amaha'))
+            self.assertNotEndsWith(b'ababahalamaha', ('ababa', 'amaha'))
         self.assertEqual(str(cm.exception), 'Expected str, not bytes')
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotEndswith([], 'amaha')
+            self.assertNotEndsWith([], 'amaha')
         self.assertEqual(str(cm.exception), 'Expected str, not list')
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotEndswith('ababahalamaha', b'amaha')
+            self.assertNotEndsWith('ababahalamaha', b'amaha')
         self.assertEqual(str(cm.exception), 'Expected bytes, not str')
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotEndswith('ababahalamaha', (b'ababa', b'amaha'))
+            self.assertNotEndsWith('ababahalamaha', (b'ababa', b'amaha'))
         self.assertEqual(str(cm.exception), 'Expected bytes, not str')
         with self.assertRaises(TypeError):
-            self.assertNotEndswith('ababahalamaha', ord('a'))
+            self.assertNotEndsWith('ababahalamaha', ord('a'))
 
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotEndswith('ababahalamaha', 'amaha', 'abracadabra')
+            self.assertNotEndsWith('ababahalamaha', 'amaha', 'abracadabra')
         self.assertIn('ababahalamaha', str(cm.exception))
         with self.assertRaises(self.failureException) as cm:
-            self.assertNotEndswith('ababahalamaha', 'amaha', msg='abracadabra')
+            self.assertNotEndsWith('ababahalamaha', 'amaha', msg='abracadabra')
         self.assertIn('ababahalamaha', str(cm.exception))
 
     def testDeprecatedFailMethods(self):

--- a/Lib/test/test_unittest/test_loader.py
+++ b/Lib/test/test_unittest/test_loader.py
@@ -76,7 +76,7 @@ class Test_TestLoader(unittest.TestCase):
 
         loader = unittest.TestLoader()
         # This has to be false for the test to succeed
-        self.assertNotStartswith('runTest', loader.testMethodPrefix)
+        self.assertNotStartsWith('runTest', loader.testMethodPrefix)
 
         suite = loader.loadTestsFromTestCase(Foo)
         self.assertIsInstance(suite, loader.suiteClass)

--- a/Lib/test/test_unittest/test_loader.py
+++ b/Lib/test/test_unittest/test_loader.py
@@ -76,7 +76,7 @@ class Test_TestLoader(unittest.TestCase):
 
         loader = unittest.TestLoader()
         # This has to be false for the test to succeed
-        self.assertFalse('runTest'.startswith(loader.testMethodPrefix))
+        self.assertNotStartswith('runTest', loader.testMethodPrefix)
 
         suite = loader.loadTestsFromTestCase(Foo)
         self.assertIsInstance(suite, loader.suiteClass)

--- a/Lib/test/test_unittest/test_program.py
+++ b/Lib/test/test_unittest/test_program.py
@@ -128,14 +128,14 @@ class Test_TestProgram(unittest.TestCase):
                                 argv=["foobar"],
                                 testRunner=unittest.TextTestRunner(stream=stream),
                                 testLoader=self.TestLoader(self.FooBar))
-        self.assertTrue(hasattr(program, 'result'))
+        self.assertHasAttr(program, 'result')
         out = stream.getvalue()
         self.assertIn('\nFAIL: testFail ', out)
         self.assertIn('\nERROR: testError ', out)
         self.assertIn('\nUNEXPECTED SUCCESS: testUnexpectedSuccess ', out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
-        self.assertTrue(out.endswith(expected))
+        self.assertEndswith(out, expected)
 
     @force_not_colorized
     def test_Exit(self):
@@ -153,7 +153,7 @@ class Test_TestProgram(unittest.TestCase):
         self.assertIn('\nUNEXPECTED SUCCESS: testUnexpectedSuccess ', out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
-        self.assertTrue(out.endswith(expected))
+        self.assertEndswith(out, expected)
 
     @force_not_colorized
     def test_ExitAsDefault(self):
@@ -169,7 +169,7 @@ class Test_TestProgram(unittest.TestCase):
         self.assertIn('\nUNEXPECTED SUCCESS: testUnexpectedSuccess ', out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
-        self.assertTrue(out.endswith(expected))
+        self.assertEndswith(out, expected)
 
     @force_not_colorized
     def test_ExitSkippedSuite(self):
@@ -182,7 +182,7 @@ class Test_TestProgram(unittest.TestCase):
         self.assertEqual(cm.exception.code, 0)
         out = stream.getvalue()
         expected = '\n\nOK (skipped=1)\n'
-        self.assertTrue(out.endswith(expected))
+        self.assertEndswith(out, expected)
 
     @force_not_colorized
     def test_ExitEmptySuite(self):

--- a/Lib/test/test_unittest/test_program.py
+++ b/Lib/test/test_unittest/test_program.py
@@ -135,7 +135,7 @@ class Test_TestProgram(unittest.TestCase):
         self.assertIn('\nUNEXPECTED SUCCESS: testUnexpectedSuccess ', out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
-        self.assertEndswith(out, expected)
+        self.assertEndsWith(out, expected)
 
     @force_not_colorized
     def test_Exit(self):
@@ -153,7 +153,7 @@ class Test_TestProgram(unittest.TestCase):
         self.assertIn('\nUNEXPECTED SUCCESS: testUnexpectedSuccess ', out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
-        self.assertEndswith(out, expected)
+        self.assertEndsWith(out, expected)
 
     @force_not_colorized
     def test_ExitAsDefault(self):
@@ -169,7 +169,7 @@ class Test_TestProgram(unittest.TestCase):
         self.assertIn('\nUNEXPECTED SUCCESS: testUnexpectedSuccess ', out)
         expected = ('\n\nFAILED (failures=1, errors=1, skipped=1, '
                     'expected failures=1, unexpected successes=1)\n')
-        self.assertEndswith(out, expected)
+        self.assertEndsWith(out, expected)
 
     @force_not_colorized
     def test_ExitSkippedSuite(self):
@@ -182,7 +182,7 @@ class Test_TestProgram(unittest.TestCase):
         self.assertEqual(cm.exception.code, 0)
         out = stream.getvalue()
         expected = '\n\nOK (skipped=1)\n'
-        self.assertEndswith(out, expected)
+        self.assertEndsWith(out, expected)
 
     @force_not_colorized
     def test_ExitEmptySuite(self):

--- a/Lib/test/test_unittest/test_result.py
+++ b/Lib/test/test_unittest/test_result.py
@@ -460,7 +460,7 @@ class Test_TestResult(unittest.TestCase):
             self.assertTrue(result.failfast)
         result = runner.run(test)
         stream.flush()
-        self.assertTrue(stream.getvalue().endswith('\n\nOK\n'))
+        self.assertEndswith(stream.getvalue(), '\n\nOK\n')
 
 
 class Test_TextTestResult(unittest.TestCase):

--- a/Lib/test/test_unittest/test_result.py
+++ b/Lib/test/test_unittest/test_result.py
@@ -460,7 +460,7 @@ class Test_TestResult(unittest.TestCase):
             self.assertTrue(result.failfast)
         result = runner.run(test)
         stream.flush()
-        self.assertEndswith(stream.getvalue(), '\n\nOK\n')
+        self.assertEndsWith(stream.getvalue(), '\n\nOK\n')
 
 
 class Test_TextTestResult(unittest.TestCase):

--- a/Lib/test/test_unittest/testmock/testasync.py
+++ b/Lib/test/test_unittest/testmock/testasync.py
@@ -586,16 +586,16 @@ class AsyncMagicMethods(unittest.TestCase):
 
     def test_magicmock_has_async_magic_methods(self):
         m_mock = MagicMock()
-        self.assertTrue(hasattr(m_mock, "__aenter__"))
-        self.assertTrue(hasattr(m_mock, "__aexit__"))
-        self.assertTrue(hasattr(m_mock, "__anext__"))
+        self.assertHasAttr(m_mock, "__aenter__")
+        self.assertHasAttr(m_mock, "__aexit__")
+        self.assertHasAttr(m_mock, "__anext__")
 
     def test_asyncmock_has_sync_magic_methods(self):
         a_mock = AsyncMock()
-        self.assertTrue(hasattr(a_mock, "__enter__"))
-        self.assertTrue(hasattr(a_mock, "__exit__"))
-        self.assertTrue(hasattr(a_mock, "__next__"))
-        self.assertTrue(hasattr(a_mock, "__len__"))
+        self.assertHasAttr(a_mock, "__enter__")
+        self.assertHasAttr(a_mock, "__exit__")
+        self.assertHasAttr(a_mock, "__next__")
+        self.assertHasAttr(a_mock, "__len__")
 
     def test_magic_methods_are_async_functions(self):
         m_mock = MagicMock()

--- a/Lib/test/test_unittest/testmock/testcallable.py
+++ b/Lib/test/test_unittest/testmock/testcallable.py
@@ -23,21 +23,21 @@ class TestCallable(unittest.TestCase):
     def test_non_callable(self):
         for mock in NonCallableMagicMock(), NonCallableMock():
             self.assertRaises(TypeError, mock)
-            self.assertFalse(hasattr(mock, '__call__'))
+            self.assertNotHasAttr(mock, '__call__')
             self.assertIn(mock.__class__.__name__, repr(mock))
 
 
     def test_hierarchy(self):
-        self.assertTrue(issubclass(MagicMock, Mock))
-        self.assertTrue(issubclass(NonCallableMagicMock, NonCallableMock))
+        self.assertIsSubclass(MagicMock, Mock)
+        self.assertIsSubclass(NonCallableMagicMock, NonCallableMock)
 
 
     def test_attributes(self):
         one = NonCallableMock()
-        self.assertTrue(issubclass(type(one.one), Mock))
+        self.assertIsSubclass(type(one.one), Mock)
 
         two = NonCallableMagicMock()
-        self.assertTrue(issubclass(type(two.two), MagicMock))
+        self.assertIsSubclass(type(two.two), MagicMock)
 
 
     def test_subclasses(self):
@@ -45,13 +45,13 @@ class TestCallable(unittest.TestCase):
             pass
 
         one = MockSub()
-        self.assertTrue(issubclass(type(one.one), MockSub))
+        self.assertIsSubclass(type(one.one), MockSub)
 
         class MagicSub(MagicMock):
             pass
 
         two = MagicSub()
-        self.assertTrue(issubclass(type(two.two), MagicSub))
+        self.assertIsSubclass(type(two.two), MagicSub)
 
 
     def test_patch_spec(self):

--- a/Lib/test/test_unittest/testmock/testhelpers.py
+++ b/Lib/test/test_unittest/testmock/testhelpers.py
@@ -951,7 +951,7 @@ class SpecSignatureTest(unittest.TestCase):
 
         proxy = Foo()
         autospec = create_autospec(proxy)
-        self.assertFalse(hasattr(autospec, '__name__'))
+        self.assertNotHasAttr(autospec, '__name__')
 
 
     def test_autospec_signature_staticmethod(self):

--- a/Lib/test/test_unittest/testmock/testmagicmethods.py
+++ b/Lib/test/test_unittest/testmock/testmagicmethods.py
@@ -10,13 +10,13 @@ class TestMockingMagicMethods(unittest.TestCase):
 
     def test_deleting_magic_methods(self):
         mock = Mock()
-        self.assertFalse(hasattr(mock, '__getitem__'))
+        self.assertNotHasAttr(mock, '__getitem__')
 
         mock.__getitem__ = Mock()
-        self.assertTrue(hasattr(mock, '__getitem__'))
+        self.assertHasAttr(mock, '__getitem__')
 
         del mock.__getitem__
-        self.assertFalse(hasattr(mock, '__getitem__'))
+        self.assertNotHasAttr(mock, '__getitem__')
 
 
     def test_magicmock_del(self):
@@ -252,12 +252,12 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(list(mock), [1, 2, 3])
 
         getattr(mock, '__bool__').return_value = False
-        self.assertFalse(hasattr(mock, '__nonzero__'))
+        self.assertNotHasAttr(mock, '__nonzero__')
         self.assertFalse(bool(mock))
 
         for entry in _magics:
-            self.assertTrue(hasattr(mock, entry))
-        self.assertFalse(hasattr(mock, '__imaginary__'))
+            self.assertHasAttr(mock, entry)
+        self.assertNotHasAttr(mock, '__imaginary__')
 
 
     def test_magic_mock_equality(self):

--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -2215,13 +2215,13 @@ class MockTest(unittest.TestCase):
     def test_attribute_deletion(self):
         for mock in (Mock(), MagicMock(), NonCallableMagicMock(),
                      NonCallableMock()):
-            self.assertTrue(hasattr(mock, 'm'))
+            self.assertHasAttr(mock, 'm')
 
             del mock.m
-            self.assertFalse(hasattr(mock, 'm'))
+            self.assertNotHasAttr(mock, 'm')
 
             del mock.f
-            self.assertFalse(hasattr(mock, 'f'))
+            self.assertNotHasAttr(mock, 'f')
             self.assertRaises(AttributeError, getattr, mock, 'f')
 
 
@@ -2230,18 +2230,18 @@ class MockTest(unittest.TestCase):
         for mock in (Mock(), MagicMock(), NonCallableMagicMock(),
                      NonCallableMock()):
             mock.foo = 3
-            self.assertTrue(hasattr(mock, 'foo'))
+            self.assertHasAttr(mock, 'foo')
             self.assertEqual(mock.foo, 3)
 
             del mock.foo
-            self.assertFalse(hasattr(mock, 'foo'))
+            self.assertNotHasAttr(mock, 'foo')
 
             mock.foo = 4
-            self.assertTrue(hasattr(mock, 'foo'))
+            self.assertHasAttr(mock, 'foo')
             self.assertEqual(mock.foo, 4)
 
             del mock.foo
-            self.assertFalse(hasattr(mock, 'foo'))
+            self.assertNotHasAttr(mock, 'foo')
 
 
     def test_mock_raises_when_deleting_nonexistent_attribute(self):
@@ -2259,7 +2259,7 @@ class MockTest(unittest.TestCase):
         mock.child = True
         del mock.child
         mock.reset_mock()
-        self.assertFalse(hasattr(mock, 'child'))
+        self.assertNotHasAttr(mock, 'child')
 
 
     def test_class_assignable(self):

--- a/Lib/test/test_unittest/testmock/testpatch.py
+++ b/Lib/test/test_unittest/testmock/testpatch.py
@@ -366,7 +366,7 @@ class PatchTest(unittest.TestCase):
             self.assertEqual(SomeClass.frooble, sentinel.Frooble)
 
         test()
-        self.assertFalse(hasattr(SomeClass, 'frooble'))
+        self.assertNotHasAttr(SomeClass, 'frooble')
 
 
     def test_patch_wont_create_by_default(self):
@@ -383,7 +383,7 @@ class PatchTest(unittest.TestCase):
             @patch.object(SomeClass, 'ord', sentinel.Frooble)
             def test(): pass
             test()
-        self.assertFalse(hasattr(SomeClass, 'ord'))
+        self.assertNotHasAttr(SomeClass, 'ord')
 
 
     def test_patch_builtins_without_create(self):
@@ -1477,7 +1477,7 @@ class PatchTest(unittest.TestCase):
         finally:
             patcher.stop()
 
-        self.assertFalse(hasattr(Foo, 'blam'))
+        self.assertNotHasAttr(Foo, 'blam')
 
 
     def test_patch_multiple_spec_set(self):

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -513,7 +513,7 @@ class BasicTest(BaseTest):
         out, err = check_output([bash, test_script])
         lines = out.splitlines()
         self.assertTrue(env_name.encode() in lines[0])
-        self.assertEndswith(lines[1], env_name.encode())
+        self.assertEndsWith(lines[1], env_name.encode())
 
     # gh-124651: test quoted strings
     @unittest.skipIf(os.name == 'nt', 'contains invalid characters on Windows')
@@ -539,7 +539,7 @@ class BasicTest(BaseTest):
         out, err = check_output([csh, test_script])
         lines = out.splitlines()
         self.assertTrue(env_name.encode() in lines[0])
-        self.assertEndswith(lines[1], env_name.encode())
+        self.assertEndsWith(lines[1], env_name.encode())
 
     # gh-124651: test quoted strings on Windows
     @unittest.skipUnless(os.name == 'nt', 'only relevant on Windows')
@@ -563,7 +563,7 @@ class BasicTest(BaseTest):
         out, err = check_output([test_batch])
         lines = out.splitlines()
         self.assertTrue(env_name.encode() in lines[0])
-        self.assertEndswith(lines[1], env_name.encode())
+        self.assertEndsWith(lines[1], env_name.encode())
 
     @unittest.skipUnless(os.name == 'nt', 'only relevant on Windows')
     def test_unicode_in_batch_file(self):

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -111,10 +111,6 @@ class BaseTest(unittest.TestCase):
             result = f.read()
         return result
 
-    def assertEndsWith(self, string, tail):
-        if not string.endswith(tail):
-            self.fail(f"String {string!r} does not end with {tail!r}")
-
 class BasicTest(BaseTest):
     """Test venv module functionality."""
 
@@ -517,7 +513,7 @@ class BasicTest(BaseTest):
         out, err = check_output([bash, test_script])
         lines = out.splitlines()
         self.assertTrue(env_name.encode() in lines[0])
-        self.assertEndsWith(lines[1], env_name.encode())
+        self.assertEndswith(lines[1], env_name.encode())
 
     # gh-124651: test quoted strings
     @unittest.skipIf(os.name == 'nt', 'contains invalid characters on Windows')
@@ -543,7 +539,7 @@ class BasicTest(BaseTest):
         out, err = check_output([csh, test_script])
         lines = out.splitlines()
         self.assertTrue(env_name.encode() in lines[0])
-        self.assertEndsWith(lines[1], env_name.encode())
+        self.assertEndswith(lines[1], env_name.encode())
 
     # gh-124651: test quoted strings on Windows
     @unittest.skipUnless(os.name == 'nt', 'only relevant on Windows')
@@ -567,7 +563,7 @@ class BasicTest(BaseTest):
         out, err = check_output([test_batch])
         lines = out.splitlines()
         self.assertTrue(env_name.encode() in lines[0])
-        self.assertEndsWith(lines[1], env_name.encode())
+        self.assertEndswith(lines[1], env_name.encode())
 
     @unittest.skipUnless(os.name == 'nt', 'only relevant on Windows')
     def test_unicode_in_batch_file(self):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1322,9 +1322,9 @@ class TestCase(object):
         default message."""
         if not isinstance(obj, cls):
             if isinstance(cls, tuple):
-                standardMsg = '%s is not an instance of any of %r' % (safe_repr(obj), cls)
+                standardMsg = f'{safe_repr(obj)} is not an instance of any of {cls!r}'
             else:
-                standardMsg = '%s is not an instance of %r' % (safe_repr(obj), cls)
+                standardMsg = f'{safe_repr(obj)} is not an instance of {cls!r}'
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertNotIsInstance(self, obj, cls, msg=None):
@@ -1335,7 +1335,7 @@ class TestCase(object):
                     if isinstance(obj, x):
                         cls = x
                         break
-            standardMsg = '%s is an instance of %r' % (safe_repr(obj), cls)
+            standardMsg = f'{safe_repr(obj)} is an instance of {cls!r}'
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertIsSubclass(self, cls, superclass, msg=None):
@@ -1344,13 +1344,12 @@ class TestCase(object):
                 return
         except TypeError:
             if not isinstance(cls, type):
-                self.fail(self._formatMessage(msg,
-                        '%r is not a class' % (cls,)))
+                self.fail(self._formatMessage(msg, f'{cls!r} is not a class'))
             raise
         if isinstance(superclass, tuple):
-            standardMsg = '%r is not a subclass of any of %r' % (cls, superclass)
+            standardMsg = f'{cls!r} is not a subclass of any of {superclass!r}'
         else:
-            standardMsg = '%r is not a subclass of %r' % (cls, superclass)
+            standardMsg = f'{cls!r} is not a subclass of {superclass!r}'
         self.fail(self._formatMessage(msg, standardMsg))
 
     def assertNotIsSubclass(self, cls, superclass, msg=None):
@@ -1359,38 +1358,31 @@ class TestCase(object):
                 return
         except TypeError:
             if not isinstance(cls, type):
-                self.fail(self._formatMessage(msg,
-                        '%r is not a class' % (cls,)))
+                self.fail(self._formatMessage(msg, f'{cls!r} is not a class'))
             raise
         if isinstance(superclass, tuple):
             for x in superclass:
                 if issubclass(cls, x):
                     superclass = x
                     break
-        self.fail(self._formatMessage(msg,
-                '%r is a subclass of %r' % (cls, superclass)))
+        standardMsg = f'{cls!r} is a subclass of {superclass!r}'
+        self.fail(self._formatMessage(msg, standardMsg))
 
     def assertHasAttr(self, obj, name, msg=None):
         if not hasattr(obj, name):
             if isinstance(obj, types.ModuleType):
-                self.fail(self._formatMessage(msg,
-                        'module %r has no attribute %r' %
-                        (obj.__name__, name)))
+                standardMsg = f'module {obj.__name__!r} has no attribute {name!r}'
             else:
-                self.fail(self._formatMessage(msg,
-                        '%s instance has no attribute %r' %
-                        (type(obj).__name__, name)))
+                standardMsg = f'{type(obj).__name__} instance has no attribute {name!r}'
+            self.fail(self._formatMessage(msg, standardMsg))
 
     def assertNotHasAttr(self, obj, name, msg=None):
         if hasattr(obj, name):
             if isinstance(obj, types.ModuleType):
-                self.fail(self._formatMessage(msg,
-                        'module %r has unexpected attribute %r' %
-                        (obj.__name__, name)))
+                standardMsg = f'module {obj.__name__!r} has unexpected attribute {name!r}'
             else:
-                self.fail(self._formatMessage(msg,
-                        '%s instance has unexpected attribute %r' %
-                        (type(obj).__name__, name)))
+                standardMsg = f'{type(obj).__name__} instance has unexpected attribute {name!r}'
+            self.fail(self._formatMessage(msg, standardMsg))
 
     def assertRaisesRegex(self, expected_exception, expected_regex,
                           *args, **kwargs):
@@ -1460,11 +1452,11 @@ class TestCase(object):
             if isinstance(tail, str):
                 if not isinstance(s, str):
                     self.fail(self._formatMessage(msg,
-                            'Expected str, not %s' % (type(s).__name__,)))
+                            f'Expected str, not {type(s).__name__}'))
             elif isinstance(tail, (bytes, bytearray)):
                 if not isinstance(s, (bytes, bytearray)):
                     self.fail(self._formatMessage(msg,
-                            'Expected bytes, not %s' % (type(s).__name__,)))
+                            f'Expected bytes, not {type(s).__name__}'))
 
     def assertStartsWith(self, s, prefix, msg=None):
         try:
@@ -1476,11 +1468,10 @@ class TestCase(object):
         a = safe_repr(s, short=True)
         b = safe_repr(prefix)
         if isinstance(prefix, tuple):
-            self.fail(self._formatMessage(msg,
-                    "%s doesn't start with any of %s" % (a, b)))
+            standardMsg = f"{a} doesn't start with any of {b}"
         else:
-            self.fail(self._formatMessage(msg,
-                    "%s doesn't start with %s" % (a, b)))
+            standardMsg = f"{a} doesn't start with {b}"
+        self.fail(self._formatMessage(msg, standardMsg))
 
     def assertNotStartsWith(self, s, prefix, msg=None):
         try:
@@ -1496,8 +1487,7 @@ class TestCase(object):
                     break
         a = safe_repr(s, short=True)
         b = safe_repr(prefix)
-        self.fail(self._formatMessage(msg,
-                "%s starts with %s" % (a, b)))
+        self.fail(self._formatMessage(msg, f"{a} starts with {b}"))
 
     def assertEndsWith(self, s, suffix, msg=None):
         try:
@@ -1509,11 +1499,10 @@ class TestCase(object):
         a = safe_repr(s, short=True)
         b = safe_repr(suffix)
         if isinstance(suffix, tuple):
-            self.fail(self._formatMessage(msg,
-                    "%s doesn't end with any of %s" % (a, b)))
+            standardMsg = f"{a} doesn't end with any of {b}"
         else:
-            self.fail(self._formatMessage(msg,
-                    "%s doesn't end with %s" % (a, b)))
+            standardMsg = f"{a} doesn't end with {b}"
+        self.fail(self._formatMessage(msg, standardMsg))
 
     def assertNotEndsWith(self, s, suffix, msg=None):
         try:
@@ -1529,8 +1518,7 @@ class TestCase(object):
                     break
         a = safe_repr(s, short=True)
         b = safe_repr(suffix)
-        self.fail(self._formatMessage(msg,
-                "%s ends with %s" % (a, b)))
+        self.fail(self._formatMessage(msg, f"{a} ends with {b}"))
 
 
 class FunctionTestCase(TestCase):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1466,7 +1466,7 @@ class TestCase(object):
                     self.fail(self._formatMessage(msg,
                             'Expected bytes, not %s' % (type(s).__name__,)))
 
-    def assertStartswith(self, s, prefix, msg=None):
+    def assertStartsWith(self, s, prefix, msg=None):
         try:
             r = s.startswith(prefix)
         except (AttributeError, TypeError):
@@ -1482,7 +1482,7 @@ class TestCase(object):
                 self.fail(self._formatMessage(msg,
                         "%s doesn't start with %s" % (a, b)))
 
-    def assertNotStartswith(self, s, prefix, msg=None):
+    def assertNotStartsWith(self, s, prefix, msg=None):
         try:
             r = s.startswith(prefix)
         except (AttributeError, TypeError):
@@ -1499,7 +1499,7 @@ class TestCase(object):
             self.fail(self._formatMessage(msg,
                     "%s starts with %s" % (a, b)))
 
-    def assertEndswith(self, s, suffix, msg=None):
+    def assertEndsWith(self, s, suffix, msg=None):
         try:
             r = s.endswith(suffix)
         except (AttributeError, TypeError):
@@ -1515,7 +1515,7 @@ class TestCase(object):
                 self.fail(self._formatMessage(msg,
                         "%s doesn't end with %s" % (a, b)))
 
-    def assertNotEndswith(self, s, suffix, msg=None):
+    def assertNotEndsWith(self, s, suffix, msg=None):
         try:
             r = s.endswith(suffix)
         except (AttributeError, TypeError):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1340,35 +1340,35 @@ class TestCase(object):
 
     def assertIsSubclass(self, cls, superclass, msg=None):
         try:
-            r = issubclass(cls, superclass)
+            if issubclass(cls, superclass):
+                return
         except TypeError:
             if not isinstance(cls, type):
                 self.fail(self._formatMessage(msg,
                         '%r is not a class' % (cls,)))
             raise
-        if not r:
-            if isinstance(superclass, tuple):
-                standardMsg = '%r is not a subclass of any of %r' % (cls, superclass)
-            else:
-                standardMsg = '%r is not a subclass of %r' % (cls, superclass)
-            self.fail(self._formatMessage(msg, standardMsg))
+        if isinstance(superclass, tuple):
+            standardMsg = '%r is not a subclass of any of %r' % (cls, superclass)
+        else:
+            standardMsg = '%r is not a subclass of %r' % (cls, superclass)
+        self.fail(self._formatMessage(msg, standardMsg))
 
     def assertNotIsSubclass(self, cls, superclass, msg=None):
         try:
-            r = issubclass(cls, superclass)
+            if not issubclass(cls, superclass):
+                return
         except TypeError:
             if not isinstance(cls, type):
                 self.fail(self._formatMessage(msg,
                         '%r is not a class' % (cls,)))
             raise
-        if r:
-            if isinstance(superclass, tuple):
-                for x in superclass:
-                    if issubclass(cls, x):
-                        superclass = x
-                        break
-            self.fail(self._formatMessage(msg,
-                    '%r is a subclass of %r' % (cls, superclass)))
+        if isinstance(superclass, tuple):
+            for x in superclass:
+                if issubclass(cls, x):
+                    superclass = x
+                    break
+        self.fail(self._formatMessage(msg,
+                '%r is a subclass of %r' % (cls, superclass)))
 
     def assertHasAttr(self, obj, name, msg=None):
         if not hasattr(obj, name):
@@ -1468,69 +1468,69 @@ class TestCase(object):
 
     def assertStartsWith(self, s, prefix, msg=None):
         try:
-            r = s.startswith(prefix)
+            if s.startswith(prefix):
+                return
         except (AttributeError, TypeError):
             self._tail_type_check(s, prefix, msg)
             raise
-        if not r:
-            a = safe_repr(s, short=True)
-            b = safe_repr(prefix)
-            if isinstance(prefix, tuple):
-                self.fail(self._formatMessage(msg,
-                        "%s doesn't start with any of %s" % (a, b)))
-            else:
-                self.fail(self._formatMessage(msg,
-                        "%s doesn't start with %s" % (a, b)))
+        a = safe_repr(s, short=True)
+        b = safe_repr(prefix)
+        if isinstance(prefix, tuple):
+            self.fail(self._formatMessage(msg,
+                    "%s doesn't start with any of %s" % (a, b)))
+        else:
+            self.fail(self._formatMessage(msg,
+                    "%s doesn't start with %s" % (a, b)))
 
     def assertNotStartsWith(self, s, prefix, msg=None):
         try:
-            r = s.startswith(prefix)
+            if not s.startswith(prefix):
+                return
         except (AttributeError, TypeError):
             self._tail_type_check(s, prefix, msg)
             raise
-        if r:
-            if isinstance(prefix, tuple):
-                for x in prefix:
-                    if s.startswith(x):
-                        prefix = x
-                        break
-            a = safe_repr(s, short=True)
-            b = safe_repr(prefix)
-            self.fail(self._formatMessage(msg,
-                    "%s starts with %s" % (a, b)))
+        if isinstance(prefix, tuple):
+            for x in prefix:
+                if s.startswith(x):
+                    prefix = x
+                    break
+        a = safe_repr(s, short=True)
+        b = safe_repr(prefix)
+        self.fail(self._formatMessage(msg,
+                "%s starts with %s" % (a, b)))
 
     def assertEndsWith(self, s, suffix, msg=None):
         try:
-            r = s.endswith(suffix)
+            if s.endswith(suffix):
+                return
         except (AttributeError, TypeError):
             self._tail_type_check(s, suffix, msg)
             raise
-        if not r:
-            a = safe_repr(s, short=True)
-            b = safe_repr(suffix)
-            if isinstance(suffix, tuple):
-                self.fail(self._formatMessage(msg,
-                        "%s doesn't end with any of %s" % (a, b)))
-            else:
-                self.fail(self._formatMessage(msg,
-                        "%s doesn't end with %s" % (a, b)))
+        a = safe_repr(s, short=True)
+        b = safe_repr(suffix)
+        if isinstance(suffix, tuple):
+            self.fail(self._formatMessage(msg,
+                    "%s doesn't end with any of %s" % (a, b)))
+        else:
+            self.fail(self._formatMessage(msg,
+                    "%s doesn't end with %s" % (a, b)))
 
     def assertNotEndsWith(self, s, suffix, msg=None):
         try:
-            r = s.endswith(suffix)
+            if not s.endswith(suffix):
+                return
         except (AttributeError, TypeError):
             self._tail_type_check(s, suffix, msg)
             raise
-        if r:
-            if isinstance(suffix, tuple):
-                for x in suffix:
-                    if s.endswith(x):
-                        suffix = x
-                        break
-            a = safe_repr(s, short=True)
-            b = safe_repr(suffix)
-            self.fail(self._formatMessage(msg,
-                    "%s ends with %s" % (a, b)))
+        if isinstance(suffix, tuple):
+            for x in suffix:
+                if s.endswith(x):
+                    suffix = x
+                    break
+        a = safe_repr(s, short=True)
+        b = safe_repr(suffix)
+        self.fail(self._formatMessage(msg,
+                "%s ends with %s" % (a, b)))
 
 
 class FunctionTestCase(TestCase):

--- a/Misc/NEWS.d/next/Library/2025-01-10-15-06-45.gh-issue-71339.EKnpzw.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-10-15-06-45.gh-issue-71339.EKnpzw.rst
@@ -1,0 +1,9 @@
+Add new assertion methods for :mod:`unittest`:
+:meth:`~unittest.TestCase.assertHasAttr`,
+:meth:`~unittest.TestCase.assertNotHasAttr`,
+:meth:`~unittest.TestCase.assertIsSubclass`,
+:meth:`~unittest.TestCase.assertNotIsSubclass`
+:meth:`~unittest.TestCase.assertStartsWith`,
+:meth:`~unittest.TestCase.assertNotStartsWith`,
+:meth:`~unittest.TestCase.assertEndsWith` and
+:meth:`~unittest.TestCase.assertNotEndsWith`.

--- a/Misc/NEWS.d/next/Library/2025-01-10-15-06-45.gh-issue-71339.EKnpzw.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-10-15-06-45.gh-issue-71339.EKnpzw.rst
@@ -3,7 +3,7 @@ Add new assertion methods for :mod:`unittest`:
 :meth:`~unittest.TestCase.assertNotHasAttr`,
 :meth:`~unittest.TestCase.assertIsSubclass`,
 :meth:`~unittest.TestCase.assertNotIsSubclass`
-:meth:`~unittest.TestCase.assertStartsWith`,
-:meth:`~unittest.TestCase.assertNotStartsWith`,
-:meth:`~unittest.TestCase.assertEndsWith` and
-:meth:`~unittest.TestCase.assertNotEndsWith`.
+:meth:`~unittest.TestCase.assertStartswith`,
+:meth:`~unittest.TestCase.assertNotStartswith`,
+:meth:`~unittest.TestCase.assertEndswith` and
+:meth:`~unittest.TestCase.assertNotEndswith`.

--- a/Misc/NEWS.d/next/Library/2025-01-10-15-06-45.gh-issue-71339.EKnpzw.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-10-15-06-45.gh-issue-71339.EKnpzw.rst
@@ -3,7 +3,7 @@ Add new assertion methods for :mod:`unittest`:
 :meth:`~unittest.TestCase.assertNotHasAttr`,
 :meth:`~unittest.TestCase.assertIsSubclass`,
 :meth:`~unittest.TestCase.assertNotIsSubclass`
-:meth:`~unittest.TestCase.assertStartswith`,
-:meth:`~unittest.TestCase.assertNotStartswith`,
-:meth:`~unittest.TestCase.assertEndswith` and
-:meth:`~unittest.TestCase.assertNotEndswith`.
+:meth:`~unittest.TestCase.assertStartsWith`,
+:meth:`~unittest.TestCase.assertNotStartsWith`,
+:meth:`~unittest.TestCase.assertEndsWith` and
+:meth:`~unittest.TestCase.assertNotEndsWith`.


### PR DESCRIPTION
Add the following methods:

* assertHasAttr() and assertNotHasAttr()
* assertIsSubclass() and assertNotIsSubclass()
* assertStartsWith() and assertNotStartsWith()
* assertEndsWith() and assertNotEndsWith()

Also improve error messages for assertIsInstance() and assertNotIsInstance().


<!-- gh-issue-number: gh-71339 -->
* Issue: gh-71339
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128707.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->