### PR TITLE
[3.13] gh-129539: Include sysexits.h before checking EX_OK

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-02-02-09-11-45.gh-issue-129539.SYXXCg.rst
+++ b/Misc/NEWS.d/next/Build/2025-02-02-09-11-45.gh-issue-129539.SYXXCg.rst
@@ -1,0 +1,1 @@
+Don't redefine ``EX_OK`` when the system has the ``sysexits.h`` header.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -52,10 +52,6 @@
 #  include "winreparse.h"
 #endif
 
-#if !defined(EX_OK) && defined(EXIT_SUCCESS)
-#  define EX_OK EXIT_SUCCESS
-#endif
-
 #ifdef __APPLE__
  /* Needed for the implementation of os.statvfs */
 #  include <sys/param.h>
@@ -290,6 +286,10 @@ corresponding Unix manual entries for more information on calls.");
 
 #ifdef HAVE_SYSEXITS_H
 #  include <sysexits.h>
+#endif
+
+#if !defined(EX_OK) && defined(EXIT_SUCCESS)
+#  define EX_OK EXIT_SUCCESS
 #endif
 
 #ifdef HAVE_SYS_LOADAVG_H


### PR DESCRIPTION
Creating #129540 for the 3.13 branch instead of master.

<!-- gh-issue-number: gh-129539 -->
* Issue: gh-129539
<!-- /gh-issue-number -->
