### PR TITLE
Improve performance of inplace additions

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1910,14 +1910,12 @@ v_iadd(digit *x, Py_ssize_t m, digit *y, Py_ssize_t n)
     digit carry = 0;
 
     assert(m >= n);
-    for (i = 0; i < n; ++i) {
-        carry += x[i] + y[i];
-        x[i] = carry & PyLong_MASK;
-        carry >>= PyLong_SHIFT;
-        assert((carry & 1) == carry);
-    }
-    for (; carry && i < m; ++i) {
-        carry += x[i];
+    for (i = 0; i < m; ++i) {
+        if (i < n) {
+            carry += x[i] + y[i];
+        } else {
+            carry += x[i];
+        }
         x[i] = carry & PyLong_MASK;
         carry >>= PyLong_SHIFT;
         assert((carry & 1) == carry);


### PR DESCRIPTION
This PR merges the two loops inside `v_iadd`. For exponents, this gives about a 10% speed improvement. 

```default
./python.exe -m timeit -n 100 -r 10 "2**1234567"
100 loops, best of 10: 5.01 msec per loop
# after
./python.exe -m timeit -n 100 -r 10 "2**1234567"
100 loops, best of 10: 4.53 msec per loop
```