### PR TITLE
gh-127146: Skip test_readinto_non_blocking on Emscripten

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -264,6 +264,7 @@ class FileTests(unittest.TestCase):
     @unittest.skipUnless(hasattr(os, 'get_blocking'),
                      'needs os.get_blocking() and os.set_blocking()')
     @unittest.skipUnless(hasattr(os, "pipe"), "requires os.pipe()")
+    @unittest.skipIf(support.is_emscripten, "set_blocking does not work correctly")
     def test_readinto_non_blocking(self):
         # Verify behavior of a readinto which would block on a non-blocking fd.
         r, w = os.pipe()


### PR DESCRIPTION
non_blocking doesn't really work on Emscripten.

<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
