### PR TITLE
gh-129370: Update `libregrtest` to use f-strings

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -402,8 +402,8 @@ def _parse_args(args, **kwargs):
     ns = Namespace()
     for k, v in kwargs.items():
         if not hasattr(ns, k):
-            raise TypeError('%r is an invalid keyword argument '
-                            'for this function' % k)
+            raise TypeError(f'{k!r} is an invalid keyword argument '
+                            'for this function')
         setattr(ns, k, v)
 
     parser = _create_parser()
@@ -412,7 +412,7 @@ def _parse_args(args, **kwargs):
     ns.args = parser.parse_known_args(args=args, namespace=ns)[1]
     for arg in ns.args:
         if arg.startswith('-'):
-            parser.error("unrecognized arguments: %s" % arg)
+            parser.error(f"unrecognized arguments: {arg}")
 
     if ns.timeout is not None:
         # Support "--timeout=" (no value) so Makefile.pre.pre TESTTIMEOUT

--- a/Lib/test/libregrtest/logger.py
+++ b/Lib/test/libregrtest/logger.py
@@ -33,7 +33,7 @@ class Logger:
 
         mins, secs = divmod(int(log_time), 60)
         hours, mins = divmod(mins, 60)
-        formatted_log_time = "%d:%02d:%02d" % (hours, mins, secs)
+        formatted_log_time = f"{hours}:{mins:02d}:{secs:02d} "
 
         line = f"{formatted_log_time} {line}"
         if empty:
@@ -68,7 +68,7 @@ class Logger:
             self.test_count_text = ''
             self.test_count_width = 3
         else:
-            self.test_count_text = '/{}'.format(len(runtests.tests))
+            self.test_count_text = f"/{len(runtests.tests)}"
             self.test_count_width = len(self.test_count_text) - 1
 
     def start_load_tracker(self) -> None:

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -457,7 +457,7 @@ class Regrtest:
                                    ignore_missing_files=True)
 
         if self.want_run_leaks:
-            os.system("leaks %d" % os.getpid())
+            os.system(f"leaks {os.getpid()}")
 
         if self.junit_filename:
             self.results.write_junit(self.junit_filename)
@@ -473,7 +473,7 @@ class Regrtest:
 
         # Total duration
         print()
