### PR TITLE
Docs: fix typo in `Doc/howto/mro.rst`

### DIFF
--- a/Doc/howto/mro.rst
+++ b/Doc/howto/mro.rst
@@ -398,7 +398,7 @@ with inheritance diagram
 
 We see that class G inherits from F and E, with F *before* E:  therefore
 we would expect the attribute *G.remember2buy* to be inherited by
-*F.rembermer2buy* and not by *E.remember2buy*:  nevertheless Python 2.2
+*F.remember2buy* and not by *E.remember2buy*:  nevertheless Python 2.2
 gives
 
   >>> G.remember2buy  # doctest: +SKIP


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
While reading the documentation, a typo was noticed and corrected.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129095.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->