### PR TITLE
CI: Mark the `cross-build-linux` job as skippable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -658,6 +658,7 @@ jobs:
             build_asan,
             build_tsan,
             test_hypothesis,
+            cross-build-linux,
             '
             || ''
           }}


### PR DESCRIPTION
Yesterday, GH-129459 marked `cross-build-linux` as a required job, which is [blocking PRs](https://github.com/python/cpython/pull/130079) that skip it.