### PR TITLE
Emscripten: use better `_Py_Version` computation for worker module

### DIFF
--- a/Tools/wasm/emscripten/web_example/python.worker.mjs
+++ b/Tools/wasm/emscripten/web_example/python.worker.mjs
@@ -70,12 +70,9 @@ const emscriptenSettings = {
     postMessage({ type: "ready", stdinBuffer: stdinBuffer.sab });
   },
   async preRun(Module) {
-    const versionHex = Module.HEAPU32[Module._Py_Version / 4].toString(16);
-    const versionTuple = versionHex
-      .padStart(8, "0")
-      .match(/.{1,2}/g)
-      .map((x) => parseInt(x, 16));
-    const [major, minor, ..._] = versionTuple;
+    const versionInt = Module.HEAPU32[Module._Py_Version >>> 2];
+    const major = (versionInt >>> 24) & 0xff;
+    const minor = (versionInt >>> 16) & 0xff;
     // Prevent complaints about not finding exec-prefix by making a lib-dynload directory
     Module.FS.mkdirTree(`/lib/python${major}.${minor}/lib-dynload/`);
     Module.addRunDependency("install-stdlib");


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Related to gh-127113

This is a small PR that improves the _Py_Version check for the Python worker module file for the Emscripten builds, which was last modified in https://github.com/python/cpython/pull/127113/files#diff-31f61a127a59386957acba86e9acedf0a96bc6ebe1ac159a48e39b1a291111b5R73-R75. I reviewed the corresponding change downstream in https://github.com/pyodide/pyodide/pull/5406 and suggested this change, and @hoodmane suggested that I should upstream the change here.

The idea is that we were converting a number to a hex string, then padding that string, splitting it up, and then bringing it back by parsing it to an integer – these operations are unnecessary. We can instead use an [unsigned right shift](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift) and apply a bitmask to grab the relevant bytes. For the format `0xMMmmpp00`, this means that the major version is in bits 24–31, the minor version in bits 16–23, and the patch/micro version in bits 8–15. These bit operations should be more direct.
