### PR TITLE
gh-128595: Fix `test__colorize` unexpected keyword argument 'file' on buildbots

### DIFF
--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -9,7 +9,7 @@ ORIGINAL_CAN_COLORIZE = _colorize.can_colorize
 
 
 def setUpModule():
-    _colorize.can_colorize = lambda: False
+    _colorize.can_colorize = lambda *args, **kwargs: False
 
 
 def tearDownModule():
@@ -21,6 +21,7 @@ class TestColorizeFunction(unittest.TestCase):
     def test_colorized_detection_checks_for_environment_variables(self):
         flags = unittest.mock.MagicMock(ignore_environment=False)
         with (unittest.mock.patch("os.isatty") as isatty_mock,
+              unittest.mock.patch("sys.stdout") as stdout_mock,
               unittest.mock.patch("sys.stderr") as stderr_mock,
               unittest.mock.patch("sys.flags", flags),
               unittest.mock.patch("_colorize.can_colorize", ORIGINAL_CAN_COLORIZE),
@@ -29,6 +30,8 @@ class TestColorizeFunction(unittest.TestCase):
                contextlib.nullcontext()) as vt_mock):
 
             isatty_mock.return_value = True
+            stdout_mock.fileno.return_value = 2
+            stdout_mock.isatty.return_value = True
             stderr_mock.fileno.return_value = 2
             stderr_mock.isatty.return_value = True
             with unittest.mock.patch("os.environ", {'TERM': 'dumb'}):
@@ -61,6 +64,7 @@ class TestColorizeFunction(unittest.TestCase):
                     self.assertEqual(_colorize.can_colorize(), True)
 
                 isatty_mock.return_value = False
+                stdout_mock.isatty.return_value = False
                 stderr_mock.isatty.return_value = False
                 self.assertEqual(_colorize.can_colorize(), False)
 

--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -30,7 +30,7 @@ class TestColorizeFunction(unittest.TestCase):
                contextlib.nullcontext()) as vt_mock):
 
             isatty_mock.return_value = True
-            stdout_mock.fileno.return_value = 2
+            stdout_mock.fileno.return_value = 1
             stdout_mock.isatty.return_value = True
             stderr_mock.fileno.return_value = 2
             stderr_mock.isatty.return_value = True


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Re: https://github.com/python/cpython/pull/128498#issuecomment-2602257129

* https://buildbot.python.org/api/v2/logs/12166870/raw_inline
* https://buildbot.python.org/#/builders/725/builds/9477


<!-- gh-issue-number: gh-128595 -->
* Issue: gh-128595
<!-- /gh-issue-number -->
