### PR TITLE
gh-129578: Fix collection of doctests from wrapped objects

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -1366,7 +1366,7 @@ DocTestFinder objects
    :class:`DocTestFinder` defines the following method:
 
 
-   .. method:: find(obj[, name][, module][, globs][, extraglobs])
+   .. method:: find(obj[, name][, module][, globs][, extraglobs][, follow_wrapped])
 
       Return a list of the :class:`DocTest`\ s that are defined by *obj*'s
       docstring, or by any of its contained objects' docstrings.
@@ -1402,6 +1402,12 @@ DocTestFinder objects
       specified, or ``{}`` otherwise.  If *extraglobs* is not specified, then it
       defaults to ``{}``.
 
+      If *follow_wrapped* is ``True``, :func:`inspect.unwrap` is used to unwrap
+      all objects before they are searched for doctests.
+
+      .. versionchanged:: 3.14
+         The *follow_wrapped* parameter was added.
+         Pass ``False`` to search objects for doctests without unwrapping them first.
 
 .. _doctest-doctestparser:
 

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -1029,6 +1029,8 @@ class singledispatchmethod:
         import weakref # see comment in singledispatch function
         self._method_cache = weakref.WeakKeyDictionary()
 
+        update_wrapper(self, func)
+
     def register(self, cls, method=None):
         """generic_method.register(cls, func) -> func
 

--- a/Lib/test/test_doctest/test_doctest.py
+++ b/Lib/test/test_doctest/test_doctest.py
@@ -123,6 +123,22 @@ class SampleClass:
         """
         return "hello"
 
+    @functools.singledispatchmethod
+    def a_singledispatchmethod(self, arg):
+        """
+        >>> print(SampleClass(30).a_singledispatchmethod(30))
+        int
+        >>> print(SampleClass(30).a_singledispatchmethod("30"))
+        base
+        """
+        return "base"
+
+    @a_singledispatchmethod.register(int)
+    def _(self, arg):
+        return "int"
+
+    del _
+
     class NestedClass:
         """
         >>> x = SampleClass.NestedClass(5)
@@ -528,6 +544,7 @@ methods, classmethods, staticmethods, properties, and nested classes.
      1  SampleClass.a_cached_property
      2  SampleClass.a_classmethod
      1  SampleClass.a_property
+     2  SampleClass.a_singledispatchmethod
      1  SampleClass.a_staticmethod
      1  SampleClass.double
      1  SampleClass.get
@@ -585,6 +602,7 @@ functions, classes, and the `__test__` dictionary, if it exists:
      1  some_module.SampleClass.a_cached_property
      2  some_module.SampleClass.a_classmethod
      1  some_module.SampleClass.a_property
+     2  some_module.SampleClass.a_singledispatchmethod
      1  some_module.SampleClass.a_staticmethod
      1  some_module.SampleClass.double
      1  some_module.SampleClass.get
@@ -642,6 +660,7 @@ By default, an object with no doctests doesn't create any tests:
      1  SampleClass.a_cached_property
      2  SampleClass.a_classmethod
      1  SampleClass.a_property
+     2  SampleClass.a_singledispatchmethod
      1  SampleClass.a_staticmethod
      1  SampleClass.double
      1  SampleClass.get
@@ -664,6 +683,7 @@ displays.
      1  SampleClass.a_cached_property
      2  SampleClass.a_classmethod
      1  SampleClass.a_property
+     2  SampleClass.a_singledispatchmethod
      1  SampleClass.a_staticmethod
      1  SampleClass.double
      1  SampleClass.get

--- a/Misc/NEWS.d/next/Library/2025-02-02-14-06-32.gh-issue-129578.t_mZ1C.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-02-14-06-32.gh-issue-129578.t_mZ1C.rst
@@ -1,0 +1,5 @@
+Add *follow_wrapped* parameter to :func:`doctest.DocTestFinder.find` to
+unwrap objects before searching them for doctests.
+
+Add :func:`functools.update_wrapper` call to constructor of
+:class:`functools.singledispatchmethod` to let it be searched by doctest.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Add `follow_wrapped` parameter to `doctest.DocTestFinder.find` to
unwrap objects before searching them for doctests.

Add `functools.update_wrapper` call to constructor of
`functools.singledispatchmethod` to let it be searched by doctest.

<!-- gh-issue-number: gh-129578 -->
* Issue: gh-129578
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129579.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->