### PR TITLE
gh-128670: Use the pyvenv.cfg home location in getpath when the default executable points to the same realpath as the running executable

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -1618,13 +1618,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
              tempfile.TemporaryDirectory() as pyvenv_home:
             ver = sys.version_info
 
-            if not MS_WINDOWS:
-                lib_dynload = os.path.join(pyvenv_home,
-                                           sys.platlibdir,
-                                           f'python{ver.major}.{ver.minor}{ABI_THREAD}',
-                                           'lib-dynload')
-                os.makedirs(lib_dynload)
-            else:
+            if MS_WINDOWS:
                 lib_folder = os.path.join(pyvenv_home, 'Lib')
                 os.makedirs(lib_folder)
                 # getpath.py uses Lib\os.py as the LANDMARK
@@ -1639,9 +1633,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 print("include-system-site-packages = false", file=fp)
 
             paths = self.module_search_paths()
-            if not MS_WINDOWS:
-                paths[-1] = lib_dynload
-            else:
+            if MS_WINDOWS:
                 paths = [
                     os.path.join(tmpdir, os.path.basename(paths[0])),
                     pyvenv_home,
@@ -1650,7 +1642,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
             executable = self.test_exe
             base_executable = os.path.join(pyvenv_home, os.path.basename(executable))
-            exec_prefix = pyvenv_home
+            exec_prefix = sys.base_exec_prefix
             config = {
                 'base_prefix': sysconfig.get_config_var("prefix"),
                 'base_exec_prefix': exec_prefix,
@@ -1659,16 +1651,15 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 'base_executable': base_executable,
                 'executable': executable,
                 'module_search_paths': paths,
+                'use_frozen_modules': bool(not support.Py_DEBUG),
             }
             if MS_WINDOWS:
                 config['base_prefix'] = pyvenv_home
                 config['stdlib_dir'] = os.path.join(pyvenv_home, 'Lib')
-                config['use_frozen_modules'] = bool(not support.Py_DEBUG)
             else:
                 # cannot reliably assume stdlib_dir here because it
                 # depends too much on our build. But it ought to be found
                 config['stdlib_dir'] = self.IGNORE_CONFIG
-                config['use_frozen_modules'] = bool(not support.Py_DEBUG)
 
             env = self.copy_paths_by_env(config)
             self.check_all_configs("test_init_compat_config", config,

--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -870,32 +870,31 @@ class MockGetPathTests(unittest.TestCase):
         we should have it as sys.executable (and sys.prefix should be the resolved location)
         """
         ns = MockPosixNamespace(
-            argv0="/venv/bin/python3",
+            argv0="/venv/bin/python9",
             PREFIX="/some/_internal/prefix",
-            base_exec_prefix="/foo/bar"
         )
         # Setup venv
-        ns.add_known_xfile("/venv/bin/python3")
-        ns.add_known_xfile("/usr/local/bin/python3")
-        ns.add_known_xfile("/some/_internal/prefix/bin/python3")
+        ns.add_known_xfile("/venv/bin/python9")
+        ns.add_known_xfile("/usr/local/bin/python9")
+        ns.add_known_xfile("/some/_internal/prefix/bin/python9")
 
         ns.add_known_file("/venv/pyvenv.cfg", [
             # The published based executable location is /usr/local/bin - we don't want to
-            # expose /some/internal/directory (this location can change under our feet)
+            # expose /some/_internal/prefix (this location can change under our feet)
             r"home = /usr/local/bin"
         ])
-        ns.add_known_link("/venv/bin/python3", "/usr/local/bin/python3")
-        ns.add_known_link("/usr/local/bin/python3", "/some/_internal/prefix/bin/python3")
+        ns.add_known_link("/venv/bin/python9", "/usr/local/bin/python9")
+        ns.add_known_link("/usr/local/bin/python9", "/some/_internal/prefix/bin/python9")
 
         ns.add_known_file("/some/_internal/prefix/lib/python9.8/os.py")
         ns.add_known_dir("/some/_internal/prefix/lib/python9.8/lib-dynload")
 
-        # Put a file completely outside of /usr/local to validate that the issue
-        # in https://github.com/python/cpython/issues/106045 is resolved.
+        # Put a file completely outside /usr/local to validate that the issue
+        # in gh-106045 is resolved.
         ns.add_known_dir("/usr/lib/python9.8/lib-dynload")
 
         expected = dict(
-            executable="/venv/bin/python3",
+            executable="/venv/bin/python9",
             prefix="/venv",
             exec_prefix="/venv",
             base_prefix="/some/_internal/prefix",
@@ -903,7 +902,7 @@ class MockGetPathTests(unittest.TestCase):
             # It is important to maintain the link to the original executable, as this
             # is used when creating a new virtual environment (which should also have home
             # set to /usr/local/bin to avoid bleeding the internal path to the venv)
-            base_executable="/usr/local/bin/python3",
+            base_executable="/usr/local/bin/python9",
             module_search_paths_set=1,
             module_search_paths=[
                 "/some/_internal/prefix/lib/python98.zip",

--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -400,7 +400,7 @@ class MockGetPathTests(unittest.TestCase):
         ns.add_known_file("/path/to/non-installed/lib/python9.8/os.py")
         ns.add_known_dir("/path/to/non-installed/lib/python9.8/lib-dynload")
         ns.add_known_file("/venv/pyvenv.cfg", [
-            r"home = /path/to/non-installed"
+            r"home = /path/to/non-installed/bin"
         ])
         expected = dict(
             executable="/venv/bin/python",
@@ -837,28 +837,28 @@ class MockGetPathTests(unittest.TestCase):
         ns = MockPosixNamespace(
             argv0="/venv/bin/python",
             PREFIX="/usr",
-            ENV_PYTHONHOME="/pythonhome",
+            ENV_PYTHONHOME="/pythonhome-p:/pythonhome-e",
         )
         # Setup venv
         ns.add_known_xfile("/venv/bin/python")
         ns.add_known_file("/venv/pyvenv.cfg", [
             r"home = /usr/bin"
         ])
-        # Seutup PYTHONHOME
-        ns.add_known_file("/pythonhome/lib/python9.8/os.py")
-        ns.add_known_dir("/pythonhome/lib/python9.8/lib-dynload")
+        # Setup PYTHONHOME
+        ns.add_known_file("/pythonhome-p/lib/python9.8/os.py")
+        ns.add_known_dir("/pythonhome-e/lib/python9.8/lib-dynload")
 
         expected = dict(
             executable="/venv/bin/python",
             prefix="/venv",
             exec_prefix="/venv",
-            base_prefix="/pythonhome",
-            base_exec_prefix="/pythonhome",
+            base_prefix="/pythonhome-p",
+            base_exec_prefix="/pythonhome-e",
             module_search_paths_set=1,
             module_search_paths=[
-                "/pythonhome/lib/python98.zip",
-                "/pythonhome/lib/python9.8",
-                "/pythonhome/lib/python9.8/lib-dynload",
+                "/pythonhome-p/lib/python98.zip",
+                "/pythonhome-p/lib/python9.8",
+                "/pythonhome-e/lib/python9.8/lib-dynload",
             ],
         )
         actual = getpath(ns, expected)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-01-16-12-24-13.gh-issue-128670.Mtt-w_.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-01-16-12-24-13.gh-issue-128670.Mtt-w_.rst
@@ -1,0 +1,2 @@
+sys._base_executable is no longer always a fully resolved symlink when
+running from a venv. The home value in pyvenv.cfg is used to determine the base executable when its realpath is the same as the running executable's realpath. A venv created from another will no longer expose the realpath of the executable in this scenario.

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -382,7 +382,7 @@ if not py_setpath:
             # the base installation — isn't set (eg. when embedded), try to find
             # it in 'home'.
             if not base_executable:
-                _home_executable = joinpath(executable_dir, basename(executable))
+                _home_executable = joinpath(executable_dir, DEFAULT_PROGRAM_NAME)
                 _realpath_executable = None
                 try:
                     _realpath_executable = realpath(executable)

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -382,15 +382,23 @@ if not py_setpath:
             # the base installation — isn't set (eg. when embedded), try to find
             # it in 'home'.
             if not base_executable:
-                # First try to resolve symlinked executables, since that may be
-                # more accurate than assuming the executable in 'home'.
+                _home_executable = joinpath(executable_dir, basename(executable))
+                _realpath_executable = None
                 try:
-                    base_executable = realpath(executable)
-                    if base_executable == executable:
-                        # No change, so probably not a link. Clear it and fall back
-                        base_executable = ''
+                    _realpath_executable = realpath(executable)
+
+                    # If the realpath of the executable identified in home is the same as
+                    # the realpath of the venv's executable use the (potentially not fully
+                    # resolved via realpath) path from home.
+                    if realpath(_home_executable) == _realpath_executable:
+                        base_executable = _home_executable
                 except OSError:
                     pass
+                if not base_executable:
+                    if _realpath_executable and _realpath_executable != executable:
+                        # Try to resolve symlinked executables, since that may be
+                        # more accurate than assuming the executable in 'home'.
+                        base_executable = _realpath_executable
                 if not base_executable:
                     base_executable = joinpath(executable_dir, basename(executable))
                     # It's possible "python" is executed from within a posix venv but that

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -383,22 +383,22 @@ if not py_setpath:
             # it in 'home'.
             if not base_executable:
                 _home_executable = joinpath(executable_dir, DEFAULT_PROGRAM_NAME)
-                _realpath_executable = None
+                _executable_realpath = None
                 try:
-                    _realpath_executable = realpath(executable)
+                    _executable_realpath = realpath(executable)
 
                     # If the realpath of the executable identified in home is the same as
-                    # the realpath of the venv's executable use the (potentially not fully
-                    # resolved via realpath) path from home.
-                    if realpath(_home_executable) == _realpath_executable:
+                    # the realpath of the venv's executable, then use the (potentially not
+                    # fully resolved via realpath) path from home.
+                    if realpath(_home_executable) == _executable_realpath:
                         base_executable = _home_executable
                 except OSError:
                     pass
                 if not base_executable:
-                    if _realpath_executable and _realpath_executable != executable:
+                    if _executable_realpath and _executable_realpath != executable:
                         # Try to resolve symlinked executables, since that may be
                         # more accurate than assuming the executable in 'home'.
-                        base_executable = _realpath_executable
+                        base_executable = _executable_realpath
                 if not base_executable:
                     base_executable = joinpath(executable_dir, basename(executable))
                     # It's possible "python" is executed from within a posix venv but that
@@ -407,10 +407,10 @@ if not py_setpath:
                     #
                     # In this case, try to fall back to known alternatives
                     if os_name != 'nt' and not isfile(base_executable):
-                        base_exe = basename(executable)
+                        _base_exe = basename(executable)
                         for candidate in (DEFAULT_PROGRAM_NAME, f'python{VERSION_MAJOR}.{VERSION_MINOR}'):
                             candidate += EXE_SUFFIX if EXE_SUFFIX else ''
-                            if base_exe == candidate:
+                            if _base_exe == candidate:
                                 continue
                             candidate = joinpath(executable_dir, candidate)
                             # Only set base_executable if the candidate exists.


### PR DESCRIPTION
Follows on from the issues raised in #128670 and #106045. It should be considered as an alternative to #115237.


<!-- gh-issue-number: gh-128670 -->
* Issue: gh-128670
<!-- /gh-issue-number -->
