### PR TITLE
gh-129205: Add os.readinto API for reading data into a caller provided buffer

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1670,9 +1670,9 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    interrupted by a signal, unless the signal handler raises an exception.
    Other errors will not be retried and an error will be raised.
 
-   Returns 0 if the fd is at end of file or if the provided buffer is
-   length 0 (can be used to check for errors without reading data). Never
-   returns a negative value.
+   Returns 0 if *fd* is at end of file or if the provided *buffer* has
+   length 0 (which can be used to check for errors without reading data).
+   A negative value is never returned by this function.
 
    .. note::
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1666,18 +1666,18 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
 
    The *buffer* should be mutable and :term:`bytes-like <bytes-like object>`. On
    success, returns the number of bytes read. Less bytes may be read than the
-   size of the buffer. Will retry the underlying system call when interrupted by
-   a signal. For other errors, the system call will not be retried.
+   size of the buffer. The underlying system call will be retried when
+   interrupted by a signal. For other errors, it will not be retried.
 
    .. note::
 
       This function is intended for low-level I/O and must be applied to a file
-      descriptor as returned by :func:`os.open` or :func:`pipe`.  To read a
+      descriptor as returned by :func:`os.open` or :func:`os.pipe`.  To read a
       "file object" returned by the built-in function :func:`open` or by
       :func:`popen` or :func:`fdopen`, or :data:`sys.stdin`, use its
       :meth:`~file.readinto` or :meth:`~file.read`.
 
-   .. versionadded:: 3.14
+   .. versionadded:: next
 
 
 .. function:: sendfile(out_fd, in_fd, offset, count)

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1662,7 +1662,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
 .. function:: readinto(fd, buffer, /)
 
    Read from a file descriptor *fd* into a mutable
-   :ref:`buffer protocol <bufferobjects>` *buffer*.
+   :ref:`buffer object <bufferobjects>` *buffer*.
 
    The *buffer* should be mutable and :term:`bytes-like <bytes-like object>`. On
    success, returns the number of bytes read. Less bytes may be read than the

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1667,15 +1667,21 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    The *buffer* should be mutable and :term:`bytes-like <bytes-like object>`. On
    success, returns the number of bytes read. Less bytes may be read than the
    size of the buffer. The underlying system call will be retried when
-   interrupted by a signal. For other errors, it will not be retried.
+   interrupted by a signal. Other errors will not be retried and an error will
+   be raised.
+
+   Returns 0 if the fd is at end of file or if the provided buffer is
+   length 0 (can be used to check for errors without reading data). Never
+   returns a negative value.
 
    .. note::
 
       This function is intended for low-level I/O and must be applied to a file
       descriptor as returned by :func:`os.open` or :func:`os.pipe`.  To read a
-      "file object" returned by the built-in function :func:`open` or by
-      :func:`popen` or :func:`fdopen`, or :data:`sys.stdin`, use its
-      :meth:`~file.readinto` or :meth:`~file.read`.
+      "file object" returned by the built-in function :func:`open`, or
+      :data:`sys.stdin`, use its member functions, for example
+      :meth:`io.BufferedIOBase.readinto`, :meth:`io.BufferedIOBase.read`, or
+      :meth:`io.TextIOBase.read`
 
    .. versionadded:: next
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1664,11 +1664,10 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    Read from a file descriptor *fd* into a mutable
    :ref:`buffer protocol <bufferobjects>` *buffer*.
 
-   The *buffer* should be mutable and :term:`bytes-like
-   objects <bytes-like object>`. On success, returns the number of
-   bytes read. Less bytes may be read than the size of the buffer. Will retry the
-   underlying system call when interrupted by a signal. For other errors, the
-   system call will not be retried.
+   The *buffer* should be mutable and :term:`bytes-like <bytes-like object>`. On
+   success, returns the number of bytes read. Less bytes may be read than the
+   size of the buffer. Will retry the underlying system call when interrupted by
+   a signal. For other errors, the system call will not be retried.
 
    .. note::
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1668,8 +1668,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    success, returns the number of bytes read. Less bytes may be read than the
    size of the buffer. The underlying system call will be retried when
    interrupted by a signal, unless the signal handler raises an exception.
