### PR TITLE
gh-129825: Skip test_faulthandler.test_register_chain under TSAN

### DIFF
--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -795,6 +795,7 @@ class FaultHandlerTests(unittest.TestCase):
     def test_register_threads(self):
         self.check_register(all_threads=True)
 
+    @support.skip_if_sanitizer("gh-129825: hangs under TSAN", thread=True)
     def test_register_chain(self):
         self.check_register(chain=True)
 


### PR DESCRIPTION
The test hangs when run under TSAN due to an interaction between TSAN's signal interception and our attempt to call the previous signal handler.


<!-- gh-issue-number: gh-129825 -->
* Issue: gh-129825
<!-- /gh-issue-number -->
