### PR TITLE
gh-128998: Fix indentation of numbered list and literal block

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1914,16 +1914,16 @@ correctly using identity tests:
    guaranteed to be distinct from other objects.  For example, here is how
    to implement a method that behaves like :meth:`dict.pop`::
 
-    _sentinel = object()
+   _sentinel = object()
 
-    def pop(self, key, default=_sentinel):
-        if key in self:
-            value = self[key]
-            del self[key]
-            return value
-        if default is _sentinel:
-            raise KeyError(key)
-        return default
+   def pop(self, key, default=_sentinel):
+       if key in self:
+           value = self[key]
+           del self[key]
+           return value
+       if default is _sentinel:
+           raise KeyError(key)
+       return default
 
 3) Container implementations sometimes need to augment equality tests with
    identity tests.  This prevents the code from being confused by objects

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1906,28 +1906,28 @@ In the standard library code, you will see several common patterns for
 correctly using identity tests:
 
 1) As recommended by :pep:`8`, an identity test is the preferred way to check
-for ``None``.  This reads like plain English in code and avoids confusion with
-other objects that may have boolean values that evaluate to false.
+   for ``None``.  This reads like plain English in code and avoids confusion
+   with other objects that may have boolean values that evaluate to false.
 
 2) Detecting optional arguments can be tricky when ``None`` is a valid input
-value.  In those situations, you can create a singleton sentinel object
-guaranteed to be distinct from other objects.  For example, here is how
-to implement a method that behaves like :meth:`dict.pop`::
+   value.  In those situations, you can create a singleton sentinel object
+   guaranteed to be distinct from other objects.  For example, here is how
+   to implement a method that behaves like :meth:`dict.pop`::
 
-   _sentinel = object()
+    _sentinel = object()
 
-   def pop(self, key, default=_sentinel):
-       if key in self:
-           value = self[key]
-           del self[key]
-           return value
-       if default is _sentinel:
-           raise KeyError(key)
-       return default
+    def pop(self, key, default=_sentinel):
+        if key in self:
+            value = self[key]
+            del self[key]
+            return value
+        if default is _sentinel:
+            raise KeyError(key)
+        return default
 
 3) Container implementations sometimes need to augment equality tests with
-identity tests.  This prevents the code from being confused by objects such as
-``float('NaN')`` that are not equal to themselves.
+   identity tests.  This prevents the code from being confused by objects
+   such as ``float('NaN')`` that are not equal to themselves.
 
 For example, here is the implementation of
 :meth:`!collections.abc.Sequence.__contains__`::

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1912,18 +1912,20 @@ correctly using identity tests:
 2) Detecting optional arguments can be tricky when ``None`` is a valid input
    value.  In those situations, you can create a singleton sentinel object
    guaranteed to be distinct from other objects.  For example, here is how
-   to implement a method that behaves like :meth:`dict.pop`::
+   to implement a method that behaves like :meth:`dict.pop`:
 
-   _sentinel = object()
+   .. code-block:: python
 
-   def pop(self, key, default=_sentinel):
-       if key in self:
-           value = self[key]
-           del self[key]
-           return value
-       if default is _sentinel:
-           raise KeyError(key)
-       return default
+      _sentinel = object()
+
+      def pop(self, key, default=_sentinel):
+          if key in self:
+              value = self[key]
+              del self[key]
+              return value
+          if default is _sentinel:
+              raise KeyError(key)
+          return default
 
 3) Container implementations sometimes need to augment equality tests with
    identity tests.  This prevents the code from being confused by objects


### PR DESCRIPTION
Fixes bad indentation in numbered list and adds one missing whitespace in literal block, to fix translated documentation generation.

The lack of indentation was turning these (supposed-to-be) numbered list items into simple paragraphs. While no error message pops up in English docs, building translation docs will emit:

```
faq/programming.rst:1912:<translated>:3: WARNING: Literal block expected; none found. [docutils]
```

Fixing indentation was enough, though. Now, translated build will emit:

```
faq/programming.rst:1926: WARNING: Definition list ends without a blank line; unexpected unindent. [docutils]
```

Adding one extra whitespace to the literal block (to make four-whitespaces indentation, instead of three) solves the whole thing

In the left is today's [faq/programming.html](https://docs.python.org/3/faq/programming.html), in right is my patch:

<img src="https://github.com/user-attachments/assets/4eedc456-6ecc-4603-b99b-3f48c9c5f315" width="40%" height="40%" />   <img src="https://github.com/user-attachments/assets/d539e6f2-de9c-4221-9254-f671e3252b9b" width="40%" height="40%" />

<!-- gh-issue-number: gh-128998 -->
* Issue: gh-128998
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--128999.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->