### PR TITLE
GH-125722: Increase minimum supported Sphinx to 8.2.0

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -100,7 +100,7 @@ highlight_language = 'python3'
 
 # Minimum version of sphinx required
 # Keep this version in sync with ``Doc/requirements.txt``.
-needs_sphinx = '8.1.3'
+needs_sphinx = '8.2.0'
 
 # Create table of contents entries for domain objects (e.g. functions, classes,
 # attributes, etc.). Default is True.

--- a/Misc/NEWS.d/next/Documentation/2025-02-22-02-24-39.gh-issue-125722.zDIUFV.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-02-22-02-24-39.gh-issue-125722.zDIUFV.rst
@@ -1,0 +1,2 @@
+Require Sphinx 8.2.0 or later to build the Python documentation. Patch by
+Adam Turner.


### PR DESCRIPTION
Required for #130376, though I don't know how long is prudent to wait following release to increase the minimum requirement.

A

<!-- gh-issue-number: gh-125722 -->
* Issue: gh-125722
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130444.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->