### PR TITLE
[3.12] gh-129044: Update glossary entry for 'loader' to reflect current import system (#129073)

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -748,9 +748,11 @@ Glossary
       processed.
 
    loader
-      An object that loads a module. It must define a method named
-      :meth:`load_module`. A loader is typically returned by a
-      :term:`finder`. See also:
+      An object that loads a module.
+      It must define the :meth:`!exec_module` and :meth:`!create_module` methods
+      to implement the :class:`~importlib.abc.Loader` interface.
+      A loader is typically returned by a :term:`finder`.
+      See also:
 
       * :ref:`finders-and-loaders`
       * :class:`importlib.abc.Loader`

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -13,11 +13,8 @@ Doc/c-api/stable.rst
 Doc/c-api/type.rst
 Doc/c-api/typeobj.rst
 Doc/extending/extending.rst
-<<<<<<< HEAD
 Doc/library/2to3.rst
 Doc/library/aifc.rst
-=======
->>>>>>> e1fa2fcc7c (gh-129044: Update glossary entry for 'loader' to reflect current import system (#129073))
 Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
 Doc/library/asyncio-policy.rst

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -18,7 +18,6 @@ Doc/library/aifc.rst
 Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
 Doc/library/asyncio-policy.rst
-Doc/library/asyncio-policy.rst
 Doc/library/asyncio-subprocess.rst
 Doc/library/audioop.rst
 Doc/library/cgi.rst

--- a/Doc/tools/.nitignore
+++ b/Doc/tools/.nitignore
@@ -13,11 +13,14 @@ Doc/c-api/stable.rst
 Doc/c-api/type.rst
 Doc/c-api/typeobj.rst
 Doc/extending/extending.rst
-Doc/glossary.rst
+<<<<<<< HEAD
 Doc/library/2to3.rst
 Doc/library/aifc.rst
+=======
+>>>>>>> e1fa2fcc7c (gh-129044: Update glossary entry for 'loader' to reflect current import system (#129073))
 Doc/library/ast.rst
 Doc/library/asyncio-extending.rst
+Doc/library/asyncio-policy.rst
 Doc/library/asyncio-policy.rst
 Doc/library/asyncio-subprocess.rst
 Doc/library/audioop.rst


### PR DESCRIPTION
Co-authored-by: Adam Turner <9087854+AA-Turner@users.noreply.github.com>
(cherry picked from commit e1fa2fcc7c1bf5291a7f71300b7828b49be9ab72)

Backport of gh-129044 to 3.12

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129130.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->