### PR TITLE
gh-130019: Fix data race in _PyType_AllocNoTrack

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2253,7 +2253,7 @@ _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems)
     }
     // Zero out the object after the PyObject header. The header fields are
     // initialized by _PyObject_Init[Var]().
-    memset((char *)obj + sizeof(PyObject), '\0', size - sizeof(PyObject));
+    memset((char *)obj + sizeof(PyObject), 0, size - sizeof(PyObject));
 
     if (type->tp_itemsize == 0) {
         _PyObject_Init(obj, type);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2251,7 +2251,9 @@ _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems)
     if (PyType_IS_GC(type)) {
         _PyObject_GC_Link(obj);
     }
-    memset(obj, '\0', size);
+    // Zero out the object after the PyObject header. The header fields are
+    // initialized by _PyObject_Init[Var]().
+    memset((char *)obj + sizeof(PyObject), '\0', size - sizeof(PyObject));
 
     if (type->tp_itemsize == 0) {
         _PyObject_Init(obj, type);

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -2309,11 +2309,12 @@ PyObject *
 PyUnstable_Object_GC_NewWithExtraData(PyTypeObject *tp, size_t extra_size)
 {
     size_t presize = _PyType_PreHeaderSize(tp);
-    PyObject *op = gc_alloc(tp, _PyObject_SIZE(tp) + extra_size, presize);
+    size_t size = _PyObject_SIZE(tp) + extra_size;
+    PyObject *op = gc_alloc(tp, size, presize);
     if (op == NULL) {
         return NULL;
     }
-    memset(op, 0, _PyObject_SIZE(tp) + extra_size);
+    memset((char *)op + sizeof(PyObject), 0, size - sizeof(PyObject));
     _PyObject_Init(op, tp);
     return op;
 }

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -2593,11 +2593,12 @@ PyObject *
 PyUnstable_Object_GC_NewWithExtraData(PyTypeObject *tp, size_t extra_size)
 {
     size_t presize = _PyType_PreHeaderSize(tp);
-    PyObject *op = gc_alloc(tp, _PyObject_SIZE(tp) + extra_size, presize);
+    size_t size = _PyObject_SIZE(tp) + extra_size;
+    PyObject *op = gc_alloc(tp, size, presize);
     if (op == NULL) {
         return NULL;
     }
-    memset(op, 0, _PyObject_SIZE(tp) + extra_size);
+    memset((char *)op + sizeof(PyObject), 0, size - sizeof(PyObject));
     _PyObject_Init(op, tp);
     return op;
 }


### PR DESCRIPTION
The reference count fields, such as `ob_tid` and `ob_ref_shared`, may be accessed concurrently in the free threading build by a `_Py_TryXGetRef` or similar operation. The PyObject header fields will be initialized by `_PyObject_Init`, so only call `memset()` to zero-initialize the remainder of the allocation.


<!-- gh-issue-number: gh-130019 -->
* Issue: gh-130019
<!-- /gh-issue-number -->
