### PR TITLE
gh-129838: Don't redefine _Py_NO_SANITIZE_UNDEFINED

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-02-07-21-20-21.gh-issue-129838.fkuiEc.rst
+++ b/Misc/NEWS.d/next/Build/2025-02-07-21-20-21.gh-issue-129838.fkuiEc.rst
@@ -1,0 +1,2 @@
+Don't redefine ``_Py_NO_SANITIZE_UNDEFINED`` when compiling with a recent
+GCC version and undefined sanitizer enabled.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -37,14 +37,15 @@
 #define PUTS(fd, str) (void)_Py_write_noraise(fd, str, strlen(str))
 
 
-// clang uses __attribute__((no_sanitize("undefined")))
-// GCC 4.9+ uses __attribute__((no_sanitize_undefined))
-#if defined(__has_feature)  // Clang
+// Clang and GCC 9.0+ use __attribute__((no_sanitize("undefined")))
+#if defined(__has_feature)
 #  if __has_feature(undefined_behavior_sanitizer)
 #    define _Py_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined")))
 #  endif
 #endif
-#if defined(__GNUC__) \
+
+// GCC 4.9+ uses __attribute__((no_sanitize_undefined))
+#if !defined(_Py_NO_SANITIZE_UNDEFINED) && defined(__GNUC__) \
     && ((__GNUC__ >= 5) || (__GNUC__ == 4) && (__GNUC_MINOR__ >= 9))
 #  define _Py_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize_undefined))
 #endif


### PR DESCRIPTION
This macro is redefined because the code was written at a time when LLVM supported:
```
__attribute__((no_sanitize("undefined")))
```

and GCC supported:
```
__attribute__((no_sanitize_undefined))
```
In 2018, GCC (then 9.0.0) was updated to also accept the LLVM syntax [1]. Since __has_feature was added to GCC in 2023 we can assume `__has_feature(undefined_behavior_sanitizer)` being true also means `__attribute__((no_sanitize("undefined")))` is supported.

Then we just check that the macro isn't defined before checking for the GCC version to use the older syntax.

[1] https://github.com/gcc-mirror/gcc/commit/19916065b7fb26bbb36f7bbe5688ae2c1661dec3

<!-- gh-issue-number: gh-129838 -->
* Issue: gh-129838
<!-- /gh-issue-number -->
