### PR TITLE
gh-118761: Always lazy import `re` in `locale`

### DIFF
--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -215,10 +215,10 @@ def format_string(f, val, grouping=False, monetary=False):
     Grouping is applied if the third parameter is true.
     Conversion uses monetary thousands separator and grouping strings if
     forth parameter monetary is true."""
+    global _percent_re
     if _percent_re is None:
         import re
 
-        global _percent_re
         _percent_re = re.compile(r'%(?:\((?P<key>.*?)\))?(?P<modifiers'
                                  r'>[-#0-9 +*.hlL]*?)[eEfFgGdiouxXcrs%]')
 

--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -13,7 +13,6 @@ also includes default encodings for all supported locale names.
 import sys
 import encodings
 import encodings.aliases
-import re
 import _collections_abc
 from builtins import str as _builtin_str
 import functools
@@ -177,9 +176,6 @@ def _strip_padding(s, amount):
         amount -= 1
     return s[lpos:rpos+1]
 
-_percent_re = re.compile(r'%(?:\((?P<key>.*?)\))?'
-                         r'(?P<modifiers>[-#0-9 +*.hlL]*?)[eEfFgGdiouxXcrs%]')
-
 def _format(percent, value, grouping=False, monetary=False, *additional):
     if additional:
         formatted = percent % ((value,) + additional)
@@ -217,6 +213,11 @@ def format_string(f, val, grouping=False, monetary=False):
     Grouping is applied if the third parameter is true.
     Conversion uses monetary thousands separator and grouping strings if
     forth parameter monetary is true."""
+    import re
+
+    _percent_re = re.compile(r'%(?:\((?P<key>.*?)\))?(?P<modifiers'
+                             r'>[-#0-9 +*.hlL]*?)[eEfFgGdiouxXcrs%]')
+
     percents = list(_percent_re.finditer(f))
     new_f = _percent_re.sub('%s', f)
 

--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -176,6 +176,8 @@ def _strip_padding(s, amount):
         amount -= 1
     return s[lpos:rpos+1]
 
+_percent_re = None
+
 def _format(percent, value, grouping=False, monetary=False, *additional):
     if additional:
         formatted = percent % ((value,) + additional)
@@ -213,10 +215,12 @@ def format_string(f, val, grouping=False, monetary=False):
     Grouping is applied if the third parameter is true.
     Conversion uses monetary thousands separator and grouping strings if
     forth parameter monetary is true."""
-    import re
+    if _percent_re is None:
+        import re
 
-    _percent_re = re.compile(r'%(?:\((?P<key>.*?)\))?(?P<modifiers'
-                             r'>[-#0-9 +*.hlL]*?)[eEfFgGdiouxXcrs%]')
+        global _percent_re
+        _percent_re = re.compile(r'%(?:\((?P<key>.*?)\))?(?P<modifiers'
+                                 r'>[-#0-9 +*.hlL]*?)[eEfFgGdiouxXcrs%]')
 
     percents = list(_percent_re.finditer(f))
     new_f = _percent_re.sub('%s', f)

--- a/Misc/NEWS.d/next/Library/2025-02-08-21-37-05.gh-issue-118761.EtqxeB.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-08-21-37-05.gh-issue-118761.EtqxeB.rst
@@ -1,0 +1,2 @@
+Improve import time of :mod:`locale` using lazy import ``re``. Patch by
+Semyon Moroz.


### PR DESCRIPTION
Improve import time of `locale` by lazy import `re`

### CPython configure flags:
```shell
./configure --enable-optimizations --with-lto --enable-loadable-sqlite-extensions
```

## Benchmarks:

Running: `pipx install tuna && ./python -X importtime -c 'import locale' 2> import.log && tuna import.log`

### Total import time: 0.014s -> 0.009s = x1.56 as fast

| main branch | PR branch |
|-------------|-----------|
| ![Screenshot from 2025-02-08 21-42-54](https://github.com/user-attachments/assets/ab645225-2e6c-4f2e-9738-ad5f72d3ac66) | ![Screenshot from 2025-02-08 21-43-12](https://github.com/user-attachments/assets/b476734c-7157-4303-bc06-e032b7d41ab7) |

### `locale` import time: 0.007s -> 0.003s = x2.34 as fast

| main branch | PR branch |
|-------------|-----------|
| ![Screenshot from 2025-02-08 21-43-46](https://github.com/user-attachments/assets/98c2d81e-eea7-4f73-bb31-d4168c5648fd) | ![Screenshot from 2025-02-08 21-43-59](https://github.com/user-attachments/assets/ef257a6c-d87e-4955-9a4d-4798e10e097b) |

### hyperfine: 14.9ms -> 12.1ms = x1.23 as fast

### Main branch:
```shell
$ hyperfine --warmup 11 --runs 3000 "./python -c 'import locale'"
Benchmark 1: ./python -c 'import locale'
  Time (mean ± σ):      14.9 ms ±   0.5 ms    [User: 12.8 ms, System: 2.1 ms]
  Range (min … max):    14.4 ms …  25.3 ms    3000 runs
```

### PR branch:
```shell
$ hyperfine --warmup 11 --runs 3000 "./python -c 'import locale'"
Benchmark 1: ./python -c 'import locale'
  Time (mean ± σ):      12.1 ms ±   0.5 ms    [User: 10.0 ms, System: 2.1 ms]
  Range (min … max):    11.6 ms …  21.6 ms    3000 runs
```


<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
