### PR TITLE
gh-129694: Add `--parallel-threads` TSAN job to CI

### DIFF
--- a/.github/workflows/reusable-tsan.yml
+++ b/.github/workflows/reusable-tsan.yml
@@ -74,6 +74,9 @@ jobs:
       run: make pythoninfo
     - name: Tests
       run: ./python -m test --tsan -j4
+    - name: Paralell Tests
+      if: fromJSON(inputs.free-threading)
+      run: ./python -m test --tsan-parallel --parallel-threads=4 -j4
     - name: Display TSAN logs
       if: always()
       run: find "${GITHUB_WORKSPACE}" -name 'tsan_log.*' | xargs head -n 1000

--- a/.github/workflows/reusable-tsan.yml
+++ b/.github/workflows/reusable-tsan.yml
@@ -74,7 +74,7 @@ jobs:
       run: make pythoninfo
     - name: Tests
       run: ./python -m test --tsan -j4
-    - name: Paralell Tests
+    - name: Parallel Tests
       if: fromJSON(inputs.free-threading)
       run: ./python -m test --tsan-parallel --parallel-threads=4 -j4
     - name: Display TSAN logs

--- a/.github/workflows/reusable-tsan.yml
+++ b/.github/workflows/reusable-tsan.yml
@@ -74,7 +74,7 @@ jobs:
       run: make pythoninfo
     - name: Tests
       run: ./python -m test --tsan -j4
-    - name: Parallel Tests
+    - name: Parallel tests
       if: fromJSON(inputs.free-threading)
       run: ./python -m test --tsan-parallel --parallel-threads=4 -j4
     - name: Display TSAN logs

--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -168,6 +168,7 @@ class Namespace(argparse.Namespace):
         self.pgo = False
         self.pgo_extended = False
         self.tsan = False
+        self.tsan_parallel = False
         self.worker_json = None
         self.start = None
         self.timeout = None
@@ -351,6 +352,9 @@ def _create_parser():
                        help='enable extended PGO training (slower training)')
     group.add_argument('--tsan', dest='tsan', action='store_true',
                        help='run a subset of test cases that are proper for the TSAN test')
+    group.add_argument('--tsan-parallel', action='store_true',
+                       help='run a subset of test cases that are appropriate '
+                            'for TSAN with `--parallel-threads=N`')
     group.add_argument('--fail-env-changed', action='store_true',
                        help='if a test file alters the environment, mark '
                             'the test as failed')

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -20,7 +20,7 @@ from .results import TestResults, EXITCODE_INTERRUPTED
 from .runtests import RunTests, HuntRefleak
 from .setup import setup_process, setup_test_dir
 from .single import run_single_test, PROGRESS_MIN_TIME
-from .tsan import setup_tsan_tests
+from .tsan import setup_tsan_tests, setup_tsan_parallel_tests
 from .utils import (
     StrPath, StrJSON, TestName, TestList, TestTuple, TestFilter,
     strip_py_suffix, count, format_duration,
@@ -60,6 +60,7 @@ class Regrtest:
         self.pgo: bool = ns.pgo
         self.pgo_extended: bool = ns.pgo_extended
         self.tsan: bool = ns.tsan
+        self.tsan_parallel: bool = ns.tsan_parallel
 
         # Test results
         self.results: TestResults = TestResults()
@@ -194,6 +195,9 @@ class Regrtest:
 
         if self.tsan:
             setup_tsan_tests(self.cmdline_args)
+
+        if self.tsan_parallel:
+            setup_tsan_parallel_tests(self.cmdline_args)
 
         exclude_tests = set()
         if self.exclude:

--- a/Lib/test/libregrtest/tsan.py
+++ b/Lib/test/libregrtest/tsan.py
@@ -28,7 +28,18 @@ TSAN_TESTS = [
     'test_free_threading.test_slots',
 ]
 
+# Tests that should be run with `--parallel-threads=N` under TSAN. These tests
+# typically do not use threads, but are run multiple times in parallel by
+# the regression test runner with the `--parallel-threads` option enabled.
+TSAN_PARALLEL_TESTS = [
+    'test_abc',
+]
+
 
 def setup_tsan_tests(cmdline_args) -> None:
     if not cmdline_args:
         cmdline_args[:] = TSAN_TESTS[:]
+
+def setup_tsan_parallel_tests(cmdline_args) -> None:
+    if not cmdline_args:
+        cmdline_args[:] = TSAN_PARALLEL_TESTS[:]


### PR DESCRIPTION
For now, this just adds a single test suite to the TSAN CI to be run with `--parallel-threads`.

<!-- gh-issue-number: gh-129694 -->
* Issue: gh-129694
<!-- /gh-issue-number -->
