### PR TITLE
gh-115999: Enable free-threaded specialization of LOAD_CONST

### DIFF
--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -1773,6 +1773,20 @@ class TestSpecializer(TestBase):
         self.assert_specialized(compare_op_str, "COMPARE_OP_STR")
         self.assert_no_opcode(compare_op_str, "COMPARE_OP")
 
+    @cpython_only
+    @requires_specialization_ft
+    def test_load_const(self):
+        def load_const():
+            def unused(): pass
+            # Currently, the empty tuple is immortal, and the otherwise
+            # unused nested function's code object is mortal. This test will
+            # have to use different values if either of that changes.
+            return ()
+
+        load_const()
+        self.assert_specialized(load_const, "LOAD_CONST_IMMORTAL")
+        self.assert_specialized(load_const, "LOAD_CONST_MORTAL")
+        self.assert_no_opcode(load_const, "LOAD_CONST")
 
 if __name__ == "__main__":
     unittest.main()

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -297,13 +297,12 @@ dummy_func(
 #if ENABLE_SPECIALIZATION_FT
 #ifdef Py_GIL_DISABLED
             uint8_t expected = LOAD_CONST;
-            _Py_atomic_compare_exchange_uint8(
-                &this_instr->op.code, &expected,
-                _Py_IsImmortal(obj) ? LOAD_CONST_IMMORTAL : LOAD_CONST_MORTAL);
-            // We might lose a race with instrumentation, which we don't care about.
-            assert(expected >= MIN_INSTRUMENTED_OPCODE ||
-                   (expected == LOAD_CONST_IMMORTAL && _Py_IsImmortal(obj)) ||
-                   (expected == LOAD_CONST_MORTAL && !_Py_IsImmortal(obj)));
+            if (!_Py_atomic_compare_exchange_uint8(
+                    &this_instr->op.code, &expected,
+                    _Py_IsImmortal(obj) ? LOAD_CONST_IMMORTAL : LOAD_CONST_MORTAL)) {
+                // We might lose a race with instrumentation, which we don't care about.
+                assert(expected >= MIN_INSTRUMENTED_OPCODE);
+            }
 #else
             if (this_instr->op.code == LOAD_CONST) {
                 this_instr->op.code = _Py_IsImmortal(obj) ? LOAD_CONST_IMMORTAL : LOAD_CONST_MORTAL;

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -294,10 +294,21 @@ dummy_func(
              * marshalling can intern strings and make them immortal. */
             PyObject *obj = GETITEM(FRAME_CO_CONSTS, oparg);
             value = PyStackRef_FromPyObjectNew(obj);
-#if ENABLE_SPECIALIZATION
+#if ENABLE_SPECIALIZATION_FT
+#ifdef Py_GIL_DISABLED
+            uint8_t expected = LOAD_CONST;
+            _Py_atomic_compare_exchange_uint8(
+                &this_instr->op.code, &expected,
+                _Py_IsImmortal(obj) ? LOAD_CONST_IMMORTAL : LOAD_CONST_MORTAL);
+            // We might lose a race with instrumentation, which we don't care about.
+            assert(expected >= MIN_INSTRUMENTED_OPCODE ||
+                   (expected == LOAD_CONST_IMMORTAL && _Py_IsImmortal(obj)) ||
+                   (expected == LOAD_CONST_MORTAL && !_Py_IsImmortal(obj)));
+#else
             if (this_instr->op.code == LOAD_CONST) {
                 this_instr->op.code = _Py_IsImmortal(obj) ? LOAD_CONST_IMMORTAL : LOAD_CONST_MORTAL;
             }
+#endif
 #endif
         }
 
@@ -2555,7 +2566,7 @@ dummy_func(
             }
             OPCODE_DEFERRED_INC(COMPARE_OP);
             ADVANCE_ADAPTIVE_COUNTER(this_instr[1].counter);
-            #endif  /* ENABLE_SPECIALIZATION */
+            #endif  /* ENABLE_SPECIALIZATION_FT */
         }
 
         op(_COMPARE_OP, (left, right -- res)) {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -6030,13 +6030,12 @@
             #if ENABLE_SPECIALIZATION_FT
             #ifdef Py_GIL_DISABLED
             uint8_t expected = LOAD_CONST;
-            _Py_atomic_compare_exchange_uint8(
-                &this_instr->op.code, &expected,
-                _Py_IsImmortal(obj) ? LOAD_CONST_IMMORTAL : LOAD_CONST_MORTAL);
-            // We might lose a race with instrumentation, which we don't care about.
-            assert(expected >= MIN_INSTRUMENTED_OPCODE ||
-                   (expected == LOAD_CONST_IMMORTAL && _Py_IsImmortal(obj)) ||
-                   (expected == LOAD_CONST_MORTAL && !_Py_IsImmortal(obj)));
+            if (!_Py_atomic_compare_exchange_uint8(
+                    &this_instr->op.code, &expected,
+                    _Py_IsImmortal(obj) ? LOAD_CONST_IMMORTAL : LOAD_CONST_MORTAL)) {
+                // We might lose a race with instrumentation, which we don't care about.
+                assert(expected >= MIN_INSTRUMENTED_OPCODE);
+            }
             #else
             if (this_instr->op.code == LOAD_CONST) {
                 this_instr->op.code = _Py_IsImmortal(obj) ? LOAD_CONST_IMMORTAL : LOAD_CONST_MORTAL;

--- a/Tools/cases_generator/analyzer.py
+++ b/Tools/cases_generator/analyzer.py
@@ -634,6 +634,7 @@ NON_ESCAPING_FUNCTIONS = (
     "_Py_STR",
     "_Py_TryIncrefCompare",
     "_Py_TryIncrefCompareStackRef",
+    "_Py_atomic_compare_exchange_uint8",
     "_Py_atomic_load_ptr_acquire",
     "_Py_atomic_load_uintptr_relaxed",
     "_Py_set_eval_breaker_bit",


### PR DESCRIPTION
Enable free-threaded specialization of LOAD_CONST, which is an unconditional specialization without stats bookkeeping, so it's a simple opcode replace. (It could even be a relaxed store if we didn't have to worry about instrumentation.)

<!-- gh-issue-number: gh-115999 -->
* Issue: gh-115999
<!-- /gh-issue-number -->
