### PR TITLE
gh-129205: Update multiprocessing.forkserver to use os.readinto

### DIFF
--- a/Lib/multiprocessing/forkserver.py
+++ b/Lib/multiprocessing/forkserver.py
@@ -382,13 +382,14 @@ def _serve_one(child_r, fds, unused_fds, handlers):
 #
 
 def read_signed(fd):
-    data = b''
-    length = SIGNED_STRUCT.size
-    while len(data) < length:
-        s = os.read(fd, length - len(data))
-        if not s:
-            raise EOFError('unexpected EOF')
-        data += s
+    data = bytearray(SIGNED_STRUCT.size)
+    bytes_read = 0
+    while count := os.readinto(fd, memoryview(data)[bytes_read:]):
+        bytes_read += count
+
+    if bytes_read < SIGNED_STRUCT.size:
+        raise EOFError('unexpected EOF')
+
     return SIGNED_STRUCT.unpack(data)[0]
 
 def write_signed(fd, n):

--- a/Lib/multiprocessing/forkserver.py
+++ b/Lib/multiprocessing/forkserver.py
@@ -383,12 +383,12 @@ def _serve_one(child_r, fds, unused_fds, handlers):
 
 def read_signed(fd):
     data = bytearray(SIGNED_STRUCT.size)
-    bytes_read = 0
-    while bytes_read < SIGNED_STRUCT.size:
-        count = os.readinto(fd, memoryview(data)[bytes_read:])
+    unread = memoryview(data)
+    while unread:
+        count = os.readinto(fd, unread)
         if count == 0:
             raise EOFError('unexpected EOF')
-        bytes_read += count
+        unread = unread[count:]
 
     return SIGNED_STRUCT.unpack(data)[0]
 

--- a/Lib/multiprocessing/forkserver.py
+++ b/Lib/multiprocessing/forkserver.py
@@ -382,13 +382,14 @@ def _serve_one(child_r, fds, unused_fds, handlers):
 #
 
 def read_signed(fd):
-    data = bytearray(SIGNED_STRUCT.size)
-    bytes_read = 0
-    while count := os.readinto(fd, memoryview(data)[bytes_read:]):
-        bytes_read += count
+    to_read = SIGNED_STRUCT.size
+    data = bytearray(to_read)
+    while to_read:
+        count = os.readinto(fd, memoryview(data)[-to_read:])
 
-    if bytes_read < SIGNED_STRUCT.size:
-        raise EOFError('unexpected EOF')
+        if count == 0:
+            raise EOFError('unexpected EOF')
+        to_read -= count
 
     return SIGNED_STRUCT.unpack(data)[0]
 

--- a/Lib/multiprocessing/forkserver.py
+++ b/Lib/multiprocessing/forkserver.py
@@ -382,14 +382,13 @@ def _serve_one(child_r, fds, unused_fds, handlers):
 #
 
 def read_signed(fd):
-    to_read = SIGNED_STRUCT.size
-    data = bytearray(to_read)
-    while to_read:
-        count = os.readinto(fd, memoryview(data)[-to_read:])
-
+    data = bytearray(SIGNED_STRUCT.size)
+    bytes_read = 0
+    while bytes_read < SIGNED_STRUCT.size:
+        count = os.readinto(fd, memoryview(data)[bytes_read:])
         if count == 0:
             raise EOFError('unexpected EOF')
-        to_read -= count
+        bytes_read += count
 
     return SIGNED_STRUCT.unpack(data)[0]
 

--- a/Misc/NEWS.d/next/Library/2025-01-28-22-11-41.gh-issue-129205.C-vE8S.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-28-22-11-41.gh-issue-129205.C-vE8S.rst
@@ -1,2 +1,0 @@
-:mod:`multiprocessing` forkserver now uses :func:`os.readinto` to read pid
-of child processes saving memory allocations and copies.

--- a/Misc/NEWS.d/next/Library/2025-01-28-22-11-41.gh-issue-129205.C-vE8S.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-28-22-11-41.gh-issue-129205.C-vE8S.rst
@@ -1,0 +1,2 @@
+:mod:`multiprocessing` forkserver now uses :func:`os.readinto` to read pid
+of child processes saving memory allocations and copies..

--- a/Misc/NEWS.d/next/Library/2025-01-28-22-11-41.gh-issue-129205.C-vE8S.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-28-22-11-41.gh-issue-129205.C-vE8S.rst
@@ -1,2 +1,2 @@
 :mod:`multiprocessing` forkserver now uses :func:`os.readinto` to read pid
-of child processes saving memory allocations and copies..
+of child processes saving memory allocations and copies.


### PR DESCRIPTION
Use a single pre-allocated bytearray for temporary storage, `os.readinto` it avoiding non-mutable bytes.

<!-- gh-issue-number: gh-129205 -->
* Issue: gh-129205
<!-- /gh-issue-number -->
