### PR TITLE
gh-129349: Accept bytes in bytes.fromhex()/bytearray.fromhex()

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2744,6 +2744,11 @@ data and are closely related to string objects in a variety of other ways.
          :meth:`bytes.fromhex` now skips all ASCII whitespace in the string,
          not just spaces.
 
+      .. versionchanged:: 3.14
+         :meth:`bytes.fromhex` now accepts an ASCII :class:`bytes` object as
+         input.
+
+
    A reverse conversion function exists to transform a bytes object into its
    hexadecimal representation.
 
@@ -2828,6 +2833,10 @@ objects.
       .. versionchanged:: 3.7
          :meth:`bytearray.fromhex` now skips all ASCII whitespace in the string,
          not just spaces.
+
+      .. versionchanged:: 3.14
+         :meth:`bytearray.fromhex` now accepts an ASCII :class:`bytes` object as
+         input.
 
    A reverse conversion function exists to transform a bytearray object into its
    hexadecimal representation.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2746,7 +2746,7 @@ data and are closely related to string objects in a variety of other ways.
 
       .. versionchanged:: next
          :meth:`bytes.fromhex` now accepts ASCII :class:`bytes` and
-         :class:`bytearray` objects as input.
+         :term:`bytes-like objects <bytes-like object>` as input.
 
 
 
@@ -2837,7 +2837,7 @@ objects.
 
       .. versionchanged:: next
          :meth:`bytearray.fromhex` now accepts ASCII :class:`bytes` and
-         :class:`bytearray` objects as input.
+         :term:`bytes-like objects <bytes-like object>` as input.
 
    A reverse conversion function exists to transform a bytearray object into its
    hexadecimal representation.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2748,8 +2748,6 @@ data and are closely related to string objects in a variety of other ways.
          :meth:`bytes.fromhex` now accepts ASCII :class:`bytes` and
          :term:`bytes-like objects <bytes-like object>` as input.
 
-
-
    A reverse conversion function exists to transform a bytes object into its
    hexadecimal representation.
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2744,7 +2744,7 @@ data and are closely related to string objects in a variety of other ways.
          :meth:`bytes.fromhex` now skips all ASCII whitespace in the string,
          not just spaces.
 
-      .. versionchanged:: 3.14
+      .. versionchanged:: next
          :meth:`bytes.fromhex` now accepts an ASCII :class:`bytes` object as
          input.
 
@@ -2834,7 +2834,7 @@ objects.
          :meth:`bytearray.fromhex` now skips all ASCII whitespace in the string,
          not just spaces.
 
-      .. versionchanged:: 3.14
+      .. versionchanged:: next
          :meth:`bytearray.fromhex` now accepts an ASCII :class:`bytes` object as
          input.
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2745,8 +2745,9 @@ data and are closely related to string objects in a variety of other ways.
          not just spaces.
 
       .. versionchanged:: next
-         :meth:`bytes.fromhex` now accepts an ASCII :class:`bytes` object as
-         input.
+         :meth:`bytes.fromhex` now accepts ASCII :class:`bytes` and
+         :class:`bytearray` objects as input.
+
 
 
    A reverse conversion function exists to transform a bytes object into its
@@ -2835,8 +2836,8 @@ objects.
          not just spaces.
 
       .. versionchanged:: next
-         :meth:`bytearray.fromhex` now accepts an ASCII :class:`bytes` object as
-         input.
+         :meth:`bytearray.fromhex` now accepts ASCII :class:`bytes` and
+         :class:`bytearray` objects as input.
 
    A reverse conversion function exists to transform a bytearray object into its
    hexadecimal representation.

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -354,6 +354,10 @@ Other language changes
   (with :func:`format` or :ref:`f-strings`).
   (Contrubuted by Sergey B Kirpichev in :gh:`87790`.)
 
+* The :func:`bytes.fromhex` and :func:`bytearray.fromhex` methods now accept
+  ASCII :class:`bytes` and :class:`bytearray` objects.
+  (Contributed by Daniel Pope in :gh:`129349`.)
+
 * ``\B`` in :mod:`regular expression <re>` now matches empty input string.
   Now it is always the opposite of ``\b``.
   (Contributed by Serhiy Storchaka in :gh:`124130`.)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -355,7 +355,7 @@ Other language changes
   (Contrubuted by Sergey B Kirpichev in :gh:`87790`.)
 
 * The :func:`bytes.fromhex` and :func:`bytearray.fromhex` methods now accept
