### PR TITLE
gh-128690: Use test_embed in PGO profile builds again

### DIFF
--- a/Lib/test/libregrtest/pgo.py
+++ b/Lib/test/libregrtest/pgo.py
@@ -19,6 +19,7 @@ PGO_TESTS = [
     'test_datetime',
     'test_decimal',
     'test_difflib',
+    'test_embed',
     'test_float',
     'test_fstring',
     'test_functools',


### PR DESCRIPTION
This reverts the temporal commit b00e1254fc00941bf91e41138940e73fd22e1cbf.

The issue with `test_init_pyvenv_cfg` failing is closed as resolved.

cc @ned-deily


<!-- gh-issue-number: gh-128690 -->
* Issue: gh-128690
<!-- /gh-issue-number -->
