### PR TITLE
gh-129984: Mark immortal objects as deferred

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -74,6 +74,7 @@ PyAPI_FUNC(int) _PyObject_IsFreed(PyObject *);
     {                                               \
         .ob_ref_local = _Py_IMMORTAL_REFCNT_LOCAL,  \
         .ob_flags = _Py_STATICALLY_ALLOCATED_FLAG,  \
+        .ob_gc_bits = _PyGC_BITS_DEFERRED,          \
         .ob_type = (type)                           \
     }
 #else
@@ -612,7 +613,7 @@ _Py_TryIncrefCompare(PyObject **src, PyObject *op)
 static inline int
 _Py_TryIncrefCompareStackRef(PyObject **src, PyObject *op, _PyStackRef *out)
 {
-    if (_Py_IsImmortal(op) || _PyObject_HasDeferredRefcount(op)) {
+    if (_PyObject_HasDeferredRefcount(op)) {
         *out = (_PyStackRef){ .bits = (intptr_t)op | Py_TAG_DEFERRED };
         return 1;
     }

--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -219,7 +219,7 @@ PyStackRef_FromPyObjectNew(PyObject *obj)
     // Make sure we don't take an already tagged value.
     assert(((uintptr_t)obj & Py_TAG_BITS) == 0);
     assert(obj != NULL);
-    if (_Py_IsImmortal(obj) || _PyObject_HasDeferredRefcount(obj)) {
+    if (_PyObject_HasDeferredRefcount(obj)) {
         return (_PyStackRef){ .bits = (uintptr_t)obj | Py_TAG_DEFERRED };
     }
     else {

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1590,7 +1590,7 @@ _Py_dict_lookup_threadsafe_stackref(PyDictObject *mp, PyObject *key, Py_hash_t h
                 *value_addr = PyStackRef_NULL;
                 return DKIX_EMPTY;
             }
-            if (_Py_IsImmortal(value) || _PyObject_HasDeferredRefcount(value)) {
+            if (_PyObject_HasDeferredRefcount(value)) {
                 *value_addr =  (_PyStackRef){ .bits = (uintptr_t)value | Py_TAG_DEFERRED };
                 return ix;
             }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2538,6 +2538,7 @@ _Py_SetImmortalUntracked(PyObject *op)
     op->ob_tid = _Py_UNOWNED_TID;
     op->ob_ref_local = _Py_IMMORTAL_REFCNT_LOCAL;
     op->ob_ref_shared = 0;
+    _Py_atomic_or_uint8(&op->ob_gc_bits, _PyGC_BITS_DEFERRED);
 #else
     op->ob_refcnt = _Py_IMMORTAL_INITIAL_REFCNT;
 #endif


### PR DESCRIPTION
Marks immortal objects as having the deferred reference counting bit, allowing these objects to be cached in the specializing interpreter loop.

Gets a significant perf win on deltablue where small ints are stored in a class and loaded repeatedly: https://github.com/facebookexperimental/free-threading-benchmarking/blob/main/results/bm-20250210-3.14.0a4%2B-8e67151-NOGIL/bm-20250210-vultr-x86_64-DinoV-immortal_deferred-3.14.0a4%2B-8e67151-vs-base.svg

<!-- gh-issue-number: gh-129984 -->
* Issue: gh-129984
<!-- /gh-issue-number -->
