### PR TITLE
gh-130177: Fix skipped tests in `test_gettext`

### DIFF
--- a/Lib/test/test_gettext.py
+++ b/Lib/test/test_gettext.py
@@ -402,7 +402,7 @@ class GNUTranslationsClassPluralFormsTestCase(PluralFormsTests, GettextBaseTest)
             numbers_only=False)
 
 
-class PluralFormsInternalTestCase:
+class PluralFormsInternalTestCase(unittest.TestCase):
     # Examples from http://www.gnu.org/software/gettext/manual/gettext.html
 
     def test_ja(self):


### PR DESCRIPTION
Running `test_gettext` before:

```
Total tests: run=37
```

and after:
```
Total tests: run=57
```


<!-- gh-issue-number: gh-130177 -->
* Issue: gh-130177
<!-- /gh-issue-number -->
