### PR TITLE
[3.13] Move to public Linux arm64 hosted runners

### DIFF
--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-aarch64]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     env:
       FORCE_COLOR: 1
       OPENSSL_VER: 3.0.15


### PR DESCRIPTION
This is a backport of https://github.com/python/cpython/pull/128964