-  ASCII :class:`bytes` and :class:`bytearray` objects.
+  ASCII :class:`bytes` and :term:`bytes-like objects <bytes-like object>`.
   (Contributed by Daniel Pope in :gh:`129349`.)
 
 * ``\B`` in :mod:`regular expression <re>` now matches empty input string.

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -457,11 +457,16 @@ class BaseBytesTest:
             self.assertRaises(ValueError, self.type2test.fromhex, c)
 
         # Check that we can parse bytes and bytearray
-        self.assertEqual(self.type2test.fromhex(b' 012abc'), b'\x01\x2a\xbc')
-        self.assertEqual(
-            self.type2test.fromhex(bytearray(b' 012abc')),
-            b'\x01\x2a\xbc',
-        )
+        tests = [
+            ("bytes", bytes),
+            ("bytearray", bytearray),
+            ("memoryview", memoryview),
+            ("array.array", lambda bs: array.array('B', bs)),
+        ]
+        for name, factory in tests:
+            with self.subTest(name=name):
+                self.assertEqual(self.type2test.fromhex(factory(b' 1A 2B 30 ')), b)
+
         # Invalid bytes are rejected
         for u8 in b"\0\x1C\x1D\x1E\x1F\x85\xa0":
             b = bytes([30, 31, u8])

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -473,6 +473,11 @@ class BaseBytesTest:
             self.assertRaises(ValueError, self.type2test.fromhex, b)
 
         self.assertEqual(self.type2test.fromhex('0000'), b'\0\0')
+        with self.assertRaisesRegex(
+            TypeError,
+            r'fromhex\(\) argument must be str or bytes-like, not tuple',
+        ):
+            self.type2test.fromhex(())
         self.assertRaises(ValueError, self.type2test.fromhex, 'a')
         self.assertRaises(ValueError, self.type2test.fromhex, 'rt')
         self.assertRaises(ValueError, self.type2test.fromhex, '1a b cd')

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -455,8 +455,14 @@ class BaseBytesTest:
         for c in "\x1C\x1D\x1E\x1F\x85\xa0\u2000\u2002\u2028":
             self.assertRaises(ValueError, self.type2test.fromhex, c)
 
+        # Check that we can parse bytes and bytearray
+        self.assertEqual(self.type2test.fromhex(b' 012abc'), b'\x01\x2a\xbc')
+        self.assertEqual(
+            self.type2test.fromhex(bytearray(b' 012abc')),
+            b'\x01\x2a\xbc',
+        )
+
         self.assertEqual(self.type2test.fromhex('0000'), b'\0\0')
-        self.assertRaises(TypeError, self.type2test.fromhex, b'1B')
         self.assertRaises(ValueError, self.type2test.fromhex, 'a')
         self.assertRaises(ValueError, self.type2test.fromhex, 'rt')
         self.assertRaises(ValueError, self.type2test.fromhex, '1a b cd')

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -450,6 +450,7 @@ class BaseBytesTest:
 
         # check that ASCII whitespace is ignored
         self.assertEqual(self.type2test.fromhex(' 1A\n2B\t30\v'), b)
+        self.assertEqual(self.type2test.fromhex(b' 1A\n2B\t30\v'), b)
         for c in "\x09\x0A\x0B\x0C\x0D\x20":
             self.assertEqual(self.type2test.fromhex(c), self.type2test())
         for c in "\x1C\x1D\x1E\x1F\x85\xa0\u2000\u2002\u2028":
@@ -461,6 +462,10 @@ class BaseBytesTest:
             self.type2test.fromhex(bytearray(b' 012abc')),
             b'\x01\x2a\xbc',
         )
