### PR TITLE
gh-128902: Fix check for fallthrough attribute support

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -625,8 +625,13 @@ extern "C" {
 //     case 2: code; break;
 //     }
 //
-// __attribute__((fallthrough)) was introduced in GCC 7.
-#if _Py__has_attribute(fallthrough)
+// __attribute__((fallthrough)) was introduced in GCC 7 and Clang 10 /
+// Apple Clang 12.0. Earlier Clang versions support only the C++11
+// style fallthrough attribute, not the GCC extension syntax used here,
+// and __has_attribute(fallthrough) evaluates to 1.
+#if _Py__has_attribute(fallthrough) && (!defined(__clang__) || \
+    (!defined(__apple_build_version__) && __clang_major__ >= 10) || \
+    (defined(__apple_build_version__) && __clang_major__ >= 12))
 #  define _Py_FALLTHROUGH __attribute__((fallthrough))
 #else
 #  define _Py_FALLTHROUGH do { } while (0)

--- a/Misc/NEWS.d/next/Build/2025-01-16-03-35-37.gh-issue-128902.Dt7xtV.rst
+++ b/Misc/NEWS.d/next/Build/2025-01-16-03-35-37.gh-issue-128902.Dt7xtV.rst
@@ -1,0 +1,1 @@
+Fix compile errors with Clang 9 and older due to lack of ``__attribute__((fallthrough))`` support.


### PR DESCRIPTION
Clang versions prior to 10 (which corresponds to Apple Clang 12) do not support the GCC extension syntax `__attribute__((fallthrough))`, but do evaluate `__has_attribute(fallthrough)` to 1 because they support the C++11 style syntax `[[fallthrough]]`. The only way to tell if the GCC style syntax is supported is thus to check the clang version.

Ref: https://github.com/llvm/llvm-project/commit/1e0affb6e564b7361b0aadb38805f26deff4ecfc


<!-- gh-issue-number: gh-128902 -->
* Issue: gh-128902
<!-- /gh-issue-number -->
