### PR TITLE
gh-130167: Improve speed of `difflib.IS_LINE_JUNK` by replacing `re`

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1052,7 +1052,9 @@ def IS_LINE_JUNK(line, pat=None):
     False
     """
 
-    return line.strip() in ('', '#')
+    return (line.strip() in ('', '#')
+            if pat is None
+            else pat(line) is not None)
 
 def IS_CHARACTER_JUNK(ch, ws=" \t"):
     r"""

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1040,7 +1040,7 @@ class Differ:
 
 def IS_LINE_JUNK(line, pat=None):
     r"""
-    Return True for ignorable line: if `line` is blank or contains a single '#'.
+    Return True for ignorable line: if and only if `line` is blank or contains a single '#'.
 
     Examples:
 

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1053,7 +1053,8 @@ def IS_LINE_JUNK(line, pat=None):
     """
 
     if pat is None:
-        return line.strip() == '' or line.strip() == '#'
+        stripped = line.strip()
+        return stripped == '' or stripped == '#'
     return pat(line) is not None
 
 def IS_CHARACTER_JUNK(ch, ws=" \t"):

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1040,7 +1040,7 @@ class Differ:
 
 def IS_LINE_JUNK(line, pat=None):
     r"""
-    Return True for ignorable line: iff `line` is blank or contains a single '#'.
+    Return True for ignorable line: if `line` is blank or contains a single '#'.
 
     Examples:
 
@@ -1052,9 +1052,9 @@ def IS_LINE_JUNK(line, pat=None):
     False
     """
 
-    return (line.strip() in ('', '#')
-            if pat is None
-            else pat(line) is not None)
+    if pat is None:
+        return line.strip() == '' or line.strip() == '#'
+    return pat(line) is not None
 
 def IS_CHARACTER_JUNK(ch, ws=" \t"):
     r"""

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1053,7 +1053,7 @@ def IS_LINE_JUNK(line, pat=None):
     """
 
     if pat is None:
-        return line.strip() in ('', '#')
+        return line.strip() in '#'
     return pat(line) is not None
 
 def IS_CHARACTER_JUNK(ch, ws=" \t"):

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1053,8 +1053,7 @@ def IS_LINE_JUNK(line, pat=None):
     """
 
     if pat is None:
-        stripped = line.strip()
-        return stripped == '' or stripped == '#'
+        return line.strip() in ('', '#')
     return pat(line) is not None
 
 def IS_CHARACTER_JUNK(ch, ws=" \t"):

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1040,7 +1040,7 @@ class Differ:
 
 def IS_LINE_JUNK(line, pat=None):
     r"""
-    Return True for ignorable line: if and only if `line` is blank or contains a single '#'.
+    Return True for ignorable line: if `line` is blank or contains a single '#'.
 
     Examples:
 

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1038,7 +1038,7 @@ class Differ:
 # remaining is that perhaps it was really the case that " volatile"
 # was inserted after "private".  I can live with that <wink>.
 
-def IS_LINE_JUNK(line):
+def IS_LINE_JUNK(line, pat=None):
     r"""
     Return True for ignorable line: iff `line` is blank or contains a single '#'.
 

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1052,7 +1052,7 @@ def IS_LINE_JUNK(line, pat=None):
     False
     """
 
-    return line.strip() == "" or line.lstrip().rstrip() == "#"
+    return line.strip() in ('', '#')
 
 def IS_CHARACTER_JUNK(ch, ws=" \t"):
     r"""

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1038,9 +1038,7 @@ class Differ:
 # remaining is that perhaps it was really the case that " volatile"
 # was inserted after "private".  I can live with that <wink>.
 
-import re
-
-def IS_LINE_JUNK(line, pat=re.compile(r"\s*(?:#\s*)?$").match):
+def IS_LINE_JUNK(line):
     r"""
     Return True for ignorable line: iff `line` is blank or contains a single '#'.
 
@@ -1054,7 +1052,7 @@ def IS_LINE_JUNK(line, pat=re.compile(r"\s*(?:#\s*)?$").match):
     False
     """
 
-    return pat(line) is not None
+    return line.strip() == "" or line.lstrip().rstrip() == "#"
 
 def IS_CHARACTER_JUNK(ch, ws=" \t"):
     r"""
@@ -2027,7 +2025,6 @@ class HtmlDiff(object):
                      replace('\1','</span>'). \
                      replace('\t','&nbsp;')
 
-del re
 
 def restore(delta, which):
     r"""

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1053,7 +1053,7 @@ def IS_LINE_JUNK(line, pat=None):
     """
 
     if pat is None:
-        return line.strip() in '#'
+        return line.strip() in {'', '#'}
     return pat(line) is not None
 
 def IS_CHARACTER_JUNK(ch, ws=" \t"):

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1053,7 +1053,10 @@ def IS_LINE_JUNK(line, pat=None):
     """
 
     if pat is None:
-        return line.strip() in {'', '#'}
+        # Default: match '#' or the empty string
+        return line.strip() in '#'
+   # Previous versions used the undocumented parameter 'pat' as a
+   # match function. Retain this behaviour for compatibility.
     return pat(line) is not None
 
 def IS_CHARACTER_JUNK(ch, ws=" \t"):

--- a/Misc/NEWS.d/next/Library/2025-02-16-06-25-01.gh-issue-130167.kUg7Rc.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-16-06-25-01.gh-issue-130167.kUg7Rc.rst
@@ -1,0 +1,2 @@
+Improve speed of :func:`difflib.IS_LINE_JUNK` by replacing :mod:`re` with
+built-in string methods.

--- a/Misc/NEWS.d/next/Library/2025-02-16-06-25-01.gh-issue-130167.kUg7Rc.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-16-06-25-01.gh-issue-130167.kUg7Rc.rst
@@ -1,2 +1,1 @@
-Improve speed of :func:`difflib.IS_LINE_JUNK` by replacing :mod:`re` with
-built-in string methods.
+Improve speed of :func:`difflib.IS_LINE_JUNK`. Patch by Semyon Moroz.


### PR DESCRIPTION
Now we don't import of `re` globally and there is no longer an extra (undocumented) function parameter (see [documentation](https://docs.python.org/3/library/difflib.html#difflib.IS_LINE_JUNK))

## How did i benchmark a new version?
I wrote next python script `difflib_bench.py`:
```python
import re
import timeit

def is_line_junk_regex(line, pat=re.compile(r"\s*(?:#\s*)?$").match):
    return pat(line) is not None

def is_line_junk_no_regex(line):
    return line.strip() == "" or line.lstrip().rstrip() == "#"

test_cases = [
    "    ", "    #", "   # comment", "code line", " 123 ", " 123 #",
    " 123 # hi", " 123 #comment", "\n", "  #   \n", "hello\n", "", " ", "\t",
    "#", " #", "# ", "   #   ", "text", "text # comment", "#text", "##", "#\t",
    "   ", " #\t ",
]

def benchmark(func, cases, n=100000):
    return timeit.timeit(lambda: [func(line) for line in cases], number=n)

regex_time = benchmark(is_line_junk_regex, test_cases)
no_regex_time = benchmark(is_line_junk_no_regex, test_cases)

print(f"Regex time: {regex_time:.6f} sec")
print(f"No regex time: {no_regex_time:.6f} sec")
```
 
### `timeit` result: 1.33s -> 0.64s = x2.08 as fast
```sh
$ ./python -B difflib_bench.py
Regex time: 1.330593 sec
No regex time: 0.638559 sec
```

<!-- gh-issue-number: gh-130167 -->
* Issue: gh-130167
<!-- /gh-issue-number -->
