### PR TITLE
Remove tail-calling wording as it is confusing

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -211,8 +211,8 @@ configuration mechanisms).
 
 .. _whatsnew314-tail-call:
 
-A new tail-calling interpreter
-------------------------------
+A new type of interpreter
+-------------------------
 
 A new type of interpreter based on tail calls has been added to CPython.
 For certain newer compilers, this interpreter provides


### PR DESCRIPTION
People seem to think we have added actual tail calls to Python itself.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129823.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->