### PR TITLE
GH-91079: Revert "GH-91079: Implement C stack limits using addresses, not counters. (GH-130007)" for now

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -921,7 +921,11 @@ because the :ref:`call protocol <call>` takes care of recursion handling.
 
    Marks a point where a recursive C-level call is about to be performed.
 
-   The function then checks if the stack limit is reached.  If this is the
+   If :c:macro:`!USE_STACKCHECK` is defined, this function checks if the OS
+   stack overflowed using :c:func:`PyOS_CheckStack`.  If this is the case, it
+   sets a :exc:`MemoryError` and returns a nonzero value.
+
+   The function then checks if the recursion limit is reached.  If this is the
    case, a :exc:`RecursionError` is set and a nonzero value is returned.
    Otherwise, zero is returned.
 

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -112,7 +112,7 @@ struct _ts {
     int py_recursion_remaining;
     int py_recursion_limit;
 
-    int c_recursion_remaining; /* Retained for backwards compatibility. Do not use */
+    int c_recursion_remaining;
     int recursion_headroom; /* Allow 50 more calls to handle any errors. */
 
     /* 'tracing' keeps track of the execution depth when tracing/profiling.
@@ -202,7 +202,36 @@ struct _ts {
     PyObject *threading_local_sentinel;
 };
 
-# define Py_C_RECURSION_LIMIT 5000
+#ifdef Py_DEBUG
+   // A debug build is likely built with low optimization level which implies
+   // higher stack memory usage than a release build: use a lower limit.
+#  define Py_C_RECURSION_LIMIT 500
+#elif defined(__s390x__)
+#  define Py_C_RECURSION_LIMIT 800
+#elif defined(_WIN32) && defined(_M_ARM64)
+#  define Py_C_RECURSION_LIMIT 1000
+#elif defined(_WIN32)
+#  define Py_C_RECURSION_LIMIT 3000
+#elif defined(__ANDROID__)
+   // On an ARM64 emulator, API level 34 was OK with 10000, but API level 21
+   // crashed in test_compiler_recursion_limit.
+#  define Py_C_RECURSION_LIMIT 3000
+#elif defined(_Py_ADDRESS_SANITIZER)
+#  define Py_C_RECURSION_LIMIT 4000
+#elif defined(__sparc__)
+   // test_descr crashed on sparc64 with >7000 but let's keep a margin of error.
+#  define Py_C_RECURSION_LIMIT 4000
+#elif defined(__wasi__)
+   // Based on wasmtime 16.
+#  define Py_C_RECURSION_LIMIT 5000
+#elif defined(__hppa__) || defined(__powerpc64__)
+   // test_descr crashed with >8000 but let's keep a margin of error.
+#  define Py_C_RECURSION_LIMIT 5000
+#else
+   // This value is duplicated in Lib/test/support/__init__.py
+#  define Py_C_RECURSION_LIMIT 10000
+#endif
+
 
 /* other API */
 
@@ -216,6 +245,7 @@ _PyThreadState_UncheckedGet(void)
 {
     return PyThreadState_GetUnchecked();
 }
+
 
 // Disable tracing and profiling.
 PyAPI_FUNC(void) PyThreadState_EnterTracing(PyThreadState *tstate);

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -193,12 +193,18 @@ extern void _PyEval_DeactivateOpCache(void);
 
 /* --- _Py_EnterRecursiveCall() ----------------------------------------- */
 
+#ifdef USE_STACKCHECK
+/* With USE_STACKCHECK macro defined, trigger stack checks in
+   _Py_CheckRecursiveCall() on every 64th call to _Py_EnterRecursiveCall. */
 static inline int _Py_MakeRecCheck(PyThreadState *tstate)  {
-    char here;
-    uintptr_t here_addr = (uintptr_t)&here;
-    _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate;
-    return here_addr < _tstate->c_stack_soft_limit;
+    return (tstate->c_recursion_remaining-- < 0
+            || (tstate->c_recursion_remaining & 63) == 0);
 }
+#else
+static inline int _Py_MakeRecCheck(PyThreadState *tstate) {
+    return tstate->c_recursion_remaining-- < 0;
+}
+#endif
 
 // Export for '_json' shared extension, used via _Py_EnterRecursiveCall()
 // static inline function.
@@ -214,31 +220,23 @@ static inline int _Py_EnterRecursiveCallTstate(PyThreadState *tstate,
     return (_Py_MakeRecCheck(tstate) && _Py_CheckRecursiveCall(tstate, where));
 }
 
+static inline void _Py_EnterRecursiveCallTstateUnchecked(PyThreadState *tstate)  {
+    assert(tstate->c_recursion_remaining > 0);
+    tstate->c_recursion_remaining--;
+}
+
 static inline int _Py_EnterRecursiveCall(const char *where) {
     PyThreadState *tstate = _PyThreadState_GET();
     return _Py_EnterRecursiveCallTstate(tstate, where);
 }
 
-static inline void _Py_LeaveRecursiveCallTstate(PyThreadState *tstate) {
-    (void)tstate;
-}
-
-PyAPI_FUNC(void) _Py_InitializeRecursionLimits(PyThreadState *tstate);
-
-static inline int _Py_ReachedRecursionLimit(PyThreadState *tstate)  {
-    char here;
-    uintptr_t here_addr = (uintptr_t)&here;
-    _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate;
-    if (here_addr > _tstate->c_stack_soft_limit) {
-        return 0;
-    }
-    if (_tstate->c_stack_hard_limit == 0) {
-        _Py_InitializeRecursionLimits(tstate);
-    }
-    return here_addr <= _tstate->c_stack_soft_limit;
+static inline void _Py_LeaveRecursiveCallTstate(PyThreadState *tstate)  {
+    tstate->c_recursion_remaining++;
 }
 
 static inline void _Py_LeaveRecursiveCall(void)  {
+    PyThreadState *tstate = _PyThreadState_GET();
+    _Py_LeaveRecursiveCallTstate(tstate);
 }
 
 extern struct _PyInterpreterFrame* _PyEval_GetFrame(void);
@@ -328,6 +326,7 @@ void _Py_set_eval_breaker_bit_all(PyInterpreterState *interp, uintptr_t bit);
 void _Py_unset_eval_breaker_bit_all(PyInterpreterState *interp, uintptr_t bit);
 
 PyAPI_FUNC(PyObject *) _PyFloat_FromDouble_ConsumeInputs(_PyStackRef left, _PyStackRef right, double value);
+
 
 #ifdef __cplusplus
 }

--- a/Include/internal/pycore_symtable.h
+++ b/Include/internal/pycore_symtable.h
@@ -82,6 +82,8 @@ struct symtable {
     PyObject *st_private;           /* name of current class or NULL */
     _PyFutureFeatures *st_future;   /* module's future features that affect
                                        the symbol table */
+    int recursion_depth;            /* current recursion depth */
+    int recursion_limit;            /* recursion limit */
 };
 
 typedef struct _symtable_entry {

--- a/Include/internal/pycore_tstate.h
+++ b/Include/internal/pycore_tstate.h
@@ -21,11 +21,6 @@ typedef struct _PyThreadStateImpl {
     // semi-public fields are in PyThreadState.
     PyThreadState base;
 
-    // These are addresses, but we need to convert to ints to avoid UB.
-    uintptr_t c_stack_top;
-    uintptr_t c_stack_soft_limit;
-    uintptr_t c_stack_hard_limit;
-
     PyObject *asyncio_running_loop; // Strong reference
     PyObject *asyncio_running_task; // Strong reference
 

--- a/Include/pythonrun.h
+++ b/Include/pythonrun.h
@@ -21,18 +21,14 @@ PyAPI_FUNC(void) PyErr_DisplayException(PyObject *);
 /* Stuff with no proper home (yet) */
 PyAPI_DATA(int) (*PyOS_InputHook)(void);
 
-/* Stack size, in "pointers". This must be large enough, so
- * no two calls to check recursion depth are more than this far
- * apart. In practice, that means it must be larger than the C
- * stack consumption of PyEval_EvalDefault */
-#if defined(Py_DEBUG) && defined(WIN32)
-#  define PYOS_STACK_MARGIN 3072
-#else
-#  define PYOS_STACK_MARGIN 2048
-#endif
-#define PYOS_STACK_MARGIN_BYTES (PYOS_STACK_MARGIN * sizeof(void *))
+/* Stack size, in "pointers" (so we get extra safety margins
+   on 64-bit platforms).  On a 32-bit platform, this translates
+   to an 8k margin. */
+#define PYOS_STACK_MARGIN 2048
 
-#if defined(WIN32)
+#if defined(WIN32) && !defined(MS_WIN64) && !defined(_M_ARM) && defined(_MSC_VER) && _MSC_VER >= 1300
+/* Enable stack checking under Microsoft C */
+// When changing the platforms, ensure PyOS_CheckStack() docs are still correct
 #define USE_STACKCHECK
 #endif
 

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -6,8 +6,7 @@ import sys
 from functools import cmp_to_key
 
 from test import seq_tests
-from test.support import ALWAYS_EQ, NEVER_EQ
-from test.support import skip_emscripten_stack_overflow, skip_wasi_stack_overflow
+from test.support import ALWAYS_EQ, NEVER_EQ, get_c_recursion_limit, skip_emscripten_stack_overflow
 
 
 class CommonTest(seq_tests.CommonTest):
@@ -60,11 +59,10 @@ class CommonTest(seq_tests.CommonTest):
         self.assertEqual(str(a2), "[0, 1, 2, [...], 3]")
         self.assertEqual(repr(a2), "[0, 1, 2, [...], 3]")
 
-    @skip_wasi_stack_overflow()
     @skip_emscripten_stack_overflow()
     def test_repr_deep(self):
         a = self.type2test([])
-        for i in range(100_000):
+        for i in range(get_c_recursion_limit() + 1):
             a = self.type2test([a])
         self.assertRaises(RecursionError, repr, a)
 

--- a/Lib/test/mapping_tests.py
+++ b/Lib/test/mapping_tests.py
@@ -1,7 +1,7 @@
 # tests common to dict and UserDict
 import unittest
 import collections
-from test import support
+from test.support import get_c_recursion_limit, skip_emscripten_stack_overflow
 
 
 class BasicTestMappingProtocol(unittest.TestCase):
@@ -622,11 +622,10 @@ class TestHashMappingProtocol(TestMappingProtocol):
         d = self._full_mapping({1: BadRepr()})
         self.assertRaises(Exc, repr, d)
 
-    @support.skip_wasi_stack_overflow()
-    @support.skip_emscripten_stack_overflow()
+    @skip_emscripten_stack_overflow()
     def test_repr_deep(self):
         d = self._empty_mapping()
-        for i in range(support.exceeds_recursion_limit()):
+        for i in range(get_c_recursion_limit() + 1):
             d0 = d
             d = self._empty_mapping()
             d[1] = d0

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -684,6 +684,7 @@ def collect_testcapi(info_add):
     for name in (
         'LONG_MAX',         # always 32-bit on Windows, 64-bit on 64-bit Unix
         'PY_SSIZE_T_MAX',
+        'Py_C_RECURSION_LIMIT',
         'SIZEOF_TIME_T',    # 32-bit or 64-bit depending on the platform
         'SIZEOF_WCHAR_T',   # 16-bit or 32-bit depending on the platform
     ):

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -56,7 +56,8 @@ __all__ = [
     "run_with_tz", "PGO", "missing_compiler_executable",
     "ALWAYS_EQ", "NEVER_EQ", "LARGEST", "SMALLEST",
     "LOOPBACK_TIMEOUT", "INTERNET_TIMEOUT", "SHORT_TIMEOUT", "LONG_TIMEOUT",
-    "Py_DEBUG", "exceeds_recursion_limit", "skip_on_s390x",
+    "Py_DEBUG", "exceeds_recursion_limit", "get_c_recursion_limit",
+    "skip_on_s390x",
     "requires_jit_enabled",
     "requires_jit_disabled",
     "force_not_colorized",
@@ -556,9 +557,6 @@ is_wasi = sys.platform == "wasi"
 
 def skip_emscripten_stack_overflow():
     return unittest.skipIf(is_emscripten, "Exhausts limited stack on Emscripten")
-
-def skip_wasi_stack_overflow():
-    return unittest.skipIf(is_wasi, "Exhausts stack on WASI")
 
 is_apple_mobile = sys.platform in {"ios", "tvos", "watchos"}
 is_apple = is_apple_mobile or sys.platform == "darwin"
@@ -2626,9 +2624,17 @@ def adjust_int_max_str_digits(max_digits):
         sys.set_int_max_str_digits(current)
 
 
+def get_c_recursion_limit():
+    try:
+        import _testcapi
+        return _testcapi.Py_C_RECURSION_LIMIT
+    except ImportError:
+        raise unittest.SkipTest('requires _testcapi')
+
+
 def exceeds_recursion_limit():
     """For recursion tests, easily exceeds default recursion limit."""
-    return 100_000
+    return get_c_recursion_limit() * 3
 
 
 # Windows doesn't have os.uname() but it doesn't support s390x.

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -18,8 +18,7 @@ except ImportError:
     _testinternalcapi = None
 
 from test import support
-from test.support import os_helper, script_helper
-from test.support import skip_emscripten_stack_overflow, skip_wasi_stack_overflow
+from test.support import os_helper, script_helper, skip_emscripten_stack_overflow
 from test.support.ast_helper import ASTTestMixin
 from test.test_ast.utils import to_tuple
 from test.test_ast.snippets import (
@@ -752,11 +751,11 @@ class AST_Tests(unittest.TestCase):
         enum._test_simple_enum(_Precedence, ast._Precedence)
 
     @support.cpython_only
-    @skip_wasi_stack_overflow()
     @skip_emscripten_stack_overflow()
     def test_ast_recursion_limit(self):
-        crash_depth = 200_000
-        success_depth = 200
+        fail_depth = support.exceeds_recursion_limit()
+        crash_depth = 100_000
+        success_depth = int(support.get_c_recursion_limit() * 0.8)
         if _testinternalcapi is not None:
             remaining = _testinternalcapi.get_c_recursion_remaining()
             success_depth = min(success_depth, remaining)
@@ -764,13 +763,13 @@ class AST_Tests(unittest.TestCase):
         def check_limit(prefix, repeated):
             expect_ok = prefix + repeated * success_depth
             ast.parse(expect_ok)
-
-            broken = prefix + repeated * crash_depth
-            details = "Compiling ({!r} + {!r} * {})".format(
-                        prefix, repeated, crash_depth)
-            with self.assertRaises(RecursionError, msg=details):
-                with support.infinite_recursion():
-                    ast.parse(broken)
+            for depth in (fail_depth, crash_depth):
+                broken = prefix + repeated * depth
+                details = "Compiling ({!r} + {!r} * {})".format(
+                            prefix, repeated, depth)
+                with self.assertRaises(RecursionError, msg=details):
+                    with support.infinite_recursion():
+                        ast.parse(broken)
 
         check_limit("a", "()")
         check_limit("a", ".b")

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -1,6 +1,6 @@
 import unittest
 from test.support import (cpython_only, is_wasi, requires_limited_api, Py_DEBUG,
-                          set_recursion_limit, skip_on_s390x, exceeds_recursion_limit, skip_emscripten_stack_overflow,
+                          set_recursion_limit, skip_on_s390x, skip_emscripten_stack_overflow,
                           skip_if_sanitizer, import_helper)
 try:
     import _testcapi
@@ -1064,10 +1064,10 @@ class TestRecursion(unittest.TestCase):
             recurse(90_000)
             with self.assertRaises(RecursionError):
                 recurse(101_000)
-            c_recurse(50)
+            c_recurse(100)
             with self.assertRaises(RecursionError):
                 c_recurse(90_000)
-            c_py_recurse(50)
+            c_py_recurse(90)
             with self.assertRaises(RecursionError):
                 c_py_recurse(100_000)
 

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -408,7 +408,7 @@ class CAPITest(unittest.TestCase):
         # activated when its tp_dealloc is being called by a subclass
         from _testcapi import MyList
         L = None
-        for i in range(100):
+        for i in range(1000):
             L = MyList((L,))
 
     @support.requires_resource('cpu')

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -8,7 +8,7 @@ import sys
 import unittest
 import weakref
 from test import support
-from test.support import import_helper
+from test.support import import_helper, get_c_recursion_limit
 
 
 class DictTest(unittest.TestCase):
@@ -594,11 +594,10 @@ class DictTest(unittest.TestCase):
         d = {1: BadRepr()}
         self.assertRaises(Exc, repr, d)
 
-    @support.skip_wasi_stack_overflow()
     @support.skip_emscripten_stack_overflow()
     def test_repr_deep(self):
         d = {}
-        for i in range(support.exceeds_recursion_limit()):
+        for i in range(get_c_recursion_limit() + 1):
             d = {1: d}
         self.assertRaises(RecursionError, repr, d)
 

--- a/Lib/test/test_dictviews.py
+++ b/Lib/test/test_dictviews.py
@@ -2,7 +2,7 @@ import collections.abc
 import copy
 import pickle
 import unittest
-from test.support import skip_emscripten_stack_overflow, skip_wasi_stack_overflow, exceeds_recursion_limit
+from test.support import get_c_recursion_limit, skip_emscripten_stack_overflow
 
 class DictSetTest(unittest.TestCase):
 
@@ -277,11 +277,10 @@ class DictSetTest(unittest.TestCase):
         # Again.
         self.assertIsInstance(r, str)
 
-    @skip_wasi_stack_overflow()
     @skip_emscripten_stack_overflow()
     def test_deeply_nested_repr(self):
         d = {}
-        for i in range(exceeds_recursion_limit()):
+        for i in range(get_c_recursion_limit()//2 + 100):
             d = {42: d.values()}
         self.assertRaises(RecursionError, repr, d)
 

--- a/Lib/test/test_exception_group.py
+++ b/Lib/test/test_exception_group.py
@@ -1,7 +1,7 @@
 import collections.abc
 import types
 import unittest
-from test.support import skip_emscripten_stack_overflow, exceeds_recursion_limit
+from test.support import get_c_recursion_limit, skip_emscripten_stack_overflow
 
 class TestExceptionGroupTypeHierarchy(unittest.TestCase):
     def test_exception_group_types(self):
@@ -460,7 +460,7 @@ class ExceptionGroupSplitTests(ExceptionGroupTestBase):
 class DeepRecursionInSplitAndSubgroup(unittest.TestCase):
     def make_deep_eg(self):
         e = TypeError(1)
-        for i in range(exceeds_recursion_limit()):
+        for i in range(get_c_recursion_limit() + 1):
             e = ExceptionGroup('eg', [e])
         return e
 

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1479,7 +1479,7 @@ class ExceptionTests(unittest.TestCase):
         """
         rc, out, err = script_helper.assert_python_failure("-c", code)
         self.assertEqual(rc, 1)
-        expected = b'RecursionError'
+        expected = b'RecursionError: maximum recursion depth exceeded'
         self.assertTrue(expected in err, msg=f"{expected!r} not found in {err[:3_000]!r}... (truncated)")
         self.assertIn(b'Done.', out)
 

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -628,23 +628,13 @@ x = (
                             r"does not match opening parenthesis '\('",
                             ["f'{a(4}'",
                             ])
-        self.assertRaises(SyntaxError, eval, "f'{" + "("*20 + "}'")
+        self.assertRaises(SyntaxError, eval, "f'{" + "("*500 + "}'")
 
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_fstring_nested_too_deeply(self):
-        def raises_syntax_or_memory_error(txt):
-            try:
-                eval(txt)
-            except SyntaxError:
-                pass
-            except MemoryError:
-                pass
-            except Exception as ex:
-                self.fail(f"Should raise SyntaxError or MemoryError, not {type(ex)}")
-            else:
-                self.fail("No exception raised")
-
-        raises_syntax_or_memory_error('f"{1+2:{1+2:{1+1:{1}}}}"')
+        self.assertAllRaise(SyntaxError,
+                            "f-string: expressions nested too deeply",
+                            ['f"{1+2:{1+2:{1+1:{1}}}}"'])
 
         def create_nested_fstring(n):
             if n == 0:
@@ -652,10 +642,9 @@ x = (
             prev = create_nested_fstring(n-1)
             return f'f"{{{prev}}}"'
 
-        raises_syntax_or_memory_error(create_nested_fstring(160))
-        raises_syntax_or_memory_error("f'{" + "("*100 + "}'")
-        raises_syntax_or_memory_error("f'{" + "("*1000 + "}'")
-        raises_syntax_or_memory_error("f'{" + "("*10_000 + "}'")
+        self.assertAllRaise(SyntaxError,
+                            "too many nested f-strings",
+                            [create_nested_fstring(160)])
 
     def test_syntax_error_in_nested_fstring(self):
         # See gh-104016 for more information on this crash

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2087,12 +2087,15 @@ class TestLRU:
                 return n
             return fib(n-1) + fib(n-2)
 
-        fib(100)
+        if not support.Py_DEBUG:
+            depth = support.get_c_recursion_limit()*2//7
+            with support.infinite_recursion():
+                fib(depth)
         if self.module == c_functools:
             fib.cache_clear()
             with support.infinite_recursion():
                 with self.assertRaises(RecursionError):
-                    fib(support.exceeds_recursion_limit())
+                    fib(10000)
 
 
 @py_functools.lru_cache()

--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -267,13 +267,15 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
     def test_subclass_recursion_limit(self):
         # make sure that issubclass raises RecursionError before the C stack is
         # blown
-        self.assertRaises(RecursionError, blowstack, issubclass, str, str)
+        with support.infinite_recursion():
+            self.assertRaises(RecursionError, blowstack, issubclass, str, str)
 
     @support.skip_emscripten_stack_overflow()
     def test_isinstance_recursion_limit(self):
         # make sure that issubclass raises RecursionError before the C stack is
         # blown
-        self.assertRaises(RecursionError, blowstack, isinstance, '', str)
+        with support.infinite_recursion():
+            self.assertRaises(RecursionError, blowstack, isinstance, '', str)
 
     def test_subclass_with_union(self):
         self.assertTrue(issubclass(int, int | float | int))
@@ -353,9 +355,8 @@ def blowstack(fxn, arg, compare_to):
     # Make sure that calling isinstance with a deeply nested tuple for its
     # argument will raise RecursionError eventually.
     tuple_arg = (compare_to,)
-    while True:
-        for _ in range(100):
-            tuple_arg = (tuple_arg,)
+    for cnt in range(support.exceeds_recursion_limit()):
+        tuple_arg = (tuple_arg,)
         fxn(arg, tuple_arg)
 
 

--- a/Lib/test/test_json/test_recursion.py
+++ b/Lib/test/test_json/test_recursion.py
@@ -82,7 +82,6 @@ class TestRecursion:
             with support.infinite_recursion():
                 self.loads('[' * 100000 + '1' + ']' * 100000)
 
-    @support.skip_wasi_stack_overflow()
     @support.skip_emscripten_stack_overflow()
     def test_highly_nested_objects_encoding(self):
         # See #12051

--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -125,7 +125,8 @@ class CodeTestCase(unittest.TestCase):
     def test_many_codeobjects(self):
         # Issue2957: bad recursion count on code objects
         # more than MAX_MARSHAL_STACK_DEPTH
-        codes = (ExceptionTestCase.test_exceptions.__code__,) * 10_000
+        count = support.exceeds_recursion_limit()
+        codes = (ExceptionTestCase.test_exceptions.__code__,) * count
         marshal.loads(marshal.dumps(codes))
 
     def test_different_filenames(self):

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -3035,18 +3035,18 @@ class TestExtendedArgs(unittest.TestCase):
 
     def test_trace_lots_of_globals(self):
 
-        count = 1000
+        count = min(1000, int(support.get_c_recursion_limit() * 0.8))
 
         code = """if 1:
             def f():
                 return (
                     {}
                 )
-        """.format("\n,\n".join(f"var{i}\n" for i in range(count)))
+        """.format("\n+\n".join(f"var{i}\n" for i in range(count)))
         ns = {f"var{i}": i for i in range(count)}
         exec(code, ns)
         counts = self.count_traces(ns["f"])
-        self.assertEqual(counts, {'call': 1, 'line': count * 2 + 1, 'return': 1})
+        self.assertEqual(counts, {'call': 1, 'line': count * 2, 'return': 1})
 
 
 class TestEdgeCases(unittest.TestCase):

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -3040,7 +3040,6 @@ async def f():
             with self.subTest(case=case):
                 self.assertRaises(tokenize.TokenError, get_tokens, case)
 
-    @support.skip_wasi_stack_overflow()
     def test_max_indent(self):
         MAXINDENT = 100
 

--- a/Lib/test/test_userdict.py
+++ b/Lib/test/test_userdict.py
@@ -213,7 +213,11 @@ class UserDictTest(mapping_tests.TestHashMappingProtocol):
         else:
             self.fail("g[42] didn't raise KeyError")
 
-    test_repr_deep = mapping_tests.TestHashMappingProtocol.test_repr_deep
+    # Decorate existing test with recursion limit, because
+    # the test is for C structure, but `UserDict` is a Python structure.
+    test_repr_deep = support.infinite_recursion(25)(
+        mapping_tests.TestHashMappingProtocol.test_repr_deep,
+    )
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_userlist.py
+++ b/Lib/test/test_userlist.py
@@ -69,7 +69,9 @@ class UserListTest(list_tests.CommonTest):
 
     # Decorate existing test with recursion limit, because
     # the test is for C structure, but `UserList` is a Python structure.
-    test_repr_deep = list_tests.CommonTest.test_repr_deep
+    test_repr_deep = support.infinite_recursion(25)(
+        list_tests.CommonTest.test_repr_deep,
+    )
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_xml_etree_c.py
+++ b/Lib/test/test_xml_etree_c.py
@@ -57,7 +57,6 @@ class MiscTests(unittest.TestCase):
             del element.attrib
         self.assertEqual(element.attrib, {'A': 'B', 'C': 'D'})
 
-    @support.skip_wasi_stack_overflow()
     @unittest.skipIf(support.is_emscripten, "segfaults")
     def test_trashcan(self):
         # If this test fails, it will most likely die via segfault.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-12-12-44-36.gh-issue-91079.8Nq08d.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-12-12-44-36.gh-issue-91079.8Nq08d.rst
@@ -1,3 +1,0 @@
-Change C stack overflow protection to consider the amount of stack consumed,
-rather than a counter. This allows deeper recursion in many cases, but
-remains safe.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3239,6 +3239,7 @@ PyInit__testcapi(void)
     PyModule_AddObject(m, "instancemethod", (PyObject *)&PyInstanceMethod_Type);
 
     PyModule_AddIntConstant(m, "the_number_three", 3);
+    PyModule_AddIntMacro(m, Py_C_RECURSION_LIMIT);
     PyModule_AddObject(m, "INT32_MIN", PyLong_FromInt32(INT32_MIN));
     PyModule_AddObject(m, "INT32_MAX", PyLong_FromInt32(INT32_MAX));
     PyModule_AddObject(m, "UINT32_MAX", PyLong_FromUInt32(UINT32_MAX));

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -115,11 +115,7 @@ static PyObject*
 get_c_recursion_remaining(PyObject *self, PyObject *Py_UNUSED(args))
 {
     PyThreadState *tstate = _PyThreadState_GET();
-    char here;
-    uintptr_t here_addr = (uintptr_t)&here;
-    _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate;
-    int remaining = (int)((here_addr - _tstate->c_stack_soft_limit)/PYOS_STACK_MARGIN_BYTES * 50);
-    return PyLong_FromLong(remaining);
+    return PyLong_FromLong(tstate->c_recursion_remaining);
 }
 
 

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -738,7 +738,7 @@ class SequenceConstructorVisitor(EmitVisitor):
 class PyTypesDeclareVisitor(PickleVisitor):
 
     def visitProduct(self, prod, name):
-        self.emit("static PyObject* ast2obj_%s(struct ast_state *state, void*);" % name, 0)
+        self.emit("static PyObject* ast2obj_%s(struct ast_state *state, struct validator *vstate, void*);" % name, 0)
         if prod.attributes:
             self.emit("static const char * const %s_attributes[] = {" % name, 0)
             for a in prod.attributes:
@@ -759,7 +759,7 @@ class PyTypesDeclareVisitor(PickleVisitor):
         ptype = "void*"
         if is_simple(sum):
             ptype = get_c_type(name)
-        self.emit("static PyObject* ast2obj_%s(struct ast_state *state, %s);" % (name, ptype), 0)
+        self.emit("static PyObject* ast2obj_%s(struct ast_state *state, struct validator *vstate, %s);" % (name, ptype), 0)
         for t in sum.types:
             self.visitConstructor(t, name)
 
@@ -1734,8 +1734,8 @@ add_attributes(struct ast_state *state, PyObject *type, const char * const *attr
 
 /* Conversion AST -> Python */
 
-static PyObject* ast2obj_list(struct ast_state *state, asdl_seq *seq,
-                              PyObject* (*func)(struct ast_state *state, void*))
+static PyObject* ast2obj_list(struct ast_state *state, struct validator *vstate, asdl_seq *seq,
+                              PyObject* (*func)(struct ast_state *state, struct validator *vstate, void*))
 {
     Py_ssize_t i, n = asdl_seq_LEN(seq);
     PyObject *result = PyList_New(n);
@@ -1743,7 +1743,7 @@ static PyObject* ast2obj_list(struct ast_state *state, asdl_seq *seq,
     if (!result)
         return NULL;
     for (i = 0; i < n; i++) {
-        value = func(state, asdl_seq_GET_UNTYPED(seq, i));
+        value = func(state, vstate, asdl_seq_GET_UNTYPED(seq, i));
         if (!value) {
             Py_DECREF(result);
             return NULL;
@@ -1753,7 +1753,7 @@ static PyObject* ast2obj_list(struct ast_state *state, asdl_seq *seq,
     return result;
 }
 
-static PyObject* ast2obj_object(struct ast_state *Py_UNUSED(state), void *o)
+static PyObject* ast2obj_object(struct ast_state *Py_UNUSED(state), struct validator *Py_UNUSED(vstate), void *o)
 {
     PyObject *op = (PyObject*)o;
     if (!op) {
@@ -1765,7 +1765,7 @@ static PyObject* ast2obj_object(struct ast_state *Py_UNUSED(state), void *o)
 #define ast2obj_identifier ast2obj_object
 #define ast2obj_string ast2obj_object
 
-static PyObject* ast2obj_int(struct ast_state *Py_UNUSED(state), long b)
+static PyObject* ast2obj_int(struct ast_state *Py_UNUSED(state), struct validator *Py_UNUSED(vstate), long b)
 {
     return PyLong_FromLong(b);
 }
@@ -2014,7 +2014,7 @@ class ObjVisitor(PickleVisitor):
     def func_begin(self, name):
         ctype = get_c_type(name)
         self.emit("PyObject*", 0)
-        self.emit("ast2obj_%s(struct ast_state *state, void* _o)" % (name), 0)
+        self.emit("ast2obj_%s(struct ast_state *state, struct validator *vstate, void* _o)" % (name), 0)
         self.emit("{", 0)
         self.emit("%s o = (%s)_o;" % (ctype, ctype), 1)
         self.emit("PyObject *result = NULL, *value = NULL;", 1)
@@ -2022,15 +2022,17 @@ class ObjVisitor(PickleVisitor):
         self.emit('if (!o) {', 1)
         self.emit("Py_RETURN_NONE;", 2)
         self.emit("}", 1)
-        self.emit('if (Py_EnterRecursiveCall("during  ast construction")) {', 1)
+        self.emit("if (++vstate->recursion_depth > vstate->recursion_limit) {", 1)
+        self.emit("PyErr_SetString(PyExc_RecursionError,", 2)
+        self.emit('"maximum recursion depth exceeded during ast construction");', 3)
         self.emit("return NULL;", 2)
         self.emit("}", 1)
 
     def func_end(self):
-        self.emit("Py_LeaveRecursiveCall();", 1)
+        self.emit("vstate->recursion_depth--;", 1)
         self.emit("return result;", 1)
         self.emit("failed:", 0)
-        self.emit("Py_LeaveRecursiveCall();", 1)
+        self.emit("vstate->recursion_depth--;", 1)
         self.emit("Py_XDECREF(value);", 1)
         self.emit("Py_XDECREF(result);", 1)
         self.emit("return NULL;", 1)
@@ -2048,7 +2050,7 @@ class ObjVisitor(PickleVisitor):
             self.visitConstructor(t, i + 1, name)
         self.emit("}", 1)
         for a in sum.attributes:
-            self.emit("value = ast2obj_%s(state, o->%s);" % (a.type, a.name), 1)
+            self.emit("value = ast2obj_%s(state, vstate, o->%s);" % (a.type, a.name), 1)
             self.emit("if (!value) goto failed;", 1)
             self.emit('if (PyObject_SetAttr(result, state->%s, value) < 0)' % a.name, 1)
             self.emit('goto failed;', 2)
@@ -2056,7 +2058,7 @@ class ObjVisitor(PickleVisitor):
         self.func_end()
 
     def simpleSum(self, sum, name):
-        self.emit("PyObject* ast2obj_%s(struct ast_state *state, %s_ty o)" % (name, name), 0)
+        self.emit("PyObject* ast2obj_%s(struct ast_state *state, struct validator *vstate, %s_ty o)" % (name, name), 0)
         self.emit("{", 0)
         self.emit("switch(o) {", 1)
         for t in sum.types:
@@ -2074,7 +2076,7 @@ class ObjVisitor(PickleVisitor):
         for field in prod.fields:
             self.visitField(field, name, 1, True)
         for a in prod.attributes:
-            self.emit("value = ast2obj_%s(state, o->%s);" % (a.type, a.name), 1)
+            self.emit("value = ast2obj_%s(state, vstate, o->%s);" % (a.type, a.name), 1)
             self.emit("if (!value) goto failed;", 1)
             self.emit("if (PyObject_SetAttr(result, state->%s, value) < 0)" % a.name, 1)
             self.emit('goto failed;', 2)
@@ -2115,7 +2117,7 @@ class ObjVisitor(PickleVisitor):
                 self.emit("for(i = 0; i < n; i++)", depth+1)
                 # This cannot fail, so no need for error handling
                 self.emit(
-                    "PyList_SET_ITEM(value, i, ast2obj_{0}(state, ({0}_ty)asdl_seq_GET({1}, i)));".format(
+                    "PyList_SET_ITEM(value, i, ast2obj_{0}(state, vstate, ({0}_ty)asdl_seq_GET({1}, i)));".format(
                         field.type,
                         value
                     ),
@@ -2124,9 +2126,9 @@ class ObjVisitor(PickleVisitor):
                 )
                 self.emit("}", depth)
             else:
-                self.emit("value = ast2obj_list(state, (asdl_seq*)%s, ast2obj_%s);" % (value, field.type), depth)
+                self.emit("value = ast2obj_list(state, vstate, (asdl_seq*)%s, ast2obj_%s);" % (value, field.type), depth)
         else:
-            self.emit("value = ast2obj_%s(state, %s);" % (field.type, value), depth, reflow=False)
+            self.emit("value = ast2obj_%s(state, vstate, %s);" % (field.type, value), depth, reflow=False)
 
 
 class PartingShots(StaticVisitor):
@@ -2138,8 +2140,28 @@ PyObject* PyAST_mod2obj(mod_ty t)
     if (state == NULL) {
         return NULL;
     }
-    PyObject *result = ast2obj_mod(state, t);
 
+    int starting_recursion_depth;
+    /* Be careful here to prevent overflow. */
+    PyThreadState *tstate = _PyThreadState_GET();
+    if (!tstate) {
+        return NULL;
+    }
+    struct validator vstate;
+    vstate.recursion_limit = Py_C_RECURSION_LIMIT;
+    int recursion_depth = Py_C_RECURSION_LIMIT - tstate->c_recursion_remaining;
+    starting_recursion_depth = recursion_depth;
+    vstate.recursion_depth = starting_recursion_depth;
+
+    PyObject *result = ast2obj_mod(state, &vstate, t);
+
+    /* Check that the recursion depth counting balanced correctly */
+    if (result && vstate.recursion_depth != starting_recursion_depth) {
+        PyErr_Format(PyExc_SystemError,
+            "AST constructor recursion depth mismatch (before=%d, after=%d)",
+            starting_recursion_depth, vstate.recursion_depth);
+        return NULL;
+    }
     return result;
 }
 
@@ -2282,6 +2304,11 @@ def generate_module_def(mod, metadata, f, internal_h):
         #include "pycore_unionobject.h"   // _Py_union_type_or
         #include "structmember.h"
         #include <stddef.h>
+
+        struct validator {
+            int recursion_depth;            /* current recursion depth */
+            int recursion_limit;            /* recursion limit */
+        };
 
         // Forward declaration
         static int init_types(void *arg);

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -14,7 +14,7 @@
 #    define MAXSTACK 4000
 #  endif
 #else
-#  define MAXSTACK 4000
+#  define MAXSTACK 6000
 #endif
 static const int n_keyword_lists = 9;
 static KeywordToken *reserved_keywords[] = {
@@ -947,7 +947,7 @@ static void *_tmp_172_rule(Parser *p);
 static mod_ty
 file_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -993,7 +993,7 @@ file_rule(Parser *p)
 static mod_ty
 interactive_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -1036,7 +1036,7 @@ interactive_rule(Parser *p)
 static mod_ty
 eval_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -1085,7 +1085,7 @@ eval_rule(Parser *p)
 static mod_ty
 func_type_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -1146,7 +1146,7 @@ func_type_rule(Parser *p)
 static asdl_stmt_seq*
 statements_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -1189,7 +1189,7 @@ statements_rule(Parser *p)
 static asdl_stmt_seq*
 statement_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -1256,7 +1256,7 @@ statement_rule(Parser *p)
 static asdl_stmt_seq*
 statement_newline_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -1387,7 +1387,7 @@ statement_newline_rule(Parser *p)
 static asdl_stmt_seq*
 simple_stmts_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -1480,7 +1480,7 @@ simple_stmts_rule(Parser *p)
 static stmt_ty
 simple_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -1825,7 +1825,7 @@ simple_stmt_rule(Parser *p)
 static stmt_ty
 compound_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -2015,7 +2015,7 @@ compound_stmt_rule(Parser *p)
 static stmt_ty
 assignment_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -2233,7 +2233,7 @@ assignment_rule(Parser *p)
 static expr_ty
 annotated_rhs_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -2303,7 +2303,7 @@ annotated_rhs_rule(Parser *p)
 static AugOperator*
 augassign_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -2634,7 +2634,7 @@ augassign_rule(Parser *p)
 static stmt_ty
 return_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -2698,7 +2698,7 @@ return_stmt_rule(Parser *p)
 static stmt_ty
 raise_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -2798,7 +2798,7 @@ raise_stmt_rule(Parser *p)
 static stmt_ty
 pass_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -2859,7 +2859,7 @@ pass_stmt_rule(Parser *p)
 static stmt_ty
 break_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -2920,7 +2920,7 @@ break_stmt_rule(Parser *p)
 static stmt_ty
 continue_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -2981,7 +2981,7 @@ continue_stmt_rule(Parser *p)
 static stmt_ty
 global_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3045,7 +3045,7 @@ global_stmt_rule(Parser *p)
 static stmt_ty
 nonlocal_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3109,7 +3109,7 @@ nonlocal_stmt_rule(Parser *p)
 static stmt_ty
 del_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3194,7 +3194,7 @@ del_stmt_rule(Parser *p)
 static stmt_ty
 yield_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3255,7 +3255,7 @@ yield_stmt_rule(Parser *p)
 static stmt_ty
 assert_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3322,7 +3322,7 @@ assert_stmt_rule(Parser *p)
 static stmt_ty
 import_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3398,7 +3398,7 @@ import_stmt_rule(Parser *p)
 static stmt_ty
 import_name_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3464,7 +3464,7 @@ import_name_rule(Parser *p)
 static stmt_ty
 import_from_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3583,7 +3583,7 @@ import_from_rule(Parser *p)
 static asdl_alias_seq*
 import_from_targets_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3718,7 +3718,7 @@ import_from_targets_rule(Parser *p)
 static asdl_alias_seq*
 import_from_as_names_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3761,7 +3761,7 @@ import_from_as_names_rule(Parser *p)
 static alias_ty
 import_from_as_name_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3825,7 +3825,7 @@ import_from_as_name_rule(Parser *p)
 static asdl_alias_seq*
 dotted_as_names_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3868,7 +3868,7 @@ dotted_as_names_rule(Parser *p)
 static alias_ty
 dotted_as_name_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -3934,7 +3934,7 @@ static expr_ty dotted_name_raw(Parser *);
 static expr_ty
 dotted_name_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     expr_ty _res = NULL;
@@ -3968,7 +3968,7 @@ dotted_name_rule(Parser *p)
 static expr_ty
 dotted_name_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -4036,7 +4036,7 @@ dotted_name_raw(Parser *p)
 static asdl_stmt_seq*
 block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -4131,7 +4131,7 @@ block_rule(Parser *p)
 static asdl_expr_seq*
 decorators_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -4174,7 +4174,7 @@ decorators_rule(Parser *p)
 static stmt_ty
 class_def_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -4241,7 +4241,7 @@ class_def_rule(Parser *p)
 static stmt_ty
 class_def_raw_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -4336,7 +4336,7 @@ class_def_raw_rule(Parser *p)
 static stmt_ty
 function_def_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -4404,7 +4404,7 @@ function_def_rule(Parser *p)
 static stmt_ty
 function_def_raw_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -4574,7 +4574,7 @@ function_def_raw_rule(Parser *p)
 static arguments_ty
 params_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -4636,7 +4636,7 @@ params_rule(Parser *p)
 static arguments_ty
 parameters_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -4799,7 +4799,7 @@ parameters_rule(Parser *p)
 static asdl_arg_seq*
 slash_no_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -4879,7 +4879,7 @@ slash_no_default_rule(Parser *p)
 static SlashWithDefault*
 slash_with_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -4968,7 +4968,7 @@ slash_with_default_rule(Parser *p)
 static StarEtc*
 star_etc_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5129,7 +5129,7 @@ star_etc_rule(Parser *p)
 static arg_ty
 kwds_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5194,7 +5194,7 @@ kwds_rule(Parser *p)
 static arg_ty
 param_no_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5274,7 +5274,7 @@ param_no_default_rule(Parser *p)
 static arg_ty
 param_no_default_star_annotation_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5352,7 +5352,7 @@ param_no_default_star_annotation_rule(Parser *p)
 static NameDefaultPair*
 param_with_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5438,7 +5438,7 @@ param_with_default_rule(Parser *p)
 static NameDefaultPair*
 param_maybe_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5522,7 +5522,7 @@ param_maybe_default_rule(Parser *p)
 static arg_ty
 param_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5586,7 +5586,7 @@ param_rule(Parser *p)
 static arg_ty
 param_star_annotation_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5650,7 +5650,7 @@ param_star_annotation_rule(Parser *p)
 static expr_ty
 annotation_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5696,7 +5696,7 @@ annotation_rule(Parser *p)
 static expr_ty
 star_annotation_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5742,7 +5742,7 @@ star_annotation_rule(Parser *p)
 static expr_ty
 default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5810,7 +5810,7 @@ default_rule(Parser *p)
 static stmt_ty
 if_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -5950,7 +5950,7 @@ if_stmt_rule(Parser *p)
 static stmt_ty
 elif_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -6087,7 +6087,7 @@ elif_stmt_rule(Parser *p)
 static asdl_stmt_seq*
 else_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -6155,7 +6155,7 @@ else_block_rule(Parser *p)
 static stmt_ty
 while_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -6251,7 +6251,7 @@ while_stmt_rule(Parser *p)
 static stmt_ty
 for_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -6448,7 +6448,7 @@ for_stmt_rule(Parser *p)
 static stmt_ty
 with_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -6720,7 +6720,7 @@ with_stmt_rule(Parser *p)
 static withitem_ty
 with_item_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -6818,7 +6818,7 @@ with_item_rule(Parser *p)
 static stmt_ty
 try_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7007,7 +7007,7 @@ try_stmt_rule(Parser *p)
 static excepthandler_ty
 except_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7160,7 +7160,7 @@ except_block_rule(Parser *p)
 static excepthandler_ty
 except_star_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7274,7 +7274,7 @@ except_star_block_rule(Parser *p)
 static asdl_stmt_seq*
 finally_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7344,7 +7344,7 @@ finally_block_rule(Parser *p)
 static stmt_ty
 match_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7442,7 +7442,7 @@ match_stmt_rule(Parser *p)
 static expr_ty
 subject_expr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7528,7 +7528,7 @@ subject_expr_rule(Parser *p)
 static match_case_ty
 case_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7602,7 +7602,7 @@ case_block_rule(Parser *p)
 static expr_ty
 guard_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7648,7 +7648,7 @@ guard_rule(Parser *p)
 static pattern_ty
 patterns_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7728,7 +7728,7 @@ patterns_rule(Parser *p)
 static pattern_ty
 pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7785,7 +7785,7 @@ pattern_rule(Parser *p)
 static pattern_ty
 as_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7871,7 +7871,7 @@ as_pattern_rule(Parser *p)
 static pattern_ty
 or_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -7940,7 +7940,7 @@ or_pattern_rule(Parser *p)
 static pattern_ty
 closed_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -8122,7 +8122,7 @@ closed_pattern_rule(Parser *p)
 static pattern_ty
 literal_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -8356,7 +8356,7 @@ literal_pattern_rule(Parser *p)
 static expr_ty
 literal_expr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -8544,7 +8544,7 @@ literal_expr_rule(Parser *p)
 static expr_ty
 complex_number_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -8650,7 +8650,7 @@ complex_number_rule(Parser *p)
 static expr_ty
 signed_number_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -8733,7 +8733,7 @@ signed_number_rule(Parser *p)
 static expr_ty
 signed_real_number_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -8816,7 +8816,7 @@ signed_real_number_rule(Parser *p)
 static expr_ty
 real_number_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -8859,7 +8859,7 @@ real_number_rule(Parser *p)
 static expr_ty
 imaginary_number_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -8902,7 +8902,7 @@ imaginary_number_rule(Parser *p)
 static pattern_ty
 capture_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -8963,7 +8963,7 @@ capture_pattern_rule(Parser *p)
 static expr_ty
 pattern_capture_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9010,7 +9010,7 @@ pattern_capture_target_rule(Parser *p)
 static pattern_ty
 wildcard_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9071,7 +9071,7 @@ wildcard_pattern_rule(Parser *p)
 static pattern_ty
 value_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9136,7 +9136,7 @@ static expr_ty attr_raw(Parser *);
 static expr_ty
 attr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     expr_ty _res = NULL;
@@ -9170,7 +9170,7 @@ attr_rule(Parser *p)
 static expr_ty
 attr_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9238,7 +9238,7 @@ attr_raw(Parser *p)
 static expr_ty
 name_or_attr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9295,7 +9295,7 @@ name_or_attr_rule(Parser *p)
 static pattern_ty
 group_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9344,7 +9344,7 @@ group_pattern_rule(Parser *p)
 static pattern_ty
 sequence_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9450,7 +9450,7 @@ sequence_pattern_rule(Parser *p)
 static asdl_seq*
 open_sequence_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9499,7 +9499,7 @@ open_sequence_pattern_rule(Parser *p)
 static asdl_seq*
 maybe_sequence_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9546,7 +9546,7 @@ maybe_sequence_pattern_rule(Parser *p)
 static pattern_ty
 maybe_star_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9603,7 +9603,7 @@ maybe_star_pattern_rule(Parser *p)
 static pattern_ty
 star_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9712,7 +9712,7 @@ star_pattern_rule(Parser *p)
 static pattern_ty
 mapping_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9911,7 +9911,7 @@ mapping_pattern_rule(Parser *p)
 static asdl_seq*
 items_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9949,7 +9949,7 @@ items_pattern_rule(Parser *p)
 static KeyPatternPair*
 key_value_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -9998,7 +9998,7 @@ key_value_pattern_rule(Parser *p)
 static expr_ty
 double_star_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10049,7 +10049,7 @@ double_star_pattern_rule(Parser *p)
 static pattern_ty
 class_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10279,7 +10279,7 @@ class_pattern_rule(Parser *p)
 static asdl_pattern_seq*
 positional_patterns_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10322,7 +10322,7 @@ positional_patterns_rule(Parser *p)
 static asdl_seq*
 keyword_patterns_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10360,7 +10360,7 @@ keyword_patterns_rule(Parser *p)
 static KeyPatternPair*
 keyword_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10409,7 +10409,7 @@ keyword_pattern_rule(Parser *p)
 static stmt_ty
 type_alias_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10482,7 +10482,7 @@ type_alias_rule(Parser *p)
 static asdl_type_param_seq*
 type_params_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10550,7 +10550,7 @@ type_params_rule(Parser *p)
 static asdl_type_param_seq*
 type_param_seq_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10601,7 +10601,7 @@ type_param_seq_rule(Parser *p)
 static type_param_ty
 type_param_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10770,7 +10770,7 @@ type_param_rule(Parser *p)
 static expr_ty
 type_param_bound_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10816,7 +10816,7 @@ type_param_bound_rule(Parser *p)
 static expr_ty
 type_param_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10862,7 +10862,7 @@ type_param_default_rule(Parser *p)
 static expr_ty
 type_param_starred_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -10908,7 +10908,7 @@ type_param_starred_default_rule(Parser *p)
 static expr_ty
 expressions_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -11036,7 +11036,7 @@ expressions_rule(Parser *p)
 static expr_ty
 expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -11190,7 +11190,7 @@ expression_rule(Parser *p)
 static expr_ty
 yield_expr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -11296,7 +11296,7 @@ yield_expr_rule(Parser *p)
 static expr_ty
 star_expressions_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -11419,7 +11419,7 @@ star_expressions_rule(Parser *p)
 static expr_ty
 star_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -11507,7 +11507,7 @@ star_expression_rule(Parser *p)
 static asdl_expr_seq*
 star_named_expressions_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -11554,7 +11554,7 @@ star_named_expressions_rule(Parser *p)
 static expr_ty
 star_named_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -11637,7 +11637,7 @@ star_named_expression_rule(Parser *p)
 static expr_ty
 assignment_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -11711,7 +11711,7 @@ assignment_expression_rule(Parser *p)
 static expr_ty
 named_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -11789,7 +11789,7 @@ named_expression_rule(Parser *p)
 static expr_ty
 disjunction_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -11877,7 +11877,7 @@ disjunction_rule(Parser *p)
 static expr_ty
 conjunction_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -11965,7 +11965,7 @@ conjunction_rule(Parser *p)
 static expr_ty
 inversion_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12053,7 +12053,7 @@ inversion_rule(Parser *p)
 static expr_ty
 comparison_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12146,7 +12146,7 @@ comparison_rule(Parser *p)
 static CmpopExprPair*
 compare_op_bitwise_or_pair_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12355,7 +12355,7 @@ compare_op_bitwise_or_pair_rule(Parser *p)
 static CmpopExprPair*
 eq_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12401,7 +12401,7 @@ eq_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 noteq_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12447,7 +12447,7 @@ noteq_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 lte_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12493,7 +12493,7 @@ lte_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 lt_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12539,7 +12539,7 @@ lt_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 gte_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12585,7 +12585,7 @@ gte_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 gt_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12631,7 +12631,7 @@ gt_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 notin_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12680,7 +12680,7 @@ notin_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 in_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12726,7 +12726,7 @@ in_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 isnot_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12775,7 +12775,7 @@ isnot_bitwise_or_rule(Parser *p)
 static CmpopExprPair*
 is_bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12823,7 +12823,7 @@ static expr_ty bitwise_or_raw(Parser *);
 static expr_ty
 bitwise_or_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     expr_ty _res = NULL;
@@ -12857,7 +12857,7 @@ bitwise_or_rule(Parser *p)
 static expr_ty
 bitwise_or_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -12945,7 +12945,7 @@ static expr_ty bitwise_xor_raw(Parser *);
 static expr_ty
 bitwise_xor_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     expr_ty _res = NULL;
@@ -12979,7 +12979,7 @@ bitwise_xor_rule(Parser *p)
 static expr_ty
 bitwise_xor_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -13067,7 +13067,7 @@ static expr_ty bitwise_and_raw(Parser *);
 static expr_ty
 bitwise_and_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     expr_ty _res = NULL;
@@ -13101,7 +13101,7 @@ bitwise_and_rule(Parser *p)
 static expr_ty
 bitwise_and_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -13189,7 +13189,7 @@ static expr_ty shift_expr_raw(Parser *);
 static expr_ty
 shift_expr_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     expr_ty _res = NULL;
@@ -13223,7 +13223,7 @@ shift_expr_rule(Parser *p)
 static expr_ty
 shift_expr_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -13369,7 +13369,7 @@ static expr_ty sum_raw(Parser *);
 static expr_ty
 sum_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     expr_ty _res = NULL;
@@ -13403,7 +13403,7 @@ sum_rule(Parser *p)
 static expr_ty
 sum_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -13537,7 +13537,7 @@ static expr_ty term_raw(Parser *);
 static expr_ty
 term_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     expr_ty _res = NULL;
@@ -13571,7 +13571,7 @@ term_rule(Parser *p)
 static expr_ty
 term_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -13832,7 +13832,7 @@ term_raw(Parser *p)
 static expr_ty
 factor_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -13992,7 +13992,7 @@ factor_rule(Parser *p)
 static expr_ty
 power_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -14078,7 +14078,7 @@ power_rule(Parser *p)
 static expr_ty
 await_primary_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -14173,7 +14173,7 @@ static expr_ty primary_raw(Parser *);
 static expr_ty
 primary_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     expr_ty _res = NULL;
@@ -14207,7 +14207,7 @@ primary_rule(Parser *p)
 static expr_ty
 primary_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -14413,7 +14413,7 @@ primary_raw(Parser *p)
 static expr_ty
 slices_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -14504,7 +14504,7 @@ slices_rule(Parser *p)
 static expr_ty
 slice_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -14608,7 +14608,7 @@ slice_rule(Parser *p)
 static expr_ty
 atom_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -14890,7 +14890,7 @@ atom_rule(Parser *p)
 static expr_ty
 group_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -14958,7 +14958,7 @@ group_rule(Parser *p)
 static expr_ty
 lambdef_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15028,7 +15028,7 @@ lambdef_rule(Parser *p)
 static arguments_ty
 lambda_params_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15090,7 +15090,7 @@ lambda_params_rule(Parser *p)
 static arguments_ty
 lambda_parameters_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15255,7 +15255,7 @@ lambda_parameters_rule(Parser *p)
 static asdl_arg_seq*
 lambda_slash_no_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15335,7 +15335,7 @@ lambda_slash_no_default_rule(Parser *p)
 static SlashWithDefault*
 lambda_slash_with_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15423,7 +15423,7 @@ lambda_slash_with_default_rule(Parser *p)
 static StarEtc*
 lambda_star_etc_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15551,7 +15551,7 @@ lambda_star_etc_rule(Parser *p)
 static arg_ty
 lambda_kwds_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15616,7 +15616,7 @@ lambda_kwds_rule(Parser *p)
 static arg_ty
 lambda_param_no_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15688,7 +15688,7 @@ lambda_param_no_default_rule(Parser *p)
 static NameDefaultPair*
 lambda_param_with_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15766,7 +15766,7 @@ lambda_param_with_default_rule(Parser *p)
 static NameDefaultPair*
 lambda_param_maybe_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15844,7 +15844,7 @@ lambda_param_maybe_default_rule(Parser *p)
 static arg_ty
 lambda_param_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15905,7 +15905,7 @@ lambda_param_rule(Parser *p)
 static expr_ty
 fstring_middle_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -15969,7 +15969,7 @@ fstring_middle_rule(Parser *p)
 static expr_ty
 fstring_replacement_field_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16064,7 +16064,7 @@ fstring_replacement_field_rule(Parser *p)
 static ResultTokenWithMetadata*
 fstring_conversion_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16110,7 +16110,7 @@ fstring_conversion_rule(Parser *p)
 static ResultTokenWithMetadata*
 fstring_full_format_spec_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16174,7 +16174,7 @@ fstring_full_format_spec_rule(Parser *p)
 static expr_ty
 fstring_format_spec_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16236,7 +16236,7 @@ fstring_format_spec_rule(Parser *p)
 static expr_ty
 fstring_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16285,7 +16285,7 @@ fstring_rule(Parser *p)
 static expr_ty
 string_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16328,7 +16328,7 @@ string_rule(Parser *p)
 static expr_ty
 strings_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16394,7 +16394,7 @@ strings_rule(Parser *p)
 static expr_ty
 list_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16461,7 +16461,7 @@ list_rule(Parser *p)
 static expr_ty
 tuple_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16528,7 +16528,7 @@ tuple_rule(Parser *p)
 static expr_ty
 set_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16595,7 +16595,7 @@ set_rule(Parser *p)
 static expr_ty
 dict_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16687,7 +16687,7 @@ dict_rule(Parser *p)
 static asdl_seq*
 double_starred_kvpairs_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16734,7 +16734,7 @@ double_starred_kvpairs_rule(Parser *p)
 static KeyValuePair*
 double_starred_kvpair_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16799,7 +16799,7 @@ double_starred_kvpair_rule(Parser *p)
 static KeyValuePair*
 kvpair_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16848,7 +16848,7 @@ kvpair_rule(Parser *p)
 static asdl_comprehension_seq*
 for_if_clauses_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -16895,7 +16895,7 @@ for_if_clauses_rule(Parser *p)
 static comprehension_ty
 for_if_clause_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -17041,7 +17041,7 @@ for_if_clause_rule(Parser *p)
 static expr_ty
 listcomp_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -17130,7 +17130,7 @@ listcomp_rule(Parser *p)
 static expr_ty
 setcomp_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -17221,7 +17221,7 @@ setcomp_rule(Parser *p)
 static expr_ty
 genexp_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -17310,7 +17310,7 @@ genexp_rule(Parser *p)
 static expr_ty
 dictcomp_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -17399,7 +17399,7 @@ dictcomp_rule(Parser *p)
 static expr_ty
 arguments_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -17474,7 +17474,7 @@ arguments_rule(Parser *p)
 static expr_ty
 args_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -17574,7 +17574,7 @@ args_rule(Parser *p)
 static asdl_seq*
 kwargs_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -17664,7 +17664,7 @@ kwargs_rule(Parser *p)
 static expr_ty
 starred_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -17766,7 +17766,7 @@ starred_expression_rule(Parser *p)
 static KeywordOrStarred*
 kwarg_or_starred_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -17876,7 +17876,7 @@ kwarg_or_starred_rule(Parser *p)
 static KeywordOrStarred*
 kwarg_or_double_starred_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -17998,7 +17998,7 @@ kwarg_or_double_starred_rule(Parser *p)
 static expr_ty
 star_targets_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -18092,7 +18092,7 @@ star_targets_rule(Parser *p)
 static asdl_expr_seq*
 star_targets_list_seq_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -18139,7 +18139,7 @@ star_targets_list_seq_rule(Parser *p)
 static asdl_expr_seq*
 star_targets_tuple_seq_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -18216,7 +18216,7 @@ star_targets_tuple_seq_rule(Parser *p)
 static expr_ty
 star_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -18307,7 +18307,7 @@ star_target_rule(Parser *p)
 static expr_ty
 target_with_star_atom_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -18448,7 +18448,7 @@ target_with_star_atom_rule(Parser *p)
 static expr_ty
 star_atom_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -18608,7 +18608,7 @@ star_atom_rule(Parser *p)
 static expr_ty
 single_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -18702,7 +18702,7 @@ single_target_rule(Parser *p)
 static expr_ty
 single_subscript_attribute_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -18822,7 +18822,7 @@ static expr_ty t_primary_raw(Parser *);
 static expr_ty
 t_primary_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     expr_ty _res = NULL;
@@ -18856,7 +18856,7 @@ t_primary_rule(Parser *p)
 static expr_ty
 t_primary_raw(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -19077,7 +19077,7 @@ t_primary_raw(Parser *p)
 static void *
 t_lookahead_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -19153,7 +19153,7 @@ t_lookahead_rule(Parser *p)
 static asdl_expr_seq*
 del_targets_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -19203,7 +19203,7 @@ del_targets_rule(Parser *p)
 static expr_ty
 del_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -19340,7 +19340,7 @@ del_target_rule(Parser *p)
 static expr_ty
 del_t_atom_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -19507,7 +19507,7 @@ del_t_atom_rule(Parser *p)
 static asdl_expr_seq*
 type_expressions_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -19751,7 +19751,7 @@ type_expressions_rule(Parser *p)
 static Token*
 func_type_comment_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -19844,7 +19844,7 @@ func_type_comment_rule(Parser *p)
 static void *
 invalid_arguments_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -20087,7 +20087,7 @@ invalid_arguments_rule(Parser *p)
 static void *
 invalid_kwarg_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -20233,7 +20233,7 @@ expression_without_invalid_rule(Parser *p)
 {
     int _prev_call_invalid = p->call_invalid_rules;
     p->call_invalid_rules = 0;
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -20352,7 +20352,7 @@ expression_without_invalid_rule(Parser *p)
 static void *
 invalid_legacy_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -20400,7 +20400,7 @@ invalid_legacy_expression_rule(Parser *p)
 static void *
 invalid_type_param_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -20491,7 +20491,7 @@ invalid_type_param_rule(Parser *p)
 static void *
 invalid_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -20708,7 +20708,7 @@ invalid_expression_rule(Parser *p)
 static void *
 invalid_named_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -20834,7 +20834,7 @@ invalid_named_expression_rule(Parser *p)
 static void *
 invalid_assignment_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -21039,7 +21039,7 @@ invalid_assignment_rule(Parser *p)
 static expr_ty
 invalid_ann_assign_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -21126,7 +21126,7 @@ invalid_ann_assign_target_rule(Parser *p)
 static void *
 invalid_del_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -21172,7 +21172,7 @@ invalid_del_stmt_rule(Parser *p)
 static void *
 invalid_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -21220,7 +21220,7 @@ invalid_block_rule(Parser *p)
 static void *
 invalid_comprehension_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -21338,7 +21338,7 @@ invalid_comprehension_rule(Parser *p)
 static void *
 invalid_dict_comprehension_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -21399,7 +21399,7 @@ invalid_dict_comprehension_rule(Parser *p)
 static void *
 invalid_parameters_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -21616,7 +21616,7 @@ invalid_parameters_rule(Parser *p)
 static void *
 invalid_default_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -21665,7 +21665,7 @@ invalid_default_rule(Parser *p)
 static void *
 invalid_star_etc_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -21807,7 +21807,7 @@ invalid_star_etc_rule(Parser *p)
 static void *
 invalid_kwds_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -21922,7 +21922,7 @@ invalid_kwds_rule(Parser *p)
 static void *
 invalid_parameters_helper_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -21990,7 +21990,7 @@ invalid_parameters_helper_rule(Parser *p)
 static void *
 invalid_lambda_parameters_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -22209,7 +22209,7 @@ invalid_lambda_parameters_rule(Parser *p)
 static void *
 invalid_lambda_parameters_helper_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -22274,7 +22274,7 @@ invalid_lambda_parameters_helper_rule(Parser *p)
 static void *
 invalid_lambda_star_etc_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -22389,7 +22389,7 @@ invalid_lambda_star_etc_rule(Parser *p)
 static void *
 invalid_lambda_kwds_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -22504,7 +22504,7 @@ invalid_lambda_kwds_rule(Parser *p)
 static void *
 invalid_double_type_comments_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -22559,7 +22559,7 @@ invalid_double_type_comments_rule(Parser *p)
 static void *
 invalid_with_item_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -22610,7 +22610,7 @@ invalid_with_item_rule(Parser *p)
 static void *
 invalid_for_if_clause_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -22662,7 +22662,7 @@ invalid_for_if_clause_rule(Parser *p)
 static void *
 invalid_for_target_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -22712,7 +22712,7 @@ invalid_for_target_rule(Parser *p)
 static void *
 invalid_group_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -22794,7 +22794,7 @@ invalid_group_rule(Parser *p)
 static void *
 invalid_import_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -22873,7 +22873,7 @@ invalid_import_rule(Parser *p)
 static void *
 invalid_import_from_targets_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -22948,7 +22948,7 @@ invalid_import_from_targets_rule(Parser *p)
 static void *
 invalid_with_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -23047,7 +23047,7 @@ invalid_with_stmt_rule(Parser *p)
 static void *
 invalid_with_stmt_indent_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -23158,7 +23158,7 @@ invalid_with_stmt_indent_rule(Parser *p)
 static void *
 invalid_try_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -23337,7 +23337,7 @@ invalid_try_stmt_rule(Parser *p)
 static void *
 invalid_except_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -23494,7 +23494,7 @@ invalid_except_stmt_rule(Parser *p)
 static void *
 invalid_except_star_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -23659,7 +23659,7 @@ invalid_except_star_stmt_rule(Parser *p)
 static void *
 invalid_finally_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -23712,7 +23712,7 @@ invalid_finally_stmt_rule(Parser *p)
 static void *
 invalid_except_stmt_indent_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -23803,7 +23803,7 @@ invalid_except_stmt_indent_rule(Parser *p)
 static void *
 invalid_except_star_stmt_indent_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -23866,7 +23866,7 @@ invalid_except_star_stmt_indent_rule(Parser *p)
 static void *
 invalid_match_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -23952,7 +23952,7 @@ invalid_match_stmt_rule(Parser *p)
 static void *
 invalid_case_block_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24044,7 +24044,7 @@ invalid_case_block_rule(Parser *p)
 static void *
 invalid_as_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24123,7 +24123,7 @@ invalid_as_pattern_rule(Parser *p)
 static void *
 invalid_class_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24173,7 +24173,7 @@ invalid_class_pattern_rule(Parser *p)
 static asdl_pattern_seq*
 invalid_class_argument_pattern_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24228,7 +24228,7 @@ invalid_class_argument_pattern_rule(Parser *p)
 static void *
 invalid_if_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24314,7 +24314,7 @@ invalid_if_stmt_rule(Parser *p)
 static void *
 invalid_elif_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24398,7 +24398,7 @@ invalid_elif_stmt_rule(Parser *p)
 static void *
 invalid_else_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24451,7 +24451,7 @@ invalid_else_stmt_rule(Parser *p)
 static void *
 invalid_while_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24537,7 +24537,7 @@ invalid_while_stmt_rule(Parser *p)
 static void *
 invalid_for_stmt_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24643,7 +24643,7 @@ invalid_for_stmt_rule(Parser *p)
 static void *
 invalid_def_raw_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24775,7 +24775,7 @@ invalid_def_raw_rule(Parser *p)
 static void *
 invalid_class_def_raw_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24878,7 +24878,7 @@ invalid_class_def_raw_rule(Parser *p)
 static void *
 invalid_double_starred_kvpairs_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -24987,7 +24987,7 @@ invalid_double_starred_kvpairs_rule(Parser *p)
 static void *
 invalid_kvpair_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -25094,7 +25094,7 @@ invalid_kvpair_rule(Parser *p)
 static void *
 invalid_starred_expression_unpacking_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -25146,7 +25146,7 @@ invalid_starred_expression_unpacking_rule(Parser *p)
 static void *
 invalid_starred_expression_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -25200,7 +25200,7 @@ invalid_starred_expression_rule(Parser *p)
 static void *
 invalid_replacement_field_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -25560,7 +25560,7 @@ invalid_replacement_field_rule(Parser *p)
 static void *
 invalid_conversion_character_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -25631,7 +25631,7 @@ invalid_conversion_character_rule(Parser *p)
 static void *
 invalid_arithmetic_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -25683,7 +25683,7 @@ invalid_arithmetic_rule(Parser *p)
 static void *
 invalid_factor_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -25732,7 +25732,7 @@ invalid_factor_rule(Parser *p)
 static void *
 invalid_type_params_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -25778,7 +25778,7 @@ invalid_type_params_rule(Parser *p)
 static asdl_seq *
 _loop0_1_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -25845,7 +25845,7 @@ _loop0_1_rule(Parser *p)
 static asdl_seq *
 _loop1_2_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -25917,7 +25917,7 @@ _loop1_2_rule(Parser *p)
 static asdl_seq *
 _loop0_3_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -25993,7 +25993,7 @@ _loop0_3_rule(Parser *p)
 static asdl_seq *
 _gather_4_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26034,7 +26034,7 @@ _gather_4_rule(Parser *p)
 static void *
 _tmp_5_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26091,7 +26091,7 @@ _tmp_5_rule(Parser *p)
 static void *
 _tmp_6_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26167,7 +26167,7 @@ _tmp_6_rule(Parser *p)
 static void *
 _tmp_7_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26224,7 +26224,7 @@ _tmp_7_rule(Parser *p)
 static void *
 _tmp_8_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26281,7 +26281,7 @@ _tmp_8_rule(Parser *p)
 static void *
 _tmp_9_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26338,7 +26338,7 @@ _tmp_9_rule(Parser *p)
 static void *
 _tmp_10_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26384,7 +26384,7 @@ _tmp_10_rule(Parser *p)
 static void *
 _tmp_11_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26452,7 +26452,7 @@ _tmp_11_rule(Parser *p)
 static asdl_seq *
 _loop1_12_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26524,7 +26524,7 @@ _loop1_12_rule(Parser *p)
 static void *
 _tmp_13_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26570,7 +26570,7 @@ _tmp_13_rule(Parser *p)
 static asdl_seq *
 _loop0_14_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26646,7 +26646,7 @@ _loop0_14_rule(Parser *p)
 static asdl_seq *
 _gather_15_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26687,7 +26687,7 @@ _gather_15_rule(Parser *p)
 static void *
 _tmp_16_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26744,7 +26744,7 @@ _tmp_16_rule(Parser *p)
 static void *
 _tmp_17_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26790,7 +26790,7 @@ _tmp_17_rule(Parser *p)
 static asdl_seq *
 _loop0_18_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26857,7 +26857,7 @@ _loop0_18_rule(Parser *p)
 static asdl_seq *
 _loop1_19_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -26929,7 +26929,7 @@ _loop1_19_rule(Parser *p)
 static asdl_seq *
 _loop0_20_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27005,7 +27005,7 @@ _loop0_20_rule(Parser *p)
 static asdl_seq *
 _gather_21_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27046,7 +27046,7 @@ _gather_21_rule(Parser *p)
 static void *
 _tmp_22_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27092,7 +27092,7 @@ _tmp_22_rule(Parser *p)
 static asdl_seq *
 _loop0_23_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27168,7 +27168,7 @@ _loop0_23_rule(Parser *p)
 static asdl_seq *
 _gather_24_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27209,7 +27209,7 @@ _gather_24_rule(Parser *p)
 static asdl_seq *
 _loop1_25_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27281,7 +27281,7 @@ _loop1_25_rule(Parser *p)
 static void *
 _tmp_26_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27330,7 +27330,7 @@ _tmp_26_rule(Parser *p)
 static void *
 _tmp_27_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27376,7 +27376,7 @@ _tmp_27_rule(Parser *p)
 static asdl_seq *
 _loop0_28_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27443,7 +27443,7 @@ _loop0_28_rule(Parser *p)
 static asdl_seq *
 _loop0_29_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27510,7 +27510,7 @@ _loop0_29_rule(Parser *p)
 static asdl_seq *
 _loop1_30_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27582,7 +27582,7 @@ _loop1_30_rule(Parser *p)
 static asdl_seq *
 _loop1_31_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27654,7 +27654,7 @@ _loop1_31_rule(Parser *p)
 static asdl_seq *
 _loop0_32_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27721,7 +27721,7 @@ _loop0_32_rule(Parser *p)
 static asdl_seq *
 _loop1_33_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27793,7 +27793,7 @@ _loop1_33_rule(Parser *p)
 static asdl_seq *
 _loop0_34_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27869,7 +27869,7 @@ _loop0_34_rule(Parser *p)
 static asdl_seq *
 _gather_35_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27910,7 +27910,7 @@ _gather_35_rule(Parser *p)
 static void *
 _tmp_36_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -27986,7 +27986,7 @@ _tmp_36_rule(Parser *p)
 static asdl_seq *
 _loop1_37_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28058,7 +28058,7 @@ _loop1_37_rule(Parser *p)
 static asdl_seq *
 _loop1_38_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28130,7 +28130,7 @@ _loop1_38_rule(Parser *p)
 static asdl_seq *
 _loop1_39_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28202,7 +28202,7 @@ _loop1_39_rule(Parser *p)
 static asdl_seq *
 _loop0_40_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28278,7 +28278,7 @@ _loop0_40_rule(Parser *p)
 static asdl_seq *
 _gather_41_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28319,7 +28319,7 @@ _gather_41_rule(Parser *p)
 static void *
 _tmp_42_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28376,7 +28376,7 @@ _tmp_42_rule(Parser *p)
 static void *
 _tmp_43_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28452,7 +28452,7 @@ _tmp_43_rule(Parser *p)
 static asdl_seq *
 _loop0_44_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28528,7 +28528,7 @@ _loop0_44_rule(Parser *p)
 static asdl_seq *
 _gather_45_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28569,7 +28569,7 @@ _gather_45_rule(Parser *p)
 static asdl_seq *
 _loop0_46_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28645,7 +28645,7 @@ _loop0_46_rule(Parser *p)
 static asdl_seq *
 _gather_47_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28686,7 +28686,7 @@ _gather_47_rule(Parser *p)
 static void *
 _tmp_48_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28743,7 +28743,7 @@ _tmp_48_rule(Parser *p)
 static asdl_seq *
 _loop0_49_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28819,7 +28819,7 @@ _loop0_49_rule(Parser *p)
 static asdl_seq *
 _gather_50_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28860,7 +28860,7 @@ _gather_50_rule(Parser *p)
 static asdl_seq *
 _loop0_51_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28936,7 +28936,7 @@ _loop0_51_rule(Parser *p)
 static asdl_seq *
 _gather_52_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -28977,7 +28977,7 @@ _gather_52_rule(Parser *p)
 static asdl_seq *
 _loop0_53_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29053,7 +29053,7 @@ _loop0_53_rule(Parser *p)
 static asdl_seq *
 _gather_54_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29094,7 +29094,7 @@ _gather_54_rule(Parser *p)
 static asdl_seq *
 _loop1_55_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29166,7 +29166,7 @@ _loop1_55_rule(Parser *p)
 static asdl_seq *
 _loop1_56_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29238,7 +29238,7 @@ _loop1_56_rule(Parser *p)
 static asdl_seq *
 _loop0_57_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29314,7 +29314,7 @@ _loop0_57_rule(Parser *p)
 static asdl_seq *
 _gather_58_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29355,7 +29355,7 @@ _gather_58_rule(Parser *p)
 static asdl_seq *
 _loop1_59_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29427,7 +29427,7 @@ _loop1_59_rule(Parser *p)
 static asdl_seq *
 _loop1_60_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29499,7 +29499,7 @@ _loop1_60_rule(Parser *p)
 static asdl_seq *
 _loop1_61_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29571,7 +29571,7 @@ _loop1_61_rule(Parser *p)
 static void *
 _tmp_62_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29614,7 +29614,7 @@ _tmp_62_rule(Parser *p)
 static asdl_seq *
 _loop0_63_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29690,7 +29690,7 @@ _loop0_63_rule(Parser *p)
 static asdl_seq *
 _gather_64_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29731,7 +29731,7 @@ _gather_64_rule(Parser *p)
 static void *
 _tmp_65_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29777,7 +29777,7 @@ _tmp_65_rule(Parser *p)
 static void *
 _tmp_66_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29834,7 +29834,7 @@ _tmp_66_rule(Parser *p)
 static void *
 _tmp_67_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29910,7 +29910,7 @@ _tmp_67_rule(Parser *p)
 static void *
 _tmp_68_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -29967,7 +29967,7 @@ _tmp_68_rule(Parser *p)
 static void *
 _tmp_69_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30062,7 +30062,7 @@ _tmp_69_rule(Parser *p)
 static void *
 _tmp_70_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30119,7 +30119,7 @@ _tmp_70_rule(Parser *p)
 static asdl_seq *
 _loop0_71_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30186,7 +30186,7 @@ _loop0_71_rule(Parser *p)
 static asdl_seq *
 _loop0_72_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30253,7 +30253,7 @@ _loop0_72_rule(Parser *p)
 static asdl_seq *
 _loop1_73_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30325,7 +30325,7 @@ _loop1_73_rule(Parser *p)
 static asdl_seq *
 _loop1_74_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30397,7 +30397,7 @@ _loop1_74_rule(Parser *p)
 static asdl_seq *
 _loop0_75_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30464,7 +30464,7 @@ _loop0_75_rule(Parser *p)
 static asdl_seq *
 _loop1_76_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30536,7 +30536,7 @@ _loop1_76_rule(Parser *p)
 static asdl_seq *
 _loop0_77_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30603,7 +30603,7 @@ _loop0_77_rule(Parser *p)
 static asdl_seq *
 _loop0_78_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30670,7 +30670,7 @@ _loop0_78_rule(Parser *p)
 static asdl_seq *
 _loop1_79_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30742,7 +30742,7 @@ _loop1_79_rule(Parser *p)
 static void *
 _tmp_80_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30791,7 +30791,7 @@ _tmp_80_rule(Parser *p)
 static asdl_seq *
 _loop0_81_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30867,7 +30867,7 @@ _loop0_81_rule(Parser *p)
 static asdl_seq *
 _gather_82_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30908,7 +30908,7 @@ _gather_82_rule(Parser *p)
 static asdl_seq *
 _loop1_83_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -30980,7 +30980,7 @@ _loop1_83_rule(Parser *p)
 static asdl_seq *
 _loop0_84_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31047,7 +31047,7 @@ _loop0_84_rule(Parser *p)
 static void *
 _tmp_85_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31106,7 +31106,7 @@ _tmp_85_rule(Parser *p)
 static asdl_seq *
 _loop0_86_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31183,7 +31183,7 @@ _loop0_86_rule(Parser *p)
 static asdl_seq *
 _gather_87_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31224,7 +31224,7 @@ _gather_87_rule(Parser *p)
 static void *
 _tmp_88_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31270,7 +31270,7 @@ _tmp_88_rule(Parser *p)
 static asdl_seq *
 _loop0_89_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31346,7 +31346,7 @@ _loop0_89_rule(Parser *p)
 static asdl_seq *
 _gather_90_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31387,7 +31387,7 @@ _gather_90_rule(Parser *p)
 static asdl_seq *
 _loop0_91_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31463,7 +31463,7 @@ _loop0_91_rule(Parser *p)
 static asdl_seq *
 _gather_92_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31504,7 +31504,7 @@ _gather_92_rule(Parser *p)
 static asdl_seq *
 _loop0_93_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31571,7 +31571,7 @@ _loop0_93_rule(Parser *p)
 static asdl_seq *
 _loop0_94_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31647,7 +31647,7 @@ _loop0_94_rule(Parser *p)
 static asdl_seq *
 _gather_95_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31688,7 +31688,7 @@ _gather_95_rule(Parser *p)
 static asdl_seq *
 _loop1_96_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31760,7 +31760,7 @@ _loop1_96_rule(Parser *p)
 static void *
 _tmp_97_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31800,7 +31800,7 @@ _tmp_97_rule(Parser *p)
 static asdl_seq *
 _loop0_98_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31876,7 +31876,7 @@ _loop0_98_rule(Parser *p)
 static asdl_seq *
 _gather_99_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31917,7 +31917,7 @@ _gather_99_rule(Parser *p)
 static asdl_seq *
 _loop0_100_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -31993,7 +31993,7 @@ _loop0_100_rule(Parser *p)
 static asdl_seq *
 _gather_101_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32034,7 +32034,7 @@ _gather_101_rule(Parser *p)
 static void *
 _tmp_102_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32077,7 +32077,7 @@ _tmp_102_rule(Parser *p)
 static void *
 _tmp_103_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32134,7 +32134,7 @@ _tmp_103_rule(Parser *p)
 static asdl_seq *
 _loop0_104_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32210,7 +32210,7 @@ _loop0_104_rule(Parser *p)
 static asdl_seq *
 _gather_105_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32251,7 +32251,7 @@ _gather_105_rule(Parser *p)
 static void *
 _tmp_106_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32311,7 +32311,7 @@ _tmp_106_rule(Parser *p)
 static void *
 _tmp_107_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32352,7 +32352,7 @@ _tmp_107_rule(Parser *p)
 static void *
 _tmp_108_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32409,7 +32409,7 @@ _tmp_108_rule(Parser *p)
 static void *
 _tmp_109_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32485,7 +32485,7 @@ _tmp_109_rule(Parser *p)
 static void *
 _tmp_110_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32526,7 +32526,7 @@ _tmp_110_rule(Parser *p)
 static asdl_seq *
 _loop1_111_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32598,7 +32598,7 @@ _loop1_111_rule(Parser *p)
 static void *
 _tmp_112_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32658,7 +32658,7 @@ _tmp_112_rule(Parser *p)
 static void *
 _tmp_113_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32715,7 +32715,7 @@ _tmp_113_rule(Parser *p)
 static void *
 _tmp_114_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32791,7 +32791,7 @@ _tmp_114_rule(Parser *p)
 static void *
 _tmp_115_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32848,7 +32848,7 @@ _tmp_115_rule(Parser *p)
 static void *
 _tmp_116_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -32981,7 +32981,7 @@ _tmp_116_rule(Parser *p)
 static asdl_seq *
 _loop0_117_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33048,7 +33048,7 @@ _loop0_117_rule(Parser *p)
 static asdl_seq *
 _loop0_118_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33115,7 +33115,7 @@ _loop0_118_rule(Parser *p)
 static void *
 _tmp_119_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33191,7 +33191,7 @@ _tmp_119_rule(Parser *p)
 static void *
 _tmp_120_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33248,7 +33248,7 @@ _tmp_120_rule(Parser *p)
 static void *
 _tmp_121_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33305,7 +33305,7 @@ _tmp_121_rule(Parser *p)
 static void *
 _tmp_122_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33362,7 +33362,7 @@ _tmp_122_rule(Parser *p)
 static void *
 _tmp_123_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33419,7 +33419,7 @@ _tmp_123_rule(Parser *p)
 static void *
 _tmp_124_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33479,7 +33479,7 @@ _tmp_124_rule(Parser *p)
 static void *
 _tmp_125_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33536,7 +33536,7 @@ _tmp_125_rule(Parser *p)
 static void *
 _tmp_126_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33612,7 +33612,7 @@ _tmp_126_rule(Parser *p)
 static void *
 _tmp_127_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33669,7 +33669,7 @@ _tmp_127_rule(Parser *p)
 static asdl_seq *
 _loop0_128_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33745,7 +33745,7 @@ _loop0_128_rule(Parser *p)
 static asdl_seq *
 _gather_129_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33786,7 +33786,7 @@ _gather_129_rule(Parser *p)
 static void *
 _tmp_130_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33843,7 +33843,7 @@ _tmp_130_rule(Parser *p)
 static void *
 _tmp_131_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33903,7 +33903,7 @@ _tmp_131_rule(Parser *p)
 static void *
 _tmp_132_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -33960,7 +33960,7 @@ _tmp_132_rule(Parser *p)
 static void *
 _tmp_133_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34005,7 +34005,7 @@ _tmp_133_rule(Parser *p)
 static asdl_seq *
 _loop0_134_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34081,7 +34081,7 @@ _loop0_134_rule(Parser *p)
 static asdl_seq *
 _gather_135_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34122,7 +34122,7 @@ _gather_135_rule(Parser *p)
 static asdl_seq *
 _loop0_136_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34198,7 +34198,7 @@ _loop0_136_rule(Parser *p)
 static asdl_seq *
 _gather_137_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34239,7 +34239,7 @@ _gather_137_rule(Parser *p)
 static asdl_seq *
 _loop0_138_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34315,7 +34315,7 @@ _loop0_138_rule(Parser *p)
 static asdl_seq *
 _gather_139_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34356,7 +34356,7 @@ _gather_139_rule(Parser *p)
 static void *
 _tmp_140_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34413,7 +34413,7 @@ _tmp_140_rule(Parser *p)
 static asdl_seq *
 _loop0_141_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34480,7 +34480,7 @@ _loop0_141_rule(Parser *p)
 static void *
 _tmp_142_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34522,7 +34522,7 @@ _tmp_142_rule(Parser *p)
 static void *
 _tmp_143_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34579,7 +34579,7 @@ _tmp_143_rule(Parser *p)
 static void *
 _tmp_144_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34620,7 +34620,7 @@ _tmp_144_rule(Parser *p)
 static void *
 _tmp_145_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34677,7 +34677,7 @@ _tmp_145_rule(Parser *p)
 static void *
 _tmp_146_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34772,7 +34772,7 @@ _tmp_146_rule(Parser *p)
 static void *
 _tmp_147_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34848,7 +34848,7 @@ _tmp_147_rule(Parser *p)
 static void *
 _tmp_148_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34889,7 +34889,7 @@ _tmp_148_rule(Parser *p)
 static void *
 _tmp_149_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -34946,7 +34946,7 @@ _tmp_149_rule(Parser *p)
 static void *
 _tmp_150_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35098,7 +35098,7 @@ _tmp_150_rule(Parser *p)
 static void *
 _tmp_151_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35174,7 +35174,7 @@ _tmp_151_rule(Parser *p)
 static void *
 _tmp_152_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35220,7 +35220,7 @@ _tmp_152_rule(Parser *p)
 static void *
 _tmp_153_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35277,7 +35277,7 @@ _tmp_153_rule(Parser *p)
 static void *
 _tmp_154_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35326,7 +35326,7 @@ _tmp_154_rule(Parser *p)
 static void *
 _tmp_155_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35372,7 +35372,7 @@ _tmp_155_rule(Parser *p)
 static void *
 _tmp_156_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35418,7 +35418,7 @@ _tmp_156_rule(Parser *p)
 static void *
 _tmp_157_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35464,7 +35464,7 @@ _tmp_157_rule(Parser *p)
 static void *
 _tmp_158_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35521,7 +35521,7 @@ _tmp_158_rule(Parser *p)
 static void *
 _tmp_159_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35578,7 +35578,7 @@ _tmp_159_rule(Parser *p)
 static void *
 _tmp_160_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35624,7 +35624,7 @@ _tmp_160_rule(Parser *p)
 static void *
 _tmp_161_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35683,7 +35683,7 @@ _tmp_161_rule(Parser *p)
 static void *
 _tmp_162_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35730,7 +35730,7 @@ _tmp_162_rule(Parser *p)
 static void *
 _tmp_163_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35774,7 +35774,7 @@ _tmp_163_rule(Parser *p)
 static void *
 _tmp_164_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35814,7 +35814,7 @@ _tmp_164_rule(Parser *p)
 static void *
 _tmp_165_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35854,7 +35854,7 @@ _tmp_165_rule(Parser *p)
 static void *
 _tmp_166_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35911,7 +35911,7 @@ _tmp_166_rule(Parser *p)
 static void *
 _tmp_167_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -35968,7 +35968,7 @@ _tmp_167_rule(Parser *p)
 static asdl_seq *
 _loop0_168_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -36035,7 +36035,7 @@ _loop0_168_rule(Parser *p)
 static void *
 _tmp_169_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -36077,7 +36077,7 @@ _tmp_169_rule(Parser *p)
 static void *
 _tmp_170_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -36119,7 +36119,7 @@ _tmp_170_rule(Parser *p)
 static void *
 _tmp_171_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {
@@ -36160,7 +36160,7 @@ _tmp_171_rule(Parser *p)
 static void *
 _tmp_172_rule(Parser *p)
 {
-    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+    if (p->level++ == MAXSTACK) {
         _Pypegen_stack_overflow(p);
     }
     if (p->error_indicator) {

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -13,6 +13,11 @@
 #include "structmember.h"
 #include <stddef.h>
 
+struct validator {
+    int recursion_depth;            /* current recursion depth */
+    int recursion_limit;            /* recursion limit */
+};
+
 // Forward declaration
 static int init_types(void *arg);
 
@@ -387,7 +392,8 @@ GENERATE_ASDL_SEQ_CONSTRUCTOR(pattern, pattern_ty)
 GENERATE_ASDL_SEQ_CONSTRUCTOR(type_ignore, type_ignore_ty)
 GENERATE_ASDL_SEQ_CONSTRUCTOR(type_param, type_param_ty)
 
-static PyObject* ast2obj_mod(struct ast_state *state, void*);
+static PyObject* ast2obj_mod(struct ast_state *state, struct validator *vstate,
+                             void*);
 static const char * const Module_fields[]={
     "body",
     "type_ignores",
@@ -408,7 +414,8 @@ static const char * const stmt_attributes[] = {
     "end_lineno",
     "end_col_offset",
 };
-static PyObject* ast2obj_stmt(struct ast_state *state, void*);
+static PyObject* ast2obj_stmt(struct ast_state *state, struct validator
+                              *vstate, void*);
 static const char * const FunctionDef_fields[]={
     "name",
     "args",
@@ -543,7 +550,8 @@ static const char * const expr_attributes[] = {
     "end_lineno",
     "end_col_offset",
 };
-static PyObject* ast2obj_expr(struct ast_state *state, void*);
+static PyObject* ast2obj_expr(struct ast_state *state, struct validator
+                              *vstate, void*);
 static const char * const BoolOp_fields[]={
     "op",
     "values",
@@ -656,12 +664,18 @@ static const char * const Slice_fields[]={
     "upper",
     "step",
 };
-static PyObject* ast2obj_expr_context(struct ast_state *state, expr_context_ty);
-static PyObject* ast2obj_boolop(struct ast_state *state, boolop_ty);
-static PyObject* ast2obj_operator(struct ast_state *state, operator_ty);
-static PyObject* ast2obj_unaryop(struct ast_state *state, unaryop_ty);
-static PyObject* ast2obj_cmpop(struct ast_state *state, cmpop_ty);
-static PyObject* ast2obj_comprehension(struct ast_state *state, void*);
+static PyObject* ast2obj_expr_context(struct ast_state *state, struct validator
+                                      *vstate, expr_context_ty);
+static PyObject* ast2obj_boolop(struct ast_state *state, struct validator
+                                *vstate, boolop_ty);
+static PyObject* ast2obj_operator(struct ast_state *state, struct validator
+                                  *vstate, operator_ty);
+static PyObject* ast2obj_unaryop(struct ast_state *state, struct validator
+                                 *vstate, unaryop_ty);
+static PyObject* ast2obj_cmpop(struct ast_state *state, struct validator
+                               *vstate, cmpop_ty);
+static PyObject* ast2obj_comprehension(struct ast_state *state, struct
+                                       validator *vstate, void*);
 static const char * const comprehension_fields[]={
     "target",
     "iter",
@@ -674,13 +688,15 @@ static const char * const excepthandler_attributes[] = {
     "end_lineno",
     "end_col_offset",
 };
-static PyObject* ast2obj_excepthandler(struct ast_state *state, void*);
+static PyObject* ast2obj_excepthandler(struct ast_state *state, struct
+                                       validator *vstate, void*);
 static const char * const ExceptHandler_fields[]={
     "type",
     "name",
     "body",
 };
-static PyObject* ast2obj_arguments(struct ast_state *state, void*);
+static PyObject* ast2obj_arguments(struct ast_state *state, struct validator
+                                   *vstate, void*);
 static const char * const arguments_fields[]={
     "posonlyargs",
     "args",
@@ -690,7 +706,8 @@ static const char * const arguments_fields[]={
     "kwarg",
     "defaults",
 };
-static PyObject* ast2obj_arg(struct ast_state *state, void*);
+static PyObject* ast2obj_arg(struct ast_state *state, struct validator *vstate,
+                             void*);
 static const char * const arg_attributes[] = {
     "lineno",
     "col_offset",
@@ -702,7 +719,8 @@ static const char * const arg_fields[]={
     "annotation",
     "type_comment",
 };
-static PyObject* ast2obj_keyword(struct ast_state *state, void*);
+static PyObject* ast2obj_keyword(struct ast_state *state, struct validator
+                                 *vstate, void*);
 static const char * const keyword_attributes[] = {
     "lineno",
     "col_offset",
@@ -713,7 +731,8 @@ static const char * const keyword_fields[]={
     "arg",
     "value",
 };
-static PyObject* ast2obj_alias(struct ast_state *state, void*);
+static PyObject* ast2obj_alias(struct ast_state *state, struct validator
+                               *vstate, void*);
 static const char * const alias_attributes[] = {
     "lineno",
     "col_offset",
@@ -724,12 +743,14 @@ static const char * const alias_fields[]={
     "name",
     "asname",
 };
-static PyObject* ast2obj_withitem(struct ast_state *state, void*);
+static PyObject* ast2obj_withitem(struct ast_state *state, struct validator
+                                  *vstate, void*);
 static const char * const withitem_fields[]={
     "context_expr",
     "optional_vars",
 };
-static PyObject* ast2obj_match_case(struct ast_state *state, void*);
+static PyObject* ast2obj_match_case(struct ast_state *state, struct validator
+                                    *vstate, void*);
 static const char * const match_case_fields[]={
     "pattern",
     "guard",
@@ -741,7 +762,8 @@ static const char * const pattern_attributes[] = {
     "end_lineno",
     "end_col_offset",
 };
-static PyObject* ast2obj_pattern(struct ast_state *state, void*);
+static PyObject* ast2obj_pattern(struct ast_state *state, struct validator
+                                 *vstate, void*);
 static const char * const MatchValue_fields[]={
     "value",
 };
@@ -772,7 +794,8 @@ static const char * const MatchAs_fields[]={
 static const char * const MatchOr_fields[]={
     "patterns",
 };
-static PyObject* ast2obj_type_ignore(struct ast_state *state, void*);
+static PyObject* ast2obj_type_ignore(struct ast_state *state, struct validator
+                                     *vstate, void*);
 static const char * const TypeIgnore_fields[]={
     "lineno",
     "tag",
@@ -783,7 +806,8 @@ static const char * const type_param_attributes[] = {
     "end_lineno",
     "end_col_offset",
 };
-static PyObject* ast2obj_type_param(struct ast_state *state, void*);
+static PyObject* ast2obj_type_param(struct ast_state *state, struct validator
+                                    *vstate, void*);
 static const char * const TypeVar_fields[]={
     "name",
     "bound",
@@ -5909,8 +5933,8 @@ add_attributes(struct ast_state *state, PyObject *type, const char * const *attr
 
 /* Conversion AST -> Python */
 
-static PyObject* ast2obj_list(struct ast_state *state, asdl_seq *seq,
-                              PyObject* (*func)(struct ast_state *state, void*))
+static PyObject* ast2obj_list(struct ast_state *state, struct validator *vstate, asdl_seq *seq,
+                              PyObject* (*func)(struct ast_state *state, struct validator *vstate, void*))
 {
     Py_ssize_t i, n = asdl_seq_LEN(seq);
     PyObject *result = PyList_New(n);
@@ -5918,7 +5942,7 @@ static PyObject* ast2obj_list(struct ast_state *state, asdl_seq *seq,
     if (!result)
         return NULL;
     for (i = 0; i < n; i++) {
-        value = func(state, asdl_seq_GET_UNTYPED(seq, i));
+        value = func(state, vstate, asdl_seq_GET_UNTYPED(seq, i));
         if (!value) {
             Py_DECREF(result);
             return NULL;
@@ -5928,7 +5952,7 @@ static PyObject* ast2obj_list(struct ast_state *state, asdl_seq *seq,
     return result;
 }
 
-static PyObject* ast2obj_object(struct ast_state *Py_UNUSED(state), void *o)
+static PyObject* ast2obj_object(struct ast_state *Py_UNUSED(state), struct validator *Py_UNUSED(vstate), void *o)
 {
     PyObject *op = (PyObject*)o;
     if (!op) {
@@ -5940,7 +5964,7 @@ static PyObject* ast2obj_object(struct ast_state *Py_UNUSED(state), void *o)
 #define ast2obj_identifier ast2obj_object
 #define ast2obj_string ast2obj_object
 
-static PyObject* ast2obj_int(struct ast_state *Py_UNUSED(state), long b)
+static PyObject* ast2obj_int(struct ast_state *Py_UNUSED(state), struct validator *Py_UNUSED(vstate), long b)
 {
     return PyLong_FromLong(b);
 }
@@ -8688,7 +8712,7 @@ _PyAST_TypeVarTuple(identifier name, expr_ty default_value, int lineno, int
 
 
 PyObject*
-ast2obj_mod(struct ast_state *state, void* _o)
+ast2obj_mod(struct ast_state *state, struct validator *vstate, void* _o)
 {
     mod_ty o = (mod_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -8696,7 +8720,9 @@ ast2obj_mod(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     switch (o->kind) {
@@ -8704,12 +8730,14 @@ ast2obj_mod(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Module_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.Module.body, ast2obj_stmt);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Module.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.Module.type_ignores,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.Module.type_ignores,
                              ast2obj_type_ignore);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_ignores, value) == -1)
@@ -8720,7 +8748,7 @@ ast2obj_mod(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Interactive_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.Interactive.body,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Interactive.body,
                              ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
@@ -8731,7 +8759,7 @@ ast2obj_mod(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Expression_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Expression.body);
+        value = ast2obj_expr(state, vstate, o->v.Expression.body);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
@@ -8741,30 +8769,31 @@ ast2obj_mod(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->FunctionType_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.FunctionType.argtypes,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.FunctionType.argtypes,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->argtypes, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.FunctionType.returns);
+        value = ast2obj_expr(state, vstate, o->v.FunctionType.returns);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->returns, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     }
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_stmt(struct ast_state *state, void* _o)
+ast2obj_stmt(struct ast_state *state, struct validator *vstate, void* _o)
 {
     stmt_ty o = (stmt_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -8772,7 +8801,9 @@ ast2obj_stmt(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     switch (o->kind) {
@@ -8780,39 +8811,41 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->FunctionDef_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.FunctionDef.name);
+        value = ast2obj_identifier(state, vstate, o->v.FunctionDef.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_arguments(state, o->v.FunctionDef.args);
+        value = ast2obj_arguments(state, vstate, o->v.FunctionDef.args);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->args, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.FunctionDef.body,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.FunctionDef.body,
                              ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.FunctionDef.decorator_list,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.FunctionDef.decorator_list,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->decorator_list, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.FunctionDef.returns);
+        value = ast2obj_expr(state, vstate, o->v.FunctionDef.returns);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->returns, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(state, o->v.FunctionDef.type_comment);
+        value = ast2obj_string(state, vstate, o->v.FunctionDef.type_comment);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.FunctionDef.type_params,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.FunctionDef.type_params,
                              ast2obj_type_param);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_params, value) == -1)
@@ -8823,40 +8856,41 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->AsyncFunctionDef_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.AsyncFunctionDef.name);
+        value = ast2obj_identifier(state, vstate, o->v.AsyncFunctionDef.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_arguments(state, o->v.AsyncFunctionDef.args);
+        value = ast2obj_arguments(state, vstate, o->v.AsyncFunctionDef.args);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->args, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.AsyncFunctionDef.body,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.AsyncFunctionDef.body,
                              ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state,
+        value = ast2obj_list(state, vstate,
                              (asdl_seq*)o->v.AsyncFunctionDef.decorator_list,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->decorator_list, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.AsyncFunctionDef.returns);
+        value = ast2obj_expr(state, vstate, o->v.AsyncFunctionDef.returns);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->returns, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(state, o->v.AsyncFunctionDef.type_comment);
+        value = ast2obj_string(state, vstate, o->v.AsyncFunctionDef.type_comment);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state,
+        value = ast2obj_list(state, vstate,
                              (asdl_seq*)o->v.AsyncFunctionDef.type_params,
                              ast2obj_type_param);
         if (!value) goto failed;
@@ -8868,36 +8902,38 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->ClassDef_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.ClassDef.name);
+        value = ast2obj_identifier(state, vstate, o->v.ClassDef.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.ClassDef.bases,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.ClassDef.bases,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->bases, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.ClassDef.keywords,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.ClassDef.keywords,
                              ast2obj_keyword);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->keywords, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.ClassDef.body,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.ClassDef.body,
                              ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.ClassDef.decorator_list,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.ClassDef.decorator_list,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->decorator_list, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.ClassDef.type_params,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.ClassDef.type_params,
                              ast2obj_type_param);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_params, value) == -1)
@@ -8908,7 +8944,7 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Return_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Return.value);
+        value = ast2obj_expr(state, vstate, o->v.Return.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
@@ -8918,7 +8954,7 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Delete_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.Delete.targets,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Delete.targets,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->targets, value) == -1)
@@ -8929,18 +8965,18 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Assign_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.Assign.targets,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Assign.targets,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->targets, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.Assign.value);
+        value = ast2obj_expr(state, vstate, o->v.Assign.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(state, o->v.Assign.type_comment);
+        value = ast2obj_string(state, vstate, o->v.Assign.type_comment);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
@@ -8950,18 +8986,19 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->TypeAlias_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.TypeAlias.name);
+        value = ast2obj_expr(state, vstate, o->v.TypeAlias.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.TypeAlias.type_params,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.TypeAlias.type_params,
                              ast2obj_type_param);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_params, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.TypeAlias.value);
+        value = ast2obj_expr(state, vstate, o->v.TypeAlias.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
@@ -8971,17 +9008,17 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->AugAssign_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.AugAssign.target);
+        value = ast2obj_expr(state, vstate, o->v.AugAssign.target);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->target, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_operator(state, o->v.AugAssign.op);
+        value = ast2obj_operator(state, vstate, o->v.AugAssign.op);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->op, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.AugAssign.value);
+        value = ast2obj_expr(state, vstate, o->v.AugAssign.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
@@ -8991,22 +9028,22 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->AnnAssign_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.AnnAssign.target);
+        value = ast2obj_expr(state, vstate, o->v.AnnAssign.target);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->target, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.AnnAssign.annotation);
+        value = ast2obj_expr(state, vstate, o->v.AnnAssign.annotation);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->annotation, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.AnnAssign.value);
+        value = ast2obj_expr(state, vstate, o->v.AnnAssign.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_int(state, o->v.AnnAssign.simple);
+        value = ast2obj_int(state, vstate, o->v.AnnAssign.simple);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->simple, value) == -1)
             goto failed;
@@ -9016,27 +9053,29 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->For_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.For.target);
+        value = ast2obj_expr(state, vstate, o->v.For.target);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->target, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.For.iter);
+        value = ast2obj_expr(state, vstate, o->v.For.iter);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->iter, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.For.body, ast2obj_stmt);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.For.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.For.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.For.orelse,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(state, o->v.For.type_comment);
+        value = ast2obj_string(state, vstate, o->v.For.type_comment);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
@@ -9046,29 +9085,29 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->AsyncFor_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.AsyncFor.target);
+        value = ast2obj_expr(state, vstate, o->v.AsyncFor.target);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->target, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.AsyncFor.iter);
+        value = ast2obj_expr(state, vstate, o->v.AsyncFor.iter);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->iter, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.AsyncFor.body,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.AsyncFor.body,
                              ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.AsyncFor.orelse,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.AsyncFor.orelse,
                              ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(state, o->v.AsyncFor.type_comment);
+        value = ast2obj_string(state, vstate, o->v.AsyncFor.type_comment);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
@@ -9078,17 +9117,19 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->While_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.While.test);
+        value = ast2obj_expr(state, vstate, o->v.While.test);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->test, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.While.body, ast2obj_stmt);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.While.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.While.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.While.orelse,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
@@ -9098,17 +9139,19 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->If_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.If.test);
+        value = ast2obj_expr(state, vstate, o->v.If.test);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->test, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.If.body, ast2obj_stmt);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.If.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.If.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.If.orelse,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
@@ -9118,18 +9161,19 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->With_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.With.items,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.With.items,
                              ast2obj_withitem);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->items, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.With.body, ast2obj_stmt);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.With.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(state, o->v.With.type_comment);
+        value = ast2obj_string(state, vstate, o->v.With.type_comment);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
@@ -9139,19 +9183,19 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->AsyncWith_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.AsyncWith.items,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.AsyncWith.items,
                              ast2obj_withitem);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->items, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.AsyncWith.body,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.AsyncWith.body,
                              ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(state, o->v.AsyncWith.type_comment);
+        value = ast2obj_string(state, vstate, o->v.AsyncWith.type_comment);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type_comment, value) == -1)
             goto failed;
@@ -9161,12 +9205,12 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Match_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Match.subject);
+        value = ast2obj_expr(state, vstate, o->v.Match.subject);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->subject, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.Match.cases,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Match.cases,
                              ast2obj_match_case);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->cases, value) == -1)
@@ -9177,12 +9221,12 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Raise_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Raise.exc);
+        value = ast2obj_expr(state, vstate, o->v.Raise.exc);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->exc, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.Raise.cause);
+        value = ast2obj_expr(state, vstate, o->v.Raise.cause);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->cause, value) == -1)
             goto failed;
@@ -9192,23 +9236,25 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Try_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.Try.body, ast2obj_stmt);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Try.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.Try.handlers,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Try.handlers,
                              ast2obj_excepthandler);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->handlers, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.Try.orelse, ast2obj_stmt);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Try.orelse,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.Try.finalbody,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Try.finalbody,
                              ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->finalbody, value) == -1)
@@ -9219,24 +9265,25 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->TryStar_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.TryStar.body, ast2obj_stmt);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.TryStar.body,
+                             ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.TryStar.handlers,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.TryStar.handlers,
                              ast2obj_excepthandler);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->handlers, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.TryStar.orelse,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.TryStar.orelse,
                              ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.TryStar.finalbody,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.TryStar.finalbody,
                              ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->finalbody, value) == -1)
