### PR TITLE
GH-128563: Don't leave `frame->lltrace` uninitialized

### DIFF
--- a/Include/internal/pycore_frame.h
+++ b/Include/internal/pycore_frame.h
@@ -215,6 +215,9 @@ _PyFrame_Initialize(
     frame->return_offset = 0;
     frame->owner = FRAME_OWNED_BY_THREAD;
     frame->visited = 0;
+#ifdef Py_DEBUG
+    frame->lltrace = 0;
+#endif
 
     for (int i = null_locals_from; i < code->co_nlocalsplus; i++) {
         frame->localsplus[i] = PyStackRef_NULL;
@@ -398,6 +401,9 @@ _PyFrame_PushTrampolineUnchecked(PyThreadState *tstate, PyCodeObject *code, int 
 #endif
     frame->owner = FRAME_OWNED_BY_THREAD;
     frame->visited = 0;
+#ifdef Py_DEBUG
+    frame->lltrace = 0;
+#endif
     frame->return_offset = 0;
 
 #ifdef Py_GIL_DISABLED

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-01-28-11-13-41.gh-issue-128563.xElppE.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-01-28-11-13-41.gh-issue-128563.xElppE.rst
@@ -1,0 +1,2 @@
+Fix an issue where the "lltrace" debug feature could have been incorrectly
+enabled for some frames.


### PR DESCRIPTION


<!-- gh-issue-number: gh-128563 -->
* Issue: gh-128563
<!-- /gh-issue-number -->
