### PR TITLE
gh-128779: Fix site venv() for system site-packages

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -633,14 +633,9 @@ def venv(known_paths):
         # Doing this here ensures venv takes precedence over user-site
         addsitepackages(known_paths, [sys.prefix])
 
-        # addsitepackages will process site_prefix again if its in PREFIXES,
-        # but that's ok; known_paths will prevent anything being added twice
         if system_site == "true":
-            PREFIXES.insert(0, sys.prefix)
-            if sys.base_exec_prefix != sys.exec_prefix:
-                PREFIXES.append(sys.base_exec_prefix)
+            PREFIXES += [sys.base_prefix, sys.base_exec_prefix]
         else:
-            PREFIXES = [sys.prefix]
             ENABLE_USER_SITE = False
 
     return known_paths

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -637,6 +637,8 @@ def venv(known_paths):
         # but that's ok; known_paths will prevent anything being added twice
         if system_site == "true":
             PREFIXES.insert(0, sys.prefix)
+            if sys.base_exec_prefix != sys.exec_prefix:
+                PREFIXES.append(sys.base_exec_prefix)
         else:
             PREFIXES = [sys.prefix]
             ENABLE_USER_SITE = False


### PR DESCRIPTION
Add sys.base_exec_prefix to prefixes if pyvenv.cfg enables system site-packages.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128779 -->
* Issue: gh-128779
<!-- /gh-issue-number -->
