### PR TITLE
gh-128928: keep consistent of logger.debug of asyncio.BaseProactorEventLoop with others of asyncio

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -628,7 +628,6 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
 
     def __init__(self, proactor):
         super().__init__()
-        logger.debug('Using proactor: %s', proactor.__class__.__name__)
         self._proactor = proactor
         self._selector = proactor   # convenient alias
         self._self_reading_future = None
@@ -638,6 +637,8 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         if threading.current_thread() is threading.main_thread():
             # wakeup fd can only be installed to a file descriptor from the main thread
             signal.set_wakeup_fd(self._csock.fileno())
+        if self._debug:
+            logger.debug('Using proactor: %s', proactor.__class__.__name__)
 
     def _make_socket_transport(self, sock, protocol, waiter=None,
                                extra=None, server=None):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

issue: https://github.com/python/cpython/issues/128928

it should logging to debug only when loop.debug is true, like other `logger.debug()` within the `asyncio` package

<!-- gh-issue-number: gh-128928 -->
* Issue: gh-128928
<!-- /gh-issue-number -->
