### PR TITLE
gh-130145: fix `loop.run_forever` when loop is already running

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -671,8 +671,8 @@ class BaseEventLoop(events.AbstractEventLoop):
 
     def run_forever(self):
         """Run until stop() is called."""
+        self._run_forever_setup()
         try:
-            self._run_forever_setup()
             while True:
                 self._run_once()
                 if self._stopping:

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -3004,6 +3004,22 @@ class GetEventLoopTestsMixin:
                 self.loop.run_until_complete(main()),
                 'hello')
 
+    def test_get_running_loop_already_running(self):
+        async def main():
+            running_loop = asyncio.get_running_loop()
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_forever()
+            except RuntimeError:
+                pass
+            else:
+                self.fail("RuntimeError not raised")
+
+            self.assertIs(asyncio.get_running_loop(), running_loop)
+
+        self.loop.run_until_complete(main())
+
+
     def test_get_event_loop_returns_running_loop(self):
         class TestError(Exception):
             pass

--- a/Misc/NEWS.d/next/Library/2025-02-15-07-50-37.gh-issue-130145.I0CkV0.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-15-07-50-37.gh-issue-130145.I0CkV0.rst
@@ -1,0 +1,1 @@
+Fix :meth:`asyncio.AbstractEventloop.run_forever` when another loop is already running.

--- a/Misc/NEWS.d/next/Library/2025-02-15-07-50-37.gh-issue-130145.I0CkV0.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-15-07-50-37.gh-issue-130145.I0CkV0.rst
@@ -1,1 +1,1 @@
-Fix :meth:`asyncio.AbstractEventloop.run_forever` when another loop is already running.
+Fix :meth:`!asyncio.AbstractEventloop.run_forever` when another loop is already running.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130145 -->
* Issue: gh-130145
<!-- /gh-issue-number -->
