### PR TITLE
gh-128679: Use _PyThreadState_GET() in tracemalloc.c

### DIFF
--- a/Python/tracemalloc.c
+++ b/Python/tracemalloc.c
@@ -338,13 +338,8 @@ traceback_hash(traceback_t *traceback)
 static void
 traceback_get_frames(traceback_t *traceback)
 {
-    PyThreadState *tstate = PyGILState_GetThisThreadState();
-    if (tstate == NULL) {
-#ifdef TRACE_DEBUG
-        tracemalloc_error("failed to get the current thread state");
-#endif
-        return;
-    }
+    PyThreadState *tstate = _PyThreadState_GET();
+    assert(tstate != NULL);
 
     _PyInterpreterFrame *pyframe = _PyThreadState_GetFrame(tstate);
     while (pyframe) {


### PR DESCRIPTION
Replace uncommon PyGILState_GetThisThreadState() with common _PyThreadState_GET().

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128679 -->
* Issue: gh-128679
<!-- /gh-issue-number -->
