### PR TITLE
gh-129268: Don't attempt to cleanup handlers again if logging.shutdown is called multiple times

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -2255,6 +2255,10 @@ def shutdown(handlerList=_handlerList):
                 raise
             #else, swallow
 
+    # Don't attempt to cleanup handlers again if logging.shutdown is called multiple times:
+    if handlerList is _handlerList:
+        _handlerList.clear()
+
 #Let's try and shutdown automatically on application exit...
 import atexit
 atexit.register(shutdown)


### PR DESCRIPTION


<!-- gh-issue-number: gh-129268 -->
* Issue: gh-129268
<!-- /gh-issue-number -->
