### PR TITLE
[doc]: Update logging cookbook to mention domain socket configuration…

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -845,7 +845,7 @@ Domain socket instead of a TCP socket by doing the following:
 
 #. In :file:`webapp.json`, change the socket handler configuration dictionary
    so that the ``host`` value is the path to the domain socket, and set the
-   ``port`` value to `null`.
+   ``port`` value to ``null``.
 
 
 .. currentmodule:: logging

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -825,15 +825,28 @@ To test these files, do the following in a POSIX environment:
    which will lead to records being written to the log.
 
 #. Inspect the log files in the :file:`run` subdirectory. You should see the
-   most recent log lines in files matching the pattern :file:`app.log*`. They won't be in
-   any particular order, since they have been handled concurrently by different
-   worker processes in a non-deterministic way.
+   most recent log lines in files matching the pattern :file:`app.log*`. They
+   won't be in any particular order, since they have been handled concurrently
+   by different worker processes in a non-deterministic way.
 
 #. You can shut down the listener and the web application by running
    ``venv/bin/supervisorctl -c supervisor.conf shutdown``.
 
 You may need to tweak the configuration files in the unlikely event that the
 configured ports clash with something else in your test environment.
+
+The default configuration uses a TCP socket on port 9020. You can use a Unix
+Domain socket instead of a TCP socket by doing the following:
+
+#. In `listener.json`, add a `socket` key with the path to the domain socket
+   you want to use. If this key is present, the listener listens on the
+   corresponding domain socket and not on a TCP socket (the `port` key is
+   ignored).
+
+#. In `webapp.json`, change the socket handler configuration dictionary so that
+   the `host` value is the path to the domain socket, and set the `port` value
+   to `null`.
+
 
 .. currentmodule:: logging
 

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -838,14 +838,14 @@ configured ports clash with something else in your test environment.
 The default configuration uses a TCP socket on port 9020. You can use a Unix
 Domain socket instead of a TCP socket by doing the following:
 
-#. In `listener.json`, add a `socket` key with the path to the domain socket
-   you want to use. If this key is present, the listener listens on the
-   corresponding domain socket and not on a TCP socket (the `port` key is
+#. In :file:`listener.json`, add a ``socket`` key with the path to the domain
+   socket you want to use. If this key is present, the listener listens on the
+   corresponding domain socket and not on a TCP socket (the ``port`` key is
    ignored).
 
-#. In `webapp.json`, change the socket handler configuration dictionary so that
-   the `host` value is the path to the domain socket, and set the `port` value
-   to `null`.
+#. In :file:`webapp.json`, change the socket handler configuration dictionary
+   so that the ``host`` value is the path to the domain socket, and set the
+   ``port`` value to `null`.
 
 
 .. currentmodule:: logging


### PR DESCRIPTION
… in a recipe.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130348.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->