### PR TITLE
gh-130160: use `.. program::` directive for documenting `cProfile` CLI

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -122,6 +122,7 @@ The :class:`pstats.Stats` class reads profile results from a file and formats
 them in various ways.
 
 .. _profile-cli:
+
 .. program:: cProfile
 
 The files :mod:`cProfile` and :mod:`profile` can also be invoked as a script to

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -142,11 +142,11 @@ profile another script.  For example::
 
    Specifies that a module is being profiled instead of a script.
 
-.. versionadded:: 3.7
-   Added the ``-m`` option to :mod:`cProfile`.
+   .. versionadded:: 3.7
+      Added the ``-m`` option to :mod:`cProfile`.
 
-.. versionadded:: 3.8
-   Added the ``-m`` option to :mod:`profile`.
+   .. versionadded:: 3.8
+      Added the ``-m`` option to :mod:`profile`.
 
 The :mod:`pstats` module's :class:`~pstats.Stats` class has a variety of methods
 for manipulating and printing the data saved into a profile results file::

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -122,18 +122,25 @@ The :class:`pstats.Stats` class reads profile results from a file and formats
 them in various ways.
 
 .. _profile-cli:
+.. program:: cProfile
 
 The files :mod:`cProfile` and :mod:`profile` can also be invoked as a script to
 profile another script.  For example::
 
    python -m cProfile [-o output_file] [-s sort_order] (-m module | myscript.py)
 
-``-o`` writes the profile results to a file instead of to stdout
+.. option:: -o <output_file>
 
-``-s`` specifies one of the :func:`~pstats.Stats.sort_stats` sort values to sort
-the output by. This only applies when ``-o`` is not supplied.
+   Writes the profile results to a file instead of to stdout.
 
-``-m`` specifies that a module is being profiled instead of a script.
+.. option:: -s <sort_order>
+
+   Specifies one of the :func:`~pstats.Stats.sort_stats` sort values to sort
+   the output by. This only applies when ``-o`` is not supplied.
+
+.. option:: -m <module>
+
+   Specifies that a module is being profiled instead of a script.
 
 .. versionadded:: 3.7
    Added the ``-m`` option to :mod:`cProfile`.

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -135,8 +135,9 @@ profile another script.  For example::
 
 .. option:: -s <sort_order>
 
-   Specifies one of the :func:`~pstats.Stats.sort_stats` sort values to sort
-   the output by. This only applies when :option:`-o <cProfile -o>` is not supplied.
+   Specifies one of the :func:`~pstats.Stats.sort_stats` sort values
+   to sort the output by.
+   This only applies when :option:`-o <cProfile -o>` is not supplied.
 
 .. option:: -m <module>
 

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -136,7 +136,7 @@ profile another script.  For example::
 .. option:: -s <sort_order>
 
    Specifies one of the :func:`~pstats.Stats.sort_stats` sort values to sort
-   the output by. This only applies when ``-o`` is not supplied.
+   the output by. This only applies when :option:`-o <cProfile -o>` is not supplied.
 
 .. option:: -m <module>
 


### PR DESCRIPTION
Use `.. program::` and `.. option::` directive for documenting `cProfile` CLI

<!-- gh-issue-number: gh-130160 -->
* Issue: gh-130160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130314.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->