### PR TITLE
gh-125522: Fix bare except in `test_uuid`

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -21,7 +21,7 @@ def importable(name):
     try:
         __import__(name)
         return True
-    except:
+    except ImportError:
         return False
 
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -21,7 +21,7 @@ def importable(name):
     try:
         __import__(name)
         return True
-    except ImportError:
+    except ModuleNotFoundError:
         return False
 
 


### PR DESCRIPTION
The intent of the helper function is only to check whether a module can be imported, so catching all exceptions could hide other issues.

(I'm adding the backport labels seeing as the other PRs were also backported)

<!-- gh-issue-number: gh-125522 -->
* Issue: gh-125522
<!-- /gh-issue-number -->
