### PR TITLE
gh-128400: Only show the current thread in `Py_FatalError` on the free-threaded build

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -75,6 +75,8 @@ class InstanceMethod:
     id = _testcapi.instancemethod(id)
     testfunction = _testcapi.instancemethod(testfunction)
 
+CURRENT_THREAD_REGEX = r'Current thread.*:\n' if not support.Py_GIL_DISABLED else r'Stack .*:\n'
+
 class CAPITest(unittest.TestCase):
 
     def test_instancemethod(self):
@@ -234,8 +236,8 @@ class CAPITest(unittest.TestCase):
                 r'Python runtime state: initialized\n'
                 r'SystemError: <built-in function return_null_without_error> '
                     r'returned NULL without setting an exception\n'
-                r'\n'
-                r'Current thread.*:\n'
+                r'\n' +
+                CURRENT_THREAD_REGEX +
                 r'  File .*", line 6 in <module>\n')
         else:
             with self.assertRaises(SystemError) as cm:
@@ -268,8 +270,8 @@ class CAPITest(unittest.TestCase):
                     r'SystemError: <built-in '
                         r'function return_result_with_error> '
                         r'returned a result with an exception set\n'
-                    r'\n'
-                    r'Current thread.*:\n'
+                    r'\n' +
+                    CURRENT_THREAD_REGEX +
                     r'  File .*, line 6 in <module>\n')
         else:
             with self.assertRaises(SystemError) as cm:
@@ -298,8 +300,8 @@ class CAPITest(unittest.TestCase):
                         r'with an exception set\n'
                     r'Python runtime state: initialized\n'
                     r'ValueError: bug\n'
-                    r'\n'
-                    r'Current thread .* \(most recent call first\):\n'
+                    r'\n' +
+                    CURRENT_THREAD_REGEX +
                     r'  File .*, line 6 in <module>\n'
                     r'\n'
                     r'Extension modules: _testcapi \(total: 1\)\n')

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -118,7 +118,7 @@ class FaultHandlerTests(unittest.TestCase):
         if all_threads_disabled and not py_fatal_error:
             regex.append("<Cannot show all threads while the GIL is disabled>")
         regex.append(fr'{header} \(most recent call first\):')
-        if py_fatal_error and not know_current_thread:
+        if support.Py_GIL_DISABLED and py_fatal_error and not know_current_thread:
             regex.append("  <tstate is freed>")
         else:
             if garbage_collecting and not all_threads_disabled:

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -101,8 +101,7 @@ class FaultHandlerTests(unittest.TestCase):
         Raise an error if the output doesn't match the expected format.
         """
         all_threads_disabled = (
-            (not py_fatal_error)
-            and all_threads
+            all_threads
             and (not sys._is_gil_enabled())
         )
         if all_threads and not all_threads_disabled:
@@ -116,12 +115,15 @@ class FaultHandlerTests(unittest.TestCase):
         if py_fatal_error:
             regex.append("Python runtime state: initialized")
         regex.append('')
-        if all_threads_disabled:
+        if all_threads_disabled and not py_fatal_error:
             regex.append("<Cannot show all threads while the GIL is disabled>")
         regex.append(fr'{header} \(most recent call first\):')
-        if garbage_collecting and not all_threads_disabled:
-            regex.append('  Garbage-collecting')
-        regex.append(fr'  File "<string>", line {lineno} in {function}')
+        if py_fatal_error and not know_current_thread:
+            regex.append("  <tstate is freed>")
+        else:
+            if garbage_collecting and not all_threads_disabled:
+                regex.append('  Garbage-collecting')
+            regex.append(fr'  File "<string>", line {lineno} in {function}')
         regex = '\n'.join(regex)
 
         if other_regex:

--- a/Misc/NEWS.d/next/C_API/2025-01-12-12-19-51.gh-issue-128400.OwoIDw.rst
+++ b/Misc/NEWS.d/next/C_API/2025-01-12-12-19-51.gh-issue-128400.OwoIDw.rst
@@ -1,0 +1,2 @@
+:c:func:`Py_FatalError` no longer shows all threads on the :term:`free
+threaded <free threading>` build to prevent crashes.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3026,13 +3026,6 @@ _Py_FatalError_DumpTracebacks(int fd, PyInterpreterState *interp,
 #ifndef Py_GIL_DISABLED
     _Py_DumpTracebackThreads(fd, interp, tstate);
 #else
-    if (tstate == NULL)
-    {
-        /* _Py_DumpTraceback() prints out a message when tstate is null,
-         * whereas _Py_DumpTracebackThreads() does not. Early-return for
-         * consistency. */
-        return;
-    }
     _Py_DumpTraceback(fd, tstate);
 #endif
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3023,7 +3023,18 @@ _Py_FatalError_DumpTracebacks(int fd, PyInterpreterState *interp,
     PUTS(fd, "\n");
 
     /* display the current Python stack */
+#ifndef Py_GIL_DISABLED
     _Py_DumpTracebackThreads(fd, interp, tstate);
+#else
+    if (tstate == NULL)
+    {
+        /* _Py_DumpTraceback() prints out a message when tstate is null,
+         * whereas _Py_DumpTracebackThreads() does not. Early-return for
+         * consistency. */
+        return;
+    }
+    _Py_DumpTraceback(fd, tstate);
+#endif
 }
 
 /* Print the current exception (if an exception is set) with its traceback,


### PR DESCRIPTION
This is a follow-up to https://github.com/python/cpython/pull/128425#issuecomment-2568392799.

<!-- gh-issue-number: gh-128400 -->
* Issue: gh-128400
<!-- /gh-issue-number -->
