### PR TITLE
gh-129388: Use user supplied env vars when checking for gdbm deps

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-01-28-09-55-01.gh-issue-129388.wIRPxg.rst
+++ b/Misc/NEWS.d/next/Build/2025-01-28-09-55-01.gh-issue-129388.wIRPxg.rst
@@ -1,0 +1,2 @@
+Use :envvar:`GDBM_CFLAGS` and :envvar:`GDBM_LIBS` for all :mod:`gdbm`
+dependency checks.

--- a/Misc/NEWS.d/next/Build/2025-01-28-09-55-01.gh-issue-129388.wIRPxg.rst
+++ b/Misc/NEWS.d/next/Build/2025-01-28-09-55-01.gh-issue-129388.wIRPxg.rst
@@ -1,2 +1,2 @@
-Use :envvar:`GDBM_CFLAGS` and :envvar:`GDBM_LIBS` for all :mod:`gdbm`
+Use :option:`GDBM_CFLAGS` and :option:`GDBM_LIBS` for all :mod:`gdbm`
 dependency checks.

--- a/configure
+++ b/configure
@@ -17037,25 +17037,12 @@ fi
 
 done
 
-CFLAGS=$save_CFLAGS
-CPPFLAGS=$save_CPPFLAGS
-LDFLAGS=$save_LDFLAGS
-LIBS=$save_LIBS
-
-
-
-       for ac_header in ndbm.h
+             for ac_header in ndbm.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "ndbm.h" "ac_cv_header_ndbm_h" "$ac_includes_default"
 if test "x$ac_cv_header_ndbm_h" = xyes
 then :
   printf "%s\n" "#define HAVE_NDBM_H 1" >>confdefs.h
-
-  save_CFLAGS=$CFLAGS
-save_CPPFLAGS=$CPPFLAGS
-save_LDFLAGS=$LDFLAGS
-save_LIBS=$LIBS
-
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing dbm_open" >&5
 printf %s "checking for library containing dbm_open... " >&6; }
@@ -17125,60 +17112,31 @@ then :
 fi
 
 
-CFLAGS=$save_CFLAGS
-CPPFLAGS=$save_CPPFLAGS
-LDFLAGS=$save_LDFLAGS
-LIBS=$save_LIBS
-
-
-
 fi
 
 done
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ndbm presence and linker args" >&5
-printf %s "checking for ndbm presence and linker args... " >&6; }
-case $ac_cv_search_dbm_open in #(
-  *ndbm*|*gdbm_compat*) :
-
-    dbm_ndbm="$ac_cv_search_dbm_open"
-    have_ndbm=yes
-   ;; #(
-  none*) :
-
-    dbm_ndbm=""
-    have_ndbm=yes
-   ;; #(
-  no) :
-    have_ndbm=no
- ;; #(
-  *) :
-     ;;
-esac
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_ndbm ($dbm_ndbm)" >&5
-printf "%s\n" "$have_ndbm ($dbm_ndbm)" >&6; }
-
-{ ac_cv_header_gdbm_ndbm_h=; unset ac_cv_header_gdbm_ndbm_h;}
-if test ${ac_cv_header_gdbm_slash_ndbm_h+y}
+      { ac_cv_header_gdbm_ndbm_h=; unset ac_cv_header_gdbm_ndbm_h;}
+  if test ${ac_cv_header_gdbm_slash_ndbm_h+y}
 then :
   printf %s "(cached) " >&6
 else case e in #(
   e)
-  ac_fn_c_check_header_compile "$LINENO" "gdbm/ndbm.h" "ac_cv_header_gdbm_ndbm_h" "$ac_includes_default"
+    ac_fn_c_check_header_compile "$LINENO" "gdbm/ndbm.h" "ac_cv_header_gdbm_ndbm_h" "$ac_includes_default"
 if test "x$ac_cv_header_gdbm_ndbm_h" = xyes
 then :
   ac_cv_header_gdbm_slash_ndbm_h=yes
 else case e in #(
   e) ac_cv_header_gdbm_slash_ndbm_h=no
+     ;;
+esac
+fi
+
    ;;
 esac
 fi
 
- ;;
-esac
-fi
-
-if test "x$ac_cv_header_gdbm_slash_ndbm_h" = xyes
+  if test "x$ac_cv_header_gdbm_slash_ndbm_h" = xyes
 then :
 
 
@@ -17187,27 +17145,27 @@ printf "%s\n" "#define HAVE_GDBM_NDBM_H 1" >>confdefs.h
 
 fi
 
