### PR TITLE
gh-111178: fix clang-cl compilation of Modules/mmapmodule.c

### DIFF
--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1094,7 +1094,7 @@ mmap__repr__method(PyObject *op)
 
 #ifdef MS_WINDOWS
 static PyObject *
-mmap__sizeof__method(PyObject *op, PyObject *Py_UNUSED(ignored))
+mmap__sizeof__method(PyObject *op, PyObject *Py_UNUSED(dummy))
 {
     mmap_object *self = mmap_object_CAST(op);
     size_t res = _PyObject_SIZE(Py_TYPE(self));

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1094,7 +1094,7 @@ mmap__repr__method(PyObject *op)
 
 #ifdef MS_WINDOWS
 static PyObject *
-mmap__sizeof__method(PyObject *op, void *Py_UNUSED(ignored))
+mmap__sizeof__method(PyObject *op, PyObject *Py_UNUSED(ignored))
 {
     mmap_object *self = mmap_object_CAST(op);
     size_t res = _PyObject_SIZE(Py_TYPE(self));


### PR DESCRIPTION
After  https://github.com/python/cpython/pull/129784 clang-cl fails with a compilation error for `mmap__sizeof__method` in `Modules/mmapmodule.c`:
```
..\Modules\mmapmodule.c(1201,25): error : incompatible function pointer types initializing 'PyCFunction' (aka 'struct _object *(*)(struct _object *, struct _object *)') with an expression of type 'PyObject *(PyObject *, void *)' (aka 's
truct _object *(struct _object *, void *)') [-Wincompatible-function-pointer-types] [e:\cpython_clang\PCbuild\pythoncore.vcxproj]
``` 

I think this is a skip-news.


<!-- gh-issue-number: gh-111178 -->
* Issue: gh-111178
<!-- /gh-issue-number -->
