### PR TITLE
[3.12] gh-129573: Fix abort from non-string suggestions in `calculate_suggestions`

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -3166,6 +3166,17 @@ class SuggestionFormattingTestBase:
         actual = self.get_suggestion(A(), 'bluch')
         self.assertNotIn("blech", actual)
 
+    def test_suggestions_do_not_trigger_with_non_string_candidates(self):
+        class Parent:
+            def __dir__(self):
+                return [0]
+
+        class WithNonStringAttrs(Parent):
+            blech = None
+
+        result = self.get_suggestion(WithNonStringAttrs(), "bluch")
+        self.assertNotIn(result, "blech")
+
     def test_getattr_suggestions_no_args(self):
         class A:
             blech = None

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -151,6 +151,10 @@ calculate_suggestions(PyObject *dir,
     }
     for (int i = 0; i < dir_size; ++i) {
         PyObject *item = PyList_GET_ITEM(dir, i);
+        if (!PyUnicode_Check(item)) {
+            PyMem_Free(buffer);
+            return NULL;
+        }
         if (_PyUnicode_Equal(name, item)) {
             continue;
         }


### PR DESCRIPTION
This PR adds a simple check that suggestion candidates are strings in `calculate_suggestions`, avoiding an abort in debug builds from code like below:

```python
class Parent:
    def __dir__(self):
        return [0]

class WithNonStringAttrs(Parent):
    blech = None

WithNonStringAttrs().bluch
```

Found using [fusil](https://github.com/devdanzin/fusil) by @vstinner.

<!-- gh-issue-number: gh-129573 -->
* Issue: gh-129573
<!-- /gh-issue-number -->
