### PR TITLE
gh-129490: Avoid using deprecated typing aliases in `importlib`

### DIFF
--- a/Lib/importlib/metadata/__init__.py
+++ b/Lib/importlib/metadata/__init__.py
@@ -24,11 +24,12 @@ from ._functools import method_cache, pass_none
 from ._itertools import always_iterable, unique_everseen
 from ._meta import PackageMetadata, SimplePath
 
+from collections.abc import Iterable, Mapping
 from contextlib import suppress
 from importlib import import_module
 from importlib.abc import MetaPathFinder
 from itertools import starmap
-from typing import Any, Iterable, List, Mapping, Match, Optional, Set, cast
+from typing import Any, Match, Optional, cast
 
 __all__ = [
     'Distribution',
@@ -193,7 +194,7 @@ class EntryPoint:
         return match.group('attr')
 
     @property
-    def extras(self) -> List[str]:
+    def extras(self) -> list[str]:
         match = self.pattern.match(self.value)
         assert match is not None
         return re.findall(r'\w+', match.group('extras') or '')
@@ -278,14 +279,14 @@ class EntryPoints(tuple):
         return EntryPoints(ep for ep in self if ep.matches(**params))
 
     @property
-    def names(self) -> Set[str]:
+    def names(self) -> set[str]:
         """
         Return the set of all names of all entry points.
         """
         return {ep.name for ep in self}
 
     @property
-    def groups(self) -> Set[str]:
+    def groups(self) -> set[str]:
         """
         Return the set of all groups of all entry points.
         """
@@ -496,7 +497,7 @@ class Distribution(DeprecatedNonAbstract):
         return EntryPoints._from_text_for(self.read_text('entry_points.txt'), self)
 
     @property
-    def files(self) -> Optional[List[PackagePath]]:
+    def files(self) -> Optional[list[PackagePath]]:
         """Files in this distribution.
 
         :return: List of PackagePath for this distribution or None
@@ -589,7 +590,7 @@ class Distribution(DeprecatedNonAbstract):
         return text and map('"{}"'.format, text.splitlines())
 
     @property
-    def requires(self) -> Optional[List[str]]:
+    def requires(self) -> Optional[list[str]]:
         """Generated requirements specified for this Distribution"""
         reqs = self._read_dist_info_reqs() or self._read_egg_info_reqs()
         return reqs and list(reqs)
@@ -692,7 +693,7 @@ class DistributionFinder(MetaPathFinder):
             vars(self).update(kwargs)
 
         @property
-        def path(self) -> List[str]:
+        def path(self) -> list[str]:
             """
             The sequence of directory path that a distribution finder
             should search.
@@ -1011,7 +1012,7 @@ def entry_points(**params) -> EntryPoints:
     return EntryPoints(eps).select(**params)
 
 
-def files(distribution_name: str) -> Optional[List[PackagePath]]:
+def files(distribution_name: str) -> Optional[list[PackagePath]]:
     """Return a list of files for the named package.
 
     :param distribution_name: The name of the distribution package to query.
@@ -1020,7 +1021,7 @@ def files(distribution_name: str) -> Optional[List[PackagePath]]:
     return distribution(distribution_name).files
 
 
-def requires(distribution_name: str) -> Optional[List[str]]:
+def requires(distribution_name: str) -> Optional[list[str]]:
     """
     Return a list of requirements for the named package.
 
@@ -1030,7 +1031,7 @@ def requires(distribution_name: str) -> Optional[List[str]]:
     return distribution(distribution_name).requires
 
 
-def packages_distributions() -> Mapping[str, List[str]]:
+def packages_distributions() -> Mapping[str, list[str]]:
     """
     Return a mapping of top-level packages to their
     distributions.

--- a/Lib/importlib/metadata/_meta.py
+++ b/Lib/importlib/metadata/_meta.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
 from typing import Protocol
-from typing import Any, Dict, Iterator, List, Optional, TypeVar, Union, overload
+from typing import Any, Optional, TypeVar, Union, overload
 
 
 _T = TypeVar("_T")
@@ -29,16 +30,16 @@ class PackageMetadata(Protocol):
     @overload
     def get_all(
         self, name: str, failobj: None = None
-    ) -> Optional[List[Any]]: ...  # pragma: no cover
+    ) -> Optional[list[Any]]: ...  # pragma: no cover
 
     @overload
-    def get_all(self, name: str, failobj: _T) -> Union[List[Any], _T]:
+    def get_all(self, name: str, failobj: _T) -> Union[list[Any], _T]:
         """
         Return all values associated with a possibly multi-valued key.
         """
 
     @property
-    def json(self) -> Dict[str, Union[str, List[str]]]:
+    def json(self) -> dict[str, Union[str, list[str]]]:
         """
         A JSON-compatible form of the metadata.
         """

--- a/Lib/importlib/resources/abc.py
+++ b/Lib/importlib/resources/abc.py
@@ -3,7 +3,8 @@ import io
 import itertools
 import os
 import pathlib
-from typing import Any, BinaryIO, Iterable, Iterator, NoReturn, Text, Optional
+from collections.abc import Iterable, Iterator
+from typing import Any, BinaryIO, NoReturn, Optional
 from typing import runtime_checkable, Protocol
 from typing import Union
 
@@ -17,7 +18,7 @@ class ResourceReader(metaclass=abc.ABCMeta):
     """Abstract base class for loaders to provide resource reading support."""
 
     @abc.abstractmethod
-    def open_resource(self, resource: Text) -> BinaryIO:
+    def open_resource(self, resource: str) -> BinaryIO:
         """Return an opened, file-like object for binary reading.
 
         The 'resource' argument is expected to represent only a file name.
@@ -29,7 +30,7 @@ class ResourceReader(metaclass=abc.ABCMeta):
         raise FileNotFoundError
 
     @abc.abstractmethod
-    def resource_path(self, resource: Text) -> Text:
+    def resource_path(self, resource: str) -> str:
         """Return the file system path to the specified resource.
 
         The 'resource' argument is expected to represent only a file name.
@@ -42,7 +43,7 @@ class ResourceReader(metaclass=abc.ABCMeta):
         raise FileNotFoundError
 
     @abc.abstractmethod
-    def is_resource(self, path: Text) -> bool:
+    def is_resource(self, path: str) -> bool:
         """Return True if the named 'path' is a resource.
 
         Files are resources, directories are not.

--- a/Lib/importlib/resources/simple.py
+++ b/Lib/importlib/resources/simple.py
@@ -5,7 +5,7 @@ Interface adapters for low-level readers.
 import abc
 import io
 import itertools
-from typing import BinaryIO, List
+from typing import BinaryIO
 
 from .abc import Traversable, TraversableResources
 
@@ -24,14 +24,14 @@ class SimpleReader(abc.ABC):
         """
 
     @abc.abstractmethod
-    def children(self) -> List['SimpleReader']:
+    def children(self) -> list['SimpleReader']:
         """
         Obtain an iterable of SimpleReader for available
         child containers (e.g. directories).
         """
 
     @abc.abstractmethod
-    def resources(self) -> List[str]:
+    def resources(self) -> list[str]:
         """
         Obtain available named resources for this virtual package.
         """

--- a/Misc/NEWS.d/next/Library/2025-01-31-09-03-57.gh-issue-129490.akkQdh.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-31-09-03-57.gh-issue-129490.akkQdh.rst
@@ -1,0 +1,2 @@
+Now the type annotations import of ``importlib`` does not use the deprecated
+typing alias


### PR DESCRIPTION
See https://github.com/python/cpython/issues/129490

<!-- gh-issue-number: gh-129490 -->
* Issue: gh-129490
<!-- /gh-issue-number -->
