### PR TITLE
gh-129870: Skip test_dump_virtual_tables if SQLite lacks FTS4 support

### DIFF
--- a/Lib/test/test_sqlite3/test_dump.py
+++ b/Lib/test/test_sqlite3/test_dump.py
@@ -4,6 +4,7 @@ import unittest
 
 from .util import memory_database
 from .util import MemoryDatabaseMixin
+from .util import requires_virtual_table
 
 
 class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
@@ -206,6 +207,7 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertEqual(self.cx.row_factory, dict_factory)
 
+    @requires_virtual_table("fts4")
     def test_dump_virtual_tables(self):
         # gh-64662
         expected = [

--- a/Lib/test/test_sqlite3/util.py
+++ b/Lib/test/test_sqlite3/util.py
@@ -4,6 +4,7 @@ import io
 import re
 import sqlite3
 import test.support
+import unittest
 
 
 # Helper for temporary memory databases
@@ -79,3 +80,10 @@ class MemoryDatabaseMixin:
     @property
     def cu(self):
         return self.cur
+
+
+def requires_virtual_table(module):
+    with memory_database() as cx:
+        supported = (module,) in list(cx.execute("PRAGMA module_list"))
+        reason = f"Requires {module!r} virtual table support"
+        return unittest.skipUnless(supported, reason)


### PR DESCRIPTION


<!-- gh-issue-number: gh-129870 -->
* Issue: gh-129870
<!-- /gh-issue-number -->
