### PR TITLE
gh-71339: Use new assertion methods in test_capi

### DIFF
--- a/Lib/test/test_capi/test_abstract.py
+++ b/Lib/test/test_capi/test_abstract.py
@@ -274,7 +274,7 @@ class CAPITest(unittest.TestCase):
 
         # PyObject_SetAttr(obj, attr_name, NULL) removes the attribute
         xsetattr(obj, 'a', NULL)
-        self.assertFalse(hasattr(obj, 'a'))
+        self.assertNotHasAttr(obj, 'a')
         self.assertRaises(AttributeError, xsetattr, obj, 'b', NULL)
         self.assertRaises(RuntimeError, xsetattr, obj, 'evil', NULL)
 
@@ -294,7 +294,7 @@ class CAPITest(unittest.TestCase):
 
         # PyObject_SetAttrString(obj, attr_name, NULL) removes the attribute
         setattrstring(obj, b'a', NULL)
-        self.assertFalse(hasattr(obj, 'a'))
+        self.assertNotHasAttr(obj, 'a')
         self.assertRaises(AttributeError, setattrstring, obj, b'b', NULL)
         self.assertRaises(RuntimeError, setattrstring, obj, b'evil', NULL)
 
@@ -311,10 +311,10 @@ class CAPITest(unittest.TestCase):
         obj.a = 1
         setattr(obj, '\U0001f40d', 2)
         xdelattr(obj, 'a')
-        self.assertFalse(hasattr(obj, 'a'))
+        self.assertNotHasAttr(obj, 'a')
         self.assertRaises(AttributeError, xdelattr, obj, 'b')
         xdelattr(obj, '\U0001f40d')
-        self.assertFalse(hasattr(obj, '\U0001f40d'))
+        self.assertNotHasAttr(obj, '\U0001f40d')
 
         self.assertRaises(AttributeError, xdelattr, 42, 'numerator')
         self.assertRaises(RuntimeError, xdelattr, obj, 'evil')
@@ -328,10 +328,10 @@ class CAPITest(unittest.TestCase):
         obj.a = 1
         setattr(obj, '\U0001f40d', 2)
         delattrstring(obj, b'a')
-        self.assertFalse(hasattr(obj, 'a'))
+        self.assertNotHasAttr(obj, 'a')
         self.assertRaises(AttributeError, delattrstring, obj, b'b')
         delattrstring(obj, '\U0001f40d'.encode())
-        self.assertFalse(hasattr(obj, '\U0001f40d'))
+        self.assertNotHasAttr(obj, '\U0001f40d')
 
         self.assertRaises(AttributeError, delattrstring, 42, b'numerator')
         self.assertRaises(RuntimeError, delattrstring, obj, b'evil')

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -116,8 +116,7 @@ class CAPITest(unittest.TestCase):
                    "after Python initialization and before Python finalization, "
                    "but it was called without an active thread state. "
                    "Are you trying to call the C API inside of a Py_BEGIN_ALLOW_THREADS block?").encode()
-        self.assertTrue(err.rstrip().startswith(msg),
-                        err)
+        self.assertStartsWith(err.rstrip(), msg)
 
     def test_memoryview_from_NULL_pointer(self):
         self.assertRaises(ValueError, _testcapi.make_memoryview_from_NULL_pointer)
@@ -720,7 +719,7 @@ class CAPITest(unittest.TestCase):
 
     def test_heaptype_with_custom_metaclass(self):
         metaclass = _testcapi.HeapCTypeMetaclass
-        self.assertTrue(issubclass(metaclass, type))
+        self.assertIsSubclass(metaclass, type)
 
         # Class creation from C
         t = _testcapi.pytype_fromspec_meta(metaclass)
@@ -736,7 +735,7 @@ class CAPITest(unittest.TestCase):
     def test_heaptype_with_custom_metaclass_null_new(self):
         metaclass = _testcapi.HeapCTypeMetaclassNullNew
 
