### PR TITLE
[3.12]: CI: Change job name to 'build arm64' on Windows (#129434)

### DIFF
--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -20,9 +20,7 @@ env:
 
 jobs:
   build:
-    name: >-
-      build${{ inputs.arch != 'arm64' && ' and test' || '' }}
-      (${{ inputs.arch }})
+    name: ${{ inputs.arch == 'arm64' && 'build' || 'build and test' }} (${{ inputs.arch }})
     runs-on: windows-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
(cherry picked from commit c67afb581eccb3ce20a4965c8f407fd2662b6bdf)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Ah, `3.12` still had the shorter "build" name for arm64:

<img width="314" alt="image" src="https://github.com/user-attachments/assets/aed99583-fa86-4756-8ea7-fb8deb0df0ae" />

https://github.com/python/cpython/actions/runs/13032779142?pr=129443

It had been changed to "build and test" in https://github.com/python/cpython/pull/125786 for `3.13` and `main`, but not `3.12`.

This PR does it a little differently, but same end result. I suggest merging just to keep `3.12`/`3.13`/`main` in sync to avoid future confusion/conflicts.
