### PR TITLE
gh-124703: Allow the user to choose how to quit pdb in 'inline' mode

### DIFF
--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -97,27 +97,30 @@ class Bdb:
         The arg parameter depends on the previous event.
         """
 
-        with self.set_enterframe(frame):
-            if self.quitting:
-                return # None
-            if event == 'line':
-                return self.dispatch_line(frame)
-            if event == 'call':
-                return self.dispatch_call(frame, arg)
-            if event == 'return':
-                return self.dispatch_return(frame, arg)
-            if event == 'exception':
-                return self.dispatch_exception(frame, arg)
-            if event == 'c_call':
+        try:
+            with self.set_enterframe(frame):
+                if self.quitting:
+                    return # None
+                if event == 'line':
+                    return self.dispatch_line(frame)
+                if event == 'call':
+                    return self.dispatch_call(frame, arg)
+                if event == 'return':
+                    return self.dispatch_return(frame, arg)
+                if event == 'exception':
+                    return self.dispatch_exception(frame, arg)
+                if event == 'c_call':
+                    return self.trace_dispatch
+                if event == 'c_exception':
+                    return self.trace_dispatch
+                if event == 'c_return':
+                    return self.trace_dispatch
+                if event == 'opcode':
+                    return self.dispatch_opcode(frame, arg)
+                print('bdb.Bdb.dispatch: unknown debugging event:', repr(event))
                 return self.trace_dispatch
-            if event == 'c_exception':
-                return self.trace_dispatch
-            if event == 'c_return':
-                return self.trace_dispatch
-            if event == 'opcode':
-                return self.dispatch_opcode(frame, arg)
-            print('bdb.Bdb.dispatch: unknown debugging event:', repr(event))
-            return self.trace_dispatch
+        except BdbQuit:  # Make stacktrace shorter
+            raise BdbQuit from None
 
     def dispatch_line(self, frame):
         """Invoke user function and return trace function for line event.

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -370,10 +370,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         if commands is not None:
             self.rcLines.extend(commands)
 
-        try:
-            super().set_trace(frame)
-        except bdb.BdbQuit:  # Make stacktrace shorter
-            raise bdb.BdbQuit from None
+        super().set_trace(frame)
 
     def sigint_handler(self, signum, frame):
         if self.allow_kbdint:
@@ -2396,10 +2393,7 @@ def set_trace(*, header=None, commands=None):
         pdb = Pdb(mode='inline')
     if header is not None:
         pdb.message(header)
-    try:
-        pdb.set_trace(sys._getframe().f_back, commands=commands)
-    except bdb.BdbQuit:   # Make stacktrace shorter
-        raise bdb.BdbQuit from None
+    pdb.set_trace(sys._getframe().f_back, commands=commands)
 
 # Post-Mortem interface
 

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1734,11 +1734,15 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                     reply = 'e'
                     self.message('')
 
-                if reply == 'e' or reply == '':
+                if reply in ('e', 'q', ''):
+                    # Will raise BdbQuit and allow returning to REPL
                     break
                 elif reply == 'k':
+                    # Kill process. Allows user to break out of infinite loop
+                    # or exit both pdb and REPL when interactive work finished.
                     sys.exit(0)
                 elif reply.lower() == 'c':
+                    # Cancel and return to debugger
                     return
 
         self._user_requested_quit = True

--- a/Misc/NEWS.d/next/Library/2025-02-07-05-10-33.gh-issue-124703.Wyw9JQ.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-07-05-10-33.gh-issue-124703.Wyw9JQ.rst
@@ -1,0 +1,1 @@
+Allow the user to choose how to quit pdb in 'inline' mode.  The user may now choose between killing the process and raising BdbQuit.  This change restores the ability to return to the REPL from a pdb session.


### PR DESCRIPTION
This PR is a compromise between the state before [PR#124704](https://github.com/python/cpython/issues/124704) and the state after that PR. 

I'm trying to preserve the ability to exit pdb and return to the REPL.

See my [comment](https://github.com/python/cpython/issues/124703#issuecomment-2641955307) on issue [#124703](https://github.com/python/cpython/issues/124703) for more info.

<!-- gh-issue-number: gh-124703 -->
* Issue: gh-124703
<!-- /gh-issue-number -->
