### PR TITLE
Add asyncio.Executor matching concurrent.futures.Executor

### DIFF
--- a/Lib/asyncio/__init__.py
+++ b/Lib/asyncio/__init__.py
@@ -9,6 +9,7 @@ from .base_events import *
 from .coroutines import *
 from .events import *
 from .exceptions import *
+from .executor import *
 from .futures import *
 from .graph import *
 from .locks import *
@@ -27,6 +28,7 @@ __all__ = (base_events.__all__ +
            coroutines.__all__ +
            events.__all__ +
            exceptions.__all__ +
+           executor.__all__ +
            futures.__all__ +
            graph.__all__ +
            locks.__all__ +

--- a/Lib/asyncio/executor.py
+++ b/Lib/asyncio/executor.py
@@ -141,10 +141,9 @@ class Executor[**P, R]:
 
             finalization_tasks = []
             while submitted_tasks.qsize() > 0:
-                task = await submitted_tasks.get()
-                if task is not None:
-                    task.cancel()
-                    finalization_tasks.append(task)
+                task = submitted_tasks.get_nowait()
+                task.cancel()
+                finalization_tasks.append(task)
             for task in finalization_tasks:
                 await _consume_cancelled_future(task)
 
@@ -157,9 +156,8 @@ class Executor[**P, R]:
             finalization_tasks = []
             while not self._input_queue.empty():
                 work_item = self._input_queue.get_nowait()
-                if work_item is not None:
-                    work_item.future.cancel()
-                    finalization_tasks.append(work_item.future)
+                work_item.future.cancel()
+                finalization_tasks.append(work_item.future)
             for task in finalization_tasks:
                 await _consume_cancelled_future(task)
 

--- a/Lib/asyncio/executor.py
+++ b/Lib/asyncio/executor.py
@@ -127,7 +127,6 @@ class Executor[**P, R]:
         fn: _WorkFunction[P, R],
         *iterables: Iterable | AsyncIterable,
         timeout: Optional[float] = None,
-        chunksize: int = 1,
     ) -> AsyncIterable[R]:
         if self._shutdown:
             raise RuntimeError("Cannot schedule new tasks after shutdown")

--- a/Lib/asyncio/executor.py
+++ b/Lib/asyncio/executor.py
@@ -1,6 +1,7 @@
 import time
 from collections.abc import AsyncIterable, Awaitable, Iterable
-from typing import Any, NamedTuple, Protocol
+from dataclasses import dataclass
+from typing import Any, Protocol
 
 from . import timeouts
 from .exceptions import CancelledError
@@ -19,7 +20,8 @@ class _WorkFunction[**P, R](Protocol):
         ...
 
 
-class _WorkItem[**P, R](NamedTuple):
+@dataclass(frozen=True, slots=True)
+class _WorkItem[**P, R]:
     fn: _WorkFunction[P, R]
     args: tuple[Any, ...]
     kwargs: dict[Any, Any]

--- a/Lib/asyncio/executor.py
+++ b/Lib/asyncio/executor.py
@@ -1,6 +1,6 @@
 import time
-from typing import (Any, AsyncIterable, Awaitable, Iterable, NamedTuple,
-                    Optional, Protocol)
+from collections.abc import AsyncIterable, Awaitable, Iterable
+from typing import Any, NamedTuple, Protocol
 
 from . import timeouts
 from .exceptions import CancelledError
@@ -124,7 +124,7 @@ class Executor[**P, R]:
         self,
         fn: _WorkFunction[P, R],
         *iterables: Iterable | AsyncIterable,
-        timeout: Optional[float] = None,
+        timeout: float | None = None,
     ) -> AsyncIterable[R]:
         if self._shutdown:
             raise RuntimeError("Cannot schedule new tasks after shutdown")

--- a/Lib/asyncio/executor.py
+++ b/Lib/asyncio/executor.py
@@ -43,11 +43,10 @@ async def _worker[**P, R](
                     **work_item.kwargs,
                 ))
                 await wait([task, item_future], return_when=FIRST_COMPLETED)
