### PR TITLE
gh-129401: Test repr rlock failing randomly

### DIFF
--- a/Misc/NEWS.d/next/Tests/2025-02-10-14-34-29.gh-issue-129401.Cq6Ruy.rst
+++ b/Misc/NEWS.d/next/Tests/2025-02-10-14-34-29.gh-issue-129401.Cq6Ruy.rst
@@ -1,1 +1,1 @@
-Fix a flaky test in `test_repr_rlock` about representation of `multiuprocessing.RLock`.
+Fix a flaky test in ``test_repr_rlock`` that checks the representation of :class:`multiprocessing.RLock`.

--- a/Misc/NEWS.d/next/Tests/2025-02-10-14-34-29.gh-issue-129401.Cq6Ruy.rst
+++ b/Misc/NEWS.d/next/Tests/2025-02-10-14-34-29.gh-issue-129401.Cq6Ruy.rst
@@ -1,0 +1,1 @@
+Fix a flaky test in `test_repr_rlock` about representation of `multiuprocessing.RLock`.


### PR DESCRIPTION
Fix and simplify a test of `test_repr_rlock` about multiprocessing.RLock primitive. 
I am wondering if this fix must not be apply to the identical test of primitive multiprocessing.Lock (in `test_repr_lock`).

- see also https://github.com/python/cpython/issues/128206

<!-- gh-issue-number: gh-129401 -->
* Issue: gh-129401
<!-- /gh-issue-number -->
