### PR TITLE
gh-129005: Align FileIO.readall allocation

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1674,22 +1674,31 @@ class FileIO(RawIOBase):
                 except OSError:
                     pass
 
-        result = bytearray()
+        result = bytearray(bufsize)
+        bytes_read = 0
         while True:
-            if len(result) >= bufsize:
-                bufsize = len(result)
-                bufsize += max(bufsize, DEFAULT_BUFFER_SIZE)
-            n = bufsize - len(result)
+            if bytes_read >= bufsize:
+                # Parallels _io/fileio.c new_buffersize
+                if bufsize > 65536:
+                    addend = bufsize >> 3
+                else:
+                    addend = bufsize + 256
+                if addend < DEFAULT_BUFFER_SIZE:
+                    addend = DEFAULT_BUFFER_SIZE
+                bufsize += addend
+                result[bytes_read:bufsize] = b'\0'
+            assert bufsize - bytes_read > 0, "Should always try and read at least one byte"
             try:
-                chunk = os.read(self._fd, n)
+                n = os.readinto(self._fd, memoryview(result)[bytes_read:])
             except BlockingIOError:
-                if result:
+                if bytes_read > 0:
                     break
                 return None
-            if not chunk: # reached the end of the file
+            if n == 0:  # reached the end of the file
                 break
-            result += chunk
+            bytes_read += n
 
+        del result[bytes_read:]
         return bytes(result)
 
     def readinto(self, buffer):

--- a/Misc/NEWS.d/next/Library/2025-01-28-21-22-44.gh-issue-129005.h57i9j.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-28-21-22-44.gh-issue-129005.h57i9j.rst
@@ -1,0 +1,1 @@
+``_pyio.FileIO.readall`` now allocates, resizes, and fills a data buffer using the same algorithm ``_io.FileIO.readall`` uses.

--- a/Misc/NEWS.d/next/Library/2025-01-28-21-22-44.gh-issue-129005.h57i9j.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-28-21-22-44.gh-issue-129005.h57i9j.rst
@@ -1,1 +1,2 @@
-``_pyio.FileIO.readall`` now allocates, resizes, and fills a data buffer using the same algorithm ``_io.FileIO.readall`` uses.
+``_pyio.FileIO.readall()`` now allocates, resizes, and fills a data buffer using
+the same algorithm ``_io.FileIO.readall()`` uses.


### PR DESCRIPTION
Both `_io` and `_pyio` now use a pre-allocated buffer of length `bufsize`, fill it using a `os.readinto` / `_Py_read`, and have matching "expand buffer" logic.

On my machine (Linux, Debug build) this takes: `./python -m test -M8g -uall test_largefile -m test_large_read -v` from ~3.7 seconds to ~3.3 seconds

`_pyio` still uses 2x the memory, there are two remaining copies
1. the `bytes(result)` currently copies. I'd like to either just rely on "duck typing" / bytearray is _close enough_ to bytes, or would need to do something similar to C++ "move" semantics where the bytes could take ownership of the data buffer from the bytearray without copying... Not sure what is most Pythonic
2. `_pyio.BufferedIO._read_unlocked` in the read-all case where no buffer has been allocated always does `return buf[:pos] + chunk` which causes another copy. Patch for that case / "if buf is length 0, just return" coming shortly.


<!-- gh-issue-number: gh-129005 -->
* Issue: gh-129005
<!-- /gh-issue-number -->
