### PR TITLE
[3.10] gh-129641: Docs GHA build: use upload-artifact@v4 & Python 3.12

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -38,7 +38,7 @@ jobs:
     - name: 'Set up Python'
       uses: actions/setup-python@v4
       with:
-        python-version: '3'
+        python-version: '3.12'
         cache: 'pip'
         cache-dependency-path: 'Doc/requirements.txt'
     - name: 'Install build dependencies'

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -46,10 +46,12 @@ jobs:
     - name: 'Build HTML documentation'
       run: make -C Doc/ SPHINXOPTS="-q" SPHINXERRORHANDLING="-W --keep-going" html
     - name: 'Upload'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: doc-html
         path: Doc/build/html
+        include-hidden-files: true
+        overwrite: true
 
   # Run "doctest" on HEAD as new syntax doesn't exist in the latest stable release
   doctest:

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -325,7 +325,7 @@ Now what can we do with instance objects?  The only operations understood by
 instance objects are attribute references.  There are two kinds of valid
 attribute names: data attributes and methods.
 
-*data attributes* correspond to "instance variables" in Smalltalk, and to "data
+*Data attributes* correspond to "instance variables" in Smalltalk, and to "data
 members" in C++.  Data attributes need not be declared; like local variables,
 they spring into existence when they are first assigned to.  For example, if
 ``x`` is the instance of :class:`MyClass` created above, the following piece of


### PR DESCRIPTION
## Use `actions/upload-artifact@v4`

The old version is discontinued and fails the build.

Switch to v4, and add options for backwards compatibility (from the docs at: https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes )

## Use Python 3.12

The required version of Sphinx requires `imghdr`, which was removed in 3.13.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129641 -->
* Issue: gh-129641
<!-- /gh-issue-number -->
