### PR TITLE
Fix some ctypes docs typos

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -689,7 +689,7 @@ This matches what ``#pragma pack(n)`` does in MSVC.
 
 It is also possible to set a minimum alignment for how the subclass itself is packed in the
 same way ``#pragma align(n)`` works in MSVC.
-This can be achieved by specifying a ::attr:`~Structure._align_` class attribute
+This can be achieved by specifying a :attr:`~Structure._align_` class attribute
 in the subclass definition.
 
 :mod:`ctypes` uses the native byte order for Structures and Unions.  To build

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -306,7 +306,7 @@ Since these types are mutable, their value can also be changed afterwards::
 Assigning a new value to instances of the pointer types :class:`c_char_p`,
 :class:`c_wchar_p`, and :class:`c_void_p` changes the *memory location* they
 point to, *not the contents* of the memory block (of course not, because Python
-bytes objects are immutable)::
+string objects are immutable)::
 
    >>> s = "Hello, World"
    >>> c_s = c_wchar_p(s)


### PR DESCRIPTION
Probably plenty of potential for improvement left (string representation and memory management on FFI boundaries are easy footguns, I'm not sure if they're treated with the appropriate respect), but I don't know how to do that.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130307.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->