### PR TITLE
gh-128889: Zero out memory ctypes for generated struct layout tests

### DIFF
--- a/Lib/test/test_ctypes/test_generated_structs.py
+++ b/Lib/test/test_ctypes/test_generated_structs.py
@@ -443,7 +443,7 @@ class GeneratedTest(unittest.TestCase):
         - None
         - reason to skip the test (str)
 
-        This does depend on the C compiler keeping padding bits zero.
+        This does depend on the C compiler keeping padding bits unchanged.
         Common compilers seem to do so.
         """
         for name, cls in TESTCASES.items():
@@ -696,7 +696,8 @@ if __name__ == '__main__':
             output('                ' + line)
         typename = f'{struct_or_union(cls)} {name}'
         output(f"""
-                {typename} value = {{0}};
+                {typename} value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString({c_str_repr(name)}));
                 APPEND(PyLong_FromLong(sizeof({typename})));
                 APPEND(PyLong_FromLong(_Alignof({typename})));

--- a/Modules/_ctypes/_ctypes_test_generated.c.h
+++ b/Modules/_ctypes/_ctypes_test_generated.c.h
@@ -56,7 +56,8 @@
                 struct SingleInt {
                     int a;
                 };
-                struct SingleInt value = {0};
+                struct SingleInt value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("SingleInt"));
                 APPEND(PyLong_FromLong(sizeof(struct SingleInt)));
                 APPEND(PyLong_FromLong(_Alignof(struct SingleInt)));
@@ -69,7 +70,8 @@
                 union SingleInt_Union {
                     int a;
                 };
-                union SingleInt_Union value = {0};
+                union SingleInt_Union value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("SingleInt_Union"));
                 APPEND(PyLong_FromLong(sizeof(union SingleInt_Union)));
                 APPEND(PyLong_FromLong(_Alignof(union SingleInt_Union)));
@@ -82,7 +84,8 @@
                 struct SingleU32 {
                     uint32_t a;
                 };
-                struct SingleU32 value = {0};
+                struct SingleU32 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("SingleU32"));
                 APPEND(PyLong_FromLong(sizeof(struct SingleU32)));
                 APPEND(PyLong_FromLong(_Alignof(struct SingleU32)));
@@ -97,7 +100,8 @@
                     int8_t y;
                     uint16_t z;
                 };
-                struct SimpleStruct value = {0};
+                struct SimpleStruct value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("SimpleStruct"));
                 APPEND(PyLong_FromLong(sizeof(struct SimpleStruct)));
                 APPEND(PyLong_FromLong(_Alignof(struct SimpleStruct)));
@@ -114,7 +118,8 @@
                     int8_t y;
                     uint16_t z;
                 };
-                union SimpleUnion value = {0};
+                union SimpleUnion value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("SimpleUnion"));
                 APPEND(PyLong_FromLong(sizeof(union SimpleUnion)));
                 APPEND(PyLong_FromLong(_Alignof(union SimpleUnion)));
@@ -136,7 +141,8 @@
                     int64_t i64;
                     uint64_t u64;
                 };
-                struct ManyTypes value = {0};
+                struct ManyTypes value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("ManyTypes"));
                 APPEND(PyLong_FromLong(sizeof(struct ManyTypes)));
                 APPEND(PyLong_FromLong(_Alignof(struct ManyTypes)));
@@ -163,7 +169,8 @@
                     int64_t i64;
                     uint64_t u64;
                 };
-                union ManyTypesU value = {0};
+                union ManyTypesU value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("ManyTypesU"));
                 APPEND(PyLong_FromLong(sizeof(union ManyTypesU)));
                 APPEND(PyLong_FromLong(_Alignof(union ManyTypesU)));
@@ -197,7 +204,8 @@
                         uint16_t z;
                     };
                 };
-                struct Nested value = {0};
+                struct Nested value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Nested"));
                 APPEND(PyLong_FromLong(sizeof(struct Nested)));
                 APPEND(PyLong_FromLong(_Alignof(struct Nested)));
@@ -223,7 +231,8 @@
                     int64_t b;
                 };
                 #pragma pack(pop)
