### PR TITLE
gh-126022: make license.rst consistent with LICENSE: fix underline

### DIFF
--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -277,7 +277,7 @@ CWI LICENSE AGREEMENT FOR PYTHON 0.9.0 THROUGH 1.2
 .. _BSD0:
 
 ZERO-CLAUSE BSD LICENSE FOR CODE IN THE PYTHON DOCUMENTATION
-----------------------------------------------------------------------
+------------------------------------------------------------
 
 .. parsed-literal::
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Follow up to https://github.com/python/cpython/pull/128516.

Already included in backports.

<!-- gh-issue-number: gh-126022 -->
* Issue: gh-126022
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129292.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->