### PR TITLE
gh-115806: Don't mangle gdbm header dependency detection output

### DIFF
--- a/configure
+++ b/configure
@@ -17158,26 +17158,28 @@ esac
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_ndbm ($dbm_ndbm)" >&5
 printf "%s\n" "$have_ndbm ($dbm_ndbm)" >&6; }
 
-{ ac_cv_header_gdbm_ndbm_h=; unset ac_cv_header_gdbm_ndbm_h;}
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for gdbm/ndbm.h" >&5
+printf %s "checking for gdbm/ndbm.h... " >&6; }
 if test ${ac_cv_header_gdbm_slash_ndbm_h+y}
 then :
   printf %s "(cached) " >&6
 else case e in #(
-  e)
-  ac_fn_c_check_header_compile "$LINENO" "gdbm/ndbm.h" "ac_cv_header_gdbm_ndbm_h" "$ac_includes_default"
-if test "x$ac_cv_header_gdbm_ndbm_h" = xyes
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <gdbm/ndbm.h>
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"
 then :
   ac_cv_header_gdbm_slash_ndbm_h=yes
 else case e in #(
-  e) ac_cv_header_gdbm_slash_ndbm_h=no
-   ;;
+  e) ac_cv_header_gdbm_slash_ndbm_h=no ;;
 esac
 fi
-
- ;;
+rm -f conftest.err conftest.i conftest.$ac_ext ;;
 esac
 fi
-
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_header_gdbm_slash_ndbm_h" >&5
+printf "%s\n" "$ac_cv_header_gdbm_slash_ndbm_h" >&6; }
 if test "x$ac_cv_header_gdbm_slash_ndbm_h" = xyes
 then :
 
@@ -17187,26 +17189,28 @@ printf "%s\n" "#define HAVE_GDBM_NDBM_H 1" >>confdefs.h
 
 fi
 
-{ ac_cv_header_gdbm_ndbm_h=; unset ac_cv_header_gdbm_ndbm_h;}
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for gdbm-ndbm.h" >&5
+printf %s "checking for gdbm-ndbm.h... " >&6; }
 if test ${ac_cv_header_gdbm_dash_ndbm_h+y}
 then :
   printf %s "(cached) " >&6
 else case e in #(
-  e)
-  ac_fn_c_check_header_compile "$LINENO" "gdbm-ndbm.h" "ac_cv_header_gdbm_ndbm_h" "$ac_includes_default"
-if test "x$ac_cv_header_gdbm_ndbm_h" = xyes
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <gdbm-ndbm.h>
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"
 then :
   ac_cv_header_gdbm_dash_ndbm_h=yes
 else case e in #(
-  e) ac_cv_header_gdbm_dash_ndbm_h=no
-   ;;
+  e) ac_cv_header_gdbm_dash_ndbm_h=no ;;
 esac
 fi
-
- ;;
+rm -f conftest.err conftest.i conftest.$ac_ext ;;
 esac
 fi
-
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_header_gdbm_dash_ndbm_h" >&5
+printf "%s\n" "$ac_cv_header_gdbm_dash_ndbm_h" >&6; }
 if test "x$ac_cv_header_gdbm_dash_ndbm_h" = xyes
 then :
 
@@ -17215,7 +17219,6 @@ printf "%s\n" "#define HAVE_GDBM_DASH_NDBM_H 1" >>confdefs.h
 
 
 fi
-{ ac_cv_header_gdbm_ndbm_h=; unset ac_cv_header_gdbm_ndbm_h;}
 
 if test "$ac_cv_header_gdbm_slash_ndbm_h" = yes -o "$ac_cv_header_gdbm_dash_ndbm_h" = yes; then
   { ac_cv_search_dbm_open=; unset ac_cv_search_dbm_open;}

--- a/configure.ac
+++ b/configure.ac
@@ -4429,29 +4429,21 @@ AS_CASE([$ac_cv_search_dbm_open],
 AC_MSG_RESULT([$have_ndbm ($dbm_ndbm)])
 
 dnl "gdbm-ndbm.h" and "gdbm/ndbm.h" are both normalized to "gdbm_ndbm_h"
-dnl unset ac_cv_header_gdbm_ndbm_h to prevent false positive cache hits.
-AS_UNSET([ac_cv_header_gdbm_ndbm_h])
-AC_CACHE_VAL([ac_cv_header_gdbm_slash_ndbm_h], [
-  AC_CHECK_HEADER(
-    [gdbm/ndbm.h],
-    [ac_cv_header_gdbm_slash_ndbm_h=yes], [ac_cv_header_gdbm_slash_ndbm_h=no]
-  )
-])
+AC_CACHE_CHECK([for gdbm/ndbm.h], [ac_cv_header_gdbm_slash_ndbm_h],
+               [AC_PREPROC_IFELSE([AC_LANG_SOURCE([@%:@include <gdbm/ndbm.h>])],
+                                  [ac_cv_header_gdbm_slash_ndbm_h=yes],
+                                  [ac_cv_header_gdbm_slash_ndbm_h=no])])
 AS_VAR_IF([ac_cv_header_gdbm_slash_ndbm_h], [yes], [
   AC_DEFINE([HAVE_GDBM_NDBM_H], [1], [Define to 1 if you have the <gdbm/ndbm.h> header file.])
 ])
 
-AS_UNSET([ac_cv_header_gdbm_ndbm_h])
-AC_CACHE_VAL([ac_cv_header_gdbm_dash_ndbm_h], [
-  AC_CHECK_HEADER(
-    [gdbm-ndbm.h],
-    [ac_cv_header_gdbm_dash_ndbm_h=yes], [ac_cv_header_gdbm_dash_ndbm_h=no]
-  )
-])
+AC_CACHE_CHECK([for gdbm-ndbm.h], [ac_cv_header_gdbm_dash_ndbm_h],
+               [AC_PREPROC_IFELSE([AC_LANG_SOURCE([@%:@include <gdbm-ndbm.h>])],
+                                  [ac_cv_header_gdbm_dash_ndbm_h=yes],
+                                  [ac_cv_header_gdbm_dash_ndbm_h=no])])
 AS_VAR_IF([ac_cv_header_gdbm_dash_ndbm_h], [yes], [
   AC_DEFINE([HAVE_GDBM_DASH_NDBM_H], [1], [Define to 1 if you have the <gdbm-ndbm.h> header file.])
 ])
-AS_UNSET([ac_cv_header_gdbm_ndbm_h])
 
 if test "$ac_cv_header_gdbm_slash_ndbm_h" = yes -o "$ac_cv_header_gdbm_dash_ndbm_h" = yes; then
   AS_UNSET([ac_cv_search_dbm_open])


### PR DESCRIPTION
Replace AC_CACHE_VAL/AC_CHECK_HEADER with a cleaner variant using
AC_CACHE_CHECK/AC_PREPROC_IFELSE.

The former would produce garbled output when config.cache was reused. It
also required directly manipulating GNU Autoconf cache variables.


<!-- gh-issue-number: gh-115806 -->
* Issue: gh-115806
<!-- /gh-issue-number -->
