### PR TITLE
gh-130123: Make __new__ wrapper be deferred

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -9564,6 +9564,7 @@ add_tp_new_wrapper(PyTypeObject *type)
     if (func == NULL) {
         return -1;
     }
+    _PyObject_SetDeferredRefcount(func);
     r = PyDict_SetItem(dict, &_Py_ID(__new__), func);
     Py_DECREF(func);
     return r;


### PR DESCRIPTION
This is just a small tweak to make `__new__` be deferred so that it can be cached in the specializing interpreter. `__new__`'s wrapper is small, doesn't hold onto other things except the circular reference between it and the type, meaning the GC reclaims it anyways. We may as well defer it and be able to load cached values.

https://github.com/facebookexperimental/free-threading-benchmarking/blob/main/results/bm-20250213-3.14.0a5%2B-82e19c2-NOGIL/bm-20250213-vultr-x86_64-DinoV-deferred_dunder_new-3.14.0a5%2B-82e19c2-vs-base.md


<!-- gh-issue-number: gh-130123 -->
* Issue: gh-130123
<!-- /gh-issue-number -->
