### PR TITLE
gh-129712: Document the wheels tags corresponding to each universal SDK.

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -984,7 +984,7 @@ See :source:`Mac/README.rst`.
    * ``3-way`` (supports i386, PPC and x86-64; supports ``fat3`` wheels);
    * ``intel`` (supports i386 and x86-64; supports ``intel`` wheels);
    * ``intel-32`` (supports i386; supports ``i386`` wheels);
-   * ``intel-64`` (supports x86-64; supports ``x86-64`` wheels);
+   * ``intel-64`` (supports x86-64; supports ``x86_64`` wheels);
    * ``all``  (supports PPC, i386, PPC64 and x86-64; supports ``universal`` wheels).
 
 .. option:: --with-framework-name=FRAMEWORK

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -978,14 +978,20 @@ See :source:`Mac/README.rst`.
 
    Options:
 
-   * ``universal2`` (x86-64 and arm64; supports ``universal2`` wheels);
-   * ``32-bit`` (PPC and i386; supports ``fat`` wheels);
-   * ``64-bit``  (PPC64 and x86-64; supports ``fat64`` wheels);
-   * ``3-way`` (i386, PPC and x86-64; supports ``fat3`` wheels);
-   * ``intel`` (i386 and x86-64; supports ``intel`` wheels);
-   * ``intel-32`` (i386; supports ``i386`` wheels);
-   * ``intel-64`` (x86-64; supports ``x86_64`` wheels);
-   * ``all``  (PPC, i386, PPC64 and x86-64; supports ``universal`` wheels).
+   * ``universal2`` (x86-64 and arm64);
+   * ``32-bit`` (PPC and i386);
+   * ``64-bit``  (PPC64 and x86-64);
+   * ``3-way`` (i386, PPC and x86-64);
+   * ``intel`` (i386 and x86-64);
+   * ``intel-32`` (i386);
+   * ``intel-64`` (x86-64);
+   * ``all``  (PPC, i386, PPC64 and x86-64).
+
+   Note that values for this configuration item are *not* the same as the
+   identifiers used for universal binary wheels on macOS. See the Python
+   Packaging User Guide for details on the `packaging platform compatibility
+   tags used on macOS
+   <https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#macos>`_
 
 .. option:: --with-framework-name=FRAMEWORK
 

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -978,14 +978,14 @@ See :source:`Mac/README.rst`.
 
    Options:
 
-   * ``universal2``;
-   * ``32-bit``;
-   * ``64-bit``;
-   * ``3-way``;
-   * ``intel``;
-   * ``intel-32``;
-   * ``intel-64``;
-   * ``all``.
+   * ``universal2`` (supports x86-64 and arm64; supports ``universal2`` wheels);
+   * ``32-bit`` (supports PPC and i386; supports ``fat`` wheels);
+   * ``64-bit``  (supports PPC64 and x86-64; supports ``fat64`` wheels);
+   * ``3-way`` (supports i386, PPC and x86-64; supports ``fat3`` wheels);
+   * ``intel`` (supports i386 and x86-64; supports ``intel`` wheels);
+   * ``intel-32`` (supports i386; supports ``i386`` wheels);
+   * ``intel-64`` (supports x86-64; supports ``x86-64`` wheels);
+   * ``all``  (supports PPC, i386, PPC64 and x86-64; supports ``universal`` wheels).
 
 .. option:: --with-framework-name=FRAMEWORK
 

--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -978,14 +978,14 @@ See :source:`Mac/README.rst`.
 
    Options:
 
-   * ``universal2`` (supports x86-64 and arm64; supports ``universal2`` wheels);
-   * ``32-bit`` (supports PPC and i386; supports ``fat`` wheels);
-   * ``64-bit``  (supports PPC64 and x86-64; supports ``fat64`` wheels);
-   * ``3-way`` (supports i386, PPC and x86-64; supports ``fat3`` wheels);
-   * ``intel`` (supports i386 and x86-64; supports ``intel`` wheels);
-   * ``intel-32`` (supports i386; supports ``i386`` wheels);
-   * ``intel-64`` (supports x86-64; supports ``x86_64`` wheels);
-   * ``all``  (supports PPC, i386, PPC64 and x86-64; supports ``universal`` wheels).
+   * ``universal2`` (x86-64 and arm64; supports ``universal2`` wheels);
+   * ``32-bit`` (PPC and i386; supports ``fat`` wheels);
+   * ``64-bit``  (PPC64 and x86-64; supports ``fat64`` wheels);
+   * ``3-way`` (i386, PPC and x86-64; supports ``fat3`` wheels);
+   * ``intel`` (i386 and x86-64; supports ``intel`` wheels);
+   * ``intel-32`` (i386; supports ``i386`` wheels);
+   * ``intel-64`` (x86-64; supports ``x86_64`` wheels);
+   * ``all``  (PPC, i386, PPC64 and x86-64; supports ``universal`` wheels).
 
 .. option:: --with-framework-name=FRAMEWORK
 

--- a/Mac/README.rst
+++ b/Mac/README.rst
@@ -200,6 +200,16 @@ a ``python3.x-32`` binary and use the value of ``sys.executable`` as the
 Likewise, use ``python3.x-intel64`` to force execution in ``x86_64`` mode
 with ``universal2`` binaries.
 
+3. How do I specify binary universal wheels
+-------------------------------------------
+
+Binary wheels can also be universal. The platform tag name used to identify
+universal binary wheels differs from the naming scheme used when configuring a
+universal build with ``--with-universal-archs``. See the Python Packaging User
+Guide for details on the `packaging platform compatibility tags used on macOS
+<https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#macos>`_.
+
+
 Building and using a framework-based Python on macOS
 ====================================================
 

--- a/Misc/NEWS.d/next/Documentation/2025-02-21-08-44-31.gh-issue-129712.4AcfWQ.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-02-21-08-44-31.gh-issue-129712.4AcfWQ.rst
@@ -1,0 +1,2 @@
+The wheel tags supported by each macOS universal SDK option are now
+documented.


### PR DESCRIPTION
In the process of getting iOS and Android wheel tags accepted into PyPI, I noticed that there isn't a 1-1 correlation between the `--with-universal-archs` flag passed to `./configure`, and the wheel tags supported by the builds produced when that flag is used. 

Most of these options are for entirely historical benefit - there's very little practical use for any value other than `universal2`. PPC64 hardware hasn't been available since 2006, and support for 32 bit Intel machines was dropped in 2011. However, the other values exist, and the inconsistency between the configuration value and wheel tag isn't documented anywhere. Until such time as these options are removed, we should at least document them.

<!-- gh-issue-number: gh-129712 -->
* Issue: gh-129712
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130389.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->