### PR TITLE
gh-126925: Make PyConfig.use_system_logger read-only

### DIFF
--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -169,7 +169,7 @@ static const PyConfigSpec PYCONFIG_SPEC[] = {
     SPEC(use_frozen_modules, BOOL, READ_ONLY, NO_SYS),
     SPEC(use_hash_seed, BOOL, READ_ONLY, NO_SYS),
 #ifdef __APPLE__
-    SPEC(use_system_logger, BOOL, PUBLIC, NO_SYS),
+    SPEC(use_system_logger, BOOL, READ_ONLY, NO_SYS),
 #endif
     SPEC(user_site_directory, BOOL, READ_ONLY, NO_SYS),  // sys.flags.no_user_site
     SPEC(warn_default_encoding, BOOL, READ_ONLY, NO_SYS),


### PR DESCRIPTION
The variable is only used once during early Python initialization, it doesn't make sense to modify it at runtime.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-126925 -->
* Issue: gh-126925
<!-- /gh-issue-number -->
