### PR TITLE
gh-129931: use functools.wraps within overloads

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6646,6 +6646,26 @@ class OverloadTests(BaseTestCase):
 
             self.assertEqual(list(get_overloads(impl)), overloads)
 
+    def test_overload_wraps(self):
+        @overload
+        def norwegian_blue(x: "int"):
+            """pining for the fjords"""
+
+        self.assertEqual(norwegian_blue.__doc__, "pining for the fjords")
+        self.assertEqual(norwegian_blue.__name__, "norwegian_blue")
+        self.assertEqual(norwegian_blue.__annotations__, {"x": int})
+
+        # But also make sure this isn't the same function each time
+        setattr(norwegian_blue, "sentinel", object())
+
+        @overload
+        def ex_parrot():
+            """ceased to be"""
+
+        self.assertFalse(hasattr(ex_parrot, "sentinel"))
+        self.assertEqual(ex_parrot.__doc__, "ceased to be")
+        self.assertEqual(norwegian_blue.__doc__, "pining for the fjords")
+
 
 from test.typinganndata import (
     ann_module, ann_module2, ann_module3, ann_module5, ann_module6,

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6653,7 +6653,7 @@ class OverloadTests(BaseTestCase):
 
         self.assertEqual(norwegian_blue.__doc__, "pining for the fjords")
         self.assertEqual(norwegian_blue.__name__, "norwegian_blue")
-        self.assertEqual(norwegian_blue.__annotations__, {"x": int})
+        self.assertEqual(norwegian_blue.__annotations__, {"x": "int"})
 
         # But also make sure this isn't the same function each time
         setattr(norwegian_blue, "sentinel", object())

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2687,7 +2687,7 @@ def overload(func):
     except AttributeError:
         # Not a normal function; ignore.
         pass
-    return _overload_dummy
+    return functools.wraps(func)(lambda *args, **kwds: _overload_dummy(*args, **kwds))
 
 
 def get_overloads(func):


### PR DESCRIPTION
Fixes #129931 - Title says pretty much everything.

I had to use a lambda, which is a bit sad, but oh well.

(Added new test)

<!-- gh-issue-number: gh-129931 -->
* Issue: gh-129931
<!-- /gh-issue-number -->
