### PR TITLE
gh-125997: suggest efficient alternatives for `time.sleep(0)`

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -5411,6 +5411,8 @@ information, consult your Unix manpages.
 The following scheduling policies are exposed if they are supported by the
 operating system.
 
+.. _os-scheduling-policy:
+
 .. data:: SCHED_OTHER
 
    The default scheduling policy.
@@ -5514,7 +5516,7 @@ operating system.
 
 .. function:: sched_yield()
 
-   Voluntarily relinquish the CPU.
+   Voluntarily relinquish the CPU. See :manpage:`sched_yield(2)` for details.
 
 
 .. function:: sched_setaffinity(pid, mask, /)

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -385,6 +385,8 @@ Functions
    The suspension time may be longer than requested by an arbitrary amount,
    because of the scheduling of other activity in the system.
 
+   .. rubric:: Windows implementation
+
    On Windows, if *secs* is zero, the thread relinquishes the remainder of its
    time slice to any other thread that is ready to run. If there are no other
    threads ready to run, the function returns immediately, and the thread
@@ -393,11 +395,20 @@ Functions
    <https://learn.microsoft.com/windows-hardware/drivers/kernel/high-resolution-timers>`_
    which provides resolution of 100 nanoseconds. If *secs* is zero, ``Sleep(0)`` is used.
 
-   Unix implementation:
+   .. rubric:: Unix implementation
 
    * Use ``clock_nanosleep()`` if available (resolution: 1 nanosecond);
    * Or use ``nanosleep()`` if available (resolution: 1 nanosecond);
    * Or use ``select()`` (resolution: 1 microsecond).
+
+   .. note::
+
+      For polling, consider using :meth:`select.poll.poll(0) <select.poll.poll>`
+      instead of ``time.sleep(0)``. To emulate a "no-op", use :keyword:`pass`.
+
+      To voluntarily relinquish the CPU, specify a read-time :ref:`scheduling
+      policy <os-scheduling-policy>` (see :manpage:`sched_yield(2)`) and use
+      :func:`os.sched_yield` instead.
 
    .. audit-event:: time.sleep secs
 

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -403,12 +403,10 @@ Functions
 
    .. note::
 
-      For polling, consider using :meth:`select.poll.poll(0) <select.poll.poll>`
-      instead of ``time.sleep(0)``. To emulate a "no-op", use :keyword:`pass`.
+      To emulate a "no-op", use :keyword:`pass` instead of ``time.sleep(0)``.
 
-      To voluntarily relinquish the CPU, specify a read-time :ref:`scheduling
-      policy <os-scheduling-policy>` (see :manpage:`sched_yield(2)`) and use
-      :func:`os.sched_yield` instead.
+      To voluntarily relinquish the CPU, specify a real-time :ref:`scheduling
+      policy <os-scheduling-policy>` and use :func:`os.sched_yield` instead.
 
    .. audit-event:: time.sleep secs
 


### PR DESCRIPTION
After a discussion with Victor and because #128274 is not convincing enough, we decide to:

- keep the current behaviour of `time.sleep()`, and
- document efficient (and probably *semantically* more correct) alternatives for `time.sleep(0)`.

See https://github.com/python/cpython/issues/125997#issuecomment-2585707064 for more details.


<!-- gh-issue-number: gh-125997 -->
* Issue: gh-125997
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128752.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->