### PR TITLE
gh-118761: substitute `re` import in `base64.b16decode` for a more efficient alternative

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -708,6 +708,17 @@ asyncio
   reduces memory usage.
   (Contributed by Kumar Aditya in :gh:`107803`.)
 
+
+base64
+------
+
+* Improve performance of :func:`base64.b16decode` by a factor ten by
+  removing an unnecessary regular expression. Consequently, :mod:`re`
+  is no more implicitly available as ``base64.re`` and import time of
+  :mod:`base64` is improved by a factor six.
+  (Contributed by Bénédikt Tran in :gh:`118761`.)
+
+
 io
 ---
 * :mod:`io` which provides the built-in :func:`open` makes less system calls

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -712,11 +712,9 @@ asyncio
 base64
 ------
 
-* Improve performance of :func:`base64.b16decode` by a factor ten by
-  removing an unnecessary regular expression. Consequently, :mod:`re`
-  is no more implicitly available as ``base64.re`` and import time of
-  :mod:`base64` is improved by a factor six.
-  (Contributed by Bénédikt Tran in :gh:`118761`.)
+* Improve the performance of :func:`base64.b16decode` by up to ten times,
+  and reduce the import time of :mod:`base64` by up to six times.
+  (Contributed by Bénédikt Tran, Chris Markiewicz, and Adam Turner in :gh:`118761`.)
 
 
 io

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -4,7 +4,6 @@
 # Modified 30-Dec-2003 by Barry Warsaw to add full RFC 3548 support
 # Modified 22-May-2007 by Guido van Rossum to use bytes everywhere
 
-import re
 import struct
 import binascii
 
@@ -281,6 +280,8 @@ def b16decode(s, casefold=False):
     s is incorrectly padded or if there are non-alphabet characters present
     in the input.
     """
+    import re
+
     s = _bytes_from_decode_data(s)
     if casefold:
         s = s.upper()

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -280,12 +280,10 @@ def b16decode(s, casefold=False):
     s is incorrectly padded or if there are non-alphabet characters present
     in the input.
     """
-    import re
-
     s = _bytes_from_decode_data(s)
     if casefold:
         s = s.upper()
-    if re.search(b'[^0-9A-F]', s):
+    if s.translate(None, delete=b'0123456789ABCDEF'):
         raise binascii.Error('Non-base16 digit found')
     return binascii.unhexlify(s)
 

--- a/Misc/NEWS.d/next/Library/2025-01-10-13-06-54.gh-issue-118761.f8oADD.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-10-13-06-54.gh-issue-118761.f8oADD.rst
@@ -1,4 +1,5 @@
-Improve performance of :func:`base64.b16decode` by a factor ten by
-removing an unnecessary regular expression. Consequently, :mod:`re`
-is no more implicitly available as ``base64.re`` and import time of
-:mod:`base64` is improved by a factor six. Patch by Bénédikt Tran.
+Improve the performance of :func:`base64.b16decode` by up to ten times
+by more efficiently checking the byte-string for hexadecimal digits.
+Reduce the import time of :mod:`base64` by up to six times,
+by no longer importing :mod:`re`.
+Patch by Bénédikt Tran, Chris Markiewicz, and Adam Turner.

--- a/Misc/NEWS.d/next/Library/2025-01-10-13-06-54.gh-issue-118761.f8oADD.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-10-13-06-54.gh-issue-118761.f8oADD.rst
@@ -1,4 +1,4 @@
 Improve performance of :func:`base64.b16decode` by a factor ten by
-removing an un-necessary regular expression. Consequently, :mod:`re`
+removing an unnecessary regular expression. Consequently, :mod:`re`
 is no more implicitly available as ``base64.re`` and import time of
 :mod:`base64` is improved by a factor six. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-01-10-13-06-54.gh-issue-118761.f8oADD.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-10-13-06-54.gh-issue-118761.f8oADD.rst
@@ -1,2 +1,4 @@
-Improve import time of :mod:`base64` by a factor six. This is achieved by
-importing :mod:`re` on demand. Patch by Bénédikt Tran.
+Improve performance of :func:`base64.b16decode` by a factor ten by
+removing an un-necessary regular expression. Consequently, :mod:`re`
+is no more implicitly available as ``base64.re`` and import time of
+:mod:`base64` is improved by a factor six. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-01-10-13-06-54.gh-issue-118761.f8oADD.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-10-13-06-54.gh-issue-118761.f8oADD.rst
@@ -1,0 +1,2 @@
+Improve import time of :mod:`base64` by a factor six. This is achieved by
+importing :mod:`re` on demand. Patch by Bénédikt Tran.


### PR DESCRIPTION
Benchmarks are on a RELEASE build (no PGO, no LTO).

See https://github.com/python/cpython/pull/128736#discussion_r1913101433 for the runtime performance improvements as well.


### PR

```sh
$ ./python -I -X importtime -c 'import base64'
import time: self [us] | cumulative | imported package
...
import time:       179 |        179 | linecache
import time:       205 |        205 |     _struct
import time:       442 |        646 |   struct
import time:       227 |        227 |   binascii
import time:       298 |       1169 | base64
```

```sh
$ hyperfine --warmup 16 "./python -c 'import base64'"
Benchmark 1: ./python -c 'import base64'
  Time (mean ± σ):       5.7 ms ±   0.5 ms    [User: 4.8 ms, System: 1.1 ms]
  Range (min … max):     5.2 ms …  11.9 ms    455 runs
```

### Main

```sh
$ ./python -I -X importtime -c 'import base64'
import time: self [us] | cumulative | imported package
...
import time:       180 |        180 | linecache
import time:       312 |        312 |       types
import time:      1609 |       1921 |     enum
import time:        87 |         87 |       _sre
import time:       250 |        250 |         re._constants
import time:       388 |        637 |       re._parser
import time:        89 |         89 |       re._casefix
import time:       339 |       1150 |     re._compiler
import time:       103 |        103 |         itertools
import time:        83 |         83 |         keyword
import time:        58 |         58 |           _operator
import time:       206 |        264 |         operator
import time:       129 |        129 |         reprlib
import time:        49 |         49 |         _collections
import time:       785 |       1411 |       collections
import time:        43 |         43 |       _functools
import time:       543 |       1997 |     functools
import time:       122 |        122 |     copyreg
import time:       826 |       6015 |   re
import time:       115 |        115 |     _struct
import time:        74 |        189 |   struct
import time:       122 |        122 |   binascii
import time:       279 |       6603 | base64
```

```sh
$ hyperfine --warmup 16 "./python -c 'import base64'"
Benchmark 1: ./python -c 'import base64'
  Time (mean ± σ):       9.5 ms ±   0.4 ms    [User: 8.2 ms, System: 1.3 ms]
  Range (min … max):     9.1 ms …  13.5 ms    295 runs
```


<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
