### PR TITLE
gh-67206: document that `string.printable` is not printable in the POSIX sense

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -68,7 +68,7 @@ The constants defined in this module are:
 
    .. note::
 
-      By design, :meth:`string.printable.isprintable() <str.printable>`
+      By design, :meth:`string.printable.isprintable() <str.isprintable>`
       returns :const:`False`. In particular, ``string.printable`` is
       neither POSIX printable (see :manpage:`LC_CTYPE <locale(2)>`)
       nor printable in the sense of :rfc:`5822`.

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -69,9 +69,8 @@ The constants defined in this module are:
    .. note::
 
       By design, :meth:`string.printable.isprintable() <str.isprintable>`
-      returns :const:`False`. In particular, ``string.printable`` is
-      neither POSIX printable (see :manpage:`LC_CTYPE <locale(5)>`)
-      nor printable in the sense of :rfc:`5822`.
+      returns :const:`False`. In particular, ``string.printable`` is not
+      printable in the POSIX sense (see :manpage:`LC_CTYPE <locale(5)>`).
 
 
 .. data:: whitespace

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -59,11 +59,19 @@ The constants defined in this module are:
    String of ASCII characters which are considered punctuation characters
    in the ``C`` locale: ``!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~``.
 
+
 .. data:: printable
 
-   String of ASCII characters which are considered printable.  This is a
-   combination of :const:`digits`, :const:`ascii_letters`, :const:`punctuation`,
-   and :const:`whitespace`.
+   String of ASCII characters which are considered printable by Python.
+   This is a combination of :const:`digits`, :const:`ascii_letters`,
+   :const:`punctuation`, and :const:`whitespace`.
+
+   .. note::
+
+      By design, :meth:`string.printable.isprintable() <str.printable>`
+      returns :const:`False`. In particular, ``string.printable`` is
+      neither POSIX printable (see :manpage:`LC_CTYPE <locale(2)>`)
+      nor printable in the sense of :rfc:`5822`.
 
 
 .. data:: whitespace

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -70,7 +70,7 @@ The constants defined in this module are:
 
       By design, :meth:`string.printable.isprintable() <str.isprintable>`
       returns :const:`False`. In particular, ``string.printable`` is
-      neither POSIX printable (see :manpage:`LC_CTYPE <locale(2)>`)
+      neither POSIX printable (see :manpage:`LC_CTYPE <locale(5)>`)
       nor printable in the sense of :rfc:`5822`.
 
 

--- a/Misc/NEWS.d/next/Documentation/2025-01-14-11-06-41.gh-issue-67206.LYKmi5.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-01-14-11-06-41.gh-issue-67206.LYKmi5.rst
@@ -1,3 +1,3 @@
 Document that :const:`string.printable` is neither printable in the sense of
 POSIX nor of :rfc:`5822` In particular, :meth:`string.printable.isprintable()
-<str.printable>` returns :const:`False`. Patch by Bénédikt Tran.
+<str.isprintable>` returns :const:`False`. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Documentation/2025-01-14-11-06-41.gh-issue-67206.LYKmi5.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-01-14-11-06-41.gh-issue-67206.LYKmi5.rst
@@ -1,3 +1,3 @@
-Document that :const:`string.printable` is neither printable in the sense of
-POSIX nor of :rfc:`5822` In particular, :meth:`string.printable.isprintable()
-<str.isprintable>` returns :const:`False`. Patch by Bénédikt Tran.
+Document that :const:`string.printable` is not printable in the POSIX sense.
+In particular, :meth:`string.printable.isprintable() <str.isprintable>` returns
+:const:`False`. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Documentation/2025-01-14-11-06-41.gh-issue-67206.LYKmi5.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-01-14-11-06-41.gh-issue-67206.LYKmi5.rst
@@ -1,0 +1,3 @@
+Document that :const:`string.printable` is neither printable in the sense of
+POSIX nor of :rfc:`5822` In particular, :meth:`string.printable.isprintable()
+<str.printable>` returns :const:`False`. Patch by Bénédikt Tran.


### PR DESCRIPTION


<!-- gh-issue-number: gh-67206 -->
* Issue: gh-67206
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128820.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->