### PR TITLE
gh-129005: Update _pyio.BytesIO to use bytearray.resize on write

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -937,7 +937,7 @@ class BytesIO(BufferedIOBase):
             return 0
         pos = self._pos
         if pos > len(self._buffer):
-            # Expand the buffer to be able to hold the new bytes.
+            # Pad buffer to pos with null bytes.
             self._buffer.resize(pos)
         self._buffer[pos:pos + n] = b
         self._pos += n

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -938,7 +938,7 @@ class BytesIO(BufferedIOBase):
         pos = self._pos
         if pos > len(self._buffer):
             # Expand the buffer to be able to hold the new bytes.
-            self._buffer.resize(pos + n)
+            self._buffer.resize(pos)
         self._buffer[pos:pos + n] = b
         self._pos += n
         return n

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -937,10 +937,8 @@ class BytesIO(BufferedIOBase):
             return 0
         pos = self._pos
         if pos > len(self._buffer):
-            # Inserts null bytes between the current end of the file
-            # and the new write position.
-            padding = b'\x00' * (pos - len(self._buffer))
-            self._buffer += padding
+            # Expand the buffer to be able to hold the new bytes.
+            self._buffer.resize(pos + n)
         self._buffer[pos:pos + n] = b
         self._pos += n
         return n


### PR DESCRIPTION
`bytearray.resize()` does the nulling if needed. Including the new write length, `n`, since doing two resizes in a row to do the `memcpy` doesn't seem worthwhile.

I think this can skip news as it's internal implementation change with no visible external changes, should just be faster.

<!-- gh-issue-number: gh-129005 -->
* Issue: gh-129005
<!-- /gh-issue-number -->
