### PR TITLE
GH-129064: deprecate sysconfig.expand_makefile_vars

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.16.rst
+++ b/Doc/deprecations/pending-removal-in-3.16.rst
@@ -80,6 +80,12 @@ Pending removal in Python 3.16
     has been deprecated since Python 3.13.
     Use the :envvar:`PYTHONLEGACYWINDOWSFSENCODING` environment variable instead.
 
+* :mod:`sysconfig`:
+
+  * The :func:`~sysconfig.expand_makefile_vars` function
+    has been deprecated since Python 3.14.
+    Use the ``vars`` argument of :func:`sysconfig.get_paths` instead.
+
 * :mod:`tarfile`:
 
   * The undocumented and unused :attr:`!TarFile.tarfile` attribute

--- a/Doc/deprecations/pending-removal-in-3.16.rst
+++ b/Doc/deprecations/pending-removal-in-3.16.rst
@@ -82,7 +82,7 @@ Pending removal in Python 3.16
 
 * :mod:`sysconfig`:
 
-  * The :func:`~sysconfig.expand_makefile_vars` function
+  * The ``~sysconfig.expand_makefile_vars`` function
     has been deprecated since Python 3.14.
     Use the ``vars`` argument of :func:`sysconfig.get_paths` instead.
 

--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -716,6 +716,15 @@ def expand_makefile_vars(s, vars):
     variable expansions; if 'vars' is the output of 'parse_makefile()',
     you're fine.  Returns a variable-expanded version of 's'.
     """
+
+    import warnings
+    warnings.warn(
+        'sysconfig.expand_makefile_vars is deprecated and will be removed in '
+        'Python 3.16. Use sysconfig.get_paths(vars=...) instead.',
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     import re
 
     _findvar1_rx = r"\$\(([A-Za-z][A-Za-z0-9_]*)\)"

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -711,5 +711,24 @@ class MakefileTests(unittest.TestCase):
         })
 
 
+class DeprecationTests(unittest.TestCase):
+    def deprecated(self, removal_version, deprecation_msg=None, attribute_msg=None):
+        if sys.version_info >= removal_version:
+            return self.assertRaises(AttributeError, msg=attribute_msg)
+        else:
+            return self.assertWarns(DeprecationWarning, msg=deprecation_msg)
+
+    def test_expand_makefile_vars(self):
+        with self.deprecated(
+            removal_version=(3, 16),
+            deprecation_msg=(
+                'sysconfig.expand_makefile_vars is deprecated and will be removed in '
+                'Python 3.16. Use sysconfig.get_paths(vars=...) instead.',
+            ),
+            attribute_msg="module 'sysconfig' has no attribute 'expand_makefile_vars'",
+        ):
+            sysconfig.expand_makefile_vars('', {})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2025-01-20-16-02-38.gh-issue-129064.JXasgJ.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-20-16-02-38.gh-issue-129064.JXasgJ.rst
@@ -1,0 +1,2 @@
+Deprecate :func:`sysconfig.expand_makefile_vars`, in favor of using
+:func:`sysconfig.get_paths` with the ``vars`` argument.

--- a/Misc/NEWS.d/next/Library/2025-01-20-16-02-38.gh-issue-129064.JXasgJ.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-20-16-02-38.gh-issue-129064.JXasgJ.rst
@@ -1,2 +1,2 @@
-Deprecate :func:`sysconfig.expand_makefile_vars`, in favor of using
+Deprecate ``sysconfig.expand_makefile_vars``, in favor of using
 :func:`sysconfig.get_paths` with the ``vars`` argument.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129064 -->
* Issue: gh-129064
<!-- /gh-issue-number -->