-                struct Packed1 value = {0};
+                struct Packed1 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Packed1"));
                 APPEND(PyLong_FromLong(sizeof(struct Packed1)));
                 APPEND(PyLong_FromLong(_Alignof(struct Packed1)));
@@ -247,7 +256,8 @@
                     int64_t b;
                 };
                 #pragma pack(pop)
-                struct Packed2 value = {0};
+                struct Packed2 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Packed2"));
                 APPEND(PyLong_FromLong(sizeof(struct Packed2)));
                 APPEND(PyLong_FromLong(_Alignof(struct Packed2)));
@@ -271,7 +281,8 @@
                     int64_t b;
                 };
                 #pragma pack(pop)
-                struct Packed3 value = {0};
+                struct Packed3 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Packed3"));
                 APPEND(PyLong_FromLong(sizeof(struct Packed3)));
                 APPEND(PyLong_FromLong(_Alignof(struct Packed3)));
@@ -295,7 +306,8 @@
                     int64_t b;
                 };
                 #pragma pack(pop)
-                struct Packed4 value = {0};
+                struct Packed4 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Packed4"));
                 APPEND(PyLong_FromLong(sizeof(struct Packed4)));
                 APPEND(PyLong_FromLong(_Alignof(struct Packed4)));
@@ -316,7 +328,8 @@
                     int64_t b;
                     int32_t c;
                 };
-                struct X86_32EdgeCase value = {0};
+                struct X86_32EdgeCase value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("X86_32EdgeCase"));
                 APPEND(PyLong_FromLong(sizeof(struct X86_32EdgeCase)));
                 APPEND(PyLong_FromLong(_Alignof(struct X86_32EdgeCase)));
@@ -333,7 +346,8 @@
                     unsigned int b :5;
                     unsigned int c :7;
                 };
-                struct MSBitFieldExample value = {0};
+                struct MSBitFieldExample value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("MSBitFieldExample"));
                 APPEND(PyLong_FromLong(sizeof(struct MSBitFieldExample)));
                 APPEND(PyLong_FromLong(_Alignof(struct MSBitFieldExample)));
@@ -351,7 +365,8 @@
                     unsigned int may_straddle :30;
                     unsigned int last :18;
                 };
-                struct MSStraddlingExample value = {0};
+                struct MSStraddlingExample value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("MSStraddlingExample"));
                 APPEND(PyLong_FromLong(sizeof(struct MSStraddlingExample)));
                 APPEND(PyLong_FromLong(_Alignof(struct MSStraddlingExample)));
@@ -375,7 +390,8 @@
                     int H :8;
                     int I :9;
                 };
-                struct IntBits value = {0};
+                struct IntBits value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("IntBits"));
                 APPEND(PyLong_FromLong(sizeof(struct IntBits)));
                 APPEND(PyLong_FromLong(_Alignof(struct IntBits)));
@@ -413,7 +429,8 @@
                     short R :6;
                     short S :7;
                 };
-                struct Bits value = {0};
+                struct Bits value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Bits"));
                 APPEND(PyLong_FromLong(sizeof(struct Bits)));
                 APPEND(PyLong_FromLong(_Alignof(struct Bits)));
@@ -456,7 +473,8 @@
                     int H :8;
                     int I :9;
                 };
-                struct IntBits_MSVC value = {0};
+                struct IntBits_MSVC value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("IntBits_MSVC"));
                 APPEND(PyLong_FromLong(sizeof(struct IntBits_MSVC)));
                 APPEND(PyLong_FromLong(_Alignof(struct IntBits_MSVC)));
@@ -499,7 +517,8 @@
                     short R :6;
                     short S :7;
                 };
-                struct Bits_MSVC value = {0};
+                struct Bits_MSVC value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Bits_MSVC"));
                 APPEND(PyLong_FromLong(sizeof(struct Bits_MSVC)));
                 APPEND(PyLong_FromLong(_Alignof(struct Bits_MSVC)));
@@ -536,7 +555,8 @@
                     int64_t b :62;
                     int64_t c :1;
                 };
-                struct I64Bits value = {0};
+                struct I64Bits value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("I64Bits"));
                 APPEND(PyLong_FromLong(sizeof(struct I64Bits)));
                 APPEND(PyLong_FromLong(_Alignof(struct I64Bits)));
