### PR TITLE
[3.12] gh-129539: Include sysexits.h before checking EX_OK (#129590)

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-02-02-09-11-45.gh-issue-129539.SYXXCg.rst
+++ b/Misc/NEWS.d/next/Build/2025-02-02-09-11-45.gh-issue-129539.SYXXCg.rst
@@ -1,0 +1,1 @@
+Don't redefine ``EX_OK`` when the system has the ``sysexits.h`` header.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -49,10 +49,6 @@
 #  include "winreparse.h"
 #endif
 
-#if !defined(EX_OK) && defined(EXIT_SUCCESS)
-#  define EX_OK EXIT_SUCCESS
-#endif
-
 /* On android API level 21, 'AT_EACCESS' is not declared although
  * HAVE_FACCESSAT is defined. */
 #ifdef __ANDROID__
@@ -268,6 +264,10 @@ corresponding Unix manual entries for more information on calls.");
 
 #ifdef HAVE_SYSEXITS_H
 #  include <sysexits.h>
+#endif
+
+#if !defined(EX_OK) && defined(EXIT_SUCCESS)
+#  define EX_OK EXIT_SUCCESS
 #endif
 
 #ifdef HAVE_SYS_LOADAVG_H


### PR DESCRIPTION
Previously, the macro would be redefined when the header was included.

(cherry picked from commit 65f3432ac32f92bc3d8b7b11103a56c5a70049c0)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129539 -->
* Issue: gh-129539
<!-- /gh-issue-number -->
