### PR TITLE
gh-129269: Exclude everything in sys.path in `test_coverage_ignore`

### DIFF
--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -390,7 +390,7 @@ class TestCoverage(unittest.TestCase):
         libpath = os.path.normpath(os.path.dirname(os.path.dirname(__file__)))
         # sys.prefix does not work when running from a checkout
         tracer = trace.Trace(ignoredirs=[sys.base_prefix, sys.base_exec_prefix,
-                             libpath], trace=0, count=1)
+                             libpath] + sys.path, trace=0, count=1)
         with captured_stdout() as stdout:
             self._coverage(tracer)
         if os.path.exists(TESTFN):


### PR DESCRIPTION
The `test_trace.test_coverage_ignore` test would fail if you had `setuptools` installed, such as in `~/.local/lib/python3.xxx/site-packages/`. Ignore everything in `sys.path` when running the test.


<!-- gh-issue-number: gh-129269 -->
* Issue: gh-129269
<!-- /gh-issue-number -->
