### PR TITLE
gh-129107: make bytearrayiter free-threading safe

### DIFF
--- a/Include/cpython/bytearrayobject.h
+++ b/Include/cpython/bytearrayobject.h
@@ -29,6 +29,10 @@ static inline char* PyByteArray_AS_STRING(PyObject *op)
 
 static inline Py_ssize_t PyByteArray_GET_SIZE(PyObject *op) {
     PyByteArrayObject *self = _PyByteArray_CAST(op);
+#ifdef Py_GIL_DISABLED
+    return _Py_atomic_load_ssize_relaxed(&(_PyVarObject_CAST(self)->ob_size));
+#else
     return Py_SIZE(self);
+#endif
 }
 #define PyByteArray_GET_SIZE(self) PyByteArray_GET_SIZE(_PyObject_CAST(self))

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -2455,9 +2455,6 @@ class FreeThreadingTest(unittest.TestCase):
             with threading_helper.start_threads(threads):
                 pass
 
-            for thread in threads:
-                threading_helper.join_thread(thread)
-
         # hard errors
 
         check([clear] + [reduce] * 10)
@@ -2541,9 +2538,6 @@ class FreeThreadingTest(unittest.TestCase):
 
             with threading_helper.start_threads(threads):
                 pass
-
-            for thread in threads:
-                threading_helper.join_thread(thread)
 
         for _ in range(10):
             ba = bytearray(b'0' * 0x4000)  # this is a load-bearing variable, do not remove

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -18,6 +18,7 @@ import threading
 import unittest
 
 import test.support
+from test import support
 from test.support import import_helper
 from test.support import threading_helper
 from test.support import warnings_helper
@@ -2189,8 +2190,7 @@ class BytesSubclassTest(SubclassTest, unittest.TestCase):
 
 
 class FreeThreadingTest(unittest.TestCase):