@@ -560,7 +580,8 @@
                     uint64_t b :62;
                     uint64_t c :1;
                 };
-                struct U64Bits value = {0};
+                struct U64Bits value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("U64Bits"));
                 APPEND(PyLong_FromLong(sizeof(struct U64Bits)));
                 APPEND(PyLong_FromLong(_Alignof(struct U64Bits)));
@@ -584,7 +605,8 @@
                     int8_t b :3;
                     int8_t c :1;
                 };
-                struct Struct331_8 value = {0};
+                struct Struct331_8 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct331_8"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct331_8)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct331_8)));
@@ -608,7 +630,8 @@
                     int8_t b :6;
                     int8_t c :1;
                 };
-                struct Struct1x1_8 value = {0};
+                struct Struct1x1_8 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1x1_8"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1x1_8)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1x1_8)));
@@ -633,7 +656,8 @@
                     int8_t b :6;
                     int8_t c :1;
                 };
-                struct Struct1nx1_8 value = {0};
+                struct Struct1nx1_8 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1nx1_8"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1nx1_8)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1nx1_8)));
@@ -658,7 +682,8 @@
                     int8_t b :6;
                     int8_t c :6;
                 };
-                struct Struct3xx_8 value = {0};
+                struct Struct3xx_8 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct3xx_8"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct3xx_8)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct3xx_8)));
@@ -682,7 +707,8 @@
                     uint8_t b :3;
                     uint8_t c :1;
                 };
-                struct Struct331_u8 value = {0};
+                struct Struct331_u8 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct331_u8"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct331_u8)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct331_u8)));
@@ -706,7 +732,8 @@
                     uint8_t b :6;
                     uint8_t c :1;
                 };
-                struct Struct1x1_u8 value = {0};
+                struct Struct1x1_u8 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1x1_u8"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1x1_u8)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1x1_u8)));
@@ -731,7 +758,8 @@
                     uint8_t b :6;
                     uint8_t c :1;
                 };
-                struct Struct1nx1_u8 value = {0};
+                struct Struct1nx1_u8 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1nx1_u8"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1nx1_u8)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1nx1_u8)));
@@ -756,7 +784,8 @@
                     uint8_t b :6;
                     uint8_t c :6;
                 };
-                struct Struct3xx_u8 value = {0};
+                struct Struct3xx_u8 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct3xx_u8"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct3xx_u8)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct3xx_u8)));
@@ -780,7 +809,8 @@
                     int16_t b :3;
                     int16_t c :1;
                 };
-                struct Struct331_16 value = {0};
+                struct Struct331_16 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct331_16"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct331_16)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct331_16)));
@@ -804,7 +834,8 @@
                     int16_t b :14;
                     int16_t c :1;
                 };
-                struct Struct1x1_16 value = {0};
+                struct Struct1x1_16 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1x1_16"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1x1_16)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1x1_16)));
@@ -829,7 +860,8 @@
                     int16_t b :14;
                     int16_t c :1;
                 };
-                struct Struct1nx1_16 value = {0};
+                struct Struct1nx1_16 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1nx1_16"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1nx1_16)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1nx1_16)));
@@ -854,7 +886,8 @@
                     int16_t b :14;
                     int16_t c :14;
                 };
-                struct Struct3xx_16 value = {0};
+                struct Struct3xx_16 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct3xx_16"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct3xx_16)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct3xx_16)));
@@ -878,7 +911,8 @@
                     uint16_t b :3;
                     uint16_t c :1;
                 };
-                struct Struct331_u16 value = {0};
+                struct Struct331_u16 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct331_u16"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct331_u16)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct331_u16)));
@@ -902,7 +936,8 @@
                     uint16_t b :14;
                     uint16_t c :1;
                 };
-                struct Struct1x1_u16 value = {0};
+                struct Struct1x1_u16 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1x1_u16"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1x1_u16)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1x1_u16)));
@@ -927,7 +962,8 @@
                     uint16_t b :14;
                     uint16_t c :1;
                 };
-                struct Struct1nx1_u16 value = {0};
+                struct Struct1nx1_u16 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1nx1_u16"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1nx1_u16)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1nx1_u16)));
@@ -952,7 +988,8 @@
                     uint16_t b :14;
                     uint16_t c :14;
                 };
