### PR TITLE
gh-129695: Optimize ``_PyFloat_FromDouble_ConsumeInputs()``

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -273,7 +273,9 @@ _Py_DECREF_SPECIALIZED(PyObject *op, const destructor destruct)
             return;
         }
         _Py_DECREF_STAT_INC();
+#ifdef Py_REF_DEBUG
         _Py_DECREF_DecRefTotal();
+#endif
         local--;
         _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);
         if (local == 0) {
@@ -296,7 +298,9 @@ _Py_DECREF_NO_DEALLOC(PyObject *op)
             return;
         }
         _Py_DECREF_STAT_INC();
+#ifdef Py_REF_DEBUG
         _Py_DECREF_DecRefTotal();
+#endif
         local--;
         assert(local > 0);
         _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, local);

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-05-11-11-40.gh-issue-129695.qt2Jsz.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-05-11-11-40.gh-issue-129695.qt2Jsz.rst
@@ -1,0 +1,2 @@
+Add an optimized version of the ``_PyFloat_FromDouble_ConsumeInputs``
+function for the free-threaded build.


### PR DESCRIPTION
Add optimization for ``_PyFloat_FromDouble_ConsumeInputs()`` for the free-threaded build.  Implement free-threaded versions of ``_Py_DECREF_SPECIALIZED`` and ``_Py_DECREF_NO_DEALLOC`` as well.

[pyperformance results vs merge base](https://github.com/facebookexperimental/free-threading-benchmarking/blob/main/results/bm-20250205-3.14.0a4%2B-ecf15ed-NOGIL/bm-20250205-vultr-x86_64-nascheme-ft_float_consume_inp-3.14.0a4%2B-ecf15ed-vs-base.svg)

Based on a microbenchmark I wrote, this seems to give a small speed up for binary operations on floats, it there are temporary results (refcnt == 1) that can be re-used.  The `_Py_DECREF_SPECIALIZED` and `_Py_DECREF_SPECIALIZED` changes seem to help as well but only a little (hard to accurately measure).

The longobject.c file also uses `_Py_DECREF_SPECIALIZED` and I guess that might be the reason the pidigits benchmark got faster.  I not sure why the pyflate benchmark got slower.  Perhaps due to `_Py_DECREF_SPECIALIZED` taking the slow path too often.

<!-- gh-issue-number: gh-129695 -->
* Issue: gh-129695
<!-- /gh-issue-number -->
