### PR TITLE
Add `.. versionadded` directive to `dis` CLI options

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -105,17 +105,25 @@ The following options are accepted:
 
    Show inline caches.
 
+   .. versionadded:: 3.13
+
 .. option:: -O, --show-offsets
 
    Show offsets of instructions.
+
+   .. versionadded:: 3.13
 
 .. option:: -P, --show-positions
 
    Show positions of instructions in the source code.
 
+   .. versionadded:: 3.14
+
 .. option:: -S, --specialized
 
    Show specialized bytecode.
+
+   .. versionadded:: 3.14
 
 If :file:`infile` is specified, its disassembled code will be written to stdout.
 Otherwise, disassembly is performed on compiled source code received from stdin.


### PR DESCRIPTION
I think that these directives are useful, because a lot of the times users just browse `/3/` version. And might use options that do not exist in their version.

- 3.14: https://github.com/python/cpython/blob/01ba7df49966eaf14f44962a77898840c70dda96/Lib/dis.py
- https://github.com/python/cpython/blob/3.13/Lib/dis.py
- https://github.com/python/cpython/blob/3.12/Lib/dis.py

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130267.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->