### PR TITLE
gh-130419: Do not build the _freeze_module twice in case of Windows PGO builds

### DIFF
--- a/PCbuild/pcbuild.proj
+++ b/PCbuild/pcbuild.proj
@@ -95,7 +95,8 @@
   </ItemGroup>
 
   <Target Name="Build">
-    <MSBuild Projects="@(FreezeProjects)"
+    <MSBuild Condition="$(Configuration) != 'PGUpdate'"
+             Projects="@(FreezeProjects)"
              Properties="Configuration=%(Configuration);Platform=%(Platform);%(Properties)"
              BuildInParallel="%(BuildInParallel)"
              StopOnFirstFailure="true"


### PR DESCRIPTION
Make the Windows PGO build slightly faster by not building the _freeze_module again in the PGUpdate phase.

I think this is a skip-news?

This will also speed up clang-cl PGO build time (https://github.com/python/cpython/issues/130090).

Using the same idea, all projects with `SupportPGO=False` could be built only once  (mostly _test modules), but I think this is not worth the effort.

<!-- gh-issue-number: gh-130419 -->
* Issue: gh-130419
<!-- /gh-issue-number -->
