### PR TITLE
gh-129732: Fix race in on shared->array in qsbr code under free-threa…

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-06-17-57-33.gh-issue-129732.yl97oq.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-06-17-57-33.gh-issue-129732.yl97oq.rst
@@ -1,0 +1,1 @@
+Fixed a race in _Py_qsbr_reserve under free-threading mode.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-06-17-57-33.gh-issue-129732.yl97oq.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-06-17-57-33.gh-issue-129732.yl97oq.rst
@@ -1,1 +1,1 @@
-Fixed a race in _Py_qsbr_reserve under free-threading mode.
+Fixed a race in ``_Py_qsbr_reserve`` in the free threading build.

--- a/Python/qsbr.c
+++ b/Python/qsbr.c
@@ -205,15 +205,15 @@ _Py_qsbr_reserve(PyInterpreterState *interp)
         }
         _PyEval_StartTheWorld(interp);
     }
-    PyMutex_Unlock(&shared->mutex);
-
-    if (qsbr == NULL) {
-        return -1;
-    }
 
     // Return an index rather than the pointer because the array may be
     // resized and the pointer invalidated.
-    return (struct _qsbr_pad *)qsbr - shared->array;
+    Py_ssize_t index = -1;
+    if (qsbr != NULL) {
+        index = (struct _qsbr_pad *)qsbr - shared->array;
+    }
+    PyMutex_Unlock(&shared->mutex);
+    return index;
 }
 
 void


### PR DESCRIPTION
…ding.

The read of shared->array should happen under the lock to avoid a race.

Fixes https://github.com/python/cpython/issues/129732


<!-- gh-issue-number: gh-129732 -->
* Issue: gh-129732
<!-- /gh-issue-number -->
