### PR TITLE
gh-130106: Fix a typo in unittest.mock doc

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2008,7 +2008,7 @@ Imagine we have a project that we want to test with the following structure::
 
 Now we want to test ``some_function`` but we want to mock out ``SomeClass`` using
 :func:`patch`. The problem is that when we import module b, which we will have to
-do then it imports ``SomeClass`` from module a. If we use :func:`patch` to mock out
+do when it imports ``SomeClass`` from module a. If we use :func:`patch` to mock out
 ``a.SomeClass`` then it will have no effect on our test; module b already has a
 reference to the *real* ``SomeClass`` and it looks like our patching had no
 effect.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130106 -->
* Issue: gh-130106
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130107.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->