### PR TITLE
gh-130167: Improve speed of `ftplib.parse150` by replacing `re`

### DIFF
--- a/Lib/ftplib.py
+++ b/Lib/ftplib.py
@@ -796,7 +796,7 @@ def parse150(resp):
         raise error_reply(resp)
 
     start = resp.find('(')
-    end = resp.find(' bytes)')
+    end = resp.lower().find(' bytes)')
 
     if start == -1 or end == -1 or start >= end:
         return None

--- a/Lib/ftplib.py
+++ b/Lib/ftplib.py
@@ -787,24 +787,24 @@ else:
     all_errors = (Error, OSError, EOFError, ssl.SSLError)
 
 
-_150_re = None
-
 def parse150(resp):
     '''Parse the '150' response for a RETR request.
     Returns the expected transfer size or None; size is not guaranteed to
     be present in the 150 message.
     '''
-    if resp[:3] != '150':
+    if not resp.startswith('150'):
         raise error_reply(resp)
-    global _150_re
-    if _150_re is None:
-        import re
-        _150_re = re.compile(
-            r"150 .* \((\d+) bytes\)", re.IGNORECASE | re.ASCII)
-    m = _150_re.match(resp)
-    if not m:
+
+    start = resp.find('(')
+    end = resp.find(' bytes)')
+
+    if start == -1 or end == -1 or start >= end:
         return None
-    return int(m.group(1))
+
+    try:
+        return int(resp[start + 1:end])
+    except ValueError:
+        return None
 
 
 _227_re = None

--- a/Misc/NEWS.d/next/Library/2025-02-18-05-00-24.gh-issue-130167.e0MXUp.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-18-05-00-24.gh-issue-130167.e0MXUp.rst
@@ -1,2 +1,2 @@
 Improve speed of :func:`ftplib.parse150` by replacing :mod:`re` with
-``.find()`` method. Patch by Semyon Moroz.
+:func:`find` method. Patch by Semyon Moroz.

--- a/Misc/NEWS.d/next/Library/2025-02-18-05-00-24.gh-issue-130167.e0MXUp.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-18-05-00-24.gh-issue-130167.e0MXUp.rst
@@ -1,0 +1,2 @@
+Improve speed of :func:`ftplib.parse150` by replacing :mod:`re` with
+*replace* method. Patch by Semyon Moroz.

--- a/Misc/NEWS.d/next/Library/2025-02-18-05-00-24.gh-issue-130167.e0MXUp.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-18-05-00-24.gh-issue-130167.e0MXUp.rst
@@ -1,2 +1,2 @@
 Improve speed of :func:`ftplib.parse150` by replacing :mod:`re` with
-*replace* method. Patch by Semyon Moroz.
+``.find()`` method. Patch by Semyon Moroz.


### PR DESCRIPTION
I also suggest adding tests for this function because they are missing in the `Lib/test/test_ftplib.py` file.
I wrote tests (would be in next comment) and benchmarks (results here)
### `parse150_bench.py`:
```python
from Lib.ftplib import error_reply
import timeit

# Regex version
_150_re = None
def parse150_re(resp):
    if resp[:3] != "150":
        raise error_reply(resp)
    global _150_re
    if _150_re is None:
        import re
        _150_re = re.compile(r"150 .* \((\d+) bytes\)", re.IGNORECASE | re.ASCII)
    m = _150_re.match(resp)
    if not m:
        return None
    return int(m.group(1))

# No regex version
def parse150(resp):
    if not resp.startswith("150"):
        raise error_reply(resp)

    start = resp.find("(")
    end = resp.find(" bytes)")

    if start == -1 or end == -1 or start >= end:
        return None

    try:
        return int(resp[start + 1 : end])
    except ValueError:
        return None

test_cases = [
    "150 Opening BINARY mode data connection (4096 bytes)",
    "150 Transfer starting (32768 bytes)",
    "150 Data connection accepted (131072 bytes)",
    "150 Some random message without bytes",
    "150 Large file transfer (987654321 bytes)",
    "150 Small file (1 bytes)",
    "150 Transfer starting (99999999 bytes)",
    "150 Weird case (42 bytes) with extra text",
]

for case in test_cases:
    regex_time = timeit.timeit(lambda: parse150_re(case), number=1_000_000)
    no_regex_time = timeit.timeit(lambda: parse150(case), number=1_000_000)
    print(f"Test case: {case}")
    print(f"  Regex version: {regex_time:.6f} sec")
    print(f"  No regex version: {no_regex_time:.6f} sec")
```
### Results for different cases (from x1.82 to x1.92 as fast):
```
$ ./python -B parse150_bench.py
Test case: 150 Opening BINARY mode data connection (4096 bytes)
  Regex version: 1.147499 sec
  No regex version: 0.630863 sec
Test case: 150 Transfer starting (32768 bytes)
  Regex version: 1.113087 sec
  No regex version: 0.610494 sec
Test case: 150 Data connection accepted (131072 bytes)
  Regex version: 1.140198 sec
  No regex version: 0.616784 sec
Test case: 150 Some random message without bytes
  Regex version: 0.643958 sec
  No regex version: 0.302508 sec
Test case: 150 Large file transfer (987654321 bytes)
  Regex version: 1.160474 sec
  No regex version: 0.605776 sec
Test case: 150 Small file (1 bytes)
  Regex version: 1.005945 sec
  No regex version: 0.522877 sec
Test case: 150 Transfer starting (99999999 bytes)
  Regex version: 1.147927 sec
  No regex version: 0.616777 sec
Test case: 150 Weird case (42 bytes) with extra text
  Regex version: 1.140925 sec
  No regex version: 0.592486 sec
```

<!-- gh-issue-number: gh-130167 -->
* Issue: gh-130167
<!-- /gh-issue-number -->
