### PR TITLE
gh-129824: Fix some data races with types in subinterpreters

### DIFF
--- a/Lib/test/libregrtest/tsan.py
+++ b/Lib/test/libregrtest/tsan.py
@@ -11,7 +11,6 @@ TSAN_TESTS = [
     'test_httpservers',
     'test_imaplib',
     'test_importlib',
-    'test_interpreters',
     'test_io',
     'test_logging',
     'test_queue',

--- a/Lib/test/libregrtest/tsan.py
+++ b/Lib/test/libregrtest/tsan.py
@@ -11,6 +11,7 @@ TSAN_TESTS = [
     'test_httpservers',
     'test_imaplib',
     'test_importlib',
+    'test_interpreters',
     'test_io',
     'test_logging',
     'test_queue',

--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -703,6 +703,7 @@ class TestInterpreterPrepareMain(TestBase):
         with self.assertRaises(ExecutionFailed):
             interp.exec('print(spam)')
 
+    @support.skip_if_sanitizer('gh-129824: file descriptor race', thread=True)
     def test_running(self):
         interp = interpreters.create()
         interp.prepare_main({'spam': True})
@@ -1530,6 +1531,7 @@ class LowLevelTests(TestBase):
             whence = eval(text)
             self.assertEqual(whence, _interpreters.WHENCE_LEGACY_CAPI)
 
+    @support.skip_if_sanitizer('gh-129824: file descriptor race', thread=True)
     def test_is_running(self):
         def check(interpid, expected):
             with self.assertRaisesRegex(InterpreterError, 'unrecognized'):

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -4231,7 +4231,8 @@ _PyExc_InitTypes(PyInterpreterState *interp)
             return -1;
         }
         if (exc->tp_new == BaseException_new
-            && exc->tp_init == (initproc)BaseException_init)
+            && exc->tp_init == (initproc)BaseException_init
+            && _Py_IsMainInterpreter(interp))
         {
             exc->tp_vectorcall = BaseException_vectorcall;
         }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -237,6 +237,7 @@ managed_static_type_state_init(PyInterpreterState *interp, PyTypeObject *self,
     int64_t prev_interp_count = _Py_atomic_add_int64(
             &_PyRuntime.types.managed_static.types[full_index].interp_count, 1);
     assert((initial == 1) == (prev_interp_count == 0));
+    (void)prev_interp_count;
 
     if (initial) {
         assert(_PyRuntime.types.managed_static.types[full_index].type == NULL);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8506,7 +8506,12 @@ type_ready_set_new(PyTypeObject *type, int initial)
         && base == &PyBaseObject_Type
         && !(type->tp_flags & Py_TPFLAGS_HEAPTYPE))
     {
-        type->tp_flags |= Py_TPFLAGS_DISALLOW_INSTANTIATION;
+        if (initial) {
+            type->tp_flags |= Py_TPFLAGS_DISALLOW_INSTANTIATION;
+        }
+        else {
+            assert(_PyType_HasFeature(type, Py_TPFLAGS_DISALLOW_INSTANTIATION));
+        }
     }
 
     if (!(type->tp_flags & Py_TPFLAGS_DISALLOW_INSTANTIATION)) {
@@ -8526,7 +8531,12 @@ type_ready_set_new(PyTypeObject *type, int initial)
     }
     else {
         // Py_TPFLAGS_DISALLOW_INSTANTIATION sets tp_new to NULL
-        type->tp_new = NULL;
+        if (initial) {
+            type->tp_new = NULL;
+        }
+        else {
+            assert(type->tp_new == NULL);
+        }
     }
     return 0;
 }
@@ -8659,7 +8669,12 @@ type_ready(PyTypeObject *type, int initial)
     }
 
     /* All done -- set the ready flag */
-    type->tp_flags |= Py_TPFLAGS_READY;
+    if (initial) {
+        type->tp_flags |= Py_TPFLAGS_READY;
+    }
+    else {
+        assert(_PyType_HasFeature(type, Py_TPFLAGS_READY));
+    }
     stop_readying(type);
 
     assert(_PyType_CheckConsistency(type));


### PR DESCRIPTION
The `test_running` and `test_is_running` test cases are skipped for now because they have file descriptor races.

<!-- gh-issue-number: gh-129824 -->
* Issue: gh-129824
<!-- /gh-issue-number -->