-        self.assertTrue(issubclass(metaclass, type))
+        self.assertIsSubclass(metaclass, type)
 
         # Class creation from C
         t = _testcapi.pytype_fromspec_meta(metaclass)
@@ -751,7 +750,7 @@ class CAPITest(unittest.TestCase):
     def test_heaptype_with_custom_metaclass_custom_new(self):
         metaclass = _testcapi.HeapCTypeMetaclassCustomNew
 
-        self.assertTrue(issubclass(_testcapi.HeapCTypeMetaclassCustomNew, type))
+        self.assertIsSubclass(_testcapi.HeapCTypeMetaclassCustomNew, type)
 
         msg = "Metaclasses with custom tp_new are not supported."
         with self.assertRaisesRegex(TypeError, msg):
@@ -910,8 +909,7 @@ class CAPITest(unittest.TestCase):
             names.append('Py_FrozenMain')
 
         for name in names:
-            with self.subTest(name=name):
-                self.assertTrue(hasattr(ctypes.pythonapi, name))
+            self.assertHasAttr(ctypes.pythonapi, name)
 
     def test_clear_managed_dict(self):
 
@@ -1503,7 +1501,8 @@ class TestHeapTypeRelative(unittest.TestCase):
         self.assertIsInstance(closure, tuple)
         self.assertEqual(len(closure), 1)
         self.assertEqual(len(closure), len(func.__code__.co_freevars))
-        self.assertTrue(all(isinstance(cell, CellType) for cell in closure))
+        for cell in closure:
+            self.assertIsInstance(cell, CellType)
         self.assertTrue(closure[0].cell_contents, 5)
 
         func = with_two_levels(1, 2)(3, 4)
@@ -1512,7 +1511,8 @@ class TestHeapTypeRelative(unittest.TestCase):
         self.assertIsInstance(closure, tuple)
         self.assertEqual(len(closure), 4)
         self.assertEqual(len(closure), len(func.__code__.co_freevars))
-        self.assertTrue(all(isinstance(cell, CellType) for cell in closure))
+        for cell in closure:
+            self.assertIsInstance(cell, CellType)
         self.assertEqual([cell.cell_contents for cell in closure],
                          [1, 2, 3, 4])
 
@@ -2365,7 +2365,7 @@ class SubinterpreterTest(unittest.TestCase):
 
         support.run_in_subinterp("import binascii; binascii.Error.foobar = 'foobar'")
 
-        self.assertFalse(hasattr(binascii.Error, "foobar"))
+        self.assertNotHasAttr(binascii.Error, "foobar")
 
     @unittest.skipIf(_testmultiphase is None, "test requires _testmultiphase module")
     # gh-117649: The free-threaded build does not currently support sharing

--- a/Lib/test/test_capi/test_sys.py
+++ b/Lib/test/test_capi/test_sys.py
@@ -51,7 +51,7 @@ class CAPITest(unittest.TestCase):
             self.assertEqual(setobject(b'newattr', value2), 0)
             self.assertIs(sys.newattr, value2)
             self.assertEqual(setobject(b'newattr', NULL), 0)
-            self.assertFalse(hasattr(sys, 'newattr'))
+            self.assertNotHasAttr(sys, 'newattr')
             self.assertEqual(setobject(b'newattr', NULL), 0)
         finally:
             with contextlib.suppress(AttributeError):
@@ -60,7 +60,7 @@ class CAPITest(unittest.TestCase):
             self.assertEqual(setobject('\U0001f40d'.encode(), value), 0)
             self.assertIs(getattr(sys, '\U0001f40d'), value)
             self.assertEqual(setobject('\U0001f40d'.encode(), NULL), 0)
-            self.assertFalse(hasattr(sys, '\U0001f40d'))
+            self.assertNotHasAttr(sys, '\U0001f40d')
         finally:
             with contextlib.suppress(AttributeError):
                 delattr(sys, '\U0001f40d')


### PR DESCRIPTION


They provide better error report.


<!-- gh-issue-number: gh-71339 -->
* Issue: gh-71339
<!-- /gh-issue-number -->
