### PR TITLE
gh-129892: Doc: Remove unnecessary role directive in graphlib.py

### DIFF
--- a/Lib/graphlib.py
+++ b/Lib/graphlib.py
@@ -154,7 +154,7 @@ class TopologicalSorter:
         This method unblocks any successor of each node in *nodes* for being returned
         in the future by a call to "get_ready".
 
-        Raises :exec:`ValueError` if any node in *nodes* has already been marked as
+        Raises ValueError if any node in *nodes* has already been marked as
         processed by a previous call to this method, if a node was not added to the
         graph by using "add" or if called without calling "prepare" previously or if
         node has not yet been returned by "get_ready".


### PR DESCRIPTION
Remove :exec: role directive from ValueError in TopologicalSorter.done() docstring since docstrings are not processed as reST contents.
  
Fixes #129892 


<!-- gh-issue-number: gh-129892 -->
* Issue: gh-129892
<!-- /gh-issue-number -->
