### PR TITLE
gh-129407: Clarify that a `SystemError` isn't always CPython's fault

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -573,6 +573,7 @@ The following exceptions are the exceptions that are usually raised.
    message (the exception's associated value) and if possible the source of the
    program that triggered the error.
 
+
 .. exception:: SystemExit
 
    This exception is raised by the :func:`sys.exit` function.  It inherits from

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -566,12 +566,13 @@ The following exceptions are the exceptions that are usually raised.
    this could be raised by incorrectly using Python's C API, such as returning
    a ``NULL`` value without an exception set.
 
-   If you're confident that this exception wasn't your fault, you should
-   report this to the author or maintainer of your Python interpreter.
-   Be sure to report the version of the Python interpreter (``sys.version``; it is
-   also printed at the start of an interactive Python session), the exact error
-   message (the exception's associated value) and if possible the source of the
-   program that triggered the error.
+   If you're confident that this exception wasn't your fault, or the fault of
+   a package you're using, you should report this to the author or maintainer
+   of your Python interpreter. Be sure to report the version of the Python
+   interpreter (``sys.version``; it is also printed at the start of an
+   interactive Python session), the exact error message (the exception's
+   associated value) and if possible the source of the program that triggered
+   the error.
 
 
 .. exception:: SystemExit

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -562,14 +562,16 @@ The following exceptions are the exceptions that are usually raised.
 
    Raised when the interpreter finds an internal error, but the situation does not
    look so serious to cause it to abandon all hope. The associated value is a
-   string indicating what went wrong (in low-level terms).
+   string indicating what went wrong (in low-level terms). In :term:`CPython`,
+   this could be raised by incorrectly using Python's C API, such as returning
+   a ``NULL`` value without an exception set.
 
-   You should report this to the author or maintainer of your Python interpreter.
+   If you're confident that this exception wasn't your fault, you should
+   report this to the author or maintainer of your Python interpreter.
    Be sure to report the version of the Python interpreter (``sys.version``; it is
    also printed at the start of an interactive Python session), the exact error
    message (the exception's associated value) and if possible the source of the
    program that triggered the error.
-
 
 .. exception:: SystemExit
 

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -568,11 +568,11 @@ The following exceptions are the exceptions that are usually raised.
 
    If you're confident that this exception wasn't your fault, or the fault of
    a package you're using, you should report this to the author or maintainer
-   of your Python interpreter. Be sure to report the version of the Python
-   interpreter (``sys.version``; it is also printed at the start of an
-   interactive Python session), the exact error message (the exception's
-   associated value) and if possible the source of the program that triggered
-   the error.
+   of your Python interpreter.
+   Be sure to report the version of the Python interpreter (``sys.version``; it is
+   also printed at the start of an interactive Python session), the exact error
+   message (the exception's associated value) and if possible the source of the
+   program that triggered the error.
 
 
 .. exception:: SystemExit


### PR DESCRIPTION

<!-- gh-issue-number: gh-129407 -->
* Issue: gh-129407
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129410.org.readthedocs.build/en/129410/library/exceptions.html#SystemError

<!-- readthedocs-preview cpython-previews end -->