### PR TITLE
gh-130185: Fix unintentionally skipped tests in `test_functools`

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1490,6 +1490,16 @@ class TestCache:
             self.module._CacheInfo(hits=0, misses=0, maxsize=None, currsize=0))
 
 
+class TestCachePy(TestCache, unittest.TestCase):
+    module = py_functools
+
+
+@unittest.skipUnless(c_functools, 'requires the C _functools module')
+class TestCacheC(TestCache, unittest.TestCase):
+    if c_functools:
+        module = c_functools
+
+
 class TestLRU:
 
     def test_lru(self):


### PR DESCRIPTION
before:
```
Total tests: run=304
```

after:
```
Total tests: run=306
```

<!-- gh-issue-number: gh-130185 -->
* Issue: gh-130185
<!-- /gh-issue-number -->
