### PR TITLE
gh-130080: return in finally in subprocess.py

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1123,10 +1123,9 @@ class Popen:
                     except TimeoutExpired:
                         pass
                 self._sigint_wait_secs = 0  # Note that this has been done.
-                return  # resume the KeyboardInterrupt
-
-            # Wait for the process to terminate, to avoid zombies.
-            self.wait()
+            else:
+                # Wait for the process to terminate, to avoid zombies.
+                self.wait()
 
     def __del__(self, _maxsize=sys.maxsize, _warn=warnings.warn):
         if not self._child_created:


### PR DESCRIPTION

This could swallow a KeyboardInterrupt coming during `stdin.close()`.

I don't know if it's easy to write a test for this, but if not I wouldn't worry about it because this will be a SyntaxWarning soon.

<!-- gh-issue-number: gh-130080 -->
* Issue: gh-130080
<!-- /gh-issue-number -->
