### PR TITLE
gh-129280: Avoid cyclic reference in contextlib.contextmanager

### DIFF
--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -164,7 +164,9 @@ class _GeneratorContextManager(
                 # Suppress StopIteration *unless* it's the same exception that
                 # was passed to throw().  This prevents a StopIteration
                 # raised inside the "with" statement from being suppressed.
-                return exc is not value
+                result = exc is not value
+                del exc, value  # avoid cyclic reference
+                return result
             except RuntimeError as exc:
                 # Don't re-raise the passed in exception. (issue27122)
                 if exc is value:


### PR DESCRIPTION

By deleting the cyclic reference between the frame object and the exception object, this allows the objects to be deleted more quickly (it doesn't need to wait until the next GC cycle)

This also has the practical impact of some packages (cysignals) using reference counting to detect whether the exception has been handled, which breaks in the presence of this situation. https://github.com/sagemath/sage/pull/39142

<!-- gh-issue-number: gh-129280 -->
* Issue: gh-129280
<!-- /gh-issue-number -->
