### PR TITLE
gh-85795: Raise a clear error when `super()` is used in `typing.NamedTuple` subclasses

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2359,6 +2359,10 @@ types.
        # A functional syntax is also supported
        Employee = NamedTuple('Employee', [('name', str), ('id', int)])
 
+   .. note::
+      Using :func:`super` (and the ``__class__`` :term:`closure variable`) in methods of ``NamedTuple`` subclasses
+      is unsupported and causes a :class:`RuntimeError`.
+
    .. versionchanged:: 3.6
       Added support for :pep:`526` variable annotation syntax.
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2359,10 +2359,6 @@ types.
        # A functional syntax is also supported
        Employee = NamedTuple('Employee', [('name', str), ('id', int)])
 
-   .. note::
-      Using :func:`super` (and the ``__class__`` :term:`closure variable`) in methods of ``NamedTuple`` subclasses
-      is unsupported and causes a :class:`RuntimeError`.
-
    .. versionchanged:: 3.6
       Added support for :pep:`526` variable annotation syntax.
 
@@ -2379,6 +2375,10 @@ types.
 
    .. versionchanged:: 3.11
       Added support for generic namedtuples.
+
+   .. versionchanged:: next
+      Using :func:`super` (and the ``__class__`` :term:`closure variable`) in methods of ``NamedTuple`` subclasses
+      is unsupported and causes a :class:`TypeError`.
 
    .. deprecated-removed:: 3.13 3.15
       The undocumented keyword argument syntax for creating NamedTuple classes

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8365,12 +8365,12 @@ class NamedTupleTests(BaseTestCase):
             "in methods of NamedTuple subclasses"
         )
 
-        with self.assertRaises(RuntimeError, msg=expected_message):
+        with self.assertRaises(TypeError, msg=expected_message):
             class ThisWontWork(NamedTuple):
                 def __repr__(self):
                     return super().__repr__()
 
-        with self.assertRaises(RuntimeError, msg=expected_message):
+        with self.assertRaises(TypeError, msg=expected_message):
             class ThisWontWorkEither(NamedTuple):
                 @property
                 def name(self):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8359,6 +8359,23 @@ class NamedTupleTests(BaseTestCase):
             class Foo(NamedTuple):
                 attr = very_annoying
 
+    def test_super_explicitly_disallowed(self):
+        expected_message = (
+            "uses of super() and __class__ are unsupported "
+            "in methods of NamedTuple subclasses"
+        )
+
+        with self.assertRaises(RuntimeError, msg=expected_message):
+            class ThisWontWork(NamedTuple):
+                def __repr__(self):
+                    return super().__repr__()
+
+        with self.assertRaises(RuntimeError, msg=expected_message):
+            class ThisWontWorkEither(NamedTuple):
+                @property
+                def name(self):
+                    return __class__.__name__
+
 
 class TypedDictTests(BaseTestCase):
     def test_basics_functional_syntax(self):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2961,6 +2961,9 @@ _special = frozenset({'__module__', '__name__', '__annotations__', '__annotate__
 class NamedTupleMeta(type):
     def __new__(cls, typename, bases, ns):
         assert _NamedTuple in bases
+        if "__classcell__" in ns:
+            raise RuntimeError(
+                "uses of super() and __class__ are unsupported in methods of NamedTuple subclasses")
         for base in bases:
             if base is not _NamedTuple and base is not Generic:
                 raise TypeError(

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2962,7 +2962,7 @@ class NamedTupleMeta(type):
     def __new__(cls, typename, bases, ns):
         assert _NamedTuple in bases
         if "__classcell__" in ns:
-            raise RuntimeError(
+            raise TypeError(
                 "uses of super() and __class__ are unsupported in methods of NamedTuple subclasses")
         for base in bases:
             if base is not _NamedTuple and base is not Generic:

--- a/Misc/NEWS.d/next/Library/2025-02-13-15-10-56.gh-issue-85795.jeXXI9.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-13-15-10-56.gh-issue-85795.jeXXI9.rst
@@ -1,3 +1,3 @@
 Using :func:`super` and ``__class__`` :term:`closure variable` in
 user-defined methods of :class:`typing.NamedTuple` subclasses is now
-explicitly prevented at runtime.
+explicitly prohibited at runtime.

--- a/Misc/NEWS.d/next/Library/2025-02-13-15-10-56.gh-issue-85795.jeXXI9.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-13-15-10-56.gh-issue-85795.jeXXI9.rst
@@ -1,0 +1,3 @@
+Using :func:`super` and ``__class__`` :term:`closure variable` in
+user-defined methods of :class:`typing.NamedTuple` subclasses is now
+explicitly prevented at runtime.

--- a/Misc/NEWS.d/next/Library/2025-02-13-15-10-56.gh-issue-85795.jeXXI9.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-13-15-10-56.gh-issue-85795.jeXXI9.rst
@@ -1,3 +1,3 @@
 Using :func:`super` and ``__class__`` :term:`closure variable` in
 user-defined methods of :class:`typing.NamedTuple` subclasses is now
-explicitly prohibited at runtime.
+explicitly prohibited at runtime. Contributed by Bartosz Sławecki in :gh:`130082`.


### PR DESCRIPTION
Follow-up to conclusions from gh-129352, closes gh-85795.

In https://github.com/python/cpython/pull/129352#issuecomment-2638812523, @rhettinger and I agreed that a clear error message is needed when a user attempts to use `super()` in `typing.NamedTuple` subclasses.

~~I believe this PR should be backported.~~ Since we no longer raise a `RuntimeError`, this cannot be backported.

### About the PR
Pure presence of `__classcell__` is enough to confirm that `__class__` closure was created to enable `super()` calls.

Tests for cases where `__classcell__` are manually set in typed named tuples were intentionally _not_ added, as I don't see the value in considering these behaviors.

~~Interestingly, I used a note admonition instead of `.. versionchanged:: next` in the docs and it's completely backward-compatible: it applies to all relevant previous versions of Python. I considered making an "important" block instead, but I think `super()` is not often enough to support that idea.~~ No longer true, we raise `TypeError` instead of `RuntimeError`

CC previous reviewers: @ZeroIntensity @AlexWaygood @JelleZijlstra @rhettinger

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-85795 -->
* Issue: gh-85795
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130082.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->