### PR TITLE
[3.12] CI: Make macOS required to succeed (GH-110362)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -559,7 +559,6 @@ jobs:
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
       with:
         allowed-failures: >-
-          build_macos,
           build_ubuntu_ssltests,
           build_windows_msi,
           test_hypothesis,


### PR DESCRIPTION
(cherry picked from commit 5add7a6724cbff6c9f0597f0257b64c4f0978c14)

By now, `build_macos` is both Intel and Arm, and both are [Tier 1 in PEP 11](https://peps.python.org/pep-0011/#tier-1).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
