### PR TITLE
gh-118761: Improve import time for `csv`

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -63,7 +63,6 @@ SETTINGS:
         written as two quotes
 """
 
-import re
 import types
 from _csv import Error, writer, reader, register_dialect, \
                  unregister_dialect, get_dialect, list_dialects, \
@@ -281,6 +280,7 @@ class Sniffer:
         If there is no quotechar the delimiter can't be determined
         this way.
         """
+        import re
 
         matches = []
         for restr in (r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?P=delim)', # ,".*?",

--- a/Misc/NEWS.d/next/Library/2025-01-15-09-45-43.gh-issue-118761.TvAC8E.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-15-09-45-43.gh-issue-118761.TvAC8E.rst
@@ -1,0 +1,3 @@
+Reduce the import time of :mod:`csv` by up to five times, by importing
+:mod:`re` on demand. In particular, ``re`` is no more implicitly exposed
+as ``csv.re``. Patch by Bénédikt Tran.


### PR DESCRIPTION
Benchmarks are for a release non-PGO build (PR) against a PGO build (main). This will be the last PR for that issue.

> [!NOTE]
> Considering that `csv` is used in many applications, I think this improvement makes sense (especially for data scientists).


#### PR

```sh
$ ./python -X importtime -c 'import csv'
import time: self [us] | cumulative | imported package
...
import time:       229 |        229 | linecache
import time:       331 |        331 |   types
import time:       175 |        175 |   _csv
import time:       629 |       1134 | csv
```

```sh
$ hyperfine --warmup 8 "./python -c 'import csv'"
Benchmark 1: ./python -c 'import csv'
  Time (mean ± σ):       5.9 ms ±   0.4 ms    [User: 5.0 ms, System: 1.0 ms]
  Range (min … max):     5.5 ms …  11.0 ms    452 runs
```

#### Main

```sh
$ ./python -X importtime -c 'import csv'
import time: self [us] | cumulative | imported package
...
import time:       227 |        227 | linecache
import time:       261 |        261 |       types
import time:      1419 |       1680 |     enum
import time:        62 |         62 |       _sre
import time:       218 |        218 |         re._constants
import time:       327 |        544 |       re._parser
import time:        79 |         79 |       re._casefix
import time:       287 |        971 |     re._compiler
import time:        90 |         90 |         itertools
import time:        86 |         86 |         keyword
import time:        46 |         46 |           _operator
import time:       187 |        233 |         operator
import time:       119 |        119 |         reprlib
import time:        45 |         45 |         _collections
import time:       733 |       1304 |       collections
import time:        39 |         39 |       _functools
import time:       498 |       1840 |     functools
import time:       114 |        114 |     copyreg
import time:       426 |       5029 |   re
import time:       107 |        107 |   _csv
import time:       575 |       5709 | csv
```

```sh
$ hyperfine --warmup 8 "./python -c 'import csv'"
Benchmark 1: ./python -c 'import csv'
  Time (mean ± σ):       9.2 ms ±   0.9 ms    [User: 8.0 ms, System: 1.2 ms]
  Range (min … max):     8.4 ms …  16.7 ms    297 runs
``` 

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