-                struct Struct3xx_u16 value = {0};
+                struct Struct3xx_u16 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct3xx_u16"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct3xx_u16)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct3xx_u16)));
@@ -976,7 +1013,8 @@
                     int32_t b :3;
                     int32_t c :1;
                 };
-                struct Struct331_32 value = {0};
+                struct Struct331_32 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct331_32"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct331_32)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct331_32)));
@@ -1000,7 +1038,8 @@
                     int32_t b :30;
                     int32_t c :1;
                 };
-                struct Struct1x1_32 value = {0};
+                struct Struct1x1_32 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1x1_32"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1x1_32)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1x1_32)));
@@ -1025,7 +1064,8 @@
                     int32_t b :30;
                     int32_t c :1;
                 };
-                struct Struct1nx1_32 value = {0};
+                struct Struct1nx1_32 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1nx1_32"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1nx1_32)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1nx1_32)));
@@ -1050,7 +1090,8 @@
                     int32_t b :30;
                     int32_t c :30;
                 };
-                struct Struct3xx_32 value = {0};
+                struct Struct3xx_32 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct3xx_32"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct3xx_32)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct3xx_32)));
@@ -1074,7 +1115,8 @@
                     uint32_t b :3;
                     uint32_t c :1;
                 };
-                struct Struct331_u32 value = {0};
+                struct Struct331_u32 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct331_u32"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct331_u32)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct331_u32)));
@@ -1098,7 +1140,8 @@
                     uint32_t b :30;
                     uint32_t c :1;
                 };
-                struct Struct1x1_u32 value = {0};
+                struct Struct1x1_u32 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1x1_u32"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1x1_u32)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1x1_u32)));
@@ -1123,7 +1166,8 @@
                     uint32_t b :30;
                     uint32_t c :1;
                 };
-                struct Struct1nx1_u32 value = {0};
+                struct Struct1nx1_u32 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1nx1_u32"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1nx1_u32)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1nx1_u32)));
@@ -1148,7 +1192,8 @@
                     uint32_t b :30;
                     uint32_t c :30;
                 };
-                struct Struct3xx_u32 value = {0};
+                struct Struct3xx_u32 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct3xx_u32"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct3xx_u32)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct3xx_u32)));
@@ -1172,7 +1217,8 @@
                     int64_t b :3;
                     int64_t c :1;
                 };
-                struct Struct331_64 value = {0};
+                struct Struct331_64 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct331_64"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct331_64)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct331_64)));
@@ -1196,7 +1242,8 @@
                     int64_t b :62;
                     int64_t c :1;
                 };
-                struct Struct1x1_64 value = {0};
+                struct Struct1x1_64 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1x1_64"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1x1_64)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1x1_64)));
@@ -1221,7 +1268,8 @@
                     int64_t b :62;
                     int64_t c :1;
                 };
-                struct Struct1nx1_64 value = {0};
+                struct Struct1nx1_64 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1nx1_64"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1nx1_64)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1nx1_64)));
@@ -1246,7 +1294,8 @@
                     int64_t b :62;
                     int64_t c :62;
                 };
-                struct Struct3xx_64 value = {0};
+                struct Struct3xx_64 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct3xx_64"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct3xx_64)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct3xx_64)));
@@ -1270,7 +1319,8 @@
                     uint64_t b :3;
                     uint64_t c :1;
                 };
-                struct Struct331_u64 value = {0};
+                struct Struct331_u64 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct331_u64"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct331_u64)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct331_u64)));
@@ -1294,7 +1344,8 @@
                     uint64_t b :62;
                     uint64_t c :1;
                 };
-                struct Struct1x1_u64 value = {0};
+                struct Struct1x1_u64 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1x1_u64"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1x1_u64)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1x1_u64)));
@@ -1319,7 +1370,8 @@
                     uint64_t b :62;
                     uint64_t c :1;
                 };
-                struct Struct1nx1_u64 value = {0};
+                struct Struct1nx1_u64 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct1nx1_u64"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct1nx1_u64)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct1nx1_u64)));
@@ -1344,7 +1396,8 @@
                     uint64_t b :62;
                     uint64_t c :62;
                 };
