### PR TITLE
GH-129763: Remove the `LLTRACE` macro

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-06-17-05-09.gh-issue-129763.6ZxQ8W.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-06-17-05-09.gh-issue-129763.6ZxQ8W.rst
@@ -1,0 +1,1 @@
+Remove the internal ``LLTRACE`` macro (use :c:macro:`Py_DEBUG` instead).

--- a/Misc/SpecialBuilds.txt
+++ b/Misc/SpecialBuilds.txt
@@ -78,22 +78,16 @@ Py_DEBUG
 
 This is what is generally meant by "a debug build" of Python.
 
-Py_DEBUG implies LLTRACE and Py_REF_DEBUG. In addition, C assert()s are enabled
+Py_DEBUG implies Py_REF_DEBUG. In addition, C assert()s are enabled
 (via the C way: by not defining NDEBUG), and some routines do additional sanity
 checks inside "#ifdef Py_DEBUG" blocks.
 
-
-LLTRACE
--------
-
-Compile in support for Low Level TRACE-ing of the main interpreter loop.
-
-When this preprocessor symbol is defined, before PyEval_EvalFrame executes a
-frame's code it checks the frame's global namespace for a variable
-"__lltrace__".  If such a variable is found, mounds of information about what
-the interpreter is doing are sprayed to stdout, such as every opcode and opcode
-argument and values pushed onto and popped off the value stack.
-
-Not useful very often, but very useful when needed.
-
-Py_DEBUG implies LLTRACE.
+Also, compile in support for "lltrace" (Low Level TRACE-ing) of the main
+interpreter loop. Before _PyEval_EvalFrameDefault executes a frame's code, it
+checks the frame's global namespace for a variable "__lltrace__" (as well as for
+the environment variable PYTHON_LLTRACE"). If such a variable is found, mounds
+of information about what the interpreter is doing are sprayed to stdout, such
+as every opcode and opcode argument and values pushed onto and popped off the
+value stack. Higher integer values for the environment variable result in more
+and more detail being printed (the global __lltrace__ always enables the maximum
+output). Not useful very often, but *very* useful when needed.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5301,7 +5301,7 @@ dummy_func(
                 goto exception_unwind;
             }
             /* Resume normal execution */
-#ifdef LLTRACE
+#ifdef Py_DEBUG
             if (frame->lltrace >= 5) {
                 lltrace_resume_frame(frame);
             }
@@ -5340,15 +5340,7 @@ dummy_func(
             }
             next_instr = frame->instr_ptr;
 
-        #ifdef LLTRACE
-            {
-                int lltrace = maybe_lltrace_resume_frame(frame, GLOBALS());
-                frame->lltrace = lltrace;
-                if (lltrace < 0) {
-                    goto exit_unwind;
-                }
-            }
-        #endif
+            LLTRACE_RESUME_FRAME();
 
         #ifdef Py_DEBUG
             /* _PyEval_EvalFrameDefault() must not be called with an exception set,

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -43,11 +43,6 @@
 
 #include <stdbool.h>              // bool
 
-#ifdef Py_DEBUG
-   /* For debugging the interpreter: */
-#  define LLTRACE  1      /* Low-level trace feature */
-#endif
-
 #if !defined(Py_BUILD_CORE)
 #  error "ceval.c must be build with Py_BUILD_CORE define for best performance"
 #endif
@@ -136,7 +131,7 @@
 #endif
 
 
