### PR TITLE
gh-129185: Fix crash during interpreter finalization in PyTraceMalloc_Untrack

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2127,14 +2127,14 @@ _Py_Finalize(_PyRuntimeState *runtime)
     _PyGC_CollectIfEnabled();
 #endif
 
-    /* Disable tracemalloc after all Python objects have been destroyed,
-       so it is possible to use tracemalloc in objects destructor. */
-    _PyTraceMalloc_Fini();
-
     /* Finalize any remaining import state */
     // XXX Move these up to where finalize_modules() is currently.
     _PyImport_FiniCore(tstate->interp);
     _PyImport_Fini();
+
+    /* Disable tracemalloc after all Python objects have been destroyed,
+       so it is possible to use tracemalloc in objects destructor. */
+    _PyTraceMalloc_Fini();
 
     /* unload faulthandler module */
     _PyFaulthandler_Fini();


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This fixes the crash by moving `_PyTraceMalloc_Fini()` after `_PyImport_Fini()`. I'm not sure if it breaks some invariant that I'm not aware of or even if it's the best solution, happy to take feedbacks!

<!-- gh-issue-number: gh-129185 -->
* Issue: gh-129185
<!-- /gh-issue-number -->
