### PR TITLE
gh-118761: Improve import time of `dataclasses`

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-02-09-16-21-42.gh-issue-118761.ryMtuz.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-09-16-21-42.gh-issue-118761.ryMtuz.rst
@@ -1,0 +1,2 @@
+Improve import time of :mod:`dataclasses` by lazy importing :mod:`re`,
+:mod:`copy`, :mod:`inspect` and :mod:`annotationlib`. Patch by Semyon Moroz.


### PR DESCRIPTION
Another attempt to improve import time of stdlib modules.
Importing `dataclasses` takes a long time and affects many other modules so it needs to do is make dataclasses better.

I use lazy importing for 4 largest modules (`re`, `copy`, `inspect`, `annotationlib`), they are also rarely called (1 and 2 times)

### CPython configure flags:
```shell
./configure --enable-optimizations --with-lto --enable-loadable-sqlite-extensions
```

## Benchmarks:

Running: `pipx install tuna && ./python -X importtime -c 'import dataclasses' 2> import.log && tuna import.log`

### Total import time: 0.022s -> 0.008s = x2.75 as fast

| main branch | PR branch |
|-------------|-----------|
| ![Screenshot from 2025-02-10 03-40-23](https://github.com/user-attachments/assets/0375ef14-40ee-467d-93e5-3d03b82d720b) | ![Screenshot from 2025-02-10 03-43-08](https://github.com/user-attachments/assets/09ec3d8f-03af-42dc-a847-d7859b0ccb1c) |


### `dataclasses` import time: 0.015s -> 0.001s = x15 as fast

| main branch | PR branch |
|-------------|-----------|
| ![Screenshot from 2025-02-10 03-41-11](https://github.com/user-attachments/assets/1efdd546-c203-4d4a-901f-1c27bd62d091) | ![Screenshot from 2025-02-10 03-43-23](https://github.com/user-attachments/assets/b5ba0fbf-dae3-4e82-99f8-e4a3adb14afb) |


### hyperfine: 24.ms -> 10.2ms = x2.4 as fast

### Main branch:
```shell
$ hyperfine --warmup 11 --runs 3000 "./python -c 'import dataclasses'"
Benchmark 1: ./python -c 'import dataclasses'
  Time (mean ± σ):      24.5 ms ±   1.2 ms    [User: 21.2 ms, System: 3.3 ms]
  Range (min … max):    22.9 ms …  38.1 ms    3000 runs
```

### PR branch:
```shell
$ hyperfine --warmup 11 --runs 3000 "./python -c 'import dataclasses'"
Benchmark 1: ./python -c 'import dataclasses'
  Time (mean ± σ):      10.2 ms ±   0.4 ms    [User: 8.3 ms, System: 1.8 ms]
  Range (min … max):     9.8 ms …  19.9 ms    3000 runs
```

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
