### PR TITLE
gh-128961: Fix exhausted array iterator crash in `__setstate__`

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1670,6 +1670,7 @@ class LargeArrayTest(unittest.TestCase):
         it = iter(a)
         list(it)
         it.__setstate__(0)
+        self.assertRaises(StopIteration, lambda: next(it))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1670,7 +1670,8 @@ class LargeArrayTest(unittest.TestCase):
         it = iter(a)
         list(it)
         it.__setstate__(0)
-        self.assertRaises(StopIteration, lambda: next(it))
+        self.assertRaises(StopIteration, next, it)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1665,5 +1665,11 @@ class LargeArrayTest(unittest.TestCase):
         self.assertEqual(ls[:8], list(example[:8]))
         self.assertEqual(ls[-8:], list(example[-8:]))
 
+    def test_gh_128961(self):
+        a = array.array('i')
+        it = iter(a)
+        list(it)
+        it.__setstate__(0)
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2025-01-17-21-33-11.gh-issue-128961.XwvyIZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-17-21-33-11.gh-issue-128961.XwvyIZ.rst
@@ -1,0 +1,1 @@
+fix crash on array iterator when setting state when exhausted

--- a/Misc/NEWS.d/next/Library/2025-01-17-21-33-11.gh-issue-128961.XwvyIZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-17-21-33-11.gh-issue-128961.XwvyIZ.rst
@@ -1,1 +1,1 @@
-fix crash on array iterator when setting state when exhausted
+Fix a crash when setting state on an exhausted :class:`array.array` iterator.

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3092,10 +3092,12 @@ array_arrayiterator___setstate__(arrayiterobject *self, PyObject *state)
         return NULL;
     arrayobject *ao = self->ao;
     if (ao != NULL) {
-        if (index < 0)
+        if (index < 0) {
             index = 0;
-        else if (index > Py_SIZE(ao))
+        }
+        else if (index > Py_SIZE(ao)) {
             index = Py_SIZE(ao); /* iterator exhausted */
+        }
         self->index = index;
     }
     Py_RETURN_NONE;

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3091,13 +3091,13 @@ array_arrayiterator___setstate__(arrayiterobject *self, PyObject *state)
     if (index == -1 && PyErr_Occurred())
         return NULL;
     arrayobject *ao = self->ao;
-    // if (ao != NULL) {
+    if (ao != NULL) {
         if (index < 0)
             index = 0;
         else if (index > Py_SIZE(ao))
             index = Py_SIZE(ao); /* iterator exhausted */
         self->index = index;
-    // }
+    }
     Py_RETURN_NONE;
 }
 

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -3090,11 +3090,14 @@ array_arrayiterator___setstate__(arrayiterobject *self, PyObject *state)
     Py_ssize_t index = PyLong_AsSsize_t(state);
     if (index == -1 && PyErr_Occurred())
         return NULL;
-    if (index < 0)
-        index = 0;
-    else if (index > Py_SIZE(self->ao))
-        index = Py_SIZE(self->ao); /* iterator exhausted */
-    self->index = index;
+    arrayobject *ao = self->ao;
+    // if (ao != NULL) {
+        if (index < 0)
+            index = 0;
+        else if (index > Py_SIZE(ao))
+            index = Py_SIZE(ao); /* iterator exhausted */
+        self->index = index;
+    // }
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Simple fix for this segfault.

<!-- gh-issue-number: gh-128961 -->
* Issue: gh-128961
<!-- /gh-issue-number -->
