### PR TITLE
gh-71339: Use new assertion methods in test_ctypes

### DIFF
--- a/Lib/test/test_ctypes/test_c_simple_type_meta.py
+++ b/Lib/test/test_ctypes/test_c_simple_type_meta.py
@@ -54,9 +54,9 @@ class PyCSimpleTypeAsMetaclassTest(unittest.TestCase):
             pass
 
         self.assertIsInstance(POINTER(Sub2), p_meta)
-        self.assertTrue(issubclass(POINTER(Sub2), Sub2))
-        self.assertTrue(issubclass(POINTER(Sub2), POINTER(Sub)))
-        self.assertTrue(issubclass(POINTER(Sub), POINTER(CtBase)))
+        self.assertIsSubclass(POINTER(Sub2), Sub2)
+        self.assertIsSubclass(POINTER(Sub2), POINTER(Sub))
+        self.assertIsSubclass(POINTER(Sub), POINTER(CtBase))
 
     def test_creating_pointer_in_dunder_new_2(self):
         # A simpler variant of the above, used in `CoClass` of the `comtypes`
@@ -84,7 +84,7 @@ class PyCSimpleTypeAsMetaclassTest(unittest.TestCase):
             pass
 
         self.assertIsInstance(POINTER(Sub), p_meta)
-        self.assertTrue(issubclass(POINTER(Sub), Sub))
+        self.assertIsSubclass(POINTER(Sub), Sub)
 
     def test_creating_pointer_in_dunder_init_1(self):
         class ct_meta(type):
@@ -120,9 +120,9 @@ class PyCSimpleTypeAsMetaclassTest(unittest.TestCase):
             pass
 
         self.assertIsInstance(POINTER(Sub2), p_meta)
-        self.assertTrue(issubclass(POINTER(Sub2), Sub2))
-        self.assertTrue(issubclass(POINTER(Sub2), POINTER(Sub)))
-        self.assertTrue(issubclass(POINTER(Sub), POINTER(CtBase)))
+        self.assertIsSubclass(POINTER(Sub2), Sub2)
+        self.assertIsSubclass(POINTER(Sub2), POINTER(Sub))
+        self.assertIsSubclass(POINTER(Sub), POINTER(CtBase))
 
     def test_creating_pointer_in_dunder_init_2(self):
         class ct_meta(type):
@@ -149,4 +149,4 @@ class PyCSimpleTypeAsMetaclassTest(unittest.TestCase):
             pass
 
         self.assertIsInstance(POINTER(Sub), p_meta)
-        self.assertTrue(issubclass(POINTER(Sub), Sub))
+        self.assertIsSubclass(POINTER(Sub), Sub)

--- a/Lib/test/test_ctypes/test_loading.py
+++ b/Lib/test/test_ctypes/test_loading.py
@@ -135,7 +135,7 @@ class LoaderTest(unittest.TestCase):
                          'test specific to Windows')
     def test_load_hasattr(self):
         # bpo-34816: shouldn't raise OSError
-        self.assertFalse(hasattr(ctypes.windll, 'test'))
+        self.assertNotHasAttr(ctypes.windll, 'test')
 
     @unittest.skipUnless(os.name == "nt",
                          'test specific to Windows')

--- a/Lib/test/test_ctypes/test_repr.py
+++ b/Lib/test/test_ctypes/test_repr.py
@@ -22,12 +22,12 @@ class ReprTest(unittest.TestCase):
     def test_numbers(self):
         for typ in subclasses:
             base = typ.__bases__[0]
-            self.assertTrue(repr(base(42)).startswith(base.__name__))
-            self.assertEqual("<X object at", repr(typ(42))[:12])
+            self.assertStartsWith(repr(base(42)), base.__name__)
+            self.assertStartsWith(repr(typ(42)), "<X object at")
 
     def test_char(self):
         self.assertEqual("c_char(b'x')", repr(c_char(b'x')))
-        self.assertEqual("<X object at", repr(X(b'x'))[:12])
+        self.assertStartsWith(repr(X(b'x')), "<X object at")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
They provide better error report.

<!-- gh-issue-number: gh-71339 -->
* Issue: gh-71339
<!-- /gh-issue-number -->
