### PR TITLE
gh-129363: Added colored printing for `python -m test` without the `-j` flag

### DIFF
--- a/Misc/NEWS.d/next/Tests/2025-01-27-16-22-23.gh-issue-129363.HzJPzC.rst
+++ b/Misc/NEWS.d/next/Tests/2025-01-27-16-22-23.gh-issue-129363.HzJPzC.rst
@@ -1,0 +1,1 @@
+Added colored printing for ``python -m test`` without the ``-j`` flag.


### PR DESCRIPTION
Fixes #129363. New version based on ``RunWorkers::display_result``.

<!-- gh-issue-number: gh-129363 -->
* Issue: gh-129363
<!-- /gh-issue-number -->
