### PR TITLE
gh-126835: make CFG optimizer skip over NOP's when looking for const sequence construction

### DIFF
--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1062,6 +1062,41 @@ class DirectCfgOptimizerTests(CfgOptimizationTestCase):
                                    consts=[0, 1, 2, 3, 4],
                                    expected_consts=[0, 2, 3])
 
+    def test_multiple_foldings(self):
+        before = [
+            ('LOAD_SMALL_INT', 1, 0),
+            ('LOAD_SMALL_INT', 2, 0),
+            ('BUILD_TUPLE', 1, 0),
+            ('LOAD_SMALL_INT', 0, 0),
+            ('BINARY_SUBSCR', None, 0),
+            ('BUILD_TUPLE', 2, 0),
+            ('RETURN_VALUE', None, 0)
+        ]
+        after = [
+            ('LOAD_CONST', 1, 0),
+            ('RETURN_VALUE', None, 0)
+        ]
+        self.cfg_optimization_test(before, after, consts=[], expected_consts=[(2,), (1, 2)])
+
+    def test_fold_tuple_of_constants_nops(self):
+        before = [
+            ('NOP', None, 0),
+            ('LOAD_SMALL_INT', 1, 0),
+            ('NOP', None, 0),
+            ('LOAD_SMALL_INT', 2, 0),
+            ('NOP', None, 0),
+            ('NOP', None, 0),
+            ('LOAD_SMALL_INT', 3, 0),
+            ('NOP', None, 0),
+            ('BUILD_TUPLE', 3, 0),
+            ('RETURN_VALUE', None, 0),
+        ]
+        after = [
+            ('LOAD_CONST', 0, 0),
+            ('RETURN_VALUE', None, 0),
+        ]
+        self.cfg_optimization_test(before, after, consts=[], expected_consts=[(1, 2, 3)])
+
     def test_conditional_jump_forward_const_condition(self):
         # The unreachable branch of the jump is removed, the jump
         # becomes redundant and is replaced by a NOP (for the lineno)

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1068,7 +1068,7 @@ class DirectCfgOptimizerTests(CfgOptimizationTestCase):
                                    consts=[0, 1, 2, 3, 4],
                                    expected_consts=[0, 2, 3])
 
-    def test_build_list_stack_use_guideline(self):
+    def test_list_exceeding_stack_use_guideline(self):
         def f():
             return [
                 0, 1, 2, 3, 4,

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1082,7 +1082,7 @@ class DirectCfgOptimizerTests(CfgOptimizationTestCase):
             ]
         self.assertEqual(f(), list(range(40)))
 
-    def test_build_set_stack_use_guideline(self):
+    def test_set_exceeding_stack_use_guideline(self):
         def f():
             return {
                 0, 1, 2, 3, 4,

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1068,6 +1068,34 @@ class DirectCfgOptimizerTests(CfgOptimizationTestCase):
                                    consts=[0, 1, 2, 3, 4],
                                    expected_consts=[0, 2, 3])
 
+    def test_build_list_stack_use_guideline(self):
+        def f():
+            return [
+                0, 1, 2, 3, 4,
+                5, 6, 7, 8, 9,
+                10, 11, 12, 13, 14,
+                15, 16, 17, 18, 19,
+                20, 21, 22, 23, 24,
+                25, 26, 27, 28, 29,
+                30, 31, 32, 33, 34,
+                35, 36, 37, 38, 39
+            ]
+        self.assertEqual(f(), list(range(40)))
+
+    def test_build_set_stack_use_guideline(self):
+        def f():
+            return {
+                0, 1, 2, 3, 4,
+                5, 6, 7, 8, 9,
+                10, 11, 12, 13, 14,
+                15, 16, 17, 18, 19,
+                20, 21, 22, 23, 24,
+                25, 26, 27, 28, 29,
+                30, 31, 32, 33, 34,
+                35, 36, 37, 38, 39
+            }
+        self.assertEqual(f(), frozenset(range(40)))
+
     def test_multiple_foldings(self):
         before = [
             ('LOAD_SMALL_INT', 1, 0),

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -36,6 +36,13 @@ def count_instr_recursively(f, opname):
     return count
 
 
+def get_binop_argval(arg):
+    for i, nb_op in enumerate(opcode._nb_ops):
+        if arg == nb_op[0]:
+            return i
+    assert False, f"{arg} is not a valid BINARY_OP argument."
+
+
 class TestTranforms(BytecodeTestCase):
 
     def check_jump_targets(self, code):
@@ -518,8 +525,7 @@ class TestTranforms(BytecodeTestCase):
             ('("a" * 10)[10]', True),
             ('(1, (1, 2))[2:6][0][2-1]', True),
         ]
