### PR TITLE
gh-103510: Support `os.mkfifo` on Windows

### DIFF
--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -8766,7 +8766,7 @@ exit:
 
 #endif /* ((defined(HAVE_SPLICE) && !defined(_AIX))) */
 
-#if defined(HAVE_MKFIFO)
+#if (defined(HAVE_MKFIFO) || defined(MS_WINDOWS))
 
 PyDoc_STRVAR(os_mkfifo__doc__,
 "mkfifo($module, /, path, mode=438, *, dir_fd=None)\n"
@@ -8857,7 +8857,7 @@ exit:
     return return_value;
 }
 
-#endif /* defined(HAVE_MKFIFO) */
+#endif /* (defined(HAVE_MKFIFO) || defined(MS_WINDOWS)) */
 
 #if (defined(HAVE_MKNOD) && defined(HAVE_MAKEDEV))
 
@@ -13196,4 +13196,4 @@ os__emscripten_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__EMSCRIPTEN_DEBUGGER_METHODDEF
     #define OS__EMSCRIPTEN_DEBUGGER_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_DEBUGGER_METHODDEF) */
-/*[clinic end generated code: output=8318c26fc2cd236c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1df8579d03303ee6 input=a9049054013a1b77]*/


### PR DESCRIPTION
Happy Year of the Snake!

The current common practice of `os.mkfifo` then `open` the path cannot possibly be made to work on Windows (barring global state hacks at least), due to the [named pipe semantics](https://github.com/python/cpython/issues/103510#issuecomment-1507422056) and indivisibility at `NtCreateNamedPipeFile` syscall level. That said, it should be feasible to support `os.mkfifo` on Windows for the simple IPC case (named pipe with single R/W end) with certain API changes. There seems to be two ways forward:

1. `os.mkfifo` to return an open fd on Windows and the original `path` object on Unix. The user would then pass the return value into `open`, which accepts both path and fd as `file`. The fd, however, will always be `O_RDWR` on Windows.

2. `os.mkfifo` to accept [an additional `open_mode` argument](https://github.com/python/cpython/issues/103510#issuecomment-2613971402), and always returns an open fd or file object on any platform.

This experimental patch that would fix #103510 implements the simpler former for a start.

It would have been convenient to automatically prepend the `\\.\pipe\` prefix so that `os.mkfifo("/tmp/mypipe")` can be truly platform independent, but this is not currently the case on VxWorks and the user likely would still need the full filename. Maybe something like `os.pipe_prefix` would help.

Any comments would be much appreciated.

<!-- gh-issue-number: gh-103510 -->
* Issue: gh-103510
<!-- /gh-issue-number -->
