### PR TITLE
gh-129244: Remove workaround for MSVC compiler crash

### DIFF
--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -53,7 +53,6 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(PySourcePath)Include;$(PySourcePath)Include\internal;$(PySourcePath)Include\internal\mimalloc;$(GeneratedPyConfigDir);$(PySourcePath)PC;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;$(_Py3NamePreprocessorDefinition);$(_PlatformPreprocessorDefinition)$(_DebugPreprocessorDefinition)$(_PyStatsPreprocessorDefinition)$(_PydPreprocessorDefinition)%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(SupportPGO)' and ($(Configuration) == 'PGInstrument' or $(Configuration) == 'PGUpdate')">_Py_USING_PGO=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -766,23 +766,6 @@ _PyObjectArray_Free(PyObject **array, PyObject **scratch)
 #define PY_EVAL_C_STACK_UNITS 2
 
 
-/* _PyEval_EvalFrameDefault is too large to optimize for speed with PGO on MSVC
-   when the JIT is enabled or GIL is disabled. Disable that optimization around
-   this function only. If this is fixed upstream, we should gate this on the
-   version of MSVC.
- */
-#if (defined(_MSC_VER) && \
-     defined(_Py_USING_PGO) && \
-     (defined(_Py_JIT) || \
-      defined(Py_GIL_DISABLED)))
-#define DO_NOT_OPTIMIZE_INTERP_LOOP
-#endif
-
-#ifdef DO_NOT_OPTIMIZE_INTERP_LOOP
-#  pragma optimize("t", off)
-/* This setting is reversed below following _PyEval_EvalFrameDefault */
-#endif
-
 PyObject* _Py_HOT_FUNCTION
 _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int throwflag)
 {
@@ -1177,10 +1160,6 @@ goto_to_tier1:
 #endif // _Py_TIER2
 
 }
-
-#ifdef DO_NOT_OPTIMIZE_INTERP_LOOP
-#  pragma optimize("", on)
-#endif
 
 #if defined(__GNUC__)
 #  pragma GCC diagnostic pop


### PR DESCRIPTION
In earlier versions of MSVC, the compiler would crash when doing a PGO build due to the large size of `PyEval_EvalFrameDefault`.  This bug has been fixed upstream in MSVC, so we should remove our workaround.

While this does re-enable optimizations on `PyEval_EvalFrameDefault`, the performance gains on the benchmarks are unfortunately [below the measurement threshold](https://github.com/faster-cpython/benchmarking-public/tree/main/results/bm-20250123-3.14.0a4+-71a13ea).  Still worth doing without a performance benefit just to simplify things.

<!-- gh-issue-number: gh-129244 -->
* Issue: gh-129244
<!-- /gh-issue-number -->
