### PR TITLE
gh-128509: Add `PyUnstable_IsImmortal` for finding immortal objects

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -615,14 +615,8 @@ Object Protocol
 
 .. c:function:: int PyUnstable_IsImmortal(PyObject *obj)
 
-   This function returns non-zero if *obj* is :term:`immortal`, and zero otherwise. This function cannot fail.
-
-   Immortal objects don't care about reference counting, thus they no-op calls to :c:func:`Py_INCREF`
-   and :c:func:`Py_DECREF`. Some immutable objects such as literal strings, small integers, or special tuples
-   might be made immortal as an optimization by the interpreter.
-
-   On the :term:`free-threaded <free threading>` build, some objects that support deferred reference counting
-   (see :c:func:`PyUnstable_Object_EnableDeferredRefcount`) might also be immortalized.
+   This function returns non-zero if *obj* is :term:`immortal`, and zero
+   otherwise. This function cannot fail.
 
    .. note::
 

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -615,7 +615,7 @@ Object Protocol
 
 .. c:function:: int PyUnstable_IsImmortal(PyObject *obj)
 
-   This function returns ``1`` if *obj* is :term:`immortal`, and ``0`` otherwise.
+   This function returns ``1`` if *obj* is :term:`immortal`, and ``0`` otherwise. This function cannot fail.
 
    Immortal objects don't care about reference counting, thus they no-op calls to :c:func:`Py_INCREF`
    and :c:func:`Py_DECREF`. Some immutable objects such as literal strings, small integers, or special tuples

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -626,6 +626,6 @@ Object Protocol
 
    .. note::
 
-      Objects that are immortal in one version are not guarunteed to be immortal in another.
+      Objects that are immortal in one Python version are not guarunteed to be immortal in another.
 
    .. versionadded:: next

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -620,6 +620,7 @@ Object Protocol
 
    .. note::
 
-      Objects that are immortal in one Python version are not guarunteed to be immortal in another.
+      Objects that are immortal in one CPython version are not guaranteed to
+      be immortal in another.
 
    .. versionadded:: next

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -615,7 +615,7 @@ Object Protocol
 
 .. c:function:: int PyUnstable_IsImmortal(PyObject *obj)
 
-   This function returns ``1`` if *obj* is :term:`immortal`, and ``0`` otherwise. This function cannot fail.
+   This function returns non-zero if *obj* is :term:`immortal`, and zero otherwise. This function cannot fail.
 
    Immortal objects don't care about reference counting, thus they no-op calls to :c:func:`Py_INCREF`
    and :c:func:`Py_DECREF`. Some immutable objects such as literal strings, small integers, or special tuples

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -613,3 +613,19 @@ Object Protocol
 
    .. versionadded:: 3.14
 
+.. c:function:: int PyUnstable_IsImmortal(PyObject *obj)
+
+   This function returns ``1`` if *obj* is :term:`immortal`, and ``0`` otherwise.
+
+   Immortal objects don't care about reference counting, thus they no-op calls to :c:func:`Py_INCREF`
+   and :c:func:`Py_DECREF`. Some immutable objects such as literal strings, small integers, or special tuples
+   might be made immortal as an optimization by the interpreter.
+
+   On the :term:`free-threaded <free threading>` build, some objects that support deferred reference counting
+   (see :c:func:`PyUnstable_Object_EnableDeferredRefcount`) might also be immortalized.
+
+   .. note::
+
+      Objects that are immortal in one version are not guarunteed to be immortal in another.
+
+   .. versionadded:: next

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1321,6 +1321,9 @@ New features
   bit-packing Python version numbers.
   (Contributed by Petr Viktorin in :gh:`128629`.)
 
+* Add :c:func:`PyUnstable_IsImmortal` for determining whether an object is :term:`immortal`,
+  for debugging purposes.
+
 
 Porting to Python 3.14
 ----------------------

--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -541,3 +541,6 @@ PyAPI_FUNC(PyRefTracer) PyRefTracer_GetTracer(void**);
  * 0 if the runtime ignored it. This function cannot fail.
  */
 PyAPI_FUNC(int) PyUnstable_Object_EnableDeferredRefcount(PyObject *);