+        # Invalid bytes are rejected
+        for u8 in b"\0\x1C\x1D\x1E\x1F\x85\xa0":
+            b = bytes([30, 31, u8])
+            self.assertRaises(ValueError, self.type2test.fromhex, b)
 
         self.assertEqual(self.type2test.fromhex('0000'), b'\0\0')
         self.assertRaises(ValueError, self.type2test.fromhex, 'a')

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-08-09-55-33.gh-issue-129349.PkcG-l.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-08-09-55-33.gh-issue-129349.PkcG-l.rst
@@ -1,1 +1,2 @@
-``bytes.fromhex()``/``bytearray.fromhex()`` now accept ASCII ``bytes``.
+:meth:`bytes.fromhex` and :meth:`bytearray.fromhex()` now accepts ASCII
+:class:`bytes` objects.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-08-09-55-33.gh-issue-129349.PkcG-l.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-08-09-55-33.gh-issue-129349.PkcG-l.rst
@@ -1,2 +1,2 @@
-:meth:`bytes.fromhex` and :meth:`bytearray.fromhex()` now accepts ASCII
+:meth:`bytes.fromhex` and :meth:`bytearray.fromhex` now accepts ASCII
 :class:`bytes` objects.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-08-09-55-33.gh-issue-129349.PkcG-l.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-08-09-55-33.gh-issue-129349.PkcG-l.rst
@@ -1,0 +1,1 @@
+``bytes.fromhex()``/``bytearray.fromhex()`` now accept ASCII ``bytes``.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-08-09-55-33.gh-issue-129349.PkcG-l.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-08-09-55-33.gh-issue-129349.PkcG-l.rst
@@ -1,2 +1,2 @@
 :meth:`bytes.fromhex` and :meth:`bytearray.fromhex` now accepts ASCII
-:class:`bytes` objects.
+:class:`bytes`/:class:`bytearray` objects.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-08-09-55-33.gh-issue-129349.PkcG-l.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-08-09-55-33.gh-issue-129349.PkcG-l.rst
@@ -1,2 +1,2 @@
 :meth:`bytes.fromhex` and :meth:`bytearray.fromhex` now accepts ASCII
-:class:`bytes`/:class:`bytearray` objects.
+:class:`bytes` and :term:`bytes-like objects <bytes-like object>`.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2533,7 +2533,7 @@ bytearray_splitlines_impl(PyByteArrayObject *self, int keepends)
 @classmethod
 bytearray.fromhex
 
-    string: unicode
+    string: object
     /
 
 Create a bytearray object from a string of hexadecimal numbers.
@@ -2543,8 +2543,8 @@ Example: bytearray.fromhex('B9 01EF') -> bytearray(b'\\xb9\\x01\\xef')
 [clinic start generated code]*/
 
 static PyObject *
