### PR TITLE
[3.12] gh-125997: suggest efficient alternatives for `time.sleep(0)` (GH-128752)

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -5058,6 +5058,8 @@ information, consult your Unix manpages.
 The following scheduling policies are exposed if they are supported by the
 operating system.
 
+.. _os-scheduling-policy:
+
 .. data:: SCHED_OTHER
 
    The default scheduling policy.
@@ -5149,7 +5151,7 @@ operating system.
 
 .. function:: sched_yield()
 
-   Voluntarily relinquish the CPU.
+   Voluntarily relinquish the CPU. See :manpage:`sched_yield(2)` for details.
 
 
 .. function:: sched_setaffinity(pid, mask, /)

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -367,6 +367,8 @@ Functions
    The suspension time may be longer than requested by an arbitrary amount,
    because of the scheduling of other activity in the system.
 
+   .. rubric:: Windows implementation
+
    On Windows, if *secs* is zero, the thread relinquishes the remainder of its
    time slice to any other thread that is ready to run. If there are no other
    threads ready to run, the function returns immediately, and the thread
@@ -375,11 +377,18 @@ Functions
    <https://learn.microsoft.com/windows-hardware/drivers/kernel/high-resolution-timers>`_
    which provides resolution of 100 nanoseconds. If *secs* is zero, ``Sleep(0)`` is used.
 
-   Unix implementation:
+   .. rubric:: Unix implementation
 
    * Use ``clock_nanosleep()`` if available (resolution: 1 nanosecond);
    * Or use ``nanosleep()`` if available (resolution: 1 nanosecond);
    * Or use ``select()`` (resolution: 1 microsecond).
+
+   .. note::
+
+      To emulate a "no-op", use :keyword:`pass` instead of ``time.sleep(0)``.
+
+      To voluntarily relinquish the CPU, specify a real-time :ref:`scheduling
+      policy <os-scheduling-policy>` and use :func:`os.sched_yield` instead.
 
    .. versionchanged:: 3.5
       The function now sleeps at least *secs* even if the sleep is interrupted


### PR DESCRIPTION
(cherry picked from commit f4afaa6f1190fbbea3e27c590096951d8ffdfb71)

<!-- gh-issue-number: gh-125997 -->
* Issue: gh-125997
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128985.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->