-   Other errors will not be retried and an error will
-   be raised.
+   Other errors will not be retried and an error will be raised.
 
    Returns 0 if the fd is at end of file or if the provided buffer is
    length 0 (can be used to check for errors without reading data). Never

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1659,6 +1659,28 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
       :exc:`InterruptedError` exception (see :pep:`475` for the rationale).
 
 
+.. function:: readinto(fd, buffer, /)
+
+   Read from a file descriptor *fd* into a mutable
+   :ref:`buffer protocol <bufferobjects>` *buffer*.
+
+   The *buffer* should be mutable and :term:`bytes-like
+   objects <bytes-like object>`. On success, returns the number of
+   bytes read. Less bytes may be read than the size of the buffer. Will retry the
+   underlying system call when interrupted by a signal. For other errors, the
+   system call will not be retried.
+
+   .. note::
+
+      This function is intended for low-level I/O and must be applied to a file
+      descriptor as returned by :func:`os.open` or :func:`pipe`.  To read a
+      "file object" returned by the built-in function :func:`open` or by
+      :func:`popen` or :func:`fdopen`, or :data:`sys.stdin`, use its
+      :meth:`~file.readinto` or :meth:`~file.read`.
+
+   .. versionadded:: 3.14
+
+
 .. function:: sendfile(out_fd, in_fd, offset, count)
               sendfile(out_fd, in_fd, offset, count, headers=(), trailers=(), flags=0)
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1672,7 +1672,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
 
    Returns 0 if *fd* is at end of file or if the provided *buffer* has
    length 0 (which can be used to check for errors without reading data).
-   A negative value is never returned by this function.
+   Never returns negative.
 
    .. note::
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1667,7 +1667,8 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    The *buffer* should be mutable and :term:`bytes-like <bytes-like object>`. On
    success, returns the number of bytes read. Less bytes may be read than the
    size of the buffer. The underlying system call will be retried when
-   interrupted by a signal. Other errors will not be retried and an error will
+   interrupted by a signal, unless the signal handler raises an exception.
+   Other errors will not be retried and an error will
    be raised.
 
    Returns 0 if the fd is at end of file or if the provided buffer is

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -561,6 +561,9 @@ os
   to the :mod:`os` module.
   (Contributed by James Roy in :gh:`127688`.)
 
+* Add the :func:`os.readinto` function to read into a
+  :ref:`buffer protocol <bufferobjects>` from a file descriptor.
+  (Contributed by Cody Maloney in :gh:`129205`.)
 
 pathlib
 -------

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -562,7 +562,7 @@ os
   (Contributed by James Roy in :gh:`127688`.)
 
 * Add the :func:`os.readinto` function to read into a
-  :ref:`buffer protocol <bufferobjects>` from a file descriptor.
+  :ref:`buffer object <bufferobjects>` from a file descriptor.
   (Contributed by Cody Maloney in :gh:`129205`.)
 
 pathlib

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -565,6 +565,7 @@ os
   :ref:`buffer object <bufferobjects>` from a file descriptor.
   (Contributed by Cody Maloney in :gh:`129205`.)
 
+
 pathlib
 -------
 

--- a/Lib/test/_test_eintr.py
+++ b/Lib/test/_test_eintr.py
@@ -160,7 +160,6 @@ class OSEINTRTest(EINTRBaseTest):
         # the payload below are smaller than PIPE_BUF, hence the writes will be
         # atomic
         datas = [b"hello", b"world", b"spam"]
