### PR TITLE
gh-129158: Fix unwanted trailing whitespace in test_asyncio.test_subprocess

### DIFF
--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -905,7 +905,7 @@ if sys.platform != 'win32':
             # Force the use of the threaded child watcher
             unix_events.can_use_pidfd = mock.Mock(return_value=False)
             super().setUp()
-        
+
         def tearDown(self):
             unix_events.can_use_pidfd = self._original_can_use_pidfd
             return super().tearDown()


### PR DESCRIPTION


<!-- gh-issue-number: gh-129158 -->
* Issue: gh-129158
<!-- /gh-issue-number -->
