### PR TITLE
gh-130164: Fix inspect.Signature.bind() handling of positional-only args without defaults

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -3077,6 +3077,9 @@ class Signature:
                         break
                     elif param.name in kwargs:
                         if param.kind == _POSITIONAL_ONLY:
+                            if param.default is _empty:
+                                msg = f'missing a required positional-only argument: {param.name!r}'
+                                raise TypeError(msg)
                             # Raise a TypeError once we are sure there is no
                             # **kwargs param later.
                             pos_only_param_in_kwargs.append(param)

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -5149,7 +5149,11 @@ class TestSignatureBind(unittest.TestCase):
     def call(func, *args, **kwargs):
         sig = inspect.signature(func)
         ba = sig.bind(*args, **kwargs)
-        return func(*ba.args, **ba.kwargs)
+        # Prevent unexpected success of assertRaises(TypeError, ...)
+        try:
+            return func(*ba.args, **ba.kwargs)
+        except TypeError as e:
+            raise AssertionError from e
 
     def test_signature_bind_empty(self):
         def test():
@@ -5349,7 +5353,7 @@ class TestSignatureBind(unittest.TestCase):
         self.assertEqual(self.call(test, 1, 2, c_po=4),
                          (1, 2, 3, 42, 50, {'c_po': 4}))
 
-        with self.assertRaisesRegex(TypeError, "missing 2 required positional arguments"):
+        with self.assertRaisesRegex(TypeError, "missing a required positional-only argument: 'a_po'"):
             self.call(test, a_po=1, b_po=2)
 
         def without_var_kwargs(c_po=3, d_po=4, /):

--- a/Misc/NEWS.d/next/Library/2025-02-16-08-56-48.gh-issue-130164.vvoaU2.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-16-08-56-48.gh-issue-130164.vvoaU2.rst
@@ -1,3 +1,3 @@
-Fixed failure to raise :exc:`TypeError` in :meth:`inspect.signature.bind`
+Fixed failure to raise :exc:`TypeError` in :meth:`inspect.Signature.bind`
 for positional-only arguments provided by keyword when a variadic keyword
 argument (e.g. ``**kwargs``) is present.

--- a/Misc/NEWS.d/next/Library/2025-02-16-08-56-48.gh-issue-130164.vvoaU2.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-16-08-56-48.gh-issue-130164.vvoaU2.rst
@@ -1,0 +1,3 @@
+Fixed failure to raise :exc:`TypeError` in :meth:`inspect.signature.bind`
+for positional-only arguments provided by keyword when a variadic keyword
+argument (e.g. ``**kwargs``) is present.


### PR DESCRIPTION
**Before**
`inspect.Signature.bind()` failed to raise TypeError for positional-only arguments passed by keyword (due to a regression handling the case where a default is defined).
**After**
This is fixed.

Regression in 9c15202.

Interestingly, we did have a test case for this, but it unexpectedly passed because after calling `bind()`, the test helper also calls the underlying function, making `assertRaises(TypeError, ...` succeed regardless of the behavior of `bind()`.

Closes #130164

<!-- gh-issue-number: gh-130164 -->
* Issue: gh-130164
<!-- /gh-issue-number -->
