### PR TITLE
gh-91048: Also clear and set ts->asyncio_running_task with eager tasks

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2324,7 +2324,6 @@ swap_current_task(asyncio_state *state, PyObject *loop, PyObject *task)
 static inline void
 set_ts_asyncio_running_task(PyObject *loop, PyObject *task)
 {
-    // This is needed to enable `asyncio.capture_call_graph()` API.
     // We want to be enable debuggers and profilers to be able to quickly
     // introspect the asyncio running state from another process.
     // When we do that, we need to essentially traverse the address space
@@ -2341,8 +2340,8 @@ set_ts_asyncio_running_task(PyObject *loop, PyObject *task)
     // and ever-changing data structure.
     //
     // So the easier solution is to put a strong reference to the currently
-    // running `asyncio.Task` on the interpreter thread state (we already
-    // have some asyncio state there.)
+    // running `asyncio.Task` on the current thread state (the current loop
+    // is also stored there.)
     _PyThreadStateImpl *ts = (_PyThreadStateImpl *)_PyThreadState_GET();
     if (ts->asyncio_running_loop == loop) {
         // Protect from a situation when someone calls this method

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2324,7 +2324,7 @@ swap_current_task(asyncio_state *state, PyObject *loop, PyObject *task)
 static inline void
 set_ts_asyncio_running_task(PyObject *loop, PyObject *task)
 {
-    // We want to be enable debuggers and profilers to be able to quickly
+    // We want to enable debuggers and profilers to be able to quickly
     // introspect the asyncio running state from another process.
     // When we do that, we need to essentially traverse the address space
     // of a Python process and understand what every Python thread in it is


### PR DESCRIPTION
This was missing from gh-124640. It's already covered by the new test_asyncio/test_free_threading.py in combination with the runtime assertion in set_ts_asyncio_running_task.


<!-- gh-issue-number: gh-91048 -->
* Issue: gh-91048
<!-- /gh-issue-number -->
