### PR TITLE
Revert "Use ubuntu-22.04-arm image for Arm runners. (#129834)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,13 +245,13 @@ jobs:
         - true
         os:
         - ubuntu-24.04
-        - ubuntu-22.04-arm
+        - ubuntu-24.04-arm
         exclude:
         # Do not test BOLT with free-threading, to conserve resources
         - bolt: true
           free-threading: true
         # BOLT currently crashes during instrumentation on aarch64
-        - os: ubuntu-22.04-arm
+        - os: ubuntu-24.04-arm
           bolt: true
     uses: ./.github/workflows/reusable-ubuntu.yml
     with:

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -86,7 +86,7 @@ jobs:
             runner: ubuntu-24.04
           - target: aarch64-unknown-linux-gnu/gcc
             architecture: aarch64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tail-call.yml
+++ b/.github/workflows/tail-call.yml
@@ -65,7 +65,7 @@ jobs:
             runner: ubuntu-24.04
           - target: aarch64-unknown-linux-gnu/gcc
             architecture: aarch64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
           - target: free-threading
             architecture: x86_64
             runner: ubuntu-24.04


### PR DESCRIPTION
GitHub discovered it was an issue with the underlying hardware and have migrated all the runners to a different arm sku (dpdsv5).

This reverts commit 80b9e79d84e835ecdb5a15c9ba73e44803ca9d32.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
