### PR TITLE
Add test checking value of a TypedDict's __total__ attribute when there is an assignment in the class body.

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8478,6 +8478,22 @@ class TypedDictTests(BaseTestCase):
             b: str
 
         self.assertIs(TD2.__total__, True)
+        
+    def test_total_with_assigned_value(self):
+        class TD(TypedDict):
+            __total__ = "some_value"
+
+        self.assertIs(TD.__total__, True)
+
+        class TD2(TypedDict, total=True):
+            __total__ = "some_value"
+            
+        self.assertIs(TD2.__total__, True)
+
+        class TD3(TypedDict, total=False):
+            __total__ = "some value"
+
+        self.assertIs(TD3.__total__, False)
 
     def test_optional_keys(self):
         class Point2Dor3D(Point2D, total=False):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -8478,7 +8478,7 @@ class TypedDictTests(BaseTestCase):
             b: str
 
         self.assertIs(TD2.__total__, True)
-        
+
     def test_total_with_assigned_value(self):
         class TD(TypedDict):
             __total__ = "some_value"
@@ -8487,7 +8487,7 @@ class TypedDictTests(BaseTestCase):
 
         class TD2(TypedDict, total=True):
             __total__ = "some_value"
-            
+
         self.assertIs(TD2.__total__, True)
 
         class TD3(TypedDict, total=False):


### PR DESCRIPTION
#109544 introduced a change in an out of spec usage when a value is assigned to `__total__` in the class body.

In such a case the assigned value is currently overwritten. Added a test cast for verification (asked by @JelleZijlstra).

Related comments from `typing_extensions`  
https://github.com/python/typing_extensions/pull/519#issuecomment-2654423339   
https://github.com/python/typing_extensions/pull/519#issuecomment-2676030610

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
