### PR TITLE
GH-91079: Fix stack overflow on AMD LTO linux

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -344,7 +344,7 @@ _Py_EnterRecursiveCallUnchecked(PyThreadState *tstate)
 #elif defined(__hppa__) || defined(__powerpc64__)
 #  define Py_C_STACK_SIZE 2000000
 #else
-#  define Py_C_STACK_SIZE 5000000
+#  define Py_C_STACK_SIZE 4000000
 #endif
 
 void

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -344,7 +344,7 @@ _Py_EnterRecursiveCallUnchecked(PyThreadState *tstate)
 #elif defined(__hppa__) || defined(__powerpc64__)
 #  define Py_C_STACK_SIZE 2000000
 #else
-#  define Py_C_STACK_SIZE 4000000
+#  define Py_C_STACK_SIZE 3000000
 #endif
 
 void


### PR DESCRIPTION
In https://github.com/python/cpython/pull/130007 we increased the default stack size from an estimated 4MB to 5MB.
This PR resets it to 3M.

This is a temporary fix until https://github.com/python/cpython/issues/130396 is implemented

<!-- gh-issue-number: gh-91079 -->
* Issue: gh-91079
<!-- /gh-issue-number -->
