### PR TITLE
GH-127432: add cross-build-linux as a required CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -621,6 +621,7 @@ jobs:
     - build_wasi
     - build_windows
     - build_windows_msi
+    - cross-build-linux
     - test_hypothesis
     - build_asan
     - build_tsan


### PR DESCRIPTION
cc @hugovk

<!-- gh-issue-number: gh-127432 -->
* Issue: gh-127432
<!-- /gh-issue-number -->
