### PR TITLE
gh-130099: Exclude NetBSD from Clang fallthrough attribute in _Py_FALLTHROUGH macro

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -630,7 +630,7 @@ extern "C" {
 // style fallthrough attribute, not the GCC extension syntax used here,
 // and __has_attribute(fallthrough) evaluates to 1.
 #if _Py__has_attribute(fallthrough) && (!defined(__clang__) || \
-    (!defined(__apple_build_version__) && __clang_major__ >= 10) || \
+    ((!defined(__apple_build_version__) && !defined(__NetBSD__)) && __clang_major__ >= 10) || \
     (defined(__apple_build_version__) && __clang_major__ >= 12))
 #  define _Py_FALLTHROUGH __attribute__((fallthrough))
 #else


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130099 -->
* Issue: gh-130099
<!-- /gh-issue-number -->