-    @unittest.skipUnless(sysconfig.get_config_var('Py_GIL_DISABLED'),
-                         'this test can only possibly fail with GIL disabled')
+    @unittest.skipUnless(support.Py_GIL_DISABLED, 'this test can only possibly fail with GIL disabled')
     @threading_helper.reap_threads
     @threading_helper.requires_working_threading()
     def test_free_threading_bytearrayiter(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-20-42-53.gh-issue-129107._olg-L.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-20-42-53.gh-issue-129107._olg-L.rst
@@ -1,1 +1,1 @@
-Make ``bytearray`` iterator safe under :term:`free threading`.
+Make :class:`bytearray` iterator safe under :term:`free threading`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-20-42-53.gh-issue-129107._olg-L.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-13-20-42-53.gh-issue-129107._olg-L.rst
@@ -1,0 +1,1 @@
+Make ``bytearray`` iterator safe under :term:`free threading`.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2916,9 +2916,7 @@ bytearrayiter_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
     PyObject *ret = NULL;
     Py_ssize_t index = FT_ATOMIC_LOAD_SSIZE_RELAXED(it->it_index);
     if (index >= 0) {
-        if (index <= PyByteArray_GET_SIZE(it->it_seq)) {
-            ret = Py_BuildValue("N(O)n", iter, it->it_seq, index);
-        }
+        ret = Py_BuildValue("N(O)n", iter, it->it_seq, index);
     }
     if (ret == NULL) {
         ret = Py_BuildValue("N(())", iter);

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2913,15 +2913,11 @@ bytearrayiter_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
      * call must be before access of iterator pointers.
      * see issue #101765 */
     bytesiterobject *it = _bytesiterobject_CAST(self);
-    PyObject *ret = NULL;
     Py_ssize_t index = FT_ATOMIC_LOAD_SSIZE_RELAXED(it->it_index);
     if (index >= 0) {
-        ret = Py_BuildValue("N(O)n", iter, it->it_seq, index);
+        return Py_BuildValue("N(O)n", iter, it->it_seq, index);
     }
-    if (ret == NULL) {
-        ret = Py_BuildValue("N(())", iter);
-    }
-    return ret;
+    return Py_BuildValue("N(())", iter);
 }
 
 static PyObject *

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2533,10 +2533,6 @@ bytearrayiter_next(PyObject *self)
         val = (unsigned char)PyByteArray_AS_STRING(seq)[index];
     }
     else {
-        val = -1;
-    }
-
-    if (val == -1) {
         FT_ATOMIC_STORE_SSIZE_RELAXED(it->it_index, -1);
 #ifndef Py_GIL_DISABLED
         it->it_seq = NULL;

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -5,6 +5,7 @@
 #include "pycore_bytes_methods.h"
 #include "pycore_bytesobject.h"
 #include "pycore_ceval.h"         // _PyEval_GetBuiltin()
+#include "pycore_critical_section.h"
 #include "pycore_object.h"        // _PyObject_GC_UNTRACK()
 #include "pycore_strhex.h"        // _Py_strhex_with_sep()
 #include "pycore_long.h"          // _PyLong_FromUnsignedChar()
@@ -2519,22 +2520,35 @@ static PyObject *
 bytearrayiter_next(PyObject *self)
 {
     bytesiterobject *it = _bytesiterobject_CAST(self);
-    PyByteArrayObject *seq;
+    int val;
 
     assert(it != NULL);
-    seq = it->it_seq;
-    if (seq == NULL)
+    Py_ssize_t index = FT_ATOMIC_LOAD_SSIZE_RELAXED(it->it_index);
+    if (index < 0) {
         return NULL;
+    }
+    PyByteArrayObject *seq = it->it_seq;
     assert(PyByteArray_Check(seq));
 
-    if (it->it_index < PyByteArray_GET_SIZE(seq)) {
-        return _PyLong_FromUnsignedChar(
-            (unsigned char)PyByteArray_AS_STRING(seq)[it->it_index++]);
+    Py_BEGIN_CRITICAL_SECTION(seq);
+    if (index < PyByteArray_GET_SIZE(seq)) {
+        val = (unsigned char)PyByteArray_AS_STRING(seq)[index];
     }
+    else {
+        val = -1;
+    }
+    Py_END_CRITICAL_SECTION();
 
-    it->it_seq = NULL;
-    Py_DECREF(seq);
-    return NULL;
+    if (val == -1) {
+        FT_ATOMIC_STORE_SSIZE_RELAXED(it->it_index, -1);
+#ifndef Py_GIL_DISABLED
+        it->it_seq = NULL;
+        Py_DECREF(seq);
+#endif
+        return NULL;
+    }
+    FT_ATOMIC_STORE_SSIZE_RELAXED(it->it_index, index + 1);
+    return _PyLong_FromUnsignedChar((unsigned char)val);
 }
 
 static PyObject *
@@ -2542,8 +2556,9 @@ bytearrayiter_length_hint(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     bytesiterobject *it = _bytesiterobject_CAST(self);
     Py_ssize_t len = 0;
-    if (it->it_seq) {
-        len = PyByteArray_GET_SIZE(it->it_seq) - it->it_index;
+    Py_ssize_t index = FT_ATOMIC_LOAD_SSIZE_RELAXED(it->it_index);
+    if (index >= 0) {
+        len = PyByteArray_GET_SIZE(it->it_seq) - index;
         if (len < 0) {
             len = 0;
         }
@@ -2563,27 +2578,41 @@ bytearrayiter_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
      * call must be before access of iterator pointers.
      * see issue #101765 */
     bytesiterobject *it = _bytesiterobject_CAST(self);
-    if (it->it_seq != NULL) {
-        return Py_BuildValue("N(O)n", iter, it->it_seq, it->it_index);
-    } else {
-        return Py_BuildValue("N(())", iter);
+    PyObject *ret = NULL;
+    Py_ssize_t index = FT_ATOMIC_LOAD_SSIZE_RELAXED(it->it_index);
+    if (index >= 0) {
+        Py_BEGIN_CRITICAL_SECTION(it->it_seq);
+        if (index <= PyByteArray_GET_SIZE(it->it_seq)) {
+            ret = Py_BuildValue("N(O)n", iter, it->it_seq, index);
+        }
+        Py_END_CRITICAL_SECTION();
     }
+    if (ret == NULL) {
+        ret = Py_BuildValue("N(())", iter);
+    }
+    return ret;
 }
 
 static PyObject *
 bytearrayiter_setstate(PyObject *self, PyObject *state)
 {
     Py_ssize_t index = PyLong_AsSsize_t(state);
-    if (index == -1 && PyErr_Occurred())
+    if (index == -1 && PyErr_Occurred()) {
         return NULL;
+    }
 
     bytesiterobject *it = _bytesiterobject_CAST(self);
-    if (it->it_seq != NULL) {
-        if (index < 0)
-            index = 0;
-        else if (index > PyByteArray_GET_SIZE(it->it_seq))
-            index = PyByteArray_GET_SIZE(it->it_seq); /* iterator exhausted */
-        it->it_index = index;
+    if (FT_ATOMIC_LOAD_SSIZE_RELAXED(it->it_index) >= 0) {
+        if (index < -1) {
+            index = -1;
+        }
+        else {
+            Py_ssize_t size = PyByteArray_GET_SIZE(it->it_seq);
+            if (index > size) {
+                index = size; /* iterator at end */
+            }
+        }
+        FT_ATOMIC_STORE_SSIZE_RELAXED(it->it_index, index);
     }
     Py_RETURN_NONE;
 }
@@ -2645,7 +2674,7 @@ bytearray_iter(PyObject *seq)
     it = PyObject_GC_New(bytesiterobject, &PyByteArrayIter_Type);
     if (it == NULL)
         return NULL;
-    it->it_index = 0;
+    it->it_index = 0;  // -1 indicates exhausted
     it->it_seq = (PyByteArrayObject *)Py_NewRef(seq);
     _PyObject_GC_TRACK(it);
     return (PyObject *)it;


### PR DESCRIPTION
This is the bytearray iterator made safe under free-threading. The behavior is copied from the list iterator, it is not synchronized but it won't crash.

<!-- gh-issue-number: gh-129107 -->
* Issue: gh-129107
<!-- /gh-issue-number -->
