### PR TITLE
gh-117657: Skip tests that may cause stack overflows under TSan

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -1,6 +1,7 @@
 import unittest
 from test.support import (cpython_only, is_wasi, requires_limited_api, Py_DEBUG,
-                          set_recursion_limit, skip_on_s390x, skip_emscripten_stack_overflow, import_helper)
+                          set_recursion_limit, skip_on_s390x, skip_emscripten_stack_overflow,
+                          skip_if_sanitizer, import_helper)
 try:
     import _testcapi
 except ImportError:
@@ -1036,6 +1037,7 @@ class TestRecursion(unittest.TestCase):
 
     @skip_on_s390x
     @unittest.skipIf(is_wasi and Py_DEBUG, "requires deep stack")
+    @skip_if_sanitizer("requires deep stack", thread=True)
     @unittest.skipIf(_testcapi is None, "requires _testcapi")
     @skip_emscripten_stack_overflow()
     def test_super_deep(self):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2067,6 +2067,7 @@ class TestLRU:
 
     @support.skip_on_s390x
     @unittest.skipIf(support.is_wasi, "WASI has limited C stack")
+    @support.skip_if_sanitizer("requires deep stack", thread=True)
     @support.skip_emscripten_stack_overflow()
     def test_lru_recursion(self):
 


### PR DESCRIPTION
These tests crash under TSan due to stack overflows. Just skip them if TSan is enabled.

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