@@ -9247,12 +9294,12 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Assert_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Assert.test);
+        value = ast2obj_expr(state, vstate, o->v.Assert.test);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->test, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.Assert.msg);
+        value = ast2obj_expr(state, vstate, o->v.Assert.msg);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->msg, value) == -1)
             goto failed;
@@ -9262,7 +9309,7 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Import_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.Import.names,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Import.names,
                              ast2obj_alias);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->names, value) == -1)
@@ -9273,18 +9320,18 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->ImportFrom_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.ImportFrom.module);
+        value = ast2obj_identifier(state, vstate, o->v.ImportFrom.module);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->module, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.ImportFrom.names,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.ImportFrom.names,
                              ast2obj_alias);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->names, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_int(state, o->v.ImportFrom.level);
+        value = ast2obj_int(state, vstate, o->v.ImportFrom.level);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->level, value) == -1)
             goto failed;
@@ -9294,7 +9341,7 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Global_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.Global.names,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Global.names,
                              ast2obj_identifier);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->names, value) == -1)
@@ -9305,7 +9352,7 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Nonlocal_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.Nonlocal.names,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Nonlocal.names,
                              ast2obj_identifier);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->names, value) == -1)
@@ -9316,7 +9363,7 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Expr_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Expr.value);
+        value = ast2obj_expr(state, vstate, o->v.Expr.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
@@ -9338,37 +9385,37 @@ ast2obj_stmt(struct ast_state *state, void* _o)
         if (!result) goto failed;
         break;
     }
