### PR TITLE
Revert "gh-128691: Use deferred reference counting on `_thread._local` (#128693)"

### DIFF
--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1414,10 +1414,6 @@ local_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         return NULL;
     }
 
-    // gh-128691: Use deferred reference counting for thread-locals to avoid
-    // contention on the shared object.
-    _PyObject_SetDeferredRefcount((PyObject *)self);
-
     self->args = Py_XNewRef(args);
     self->kw = Py_XNewRef(kw);
 


### PR DESCRIPTION
This reverts commit c1417487e98e270d614965ed78ff9439044b65a6.

Just as a test to check the buildbots: https://buildbot.python.org/#/builders/345/builds/9906

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128691 -->
* Issue: gh-128691
<!-- /gh-issue-number -->
