### PR TITLE
gh-57537: Support breakpoints for zipimport modules on pdb

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4205,15 +4205,15 @@ def bœr():
             os.mkdir(os.path.join(temp_dir, 'source'))
             zipmodule = textwrap.dedent(
                 """
-                def bar(x):
-                    return x + 1
+                def bar():
+                    pass
                 """
             )
             script = textwrap.dedent(
                 f"""
                 import sys; sys.path.insert(0, {repr(os.path.join(temp_dir, 'zipmodule.zip'))})
                 import foo
-                foo.bar(41)
+                foo.bar()
                 """
             )
 
@@ -4227,10 +4227,10 @@ def bœr():
                 'n',
                 'b foo.bar',
                 'c',
-                'p x + x',
+                'p f"break in {$_frame.f_code.co_name}"',
                 'q'
             ]))
-            self.assertIn('82', stdout)
+            self.assertIn('break in bar', stdout)
 
 
 class ChecklineTests(unittest.TestCase):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4211,7 +4211,7 @@ def bœr():
             )
             script = textwrap.dedent(
                 f"""
-                import sys; sys.path.insert(0, '{os.path.join(temp_dir, 'zipmodule.zip')}')
+                import sys; sys.path.insert(0, {repr(os.path.join(temp_dir, 'zipmodule.zip'))})
                 import foo
                 foo.bar(41)
                 """

--- a/Misc/NEWS.d/next/Library/2025-02-19-01-29-16.gh-issue-57537.4tdVuK.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-19-01-29-16.gh-issue-57537.4tdVuK.rst
@@ -1,0 +1,1 @@
+Support breakpoints for :mod:`zipimport` modules on :mod:`pdb`


### PR DESCRIPTION
Currently when pdb sets a breakpoint on a known function, it uses the filename of the code object of that specific function to locate the source. However, this does not work for zipimport modules, because the `module_globals` passed in is of the current frame, and `linecache` needs that to get the source.

The correct way to deal with this is to pass in the `module_globals` of the function itself, not of the current frame. This not only solves the problem for zipimport, but also fixes other potential issues when the module of the function has its own loader.

<!-- gh-issue-number: gh-57537 -->
* Issue: gh-57537
<!-- /gh-issue-number -->