-    value = ast2obj_int(state, o->lineno);
+    value = ast2obj_int(state, vstate, o->lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->col_offset);
+    value = ast2obj_int(state, vstate, o->col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_lineno);
+    value = ast2obj_int(state, vstate, o->end_lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_col_offset);
+    value = ast2obj_int(state, vstate, o->end_col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_expr(struct ast_state *state, void* _o)
+ast2obj_expr(struct ast_state *state, struct validator *vstate, void* _o)
 {
     expr_ty o = (expr_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -9376,7 +9423,9 @@ ast2obj_expr(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     switch (o->kind) {
@@ -9384,12 +9433,12 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->BoolOp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_boolop(state, o->v.BoolOp.op);
+        value = ast2obj_boolop(state, vstate, o->v.BoolOp.op);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->op, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.BoolOp.values,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.BoolOp.values,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->values, value) == -1)
@@ -9400,12 +9449,12 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->NamedExpr_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.NamedExpr.target);
+        value = ast2obj_expr(state, vstate, o->v.NamedExpr.target);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->target, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.NamedExpr.value);
+        value = ast2obj_expr(state, vstate, o->v.NamedExpr.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
@@ -9415,17 +9464,17 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->BinOp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.BinOp.left);
+        value = ast2obj_expr(state, vstate, o->v.BinOp.left);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->left, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_operator(state, o->v.BinOp.op);
+        value = ast2obj_operator(state, vstate, o->v.BinOp.op);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->op, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.BinOp.right);
+        value = ast2obj_expr(state, vstate, o->v.BinOp.right);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->right, value) == -1)
             goto failed;
