### PR TITLE
gh-130163: Fix usage of borrow references from _PySys_GetAttr

### DIFF
--- a/Lib/test/test_sys_getattr.py
+++ b/Lib/test/test_sys_getattr.py
@@ -1,0 +1,47 @@
+import test.support
+from test.support.script_helper import assert_python_failure, assert_python_ok
+import textwrap
+import unittest
+
+
+
+
+@test.support.cpython_only
+class PySysGetAttrTest(unittest.TestCase):
+
+
+    def test_changing_stdout_from_thread(self):
+        # print should use strong reference to the stdout.
+        code = textwrap.dedent('''
+            from contextlib import redirect_stdout
+            from io import StringIO
+            from threading import Thread
+            import time
+
+            class Foo:
+                def __repr__(self):
+                    time.sleep(0.2)
+                    return "Foo"
+
+
+            def thread1():
+                text = StringIO()
+                with redirect_stdout(text):
+                    time.sleep(0.2)
+
+            def main():
+                t1 = Thread(target=thread1, args=())
+                t1.start()
+                time.sleep(0.1)
+                print(Foo())
+
+
+            if __name__ == "__main__":
+                main()
+        ''')
+        rc, out, err = assert_python_ok('-c', code)
+        self.assertEqual(out, b"")
+        self.assertEqual(err, b"")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_sys_getattr.py
+++ b/Lib/test/test_sys_getattr.py
@@ -103,20 +103,20 @@ class PySysGetAttrTest(unittest.TestCase):
                 del stdout
                 return "CrashStdout"
 
-            class CrashStderr:
-                def __init__(self):
-                    self.stderr = sys.stderr
-                    setattr(sys, "stderr", FakeIO())
+        class CrashStderr:
+            def __init__(self):
+                self.stderr = sys.stderr
+                setattr(sys, "stderr", FakeIO())
 
-                def __repr__(self):
-                    stderr = sys.stderr
-                    setattr(sys, "stderr", self.stderr)
-                    del stderr
-                    return "CrashStderr"
+            def __repr__(self):
+                stderr = sys.stderr
+                setattr(sys, "stderr", self.stderr)
+                del stderr
+                return "CrashStderr"
 
-            def audit(event, args):
-                if event == 'builtins.input':
-                    repr(args)
+        def audit(event, args):
+            if event == 'builtins.input':
+                repr(args)
 
         def main():
             {0}

--- a/Lib/test/test_sys_getattr.py
+++ b/Lib/test/test_sys_getattr.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+import tempfile
 import test.support
 from test.support.script_helper import assert_python_failure, assert_python_ok
 import textwrap
@@ -9,10 +11,44 @@ import unittest
 @test.support.cpython_only
 class PySysGetAttrTest(unittest.TestCase):
 
