### PR TITLE
cover `**/*hashopenssl*` in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,6 +106,7 @@ Objects/exceptions.c          @iritkatriel
 
 # Hashing & cryptographic primitives
 **/*hashlib*                  @gpshead @tiran @picnixz
+**/*hashopenssl*              @gpshead @tiran @picnixz
 **/*pyhash*                   @gpshead @tiran
 **/sha*                       @gpshead @tiran @picnixz
 Modules/md5*                  @gpshead @tiran @picnixz


### PR DESCRIPTION
Modules/_hashopenssl.c (and its clinic/ file) have unusual naming. that is for the `_hashlib` internal implementation module but "lib" isn't in its name.  renaming the file is an option but is high touch across a bunch of builds and might make backporting or patching easier. So, meh, this is easy at least.