### PR TITLE
gh-129928: Raise more accurate exception for sqlite3 UDF creation misuse

### DIFF
--- a/Lib/test/test_sqlite3/test_userfunctions.py
+++ b/Lib/test/test_sqlite3/test_userfunctions.py
@@ -171,7 +171,7 @@ class FunctionTests(unittest.TestCase):
         self.con.close()
 
     def test_func_error_on_create(self):
-        with self.assertRaises(sqlite.OperationalError):
+        with self.assertRaisesRegex(sqlite.ProgrammingError, "not -100"):
             self.con.create_function("bla", -100, lambda x: 2*x)
 
     def test_func_too_many_args(self):
@@ -507,9 +507,8 @@ class WindowFunctionTests(unittest.TestCase):
         self.assertEqual(self.cur.fetchall(), self.expected)
 
     def test_win_error_on_create(self):
-        self.assertRaises(sqlite.ProgrammingError,
-                          self.con.create_window_function,
-                          "shouldfail", -100, WindowSumInt)
+        with self.assertRaisesRegex(sqlite.ProgrammingError, "not -100"):
+            self.con.create_window_function("shouldfail", -100, WindowSumInt)
 
     @with_tracebacks(BadWindow)
     def test_win_exception_in_method(self):
@@ -638,7 +637,7 @@ class AggregateTests(unittest.TestCase):
         self.con.close()
 
     def test_aggr_error_on_create(self):
-        with self.assertRaises(sqlite.OperationalError):
+        with self.assertRaisesRegex(sqlite.ProgrammingError, "not -100"):
             self.con.create_function("bla", -100, AggrSum)
 
     @with_tracebacks(AttributeError, msg_regex="AggrNoStep")

--- a/Misc/NEWS.d/next/Library/2025-02-10-08-44-11.gh-issue-129928.QuiZEz.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-10-08-44-11.gh-issue-129928.QuiZEz.rst
@@ -1,0 +1,2 @@
+Raise :exc:`sqlite3.ProgrammingError` if a user-defined SQL function with
+invalid number of parameters is created. Patch by Erlend Aasland.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1139,6 +1139,20 @@ destructor_callback(void *ctx)
     }
 }
 
+static int
+check_num_params(pysqlite_Connection *self, const int n, const char *name)
+{
+    int limit = sqlite3_limit(self->db, SQLITE_LIMIT_FUNCTION_ARG, -1);
+    assert(limit >= 0);
+    if (n < -1 || n > limit) {
+        PyErr_Format(self->ProgrammingError,
+                     "'%s' must be between -1 and %d, not %d",
+                     name, limit, n);
+        return -1;
+    }
+    return 0;
+}
+
 /*[clinic input]
 _sqlite3.Connection.create_function as pysqlite_connection_create_function
 
@@ -1165,6 +1179,9 @@ pysqlite_connection_create_function_impl(pysqlite_Connection *self,
     int flags = SQLITE_UTF8;
 
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+    if (check_num_params(self, narg, "narg") < 0) {
         return NULL;
     }
 
@@ -1307,8 +1324,10 @@ create_window_function_impl(pysqlite_Connection *self, PyTypeObject *cls,
                         "SQLite 3.25.0 or higher");
         return NULL;
     }
-
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+    if (check_num_params(self, num_params, "num_params") < 0) {
         return NULL;
     }
 
@@ -1365,6 +1384,9 @@ pysqlite_connection_create_aggregate_impl(pysqlite_Connection *self,
     int rc;
 
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
+        return NULL;
+    }
+    if (check_num_params(self, n_arg, "n_arg") < 0) {
         return NULL;
     }
 


### PR DESCRIPTION
Consistently raise ProgrammingError if the user tries to create an UDF
with an invalid number of parameters.


<!-- gh-issue-number: gh-129928 -->
* Issue: gh-129928
<!-- /gh-issue-number -->
