### PR TITLE
[3.10] Docs: pin python-docs-theme to 2025.2 (GH-129576)

### DIFF
--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -15,6 +15,6 @@ blurb
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.
-python-docs-theme>=2022.1
+python-docs-theme==2025.2
 
 -c constraints.txt


### PR DESCRIPTION
(cherry picked from commit 77ca2f66ea733f283fdaab403730e281babcbce8)
