### PR TITLE
gh-118761: improve import time for ``secrets``

### DIFF
--- a/Lib/secrets.py
+++ b/Lib/secrets.py
@@ -12,8 +12,6 @@ __all__ = ['choice', 'randbelow', 'randbits', 'SystemRandom',
            ]
 
 
-import base64
-
 from hmac import compare_digest
 from random import SystemRandom
 
@@ -67,5 +65,7 @@ def token_urlsafe(nbytes=None):
     'Drmhze6EPcv0fN_81Bj-nA'
 
     """
+    import base64
+
     tok = token_bytes(nbytes)
     return base64.urlsafe_b64encode(tok).rstrip(b'=').decode('ascii')

--- a/Misc/NEWS.d/next/Library/2025-01-10-12-19-42.gh-issue-118761.i4yXe3.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-10-12-19-42.gh-issue-118761.i4yXe3.rst
@@ -1,0 +1,2 @@
+Improve import time of :mod:`secrets` by a factor two. This is achieved by
+importing :mod:`base64` on demand. Patch by Bénédikt Tran.


### PR DESCRIPTION
Benchmarks were performed on a RELEASE build (no PGO, no LTO).

### PR

```sh
$ ./python -X importtime -c 'import secrets'
import time: self [us] | cumulative | imported package
...
import time:       236 |        236 | linecache
import time:       415 |        415 |     warnings
import time:       698 |        698 |     _hashlib
import time:       133 |        133 |       _blake2
import time:       226 |        358 |     hashlib
import time:       498 |       1968 |   hmac
import time:       152 |        152 |     math
import time:        66 |         66 |       _operator
import time:       252 |        318 |     operator
import time:        97 |         97 |     itertools
import time:        79 |         79 |       _bisect
import time:        99 |        177 |     bisect
import time:        70 |         70 |     _random
import time:       418 |       1230 |   random
import time:       139 |       3336 | secrets
``` 

```sh
$ hyperfine --warmup 16 "./python -c 'import secrets'"
Benchmark 1: ./python -c 'import secrets'
  Time (mean ± σ):       7.0 ms ±   0.7 ms    [User: 6.0 ms, System: 1.2 ms]
  Range (min … max):     6.5 ms …  14.9 ms    372 runs
```

### Main

```sh
$ ./python -X importtime -c 'import secrets'
import time: self [us] | cumulative | imported package
...
import time:       190 |        190 | linecache
import time:       243 |        243 |         types
import time:      1168 |       1411 |       enum
import time:        58 |         58 |         _sre
import time:       187 |        187 |           re._constants
import time:       269 |        455 |         re._parser
import time:        67 |         67 |         re._casefix
import time:       240 |        819 |       re._compiler
import time:        71 |         71 |           itertools
import time:        72 |         72 |           keyword
import time:        41 |         41 |             _operator
import time:       163 |        203 |           operator
import time:       101 |        101 |           reprlib
import time:        40 |         40 |           _collections
import time:       603 |       1089 |         collections
import time:        36 |         36 |         _functools
import time:       423 |       1548 |       functools
import time:       105 |        105 |       copyreg
import time:       403 |       4285 |     re
import time:       100 |        100 |       _struct
import time:        67 |        166 |     struct
import time:       113 |        113 |     binascii
import time:       387 |       4949 |   base64
import time:       157 |        157 |     warnings
import time:       297 |        297 |     _hashlib
import time:        67 |         67 |       _blake2
import time:       113 |        179 |     hashlib
import time:       113 |        744 |   hmac
import time:        75 |         75 |     math
import time:        39 |         39 |       _bisect
import time:        51 |         90 |     bisect
import time:        37 |         37 |     _random
import time:       335 |        535 |   random
import time:       105 |       6332 | secrets
```

```sh
$ hyperfine --warmup 16 "./python -c 'import secrets'"
Benchmark 1: ./python -c 'import secrets'
  Time (mean ± σ):      10.9 ms ±   0.6 ms    [User: 9.3 ms, System: 1.5 ms]
  Range (min … max):    10.2 ms …  14.7 ms    262 runs
```


<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
