### PR TITLE
[3.13] gh-127599: Fix _Py_RefcntAdd missing calls to _Py_INCREF_STAT_INC/_Py_INCREF_IMMORTAL_STAT_INC (GH-127717)

### DIFF
--- a/Include/cpython/pystats.h
+++ b/Include/cpython/pystats.h
@@ -18,6 +18,12 @@
 //
 // Define _PY_INTERPRETER macro to increment interpreter_increfs and
 // interpreter_decrefs. Otherwise, increment increfs and decrefs.
+//
+// The number of incref operations counted by `incref` and
+// `interpreter_incref` is the number of increment operations, which is
+// not equal to the total of all reference counts. A single increment
+// operation may increase the reference count of an object by more than
+// one. For example, see `_Py_RefcntAdd`.
 
 #ifndef Py_CPYTHON_PYSTATS_H
 #  error "this header file must not be included directly"

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -155,6 +155,10 @@ static inline void _Py_RefcntAdd(PyObject* op, Py_ssize_t n)
         _Py_atomic_add_ssize(&op->ob_ref_shared, (n << _Py_REF_SHARED_SHIFT));
     }
 #endif
+    // Although the ref count was increased by `n` (which may be greater than 1)
+    // it is only a single increment (i.e. addition) operation, so only 1 refcnt
+    // increment operation is counted.
+    _Py_INCREF_STAT_INC();
 }
 #define _Py_RefcntAdd(op, n) _Py_RefcntAdd(_PyObject_CAST(op), n)
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2024-12-07-13-06-09.gh-issue-127599.tXCZb_.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2024-12-07-13-06-09.gh-issue-127599.tXCZb_.rst
@@ -1,0 +1,2 @@
+Fix statistics for increments of object reference counts (in particular, when
+a reference count was increased by more than 1 in a single operation).


### PR DESCRIPTION
Previously, `_Py_RefcntAdd` hasn't called `_Py_INCREF_STAT_INC/_Py_INCREF_IMMORTAL_STAT_INC` which is incorrect. Now it has been fixed.

(cherry picked from commit ab05beb8cea62636bd86f6f7cf1a82d7efca7162)


<!-- gh-issue-number: gh-127599 -->
* Issue: gh-127599
<!-- /gh-issue-number -->
