### PR TITLE
gh-119461: Restore the testSocket VSOCK skipUnless removed by PR #119465

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -520,6 +520,8 @@ class ThreadedRDSSocketTest(SocketRDSTest, ThreadableTest):
 @unittest.skipIf(WSL, 'VSOCK does not work on Microsoft WSL')
 @unittest.skipUnless(HAVE_SOCKET_VSOCK,
           'VSOCK sockets required for this test.')
+@unittest.skipUnless(get_cid() != 2,  # VMADDR_CID_HOST
+                     "This test can only be run on a virtual guest.")
 class ThreadedVSOCKSocketStreamTest(unittest.TestCase, ThreadableTest):
 
     def __init__(self, methodName='runTest'):


### PR DESCRIPTION
This test can only pass on virtual machines, not actual machines.

actual machines see:

```
    self.cli.connect((cid, VSOCKPORT))
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
OSError: [Errno 19] No such device
```

Reproduced on Ubuntu 24.04.1 running 6.8.0-52-generic.


<!-- gh-issue-number: gh-119461 -->
* Issue: gh-119461
<!-- /gh-issue-number -->
