### PR TITLE
refactor logging: Or assignment instead of if-else blocks

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -741,10 +741,7 @@ class BufferingFormatter(object):
         Optionally specify a formatter which will be used to format each
         individual record.
         """
-        if linefmt:
-            self.linefmt = linefmt
-        else:
-            self.linefmt = _defaultFormatter
+        self.linefmt = linefmt or _defaultFormatter
 
     def formatHeader(self, records):
         """
@@ -991,10 +988,7 @@ class Handler(Filterer):
         If a formatter is set, use it. Otherwise, use the default formatter
         for the module.
         """
-        if self.formatter:
-            fmt = self.formatter
-        else:
-            fmt = _defaultFormatter
+        fmt = self.formatter or _defaultFormatter
         return fmt.format(record)
 
     def emit(self, record):


### PR DESCRIPTION
In the file \`Lib/logging/\_\_init\_\_.py\` I found this pattern

``` python
if possible_false:
    target = possible_false
else:
    target = default_value
```

and thought it can be refactorized to

``` python
target = possible_false or default_value
```

in order to reduce source code space and increase human comprehension speed.

## Pitfalls

- Harder to measure coverage (source <https://docs.astral.sh/ruff/rules/if-else-block-instead-of-if-exp/#known-issues> )

- This unnecessary change could cause conflicts in other PRs opened changing the same line of code. However,

  ``` shell
  # source: https://stackoverflow.com/a/78905336/16926605
  $ gh pr list --state all --repo python/cpython --json number,title,files,url | jq 'map(select(.files | any(.path | contains("logging"))) | {number, title,url})'
  [
    {
      "number": 129681,
      "title": "gh-129268: Don't attempt to cleanup handlers again if logging.shutdown is called multiple times",
      "url": "https://github.com/python/cpython/pull/129681"
    }
  ]
  ```

  this is the only PR that touches the same file. It does not change the same region.

## How was found

<details>
  <summary>details</summary>

``` python
import sys
import ast
from typing import Union

def match_if(node: ast.If):
    # Exagerated use of assignment expressions for fun and experimenting
    if (
        len(node.body) == 1
        and isinstance(assign_if := node.body[0], ast.Assign)
        and len(targets := assign_if.targets) == 1
        and len(orelse := node.orelse) == 1
        and isinstance(assign_else := orelse[0], ast.Assign)
        ### expensive, so last:
        and compare_ast(assign_if.value, possible_false := node.test)
        and compare_ast(
            target := targets[0], assign_else.targets[0]
        )
    ):
        default_value = assign_else.value
        return (target, possible_false, default_value)

def compare_ast(
    node1: Union[ast.expr, list[ast.expr]], node2: Union[ast.expr, list[ast.expr]]
) -> bool:
    "https://stackoverflow.com/a/66733795/16926605"
    if type(node1) is not type(node2):
        return False

    if isinstance(node1, ast.AST):
        for k, v in vars(node1).items():
            if k in {"lineno", "end_lineno", "col_offset", "end_col_offset", "ctx"}:
                continue
            if not compare_ast(v, getattr(node2, k)):
                return False
        return True

    elif isinstance(node1, list) and isinstance(node2, list):
        return all(compare_ast(n1, n2) for n1, n2 in zip_longest(node1, node2))
    else:
        return node1 == node2

class IfAssignmentFinder(ast.NodeVisitor):
    def visit_If(self, node):
        if match := match_if(node):
            target, possible_false, default_value = match
            msg = "found possible refactor: %s = %s or %s" % tuple(
                ast.unparse(node) for node in [target, possible_false, default_value]
            )
            print('%d:%d:%s' % (node.lineno, node.col_offset , msg))
        else:
            self.generic_visit(node)

with open(sys.argv[1]) as f:
    tree = ast.parse(f.read())
    IfAssignmentFinder().visit(tree)
```

``` shell
$ python my_linter.py Lib/logging/__init__.py
744:8:found possible refactor: self.linefmt = linefmt or _defaultFormatter
994:8:found possible refactor: fmt = self.formatter or _defaultFormatter
```

Related: <https://github.com/MartinThoma/flake8-simplify?tab=readme-ov-file#sim108>

</details>
