### PR TITLE
gh-118761: Always lazy import `warnings` in `threading`

### DIFF
--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -3,7 +3,6 @@
 import os as _os
 import sys as _sys
 import _thread
-import warnings
 
 from time import monotonic as _time
 from _weakrefset import WeakSet
@@ -133,6 +132,7 @@ def RLock(*args, **kwargs):
 
     """
     if args or kwargs:
+        import warnings
         warnings.warn(
             'Passing arguments to RLock is deprecated and will be removed in 3.15',
             DeprecationWarning,

--- a/Misc/NEWS.d/next/Library/2025-01-29-11-14-20.gh-issue-118761.gMZwE1.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-29-11-14-20.gh-issue-118761.gMZwE1.rst
@@ -1,0 +1,2 @@
+Always lazy import ``warnings`` in :mod:`threading`. Patch by Taneli
+Hukkinen.


### PR DESCRIPTION
`threading` seems to lazy import `warnings` in 8 locations, but also has a non-lazy import used in one location, rendering all the lazy imports useless.

This PR makes the one remaining non-lazy import also lazy.

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