-        print("Total duration: %s" % format_duration(duration))
+        print(f"Total duration: {format_duration(duration)}")
 
         self.results.display_summary(self.first_runtests, filtered)
 

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -209,8 +209,7 @@ def runtest_refleak(test_name, test_func,
         failing = checker(deltas)
         suspicious = any(deltas)
         if failing or suspicious:
-            msg = '%s leaked %s %s, sum=%s' % (
-                test_name, deltas, item_name, sum(deltas))
+            msg = f'{test_name} leaked {deltas} {item_name}, sum={sum(deltas)}'
             print(msg, end='', file=sys.stderr)
             if failing:
                 print(file=sys.stderr, flush=True)

--- a/Lib/test/libregrtest/run_workers.py
+++ b/Lib/test/libregrtest/run_workers.py
@@ -134,7 +134,7 @@ class WorkerThread(threading.Thread):
             dt = time.monotonic() - self.start_time
             info.extend((f'pid={popen.pid}',
                          f'time={format_duration(dt)}'))
-        return '<%s>' % ' '.join(info)
+        return '<{}>'.format(' '.join(info))
 
     def _kill(self) -> None:
         popen = self._popen
@@ -510,9 +510,7 @@ class RunWorkers:
         msg = (f"Run {tests} in parallel using "
                f"{nworkers} worker {processes}")
         if self.timeout and self.worker_timeout is not None:
-            msg += (" (timeout: %s, worker timeout: %s)"
-                    % (format_duration(self.timeout),
-                       format_duration(self.worker_timeout)))
+            msg += (f" (timeout: {format_duration(self.timeout)}, worker timeout: {format_duration(self.worker_timeout)})")
         self.log(msg)
         for worker in self.workers:
             worker.start()
@@ -560,9 +558,9 @@ class RunWorkers:
         text = str(result)
         if mp_result.err_msg:
             # WORKER_BUG
-            text += ' (%s)' % mp_result.err_msg
+            text += f' ({mp_result.err_msg})'
         elif (result.duration and result.duration >= PROGRESS_MIN_TIME and not pgo):
-            text += ' (%s)' % format_duration(result.duration)
+            text += f' ({format_duration(result.duration)})'
         if not pgo:
             running = get_running(self.workers)
             if running:

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -66,18 +66,18 @@ def format_duration(seconds: float) -> str:
 
     parts = []
     if hours:
-        parts.append('%s hour' % hours)
+        parts.append(f'{hours} hour')
     if minutes:
-        parts.append('%s min' % minutes)
+        parts.append(f'{minutes} min')
     if seconds:
         if parts:
             # 2 min 1 sec
-            parts.append('%s sec' % seconds)
+            parts.append(f'{seconds} sec')
         else:
             # 1.0 sec
             parts.append('%.1f sec' % (seconds + ms / 1000))
     if not parts:
-        return '%s ms' % ms
+        return f'{ms} ms'
 
     parts = parts[:2]
     return ' '.join(parts)
@@ -650,7 +650,7 @@ def display_header(use_resources: tuple[str, ...],
     # Print basic platform information
     print("==", platform.python_implementation(), *sys.version.split())
     print("==", platform.platform(aliased=True),
-                  "%s-endian" % sys.byteorder)
+                  f"{sys.byteorder}-endian")
     print("== Python build:", ' '.join(get_build_info()))
     print("== cwd:", os.getcwd())
 
@@ -661,8 +661,7 @@ def display_header(use_resources: tuple[str, ...],
         if process_cpu_count and process_cpu_count != cpu_count:
             cpu_count = f"{process_cpu_count} (process) / {cpu_count} (system)"
         print("== CPU count:", cpu_count)
-    print("== encodings: locale=%s FS=%s"
-          % (locale.getencoding(), sys.getfilesystemencoding()))
+    print(f"== encodings: locale={locale.getencoding()} FS={sys.getfilesystemencoding()}")
 
     if use_resources:
         text = format_resources(use_resources)
@@ -728,13 +727,13 @@ def cleanup_temp_dir(tmp_dir: StrPath) -> None:
     import glob
 
     path = os.path.join(glob.escape(tmp_dir), TMP_PREFIX + '*')
-    print("Cleanup %s directory" % tmp_dir)
+    print(f"Cleanup {tmp_dir} directory")
     for name in glob.glob(path):
         if os.path.isdir(name):
-            print("Remove directory: %s" % name)
+            print(f"Remove directory: {name}")
             os_helper.rmtree(name)
         else:
-            print("Remove file: %s" % name)
+            print(f"Remove file: {name}")
             os_helper.unlink(name)
 
 

--- a/Misc/NEWS.d/next/Tests/2025-01-27-16-44-00.gh-issue-129370.wI-jb4.rst
+++ b/Misc/NEWS.d/next/Tests/2025-01-27-16-44-00.gh-issue-129370.wI-jb4.rst
@@ -1,0 +1,1 @@
+Update libregrtest to use f-strings


### PR DESCRIPTION
Found and fixed all instances with `ruff` (And *did* read through them as opposed to just submitting a PR with a tool result! 😉):

```sh
ruff check --select UP031,UP032 --fix --unsafe-fixes ./Lib/test/libregrtest/
```

I've omitted the changes to `Regtest::run_tests_sequentially` as to not conflict with #129363.

### CPython versions tested on:

CPython main branch

### Operating systems tested on:

macOS


<!-- gh-issue-number: gh-129370 -->
* Issue: gh-129370
<!-- /gh-issue-number -->
