### PR TITLE
GH-128690: skip test_init_pyvenv_cfg on shared builds

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -44,6 +44,7 @@ __all__ = [
     # sys
     "MS_WINDOWS", "is_jython", "is_android", "is_emscripten", "is_wasi",
     "is_apple_mobile", "check_impl_detail", "unix_shell", "setswitchinterval",
+    "has_runtime_library",
     # os
     "get_pagesize",
     # network
@@ -535,6 +536,8 @@ else:
 # have subprocess or fork support.
 is_emscripten = sys.platform == "emscripten"
 is_wasi = sys.platform == "wasi"
+
+has_runtime_library = bool(hasattr(sys, 'dllhandle') or sysconfig.get_config_var('LD_LIBRARY'))
 
 def skip_emscripten_stack_overflow():
     return unittest.skipIf(is_emscripten, "Exhausts limited stack on Emscripten")

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1608,6 +1608,10 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                                    api=API_COMPAT, env=env,
                                    ignore_stderr=False, cwd=tmpdir)
 
+    @unittest.skipIf(
+        sysconfig.get_config_var('LDLIBRARY') != sysconfig.get_config_var('LIBRARY'),
+        "Test only available when static linking libpython",
+    )
     def test_init_pyvenv_cfg(self):
         # Test path configuration with pyvenv.cfg configuration file
 

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1,7 +1,9 @@
 # Run the tests in Programs/_testembed.c (tests for the CPython embedding APIs)
 from test import support
 from test.libregrtest.utils import get_build_info
-from test.support import import_helper, os_helper, threading_helper, MS_WINDOWS
+from test.support import (
+    import_helper, os_helper, threading_helper, MS_WINDOWS, has_runtime_library
+)
 import unittest
 
 from collections import namedtuple
@@ -1608,10 +1610,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                                    api=API_COMPAT, env=env,
                                    ignore_stderr=False, cwd=tmpdir)
 
-    @unittest.skipIf(
-        sysconfig.get_config_var('LDLIBRARY') != sysconfig.get_config_var('LIBRARY'),
-        "Test only available when static linking libpython",
-    )
+    @unittest.skipIf(has_runtime_library, "Test only available when static linking libpython")
     def test_init_pyvenv_cfg(self):
         # Test path configuration with pyvenv.cfg configuration file
 


### PR DESCRIPTION
@WolframAlph can you make sure this resolves your issue?

<!-- gh-issue-number: gh-128690 -->
* Issue: gh-128690
<!-- /gh-issue-number -->
