### PR TITLE
gh-130425: Add "Did you mean" suggestion for `del obj.attr`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-22-01-23-23.gh-issue-130425.x5SNQ8.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-22-01-23-23.gh-issue-130425.x5SNQ8.rst
@@ -1,0 +1,2 @@
+Add ``"Did you mean"`` suggestion when using ``del obj.attr`` if ``attr``
+does not exist.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-22-01-23-23.gh-issue-130425.x5SNQ8.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-22-01-23-23.gh-issue-130425.x5SNQ8.rst
@@ -1,2 +1,2 @@
-Add ``"Did you mean"`` suggestion when using ``del obj.attr`` if ``attr``
+Add ``"Did you mean: 'attr'?"`` suggestion when using ``del obj.attr`` if ``attr``
 does not exist.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -6898,6 +6898,7 @@ store_instance_attr_lock_held(PyObject *obj, PyDictValues *values,
         PyErr_Format(PyExc_AttributeError,
                         "'%.100s' object has no attribute '%U'",
                         Py_TYPE(obj)->tp_name, name);
+        _PyObject_SetAttributeErrorContext(obj, name);
         return -1;
     }
 


### PR DESCRIPTION
I am not quite sure about the proper way to test this:
- There are no tests for `delattr` and `setattr` suggestions, it feels like this should be a separate issue to add them. I can do it in the next PR, there would be lots of corner cases
- Local testing works:

```python
» ./python.exe     
Python 3.14.0a5+ (heads/main-dirty:38642bff139, Feb 22 2025, 01:18:34) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> class A:
...     pass
... 
... a = A()
... a.abcde = 1
... del a.abcdf # typo
... 
Traceback (most recent call last):
  File "<python-input-0>", line 6, in <module>
    del a.abcdf # typo
        ^^^^^^^
AttributeError: 'A' object has no attribute 'abcdf'. Did you mean: 'abcde'?
>>> 
```

<!-- gh-issue-number: gh-130425 -->
* Issue: gh-130425
<!-- /gh-issue-number -->
