### PR TITLE
[3.9] gh-129641: Docs GHA build: use upload-artifact@v4 (GH-129642)

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -36,7 +36,9 @@ jobs:
     - name: 'Build documentation'
       run: xvfb-run make -C Doc/ PYTHON=../python SPHINXOPTS="-q -W -j4" doctest suspicious html
     - name: 'Upload'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: doc-html
         path: Doc/build/html
+        include-hidden-files: true
+        overwrite: true

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -325,7 +325,7 @@ Now what can we do with instance objects?  The only operations understood by
 instance objects are attribute references.  There are two kinds of valid
 attribute names: data attributes and methods.
 
-*data attributes* correspond to "instance variables" in Smalltalk, and to "data
+*Data attributes* correspond to "instance variables" in Smalltalk, and to "data
 members" in C++.  Data attributes need not be declared; like local variables,
 they spring into existence when they are first assigned to.  For example, if
 ``x`` is the instance of :class:`MyClass` created above, the following piece of


### PR DESCRIPTION
Backported from commit 7b0351cf6afb7ff8aae8d7fb2949e5578d483bca

Includes a typo fix to trigger a docs build in CI
(backported from GH-128077, commit 5a584c8f54bbeceae7ffa501291e29b7ddc8a0b9)

<!-- gh-issue-number: gh-129641 -->
* Issue: gh-129641
<!-- /gh-issue-number -->
