### PR TITLE
gh-71339: Use new assertion methods in the email tests

### DIFF
--- a/Lib/test/test_email/test_contentmanager.py
+++ b/Lib/test/test_email/test_contentmanager.py
@@ -288,7 +288,7 @@ class TestRawDataManager(TestEmailBase):
 
             The real body is in another message.
             """))
-        self.assertEqual(raw_data_manager.get_content(m)[:10], b'To: foo@ex')
+        self.assertStartsWith(raw_data_manager.get_content(m), b'To: foo@ex')
 
     def test_set_text_plain(self):
         m = self._make_message()

--- a/Lib/test/test_email/test_defect_handling.py
+++ b/Lib/test/test_email/test_defect_handling.py
@@ -57,7 +57,7 @@ class TestDefectsBase:
             msg = self._str_msg(source)
         if self.raise_expected: return
         inner = msg.get_payload(0)
-        self.assertTrue(hasattr(inner, 'defects'))
+        self.assertHasAttr(inner, 'defects')
         self.assertEqual(len(self.get_defects(inner)), 1)
         self.assertIsInstance(self.get_defects(inner)[0],
                               errors.StartBoundaryNotFoundDefect)
@@ -151,7 +151,7 @@ class TestDefectsBase:
         with self._raise_point(errors.NoBoundaryInMultipartDefect):
             msg = self._str_msg(source)
         if self.raise_expected: return
-        self.assertTrue(hasattr(msg, 'defects'))
+        self.assertHasAttr(msg, 'defects')
         self.assertEqual(len(self.get_defects(msg)), 2)
         self.assertIsInstance(self.get_defects(msg)[0],
                               errors.NoBoundaryInMultipartDefect)

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -210,8 +210,8 @@ class TestMessageAPI(TestEmailBase):
         self.assertEqual(msg.items()[0][1], 'multipart/form-data')
         # Trigger creation of boundary
         msg.as_string()
-        self.assertEqual(msg.items()[0][1][:33],
-                        'multipart/form-data; boundary="==')
+        self.assertStartsWith(msg.items()[0][1],
+                              'multipart/form-data; boundary="==')
         # XXX: there ought to be tests of the uniqueness of the boundary, too.
 
     def test_message_rfc822_only(self):
@@ -303,7 +303,7 @@ class TestMessageAPI(TestEmailBase):
         self.assertEqual(text, str(msg))
         fullrepr = msg.as_string(unixfrom=True)
         lines = fullrepr.split('\n')
-        self.assertTrue(lines[0].startswith('From '))
+        self.assertStartsWith(lines[0], 'From ')
         self.assertEqual(text, NL.join(lines[1:]))
 
     def test_as_string_policy(self):
@@ -372,7 +372,7 @@ class TestMessageAPI(TestEmailBase):
         self.assertEqual(data, bytes(msg))
         fullrepr = msg.as_bytes(unixfrom=True)
         lines = fullrepr.split(b'\n')
-        self.assertTrue(lines[0].startswith(b'From '))
+        self.assertStartsWith(lines[0], b'From ')
         self.assertEqual(data, b'\n'.join(lines[1:]))
 
     def test_as_bytes_policy(self):
@@ -2203,7 +2203,7 @@ class TestNonConformant(TestEmailBase):
         msg = self._msgobj('msg_15.txt')
         # XXX We can probably eventually do better
         inner = msg.get_payload(0)
-        self.assertTrue(hasattr(inner, 'defects'))
+        self.assertHasAttr(inner, 'defects')
         self.assertEqual(len(inner.defects), 1)
         self.assertIsInstance(inner.defects[0],
                               errors.StartBoundaryNotFoundDefect)
@@ -2315,7 +2315,7 @@ counter to RFC 2822, there's no separating newline here
     # test_defect_handling
     def test_lying_multipart(self):
         msg = self._msgobj('msg_41.txt')
-        self.assertTrue(hasattr(msg, 'defects'))
+        self.assertHasAttr(msg, 'defects')
         self.assertEqual(len(msg.defects), 2)
         self.assertIsInstance(msg.defects[0],
                               errors.NoBoundaryInMultipartDefect)
@@ -3659,9 +3659,7 @@ multipart/report
     def test_make_msgid_default_domain(self):
         with patch('socket.getfqdn') as mock_getfqdn:
             mock_getfqdn.return_value = domain = 'pythontest.example.com'
-            self.assertTrue(
-                email.utils.make_msgid().endswith(
-                    '@' + domain + '>'))
+            self.assertEndsWith(email.utils.make_msgid(), '@' + domain + '>')
 
     def test_Generator_linend(self):
         # Issue 14645.
@@ -4128,7 +4126,7 @@ Here's the message body
             "--BOUNDARY--\n"
           )
         msg = email.message_from_string(m)
-        self.assertTrue(msg.get_payload(0).get_payload().endswith('\r\n'))
+        self.assertEndsWith(msg.get_payload(0).get_payload(), '\r\n')
 
 
 class Test8BitBytesHandling(TestEmailBase):

--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -1303,12 +1303,12 @@ class TestMbox(_TestMboxMMDF, unittest.TestCase):
         self._box.add('From: foo\n\n0')  # No newline at the end
         with open(self._path, encoding='utf-8') as f:
             data = f.read()
-            self.assertEqual(data[-3:], '0\n\n')
+            self.assertEndsWith(data, '0\n\n')
 
         self._box.add('From: foo\n\n0\n')  # Newline at the end
         with open(self._path, encoding='utf-8') as f:
             data = f.read()
-            self.assertEqual(data[-3:], '0\n\n')
+            self.assertEndsWith(data, '0\n\n')
 
 
 class TestMMDF(_TestMboxMMDF, unittest.TestCase):
@@ -2357,7 +2357,7 @@ class MaildirTestCase(unittest.TestCase):
         # Test for regression on bug #117490:
         # Make sure the boxes attribute actually gets set.
         self.mbox = mailbox.Maildir(os_helper.TESTFN)
-        #self.assertTrue(hasattr(self.mbox, "boxes"))
+        #self.assertHasAttr(self.mbox, "boxes")
         #self.assertEqual(len(self.mbox.boxes), 0)
         self.assertIsNone(self.mbox.next())
         self.assertIsNone(self.mbox.next())

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -257,7 +257,7 @@ class DummyPOP3Server(asyncore.dispatcher, threading.Thread):
 
 class TestPOP3Class(TestCase):
     def assertOK(self, resp):
-        self.assertTrue(resp.startswith(b"+OK"))
+        self.assertStartsWith(resp, b"+OK")
 
     def setUp(self):
         self.server = DummyPOP3Server((HOST, PORT))
@@ -293,7 +293,7 @@ class TestPOP3Class(TestCase):
         self.assertEqual(self.client.list()[1:],
                          ([b'1 1', b'2 2', b'3 3', b'4 4', b'5 5'],
                           25))
-        self.assertTrue(self.client.list('1').endswith(b"OK 1 1"))
+        self.assertEndsWith(self.client.list('1'), b"OK 1 1")
 
     def test_retr(self):
         expected = (b'+OK 116 bytes',
@@ -428,7 +428,7 @@ class TestPOP3_SSLClass(TestPOP3Class):
                                         context=ctx)
         self.assertIsInstance(self.client.sock, ssl.SSLSocket)
         self.assertIs(self.client.sock.context, ctx)
-        self.assertTrue(self.client.noop().startswith(b'+OK'))
+        self.assertStartsWith(self.client.noop(), b'+OK')
 
     def test_stls(self):
         self.assertRaises(poplib.error_proto, self.client.stls)


### PR DESCRIPTION
They provide better error report.

<!-- gh-issue-number: gh-71339 -->
* Issue: gh-71339
<!-- /gh-issue-number -->
