### PR TITLE
[3.12] gh-129093: Fix f-string debug text sometimes getting cut off when expression contains !

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1875,6 +1875,24 @@ print(f'''{{
             self.assertIn(rb"\1", stdout)
             self.assertEqual(len(stderr.strip().splitlines()), 2)
 
+    def test_gh129093(self):
+        self.assertEqual(f'{1==2=}', '1==2=False')
+        self.assertEqual(f'{1 == 2=}', '1 == 2=False')
+        self.assertEqual(f'{1!=2=}', '1!=2=True')
+        self.assertEqual(f'{1 != 2=}', '1 != 2=True')
+
+        self.assertEqual(f'{(1) != 2=}', '(1) != 2=True')
+        self.assertEqual(f'{(1*2) != (3)=}', '(1*2) != (3)=True')
+
+        self.assertEqual(f'{1 != 2 == 3 != 4=}', '1 != 2 == 3 != 4=False')
+        self.assertEqual(f'{1 == 2 != 3 == 4=}', '1 == 2 != 3 == 4=False')
+
+        self.assertEqual(f'{f'{1==2=}'=}', "f'{1==2=}'='1==2=False'")
+        self.assertEqual(f'{f'{1 == 2=}'=}', "f'{1 == 2=}'='1 == 2=False'")
+        self.assertEqual(f'{f'{1!=2=}'=}', "f'{1!=2=}'='1!=2=True'")
+        self.assertEqual(f'{f'{1 != 2=}'=}', "f'{1 != 2=}'='1 != 2=True'")
+
 
 if __name__ == "__main__":
+
     unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-01-21-23-35-41.gh-issue-129093.0rvETC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-01-21-23-35-41.gh-issue-129093.0rvETC.rst
@@ -1,0 +1,2 @@
+Fix f-strings such as ``f'{expr=}'`` sometimes not displaying the full
+expression when the expression contains ``!=``.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -480,9 +480,7 @@ static int update_fstring_expr(struct tok_state *tok, char cur) {
   case '}':
   case '!':
   case ':':
-    if (tok_mode->last_expr_end == -1) {
-      tok_mode->last_expr_end = strlen(tok->start);
-    }
+    tok_mode->last_expr_end = strlen(tok->start);
     break;
   default:
     Py_UNREACHABLE();


### PR DESCRIPTION
…

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129093 -->
* Issue: gh-129093
<!-- /gh-issue-number -->