-                struct Struct3xx_u64 value = {0};
+                struct Struct3xx_u64 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Struct3xx_u64"));
                 APPEND(PyLong_FromLong(sizeof(struct Struct3xx_u64)));
                 APPEND(PyLong_FromLong(_Alignof(struct Struct3xx_u64)));
@@ -1367,7 +1420,8 @@
                     signed char a :4;
                     int b :4;
                 };
-                struct Mixed1 value = {0};
+                struct Mixed1 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Mixed1"));
                 APPEND(PyLong_FromLong(sizeof(struct Mixed1)));
                 APPEND(PyLong_FromLong(_Alignof(struct Mixed1)));
@@ -1389,7 +1443,8 @@
                     signed char a :4;
                     int32_t b :32;
                 };
-                struct Mixed2 value = {0};
+                struct Mixed2 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Mixed2"));
                 APPEND(PyLong_FromLong(sizeof(struct Mixed2)));
                 APPEND(PyLong_FromLong(_Alignof(struct Mixed2)));
@@ -1411,7 +1466,8 @@
                     signed char a :4;
                     unsigned char b :4;
                 };
-                struct Mixed3 value = {0};
+                struct Mixed3 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Mixed3"));
                 APPEND(PyLong_FromLong(sizeof(struct Mixed3)));
                 APPEND(PyLong_FromLong(_Alignof(struct Mixed3)));
@@ -1437,7 +1493,8 @@
                     short e :4;
                     int f :24;
                 };
-                struct Mixed4 value = {0};
+                struct Mixed4 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Mixed4"));
                 APPEND(PyLong_FromLong(sizeof(struct Mixed4)));
                 APPEND(PyLong_FromLong(_Alignof(struct Mixed4)));
@@ -1463,7 +1520,8 @@
                     unsigned int A :1;
                     unsigned short B :16;
                 };
-                struct Mixed5 value = {0};
+                struct Mixed5 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Mixed5"));
                 APPEND(PyLong_FromLong(sizeof(struct Mixed5)));
                 APPEND(PyLong_FromLong(_Alignof(struct Mixed5)));
@@ -1485,7 +1543,8 @@
                     unsigned long long A :1;
                     unsigned int B :32;
                 };
-                struct Mixed6 value = {0};
+                struct Mixed6 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Mixed6"));
                 APPEND(PyLong_FromLong(sizeof(struct Mixed6)));
                 APPEND(PyLong_FromLong(_Alignof(struct Mixed6)));
@@ -1508,7 +1567,8 @@
                     uint32_t B :20;
                     uint64_t C :24;
                 };
-                struct Mixed7 value = {0};
+                struct Mixed7 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Mixed7"));
                 APPEND(PyLong_FromLong(sizeof(struct Mixed7)));
                 APPEND(PyLong_FromLong(_Alignof(struct Mixed7)));
@@ -1532,7 +1592,8 @@
                     uint32_t B :32;
                     unsigned long long C :1;
                 };
-                struct Mixed8_a value = {0};
+                struct Mixed8_a value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Mixed8_a"));
                 APPEND(PyLong_FromLong(sizeof(struct Mixed8_a)));
                 APPEND(PyLong_FromLong(_Alignof(struct Mixed8_a)));
@@ -1556,7 +1617,8 @@
                     uint32_t B;
                     unsigned long long C :1;
                 };
-                struct Mixed8_b value = {0};
+                struct Mixed8_b value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Mixed8_b"));
                 APPEND(PyLong_FromLong(sizeof(struct Mixed8_b)));
                 APPEND(PyLong_FromLong(_Alignof(struct Mixed8_b)));
@@ -1579,7 +1641,8 @@
                     uint8_t A;
                     uint32_t B :1;
                 };
-                struct Mixed9 value = {0};
+                struct Mixed9 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Mixed9"));
                 APPEND(PyLong_FromLong(sizeof(struct Mixed9)));
                 APPEND(PyLong_FromLong(_Alignof(struct Mixed9)));
@@ -1601,7 +1664,8 @@
                     uint32_t A :1;
                     uint64_t B :1;
                 };
