### PR TITLE
gh-129205: Experiment BytesIO._readfrom()

### DIFF
--- a/Include/internal/pycore_global_objects_fini_generated.h
+++ b/Include/internal/pycore_global_objects_fini_generated.h
@@ -916,6 +916,7 @@ _PyStaticObjects_CheckRefcnt(PyInterpreterState *interp) {
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(entrypoint));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(env));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(errors));
+    _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(estimate));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(event));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(eventmask));
     _PyStaticObject_CheckRefcnt((PyObject *)&_Py_ID(exc_type));

--- a/Include/internal/pycore_global_strings.h
+++ b/Include/internal/pycore_global_strings.h
@@ -405,6 +405,7 @@ struct _Py_global_strings {
         STRUCT_FOR_ID(entrypoint)
         STRUCT_FOR_ID(env)
         STRUCT_FOR_ID(errors)
+        STRUCT_FOR_ID(estimate)
         STRUCT_FOR_ID(event)
         STRUCT_FOR_ID(eventmask)
         STRUCT_FOR_ID(exc_type)

--- a/Include/internal/pycore_runtime_init_generated.h
+++ b/Include/internal/pycore_runtime_init_generated.h
@@ -914,6 +914,7 @@ extern "C" {
     INIT_ID(entrypoint), \
     INIT_ID(env), \
     INIT_ID(errors), \
+    INIT_ID(estimate), \
     INIT_ID(event), \
     INIT_ID(eventmask), \
     INIT_ID(exc_type), \

--- a/Include/internal/pycore_unicodeobject_generated.h
+++ b/Include/internal/pycore_unicodeobject_generated.h
@@ -1416,6 +1416,10 @@ _PyUnicode_InitStaticStrings(PyInterpreterState *interp) {
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));
     assert(PyUnicode_GET_LENGTH(string) != 1);
+    string = &_Py_ID(estimate);
+    _PyUnicode_InternStatic(interp, &string);
+    assert(_PyUnicode_CheckConsistency(string, 1));
+    assert(PyUnicode_GET_LENGTH(string) != 1);
     string = &_Py_ID(event);
     _PyUnicode_InternStatic(interp, &string);
     assert(_PyUnicode_CheckConsistency(string, 1));

--- a/Lib/_compression.py
+++ b/Lib/_compression.py
@@ -111,14 +111,10 @@ class DecompressReader(io.RawIOBase):
         return data
 
     def readall(self):
-        chunks = []
-        # sys.maxsize means the max length of output buffer is unlimited,
-        # so that the whole input buffer can be decompressed within one
-        # .decompress() call.
-        while data := self.read(sys.maxsize):
-            chunks.append(data)
-
-        return b"".join(chunks)
+        # FIXME(cmaloney): non blocking support?
+        bio = io.BytesIO()
+        bio.readfrom(self)
+        return bio.getvalue()
 
     # Rewind the file to the beginning of the data stream.
     def _rewind(self):

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -939,7 +939,6 @@ class BytesIO(BufferedIOBase):
         # byte which returns size 0. Oversize the buffer by 1 byte so the
         # I/O can be completed with two read() calls (one for all data, one
         # for EOF) without needing to resize the buffer.
-        # FIXME(cmaloney): This should probably be a memoryview....
         target_read = None
         if estimate is not None:
             target_read = int(estimate) + 1
@@ -954,16 +953,14 @@ class BytesIO(BufferedIOBase):
             if limit < 0:
                 raise ValueError(f"limit must be larger than 0, got {limit}")
 
-        # Expand buffer to get target read in one read when possible.
         if limit is not None:
             target_read = min(target_read, limit)
 
-        # Expand so target read definitely fits.
+        # Expand buffer to get target read in one read when possible.
         if len(self._buffer) < target_read + self._pos:
             self._buffer.resize(self._pos + target_read)
 
-        # File descriptor
-        if isinstance(file, int):
+        if isinstance(file, int):  # File descriptor
             read_fn = lambda: os.readinto(file, memoryview(self._buffer)[self._pos:])
         elif file_readinto := getattr(file, "readinto", None):
             read_fn = lambda: file_readinto(memoryview(self._buffer)[self._pos:])

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -949,7 +949,7 @@ class BytesIO(BufferedIOBase):
         # Cap to limit
         if limit is not None:
             limit = int(limit)
-            if limit == 0:
+            if limit == 0:  # Nothing to read.
                 return False
             if limit < 0:
                 raise ValueError(f"limit must be larger than 0, got {limit}")

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -991,7 +991,7 @@ class BytesIO(BufferedIOBase):
         except BlockingIOError:
             pass
 
-        # Buffer must be
+        # Remove all excess bytes.
         self._buffer.resize(self._pos)
         return found_eof
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1921,12 +1921,9 @@ class Popen:
 
                 # Wait for exec to fail or succeed; possibly raising an
                 # exception (limited in size)
-                errpipe_data = bytearray()
-                while True:
-                    part = os.read(errpipe_read, 50000)
-                    errpipe_data += part
-                    if not part or len(errpipe_data) > 50000:
-                        break
+                bio = io.BytesIO()
+                bio.readfrom(errpipe_read, estimate=0, limit=50_000)
+                errpipe_data = bio.getvalue()
             finally:
                 # be sure the FD is closed no matter what
                 os.close(errpipe_read)

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -570,6 +570,7 @@ _io_BytesIO_readfrom_impl(bytesio *self, int file, Py_ssize_t estimate,
                           Py_ssize_t limit)
 /*[clinic end generated code: output=71dcfcf7e9a50527 input=9bce10ea48db6415]*/
 {
+    /* FIXME: Cap to _PY_READ_MAX */
     if (check_closed(self)) {
         return -1;
     }

--- a/Modules/_io/clinic/bytesio.c.h
+++ b/Modules/_io/clinic/bytesio.c.h
@@ -233,6 +233,107 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(_io_BytesIO_readfrom__doc__,
+"readfrom($self, file, /, *, estimate=-1, limit=-1)\n"
+"--\n"
+"\n"
+"Efficiently read from the provided file and return True if hit end of file.\n"
+"\n"
+"Returns True if and only if a read into a non-zero length buffer returns 0\n"
+"bytes. On most systems this indicates end of file / stream.\n"
+"\n"
+"FIXME?: Allow fileobj that provides readinto.?\n"
+"FIXME?:Allow fileobj that only has read?\n"
+"\n"
+"If a readinto call raises NonBlockingError or returns None, data returned to\n"
+"that point will be stored in buffer, and will return False. For other exceptions\n"
+"while reading, as much data as possible will be in the buffer.\n"
+"\n"
+"FIXME: BlockingIOError contains data from partial reads. Append it.\n"
+"    -> Include test that no data is lost w/ multiple repeated blocks\n"
+"        (There is one already in tests, make sure this is exercised and passes\n"
+"         it)\n"
+"FIXME: Does this need to document that all reads are Limited to PY_SSIZE_T_MAX.\n"
+"FIXME? It would be nice if this could support a timeout, but probably a feature\n"
+"       for later.");
+
+#define _IO_BYTESIO_READFROM_METHODDEF    \
+    {"readfrom", _PyCFunction_CAST(_io_BytesIO_readfrom), METH_FASTCALL|METH_KEYWORDS, _io_BytesIO_readfrom__doc__},
+
+static int
+_io_BytesIO_readfrom_impl(bytesio *self, int file, Py_ssize_t estimate,
+                          Py_ssize_t limit);
+
+static PyObject *
+_io_BytesIO_readfrom(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
+
+    #define NUM_KEYWORDS 2
+    static struct {
+        PyGC_Head _this_is_not_used;
+        PyObject_VAR_HEAD
+        PyObject *ob_item[NUM_KEYWORDS];
+    } _kwtuple = {
+        .ob_base = PyVarObject_HEAD_INIT(&PyTuple_Type, NUM_KEYWORDS)
+        .ob_item = { &_Py_ID(estimate), &_Py_ID(limit), },
+    };
+    #undef NUM_KEYWORDS
+    #define KWTUPLE (&_kwtuple.ob_base.ob_base)
+
+    #else  // !Py_BUILD_CORE
+    #  define KWTUPLE NULL
+    #endif  // !Py_BUILD_CORE
+
+    static const char * const _keywords[] = {"", "estimate", "limit", NULL};
+    static _PyArg_Parser _parser = {
+        .keywords = _keywords,
+        .fname = "readfrom",
+        .kwtuple = KWTUPLE,
+    };
+    #undef KWTUPLE
+    PyObject *argsbuf[3];
+    Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
+    int file;
+    Py_ssize_t estimate = -1;
+    Py_ssize_t limit = -1;
+    int _return_value;
+
+    args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser,
+            /*minpos*/ 1, /*maxpos*/ 1, /*minkw*/ 0, /*varpos*/ 0, argsbuf);
+    if (!args) {
+        goto exit;
+    }
+    file = PyLong_AsInt(args[0]);
+    if (file == -1 && PyErr_Occurred()) {
+        goto exit;
+    }
+    if (!noptargs) {
+        goto skip_optional_kwonly;
+    }
+    if (args[1]) {
+        if (!_Py_convert_optional_to_ssize_t(args[1], &estimate)) {
+            goto exit;
+        }
+        if (!--noptargs) {
+            goto skip_optional_kwonly;
+        }
+    }
+    if (!_Py_convert_optional_to_ssize_t(args[2], &limit)) {
+        goto exit;
+    }
+skip_optional_kwonly:
+    _return_value = _io_BytesIO_readfrom_impl((bytesio *)self, file, estimate, limit);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyBool_FromLong((long)_return_value);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_io_BytesIO_readline__doc__,
 "readline($self, size=-1, /)\n"
 "--\n"
@@ -535,4 +636,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8a5e153bc7584b55 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=bab5a4081d518e22 input=a9049054013a1b77]*/

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -735,6 +735,7 @@ static PyObject *
 _io_FileIO_readall_impl(fileio *self)
 /*[clinic end generated code: output=faa0292b213b4022 input=dbdc137f55602834]*/
 {
+    Py_ssize_t pos = 0;
     PyObject* estimate_obj = Py_None;
     PyObject* result = NULL;
 
@@ -749,7 +750,7 @@ _io_FileIO_readall_impl(fileio *self)
            then calls readall() to get the rest, which would result in allocating
            more than required. Guard against that for larger files where we expect
            the I/O time to dominate anyways while keeping small files fast. */
-        if (bufsize > LARGE_BUFFER_CUTOFF_SIZE) {
+        if (estimate > LARGE_BUFFER_CUTOFF_SIZE) {
             Py_BEGIN_ALLOW_THREADS
             _Py_BEGIN_SUPPRESS_IPH
 #ifdef MS_WINDOWS
@@ -769,6 +770,13 @@ _io_FileIO_readall_impl(fileio *self)
             return NULL;
         }
     }
+
+    /*
+    bio = io.BytesIO();
+    found_eof = bio.readfrom(self->fd, estimate=estimate)
+    result = bio.getvalue()
+    return result if result or found_eof else None
+    */
 
     /* Use BytesIO.readfrom(fd, estimate=estimate) */
     PyObject *bytesio_class = PyImport_ImportModuleAttrString("io", "BytesIO");

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -716,7 +716,6 @@ static PyObject *
 _io_FileIO_readall_impl(fileio *self)
 /*[clinic end generated code: output=faa0292b213b4022 input=dbdc137f55602834]*/
 {
-    Py_ssize_t pos = 0;
     PyObject* estimate_obj = Py_None;
     PyObject *args[3] = {NULL, NULL, NULL};
     PyObject *fn_name = NULL;
@@ -729,6 +728,7 @@ _io_FileIO_readall_impl(fileio *self)
     }
 
     if (self->stat_atopen != NULL && self->stat_atopen->st_size >= 0) {
+        Py_ssize_t pos = 0;
         Py_ssize_t estimate = self->stat_atopen->st_size;
         /* While a lot of code does open().read() to get the whole contents
            of a file it is possible a caller seeks/reads a ways into the file
@@ -808,7 +808,8 @@ _io_FileIO_readall_impl(fileio *self)
         goto leave;
     }
 
-    if (!PyBool_Check(found_eof) && !PyBool_Check(result)) {
+    /* Read was blocked (didn't get to end, and didn't find data) */
+    if (!PyObject_IsTrue(result) && !PyObject_IsTrue(found_eof)) {
         Py_DECREF(result);
         result = Py_None;
     }


### PR DESCRIPTION
## Draft PR / Experiment

Rather than directly moving loops, I have been experimenting with a `BytesIO._readfrom(file, /, *, estimate=None, limit=None)` that encapsulates the buffer resizing efficiently as well as the read loop, adding common code for features "estimated size" and "limit size". It can be used to implement `FileIO.readall` with minimal perf change (is in PR). In general I think "If there is a read loop, it should be faster and simpler".

The `_pyio` implementation supports for three kinds of IO objects: Direct FD ints, those with a `.readinto` member, and those with `.read` member. If that looks like a reasonable approach, I'd likely introduce it as a internal method `BytesIO._readfrom()` and move cases (with perf tests to make sure things don't regress).

In the C implementation I included an optimization to avoid a heap allocation by using 1KB of stack space in the `estimate=0` case instead. Not sure that's worth the complexity and cost (if it gets used, need an extra copy compared to just using a bytes; and a warmed up interpreter feels like 1KB PyBytes is likely to be quickly available / allocated).

The CPython codebase has a common pattern of build a list of I/O chunks than "join" them together at the end of the loop. I think readfrom makes a tradeoff in that case, in that as long as resize infrequently copies (I think not lots of other memory buffers being allocated), it should be faster than that single extra large join and copy at the end. I haven't run full performance numbers though. In my mental model using non-linear buffer resizing for large readall is likely a much bigger performance gain and reducing number of allocs + deallocs, than potential `realloc` copies; definitely uses less memory overall.

<!-- gh-issue-number: gh-129205 -->
* Issue: gh-129205
<!-- /gh-issue-number -->
