### PR TITLE
gh-102471: Change PyLongWriter_Discard(NULL) to do nothing

### DIFF
--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -824,6 +824,6 @@ The :c:type:`PyLongWriter` API can be used to import an integer.
 
    Discard a :c:type:`PyLongWriter` created by :c:func:`PyLongWriter_Create`.
 
-   *writer* must not be ``NULL``.
+   If *writer* is ``NULL``, no operation is performed.
 
    The writer instance and the *digits* array are invalid after the call.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6953,6 +6953,10 @@ error:
 void
 PyLongWriter_Discard(PyLongWriter *writer)
 {
+    if (writer == NULL) {
+        return;
+    }
+
     PyLongObject *obj = (PyLongObject *)writer;
     assert(Py_REFCNT(obj) == 1);
     Py_DECREF(obj);


### PR DESCRIPTION
It's convenient to be able to call PyLongWriter_Discard(NULL) in error handling code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-102471 -->
* Issue: gh-102471
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129339.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->