### PR TITLE
gh-130160: use `option` instead of `cmdoption` in `dis.rst`

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -97,23 +97,23 @@ The following options are accepted:
 
 .. program:: dis
 
-.. cmdoption:: -h, --help
+.. option:: -h, --help
 
    Display usage and exit.
 
-.. cmdoption:: -C, --show-caches
+.. option:: -C, --show-caches
 
    Show inline caches.
 
-.. cmdoption:: -O, --show-offsets
+.. option:: -O, --show-offsets
 
    Show offsets of instructions.
 
-.. cmdoption:: -P, --show-positions
+.. option:: -P, --show-positions
 
    Show positions of instructions in the source code.
 
-.. cmdoption:: -S, --specialized
+.. option:: -S, --specialized
 
    Show specialized bytecode.
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-130160 -->
* Issue: gh-130160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130255.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->