### PR TITLE
gh-130384: Skip a test_getallocatedblocks test pre-condition on iOS.

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1100,7 +1100,13 @@ class SysModuleTest(unittest.TestCase):
             # code objects is a large fraction of the total number of
             # references, this can cause the total number of allocated
             # blocks to exceed the total number of references.
-            if not support.Py_GIL_DISABLED:
+            #
+            # For some reason, iOS seems to trigger the "unlikely to happen"
+            # case reliably under CI conditions. It's not clear why; but as
+            # this test is checking the behavior of getallocatedblock()
+            # under garbage collection, we can skip this pre-condition check
+            # for now. See GH-130384.
+            if not support.Py_GIL_DISABLED and not support.is_apple_mobile:
                 self.assertLess(a, sys.gettotalrefcount())
         except AttributeError:
             # gettotalrefcount() not available


### PR DESCRIPTION
#130007 introduced a change to the handling of C stack limits, which caused the `test_sys.SysModuleTest.get_allocated_blocks()` test to start failing in CI on iOS.

This PR skips the specific test precondition that is causing the test failure when running on iOS. This is based on the fact that the assertion appears to be a precondition that has some other "escape clauses" (like running on a free threading build), and is documented as asserting something that is "unlikely to happen in a normal test run". I don't know why iOS is causing the "unlikely" condition to happen reliably in CI... but it apparently does.

I'll be honest - I don't feel *good* about this PR. However, I don't have anywhere near enough knowledge or experience to understand what interaction of memory allocation and garbage collection would be causing this to *only* occur on iOS, and *only* in CI. I can't reproduce the problem locally, and it doesn't appear to be causing any larger issues with operation on iOS. 

<!-- gh-issue-number: gh-130384 -->
* Issue: gh-130384
<!-- /gh-issue-number -->
