### PR TITLE
[3.9] gh-119511: Fix a potential denial of service in imaplib (GH-119514)

### DIFF
--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -907,6 +907,21 @@ class ThreadedNetworkedTests(unittest.TestCase):
                               self.imap_class, *server.server_address)
 
     @reap_threads
+    def test_truncated_large_literal(self):
+        size = 0
+        class BadHandler(SimpleIMAPHandler):
+            def handle(self):
+                self._send_textline('* OK {%d}' % size)
+                self._send_textline('IMAP4rev1')
+
+        for exponent in range(15, 64):
+            size = 1 << exponent
+            with self.subTest(f"size=2e{size}"):
+                with self.reaped_server(BadHandler) as server:
+                    with self.assertRaises(imaplib.IMAP4.abort):
+                        self.imap_class(*server.server_address)
+
+    @reap_threads
     def test_simple_with_statement(self):
         # simplest call
         with self.reaped_server(SimpleIMAPHandler) as server:

--- a/Misc/NEWS.d/next/Security/2024-05-24-21-00-52.gh-issue-119511.jKrXQ8.rst
+++ b/Misc/NEWS.d/next/Security/2024-05-24-21-00-52.gh-issue-119511.jKrXQ8.rst
@@ -1,0 +1,7 @@
+Fix a potential denial of service in the :mod:`imaplib` module. When connecting
+to a malicious server, it could cause an arbitrary amount of memory to be
+allocated. On many systems this is harmless as unused virtual memory is only a
+mapping, but if this hit a virtual address size limit it could lead to a
+:exc:`MemoryError` or other process crash. On unusual systems or builds where
+all allocated memory is touched and backed by actual ram or storage it could've
+consumed resources doing so until similarly crashing.


### PR DESCRIPTION

> The IMAP4 client could consume an arbitrary amount of memory when trying to connect to a malicious server, because it read a "literal" data with a single read(size) call, and BufferedReader.read() allocates the bytes object of the specified size before reading. Now the IMAP4 client reads data by chunks, therefore the amount of used memory is limited by the amount of the data actually been sent by the server. 

(cherry picked from commit 735f25c5e3a0f74438c86468ec4dfbe219d93c91)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119511 -->
* Issue: gh-119511
<!-- /gh-issue-number -->
