### PR TITLE
Remove unused DPRINTF in ceval.c

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1063,13 +1063,6 @@ enter_tier_two:
 #undef ENABLE_SPECIALIZATION_FT
 #define ENABLE_SPECIALIZATION_FT 0
 
-#ifdef Py_DEBUG
-    #define DPRINTF(level, ...) \
-        if (lltrace >= (level)) { printf(__VA_ARGS__); }
-#else
-    #define DPRINTF(level, ...)
-#endif
-
     ; // dummy statement after a label, before a declaration
     uint16_t uopcode;
 #ifdef Py_STATS


### PR DESCRIPTION

Per encouragement from @Fidget-Spinner in https://github.com/python/cpython/pull/129113#issuecomment-2605948331.

`DPRINTF` was introduced in https://github.com/python/cpython/commit/7e135a48d619407cd4b2a6d80a4ce204b2f5f938, but is currently unused.

Alternatively, I can modify it to use `frame->lltrace`, since `lltrace` has been moved into the frame (https://github.com/python/cpython/pull/129113).

I think this is a `skip news`?

<!-- gh-issue-number: gh-128563 -->
* Issue: gh-128563
<!-- /gh-issue-number -->
