### PR TITLE
gh-128396: Fix a crash when inline comprehension has the same local variable as the outside scope

### DIFF
--- a/Lib/test/test_frame.py
+++ b/Lib/test/test_frame.py
@@ -346,6 +346,12 @@ class TestFrameLocals(unittest.TestCase):
         self.assertEqual(x, 2)
         self.assertEqual(y, 3)
 
+    def test_closure_with_inline_comprehension(self):
+        lambda: k
+        k = 1
+        lst = [locals() for k in [0]]
+        self.assertEqual(lst[0]['k'], 0)
+
     def test_as_dict(self):
         x = 1
         y = 2

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-17-18-59-33.gh-issue-128396.iVtoYY.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-17-18-59-33.gh-issue-128396.iVtoYY.rst
@@ -1,0 +1,1 @@
+Fix a crash that occurs when calling :func:`locals()` inside an inline comprehension that uses the same local variable as the outer frame scope where the variable is a free or cell var.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-17-18-59-33.gh-issue-128396.iVtoYY.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-17-18-59-33.gh-issue-128396.iVtoYY.rst
@@ -1,1 +1,1 @@
-Fix a crash that occurs when calling :func:`locals()` inside an inline comprehension that uses the same local variable as the outer frame scope where the variable is a free or cell var.
+Fix a crash that occurs when calling :func:`locals` inside an inline comprehension that uses the same local variable as the outer frame scope where the variable is a free or cell var.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -45,8 +45,15 @@ framelocalsproxy_getval(_PyInterpreterFrame *frame, PyCodeObject *co, int i)
     if (kind == CO_FAST_FREE || kind & CO_FAST_CELL) {
         // The cell was set when the frame was created from
         // the function's closure.
-        assert(PyCell_Check(value));
-        cell = value;
+        // GH-128396: With PEP 709, it's possible to have a fast variable in
+        // an inlined comprehension that has the same name as the cell variable
+        // in the frame, where the `kind` obtained from frame can not guarantee
+        // that the variable is a cell.
+        // If the variable is not a cell, we are okay with it and we can simply
+        // return the value.
+        if (PyCell_Check(value)) {
+            cell = value;
+        }
     }
 
     if (cell != NULL) {


### PR DESCRIPTION
With PEP 709 + PEP 667, we have a rather special case.

When we have code like

```python
def f():
    lambda: k
    k = 1
    [locals() for k in [0]]
f()
```

In `f`, the code object will consider `k` a free var (so in C it's a `CellType`) because it is used in closure (`lambda: k`). However for the list comprehension `[locals() for k in [0]]`, `k` will be considered as a pure fast variable which is defined by PEP 709.

I think this is correct because PEP 709 says that the inlined list comprehension should behave the same as we created a new function. If we created a new function

```python
def g()
    lst = []
    for k in [0]:
        lst.append(k)
    return lst
```

`k` would be a pure fast, not a cell variable.

However, in reality, this piece of code does execute in the same frame, and `locals()` tries to read the `kind` data of the variable `k` before accessing the value - and it is a `CO_FAST_FREE` - so `locals()` will thus try to get the actual value from the cell that does not exist - which would eventually cause a crash (with `--py-debug`, an assertion failure).

We can of course do something in the runtime, for example setting some special flag on `k` or secretly change the `kind` of the code object during execution, but I feel like that's not necessary.

My fix here is simply check if the cell exists, and if not, just get the value, which is how `PyFrame_GetVar` does it. Unless people think this run time behavior should be improved, I think this fix is straightforward and simple.

<!-- gh-issue-number: gh-128396 -->
* Issue: gh-128396
<!-- /gh-issue-number -->
