### PR TITLE
Implement retry on checkout for reusable-ubuntu

### DIFF
--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -34,9 +34,12 @@ jobs:
       PYTHONSTRICTEXTENSIONBUILD: 1
       TERM: linux
     steps:
-    - uses: actions/checkout@v4
+    - uses: Wandalen/wretry.action@master
       with:
-        persist-credentials: false
+        action: actions/checkout@v4
+        attempt_limit: 3
+        with: |
+          persist-credentials: false
     - name: Register gcc problem matcher
       run: echo "::add-matcher::.github/problem-matchers/gcc.json"
     - name: Install dependencies


### PR DESCRIPTION
There are a few occasions where the checkout on reusable-ubuntu is failing. This happens on Ubuntu arm for free threading builds. Examples:
* https://github.com/python/cpython/actions/runs/12934438169/job/36075486419?pr=129232
* https://github.com/python/cpython/actions/runs/12918705578/job/36027797316?pr=129203
* https://github.com/python/cpython/actions/runs/12916370948/job/36020416334?pr=129197

The retry mechanism should protect us from a failure.