### PR TITLE
gh-85795: Add support for `super()` in `NamedTuple` subclasses

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2341,6 +2341,9 @@ types.
           def __repr__(self) -> str:
               return f'<Employee {self.name}, id={self.id}>'
 
+   Calls to :func:`super` are supported inside user-defined methods of ``NamedTuple`` subclasses
+   to reuse functionality from built-in classes :class:`tuple` and :class:`object`.
+
    ``NamedTuple`` subclasses can be generic::
 
       class Group[T](NamedTuple):

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2341,9 +2341,6 @@ types.
           def __repr__(self) -> str:
               return f'<Employee {self.name}, id={self.id}>'
 
-   Calls to :func:`super` are supported inside user-defined methods of ``NamedTuple`` subclasses
-   to reuse functionality from built-in classes :class:`tuple` and :class:`object`.
-
    ``NamedTuple`` subclasses can be generic::
 
       class Group[T](NamedTuple):
@@ -2391,6 +2388,11 @@ types.
       (``NT = NamedTuple("NT", None)``) is also deprecated. Both will be
       disallowed in Python 3.15. To create a NamedTuple class with 0 fields,
       use ``class NT(NamedTuple): pass`` or ``NT = NamedTuple("NT", [])``.
+
+   .. versionchanged:: 3.14
+      Added support for calls to :func:`super` inside user-defined methods
+      of ``NamedTuple`` subclasses to reuse functionality from built-in classes
+      :class:`tuple` and :class:`object`.
 
 .. class:: NewType(name, tp)
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2389,7 +2389,7 @@ types.
       disallowed in Python 3.15. To create a NamedTuple class with 0 fields,
       use ``class NT(NamedTuple): pass`` or ``NT = NamedTuple("NT", [])``.
 
-   .. versionchanged:: 3.14
+   .. versionchanged:: next
       Added support for calls to :func:`super` inside user-defined methods
       of ``NamedTuple`` subclasses to reuse functionality from built-in classes
       :class:`tuple` and :class:`object`.

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -358,30 +358,7 @@ try:
 except ImportError:
     _tuplegetter = lambda index, doc: property(_itemgetter(index), doc=doc)
 
-def namedtuple(typename, field_names, *, rename=False, defaults=None, module=None, _classcell=None):
-    """Returns a new subclass of tuple with named fields.
-
-    >>> Point = namedtuple('Point', ['x', 'y'])
-    >>> Point.__doc__                   # docstring for the new class
-    'Point(x, y)'
-    >>> p = Point(11, y=22)             # instantiate with positional args or keywords
-    >>> p[0] + p[1]                     # indexable like a plain tuple
-    33
-    >>> x, y = p                        # unpack like a regular tuple
-    >>> x, y
-    (11, 22)
-    >>> p.x + p.y                       # fields also accessible by name
-    33
-    >>> d = p._asdict()                 # convert to a dictionary
-    >>> d['x']
-    11
-    >>> Point(**d)                      # convert from a dictionary
-    Point(x=11, y=22)
-    >>> p._replace(x=100)               # _replace() is like str.replace() but targets named fields
-    Point(x=100, y=22)
-
-    """
-
+def _namedtuple(typename, field_names, *, rename=False, defaults=None, module=None, classcell=None):
     # Validate the field names.  At the user's option, either generate an error
     # message or automatically replace the field name with a valid name.
     if isinstance(field_names, str):
@@ -509,8 +486,8 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
         '__match_args__': field_names,
     }
 
-    if _classcell is not None:
-        class_namespace["__classcell__"] = _classcell
+    if classcell is not None:
+        class_namespace["__classcell__"] = classcell
 
     for index, name in enumerate(field_names):
         doc = _sys.intern(f'Alias for field number {index}')
@@ -536,6 +513,30 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
 
     return result
 
