### PR TITLE
gh-129393: Make 'sys.platform' return "freebsd" only on FreeBSD witho…

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1422,6 +1422,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    AIX              ``'aix'``
    Android          ``'android'``
    Emscripten       ``'emscripten'``
+   FreeBSD          ``'freebsd'``
    iOS              ``'ios'``
    Linux            ``'linux'``
    macOS            ``'darwin'``
@@ -1432,12 +1433,12 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
    On Unix systems not listed in the table, the value is the lowercased OS name
    as returned by ``uname -s``, with the first part of the version as returned by
-   ``uname -r`` appended, e.g. ``'sunos5'`` or ``'freebsd8'``, *at the time
-   when Python was built*.  Unless you want to test for a specific system
-   version, it is therefore recommended to use the following idiom::
+   ``uname -r`` appended, e.g. ``'sunos5'``, *at the time when Python was built*.
+   Unless you want to test for a specific system version, it is therefore
+   recommended to use the following idiom::
 
-      if sys.platform.startswith('freebsd'):
-          # FreeBSD-specific code here...
+      if sys.platform.startswith('sunos'):
+          # SunOS-specific code here...
 
    .. versionchanged:: 3.3
       On Linux, :data:`sys.platform` doesn't contain the major version anymore.
@@ -1450,6 +1451,10 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    .. versionchanged:: 3.13
       On Android, :data:`sys.platform` now returns ``'android'`` rather than
       ``'linux'``.
+
+   .. versionchanged:: 3.14
+      On FreeBSD, :data:`sys.platform` doesn't contain the major version anymore.
+      It is always ``'freebsd'``, instead of ``'freebsd13'`` or ``'freebsd14'``.
 
    .. seealso::
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -649,6 +649,9 @@ sys
   which only exists in specialized builds of Python, may now return objects
   from other interpreters than the one it's called in.
 
+* On FreeBSD, :data:`sys.platform` doesn't contain the major version anymore.
+  It is always ``'freebsd'``, instead of ``'freebsd13'`` or ``'freebsd14'``.
+
 sys.monitoring
 --------------
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-01-28-10-26-04.gh-issue-129393.0eICq6.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-01-28-10-26-04.gh-issue-129393.0eICq6.rst
@@ -1,0 +1,2 @@
+On FreeBSD, :data:`sys.platform` doesn't contain the major version anymore.
+It is always ``'freebsd'``, instead of ``'freebsd13'`` or ``'freebsd14'``.

--- a/configure
+++ b/configure
@@ -4132,6 +4132,7 @@ then
 
     case $MACHDEP in
 	aix*) MACHDEP="aix";;
+	freebsd*) MACHDEP="freebsd";;
 	linux-android*) MACHDEP="android";;
 	linux*) MACHDEP="linux";;
 	cygwin*) MACHDEP="cygwin";;

--- a/configure.ac
+++ b/configure.ac
@@ -365,6 +365,7 @@ then
 
     case $MACHDEP in
 	aix*) MACHDEP="aix";;
+	freebsd*) MACHDEP="freebsd";;
 	linux-android*) MACHDEP="android";;
 	linux*) MACHDEP="linux";;
 	cygwin*) MACHDEP="cygwin";;


### PR DESCRIPTION
…ut major version

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Result:
```
osipovmi@deblndw011x:~/var/Projekte/cpython (main *+>)
$ /tmp/python-3.13/bin/python3
Python 3.14.0a4+ (heads/main-dirty:8e57877e3f4, Jan 28 2025, 10:01:48) [Clang 19.1.5 (https://github.com/llvm/llvm-project.git llvmorg-19.1.5-0-gab4b5a on freebsd
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.platform
'freebsd'
>>>
```

<!-- gh-issue-number: gh-129393 -->
* Issue: gh-129393
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129394.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->