### PR TITLE
gh-127787: Move _PyUnicodeError_GetParams() to the internal C API

### DIFF
--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -94,12 +94,6 @@ PyAPI_FUNC(void) _PyErr_ChainExceptions1(PyObject *);
 
 /* In exceptions.c */
 
-PyAPI_FUNC(int) _PyUnicodeError_GetParams(
-    PyObject *self,
-    PyObject **obj, Py_ssize_t *objlen,
-    Py_ssize_t *start, Py_ssize_t *end,
-    int as_bytes);
-
 PyAPI_FUNC(PyObject*) PyUnstable_Exc_PrepReraiseStar(
      PyObject *orig,
      PyObject *excs);

--- a/Include/internal/pycore_pyerrors.h
+++ b/Include/internal/pycore_pyerrors.h
@@ -190,6 +190,15 @@ Py_DEPRECATED(3.12) extern void _PyErr_ChainExceptions(PyObject *, PyObject *, P
 PyAPI_DATA(PyTypeObject) _PyExc_IncompleteInputError;
 #define PyExc_IncompleteInputError ((PyObject *)(&_PyExc_IncompleteInputError))
 
+extern int _PyUnicodeError_GetParams(
+    PyObject *self,
+    PyObject **obj,
+    Py_ssize_t *objlen,
+    Py_ssize_t *start,
+    Py_ssize_t *end,
+    int as_bytes);
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127787 -->
* Issue: gh-127787
<!-- /gh-issue-number -->
