### PR TITLE
gh-129805: Fix `bytes` annotation in `Tools/jit`

### DIFF
--- a/Tools/jit/_stencils.py
+++ b/Tools/jit/_stencils.py
@@ -141,7 +141,11 @@ class Hole:
     def __post_init__(self) -> None:
         self.func = _PATCH_FUNCS[self.kind]
 
-    def fold(self, other: typing.Self, body: bytes) -> typing.Self | None:
+    def fold(
+        self,
+        other: typing.Self,
+        body: bytes | bytearray,
+    ) -> typing.Self | None:
         """Combine two holes into a single hole, if possible."""
         instruction_a = int.from_bytes(
             body[self.offset : self.offset + 4], byteorder=sys.byteorder

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -97,7 +97,7 @@ class _Target(typing.Generic[_S, _R]):
         raise NotImplementedError(type(self))
 
     def _handle_relocation(
-        self, base: int, relocation: _R, raw: bytes
+        self, base: int, relocation: _R, raw: bytes | bytearray
     ) -> _stencils.Hole:
         raise NotImplementedError(type(self))
 
@@ -257,7 +257,10 @@ class _COFF(
         return _stencils.symbol_to_value(name)
 
     def _handle_relocation(
-        self, base: int, relocation: _schema.COFFRelocation, raw: bytes
+        self,
+        base: int,
+        relocation: _schema.COFFRelocation,
+        raw: bytes | bytearray,
     ) -> _stencils.Hole:
         match relocation:
             case {
@@ -348,7 +351,10 @@ class _ELF(
             }, section_type
 
     def _handle_relocation(
-        self, base: int, relocation: _schema.ELFRelocation, raw: bytes
+        self,
+        base: int,
+        relocation: _schema.ELFRelocation,
+        raw: bytes | bytearray,
     ) -> _stencils.Hole:
         symbol: str | None
         match relocation:
@@ -424,7 +430,10 @@ class _MachO(
             stencil.holes.append(hole)
 
     def _handle_relocation(
-        self, base: int, relocation: _schema.MachORelocation, raw: bytes
+        self,
+        base: int,
+        relocation: _schema.MachORelocation,
+        raw: bytes | bytearray,
     ) -> _stencils.Hole:
         symbol: str | None
         match relocation:


### PR DESCRIPTION
I can confirm that this now passes `--strict-bytes` check from mypy:

```
(.venv) ~/Desktop/cpython2  issue-129805 ✔                                                
» mypy --version
mypy 1.15.0 (compiled: yes)
                                                                                           
(.venv) ~/Desktop/cpython2  issue-129805 ✔                                                
» mypy --config-file=Tools/jit/mypy.ini --strict-bytes            
Success: no issues found in 6 source files
```

We can yet use `mypy@1.15` in CPython to verify it, because there are known regressions :(

<!-- gh-issue-number: gh-129805 -->
* Issue: gh-129805
<!-- /gh-issue-number -->
