### PR TITLE
[3.12] gh-129502: Fix handling errors in ctypes callbacks (GH-129504)

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-01-31-11-14-05.gh-issue-129502.j_ArNo.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-31-11-14-05.gh-issue-129502.j_ArNo.rst
@@ -1,0 +1,5 @@
+Unlikely errors in preparing arguments for :mod:`ctypes` callback are now
+handled in the same way as errors raised in the callback of in converting
+the result of the callback -- using :func:`sys.unraisablehook` instead of
+:func:`sys.excepthook` and not setting :data:`sys.last_exc` and other
+variables.


### PR DESCRIPTION
Unlikely errors in preparing arguments for ctypes callback are now handled in the same way as errors raised in the callback of in converting the result of the callback -- using sys.unraisablehook() instead of sys.excepthook() and not setting sys.last_exc and other variables.

(cherry picked from commit 9d63ae5fe52d95059ab1bcd4cbb1f9e17033c897)


<!-- gh-issue-number: gh-129502 -->
* Issue: gh-129502
<!-- /gh-issue-number -->
