### PR TITLE
gh-130050: Fix memory leaks in _testexternalinspection

### DIFF
--- a/Modules/_testexternalinspection.c
+++ b/Modules/_testexternalinspection.c
@@ -778,6 +778,7 @@ parse_coro_chain(
     }
 
     if (PyList_Append(render_to, name)) {
+        Py_DECREF(name);
         return -1;
     }
     Py_DECREF(name);
@@ -955,7 +956,6 @@ parse_task(
     if (PyList_Append(render_to, result)) {
         goto err;
     }
-    Py_DECREF(result);
 
     PyObject *awaited_by = PyList_New(0);
     if (awaited_by == NULL) {
@@ -973,6 +973,7 @@ parse_task(
     ) {
         goto err;
     }
+    Py_DECREF(result);
 
     return 0;
 
@@ -1527,6 +1528,7 @@ get_async_stack_trace(PyObject* self, PyObject* args)
     }
     PyObject* calls = PyList_New(0);
     if (calls == NULL) {
+        Py_DECREF(result);
         return NULL;
     }
     if (PyList_SetItem(result, 0, calls)) { /* steals ref to 'calls' */


### PR DESCRIPTION
I have found some memory leaks in parse_coro_chain, parse_task and get_async_stack_trace. 
This PR fixes them.

<!-- gh-issue-number: gh-130050 -->
* Issue: gh-130050
<!-- /gh-issue-number -->
