### PR TITLE
[3.13] gh-130160: use `option` instead of `cmdoption` in `dis.rst` (GH-130255)

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -91,15 +91,15 @@ The following options are accepted:
 
 .. program:: dis
 
-.. cmdoption:: -h, --help
+.. option:: -h, --help
 
    Display usage and exit.
 
-.. cmdoption:: -C, --show-caches
+.. option:: -C, --show-caches
 
    Show inline caches.
 
-.. cmdoption:: -O, --show-offsets
+.. option:: -O, --show-offsets
 
    Show offsets of instructions.
 


### PR DESCRIPTION
(cherry picked from commit 97d0011e7ec0c8222de46ce581b8bac3cc7dddda)


<!-- gh-issue-number: gh-130160 -->
* Issue: gh-130160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130264.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->