### PR TITLE
gh-128910: Remove `_PyTrash_begin` and `_PyTrash_end` C-API functions

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -475,9 +475,6 @@ partially-deallocated object. To check this, the tp_dealloc function must be
 passed as second argument to Py_TRASHCAN_BEGIN().
 */
 
-/* Python 3.9 private API, invoked by the macros below. */
-PyAPI_FUNC(int) _PyTrash_begin(PyThreadState *tstate, PyObject *op);
-PyAPI_FUNC(void) _PyTrash_end(PyThreadState *tstate);
 
 PyAPI_FUNC(void) _PyTrash_thread_deposit_object(PyThreadState *tstate, PyObject *op);
 PyAPI_FUNC(void) _PyTrash_thread_destroy_chain(PyThreadState *tstate);

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-01-16-18-16-18.gh-issue-128910.9pqfab.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-01-16-18-16-18.gh-issue-128910.9pqfab.rst
@@ -1,0 +1,2 @@
+Undocumented and unused private C-API functions ``_PyTrash_begin`` and
+``_PyTrash_end`` are removed.


### PR DESCRIPTION


<!-- gh-issue-number: gh-128910 -->
* Issue: gh-128910
<!-- /gh-issue-number -->
