### PR TITLE
[3.12] gh-127599: Fix _Py_RefcntAdd missing calls to _Py_INCREF_STAT_INC/_Py_INCREF_IMMORTAL_STAT_INC (GH-127717)

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -65,6 +65,11 @@ static inline void _Py_RefcntAdd(PyObject* op, Py_ssize_t n)
     _Py_AddRefTotal(_PyInterpreterState_GET(), n);
 #endif
     op->ob_refcnt += n;
+
+    // Although the ref count was increased by `n` (which may be greater than 1)
+    // it is only a single increment (i.e. addition) operation, so only 1 refcnt
+    // increment operation is counted.
+    _Py_INCREF_STAT_INC();
 }
 #define _Py_RefcntAdd(op, n) _Py_RefcntAdd(_PyObject_CAST(op), n)
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-07-13-06-09.gh-issue-127599.tXCZb_.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-07-13-06-09.gh-issue-127599.tXCZb_.rst
@@ -1,0 +1,2 @@
+Fix statistics for increments of object reference counts (in particular, when
+a reference count was increased by more than 1 in a single operation).


### PR DESCRIPTION
Previously, `_Py_RefcntAdd` hasn't called `_Py_INCREF_STAT_INC/_Py_INCREF_IMMORTAL_STAT_INC` which is incorrect. Now it has been fixed.

(cherry picked from commit ab05beb8cea62636bd86f6f7cf1a82d7efca7162)

<!-- gh-issue-number: gh-127599 -->
* Issue: gh-127599
<!-- /gh-issue-number -->
