### PR TITLE
gh-128563: Move assignment of opcode into ifdef

### DIFF
--- a/Lib/test/test_generated_cases.py
+++ b/Lib/test/test_generated_cases.py
@@ -305,10 +305,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -328,10 +327,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -354,10 +352,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -381,10 +378,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -409,10 +405,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -440,10 +435,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -473,10 +467,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP1) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP1;
+            int opcode = OP1;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP1);
@@ -489,10 +482,9 @@ class TestGeneratedCases(unittest.TestCase):
 
         TARGET(OP3) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP3;
+            int opcode = OP3;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -528,10 +520,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(A) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = A;
+            int opcode = A;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(A);
@@ -550,10 +541,9 @@ class TestGeneratedCases(unittest.TestCase):
 
         TARGET(B) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = B;
+            int opcode = B;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(B);
@@ -592,10 +582,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -616,10 +605,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -644,10 +632,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -680,10 +667,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -712,10 +698,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -744,10 +729,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -780,10 +764,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 6;
             INSTRUCTION_STATS(OP);
@@ -822,10 +805,9 @@ class TestGeneratedCases(unittest.TestCase):
 
         TARGET(OP1) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP1;
+            int opcode = OP1;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -845,10 +827,9 @@ class TestGeneratedCases(unittest.TestCase):
 
         TARGET(OP3) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP3;
+            int opcode = OP3;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 6;
             INSTRUCTION_STATS(OP3);
@@ -881,10 +862,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 4;
             INSTRUCTION_STATS(OP);
@@ -908,10 +888,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP1) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP1;
+            int opcode = OP1;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP1);
@@ -932,10 +911,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP1) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP1;
+            int opcode = OP1;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP1);
@@ -959,10 +937,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP1) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP1;
+            int opcode = OP1;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP1);
@@ -971,10 +948,9 @@ class TestGeneratedCases(unittest.TestCase):
 
         TARGET(OP2) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP2;
