### PR TITLE
Revert "gh-129005: _pyio.BufferedIO remove copy on readall (#129454)"

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1062,9 +1062,6 @@ class BufferedReader(_BufferedIOMixin):
                 if chunk is None:
                     return buf[pos:] or None
                 else:
-                    # Avoid slice + copy if there is no data in buf
-                    if not buf:
-                        return chunk
                     return buf[pos:] + chunk
             chunks = [buf[pos:]]  # Strip the consumed bytes.
             current_size = 0

--- a/Misc/NEWS.d/next/Library/2025-01-29-00-00-01.gh-issue-129005.aV_3O8.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-29-00-00-01.gh-issue-129005.aV_3O8.rst
@@ -1,2 +1,0 @@
-:mod:`!_pyio`: Remove an unnecessary copy when ``_pyio.BufferedReader.read()``
-is called to read all data from a file and has no data already in buffer.


### PR DESCRIPTION
This reverts commit e1c4ba928852eac0b0e0bded1c314e3e36975286.

This seems to be the commit where bots started failing. Not sure why.

cc: @vstinner 

<!-- gh-issue-number: gh-129005 -->
* Issue: gh-129005
<!-- /gh-issue-number -->
