### PR TITLE
gh-117657: Fix data race in `dict_dict_merge`

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3793,7 +3793,7 @@ dict_dict_merge(PyInterpreterState *interp, PyDictObject *mp, PyDictObject *othe
 
             ensure_shared_on_resize(mp);
             dictkeys_decref(interp, mp->ma_keys, IS_DICT_SHARED(mp));
-            mp->ma_keys = keys;
+            set_keys(mp, keys);
             STORE_USED(mp, other->ma_used);
             ASSERT_CONSISTENT(mp);
 


### PR DESCRIPTION
Found while running `test_load_attr_module` from `test_opcache` under TSan.


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
