### PR TITLE
gh-118761: improve import time for ``pickle``

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -189,6 +189,7 @@ READONLY_BUFFER  = b'\x98'  # make top of stack readonly
 
 __all__.extend(x for x in dir() if x.isupper() and not x.startswith('_'))
 
+
 class _Framer:
 
     _FRAME_SIZE_MIN = 4

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -31,7 +31,6 @@ from functools import partial
 import sys
 from sys import maxsize
 from struct import pack, unpack
-import re
 import io
 import codecs
 import _compat_pickle
@@ -188,8 +187,10 @@ BYTEARRAY8       = b'\x96'  # push bytearray
 NEXT_BUFFER      = b'\x97'  # push next out-of-band buffer
 READONLY_BUFFER  = b'\x98'  # make top of stack readonly
 
-__all__.extend([x for x in dir() if re.match("[A-Z][A-Z0-9_]+$", x)])
-
+__all__.extend([
+    x for x in dir()
+    if x.isupper() and x.isidentifier() and not x.startswith('_')
+])
 
 class _Framer:
 

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -187,10 +187,7 @@ BYTEARRAY8       = b'\x96'  # push bytearray
 NEXT_BUFFER      = b'\x97'  # push next out-of-band buffer
 READONLY_BUFFER  = b'\x98'  # make top of stack readonly
 
-__all__.extend([
-    x for x in dir()
-    if x.isupper() and x.isidentifier() and not x.startswith('_')
-])
+__all__.extend(x for x in dir() if x.isupper() and not x.startswith('_'))
 
 class _Framer:
 

--- a/Misc/NEWS.d/next/Library/2025-01-10-13-34-33.gh-issue-118761.qRB8nS.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-10-13-34-33.gh-issue-118761.qRB8nS.rst
@@ -1,0 +1,2 @@
+Improve import time of :mod:`pickle` by 25% by removing an un-necessary
+import to :mod:`re`. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-01-10-13-34-33.gh-issue-118761.qRB8nS.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-10-13-34-33.gh-issue-118761.qRB8nS.rst
@@ -1,2 +1,3 @@
-Improve import time of :mod:`pickle` by 25% by removing an un-necessary
-import to :mod:`re`. Patch by Bénédikt Tran.
+Improve import time of :mod:`pickle` by 25% by removing an unnecessary
+regular expression. As such, :mod:`re` is no more implicitly available
+as ``pickle.re``. Patch by Bénédikt Tran.


### PR DESCRIPTION
We can remove the ``re`` import which takes quite a long time. Benchmarks were performed on a RELEASE build (no PGO, no LTO). It's a bit hard to have stable numbers with `-X importtime`, so I'm only using the `hyperfine` benchmarks.

### PR

```sh
$ hyperfine --warmup 8 "./python -c 'import pickle'"
Benchmark 1: ./python -c 'import pickle'
  Time (mean ± σ):       7.8 ms ±   0.3 ms    [User: 6.6 ms, System: 1.3 ms]
  Range (min … max):     7.4 ms …   9.8 ms    337 runs
```

### Main

```sh
$ hyperfine --warmup 8 "./python -c 'import pickle'"
Benchmark 1: ./python -c 'import pickle'
  Time (mean ± σ):       9.7 ms ±   0.3 ms    [User: 8.3 ms, System: 1.4 ms]
  Range (min … max):     9.3 ms …  12.6 ms    282 runs
```

Since something that is no more present in the global namespace is removed, I've added a NEWS entry and a detailed changelog.

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
