### PR TITLE
gh-126554: correct detection of `gcc` for `TestNullDlsym.test_null_dlsym`

### DIFF
--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -62,7 +62,7 @@ class TestNullDlsym(unittest.TestCase):
             retcode = subprocess.call(["gcc", "--version"],
                                       stdout=subprocess.DEVNULL,
                                       stderr=subprocess.DEVNULL)
-        except FileNotFoundError:
+        except OSError:
             self.skipTest("gcc is missing")
         if retcode != 0:
             self.skipTest("gcc --version failed")

--- a/Lib/test/test_ctypes/test_dlerror.py
+++ b/Lib/test/test_ctypes/test_dlerror.py
@@ -58,11 +58,14 @@ class TestNullDlsym(unittest.TestCase):
         import subprocess
         import tempfile
 
-        retcode = subprocess.call(["gcc", "--version"],
-                                  stdout=subprocess.DEVNULL,
-                                  stderr=subprocess.DEVNULL)
-        if retcode != 0:
+        try:
+            retcode = subprocess.call(["gcc", "--version"],
+                                      stdout=subprocess.DEVNULL,
+                                      stderr=subprocess.DEVNULL)
+        except FileNotFoundError:
             self.skipTest("gcc is missing")
+        if retcode != 0:
+            self.skipTest("gcc --version failed")
 
         pipe_r, pipe_w = os.pipe()
         self.addCleanup(os.close, pipe_r)


### PR DESCRIPTION
In case gcc is not available, it will throw exception and test fails. So catch the exception to skip the test correctly.

```
======================================================================
ERROR: test_null_dlsym (test.test_ctypes.test_dlerror.TestNullDlsym.test_null_dlsym)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.12/test/test_ctypes/test_dlerror.py", line 61, in test_null_dlsym
    retcode = subprocess.call(["gcc", "--version"],
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 391, in call
    with Popen(*popenargs, **kwargs) as p:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 1028, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.12/subprocess.py", line 1963, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'gcc'
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-126554 -->
* Issue: gh-126554
<!-- /gh-issue-number -->
