### PR TITLE
[3.13] gh-129660: Do not use test_embed in PGO profile builds

### DIFF
--- a/Lib/test/libregrtest/pgo.py
+++ b/Lib/test/libregrtest/pgo.py
@@ -19,7 +19,6 @@ PGO_TESTS = [
     'test_datetime',
     'test_decimal',
     'test_difflib',
-    'test_embed',
     'test_float',
     'test_fstring',
     'test_functools',

--- a/Misc/NEWS.d/next/Build/2025-02-04-12-30-43.gh-issue-129660.SitXa7.rst
+++ b/Misc/NEWS.d/next/Build/2025-02-04-12-30-43.gh-issue-129660.SitXa7.rst
@@ -1,0 +1,2 @@
+Drop ``test_embed`` from the PGO exercises, whose contribution in recent
+versions is considered to be ignorable.

--- a/Misc/NEWS.d/next/Build/2025-02-04-12-30-43.gh-issue-129660.SitXa7.rst
+++ b/Misc/NEWS.d/next/Build/2025-02-04-12-30-43.gh-issue-129660.SitXa7.rst
@@ -1,2 +1,2 @@
-Drop ``test_embed`` from the PGO exercises, whose contribution in recent
+Drop ``test_embed`` from PGO training, whose contribution in recent
 versions is considered to be ignorable.


### PR DESCRIPTION
This patch is backportable to 3.12.

<!-- gh-issue-number: gh-129660 -->
* Issue: gh-129660
<!-- /gh-issue-number -->
