### PR TITLE
gh-96092: Fix traceback.walk_stack(None) skipping too many frames

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -257,6 +257,11 @@ Module-Level Functions
 
    .. versionadded:: 3.5
 
+   .. versionchanged:: 3.14
+      This function previously returned a generator that would walk the stack
+      when first iterated over. The generator returned now is the state of the
+      stack when ``walk_stack`` is called.
+
 .. function:: walk_tb(tb)
 
    Walk a traceback following :attr:`~traceback.tb_next` yielding the frame and

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -3229,10 +3229,16 @@ class TestStack(unittest.TestCase):
     def test_walk_stack(self):
         def deeper():
             return list(traceback.walk_stack(None))
-        s1 = list(traceback.walk_stack(None))
-        s2 = deeper()
+        s1, s2 = list(traceback.walk_stack(None)), deeper()
         self.assertEqual(len(s2) - len(s1), 1)
         self.assertEqual(s2[1:], s1)
+
+    def test_walk_innermost_frame(self):
+        def inner():
+            return list(traceback.walk_stack(None))
+        frames = inner()
+        innermost_frame, _ = frames[0]
+        self.assertEqual(innermost_frame.f_code.co_name, "inner")
 
     def test_walk_tb(self):
         try:

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -380,10 +380,14 @@ def walk_stack(f):
     current stack is used. Usually used with StackSummary.extract.
     """
     if f is None:
-        f = sys._getframe().f_back.f_back.f_back.f_back
-    while f is not None:
-        yield f, f.f_lineno
-        f = f.f_back
+        f = sys._getframe().f_back
+
+    def walk_stack_generator(frame):
+        while frame is not None:
+            yield frame, frame.f_lineno
+            frame = frame.f_back
+
+    return walk_stack_generator(f)
 
 
 def walk_tb(tb):

--- a/Misc/NEWS.d/next/Library/2025-01-26-19-35-06.gh-issue-96092.mMg3gL.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-26-19-35-06.gh-issue-96092.mMg3gL.rst
@@ -1,0 +1,4 @@
+Fix bug in :func:`traceback.walk_stack` called with None where it was skipping
+more frames than in prior versions. This bug fix also changes walk_stack to
+walk the stack in the frame where it was called rather than where it first gets
+used.


### PR DESCRIPTION
Fixes https://github.com/python/cpython/issues/96092. Please see my comment in https://github.com/python/cpython/pull/99015#issuecomment-1301363288 for more details on the root cause analysis of this issue.

---

This changes the `walk_stack` generator to capture the stack when `walk_stack` is called, rather than when it is first iterated over. Since this is technically a breaking change in behavior, I added a versionchanged to the documentation. In practice, this is unlikely to break anyone, you would have been needing to store the result of `walk_stack` and expecting it to change.

It also adds a direct test for what the innermost frame `walk_stack` returns is.


<!-- gh-issue-number: gh-96092 -->
* Issue: gh-96092
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129330.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->