### PR TITLE
Add colour to GitHub Actions output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-reusable
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   check_source:
     name: Change detection

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -25,6 +25,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   interpreter:
     name: Interpreter (Debug)

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -15,12 +15,14 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build_macos:
     name: build and test (${{ inputs.os }})
     timeout-minutes: 60
     env:
-      FORCE_COLOR: 1
       HOMEBREW_NO_ANALYTICS: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -20,6 +20,7 @@ jobs:
     name: build and test (${{ inputs.os }})
     timeout-minutes: 60
     env:
+      FORCE_COLOR: 1
       HOMEBREW_NO_ANALYTICS: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/.github/workflows/reusable-tsan.yml
+++ b/.github/workflows/reusable-tsan.yml
@@ -18,6 +18,9 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build_tsan_reusable:
     name: 'Thread sanitizer'

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -21,13 +21,15 @@ on:
          required: true
          type: string
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build_ubuntu_reusable:
     name: build and test (${{ inputs.os }})
     timeout-minutes: 60
     runs-on: ${{ inputs.os }}
     env:
-      FORCE_COLOR: 1
       OPENSSL_VER: 3.0.15
       PYTHONSTRICTEXTENSIONBUILD: 1
       TERM: linux

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build_wasi_reusable:
     name: 'build and test'

--- a/.github/workflows/reusable-windows-msi.yml
+++ b/.github/workflows/reusable-windows-msi.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build:
     name: installer for ${{ inputs.arch }}

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -18,6 +18,7 @@ on:
         default: false
 
 env:
+  FORCE_COLOR: 1
   IncludeUwp: >-
     true
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Following the merge of https://github.com/python/cpython/pull/127223, https://github.com/python/cpython/pull/127719, https://github.com/python/cpython/pull/127877, https://github.com/python/cpython/pull/128498 and https://github.com/python/cpython/pull/128687, we can now enable colour in the `unittest` and `test.regrtest` output on GitHub Actions using [`FORCE_COLOR`](https://force-color.org/).

The biggest benefit is it helps us find failures when scrolling the long logs, and usually the reason to open the logs in the first place is to find a failure.

For example, here's a forced failure in another branch:

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/c013e1e8-8fcb-4dfa-be0d-722c81460e9a" />

https://github.com/hugovk/cpython/actions/runs/12915439756/job/36017613160

Accessibility check: it's important not to rely on colour alone to confer information, and the current textual output is not changed, and continues to say pass/skip/fail as now. The colour is an addition.

