### PR TITLE
gh-129707: Check `Tools/build/compute-changes.py` with `mypy`

### DIFF
--- a/Tools/build/compute-changes.py
+++ b/Tools/build/compute-changes.py
@@ -15,8 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 TYPE_CHECKING = False
-if False:
-    from collections.abc import Set  # type: ignore[unreachable]
+if TYPE_CHECKING:
+    from collections.abc import Set
 
 GITHUB_DEFAULT_BRANCH = os.environ["GITHUB_DEFAULT_BRANCH"]
 GITHUB_CODEOWNERS_PATH = Path(".github/CODEOWNERS")

--- a/Tools/build/compute-changes.py
+++ b/Tools/build/compute-changes.py
@@ -14,10 +14,6 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from collections.abc import Set
-
 GITHUB_DEFAULT_BRANCH = os.environ["GITHUB_DEFAULT_BRANCH"]
 GITHUB_CODEOWNERS_PATH = Path(".github/CODEOWNERS")
 GITHUB_WORKFLOWS_PATH = Path(".github/workflows")
@@ -83,7 +79,7 @@ def git_branches() -> tuple[str, str]:
 
 def get_changed_files(
     ref_a: str = GITHUB_DEFAULT_BRANCH, ref_b: str = "HEAD"
-) -> Set[Path]:
+) -> frozenset[Path]:
     """List the files changed between two Git refs, filtered by change type."""
     args = ("git", "diff", "--name-only", f"{ref_a}...{ref_b}", "--")
     print(*args)
@@ -94,7 +90,7 @@ def get_changed_files(
     return frozenset(map(Path, filter(None, map(str.strip, changed_files))))
 
 
-def process_changed_files(changed_files: Set[Path]) -> Outputs:
+def process_changed_files(changed_files: frozenset[Path]) -> Outputs:
     run_tests = False
     run_ci_fuzz = False
     run_docs = False

--- a/Tools/build/compute-changes.py
+++ b/Tools/build/compute-changes.py
@@ -14,6 +14,10 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+TYPE_CHECKING = False
+if False:
+    from collections.abc import Set  # type: ignore[unreachable]
+
 GITHUB_DEFAULT_BRANCH = os.environ["GITHUB_DEFAULT_BRANCH"]
 GITHUB_CODEOWNERS_PATH = Path(".github/CODEOWNERS")
 GITHUB_WORKFLOWS_PATH = Path(".github/workflows")
@@ -79,7 +83,7 @@ def git_branches() -> tuple[str, str]:
 
 def get_changed_files(
     ref_a: str = GITHUB_DEFAULT_BRANCH, ref_b: str = "HEAD"
-) -> frozenset[Path]:
+) -> Set[Path]:
     """List the files changed between two Git refs, filtered by change type."""
     args = ("git", "diff", "--name-only", f"{ref_a}...{ref_b}", "--")
     print(*args)
@@ -90,7 +94,7 @@ def get_changed_files(
     return frozenset(map(Path, filter(None, map(str.strip, changed_files))))
 
 
-def process_changed_files(changed_files: frozenset[Path]) -> Outputs:
+def process_changed_files(changed_files: Set[Path]) -> Outputs:
     run_tests = False
     run_ci_fuzz = False
     run_docs = False

--- a/Tools/build/mypy.ini
+++ b/Tools/build/mypy.ini
@@ -1,5 +1,7 @@
 [mypy]
-files = Tools/build/generate_sbom.py, Tools/build/compute-changes.py
+files =
+    Tools/build/compute-changes.py,
+    Tools/build/generate_sbom.py
 pretty = True
 
 # Make sure Python can still be built

--- a/Tools/build/mypy.ini
+++ b/Tools/build/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-files = Tools/build/generate_sbom.py
+files = Tools/build/generate_sbom.py, Tools/build/compute-changes.py
 pretty = True
 
 # Make sure Python can still be built


### PR DESCRIPTION
There was one error locally:

```
» mypy --config-file Tools/build/mypy.ini
Tools/build/compute-changes.py:90: error: Incompatible return value type (got
"frozenset[Path]", expected "set[Path]")  [return-value]
        return frozenset(map(Path, filter(None, map(str.strip, changed_files))))
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 2 source files)
```

<!-- gh-issue-number: gh-129707 -->
* Issue: gh-129707
<!-- /gh-issue-number -->
