### PR TITLE
gh-124703: Add extra checks for pdb quit test

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4291,6 +4291,14 @@ class PdbTestInline(unittest.TestCase):
         stdout, stderr = self._run_script(script, commands)
         self.assertIn("2", stdout)
         self.assertIn("Quit anyway", stdout)
+        # Closing stdin will quit the debugger anyway so we need to confirm
+        # it's the quit command that does the job
+        # call/return event will print --Call-- and --Return--
+        self.assertNotIn("--", stdout)
+        # Normal exit should not print anything to stderr
+        self.assertEqual(stderr, "")
+        # The quit prompt should be printed exactly twice
+        self.assertEqual(stdout.count("Quit anyway"), 2)
 
 
 @support.requires_subprocess()


### PR DESCRIPTION
The existing checks is not sufficient to confirm pdb quits as expected. Even if it does not quit normally, shutting down stdin might just quit it eventually. We need to add some extra checks in the test.

<!-- gh-issue-number: gh-124703 -->
* Issue: gh-124703
<!-- /gh-issue-number -->
