### PR TITLE
gh-129726: Break `gzip.GzipFile` reference loop

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -5,12 +5,15 @@ but random access is not allowed."""
 
 # based on Andrew Kuchling's minigzip.py distributed with the zlib module
 
-import struct, sys, time, os
-import zlib
+import _compression
 import builtins
 import io
-import _compression
+import os
+import struct
+import sys
+import time
 import weakref
+import zlib
 
 __all__ = ["BadGzipFile", "GzipFile", "open", "compress", "decompress"]
 
@@ -126,10 +129,13 @@ class BadGzipFile(OSError):
 class _WriteBufferStream(io.RawIOBase):
     """Minimal object to pass WriteBuffer flushes into GzipFile"""
     def __init__(self, gzip_file):
-        self.gzip_file = gzip_file
+        self.gzip_file = weakref.ref(gzip_file)
 
     def write(self, data):
-        return self.gzip_file._write_raw(data)
+        gzip_file = self.gzip_file()
+        if gzip_file is None:
+            raise RuntimeError("lost gzip_file")
+        return gzip_file._write_raw(data)
 
     def seekable(self):
         return False
@@ -227,7 +233,7 @@ class GzipFile(_compression.BaseStream):
                                              0)
             self._write_mtime = mtime
             self._buffer_size = _WRITE_BUFFER_SIZE
-            write_wrap = _WriteBufferStream(weakref.proxy(self))
+            write_wrap = _WriteBufferStream(self)
             self._buffer = io.BufferedWriter(write_wrap,
                                              buffer_size=self._buffer_size)
         else:

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -233,8 +233,7 @@ class GzipFile(_compression.BaseStream):
                                              0)
             self._write_mtime = mtime
             self._buffer_size = _WRITE_BUFFER_SIZE
-            write_wrap = _WriteBufferStream(self)
-            self._buffer = io.BufferedWriter(write_wrap,
+            self._buffer = io.BufferedWriter(_WriteBufferStream(self),
                                              buffer_size=self._buffer_size)
         else:
             raise ValueError("Invalid mode: {!r}".format(mode))

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -10,6 +10,7 @@ import zlib
 import builtins
 import io
 import _compression
+import weakref
 
 __all__ = ["BadGzipFile", "GzipFile", "open", "compress", "decompress"]
 
@@ -226,7 +227,8 @@ class GzipFile(_compression.BaseStream):
                                              0)
             self._write_mtime = mtime
             self._buffer_size = _WRITE_BUFFER_SIZE
-            self._buffer = io.BufferedWriter(_WriteBufferStream(self),
+            write_wrap = _WriteBufferStream(weakref.proxy(self))
+            self._buffer = io.BufferedWriter(write_wrap,
                                              buffer_size=self._buffer_size)
         else:
             raise ValueError("Invalid mode: {!r}".format(mode))

--- a/Misc/NEWS.d/next/Library/2025-02-12-12-38-24.gh-issue-129726.jB0sxu.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-12-12-38-24.gh-issue-129726.jB0sxu.rst
@@ -1,0 +1,3 @@
+Fix :class:`gzip.GzipFile` raising an unraisable exception during garbage
+collection when referring to a temporary object by breaking the reference
+loop with :mod:`weakref`.


### PR DESCRIPTION
A reference loop was resulting in the `fileobj` held by the `GzipFile` being closed before the `GzipFile`.

The issue started with gh-89550 in 3.12, but was hidden in most cases until 3.13 when gh-62948 made it more visible. I think this needs backporting to 3.12 

Sample of test failing on `main`:
```
$ ./python -Wd -E -m test -uall -M8g test_gzip 
Using random seed: 195107833
0:00:00 load avg: 0.54 Run 1 test sequentially in a single process
0:00:00 load avg: 0.54 [1/1] test_gzip
test test_gzip failed -- Traceback (most recent call last):
  File "/<workdir>/python/cpython/Lib/test/test_gzip.py", line 872, in test_refloop_unraisable
    self.assertIsNone(cm.unraisable)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
AssertionError: UnraisableHookArgs(exc_type=<class 'ValueError'>, exc_value=ValueError('I/O operation on closed file.'), exc_traceback=<traceback object at 0x76afdad089b0>, err_msg='Exception ignored while finalizing file <gzip on 0x76afdad08910>', object=None) is not None

test_gzip failed (1 failure)

== Tests result: FAILURE ==

1 test failed:
    test_gzip

Total duration: 735 ms
Total tests: run=73 failures=1
Total test files: run=1/1 failed=1
Result: FAILURE
```

loop found by @danifus , bug found and explored by @xrmx 

<!-- gh-issue-number: gh-129726 -->
* Issue: gh-129726
<!-- /gh-issue-number -->
