### PR TITLE
gh-130130: Clarify `hash=False` docs in `dataclasses.field`

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -270,10 +270,11 @@ Module contents
      string returned by the generated :meth:`~object.__repr__` method.
 
    - *hash*: This can be a bool or ``None``.  If true, this field is
-     included in the generated :meth:`~object.__hash__` method.  If ``None`` (the
-     default), use the value of *compare*: this would normally be
-     the expected behavior.  A field should be considered in the hash
-     if it's used for comparisons.  Setting this value to anything
+     included in the generated :meth:`~object.__hash__` method. If false,
+     this field is excluded from the generated :meth:`~object.__hash__`.
+     If ``None`` (the default), use the value of *compare*: this would
+     normally be the expected behavior.  A field should be considered in
+     the hash if it's used for comparisons.  Setting this value to anything
      other than ``None`` is discouraged.
 
      One possible reason to set ``hash=False`` but ``compare=True``

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -270,11 +270,11 @@ Module contents
      string returned by the generated :meth:`~object.__repr__` method.
 
    - *hash*: This can be a bool or ``None``.  If true, this field is
-     included in the generated :meth:`~object.__hash__` method. If false,
+     included in the generated :meth:`~object.__hash__` method.  If false,
      this field is excluded from the generated :meth:`~object.__hash__`.
      If ``None`` (the default), use the value of *compare*: this would
-     normally be the expected behavior.  A field should be considered in
-     the hash if it's used for comparisons.  Setting this value to anything
+     normally be the expected behavior, since a field should be included
+     in the hash if it's used for comparisons.  Setting this value to anything
      other than ``None`` is discouraged.
 
      One possible reason to set ``hash=False`` but ``compare=True``


### PR DESCRIPTION
Clarify the meaning `dataclasses.field(..., hash=False)`


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130324.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-130130 -->
* Issue: gh-130130
<!-- /gh-issue-number -->
