### PR TITLE
gh-126022: Remove zope.org from the permitted linkcheck redirects

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -560,8 +560,6 @@ linkcheck_allowed_redirects = {
     r'https://github.com/python/cpython/tree/.*': 'https://github.com/python/cpython/blob/.*',
     # Intentional HTTP use at Misc/NEWS.d/3.5.0a1.rst
     r'http://www.python.org/$': 'https://www.python.org/$',
-    # Used in license page, keep as is
-    r'https://www.zope.org/': r'https://www.zope.dev/',
     # Microsoft's redirects to learn.microsoft.com
     r'https://msdn.microsoft.com/.*': 'https://learn.microsoft.com/.*',
     r'https://docs.microsoft.com/.*': 'https://learn.microsoft.com/.*',


### PR DESCRIPTION
remove zope.org redirect since it has been removed from license file

PR #128516 removed the link to zope.org and therefore it is not needed in here anymore

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129308.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-126022 -->
* Issue: gh-126022
<!-- /gh-issue-number -->
