### PR TITLE
gh-124703: Change back to raising bdb.BdbQuit when exiting pdb in 'inline' mode in a REPL session

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1758,7 +1758,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
         Quit from the debugger. The program being executed is aborted.
         """
-        if self.mode == 'inline':
+        in_repl_session = hasattr(sys, 'ps1')
+        if self.mode == 'inline' and not in_repl_session:
             while True:
                 try:
                     reply = input('Quitting pdb will kill the process. Quit anyway? [y/n] ')

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1759,7 +1759,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         Quit from the debugger. The program being executed is aborted.
         """
         # Show prompt to kill process when in 'inline' mode and if pdb was not
-        # started from an interactive console. The constant sys.ps1 is only
+        # started from an interactive console. The attribute sys.ps1 is only
         # defined if the interpreter is in interactive mode.
         if self.mode == 'inline' and not hasattr(sys, 'ps1'):
             while True:

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1758,8 +1758,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
         Quit from the debugger. The program being executed is aborted.
         """
-        in_repl_session = hasattr(sys, 'ps1')
-        if self.mode == 'inline' and not in_repl_session:
+        # Show prompt to kill process when in 'inline' mode and if pdb was not
+        # started from an interactive console. The constant sys.ps1 is only
+        # defined if the interpreter is in interactive mode.
+        if self.mode == 'inline' and not hasattr(sys, 'ps1'):
             while True:
                 try:
                     reply = input('Quitting pdb will kill the process. Quit anyway? [y/n] ')

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4364,7 +4364,7 @@ def spawn_repl():
 @support.requires_subprocess()
 class TestREPLSession(unittest.TestCase):
     def test_return_from_inline_mode_to_REPL(self):
-        # Issue #124703: Raise BdbQuit when exiting pdb in REPL session.
+        # GH-124703: Raise BdbQuit when exiting pdb in REPL session.
         # This allows the REPL session to continue.
         user_input = """
             x = 'Spam'

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -16,6 +16,7 @@ import zipfile
 from contextlib import ExitStack, redirect_stdout
 from io import StringIO
 from test import support
+# Deferred import: from test.test_repl import spawn_repl
 from test.support import force_not_colorized, os_helper
 from test.support.import_helper import import_module
 from test.support.pty_helper import run_pty, FakeInput

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -20,7 +20,6 @@ from test.support import force_not_colorized, os_helper
 from test.support.import_helper import import_module
 from test.support.pty_helper import run_pty, FakeInput
 from test.support.script_helper import kill_python
-# Deferred import: from test.test_repl import spawn_repl
 from unittest.mock import patch
 
 SKIP_CORO_TESTS = False
@@ -4352,14 +4351,14 @@ class TestREPLSession(unittest.TestCase):
     def test_return_from_inline_mode_to_REPL(self):
         # GH-124703: Raise BdbQuit when exiting pdb in REPL session.
         # This allows the REPL session to continue.
+        from test.test_repl import spawn_repl
+        p = spawn_repl()
         user_input = """
             x = 'Spam'
             import pdb
             pdb.set_trace(commands=['x * 3', 'q'])
             x[::-1] * 3
         """
-        from test.test_repl import spawn_repl
-        p = spawn_repl()
         p.stdin.write(textwrap.dedent(user_input))
         output = kill_python(p)
         self.assertIn('SpamSpamSpam', output)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4279,6 +4279,8 @@ class ChecklineTests(unittest.TestCase):
                 self.assertFalse(db.checkline(os_helper.TESTFN, lineno))
 
 
