### PR TITLE
gh-127271: Remove the PyCell_Get usage for framelocalsproxy

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -58,7 +58,8 @@ framelocalsproxy_getval(_PyInterpreterFrame *frame, PyCodeObject *co, int i)
 
     if (cell != NULL) {
         value = PyCell_GetRef((PyCellObject *)cell);
-    } else {
+    }
+    else {
         Py_XINCREF(value);
     }
 

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -57,7 +57,7 @@ framelocalsproxy_getval(_PyInterpreterFrame *frame, PyCodeObject *co, int i)
     }
 
     if (cell != NULL) {
-        value = PyCell_GetRef(cell);
+        value = PyCell_GetRef((PyCellObject *)cell);
     } else {
         Py_XINCREF(value);
     }

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -193,9 +193,11 @@ framelocalsproxy_getitem(PyObject *self, PyObject *key)
 
     PyObject *extra = frame->f_extra_locals;
     if (extra != NULL) {
-        value = PyDict_GetItem(extra, key);
+        if (PyDict_GetItemRef(extra, key, &value) < 0) {
+            return NULL;
+        }
         if (value != NULL) {
-            return Py_NewRef(value);
+            return value;
         }
     }
 

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -177,7 +177,6 @@ static PyObject *
 framelocalsproxy_getitem(PyObject *self, PyObject *key)
 {
     PyFrameObject *frame = PyFrameLocalsProxyObject_CAST(self)->frame;
-    PyCodeObject *co = _PyFrame_GetCode(frame->f_frame);
     PyObject *value = NULL;
 
     int i = framelocalsproxy_getkeyindex(frame, key, true, &value);

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -118,7 +118,8 @@ framelocalsproxy_getkeyindex(PyFrameObject *frame, PyObject *key, bool read, PyO
                 if (value != NULL) {
                     if (value_ptr != NULL) {
                         *value_ptr = value;
-                    } else {
+                    }
+                    else {
                         Py_DECREF(value);
                     }
                     return i;
@@ -155,7 +156,8 @@ framelocalsproxy_getkeyindex(PyFrameObject *frame, PyObject *key, bool read, PyO
                 if (value != NULL) {
                     if (value_ptr != NULL) {
                         *value_ptr = value;
-                    } else {
+                    }
+                    else {
                         Py_DECREF(value);
                     }
                     return i;

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -90,7 +90,7 @@ framelocalsproxy_getkeyindex(PyFrameObject *frame, PyObject *key, bool read, PyO
      *   - if read == true, returns the index if the value is not NULL
      *   - if read == false, returns the index if the value is not hidden
      * Otherwise returns -1.
-     * 
+     *
      * If read == true and value_ptr is not NULL, *value_ptr is set to
      * the value of the key if it is found (with a new reference).
      */


### PR DESCRIPTION
In #127272 a `PyCell_Get` usage in `frameobject.c` was missed from being replaced for free-threaded safety. I guess the reason was probably the function was labelled to return a borrowed reference and a deeper understanding of the piece of code is needed to make that change. (or maybe I'm just thinking too much and it just slipped away :))

I made the change to use `PyCell_GetRef` and changed the function to return a new reference (because otherwise it won't be safe in free-threaded build). However, there are a few places in the code where it does not care about the actual value stored, it only cares whether such value exists - so I added a util function to avoid having `Py_XDECREF`s all around the code.

<!-- gh-issue-number: gh-127271 -->
* Issue: gh-127271
<!-- /gh-issue-number -->
