### PR TITLE
Revert "gh-128770: raise warnings as errors in test suite - except for test_socket which still logs warnings (#128726)"

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -642,9 +642,9 @@ class Regrtest:
         if not sys.stdout.write_through:
             python_opts.append('-u')
 
-        # Add warnings filter 'error'
+        # Add warnings filter 'default'
         if 'default' not in sys.warnoptions:
-            python_opts.extend(('-W', 'error'))
+            python_opts.extend(('-W', 'default'))
 
         # Error on bytes/str comparison
         if sys.flags.bytes_warning < 2:

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1324,21 +1324,22 @@ class TestMain(ReplTestCase):
         if readline.backend != "editline":
             self.skipTest("GNU readline is not affected by this issue")
 
-        with tempfile.NamedTemporaryFile() as hfile:
-            env = os.environ.copy()
-            env["PYTHON_HISTORY"] = hfile.name
+        hfile = tempfile.NamedTemporaryFile()
+        self.addCleanup(unlink, hfile.name)
+        env = os.environ.copy()
+        env["PYTHON_HISTORY"] = hfile.name
 
-            env["PYTHON_BASIC_REPL"] = "1"
-            output, exit_code = self.run_repl("spam \nexit()\n", env=env)
-            self.assertEqual(exit_code, 0)
-            self.assertIn("spam ", output)
-            self.assertNotEqual(pathlib.Path(hfile.name).stat().st_size, 0)
-            self.assertIn("spam\\040", pathlib.Path(hfile.name).read_text())
+        env["PYTHON_BASIC_REPL"] = "1"
+        output, exit_code = self.run_repl("spam \nexit()\n", env=env)
+        self.assertEqual(exit_code, 0)
+        self.assertIn("spam ", output)
+        self.assertNotEqual(pathlib.Path(hfile.name).stat().st_size, 0)
+        self.assertIn("spam\\040", pathlib.Path(hfile.name).read_text())
 
-            env.pop("PYTHON_BASIC_REPL", None)
-            output, exit_code = self.run_repl("exit\n", env=env)
-            self.assertEqual(exit_code, 0)
-            self.assertNotIn("\\040", pathlib.Path(hfile.name).read_text())
+        env.pop("PYTHON_BASIC_REPL", None)
+        output, exit_code = self.run_repl("exit\n", env=env)
+        self.assertEqual(exit_code, 0)
+        self.assertNotIn("\\040", pathlib.Path(hfile.name).read_text())
 
     def test_keyboard_interrupt_after_isearch(self):
         output, exit_code = self.run_repl(["\x12", "\x03", "exit"])

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1,8 +1,7 @@
 import unittest
-import warnings
 from test import support
 from test.support import (
-    is_apple, os_helper, refleak_helper, socket_helper, threading_helper,
+    is_apple, os_helper, refleak_helper, socket_helper, threading_helper
 )
 import _thread as thread
 import array
@@ -197,24 +196,6 @@ def socket_setdefaulttimeout(timeout):
         yield
     finally:
         socket.setdefaulttimeout(old_timeout)
-
-
-@contextlib.contextmanager
-def downgrade_malformed_data_warning():
-    # This warning happens on macos and win, but does not always happen on linux.
-    if sys.platform not in {"win32", "darwin"}:
-        yield
-        return
-
-    with warnings.catch_warnings():
-        # TODO: gh-110012, we should investigate why this warning is happening
-        # and fix it properly.
-        warnings.filterwarnings(
-            action="always",
-            message=r"received malformed or improperly-truncated ancillary data",
-            category=RuntimeWarning,
-        )
-        yield
 
 
 HAVE_SOCKET_CAN = _have_socket_can()
@@ -3965,9 +3946,8 @@ class SCMRightsTest(SendrecvmsgServerTimeoutBase):
         # mindata and maxdata bytes when received with buffer size
         # ancbuf, and that any complete file descriptor numbers are
         # valid.
-        with downgrade_malformed_data_warning():  # TODO: gh-110012
-            msg, ancdata, flags, addr = self.doRecvmsg(self.serv_sock,
-                                                    len(MSG), ancbuf)
+        msg, ancdata, flags, addr = self.doRecvmsg(self.serv_sock,
+                                                   len(MSG), ancbuf)
         self.assertEqual(msg, MSG)
         self.checkRecvmsgAddress(addr, self.cli_addr)
         self.checkFlags(flags, eor=True, checkset=socket.MSG_CTRUNC)
@@ -4318,9 +4298,8 @@ class RFC3542AncillaryTest(SendrecvmsgServerTimeoutBase):
         self.serv_sock.setsockopt(socket.IPPROTO_IPV6,
                                   socket.IPV6_RECVHOPLIMIT, 1)
         self.misc_event.set()
-        with downgrade_malformed_data_warning():  # TODO: gh-110012
-            msg, ancdata, flags, addr = self.doRecvmsg(
-                self.serv_sock, len(MSG), socket.CMSG_LEN(SIZEOF_INT) - 1)
+        msg, ancdata, flags, addr = self.doRecvmsg(
+            self.serv_sock, len(MSG), socket.CMSG_LEN(SIZEOF_INT) - 1)
 
         self.assertEqual(msg, MSG)
         self.checkRecvmsgAddress(addr, self.cli_addr)
@@ -4423,10 +4402,9 @@ class RFC3542AncillaryTest(SendrecvmsgServerTimeoutBase):
         self.serv_sock.setsockopt(socket.IPPROTO_IPV6,
                                   socket.IPV6_RECVTCLASS, 1)
         self.misc_event.set()
-        with downgrade_malformed_data_warning():  # TODO: gh-110012
-            msg, ancdata, flags, addr = self.doRecvmsg(
-                self.serv_sock, len(MSG),
-                socket.CMSG_SPACE(SIZEOF_INT) + socket.CMSG_LEN(SIZEOF_INT) - 1)
+        msg, ancdata, flags, addr = self.doRecvmsg(
+            self.serv_sock, len(MSG),
+            socket.CMSG_SPACE(SIZEOF_INT) + socket.CMSG_LEN(SIZEOF_INT) - 1)
 
         self.assertEqual(msg, MSG)
         self.checkRecvmsgAddress(addr, self.cli_addr)


### PR DESCRIPTION
This reverts commit 7807b407306d3c311bcc601cc279623180f8da05.

We need to fix the buildbots first: https://github.com/python/cpython/pull/128726#issuecomment-2598205353.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128770 -->
* Issue: gh-128770
<!-- /gh-issue-number -->
