### PR TITLE
Align error message of `_pyio.TextIOWrapper.seek` with its C implementation

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2458,6 +2458,8 @@ class TextIOWrapper(TextIOBase):
         return buffer
 
     def seek(self, cookie, whence=0):
+        self._checkClosed()
+
         def _reset_encoder(position):
             """Reset the encoder (merely useful for proper BOM handling)"""
             try:
@@ -2471,8 +2473,6 @@ class TextIOWrapper(TextIOBase):
                 else:
                     encoder.reset()
 
-        if self.closed:
-            raise ValueError("seek on closed file")
         if not self._seekable:
             raise UnsupportedOperation("underlying stream is not seekable")
         if whence == SEEK_CUR:

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2472,7 +2472,7 @@ class TextIOWrapper(TextIOBase):
                     encoder.reset()
 
         if self.closed:
-            raise ValueError("tell on closed file")
+            raise ValueError("seek on closed file")
         if not self._seekable:
             raise UnsupportedOperation("underlying stream is not seekable")
         if whence == SEEK_CUR:

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2458,8 +2458,6 @@ class TextIOWrapper(TextIOBase):
         return buffer
 
     def seek(self, cookie, whence=0):
-        self._checkClosed()
-
         def _reset_encoder(position):
             """Reset the encoder (merely useful for proper BOM handling)"""
             try:
@@ -2473,6 +2471,7 @@ class TextIOWrapper(TextIOBase):
                 else:
                     encoder.reset()
 
+        self._checkClosed()
         if not self._seekable:
             raise UnsupportedOperation("underlying stream is not seekable")
         if whence == SEEK_CUR:

--- a/Misc/NEWS.d/next/Library/2025-01-15-23-51-44.gh-issue-128852.89wrex.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-15-23-51-44.gh-issue-128852.89wrex.rst
@@ -1,2 +1,2 @@
-Fix error message when calling seek on a closed :class:`!_pyio.TextIOWrapper`
-file.
+Fix the :exc:`ValueError` message when calling :meth:`~io.TextIOWrapper.seek`
+on a closed :class:`!_pyio.TextIOWrapper`.

--- a/Misc/NEWS.d/next/Library/2025-01-15-23-51-44.gh-issue-128852.89wrex.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-15-23-51-44.gh-issue-128852.89wrex.rst
@@ -1,2 +1,2 @@
-Align ``_pyio.TextIOWrapper.seek``'s file closed check with its C
-implementation
+Fix error message when calling seek on a closed :class:`_pyio.TextIOWrapper`
+file.

--- a/Misc/NEWS.d/next/Library/2025-01-15-23-51-44.gh-issue-128852.89wrex.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-15-23-51-44.gh-issue-128852.89wrex.rst
@@ -1,0 +1,2 @@
+Align ``_pyio.TextIOWrapper.seek``'s file closed check with its C
+implementation

--- a/Misc/NEWS.d/next/Library/2025-01-15-23-51-44.gh-issue-128852.89wrex.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-15-23-51-44.gh-issue-128852.89wrex.rst
@@ -1,2 +1,2 @@
-Fix error message when calling seek on a closed :class:`_pyio.TextIOWrapper`
+Fix error message when calling seek on a closed :class:`!_pyio.TextIOWrapper`
 file.


### PR DESCRIPTION
fix error message on seek of closed TextIOWrapper file in the python implementation of the io module