### PR TITLE
gh-129005: _pyio.BufferedIO remove copy on readall

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1062,6 +1062,9 @@ class BufferedReader(_BufferedIOMixin):
                 if chunk is None:
                     return buf[pos:] or None
                 else:
+                    # Avoid slice + copy if there is no data in buf
+                    if not buf:
+                        return chunk
                     return buf[pos:] + chunk
             chunks = [buf[pos:]]  # Strip the consumed bytes.
             current_size = 0

--- a/Misc/NEWS.d/next/Library/2025-01-29-00-00-01.gh-issue-129005.aV_3O8.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-29-00-00-01.gh-issue-129005.aV_3O8.rst
@@ -1,2 +1,2 @@
-Remove an unnecessary copy when ``_pyio.BufferedReader.read`` is called to
-read all data from a file and has no data already in buffer.
+:mod:`_pyio`: Remove an unnecessary copy when ``_pyio.BufferedReader.read()``
+is called to read all data from a file and has no data already in buffer.

--- a/Misc/NEWS.d/next/Library/2025-01-29-00-00-01.gh-issue-129005.aV_3O8.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-29-00-00-01.gh-issue-129005.aV_3O8.rst
@@ -1,2 +1,2 @@
-:mod:`_pyio`: Remove an unnecessary copy when ``_pyio.BufferedReader.read()``
+:mod:`!_pyio`: Remove an unnecessary copy when ``_pyio.BufferedReader.read()``
 is called to read all data from a file and has no data already in buffer.

--- a/Misc/NEWS.d/next/Library/2025-01-29-00-00-01.gh-issue-129005.aV_3O8.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-29-00-00-01.gh-issue-129005.aV_3O8.rst
@@ -1,0 +1,2 @@
+Remove an unnecessary copy when ``_pyio.BufferedReader.read`` is called to
+read all data from a file and has no data already in buffer.


### PR DESCRIPTION
Slicing buf and appending chunk would always result in a copy / another memory allocation of the length of chunk. Commonly in a readall there is no already read data in buf, and the amount of data read may be large, so the copy is expensive.

<!-- gh-issue-number: gh-129005 -->
* Issue: gh-129005
<!-- /gh-issue-number -->