-                if item_future.cancelled():
+                if not item_future.cancelled():
+                    item_future.set_result(task.result())
+                else:
                     task.cancel()
-                    continue
-                result = task.result()
-                item_future.set_result(result)
             except BaseException as exception:
                 if not item_future.cancelled():
                     item_future.set_exception(exception)

--- a/Lib/asyncio/executor.py
+++ b/Lib/asyncio/executor.py
@@ -74,7 +74,7 @@ async def _azip(*iterables: Iterable | AsyncIterable) -> AsyncIterable[tuple]:
     iterators = [aiter(async_iterable) for async_iterable in async_iterables]
     while True:
         try:
-            items = await gather(*[anext(iterator) for iterator in iterators])
+            items = [await anext(iterator) for iterator in iterators]
             yield tuple(items)
         except StopAsyncIteration:
             break

--- a/Lib/test/test_asyncio/test_executor.py
+++ b/Lib/test/test_asyncio/test_executor.py
@@ -1,0 +1,229 @@
+import asyncio
+import itertools
+import unittest
+from asyncio import Executor
+
+
+class ExecutorSubmitTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_submit_sync_function(self):
+        async with asyncio.timeout(1), Executor(max_workers=2) as executor:
+            def sync_fn(x):
+                return x * 2
+
+            future = await executor.submit(sync_fn, 5)
+            result = await future
+            self.assertEqual(result, 10)
+
+    async def test_submit_async_function(self):
+        async with asyncio.timeout(1), Executor(max_workers=2) as executor:
+            async def async_fn(x):
+                await asyncio.sleep(0.1)
+                return x * 2
+
+            future = await executor.submit(async_fn, 5)
+            result = await future
+            self.assertEqual(result, 10)
+
+    async def test_submit_function_raises_exception(self):
+        async with asyncio.timeout(1), Executor(max_workers=2) as executor:
+            def sync_fn(x):
+                raise ValueError("Test exception")
+
+            future = await executor.submit(sync_fn, 5)
+            with self.assertRaises(ValueError):
+                await future
+
+    async def test_submit_cancel_task(self):
+        async with asyncio.timeout(2), Executor(max_workers=2) as executor:
+            was_not_cancelled = False
+
+            async def async_fn(x):
+                nonlocal was_not_cancelled
+                await asyncio.sleep(1)
+                was_not_cancelled = True
+                return x * 2
+
+            future = await executor.submit(async_fn, 5)
+            await asyncio.sleep(0.1)
+            future.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await future
+            self.assertFalse(was_not_cancelled)
+
+
+class ExecutorMapTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_map_sync_function(self):
+        async with asyncio.timeout(1), Executor(max_workers=2) as executor:
+            def sync_fn(x):
+                return x * 2
+
+            results = [
+                result
+                async for result in executor.map(sync_fn, range(5))
+            ]
+            self.assertEqual(results, [0, 2, 4, 6, 8])
+
+    async def test_map_async_function(self):
+        async with asyncio.timeout(1), Executor(max_workers=2) as executor:
+            async def async_fn(x):
+                await asyncio.sleep(0.1)
+                return x * 2
+
+            results = [
+                result
+                async for result in executor.map(async_fn, range(5))
+            ]
+            self.assertEqual(results, [0, 2, 4, 6, 8])
+
+    async def test_map_function_raises_exception(self):
+        async with asyncio.timeout(1), Executor(max_workers=2) as executor:
+            def sync_fn(x):
+                if x == 3:
+                    raise ValueError("Test exception")
+                return x * 2
+
+            with self.assertRaises(ValueError):
+                _ = [
+                    result
+                    async for result in executor.map(sync_fn, range(5))
+                ]
+
+    async def test_map_cancel_task(self):
+        async with asyncio.timeout(3), Executor(max_workers=2) as executor:
+            was_not_cancelled = False
+
+            async def async_fn(x):
+                nonlocal was_not_cancelled
+                await asyncio.sleep(1)
+                if x == 3:
+                    was_not_cancelled = True
+                return x * 2
+
+            async for _ in executor.map(async_fn, range(5)):
+                # There are 2 workers, therefore the first 2 tasks will be
+                # completed when we reach the break statement, at which point
+                # the third task would have started.
+                break
+
+            await asyncio.sleep(0.1)  # Make sure the 3rd task is running.
+            await executor.shutdown(cancel_futures=True)
+            self.assertFalse(was_not_cancelled)
+
+
+class ExecutorStressTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_map_with_large_number_of_tasks(self):
+        async with asyncio.timeout(4), Executor(max_workers=64) as executor:
+            def sync_fn(x):
+                return x * 2
+
+            results = [
+                result
+                async for result in executor.map(sync_fn, range(1000))
+            ]
+            self.assertEqual(results, [x * 2 for x in range(1000)])
+
+    async def test_map_with_infinite_iterable(self):
+        async with asyncio.timeout(1), Executor(max_workers=2) as executor:
+            def sync_fn(x):
+                return x * 2
+
+            results = []
+            async for result in executor.map(sync_fn, itertools.count()):
+                results.append(result)
+                if len(results) >= 10:
+                    break
+            self.assertEqual(results, [x * 2 for x in range(10)])
+
+
+class ExecutorEdgeCasesTests(unittest.IsolatedAsyncioTestCase):
+
+    async def test_map_timeout(self):
+        async with asyncio.timeout(2), Executor(max_workers=2) as executor:
+            async def async_fn(x):
+                await asyncio.sleep(1)
+                return x * 2
+
+            with self.assertRaises(asyncio.TimeoutError):
+                _ = [
+                    result
+                    async for result in executor.map(
+                        async_fn,
+                        range(5),
+                        timeout=0.5,
+                    )
+                ]
+
+    async def test_shutdown_while_tasks_running(self):
+        async with asyncio.timeout(3), Executor(max_workers=2) as executor:
+            async def async_fn(x):
+                await asyncio.sleep(1)
+                return x * 2
+
+            futures = [await executor.submit(async_fn, i) for i in range(5)]
+            # Since we used submit instead of map, and the input queue is 2,
+            # we have 2 finished tasks, 2 running tasks, and 1 pending task.
+            # Therefore, the graceful shutdown will let the 2 running tasks
+            # finish, and cancel the pending task.
+            await executor.shutdown(cancel_futures=True)
+            for future in futures[:4]:
+                await future
+            with self.assertRaises(asyncio.CancelledError):
+                await futures[-1]
+
+    async def test_resource_cleanup(self):
+        async with asyncio.timeout(1), Executor(max_workers=2) as executor:
+            async def async_fn(x):
+                await asyncio.sleep(0.1)
+                return x * 2
+
+            futures = [await executor.submit(async_fn, i) for i in range(5)]
+            await executor.shutdown()
+            for future in futures:
+                self.assertTrue(future.done())
+
+    async def test_reject_submit_on_shutdown_executor(self):
+        executor = Executor(max_workers=2)
+        await executor.shutdown()
+        with self.assertRaises(RuntimeError):
+            await executor.submit(lambda x: x, 5)
+
+    async def test_reject_map_on_shutdown_executor(self):
+        executor = Executor(max_workers=2)
+        await executor.shutdown()
+        with self.assertRaises(RuntimeError):
+            async for _ in executor.map(lambda x: x, range(5)):
+                pass
+
+    async def test_submitted_task_cancellation_after_leaving_context(self):
+        # This test also verifies that all created async generators are
+        # terminated gracefully, which requires gracefully terminating the
+        # feeders.
+        async with asyncio.timeout(1), Executor(max_workers=1) as executor:
+            async def async_fn(x):
+                await asyncio.sleep(0.1)
+                return x * 2
+
+            results = []
+            results_stream = executor.map(async_fn, range(3))
+            results = [await anext(results_stream)]
+        # Exiting the async content manager calls shutdown(wait=True,
+        # cancel_futures=False). With max_workers=1, the first task will be
+        # running, and the second task will be pending in queue. The third task
+        # will not be submitted yet. Therefore, the first and second tasks will
+        # be completed, and the third task will be cancelled (cancel_futures
+        # cancels already scheduled tasks).
+
+        await asyncio.sleep(0.1)
+
+        results += [
+            result
+            async for result in results_stream
+        ]
+        self.assertEqual(results, [0, 2])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Lib/test/test_asyncio/test_executor.py
+++ b/Lib/test/test_asyncio/test_executor.py
@@ -6,16 +6,7 @@ from asyncio import Executor
 
 class ExecutorSubmitTests(unittest.IsolatedAsyncioTestCase):
 