+def namedtuple(typename, field_names, *, rename=False, defaults=None, module=None):
+    """Returns a new subclass of tuple with named fields.
+
+    >>> Point = namedtuple('Point', ['x', 'y'])
+    >>> Point.__doc__                   # docstring for the new class
+    'Point(x, y)'
+    >>> p = Point(11, y=22)             # instantiate with positional args or keywords
+    >>> p[0] + p[1]                     # indexable like a plain tuple
+    33
+    >>> x, y = p                        # unpack like a regular tuple
+    >>> x, y
+    (11, 22)
+    >>> p.x + p.y                       # fields also accessible by name
+    33
+    >>> d = p._asdict()                 # convert to a dictionary
+    >>> d['x']
+    11
+    >>> Point(**d)                      # convert from a dictionary
+    Point(x=11, y=22)
+    >>> p._replace(x=100)               # _replace() is like str.replace() but targets named fields
+    Point(x=100, y=22)
+
+    """
+    return _namedtuple(typename, field_names, rename=rename, defaults=defaults, module=module)
 
 ########################################################################
 ###  Counter

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -358,7 +358,9 @@ try:
 except ImportError:
     _tuplegetter = lambda index, doc: property(_itemgetter(index), doc=doc)
 
-def _namedtuple(typename, field_names, *, rename=False, defaults=None, module=None, classcell=None):
+_nmtuple_classcell_sentinel = object()
+
+def _namedtuple(typename, field_names, *, rename=False, defaults=None, module=None, classcell=_nmtuple_classcell_sentinel):
     # Validate the field names.  At the user's option, either generate an error
     # message or automatically replace the field name with a valid name.
     if isinstance(field_names, str):
@@ -486,7 +488,7 @@ def _namedtuple(typename, field_names, *, rename=False, defaults=None, module=No
         '__match_args__': field_names,
     }
 
-    if classcell is not None:
+    if classcell is not _nmtuple_classcell_sentinel:
         class_namespace["__classcell__"] = classcell
 
     for index, name in enumerate(field_names):

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -361,7 +361,7 @@ except ImportError:
 _nmtuple_classcell_sentinel = object()
 
 def _namedtuple(typename, field_names, *, rename=False, defaults=None, module=None,
-                classcell=_nmtuple_classcell_sentinel):
+                classcell=_nmtuple_classcell_sentinel, stack_offset=1):
     # Validate the field names.  At the user's option, either generate an error
     # message or automatically replace the field name with a valid name.
     if isinstance(field_names, str):
