### PR TITLE
gh-71339: Use assertIsSubclass() and assertNotIsSubclass() in test_decimal

### DIFF
--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -752,7 +752,7 @@ class ExplicitConstructionTest:
         for v in [-2**63-1, -2**63, -2**31-1, -2**31, 0,
                    2**31-1, 2**31, 2**63-1, 2**63]:
             d = nc.create_decimal(v)
-            self.assertTrue(isinstance(d, Decimal))
+            self.assertIsInstance(d, Decimal)
             self.assertEqual(int(d), v)
 
         nc.prec = 3
@@ -2590,8 +2590,8 @@ class PythonAPItests:
     def test_abc(self):
         Decimal = self.decimal.Decimal
 
-        self.assertTrue(issubclass(Decimal, numbers.Number))
-        self.assertFalse(issubclass(Decimal, numbers.Real))
+        self.assertIsSubclass(Decimal, numbers.Number)
+        self.assertNotIsSubclass(Decimal, numbers.Real)
         self.assertIsInstance(Decimal(0), numbers.Number)
         self.assertNotIsInstance(Decimal(0), numbers.Real)
 
@@ -2690,7 +2690,7 @@ class PythonAPItests:
             def __init__(self, _):
                 self.x = 'y'
 
-        self.assertTrue(issubclass(MyDecimal, Decimal))
+        self.assertIsSubclass(MyDecimal, Decimal)
 
         r = MyDecimal.from_float(0.1)
         self.assertEqual(type(r), MyDecimal)
@@ -2908,31 +2908,31 @@ class PythonAPItests:
         Rounded = decimal.Rounded
         Clamped = decimal.Clamped
 
-        self.assertTrue(issubclass(DecimalException, ArithmeticError))
+        self.assertIsSubclass(DecimalException, ArithmeticError)
 
-        self.assertTrue(issubclass(InvalidOperation, DecimalException))
-        self.assertTrue(issubclass(FloatOperation, DecimalException))
-        self.assertTrue(issubclass(FloatOperation, TypeError))
-        self.assertTrue(issubclass(DivisionByZero, DecimalException))
-        self.assertTrue(issubclass(DivisionByZero, ZeroDivisionError))
-        self.assertTrue(issubclass(Overflow, Rounded))
-        self.assertTrue(issubclass(Overflow, Inexact))
-        self.assertTrue(issubclass(Overflow, DecimalException))
-        self.assertTrue(issubclass(Underflow, Inexact))
-        self.assertTrue(issubclass(Underflow, Rounded))
-        self.assertTrue(issubclass(Underflow, Subnormal))
-        self.assertTrue(issubclass(Underflow, DecimalException))
+        self.assertIsSubclass(InvalidOperation, DecimalException)
+        self.assertIsSubclass(FloatOperation, DecimalException)
+        self.assertIsSubclass(FloatOperation, TypeError)
+        self.assertIsSubclass(DivisionByZero, DecimalException)
+        self.assertIsSubclass(DivisionByZero, ZeroDivisionError)
+        self.assertIsSubclass(Overflow, Rounded)
+        self.assertIsSubclass(Overflow, Inexact)
+        self.assertIsSubclass(Overflow, DecimalException)
+        self.assertIsSubclass(Underflow, Inexact)
+        self.assertIsSubclass(Underflow, Rounded)
+        self.assertIsSubclass(Underflow, Subnormal)
+        self.assertIsSubclass(Underflow, DecimalException)
 
-        self.assertTrue(issubclass(Subnormal, DecimalException))
-        self.assertTrue(issubclass(Inexact, DecimalException))
-        self.assertTrue(issubclass(Rounded, DecimalException))
-        self.assertTrue(issubclass(Clamped, DecimalException))
+        self.assertIsSubclass(Subnormal, DecimalException)
+        self.assertIsSubclass(Inexact, DecimalException)
+        self.assertIsSubclass(Rounded, DecimalException)
+        self.assertIsSubclass(Clamped, DecimalException)
 
-        self.assertTrue(issubclass(decimal.ConversionSyntax, InvalidOperation))
-        self.assertTrue(issubclass(decimal.DivisionImpossible, InvalidOperation))
-        self.assertTrue(issubclass(decimal.DivisionUndefined, InvalidOperation))
-        self.assertTrue(issubclass(decimal.DivisionUndefined, ZeroDivisionError))
-        self.assertTrue(issubclass(decimal.InvalidContext, InvalidOperation))
+        self.assertIsSubclass(decimal.ConversionSyntax, InvalidOperation)
+        self.assertIsSubclass(decimal.DivisionImpossible, InvalidOperation)
+        self.assertIsSubclass(decimal.DivisionUndefined, InvalidOperation)
+        self.assertIsSubclass(decimal.DivisionUndefined, ZeroDivisionError)
+        self.assertIsSubclass(decimal.InvalidContext, InvalidOperation)
 
 @requires_cdecimal
 class CPythonAPItests(PythonAPItests, unittest.TestCase):


### PR DESCRIPTION
They provide better error report.

<!-- gh-issue-number: gh-71339 -->
* Issue: gh-71339
<!-- /gh-issue-number -->
