### PR TITLE
gh-129143: Fix incorrect documentation for logging.Handler.close().

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -592,10 +592,12 @@ subclasses. However, the :meth:`!__init__` method in subclasses needs to call
 
    .. method:: Handler.close()
 
-      Tidy up any resources used by the handler. This version does no output but
-      removes the handler from an internal list of handlers which is closed when
-      :func:`shutdown` is called. Subclasses should ensure that this gets called
-      from overridden :meth:`close` methods.
+      Tidy up any resources used by the handler. This version does no output
+      but removes the handler from an internal map of handlers, which is used
+      for handler lookup by name.
+
+      Subclasses should ensure that this gets called from overridden :meth:`close`
+      methods.
 
 
    .. method:: Handler.handle(record)


### PR DESCRIPTION


<!-- gh-issue-number: gh-129143 -->
* Issue: gh-129143
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--129950.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->