### PR TITLE
gh-128679: Fix tracemalloc.stop() race condition

### DIFF
--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -1101,6 +1101,11 @@ class TestCAPI(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.untrack()
 
+    @unittest.skipIf(_testcapi is None, 'need _testcapi')
+    def test_tracemalloc_track_race(self):
+        # gh-128679: Test fix for tracemalloc.stop() race condition
+        _testcapi.tracemalloc_track_race()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -7,8 +7,9 @@ from unittest.mock import patch
 from test.support.script_helper import (assert_python_ok, assert_python_failure,
                                         interpreter_requires_environment)
 from test import support
-from test.support import os_helper
 from test.support import force_not_colorized
+from test.support import os_helper
+from test.support import threading_helper
 
 try:
     import _testcapi
@@ -952,7 +953,6 @@ class TestCommandLine(unittest.TestCase):
             return
         self.fail(f"unexpected output: {stderr!a}")
 
-
     def test_env_var_invalid(self):
         for nframe in INVALID_NFRAME:
             with self.subTest(nframe=nframe):
@@ -1102,6 +1102,7 @@ class TestCAPI(unittest.TestCase):
             self.untrack()
 
     @unittest.skipIf(_testcapi is None, 'need _testcapi')
+    @threading_helper.requires_working_threading()
     def test_tracemalloc_track_race(self):
         # gh-128679: Test fix for tracemalloc.stop() race condition
         _testcapi.tracemalloc_track_race()

--- a/Misc/NEWS.d/next/Library/2025-01-10-15-43-52.gh-issue-128679.KcfVVR.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-10-15-43-52.gh-issue-128679.KcfVVR.rst
@@ -1,0 +1,3 @@
+Fix :func:`tracemalloc.stop` race condition. Fix :mod:`tracemalloc` to
+support calling :func:`tracemalloc.stop` in one thread, while another thread
+is tracing memory allocations. Patch by Victor Stinner.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -52,6 +52,23 @@ get_testerror(PyObject *self) {
     return state->error;
 }
 
+
+// Sleep 'ms' microseconds.
+static void
+pysleep_ms(int ms)
+{
+    assert(ms >= 1);
+#ifdef MS_WINDOWS
+    Sleep(ms);
+#else
+    struct timeval timeout;
+    timeout.tv_sec = 0;
+    timeout.tv_usec = ms * 1000;
+    (void)select(0, (fd_set *)0, (fd_set *)0, (fd_set *)0, &timeout);
+#endif
+}
+
+
 /* Raise _testcapi.error with test_name + ": " + msg, and return NULL. */
 
 static PyObject *
@@ -3511,7 +3528,8 @@ tracemalloc_track_race(PyObject *self, PyObject *args)
         if (completed >= NTHREAD) {
             break;
         }
-        sleep(1);
+
+        pysleep_ms(10);
     }
     Py_END_ALLOW_THREADS
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3469,6 +3469,7 @@ tracemalloc_track_race(PyObject *self, PyObject *args)
     if (res == NULL) {
         goto error;
     }
+    Py_DECREF(res);
 
     stop = PyObject_GetAttrString(tracemalloc, "stop");
     Py_CLEAR(tracemalloc);
@@ -3501,6 +3502,7 @@ tracemalloc_track_race(PyObject *self, PyObject *args)
     if (res == NULL) {
         goto error;
     }
+    Py_DECREF(res);
 
     // Wait until threads complete with the GIL released
     Py_BEGIN_ALLOW_THREADS

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -18,6 +18,7 @@
 #include <float.h>                // FLT_MAX
 #include <signal.h>
 #include <stddef.h>               // offsetof()
+
 #ifdef HAVE_SYS_WAIT_H
 #  include <sys/wait.h>           // W_STOPCODE
 #endif
@@ -50,7 +51,6 @@ get_testerror(PyObject *self) {
     testcapistate_t *state = get_testcapi_state(self);
     return state->error;
 }
-
 
 /* Raise _testcapi.error with test_name + ": " + msg, and return NULL. */
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3475,10 +3475,11 @@ static PyObject *
 tracemalloc_track_race(PyObject *self, PyObject *args)
 {
 #define NTHREAD 50
+    PyObject *tracemalloc = NULL;
     PyObject *stop = NULL;
     tracemalloc_track_race_data data = {0};
 
-    PyObject *tracemalloc = PyImport_ImportModule("tracemalloc");
+    tracemalloc = PyImport_ImportModule("tracemalloc");
     if (tracemalloc == NULL) {
         goto error;
     }
@@ -3494,7 +3495,7 @@ tracemalloc_track_race(PyObject *self, PyObject *args)
     }
 
     stop = PyObject_GetAttrString(tracemalloc, "stop");
-    Py_DECREF(tracemalloc);
+    Py_CLEAR(tracemalloc);
     if (stop == NULL) {
         goto error;
     }
@@ -3536,6 +3537,7 @@ tracemalloc_track_race(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 
 error:
+    Py_CLEAR(tracemalloc);
     Py_CLEAR(stop);
     if (data.lock) {
         PyThread_free_lock(data.lock);

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -18,9 +18,12 @@
 #include <float.h>                // FLT_MAX
 #include <signal.h>
 #include <stddef.h>               // offsetof()
-
 #ifdef HAVE_SYS_WAIT_H
 #  include <sys/wait.h>           // W_STOPCODE
+#endif
+#ifdef MS_WINDOWS
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>            // Sleep()
 #endif
 
 #ifdef bool

--- a/Python/tracemalloc.c
+++ b/Python/tracemalloc.c
@@ -1336,6 +1336,7 @@ PyTraceMalloc_Track(unsigned int domain, uintptr_t ptr,
     else {
         // gh-128679: tracemalloc.stop() was called by another thread during
         // PyGILState_Ensure() call.
+        res = 0;
     }
 
     PyGILState_Release(gil_state);


### PR DESCRIPTION
Check again 'tracemalloc_config.tracing' once the GIL is held in tracemalloc_raw_alloc() and PyTraceMalloc_Track(), since another thread can call tracemalloc.stop() during PyGILState_Ensure() call.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128679 -->
* Issue: gh-128679
<!-- /gh-issue-number -->
