### PR TITLE
gh-129296: Fix `pyatomic.h` include paths

### DIFF
--- a/Include/cpython/pyatomic.h
+++ b/Include/cpython/pyatomic.h
@@ -574,15 +574,15 @@ static inline void _Py_atomic_fence_release(void);
 
 #if _Py_USE_GCC_BUILTIN_ATOMICS
 #  define Py_ATOMIC_GCC_H
-#  include "cpython/pyatomic_gcc.h"
+#  include "pyatomic_gcc.h"
 #  undef Py_ATOMIC_GCC_H
 #elif __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
 #  define Py_ATOMIC_STD_H
-#  include "cpython/pyatomic_std.h"
+#  include "pyatomic_std.h"
 #  undef Py_ATOMIC_STD_H
 #elif defined(_MSC_VER)
 #  define Py_ATOMIC_MSC_H
-#  include "cpython/pyatomic_msc.h"
+#  include "pyatomic_msc.h"
 #  undef Py_ATOMIC_MSC_H
 #else
 #  error "no available pyatomic implementation for this platform/compiler"

--- a/Include/cpython/pythread.h
+++ b/Include/cpython/pythread.h
@@ -22,7 +22,7 @@ PyAPI_DATA(const long long) PY_TIMEOUT_MAX;
     */
 #   define NATIVE_TSS_KEY_T     unsigned long
 #elif defined(HAVE_PTHREAD_STUBS)
-#   include "cpython/pthread_stubs.h"
+#   include "pthread_stubs.h"
 #   define NATIVE_TSS_KEY_T     pthread_key_t
 #else
 #   error "Require native threads. See https://bugs.python.org/issue31370"


### PR DESCRIPTION
As reported in the issue, these paths are relative to the base include directory instead of the header file. While this is fine in practice because the compiler falls back to the base include directory, it doesn't match the style of other includes in the project.

Originally added in 

- https://github.com/python/cpython/pull/108701
- https://github.com/python/cpython/pull/108338

-----

<!-- gh-issue-number: gh-129296 -->
* Issue: gh-129296
<!-- /gh-issue-number -->
