### PR TITLE
GH-128563: (Re)move some labels, to simplify implementing tailcalling interpeter.

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5303,14 +5303,11 @@ dummy_func(
                 tstate->c_recursion_remaining += PY_EVAL_C_STACK_UNITS;
                 return NULL;
             }
-            goto resume_with_error;
-        }
-
-        label(resume_with_error) {
             next_instr = frame->instr_ptr;
             stack_pointer = _PyFrame_GetStackPointer(frame);
             goto error;
         }
+
 // END BYTECODES //
 
     }
@@ -5320,7 +5317,6 @@ dummy_func(
  exit_unwind:
  handle_eval_breaker:
  resume_frame:
- resume_with_error:
  start_frame:
  unbound_local_error:
     ;

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5308,6 +5308,35 @@ dummy_func(
             goto error;
         }
 
+        label(start_frame) {
+            if (_Py_EnterRecursivePy(tstate)) {
+                goto exit_unwind;
+            }
+            next_instr = frame->instr_ptr;
+            stack_pointer = _PyFrame_GetStackPointer(frame);
+
+        #ifdef LLTRACE
+            {
+                int lltrace = maybe_lltrace_resume_frame(frame, GLOBALS());
+                frame->lltrace = lltrace;
+                if (lltrace < 0) {
+                    goto exit_unwind;
+                }
+            }
+        #endif
+
+        #ifdef Py_DEBUG
+            /* _PyEval_EvalFrameDefault() must not be called with an exception set,
+            because it can clear it (directly or indirectly) and so the
+            caller loses its exception */
+            assert(!_PyErr_Occurred(tstate));
+        #endif
+
+            DISPATCH();
+        }
+
+
+
 // END BYTECODES //
 
     }

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -381,7 +381,9 @@ do {                                                   \
     tstate->previous_executor = NULL;                  \
     frame = tstate->current_frame;                     \
     if (next_instr == NULL) {                          \
-        goto resume_with_error;                        \
+        next_instr = frame->instr_ptr;                 \
+        stack_pointer = _PyFrame_GetStackPointer(frame); \
+        goto error;                                    \
     }                                                  \
     stack_pointer = _PyFrame_GetStackPointer(frame);   \
     DISPATCH();                                        \

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -8708,5 +8708,32 @@
             goto error;
         }
 
+        start_frame:
+        {
+            if (_Py_EnterRecursivePy(tstate)) {
+                goto exit_unwind;
+            }
+            next_instr = frame->instr_ptr;
+            stack_pointer = _PyFrame_GetStackPointer(frame);
+            #ifdef LLTRACE
+            {
+                int lltrace = maybe_lltrace_resume_frame(frame, GLOBALS());
+                frame->lltrace = lltrace;
+                if (lltrace < 0) {
+                    goto exit_unwind;
+                }
+            }
+            #endif
+
+            #ifdef Py_DEBUG
+            /* _PyEval_EvalFrameDefault() must not be called with an exception set,
+               because it can clear it (directly or indirectly) and so the
+               caller loses its exception */
+            assert(!_PyErr_Occurred(tstate));
+            #endif
+
+            DISPATCH();
+        }
+
 /* END LABELS */
 #undef TIER_ONE

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -8703,11 +8703,6 @@
                 tstate->c_recursion_remaining += PY_EVAL_C_STACK_UNITS;
                 return NULL;
             }
-            goto resume_with_error;
-        }
-
-        resume_with_error:
-        {
             next_instr = frame->instr_ptr;
             stack_pointer = _PyFrame_GetStackPointer(frame);
             goto error;

--- a/Tools/cases_generator/analyzer.py
+++ b/Tools/cases_generator/analyzer.py
@@ -511,7 +511,6 @@ def has_error_with_pop(op: parser.InstDef) -> bool:
         variable_used(op, "ERROR_IF")
         or variable_used(op, "pop_1_error")
         or variable_used(op, "exception_unwind")
-        or variable_used(op, "resume_with_error")
     )
 
 
@@ -520,7 +519,6 @@ def has_error_without_pop(op: parser.InstDef) -> bool:
         variable_used(op, "ERROR_NO_POP")
         or variable_used(op, "pop_1_error")
         or variable_used(op, "exception_unwind")
-        or variable_used(op, "resume_with_error")
     )
 
 


### PR DESCRIPTION
Following on from [an earlier discussion](https://github.com/python/cpython/pull/128718#discussion_r1935440005): It complicates the code a lot if we need to be able to jump from generated code back into manually written labels and vice-versa.

This PR refactors the code so that there are only two transfers from the the code in ceval.c to bytecodes.c and none the other way,
for tier 1 (we can do much the same for tier 2 later).

The two transfers from `PyEval_EvalDefault` into the interpreter "loop" are:
* `goto error;` on line 847
* `goto start_frame;` on line 856

<!-- gh-issue-number: gh-128563 -->
* Issue: gh-128563
<!-- /gh-issue-number -->
