### PR TITLE
[3.13] gh-129643: Fix `PyList_Insert` in free-threading builds (GH-129680)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2025-02-05-11-29-52.gh-issue-129643.4mGzvg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-02-05-11-29-52.gh-issue-129643.4mGzvg.rst
@@ -1,0 +1,1 @@
+Fix thread safety of :c:func:`PyList_Insert` in free-threading builds.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -498,8 +498,8 @@ ins1(PyListObject *self, Py_ssize_t where, PyObject *v)
         where = n;
     items = self->ob_item;
     for (i = n; --i >= where; )
-        items[i+1] = items[i];
-    items[where] = Py_NewRef(v);
+        FT_ATOMIC_STORE_PTR_RELAXED(items[i+1], items[i]);
+    FT_ATOMIC_STORE_PTR_RELEASE(items[where], Py_NewRef(v));
     return 0;
 }
 


### PR DESCRIPTION
(cherry picked from commit 63f0406d5ad25a55e49c3903b29407c50a17cfd5)


<!-- gh-issue-number: gh-129643 -->
* Issue: gh-129643
<!-- /gh-issue-number -->