-        bufs = [bytearray(5), bytearray(5), bytearray(4)]
 
         code = '\n'.join((
             'import os, sys, time',
@@ -178,9 +177,10 @@ class OSEINTRTest(EINTRBaseTest):
         proc = self.subprocess(code, str(wr), pass_fds=[wr])
         with kill_on_error(proc):
             os.close(wr)
-            for data, buffer in zip(datas, bufs):
-                os.readinto(rd, buffer)
-                self.assertEqual(data, buffer)
+            for data in datas:
+                buffer = bytearray(len(data))
+                self.assertEqual(os.readinto(rd, buffer), len(data))
+                self.assertEqual(buffer, data)
             self.assertEqual(proc.wait(), 0)
 
     def test_write(self):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -311,7 +311,7 @@ class FileTests(unittest.TestCase):
         # Issue #21932: For readinto the buffer contains the length rather than
         # a length being passed explicitly to read, should still get capped to a
         # valid size / not raise an OverflowError for sizes larger than INT_MAX.
-        buffer = bytearray(INT_MAX+10)
+        buffer = bytearray(INT_MAX + 10)
         with open(os_helper.TESTFN, "rb") as fp:
             length = os.readinto(fp.fileno(), buffer)
 

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -236,22 +236,22 @@ class FileTests(unittest.TestCase):
             fobj.flush()
             fd = fobj.fileno()
             os.lseek(fd, 0, 0)
-            buffer = bytearray(8)
+            buffer = bytearray(7)
             s = os.readinto(fd, buffer)
             self.assertEqual(type(s), int)
             self.assertEqual(s, 4)
             # Should overwrite the first 4 bytes of the buffer.
-            self.assertEqual(bytes(buffer), b"spam\0\0\0\0")
+            self.assertEqual(buffer[:4], b"spam")
 
-            # Readinto at EOF shold return 0 and not touch buffer
-            buffer[:] = b"notspam\0"
+            # Readinto at EOF should return 0 and not touch buffer.
+            buffer[:] = b"notspam"
             s = os.readinto(fd, buffer)
             self.assertEqual(type(s), int)
             self.assertEqual(s, 0)
-            self.assertEqual(bytes(buffer), b"notspam\0")
+            self.assertEqual(bytes(buffer), b"notspam")
             s = os.readinto(fd, buffer)
             self.assertEqual(s, 0)
-            self.assertEqual(bytes(buffer), b"notspam\0")
+            self.assertEqual(bytes(buffer), b"notspam")
 
             # Readinto a 0 length bytearray when at EOF should return 0
             self.assertEqual(os.readinto(fd, bytearray()), 0)

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -253,6 +253,13 @@ class FileTests(unittest.TestCase):
             self.assertEqual(s, 0)
             self.assertEqual(bytes(buffer), b"notspam\0")
 
+            # Readinto a 0 length bytearray when at EOF should return 0
+            self.assertEqual(os.readinto(fd, bytearray()), 0)
+
+            # Readinto a 0 length bytearray with data available should return 0.
+            os.lseek(fd, 0, 0)
+            self.assertEqual(os.readinto(fd, bytearray()), 0)
+
     def test_readinto_badbuffer(self):
         with open(os_helper.TESTFN, "w+b") as fobj:
             fobj.write(b"spam")
@@ -302,7 +309,7 @@ class FileTests(unittest.TestCase):
         create_file(os_helper.TESTFN, b'test')
 
         # Issue #21932: For readinto the buffer contains the length rather than
-        # a length being passed explicitly to read, shold still get capped to a
+        # a length being passed explicitly to read, should still get capped to a
         # valid size / not raise an OverflowError for sizes larger than INT_MAX.
         buffer = bytearray(INT_MAX+10)
         with open(os_helper.TESTFN, "rb") as fp:

--- a/Misc/NEWS.d/next/Library/2025-01-22-16-54-25.gh-issue-129205.FMqrUt.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-22-16-54-25.gh-issue-129205.FMqrUt.rst
@@ -1,1 +1,1 @@
-Add :func:`os.readinto` to read into a :ref:`buffer protocol <bufferobjects>` from a file descriptor.
+Add :func:`os.readinto` to read into a :ref:`buffer object <bufferobjects>` from a file descriptor.

--- a/Misc/NEWS.d/next/Library/2025-01-22-16-54-25.gh-issue-129205.FMqrUt.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-22-16-54-25.gh-issue-129205.FMqrUt.rst
@@ -1,1 +1,1 @@
-Add ``os.readinto`` to read into a :ref:`buffer protocol <bufferobjects>` from a file descriptor.
+Add :func:`os.readinto` to read into a :ref:`buffer protocol <bufferobjects>` from a file descriptor.

--- a/Misc/NEWS.d/next/Library/2025-01-22-16-54-25.gh-issue-129205.FMqrUt.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-22-16-54-25.gh-issue-129205.FMqrUt.rst
@@ -1,1 +1,1 @@
-Add :func:`os.readinto` to read into a :ref:`buffer protocol <bufferobjects>` from a file descriptor.
+Add ``os.readinto`` to read into a :ref:`buffer protocol <bufferobjects>` from a file descriptor.

--- a/Misc/NEWS.d/next/Library/2025-01-22-16-54-25.gh-issue-129205.FMqrUt.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-22-16-54-25.gh-issue-129205.FMqrUt.rst
@@ -1,0 +1,1 @@
+Add :meth:`os.readinto` to read into a :ref:`buffer protocol <bufferobjects>` from a file descriptor.

--- a/Misc/NEWS.d/next/Library/2025-01-22-16-54-25.gh-issue-129205.FMqrUt.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-22-16-54-25.gh-issue-129205.FMqrUt.rst
@@ -1,1 +1,1 @@
-Add :meth:`os.readinto` to read into a :ref:`buffer protocol <bufferobjects>` from a file descriptor.
+Add :func:`os.readinto` to read into a :ref:`buffer protocol <bufferobjects>` from a file descriptor.

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -7583,10 +7583,15 @@ PyDoc_STRVAR(os_readinto__doc__,
 "\n"
 "Read into a Buffer Protocol object from a file descriptor.\n"
 "\n"
-"The buffer should be mutable and bytes-like. On success, returns the number of\n"
-"bytes read. Less bytes may be read than the size of the buffer. Will retry the\n"
-"underlying system call when interrupted by a signal. For other errors, the\n"
-"system call will not be retried.");
+"The buffer should be mutable and bytes-like.\n"
+"\n"
+"On success, returns the number of bytes read. Less bytes may be read than the\n"
+"size of the buffer without reaching end of stream. Will retry the underlying\n"
+"system call when interrupted by a signal. Other errors will not be retried and\n"
+"an error will be raised.\n"
+"\n"
+"Returns 0 if the fd is at end of file or the provided buffer is length 0 (can be\n"
+"used to check for errors without reading data). Never returns a negative value.");
 
 #define OS_READINTO_METHODDEF    \
     {"readinto", _PyCFunction_CAST(os_readinto), METH_FASTCALL, os_readinto__doc__},
@@ -13191,4 +13196,4 @@ os__emscripten_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__EMSCRIPTEN_DEBUGGER_METHODDEF
     #define OS__EMSCRIPTEN_DEBUGGER_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_DEBUGGER_METHODDEF) */
-/*[clinic end generated code: output=c2333102aef2f39a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=84e2430fb1a3cff1 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -7581,9 +7581,9 @@ PyDoc_STRVAR(os_readinto__doc__,
 "readinto($module, fd, buffer, /)\n"
 "--\n"
 "\n"
-"Read into a :ref:`buffer protocol <bufferobjects>` object from a file descriptor.\n"
+"Read into a Buffer Protocol object from a file descriptor.\n"
 "\n"
-"The buffer should be mutable and accept bytes. On success, returns the number of\n"
+"The buffer should be mutable and bytes-like. On success, returns the number of\n"
 "bytes read. Less bytes may be read than the size of the buffer. Will retry the\n"
 "underlying system call when interrupted by a signal. For other errors, the\n"
 "system call will not be retried.");
@@ -13191,4 +13191,4 @@ os__emscripten_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__EMSCRIPTEN_DEBUGGER_METHODDEF
     #define OS__EMSCRIPTEN_DEBUGGER_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_DEBUGGER_METHODDEF) */
-/*[clinic end generated code: output=c2f04dda4ea1a399 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c2333102aef2f39a input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -7581,7 +7581,7 @@ PyDoc_STRVAR(os_readinto__doc__,
 "readinto($module, fd, buffer, /)\n"
 "--\n"
 "\n"
-"Read into a Buffer Protocol object from a file descriptor.\n"
+"Read into a buffer object from a file descriptor.\n"
 "\n"
 "The buffer should be mutable and bytes-like.\n"
 "\n"
@@ -13196,4 +13196,4 @@ os__emscripten_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__EMSCRIPTEN_DEBUGGER_METHODDEF
     #define OS__EMSCRIPTEN_DEBUGGER_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_DEBUGGER_METHODDEF) */
-/*[clinic end generated code: output=84e2430fb1a3cff1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c0f95415cf1db474 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -7583,15 +7583,15 @@ PyDoc_STRVAR(os_readinto__doc__,
 "\n"
 "Read into a buffer object from a file descriptor.\n"
 "\n"
-"The buffer should be mutable and bytes-like.\n"
+"The buffer should be mutable and bytes-like. On success, returns the number of\n"
+"bytes read. Less bytes may be read than the size of the buffer. The underlying\n"
+"system call will be retried when interrupted by a signal, unless the signal\n"
+"handler raises an exception. Other errors will not be retried and an error will\n"
+"be raised.\n"
 "\n"
-"On success, returns the number of bytes read. Less bytes may be read than the\n"
-"size of the buffer without reaching end of stream. Will retry the underlying\n"
-"system call when interrupted by a signal. Other errors will not be retried and\n"
-"an error will be raised.\n"
-"\n"
-"Returns 0 if the fd is at end of file or the provided buffer is length 0 (can be\n"
-"used to check for errors without reading data). Never returns a negative value.");
+"Returns 0 if *fd* is at end of file or if the provided *buffer* has length 0\n"
+"(which can be used to check for errors without reading data). Never returns\n"
+"negative.");
 
 #define OS_READINTO_METHODDEF    \
     {"readinto", _PyCFunction_CAST(os_readinto), METH_FASTCALL, os_readinto__doc__},
@@ -13196,4 +13196,4 @@ os__emscripten_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__EMSCRIPTEN_DEBUGGER_METHODDEF
     #define OS__EMSCRIPTEN_DEBUGGER_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_DEBUGGER_METHODDEF) */
-/*[clinic end generated code: output=c0f95415cf1db474 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8318c26fc2cd236c input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -7577,6 +7577,57 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(os_readinto__doc__,
+"readinto($module, fd, buffer, /)\n"
+"--\n"
+"\n"
+"Read into a :ref:`buffer protocol <bufferobjects>` object from a file descriptor.\n"
+"\n"
+"The buffer should be mutable and accept bytes. On success, returns the number of\n"
+"bytes read. Less bytes may be read than the size of the buffer. Will retry the\n"
+"underlying system call when interrupted by a signal. For other errors, the\n"
+"system call will not be retried.");
+
+#define OS_READINTO_METHODDEF    \
+    {"readinto", _PyCFunction_CAST(os_readinto), METH_FASTCALL, os_readinto__doc__},
+
+static Py_ssize_t
+os_readinto_impl(PyObject *module, int fd, Py_buffer *buffer);
+
+static PyObject *
+os_readinto(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    int fd;
+    Py_buffer buffer = {NULL, NULL};
+    Py_ssize_t _return_value;
+
+    if (!_PyArg_CheckPositional("readinto", nargs, 2, 2)) {
+        goto exit;
+    }
+    fd = PyLong_AsInt(args[0]);
+    if (fd == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (PyObject_GetBuffer(args[1], &buffer, PyBUF_WRITABLE) < 0) {
+        _PyArg_BadArgument("readinto", "argument 2", "read-write bytes-like object", args[1]);
+        goto exit;
+    }
+    _return_value = os_readinto_impl(module, fd, &buffer);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromSsize_t(_return_value);
+
+exit:
+    /* Cleanup for buffer */
+    if (buffer.obj) {
+       PyBuffer_Release(&buffer);
+    }
+
+    return return_value;
+}
+
 #if defined(HAVE_READV)
 
 PyDoc_STRVAR(os_readv__doc__,
@@ -13140,4 +13191,4 @@ os__emscripten_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__EMSCRIPTEN_DEBUGGER_METHODDEF
     #define OS__EMSCRIPTEN_DEBUGGER_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_DEBUGGER_METHODDEF) */
-/*[clinic end generated code: output=34cb96bd07bcef90 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c2f04dda4ea1a399 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11451,9 +11451,11 @@ static Py_ssize_t
 os_readinto_impl(PyObject *module, int fd, Py_buffer *buffer)
 /*[clinic end generated code: output=8091a3513c683a80 input=810c820f4d9b1c6b]*/
 {
-    // Cap to max read size to prevent overflow in cast to size_t for _Py_read.
-    size_t length = Py_MIN(buffer->len, _PY_READ_MAX);
-    return _Py_read(fd, buffer->buf, length);
+    if (buffer->len < 0) {
+        errno = EINVAL
+        return posix_error();
+    }
+    return _Py_read(fd, buffer->buf, buffer->len);
 }
 
 #if (defined(HAVE_SENDFILE) && (defined(__FreeBSD__) || defined(__DragonFly__) \

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11441,20 +11441,20 @@ os.readinto -> Py_ssize_t
 
 Read into a buffer object from a file descriptor.
 
-The buffer should be mutable and bytes-like.
+The buffer should be mutable and bytes-like. On success, returns the number of
+bytes read. Less bytes may be read than the size of the buffer. The underlying
+system call will be retried when interrupted by a signal, unless the signal
+handler raises an exception. Other errors will not be retried and an error will
+be raised.
 
-On success, returns the number of bytes read. Less bytes may be read than the
-size of the buffer without reaching end of stream. Will retry the underlying
-system call when interrupted by a signal. Other errors will not be retried and
-an error will be raised.
-
-Returns 0 if the fd is at end of file or the provided buffer is length 0 (can be
-used to check for errors without reading data). Never returns a negative value.
+Returns 0 if *fd* is at end of file or if the provided *buffer* has length 0
+(which can be used to check for errors without reading data). Never returns
+negative.
 [clinic start generated code]*/
 
 static Py_ssize_t
 os_readinto_impl(PyObject *module, int fd, Py_buffer *buffer)
-/*[clinic end generated code: output=8091a3513c683a80 input=2a0ac4256f469f93]*/
+/*[clinic end generated code: output=8091a3513c683a80 input=d40074d0a68de575]*/
 {
     assert(buffer->len >= 0);
     Py_ssize_t result = _Py_read(fd, buffer->buf, buffer->len);

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11439,9 +11439,9 @@ os.readinto -> Py_ssize_t
     buffer: Py_buffer(accept={rwbuffer})
     /
 
-Read into a :ref:`buffer protocol <bufferobjects>` object from a file descriptor.
+Read into a Buffer Protocol object from a file descriptor.
 
-The buffer should be mutable and accept bytes. On success, returns the number of
+The buffer should be mutable and bytes-like. On success, returns the number of
 bytes read. Less bytes may be read than the size of the buffer. Will retry the
 underlying system call when interrupted by a signal. For other errors, the
 system call will not be retried.
@@ -11449,7 +11449,7 @@ system call will not be retried.
 
 static Py_ssize_t
 os_readinto_impl(PyObject *module, int fd, Py_buffer *buffer)
-/*[clinic end generated code: output=8091a3513c683a80 input=810c820f4d9b1c6b]*/
+/*[clinic end generated code: output=8091a3513c683a80 input=2d815e709ab6a85b]*/
 {
     if (buffer->len < 0) {
         errno = EINVAL;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11454,7 +11454,7 @@ used to check for errors without reading data). Never returns a negative value.
 
 static Py_ssize_t
 os_readinto_impl(PyObject *module, int fd, Py_buffer *buffer)
-/*[clinic end generated code: output=8091a3513c683a80 input=7485bbbb143bf7e8]*/
+/*[clinic end generated code: output=8091a3513c683a80 input=2a0ac4256f469f93]*/
 {
     assert(buffer->len >= 0);
     Py_ssize_t result = _Py_read(fd, buffer->buf, buffer->len);

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11439,7 +11439,7 @@ os.readinto -> Py_ssize_t
     buffer: Py_buffer(accept={rwbuffer})
     /
 
-Read into a Buffer Protocol object from a file descriptor.
+Read into a buffer object from a file descriptor.
 
 The buffer should be mutable and bytes-like.
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11452,8 +11452,9 @@ os_readinto_impl(PyObject *module, int fd, Py_buffer *buffer)
 /*[clinic end generated code: output=8091a3513c683a80 input=810c820f4d9b1c6b]*/
 {
     if (buffer->len < 0) {
-        errno = EINVAL
-        return posix_error();
+        errno = EINVAL;
+        PyErr_SetFromErrno(PyExc_OSError);
+        return -1;
     }
     return _Py_read(fd, buffer->buf, buffer->len);
 }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11456,12 +11456,7 @@ static Py_ssize_t
 os_readinto_impl(PyObject *module, int fd, Py_buffer *buffer)
 /*[clinic end generated code: output=8091a3513c683a80 input=7485bbbb143bf7e8]*/
 {
-    if (buffer->len < 0) {
-        assert(!PyErr_Occurred());
-        errno = EINVAL;
-        PyErr_SetFromErrno(PyExc_OSError);
-        return -1;
-    }
+    assert(buffer->len >= 0);
     Py_ssize_t result = _Py_read(fd, buffer->buf, buffer->len);
     /* Ensure negative is never returned without an error. Simplifies calling
         code. _Py_read should succeed, possibly reading 0 bytes, _or_ set an

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11433,6 +11433,29 @@ os_read_impl(PyObject *module, int fd, Py_ssize_t length)
     return buffer;
 }
 
+/*[clinic input]
+os.readinto -> Py_ssize_t
+    fd: int
+    buffer: Py_buffer(accept={rwbuffer})
+    /
+
+Read into a :ref:`buffer protocol <bufferobjects>` object from a file descriptor.
+
+The buffer should be mutable and accept bytes. On success, returns the number of
+bytes read. Less bytes may be read than the size of the buffer. Will retry the
+underlying system call when interrupted by a signal. For other errors, the
+system call will not be retried.
+[clinic start generated code]*/
+
+static Py_ssize_t
+os_readinto_impl(PyObject *module, int fd, Py_buffer *buffer)
+/*[clinic end generated code: output=8091a3513c683a80 input=810c820f4d9b1c6b]*/
+{
+    // Cap to max read size to prevent overflow in cast to size_t for _Py_read.
+    size_t length = Py_MIN(buffer->len, _PY_READ_MAX);
+    return _Py_read(fd, buffer->buf, length);
+}
+
 #if (defined(HAVE_SENDFILE) && (defined(__FreeBSD__) || defined(__DragonFly__) \
                                 || defined(__APPLE__))) \
     || defined(HAVE_READV) || defined(HAVE_PREADV) || defined (HAVE_PREADV2) \
@@ -16973,6 +16996,7 @@ static PyMethodDef posix_methods[] = {
     OS_LOCKF_METHODDEF
     OS_LSEEK_METHODDEF
     OS_READ_METHODDEF
+    OS_READINTO_METHODDEF
     OS_READV_METHODDEF
     OS_PREAD_METHODDEF
     OS_PREADV_METHODDEF


### PR DESCRIPTION
Adds `os.readinto` API as well as associated tests. Most functionality is provided by `_Py_read` which is fairly well exercised by `os.read` tests.

For testing I have been running:
```bash
make buildbottest
python -bb -E -Wd -m test -M32g -uall test_os _test_eintr  -vvv
```

I skipped adding to `test_largefile`, that path should get exercised in part by `test_os.FileTests.test_large_readinto`, and will get exercised reading 2GB+ of bytes as move `_pyio` to use `os.readinto` (`test_largefile.PyLargeFileTest`).

Not sure how to make a negative length buffer for testing that case getting handled as expected (`_Py_read` takes a `size_t` and `Py_buffer.len` is a `Py_ssize_t`)

Should probably have buildbots run once reviewed. This should work across platforms, but I've only tested on Linux and things like large file tests aren't run by all bots.

<!-- gh-issue-number: gh-129205 -->
* Issue: gh-129205
<!-- /gh-issue-number -->
