### PR TITLE
gh-129683 : in 'urllib.request.pathname2url' adding test of the object type before calling 'quote'

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1392,10 +1392,18 @@ class Pathname_Tests(unittest.TestCase):
         self.assertEqual(expected_url, result,
                          "pathname2url() failed; %s != %s" %
                          (result, expected_url))
+        # Also test "pathname2url" for a bytes object
+        bytes_expected_path = bytes(expected_path,sys.getfilesystemencoding())
+        result = urllib.request.pathname2url(bytes_expected_path)
+        self.assertEqual(expected_url, result,
+                         "pathname2url() failed; %s != %s" %
+                         (result, expected_url))
+
         result = urllib.request.url2pathname(expected_url)
         self.assertEqual(expected_path, result,
                          "url2pathame() failed; %s != %s" %
                          (result, expected_path))
+
 
     def test_quoting(self):
         # Test automatic quoting and unquoting works for pathnam2url() and

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1673,8 +1673,13 @@ else:
             # cosmetic, but if it begins with two or more slashes then this
             # avoids interpreting the path as a URL authority.
             pathname = '//' + pathname
-        encoding = sys.getfilesystemencoding()
-        errors = sys.getfilesystemencodeerrors()
+        if isinstance(pathname, (bytes, bytearray)):
+            # quote() doesn't support 'encoding' nor 'errors' for bytes
+            encoding = None
+            errors = None
+        else:
+            encoding = sys.getfilesystemencoding()
+            errors = sys.getfilesystemencodeerrors()
         return quote(pathname, encoding=encoding, errors=errors)
 
 


### PR DESCRIPTION
In func 'urllib.request.pathname2url' adding test of the object type before calling 'urllib.parse.quote'. 

Also add automatic test for this case in "Lib/test/test_urllib.py"



<!-- gh-issue-number: gh-129683 -->
* Issue: gh-129683
<!-- /gh-issue-number -->
