### PR TITLE
GH-125722: Remove Sphinx patches

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -34,16 +34,6 @@ Body.enum.converters['loweralpha'] = \
     Body.enum.converters['lowerroman'] = \
     Body.enum.converters['upperroman'] = lambda x: None
 
-# monkey-patch the productionlist directive to allow hyphens in group names
-# https://github.com/sphinx-doc/sphinx/issues/11854
-from sphinx.domains import std
-
-std.token_re = re.compile(r'`((~?[\w-]*:)?\w+)`')
-
-# backport :no-index:
-PyModule.option_spec['no-index'] = directives.flag
-
-
 # Support for marking up and linking to bugs.python.org issues
 
 def issue_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):


### PR DESCRIPTION
This should have been in #128922, but we missed removing it.

* `:no-index:` is supported from Sphinx 7.2 (we require 8.1)
* The linked https://github.com/sphinx-doc/sphinx/issues/11854 was fixed in Sphinx 7.3 (we require 8.1)

A

<!-- gh-issue-number: gh-125722 -->
* Issue: gh-125722
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129277.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->