-{ ac_cv_header_gdbm_ndbm_h=; unset ac_cv_header_gdbm_ndbm_h;}
-if test ${ac_cv_header_gdbm_dash_ndbm_h+y}
+  { ac_cv_header_gdbm_ndbm_h=; unset ac_cv_header_gdbm_ndbm_h;}
+  if test ${ac_cv_header_gdbm_dash_ndbm_h+y}
 then :
   printf %s "(cached) " >&6
 else case e in #(
   e)
-  ac_fn_c_check_header_compile "$LINENO" "gdbm-ndbm.h" "ac_cv_header_gdbm_ndbm_h" "$ac_includes_default"
+    ac_fn_c_check_header_compile "$LINENO" "gdbm-ndbm.h" "ac_cv_header_gdbm_ndbm_h" "$ac_includes_default"
 if test "x$ac_cv_header_gdbm_ndbm_h" = xyes
 then :
   ac_cv_header_gdbm_dash_ndbm_h=yes
 else case e in #(
   e) ac_cv_header_gdbm_dash_ndbm_h=no
+     ;;
+esac
+fi
+
    ;;
 esac
 fi
 
- ;;
-esac
-fi
-
-if test "x$ac_cv_header_gdbm_dash_ndbm_h" = xyes
+  if test "x$ac_cv_header_gdbm_dash_ndbm_h" = xyes
 then :
 
 
@@ -17215,16 +17173,10 @@ printf "%s\n" "#define HAVE_GDBM_DASH_NDBM_H 1" >>confdefs.h
 
 
 fi
-{ ac_cv_header_gdbm_ndbm_h=; unset ac_cv_header_gdbm_ndbm_h;}
+  { ac_cv_header_gdbm_ndbm_h=; unset ac_cv_header_gdbm_ndbm_h;}
 
-if test "$ac_cv_header_gdbm_slash_ndbm_h" = yes -o "$ac_cv_header_gdbm_dash_ndbm_h" = yes; then
-  { ac_cv_search_dbm_open=; unset ac_cv_search_dbm_open;}
-  save_CFLAGS=$CFLAGS
-save_CPPFLAGS=$CPPFLAGS
-save_LDFLAGS=$LDFLAGS
-save_LIBS=$LIBS
-
-
+  if test "$ac_cv_header_gdbm_slash_ndbm_h" = yes -o "$ac_cv_header_gdbm_dash_ndbm_h" = yes; then
+    { ac_cv_search_dbm_open=; unset ac_cv_search_dbm_open;}
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing dbm_open" >&5
 printf %s "checking for library containing dbm_open... " >&6; }
 if test ${ac_cv_search_dbm_open+y}
@@ -17295,6 +17247,7 @@ else case e in #(
 esac
 fi
 
+  fi
 
 CFLAGS=$save_CFLAGS
 CPPFLAGS=$save_CPPFLAGS
@@ -17302,7 +17255,28 @@ LDFLAGS=$save_LDFLAGS
 LIBS=$save_LIBS
 
 
-fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ndbm presence and linker args" >&5
+printf %s "checking for ndbm presence and linker args... " >&6; }
+case $ac_cv_search_dbm_open in #(
+  *ndbm*|*gdbm_compat*) :
+
+    dbm_ndbm="$ac_cv_search_dbm_open"
+    have_ndbm=yes
+   ;; #(
+  none*) :
+
+    dbm_ndbm=""
+    have_ndbm=yes
+   ;; #(
+  no) :
+    have_ndbm=no
+ ;; #(
+  *) :
+     ;;
+esac
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_ndbm ($dbm_ndbm)" >&5
+printf "%s\n" "$have_ndbm ($dbm_ndbm)" >&6; }
 
 # Check for libdb >= 5 with dbm_open()
 # db.h re-defines the name of the function

--- a/configure.ac
+++ b/configure.ac
@@ -4404,14 +4404,42 @@ WITH_SAVE_ENV([
       GDBM_LIBS=${GDBM_LIBS-"-lgdbm"}
     ], [have_gdbm=no])
   ], [have_gdbm=no])
-])
 
