### PR TITLE
gh-128078: Clear exception in `anext` before calling `_PyGen_SetStopIterationValue`

### DIFF
--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -1152,6 +1152,24 @@ class AsyncGenAsyncioTest(unittest.TestCase):
 
         self.loop.run_until_complete(run())
 
+    def test_async_gen_asyncio_anext_tuple_no_exceptions(self):
+        # StopAsyncIteration exceptions should be cleared.
+        # See: https://github.com/python/cpython/issues/128078.
+
+        async def foo():
+            if False:
+                yield (1, 2)
+
+        async def run():
+            it = foo().__aiter__()
+            with self.assertRaises(StopAsyncIteration):
+                await it.__anext__()
+            a, b = await anext(it, ('a', 'b'))
+            self.assertEqual(a, 'a')
+            self.assertEqual(b, 'b')
+
+        self.loop.run_until_complete(run())
+
     def test_async_gen_asyncio_anext_stopiteration(self):
         async def foo():
             try:

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -1164,9 +1164,8 @@ class AsyncGenAsyncioTest(unittest.TestCase):
             it = foo().__aiter__()
             with self.assertRaises(StopAsyncIteration):
                 await it.__anext__()
-            a, b = await anext(it, ('a', 'b'))
-            self.assertEqual(a, 'a')
-            self.assertEqual(b, 'b')
+            res = await anext(it, ('a', 'b'))
+            self.assertEqual(res, ('a', 'b'))
 
         self.loop.run_until_complete(run())
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-01-13-12-48-30.gh-issue-128078.qOsl9B.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-01-13-12-48-30.gh-issue-128078.qOsl9B.rst
@@ -1,0 +1,2 @@
+Fix a :exc:`SystemError` when using :func:`anext` with a default tuple
+value. Patch by Bénédikt Tran.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -633,6 +633,7 @@ gen_iternext(PyObject *self)
 int
 _PyGen_SetStopIterationValue(PyObject *value)
 {
+    assert(!PyErr_Occurred());
     PyObject *e;
 
     if (value == NULL ||

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -384,6 +384,7 @@ anextawaitable_iternext(anextawaitableobject *obj)
         return result;
     }
     if (PyErr_ExceptionMatches(PyExc_StopAsyncIteration)) {
+        PyErr_Clear();
         _PyGen_SetStopIterationValue(obj->default_value);
     }
     return NULL;
@@ -407,6 +408,7 @@ anextawaitable_proxy(anextawaitableobject *obj, char *meth, PyObject *arg) {
          * exception we replace it with a `StopIteration(default)`, as if
          * it was the return value of `__anext__()` coroutine.
          */
+        PyErr_Clear();
         _PyGen_SetStopIterationValue(obj->default_value);
     }
     return NULL;


### PR DESCRIPTION
See https://github.com/python/cpython/issues/128078#issuecomment-2585252352.

@kumaraditya303: There are a couple of other calls to `_PyGen_SetStopIterationValue()` but I'm not well-versed enough in asyncio to know whether I should clear them or not. The regression test now passes but please confirm whether some other `PyErr_Clear()` should happen or not.

In `async_gen_unwrap_value`:

```c
    if (_PyAsyncGenWrappedValue_CheckExact(result)) {
        /* async yield */
        _PyGen_SetStopIterationValue(((_PyAsyncGenWrappedValue*)result)->agw_val);
        Py_DECREF(result);
        gen->ag_running_async = 0;
        return NULL;
    }
```

In `gen_iternext`:

``` c
    if (gen_send_ex2(gen, NULL, &result, 0, 0) == PYGEN_RETURN) {
        if (result != Py_None) {
            _PyGen_SetStopIterationValue(result);
        }
        Py_CLEAR(result);
    }
```

In this case, I think we should satisfy `assert(!PyErr_Occurred())` since it's `PYGEN_RETURN`, right? Same question for `gen_send_ex` and `FutureIter_iternext()`.



<!-- gh-issue-number: gh-128078 -->
* Issue: gh-128078
<!-- /gh-issue-number -->
