### PR TITLE
gh-118761: Improve import time of `tomllib`

### DIFF
--- a/Lib/test/test_tomllib/test_misc.py
+++ b/Lib/test/test_tomllib/test_misc.py
@@ -5,6 +5,7 @@
 import copy
 import datetime
 from decimal import Decimal as D
+import importlib
 from pathlib import Path
 import sys
 import tempfile
@@ -113,3 +114,11 @@ class TestMiscellaneous(unittest.TestCase):
                               nest_count=nest_count):
                 recursive_table_toml = nest_count * "key = {" + nest_count * "}"
                 tomllib.loads(recursive_table_toml)
+
+    def test_types_import(self):
+        """Test that `_types` module runs.
+
+        The module is for type annotations only, so it is otherwise
+        never imported by tests.
+        """
+        importlib.import_module(f"{tomllib.__name__}._types")

--- a/Lib/tomllib/_re.py
+++ b/Lib/tomllib/_re.py
@@ -7,9 +7,12 @@ from __future__ import annotations
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from functools import lru_cache
 import re
-from typing import Any
 
-from ._types import ParseFloat
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Any
+
+    from ._types import ParseFloat
 
 # E.g.
 # - 00:32:00.999999

--- a/Misc/NEWS.d/next/Library/2025-01-16-10-06-40.gh-issue-118761.z100LC.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-16-10-06-40.gh-issue-118761.z100LC.rst
@@ -1,0 +1,2 @@
+Improve import time of :mod:`tomllib` by removing ``typing``, ``string``,
+and ``tomllib._types`` imports. Patch by Taneli Hukkinen.


### PR DESCRIPTION
This is a port of two commits in Tomli repository (the diff of these commits being https://github.com/hukkin/tomli/compare/42a570d5222ec8abfa6e20421d3f2e5132da2f83...1da01ef78fee9f491f55feb5e2d9fcf24d4977f0).

This removes runtime overhead of `string`, `typing`, and `tomllib._types` imports from `import tomllib`.

### `main` branch
```console
$ hyperfine --warmup 8 "./python -c 'import tomllib'" "./python -c 'pass'"
Benchmark 1: ./python -c 'import tomllib'
  Time (mean ± σ):      70.3 ms ±   1.8 ms    [User: 66.0 ms, System: 4.3 ms]
  Range (min … max):    68.6 ms …  76.8 ms    41 runs
 
Benchmark 2: ./python -c 'pass'
  Time (mean ± σ):      26.2 ms ±   0.7 ms    [User: 23.3 ms, System: 3.0 ms]
  Range (min … max):    25.1 ms …  29.7 ms    110 runs
 
Summary
  './python -c 'pass'' ran
    2.69 ± 0.10 times faster than './python -c 'import tomllib''
```

### PR branch
```console
$ hyperfine --warmup 8 "./python -c 'import tomllib'" "./python -c 'pass'"
Benchmark 1: ./python -c 'import tomllib'
  Time (mean ± σ):      48.0 ms ±   0.7 ms    [User: 43.4 ms, System: 4.7 ms]
  Range (min … max):    46.8 ms …  50.2 ms    60 runs
 
Benchmark 2: ./python -c 'pass'
  Time (mean ± σ):      26.1 ms ±   0.4 ms    [User: 23.5 ms, System: 2.7 ms]
  Range (min … max):    25.3 ms …  27.4 ms    110 runs
 
Summary
  './python -c 'pass'' ran
    1.84 ± 0.04 times faster than './python -c 'import tomllib''
```

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
