### PR TITLE
gh-71339: Use new assertion methods in test_functools

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -645,11 +645,11 @@ class TestPartialMethod(unittest.TestCase):
 
     def test_unbound_method_retrieval(self):
         obj = self.A
-        self.assertFalse(hasattr(obj.both, "__self__"))
-        self.assertFalse(hasattr(obj.nested, "__self__"))
-        self.assertFalse(hasattr(obj.over_partial, "__self__"))
-        self.assertFalse(hasattr(obj.static, "__self__"))
-        self.assertFalse(hasattr(self.a.static, "__self__"))
+        self.assertNotHasAttr(obj.both, "__self__")
+        self.assertNotHasAttr(obj.nested, "__self__")
+        self.assertNotHasAttr(obj.over_partial, "__self__")
+        self.assertNotHasAttr(obj.static, "__self__")
+        self.assertNotHasAttr(self.a.static, "__self__")
 
     def test_descriptors(self):
         for obj in [self.A, self.a]:
@@ -791,7 +791,7 @@ class TestUpdateWrapper(unittest.TestCase):
         self.assertNotEqual(wrapper.__qualname__, f.__qualname__)
         self.assertEqual(wrapper.__doc__, None)
         self.assertEqual(wrapper.__annotations__, {})
-        self.assertFalse(hasattr(wrapper, 'attr'))
+        self.assertNotHasAttr(wrapper, 'attr')
 
     def test_selective_update(self):
         def f():
@@ -840,7 +840,7 @@ class TestUpdateWrapper(unittest.TestCase):
             pass
         functools.update_wrapper(wrapper, max)
         self.assertEqual(wrapper.__name__, 'max')
-        self.assertTrue(wrapper.__doc__.startswith('max('))
+        self.assertStartsWith(wrapper.__doc__, 'max(')
         self.assertEqual(wrapper.__annotations__, {})
 
     def test_update_type_wrapper(self):
@@ -910,7 +910,7 @@ class TestWraps(TestUpdateWrapper):
         self.assertEqual(wrapper.__name__, 'wrapper')
         self.assertNotEqual(wrapper.__qualname__, f.__qualname__)
         self.assertEqual(wrapper.__doc__, None)
-        self.assertFalse(hasattr(wrapper, 'attr'))
+        self.assertNotHasAttr(wrapper, 'attr')
 
     def test_selective_update(self):
         def f():
@@ -2666,15 +2666,15 @@ class TestSingleDispatch(unittest.TestCase):
         a.t(0)
         self.assertEqual(a.arg, "int")
         aa = A()
-        self.assertFalse(hasattr(aa, 'arg'))
+        self.assertNotHasAttr(aa, 'arg')
         a.t('')
         self.assertEqual(a.arg, "str")
         aa = A()
-        self.assertFalse(hasattr(aa, 'arg'))
+        self.assertNotHasAttr(aa, 'arg')
         a.t(0.0)
         self.assertEqual(a.arg, "base")
         aa = A()
-        self.assertFalse(hasattr(aa, 'arg'))
+        self.assertNotHasAttr(aa, 'arg')
 
     def test_staticmethod_register(self):
         class A:
@@ -3036,16 +3036,16 @@ class TestSingleDispatch(unittest.TestCase):
             @i.register(42)
             def _(arg):
                 return "I annotated with a non-type"
-        self.assertTrue(str(exc.exception).startswith(msg_prefix + "42"))
-        self.assertTrue(str(exc.exception).endswith(msg_suffix))
+        self.assertStartsWith(str(exc.exception), msg_prefix + "42")
+        self.assertEndsWith(str(exc.exception), msg_suffix)
         with self.assertRaises(TypeError) as exc:
             @i.register
             def _(arg):
                 return "I forgot to annotate"
-        self.assertTrue(str(exc.exception).startswith(msg_prefix +
+        self.assertStartsWith(str(exc.exception), msg_prefix +
             "<function TestSingleDispatch.test_invalid_registrations.<locals>._"
-        ))
-        self.assertTrue(str(exc.exception).endswith(msg_suffix))
+        )
+        self.assertEndsWith(str(exc.exception), msg_suffix)
 
         with self.assertRaises(TypeError) as exc:
             @i.register
@@ -3055,23 +3055,23 @@ class TestSingleDispatch(unittest.TestCase):
                 # types from `typing`. Instead, annotate with regular types
                 # or ABCs.
                 return "I annotated with a generic collection"
-        self.assertTrue(str(exc.exception).startswith(
+        self.assertStartsWith(str(exc.exception),
             "Invalid annotation for 'arg'."
-        ))
-        self.assertTrue(str(exc.exception).endswith(
+        )
+        self.assertEndsWith(str(exc.exception),
             'typing.Iterable[str] is not a class.'
-        ))
+        )
 
         with self.assertRaises(TypeError) as exc:
             @i.register
             def _(arg: typing.Union[int, typing.Iterable[str]]):
                 return "Invalid Union"
-        self.assertTrue(str(exc.exception).startswith(
+        self.assertStartsWith(str(exc.exception),
             "Invalid annotation for 'arg'."
-        ))
-        self.assertTrue(str(exc.exception).endswith(
+        )
+        self.assertEndsWith(str(exc.exception),
             'typing.Union[int, typing.Iterable[str]] not all arguments are classes.'
-        ))
+        )
 
     def test_invalid_positional_argument(self):
         @functools.singledispatch


### PR DESCRIPTION
They provide better error report.


<!-- gh-issue-number: gh-71339 -->
* Issue: gh-71339
<!-- /gh-issue-number -->
