### PR TITLE
gh-109765: Detect TLS handshake attempt in HTTP server

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -287,6 +287,15 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
         requestline = str(self.raw_requestline, 'iso-8859-1')
         requestline = requestline.rstrip('\r\n')
         self.requestline = requestline
+
+        # Detect TLS handshake attempt (common when browser forces HTTPS)
+        if self.raw_requestline[0] == 0x16:  # First TLS handshake bytes
+            self.requestline = "[TLS handshake bytes]"
+            self.send_error(
+                HTTPStatus.BAD_REQUEST,
+                "Unsupported protocol: HTTPS is not available")
+            return False
+
         words = requestline.split()
         if len(words) == 0:
             return False

--- a/Misc/NEWS.d/next/Library/2025-02-12-18-31-12.gh-issue-109765.QqoBW2.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-12-18-31-12.gh-issue-109765.QqoBW2.rst
@@ -1,2 +1,2 @@
-Detect TLS handshake attempt in :class:`BaseHTTPRequestHandler` of
-:mod:`http.server` module to clear the output. Patch by Semyon Moroz.
+Detect TLS handshake attempt in :class:`http.server.BaseHTTPRequestHandler` to
+more clear the output. Patch by Semyon Moroz.

--- a/Misc/NEWS.d/next/Library/2025-02-12-18-31-12.gh-issue-109765.QqoBW2.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-12-18-31-12.gh-issue-109765.QqoBW2.rst
@@ -1,0 +1,2 @@
+Detect TLS handshake attempt in :class:`BaseHTTPRequestHandler` of
+:mod:`http.server` module to clear the output. Patch by Semyon Moroz.


### PR DESCRIPTION
I set `self.requestline = "[TLS handshake bytes]"` because `BaseHTTPRequestHandler` print `self.requestline` as a log, but it is bytes and to keep `requestline` readable I use `"[TLS handshake bytes]"` string value


<!-- gh-issue-number: gh-109765 -->
* Issue: gh-109765
<!-- /gh-issue-number -->
