### PR TITLE
[3.13] gh-127096: Do not recreate unnamed section on every read in ConfigParser (GH-127228)

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -1093,11 +1093,7 @@ class RawConfigParser(MutableMapping):
     def _handle_rest(self, st, line, fpname):
         # a section header or option header?
         if self._allow_unnamed_section and st.cursect is None:
-            st.sectname = UNNAMED_SECTION
-            st.cursect = self._dict()
-            self._sections[st.sectname] = st.cursect
-            self._proxies[st.sectname] = SectionProxy(self, st.sectname)
-            st.elements_added.add(st.sectname)
+            self._handle_header(st, UNNAMED_SECTION, fpname)
 
         st.indent_level = st.cur_indent_level
         # is it a section header?
@@ -1106,10 +1102,10 @@ class RawConfigParser(MutableMapping):
         if not mo and st.cursect is None:
             raise MissingSectionHeaderError(fpname, st.lineno, line)
 
-        self._handle_header(st, mo, fpname) if mo else self._handle_option(st, line, fpname)
+        self._handle_header(st, mo.group('header'), fpname) if mo else self._handle_option(st, line, fpname)
 
-    def _handle_header(self, st, mo, fpname):
-        st.sectname = mo.group('header')
+    def _handle_header(self, st, sectname, fpname):
+        st.sectname = sectname
         if st.sectname in self._sections:
             if self._strict and st.sectname in st.elements_added:
                 raise DuplicateSectionError(st.sectname, fpname,

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -2161,6 +2161,15 @@ class SectionlessTestCase(unittest.TestCase):
         self.assertEqual('1', cfg2[configparser.UNNAMED_SECTION]['a'])
         self.assertEqual('2', cfg2[configparser.UNNAMED_SECTION]['b'])
 
+    def test_multiple_configs(self):
+        cfg = configparser.ConfigParser(allow_unnamed_section=True)
+        cfg.read_string('a = 1')
+        cfg.read_string('b = 2')
+
+        self.assertEqual([configparser.UNNAMED_SECTION], cfg.sections())
+        self.assertEqual('1', cfg[configparser.UNNAMED_SECTION]['a'])
+        self.assertEqual('2', cfg[configparser.UNNAMED_SECTION]['b'])
+
 
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):

--- a/Misc/NEWS.d/next/Library/2024-11-24-22-06-42.gh-issue-127096.R7LLpQ.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-24-22-06-42.gh-issue-127096.R7LLpQ.rst
@@ -1,0 +1,2 @@
+Do not recreate unnamed section on every read in
+:class:`configparser.ConfigParser`. Patch by Andrey Efremov.


### PR DESCRIPTION


<!-- gh-issue-number: gh-127096 -->
* Issue: gh-127096
<!-- /gh-issue-number -->
