### PR TITLE
gh-126609: localize list, allow translation of a phrase, use ge operator character in the availability directive

### DIFF
--- a/Doc/tools/extensions/availability.py
+++ b/Doc/tools/extensions/availability.py
@@ -52,16 +52,6 @@ _THREADING = frozenset({
 KNOWN_PLATFORMS = _PLATFORMS | _LIBC | _THREADING
 
 
-def _print_platform(
-    platform: str, version: str | bool
-) -> str | Callable[[str], str]:
-    if version is True:
-        return platform
-    if not version:
-        return sphinx_gettext("not {platform}").format(platform=platform)
-    return f"{platform} ≥ {version}"
-
-
 class Availability(SphinxDirective):
     has_content = True
     required_arguments = 1
@@ -130,6 +120,16 @@ class Availability(SphinxDirective):
             )
 
         return platforms
+
+
+def _print_platform(
+    platform: str, version: str | bool
+) -> str | Callable[[str], str]:
+    if version is True:
+        return platform
+    if not version:
+        return sphinx_gettext("not {platform}").format(platform=platform)
+    return f"{platform} ≥ {version}"
 
 
 def setup(app: Sphinx) -> ExtensionMetadata:

--- a/Doc/tools/extensions/availability.py
+++ b/Doc/tools/extensions/availability.py
@@ -119,7 +119,7 @@ class Availability(SphinxDirective):
         return platforms
 
 
-def _print_platform(platform: str, version: str | bool) -> str:
+def _format_platform(platform: str, version: str | bool) -> str:
     if version is True:
         return platform
     if not version:

--- a/Doc/tools/extensions/availability.py
+++ b/Doc/tools/extensions/availability.py
@@ -71,7 +71,7 @@ class Availability(SphinxDirective):
         )
         sep = nodes.Text(": ")
         platforms = self.parse_platforms()
-        platforms_text = f"{format_list(list(starmap(_print_platform, platforms.items())), locale=self.config.language)}."
+        platforms_text = f"{format_list(list(starmap(_format_platform, platforms.items())), locale=self.config.language)}."
         parsed, msgs = self.state.inline_text(platforms_text, self.lineno)
         pnode = nodes.paragraph(title, "", refnode, sep, *parsed, *msgs)
         self.set_source_info(pnode)

--- a/Doc/tools/extensions/availability.py
+++ b/Doc/tools/extensions/availability.py
@@ -59,7 +59,7 @@ def _print_platform(
         return platform
     if not version:
         return sphinx_gettext("not {platform}").format(platform=platform)
-    return f"{platform} >= {version}"
+    return f"{platform} ≥ {version}"
 
 
 class Availability(SphinxDirective):

--- a/Doc/tools/extensions/availability.py
+++ b/Doc/tools/extensions/availability.py
@@ -12,8 +12,6 @@ from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from sphinx.application import Sphinx
     from sphinx.util.typing import ExtensionMetadata
 
@@ -122,9 +120,7 @@ class Availability(SphinxDirective):
         return platforms
 
 
-def _print_platform(
-    platform: str, version: str | bool
-) -> str | Callable[[str], str]:
+def _print_platform(platform: str, version: str | bool) -> str:
     if version is True:
         return platform
     if not version:

--- a/Doc/tools/extensions/availability.py
+++ b/Doc/tools/extensions/availability.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from itertools import starmap
 from typing import TYPE_CHECKING
 
+from babel.lists import format_list
 from docutils import nodes
 from sphinx import addnodes
 from sphinx.locale import _ as sphinx_gettext
@@ -70,9 +71,7 @@ class Availability(SphinxDirective):
         )
         sep = nodes.Text(": ")
         platforms = self.parse_platforms()
-        platforms_text = (
-            f"{', '.join(starmap(_print_platform, platforms.items()))}."
-        )
+        platforms_text = f"{format_list(list(starmap(_print_platform, platforms.items())), locale=self.config.language)}."
         parsed, msgs = self.state.inline_text(platforms_text, self.lineno)
         pnode = nodes.paragraph(title, "", refnode, sep, *parsed, *msgs)
         self.set_source_info(pnode)

--- a/Doc/tools/templates/dummy.html
+++ b/Doc/tools/templates/dummy.html
@@ -10,6 +10,7 @@ In extensions/pyspecific.py:
 In extensions/availability.py:
 
 {% trans %}Availability{% endtrans %}
+{% trans %}not {platform}{% endtrans %}
 
 In extensions/c_annotations.py:
 


### PR DESCRIPTION
1. Localizes platform support lists using Babel's [format_list()](https://babel.pocoo.org/en/latest/api/lists.html).
2. Exposes translation phrase `not {platform}` and fetches its translation in the availability directive content. This will allow full translations of availability directive content.
2. Renders text-based greater-than or equal-to sing `>=` as UTF-8 `≥`.

Tested locally, both `make gettext` (exposes new phrase in `sphinx.pot`) and rendering with `make html`. Examples of renderings:

[library/os.rst:2311](https://github.com/python/cpython/blob/1ed44879686c4b893d92a89d9259da3cbed6e166/Doc/library/os.rst?plain=1#L2311)
* original:
<img width="690" alt="Zrzut ekranu 2025-02-3 o 11 47 58" src="https://github.com/user-attachments/assets/9644ab3a-c542-43e6-8736-d3bafb3ebda1" />

* Traditional Chinese:
<img width="664" alt="Zrzut ekranu 2025-02-3 o 12 06 24" src="https://github.com/user-attachments/assets/a604cc61-1fcb-484e-969a-c069fec1c36e" />

* Polish: 
<img width="665" alt="Zrzut ekranu 2025-02-3 o 12 06 35" src="https://github.com/user-attachments/assets/a124246c-6ba0-45ac-93e6-699cc61af8d0" />
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129597.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-126609 -->
* Issue: gh-126609
<!-- /gh-issue-number -->