+
+/* Check whether the object is immortal. This cannot fail. */
+PyAPI_FUNC(int) PyUnstable_IsImmortal(PyObject *);

--- a/Lib/test/test_capi/test_immortal.py
+++ b/Lib/test/test_capi/test_immortal.py
@@ -40,6 +40,7 @@ class TestInternalCAPI(unittest.TestCase):
             with self.subTest(non_immortal=non_immortal):
                 self.assertFalse(_testcapi.is_immortal(non_immortal))
 
+        # CRASHES _testcapi.is_immortal(NULL)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_capi/test_immortal.py
+++ b/Lib/test/test_capi/test_immortal.py
@@ -5,12 +5,22 @@ _testcapi = import_helper.import_module('_testcapi')
 _testinternalcapi = import_helper.import_module('_testinternalcapi')
 
 
-class TestCAPI(unittest.TestCase):
-    def test_immortal_builtins(self):
-        _testcapi.test_immortal_builtins()
+class TestUnstableCAPI(unittest.TestCase):
+    def test_immortal(self):
+        # Not extensive
+        known_immortals = (True, False, None, 0, ())
+        for immortal in known_immortals:
+            with self.subTest(immortal=immortal):
+                self.assertTrue(_testcapi.is_immortal(immortal))
 
-    def test_immortal_small_ints(self):
-        _testcapi.test_immortal_small_ints()
+        # Some arbitrary mutable objects
+        non_immortals = (object(), self, [object()])
+        for non_immortal in non_immortals:
+            with self.subTest(non_immortal=non_immortal):
+                self.assertFalse(_testcapi.is_immortal(non_immortal))
+
+        # CRASHES _testcapi.is_immortal(NULL)
+
 
 class TestInternalCAPI(unittest.TestCase):
 
@@ -26,21 +36,6 @@ class TestInternalCAPI(unittest.TestCase):
             self.assertFalse(_testinternalcapi.is_static_immortal(obj))
         for obj in ([], {}, set()):
             self.assertFalse(_testinternalcapi.is_static_immortal(obj))
-
-    def test_immortal(self):
-        # Not extensive
-        known_immortals = (True, False, None, 0, ())
-        for immortal in known_immortals:
-            with self.subTest(immortal=immortal):
-                self.assertTrue(_testcapi.is_immortal(immortal))
-
-        # Some arbitrary mutable objects
-        non_immortals = (object(), self, [object()])
-        for non_immortal in non_immortals:
-            with self.subTest(non_immortal=non_immortal):
-                self.assertFalse(_testcapi.is_immortal(non_immortal))
-
-        # CRASHES _testcapi.is_immortal(NULL)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_capi/test_immortal.py
+++ b/Lib/test/test_capi/test_immortal.py
@@ -27,6 +27,20 @@ class TestInternalCAPI(unittest.TestCase):
         for obj in ([], {}, set()):
             self.assertFalse(_testinternalcapi.is_static_immortal(obj))
 
+    def test_immortal(self):
+        # Not extensive
+        known_immortals = (True, False, None, 0, ())
+        for immortal in known_immortals:
+            with self.subTest(immortal=immortal):
+                self.assertTrue(_testcapi.is_immortal(immortal))
+
+        # Some arbitrary mutable objects
+        non_immortals = (object(), self, [object()])
+        for non_immortal in non_immortals:
+            with self.subTest(non_immortal=non_immortal):
+                self.assertFalse(_testcapi.is_immortal(non_immortal))
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/C_API/2025-01-22-09-28-04.gh-issue-128509.gqQ36L.rst
+++ b/Misc/NEWS.d/next/C_API/2025-01-22-09-28-04.gh-issue-128509.gqQ36L.rst
@@ -1,0 +1,2 @@
+Add :c:func:`PyUnstable_IsImmortal` for determining whether an object is
+:term:`immortal`.

