### PR TITLE
Replace non-breaking spaces with normal spaces

### DIFF
--- a/Android/README.md
+++ b/Android/README.md
@@ -119,10 +119,10 @@ stderr. Add the `-v` option to also show Gradle output, and non-Python logcat
 messages.
 
 Any other arguments on the `android.py test` command line will be passed through
-to `python -m test` – use `--` to separate them from android.py's own options.
+to `python -m test` – use `--` to separate them from android.py's own options.
 See the [Python Developer's
 Guide](https://devguide.python.org/testing/run-write-tests/) for common options
-– most of them will work on Android, except for those that involve subprocesses,
+– most of them will work on Android, except for those that involve subprocesses,
 such as `-j`.
 
 Every time you run `android.py test`, changes in pure-Python files in the

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -79,7 +79,7 @@ Examples                                         Results
 ``product('ABCD', repeat=2)``                    ``AA AB AC AD BA BB BC BD CA CB CC CD DA DB DC DD``
 ``permutations('ABCD', 2)``                      ``AB AC AD BA BC BD CA CB CD DA DB DC``
 ``combinations('ABCD', 2)``                      ``AB AC AD BC BD CD``
-``combinations_with_replacement('ABCD', 2)``     ``AA AB AC AD BB BC BD CC CD DD``
+``combinations_with_replacement('ABCD', 2)``     ``AA AB AC AD BB BC BD CC CD DD``
 ==============================================   =============================================================
 
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -1148,7 +1148,7 @@ Connection objects
           the *remaining* number of pages still to be copied,
           and the *total* number of pages.
           Defaults to ``None``.
-      :type progress: :term:`callback` | None
+      :type progress: :term:`callback` | None
 
       :param str name:
           The name of the database to back up.

--- a/Doc/whatsnew/3.1.rst
+++ b/Doc/whatsnew/3.1.rst
@@ -47,7 +47,7 @@
    when researching a change.
 
 This article explains the new features in Python 3.1, compared to 3.0.
-Python 3.1 was released on June 27, 2009.
+Python 3.1 was released on June 27, 2009.
 
 
 PEP 372: Ordered Dictionaries

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -45,7 +45,7 @@
    when researching a change.
 
 This article explains the new features in Python 3.5, compared to 3.4.
-Python 3.5 was released on September 13, 2015.  See the
+Python 3.5 was released on September 13, 2015.  See the
 `changelog <https://docs.python.org/3.5/whatsnew/changelog.html>`_ for a full
 list of changes.
 

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -45,7 +45,7 @@
    when researching a change.
 
 This article explains the new features in Python 3.6, compared to 3.5.
-Python 3.6 was released on December 23, 2016.  See the
+Python 3.6 was released on December 23, 2016.  See the
 `changelog <https://docs.python.org/3.6/whatsnew/changelog.html>`_ for a full
 list of changes.
 

--- a/InternalDocs/interpreter.md
+++ b/InternalDocs/interpreter.md
@@ -105,7 +105,7 @@ snippet decode a complete instruction:
 For various reasons we'll get to later (mostly efficiency, given that `EXTENDED_ARG`
 is rare) the actual code is different.
 
-## Jumps
+## Jumps
 
 Note that when the `switch` statement is reached, `next_instr` (the "instruction offset")
 already points to the next instruction.

--- a/Lib/test/clinic.test.c
+++ b/Lib/test/clinic.test.c
@@ -3976,7 +3976,7 @@ test_preprocessor_guarded_if_with_continuation_impl(PyObject *module)
 /*[clinic end generated code: output=3d0712ca9e2d15b9 input=4a956fd91be30284]*/
 #endif
 
-#if CONDITION_E || CONDITION_F
+#if CONDITION_E || CONDITION_F
 #warning "different type of CPP directive"
 /*[clinic input]
 test_preprocessor_guarded_if_e_or_f

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -1086,7 +1086,7 @@ class SelectorSocketTransportTests(test_utils.TestCase):
         self.assertFalse(self.protocol.connection_lost.called)
 
         self.loop.writers[7]._run()
-        # during this ^ run, the _resume_writing mock above was called and added more data
+        # during this ^ run, the _resume_writing mock above was called and added more data
 
         self.assertEqual(transport.get_write_buffer_size(), 2)
         self.loop.writers[7]._run()

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1382,7 +1382,7 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
         self.assertIsNone(ba.resize(10))
         self.assertEqual(ba, bytearray(b'\0' * 10))
 
-        # Subclass
+        # Subclass
         ba = ByteArraySubclass(b'abcdef')
         self.assertIsNone(ba.resize(3))
         self.assertEqual(ba, bytearray(b'abc'))

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -51,7 +51,7 @@ INIT_LOOPS = 4
 MAX_HASH_SEED = 4294967295
 
 ABI_THREAD = 't' if sysconfig.get_config_var('Py_GIL_DISABLED') else ''
-# PLATSTDLIB_LANDMARK copied from Modules/getpath.py
+# PLATSTDLIB_LANDMARK copied from Modules/getpath.py
 if os.name == 'nt':
     PLATSTDLIB_LANDMARK = f'{sys.platlibdir}'
 else:

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -197,7 +197,7 @@ class TestReader(TestCase):
                 Event(evt="key", data="down", raw=bytearray(b"\x1bOB")),
                 Event(evt="key", data="\x05", raw=bytearray(b"\x1bO5")),
                 # a double new line in-block should terminate the block
-                # even if its followed by whitespace
+                # even if its followed by whitespace
                 Event(evt="key", data="\n", raw=bytearray(b"\n")),
                 Event(evt="key", data="\n", raw=bytearray(b"\n")),
             ],

--- a/Misc/NEWS.d/3.11.0b1.rst
+++ b/Misc/NEWS.d/3.11.0b1.rst
@@ -415,7 +415,7 @@ Make opcodes :opcode:`!JUMP_IF_TRUE_OR_POP` and
 
 Replace the ``f_lasti`` member of the internal ``_PyInterpreterFrame``
 structure with a ``prev_instr`` pointer, which reduces overhead in the main
-interpreter loop. The ``f_lasti`` attribute of Python-layer frame objects is
+interpreter loop. The ``f_lasti`` attribute of Python-layer frame objects is
 preserved for backward-compatibility.
 
 ..


### PR DESCRIPTION
When reading the [document](https://github.com/python/cpython/blob/main/InternalDocs/interpreter.md)s, I found that a Markdown marker was not rendered correctly by GitHub. I discovered that this was caused by a non-breaking space (`\xa0`):

<img width="410" alt="case" src="https://github.com/user-attachments/assets/b14f8569-ef7c-4d35-a739-64f4d55603d5" />

There are some more non-breaking spaces in the codebase, so I just changed them as well.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130116.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->