### PR TITLE
gh-130293: Ensure test__colorize will pass on dumb terminals.

### DIFF
--- a/Lib/test/test__colorize.py
+++ b/Lib/test/test__colorize.py
@@ -10,7 +10,7 @@ from test.support.os_helper import EnvironmentVarGuard
 @contextlib.contextmanager
 def clear_env():
     with EnvironmentVarGuard() as mock_env:
-        for var in "FORCE_COLOR", "NO_COLOR", "PYTHON_COLORS":
+        for var in "FORCE_COLOR", "NO_COLOR", "PYTHON_COLORS", "TERM":
             mock_env.unset(var)
         yield mock_env
 

--- a/Misc/NEWS.d/next/Tests/2025-02-20-13-39-12.gh-issue-130293.5igSsu.rst
+++ b/Misc/NEWS.d/next/Tests/2025-02-20-13-39-12.gh-issue-130293.5igSsu.rst
@@ -1,2 +1,2 @@
-The tests of terminal colorization are no longer sensitve to the value of
-the TERM variable in the testing environment.
+The tests of terminal colorization are no longer sensitive to the value of
+the ``TERM`` variable in the testing environment.

--- a/Misc/NEWS.d/next/Tests/2025-02-20-13-39-12.gh-issue-130293.5igSsu.rst
+++ b/Misc/NEWS.d/next/Tests/2025-02-20-13-39-12.gh-issue-130293.5igSsu.rst
@@ -1,0 +1,2 @@
+The tests of terminal colorization are no longer sensitve to the value of
+the TERM variable in the testing environment.

--- a/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
+++ b/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
@@ -28,7 +28,7 @@
     // Xcode log can't display color. Stdout will report that it is *not* a
     // TTY.
     setenv("NO_COLOR", "1", true);
-    setenv("PY_COLORS", "0", true);
+    setenv("PYTHON_COLORS", "0", true);
 
     // Arguments to pass into the test suite runner.
     // argv[0] must identify the process; any subsequent arg


### PR DESCRIPTION
#129140 slightly modified the logic associated with determining if a console could be colorised. In doing so, the test became sensitive to the test environment's value for the TERM setting. 

The iOS 18.2 test simulator sets `TERM=dumb` in the test environment - this makes some sense, as stdout/stderr handling is performed by the system log, which won't honor tty control sequences. 

This appears to be a recent change to iOS; it wasn't true in iOS 17.2. With the recent update to the iOS buildbot, the problem became apparent. 

However, the issue isn't iOS specific - it will occur on any machine where `TERM=dumb` is set in the testing environment. On macOS, I can reproduce the issue with:
```
TERM=dumb python3.14 -m test test__colorize
```

This PR ensures that TERM is correctly mocked as part of the colorise test, and normalizes the name used by the iOS Testbed to disable terminal colors.

<!-- gh-issue-number: gh-130293 -->
* Issue: gh-130293
<!-- /gh-issue-number -->
