### PR TITLE
gh-129005: Remove copy in `_pyio.FileIO.readall()`

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1702,7 +1702,7 @@ class FileIO(RawIOBase):
             bytes_read += n
 
         del result[bytes_read:]
-        return bytes(result)
+        return result
 
     def readinto(self, buffer):
         """Same as RawIOBase.readinto()."""

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -56,9 +56,7 @@ class TestFileMethods(LargeFileTest):
     (i.e. > 2 GiB) files.
     """
 
-    # _pyio.FileIO.readall() uses a temporary bytearray then casted to bytes,
-    # so memuse=2 is needed
-    @bigmemtest(size=size, memuse=2, dry_run=False)
+    @bigmemtest(size=size, memuse=1, dry_run=False)
     def test_large_read(self, _size):
         # bpo-24658: Test that a read greater than 2GB does not fail.
         with self.open(TESTFN, "rb") as f:
@@ -154,7 +152,7 @@ class TestFileMethods(LargeFileTest):
                 f.seek(pos)
                 self.assertTrue(f.seekable())
 
-    @bigmemtest(size=size, memuse=2, dry_run=False)
+    @bigmemtest(size=size, memuse=1, dry_run=False)
     def test_seek_readall(self, _size):
         # Seek which doesn't change position should readall successfully.
         with self.open(TESTFN, 'rb') as f:

--- a/Misc/NEWS.d/next/Library/2025-01-28-21-51-50.gh-issue-129005.OIdODu.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-28-21-51-50.gh-issue-129005.OIdODu.rst
@@ -1,0 +1,2 @@
+:mod:`!_pyio`: Return bytearray from ``_pyio.FileIO.readall()`` rather than
+copying into a bytes. Memory usage now matches ``_io.FileIO.readall()``


### PR DESCRIPTION
This aligns the memory usage between _pyio and _io. Both now use the same amount of memory when reading a file.

On my linux dev box, drops `./python -m test -M8g -uall test_largefile -m test_large_read -v` from ~3.3 to ~2.4 seconds.

```
./python -m test -M8g -uall test_largefile -m test_large_read -v
Checked 112 modules (34 built-in, 77 shared, 1 n/a on linux-x86_64, 0 disabled, 0 missing, 0 failed on import)
== CPython 3.14.0a4+ (heads/pyio_readall_match_mem-dirty:9d23eb4375b, Jan 30 2025, 20:33:11) [Clang 19.1.7 ]
== Linux-6.12.10-arch1-1-x86_64-with-glibc2.40 little-endian
== Python build: debug
== cwd: <workdir>/python/build/build/test_python_worker_486953æ
== CPU count: 32
== encodings: locale=UTF-8 FS=utf-8
== resources: all

Using random seed: 4286629456
0:00:00 load avg: 1.00 Run 1 test sequentially in a single process
0:00:00 load avg: 1.00 [1/1] test_largefile
test_large_read (test.test_largefile.CLargeFileTest.test_large_read) ... 
 ... expected peak memory use: 2.3G
 ... process data size: 2.3G
ok
test_large_read (test.test_largefile.PyLargeFileTest.test_large_read) ... 
 ... expected peak memory use: 2.3G
 ... process data size: 2.3G
 ... process data size: 2.3G
ok

----------------------------------------------------------------------
Ran 2 tests in 2.353s

OK

== Tests result: SUCCESS ==

1 test OK.

Total duration: 2.4 sec
Total tests: run=2 (filtered)
Total test files: run=1/1 (filtered)
Result: SUCCESS
```

<!-- gh-issue-number: gh-129005 -->
* Issue: gh-129005
<!-- /gh-issue-number -->