-    async def test_submit_sync_function(self):
-        async with asyncio.timeout(1), Executor(max_workers=2) as executor:
-            def sync_fn(x):
-                return x * 2
-
-            future = await executor.submit(sync_fn, 5)
-            result = await future
-            self.assertEqual(result, 10)
-
-    async def test_submit_async_function(self):
+    async def test_submit_sleeping_function(self):
         async with asyncio.timeout(1), Executor(max_workers=2) as executor:
             async def async_fn(x):
                 await asyncio.sleep(0.1)
@@ -27,7 +18,7 @@ class ExecutorSubmitTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_submit_function_raises_exception(self):
         async with asyncio.timeout(1), Executor(max_workers=2) as executor:
-            def sync_fn(x):
+            async def sync_fn(x):
                 raise ValueError("Test exception")
 
             future = await executor.submit(sync_fn, 5)
@@ -54,18 +45,7 @@ class ExecutorSubmitTests(unittest.IsolatedAsyncioTestCase):
 
 class ExecutorMapTests(unittest.IsolatedAsyncioTestCase):
 
-    async def test_map_sync_function(self):
-        async with asyncio.timeout(1), Executor(max_workers=2) as executor:
-            def sync_fn(x):
-                return x * 2
-
-            results = [
-                result
-                async for result in executor.map(sync_fn, range(5))
-            ]
-            self.assertEqual(results, [0, 2, 4, 6, 8])
-
-    async def test_map_async_function(self):
+    async def test_map_sleeping_function(self):
         async with asyncio.timeout(1), Executor(max_workers=2) as executor:
             async def async_fn(x):
                 await asyncio.sleep(0.1)
