### PR TITLE
Remove an inaccurate note from `socket.recv`

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1668,11 +1668,6 @@ to sockets.
    See the Unix manual page :manpage:`recv(2)` for the meaning of the optional argument
    *flags*; it defaults to zero.
 
-   .. note::
-
-      For best match with hardware and network realities, the value of  *bufsize*
-      should be a relatively small power of 2, for example, 4096.
-
    .. versionchanged:: 3.5
       If the system call is interrupted and the signal handler does not raise
       an exception, the method now retries the system call instead of raising


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129733.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->