### PR TITLE
gh-118761: Revert "Improve import time of `subprocess` (GH-129427)"

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -43,8 +43,10 @@ getstatusoutput(...): Runs a command in the shell, waits for it to complete,
 import builtins
 import errno
 import io
+import locale
 import os
 import time
+import signal
 import sys
 import threading
 import warnings
@@ -142,8 +144,6 @@ class CalledProcessError(SubprocessError):
 
     def __str__(self):
         if self.returncode and self.returncode < 0:
-            # Lazy import to improve module import time
-            import signal
             try:
                 return "Command '%s' died with %r." % (
                         self.cmd, signal.Signals(-self.returncode))
@@ -381,8 +381,6 @@ def _text_encoding():
     if sys.flags.utf8_mode:
         return "utf-8"
     else:
-        # Lazy import to improve module import time
-        import locale
         return locale.getencoding()
 
 
@@ -1665,9 +1663,6 @@ class Popen:
             # Don't signal a process that we know has already died.
             if self.returncode is not None:
                 return
-
-            # Lazy import to improve module import time
-            import signal
             if sig == signal.SIGTERM:
                 self.terminate()
             elif sig == signal.CTRL_C_EVENT:
@@ -1769,9 +1764,6 @@ class Popen:
             """Execute program using os.posix_spawn()."""
             kwargs = {}
             if restore_signals:
-                # Lazy import to improve module import time
-                import signal
-
                 # See _Py_RestoreSignals() in Python/pylifecycle.c
                 sigset = []
                 for signame in ('SIGPIPE', 'SIGXFZ', 'SIGXFSZ'):
@@ -2221,13 +2213,9 @@ class Popen:
         def terminate(self):
             """Terminate the process with SIGTERM
             """
-            # Lazy import to improve module import time
-            import signal
             self.send_signal(signal.SIGTERM)
 
         def kill(self):
             """Kill the process with SIGKILL
             """
-            # Lazy import to improve module import time
-            import signal
             self.send_signal(signal.SIGKILL)

--- a/Misc/NEWS.d/next/Library/2025-02-16-10-12-27.gh-issue-118761.TNw5ZC.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-16-10-12-27.gh-issue-118761.TNw5ZC.rst
@@ -1,4 +1,4 @@
 Reverts a change in the previous release attempting to make some stdlib
 imports used within the :mod:`subprocess` module lazy as this was causing
-errors during `__del__` finalizers calling methods such as ``terminate``, or
+errors during ``__del__`` finalizers calling methods such as ``terminate``, or
 ``kill``, or ``send_signal``.

--- a/Misc/NEWS.d/next/Library/2025-02-16-10-12-27.gh-issue-118761.TNw5ZC.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-16-10-12-27.gh-issue-118761.TNw5ZC.rst
@@ -1,0 +1,4 @@
+Reverts a change in the previous release attempting to make some stdlib
+imports used within the :mod:`subprocess` module lazy as this was causing
+errors during `__del__` finalizers calling methods such as ``terminate``, or
+``kill``, or ``send_signal``.


### PR DESCRIPTION
This reverts commit 49f24650e4541456872490ec2b59d6d186204891.

This caused bugs in the `__del__` finalizer:
 https://github.com/python/cpython/issues/118761#issuecomment-2661504264

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
