### PR TITLE
GH-103180: Set a timeout for every job in GitHub Actions

### DIFF
--- a/.github/workflows/add-issue-header.yml
+++ b/.github/workflows/add-issue-header.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    timeout-minutes: 5
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     if: fromJSON(needs.build-context.outputs.run-docs)
     uses: ./.github/workflows/reusable-docs.yml
 
-  check_autoconf_regen:
+  check-autoconf-regen:
     name: 'Check if Autoconf files are up to date'
     # Don't use ubuntu-latest but a specific version to make the job
     # reproducible: to get the same tools versions (autoconf, aclocal, ...)
@@ -86,7 +86,7 @@ jobs:
             exit 1
           fi
 
-  check_generated_files:
+  check-generated-files:
     name: 'Check if generated files are up to date'
     # Don't use ubuntu-latest but a specific version to make the job
     # reproducible: to get the same tools versions (autoconf, aclocal, ...)
@@ -147,7 +147,7 @@ jobs:
         if: github.event_name == 'pull_request'  # $GITHUB_EVENT_NAME
         run: make check-c-globals
 
-  build_windows:
+  build-windows:
     name: >-
       Windows
       ${{ fromJSON(matrix.free-threading) && '(free-threading)' || '' }}
@@ -179,7 +179,7 @@ jobs:
       arch: ${{ matrix.arch }}
       free-threading: ${{ matrix.free-threading }}
 
-  build_windows_msi:
+  build-windows-msi:
     name: >-  # ${{ '' } is a hack to nest jobs under the same sidebar category
       Windows MSI${{ '' }}
     needs: build-context
@@ -194,7 +194,7 @@ jobs:
     with:
       arch: ${{ matrix.arch }}
 
-  build_macos:
+  build-macos:
     name: >-
       macOS
       ${{ fromJSON(matrix.free-threading) && '(free-threading)' || '' }}
@@ -228,7 +228,7 @@ jobs:
       free-threading: ${{ matrix.free-threading }}
       os: ${{ matrix.os }}
 
-  build_ubuntu:
+  build-ubuntu:
     name: >-
       Ubuntu
       ${{ fromJSON(matrix.free-threading) && '(free-threading)' || '' }}
@@ -260,7 +260,7 @@ jobs:
       free-threading: ${{ matrix.free-threading }}
       os: ${{ matrix.os }}
 
-  build_ubuntu_ssltests:
+  build-ubuntu-ssltests:
     name: 'Ubuntu SSL tests with OpenSSL'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -322,7 +322,7 @@ jobs:
     - name: SSL tests
       run: ./python Lib/test/ssltests.py
 
-  build_wasi:
+  build-wasi:
     name: 'WASI'
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
@@ -330,7 +330,7 @@ jobs:
     with:
       config_hash: ${{ needs.build-context.outputs.config-hash }}
 
-  test_hypothesis:
+  test-hypothesis:
     name: "Hypothesis tests on Ubuntu"
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -445,8 +445,7 @@ jobs:
         name: hypothesis-example-db
         path: ${{ env.CPYTHON_BUILDDIR }}/.hypothesis/examples/
 
-
-  build_asan:
+  build-asan:
     name: 'Address sanitizer'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -509,7 +508,7 @@ jobs:
     - name: Tests
       run: xvfb-run make ci
 
-  build_tsan:
+  build-tsan:
     name: >-
       Thread sanitizer
       ${{ fromJSON(matrix.free-threading) && '(free-threading)' || '' }}
@@ -528,6 +527,7 @@ jobs:
   cross-build-linux:
     name: Cross build Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
     steps:
@@ -592,8 +592,8 @@ jobs:
           output-sarif: true
           sanitizer: ${{ matrix.sanitizer }}
       - name: Upload crash
-        uses: actions/upload-artifact@v4
         if: failure() && steps.build.outcome == 'success'
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.sanitizer }}-artifacts
           path: ./out/artifacts
@@ -606,36 +606,35 @@ jobs:
 
   all-required-green:  # This job does nothing and is only used for the branch protection
     name: All required checks pass
-    if: always()
-
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
     - build-context  # Transitive dependency, needed to access `run-tests` value
     - check-docs
-    - check_autoconf_regen
-    - check_generated_files
-    - build_macos
-    - build_ubuntu
-    - build_ubuntu_ssltests
-    - build_wasi
-    - build_windows
-    - build_windows_msi
+    - check-autoconf-regen
+    - check-generated-files
+    - build-macos
+    - build-ubuntu
+    - build-ubuntu-ssltests
+    - build-wasi
+    - build-windows
+    - build-windows-msi
     - cross-build-linux
-    - test_hypothesis
-    - build_asan
-    - build_tsan
+    - test-hypothesis
+    - build-asan
+    - build-tsan
     - cifuzz
-
-    runs-on: ubuntu-latest
+    if: always()
 
     steps:
     - name: Check whether the needed jobs succeeded or failed
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
       with:
         allowed-failures: >-
-          build_ubuntu_ssltests,
-          build_windows_msi,
+          build-ubuntu-ssltests,
+          build-windows-msi,
           cifuzz,
