### PR TITLE
Alphabetize imports in Lib/venv/__init__.py

### DIFF
--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -6,12 +6,12 @@ Licensed to the PSF under a contributor agreement.
 """
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import sys
 import sysconfig
 import types
-import shlex
 
 
 CORE_VENV_DEPS = ('pip',)


### PR DESCRIPTION
Alphabetize imports in `Lib/venv/__init__.py`. This change is not necessary to comply with [PEP 8 style guide for imports](https://peps.python.org/pep-0008/#imports) but it is preferred by some style guides (e.g. [isort](https://pypi.org/project/isort/)).