### PR TITLE
GH-125413: pathlib ABCs: use caching `path.info.exists()` when globbing

### DIFF
--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -533,7 +533,9 @@ class _PathGlobber(_GlobberBase):
     """Provides shell-style pattern matching and globbing for pathlib paths.
     """
 
-    lexists = operator.methodcaller('exists', follow_symlinks=False)
+    @staticmethod
+    def lexists(path):
+        return path.info.exists(follow_symlinks=False)
 
     @staticmethod
     def scandir(path):

--- a/Lib/pathlib/_abc.py
+++ b/Lib/pathlib/_abc.py
@@ -316,14 +316,11 @@ class ReadablePath(JoinablePath):
                 paths.append((path, dirnames, filenames))
             try:
                 for child in path.iterdir():
-                    try:
-                        if child.info.is_dir(follow_symlinks=follow_symlinks):
-                            if not top_down:
-                                paths.append(child)
-                            dirnames.append(child.name)
-                        else:
-                            filenames.append(child.name)
-                    except OSError:
+                    if child.info.is_dir(follow_symlinks=follow_symlinks):
+                        if not top_down:
+                            paths.append(child)
+                        dirnames.append(child.name)
+                    else:
                         filenames.append(child.name)
             except OSError as error:
                 if on_error is not None:

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -1107,7 +1107,7 @@ class ReadablePathTest(JoinablePathTest):
         p = P(self.base)
         q = p / "FILEa"
         given = set(p.glob("FILEa"))
-        expect = {q} if q.exists() else set()
+        expect = {q} if q.info.exists() else set()
         self.assertEqual(given, expect)
         self.assertEqual(set(p.glob("FILEa*")), set())
 


### PR DESCRIPTION
Call `ReadablePath.info.exists()` rather than `ReadablePath.exists()` when globbing so that we use (or populate) the `info` cache.

No change to `Path.glob()`, which uses `glob._StringGlobber` (hence `os.lexists()`) rather than `glob._PathGlobber`.

<!-- gh-issue-number: gh-125413 -->
* Issue: gh-125413
<!-- /gh-issue-number -->
