### PR TITLE
gh-129915: Add `__qualname__` to class namespace when constructing slotted dataclass

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1299,11 +1299,12 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
     # Clear existing `__weakref__` descriptor, it belongs to a previous type:
     cls_dict.pop('__weakref__', None)  # gh-102069
 
+    # Set the `__qualname__ accordingly
+    if (qualname := getattr(cls, '__qualname__', None) is not None):
+        cls_dict['__qualname__'] = qualname
+
     # And finally create the class.
-    qualname = getattr(cls, '__qualname__', None)
     newcls = type(cls)(cls.__name__, cls.__bases__, cls_dict)
-    if qualname is not None:
-        newcls.__qualname__ = qualname
 
     if is_frozen:
         # Need this for pickling frozen classes with slots.

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1300,7 +1300,7 @@ def _add_slots(cls, is_frozen, weakref_slot, defined_fields):
     cls_dict.pop('__weakref__', None)  # gh-102069
 
     # Set the `__qualname__ accordingly
-    if (qualname := getattr(cls, '__qualname__', None) is not None):
+    if (qualname := getattr(cls, '__qualname__', None)) is not None:
         cls_dict['__qualname__'] = qualname
 
     # And finally create the class.

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -3367,6 +3367,25 @@ class TestSlots(unittest.TestCase):
         self.assertFalse(hasattr(A, "__slots__"))
         self.assertTrue(hasattr(B, "__slots__"))
 
+    def test_slots_qualname(self):
+        # Test that __qualname__ is set correctly when using slots
+        @dataclass(slots=True)
+        class C:
+            x: int
+
+            def __init_subclass__(cls):
+                expected = f'TestSlots.test_slots_qualname.<locals>.{cls.__name__}'
+                self.assertEqual(cls.__qualname__, expected)
+
+        self.assertTrue('__qualname__' in C.__dict__)
+        self.assertEqual(C.__qualname__, 'TestSlots.test_slots_qualname.<locals>.C')
+
+        @dataclass(slots=True)
+        class D(C):
+            pass
+
+        self.assertEqual(D.__qualname__, 'TestSlots.test_slots_qualname.<locals>.D')
+
     # Can't be local to test_frozen_pickle.
     @dataclass(frozen=True, slots=True)
     class FrozenSlotsClass:

--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -3377,7 +3377,6 @@ class TestSlots(unittest.TestCase):
                 expected = f'TestSlots.test_slots_qualname.<locals>.{cls.__name__}'
                 self.assertEqual(cls.__qualname__, expected)
 
-        self.assertTrue('__qualname__' in C.__dict__)
         self.assertEqual(C.__qualname__, 'TestSlots.test_slots_qualname.<locals>.C')
 
         @dataclass(slots=True)


### PR DESCRIPTION
Fixes #129915 by shifting the "set the `__qualname__`" responsibility to be a property of the `__qualname__` being inside the class namespace.

(For the record, oof the bug was really painful to run into 😅 )


<!-- gh-issue-number: gh-129915 -->
* Issue: gh-129915
<!-- /gh-issue-number -->
