### PR TITLE
[3.13] gh-128772: Fix pydoc for methods with __module__ is None (GH-129177)

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -242,7 +242,7 @@ def parentname(object, modname):
     if necessary) or module."""
     if '.' in object.__qualname__:
         name = object.__qualname__.rpartition('.')[0]
-        if object.__module__ != modname:
+        if object.__module__ != modname and object.__module__ is not None:
             return object.__module__ + '.' + name
         else:
             return name

--- a/Lib/test/test_pydoc/module_none.py
+++ b/Lib/test/test_pydoc/module_none.py
@@ -1,0 +1,8 @@
+def func():
+    pass
+func.__module__ = None
+
+class A:
+    def method(self):
+        pass
+    method.__module__ = None

--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -1875,6 +1875,11 @@ foo
             html
         )
 
+    def test_module_none(self):
+        # Issue #128772
+        from test.test_pydoc import module_none
+        pydoc.render_doc(module_none)
+
 
 class PydocFodderTest(unittest.TestCase):
     def tearDown(self):

--- a/Misc/NEWS.d/next/Library/2025-01-22-13-29-06.gh-issue-128772.6YrxYM.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-22-13-29-06.gh-issue-128772.6YrxYM.rst
@@ -1,0 +1,2 @@
+Fix :mod:`pydoc` for methods with the ``__module__`` attribute equal to
+``None``.


### PR DESCRIPTION
(cherry picked from commit 979d76620990e6f8d68fa63e0ae0db1ec5b4d14c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128772 -->
* Issue: gh-128772
<!-- /gh-issue-number -->
