### PR TITLE
gh-129363: Change regrtest sequential mode output

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -427,9 +427,6 @@ class Regrtest:
             test_time = time.perf_counter() - start_time
             if test_time >= PROGRESS_MIN_TIME:
                 previous_test = "%s in %s" % (previous_test, format_duration(test_time))
-            elif result.state == State.PASSED:
-                # be quiet: say nothing if the test passed shortly
-                previous_test = None
 
         if previous_test:
             print(previous_test)


### PR DESCRIPTION
Always display the previous test, even if it passed in less than 30 seconds.

Example, before:

![Capture d’écran du 2025-02-05 14-06-10](https://github.com/user-attachments/assets/f22765f0-007b-47ce-b832-95cf34406bd3)

Example, after **with colors**:

![Capture d’écran du 2025-02-05 13-57-34](https://github.com/user-attachments/assets/01a51218-d4b9-4225-91d5-7e764f5a2f6c)


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129363 -->
* Issue: gh-129363
<!-- /gh-issue-number -->
