### PR TITLE
gh-118761: improve optparse import time by delaying textwrap import

### DIFF
--- a/Lib/optparse.py
+++ b/Lib/optparse.py
@@ -74,7 +74,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import sys, os
-import textwrap
 from gettext import gettext as _, ngettext
 
 
@@ -252,6 +251,7 @@ class HelpFormatter:
         Format a paragraph of free-form text for inclusion in the
         help output at the current indentation level.
         """
+        import textwrap
         text_width = max(self.width - self.current_indent, 11)
         indent = " "*self.current_indent
         return textwrap.fill(text,
@@ -308,6 +308,7 @@ class HelpFormatter:
             indent_first = 0
         result.append(opts)
         if option.help:
+            import textwrap
             help_text = self.expand_default(option)
             help_lines = textwrap.wrap(help_text, self.help_width)
             result.append("%*s%s\n" % (indent_first, "", help_lines[0]))

--- a/Misc/NEWS.d/next/Library/2025-01-15-18-54-48.gh-issue-118761.G1dv6E.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-15-18-54-48.gh-issue-118761.G1dv6E.rst
@@ -1,0 +1,2 @@
+Reduce the import time of :mod:`optparse` when no help text is printed.
+Patch by Eli Schwartz.


### PR DESCRIPTION
The same change was made, and for the same reason, by argparse back in
2017. The textwrap module is only used when printing help text, so most invocations will never need it imported.

See: https://github.com/python/cpython/pull/1269
See: 81108375d9b2ccd0add1572da745311d4dfac505

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
