### PR TITLE
gh-130203: Further simplify `math.sumprod` documentation

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -607,7 +607,7 @@ Summation and product functions
 
    Roughly equivalent to::
 
-       sum(map(operator.mul, p, q, strict=True))
+       sum(px * qx for px, qx in zip(p, q, strict=True))
 
    For float and mixed int/float inputs, the intermediate products
    and sums are computed with extended precision.

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -451,7 +451,7 @@ PyDoc_STRVAR(math_sumprod__doc__,
 "\n"
 "Roughly equivalent to:\n"
 "\n"
-"    sum(map(operator.mul, p, q, strict=True))\n"
+"    sum(px * qx for px, qx in zip(p, q, strict=True))\n"
 "\n"
 "For float and mixed int/float inputs, the intermediate products\n"
 "and sums are computed with extended precision.");
@@ -1106,4 +1106,4 @@ math_ulp(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=1ccb4b9f570d6dad input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9d67d5d98ac25743 input=a9049054013a1b77]*/

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2750,7 +2750,7 @@ Return the sum of products of values from two iterables p and q.
 
 Roughly equivalent to:
 
-    sum(map(operator.mul, p, q, strict=True))
+    sum(px * qx for px, qx in zip(p, q, strict=True))
 
 For float and mixed int/float inputs, the intermediate products
 and sums are computed with extended precision.
@@ -2758,7 +2758,7 @@ and sums are computed with extended precision.
 
 static PyObject *
 math_sumprod_impl(PyObject *module, PyObject *p, PyObject *q)
-/*[clinic end generated code: output=6722dbfe60664554 input=a2880317828c61d2]*/
+/*[clinic end generated code: output=6722dbfe60664554 input=75b4b596dce5611e]*/
 {
     PyObject *p_i = NULL, *q_i = NULL, *term_i = NULL, *new_total = NULL;
     PyObject *p_it, *q_it, *total;


### PR DESCRIPTION
Docs-only change. Simplifies `math.sumprod` documentation so that it doesn't assume the reader knows about `operator.mul`, making it clear what kind of comprehensions can be replaced with `math.sumprod()`.

<!-- gh-issue-number: gh-130203 -->
* Issue: gh-130203
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130206.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->