@@ -79,7 +59,7 @@ class ExecutorMapTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_map_function_raises_exception(self):
         async with asyncio.timeout(1), Executor(max_workers=2) as executor:
-            def sync_fn(x):
+            async def sync_fn(x):
                 if x == 3:
                     raise ValueError("Test exception")
                 return x * 2
@@ -116,7 +96,7 @@ class ExecutorStressTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_map_with_large_number_of_tasks(self):
         async with asyncio.timeout(4), Executor(max_workers=64) as executor:
-            def sync_fn(x):
+            async def sync_fn(x):
                 return x * 2
 
             results = [
@@ -127,7 +107,7 @@ class ExecutorStressTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_map_with_infinite_iterable(self):
         async with asyncio.timeout(1), Executor(max_workers=2) as executor:
-            def sync_fn(x):
+            async def sync_fn(x):
                 return x * 2
 
             results = []


### PR DESCRIPTION
The Executor provides means for scheduling a executing asyncio tasks with capped parallelism. The asyncio Executor's API matches the concurrent.futures.Executor's API for consistency.

See also: https://discuss.python.org/t/add-task-pipeline-to-asyncio-with-capped-parallelism-and-lazy-input-reading/79292

I will add documentation once the API is agreed upon to prevent any differences between code and docs.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