+    common_faulthandler_code = textwrap.dedent('''
+        from contextlib import redirect_stderr
+        from threading import Thread
+        import time
+        from faulthandler import dump_traceback, enable, dump_traceback_later
 
-    def test_changing_stdout_from_thread(self):
+        class FakeFile:
+            def __init__(self):
+                self.f = open("{0}", "w")
+            def write(self, s):
+                self.f.write(s)
+            def flush(self):
+                time.sleep(0.2)
+            def fileno(self):
+                time.sleep(0.2)
+                return self.f.fileno()
+
+        def thread1():
+            text = FakeFile()
+            with redirect_stderr(text):
+                time.sleep(0.2)
+
+        def main():
+            enable(None, True)
+            t1 = Thread(target=thread1, args=())
+            t1.start()
+            time.sleep(0.1)
+            {1}
+
+        if __name__ == "__main__":
+            main()
+    ''')
+
+
+    def test_print_deleted_stdout(self):
         # print should use strong reference to the stdout.
         code = textwrap.dedent('''
+            # from https://gist.github.com/colesbury/c48f50e95d5d68e24814a56e2664e587
             from contextlib import redirect_stdout
             from io import StringIO
             from threading import Thread
@@ -22,7 +58,6 @@ class PySysGetAttrTest(unittest.TestCase):
                 def __repr__(self):
                     time.sleep(0.2)
                     return "Foo"
-
 
             def thread1():
                 text = StringIO()
@@ -42,6 +77,42 @@ class PySysGetAttrTest(unittest.TestCase):
         rc, out, err = assert_python_ok('-c', code)
         self.assertEqual(out, b"")
         self.assertEqual(err, b"")
+
+    def test_faulthandler_enable_deleted_stderr(self):
+        # faulthandler should use strong reference to the stderr
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "test_faulthandler_enable")
+            test_code = self.common_faulthandler_code.format(
+                path.as_posix(),
+                "enable(None, True)"
+            )
+            rc, out, err = assert_python_ok('-c', test_code)
+            self.assertEqual(out, b"")
+            self.assertEqual(err, b"")
+
+    def test_faulthandler_dump_traceback_deleted_stderr(self):
+        # faulthandler should use strong reference to the stderr
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "test_faulthandler_dump_traceback")
+            test_code = self.common_faulthandler_code.format(
+                path.as_posix(),
+                "dump_traceback(None, False)"
+            )
+            rc, out, err = assert_python_ok('-c', test_code)
+            self.assertEqual(out, b"")
+            self.assertEqual(err, b"")
+
+    def test_faulthandler_dump_traceback_later_deleted_stderr(self):
+        # faulthandler should use strong reference to the stderr
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "test_faulthandler_dump_traceback_later")
+            test_code = self.common_faulthandler_code.format(
+                path.as_posix(),
+                "dump_traceback_later(0.1, True, None, False)"
+            )
+            rc, out, err = assert_python_ok('-c', test_code)
+            self.assertEqual(out, b"")
+            self.assertEqual(err, b"")
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_sys_getattr.py
+++ b/Lib/test/test_sys_getattr.py
@@ -12,37 +12,37 @@ import unittest
 class PySysGetAttrTest(unittest.TestCase):
 
     common_faulthandler_code = textwrap.dedent('''
-        from contextlib import redirect_stderr
+        import sys
         from faulthandler import dump_traceback, enable, dump_traceback_later
-        from threading import Thread
-        import time
 
-        class FakeFile:
-            def __init__(self):
-                self.f = open("{0}", "w")
-            def write(self, s):
-                self.f.write(s)
+        class FakeIO:
+            def __init__(self, what):
+                self.what = what
+            def write(self, str):
+                pass
             def flush(self):
-                time.sleep(0.2)
+                pass
             def fileno(self):
-                time.sleep(0.2)
-                return self.f.fileno()
+                self.restore_std('stderr')
+                return 0
 
-        def thread1():
-            text = FakeFile()
-            with redirect_stderr(text):
-                time.sleep(0.2)
+            @staticmethod
+            def restore_std(what):
+                stdfile = getattr(sys, what)
+                setattr(sys, what, getattr(sys, "__" + what + "__"))
+                del stdfile
+
+            @staticmethod
+            def set_std(what):
+                setattr(sys, what, FakeIO(what))
 
         def main():
             enable(None, True)
-            t1 = Thread(target=thread1, args=())
-            t1.start()
-            time.sleep(0.1)
-            {1}
+            FakeIO.set_std('stderr')
+            {0}
 
         if __name__ == "__main__":
             main()
-            exit(0)
     ''')
 
     common_warnings_code = textwrap.dedent('''
@@ -210,150 +210,106 @@ class PySysGetAttrTest(unittest.TestCase):
             main()
     ''')
 
+    print_code = textwrap.dedent('''
+        from io import StringIO
+        import sys
 
-    def test_print_deleted_stdout(self):
-        # print should use strong reference to the stdout.
-        code = textwrap.dedent('''
-            from io import StringIO
-            import sys
+        class Bar:
+            def __init__(self):
+                self.x = sys.stdout
+                setattr(sys, "stdout", StringIO())
 
-            class Bar:
-                def __init__(self):
-                    self.x = sys.stdout
-                    setattr(sys, "stdout", StringIO())
+            def __repr__(self):
+                x = sys.stdout
+                setattr(sys, "stdout", self.x)
+                del x
+                return "Bar"
 
-                def __repr__(self):
-                    x = sys.stdout
-                    setattr(sys, "stdout", self.x)
-                    del x
-                    return "Bar"
+        def main():
+            print(Bar())
 
-            def main():
-                print(Bar())
+        if __name__ == "__main__":
+            main()
+            exit(0)
+    ''')
 
-            if __name__ == "__main__":
-                main()
-                exit(0)
-        ''')
+    def _check(self, code):
         rc, out, err = assert_python_ok('-c', code)
         self.assertEqual(rc, 0)
         self.assertNotIn(b"Segmentation fault", err)
         self.assertNotIn(b"access violation", err)
 
+    def test_print_deleted_stdout(self):
+        # print should use strong reference to the stdout.
+        self._check(self.print_code)
+
     def test_faulthandler_enable_deleted_stderr(self):
         # faulthandler should use strong reference to the stderr
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = Path(tmpdir, "test_faulthandler_enable")
-            test_code = self.common_faulthandler_code.format(
-                path.as_posix(),
-                "enable(None, True)"
-            )
-            rc, out, err = assert_python_ok('-c', test_code)
-            self.assertEqual(rc, 0)
-            self.assertNotIn(b"Segmentation fault", err)
-            self.assertNotIn(b"access violation", err)
+        code = self.common_faulthandler_code.format(
+            "enable(None, True)"
+        )
+        self._check(code)
 
     def test_faulthandler_dump_traceback_deleted_stderr(self):
         # faulthandler should use strong reference to the stderr
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = Path(tmpdir, "test_faulthandler_dump_traceback")
-            test_code = self.common_faulthandler_code.format(
-                path.as_posix(),
-                "dump_traceback(None, False)"
-            )
-            rc, out, err = assert_python_ok('-c', test_code)
-            self.assertEqual(rc, 0)
-            self.assertNotIn(b"Segmentation fault", err)
-            self.assertNotIn(b"access violation", err)
+        code = self.common_faulthandler_code.format(
+            "dump_traceback(None, False)"
+        )
+        self._check(code)
 
     def test_faulthandler_dump_traceback_later_deleted_stderr(self):
         # faulthandler should use strong reference to the stderr
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = Path(tmpdir, "test_faulthandler_dump_traceback_later")
-            test_code = self.common_faulthandler_code.format(
-                path.as_posix(),
-                "dump_traceback_later(0.1, True, None, False)"
-            )
-            rc, out, err = assert_python_ok('-c', test_code)
-            self.assertEqual(rc, 0)
-            self.assertNotIn(b"Segmentation fault", err)
-            self.assertNotIn(b"access violation", err)
+        code = self.common_faulthandler_code.format(
+            "dump_traceback_later(0.1, True, None, False)"
+        )
+        self._check(code)
 
     def test_warnings_warn(self):
-        test_code = self.common_warnings_code.format(
+        code = self.common_warnings_code.format(
             "warnings.warn(Foo())"
         )
-        rc, _, err = assert_python_ok('-c', test_code)
-        self.assertEqual(rc, 0)
-        self.assertNotIn(b"Segmentation fault", err)
-        self.assertNotIn(b"access violation", err)
+        self._check(code)
 
     def test_warnings_warn_explicit(self):
-        test_code = self.common_warnings_code.format(
+        code = self.common_warnings_code.format(
             "warnings.warn_explicit(Foo(), UserWarning, 'filename', 0)"
         )
-        rc, _, err = assert_python_ok('-c', test_code)
-        self.assertEqual(rc, 0)
-        self.assertNotIn(b"Segmentation fault", err)
-        self.assertNotIn(b"access violation", err)
+        self._check(code)
 
     def test_input_stdin(self):
-        test_code = self.common_input_code.format(
+        code = self.common_input_code.format(
             "",
             "CrashStdin()"
         )
-        rc, _, err = assert_python_ok('-c', test_code)
-        self.assertEqual(rc, 0)
-        self.assertNotIn(b"Segmentation fault", err)
-        self.assertNotIn(b"access violation", err)
+        self._check(code)
 
     def test_input_stdout(self):
-        test_code = self.common_input_code.format(
+        code = self.common_input_code.format(
             "",
             "CrashStdout()"
         )
-        rc, _, err = assert_python_ok('-c', test_code)
-        self.assertEqual(rc, 0)
-        self.assertNotIn(b"Segmentation fault", err)
-        self.assertNotIn(b"access violation", err)
+        self._check(code)
 
     def test_input_stderr(self):
-        test_code = self.common_input_code.format(
+        code = self.common_input_code.format(
             "sys.addaudithook(audit)",
             "CrashStderr()"
         )
-        rc, _, err = assert_python_ok('-c', test_code)
-        self.assertEqual(rc, 0)
-        self.assertNotIn(b"Segmentation fault", err)
-        self.assertNotIn(b"access violation", err)
+        self._check(code)
 
     def test_errors_unraisablehook(self):
-        test_code = self.unraisable_hook_code
-        rc, _, err = assert_python_ok('-c', test_code)
-        self.assertEqual(rc, 0)
-        self.assertNotIn(b"Segmentation fault", err)
-        self.assertNotIn(b"access violation", err)
+        self._check(self.unraisable_hook_code)
 
     def test_py_finalize_flush_std_files_stdout(self):
-        test_code = self.flush_std_files_common_code.format("stdout")
-        rc, _, err = assert_python_ok('-c', test_code)
-        self.assertEqual(rc, 0)
-        self.assertNotIn(b"Segmentation fault", err)
-        self.assertNotIn(b"access violation", err)
+        code = self.flush_std_files_common_code.format("stdout")
+        self._check(code)
 
     def test_py_finalize_flush_std_files_stderr(self):
-        test_code = self.flush_std_files_common_code.format("stderr")
-        rc, _, err = assert_python_ok('-c', test_code)
-        self.assertEqual(rc, 0)
-        self.assertNotIn(b"Segmentation fault", err)
-        self.assertNotIn(b"access violation", err)
+        code = self.flush_std_files_common_code.format("stderr")
+        self._check(code)
 
     def test_pyerr_printex_excepthook(self):
-        test_code = self.pyerr_printex_code
-        rc, _, err = assert_python_ok('-c', test_code)
-        self.assertEqual(rc, 0)
-        self.assertNotIn(b"Segmentation fault", err)
-        self.assertNotIn(b"access violation", err)
+        self._check(self.pyerr_printex_code)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
WIP

<!-- gh-issue-number: gh-130163 -->
* Issue: gh-130163
<!-- /gh-issue-number -->

|                                                        | Repro  | Tests  | Raised exception |
| ------------------------------------------------------ |:------:|:------:| ---------------- |
| `_pickle.c/whichmodule`                                |   No   |   No   | Don't keep       |
| `_threadmodule.c/thread_excepthook`                    |   No   |   No   | Keep             |
| `faulthandler.c/faulthandler_get_fileno`               |  Yes   |  Yes   | Don't keep       |
| `bltinmodule.c/builtin_print_impl`                     |  Yes   |  Yes   | Don't keep       |
| `bltinmodule.c/builtin_input_impl`                     |  Yes   |  Yes   | Don't keep       |
| `errors.c/write_unraisable_exc`                        |   No   |   No   | Keep             |
| `errors.c/format_unraisable_v`                         |  Yes   |  Yes   | Keep             |
| `_warnings.c/show_warning`                             |  Yes   |  Yes   | Don't keep       |
| `intrinsics.c/print_expr`                              |   No   |   No   | Don't keep       |
| `pylifecycle.c/flush_std_files`                        | Yes/No | Yes/No | Don't keep       |
| `pythonrun.c/_PyRun_InteractiveLoopObject`             |   No   |   No   | Don't keep       |
| `pythonrun.c/pyrun_one_parse_ast`                      |   No   |   No   | Don't keep       |
| `pythonrun.c/_Py_HandleSystemExitAndKeyboardInterrupt` |   No   |   No   | Don't keep       |
| `pythonrun.c/_PyErr_PrintEx`                           |  Yes   |  Yes   | Don't keep       |
| `pythonrun.c/PyErr_Display`                            |   No   |   No   | Don't keep       |
| `pythonrun.c/flush_io_stream`                          |   No   |   No   | Don't keep       |
| `sysmodule.c/sys_displayhook`                          |  Maybe |   No   | Don't keep       |
| `sysmodule.c/get_warnoptions`                          |   No   |   No   | Don't keep       |
| `sysmodule.c/PySys_ResetWarnOptions`                   |   No   |   No   | Don't keep       |
| `sysmodule.c/PySys_HasWarnOptions`                     |   No   |   No   | Don't keep       |
| `sysmodule.c/_PySys_AddXOptionWithError`               |   No   |   No   | Don't keep       |
| `sysmodule.c/PySys_SetArgvEx`                          |   No   |   No   | Don't keep       |
| `sysmodule.c/sys_write`                                |   No   |   No   | Don't keep       |
| `sysmodule.c/sys_format`                               |   No   |   No   | Don't keep       |
| `traceback.c/_Py_FindSourceFile`                       |   No   |   No   | Don't keep       |
|                                                        |        |        |                  |

* I can get a "segfault" error when I use `sys_displayhook`, but not where it's used.
* For `sys_write`, `sys_format` - I have checked all the places where they called, and most of the locations are safe. However, a few places use `%s` specifier, in such places it is very tricky to get `segfault`.
* `get_warnoptions`, `PySys_ResetWarnOptions`, `_PySys_AddXOptionWithError` - are deprecated, but it is a very tricky to get `segfault` too.
* `flush_io_stream`, `PyErr_Display`, `pyrun_one_parse_ast`, `print_expr`, `write_unraisable_exc`, `thread_excepthook` - very tight - They use a borrowed reference right after getting. It might be possible to reproduce it under heavy contention, but I wasn't able to do so.
* `_PyRun_InteractiveLoopObject` only checks presence of `ps1` and `ps2`.
* `flush_std_files` used from `_Py_Finalize` and from `fatal_error`. For `_Py_Finalize` I can repro, for `fatal_error` - no.
* `whichmodule`, `_Py_FindSourceFile` iterate borrowed reference, but I wasn't able to reproduce `segfault`.
* Keep or not before raised exception - in the most places `_PySys_GetAttr` called without an exception set.