### PR TITLE
Use ubuntu-22.04-arm image for Arm runners.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,13 +247,13 @@ jobs:
         - true
         os:
         - ubuntu-24.04
-        - ubuntu-24.04-arm
+        - ubuntu-22.04-arm
         exclude:
         # Do not test BOLT with free-threading, to conserve resources
         - bolt: true
           free-threading: true
         # BOLT currently crashes during instrumentation on aarch64
-        - os: ubuntu-24.04-arm
+        - os: ubuntu-22.04-arm
           bolt: true
     uses: ./.github/workflows/reusable-ubuntu.yml
     with:

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -86,7 +86,7 @@ jobs:
             runner: ubuntu-24.04
           - target: aarch64-unknown-linux-gnu/gcc
             architecture: aarch64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tail-call.yml
+++ b/.github/workflows/tail-call.yml
@@ -62,7 +62,7 @@ jobs:
             runner: ubuntu-24.04
           - target: aarch64-unknown-linux-gnu/gcc
             architecture: aarch64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
GitHub suggested us to try the 22.04 images for the Arm runners while they are invetigating the failures we've been having using 24.04.