### PR TITLE
gh-71339: Fix an order-dependent failure in test_unittest

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1833,7 +1833,10 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
 
     def test_setattr(self):
         setattr(sys, 'spam', 1)
-        self.assertEqual(sys.spam, 1)
+        try:
+            self.assertEqual(sys.spam, 1)
+        finally:
+            del sys.spam
         self.assertRaises(TypeError, setattr)
         self.assertRaises(TypeError, setattr, sys)
         self.assertRaises(TypeError, setattr, sys, 'spam')

--- a/Lib/test/test_unittest/test_case.py
+++ b/Lib/test/test_unittest/test_case.py
@@ -801,9 +801,9 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         self.assertEqual(str(cm.exception),
                 "type object 'List' has no attribute 'spam'")
         with self.assertRaises(self.failureException) as cm:
-            self.assertHasAttr(sys, 'spam')
+            self.assertHasAttr(sys, 'nonexistent')
         self.assertEqual(str(cm.exception),
-                "module 'sys' has no attribute 'spam'")
+                "module 'sys' has no attribute 'nonexistent'")
 
         with self.assertRaises(self.failureException) as cm:
             self.assertHasAttr(a, 'y', 'ababahalamaha')


### PR DESCRIPTION
It failed if it was preceded by test_builtin.


<!-- gh-issue-number: gh-71339 -->
* Issue: gh-71339
<!-- /gh-issue-number -->