+            int opcode = OP2;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP2);
@@ -993,10 +969,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1021,10 +996,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1054,10 +1028,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1083,10 +1056,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1114,10 +1086,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1160,10 +1131,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(M) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = M;
+            int opcode = M;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(M);
@@ -1209,10 +1179,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(M) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = M;
+            int opcode = M;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(M);
@@ -1247,10 +1216,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1273,10 +1241,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(M) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = M;
+            int opcode = M;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(M);
@@ -1295,10 +1262,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1318,10 +1284,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(M) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = M;
+            int opcode = M;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(M);
@@ -1359,10 +1324,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1386,10 +1350,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1429,10 +1392,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(INST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INST;
+            int opcode = INST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(INST);
@@ -1460,10 +1422,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(TEST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TEST;
+            int opcode = TEST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(TEST);
@@ -1505,10 +1466,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(TEST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TEST;
+            int opcode = TEST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(TEST);
@@ -1549,10 +1509,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(TEST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TEST;
+            int opcode = TEST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(TEST);
@@ -1602,10 +1561,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(TEST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TEST;
+            int opcode = TEST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(TEST);
@@ -1655,10 +1613,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(TEST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TEST;
+            int opcode = TEST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(TEST);
@@ -1701,10 +1658,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP1) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP1;
+            int opcode = OP1;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP1);
@@ -1713,10 +1669,9 @@ class TestGeneratedCases(unittest.TestCase):
 
         TARGET(OP2) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP2;
+            int opcode = OP2;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP2);
@@ -1775,10 +1730,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(BALANCED) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BALANCED;
+            int opcode = BALANCED;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(BALANCED);
@@ -1800,10 +1754,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(BALANCED) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BALANCED;
+            int opcode = BALANCED;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(BALANCED);
@@ -1826,10 +1779,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(BALANCED) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BALANCED;
+            int opcode = BALANCED;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -1853,10 +1805,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1893,10 +1844,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1932,10 +1882,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);
@@ -1968,10 +1917,9 @@ class TestGeneratedCases(unittest.TestCase):
         output = """
         TARGET(OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = OP;
+            int opcode = OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(OP);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -20,10 +20,9 @@
 
         TARGET(BINARY_OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_OP;
+            int opcode = BINARY_OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 6;
             INSTRUCTION_STATS(BINARY_OP);
@@ -77,10 +76,9 @@
 
         TARGET(BINARY_OP_ADD_FLOAT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_OP_ADD_FLOAT;
+            int opcode = BINARY_OP_ADD_FLOAT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -132,10 +130,9 @@
 
         TARGET(BINARY_OP_ADD_INT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_OP_ADD_INT;
+            int opcode = BINARY_OP_ADD_INT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -186,10 +183,9 @@
 
         TARGET(BINARY_OP_ADD_UNICODE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_OP_ADD_UNICODE;
+            int opcode = BINARY_OP_ADD_UNICODE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -240,10 +236,9 @@
 
         TARGET(BINARY_OP_EXTEND) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_OP_EXTEND;
+            int opcode = BINARY_OP_EXTEND;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -297,10 +292,9 @@
 
         TARGET(BINARY_OP_INPLACE_ADD_UNICODE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_OP_INPLACE_ADD_UNICODE;
+            int opcode = BINARY_OP_INPLACE_ADD_UNICODE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -381,10 +375,9 @@
 
         TARGET(BINARY_OP_MULTIPLY_FLOAT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_OP_MULTIPLY_FLOAT;
+            int opcode = BINARY_OP_MULTIPLY_FLOAT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -436,10 +429,9 @@
 
         TARGET(BINARY_OP_MULTIPLY_INT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_OP_MULTIPLY_INT;
+            int opcode = BINARY_OP_MULTIPLY_INT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -490,10 +482,9 @@
 
         TARGET(BINARY_OP_SUBTRACT_FLOAT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_OP_SUBTRACT_FLOAT;
+            int opcode = BINARY_OP_SUBTRACT_FLOAT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -545,10 +536,9 @@
 
         TARGET(BINARY_OP_SUBTRACT_INT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_OP_SUBTRACT_INT;
+            int opcode = BINARY_OP_SUBTRACT_INT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -599,10 +589,9 @@
 
         TARGET(BINARY_SLICE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_SLICE;
+            int opcode = BINARY_SLICE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(BINARY_SLICE);
@@ -660,10 +649,9 @@
 
         TARGET(BINARY_SUBSCR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_SUBSCR;
+            int opcode = BINARY_SUBSCR;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 2;
             INSTRUCTION_STATS(BINARY_SUBSCR);
@@ -714,10 +702,9 @@
 
         TARGET(BINARY_SUBSCR_DICT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_SUBSCR_DICT;
+            int opcode = BINARY_SUBSCR_DICT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -762,10 +749,9 @@
 
         TARGET(BINARY_SUBSCR_GETITEM) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_SUBSCR_GETITEM;
+            int opcode = BINARY_SUBSCR_GETITEM;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -848,10 +834,9 @@
 
         TARGET(BINARY_SUBSCR_LIST_INT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_SUBSCR_LIST_INT;
+            int opcode = BINARY_SUBSCR_LIST_INT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -919,10 +904,9 @@
 
         TARGET(BINARY_SUBSCR_STR_INT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_SUBSCR_STR_INT;
+            int opcode = BINARY_SUBSCR_STR_INT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -982,10 +966,9 @@
 
         TARGET(BINARY_SUBSCR_TUPLE_INT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BINARY_SUBSCR_TUPLE_INT;
+            int opcode = BINARY_SUBSCR_TUPLE_INT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -1041,10 +1024,9 @@
 
         TARGET(BUILD_LIST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BUILD_LIST;
+            int opcode = BUILD_LIST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(BUILD_LIST);
@@ -1064,10 +1046,9 @@
 
         TARGET(BUILD_MAP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BUILD_MAP;
+            int opcode = BUILD_MAP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(BUILD_MAP);
@@ -1107,10 +1088,9 @@
 
         TARGET(BUILD_SET) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BUILD_SET;
+            int opcode = BUILD_SET;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(BUILD_SET);
@@ -1156,10 +1136,9 @@
 
         TARGET(BUILD_SLICE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BUILD_SLICE;
+            int opcode = BUILD_SLICE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(BUILD_SLICE);
@@ -1187,10 +1166,9 @@
 
         TARGET(BUILD_STRING) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BUILD_STRING;
+            int opcode = BUILD_STRING;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(BUILD_STRING);
@@ -1225,10 +1203,9 @@
 
         TARGET(BUILD_TUPLE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = BUILD_TUPLE;
+            int opcode = BUILD_TUPLE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(BUILD_TUPLE);
@@ -1248,10 +1225,9 @@
 
         TARGET(CACHE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CACHE;
+            int opcode = CACHE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(CACHE);
@@ -1262,16 +1238,16 @@
 
         TARGET(CALL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL;
+            int opcode = CALL;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 4;
             INSTRUCTION_STATS(CALL);
             PREDICTED_CALL:;
             _Py_CODEUNIT* const this_instr = next_instr - 4;
             (void)this_instr;
+            opcode = CALL;
             _PyStackRef *callable;
             _PyStackRef *self_or_null;
             _PyStackRef *args;
@@ -1432,10 +1408,9 @@
 
         TARGET(CALL_ALLOC_AND_ENTER_INIT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_ALLOC_AND_ENTER_INIT;
+            int opcode = CALL_ALLOC_AND_ENTER_INIT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -1559,10 +1534,9 @@
 
         TARGET(CALL_BOUND_METHOD_EXACT_ARGS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_BOUND_METHOD_EXACT_ARGS;
+            int opcode = CALL_BOUND_METHOD_EXACT_ARGS;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -1699,10 +1673,9 @@
 
         TARGET(CALL_BOUND_METHOD_GENERAL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_BOUND_METHOD_GENERAL;
+            int opcode = CALL_BOUND_METHOD_GENERAL;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -1822,10 +1795,9 @@
 
         TARGET(CALL_BUILTIN_CLASS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_BUILTIN_CLASS;
+            int opcode = CALL_BUILTIN_CLASS;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -1915,10 +1887,9 @@
 
         TARGET(CALL_BUILTIN_FAST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_BUILTIN_FAST;
+            int opcode = CALL_BUILTIN_FAST;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -2014,10 +1985,9 @@
 
         TARGET(CALL_BUILTIN_FAST_WITH_KEYWORDS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_BUILTIN_FAST_WITH_KEYWORDS;
+            int opcode = CALL_BUILTIN_FAST_WITH_KEYWORDS;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -2114,10 +2084,9 @@
 
         TARGET(CALL_BUILTIN_O) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_BUILTIN_O;
+            int opcode = CALL_BUILTIN_O;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -2211,15 +2180,15 @@
 
         TARGET(CALL_FUNCTION_EX) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_FUNCTION_EX;
+            int opcode = CALL_FUNCTION_EX;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(CALL_FUNCTION_EX);
+            opcode = CALL_FUNCTION_EX;
             _PyStackRef func;
             _PyStackRef callargs;
             _PyStackRef kwargs_in;
@@ -2403,10 +2372,9 @@
 
         TARGET(CALL_INTRINSIC_1) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_INTRINSIC_1;
+            int opcode = CALL_INTRINSIC_1;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(CALL_INTRINSIC_1);
@@ -2428,10 +2396,9 @@
 
         TARGET(CALL_INTRINSIC_2) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_INTRINSIC_2;
+            int opcode = CALL_INTRINSIC_2;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(CALL_INTRINSIC_2);
@@ -2460,10 +2427,9 @@
 
         TARGET(CALL_ISINSTANCE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_ISINSTANCE;
+            int opcode = CALL_ISINSTANCE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -2522,16 +2488,16 @@
 
         TARGET(CALL_KW) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_KW;
+            int opcode = CALL_KW;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 4;
             INSTRUCTION_STATS(CALL_KW);
             PREDICTED_CALL_KW:;
             _Py_CODEUNIT* const this_instr = next_instr - 4;
             (void)this_instr;
+            opcode = CALL_KW;
             _PyStackRef *callable;
             _PyStackRef *self_or_null;
             _PyStackRef *args;
@@ -2691,10 +2657,9 @@
 
         TARGET(CALL_KW_BOUND_METHOD) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_KW_BOUND_METHOD;
+            int opcode = CALL_KW_BOUND_METHOD;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -2825,15 +2790,15 @@
 
         TARGET(CALL_KW_NON_PY) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_KW_NON_PY;
+            int opcode = CALL_KW_NON_PY;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
             next_instr += 4;
             INSTRUCTION_STATS(CALL_KW_NON_PY);
+            opcode = CALL_KW_NON_PY;
             static_assert(INLINE_CACHE_ENTRIES_CALL_KW == 3, "incorrect cache size");
             _PyStackRef *callable;
             _PyStackRef kwnames;
@@ -2938,10 +2903,9 @@
 
         TARGET(CALL_KW_PY) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_KW_PY;
+            int opcode = CALL_KW_PY;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -3046,10 +3010,9 @@
 
         TARGET(CALL_LEN) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_LEN;
+            int opcode = CALL_LEN;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -3114,10 +3077,9 @@
 
         TARGET(CALL_LIST_APPEND) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_LIST_APPEND;
+            int opcode = CALL_LIST_APPEND;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -3179,10 +3141,9 @@
 
         TARGET(CALL_METHOD_DESCRIPTOR_FAST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_METHOD_DESCRIPTOR_FAST;
+            int opcode = CALL_METHOD_DESCRIPTOR_FAST;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -3284,10 +3245,9 @@
 
         TARGET(CALL_METHOD_DESCRIPTOR_FAST_WITH_KEYWORDS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_METHOD_DESCRIPTOR_FAST_WITH_KEYWORDS;
+            int opcode = CALL_METHOD_DESCRIPTOR_FAST_WITH_KEYWORDS;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -3389,10 +3349,9 @@
 
         TARGET(CALL_METHOD_DESCRIPTOR_NOARGS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_METHOD_DESCRIPTOR_NOARGS;
+            int opcode = CALL_METHOD_DESCRIPTOR_NOARGS;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -3494,10 +3453,9 @@
 
         TARGET(CALL_METHOD_DESCRIPTOR_O) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_METHOD_DESCRIPTOR_O;
+            int opcode = CALL_METHOD_DESCRIPTOR_O;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -3601,15 +3559,15 @@
 
         TARGET(CALL_NON_PY_GENERAL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_NON_PY_GENERAL;
+            int opcode = CALL_NON_PY_GENERAL;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
             next_instr += 4;
             INSTRUCTION_STATS(CALL_NON_PY_GENERAL);
+            opcode = CALL_NON_PY_GENERAL;
             static_assert(INLINE_CACHE_ENTRIES_CALL == 3, "incorrect cache size");
             _PyStackRef *callable;
             _PyStackRef *self_or_null;
@@ -3704,10 +3662,9 @@
 
         TARGET(CALL_PY_EXACT_ARGS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_PY_EXACT_ARGS;
+            int opcode = CALL_PY_EXACT_ARGS;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -3816,10 +3773,9 @@
 
         TARGET(CALL_PY_GENERAL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_PY_GENERAL;
+            int opcode = CALL_PY_GENERAL;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -3913,10 +3869,9 @@
 
         TARGET(CALL_STR_1) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_STR_1;
+            int opcode = CALL_STR_1;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -3987,10 +3942,9 @@
 
         TARGET(CALL_TUPLE_1) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_TUPLE_1;
+            int opcode = CALL_TUPLE_1;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -4061,10 +4015,9 @@
 
         TARGET(CALL_TYPE_1) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CALL_TYPE_1;
+            int opcode = CALL_TYPE_1;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -4106,10 +4059,9 @@
 
         TARGET(CHECK_EG_MATCH) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CHECK_EG_MATCH;
+            int opcode = CHECK_EG_MATCH;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(CHECK_EG_MATCH);
@@ -4162,10 +4114,9 @@
 
         TARGET(CHECK_EXC_MATCH) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CHECK_EXC_MATCH;
+            int opcode = CHECK_EXC_MATCH;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(CHECK_EXC_MATCH);
@@ -4195,10 +4146,9 @@
 
         TARGET(CLEANUP_THROW) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CLEANUP_THROW;
+            int opcode = CLEANUP_THROW;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -4244,10 +4194,9 @@
 
         TARGET(COMPARE_OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = COMPARE_OP;
+            int opcode = COMPARE_OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 2;
             INSTRUCTION_STATS(COMPARE_OP);
@@ -4314,10 +4263,9 @@
 
         TARGET(COMPARE_OP_FLOAT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = COMPARE_OP_FLOAT;
+            int opcode = COMPARE_OP_FLOAT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -4367,10 +4315,9 @@
 
         TARGET(COMPARE_OP_INT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = COMPARE_OP_INT;
+            int opcode = COMPARE_OP_INT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -4432,10 +4379,9 @@
 
         TARGET(COMPARE_OP_STR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = COMPARE_OP_STR;
+            int opcode = COMPARE_OP_STR;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -4486,10 +4432,9 @@
 
         TARGET(CONTAINS_OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CONTAINS_OP;
+            int opcode = CONTAINS_OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 2;
             INSTRUCTION_STATS(CONTAINS_OP);
@@ -4539,10 +4484,9 @@
 
         TARGET(CONTAINS_OP_DICT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CONTAINS_OP_DICT;
+            int opcode = CONTAINS_OP_DICT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -4580,10 +4524,9 @@
 
         TARGET(CONTAINS_OP_SET) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CONTAINS_OP_SET;
+            int opcode = CONTAINS_OP_SET;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -4622,10 +4565,9 @@
 
         TARGET(CONVERT_VALUE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = CONVERT_VALUE;
+            int opcode = CONVERT_VALUE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(CONVERT_VALUE);
@@ -4655,10 +4597,9 @@
 
         TARGET(COPY) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = COPY;
+            int opcode = COPY;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(COPY);
@@ -4675,10 +4616,9 @@
 
         TARGET(COPY_FREE_VARS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = COPY_FREE_VARS;
+            int opcode = COPY_FREE_VARS;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(COPY_FREE_VARS);
@@ -4698,10 +4638,9 @@
 
         TARGET(DELETE_ATTR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = DELETE_ATTR;
+            int opcode = DELETE_ATTR;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(DELETE_ATTR);
@@ -4722,10 +4661,9 @@
 
         TARGET(DELETE_DEREF) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = DELETE_DEREF;
+            int opcode = DELETE_DEREF;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(DELETE_DEREF);
@@ -4747,10 +4685,9 @@
 
         TARGET(DELETE_FAST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = DELETE_FAST;
+            int opcode = DELETE_FAST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(DELETE_FAST);
@@ -4774,10 +4711,9 @@
 
         TARGET(DELETE_GLOBAL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = DELETE_GLOBAL;
+            int opcode = DELETE_GLOBAL;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(DELETE_GLOBAL);
@@ -4801,10 +4737,9 @@
 
         TARGET(DELETE_NAME) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = DELETE_NAME;
+            int opcode = DELETE_NAME;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(DELETE_NAME);
@@ -4835,10 +4770,9 @@
 
         TARGET(DELETE_SUBSCR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = DELETE_SUBSCR;
+            int opcode = DELETE_SUBSCR;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(DELETE_SUBSCR);
@@ -4863,10 +4797,9 @@
 
         TARGET(DICT_MERGE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = DICT_MERGE;
+            int opcode = DICT_MERGE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(DICT_MERGE);
@@ -4897,10 +4830,9 @@
 
         TARGET(DICT_UPDATE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = DICT_UPDATE;
+            int opcode = DICT_UPDATE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(DICT_UPDATE);
@@ -4935,10 +4867,9 @@
 
         TARGET(END_ASYNC_FOR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = END_ASYNC_FOR;
+            int opcode = END_ASYNC_FOR;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -4973,10 +4904,9 @@
 
         TARGET(END_FOR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = END_FOR;
+            int opcode = END_FOR;
             (void)(opcode);
+            #endif
             next_instr += 1;
             INSTRUCTION_STATS(END_FOR);
             _PyStackRef value;
@@ -4996,10 +4926,9 @@
 
         TARGET(END_SEND) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = END_SEND;
+            int opcode = END_SEND;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(END_SEND);
@@ -5019,15 +4948,15 @@
 
         TARGET(ENTER_EXECUTOR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = ENTER_EXECUTOR;
+            int opcode = ENTER_EXECUTOR;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(ENTER_EXECUTOR);
+            opcode = ENTER_EXECUTOR;
             #ifdef _Py_TIER2
             PyCodeObject *code = _PyFrame_GetCode(frame);
             _PyExecutorObject *executor = code->co_executors->executors[oparg & 255];
@@ -5058,10 +4987,9 @@
 
         TARGET(EXIT_INIT_CHECK) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = EXIT_INIT_CHECK;
+            int opcode = EXIT_INIT_CHECK;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(EXIT_INIT_CHECK);
@@ -5083,13 +5011,13 @@
 
         TARGET(EXTENDED_ARG) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = EXTENDED_ARG;
+            int opcode = EXTENDED_ARG;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(EXTENDED_ARG);
+            opcode = EXTENDED_ARG;
             assert(oparg);
             opcode = next_instr->op.code;
             oparg = oparg << 8 | next_instr->op.arg;
@@ -5099,10 +5027,9 @@
 
         TARGET(FORMAT_SIMPLE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = FORMAT_SIMPLE;
+            int opcode = FORMAT_SIMPLE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(FORMAT_SIMPLE);
@@ -5139,10 +5066,9 @@
 
         TARGET(FORMAT_WITH_SPEC) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = FORMAT_WITH_SPEC;
+            int opcode = FORMAT_WITH_SPEC;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(FORMAT_WITH_SPEC);
@@ -5168,10 +5094,9 @@
 
         TARGET(FOR_ITER) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = FOR_ITER;
+            int opcode = FOR_ITER;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 2;
             INSTRUCTION_STATS(FOR_ITER);
@@ -5235,10 +5160,9 @@
 
         TARGET(FOR_ITER_GEN) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = FOR_ITER_GEN;
+            int opcode = FOR_ITER_GEN;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -5302,10 +5226,9 @@
 
         TARGET(FOR_ITER_LIST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = FOR_ITER_LIST;
+            int opcode = FOR_ITER_LIST;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -5364,10 +5287,9 @@
 
         TARGET(FOR_ITER_RANGE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = FOR_ITER_RANGE;
+            int opcode = FOR_ITER_RANGE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -5420,10 +5342,9 @@
 
         TARGET(FOR_ITER_TUPLE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = FOR_ITER_TUPLE;
+            int opcode = FOR_ITER_TUPLE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -5479,10 +5400,9 @@
 
         TARGET(GET_AITER) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = GET_AITER;
+            int opcode = GET_AITER;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(GET_AITER);
@@ -5533,10 +5453,9 @@
 
         TARGET(GET_ANEXT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = GET_ANEXT;
+            int opcode = GET_ANEXT;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(GET_ANEXT);
@@ -5558,10 +5477,9 @@
 
         TARGET(GET_AWAITABLE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = GET_AWAITABLE;
+            int opcode = GET_AWAITABLE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(GET_AWAITABLE);
@@ -5582,10 +5500,9 @@
 
         TARGET(GET_ITER) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = GET_ITER;
+            int opcode = GET_ITER;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(GET_ITER);
@@ -5607,10 +5524,9 @@
 
         TARGET(GET_LEN) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = GET_LEN;
+            int opcode = GET_LEN;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(GET_LEN);
@@ -5637,10 +5553,9 @@
 
         TARGET(GET_YIELD_FROM_ITER) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = GET_YIELD_FROM_ITER;
+            int opcode = GET_YIELD_FROM_ITER;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(GET_YIELD_FROM_ITER);
@@ -5685,10 +5600,9 @@
 
         TARGET(IMPORT_FROM) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = IMPORT_FROM;
+            int opcode = IMPORT_FROM;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(IMPORT_FROM);
@@ -5711,10 +5625,9 @@
 
         TARGET(IMPORT_NAME) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = IMPORT_NAME;
+            int opcode = IMPORT_NAME;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(IMPORT_NAME);
@@ -5743,15 +5656,15 @@
 
         TARGET(INSTRUMENTED_CALL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_CALL;
+            int opcode = INSTRUMENTED_CALL;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
             next_instr += 4;
             INSTRUCTION_STATS(INSTRUMENTED_CALL);
+            opcode = INSTRUMENTED_CALL;
             _PyStackRef *callable;
             _PyStackRef *self_or_null;
             _PyStackRef *args;
@@ -5924,15 +5837,15 @@
 
         TARGET(INSTRUMENTED_CALL_FUNCTION_EX) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_CALL_FUNCTION_EX;
+            int opcode = INSTRUMENTED_CALL_FUNCTION_EX;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(INSTRUMENTED_CALL_FUNCTION_EX);
+            opcode = INSTRUMENTED_CALL_FUNCTION_EX;
             _PyStackRef func;
             _PyStackRef callargs;
             _PyStackRef kwargs_in;
@@ -6116,15 +6029,15 @@
 
         TARGET(INSTRUMENTED_CALL_KW) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_CALL_KW;
+            int opcode = INSTRUMENTED_CALL_KW;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
             next_instr += 4;
             INSTRUCTION_STATS(INSTRUMENTED_CALL_KW);
+            opcode = INSTRUMENTED_CALL_KW;
             _PyStackRef *callable;
             _PyStackRef *self_or_null;
             _PyStackRef *args;
@@ -6294,10 +6207,9 @@
 
         TARGET(INSTRUMENTED_END_FOR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_END_FOR;
+            int opcode = INSTRUMENTED_END_FOR;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             next_instr += 1;
@@ -6324,10 +6236,9 @@
 
         TARGET(INSTRUMENTED_END_SEND) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_END_SEND;
+            int opcode = INSTRUMENTED_END_SEND;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -6359,10 +6270,9 @@
 
         TARGET(INSTRUMENTED_FOR_ITER) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_FOR_ITER;
+            int opcode = INSTRUMENTED_FOR_ITER;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -6402,15 +6312,15 @@
 
         TARGET(INSTRUMENTED_INSTRUCTION) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_INSTRUCTION;
+            int opcode = INSTRUMENTED_INSTRUCTION;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(INSTRUMENTED_INSTRUCTION);
+            opcode = INSTRUMENTED_INSTRUCTION;
             _PyFrame_SetStackPointer(frame, stack_pointer);
             int next_opcode = _Py_call_instrumentation_instruction(
                 tstate, frame, this_instr);
@@ -6429,10 +6339,9 @@
 
         TARGET(INSTRUMENTED_JUMP_BACKWARD) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_JUMP_BACKWARD;
+            int opcode = INSTRUMENTED_JUMP_BACKWARD;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -6461,10 +6370,9 @@
 
         TARGET(INSTRUMENTED_JUMP_FORWARD) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_JUMP_FORWARD;
+            int opcode = INSTRUMENTED_JUMP_FORWARD;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -6476,16 +6384,16 @@
 
         TARGET(INSTRUMENTED_LINE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_LINE;
+            int opcode = INSTRUMENTED_LINE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const prev_instr = frame->instr_ptr;
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(INSTRUMENTED_LINE);
+            opcode = INSTRUMENTED_LINE;
             int original_opcode = 0;
             if (tstate->tracing) {
                 PyCodeObject *code = _PyFrame_GetCode(frame);
@@ -6520,15 +6428,15 @@
 
         TARGET(INSTRUMENTED_LOAD_SUPER_ATTR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_LOAD_SUPER_ATTR;
+            int opcode = INSTRUMENTED_LOAD_SUPER_ATTR;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
             next_instr += 2;
             INSTRUCTION_STATS(INSTRUMENTED_LOAD_SUPER_ATTR);
+            opcode = INSTRUMENTED_LOAD_SUPER_ATTR;
             _PyStackRef global_super_st;
             _PyStackRef class_st;
             _PyStackRef self_st;
@@ -6616,10 +6524,9 @@
 
         TARGET(INSTRUMENTED_NOT_TAKEN) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_NOT_TAKEN;
+            int opcode = INSTRUMENTED_NOT_TAKEN;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const prev_instr = frame->instr_ptr;
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
@@ -6633,10 +6540,9 @@
 
         TARGET(INSTRUMENTED_POP_ITER) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_POP_ITER;
+            int opcode = INSTRUMENTED_POP_ITER;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const prev_instr = frame->instr_ptr;
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
@@ -6656,10 +6562,9 @@
 
         TARGET(INSTRUMENTED_POP_JUMP_IF_FALSE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_POP_JUMP_IF_FALSE;
+            int opcode = INSTRUMENTED_POP_JUMP_IF_FALSE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -6678,10 +6583,9 @@
 
         TARGET(INSTRUMENTED_POP_JUMP_IF_NONE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_POP_JUMP_IF_NONE;
+            int opcode = INSTRUMENTED_POP_JUMP_IF_NONE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -6704,10 +6608,9 @@
 
         TARGET(INSTRUMENTED_POP_JUMP_IF_NOT_NONE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_POP_JUMP_IF_NOT_NONE;
+            int opcode = INSTRUMENTED_POP_JUMP_IF_NOT_NONE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -6728,10 +6631,9 @@
 
         TARGET(INSTRUMENTED_POP_JUMP_IF_TRUE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_POP_JUMP_IF_TRUE;
+            int opcode = INSTRUMENTED_POP_JUMP_IF_TRUE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -6750,10 +6652,9 @@
 
         TARGET(INSTRUMENTED_RESUME) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_RESUME;
+            int opcode = INSTRUMENTED_RESUME;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -6834,10 +6735,9 @@
 
         TARGET(INSTRUMENTED_RETURN_VALUE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_RETURN_VALUE;
+            int opcode = INSTRUMENTED_RETURN_VALUE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -6885,10 +6785,9 @@
 
         TARGET(INSTRUMENTED_YIELD_VALUE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INSTRUMENTED_YIELD_VALUE;
+            int opcode = INSTRUMENTED_YIELD_VALUE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -6958,10 +6857,9 @@
 
         TARGET(INTERPRETER_EXIT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = INTERPRETER_EXIT;
+            int opcode = INTERPRETER_EXIT;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(INTERPRETER_EXIT);
@@ -6982,10 +6880,9 @@
 
         TARGET(IS_OP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = IS_OP;
+            int opcode = IS_OP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(IS_OP);
@@ -7006,10 +6903,9 @@
 
         TARGET(JUMP_BACKWARD) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = JUMP_BACKWARD;
+            int opcode = JUMP_BACKWARD;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 2;
             INSTRUCTION_STATS(JUMP_BACKWARD);
@@ -7056,10 +6952,9 @@
 
         TARGET(JUMP_BACKWARD_JIT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = JUMP_BACKWARD_JIT;
+            int opcode = JUMP_BACKWARD_JIT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -7130,10 +7025,9 @@
 
         TARGET(JUMP_BACKWARD_NO_INTERRUPT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = JUMP_BACKWARD_NO_INTERRUPT;
+            int opcode = JUMP_BACKWARD_NO_INTERRUPT;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(JUMP_BACKWARD_NO_INTERRUPT);
@@ -7149,10 +7043,9 @@
 
         TARGET(JUMP_BACKWARD_NO_JIT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = JUMP_BACKWARD_NO_JIT;
+            int opcode = JUMP_BACKWARD_NO_JIT;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 2;
             INSTRUCTION_STATS(JUMP_BACKWARD_NO_JIT);
@@ -7186,10 +7079,9 @@
 
         TARGET(JUMP_FORWARD) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = JUMP_FORWARD;
+            int opcode = JUMP_FORWARD;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(JUMP_FORWARD);
@@ -7199,10 +7091,9 @@
 
         TARGET(LIST_APPEND) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LIST_APPEND;
+            int opcode = LIST_APPEND;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LIST_APPEND);
@@ -7222,10 +7113,9 @@
 
         TARGET(LIST_EXTEND) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LIST_EXTEND;
+            int opcode = LIST_EXTEND;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LIST_EXTEND);
@@ -7264,10 +7154,9 @@
 
         TARGET(LOAD_ATTR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR;
+            int opcode = LOAD_ATTR;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 10;
             INSTRUCTION_STATS(LOAD_ATTR);
@@ -7349,10 +7238,9 @@
 
         TARGET(LOAD_ATTR_CLASS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_CLASS;
+            int opcode = LOAD_ATTR_CLASS;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -7402,10 +7290,9 @@
 
         TARGET(LOAD_ATTR_CLASS_WITH_METACLASS_CHECK) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_CLASS_WITH_METACLASS_CHECK;
+            int opcode = LOAD_ATTR_CLASS_WITH_METACLASS_CHECK;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -7465,10 +7352,9 @@
 
         TARGET(LOAD_ATTR_GETATTRIBUTE_OVERRIDDEN) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_GETATTRIBUTE_OVERRIDDEN;
+            int opcode = LOAD_ATTR_GETATTRIBUTE_OVERRIDDEN;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -7524,10 +7410,9 @@
 
         TARGET(LOAD_ATTR_INSTANCE_VALUE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_INSTANCE_VALUE;
+            int opcode = LOAD_ATTR_INSTANCE_VALUE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -7602,10 +7487,9 @@
 
         TARGET(LOAD_ATTR_METHOD_LAZY_DICT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_METHOD_LAZY_DICT;
+            int opcode = LOAD_ATTR_METHOD_LAZY_DICT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -7660,10 +7544,9 @@
 
         TARGET(LOAD_ATTR_METHOD_NO_DICT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_METHOD_NO_DICT;
+            int opcode = LOAD_ATTR_METHOD_NO_DICT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -7707,10 +7590,9 @@
 
         TARGET(LOAD_ATTR_METHOD_WITH_VALUES) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_METHOD_WITH_VALUES;
+            int opcode = LOAD_ATTR_METHOD_WITH_VALUES;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -7776,10 +7658,9 @@
 
         TARGET(LOAD_ATTR_MODULE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_MODULE;
+            int opcode = LOAD_ATTR_MODULE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -7856,10 +7737,9 @@
 
         TARGET(LOAD_ATTR_NONDESCRIPTOR_NO_DICT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_NONDESCRIPTOR_NO_DICT;
+            int opcode = LOAD_ATTR_NONDESCRIPTOR_NO_DICT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -7898,10 +7778,9 @@
 
         TARGET(LOAD_ATTR_NONDESCRIPTOR_WITH_VALUES) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_NONDESCRIPTOR_WITH_VALUES;
+            int opcode = LOAD_ATTR_NONDESCRIPTOR_WITH_VALUES;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -7961,10 +7840,9 @@
 
         TARGET(LOAD_ATTR_PROPERTY) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_PROPERTY;
+            int opcode = LOAD_ATTR_PROPERTY;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -8057,10 +7935,9 @@
 
         TARGET(LOAD_ATTR_SLOT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_SLOT;
+            int opcode = LOAD_ATTR_SLOT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -8121,10 +7998,9 @@
 
         TARGET(LOAD_ATTR_WITH_HINT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_ATTR_WITH_HINT;
+            int opcode = LOAD_ATTR_WITH_HINT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -8226,10 +8102,9 @@
 
         TARGET(LOAD_BUILD_CLASS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_BUILD_CLASS;
+            int opcode = LOAD_BUILD_CLASS;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_BUILD_CLASS);
@@ -8257,10 +8132,9 @@
 
         TARGET(LOAD_COMMON_CONSTANT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_COMMON_CONSTANT;
+            int opcode = LOAD_COMMON_CONSTANT;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_COMMON_CONSTANT);
@@ -8284,10 +8158,9 @@
 
         TARGET(LOAD_CONST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_CONST;
+            int opcode = LOAD_CONST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_CONST);
@@ -8322,10 +8195,9 @@
 
         TARGET(LOAD_CONST_IMMORTAL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_CONST_IMMORTAL;
+            int opcode = LOAD_CONST_IMMORTAL;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_CONST_IMMORTAL);
@@ -8342,10 +8214,9 @@
 
         TARGET(LOAD_CONST_MORTAL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_CONST_MORTAL;
+            int opcode = LOAD_CONST_MORTAL;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_CONST_MORTAL);
@@ -8361,10 +8232,9 @@
 
         TARGET(LOAD_DEREF) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_DEREF;
+            int opcode = LOAD_DEREF;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_DEREF);
@@ -8386,10 +8256,9 @@
 
         TARGET(LOAD_FAST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_FAST;
+            int opcode = LOAD_FAST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_FAST);
@@ -8404,10 +8273,9 @@
 
         TARGET(LOAD_FAST_AND_CLEAR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_FAST_AND_CLEAR;
+            int opcode = LOAD_FAST_AND_CLEAR;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_FAST_AND_CLEAR);
@@ -8422,10 +8290,9 @@
 
         TARGET(LOAD_FAST_CHECK) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_FAST_CHECK;
+            int opcode = LOAD_FAST_CHECK;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_FAST_CHECK);
@@ -8449,10 +8316,9 @@
 
         TARGET(LOAD_FAST_LOAD_FAST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_FAST_LOAD_FAST;
+            int opcode = LOAD_FAST_LOAD_FAST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_FAST_LOAD_FAST);
@@ -8471,10 +8337,9 @@
 
         TARGET(LOAD_FROM_DICT_OR_DEREF) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_FROM_DICT_OR_DEREF;
+            int opcode = LOAD_FROM_DICT_OR_DEREF;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_FROM_DICT_OR_DEREF);
@@ -8517,10 +8382,9 @@
 
         TARGET(LOAD_FROM_DICT_OR_GLOBALS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_FROM_DICT_OR_GLOBALS;
+            int opcode = LOAD_FROM_DICT_OR_GLOBALS;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_FROM_DICT_OR_GLOBALS);
@@ -8598,10 +8462,9 @@
 
         TARGET(LOAD_GLOBAL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_GLOBAL;
+            int opcode = LOAD_GLOBAL;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 5;
             INSTRUCTION_STATS(LOAD_GLOBAL);
@@ -8653,10 +8516,9 @@
 
         TARGET(LOAD_GLOBAL_BUILTIN) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_GLOBAL_BUILTIN;
+            int opcode = LOAD_GLOBAL_BUILTIN;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -8738,10 +8600,9 @@
 
         TARGET(LOAD_GLOBAL_MODULE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_GLOBAL_MODULE;
+            int opcode = LOAD_GLOBAL_MODULE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -8807,10 +8668,9 @@
 
         TARGET(LOAD_LOCALS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_LOCALS;
+            int opcode = LOAD_LOCALS;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_LOCALS);
@@ -8832,10 +8692,9 @@
 
         TARGET(LOAD_NAME) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_NAME;
+            int opcode = LOAD_NAME;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_NAME);
@@ -8856,10 +8715,9 @@
 
         TARGET(LOAD_SMALL_INT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_SMALL_INT;
+            int opcode = LOAD_SMALL_INT;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_SMALL_INT);
@@ -8875,10 +8733,9 @@
 
         TARGET(LOAD_SPECIAL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_SPECIAL;
+            int opcode = LOAD_SPECIAL;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(LOAD_SPECIAL);
@@ -8917,16 +8774,16 @@
 
         TARGET(LOAD_SUPER_ATTR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_SUPER_ATTR;
+            int opcode = LOAD_SUPER_ATTR;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 2;
             INSTRUCTION_STATS(LOAD_SUPER_ATTR);
             PREDICTED_LOAD_SUPER_ATTR:;
             _Py_CODEUNIT* const this_instr = next_instr - 2;
             (void)this_instr;
+            opcode = LOAD_SUPER_ATTR;
             _PyStackRef global_super_st;
             _PyStackRef class_st;
             _PyStackRef self_st;
@@ -9030,10 +8887,9 @@
 
         TARGET(LOAD_SUPER_ATTR_ATTR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_SUPER_ATTR_ATTR;
+            int opcode = LOAD_SUPER_ATTR_ATTR;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -9082,10 +8938,9 @@
 
         TARGET(LOAD_SUPER_ATTR_METHOD) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = LOAD_SUPER_ATTR_METHOD;
+            int opcode = LOAD_SUPER_ATTR_METHOD;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -9150,10 +9005,9 @@
 
         TARGET(MAKE_CELL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = MAKE_CELL;
+            int opcode = MAKE_CELL;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(MAKE_CELL);
@@ -9174,10 +9028,9 @@
 
         TARGET(MAKE_FUNCTION) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = MAKE_FUNCTION;
+            int opcode = MAKE_FUNCTION;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(MAKE_FUNCTION);
@@ -9208,10 +9061,9 @@
 
         TARGET(MAP_ADD) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = MAP_ADD;
+            int opcode = MAP_ADD;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(MAP_ADD);
@@ -9242,10 +9094,9 @@
 
         TARGET(MATCH_CLASS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = MATCH_CLASS;
+            int opcode = MATCH_CLASS;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(MATCH_CLASS);
@@ -9287,10 +9138,9 @@
 
         TARGET(MATCH_KEYS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = MATCH_KEYS;
+            int opcode = MATCH_KEYS;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(MATCH_KEYS);
@@ -9316,10 +9166,9 @@
 
         TARGET(MATCH_MAPPING) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = MATCH_MAPPING;
+            int opcode = MATCH_MAPPING;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(MATCH_MAPPING);
@@ -9336,10 +9185,9 @@
 
         TARGET(MATCH_SEQUENCE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = MATCH_SEQUENCE;
+            int opcode = MATCH_SEQUENCE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(MATCH_SEQUENCE);
@@ -9356,10 +9204,9 @@
 
         TARGET(NOP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = NOP;
+            int opcode = NOP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(NOP);
@@ -9368,10 +9215,9 @@
 
         TARGET(NOT_TAKEN) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = NOT_TAKEN;
+            int opcode = NOT_TAKEN;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(NOT_TAKEN);
@@ -9380,10 +9226,9 @@
 
         TARGET(POP_EXCEPT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = POP_EXCEPT;
+            int opcode = POP_EXCEPT;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(POP_EXCEPT);
@@ -9402,10 +9247,9 @@
 
         TARGET(POP_ITER) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = POP_ITER;
+            int opcode = POP_ITER;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(POP_ITER);
@@ -9419,10 +9263,9 @@
 
         TARGET(POP_JUMP_IF_FALSE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = POP_JUMP_IF_FALSE;
+            int opcode = POP_JUMP_IF_FALSE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -9442,10 +9285,9 @@
 
         TARGET(POP_JUMP_IF_NONE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = POP_JUMP_IF_NONE;
+            int opcode = POP_JUMP_IF_NONE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -9481,10 +9323,9 @@
 
         TARGET(POP_JUMP_IF_NOT_NONE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = POP_JUMP_IF_NOT_NONE;
+            int opcode = POP_JUMP_IF_NOT_NONE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -9520,10 +9361,9 @@
 
         TARGET(POP_JUMP_IF_TRUE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = POP_JUMP_IF_TRUE;
+            int opcode = POP_JUMP_IF_TRUE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -9543,10 +9383,9 @@
 
         TARGET(POP_TOP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = POP_TOP;
+            int opcode = POP_TOP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(POP_TOP);
@@ -9560,10 +9399,9 @@
 
         TARGET(PUSH_EXC_INFO) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = PUSH_EXC_INFO;
+            int opcode = PUSH_EXC_INFO;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(PUSH_EXC_INFO);
@@ -9590,10 +9428,9 @@
 
         TARGET(PUSH_NULL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = PUSH_NULL;
+            int opcode = PUSH_NULL;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(PUSH_NULL);
@@ -9607,10 +9444,9 @@
 
         TARGET(RAISE_VARARGS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = RAISE_VARARGS;
+            int opcode = RAISE_VARARGS;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -9639,10 +9475,9 @@
 
         TARGET(RERAISE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = RERAISE;
+            int opcode = RERAISE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -9689,10 +9524,9 @@
 
         TARGET(RESERVED) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = RESERVED;
+            int opcode = RESERVED;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(RESERVED);
@@ -9703,10 +9537,9 @@
 
         TARGET(RESUME) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = RESUME;
+            int opcode = RESUME;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(RESUME);
@@ -9782,10 +9615,9 @@
 
         TARGET(RESUME_CHECK) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = RESUME_CHECK;
+            int opcode = RESUME_CHECK;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -9821,10 +9653,9 @@
 
         TARGET(RETURN_GENERATOR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = RETURN_GENERATOR;
+            int opcode = RETURN_GENERATOR;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(RETURN_GENERATOR);
@@ -9861,10 +9692,9 @@
 
         TARGET(RETURN_VALUE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = RETURN_VALUE;
+            int opcode = RETURN_VALUE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(RETURN_VALUE);
@@ -9894,10 +9724,9 @@
 
         TARGET(SEND) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = SEND;
+            int opcode = SEND;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 2;
             INSTRUCTION_STATS(SEND);
@@ -9995,10 +9824,9 @@
 
         TARGET(SEND_GEN) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = SEND_GEN;
+            int opcode = SEND_GEN;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -10066,10 +9894,9 @@
 
         TARGET(SETUP_ANNOTATIONS) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = SETUP_ANNOTATIONS;
+            int opcode = SETUP_ANNOTATIONS;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(SETUP_ANNOTATIONS);
@@ -10114,10 +9941,9 @@
 
         TARGET(SET_ADD) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = SET_ADD;
+            int opcode = SET_ADD;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(SET_ADD);
@@ -10140,10 +9966,9 @@
 
         TARGET(SET_FUNCTION_ATTRIBUTE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = SET_FUNCTION_ATTRIBUTE;
+            int opcode = SET_FUNCTION_ATTRIBUTE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(SET_FUNCTION_ATTRIBUTE);
@@ -10169,10 +9994,9 @@
 
         TARGET(SET_UPDATE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = SET_UPDATE;
+            int opcode = SET_UPDATE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(SET_UPDATE);
@@ -10195,10 +10019,9 @@
 
         TARGET(STORE_ATTR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_ATTR;
+            int opcode = STORE_ATTR;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 5;
             INSTRUCTION_STATS(STORE_ATTR);
@@ -10247,10 +10070,9 @@
 
         TARGET(STORE_ATTR_INSTANCE_VALUE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_ATTR_INSTANCE_VALUE;
+            int opcode = STORE_ATTR_INSTANCE_VALUE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -10324,10 +10146,9 @@
 
         TARGET(STORE_ATTR_SLOT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_ATTR_SLOT;
+            int opcode = STORE_ATTR_SLOT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -10376,10 +10197,9 @@
 
         TARGET(STORE_ATTR_WITH_HINT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_ATTR_WITH_HINT;
+            int opcode = STORE_ATTR_WITH_HINT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -10477,10 +10297,9 @@
 
         TARGET(STORE_DEREF) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_DEREF;
+            int opcode = STORE_DEREF;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(STORE_DEREF);
@@ -10497,10 +10316,9 @@
 
         TARGET(STORE_FAST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_FAST;
+            int opcode = STORE_FAST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(STORE_FAST);
@@ -10518,10 +10336,9 @@
 
         TARGET(STORE_FAST_LOAD_FAST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_FAST_LOAD_FAST;
+            int opcode = STORE_FAST_LOAD_FAST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(STORE_FAST_LOAD_FAST);
@@ -10542,10 +10359,9 @@
 
         TARGET(STORE_FAST_STORE_FAST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_FAST_STORE_FAST;
+            int opcode = STORE_FAST_STORE_FAST;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(STORE_FAST_STORE_FAST);
@@ -10574,10 +10390,9 @@
 
         TARGET(STORE_GLOBAL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_GLOBAL;
+            int opcode = STORE_GLOBAL;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(STORE_GLOBAL);
@@ -10598,10 +10413,9 @@
 
         TARGET(STORE_NAME) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_NAME;
+            int opcode = STORE_NAME;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(STORE_NAME);
@@ -10639,10 +10453,9 @@
 
         TARGET(STORE_SLICE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_SLICE;
+            int opcode = STORE_SLICE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(STORE_SLICE);
@@ -10694,10 +10507,9 @@
 
         TARGET(STORE_SUBSCR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_SUBSCR;
+            int opcode = STORE_SUBSCR;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 2;
             INSTRUCTION_STATS(STORE_SUBSCR);
@@ -10746,10 +10558,9 @@
 
         TARGET(STORE_SUBSCR_DICT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_SUBSCR_DICT;
+            int opcode = STORE_SUBSCR_DICT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -10788,10 +10599,9 @@
 
         TARGET(STORE_SUBSCR_LIST_INT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = STORE_SUBSCR_LIST_INT;
+            int opcode = STORE_SUBSCR_LIST_INT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -10855,10 +10665,9 @@
 
         TARGET(SWAP) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = SWAP;
+            int opcode = SWAP;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(SWAP);
@@ -10875,10 +10684,9 @@
 
         TARGET(TO_BOOL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TO_BOOL;
+            int opcode = TO_BOOL;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 4;
             INSTRUCTION_STATS(TO_BOOL);
@@ -10922,10 +10730,9 @@
 
         TARGET(TO_BOOL_ALWAYS_TRUE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TO_BOOL_ALWAYS_TRUE;
+            int opcode = TO_BOOL_ALWAYS_TRUE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -10960,10 +10767,9 @@
 
         TARGET(TO_BOOL_BOOL) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TO_BOOL_BOOL;
+            int opcode = TO_BOOL_BOOL;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -10985,10 +10791,9 @@
 
         TARGET(TO_BOOL_INT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TO_BOOL_INT;
+            int opcode = TO_BOOL_INT;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -11021,10 +10826,9 @@
 
         TARGET(TO_BOOL_LIST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TO_BOOL_LIST;
+            int opcode = TO_BOOL_LIST;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -11051,10 +10855,9 @@
 
         TARGET(TO_BOOL_NONE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TO_BOOL_NONE;
+            int opcode = TO_BOOL_NONE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -11080,10 +10883,9 @@
 
         TARGET(TO_BOOL_STR) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = TO_BOOL_STR;
+            int opcode = TO_BOOL_STR;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -11117,10 +10919,9 @@
 
         TARGET(UNARY_INVERT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = UNARY_INVERT;
+            int opcode = UNARY_INVERT;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(UNARY_INVERT);
@@ -11141,10 +10942,9 @@
 
         TARGET(UNARY_NEGATIVE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = UNARY_NEGATIVE;
+            int opcode = UNARY_NEGATIVE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(UNARY_NEGATIVE);
@@ -11165,10 +10965,9 @@
 
         TARGET(UNARY_NOT) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = UNARY_NOT;
+            int opcode = UNARY_NOT;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(UNARY_NOT);
@@ -11184,10 +10983,9 @@
 
         TARGET(UNPACK_EX) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = UNPACK_EX;
+            int opcode = UNPACK_EX;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(UNPACK_EX);
@@ -11210,10 +11008,9 @@
 
         TARGET(UNPACK_SEQUENCE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = UNPACK_SEQUENCE;
+            int opcode = UNPACK_SEQUENCE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 2;
             INSTRUCTION_STATS(UNPACK_SEQUENCE);
@@ -11260,10 +11057,9 @@
 
         TARGET(UNPACK_SEQUENCE_LIST) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = UNPACK_SEQUENCE_LIST;
+            int opcode = UNPACK_SEQUENCE_LIST;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -11308,10 +11104,9 @@
 
         TARGET(UNPACK_SEQUENCE_TUPLE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = UNPACK_SEQUENCE_TUPLE;
+            int opcode = UNPACK_SEQUENCE_TUPLE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -11347,10 +11142,9 @@
 
         TARGET(UNPACK_SEQUENCE_TWO_TUPLE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = UNPACK_SEQUENCE_TWO_TUPLE;
+            int opcode = UNPACK_SEQUENCE_TWO_TUPLE;
             (void)(opcode);
+            #endif
             _Py_CODEUNIT* const this_instr = next_instr;
             (void)this_instr;
             frame->instr_ptr = next_instr;
@@ -11387,10 +11181,9 @@
 
         TARGET(WITH_EXCEPT_START) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = WITH_EXCEPT_START;
+            int opcode = WITH_EXCEPT_START;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(WITH_EXCEPT_START);
@@ -11446,10 +11239,9 @@
 
         TARGET(YIELD_VALUE) {
             #if defined(Py_TAIL_CALL_INTERP)
-            int opcode;
-            #endif
-            opcode = YIELD_VALUE;
+            int opcode = YIELD_VALUE;
             (void)(opcode);
+            #endif
             frame->instr_ptr = next_instr;
             next_instr += 1;
             INSTRUCTION_STATS(YIELD_VALUE);

--- a/Tools/cases_generator/tier1_generator.py
+++ b/Tools/cases_generator/tier1_generator.py
@@ -230,10 +230,9 @@ def generate_tier1_cases(
         # We need to ifdef it because this breaks platforms
         # without computed gotos/tail calling.
         out.emit(f"#if defined(Py_TAIL_CALL_INTERP)\n")
-        out.emit(f"int opcode;\n")
-        out.emit(f"#endif\n")
-        out.emit(f"opcode = {name};\n")
+        out.emit(f"int opcode = {name};\n")
         out.emit(f"(void)(opcode);\n")
+        out.emit(f"#endif\n")
         needs_this = uses_this(inst)
         unused_guard = "(void)this_instr;\n"
         if inst.properties.needs_prev:
@@ -252,6 +251,8 @@ def generate_tier1_cases(
             if needs_this:
                 out.emit(f"_Py_CODEUNIT* const this_instr = next_instr - {inst.size};\n")
                 out.emit(unused_guard)
+        if inst.properties.uses_opcode:
+            out.emit(f"opcode = {name};\n")
         if inst.family is not None:
             out.emit(
                 f"static_assert({inst.family.size} == {inst.size-1}"


### PR DESCRIPTION
This moves the opcode assignment into the tail call ifdef, to aid with really old compilers that might not be able to optimize it away.

Though we might think a single assignment doesn't matter. I have a feeling it's not optimized away.

See the comment thread from https://github.com/python/cpython/issues/128563#issuecomment-2642636965 onwards for rationale.

<!-- gh-issue-number: gh-128563 -->
* Issue: gh-128563
<!-- /gh-issue-number -->
