### PR TITLE
gh-129766: Fix crash on calling `warnings._release_lock` with no lock

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -1432,6 +1432,17 @@ class PyEnvironmentVariableTests(EnvironmentVariableTests, unittest.TestCase):
     module = py_warnings
 
 
+class LocksTest(unittest.TestCase):
+    @support.cpython_only
+    @unittest.skipUnless(c_warnings, 'C module is required')
+    def test_release_lock_no_lock(self):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            'cannot release un-acquired lock',
+        ):
+            c_warnings._release_lock()
+
+
 class _DeprecatedTest(BaseTest, unittest.TestCase):
 
     """Test _deprecated()."""

--- a/Misc/NEWS.d/next/Library/2025-02-07-10-34-09.gh-issue-129766.6n5fQZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-07-10-34-09.gh-issue-129766.6n5fQZ.rst
@@ -1,0 +1,2 @@
+Fix crash in :mod:`warnings`, when calling ``_release_lock()`` with no
+existing lock.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -240,12 +240,12 @@ warnings_lock(PyInterpreterState *interp)
     _PyRecursiveMutex_Lock(&st->lock);
 }
 
-static inline void
+static inline int
 warnings_unlock(PyInterpreterState *interp)
 {
     WarningsState *st = warnings_get_state(interp);
     assert(st != NULL);
-    _PyRecursiveMutex_Unlock(&st->lock);
+    return _PyRecursiveMutex_TryUnlock(&st->lock);
 }
 
 static inline bool
@@ -284,7 +284,10 @@ warnings_release_lock_impl(PyObject *module)
     if (interp == NULL) {
         return NULL;
     }
-    warnings_unlock(interp);
+    if (warnings_unlock(interp) < 0) {
+        PyErr_SetString(PyExc_RuntimeError, "cannot release un-acquired lock");
+        return NULL;
+    }
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
After:

```python
>>> import warnings
>>> warnings._release_lock()
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    warnings._release_lock()
    ~~~~~~~~~~~~~~~~~~~~~~^^
RuntimeError: cannot release un-acquired lock
```

Refs https://github.com/python/cpython/pull/128386
Refs https://github.com/python/cpython/issues/128384

<!-- gh-issue-number: gh-129766 -->
* Issue: gh-129766
<!-- /gh-issue-number -->
