### PR TITLE
[3.13] gh-128595: Default to stdout isatty for colour detection instead of stderr (GH-128498)

### DIFF
--- a/Lib/_colorize.py
+++ b/Lib/_colorize.py
@@ -24,14 +24,17 @@ for attr in dir(NoColors):
         setattr(NoColors, attr, "")
 
 
-def get_colors(colorize: bool = False) -> ANSIColors:
-    if colorize or can_colorize():
+def get_colors(colorize: bool = False, *, file=None) -> ANSIColors:
+    if colorize or can_colorize(file=file):
         return ANSIColors()
     else:
         return NoColors
 
 
-def can_colorize() -> bool:
+def can_colorize(*, file=None) -> bool:
+    if file is None:
+        file = sys.stdout
+
     if not sys.flags.ignore_environment:
         if os.environ.get("PYTHON_COLORS") == "0":
             return False
@@ -47,7 +50,7 @@ def can_colorize() -> bool:
         if os.environ.get("TERM") == "dumb":
             return False
 
-    if not hasattr(sys.stderr, "fileno"):
+    if not hasattr(file, "fileno"):
         return False
 
     if sys.platform == "win32":
@@ -60,6 +63,6 @@ def can_colorize() -> bool:
             return False
 
     try:
-        return os.isatty(sys.stderr.fileno())
+        return os.isatty(file.fileno())
     except io.UnsupportedOperation:
-        return sys.stderr.isatty()
+        return file.isatty()

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -1558,7 +1558,7 @@ class DocTestRunner:
         save_displayhook = sys.displayhook
         sys.displayhook = sys.__displayhook__
         saved_can_colorize = _colorize.can_colorize
-        _colorize.can_colorize = lambda: False
+        _colorize.can_colorize = lambda *args, **kwargs: False
         color_variables = {"PYTHON_COLORS": None, "FORCE_COLOR": None}
         for key in color_variables:
             color_variables[key] = os.environ.pop(key, None)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2700,7 +2700,7 @@ def no_color():
     from .os_helper import EnvironmentVarGuard
 
     with (
-        swap_attr(_colorize, "can_colorize", lambda: False),
+        swap_attr(_colorize, "can_colorize", lambda file=None: False),
         EnvironmentVarGuard() as env,
     ):
         for var in {"FORCE_COLOR", "NO_COLOR", "PYTHON_COLORS"}:

--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -9,7 +9,7 @@ ORIGINAL_CAN_COLORIZE = _colorize.can_colorize
 
 
 def setUpModule():
-    _colorize.can_colorize = lambda: False
+    _colorize.can_colorize = lambda *args, **kwargs: False
 
 
 def tearDownModule():
@@ -21,6 +21,7 @@ class TestColorizeFunction(unittest.TestCase):
     def test_colorized_detection_checks_for_environment_variables(self):
         flags = unittest.mock.MagicMock(ignore_environment=False)
         with (unittest.mock.patch("os.isatty") as isatty_mock,
+              unittest.mock.patch("sys.stdout") as stdout_mock,
               unittest.mock.patch("sys.stderr") as stderr_mock,
               unittest.mock.patch("sys.flags", flags),
               unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE),
@@ -29,6 +30,8 @@ class TestColorizeFunction(unittest.TestCase):
                contextlib.nullcontext()) as vt_mock):
 
             isatty_mock.return_value = True
+            stdout_mock.fileno.return_value = 1
+            stdout_mock.isatty.return_value = True
             stderr_mock.fileno.return_value = 2
             stderr_mock.isatty.return_value = True
             with unittest.mock.patch("os.environ", {'TERM': 'dumb'}):
@@ -61,6 +64,7 @@ class TestColorizeFunction(unittest.TestCase):
                     self.assertEqual(_colorize.can_colorize(), True)
 
                 isatty_mock.return_value = False
+                stdout_mock.isatty.return_value = False
                 stderr_mock.isatty.return_value = False
                 self.assertEqual(_colorize.can_colorize(), False)
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -135,7 +135,7 @@ BUILTIN_EXCEPTION_LIMIT = object()
 
 def _print_exception_bltin(exc, /):
     file = sys.stderr if sys.stderr is not None else sys.__stderr__
-    colorize = _colorize.can_colorize()
+    colorize = _colorize.can_colorize(file=file)
     return print_exception(exc, limit=BUILTIN_EXCEPTION_LIMIT, file=file, colorize=colorize)
 
 

--- a/Misc/NEWS.d/next/Library/2025-01-07-21-48-32.gh-issue-128498.n6jtlW.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-07-21-48-32.gh-issue-128498.n6jtlW.rst
@@ -1,0 +1,2 @@
+Default to stdout isatty for color detection instead of stderr. Patch by
+Hugo van Kemenade.


### PR DESCRIPTION
(cherry picked from commit 6f167d71347de6717d9f6b64026e21f23d41ef0b)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128595 -->
* Issue: gh-128595
<!-- /gh-issue-number -->