-#ifdef LLTRACE
+#ifdef Py_DEBUG
 static void
 dump_stack(_PyInterpreterFrame *frame, _PyStackRef *stack_pointer)
 {
@@ -818,7 +813,7 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int 
     entry_frame.owner = FRAME_OWNED_BY_INTERPRETER;
     entry_frame.visited = 0;
     entry_frame.return_offset = 0;
-#ifdef LLTRACE
+#ifdef Py_DEBUG
     entry_frame.lltrace = 0;
 #endif
     /* Push frame */

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -115,7 +115,7 @@
 #define PRE_DISPATCH_GOTO() ((void)0)
 #endif
 
-#if Py_DEBUG
+#ifdef Py_DEBUG
 #define LLTRACE_RESUME_FRAME() \
 do { \
     int lltrace = maybe_lltrace_resume_frame(frame, GLOBALS()); \

--- a/Python/ceval_macros.h
+++ b/Python/ceval_macros.h
@@ -108,21 +108,21 @@
 #endif
 
 /* PRE_DISPATCH_GOTO() does lltrace if enabled. Normally a no-op */
-#ifdef LLTRACE
+#ifdef Py_DEBUG
 #define PRE_DISPATCH_GOTO() if (frame->lltrace >= 5) { \
     lltrace_instruction(frame, stack_pointer, next_instr, opcode, oparg); }
 #else
 #define PRE_DISPATCH_GOTO() ((void)0)
 #endif
 
-#if LLTRACE
+#if Py_DEBUG
 #define LLTRACE_RESUME_FRAME() \
 do { \
     int lltrace = maybe_lltrace_resume_frame(frame, GLOBALS()); \
-    frame->lltrace = lltrace; \
     if (lltrace < 0) { \
         JUMP_TO_LABEL(exit_unwind); \
     } \
+    frame->lltrace = lltrace; \
 } while (0)
 #else
 #define LLTRACE_RESUME_FRAME() ((void)0)

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -11624,7 +11624,7 @@ JUMP_TO_LABEL(error);
                 JUMP_TO_LABEL(exception_unwind);
             }
             /* Resume normal execution */
-            #ifdef LLTRACE
+            #ifdef Py_DEBUG
             if (frame->lltrace >= 5) {
                 lltrace_resume_frame(frame);
             }
@@ -11666,16 +11666,7 @@ JUMP_TO_LABEL(error);
                 JUMP_TO_LABEL(exit_unwind);
             }
             next_instr = frame->instr_ptr;
-            #ifdef LLTRACE
-            {
-                int lltrace = maybe_lltrace_resume_frame(frame, GLOBALS());
-                frame->lltrace = lltrace;
-                if (lltrace < 0) {
-                    JUMP_TO_LABEL(exit_unwind);
-                }
-            }
-            #endif
-
+            LLTRACE_RESUME_FRAME();
             #ifdef Py_DEBUG
             /* _PyEval_EvalFrameDefault() must not be called with an exception set,
                because it can clear it (directly or indirectly) and so the

--- a/Tools/c-analyzer/TODO
+++ b/Tools/c-analyzer/TODO
@@ -69,7 +69,6 @@ Objects/tupleobject.c:_Py_tuple_zero_allocs                      Py_ssize_t _Py_
 Objects/typeobject.c:next_version_tag                            static unsigned int next_version_tag
 Python/Python-ast.c:init_types():initialized                     static int initialized
 Python/bootstrap_hash.c:urandom_cache                            static struct { int fd; dev_t st_dev; ino_t st_ino; } urandom_cache
-Python/ceval.c:lltrace                                           static int lltrace
 Python/ceval.c:make_pending_calls():busy                         static int busy
 Python/dynload_shlib.c:handles                                   static struct { dev_t dev; ino_t ino; void *handle; } handles[128]
 Python/dynload_shlib.c:nhandles                                  static int nhandles

--- a/Tools/cases_generator/analyzer.py
+++ b/Tools/cases_generator/analyzer.py
@@ -676,7 +676,6 @@ NON_ESCAPING_FUNCTIONS = (
     "backoff_counter_triggers",
     "initial_temperature_backoff_counter",
     "JUMP_TO_LABEL",
-    "maybe_lltrace_resume_frame",
     "restart_backoff_counter",
 )
 

--- a/Tools/jit/template.c
+++ b/Tools/jit/template.c
@@ -81,6 +81,11 @@ do {                                                         \
 #undef WITHIN_STACK_BOUNDS
 #define WITHIN_STACK_BOUNDS() 1
 
+#undef LLTRACE_RESUME_FRAME
+#define LLTRACE_RESUME_FRAME() \
+    do {                       \
+    } while (0)
+
 #define TIER_TWO 2
 
 __attribute__((preserve_none)) _Py_CODEUNIT *


### PR DESCRIPTION
It's already used interchangeably with `Py_DEBUG`.

Also, fix some buggy error handling when checking for `__lltrace__` on frame resumption.


<!-- gh-issue-number: gh-129763 -->
* Issue: gh-129763
<!-- /gh-issue-number -->