@@ -9435,12 +9484,12 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->UnaryOp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_unaryop(state, o->v.UnaryOp.op);
+        value = ast2obj_unaryop(state, vstate, o->v.UnaryOp.op);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->op, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.UnaryOp.operand);
+        value = ast2obj_expr(state, vstate, o->v.UnaryOp.operand);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->operand, value) == -1)
             goto failed;
@@ -9450,12 +9499,12 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Lambda_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_arguments(state, o->v.Lambda.args);
+        value = ast2obj_arguments(state, vstate, o->v.Lambda.args);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->args, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.Lambda.body);
+        value = ast2obj_expr(state, vstate, o->v.Lambda.body);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
@@ -9465,17 +9514,17 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->IfExp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.IfExp.test);
+        value = ast2obj_expr(state, vstate, o->v.IfExp.test);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->test, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.IfExp.body);
+        value = ast2obj_expr(state, vstate, o->v.IfExp.body);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.IfExp.orelse);
+        value = ast2obj_expr(state, vstate, o->v.IfExp.orelse);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->orelse, value) == -1)
             goto failed;
@@ -9485,12 +9534,14 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Dict_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.Dict.keys, ast2obj_expr);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Dict.keys,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->keys, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.Dict.values, ast2obj_expr);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Dict.values,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->values, value) == -1)
             goto failed;
