### PR TITLE
gh-126609: docs: revert changes made to the internal structure of availability directive

### DIFF
--- a/Doc/tools/extensions/availability.py
+++ b/Doc/tools/extensions/availability.py
@@ -55,20 +55,12 @@ class Availability(SphinxDirective):
     final_argument_whitespace = True
 
     def run(self) -> list[nodes.container]:
-        title = "Availability"
-        refnode = addnodes.pending_xref(
-            title,
-            nodes.inline(title, title, classes=["xref", "std", "std-ref"]),
-            refdoc=self.env.docname,
-            refdomain="std",
-            refexplicit=True,
-            reftarget="availability",
-            reftype="ref",
-            refwarn=True,
-        )
-        sep = nodes.Text(": ")
-        parsed, msgs = self.state.inline_text(self.arguments[0], self.lineno)
-        pnode = nodes.paragraph(title, "", refnode, sep, *parsed, *msgs)
+        availability_ref = ':ref:`Availability <availability>`: '
+        avail_nodes, avail_msgs = self.state.inline_text(
+            availability_ref + self.arguments[0],
+            self.lineno)
+        pnode = nodes.paragraph(availability_ref + self.arguments[0],
+                                '', *avail_nodes, *avail_msgs)
         self.set_source_info(pnode)
         cnode = nodes.container("", pnode, classes=["availability"])
         self.set_source_info(cnode)

--- a/Doc/tools/extensions/availability.py
+++ b/Doc/tools/extensions/availability.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from docutils import nodes
-from sphinx import addnodes
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 

--- a/Doc/tools/extensions/availability.py
+++ b/Doc/tools/extensions/availability.py
@@ -56,10 +56,11 @@ class Availability(SphinxDirective):
     def run(self) -> list[nodes.container]:
         availability_ref = ':ref:`Availability <availability>`: '
         avail_nodes, avail_msgs = self.state.inline_text(
-            availability_ref + self.arguments[0],
-            self.lineno)
-        pnode = nodes.paragraph(availability_ref + self.arguments[0],
-                                '', *avail_nodes, *avail_msgs)
+            availability_ref + self.arguments[0], self.lineno
+        )
+        pnode = nodes.paragraph(
+            availability_ref + self.arguments[0], '', *avail_nodes, *avail_msgs
+        )
         self.set_source_info(pnode)
         cnode = nodes.container("", pnode, classes=["availability"])
         self.set_source_info(cnode)


### PR DESCRIPTION
# gh-126609: docs: revert changes made to the internal structure of availability directive

In #125082.

It exposes strings like <code>:ref:`Availability <availability>`: not WASI, not Android.</code> instead of just `Availability` and fixes rendering.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129482.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->