### PR TITLE
gh-86069: correct object.__ipow__() signature

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -3376,7 +3376,7 @@ left undefined.
             object.__itruediv__(self, other)
             object.__ifloordiv__(self, other)
             object.__imod__(self, other)
-            object.__ipow__(self, other[, modulo])
+            object.__ipow__(self, other)
             object.__ilshift__(self, other)
             object.__irshift__(self, other)
             object.__iand__(self, other)


### PR DESCRIPTION
There is no way to call ternary form of this dunder.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-86069 -->
* Issue: gh-86069
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130103.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->