@@ -507,10 +507,10 @@ def _namedtuple(typename, field_names, *, rename=False, defaults=None, module=No
     # specified a particular module.
     if module is None:
         try:
-            module = _sys._getframemodulename(1) or '__main__'
+            module = _sys._getframemodulename(stack_offset) or '__main__'
         except AttributeError:
             try:
-                module = _sys._getframe(1).f_globals.get('__name__', '__main__')
+                module = _sys._getframe(stack_offset).f_globals.get('__name__', '__main__')
             except (AttributeError, ValueError):
                 pass
     if module is not None:
@@ -541,7 +541,8 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
     Point(x=100, y=22)
 
     """
-    return _namedtuple(typename, field_names, rename=rename, defaults=defaults, module=module)
+    return _namedtuple(typename, field_names, rename=rename, defaults=defaults, module=module,
+                       stack_offset=2)
 
 ########################################################################
 ###  Counter

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -488,6 +488,8 @@ def _namedtuple(typename, field_names, *, rename=False, defaults=None, module=No
         '__match_args__': field_names,
     }
 
+    # gh-85795: `super()` calls inside `typing.NamedTuple` methods will not
+    # work unless `__classcell__` is propagated by `collections._namedtuple`
     if classcell is not _nmtuple_classcell_sentinel:
         class_namespace["__classcell__"] = classcell
 

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -358,7 +358,7 @@ try:
 except ImportError:
     _tuplegetter = lambda index, doc: property(_itemgetter(index), doc=doc)
 
-def namedtuple(typename, field_names, *, rename=False, defaults=None, module=None):
+def namedtuple(typename, field_names, *, rename=False, defaults=None, module=None, _classcell=None):
     """Returns a new subclass of tuple with named fields.
 
     >>> Point = namedtuple('Point', ['x', 'y'])
@@ -508,6 +508,10 @@ def namedtuple(typename, field_names, *, rename=False, defaults=None, module=Non
         '__getnewargs__': __getnewargs__,
         '__match_args__': field_names,
     }
+
+    if _classcell is not None:
+        class_namespace["__classcell__"] = _classcell
+
     for index, name in enumerate(field_names):
         doc = _sys.intern(f'Alias for field number {index}')
         class_namespace[name] = _tuplegetter(index, doc)

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -360,7 +360,8 @@ except ImportError:
 
 _nmtuple_classcell_sentinel = object()
 
-def _namedtuple(typename, field_names, *, rename=False, defaults=None, module=None, classcell=_nmtuple_classcell_sentinel):
+def _namedtuple(typename, field_names, *, rename=False, defaults=None, module=None,
+                classcell=_nmtuple_classcell_sentinel):
     # Validate the field names.  At the user's option, either generate an error
     # message or automatically replace the field name with a valid name.
     if isinstance(field_names, str):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8135,7 +8135,7 @@ class NamedTupleTests(BaseTestCase):
         self.assertIs(type(a), Group)
         self.assertEqual(a, (1, [2]))
 
-    def test_super_works_in_namedtuples(self):
+    def test_super_works(self):
         # See #85795: __class__ not set defining 'X' as <class '__main__.X'>
         class Pointer(NamedTuple):
             address: int

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8137,6 +8137,7 @@ class NamedTupleTests(BaseTestCase):
 
     def test_super_and_dunder_class_work(self):
         # See #85795: __class__ not set defining 'X' as <class '__main__.X'>
+
         class Pointer(NamedTuple):
             address: int
             target_type = "int"
@@ -8157,7 +8158,7 @@ class NamedTupleTests(BaseTestCase):
 
     @cpython_only
     def test_classcell_not_leaked(self):
-        # __classcell__ should never be leaked into end classes
+        # __classcell__ should never leak into end classes
 
         class Spam(NamedTuple):
             lambda: super()

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8155,6 +8155,10 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(ptr.count(0), -1)
         self.assertEqual(ptr.count(0xdeadbeef), 1)
 
+        with self.assertRaises(AttributeError):
+            # __classcell__ should never be leaked into end classes
+            Pointer.__classcell__
+
     def test_namedtuple_keyword_usage(self):
         with self.assertWarnsRegex(
             DeprecationWarning,

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8135,7 +8135,7 @@ class NamedTupleTests(BaseTestCase):
         self.assertIs(type(a), Group)
         self.assertEqual(a, (1, [2]))
 
-    def test_classcell_access(self):
+    def test_super_works_in_namedtuples(self):
         # See #85795: __class__ not set defining 'X' as <class '__main__.X'>
         class Pointer(NamedTuple):
             address: int
@@ -8155,9 +8155,16 @@ class NamedTupleTests(BaseTestCase):
         self.assertEqual(ptr.count(0), -1)
         self.assertEqual(ptr.count(0xdeadbeef), 1)
 
+    @cpython_only
+    def test_classcell_not_leaked(self):
+        # __classcell__ should never be leaked into end classes
+
+        class Spam(NamedTuple):
+            lambda: super()
+            lambda: __class__
+
         with self.assertRaises(AttributeError):
-            # __classcell__ should never be leaked into end classes
-            Pointer.__classcell__
+            Spam.__classcell__
 
     def test_namedtuple_keyword_usage(self):
         with self.assertWarnsRegex(

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8135,7 +8135,7 @@ class NamedTupleTests(BaseTestCase):
         self.assertIs(type(a), Group)
         self.assertEqual(a, (1, [2]))
 
-    def test_super_works(self):
+    def test_super_and_dunder_class_works(self):
         # See #85795: __class__ not set defining 'X' as <class '__main__.X'>
         class Pointer(NamedTuple):
             address: int

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8135,7 +8135,7 @@ class NamedTupleTests(BaseTestCase):
         self.assertIs(type(a), Group)
         self.assertEqual(a, (1, [2]))
 
-    def test_super_and_dunder_class_works(self):
+    def test_super_and_dunder_class_work(self):
         # See #85795: __class__ not set defining 'X' as <class '__main__.X'>
         class Pointer(NamedTuple):
             address: int

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8135,6 +8135,25 @@ class NamedTupleTests(BaseTestCase):
         self.assertIs(type(a), Group)
         self.assertEqual(a, (1, [2]))
 
+    def test_classcell_access(self):
+        # See #85795: __class__ not set defining 'X' as <class '__main__.X'>
+        class AspiringTriager(NamedTuple):
+            name: str = "Bartosz"
+
+            @property
+            def tablename(self):
+                return __class__.__name__.lower() + "s"
+
+            def count(self, item):
+                if item == "Bartosz":
+                    return super().count(item)
+                return -1
+
+        aspiring_triager = AspiringTriager()
+        self.assertEqual(aspiring_triager.tablename, "aspiringtriagers")
+        self.assertEqual(aspiring_triager.count("Bartosz"), 1)
+        self.assertEqual(aspiring_triager.count("Peter"), -1)  # already a triager!
+
     def test_namedtuple_keyword_usage(self):
         with self.assertWarnsRegex(
             DeprecationWarning,

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8144,7 +8144,7 @@ class NamedTupleTests(BaseTestCase):
 
             @property
             def typename(self):
-                return __class__.target_type.__name__
+                return __class__.target_type
 
             def count(self, item):
                 if item == 0:

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8137,22 +8137,23 @@ class NamedTupleTests(BaseTestCase):
 
     def test_classcell_access(self):
         # See #85795: __class__ not set defining 'X' as <class '__main__.X'>
-        class AspiringTriager(NamedTuple):
-            name: str = "Bartosz"
+        class Pointer(NamedTuple):
+            address: int
+            target_type = "int"
 
             @property
-            def tablename(self):
-                return __class__.__name__.lower() + "s"
+            def typename(self):
+                return __class__.target_type.__name__
 
             def count(self, item):
-                if item == "Bartosz":
-                    return super().count(item)
-                return -1
+                if item == 0:
+                    return -1
+                return super().count(self.address)
 
-        aspiring_triager = AspiringTriager()
-        self.assertEqual(aspiring_triager.tablename, "aspiringtriagers")
-        self.assertEqual(aspiring_triager.count("Bartosz"), 1)
-        self.assertEqual(aspiring_triager.count("Peter"), -1)  # already a triager!
+        ptr = Pointer(0xdeadbeef)
+        self.assertEqual(ptr.typename, "int")
+        self.assertEqual(ptr.count(0), -1)
+        self.assertEqual(ptr.count(0xdeadbeef), 1)
 
     def test_namedtuple_keyword_usage(self):
         with self.assertWarnsRegex(

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2929,7 +2929,8 @@ class SupportsRound[T](Protocol):
         pass
 
 
-def _make_nmtuple(name, fields, annotate_func, module, defaults = (), classcell=collections._nmtuple_classcell_sentinel):
+def _make_nmtuple(name, fields, annotate_func, module, defaults = (),
+                  classcell=collections._nmtuple_classcell_sentinel):
     nm_tpl = collections._namedtuple(name, fields, defaults=defaults,
                                      module=module, classcell=classcell)
     nm_tpl.__annotate__ = nm_tpl.__new__.__annotate__ = annotate_func

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2929,9 +2929,9 @@ class SupportsRound[T](Protocol):
         pass
 
 
-def _make_nmtuple(name, fields, annotate_func, module, defaults = (), _classcell=None):
-    nm_tpl = collections.namedtuple(name, fields, defaults=defaults,
-                                    module=module, _classcell=_classcell)
+def _make_nmtuple(name, fields, annotate_func, module, defaults = (), classcell=None):
+    nm_tpl = collections._namedtuple(name, fields, defaults=defaults,
+                                     module=module, classcell=classcell)
     nm_tpl.__annotate__ = nm_tpl.__new__.__annotate__ = annotate_func
     return nm_tpl
 
@@ -2999,8 +2999,8 @@ class NamedTupleMeta(type):
                                 f"{'s' if len(default_names) > 1 else ''} "
                                 f"{', '.join(default_names)}")
         nm_tpl = _make_nmtuple(typename, field_names, annotate,
-                               defaults=[ns[n] for n in default_names],
-                               module=ns['__module__'], _classcell=ns.pop("__classcell__", None))
+                               defaults=[ns[n] for n in default_names], module=ns['__module__'],
+                               classcell=ns.pop('__classcell__', None))
         nm_tpl.__bases__ = bases
         if Generic in bases:
             class_getitem = _generic_class_getitem

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2929,7 +2929,7 @@ class SupportsRound[T](Protocol):
         pass
 
 
-def _make_nmtuple(name, fields, annotate_func, module, defaults = (), classcell=None):
+def _make_nmtuple(name, fields, annotate_func, module, defaults = (), classcell=collections._nmtuple_classcell_sentinel):
     nm_tpl = collections._namedtuple(name, fields, defaults=defaults,
                                      module=module, classcell=classcell)
     nm_tpl.__annotate__ = nm_tpl.__new__.__annotate__ = annotate_func
@@ -3000,7 +3000,7 @@ class NamedTupleMeta(type):
                                 f"{', '.join(default_names)}")
         nm_tpl = _make_nmtuple(typename, field_names, annotate,
                                defaults=[ns[n] for n in default_names], module=ns['__module__'],
-                               classcell=ns.pop('__classcell__', None))
+                               classcell=ns.pop('__classcell__', collections._nmtuple_classcell_sentinel))
         nm_tpl.__bases__ = bases
         if Generic in bases:
             class_getitem = _generic_class_getitem

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2929,9 +2929,9 @@ class SupportsRound[T](Protocol):
         pass
 
 
-def _make_nmtuple(name, fields, annotate_func, module, defaults = ()):
-    nm_tpl = collections.namedtuple(name, fields,
-                                    defaults=defaults, module=module)
+def _make_nmtuple(name, fields, annotate_func, module, defaults = (), _classcell=None):
+    nm_tpl = collections.namedtuple(name, fields, defaults=defaults,
+                                    module=module, _classcell=_classcell)
     nm_tpl.__annotate__ = nm_tpl.__new__.__annotate__ = annotate_func
     return nm_tpl
 
@@ -3000,7 +3000,7 @@ class NamedTupleMeta(type):
                                 f"{', '.join(default_names)}")
         nm_tpl = _make_nmtuple(typename, field_names, annotate,
                                defaults=[ns[n] for n in default_names],
-                               module=ns['__module__'])
+                               module=ns['__module__'], _classcell=ns.pop("__classcell__", None))
         nm_tpl.__bases__ = bases
         if Generic in bases:
             class_getitem = _generic_class_getitem

--- a/Misc/NEWS.d/next/Library/2025-01-27-12-55-40.gh-issue-85795.fnGbGS.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-27-12-55-40.gh-issue-85795.fnGbGS.rst
@@ -1,0 +1,2 @@
+Added support for :func:`super` calls in user-defined
+:class:`~typing.NamedTuple` methods. Contributed by Bartosz Sławecki.


### PR DESCRIPTION
~~Fi​xes gh-85795.~~

A private parameter `_classcell` was added to `collections.namedtuple()` and its wrappers in `typing` in order to deliver it to the targeted `type.__new__`.

It's the easiest approach here.

`__classcell__` is *popped* from the original class namespace, as it would otherwise leak to the end class (metaclasses should clean up the `__classcell__` attribute).

It is expected not to be added to typeshed, as the parameter is intended for internal use only.

After this PR, please consider a follow-up issue gh-129343 and the PR associated with it.

<!-- gh-issue-number: gh-85795 -->
* Issue: gh-85795
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129352.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->