-        subscr_argval = 26
-        assert opcode._nb_ops[subscr_argval][0] == 'NB_SUBSCR'
+        subscr_argval = get_binop_argval('NB_SUBSCR')
         for expr, has_error in tests:
             with self.subTest(expr=expr, has_error=has_error):
                 code = compile(expr, '', 'single')
@@ -1068,7 +1074,7 @@ class DirectCfgOptimizerTests(CfgOptimizationTestCase):
             ('LOAD_SMALL_INT', 2, 0),
             ('BUILD_TUPLE', 1, 0),
             ('LOAD_SMALL_INT', 0, 0),
-            ('BINARY_SUBSCR', None, 0),
+            ('BINARY_OP', get_binop_argval('NB_SUBSCR'), 0),
             ('BUILD_TUPLE', 2, 0),
             ('RETURN_VALUE', None, 0)
         ]

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -264,7 +264,7 @@ basicblock_insert_instruction(basicblock *block, int pos, cfg_instr *instr) {
 }
 
 /* For debugging purposes only */
-#if 1
+#if 0
 static void
 dump_instr(cfg_instr *i)
 {


### PR DESCRIPTION
We need to account for optimizations interfering with each other when moving more and more AST optimizations to CFG. Currently `is_constant_sequence` & (`fold_tuple_on_constants` & `optimize_if_const_list_or_set` that use it) do not take into account `NOP`s in between. This becomes problematic when there are several optimizations performed one after another as they `NOP` out unused instructions. Example:
```python
(1, (1+2,),)[1][0]
```
This expression will trigger subscript & binop foldings. With current `is_constant_sequence` implementation, resulting instruction sequence cannot be optimized correctly. Here is final dis:
```bash
  1           RESUME                   0

  2           LOAD_SMALL_INT           1
              LOAD_CONST               1 ((3,))
              BUILD_TUPLE              2
              LOAD_SMALL_INT           1
              BINARY_SUBSCR
              LOAD_SMALL_INT           0
              BINARY_SUBSCR
              RETURN_VALUE
```
When correct sequence should be:
```bash
  1           RESUME                   0

  2           LOAD_SMALL_INT           3
              RETURN_VALUE
```
Here is basic block dump in a state when `BUILD_TUPLE` fails to be optimized by `fold_tuple_on_constants`:

<img width="177" alt="Screenshot 2025-02-05 at 21 47 58" src="https://github.com/user-attachments/assets/b0b3598a-46fb-486e-a481-4f9f62213bc8" />


As you can see, `BUILD_TUPLE 2` has 2 consts before it but they are separated by `NOP`s due to previous binop folding. Obvious solution would be to remove `NOP`s on every iteration in `optimize_basic_block` which makes sense, but we cannot do that because we would be changing basic block size while iterating over it which breaks everything. So a different approach should be implemented. This PR presents one of the possible approaches to prepare us for the next optimizations migration to CFG. My main concern is complexity & readability as I think they suffer a bit from it. Another cleaner way I see is to use `PyMem_Malloc` to store indexes of corresponding instructions which seems cleaner but should be discussed.

cc @Eclips4 @tomasr8 @iritkatriel 

<!-- gh-issue-number: gh-126835 -->
* Issue: gh-126835
<!-- /gh-issue-number -->
