### PR TITLE
gh-118761: Improve import time of `subprocess`

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -43,10 +43,8 @@ getstatusoutput(...): Runs a command in the shell, waits for it to complete,
 import builtins
 import errno
 import io
-import locale
 import os
 import time
-import signal
 import sys
 import threading
 import warnings
@@ -144,6 +142,8 @@ class CalledProcessError(SubprocessError):
 
     def __str__(self):
         if self.returncode and self.returncode < 0:
+            # Lazy import to improve module import time
+            import signal
             try:
                 return "Command '%s' died with %r." % (
                         self.cmd, signal.Signals(-self.returncode))
@@ -381,6 +381,8 @@ def _text_encoding():
     if sys.flags.utf8_mode:
         return "utf-8"
     else:
+        # Lazy import to improve module import time
+        import locale
         return locale.getencoding()
 
 
@@ -1664,6 +1666,9 @@ class Popen:
             # Don't signal a process that we know has already died.
             if self.returncode is not None:
                 return
+
+            # Lazy import to improve module import time
+            import signal
             if sig == signal.SIGTERM:
                 self.terminate()
             elif sig == signal.CTRL_C_EVENT:
@@ -1765,6 +1770,9 @@ class Popen:
             """Execute program using os.posix_spawn()."""
             kwargs = {}
             if restore_signals:
+                # Lazy import to improve module import time
+                import signal
+
                 # See _Py_RestoreSignals() in Python/pylifecycle.c
                 sigset = []
                 for signame in ('SIGPIPE', 'SIGXFZ', 'SIGXFSZ'):
@@ -2214,9 +2222,13 @@ class Popen:
         def terminate(self):
             """Terminate the process with SIGTERM
             """
+            # Lazy import to improve module import time
+            import signal
             self.send_signal(signal.SIGTERM)
 
         def kill(self):
             """Kill the process with SIGKILL
             """
+            # Lazy import to improve module import time
+            import signal
             self.send_signal(signal.SIGKILL)

--- a/Misc/NEWS.d/next/Library/2025-01-29-10-53-32.gh-issue-118761.i8wjpV.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-29-10-53-32.gh-issue-118761.i8wjpV.rst
@@ -1,0 +1,2 @@
+Improve import time of :mod:`subprocess` by lazy importing ``locale`` and
+``signal``. Patch by Taneli Hukkinen.


### PR DESCRIPTION
This makes `import subprocess` lazy import `locale` and `signal`. As a result, also `re` (imported by `locale`) and `enum` (imported by `signal`) imports are skipped.

## Benchmark import time

### `main` branch

```console
$ hyperfine --warmup 11 "./python -c 'import subprocess'" "./python -c 'pass'"
Benchmark 1: ./python -c 'import subprocess'
  Time (mean ± σ):      24.6 ms ±   0.9 ms    [User: 20.8 ms, System: 4.0 ms]
  Range (min … max):    23.5 ms …  28.0 ms    108 runs
 
Benchmark 2: ./python -c 'pass'
  Time (mean ± σ):      10.8 ms ±   0.6 ms    [User: 8.9 ms, System: 2.3 ms]
  Range (min … max):    10.1 ms …  14.2 ms    190 runs
 
Summary
  './python -c 'pass'' ran
    2.28 ± 0.16 times faster than './python -c 'import subprocess''
```

### PR branch

```console
$ hyperfine --warmup 11 "./python -c 'import subprocess'" "./python -c 'pass'"
Benchmark 1: ./python -c 'import subprocess'
  Time (mean ± σ):      18.7 ms ±   0.8 ms    [User: 16.1 ms, System: 3.2 ms]
  Range (min … max):    17.6 ms …  21.7 ms    139 runs
 
Benchmark 2: ./python -c 'pass'
  Time (mean ± σ):      10.4 ms ±   0.5 ms    [User: 9.4 ms, System: 1.8 ms]
  Range (min … max):     9.7 ms …  12.9 ms    226 runs
 
Summary
  './python -c 'pass'' ran
    1.80 ± 0.11 times faster than './python -c 'import subprocess''
```

## Benchmark `subprocess.run` call 
In fact, this not only has an effect on import time, but simple `subprocess.run` calls, too:

### `main` branch

```console
$ hyperfine --warmup 11 "./python -c 'import subprocess; subprocess.run([\"sleep\", \"0\"])'" "./python -c 'pass'"
Benchmark 1: ./python -c 'import subprocess; subprocess.run(["sleep", "0"])'
  Time (mean ± σ):      26.7 ms ±   1.1 ms    [User: 23.4 ms, System: 3.4 ms]
  Range (min … max):    25.5 ms …  31.7 ms    103 runs
 
Benchmark 2: ./python -c 'pass'
  Time (mean ± σ):      11.7 ms ±   0.8 ms    [User: 9.5 ms, System: 2.4 ms]
  Range (min … max):    10.9 ms …  15.4 ms    235 runs
 
Summary
  './python -c 'pass'' ran
    2.28 ± 0.18 times faster than './python -c 'import subprocess; subprocess.run(["sleep", "0"])''
```

### PR branch

```console
$ hyperfine --warmup 11 "./python -c 'import subprocess; subprocess.run([\"sleep\", \"0\"])'" "./python -c 'pass'"
Benchmark 1: ./python -c 'import subprocess; subprocess.run(["sleep", "0"])'
  Time (mean ± σ):      22.0 ms ±   1.3 ms    [User: 18.1 ms, System: 3.9 ms]
  Range (min … max):    20.3 ms …  27.2 ms    119 runs
 
Benchmark 2: ./python -c 'pass'
  Time (mean ± σ):      12.0 ms ±   0.4 ms    [User: 9.8 ms, System: 2.3 ms]
  Range (min … max):    11.5 ms …  13.6 ms    224 runs
 
Summary
  './python -c 'pass'' ran
    1.84 ± 0.12 times faster than './python -c 'import subprocess; subprocess.run(["sleep", "0"])''
```


<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