-bytearray_fromhex_impl(PyTypeObject *type, PyObject *string)
-/*[clinic end generated code: output=8f0f0b6d30fb3ba0 input=f033a16d1fb21f48]*/
+bytearray_fromhex(PyTypeObject *type, PyObject *string)
+/*[clinic end generated code: output=da84dc708e9c4b36 input=7e314e5b2d7ab484]*/
 {
     PyObject *result = _PyBytes_FromHex(string, type == &PyByteArray_Type);
     if (type != &PyByteArray_Type && result != NULL) {

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2554,8 +2554,9 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
 
     /* This overestimates if there are spaces */
     buf = _PyBytesWriter_Alloc(&writer, hexlen / 2);
-    if (buf == NULL)
+    if (buf == NULL) {
         goto release_buffer;
+    }
 
     start = str;
     end = str + hexlen;

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2535,16 +2535,19 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
 
         assert(PyUnicode_KIND(string) == PyUnicode_1BYTE_KIND);
         str = start = PyUnicode_1BYTE_DATA(string);
-    } else if (PyBytes_Check(string)) {
+    }
+    else if (PyBytes_Check(string)) {
         hexlen = PyBytes_GET_SIZE(string);
-        str = start = (Py_UCS1 *) PyBytes_AS_STRING(string);
-    } else if (PyByteArray_Check(string)) {
+        str = start = (Py_UCS1 *)PyBytes_AS_STRING(string);
+    }
+    else if (PyByteArray_Check(string)) {
         hexlen = PyByteArray_GET_SIZE(string);
-        str = start = (Py_UCS1 *) PyByteArray_AS_STRING(string);
-    } else {
+        str = start = (Py_UCS1 *)PyByteArray_AS_STRING(string);
+    }
+    else {
         PyErr_Format(PyExc_TypeError,
-                        "fromhex() argument must be str or bytes, not %s",
-                        Py_TYPE(string)->tp_name);
+                     "fromhex() argument must be str or bytes, not %T",
+                     string);
         return NULL;
     }
 

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2547,7 +2547,7 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
     }
     else {
         PyErr_Format(PyExc_TypeError,
-                     "fromhex() argument must be str or bytes, not %T",
+                     "fromhex() argument must be str or bytes-like, not %T",
                      string);
         return NULL;
     }

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2539,8 +2539,9 @@ _PyBytes_FromHex(PyObject *string, int use_bytearray)
         str = PyUnicode_1BYTE_DATA(string);
     }
     else if (PyObject_CheckBuffer(string)) {
-        if (PyObject_GetBuffer(string, &view, PyBUF_SIMPLE) != 0)
+        if (PyObject_GetBuffer(string, &view, PyBUF_SIMPLE) != 0) {
             return NULL;
+        }
         hexlen = view.len;
         str = view.buf;
     }

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -1601,26 +1601,6 @@ PyDoc_STRVAR(bytearray_fromhex__doc__,
 #define BYTEARRAY_FROMHEX_METHODDEF    \
     {"fromhex", (PyCFunction)bytearray_fromhex, METH_O|METH_CLASS, bytearray_fromhex__doc__},
 
-static PyObject *
-bytearray_fromhex_impl(PyTypeObject *type, PyObject *string);
-
-static PyObject *
-bytearray_fromhex(PyTypeObject *type, PyObject *arg)
-{
-    PyObject *return_value = NULL;
-    PyObject *string;
-
-    if (!PyUnicode_Check(arg)) {
-        _PyArg_BadArgument("fromhex", "argument", "str", arg);
-        goto exit;
-    }
-    string = arg;
-    return_value = bytearray_fromhex_impl(type, string);
-
-exit:
-    return return_value;
-}
-
 PyDoc_STRVAR(bytearray_hex__doc__,
 "hex($self, /, sep=<unrepresentable>, bytes_per_sep=1)\n"
 "--\n"
@@ -1789,4 +1769,4 @@ bytearray_sizeof(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl((PyByteArrayObject *)self);
 }
-/*[clinic end generated code: output=7c924a56e0a8bfe6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=13a4231325b7d3c1 input=a9049054013a1b77]*/

--- a/Objects/clinic/bytesobject.c.h
+++ b/Objects/clinic/bytesobject.c.h
@@ -1204,26 +1204,6 @@ PyDoc_STRVAR(bytes_fromhex__doc__,
 #define BYTES_FROMHEX_METHODDEF    \
     {"fromhex", (PyCFunction)bytes_fromhex, METH_O|METH_CLASS, bytes_fromhex__doc__},
 
-static PyObject *
-bytes_fromhex_impl(PyTypeObject *type, PyObject *string);
-
-static PyObject *
-bytes_fromhex(PyTypeObject *type, PyObject *arg)
-{
-    PyObject *return_value = NULL;
-    PyObject *string;
-
-    if (!PyUnicode_Check(arg)) {
-        _PyArg_BadArgument("fromhex", "argument", "str", arg);
-        goto exit;
-    }
-    string = arg;
-    return_value = bytes_fromhex_impl(type, string);
-
-exit:
-    return return_value;
-}
-
 PyDoc_STRVAR(bytes_hex__doc__,
 "hex($self, /, sep=<unrepresentable>, bytes_per_sep=1)\n"
 "--\n"
@@ -1404,4 +1384,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=61cb2cf6506df4c6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=967aae4b46423586 input=a9049054013a1b77]*/


### PR DESCRIPTION
Change `bytes.fromhex()` and `bytearray.fromhex()` to accept a `bytes` object interpreted as ASCII.

This matches the behaviour of `int` e.g

```python
>>> int(b'123abc', 16)
1194684
>>> bytes.fromhex(b'123abc')
b'\x12:\xbc'
```

Fixes #129349


<!-- gh-issue-number: gh-129349 -->
* Issue: gh-129349
<!-- /gh-issue-number -->
