### PR TITLE
gh-129333: fix import error over nfs on Windows

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -439,6 +439,7 @@ Erik Demaine
 Jeroen Demeyer
 Martin Dengler
 John Dennis
+Chris Denton
 L. Peter Deutsch
 Roger Dev
 Philippe Devalkeneer

--- a/Misc/NEWS.d/next/Windows/2025-02-01-01-30-10.gh-issue-129333.tnKrqz.rst
+++ b/Misc/NEWS.d/next/Windows/2025-02-01-01-30-10.gh-issue-129333.tnKrqz.rst
@@ -1,0 +1,1 @@
+Fixes import error when running Python from a network drive


### PR DESCRIPTION
On Windows, `getpath_realpath` uses `GetFinalPathNameByHandleW` to resolve paths. This returns paths starting with a `\\?\` prefix, which is usually not what we want.

This change attempts to remove the prefix for `\\?\UNC\` paths. A similar thing was already done for drive paths such as `\\?\C:\`.


<!-- gh-issue-number: gh-129333 -->
* Issue: gh-129333
<!-- /gh-issue-number -->
