### PR TITLE
gh-130313: Avoid locking when clearing objects

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -7167,7 +7167,7 @@ static void
 clear_inline_values(PyDictValues *values)
 {
     if (values->valid) {
-        values->valid = 0;
+        FT_ATOMIC_STORE_UINT8(values->valid, 0);
         for (Py_ssize_t i = 0; i < values->capacity; i++) {
             Py_CLEAR(values->values[i]);
         }


### PR DESCRIPTION
There's no need for us to lock the object when clearing the managed dict. We may need to lock the dict if it's been materialized and points to external objects as we could be doing a simple free of the object while other things refer to the dict.

This requires us to relax an assert because we clear objects after we've restarted the world. But we're past the point of resurrection so no one else can be referring to this object.

https://github.com/facebookexperimental/free-threading-benchmarking/tree/main/results/bm-20250214-3.14.0a5+-c00cd86-NOGIL

<!-- gh-issue-number: gh-130313 -->
* Issue: gh-130313
<!-- /gh-issue-number -->