+QUIT_PROMPT_QUESTION = "Quit anyway"
+
 @support.requires_subprocess()
 class PdbTestInline(unittest.TestCase):
     @unittest.skipIf(sys.flags.safe_path,
@@ -4332,7 +4334,7 @@ class PdbTestInline(unittest.TestCase):
 
         stdout, stderr = self._run_script(script, commands)
         self.assertIn("2", stdout)
-        self.assertIn("Quit anyway", stdout)
+        self.assertIn(QUIT_PROMPT_QUESTION, stdout)
         # Closing stdin will quit the debugger anyway so we need to confirm
         # it's the quit command that does the job
         # call/return event will print --Call-- and --Return--
@@ -4340,7 +4342,7 @@ class PdbTestInline(unittest.TestCase):
         # Normal exit should not print anything to stderr
         self.assertEqual(stderr, "")
         # The quit prompt should be printed exactly twice
-        self.assertEqual(stdout.count("Quit anyway"), 2)
+        self.assertEqual(stdout.count(QUIT_PROMPT_QUESTION), 2)
 
 
 def spawn_repl():
@@ -4369,15 +4371,15 @@ class TestREPLSession(unittest.TestCase):
             x = 'Spam'
             import pdb
             pdb.set_trace(commands=['x * 3', 'q'])
-            print('Afterward')
+            x[::-1] * 3
         """
         p = spawn_repl()
         p.stdin.write(textwrap.dedent(user_input))
         output = kill_python(p)
         self.assertIn('SpamSpamSpam', output)
-        self.assertNotIn('Quit anyway', output)
+        self.assertNotIn(QUIT_PROMPT_QUESTION, output)
         self.assertIn('BdbQuit', output)
-        self.assertIn('Afterward', output)
+        self.assertIn('mapSmapSmapS', output)
         self.assertEqual(p.returncode, 0)
 
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4350,7 +4350,6 @@ def spawn_repl():
     stdin_fname = os.path.join(os.path.dirname(sys.executable), '<stdin>')
     proc = subprocess.Popen(
         [stdin_fname, '-I', '-i'],
-        env={'PYTHON_BASIC_REPL': '1'},
         executable=sys.executable,
         text=True,
         stdin=subprocess.PIPE,

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4356,15 +4356,15 @@ class TestREPLSession(unittest.TestCase):
         user_input = """
             x = 'Spam'
             import pdb
-            pdb.set_trace(commands=['x * 3', 'q'])
-            x[::-1] * 3
+            pdb.set_trace(commands=['x + "During"', 'q'])
+            x + 'After'
         """
         p.stdin.write(textwrap.dedent(user_input))
         output = kill_python(p)
-        self.assertIn('SpamSpamSpam', output)
+        self.assertIn('SpamDuring', output)
         self.assertNotIn(QUIT_PROMPT_QUESTION, output)
         self.assertIn('BdbQuit', output)
-        self.assertIn('mapSmapSmapS', output)
+        self.assertIn('SpamAfter', output)
         self.assertEqual(p.returncode, 0)
 
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4279,8 +4279,6 @@ class ChecklineTests(unittest.TestCase):
                 self.assertFalse(db.checkline(os_helper.TESTFN, lineno))
 
 
-QUIT_PROMPT_QUESTION = "Quit anyway"
-
 @support.requires_subprocess()
 class PdbTestInline(unittest.TestCase):
     @unittest.skipIf(sys.flags.safe_path,
@@ -4334,7 +4332,7 @@ class PdbTestInline(unittest.TestCase):
 
         stdout, stderr = self._run_script(script, commands)
         self.assertIn("2", stdout)
-        self.assertIn(QUIT_PROMPT_QUESTION, stdout)
+        self.assertIn("Quit anyway", stdout)
         # Closing stdin will quit the debugger anyway so we need to confirm
         # it's the quit command that does the job
         # call/return event will print --Call-- and --Return--
@@ -4342,7 +4340,7 @@ class PdbTestInline(unittest.TestCase):
         # Normal exit should not print anything to stderr
         self.assertEqual(stderr, "")
         # The quit prompt should be printed exactly twice
-        self.assertEqual(stdout.count(QUIT_PROMPT_QUESTION), 2)
+        self.assertEqual(stdout.count("Quit anyway"), 2)
 
 
 @support.force_not_colorized_test_class
@@ -4362,7 +4360,7 @@ class TestREPLSession(unittest.TestCase):
         p.stdin.write(textwrap.dedent(user_input))
         output = kill_python(p)
         self.assertIn('SpamDuring', output)
-        self.assertNotIn(QUIT_PROMPT_QUESTION, output)
+        self.assertNotIn("Quit anyway", output)
         self.assertIn('BdbQuit', output)
         self.assertIn('SpamAfter', output)
         self.assertEqual(p.returncode, 0)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4345,22 +4345,6 @@ class PdbTestInline(unittest.TestCase):
         self.assertEqual(stdout.count(QUIT_PROMPT_QUESTION), 2)
 
 
-def spawn_repl():
-    """Run the basic Python REPL. Returns a Popen object."""
-    # This function is based on the function "spawn_repl" in test_repl.py.
-    # See comments there for the rationale for the command line args.
-    stdin_fname = os.path.join(os.path.dirname(sys.executable), '<stdin>')
-    proc = subprocess.Popen(
-        [stdin_fname, '-I', '-i'],
-        executable=sys.executable,
-        text=True,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-    return proc
-
-
 @support.force_not_colorized_test_class
 @support.requires_subprocess()
 class TestREPLSession(unittest.TestCase):
@@ -4373,6 +4357,7 @@ class TestREPLSession(unittest.TestCase):
             pdb.set_trace(commands=['x * 3', 'q'])
             x[::-1] * 3
         """
+        from test.test_repl import spawn_repl
         p = spawn_repl()
         p.stdin.write(textwrap.dedent(user_input))
         output = kill_python(p)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -16,11 +16,11 @@ import zipfile
 from contextlib import ExitStack, redirect_stdout
 from io import StringIO
 from test import support
-# Deferred import: from test.test_repl import spawn_repl
 from test.support import force_not_colorized, os_helper
 from test.support.import_helper import import_module
 from test.support.pty_helper import run_pty, FakeInput
 from test.support.script_helper import kill_python
+# Deferred import: from test.test_repl import spawn_repl
 from unittest.mock import patch
 
 SKIP_CORO_TESTS = False

--- a/Misc/NEWS.d/next/Library/2025-02-21-09-05-44.gh-issue-124703.AMJD4Y.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-21-09-05-44.gh-issue-124703.AMJD4Y.rst
@@ -1,1 +1,1 @@
-Restore the ability to easily return to the REPL from a pdb session after calling ``breakpoint`` or ``set_trace``.
+Executing ``quit`` command in :mod:`pdb` will raise :exc:`bdb.BdbQuit` when :mod:`pdb` is started from an interactive console using :func:`breakpoint` or :func:`pdb.set_trace`.

--- a/Misc/NEWS.d/next/Library/2025-02-21-09-05-44.gh-issue-124703.AMJD4Y.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-21-09-05-44.gh-issue-124703.AMJD4Y.rst
@@ -1,0 +1,1 @@
+Restore the ability to easily return to the REPL from a pdb session after calling ``breakpoint`` or ``set_trace``.


### PR DESCRIPTION
This change should mean it's again possible to call breakpoint() in a REPL session and return to the REPL session with q/quit/exit/EOF.

The test has a slight workaround/hack because I couldn't figure out how to call breakpoint() and simulate using pdb interactively within a simulated REPL session in a subprocess.  After set_trace() was called, pdb would receive an EOF and exit before it could receive further commands.

If there's interest, I could also add the code from [PR129768](https://github.com/python/cpython/pull/129768) to shorten the BdbQuit traceback by one frame.




<!-- gh-issue-number: gh-124703 -->
* Issue: gh-124703
<!-- /gh-issue-number -->