--- a/Modules/_testcapi/immortal.c
+++ b/Modules/_testcapi/immortal.c
@@ -40,7 +40,7 @@ is_immortal(PyObject *self, PyObject *op)
 static PyMethodDef test_methods[] = {
     {"test_immortal_builtins",   test_immortal_builtins,     METH_NOARGS},
     {"test_immortal_small_ints", test_immortal_small_ints,   METH_NOARGS},
-    {"is_immortal",              is_immortal,                METH_O}
+    {"is_immortal",              is_immortal,                METH_O},
     {NULL},
 };
 

--- a/Modules/_testcapi/immortal.c
+++ b/Modules/_testcapi/immortal.c
@@ -31,9 +31,16 @@ test_immortal_small_ints(PyObject *self, PyObject *Py_UNUSED(ignored))
     Py_RETURN_NONE;
 }
 
+static PyObject *
+is_immortal(PyObject *self, PyObject *op)
+{
+    return PyBool_FromLong(PyUnstable_IsImmortal(op));
+}
+
 static PyMethodDef test_methods[] = {
     {"test_immortal_builtins",   test_immortal_builtins,     METH_NOARGS},
     {"test_immortal_small_ints", test_immortal_small_ints,   METH_NOARGS},
+    {"is_immortal",              is_immortal,                METH_O}
     {NULL},
 };
 

--- a/Modules/_testcapi/object.c
+++ b/Modules/_testcapi/object.c
@@ -131,6 +131,14 @@ pyobject_enable_deferred_refcount(PyObject *self, PyObject *obj)
     return PyLong_FromLong(result);
 }
 
+
+static PyObject *
+is_immortal(PyObject *self, PyObject *op)
+{
+    return PyBool_FromLong(PyUnstable_IsImmortal(op));
+}
+
+
 static PyMethodDef test_methods[] = {
     {"call_pyobject_print", call_pyobject_print, METH_VARARGS},
     {"pyobject_print_null", pyobject_print_null, METH_VARARGS},
@@ -138,6 +146,7 @@ static PyMethodDef test_methods[] = {
     {"pyobject_print_os_error", pyobject_print_os_error, METH_VARARGS},
     {"pyobject_clear_weakrefs_no_callbacks", pyobject_clear_weakrefs_no_callbacks, METH_O},
     {"pyobject_enable_deferred_refcount", pyobject_enable_deferred_refcount, METH_O},
+    {"is_immortal", is_immortal, METH_O},
     {NULL},
 };
 

--- a/Modules/_testcapi/object.c
+++ b/Modules/_testcapi/object.c
@@ -132,13 +132,6 @@ pyobject_enable_deferred_refcount(PyObject *self, PyObject *obj)
 }
 
 
-static PyObject *
-is_immortal(PyObject *self, PyObject *op)
-{
-    return PyBool_FromLong(PyUnstable_IsImmortal(op));
-}
-
-
 static PyMethodDef test_methods[] = {
     {"call_pyobject_print", call_pyobject_print, METH_VARARGS},
     {"pyobject_print_null", pyobject_print_null, METH_VARARGS},
@@ -146,7 +139,6 @@ static PyMethodDef test_methods[] = {
     {"pyobject_print_os_error", pyobject_print_os_error, METH_VARARGS},
     {"pyobject_clear_weakrefs_no_callbacks", pyobject_clear_weakrefs_no_callbacks, METH_O},
     {"pyobject_enable_deferred_refcount", pyobject_enable_deferred_refcount, METH_O},
-    {"is_immortal", is_immortal, METH_O},
     {NULL},
 };
 

--- a/Modules/_testcapi/object.c
+++ b/Modules/_testcapi/object.c
@@ -135,7 +135,8 @@ pyobject_enable_deferred_refcount(PyObject *self, PyObject *obj)
 static PyObject *
 is_immortal(PyObject *self, PyObject *op)
 {
-    return PyBool_FromLong(PyUnstable_IsImmortal(op));
+    NULLABLE(op)
+    return PyLong_FromLong(PyUnstable_IsImmortal(op));
 }
 
 

--- a/Modules/_testcapi/object.c
+++ b/Modules/_testcapi/object.c
@@ -135,8 +135,7 @@ pyobject_enable_deferred_refcount(PyObject *self, PyObject *obj)
 static PyObject *
 is_immortal(PyObject *self, PyObject *op)
 {
-    NULLABLE(op)
-    return PyLong_FromLong(PyUnstable_IsImmortal(op));
+    return PyBool_FromLong(PyUnstable_IsImmortal(op));
 }
 
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3487,12 +3487,6 @@ error:
 #undef NTHREAD
 }
 
