### PR TITLE
gh-117657: Add test_thread_local_bytecode to TSAN tests

### DIFF
--- a/Lib/test/libregrtest/tsan.py
+++ b/Lib/test/libregrtest/tsan.py
@@ -20,6 +20,7 @@ TSAN_TESTS = [
     'test_ssl',
     'test_syslog',
     'test_thread',
+    'test_thread_local_bytecode',
     'test_threadedtempfile',
     'test_threading',
     'test_threading_local',

--- a/Lib/test/test_thread_local_bytecode.py
+++ b/Lib/test/test_thread_local_bytecode.py
@@ -109,6 +109,7 @@ class TLBCTests(unittest.TestCase):
         """)
         assert_python_ok("-X", "tlbc=1", "-c", code)
 
+    @support.skip_if_sanitizer("gh-129752: data race on adaptive counter", thread=True)
     def test_no_copies_if_tlbc_disabled(self):
         code = textwrap.dedent("""
         import queue


### PR DESCRIPTION
Skip `test_no_copies_if_tlbc_disabled` when run under TSAN for now due to a data race on the adaptive counter (see gh-129752).

<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
