### PR TITLE
Revert "gh-129005: Align FileIO.readall() allocation (#129458)"

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1674,31 +1674,22 @@ class FileIO(RawIOBase):
                 except OSError:
                     pass
 
-        result = bytearray(bufsize)
-        bytes_read = 0
+        result = bytearray()
         while True:
-            if bytes_read >= bufsize:
-                # Parallels _io/fileio.c new_buffersize
-                if bufsize > 65536:
-                    addend = bufsize >> 3
-                else:
-                    addend = bufsize + 256
-                if addend < DEFAULT_BUFFER_SIZE:
-                    addend = DEFAULT_BUFFER_SIZE
-                bufsize += addend
-                result[bytes_read:bufsize] = b'\0'
-            assert bufsize - bytes_read > 0, "Should always try and read at least one byte"
+            if len(result) >= bufsize:
+                bufsize = len(result)
+                bufsize += max(bufsize, DEFAULT_BUFFER_SIZE)
+            n = bufsize - len(result)
             try:
-                n = os.readinto(self._fd, memoryview(result)[bytes_read:])
+                chunk = os.read(self._fd, n)
             except BlockingIOError:
-                if bytes_read > 0:
+                if result:
                     break
                 return None
-            if n == 0:  # reached the end of the file
+            if not chunk: # reached the end of the file
                 break
-            bytes_read += n
+            result += chunk
 
-        del result[bytes_read:]
         return bytes(result)
 
     def readinto(self, buffer):

--- a/Misc/NEWS.d/next/Library/2025-01-28-21-22-44.gh-issue-129005.h57i9j.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-28-21-22-44.gh-issue-129005.h57i9j.rst
@@ -1,2 +1,0 @@
-``_pyio.FileIO.readall()`` now allocates, resizes, and fills a data buffer using
-the same algorithm ``_io.FileIO.readall()`` uses.


### PR DESCRIPTION
This reverts commit f927204f64b3f8dbecec784e05bc8e25d2a78b2e.

@vstinner : Should get the buildbots back green, then can work on new features like `bytearray.resize()`. Feels like I’ve been rushing digging more holes rather than get all green.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129005 -->
* Issue: gh-129005
<!-- /gh-issue-number -->