@@ -9500,7 +9551,8 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Set_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.Set.elts, ast2obj_expr);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Set.elts,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->elts, value) == -1)
             goto failed;
@@ -9510,12 +9562,13 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->ListComp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.ListComp.elt);
+        value = ast2obj_expr(state, vstate, o->v.ListComp.elt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.ListComp.generators,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.ListComp.generators,
                              ast2obj_comprehension);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->generators, value) == -1)
@@ -9526,12 +9579,12 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->SetComp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.SetComp.elt);
+        value = ast2obj_expr(state, vstate, o->v.SetComp.elt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.SetComp.generators,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.SetComp.generators,
                              ast2obj_comprehension);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->generators, value) == -1)
@@ -9542,17 +9595,18 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->DictComp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.DictComp.key);
+        value = ast2obj_expr(state, vstate, o->v.DictComp.key);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->key, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.DictComp.value);
+        value = ast2obj_expr(state, vstate, o->v.DictComp.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.DictComp.generators,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.DictComp.generators,
                              ast2obj_comprehension);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->generators, value) == -1)
@@ -9563,12 +9617,13 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->GeneratorExp_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.GeneratorExp.elt);
+        value = ast2obj_expr(state, vstate, o->v.GeneratorExp.elt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->elt, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.GeneratorExp.generators,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.GeneratorExp.generators,
                              ast2obj_comprehension);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->generators, value) == -1)
@@ -9579,7 +9634,7 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Await_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Await.value);
+        value = ast2obj_expr(state, vstate, o->v.Await.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
@@ -9589,7 +9644,7 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Yield_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Yield.value);
+        value = ast2obj_expr(state, vstate, o->v.Yield.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
@@ -9599,7 +9654,7 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->YieldFrom_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.YieldFrom.value);
+        value = ast2obj_expr(state, vstate, o->v.YieldFrom.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
@@ -9609,7 +9664,7 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Compare_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Compare.left);
+        value = ast2obj_expr(state, vstate, o->v.Compare.left);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->left, value) == -1)
             goto failed;
@@ -9619,14 +9674,14 @@ ast2obj_expr(struct ast_state *state, void* _o)
             value = PyList_New(n);
             if (!value) goto failed;
             for(i = 0; i < n; i++)
-                PyList_SET_ITEM(value, i, ast2obj_cmpop(state, (cmpop_ty)asdl_seq_GET(o->v.Compare.ops, i)));
+                PyList_SET_ITEM(value, i, ast2obj_cmpop(state, vstate, (cmpop_ty)asdl_seq_GET(o->v.Compare.ops, i)));
         }
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->ops, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.Compare.comparators,
-                             ast2obj_expr);
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.Compare.comparators, ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->comparators, value) == -1)
             goto failed;
@@ -9636,17 +9691,18 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Call_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Call.func);
+        value = ast2obj_expr(state, vstate, o->v.Call.func);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->func, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.Call.args, ast2obj_expr);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Call.args,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->args, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.Call.keywords,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Call.keywords,
                              ast2obj_keyword);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->keywords, value) == -1)
@@ -9657,17 +9713,17 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->FormattedValue_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.FormattedValue.value);
+        value = ast2obj_expr(state, vstate, o->v.FormattedValue.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_int(state, o->v.FormattedValue.conversion);
+        value = ast2obj_int(state, vstate, o->v.FormattedValue.conversion);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->conversion, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.FormattedValue.format_spec);
+        value = ast2obj_expr(state, vstate, o->v.FormattedValue.format_spec);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->format_spec, value) == -1)
             goto failed;
@@ -9677,7 +9733,7 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->JoinedStr_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.JoinedStr.values,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.JoinedStr.values,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->values, value) == -1)
@@ -9688,12 +9744,12 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Constant_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_constant(state, o->v.Constant.value);
+        value = ast2obj_constant(state, vstate, o->v.Constant.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(state, o->v.Constant.kind);
+        value = ast2obj_string(state, vstate, o->v.Constant.kind);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->kind, value) == -1)
             goto failed;
@@ -9703,17 +9759,17 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Attribute_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Attribute.value);
+        value = ast2obj_expr(state, vstate, o->v.Attribute.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_identifier(state, o->v.Attribute.attr);
+        value = ast2obj_identifier(state, vstate, o->v.Attribute.attr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->attr, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(state, o->v.Attribute.ctx);
+        value = ast2obj_expr_context(state, vstate, o->v.Attribute.ctx);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
@@ -9723,17 +9779,17 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Subscript_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Subscript.value);
+        value = ast2obj_expr(state, vstate, o->v.Subscript.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.Subscript.slice);
+        value = ast2obj_expr(state, vstate, o->v.Subscript.slice);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->slice, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(state, o->v.Subscript.ctx);
+        value = ast2obj_expr_context(state, vstate, o->v.Subscript.ctx);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
@@ -9743,12 +9799,12 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Starred_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Starred.value);
+        value = ast2obj_expr(state, vstate, o->v.Starred.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(state, o->v.Starred.ctx);
+        value = ast2obj_expr_context(state, vstate, o->v.Starred.ctx);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
@@ -9758,12 +9814,12 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Name_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.Name.id);
+        value = ast2obj_identifier(state, vstate, o->v.Name.id);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->id, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(state, o->v.Name.ctx);
+        value = ast2obj_expr_context(state, vstate, o->v.Name.ctx);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
@@ -9773,12 +9829,13 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->List_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.List.elts, ast2obj_expr);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.List.elts,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->elts, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(state, o->v.List.ctx);
+        value = ast2obj_expr_context(state, vstate, o->v.List.ctx);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
@@ -9788,12 +9845,13 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Tuple_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.Tuple.elts, ast2obj_expr);
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.Tuple.elts,
+                             ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->elts, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr_context(state, o->v.Tuple.ctx);
+        value = ast2obj_expr_context(state, vstate, o->v.Tuple.ctx);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->ctx, value) == -1)
             goto failed;
