### PR TITLE
Docs: Test presence of optional extensions with importlib

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -6,9 +6,10 @@
 # The contents of this file are pickled, so don't put values in the namespace
 # that aren't pickleable (module imports are okay, they're removed automatically).
 
-import importlib
 import os
 import sys
+from importlib import import_module
+from importlib.util import find_spec
 
 # Make our custom extensions available to Sphinx
 sys.path.append(os.path.abspath('tools/extensions'))
@@ -39,19 +40,17 @@ extensions = [
 ]
 
 # Skip if downstream redistributors haven't installed them
-try:
-    import notfound.extension  # noqa: F401
-except ImportError:
-    pass
-else:
-    extensions.append('notfound.extension')
-try:
-    import sphinxext.opengraph  # noqa: F401
-except ImportError:
-    pass
-else:
-    extensions.append('sphinxext.opengraph')
-
+_OPTIONAL_EXTENSIONS = (
+    'notfound.extension',
+    'sphinxext.opengraph',
+)
+for optional_ext in _OPTIONAL_EXTENSIONS:
+    try:
+        if find_spec(optional_ext) is not None:
+            extensions.append(optional_ext)
+    except (ImportError, ValueError):
+        pass
+del _OPTIONAL_EXTENSIONS
 
 doctest_global_setup = '''
 try:
@@ -74,7 +73,7 @@ copyright = "2001 Python Software Foundation"
 # We look for the Include/patchlevel.h file in the current Python source tree
 # and replace the values accordingly.
 # See Doc/tools/extensions/patchlevel.py
-version, release = importlib.import_module('patchlevel').get_version_info()
+version, release = import_module('patchlevel').get_version_info()
 
 rst_epilog = f"""
 .. |python_version_literal| replace:: ``Python {version}``


### PR DESCRIPTION
We don't need to import the extensions, and this is more compact if we add more optional extensions.

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130445.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->