### PR TITLE
gh-128810: Added .shorthand property to IPv4Network and IPv6Network in the ipaddress module

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1548,6 +1548,30 @@ class IPv4Network(_BaseV4, _BaseNetwork):
             self.hosts = lambda: [IPv4Address(addr)]
 
     @property
+    def shorthand(self):
+        """
+        Returns the shorthand representation of the IPv4 network.
+
+        This method abbreviates the IPv4 network by removing trailing
+        zero octets from the network address.
+
+        Returns:
+            str: The shorthand IPv4 network in the format 'X.X/X'.
+
+        Example:
+            >>> network = IPv4Network('192.168.0.0/24')
+            >>> network.shorthand
+            '192.168/24'
+        """
+        # Split the network address into octets
+        octets = str(self.network_address).split('.')
+        # Remove trailing zero octets
+        while octets and octets[-1] == '0':
+            octets.pop()
+        # Rejoin the remaining octets and append the prefix length
+        return '.'.join(octets) + f"/{self.prefixlen}"
+
+    @property
     @functools.lru_cache()
     def is_global(self):
         """Test if this address is allocated for public networks.
@@ -2340,6 +2364,24 @@ class IPv6Network(_BaseV6, _BaseNetwork):
         broadcast = int(self.broadcast_address)
         for x in range(network + 1, broadcast + 1):
             yield self._address_class(x)
+
+    @property
+    def shorthand(self):
+        """
+        Returns the shorthand representation of the IPv6 network.
+
+        This method compresses the IPv6 address to its shortest form
+        and appends the prefix length.
+
+        Returns:
+            str: The shorthand IPv6 network in the format 'X::/Y'.
+
+        Example:
+            >>> network = IPv6Network('2001:db8:0:0:0:0:0:0/32')
+            >>> network.shorthand
+            '2001:db8::/32'
+        """
+        return f"{self.network_address.compressed}/{self.prefixlen}"
 
     @property
     def is_site_local(self):

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -709,6 +709,12 @@ class NetworkTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
             ipaddress.IPv6Network('::1/128').subnet_of(
                 ipaddress.IPv4Network('10.0.0.0/30'))
 
+    def test_shorthand_ipv4(self):
+        self.assertEqual(ipaddress.IPv4Network("1.2.0.0/16").shorthand, "1.2/16")
+        self.assertEqual(ipaddress.IPv4Network("10.0.0.0/8").shorthand, "10/8")
+        self.assertEqual(ipaddress.IPv4Network("192.168.0.0/24").shorthand, "192.168/24")
+        self.assertEqual(ipaddress.IPv4Network("0.0.0.0/0").shorthand, "/0")
+
 
 class NetmaskTestMixin_v6(CommonTestMixin_v6):
     """Input validation on interfaces and networks is very similar"""
@@ -864,6 +870,13 @@ class NetworkTestCase_v6(BaseTestCase, NetmaskTestMixin_v6):
         self.assertTrue(
             self.factory('2000:aaa::/48').supernet_of(
                 self.factory('2000:aaa::/56')))
+
+    def test_shorthand_ipv6(self):
+        self.assertEqual(ipaddress.IPv6Network("2001:db8:0:0:0:0:0:0/32").shorthand, "2001:db8::/32")
+        self.assertEqual(ipaddress.IPv6Network("::/0").shorthand, "::/0")
+        self.assertEqual(ipaddress.IPv6Network("0:0:0:0:0:0:0:0/0").shorthand, "::/0")
+        self.assertEqual(ipaddress.IPv6Network("2001:db8:0:0:0:0:0:1/128").shorthand, "2001:db8::1/128")
+        self.assertEqual(ipaddress.IPv6Network("::1/128").shorthand, "::1/128")
 
 
 class FactoryFunctionErrors(BaseTestCase):

--- a/Misc/NEWS.d/next/Library/2025-01-14-05-46-29.gh-issue-128810.cj6Vhq.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-14-05-46-29.gh-issue-128810.cj6Vhq.rst
@@ -1,0 +1,1 @@
+Added a .shorthand function to IPv4Network and IPv6Network's in the ipaddress module to be able to display a prefix such as 1.2.0.0/16 as it's shorthand version (often used by network operators) as 1.2/16.


### PR DESCRIPTION
Pretty straightforward. Addresses gh-128810. Added a .shorthand property to all ip_networks for ease-of-use, since this is how they are commonly written by network operators. This way for a prefix 1.2.0.0/16 the shorthand of 1.2/16 can easily be accessed.

https://github.com/python/cpython/issues/128810