### PR TITLE
gh-128916: Do not set `SO_REUSEPORT` on non-`AF_INET*` sockets

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1593,7 +1593,9 @@ class BaseEventLoop(events.AbstractEventLoop):
                     if reuse_address:
                         sock.setsockopt(
                             socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
-                    if reuse_port:
+                    # Since Linux 6.12.9, SO_REUSEPORT is not allowed
+                    # on other address families than AF_INET/AF_INET6.
+                    if reuse_port and af in (socket.AF_INET, socket.AF_INET6):
                         _set_reuseport(sock)
                     if keep_alive:
                         sock.setsockopt(

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -937,7 +937,9 @@ def create_server(address, *, family=AF_INET, backlog=None, reuse_port=False,
                 # Fail later on bind(), for platforms which may not
                 # support this option.
                 pass
-        if reuse_port:
+        # Since Linux 6.12.9, SO_REUSEPORT is not allowed
+        # on other address families than AF_INET/AF_INET6.
+        if reuse_port and family in (AF_INET, AF_INET6):
             sock.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1)
         if has_ipv6 and family == AF_INET6:
             if dualstack_ipv6:

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -468,7 +468,12 @@ class TCPServer(BaseServer):
         """
         if self.allow_reuse_address and hasattr(socket, "SO_REUSEADDR"):
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        if self.allow_reuse_port and hasattr(socket, "SO_REUSEPORT"):
+        # Since Linux 6.12.9, SO_REUSEPORT is not allowed
+        # on other address families than AF_INET/AF_INET6.
+        if (
+            self.allow_reuse_port and hasattr(socket, "SO_REUSEPORT")
+            and self.address_family in (socket.AF_INET, socket.AF_INET6)
+        ):
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         self.socket.bind(self.server_address)
         self.server_address = self.socket.getsockname()

--- a/Misc/NEWS.d/next/Library/2025-01-17-11-46-16.gh-issue-128916.GEePbO.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-17-11-46-16.gh-issue-128916.GEePbO.rst
@@ -1,3 +1,3 @@
-Do not attempt to set ``SO_REUSEPORT`` on sockets of address familifies
+Do not attempt to set ``SO_REUSEPORT`` on sockets of address families
 other than ``AF_INET`` and ``AF_INET6``, as it is meaningless with these
 address families, and the call with fail with Linux kernel 6.12.9 and newer.

--- a/Misc/NEWS.d/next/Library/2025-01-17-11-46-16.gh-issue-128916.GEePbO.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-17-11-46-16.gh-issue-128916.GEePbO.rst
@@ -1,0 +1,3 @@
+Do not attempt to set ``SO_REUSEPORT`` on sockets of address familifies
+other than ``AF_INET`` and ``AF_INET6``, as it is meaningless with these
+address families, and the call with fail with Linux kernel 6.12.9 and newer.


### PR DESCRIPTION
Do not attempt to set ``SO_REUSEPORT`` on sockets of address familifies other than ``AF_INET`` and ``AF_INET6``, as it is meaningless with these address families, and the call with fail with Linux kernel 6.12.9 and newer.

<!-- gh-issue-number: gh-128916 -->
* Issue: gh-128916
<!-- /gh-issue-number -->
