### PR TITLE
gh-129248: Filter out the iOS log prefix from testbed runner output.

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2025-01-24-14-49-40.gh-issue-129248.JAapG2.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-01-24-14-49-40.gh-issue-129248.JAapG2.rst
@@ -1,0 +1,2 @@
+The iOS test runner now strips the log prefix from each line output by the
+test suite.


### PR DESCRIPTION
Modifies the iOS test runner to strip out the log prefix inserted by the Apple system log.

iOS test logs are gathered by streaming the Apple System log looking for log items from the test process. These log prefixes look like:
```
2025-01-17 16:14:29.090 Df iOSTestbed[23987:1fd393b4] (Python) ...
2025-01-17 16:14:29.090 E  iOSTestbed[23987:1fd393b4] (Python) ...
```

The existence of these prefixes was preventing the buildbots from parsing log output to discover test failures. Since the prefix doesn't actually help diagnose issues with the Python test suite, this PR strips out the prefix. This matches what the Android test runner does with ADB log prefixes. It *doesn't* strip the prefix from the iOS setup/teardown code (the ObjC code that instantiates the XUnit test case, which *might* be helpful in a diagnostic context, but won't interfere with the Python operation

The acid test for this fix is a test failing and being correctly parsed by the buildbot; that's a little difficult to manufacture, though. For review purposes, you can inspect the test log for the buildbot to see that it matches the test output from other platforms; at which point the buildbot log parser should work as it does on any other platform.

Fixes #129248.

<!-- gh-issue-number: gh-129248 -->
* Issue: gh-129248
<!-- /gh-issue-number -->
