### PR TITLE
gh-129025: fix too wide source location for bytecodes emitted for except*

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -260,7 +260,7 @@ class ExceptionTests(unittest.TestCase):
         check('class foo:return 1', 1, 11)
         check('def f():\n  continue', 2, 3)
         check('def f():\n  break', 2, 3)
-        check('try:\n  pass\nexcept:\n  pass\nexcept ValueError:\n  pass', 3, 0)
+        check('try:\n  pass\nexcept:\n  pass\nexcept ValueError:\n  pass', 3, 1)
         check('try:\n  pass\nexcept*:\n  pass', 3, 8)
         check('try:\n  pass\nexcept*:\n  pass\nexcept* ValueError:\n  pass', 3, 8)
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -260,7 +260,7 @@ class ExceptionTests(unittest.TestCase):
         check('class foo:return 1', 1, 11)
         check('def f():\n  continue', 2, 3)
         check('def f():\n  break', 2, 3)
-        check('try:\n  pass\nexcept:\n  pass\nexcept ValueError:\n  pass', 3, 1)
+        check('try:\n  pass\nexcept:\n  pass\nexcept ValueError:\n  pass', 3, 0)
         check('try:\n  pass\nexcept*:\n  pass', 3, 8)
         check('try:\n  pass\nexcept*:\n  pass\nexcept* ValueError:\n  pass', 3, 8)
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -2919,6 +2919,47 @@ class BaseExceptionReportingTests:
         report = self.get_report(exc)
         self.assertEqual(report, expected)
 
+    def test_except_star_lineno(self):
+        def exc():
+            class Bad(ExceptionGroup):
+                def split(*args):
+                    1/0
+
+            try:
+                raise Bad("", [ValueError(), TypeError()])
+            except* ValueError:
+                1
+                2
+                3
+
+        expected = (f'  + Exception Group Traceback (most recent call last):\n'
+                    f'  |   File "{__file__}", line {exc.__code__.co_firstlineno + 6}, in exc\n'
+                    f'  |     raise Bad("", [ValueError(), TypeError()])\n'
+                    f'  | test.test_traceback.BaseExceptionReportingTests.test_except_star_lineno.<locals>.exc.<locals>.Bad:  (2 sub-exceptions)\n'
+                    f'  +-+---------------- 1 ----------------\n'
+                    f'    | ValueError\n'
+                    f'    +---------------- 2 ----------------\n'
+                    f'    | TypeError\n'
+                    f'    +------------------------------------\n'
+                    f'\n'
+                    f'During handling of the above exception, another exception occurred:\n'
+                    f'\n'
+                    f'Traceback (most recent call last):\n'
+                    f'  File "{__file__}", line '
+                    f'{self.callable_line}, in get_exception\n'
+                    f'    exception_or_callable()\n'
+                    f'    ~~~~~~~~~~~~~~~~~~~~~^^\n'
+                    f'  File "{__file__}", line {exc.__code__.co_firstlineno + 7}, in exc\n'
+                    f'    except* ValueError:\n'
+                    f'    \n'
+                    f'  File "{__file__}", line {exc.__code__.co_firstlineno + 3}, in split\n'
+                    f'    1/0\n'
+                    f'    ~^~\n'
+                    f'ZeroDivisionError: division by zero\n')
+
+        report = self.get_report(exc)
+        self.assertEqual(report, expected)
+
     def test_KeyboardInterrupt_at_first_line_of_frame(self):
         # see GH-93249
         def f():

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-01-19-14-36-37.gh-issue-129025.QFXeS2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-01-19-14-36-37.gh-issue-129025.QFXeS2.rst
@@ -1,0 +1,2 @@
+Fix too wide source locations of instructions emitted for ``except`` and
+``except*``.

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -2365,7 +2365,8 @@ codegen_try_except(compiler *c, stmt_ty s)
     for (i = 0; i < n; i++) {
         excepthandler_ty handler = (excepthandler_ty)asdl_seq_GET(
             s->v.Try.handlers, i);
-        location loc = LOC(handler);
+        /* Set location to the entire line of the except keyword */
+        location loc = LOCATION(handler->lineno, handler->lineno, 0, 0);
         if (!handler->v.ExceptHandler.type && i < n-1) {
             return _PyCompile_Error(c, loc, "default 'except:' must be last");
         }
@@ -2546,7 +2547,8 @@ codegen_try_star_except(compiler *c, stmt_ty s)
     for (Py_ssize_t i = 0; i < n; i++) {
         excepthandler_ty handler = (excepthandler_ty)asdl_seq_GET(
             s->v.TryStar.handlers, i);
-        location loc = LOC(handler);
+        /* Set location to the entire line of the except keyword */
+        location loc = LOCATION(handler->lineno, handler->lineno, 0, 0);
         NEW_JUMP_TARGET_LABEL(c, next_except);
         except = next_except;
         NEW_JUMP_TARGET_LABEL(c, except_with_error);


### PR DESCRIPTION

Fixes #129025.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129025 -->
* Issue: gh-129025
<!-- /gh-issue-number -->