-static PyObject *
-is_immortal(PyObject *self, PyObject *op)
-{
-    return PyBool_FromLong(PyUnstable_IsImmortal(op));
-}
-
 static PyMethodDef TestMethods[] = {
     {"set_errno",               set_errno,                       METH_VARARGS},
     {"test_config",             test_config,                     METH_NOARGS},
@@ -3636,7 +3630,6 @@ static PyMethodDef TestMethods[] = {
     {"test_atexit", test_atexit, METH_NOARGS},
     {"code_offset_to_line", _PyCFunction_CAST(code_offset_to_line), METH_FASTCALL},
     {"tracemalloc_track_race", tracemalloc_track_race, METH_NOARGS},
-    {"is_immortal", is_immortal, METH_O},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3487,6 +3487,12 @@ error:
 #undef NTHREAD
 }
 
+static PyObject *
+is_immortal(PyObject *self, PyObject *op)
+{
+    return PyUnstable_IsImmortal(op);
+}
+
 static PyMethodDef TestMethods[] = {
     {"set_errno",               set_errno,                       METH_VARARGS},
     {"test_config",             test_config,                     METH_NOARGS},
@@ -3630,6 +3636,7 @@ static PyMethodDef TestMethods[] = {
     {"test_atexit", test_atexit, METH_NOARGS},
     {"code_offset_to_line", _PyCFunction_CAST(code_offset_to_line), METH_FASTCALL},
     {"tracemalloc_track_race", tracemalloc_track_race, METH_NOARGS},
+    {"is_immortal", is_immortal, METH_O}
     {NULL, NULL} /* sentinel */
 };
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3490,7 +3490,7 @@ error:
 static PyObject *
 is_immortal(PyObject *self, PyObject *op)
 {
-    return PyUnstable_IsImmortal(op);
+    return PyBool_FromLong(PyUnstable_IsImmortal(op));
 }
 
 static PyMethodDef TestMethods[] = {
@@ -3636,7 +3636,7 @@ static PyMethodDef TestMethods[] = {
     {"test_atexit", test_atexit, METH_NOARGS},
     {"code_offset_to_line", _PyCFunction_CAST(code_offset_to_line), METH_FASTCALL},
     {"tracemalloc_track_race", tracemalloc_track_race, METH_NOARGS},
-    {"is_immortal", is_immortal, METH_O}
+    {"is_immortal", is_immortal, METH_O},
     {NULL, NULL} /* sentinel */
 };
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -3161,5 +3161,6 @@ PyUnstable_IsImmortal(PyObject *op)
 {
     /* Checking a reference count requires a thread state */
     _Py_AssertHoldsTstate();
+    assert(op != NULL);
     return _Py_IsImmortal(op);
 }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -3155,3 +3155,11 @@ Py_REFCNT(PyObject *ob)
 {
     return _Py_REFCNT(ob);
 }
+
+int
+PyUnstable_IsImmortal(PyObject *op)
+{
+    /* Checking a reference count requires a thread state */
+    _Py_AssertHoldsTstate();
+    return _Py_IsImmortal(op);
+}


### PR DESCRIPTION
- I've reused the test from my other PR.
- The plan is to go for this, and then possibly go for #128510 afterwards.

<!-- gh-issue-number: gh-128509 -->
* Issue: gh-128509
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129182.org.readthedocs.build/en/129182/c-api/object.html#c.PyUnstable_IsImmortal

<!-- readthedocs-preview cpython-previews end -->