@@ -9803,53 +9861,54 @@ ast2obj_expr(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->Slice_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.Slice.lower);
+        value = ast2obj_expr(state, vstate, o->v.Slice.lower);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->lower, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.Slice.upper);
+        value = ast2obj_expr(state, vstate, o->v.Slice.upper);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->upper, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.Slice.step);
+        value = ast2obj_expr(state, vstate, o->v.Slice.step);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->step, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     }
-    value = ast2obj_int(state, o->lineno);
+    value = ast2obj_int(state, vstate, o->lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->col_offset);
+    value = ast2obj_int(state, vstate, o->col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_lineno);
+    value = ast2obj_int(state, vstate, o->end_lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_col_offset);
+    value = ast2obj_int(state, vstate, o->end_col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
-PyObject* ast2obj_expr_context(struct ast_state *state, expr_context_ty o)
+PyObject* ast2obj_expr_context(struct ast_state *state, struct validator
+                               *vstate, expr_context_ty o)
 {
     switch(o) {
         case Load:
@@ -9861,7 +9920,8 @@ PyObject* ast2obj_expr_context(struct ast_state *state, expr_context_ty o)
     }
     Py_UNREACHABLE();
 }
-PyObject* ast2obj_boolop(struct ast_state *state, boolop_ty o)
+PyObject* ast2obj_boolop(struct ast_state *state, struct validator *vstate,
+                         boolop_ty o)
 {
     switch(o) {
         case And:
@@ -9871,7 +9931,8 @@ PyObject* ast2obj_boolop(struct ast_state *state, boolop_ty o)
     }
     Py_UNREACHABLE();
 }
-PyObject* ast2obj_operator(struct ast_state *state, operator_ty o)
+PyObject* ast2obj_operator(struct ast_state *state, struct validator *vstate,
+                           operator_ty o)
 {
     switch(o) {
         case Add:
@@ -9903,7 +9964,8 @@ PyObject* ast2obj_operator(struct ast_state *state, operator_ty o)
     }
     Py_UNREACHABLE();
 }
-PyObject* ast2obj_unaryop(struct ast_state *state, unaryop_ty o)
+PyObject* ast2obj_unaryop(struct ast_state *state, struct validator *vstate,
+                          unaryop_ty o)
 {
     switch(o) {
         case Invert:
@@ -9917,7 +9979,8 @@ PyObject* ast2obj_unaryop(struct ast_state *state, unaryop_ty o)
     }
     Py_UNREACHABLE();
 }
-PyObject* ast2obj_cmpop(struct ast_state *state, cmpop_ty o)
+PyObject* ast2obj_cmpop(struct ast_state *state, struct validator *vstate,
+                        cmpop_ty o)
 {
     switch(o) {
         case Eq:
@@ -9944,7 +10007,8 @@ PyObject* ast2obj_cmpop(struct ast_state *state, cmpop_ty o)
     Py_UNREACHABLE();
 }
 PyObject*
-ast2obj_comprehension(struct ast_state *state, void* _o)
+ast2obj_comprehension(struct ast_state *state, struct validator *vstate, void*
+                      _o)
 {
     comprehension_ty o = (comprehension_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -9952,43 +10016,46 @@ ast2obj_comprehension(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     tp = (PyTypeObject *)state->comprehension_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_expr(state, o->target);
+    value = ast2obj_expr(state, vstate, o->target);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->target, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_expr(state, o->iter);
+    value = ast2obj_expr(state, vstate, o->iter);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->iter, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(state, (asdl_seq*)o->ifs, ast2obj_expr);
+    value = ast2obj_list(state, vstate, (asdl_seq*)o->ifs, ast2obj_expr);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->ifs, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->is_async);
+    value = ast2obj_int(state, vstate, o->is_async);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->is_async, value) == -1)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_excepthandler(struct ast_state *state, void* _o)
+ast2obj_excepthandler(struct ast_state *state, struct validator *vstate, void*
+                      _o)
 {
     excepthandler_ty o = (excepthandler_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -9996,7 +10063,9 @@ ast2obj_excepthandler(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     switch (o->kind) {
@@ -10004,17 +10073,17 @@ ast2obj_excepthandler(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->ExceptHandler_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.ExceptHandler.type);
+        value = ast2obj_expr(state, vstate, o->v.ExceptHandler.type);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->type, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_identifier(state, o->v.ExceptHandler.name);
+        value = ast2obj_identifier(state, vstate, o->v.ExceptHandler.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.ExceptHandler.body,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.ExceptHandler.body,
                              ast2obj_stmt);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->body, value) == -1)
@@ -10022,37 +10091,37 @@ ast2obj_excepthandler(struct ast_state *state, void* _o)
         Py_DECREF(value);
         break;
     }
-    value = ast2obj_int(state, o->lineno);
+    value = ast2obj_int(state, vstate, o->lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->col_offset);
+    value = ast2obj_int(state, vstate, o->col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_lineno);
+    value = ast2obj_int(state, vstate, o->end_lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_col_offset);
+    value = ast2obj_int(state, vstate, o->end_col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_arguments(struct ast_state *state, void* _o)
+ast2obj_arguments(struct ast_state *state, struct validator *vstate, void* _o)
 {
     arguments_ty o = (arguments_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -10060,58 +10129,61 @@ ast2obj_arguments(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     tp = (PyTypeObject *)state->arguments_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_list(state, (asdl_seq*)o->posonlyargs, ast2obj_arg);
+    value = ast2obj_list(state, vstate, (asdl_seq*)o->posonlyargs, ast2obj_arg);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->posonlyargs, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(state, (asdl_seq*)o->args, ast2obj_arg);
+    value = ast2obj_list(state, vstate, (asdl_seq*)o->args, ast2obj_arg);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->args, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_arg(state, o->vararg);
+    value = ast2obj_arg(state, vstate, o->vararg);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->vararg, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(state, (asdl_seq*)o->kwonlyargs, ast2obj_arg);
+    value = ast2obj_list(state, vstate, (asdl_seq*)o->kwonlyargs, ast2obj_arg);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->kwonlyargs, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(state, (asdl_seq*)o->kw_defaults, ast2obj_expr);
+    value = ast2obj_list(state, vstate, (asdl_seq*)o->kw_defaults,
+                         ast2obj_expr);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->kw_defaults, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_arg(state, o->kwarg);
+    value = ast2obj_arg(state, vstate, o->kwarg);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->kwarg, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(state, (asdl_seq*)o->defaults, ast2obj_expr);
+    value = ast2obj_list(state, vstate, (asdl_seq*)o->defaults, ast2obj_expr);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->defaults, value) == -1)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_arg(struct ast_state *state, void* _o)
+ast2obj_arg(struct ast_state *state, struct validator *vstate, void* _o)
 {
     arg_ty o = (arg_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -10119,58 +10191,60 @@ ast2obj_arg(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     tp = (PyTypeObject *)state->arg_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_identifier(state, o->arg);
+    value = ast2obj_identifier(state, vstate, o->arg);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->arg, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_expr(state, o->annotation);
+    value = ast2obj_expr(state, vstate, o->annotation);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->annotation, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_string(state, o->type_comment);
+    value = ast2obj_string(state, vstate, o->type_comment);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->type_comment, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->lineno);
+    value = ast2obj_int(state, vstate, o->lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->col_offset);
+    value = ast2obj_int(state, vstate, o->col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_lineno);
+    value = ast2obj_int(state, vstate, o->end_lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_col_offset);
+    value = ast2obj_int(state, vstate, o->end_col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_keyword(struct ast_state *state, void* _o)
+ast2obj_keyword(struct ast_state *state, struct validator *vstate, void* _o)
 {
     keyword_ty o = (keyword_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -10178,53 +10252,55 @@ ast2obj_keyword(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     tp = (PyTypeObject *)state->keyword_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_identifier(state, o->arg);
+    value = ast2obj_identifier(state, vstate, o->arg);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->arg, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_expr(state, o->value);
+    value = ast2obj_expr(state, vstate, o->value);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->value, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->lineno);
+    value = ast2obj_int(state, vstate, o->lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->col_offset);
+    value = ast2obj_int(state, vstate, o->col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_lineno);
+    value = ast2obj_int(state, vstate, o->end_lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_col_offset);
+    value = ast2obj_int(state, vstate, o->end_col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_alias(struct ast_state *state, void* _o)
+ast2obj_alias(struct ast_state *state, struct validator *vstate, void* _o)
 {
     alias_ty o = (alias_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -10232,53 +10308,55 @@ ast2obj_alias(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     tp = (PyTypeObject *)state->alias_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_identifier(state, o->name);
+    value = ast2obj_identifier(state, vstate, o->name);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->name, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_identifier(state, o->asname);
+    value = ast2obj_identifier(state, vstate, o->asname);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->asname, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->lineno);
+    value = ast2obj_int(state, vstate, o->lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->col_offset);
+    value = ast2obj_int(state, vstate, o->col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_lineno);
+    value = ast2obj_int(state, vstate, o->end_lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_col_offset);
+    value = ast2obj_int(state, vstate, o->end_col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_withitem(struct ast_state *state, void* _o)
+ast2obj_withitem(struct ast_state *state, struct validator *vstate, void* _o)
 {
     withitem_ty o = (withitem_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -10286,33 +10364,35 @@ ast2obj_withitem(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     tp = (PyTypeObject *)state->withitem_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_expr(state, o->context_expr);
+    value = ast2obj_expr(state, vstate, o->context_expr);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->context_expr, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_expr(state, o->optional_vars);
+    value = ast2obj_expr(state, vstate, o->optional_vars);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->optional_vars, value) == -1)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_match_case(struct ast_state *state, void* _o)
+ast2obj_match_case(struct ast_state *state, struct validator *vstate, void* _o)
 {
     match_case_ty o = (match_case_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -10320,38 +10400,40 @@ ast2obj_match_case(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     tp = (PyTypeObject *)state->match_case_type;
     result = PyType_GenericNew(tp, NULL, NULL);
     if (!result) return NULL;
-    value = ast2obj_pattern(state, o->pattern);
+    value = ast2obj_pattern(state, vstate, o->pattern);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->pattern, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_expr(state, o->guard);
+    value = ast2obj_expr(state, vstate, o->guard);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->guard, value) == -1)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_list(state, (asdl_seq*)o->body, ast2obj_stmt);
+    value = ast2obj_list(state, vstate, (asdl_seq*)o->body, ast2obj_stmt);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->body, value) == -1)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_pattern(struct ast_state *state, void* _o)
+ast2obj_pattern(struct ast_state *state, struct validator *vstate, void* _o)
 {
     pattern_ty o = (pattern_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -10359,7 +10441,9 @@ ast2obj_pattern(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     switch (o->kind) {
@@ -10367,7 +10451,7 @@ ast2obj_pattern(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->MatchValue_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.MatchValue.value);
+        value = ast2obj_expr(state, vstate, o->v.MatchValue.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
@@ -10377,7 +10461,7 @@ ast2obj_pattern(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->MatchSingleton_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_constant(state, o->v.MatchSingleton.value);
+        value = ast2obj_constant(state, vstate, o->v.MatchSingleton.value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->value, value) == -1)
             goto failed;
@@ -10387,7 +10471,8 @@ ast2obj_pattern(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->MatchSequence_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.MatchSequence.patterns,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.MatchSequence.patterns,
                              ast2obj_pattern);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->patterns, value) == -1)
@@ -10398,19 +10483,20 @@ ast2obj_pattern(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->MatchMapping_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.MatchMapping.keys,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.MatchMapping.keys,
                              ast2obj_expr);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->keys, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.MatchMapping.patterns,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.MatchMapping.patterns,
                              ast2obj_pattern);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->patterns, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_identifier(state, o->v.MatchMapping.rest);
+        value = ast2obj_identifier(state, vstate, o->v.MatchMapping.rest);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->rest, value) == -1)
             goto failed;
@@ -10420,24 +10506,27 @@ ast2obj_pattern(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->MatchClass_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_expr(state, o->v.MatchClass.cls);
+        value = ast2obj_expr(state, vstate, o->v.MatchClass.cls);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->cls, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.MatchClass.patterns,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.MatchClass.patterns,
                              ast2obj_pattern);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->patterns, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.MatchClass.kwd_attrs,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.MatchClass.kwd_attrs,
                              ast2obj_identifier);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->kwd_attrs, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_list(state, (asdl_seq*)o->v.MatchClass.kwd_patterns,
+        value = ast2obj_list(state, vstate,
+                             (asdl_seq*)o->v.MatchClass.kwd_patterns,
                              ast2obj_pattern);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->kwd_patterns, value) == -1)
@@ -10448,7 +10537,7 @@ ast2obj_pattern(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->MatchStar_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.MatchStar.name);
+        value = ast2obj_identifier(state, vstate, o->v.MatchStar.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
@@ -10458,12 +10547,12 @@ ast2obj_pattern(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->MatchAs_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_pattern(state, o->v.MatchAs.pattern);
+        value = ast2obj_pattern(state, vstate, o->v.MatchAs.pattern);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->pattern, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_identifier(state, o->v.MatchAs.name);
+        value = ast2obj_identifier(state, vstate, o->v.MatchAs.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
@@ -10473,7 +10562,7 @@ ast2obj_pattern(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->MatchOr_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_list(state, (asdl_seq*)o->v.MatchOr.patterns,
+        value = ast2obj_list(state, vstate, (asdl_seq*)o->v.MatchOr.patterns,
                              ast2obj_pattern);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->patterns, value) == -1)
@@ -10481,37 +10570,37 @@ ast2obj_pattern(struct ast_state *state, void* _o)
         Py_DECREF(value);
         break;
     }
-    value = ast2obj_int(state, o->lineno);
+    value = ast2obj_int(state, vstate, o->lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->col_offset);
+    value = ast2obj_int(state, vstate, o->col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_lineno);
+    value = ast2obj_int(state, vstate, o->end_lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_col_offset);
+    value = ast2obj_int(state, vstate, o->end_col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_type_ignore(struct ast_state *state, void* _o)
+ast2obj_type_ignore(struct ast_state *state, struct validator *vstate, void* _o)
 {
     type_ignore_ty o = (type_ignore_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -10519,7 +10608,9 @@ ast2obj_type_ignore(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     switch (o->kind) {
@@ -10527,29 +10618,29 @@ ast2obj_type_ignore(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->TypeIgnore_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_int(state, o->v.TypeIgnore.lineno);
+        value = ast2obj_int(state, vstate, o->v.TypeIgnore.lineno);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->lineno, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_string(state, o->v.TypeIgnore.tag);
+        value = ast2obj_string(state, vstate, o->v.TypeIgnore.tag);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->tag, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     }
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
 }
 
 PyObject*
-ast2obj_type_param(struct ast_state *state, void* _o)
+ast2obj_type_param(struct ast_state *state, struct validator *vstate, void* _o)
 {
     type_param_ty o = (type_param_ty)_o;
     PyObject *result = NULL, *value = NULL;
@@ -10557,7 +10648,9 @@ ast2obj_type_param(struct ast_state *state, void* _o)
     if (!o) {
         Py_RETURN_NONE;
     }
-    if (Py_EnterRecursiveCall("during  ast construction")) {
+    if (++vstate->recursion_depth > vstate->recursion_limit) {
+        PyErr_SetString(PyExc_RecursionError,
+            "maximum recursion depth exceeded during ast construction");
         return NULL;
     }
     switch (o->kind) {
@@ -10565,17 +10658,17 @@ ast2obj_type_param(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->TypeVar_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.TypeVar.name);
+        value = ast2obj_identifier(state, vstate, o->v.TypeVar.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.TypeVar.bound);
+        value = ast2obj_expr(state, vstate, o->v.TypeVar.bound);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->bound, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.TypeVar.default_value);
+        value = ast2obj_expr(state, vstate, o->v.TypeVar.default_value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->default_value, value) == -1)
             goto failed;
@@ -10585,12 +10678,12 @@ ast2obj_type_param(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->ParamSpec_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.ParamSpec.name);
+        value = ast2obj_identifier(state, vstate, o->v.ParamSpec.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.ParamSpec.default_value);
+        value = ast2obj_expr(state, vstate, o->v.ParamSpec.default_value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->default_value, value) == -1)
             goto failed;
@@ -10600,42 +10693,42 @@ ast2obj_type_param(struct ast_state *state, void* _o)
         tp = (PyTypeObject *)state->TypeVarTuple_type;
         result = PyType_GenericNew(tp, NULL, NULL);
         if (!result) goto failed;
-        value = ast2obj_identifier(state, o->v.TypeVarTuple.name);
+        value = ast2obj_identifier(state, vstate, o->v.TypeVarTuple.name);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->name, value) == -1)
             goto failed;
         Py_DECREF(value);
-        value = ast2obj_expr(state, o->v.TypeVarTuple.default_value);
+        value = ast2obj_expr(state, vstate, o->v.TypeVarTuple.default_value);
         if (!value) goto failed;
         if (PyObject_SetAttr(result, state->default_value, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
     }
-    value = ast2obj_int(state, o->lineno);
+    value = ast2obj_int(state, vstate, o->lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->col_offset);
+    value = ast2obj_int(state, vstate, o->col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_lineno);
+    value = ast2obj_int(state, vstate, o->end_lineno);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_lineno, value) < 0)
         goto failed;
     Py_DECREF(value);
-    value = ast2obj_int(state, o->end_col_offset);
+    value = ast2obj_int(state, vstate, o->end_col_offset);
     if (!value) goto failed;
     if (PyObject_SetAttr(result, state->end_col_offset, value) < 0)
         goto failed;
     Py_DECREF(value);
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     return result;
 failed:
-    Py_LeaveRecursiveCall();
+    vstate->recursion_depth--;
     Py_XDECREF(value);
     Py_XDECREF(result);
     return NULL;
@@ -18042,8 +18135,28 @@ PyObject* PyAST_mod2obj(mod_ty t)
     if (state == NULL) {
         return NULL;
     }
-    PyObject *result = ast2obj_mod(state, t);
 
+    int starting_recursion_depth;
+    /* Be careful here to prevent overflow. */
+    PyThreadState *tstate = _PyThreadState_GET();
+    if (!tstate) {
+        return NULL;
+    }
+    struct validator vstate;
+    vstate.recursion_limit = Py_C_RECURSION_LIMIT;
+    int recursion_depth = Py_C_RECURSION_LIMIT - tstate->c_recursion_remaining;
+    starting_recursion_depth = recursion_depth;
+    vstate.recursion_depth = starting_recursion_depth;
+
+    PyObject *result = ast2obj_mod(state, &vstate, t);
+
+    /* Check that the recursion depth counting balanced correctly */
+    if (result && vstate.recursion_depth != starting_recursion_depth) {
+        PyErr_Format(PyExc_SystemError,
+            "AST constructor recursion depth mismatch (before=%d, after=%d)",
+            starting_recursion_depth, vstate.recursion_depth);
+        return NULL;
+    }
     return result;
 }
 

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -9,22 +9,34 @@
 #include <assert.h>
 #include <stdbool.h>
 
-#define ENTER_RECURSIVE() \
-if (Py_EnterRecursiveCall(" during compilation")) { \
-    return 0; \
-}
+struct validator {
+    int recursion_depth;            /* current recursion depth */
+    int recursion_limit;            /* recursion limit */
+};
 
-#define LEAVE_RECURSIVE() Py_LeaveRecursiveCall();
+#define ENTER_RECURSIVE(ST) \
+    do { \
+        if (++(ST)->recursion_depth > (ST)->recursion_limit) { \
+            PyErr_SetString(PyExc_RecursionError, \
+                "maximum recursion depth exceeded during compilation"); \
+            return 0; \
+        } \
+    } while(0)
 
-static int validate_stmts(asdl_stmt_seq *);
-static int validate_exprs(asdl_expr_seq *, expr_context_ty, int);
-static int validate_patterns(asdl_pattern_seq *, int);
-static int validate_type_params(asdl_type_param_seq *);
+#define LEAVE_RECURSIVE(ST) \
+    do { \
+        --(ST)->recursion_depth; \
+    } while(0)
+
+static int validate_stmts(struct validator *, asdl_stmt_seq *);
+static int validate_exprs(struct validator *, asdl_expr_seq *, expr_context_ty, int);
+static int validate_patterns(struct validator *, asdl_pattern_seq *, int);
+static int validate_type_params(struct validator *, asdl_type_param_seq *);
 static int _validate_nonempty_seq(asdl_seq *, const char *, const char *);
-static int validate_stmt(stmt_ty);
-static int validate_expr(expr_ty, expr_context_ty);
-static int validate_pattern(pattern_ty, int);
-static int validate_typeparam(type_param_ty);
+static int validate_stmt(struct validator *, stmt_ty);
+static int validate_expr(struct validator *, expr_ty, expr_context_ty);
+static int validate_pattern(struct validator *, pattern_ty, int);
+static int validate_typeparam(struct validator *, type_param_ty);
 
 #define VALIDATE_POSITIONS(node) \
     if (node->lineno > node->end_lineno) { \
@@ -68,7 +80,7 @@ validate_name(PyObject *name)
 }
 
 static int
-validate_comprehension(asdl_comprehension_seq *gens)
+validate_comprehension(struct validator *state, asdl_comprehension_seq *gens)
 {
     assert(!PyErr_Occurred());
     if (!asdl_seq_LEN(gens)) {
@@ -77,32 +89,32 @@ validate_comprehension(asdl_comprehension_seq *gens)
     }
     for (Py_ssize_t i = 0; i < asdl_seq_LEN(gens); i++) {
         comprehension_ty comp = asdl_seq_GET(gens, i);
-        if (!validate_expr(comp->target, Store) ||
-            !validate_expr(comp->iter, Load) ||
-            !validate_exprs(comp->ifs, Load, 0))
+        if (!validate_expr(state, comp->target, Store) ||
+            !validate_expr(state, comp->iter, Load) ||
+            !validate_exprs(state, comp->ifs, Load, 0))
             return 0;
     }
     return 1;
 }
 
 static int
-validate_keywords(asdl_keyword_seq *keywords)
+validate_keywords(struct validator *state, asdl_keyword_seq *keywords)
 {
     assert(!PyErr_Occurred());
     for (Py_ssize_t i = 0; i < asdl_seq_LEN(keywords); i++)
-        if (!validate_expr((asdl_seq_GET(keywords, i))->value, Load))
+        if (!validate_expr(state, (asdl_seq_GET(keywords, i))->value, Load))
             return 0;
     return 1;
 }
 
 static int
-validate_args(asdl_arg_seq *args)
+validate_args(struct validator *state, asdl_arg_seq *args)
 {
     assert(!PyErr_Occurred());
     for (Py_ssize_t i = 0; i < asdl_seq_LEN(args); i++) {
         arg_ty arg = asdl_seq_GET(args, i);
         VALIDATE_POSITIONS(arg);
-        if (arg->annotation && !validate_expr(arg->annotation, Load))
+        if (arg->annotation && !validate_expr(state, arg->annotation, Load))
             return 0;
     }
     return 1;
@@ -124,20 +136,20 @@ expr_context_name(expr_context_ty ctx)
 }
 
 static int
-validate_arguments(arguments_ty args)
+validate_arguments(struct validator *state, arguments_ty args)
 {
     assert(!PyErr_Occurred());
-    if (!validate_args(args->posonlyargs) || !validate_args(args->args)) {
+    if (!validate_args(state, args->posonlyargs) || !validate_args(state, args->args)) {
         return 0;
     }
     if (args->vararg && args->vararg->annotation
-        && !validate_expr(args->vararg->annotation, Load)) {
+        && !validate_expr(state, args->vararg->annotation, Load)) {
             return 0;
     }
-    if (!validate_args(args->kwonlyargs))
+    if (!validate_args(state, args->kwonlyargs))
         return 0;
     if (args->kwarg && args->kwarg->annotation
-        && !validate_expr(args->kwarg->annotation, Load)) {
+        && !validate_expr(state, args->kwarg->annotation, Load)) {
             return 0;
     }
     if (asdl_seq_LEN(args->defaults) > asdl_seq_LEN(args->posonlyargs) + asdl_seq_LEN(args->args)) {
@@ -149,11 +161,11 @@ validate_arguments(arguments_ty args)
                         "kw_defaults on arguments");
         return 0;
     }
-    return validate_exprs(args->defaults, Load, 0) && validate_exprs(args->kw_defaults, Load, 1);
+    return validate_exprs(state, args->defaults, Load, 0) && validate_exprs(state, args->kw_defaults, Load, 1);
 }
 
 static int
-validate_constant(PyObject *value)
+validate_constant(struct validator *state, PyObject *value)
 {
     assert(!PyErr_Occurred());
     if (value == Py_None || value == Py_Ellipsis)
@@ -168,7 +180,7 @@ validate_constant(PyObject *value)
         return 1;
 
     if (PyTuple_CheckExact(value) || PyFrozenSet_CheckExact(value)) {
-        ENTER_RECURSIVE();
+        ENTER_RECURSIVE(state);
 
         PyObject *it = PyObject_GetIter(value);
         if (it == NULL)
@@ -184,7 +196,7 @@ validate_constant(PyObject *value)
                 break;
             }
 
-            if (!validate_constant(item)) {
+            if (!validate_constant(state, item)) {
                 Py_DECREF(it);
                 Py_DECREF(item);
                 return 0;
@@ -193,7 +205,7 @@ validate_constant(PyObject *value)
         }
 
         Py_DECREF(it);
-        LEAVE_RECURSIVE();
+        LEAVE_RECURSIVE(state);
         return 1;
     }
 
@@ -206,12 +218,12 @@ validate_constant(PyObject *value)
 }
 
 static int
-validate_expr(expr_ty exp, expr_context_ty ctx)
+validate_expr(struct validator *state, expr_ty exp, expr_context_ty ctx)
 {
     assert(!PyErr_Occurred());
     VALIDATE_POSITIONS(exp);
     int ret = -1;
-    ENTER_RECURSIVE();
+    ENTER_RECURSIVE(state);
     int check_ctx = 1;
     expr_context_ty actual_ctx;
 
@@ -261,23 +273,23 @@ validate_expr(expr_ty exp, expr_context_ty ctx)
             PyErr_SetString(PyExc_ValueError, "BoolOp with less than 2 values");
             return 0;
         }
-        ret = validate_exprs(exp->v.BoolOp.values, Load, 0);
+        ret = validate_exprs(state, exp->v.BoolOp.values, Load, 0);
         break;
     case BinOp_kind:
-        ret = validate_expr(exp->v.BinOp.left, Load) &&
-            validate_expr(exp->v.BinOp.right, Load);
+        ret = validate_expr(state, exp->v.BinOp.left, Load) &&
+            validate_expr(state, exp->v.BinOp.right, Load);
         break;
     case UnaryOp_kind:
-        ret = validate_expr(exp->v.UnaryOp.operand, Load);
+        ret = validate_expr(state, exp->v.UnaryOp.operand, Load);
         break;
     case Lambda_kind:
-        ret = validate_arguments(exp->v.Lambda.args) &&
-            validate_expr(exp->v.Lambda.body, Load);
+        ret = validate_arguments(state, exp->v.Lambda.args) &&
+            validate_expr(state, exp->v.Lambda.body, Load);
         break;
     case IfExp_kind:
-        ret = validate_expr(exp->v.IfExp.test, Load) &&
-            validate_expr(exp->v.IfExp.body, Load) &&
-            validate_expr(exp->v.IfExp.orelse, Load);
+        ret = validate_expr(state, exp->v.IfExp.test, Load) &&
+            validate_expr(state, exp->v.IfExp.body, Load) &&
+            validate_expr(state, exp->v.IfExp.orelse, Load);
         break;
     case Dict_kind:
         if (asdl_seq_LEN(exp->v.Dict.keys) != asdl_seq_LEN(exp->v.Dict.values)) {
@@ -287,34 +299,34 @@ validate_expr(expr_ty exp, expr_context_ty ctx)
         }
         /* null_ok=1 for keys expressions to allow dict unpacking to work in
            dict literals, i.e. ``{**{a:b}}`` */
-        ret = validate_exprs(exp->v.Dict.keys, Load, /*null_ok=*/ 1) &&
-            validate_exprs(exp->v.Dict.values, Load, /*null_ok=*/ 0);
+        ret = validate_exprs(state, exp->v.Dict.keys, Load, /*null_ok=*/ 1) &&
+            validate_exprs(state, exp->v.Dict.values, Load, /*null_ok=*/ 0);
         break;
     case Set_kind:
-        ret = validate_exprs(exp->v.Set.elts, Load, 0);
+        ret = validate_exprs(state, exp->v.Set.elts, Load, 0);
         break;
 #define COMP(NAME) \
         case NAME ## _kind: \
-            ret = validate_comprehension(exp->v.NAME.generators) && \
-                validate_expr(exp->v.NAME.elt, Load); \
+            ret = validate_comprehension(state, exp->v.NAME.generators) && \
+                validate_expr(state, exp->v.NAME.elt, Load); \
             break;
     COMP(ListComp)
     COMP(SetComp)
     COMP(GeneratorExp)
 #undef COMP
     case DictComp_kind:
-        ret = validate_comprehension(exp->v.DictComp.generators) &&
-            validate_expr(exp->v.DictComp.key, Load) &&
-            validate_expr(exp->v.DictComp.value, Load);
+        ret = validate_comprehension(state, exp->v.DictComp.generators) &&
+            validate_expr(state, exp->v.DictComp.key, Load) &&
+            validate_expr(state, exp->v.DictComp.value, Load);
         break;
     case Yield_kind:
-        ret = !exp->v.Yield.value || validate_expr(exp->v.Yield.value, Load);
+        ret = !exp->v.Yield.value || validate_expr(state, exp->v.Yield.value, Load);
         break;
     case YieldFrom_kind:
-        ret = validate_expr(exp->v.YieldFrom.value, Load);
+        ret = validate_expr(state, exp->v.YieldFrom.value, Load);
         break;
     case Await_kind:
-        ret = validate_expr(exp->v.Await.value, Load);
+        ret = validate_expr(state, exp->v.Await.value, Load);
         break;
     case Compare_kind:
         if (!asdl_seq_LEN(exp->v.Compare.comparators)) {
@@ -327,52 +339,52 @@ validate_expr(expr_ty exp, expr_context_ty ctx)
                             "of comparators and operands");
             return 0;
         }
-        ret = validate_exprs(exp->v.Compare.comparators, Load, 0) &&
-            validate_expr(exp->v.Compare.left, Load);
+        ret = validate_exprs(state, exp->v.Compare.comparators, Load, 0) &&
+            validate_expr(state, exp->v.Compare.left, Load);
         break;
     case Call_kind:
-        ret = validate_expr(exp->v.Call.func, Load) &&
-            validate_exprs(exp->v.Call.args, Load, 0) &&
-            validate_keywords(exp->v.Call.keywords);
+        ret = validate_expr(state, exp->v.Call.func, Load) &&
+            validate_exprs(state, exp->v.Call.args, Load, 0) &&
+            validate_keywords(state, exp->v.Call.keywords);
         break;
     case Constant_kind:
-        if (!validate_constant(exp->v.Constant.value)) {
+        if (!validate_constant(state, exp->v.Constant.value)) {
             return 0;
         }
         ret = 1;
         break;
     case JoinedStr_kind:
-        ret = validate_exprs(exp->v.JoinedStr.values, Load, 0);
+        ret = validate_exprs(state, exp->v.JoinedStr.values, Load, 0);
         break;
     case FormattedValue_kind:
-        if (validate_expr(exp->v.FormattedValue.value, Load) == 0)
+        if (validate_expr(state, exp->v.FormattedValue.value, Load) == 0)
             return 0;
         if (exp->v.FormattedValue.format_spec) {
-            ret = validate_expr(exp->v.FormattedValue.format_spec, Load);
+            ret = validate_expr(state, exp->v.FormattedValue.format_spec, Load);
             break;
         }
         ret = 1;
         break;
     case Attribute_kind:
-        ret = validate_expr(exp->v.Attribute.value, Load);
+        ret = validate_expr(state, exp->v.Attribute.value, Load);
         break;
     case Subscript_kind:
-        ret = validate_expr(exp->v.Subscript.slice, Load) &&
-            validate_expr(exp->v.Subscript.value, Load);
+        ret = validate_expr(state, exp->v.Subscript.slice, Load) &&
+            validate_expr(state, exp->v.Subscript.value, Load);
         break;
     case Starred_kind:
-        ret = validate_expr(exp->v.Starred.value, ctx);
+        ret = validate_expr(state, exp->v.Starred.value, ctx);
         break;
     case Slice_kind:
-        ret = (!exp->v.Slice.lower || validate_expr(exp->v.Slice.lower, Load)) &&
-            (!exp->v.Slice.upper || validate_expr(exp->v.Slice.upper, Load)) &&
-            (!exp->v.Slice.step || validate_expr(exp->v.Slice.step, Load));
+        ret = (!exp->v.Slice.lower || validate_expr(state, exp->v.Slice.lower, Load)) &&
+            (!exp->v.Slice.upper || validate_expr(state, exp->v.Slice.upper, Load)) &&
+            (!exp->v.Slice.step || validate_expr(state, exp->v.Slice.step, Load));
         break;
     case List_kind:
-        ret = validate_exprs(exp->v.List.elts, ctx, 0);
+        ret = validate_exprs(state, exp->v.List.elts, ctx, 0);
         break;
     case Tuple_kind:
-        ret = validate_exprs(exp->v.Tuple.elts, ctx, 0);
+        ret = validate_exprs(state, exp->v.Tuple.elts, ctx, 0);
         break;
     case NamedExpr_kind:
         if (exp->v.NamedExpr.target->kind != Name_kind) {
@@ -380,7 +392,7 @@ validate_expr(expr_ty exp, expr_context_ty ctx)
                             "NamedExpr target must be a Name");
             return 0;
         }
-        ret = validate_expr(exp->v.NamedExpr.value, Load);
+        ret = validate_expr(state, exp->v.NamedExpr.value, Load);
         break;
     /* This last case doesn't have any checking. */
     case Name_kind:
@@ -392,7 +404,7 @@ validate_expr(expr_ty exp, expr_context_ty ctx)
         PyErr_SetString(PyExc_SystemError, "unexpected expression");
         ret = 0;
     }
-    LEAVE_RECURSIVE();
+    LEAVE_RECURSIVE(state);
     return ret;
 }
 
@@ -468,10 +480,10 @@ ensure_literal_complex(expr_ty exp)
 }
 
 static int
-validate_pattern_match_value(expr_ty exp)
+validate_pattern_match_value(struct validator *state, expr_ty exp)
 {
     assert(!PyErr_Occurred());
-    if (!validate_expr(exp, Load)) {
+    if (!validate_expr(state, exp, Load)) {
         return 0;
     }
 
@@ -481,7 +493,7 @@ validate_pattern_match_value(expr_ty exp)
             /* Ellipsis and immutable sequences are not allowed.
                For True, False and None, MatchSingleton() should
                be used */
-            if (!validate_expr(exp, Load)) {
+            if (!validate_expr(state, exp, Load)) {
                 return 0;
             }
             PyObject *literal = exp->v.Constant.value;
@@ -533,15 +545,15 @@ validate_capture(PyObject *name)
 }
 
 static int
-validate_pattern(pattern_ty p, int star_ok)
+validate_pattern(struct validator *state, pattern_ty p, int star_ok)
 {
     assert(!PyErr_Occurred());
     VALIDATE_POSITIONS(p);
     int ret = -1;
-    ENTER_RECURSIVE();
+    ENTER_RECURSIVE(state);
     switch (p->kind) {
         case MatchValue_kind:
-            ret = validate_pattern_match_value(p->v.MatchValue.value);
+            ret = validate_pattern_match_value(state, p->v.MatchValue.value);
             break;
         case MatchSingleton_kind:
             ret = p->v.MatchSingleton.value == Py_None || PyBool_Check(p->v.MatchSingleton.value);
@@ -551,7 +563,7 @@ validate_pattern(pattern_ty p, int star_ok)
             }
             break;
         case MatchSequence_kind:
-            ret = validate_patterns(p->v.MatchSequence.patterns, /*star_ok=*/1);
+            ret = validate_patterns(state, p->v.MatchSequence.patterns, /*star_ok=*/1);
             break;
         case MatchMapping_kind:
             if (asdl_seq_LEN(p->v.MatchMapping.keys) != asdl_seq_LEN(p->v.MatchMapping.patterns)) {
@@ -579,7 +591,7 @@ validate_pattern(pattern_ty p, int star_ok)
                         continue;
                     }
                 }
-                if (!validate_pattern_match_value(key)) {
+                if (!validate_pattern_match_value(state, key)) {
                     ret = 0;
                     break;
                 }
@@ -587,7 +599,7 @@ validate_pattern(pattern_ty p, int star_ok)
             if (ret == 0) {
                 break;
             }
-            ret = validate_patterns(p->v.MatchMapping.patterns, /*star_ok=*/0);
+            ret = validate_patterns(state, p->v.MatchMapping.patterns, /*star_ok=*/0);
             break;
         case MatchClass_kind:
             if (asdl_seq_LEN(p->v.MatchClass.kwd_attrs) != asdl_seq_LEN(p->v.MatchClass.kwd_patterns)) {
@@ -596,7 +608,7 @@ validate_pattern(pattern_ty p, int star_ok)
                 ret = 0;
                 break;
             }
-            if (!validate_expr(p->v.MatchClass.cls, Load)) {
+            if (!validate_expr(state, p->v.MatchClass.cls, Load)) {
                 ret = 0;
                 break;
             }
@@ -632,12 +644,12 @@ validate_pattern(pattern_ty p, int star_ok)
                 break;
             }
 
-            if (!validate_patterns(p->v.MatchClass.patterns, /*star_ok=*/0)) {
+            if (!validate_patterns(state, p->v.MatchClass.patterns, /*star_ok=*/0)) {
                 ret = 0;
                 break;
             }
 
-            ret = validate_patterns(p->v.MatchClass.kwd_patterns, /*star_ok=*/0);
+            ret = validate_patterns(state, p->v.MatchClass.kwd_patterns, /*star_ok=*/0);
             break;
         case MatchStar_kind:
             if (!star_ok) {
@@ -661,7 +673,7 @@ validate_pattern(pattern_ty p, int star_ok)
                 ret = 0;
             }
             else {
-                ret = validate_pattern(p->v.MatchAs.pattern, /*star_ok=*/0);
+                ret = validate_pattern(state, p->v.MatchAs.pattern, /*star_ok=*/0);
             }
             break;
         case MatchOr_kind:
@@ -671,7 +683,7 @@ validate_pattern(pattern_ty p, int star_ok)
                 ret = 0;
                 break;
             }
-            ret = validate_patterns(p->v.MatchOr.patterns, /*star_ok=*/0);
+            ret = validate_patterns(state, p->v.MatchOr.patterns, /*star_ok=*/0);
             break;
     // No default case, so the compiler will emit a warning if new pattern
     // kinds are added without being handled here
@@ -680,7 +692,7 @@ validate_pattern(pattern_ty p, int star_ok)
         PyErr_SetString(PyExc_SystemError, "unexpected pattern");
         ret = 0;
     }
-    LEAVE_RECURSIVE();
+    LEAVE_RECURSIVE(state);
     return ret;
 }
 
@@ -695,56 +707,56 @@ _validate_nonempty_seq(asdl_seq *seq, const char *what, const char *owner)
 #define validate_nonempty_seq(seq, what, owner) _validate_nonempty_seq((asdl_seq*)seq, what, owner)
 
 static int
-validate_assignlist(asdl_expr_seq *targets, expr_context_ty ctx)
+validate_assignlist(struct validator *state, asdl_expr_seq *targets, expr_context_ty ctx)
 {
     assert(!PyErr_Occurred());
     return validate_nonempty_seq(targets, "targets", ctx == Del ? "Delete" : "Assign") &&
-        validate_exprs(targets, ctx, 0);
+        validate_exprs(state, targets, ctx, 0);
 }
 
 static int
-validate_body(asdl_stmt_seq *body, const char *owner)
+validate_body(struct validator *state, asdl_stmt_seq *body, const char *owner)
 {
     assert(!PyErr_Occurred());
-    return validate_nonempty_seq(body, "body", owner) && validate_stmts(body);
+    return validate_nonempty_seq(body, "body", owner) && validate_stmts(state, body);
 }
 
 static int
-validate_stmt(stmt_ty stmt)
+validate_stmt(struct validator *state, stmt_ty stmt)
 {
     assert(!PyErr_Occurred());
     VALIDATE_POSITIONS(stmt);
     int ret = -1;
-    ENTER_RECURSIVE();
+    ENTER_RECURSIVE(state);
     switch (stmt->kind) {
     case FunctionDef_kind:
-        ret = validate_body(stmt->v.FunctionDef.body, "FunctionDef") &&
-            validate_type_params(stmt->v.FunctionDef.type_params) &&
-            validate_arguments(stmt->v.FunctionDef.args) &&
-            validate_exprs(stmt->v.FunctionDef.decorator_list, Load, 0) &&
+        ret = validate_body(state, stmt->v.FunctionDef.body, "FunctionDef") &&
+            validate_type_params(state, stmt->v.FunctionDef.type_params) &&
+            validate_arguments(state, stmt->v.FunctionDef.args) &&
+            validate_exprs(state, stmt->v.FunctionDef.decorator_list, Load, 0) &&
             (!stmt->v.FunctionDef.returns ||
-             validate_expr(stmt->v.FunctionDef.returns, Load));
+             validate_expr(state, stmt->v.FunctionDef.returns, Load));
         break;
     case ClassDef_kind:
-        ret = validate_body(stmt->v.ClassDef.body, "ClassDef") &&
-            validate_type_params(stmt->v.ClassDef.type_params) &&
-            validate_exprs(stmt->v.ClassDef.bases, Load, 0) &&
-            validate_keywords(stmt->v.ClassDef.keywords) &&
-            validate_exprs(stmt->v.ClassDef.decorator_list, Load, 0);
+        ret = validate_body(state, stmt->v.ClassDef.body, "ClassDef") &&
+            validate_type_params(state, stmt->v.ClassDef.type_params) &&
+            validate_exprs(state, stmt->v.ClassDef.bases, Load, 0) &&
+            validate_keywords(state, stmt->v.ClassDef.keywords) &&
+            validate_exprs(state, stmt->v.ClassDef.decorator_list, Load, 0);
         break;
     case Return_kind:
-        ret = !stmt->v.Return.value || validate_expr(stmt->v.Return.value, Load);
+        ret = !stmt->v.Return.value || validate_expr(state, stmt->v.Return.value, Load);
         break;
     case Delete_kind:
-        ret = validate_assignlist(stmt->v.Delete.targets, Del);
+        ret = validate_assignlist(state, stmt->v.Delete.targets, Del);
         break;
     case Assign_kind:
-        ret = validate_assignlist(stmt->v.Assign.targets, Store) &&
-            validate_expr(stmt->v.Assign.value, Load);
+        ret = validate_assignlist(state, stmt->v.Assign.targets, Store) &&
+            validate_expr(state, stmt->v.Assign.value, Load);
         break;
     case AugAssign_kind:
-        ret = validate_expr(stmt->v.AugAssign.target, Store) &&
-            validate_expr(stmt->v.AugAssign.value, Load);
+        ret = validate_expr(state, stmt->v.AugAssign.target, Store) &&
+            validate_expr(state, stmt->v.AugAssign.value, Load);
         break;
     case AnnAssign_kind:
         if (stmt->v.AnnAssign.target->kind != Name_kind &&
@@ -753,10 +765,10 @@ validate_stmt(stmt_ty stmt)
                             "AnnAssign with simple non-Name target");
             return 0;
         }
-        ret = validate_expr(stmt->v.AnnAssign.target, Store) &&
+        ret = validate_expr(state, stmt->v.AnnAssign.target, Store) &&
                (!stmt->v.AnnAssign.value ||
-                validate_expr(stmt->v.AnnAssign.value, Load)) &&
-               validate_expr(stmt->v.AnnAssign.annotation, Load);
+                validate_expr(state, stmt->v.AnnAssign.value, Load)) &&
+               validate_expr(state, stmt->v.AnnAssign.annotation, Load);
         break;
     case TypeAlias_kind:
         if (stmt->v.TypeAlias.name->kind != Name_kind) {
@@ -764,64 +776,64 @@ validate_stmt(stmt_ty stmt)
                             "TypeAlias with non-Name name");
             return 0;
         }
-        ret = validate_expr(stmt->v.TypeAlias.name, Store) &&
-            validate_type_params(stmt->v.TypeAlias.type_params) &&
-            validate_expr(stmt->v.TypeAlias.value, Load);
+        ret = validate_expr(state, stmt->v.TypeAlias.name, Store) &&
+            validate_type_params(state, stmt->v.TypeAlias.type_params) &&
+            validate_expr(state, stmt->v.TypeAlias.value, Load);
         break;
     case For_kind:
-        ret = validate_expr(stmt->v.For.target, Store) &&
-            validate_expr(stmt->v.For.iter, Load) &&
-            validate_body(stmt->v.For.body, "For") &&
-            validate_stmts(stmt->v.For.orelse);
+        ret = validate_expr(state, stmt->v.For.target, Store) &&
+            validate_expr(state, stmt->v.For.iter, Load) &&
+            validate_body(state, stmt->v.For.body, "For") &&
+            validate_stmts(state, stmt->v.For.orelse);
         break;
     case AsyncFor_kind:
-        ret = validate_expr(stmt->v.AsyncFor.target, Store) &&
-            validate_expr(stmt->v.AsyncFor.iter, Load) &&
-            validate_body(stmt->v.AsyncFor.body, "AsyncFor") &&
-            validate_stmts(stmt->v.AsyncFor.orelse);
+        ret = validate_expr(state, stmt->v.AsyncFor.target, Store) &&
+            validate_expr(state, stmt->v.AsyncFor.iter, Load) &&
+            validate_body(state, stmt->v.AsyncFor.body, "AsyncFor") &&
+            validate_stmts(state, stmt->v.AsyncFor.orelse);
         break;
     case While_kind:
-        ret = validate_expr(stmt->v.While.test, Load) &&
-            validate_body(stmt->v.While.body, "While") &&
-            validate_stmts(stmt->v.While.orelse);
+        ret = validate_expr(state, stmt->v.While.test, Load) &&
+            validate_body(state, stmt->v.While.body, "While") &&
+            validate_stmts(state, stmt->v.While.orelse);
         break;
     case If_kind:
-        ret = validate_expr(stmt->v.If.test, Load) &&
-            validate_body(stmt->v.If.body, "If") &&
-            validate_stmts(stmt->v.If.orelse);
+        ret = validate_expr(state, stmt->v.If.test, Load) &&
+            validate_body(state, stmt->v.If.body, "If") &&
+            validate_stmts(state, stmt->v.If.orelse);
         break;
     case With_kind:
         if (!validate_nonempty_seq(stmt->v.With.items, "items", "With"))
             return 0;
         for (Py_ssize_t i = 0; i < asdl_seq_LEN(stmt->v.With.items); i++) {
             withitem_ty item = asdl_seq_GET(stmt->v.With.items, i);
-            if (!validate_expr(item->context_expr, Load) ||
-                (item->optional_vars && !validate_expr(item->optional_vars, Store)))
+            if (!validate_expr(state, item->context_expr, Load) ||
+                (item->optional_vars && !validate_expr(state, item->optional_vars, Store)))
                 return 0;
         }
-        ret = validate_body(stmt->v.With.body, "With");
+        ret = validate_body(state, stmt->v.With.body, "With");
         break;
     case AsyncWith_kind:
         if (!validate_nonempty_seq(stmt->v.AsyncWith.items, "items", "AsyncWith"))
             return 0;
         for (Py_ssize_t i = 0; i < asdl_seq_LEN(stmt->v.AsyncWith.items); i++) {
             withitem_ty item = asdl_seq_GET(stmt->v.AsyncWith.items, i);
-            if (!validate_expr(item->context_expr, Load) ||
-                (item->optional_vars && !validate_expr(item->optional_vars, Store)))
+            if (!validate_expr(state, item->context_expr, Load) ||
+                (item->optional_vars && !validate_expr(state, item->optional_vars, Store)))
                 return 0;
         }
-        ret = validate_body(stmt->v.AsyncWith.body, "AsyncWith");
+        ret = validate_body(state, stmt->v.AsyncWith.body, "AsyncWith");
         break;
     case Match_kind:
-        if (!validate_expr(stmt->v.Match.subject, Load)
+        if (!validate_expr(state, stmt->v.Match.subject, Load)
             || !validate_nonempty_seq(stmt->v.Match.cases, "cases", "Match")) {
             return 0;
         }
         for (Py_ssize_t i = 0; i < asdl_seq_LEN(stmt->v.Match.cases); i++) {
             match_case_ty m = asdl_seq_GET(stmt->v.Match.cases, i);
-            if (!validate_pattern(m->pattern, /*star_ok=*/0)
-                || (m->guard && !validate_expr(m->guard, Load))
-                || !validate_body(m->body, "match_case")) {
+            if (!validate_pattern(state, m->pattern, /*star_ok=*/0)
+                || (m->guard && !validate_expr(state, m->guard, Load))
+                || !validate_body(state, m->body, "match_case")) {
                 return 0;
             }
         }
@@ -829,8 +841,8 @@ validate_stmt(stmt_ty stmt)
         break;
     case Raise_kind:
         if (stmt->v.Raise.exc) {
-            ret = validate_expr(stmt->v.Raise.exc, Load) &&
-                (!stmt->v.Raise.cause || validate_expr(stmt->v.Raise.cause, Load));
+            ret = validate_expr(state, stmt->v.Raise.exc, Load) &&
+                (!stmt->v.Raise.cause || validate_expr(state, stmt->v.Raise.cause, Load));
             break;
         }
         if (stmt->v.Raise.cause) {
@@ -840,7 +852,7 @@ validate_stmt(stmt_ty stmt)
         ret = 1;
         break;
     case Try_kind:
-        if (!validate_body(stmt->v.Try.body, "Try"))
+        if (!validate_body(state, stmt->v.Try.body, "Try"))
             return 0;
         if (!asdl_seq_LEN(stmt->v.Try.handlers) &&
             !asdl_seq_LEN(stmt->v.Try.finalbody)) {
@@ -856,17 +868,17 @@ validate_stmt(stmt_ty stmt)
             excepthandler_ty handler = asdl_seq_GET(stmt->v.Try.handlers, i);
             VALIDATE_POSITIONS(handler);
             if ((handler->v.ExceptHandler.type &&
-                 !validate_expr(handler->v.ExceptHandler.type, Load)) ||
-                !validate_body(handler->v.ExceptHandler.body, "ExceptHandler"))
+                 !validate_expr(state, handler->v.ExceptHandler.type, Load)) ||
+                !validate_body(state, handler->v.ExceptHandler.body, "ExceptHandler"))
                 return 0;
         }
         ret = (!asdl_seq_LEN(stmt->v.Try.finalbody) ||
-                validate_stmts(stmt->v.Try.finalbody)) &&
+                validate_stmts(state, stmt->v.Try.finalbody)) &&
             (!asdl_seq_LEN(stmt->v.Try.orelse) ||
-             validate_stmts(stmt->v.Try.orelse));
+             validate_stmts(state, stmt->v.Try.orelse));
         break;
     case TryStar_kind:
-        if (!validate_body(stmt->v.TryStar.body, "TryStar"))
+        if (!validate_body(state, stmt->v.TryStar.body, "TryStar"))
             return 0;
         if (!asdl_seq_LEN(stmt->v.TryStar.handlers) &&
             !asdl_seq_LEN(stmt->v.TryStar.finalbody)) {
@@ -881,18 +893,18 @@ validate_stmt(stmt_ty stmt)
         for (Py_ssize_t i = 0; i < asdl_seq_LEN(stmt->v.TryStar.handlers); i++) {
             excepthandler_ty handler = asdl_seq_GET(stmt->v.TryStar.handlers, i);
             if ((handler->v.ExceptHandler.type &&
-                 !validate_expr(handler->v.ExceptHandler.type, Load)) ||
-                !validate_body(handler->v.ExceptHandler.body, "ExceptHandler"))
+                 !validate_expr(state, handler->v.ExceptHandler.type, Load)) ||
+                !validate_body(state, handler->v.ExceptHandler.body, "ExceptHandler"))
                 return 0;
         }
         ret = (!asdl_seq_LEN(stmt->v.TryStar.finalbody) ||
-                validate_stmts(stmt->v.TryStar.finalbody)) &&
+                validate_stmts(state, stmt->v.TryStar.finalbody)) &&
             (!asdl_seq_LEN(stmt->v.TryStar.orelse) ||
-             validate_stmts(stmt->v.TryStar.orelse));
+             validate_stmts(state, stmt->v.TryStar.orelse));
         break;
     case Assert_kind:
-        ret = validate_expr(stmt->v.Assert.test, Load) &&
-            (!stmt->v.Assert.msg || validate_expr(stmt->v.Assert.msg, Load));
+        ret = validate_expr(state, stmt->v.Assert.test, Load) &&
+            (!stmt->v.Assert.msg || validate_expr(state, stmt->v.Assert.msg, Load));
         break;
     case Import_kind:
         ret = validate_nonempty_seq(stmt->v.Import.names, "names", "Import");
@@ -911,15 +923,15 @@ validate_stmt(stmt_ty stmt)
         ret = validate_nonempty_seq(stmt->v.Nonlocal.names, "names", "Nonlocal");
         break;
     case Expr_kind:
-        ret = validate_expr(stmt->v.Expr.value, Load);
+        ret = validate_expr(state, stmt->v.Expr.value, Load);
         break;
     case AsyncFunctionDef_kind:
-        ret = validate_body(stmt->v.AsyncFunctionDef.body, "AsyncFunctionDef") &&
-            validate_type_params(stmt->v.AsyncFunctionDef.type_params) &&
-            validate_arguments(stmt->v.AsyncFunctionDef.args) &&
-            validate_exprs(stmt->v.AsyncFunctionDef.decorator_list, Load, 0) &&
+        ret = validate_body(state, stmt->v.AsyncFunctionDef.body, "AsyncFunctionDef") &&
+            validate_type_params(state, stmt->v.AsyncFunctionDef.type_params) &&
+            validate_arguments(state, stmt->v.AsyncFunctionDef.args) &&
+            validate_exprs(state, stmt->v.AsyncFunctionDef.decorator_list, Load, 0) &&
             (!stmt->v.AsyncFunctionDef.returns ||
-             validate_expr(stmt->v.AsyncFunctionDef.returns, Load));
+             validate_expr(state, stmt->v.AsyncFunctionDef.returns, Load));
         break;
     case Pass_kind:
     case Break_kind:
@@ -932,18 +944,18 @@ validate_stmt(stmt_ty stmt)
         PyErr_SetString(PyExc_SystemError, "unexpected statement");
         ret = 0;
     }
-    LEAVE_RECURSIVE();
+    LEAVE_RECURSIVE(state);
     return ret;
 }
 
 static int
-validate_stmts(asdl_stmt_seq *seq)
+validate_stmts(struct validator *state, asdl_stmt_seq *seq)
 {
     assert(!PyErr_Occurred());
     for (Py_ssize_t i = 0; i < asdl_seq_LEN(seq); i++) {
         stmt_ty stmt = asdl_seq_GET(seq, i);
         if (stmt) {
-            if (!validate_stmt(stmt))
+            if (!validate_stmt(state, stmt))
                 return 0;
         }
         else {
@@ -956,13 +968,13 @@ validate_stmts(asdl_stmt_seq *seq)
 }
 
 static int
-validate_exprs(asdl_expr_seq *exprs, expr_context_ty ctx, int null_ok)
+validate_exprs(struct validator *state, asdl_expr_seq *exprs, expr_context_ty ctx, int null_ok)
 {
     assert(!PyErr_Occurred());
     for (Py_ssize_t i = 0; i < asdl_seq_LEN(exprs); i++) {
         expr_ty expr = asdl_seq_GET(exprs, i);
         if (expr) {
-            if (!validate_expr(expr, ctx))
+            if (!validate_expr(state, expr, ctx))
                 return 0;
         }
         else if (!null_ok) {
@@ -976,12 +988,12 @@ validate_exprs(asdl_expr_seq *exprs, expr_context_ty ctx, int null_ok)
 }
 
 static int
-validate_patterns(asdl_pattern_seq *patterns, int star_ok)
+validate_patterns(struct validator *state, asdl_pattern_seq *patterns, int star_ok)
 {
     assert(!PyErr_Occurred());
     for (Py_ssize_t i = 0; i < asdl_seq_LEN(patterns); i++) {
         pattern_ty pattern = asdl_seq_GET(patterns, i);
-        if (!validate_pattern(pattern, star_ok)) {
+        if (!validate_pattern(state, pattern, star_ok)) {
             return 0;
         }
     }
@@ -989,7 +1001,7 @@ validate_patterns(asdl_pattern_seq *patterns, int star_ok)
 }
 
 static int
-validate_typeparam(type_param_ty tp)
+validate_typeparam(struct validator *state, type_param_ty tp)
 {
     VALIDATE_POSITIONS(tp);
     int ret = -1;
@@ -997,32 +1009,32 @@ validate_typeparam(type_param_ty tp)
         case TypeVar_kind:
             ret = validate_name(tp->v.TypeVar.name) &&
                 (!tp->v.TypeVar.bound ||
-                 validate_expr(tp->v.TypeVar.bound, Load)) &&
+                 validate_expr(state, tp->v.TypeVar.bound, Load)) &&
                 (!tp->v.TypeVar.default_value ||
-                 validate_expr(tp->v.TypeVar.default_value, Load));
+                 validate_expr(state, tp->v.TypeVar.default_value, Load));
             break;
         case ParamSpec_kind:
             ret = validate_name(tp->v.ParamSpec.name) &&
                 (!tp->v.ParamSpec.default_value ||
-                 validate_expr(tp->v.ParamSpec.default_value, Load));
+                 validate_expr(state, tp->v.ParamSpec.default_value, Load));
             break;
         case TypeVarTuple_kind:
             ret = validate_name(tp->v.TypeVarTuple.name) &&
                 (!tp->v.TypeVarTuple.default_value ||
-                 validate_expr(tp->v.TypeVarTuple.default_value, Load));
+                 validate_expr(state, tp->v.TypeVarTuple.default_value, Load));
             break;
     }
     return ret;
 }
 
 static int
-validate_type_params(asdl_type_param_seq *tps)
+validate_type_params(struct validator *state, asdl_type_param_seq *tps)
 {
     Py_ssize_t i;
     for (i = 0; i < asdl_seq_LEN(tps); i++) {
         type_param_ty tp = asdl_seq_GET(tps, i);
         if (tp) {
-            if (!validate_typeparam(tp))
+            if (!validate_typeparam(state, tp))
                 return 0;
         }
     }
@@ -1034,26 +1046,48 @@ _PyAST_Validate(mod_ty mod)
 {
     assert(!PyErr_Occurred());
     int res = -1;
+    struct validator state;
+    PyThreadState *tstate;
+    int starting_recursion_depth;
+
+    /* Setup recursion depth check counters */
+    tstate = _PyThreadState_GET();
+    if (!tstate) {
+        return 0;
+    }
+    /* Be careful here to prevent overflow. */
+    int recursion_depth = Py_C_RECURSION_LIMIT - tstate->c_recursion_remaining;
+    starting_recursion_depth = recursion_depth;
+    state.recursion_depth = starting_recursion_depth;
+    state.recursion_limit = Py_C_RECURSION_LIMIT;
 
     switch (mod->kind) {
     case Module_kind:
-        res = validate_stmts(mod->v.Module.body);
+        res = validate_stmts(&state, mod->v.Module.body);
         break;
     case Interactive_kind:
-        res = validate_stmts(mod->v.Interactive.body);
+        res = validate_stmts(&state, mod->v.Interactive.body);
         break;
     case Expression_kind:
-        res = validate_expr(mod->v.Expression.body, Load);
+        res = validate_expr(&state, mod->v.Expression.body, Load);
         break;
     case FunctionType_kind:
-        res = validate_exprs(mod->v.FunctionType.argtypes, Load, /*null_ok=*/0) &&
-              validate_expr(mod->v.FunctionType.returns, Load);
+        res = validate_exprs(&state, mod->v.FunctionType.argtypes, Load, /*null_ok=*/0) &&
+              validate_expr(&state, mod->v.FunctionType.returns, Load);
         break;
     // No default case so compiler emits warning for unhandled cases
     }
 
     if (res < 0) {
         PyErr_SetString(PyExc_SystemError, "impossible module node");
+        return 0;
+    }
+
+    /* Check that the recursion depth counting balanced correctly */
+    if (res && state.recursion_depth != starting_recursion_depth) {
+        PyErr_Format(PyExc_SystemError,
+            "AST validator recursion depth mismatch (before=%d, after=%d)",
+            starting_recursion_depth, state.recursion_depth);
         return 0;
     }
     return res;

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -10,14 +10,24 @@
 typedef struct {
     int optimize;
     int ff_features;
+
+    int recursion_depth;            /* current recursion depth */
+    int recursion_limit;            /* recursion limit */
 } _PyASTOptimizeState;
 
-#define ENTER_RECURSIVE() \
-if (Py_EnterRecursiveCall(" during compilation")) { \
-    return 0; \
-}
+#define ENTER_RECURSIVE(ST) \
+    do { \
+        if (++(ST)->recursion_depth > (ST)->recursion_limit) { \
+            PyErr_SetString(PyExc_RecursionError, \
+                "maximum recursion depth exceeded during compilation"); \
+            return 0; \
+        } \
+    } while(0)
 
-#define LEAVE_RECURSIVE() Py_LeaveRecursiveCall();
+#define LEAVE_RECURSIVE(ST) \
+    do { \
+        --(ST)->recursion_depth; \
+    } while(0)
 
 static int
 make_const(expr_ty node, PyObject *val, PyArena *arena)
@@ -658,7 +668,7 @@ astfold_mod(mod_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 static int
 astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 {
-    ENTER_RECURSIVE();
+    ENTER_RECURSIVE(state);
     switch (node_->kind) {
     case BoolOp_kind:
         CALL_SEQ(astfold_expr, expr, node_->v.BoolOp.values);
@@ -755,7 +765,7 @@ astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     case Name_kind:
         if (node_->v.Name.ctx == Load &&
                 _PyUnicode_EqualToASCIIString(node_->v.Name.id, "__debug__")) {
-            LEAVE_RECURSIVE();
+            LEAVE_RECURSIVE(state);
             return make_const(node_, PyBool_FromLong(!state->optimize), ctx_);
         }
         break;
@@ -768,7 +778,7 @@ astfold_expr(expr_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     // No default case, so the compiler will emit a warning if new expression
     // kinds are added without being handled here
     }
-    LEAVE_RECURSIVE();
+    LEAVE_RECURSIVE(state);;
     return 1;
 }
 
@@ -813,7 +823,7 @@ astfold_arg(arg_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 static int
 astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 {
-    ENTER_RECURSIVE();
+    ENTER_RECURSIVE(state);
     switch (node_->kind) {
     case FunctionDef_kind:
         CALL_SEQ(astfold_type_param, type_param, node_->v.FunctionDef.type_params);
@@ -935,7 +945,7 @@ astfold_stmt(stmt_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     // No default case, so the compiler will emit a warning if new statement
     // kinds are added without being handled here
     }
-    LEAVE_RECURSIVE();
+    LEAVE_RECURSIVE(state);
     return 1;
 }
 
@@ -967,7 +977,7 @@ astfold_pattern(pattern_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     // Currently, this is really only used to form complex/negative numeric
     // constants in MatchValue and MatchMapping nodes
     // We still recurse into all subexpressions and subpatterns anyway
-    ENTER_RECURSIVE();
+    ENTER_RECURSIVE(state);
     switch (node_->kind) {
         case MatchValue_kind:
             CALL(astfold_expr, expr_ty, node_->v.MatchValue.value);
@@ -999,7 +1009,7 @@ astfold_pattern(pattern_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
     // No default case, so the compiler will emit a warning if new pattern
     // kinds are added without being handled here
     }
-    LEAVE_RECURSIVE();
+    LEAVE_RECURSIVE(state);
     return 1;
 }
 
@@ -1037,12 +1047,34 @@ astfold_type_param(type_param_ty node_, PyArena *ctx_, _PyASTOptimizeState *stat
 int
 _PyAST_Optimize(mod_ty mod, PyArena *arena, int optimize, int ff_features)
 {
+    PyThreadState *tstate;
+    int starting_recursion_depth;
+
     _PyASTOptimizeState state;
     state.optimize = optimize;
     state.ff_features = ff_features;
 
+    /* Setup recursion depth check counters */
+    tstate = _PyThreadState_GET();
+    if (!tstate) {
+        return 0;
+    }
+    /* Be careful here to prevent overflow. */
+    int recursion_depth = Py_C_RECURSION_LIMIT - tstate->c_recursion_remaining;
+    starting_recursion_depth = recursion_depth;
+    state.recursion_depth = starting_recursion_depth;
+    state.recursion_limit = Py_C_RECURSION_LIMIT;
+
     int ret = astfold_mod(mod, arena, &state);
     assert(ret || PyErr_Occurred());
+
+    /* Check that the recursion depth counting balanced correctly */
+    if (ret && state.recursion_depth != starting_recursion_depth) {
+        PyErr_Format(PyExc_SystemError,
+            "AST optimizer recursion depth mismatch (before=%d, after=%d)",
+            starting_recursion_depth, state.recursion_depth);
+        return 0;
+    }
 
     return ret;
 }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -304,106 +304,36 @@ Py_SetRecursionLimit(int new_limit)
     _PyEval_StartTheWorld(interp);
 }
 
-int
-_Py_ReachedRecursionLimitWithMargin(PyThreadState *tstate, int margin_count)
-{
-    char here;
-    uintptr_t here_addr = (uintptr_t)&here;
-    _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate;
-    if (here_addr > _tstate->c_stack_soft_limit + margin_count * PYOS_STACK_MARGIN_BYTES) {
-        return 0;
-    }
-    if (_tstate->c_stack_hard_limit == 0) {
-        _Py_InitializeRecursionLimits(tstate);
-    }
-    return here_addr <= _tstate->c_stack_soft_limit + margin_count * PYOS_STACK_MARGIN_BYTES;
-}
-
-void
-_Py_EnterRecursiveCallUnchecked(PyThreadState *tstate)
-{
-    char here;
-    uintptr_t here_addr = (uintptr_t)&here;
-    _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate;
-    if (here_addr < _tstate->c_stack_hard_limit) {
-        Py_FatalError("Unchecked stack overflow.");
-    }
-}
-
-#if defined(__s390x__)
-#  define Py_C_STACK_SIZE 320000
-#elif defined(_WIN32)
-   // Don't define Py_C_STACK_SIZE, ask the O/S
-#elif defined(__ANDROID__)
-#  define Py_C_STACK_SIZE 1200000
-#elif defined(__sparc__)
-#  define Py_C_STACK_SIZE 1600000
-#elif defined(__wasi__)
-   /* Web assembly has two stacks, so this isn't really the stack depth */
-#  define Py_C_STACK_SIZE 100000
-#elif defined(__hppa__) || defined(__powerpc64__)
-#  define Py_C_STACK_SIZE 2000000
-#else
-#  define Py_C_STACK_SIZE 5000000
-#endif
-
-void
-_Py_InitializeRecursionLimits(PyThreadState *tstate)
-{
-    _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate;
-#ifdef WIN32
-    ULONG_PTR low, high;
-    GetCurrentThreadStackLimits(&low, &high);
-    _tstate->c_stack_top = (uintptr_t)high;
-    ULONG guarantee = 0;
-    SetThreadStackGuarantee(&guarantee);
-    _tstate->c_stack_hard_limit = ((uintptr_t)low) + guarantee + PYOS_STACK_MARGIN_BYTES;
-    _tstate->c_stack_soft_limit = _tstate->c_stack_hard_limit + PYOS_STACK_MARGIN_BYTES;
-#else
-    char here;
-    uintptr_t here_addr = (uintptr_t)&here;
-    _tstate->c_stack_top = _Py_SIZE_ROUND_UP(here_addr, 4096);
-    _tstate->c_stack_soft_limit = _tstate->c_stack_top - Py_C_STACK_SIZE;
-    _tstate->c_stack_hard_limit = _tstate->c_stack_top - (Py_C_STACK_SIZE + PYOS_STACK_MARGIN_BYTES);
-#endif
-}
-
 /* The function _Py_EnterRecursiveCallTstate() only calls _Py_CheckRecursiveCall()
    if the recursion_depth reaches recursion_limit. */
 int
 _Py_CheckRecursiveCall(PyThreadState *tstate, const char *where)
 {
-    _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate;
-    char here;
-    uintptr_t here_addr = (uintptr_t)&here;
-    assert(_tstate->c_stack_soft_limit != 0);
-    if (_tstate->c_stack_hard_limit == 0) {
-        _Py_InitializeRecursionLimits(tstate);
-    }
-    if (here_addr >= _tstate->c_stack_soft_limit) {
-        return 0;
-    }
-    assert(_tstate->c_stack_hard_limit != 0);
-    if (here_addr < _tstate->c_stack_hard_limit) {
-        /* Overflowing while handling an overflow. Give up. */
-        int kbytes_used = (int)(_tstate->c_stack_top - here_addr)/1024;
-        char buffer[80];
-        snprintf(buffer, 80, "Unrecoverable stack overflow (used %d kB)%s", kbytes_used, where);
-        Py_FatalError(buffer);
-    }
-    if (tstate->recursion_headroom) {
-        return 0;
-    }
-    else {
-        int kbytes_used = (int)(_tstate->c_stack_top - here_addr)/1024;
-        tstate->recursion_headroom++;
-        _PyErr_Format(tstate, PyExc_RecursionError,
-                    "Stack overflow (used %d kB)%s",
-                    kbytes_used,
-                    where);
-        tstate->recursion_headroom--;
+#ifdef USE_STACKCHECK
+    if (PyOS_CheckStack()) {
+        ++tstate->c_recursion_remaining;
+        _PyErr_SetString(tstate, PyExc_MemoryError, "Stack overflow");
         return -1;
     }
+#endif
+    if (tstate->recursion_headroom) {
+        if (tstate->c_recursion_remaining < -50) {
+            /* Overflowing while handling an overflow. Give up. */
+            Py_FatalError("Cannot recover from stack overflow.");
+        }
+    }
+    else {
+        if (tstate->c_recursion_remaining <= 0) {
+            tstate->recursion_headroom++;
+            _PyErr_Format(tstate, PyExc_RecursionError,
+                        "maximum recursion depth exceeded%s",
+                        where);
+            tstate->recursion_headroom--;
+            ++tstate->c_recursion_remaining;
+            return -1;
+        }
+    }
+    return 0;
 }
 
 
@@ -831,6 +761,11 @@ _PyObjectArray_Free(PyObject **array, PyObject **scratch)
 }
 
 
+/* _PyEval_EvalFrameDefault() is a *big* function,
+ * so consume 3 units of C stack */
+#define PY_EVAL_C_STACK_UNITS 2
+
+
 /* _PyEval_EvalFrameDefault is too large to optimize for speed with PGO on MSVC.
  */
 #if (defined(_MSC_VER) && \
@@ -902,6 +837,8 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, _PyInterpreterFrame *frame, int 
     entry_frame.previous = tstate->current_frame;
     frame->previous = &entry_frame;
     tstate->current_frame = frame;
+
+    tstate->c_recursion_remaining -= (PY_EVAL_C_STACK_UNITS - 1);
 
     /* support for generator.throw() */
     if (throwflag) {
@@ -1061,6 +998,7 @@ early_exit:
     assert(frame->owner == FRAME_OWNED_BY_INTERPRETER);
     /* Restore previous frame and exit */
     tstate->current_frame = frame->previous;
+    tstate->c_recursion_remaining += PY_EVAL_C_STACK_UNITS;
     return NULL;
 }
 
@@ -1624,9 +1562,11 @@ clear_thread_frame(PyThreadState *tstate, _PyInterpreterFrame * frame)
     // _PyThreadState_PopFrame, since f_code is already cleared at that point:
     assert((PyObject **)frame + _PyFrame_GetCode(frame)->co_framesize ==
         tstate->datastack_top);
+    tstate->c_recursion_remaining--;
     assert(frame->frame_obj == NULL || frame->frame_obj->f_frame == frame);
     _PyFrame_ClearExceptCode(frame);
     PyStackRef_CLEAR(frame->f_executable);
+    tstate->c_recursion_remaining++;
     _PyThreadState_PopFrame(tstate, frame);
 }
 
@@ -1639,9 +1579,11 @@ clear_gen_frame(PyThreadState *tstate, _PyInterpreterFrame * frame)
     assert(tstate->exc_info == &gen->gi_exc_state);
     tstate->exc_info = gen->gi_exc_state.previous_item;
     gen->gi_exc_state.previous_item = NULL;
+    tstate->c_recursion_remaining--;
     assert(frame->frame_obj == NULL || frame->frame_obj->f_frame == frame);
     _PyFrame_ClearExceptCode(frame);
     _PyErr_ClearExcState(&gen->gi_exc_state);
+    tstate->c_recursion_remaining++;
     frame->previous = NULL;
 }
 

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -5426,13 +5426,14 @@
                 JUMP_TO_JUMP_TARGET();
             }
             // CPython promises to check all non-vectorcall function calls.
-            if (_Py_ReachedRecursionLimit(tstate)) {
+            if (tstate->c_recursion_remaining <= 0) {
                 UOP_STAT_INC(uopcode, miss);
                 JUMP_TO_JUMP_TARGET();
             }
             STAT_INC(CALL, hit);
             PyCFunction cfunc = PyCFunction_GET_FUNCTION(callable_o);
             _PyStackRef arg = args[0];
+            _Py_EnterRecursiveCallTstateUnchecked(tstate);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             PyObject *res_o = _PyCFunction_TrampolineCall(cfunc, PyCFunction_GET_SELF(callable_o), PyStackRef_AsPyObjectBorrow(arg));
             stack_pointer = _PyFrame_GetStackPointer(frame);
@@ -5812,7 +5813,7 @@
                 JUMP_TO_JUMP_TARGET();
             }
             // CPython promises to check all non-vectorcall function calls.
-            if (_Py_ReachedRecursionLimit(tstate)) {
+            if (tstate->c_recursion_remaining <= 0) {
                 UOP_STAT_INC(uopcode, miss);
                 JUMP_TO_JUMP_TARGET();
             }
@@ -5825,6 +5826,7 @@
             }
             STAT_INC(CALL, hit);
             PyCFunction cfunc = meth->ml_meth;
+            _Py_EnterRecursiveCallTstateUnchecked(tstate);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             PyObject *res_o = _PyCFunction_TrampolineCall(cfunc,
                 PyStackRef_AsPyObjectBorrow(self_stackref),
@@ -5982,12 +5984,13 @@
                 JUMP_TO_JUMP_TARGET();
             }
             // CPython promises to check all non-vectorcall function calls.
-            if (_Py_ReachedRecursionLimit(tstate)) {
+            if (tstate->c_recursion_remaining <= 0) {
                 UOP_STAT_INC(uopcode, miss);
                 JUMP_TO_JUMP_TARGET();
             }
             STAT_INC(CALL, hit);
             PyCFunction cfunc = meth->ml_meth;
+            _Py_EnterRecursiveCallTstateUnchecked(tstate);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             PyObject *res_o = _PyCFunction_TrampolineCall(cfunc, self, NULL);
             stack_pointer = _PyFrame_GetStackPointer(frame);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1490,9 +1490,10 @@ init_threadstate(_PyThreadStateImpl *_tstate,
 
     // thread_id and native_thread_id are set in bind_tstate().
 
-    tstate->py_recursion_limit = interp->ceval.recursion_limit;
-    tstate->py_recursion_remaining = interp->ceval.recursion_limit;
-    tstate->c_recursion_remaining = 2;
+    tstate->py_recursion_limit = interp->ceval.recursion_limit,
+    tstate->py_recursion_remaining = interp->ceval.recursion_limit,
+    tstate->c_recursion_remaining = Py_C_RECURSION_LIMIT;
+
     tstate->exc_info = &tstate->exc_state;
 
     // PyGILState_Release must not try to delete this thread state.
@@ -1506,10 +1507,6 @@ init_threadstate(_PyThreadStateImpl *_tstate,
     tstate->what_event = -1;
     tstate->previous_executor = NULL;
     tstate->dict_global_version = 0;
-
-    _tstate->c_stack_soft_limit = UINTPTR_MAX;
-    _tstate->c_stack_top = 0;
-    _tstate->c_stack_hard_limit = 0;
 
     _tstate->asyncio_running_loop = NULL;
     _tstate->asyncio_running_task = NULL;

--- a/Tools/cases_generator/analyzer.py
+++ b/Tools/cases_generator/analyzer.py
@@ -653,6 +653,7 @@ NON_ESCAPING_FUNCTIONS = (
     "_PyUnicode_JoinArray",
     "_Py_CHECK_EMSCRIPTEN_SIGNALS_PERIODICALLY",
     "_Py_DECREF_NO_DEALLOC",
+    "_Py_EnterRecursiveCallTstateUnchecked",
     "_Py_ID",
     "_Py_IsImmortal",
     "_Py_LeaveRecursiveCallPy",
@@ -672,7 +673,6 @@ NON_ESCAPING_FUNCTIONS = (
     "initial_temperature_backoff_counter",
     "JUMP_TO_LABEL",
     "restart_backoff_counter",
-    "_Py_ReachedRecursionLimit",
 )
 
 def find_stmt_start(node: parser.CodeDef, idx: int) -> lexer.Token:

--- a/Tools/peg_generator/pegen/c_generator.py
+++ b/Tools/peg_generator/pegen/c_generator.py
@@ -44,7 +44,7 @@ EXTENSION_PREFIX = """\
 #    define MAXSTACK 4000
 #  endif
 #else
-#  define MAXSTACK 4000
+#  define MAXSTACK 6000
 #endif
 
 """
@@ -380,7 +380,7 @@ class CParserGenerator(ParserGenerator, GrammarVisitor):
         self.cleanup_statements: List[str] = []
 
     def add_level(self) -> None:
-        self.print("if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {")
+        self.print("if (p->level++ == MAXSTACK) {")
         with self.indent():
             self.print("_Pypegen_stack_overflow(p);")
         self.print("}")


### PR DESCRIPTION
Unfortunatlely, the change broke some buildbots. To make them usable again, and allow time for proper fixes, it's best to revert for now.

This reverts commit 2498c22fa0a2b560491bc503fa676585c1a603d0.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-91079 -->
* Issue: gh-91079
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130413.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->