### PR TITLE
doc: fix venv creating for the local Python using uv

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -172,7 +172,7 @@ venv:
 	else \
 		echo "Creating venv in $(VENVDIR)"; \
 		if $(UV) --version >/dev/null 2>&1; then \
-			$(UV) venv $(VENVDIR); \
+			$(UV) venv --python=$(PYTHON) $(VENVDIR); \
 			VIRTUAL_ENV=$(VENVDIR) $(UV) pip install -r $(REQUIREMENTS); \
 		else \
 			$(PYTHON) -m venv $(VENVDIR); \


### PR DESCRIPTION
GH-120711 introduced uv as an alternative venv provisioning and method, but failed to honor the `PYTHON` variable, leading uv to the system's default Python installation. Honoring `PYTHON` is important for use cases such as `doctest`, which should run with the locally built Python.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129094.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->