### PR TITLE
gh-129205: Use os.readinto() in subprocess errpipe_read

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1921,12 +1921,13 @@ class Popen:
 
                 # Wait for exec to fail or succeed; possibly raising an
                 # exception (limited in size)
-                errpipe_data = bytearray()
-                while True:
-                    part = os.read(errpipe_read, 50000)
-                    errpipe_data += part
-                    if not part or len(errpipe_data) > 50000:
-                        break
+                errpipe_data = bytearray(50000)
+                unread = memoryview(errpipe_data)
+                while count := os.readinto(errpipe_read, unread):
+                    unread = unread[count:]
+                bytes_left = len(unread)
+                del unread
+                del errpipe_data[-bytes_left:]
             finally:
                 # be sure the FD is closed no matter what
                 os.close(errpipe_read)

--- a/Misc/NEWS.d/next/Library/2025-02-02-20-55-18.gh-issue-129205.hb1iMy.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-02-20-55-18.gh-issue-129205.hb1iMy.rst
@@ -1,0 +1,1 @@
+:mod:`subprocess` forkserver now uses a fixed 50,000 byte buffer to read startup errors from the child processes it runs. Previously there could be up to 100,000 bytes read with multiple allocations and copies.


### PR DESCRIPTION
Read into a pre-allocated fixed size buffer.

The previous code the buffer could actually get to 100_000 bytes in two reads (first read returns 50_000, second pass through loop gets another 50_000), so this does change behavior. I think the fixed length of 50_000 was the intention though. This is used to pass exception issues that happen during _fork_exec from the child to parent process.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129205 -->
* Issue: gh-129205
<!-- /gh-issue-number -->
