### PR TITLE
[3.11] Docs: pin python-docs-theme to 2025.2

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -16,6 +16,6 @@ sphinx-notfound-page==1.0.0
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.
-python-docs-theme>=2023.3.1,!=2023.7
+python-docs-theme==2024.12
 
 -c constraints.txt

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -16,6 +16,6 @@ sphinx-notfound-page==1.0.0
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.
-python-docs-theme==2024.12
+python-docs-theme==2025.2
 
 -c constraints.txt


### PR DESCRIPTION
We pinned python-docs-theme in February last year (#115351) for Python 3.8 and 3.9. I propose doing the same for Python 3.10 and 3.11. This would simplify maintenence of p-d-t, as we can reduce our support for Sphinx versions from $3.4 \le x \le 8.1$ to just Sphinx 8.1, at the extreme.

See also https://github.com/python/python-docs-theme/pull/216.

cc @pablogsal as release manager for 3.10 and 3.11.

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129576.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->