### PR TITLE
gh-129141: Fix build on gcc-9.4.0

### DIFF
--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -9,8 +9,12 @@
 // For Apple's libffi, this must be determined at runtime (see gh-128156).
 #if defined(Py_HAVE_C_COMPLEX) && defined(Py_FFI_SUPPORT_C_COMPLEX)
 #   include "../_complex.h"       // complex
-#   if USING_APPLE_OS_LIBFFI && defined(__has_builtin) && __has_builtin(__builtin_available)
-#       define Py_FFI_COMPLEX_AVAILABLE __builtin_available(macOS 10.15, *)
+#   if USING_APPLE_OS_LIBFFI && defined(__has_builtin)
+#       if __has_builtin(__builtin_available)
+#           define Py_FFI_COMPLEX_AVAILABLE __builtin_available(macOS 10.15, *)
+#       else
+#           define Py_FFI_COMPLEX_AVAILABLE 1
+#       endif
 #   else
 #       define Py_FFI_COMPLEX_AVAILABLE 1
 #   endif


### PR DESCRIPTION
d3b1bb228c95 introduced the line: 

```
#   if USING_APPLE_OS_LIBFFI && defined(__has_builtin) && __has_builtin(__builtin_available)
```

Unfortunately this doesn't work on compilers that don't have `__has_builtin`, because the parser fails on the usage of `__has_builtin(__builtin_available)` before is has a change to run the test `defined(__has_builtin)`.  Separating the `defined` check to its own expression seems to resolve this.

<!-- gh-issue-number: gh-129141 -->
* Issue: gh-129141
<!-- /gh-issue-number -->
