### PR TITLE
gh-97850: Update the deprecation warning of `importlib.abc.Loader.load_module`

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.15.rst
+++ b/Doc/deprecations/pending-removal-in-3.15.rst
@@ -29,6 +29,10 @@ Pending removal in Python 3.15
   * The :option:`!--cgi` flag to the :program:`python -m http.server`
     command-line interface has been deprecated since Python 3.13.
 
+* :mod:`importlib`:
+
+  * ``load_module()`` method: use ``exec_module()`` instead.
+
 * :class:`locale`:
 
   * The :func:`~locale.getdefaultlocale` function

--- a/Doc/deprecations/pending-removal-in-future.rst
+++ b/Doc/deprecations/pending-removal-in-future.rst
@@ -63,7 +63,6 @@ although there is currently no date scheduled for their removal.
 
 * :mod:`importlib`:
 
-  * ``load_module()`` method: use ``exec_module()`` instead.
   * :func:`~importlib.util.cache_from_source` *debug_override* parameter is
     deprecated: use the *optimization* parameter instead.
 

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -370,7 +370,7 @@ ABC hierarchy::
            :exc:`NotImplementedError`.  Functionality provided when
            :meth:`exec_module` is available.
 
-        .. deprecated:: 3.4
+        .. deprecated-removed:: 3.4 3.15
            The recommended API for loading a module is :meth:`exec_module`
            (and :meth:`create_module`).  Loaders should implement it instead of
            :meth:`load_module`.  The import machinery takes care of all the
@@ -474,7 +474,7 @@ ABC hierarchy::
 
        Implementation of :meth:`Loader.load_module`.
 
-       .. deprecated:: 3.4
+       .. deprecated-removed:: 3.4 3.15
           use :meth:`exec_module` instead.
 
 
@@ -521,7 +521,7 @@ ABC hierarchy::
 
       Calls super's ``load_module()``.
 
-      .. deprecated:: 3.4
+      .. deprecated-removed:: 3.4 3.15
          Use :meth:`Loader.exec_module` instead.
 
    .. abstractmethod:: get_filename(fullname)
@@ -610,7 +610,7 @@ ABC hierarchy::
 
        Concrete implementation of :meth:`Loader.load_module`.
 
-       .. deprecated:: 3.4
+       .. deprecated-removed:: 3.4 3.15
           Use :meth:`exec_module` instead.
 
     .. method:: get_source(fullname)
@@ -1020,7 +1020,7 @@ find and load modules.
       Concrete implementation of :meth:`importlib.abc.Loader.load_module` where
       specifying the name of the module to load is optional.
 
-      .. deprecated:: 3.6
+      .. deprecated-removed:: 3.6 3.15
 
          Use :meth:`importlib.abc.Loader.exec_module` instead.
 
@@ -1063,7 +1063,7 @@ find and load modules.
    Concrete implementation of :meth:`importlib.abc.Loader.load_module` where
    specifying the name of the module to load is optional.
 
-   .. deprecated:: 3.6
+   .. deprecated-removed:: 3.6 3.15
 
       Use :meth:`importlib.abc.Loader.exec_module` instead.
 

--- a/Lib/importlib/_bootstrap.py
+++ b/Lib/importlib/_bootstrap.py
@@ -526,7 +526,7 @@ def _load_module_shim(self, fullname):
 
     """
     msg = ("the load_module() method is deprecated and slated for removal in "
-          "Python 3.12; use exec_module() instead")
+           "Python 3.15; use exec_module() instead")
     _warnings.warn(msg, DeprecationWarning)
     spec = spec_from_loader(fullname, self)
     if fullname in sys.modules:

--- a/Misc/NEWS.d/next/Library/2025-02-08-15-13-43.gh-issue-97850.jQ0CvW.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-08-15-13-43.gh-issue-97850.jQ0CvW.rst
@@ -1,0 +1,2 @@
+Update the deprecation warning of
+:meth:`importlib.abc.Loader.load_module`.


### PR DESCRIPTION
The deprecation warning was added in 3.10 by https://github.com/python/cpython/pull/23469.

The warning currently states that the removal is planned for 3.12. I suggest we update it to say 3.15 which, following the 5 releases rule, is the earliest release in which the methods can be removed (whether or not we'll actually be able to do that is another question, but let's at least keep the warnings up to date).

Related discussion: https://github.com/python/cpython/issues/97850#issuecomment-2551304644 , https://github.com/python/cpython/issues/97850#issuecomment-2551943640

<!-- gh-issue-number: gh-97850 -->
* Issue: gh-97850
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129855.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->