### PR TITLE
gh-129005: Fix buffer expansion in _pyio.FileIO.readall

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -10,6 +10,7 @@ import stat
 import sys
 # Import _thread instead of threading to reduce startup cost
 from _thread import allocate_lock as Lock
+from itertools import repeat
 if sys.platform in {'win32', 'cygwin'}:
     from msvcrt import setmode as _setmode
 else:
@@ -1686,7 +1687,8 @@ class FileIO(RawIOBase):
                 if addend < DEFAULT_BUFFER_SIZE:
                     addend = DEFAULT_BUFFER_SIZE
                 bufsize += addend
-                result[bytes_read:bufsize] = b'\0'
+                result.extend(repeat(0, addend))
+                assert len(result) == bufsize, "Should have expanded in size"
             assert bufsize - bytes_read > 0, "Should always try and read at least one byte"
             try:
                 n = os.readinto(self._fd, memoryview(result)[bytes_read:])

--- a/Misc/NEWS.d/next/Library/2025-01-31-19-07-31.gh-issue-129005.II6go0.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-31-19-07-31.gh-issue-129005.II6go0.rst
@@ -1,0 +1,1 @@
+:mod:`!pyio`: Fix expansion of buffer in _pyio.FileIO.readall


### PR DESCRIPTION
Move to a linear slice append with an iterator which has a length hint. This is more expensive then PyByteArray_Resize, but I think as efficient as can get without a new bytearray Python API to resize.

The previous code didn't append as I had intended:

```python
a = bytearray()
>>> a[0:5] = b'\0'
>>> a
bytearray(b'\x00')
>>> a[5:16] = b'\01'
>>> a
bytearray(b'\x00\x01')
>>> len(a)
2
```

This should get the buildbots which are failing on `test_io.test_io.PyMiscIOTest` back to green. (A number have independent failures on `test_getpath` still)

What `bytearray.resize` looks like (Wrapping the C API): https://github.com/python/cpython/compare/main...cmaloney:cpython:resize_fixup?expand=0 (Currently that returns an int, but probably would make sense to return None)

<!-- gh-issue-number: gh-129005 -->
* Issue: gh-129005
<!-- /gh-issue-number -->
