### PR TITLE
[3.13] gh-127750: Fix functools.singledispatchmethod() 

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -958,9 +958,6 @@ class singledispatchmethod:
         self.dispatcher = singledispatch(func)
         self.func = func
 
-        import weakref # see comment in singledispatch function
-        self._method_cache = weakref.WeakKeyDictionary()
-
     def register(self, cls, method=None):
         """generic_method.register(cls, func) -> func
 
@@ -969,16 +966,6 @@ class singledispatchmethod:
         return self.dispatcher.register(cls, func=method)
 
     def __get__(self, obj, cls=None):
-        if self._method_cache is not None:
-            try:
-                _method = self._method_cache[obj]
-            except TypeError:
-                self._method_cache = None
-            except KeyError:
-                pass
-            else:
-                return _method
-
         dispatch = self.dispatcher.dispatch
         funcname = getattr(self.func, '__name__', 'singledispatchmethod method')
         def _method(*args, **kwargs):
@@ -990,9 +977,6 @@ class singledispatchmethod:
         _method.__isabstractmethod__ = self.__isabstractmethod__
         _method.register = self.register
         update_wrapper(_method, self.func)
-
-        if self._method_cache is not None:
-            self._method_cache[obj] = _method
 
         return _method
 

--- a/Misc/NEWS.d/next/Library/2025-02-12-09-48-25.gh-issue-127750.ibhIZg.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-12-09-48-25.gh-issue-127750.ibhIZg.rst
@@ -1,0 +1,2 @@
+Remove broken :func:`functools.singledispatchmethod` caching introduced in
+:gh:`85160`.


### PR DESCRIPTION
In this PR we revert the changes from #107148 (but keep the added tests). This addresses

* Collisions between different objects with equal `__hash__`/`__eq__`
* Keeping object instances alive

For 3.14+ there are open PRs to address the same issues without the performance regression, but for 3.13 it seems safer to revert the changes (https://github.com/python/cpython/issues/127750#issuecomment-2651456095)

@serhiy-storchaka @Yhg1s 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127750 -->
* Issue: gh-127750
<!-- /gh-issue-number -->