-          test_hypothesis,
+          test-hypothesis,
         allowed-skips: >-
           ${{
             !fromJSON(needs.build-context.outputs.run-docs)
@@ -647,15 +646,15 @@ jobs:
           ${{
             needs.build-context.outputs.run-tests != 'true'
             && '
-            check_autoconf_regen,
-            check_generated_files,
-            build_macos,
-            build_ubuntu,
-            build_ubuntu_ssltests,
-            build_wasi,
-            build_asan,
-            build_tsan,
-            test_hypothesis,
+            check-autoconf-regen,
+            check-generated-files,
+            build-macos,
+            build-ubuntu,
+            build-ubuntu-ssltests,
+            build-wasi,
+            build-asan,
+            build-tsan,
+            test-hypothesis,
             cross-build-linux,
             '
             || ''
@@ -663,7 +662,7 @@ jobs:
           ${{
             !fromJSON(needs.build-context.outputs.run-windows-tests)
             && '
-            build_windows,
+            build-windows,
             '
             || ''
           }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -613,16 +613,16 @@ jobs:
     - check-docs
     - check-autoconf-regen
     - check-generated-files
+    - build-windows
+    - build-windows-msi
     - build-macos
     - build-ubuntu
     - build-ubuntu-ssltests
     - build-wasi
-    - build-windows
-    - build-windows-msi
-    - cross-build-linux
     - test-hypothesis
     - build-asan
     - build-tsan
+    - cross-build-linux
     - cifuzz
     if: always()
 
@@ -631,10 +631,10 @@ jobs:
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
       with:
         allowed-failures: >-
-          build-ubuntu-ssltests,
           build-windows-msi,
-          cifuzz,
+          build-ubuntu-ssltests,
           test-hypothesis,
+          cifuzz,
         allowed-skips: >-
           ${{
             !fromJSON(needs.build-context.outputs.run-docs)
@@ -652,9 +652,9 @@ jobs:
             build-ubuntu,
             build-ubuntu-ssltests,
             build-wasi,
+            test-hypothesis,
             build-asan,
             build-tsan,
-            test-hypothesis,
             cross-build-linux,
             '
             || ''

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    timeout-minutes: 5
 
     steps:
       - uses: readthedocs/actions/preview@v1

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -137,6 +137,7 @@ jobs:
     name: Free-Threaded (Debug)
     needs: interpreter
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     strategy:
       matrix:
         llvm:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -33,6 +33,9 @@ concurrency:
 
 jobs:
   mypy:
+    name: Run mypy on ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -46,9 +49,6 @@ jobs:
           "Tools/peg_generator",
           "Tools/wasm",
         ]
-    name: Run mypy on ${{ matrix.target }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -15,7 +15,7 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  build_doc:
+  build-doc:
     name: 'Docs'
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/reusable-macos.yml
+++ b/.github/workflows/reusable-macos.yml
@@ -19,8 +19,9 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  build_macos:
+  build-macos:
     name: build and test (${{ inputs.os }})
+    runs-on: ${{ inputs.os }}
     timeout-minutes: 60
     env:
       HOMEBREW_NO_ANALYTICS: 1
@@ -29,7 +30,6 @@ jobs:
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       PYTHONSTRICTEXTENSIONBUILD: 1
       TERM: linux
-    runs-on: ${{ inputs.os }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/reusable-tsan.yml
+++ b/.github/workflows/reusable-tsan.yml
@@ -16,7 +16,7 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  build_tsan_reusable:
+  build-tsan-reusable:
     name: 'Thread sanitizer'
     runs-on: ubuntu-24.04
     timeout-minutes: 60

--- a/.github/workflows/reusable-ubuntu.yml
+++ b/.github/workflows/reusable-ubuntu.yml
@@ -25,10 +25,10 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  build_ubuntu_reusable:
+  build-ubuntu-reusable:
     name: build and test (${{ inputs.os }})
-    timeout-minutes: 60
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 60
     env:
       OPENSSL_VER: 3.0.15
       PYTHONSTRICTEXTENSIONBUILD: 1

--- a/.github/workflows/reusable-wasi.yml
+++ b/.github/workflows/reusable-wasi.yml
@@ -11,10 +11,10 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  build_wasi_reusable:
+  build-wasi-reusable:
     name: 'build and test'
-    timeout-minutes: 60
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     env:
       WASMTIME_VERSION: 22.0.0
       WASI_SDK_VERSION: 24

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   stale:
     if: github.repository_owner == 'python'
-
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
As a half-workaround to GHA job hangs, this sets an explicit timeout on every job, meaning that it can be restarted after a sane period, rather than the default 6 hour (360 minute) allowance. This has a marginal benefit of freeing up CI resource quicker on such hangs, as we fail far sooner.

I've also standardised job names to use hyphens instead of the current mix of underscores and dashes, and made the order of inputs more consistent in a couple of cases.

Most notably, this means that if the required 'Check whether the needed jobs succeeded or failed' job hangs/fails, it can be restarted in 5 minutes, rather than pushing an empty commit or closing/reopening and triggering the full test suite again.

A

See also:

* https://github.com/python/cpython/issues/103437
* https://github.com/python/cpython/issues/103180

<!-- gh-issue-number: gh-103180 -->
* Issue: gh-103180
<!-- /gh-issue-number -->