-                struct Mixed10 value = {0};
+                struct Mixed10 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Mixed10"));
                 APPEND(PyLong_FromLong(sizeof(struct Mixed10)));
                 APPEND(PyLong_FromLong(_Alignof(struct Mixed10)));
@@ -1623,7 +1687,8 @@
                     uint32_t A :1;
                     uint64_t B :1;
                 };
-                struct Example_gh_95496 value = {0};
+                struct Example_gh_95496 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Example_gh_95496"));
                 APPEND(PyLong_FromLong(sizeof(struct Example_gh_95496)));
                 APPEND(PyLong_FromLong(_Alignof(struct Example_gh_95496)));
@@ -1655,7 +1720,8 @@
                     uint16_t b1 :12;
                 };
                 #pragma pack(pop)
-                struct Example_gh_84039_bad value = {0};
+                struct Example_gh_84039_bad value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Example_gh_84039_bad"));
                 APPEND(PyLong_FromLong(sizeof(struct Example_gh_84039_bad)));
                 APPEND(PyLong_FromLong(_Alignof(struct Example_gh_84039_bad)));
@@ -1693,7 +1759,8 @@
                     uint8_t a7 :1;
                 };
                 #pragma pack(pop)
-                struct Example_gh_84039_good_a value = {0};
+                struct Example_gh_84039_good_a value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Example_gh_84039_good_a"));
                 APPEND(PyLong_FromLong(sizeof(struct Example_gh_84039_good_a)));
                 APPEND(PyLong_FromLong(_Alignof(struct Example_gh_84039_good_a)));
@@ -1735,7 +1802,8 @@
                     uint16_t b1 :12;
                 };
                 #pragma pack(pop)
-                struct Example_gh_84039_good value = {0};
+                struct Example_gh_84039_good value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Example_gh_84039_good"));
                 APPEND(PyLong_FromLong(sizeof(struct Example_gh_84039_good)));
                 APPEND(PyLong_FromLong(_Alignof(struct Example_gh_84039_good)));
@@ -1775,7 +1843,8 @@
                     uint32_t R2 :2;
                 };
                 #pragma pack(pop)
-                struct Example_gh_73939 value = {0};
+                struct Example_gh_73939 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Example_gh_73939"));
                 APPEND(PyLong_FromLong(sizeof(struct Example_gh_73939)));
                 APPEND(PyLong_FromLong(_Alignof(struct Example_gh_73939)));
@@ -1806,7 +1875,8 @@
                     uint8_t b :8;
                     uint32_t c :16;
                 };
-                struct Example_gh_86098 value = {0};
+                struct Example_gh_86098 value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Example_gh_86098"));
                 APPEND(PyLong_FromLong(sizeof(struct Example_gh_86098)));
                 APPEND(PyLong_FromLong(_Alignof(struct Example_gh_86098)));
@@ -1832,7 +1902,8 @@
                     uint32_t c :16;
                 };
                 #pragma pack(pop)
-                struct Example_gh_86098_pack value = {0};
+                struct Example_gh_86098_pack value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("Example_gh_86098_pack"));
                 APPEND(PyLong_FromLong(sizeof(struct Example_gh_86098_pack)));
                 APPEND(PyLong_FromLong(_Alignof(struct Example_gh_86098_pack)));
@@ -1858,7 +1929,8 @@
                     };
                     signed char y;
                 };
-                struct AnonBitfields value = {0};
+                struct AnonBitfields value;
+                memset(&value, 0, sizeof(value));
                 APPEND(PyUnicode_FromString("AnonBitfields"));
                 APPEND(PyLong_FromLong(sizeof(struct AnonBitfields)));
                 APPEND(PyLong_FromLong(_Alignof(struct AnonBitfields)));


### PR DESCRIPTION
GCC 15 doesn't set padding bits to zero (as it's allowed to, according to standard). Let's zero the test structs explicitly.

Even with this PR, the tests still depend on the compiler keeping padding bits *unchanged* when surrounding values are set. (AFAIK, this is not guaranteed by the standard, and when bitfields are involved, changing padding bits might make sense as an optimization.)
Removing that limitation will be easier with introspection attributes I want to add in gh-128715.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128889 -->
* Issue: gh-128889
<!-- /gh-issue-number -->
