### PR TITLE
gh-129005: Avoid copy in _pyio.FileIO.readinto

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1695,18 +1695,19 @@ class FileIO(RawIOBase):
     def readinto(self, b):
         """Same as RawIOBase.readinto()."""
         m = memoryview(b).cast('B')
-        if not hasattr(os, 'readv'):
-            data = self.read(len(m))
-            n = len(data)
-            m[:n] = data
-            return n
-
         self._checkClosed()
         self._checkReadable()
         try:
-            return os.readv(self._fd, (m, ))
+            if hasattr(os, 'readv'):
+                return os.readv(self._fd, (m, ))
+
+            data = os.read(self._fd, len(m))
+            n = len(data)
+            m[:n] = data
+            return n
         except BlockingIOError:
             return None
+
 
 
     def write(self, b):

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1695,10 +1695,12 @@ class FileIO(RawIOBase):
     def readinto(self, b):
         """Same as RawIOBase.readinto()."""
         m = memoryview(b).cast('B')
-        data = self.read(len(m))
-        n = len(data)
-        m[:n] = data
-        return n
+        self._checkClosed()
+        self._checkReadable()
+        try:
+            return os.readv(self._fd, (m, ))
+        except BlockingIOError:
+            return None
 
     def write(self, b):
         """Write bytes b to file, return number written.

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1695,18 +1695,19 @@ class FileIO(RawIOBase):
     def readinto(self, b):
         """Same as RawIOBase.readinto()."""
         m = memoryview(b).cast('B')
-        if hasattr(os, 'readv'):
-            self._checkClosed()
-            self._checkReadable()
-            try:
-                return os.readv(self._fd, (m, ))
-            except BlockingIOError:
-                return None
-        else:
+        if not hasattr(os, 'readv'):
             data = self.read(len(m))
             n = len(data)
             m[:n] = data
             return n
+
+        self._checkClosed()
+        self._checkReadable()
+        try:
+            return os.readv(self._fd, (m, ))
+        except BlockingIOError:
+            return None
+
 
     def write(self, b):
         """Write bytes b to file, return number written.

--- a/Misc/NEWS.d/next/Library/2025-01-18-15-29-08.gh-issue-129005.mM5dmV.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-18-15-29-08.gh-issue-129005.mM5dmV.rst
@@ -1,0 +1,1 @@
+Change ``_pyio.FileIO.readinto`` to use :func:`os.readv` avoiding a copy that was present when using :func:`os.read`

--- a/Misc/NEWS.d/next/Library/2025-01-18-15-29-08.gh-issue-129005.mM5dmV.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-18-15-29-08.gh-issue-129005.mM5dmV.rst
@@ -1,1 +1,1 @@
-Change ``_pyio.FileIO.readinto`` to use :func:`os.readv` avoiding a copy that was present when using :func:`os.read`
+Change ``_pyio.FileIO.readinto`` to use :func:`os.readv` avoiding a copy that was present when using :func:`os.read` on platforms with :func:`os.readv`

--- a/Misc/NEWS.d/next/Library/2025-01-18-15-29-08.gh-issue-129005.mM5dmV.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-18-15-29-08.gh-issue-129005.mM5dmV.rst
@@ -1,1 +1,1 @@
-Optimize :meth:`_pyio.FileIO.readinto` by using :func:`os.readv` on platforms that support it which avoids an additional copy.
+Optimize ``_pyio.FileIO.readinto`` by using :func:`os.readv` on platforms that support it which avoids an additional copy.

--- a/Misc/NEWS.d/next/Library/2025-01-18-15-29-08.gh-issue-129005.mM5dmV.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-18-15-29-08.gh-issue-129005.mM5dmV.rst
@@ -1,1 +1,1 @@
-Change ``_pyio.FileIO.readinto`` to use :func:`os.readv` avoiding a copy that was present when using :func:`os.read` on platforms with :func:`os.readv`
+Optimize :meth:`_pyio.FileIO.readinto` by using :func:`os.readv` on platforms that support it which avoids an additional copy.


### PR DESCRIPTION
`os.read` allocated and filled a buffer by calling `read(2)`, than that data was copied into the user provied buffer. Read directly into the caller's buffer instead by using `os.readv`. `self.read()` was doing the closed and readable checks so move those into `readinto`

PR of `readinto` first as it is a lot smaller diff than the `readall` code but has the core `os.read` -> `os.readv` change. In `main` how the buffer is expanded between `_io` ([`new_buffersize`](https://github.com/python/cpython/blob/main/Modules/_io/fileio.c#L705-L721)) and `_pyio` ([inline in `read()`](https://github.com/python/cpython/blob/main/Lib/_pyio.py#L1679-L1681)) should get lined up.

<!-- gh-issue-number: gh-129005 -->
* Issue: gh-129005
<!-- /gh-issue-number -->
