### PR TITLE
gh-129430: Make walking vm regions more efficient in MacOS

### DIFF
--- a/Modules/_testexternalinspection.c
+++ b/Modules/_testexternalinspection.c
@@ -232,15 +232,15 @@ search_map_for_section(pid_t pid, const char* secname, const char* substr) {
                    &count,
                    &object_name) == KERN_SUCCESS)
     {
-        int path_len = proc_regionfilename(
-            pid, address, map_filename, MAXPATHLEN);
-        if (path_len == 0) {
+        if ((region_info.protection & VM_PROT_READ) == 0
+            || (region_info.protection & VM_PROT_EXECUTE) == 0) {
             address += size;
             continue;
         }
 
-        if ((region_info.protection & VM_PROT_READ) == 0
-            || (region_info.protection & VM_PROT_EXECUTE) == 0) {
+        int path_len = proc_regionfilename(
+            pid, address, map_filename, MAXPATHLEN);
+        if (path_len == 0) {
             address += size;
             continue;
         }


### PR DESCRIPTION
Turns out the `proc_regionfilename` is very expensive in Intel mac when compiled with ASAN for some reason as this creates tons of VM regions and that call is very costly. To avoid unnecessary lookups, check first if the section are READ/WRITE before checking for the region filename

<!-- gh-issue-number: gh-129430 -->
* Issue: gh-129430
<!-- /gh-issue-number -->
