### PR TITLE
gh-128627: Skip wasm-gc on iOS Safari where it's broken

### DIFF
--- a/Python/emscripten_trampoline.c
+++ b/Python/emscripten_trampoline.c
@@ -79,7 +79,7 @@ EM_JS(CountArgsFunc, _PyEM_GetCountArgsPtr, (), {
 // )
 
 function getPyEMCountArgsPtr() {
-    let isIOS = /iPad|iPhone|iPod/.test(navigator.platform);
+    let isIOS = globalThis.navigator && /iPad|iPhone|iPod/.test(navigator.platform);
     if (isIOS) {
         return 0;
     }

--- a/Python/emscripten_trampoline.c
+++ b/Python/emscripten_trampoline.c
@@ -77,11 +77,13 @@ EM_JS(CountArgsFunc, _PyEM_GetCountArgsPtr, (), {
 //         i32.const -1
 //     )
 // )
-addOnPreRun(() => {
+
+function getPyEMCountArgsPtr() {
     let isIOS = /iPad|iPhone|iPod/.test(navigator.platform);
     if (isIOS) {
-        return;
+        return 0;
     }
+
     // Try to initialize countArgsFunc
     const code = new Uint8Array([
         0x00, 0x61, 0x73, 0x6d, // \0asm magic number
@@ -153,15 +155,19 @@ addOnPreRun(() => {
             0x41, 0x7f,       // i32.const -1
             0x0b // end function
     ]);
-    let ptr = 0;
     try {
         const mod = new WebAssembly.Module(code);
         const inst = new WebAssembly.Instance(mod, { e: { t: wasmTable } });
-        ptr = addFunction(inst.exports.f);
+        return addFunction(inst.exports.f);
     } catch (e) {
         // If something goes wrong, we'll null out _PyEM_CountFuncParams and fall
         // back to the JS trampoline.
+        return 0;
     }
+}
+
+addOnPreRun(() => {
+    const ptr = getPyEMCountArgsPtr();
     Module._PyEM_CountArgsPtr = ptr;
     const offset = HEAP32[__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET / 4];
     HEAP32[(__PyRuntime + offset) / 4] = ptr;

--- a/Python/emscripten_trampoline.c
+++ b/Python/emscripten_trampoline.c
@@ -78,6 +78,10 @@ EM_JS(CountArgsFunc, _PyEM_GetCountArgsPtr, (), {
 //     )
 // )
 addOnPreRun(() => {
+    let isIOS = /iPad|iPhone|iPod/.test(navigator.platform);
+    if (isIOS) {
+        return;
+    }
     // Try to initialize countArgsFunc
     const code = new Uint8Array([
         0x00, 0x61, 0x73, 0x6d, // \0asm magic number


### PR DESCRIPTION
As of iOS 18.3.1, enabling wasm-gc is making the interpreter fail to load. Downstream pyodide issue: pyodide/pyodide#5428.

macOS Safari 18.3 does not surface the issue.

Confirmed on device that disabling this restores interpreter function.


<!-- gh-issue-number: gh-128627 -->
* Issue: gh-128627
<!-- /gh-issue-number -->
