### PR TITLE
GH-128469: Revert "warn when libpython was loaded from outside the build directory (#128645)"

### DIFF
--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -1,13 +1,7 @@
 import copy
 import ntpath
-import os
 import pathlib
 import posixpath
-import shutil
-import subprocess
-import sys
-import sysconfig
-import tempfile
 import unittest
 
 from test.support import verbose
@@ -869,37 +863,6 @@ class MockGetPathTests(unittest.TestCase):
         )
         actual = getpath(ns, expected)
         self.assertEqual(expected, actual)
-
-
-class RealGetPathTests(unittest.TestCase):
-    @unittest.skipUnless(
-        sysconfig.is_python_build(),
-        'Test only available when running from the buildir',
-    )
-    @unittest.skipUnless(
-        any(sys.platform.startswith(p) for p in ('linux', 'freebsd', 'centos')),
-        'Test only support on Linux-like OS-es (support LD_LIBRARY_PATH)',
-    )
-    @unittest.skipUnless(
-        sysconfig.get_config_var('LDLIBRARY') != sysconfig.get_config_var('LIBRARY'),
-        'Test only available when using a dynamic libpython',
-    )
-    def test_builddir_wrong_library_warning(self):
-        library_name = sysconfig.get_config_var('INSTSONAME')
-        with tempfile.TemporaryDirectory() as tmpdir:
-            shutil.copy2(
-                os.path.join(sysconfig.get_config_var('srcdir'), library_name),
-                os.path.join(tmpdir, library_name)
-            )
-            env = os.environ.copy()
-            env['LD_LIBRARY_PATH'] = tmpdir
-            process = subprocess.run(
-                [sys.executable, '-c', ''],
-                env=env, check=True, capture_output=True, text=True,
-            )
-        error_msg = 'The runtime library has been loaded from outside the build directory'
-        self.assertTrue(process.stderr.startswith(error_msg), process.stderr)
-
 
 # ******************************************************************************
 

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -786,19 +786,6 @@ if os_name != 'nt' and build_prefix:
 
 
 # ******************************************************************************
-# MISC. RUNTIME WARNINGS
-# ******************************************************************************
-
-# When running Python from the build directory, if libpython is dynamically
-# linked, the wrong library might be loaded.
-if build_prefix and library and not dirname(abspath(library)).startswith(build_prefix):
-    msg = f'The runtime library has been loaded from outside the build directory ({library})!'
-    if os_name == 'posix':
-        msg += ' Consider setting LD_LIBRARY_PATH=. to force it to be loaded from the build directory.'
-    warn(msg)
-
-
-# ******************************************************************************
 # SET pythonpath FROM _PTH FILE
 # ******************************************************************************
 


### PR DESCRIPTION
This reverts commit 29b3ce8355b7d141ef61fa28757b7ff389189604.

The new test fails on several Tier-1 buildbots. Per PEP-11, “any breakage should be fixed or reverted immediately”. It's important to keep the tests passing so that we can use them to detect other issues.

I hope the issue can be fixed again soon. Please send a new PR, and add the `test-with-buildbots` label to check ahead of time.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128469 -->
* Issue: gh-128469
<!-- /gh-issue-number -->
