### PR TITLE
gh-128540: Fixed `webbrowser.open` with `file:` URLs may launching editor instead of browser

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -575,6 +575,8 @@ if sys.platform[:3] == "win":
     class WindowsDefault(BaseBrowser):
         def open(self, url, new=0, autoraise=True):
             sys.audit("webbrowser.open", url)
+            if url.startswith("file:"):
+                return False
             try:
                 os.startfile(url)
             except OSError:
@@ -595,6 +597,8 @@ if sys.platform == 'darwin':
 
         def open(self, url, new=0, autoraise=True):
             sys.audit("webbrowser.open", url)
+            if url.startswith("file:"):
+                return False
             url = url.replace('"', '%22')
             if self.name == 'default':
                 script = f'open location "{url}"'  # opens in default browser
@@ -626,6 +630,8 @@ if sys.platform == "ios":
     class IOSBrowser(BaseBrowser):
         def open(self, url, new=0, autoraise=True):
             sys.audit("webbrowser.open", url)
+            if url.startswith("file:"):
+                return False
             # If ctypes isn't available, we can't open a browser
             if objc is None:
                 return False

--- a/Misc/NEWS.d/next/Library/2025-02-12-20-17-44.gh-issue-128540.veBJG_.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-12-20-17-44.gh-issue-128540.veBJG_.rst
@@ -1,0 +1,2 @@
+Fixed :func:`webbrowser.open` with ``file:`` URLs may launching editor
+instead of browser


### PR DESCRIPTION
Solved : #128540


<!-- gh-issue-number: gh-128540 -->
* Issue: gh-128540
<!-- /gh-issue-number -->
