### PR TITLE
gh-129093: Fix f-string debug text sometimes getting cut off when expression contains `!`

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1757,5 +1757,23 @@ print(f'''{{
         for s in ["", "some string"]:
             self.assertEqual(get_code(f"'{s}'"), get_code(f"f'{s}'"))
 
+    def test_gh129093(self):
+        self.assertEqual(f'{1==2=}', '1==2=False')
+        self.assertEqual(f'{1 == 2=}', '1 == 2=False')
+        self.assertEqual(f'{1!=2=}', '1!=2=True')
+        self.assertEqual(f'{1 != 2=}', '1 != 2=True')
+
+        self.assertEqual(f'{(1) != 2=}', '(1) != 2=True')
+        self.assertEqual(f'{(1*2) != (3)=}', '(1*2) != (3)=True')
+
+        self.assertEqual(f'{1 != 2 == 3 != 4=}', '1 != 2 == 3 != 4=False')
+        self.assertEqual(f'{1 == 2 != 3 == 4=}', '1 == 2 != 3 == 4=False')
+
+        self.assertEqual(f'{f'{1==2=}'=}', "f'{1==2=}'='1==2=False'")
+        self.assertEqual(f'{f'{1 == 2=}'=}', "f'{1 == 2=}'='1 == 2=False'")
+        self.assertEqual(f'{f'{1!=2=}'=}', "f'{1!=2=}'='1!=2=True'")
+        self.assertEqual(f'{f'{1 != 2=}'=}', "f'{1 != 2=}'='1 != 2=True'")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-01-21-23-35-41.gh-issue-129093.0rvETC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-01-21-23-35-41.gh-issue-129093.0rvETC.rst
@@ -1,0 +1,2 @@
+Fix f-strings such as ``f'{expr=}'`` sometimes not displaying the full
+expression when the expression contains ``!=``.

--- a/Parser/lexer/lexer.c
+++ b/Parser/lexer/lexer.c
@@ -212,9 +212,7 @@ _PyLexer_update_fstring_expr(struct tok_state *tok, char cur)
         case '}':
         case '!':
         case ':':
-            if (tok_mode->last_expr_end == -1) {
-                tok_mode->last_expr_end = strlen(tok->start);
-            }
+            tok_mode->last_expr_end = strlen(tok->start);
             break;
         default:
             Py_UNREACHABLE();


### PR DESCRIPTION
Here's what I think is happening (though I may be wrong, the lexer code and especially the f-string code is really complex):

For an f-string replacement field such as `{1!=2=}` we end up in this branch of the parser:

https://github.com/python/cpython/blob/29caec62ee0650493c83c778ee2ea50b0501bc41/Grammar/python.gram#L916-L918

The original source (i.e. `debug_expr`) is stored on the `rbrace`'s `token->metadata`:

https://github.com/python/cpython/blob/29caec62ee0650493c83c778ee2ea50b0501bc41/Parser/lexer/lexer.c#L171

which is how the `_PyPegen_formatted_value` function injects it into the AST (as `debug_text`):

https://github.com/python/cpython/blob/29caec62ee0650493c83c778ee2ea50b0501bc41/Parser/action_helpers.c#L1492-L1493

The `token->metadata` itself gets the debug text from `tok_mode->last_expr_buffer` and `tok_mode->last_expr_end`.

https://github.com/python/cpython/blob/29caec62ee0650493c83c778ee2ea50b0501bc41/Parser/lexer/lexer.c#L159-L163

If we go back to the example `{1!=2=}`, to parse the `fstring_replacement_field` rule, the parser first tries to parse the `annotated_rhs` which consumes `1` at first since it's a valid expression. It then skips `debug_expr='='?` and starts parsing the conversion specifier which matches the following `!`. Now that it hit `!`, it sets `tok_mode->last_expr_end` in `_PyLexer_update_fstring_expr`:

https://github.com/python/cpython/blob/29caec62ee0650493c83c778ee2ea50b0501bc41/Parser/lexer/lexer.c#L212-L218

The problem is that now the parser needs to backtrack. The second time it parses the full `1!=2` as `annotated_rhs` but because  `tok_mode->last_expr_end` is guarded with `if(tok_mode->last_expr_end == -1){}` it never gets updated which is what is causing this issue.

Simply removing that if check _seems_ to work, but I'm not 100% sure this is the best way to fix it. It'd be great if a parser expert could check this :)

<!-- gh-issue-number: gh-129093 -->
* Issue: gh-129093
<!-- /gh-issue-number -->
