### PR TITLE
gh-130070: Fix `exec(<string>, closure=<non-None>)` unexpected path

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -985,13 +985,6 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         self.assertEqual(result, 2520)
 
         # should fail: closure isn't allowed
-        # when source is a string
-        self.assertRaises(TypeError,
-            exec,
-            "pass",
-            closure=my_closure)
-
-        # should fail: closure isn't allowed
         # for functions without free vars
         self.assertRaises(TypeError,
             exec,
@@ -1019,6 +1012,20 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             exec,
             three_freevars.__code__,
             three_freevars.__globals__,
+            closure=my_closure)
+
+        # should fail: incorrect closure isn't allowed
+        # when source is a string
+        self.assertRaises(TypeError,
+            exec,
+            "pass",
+            closure=object())
+
+        # should fail: correct closure isn't allowed
+        # when source is a string
+        self.assertRaises(TypeError,
+            exec,
+            "pass",
             closure=my_closure)
 
         # should fail: closure tuple with one non-cell-var

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1013,6 +1013,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             three_freevars.__code__,
             three_freevars.__globals__,
             closure=my_closure)
+        my_closure = tuple(my_closure)
 
         # should fail: anything passed to closure= isn't allowed
         # when the source is a string
@@ -1029,6 +1030,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             closure=my_closure)
 
         # should fail: closure tuple with one non-cell-var
+        my_closure = list(my_closure)
         my_closure[0] = int
         my_closure = tuple(my_closure)
         self.assertRaises(TypeError,

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -985,6 +985,13 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         self.assertEqual(result, 2520)
 
         # should fail: closure isn't allowed
+        # when source is a string
+        self.assertRaises(TypeError,
+            exec,
+            "pass",
+            closure=my_closure)
+
+        # should fail: closure isn't allowed
         # for functions without free vars
         self.assertRaises(TypeError,
             exec,

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1020,7 +1020,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         self.assertRaises(TypeError,
             exec,
             "pass",
-            closure=object())
+            closure=int)
 
         # should fail: correct closure= argument isn't allowed
         # when the source is a string

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1014,15 +1014,15 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             three_freevars.__globals__,
             closure=my_closure)
 
-        # should fail: incorrect closure isn't allowed
-        # when source is a string
+        # should fail: anything passed to closure= isn't allowed
+        # when the source is a string
         self.assertRaises(TypeError,
             exec,
             "pass",
             closure=object())
 
-        # should fail: correct closure isn't allowed
-        # when source is a string
+        # should fail: correct closure= argument isn't allowed
+        # when the source is a string
         self.assertRaises(TypeError,
             exec,
             "pass",

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-05-09-31.gh-issue-130070.C8c9gK.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-05-09-31.gh-issue-130070.C8c9gK.rst
@@ -1,2 +1,2 @@
-:func:`builtins.exec` called with a string ``source`` argument and non-``None`` ``closure`` argument no longer fails with a segmentation
+:func:`exec` called with a string ``source`` argument and non-``None`` ``closure`` argument no longer fails with a segmentation
 fault. Patch by Bartosz Sławecki.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-05-09-31.gh-issue-130070.C8c9gK.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-05-09-31.gh-issue-130070.C8c9gK.rst
@@ -1,0 +1,2 @@
+``exec()`` called with a string ``source`` argument and non-``None`` ``closure`` argument no longer fails with a segmentation
+fault. Patch by Bartosz Sławecki.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-05-09-31.gh-issue-130070.C8c9gK.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-05-09-31.gh-issue-130070.C8c9gK.rst
@@ -1,2 +1,2 @@
-``exec()`` called with a string ``source`` argument and non-``None`` ``closure`` argument no longer fails with a segmentation
+:func:`builtins.exec` called with a string ``source`` argument and non-``None`` ``closure`` argument no longer fails with a segmentation
 fault. Patch by Bartosz Sławecki.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-05-09-31.gh-issue-130070.C8c9gK.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-05-09-31.gh-issue-130070.C8c9gK.rst
@@ -1,2 +1,1 @@
-:func:`exec` called with a string ``source`` argument and non-``None`` ``closure`` argument no longer fails with a segmentation
-fault. Patch by Bartosz Sławecki.
+Fixed an assertion error for :func:`exec` passed a string ``source`` and a non-``None`` ``closure``. Patch by Bartosz Sławecki.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1175,6 +1175,7 @@ builtin_exec_impl(PyObject *module, PyObject *source, PyObject *globals,
         if (closure != NULL) {
             PyErr_SetString(PyExc_TypeError,
                 "closure can only be used when source is a code object");
+            goto error;
         }
         PyObject *source_copy;
         const char *str;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130070 -->
Closes gh-130070
<!-- /gh-issue-number -->
