### PR TITLE
gh-128627: Emscripten: Fix address calculation for wasm-gc trampoline

### DIFF
--- a/Python/emscripten_trampoline.c
+++ b/Python/emscripten_trampoline.c
@@ -26,11 +26,9 @@ EM_JS(CountArgsFunc, _PyEM_GetCountArgsPtr, (), {
 // Binary module for the checks. It has to be done in web assembly because
 // clang/llvm have no support yet for the reference types yet. In fact, the wasm
 // binary toolkit doesn't yet support the ref.test instruction either. To
-// convert the following module to the binary, my approach is to find and
-// replace "ref.test $type" -> "drop i32.const n" on the source text. This
-// results in the bytes "0x1a, 0x41, n" where we need the bytes "0xfb, 0x14, n"
-// so doing a find and replace on the output from "0x1a, 0x41" -> "0xfb, 0x14"
-// gets us the output we need.
+// convert the following textual wasm to a binary, you can build wabt from this
+// branch: https://github.com/WebAssembly/wabt/pull/2529 and then use that
+// wat2wasm binary.
 //
 // (module
 //     (type $type0 (func (param) (result i32)))

--- a/Python/emscripten_trampoline.c
+++ b/Python/emscripten_trampoline.c
@@ -154,15 +154,15 @@ addOnPreRun(() => {
     let ptr = 0;
     try {
         const mod = new WebAssembly.Module(code);
-        const inst = new WebAssembly.Instance(mod, {e: {t: wasmTable}});
+        const inst = new WebAssembly.Instance(mod, { e: { t: wasmTable } });
         ptr = addFunction(inst.exports.f);
-    } catch(e) {
+    } catch (e) {
         // If something goes wrong, we'll null out _PyEM_CountFuncParams and fall
         // back to the JS trampoline.
     }
     Module._PyEM_CountArgsPtr = ptr;
-    const offset = HEAP32[__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET/4];
-    HEAP32[__PyRuntime/4 + offset] = ptr;
+    const offset = HEAP32[__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET / 4];
+    HEAP32[(__PyRuntime + offset) / 4] = ptr;
 });
 );
 

--- a/configure
+++ b/configure
@@ -9627,7 +9627,7 @@ fi
 
         as_fn_append LINKFORSHARED " -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"
     as_fn_append LINKFORSHARED " -sEXPORTED_RUNTIME_METHODS=FS,callMain,ENV"
-    as_fn_append LINKFORSHARED " -sEXPORTED_FUNCTIONS=_main,_Py_Version"
+    as_fn_append LINKFORSHARED " -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET"
     as_fn_append LINKFORSHARED " -sSTACK_SIZE=5MB"
 
     if test "x$enable_wasm_dynamic_linking" = xyes

--- a/configure.ac
+++ b/configure.ac
@@ -2369,7 +2369,7 @@ AS_CASE([$ac_sys_system],
     dnl Include file system support
     AS_VAR_APPEND([LINKFORSHARED], [" -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"])
     AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_RUNTIME_METHODS=FS,callMain,ENV"])
-    AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_FUNCTIONS=_main,_Py_Version"])
+    AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET"])
     AS_VAR_APPEND([LINKFORSHARED], [" -sSTACK_SIZE=5MB"])
 
     AS_VAR_IF([enable_wasm_dynamic_linking], [yes], [


### PR DESCRIPTION
We need to divide the entire memory address by 4, not just the base address. I also did a little code formatting while I'm at it.

<!-- gh-issue-number: gh-128627 -->
* Issue: gh-128627
<!-- /gh-issue-number -->
