### PR TITLE
gh-117657: Include all of test_free_threading in TSAN tests

### DIFF
--- a/Lib/test/libregrtest/tsan.py
+++ b/Lib/test/libregrtest/tsan.py
@@ -25,7 +25,7 @@ TSAN_TESTS = [
     'test_threading_local',
     'test_threadsignals',
     'test_weakref',
-    'test_free_threading.test_slots',
+    'test_free_threading',
 ]
 
 # Tests that should be run with `--parallel-threads=N` under TSAN. These tests

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -44,5 +44,11 @@ race_top:PyThreadState_Clear
 # Only seen on macOS, sample: https://gist.github.com/aisk/dda53f5d494a4556c35dde1fce03259c
 race_top:set_default_allocator_unlocked
 
+# gh-129068: race on shared range iterators (test_free_threading.test_zip.ZipThreading.test_threading)
+race_top:rangeiter_next
+
+# gh-129748: test.test_free_threading.test_slots.TestSlots.test_object
+race_top:mi_block_set_nextx
+
 # https://gist.github.com/mpage/6962e8870606cfc960e159b407a0cb40
 thread:pthread_create


### PR DESCRIPTION
Add suppressions for existing data races in `test_free_threading`.

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
