### PR TITLE
gh-130312: SET_ADD should not lock

### DIFF
--- a/Include/internal/pycore_setobject.h
+++ b/Include/internal/pycore_setobject.h
@@ -35,9 +35,6 @@ extern void _PySet_ClearInternal(PySetObject *so);
 
 PyAPI_FUNC(int) _PySet_AddTakeRef(PySetObject *so, PyObject *key);
 
-PyAPI_FUNC(PyObject *)
-_PySet_FromStackRefSteal(const _PyStackRef *src, Py_ssize_t n);
-
 
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_setobject.h
+++ b/Include/internal/pycore_setobject.h
@@ -35,8 +35,6 @@ extern void _PySet_ClearInternal(PySetObject *so);
 
 PyAPI_FUNC(int) _PySet_AddTakeRef(PySetObject *so, PyObject *key);
 
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/Include/internal/pycore_setobject.h
+++ b/Include/internal/pycore_setobject.h
@@ -33,6 +33,13 @@ PyAPI_FUNC(int) _PySet_Contains(PySetObject *so, PyObject *key);
 // Clears the set without acquiring locks. Used by _PyCode_Fini.
 extern void _PySet_ClearInternal(PySetObject *so);
 
+PyAPI_FUNC(int) _PySet_AddTakeRef(PySetObject *so, PyObject *key);
+
+PyAPI_FUNC(PyObject *)
+_PySet_FromStackRefSteal(const _PyStackRef *src, Py_ssize_t n);
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -208,11 +208,7 @@ set_add_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
 {
     _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(so);
 
-    /* Pre-increment is necessary to prevent arbitrary code in the rich
-       comparison from deallocating the key just before the insertion. */
-    Py_INCREF(key);
-
-    return set_add_entry_takeref(so, key, hash);
+    return set_add_entry_takeref(so, Py_NewRef(key), hash);
 }
 
 int
