### PR TITLE
gh-128657: Skip test_get_builtin_constructor when running with --parallel-threads

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -253,6 +253,7 @@ class HashLibTestCase(unittest.TestCase):
     def test_new_upper_to_lower(self):
         self.assertEqual(hashlib.new("SHA256").name, "sha256")
 
+    @support.thread_unsafe("modifies sys.modules")
     def test_get_builtin_constructor(self):
         get_builtin_constructor = getattr(hashlib,
                                           '__get_builtin_constructor')


### PR DESCRIPTION
The test modifies sys.modules and is not thread-safe with `--parallel-threads`.


<!-- gh-issue-number: gh-128657 -->
* Issue: gh-128657
<!-- /gh-issue-number -->
