### PR TITLE
gh-128690: temporarily do not use test_embed in PGO profile builds

### DIFF
--- a/Lib/test/libregrtest/pgo.py
+++ b/Lib/test/libregrtest/pgo.py
@@ -19,7 +19,6 @@ PGO_TESTS = [
     'test_datetime',
     'test_decimal',
     'test_difflib',
-    'test_embed',
     'test_float',
     'test_fstring',
     'test_functools',

--- a/Misc/NEWS.d/next/Tests/2025-01-13-01-29-08.gh-issue-128690.cPFVDb.rst
+++ b/Misc/NEWS.d/next/Tests/2025-01-13-01-29-08.gh-issue-128690.cPFVDb.rst
@@ -1,0 +1,2 @@
+Temporarily do not use test_embed in PGO profile builds until the problem
+with test_init_pyvenv_cfg failing in some configurations is resolved.


### PR DESCRIPTION
As documented in #128690, under certain configurations test case `test_init_pyvenv_cfg` of `test_embed` fails apparently since 34e840f9ddd9c04991cf004e2594c6a1e0e278d3. This behavior was not seen in 3.14.0a3, the most recent alpha before this change. Unfortunately, `test_embed` is included in the subset of tests used for PGO profile builds when Python is built with `--enable-optimizations`. If any of the tests included in the PGO profile build fails, including `test_embed`, the whole Python build fails. Besides the originally reported case, I have now seen this failure in two other macOS build configurations, both rather complex; one is for the build of the python.org installer package. (At the moment, I haven't had time to produce a manageable reproducible test case.) It *could* be that this is just an existing test case issue that was brought to the fore by the above change. Since the failure involves sys._base_executable, it's possible that the behavior documented in #128670 might be the root cause.

If necessary for 3.14.0a4, I could apply this PR manually to avoid using `test_embed` in the profile builds. But I would prefer to either have the test failure resolved prior to a4 or merge this PR to temporarily avoid using `test_embed`.  Marking as `release-blocker` for release manager decision.

cc: @hugovk @FFY00 

<!-- gh-issue-number: gh-128690 -->
* Issue: gh-128690
<!-- /gh-issue-number -->