-dnl check for _dbmmodule.c dependencies
-dnl ndbm, gdbm_compat, libdb
-AC_CHECK_HEADERS([ndbm.h], [
-  WITH_SAVE_ENV([
+  dnl check for _dbmmodule.c dependencies
+  dnl ndbm, gdbm_compat, libdb
+  AC_CHECK_HEADERS([ndbm.h], [
     AC_SEARCH_LIBS([dbm_open], [ndbm gdbm_compat])
   ])
+
+  dnl "gdbm-ndbm.h" and "gdbm/ndbm.h" are both normalized to "gdbm_ndbm_h"
+  dnl unset ac_cv_header_gdbm_ndbm_h to prevent false positive cache hits.
+  AS_UNSET([ac_cv_header_gdbm_ndbm_h])
+  AC_CACHE_VAL([ac_cv_header_gdbm_slash_ndbm_h], [
+    AC_CHECK_HEADER(
+      [gdbm/ndbm.h],
+      [ac_cv_header_gdbm_slash_ndbm_h=yes], [ac_cv_header_gdbm_slash_ndbm_h=no]
+    )
+  ])
+  AS_VAR_IF([ac_cv_header_gdbm_slash_ndbm_h], [yes], [
+    AC_DEFINE([HAVE_GDBM_NDBM_H], [1], [Define to 1 if you have the <gdbm/ndbm.h> header file.])
+  ])
+
+  AS_UNSET([ac_cv_header_gdbm_ndbm_h])
+  AC_CACHE_VAL([ac_cv_header_gdbm_dash_ndbm_h], [
+    AC_CHECK_HEADER(
+      [gdbm-ndbm.h],
+      [ac_cv_header_gdbm_dash_ndbm_h=yes], [ac_cv_header_gdbm_dash_ndbm_h=no]
+    )
+  ])
+  AS_VAR_IF([ac_cv_header_gdbm_dash_ndbm_h], [yes], [
+    AC_DEFINE([HAVE_GDBM_DASH_NDBM_H], [1], [Define to 1 if you have the <gdbm-ndbm.h> header file.])
+  ])
+  AS_UNSET([ac_cv_header_gdbm_ndbm_h])
+
+  if test "$ac_cv_header_gdbm_slash_ndbm_h" = yes -o "$ac_cv_header_gdbm_dash_ndbm_h" = yes; then
+    AS_UNSET([ac_cv_search_dbm_open])
+    AC_SEARCH_LIBS([dbm_open], [gdbm_compat], [have_gdbm_compat=yes], [have_gdbm_compat=no])
+  fi
 ])
 
 AC_MSG_CHECKING([for ndbm presence and linker args])
@@ -4427,38 +4455,6 @@ AS_CASE([$ac_cv_search_dbm_open],
   [no], [have_ndbm=no]
 )
 AC_MSG_RESULT([$have_ndbm ($dbm_ndbm)])
-
-dnl "gdbm-ndbm.h" and "gdbm/ndbm.h" are both normalized to "gdbm_ndbm_h"
-dnl unset ac_cv_header_gdbm_ndbm_h to prevent false positive cache hits.
-AS_UNSET([ac_cv_header_gdbm_ndbm_h])
-AC_CACHE_VAL([ac_cv_header_gdbm_slash_ndbm_h], [
-  AC_CHECK_HEADER(
-    [gdbm/ndbm.h],
-    [ac_cv_header_gdbm_slash_ndbm_h=yes], [ac_cv_header_gdbm_slash_ndbm_h=no]
-  )
-])
-AS_VAR_IF([ac_cv_header_gdbm_slash_ndbm_h], [yes], [
-  AC_DEFINE([HAVE_GDBM_NDBM_H], [1], [Define to 1 if you have the <gdbm/ndbm.h> header file.])
-])
-
-AS_UNSET([ac_cv_header_gdbm_ndbm_h])
-AC_CACHE_VAL([ac_cv_header_gdbm_dash_ndbm_h], [
-  AC_CHECK_HEADER(
-    [gdbm-ndbm.h],
-    [ac_cv_header_gdbm_dash_ndbm_h=yes], [ac_cv_header_gdbm_dash_ndbm_h=no]
-  )
-])
-AS_VAR_IF([ac_cv_header_gdbm_dash_ndbm_h], [yes], [
-  AC_DEFINE([HAVE_GDBM_DASH_NDBM_H], [1], [Define to 1 if you have the <gdbm-ndbm.h> header file.])
-])
-AS_UNSET([ac_cv_header_gdbm_ndbm_h])
-
-if test "$ac_cv_header_gdbm_slash_ndbm_h" = yes -o "$ac_cv_header_gdbm_dash_ndbm_h" = yes; then
-  AS_UNSET([ac_cv_search_dbm_open])
-  WITH_SAVE_ENV([
-    AC_SEARCH_LIBS([dbm_open], [gdbm_compat], [have_gdbm_compat=yes], [have_gdbm_compat=no])
-  ])
-fi
 
 # Check for libdb >= 5 with dbm_open()
 # db.h re-defines the name of the function


### PR DESCRIPTION
Use GDBM_CFLAGS and GDBM_LIBS for all gdbm related checks.


<!-- gh-issue-number: gh-129388 -->
* Issue: gh-129388
<!-- /gh-issue-number -->