@@ -220,38 +216,12 @@ _PySet_AddTakeRef(PySetObject *so, PyObject *key)
 {
     Py_hash_t hash = _PyObject_HashFast(key);
     if (hash == -1) {
+        Py_DECREF(key);
         return -1;
     }
     // We don't pre-increment here, the caller holds a strong
     // reference to the object which we are stealing.
     return set_add_entry_takeref(so, key, hash);
-}
-
-PyObject *
-_PySet_FromStackRefSteal(const _PyStackRef *src, Py_ssize_t n)
-{
-    PySetObject *set = (PySetObject *)PySet_New(NULL);
-    if (n == 0) {
-        return (PyObject *)set;
-    }
-
-    if (set_table_resize(set, n*2) != 0) {
-        return NULL;
-    }
-
-    int err = 0;
-    for (Py_ssize_t i = 0; i < n; i++) {
-        if (err == 0) {
-            err = _PySet_AddTakeRef(set, PyStackRef_AsPyObjectSteal(src[i]));
-        } else {
-            PyStackRef_CLOSE(src[i]);
-        }
-    }
-    if (err) {
-        Py_CLEAR(set);
-    }
-
-    return (PyObject *)set;
 }
 
 /*

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -975,9 +975,8 @@ dummy_func(
         }
 
         inst(SET_ADD, (set, unused[oparg-1], v -- set, unused[oparg-1])) {
-            int err = PySet_Add(PyStackRef_AsPyObjectBorrow(set),
-                                PyStackRef_AsPyObjectBorrow(v));
-            PyStackRef_CLOSE(v);
+            int err = _PySet_AddTakeRef((PySetObject *)PyStackRef_AsPyObjectBorrow(set),
+                                PyStackRef_AsPyObjectSteal(v));
             ERROR_IF(err, error);
         }
 
@@ -1911,22 +1910,11 @@ dummy_func(
         }
 
         inst(BUILD_SET, (values[oparg] -- set)) {
-            PyObject *set_o = PySet_New(NULL);
+            PyObject *set_o = _PySet_FromStackRefSteal(values, oparg);
             if (set_o == NULL) {
-                DECREF_INPUTS();
                 ERROR_IF(true, error);
             }
-            int err = 0;
-            for (int i = 0; i < oparg; i++) {
-                if (err == 0) {
-                    err = PySet_Add(set_o, PyStackRef_AsPyObjectBorrow(values[i]));
-                }
-            }
-            DECREF_INPUTS();
-            if (err != 0) {
-                Py_DECREF(set_o);
-                ERROR_IF(true, error);
-            }
+            INPUTS_DEAD();
             set = PyStackRef_FromPyObjectStealMortal(set_o);
         }
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -976,7 +976,7 @@ dummy_func(
 
         inst(SET_ADD, (set, unused[oparg-1], v -- set, unused[oparg-1])) {
             int err = _PySet_AddTakeRef((PySetObject *)PyStackRef_AsPyObjectBorrow(set),
-                                PyStackRef_AsPyObjectSteal(v));
+                                        PyStackRef_AsPyObjectSteal(v));
             ERROR_IF(err, error);
         }
 

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1481,17 +1481,16 @@
             v = stack_pointer[-1];
             set = stack_pointer[-2 - (oparg-1)];
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            int err = PySet_Add(PyStackRef_AsPyObjectBorrow(set),
-                                PyStackRef_AsPyObjectBorrow(v));
-            stack_pointer = _PyFrame_GetStackPointer(frame);
-            stack_pointer += -1;
-            assert(WITHIN_STACK_BOUNDS());
-            _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(v);
+            int err = _PySet_AddTakeRef((PySetObject *)PyStackRef_AsPyObjectBorrow(set),
+                                        PyStackRef_AsPyObjectSteal(v));
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {
+                stack_pointer += -1;
+                assert(WITHIN_STACK_BOUNDS());
                 JUMP_TO_ERROR();
             }
+            stack_pointer += -1;
+            assert(WITHIN_STACK_BOUNDS());
             break;
         }
 
@@ -2671,48 +2670,16 @@
             oparg = CURRENT_OPARG();
             values = &stack_pointer[-oparg];
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyObject *set_o = PySet_New(NULL);
+            PyObject *set_o = _PySet_FromStackRefSteal(values, oparg);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (set_o == NULL) {
-                _PyFrame_SetStackPointer(frame, stack_pointer);
-                _PyStackRef tmp;
-                for (int _i = oparg; --_i >= 0;) {
-                    tmp = values[_i];
-                    values[_i] = PyStackRef_NULL;
-                    PyStackRef_CLOSE(tmp);
-                }
-                stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -oparg;
                 assert(WITHIN_STACK_BOUNDS());
                 JUMP_TO_ERROR();
             }
-            int err = 0;
-            for (int i = 0; i < oparg; i++) {
-                if (err == 0) {
-                    _PyFrame_SetStackPointer(frame, stack_pointer);
-                    err = PySet_Add(set_o, PyStackRef_AsPyObjectBorrow(values[i]));
-                    stack_pointer = _PyFrame_GetStackPointer(frame);
-                }
-            }
-            _PyFrame_SetStackPointer(frame, stack_pointer);
-            _PyStackRef tmp;
-            for (int _i = oparg; --_i >= 0;) {
-                tmp = values[_i];
-                values[_i] = PyStackRef_NULL;
-                PyStackRef_CLOSE(tmp);
-            }
-            stack_pointer = _PyFrame_GetStackPointer(frame);
-            stack_pointer += -oparg;
-            assert(WITHIN_STACK_BOUNDS());
-            if (err != 0) {
-                _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_DECREF(set_o);
-                stack_pointer = _PyFrame_GetStackPointer(frame);
-                JUMP_TO_ERROR();
-            }
             set = PyStackRef_FromPyObjectStealMortal(set_o);
-            stack_pointer[0] = set;
-            stack_pointer += 1;
+            stack_pointer[-oparg] = set;
+            stack_pointer += 1 - oparg;
             assert(WITHIN_STACK_BOUNDS());
             break;
         }

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -2670,9 +2670,40 @@
             oparg = CURRENT_OPARG();
             values = &stack_pointer[-oparg];
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyObject *set_o = _PySet_FromStackRefSteal(values, oparg);
+            PyObject *set_o = PySet_New(NULL);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (set_o == NULL) {
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                _PyStackRef tmp;
+                for (int _i = oparg; --_i >= 0;) {
+                    tmp = values[_i];
+                    values[_i] = PyStackRef_NULL;
+                    PyStackRef_CLOSE(tmp);
+                }
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                stack_pointer += -oparg;
+                assert(WITHIN_STACK_BOUNDS());
+                JUMP_TO_ERROR();
+            }
+            int err = 0;
+            for (Py_ssize_t i = 0; i < oparg; i++) {
+                _PyStackRef value = values[i];
+                values[i] = PyStackRef_NULL;
+                if (err == 0) {
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    err = _PySet_AddTakeRef((PySetObject *)set_o, PyStackRef_AsPyObjectSteal(value));
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                }
+                else {
+                    _PyFrame_SetStackPointer(frame, stack_pointer);
+                    PyStackRef_CLOSE(value);
+                    stack_pointer = _PyFrame_GetStackPointer(frame);
+                }
+            }
+            if (err) {
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                Py_DECREF(set_o);
+                stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -oparg;
                 assert(WITHIN_STACK_BOUNDS());
                 JUMP_TO_ERROR();

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1094,48 +1094,16 @@
             _PyStackRef set;
             values = &stack_pointer[-oparg];
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyObject *set_o = PySet_New(NULL);
+            PyObject *set_o = _PySet_FromStackRefSteal(values, oparg);
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (set_o == NULL) {
-                _PyFrame_SetStackPointer(frame, stack_pointer);
-                _PyStackRef tmp;
-                for (int _i = oparg; --_i >= 0;) {
-                    tmp = values[_i];
-                    values[_i] = PyStackRef_NULL;
-                    PyStackRef_CLOSE(tmp);
-                }
-                stack_pointer = _PyFrame_GetStackPointer(frame);
                 stack_pointer += -oparg;
                 assert(WITHIN_STACK_BOUNDS());
                 JUMP_TO_LABEL(error);
             }
-            int err = 0;
-            for (int i = 0; i < oparg; i++) {
-                if (err == 0) {
-                    _PyFrame_SetStackPointer(frame, stack_pointer);
-                    err = PySet_Add(set_o, PyStackRef_AsPyObjectBorrow(values[i]));
-                    stack_pointer = _PyFrame_GetStackPointer(frame);
-                }
-            }
-            _PyFrame_SetStackPointer(frame, stack_pointer);
-            _PyStackRef tmp;
-            for (int _i = oparg; --_i >= 0;) {
-                tmp = values[_i];
-                values[_i] = PyStackRef_NULL;
-                PyStackRef_CLOSE(tmp);
-            }
-            stack_pointer = _PyFrame_GetStackPointer(frame);
-            stack_pointer += -oparg;
-            assert(WITHIN_STACK_BOUNDS());
-            if (err != 0) {
-                _PyFrame_SetStackPointer(frame, stack_pointer);
-                Py_DECREF(set_o);
-                stack_pointer = _PyFrame_GetStackPointer(frame);
-                JUMP_TO_LABEL(error);
-            }
             set = PyStackRef_FromPyObjectStealMortal(set_o);
-            stack_pointer[0] = set;
-            stack_pointer += 1;
+            stack_pointer[-oparg] = set;
+            stack_pointer += 1 - oparg;
             assert(WITHIN_STACK_BOUNDS());
             DISPATCH();
         }
@@ -10641,17 +10609,14 @@
             v = stack_pointer[-1];
             set = stack_pointer[-2 - (oparg-1)];
             _PyFrame_SetStackPointer(frame, stack_pointer);
-            int err = PySet_Add(PyStackRef_AsPyObjectBorrow(set),
-                                PyStackRef_AsPyObjectBorrow(v));
-            stack_pointer = _PyFrame_GetStackPointer(frame);
-            stack_pointer += -1;
-            assert(WITHIN_STACK_BOUNDS());
-            _PyFrame_SetStackPointer(frame, stack_pointer);
-            PyStackRef_CLOSE(v);
+            int err = _PySet_AddTakeRef((PySetObject *)PyStackRef_AsPyObjectBorrow(set),
+                                        PyStackRef_AsPyObjectSteal(v));
             stack_pointer = _PyFrame_GetStackPointer(frame);
             if (err) {
-                JUMP_TO_LABEL(error);
+                JUMP_TO_LABEL(pop_1_error);
             }
+            stack_pointer += -1;
+            assert(WITHIN_STACK_BOUNDS());
             DISPATCH();
         }
 


### PR DESCRIPTION
Updates the bytecode so that we don't lock on sets as we're populating them for comprehensions or set creation.

https://github.com/facebookexperimental/free-threading-benchmarking/tree/main/results/bm-20250214-3.14.0a5+-247f5bf-NOGIL

<!-- gh-issue-number: gh-130312 -->
* Issue: gh-130312
<!-- /gh-issue-number -->
