### PR TITLE
Fix outdated reference link in collections module

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -595,7 +595,7 @@ class Counter(dict):
     # References:
     #   http://en.wikipedia.org/wiki/Multiset
     #   http://www.gnu.org/software/smalltalk/manual-base/html_node/Bag.html
-    #   http://www.demo2s.com/Tutorial/Cpp/0380__set-multiset/Catalog0380__set-multiset.htm
+    #   http://www.java2s.com/Tutorial/Cpp/0380__set-multiset/Catalog0380__set-multiset.htm
     #   http://code.activestate.com/recipes/259174/
     #   Knuth, TAOCP Vol. II section 4.6.3
 


### PR DESCRIPTION
The reference link to the multiset tutorial in [Lib/collections/__init__.py](https://github.com/python/cpython/blob/main/Lib/collections/__init__.py#L598) was incorrect.  
It has been updated to match the correct link already used in [Doc/library/collections.rst](https://github.com/python/cpython/blob/main/Doc/library/collections.rst?plain=1#L437).

### Changes:
- Replaced the incorrect link `http://www.demo2s.com/...`  
  with the correct link `http://www.java2s.com/...`

This is a minor documentation fix and does not require an issue.  