### PR TITLE
Fix definition of a `generator iterator` in `glossary.rst`

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -115,7 +115,7 @@ Glossary
       :keyword:`yield` expression.
 
       Each :keyword:`yield` temporarily suspends processing, remembering the
-      location execution state (including local variables and pending
+      execution state (including local variables and pending
       try-statements).  When the *asynchronous generator iterator* effectively
       resumes with another awaitable returned by :meth:`~object.__anext__`, it
       picks up where it left off.  See :pep:`492` and :pep:`525`.
@@ -564,7 +564,7 @@ Glossary
       An object created by a :term:`generator` function.
 
       Each :keyword:`yield` temporarily suspends processing, remembering the
-      location execution state (including local variables and pending
+      execution state (including local variables and pending
       try-statements).  When the *generator iterator* resumes, it picks up where
       it left off (in contrast to functions which start fresh on every
       invocation).


### PR DESCRIPTION
# Fix typo/grammar in glossary.rst

As discussed in https://discuss.python.org/t/typo-in-glossary-entry-for-generator-iterator/77163 , copying here for context:

> In the [“generator iterator” definition](https://docs.python.org/3/glossary.html#term-generator-iterator):
> > Each [yield](https://docs.python.org/3/reference/simple_stmts.html#yield) temporarily suspends processing, remembering the location execution state (including local variables and pending try-statements).

> I find it hard to parse the first sentence, particularly “the location execution state”. I do know how a generator works, but I’m unsure if this is attempting to say “location and execution state”, “local execution state,” or something else. I am not a native English speaker, but the three nouns on a row are challenging for me to read (if it is a noun phrase, shouldn’t they be dashed?)

Note: The phrase appears again in the “asynchronous generator iterator” entry.

No github issue, based on: Trivial changes, like fixing a typo, do not need an issue.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128952.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->