### PR TITLE
gh-124703: Add documentation and whatsnew entry for pdb exit change

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -706,8 +706,8 @@ can be overridden by the local file.
    .. versionchanged:: 3.14
       A confirmation prompt will be shown if the debugger is invoked in
       ``'inline'`` mode. After the confirmation, the debugger will call
-      :func:`sys.exit` immediately, instead of raising :exc:`BdbQuit` in
-      the next trace event.
+      :func:`sys.exit` immediately, instead of raising :exc:`bdb.BdbQuit`
+      in the next trace event.
 
 .. pdbcommand:: debug code
 

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -697,6 +697,17 @@ can be overridden by the local file.
 .. pdbcommand:: q(uit)
 
    Quit from the debugger.  The program being executed is aborted.
+   An end-of-file input is equivalent to :pdbcmd:`quit`.
+
+   A confirmation prompt will be shown if the debugger is invoked in
+   ``'inline'`` mode. Either ``y``, ``Y``, ``<Enter>`` or ``EOF``
+   will confirm the quit.
+
+   .. versionchanged:: 3.14
+      A confirmation prompt will be shown if the debugger is invoked in
+      ``'inline'`` mode. After the confirmation, the debugger will call
+      :func:`sys.exit` immediately, instead of raising :exc:`BdbQuit` in
+      the next trace event.
 
 .. pdbcommand:: debug code
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -634,7 +634,7 @@ pdb
 
 * A confirmation prompt will be shown when the user tries to quit :mod:`pdb`
   in ``inline`` mode. ``y``, ``Y``, ``<Enter>`` or ``EOF`` will confirm
-  the quit and call :func:`sys.exit`, instead of raising :exc:`BdbQuit`.
+  the quit and call :func:`sys.exit`, instead of raising :exc:`bdb.BdbQuit`.
   (Contributed by Tian Gao in :gh:`124704`.)
 
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -632,6 +632,11 @@ pdb
   command when :mod:`pdb` is in ``inline`` mode.
   (Contributed by Tian Gao in :gh:`123757`.)
 
+* A confirmation prompt will be shown when the user tries to quit :mod:`pdb`
+  in ``inline`` mode. ``y``, ``Y``, ``<Enter>`` or ``EOF`` will confirm
+  the quit and call :func:`sys.exit`, instead of raising :exc:`BdbQuit`.
+  (Contributed by Tian Gao in :gh:`124704`.)
+
 
 pickle
 ------


### PR DESCRIPTION
I feel like this is something we should mention in whatsnew for 3.14 because it is a behavioral change and we don't want to surprise users (or at least have an explanation after we surprise them). Also the documetation for pdb should be updated. I did not mention `EOF` and `<Enter>` in the prompt because it's too cumbersome, but the documentation seems like the place to mention it.

<!-- gh-issue-number: gh-124703 -->
* Issue: gh-124703
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129818.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->