### PR TITLE
CI: Change job name to 'build arm64' on Windows

### DIFF
--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build:
-    name: 'build and test (${{ inputs.arch }})'
+    name: ${{ inputs.arch == 'arm64' && 'build' || 'build and test' }} (${{ inputs.arch }})
     runs-on: ${{ inputs.os }}
     timeout-minutes: 60
     env:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

The arm64 jobs only build, and don't test, but the job name is build and test (arm64):

<img width="304" alt="image" src="https://github.com/user-attachments/assets/5485afe0-23eb-4dbd-a942-a47e0fb18db7" />

https://github.com/python/cpython/actions/runs/13029187014/job/36344506016?pr=129426

Until we can add testing, let's update the name to just "build (arm64)":

<img width="293" alt="image" src="https://github.com/user-attachments/assets/7b4a5568-6710-4481-bc67-289e68cec4f9" />

https://github.com/python/cpython/actions/runs/13030013914/job/36347048011?pr=129434
