### PR TITLE
gh-129539: Include sysexits.h before checking EX_OK

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-01-31-19-01-24.gh-issue-129539.6ndioH.rst
+++ b/Misc/NEWS.d/next/Build/2025-01-31-19-01-24.gh-issue-129539.6ndioH.rst
@@ -1,0 +1,1 @@
+Don't redefine ``EX_OK`` when the system has the ``sysexits.h`` header.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -52,10 +52,6 @@
 #  include "winreparse.h"
 #endif
 
-#if !defined(EX_OK) && defined(EXIT_SUCCESS)
-#  define EX_OK EXIT_SUCCESS
-#endif
-
 #ifdef __APPLE__
  /* Needed for the implementation of os.statvfs */
 #  include <sys/param.h>
@@ -292,7 +288,11 @@ corresponding Unix manual entries for more information on calls.");
 #endif
 
 #ifdef HAVE_SYSEXITS_H
-#  include <sysexits.h>
+#  include <sysexits.h>           //  EX_OK
+#endif
+
+#if !defined(EX_OK) && defined(EXIT_SUCCESS)
+#  define EX_OK EXIT_SUCCESS
 #endif
 
 #ifdef HAVE_SYS_LOADAVG_H


### PR DESCRIPTION
Previously the macro would be redefined when the header was included.


<!-- gh-issue-number: gh-129539 -->
* Issue: gh-129539
<!-- /gh-issue-number -->
