### PR TITLE
gh-91048: Improve example in `asyncio-graph.rst` doc

### DIFF
--- a/Doc/library/asyncio-graph.rst
+++ b/Doc/library/asyncio-graph.rst
@@ -59,13 +59,13 @@ and debuggers.
 
       async def main():
           async with asyncio.TaskGroup() as g:
-              g.create_task(test())
+              g.create_task(test(), name='test')
 
       asyncio.run(main())
 
    will print::
 
-      * Task(name='Task-2', id=0x1039f0fe0)
+      * Task(name='test', id=0x1039f0fe0)
       + Call stack:
       |   File 't2.py', line 4, in async test()
       + Awaited by:


### PR DESCRIPTION
I propose adding an explicit `name`, because it is not clear what "Task-1" and "Task-2" are. Now with this explicit name it is more readable.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129224.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-91048 -->
* Issue: gh-91048
<!-- /gh-issue-number -->
