### PR TITLE
gh-130213: POC let blake2module.c see far less internals

### DIFF
--- a/Modules/_hacl/Hacl_Hash_Blake2b_Simd256.c
+++ b/Modules/_hacl/Hacl_Hash_Blake2b_Simd256.c
@@ -670,7 +670,7 @@ The caller must satisfy the following requirements.
 - The digest_length must not exceed 256 for S, 64 for B.
 
 */
-Hacl_Hash_Blake2b_Simd256_state_t
+void
 *Hacl_Hash_Blake2b_Simd256_malloc_with_params_and_key(
   Hacl_Hash_Blake2b_blake2_params *p,
   bool last_node,
@@ -901,11 +901,12 @@ void Hacl_Hash_Blake2b_Simd256_reset(Hacl_Hash_Blake2b_Simd256_state_t *s)
 */
 Hacl_Streaming_Types_error_code
 Hacl_Hash_Blake2b_Simd256_update(
-  Hacl_Hash_Blake2b_Simd256_state_t *state,
+  void *state_in,
   uint8_t *chunk,
   uint32_t chunk_len
 )
 {
+  Hacl_Hash_Blake2b_Simd256_state_t* state = (Hacl_Hash_Blake2b_Simd256_state_t*)state_in;
   Hacl_Hash_Blake2b_Simd256_state_t s = *state;
   uint64_t total_len = s.total_len;
   if ((uint64_t)chunk_len > 0xffffffffffffffffULL - total_len)
@@ -1122,8 +1123,9 @@ For convenience, this function returns `digest_length`. When in doubt, callers
 can pass an array of size HACL_BLAKE2B_256_OUT_BYTES, then use the return value
 to see how many bytes were actually written.
 */
-uint8_t Hacl_Hash_Blake2b_Simd256_digest(Hacl_Hash_Blake2b_Simd256_state_t *s, uint8_t *dst)
+uint8_t Hacl_Hash_Blake2b_Simd256_digest(void * state, uint8_t *dst)
 {
+  Hacl_Hash_Blake2b_Simd256_state_t* s = (Hacl_Hash_Blake2b_Simd256_state_t*)state;
   Hacl_Hash_Blake2b_Simd256_block_state_t block_state0 = (*s).block_state;
   bool last_node0 = block_state0.thd;
   uint8_t nn0 = block_state0.snd;
@@ -1203,8 +1205,9 @@ uint8_t Hacl_Hash_Blake2b_Simd256_digest(Hacl_Hash_Blake2b_Simd256_state_t *s, u
     ((Hacl_Hash_Blake2b_index){ .key_length = kk, .digest_length = nn, .last_node = last_node }).digest_length;
 }
 
-Hacl_Hash_Blake2b_index Hacl_Hash_Blake2b_Simd256_info(Hacl_Hash_Blake2b_Simd256_state_t *s)
+Hacl_Hash_Blake2b_index Hacl_Hash_Blake2b_Simd256_info(void * state)
 {
+  Hacl_Hash_Blake2b_Simd256_state_t* s = (Hacl_Hash_Blake2b_Simd256_state_t*)state;
   Hacl_Hash_Blake2b_Simd256_block_state_t block_state = (*s).block_state;
   bool last_node = block_state.thd;
   uint8_t nn = block_state.snd;
@@ -1216,8 +1219,9 @@ Hacl_Hash_Blake2b_index Hacl_Hash_Blake2b_Simd256_info(Hacl_Hash_Blake2b_Simd256
 /**
   Free state function when there is no key
 */
-void Hacl_Hash_Blake2b_Simd256_free(Hacl_Hash_Blake2b_Simd256_state_t *state)
+void Hacl_Hash_Blake2b_Simd256_free(void *state_in)
 {
+  Hacl_Hash_Blake2b_Simd256_state_t* state = (Hacl_Hash_Blake2b_Simd256_state_t*)state_in;
   Hacl_Hash_Blake2b_Simd256_state_t scrut = *state;
   uint8_t *buf = scrut.buf;
   Hacl_Hash_Blake2b_Simd256_block_state_t block_state = scrut.block_state;
@@ -1232,9 +1236,10 @@ void Hacl_Hash_Blake2b_Simd256_free(Hacl_Hash_Blake2b_Simd256_state_t *state)
 /**
   Copying. This preserves all parameters.
 */
-Hacl_Hash_Blake2b_Simd256_state_t
-*Hacl_Hash_Blake2b_Simd256_copy(Hacl_Hash_Blake2b_Simd256_state_t *state)
+void
+*Hacl_Hash_Blake2b_Simd256_copy(void * state_in)
 {
+  Hacl_Hash_Blake2b_Simd256_state_t* state = (Hacl_Hash_Blake2b_Simd256_state_t*)state_in;
   Hacl_Hash_Blake2b_Simd256_state_t scrut = *state;
   Hacl_Hash_Blake2b_Simd256_block_state_t block_state0 = scrut.block_state;
   uint8_t *buf0 = scrut.buf;

--- a/Modules/_hacl/Hacl_Hash_Blake2b_Simd256.h
+++ b/Modules/_hacl/Hacl_Hash_Blake2b_Simd256.h
@@ -30,50 +30,11 @@
 extern "C" {
 #endif
 
-#include <string.h>
 #include "python_hacl_namespaces.h"
-#include "krml/types.h"
-#include "krml/lowstar_endianness.h"
-#include "krml/internal/target.h"
 
 #include "Hacl_Streaming_Types.h"
 
 #include "Hacl_Hash_Blake2b.h"
-#include "libintvector.h"
-
-#define HACL_HASH_BLAKE2B_SIMD256_BLOCK_BYTES (128U)
-
-#define HACL_HASH_BLAKE2B_SIMD256_OUT_BYTES (64U)
-
-#define HACL_HASH_BLAKE2B_SIMD256_KEY_BYTES (64U)
-
-#define HACL_HASH_BLAKE2B_SIMD256_SALT_BYTES (16U)
-
-#define HACL_HASH_BLAKE2B_SIMD256_PERSONAL_BYTES (16U)
-
-typedef struct K____Lib_IntVector_Intrinsics_vec256___Lib_IntVector_Intrinsics_vec256__s
-{
-  Lib_IntVector_Intrinsics_vec256 *fst;
-  Lib_IntVector_Intrinsics_vec256 *snd;
-}
-K____Lib_IntVector_Intrinsics_vec256___Lib_IntVector_Intrinsics_vec256_;
-
-typedef struct Hacl_Hash_Blake2b_Simd256_block_state_t_s
-{
-  uint8_t fst;
-  uint8_t snd;
-  bool thd;
-  K____Lib_IntVector_Intrinsics_vec256___Lib_IntVector_Intrinsics_vec256_ f3;
-}
-Hacl_Hash_Blake2b_Simd256_block_state_t;
-
-typedef struct Hacl_Hash_Blake2b_Simd256_state_t_s
-{
-  Hacl_Hash_Blake2b_Simd256_block_state_t block_state;
-  uint8_t *buf;
-  uint64_t total_len;
-}
-Hacl_Hash_Blake2b_Simd256_state_t;
 
 /**
  General-purpose allocation function that gives control over all
@@ -90,7 +51,7 @@ The caller must satisfy the following requirements.
 - The digest_length must not exceed 256 for S, 64 for B.
 
 */
-Hacl_Hash_Blake2b_Simd256_state_t
+void
 *Hacl_Hash_Blake2b_Simd256_malloc_with_params_and_key(
   Hacl_Hash_Blake2b_blake2_params *p,
   bool last_node,
@@ -98,66 +59,11 @@ Hacl_Hash_Blake2b_Simd256_state_t
 );
 
 /**
- Specialized allocation function that picks default values for all
-parameters, except for the key_length. Further resettings of the state SHALL be
-done with `reset_with_key`, and SHALL feature the exact same key length `kk` as
-passed here. In other words, once you commit to a key length, the only way to
-change this parameter is to allocate a new object.
-
-The caller must satisfy the following requirements.
-- The key_length must not exceed 256 for S, 64 for B.
-
-*/
-Hacl_Hash_Blake2b_Simd256_state_t
-*Hacl_Hash_Blake2b_Simd256_malloc_with_key0(uint8_t *k, uint8_t kk);
-
-/**
- Specialized allocation function that picks default values for all
-parameters, and has no key. Effectively, this is what you want if you intend to
-use Blake2 as a hash function. Further resettings of the state SHALL be done with `reset`.
-*/
-Hacl_Hash_Blake2b_Simd256_state_t *Hacl_Hash_Blake2b_Simd256_malloc(void);
-
-/**
- General-purpose re-initialization function with parameters and
-key. You cannot change digest_length, key_length, or last_node, meaning those values in
-the parameters object must be the same as originally decided via one of the
-malloc functions. All other values of the parameter can be changed. The behavior
-is unspecified if you violate this precondition.
-*/
-void
-Hacl_Hash_Blake2b_Simd256_reset_with_key_and_params(
-  Hacl_Hash_Blake2b_Simd256_state_t *s,
-  Hacl_Hash_Blake2b_blake2_params *p,
-  uint8_t *k
-);
-
-/**
- Specialized-purpose re-initialization function with no parameters,
-and a key. The key length must be the same as originally decided via your choice
-of malloc function. All other parameters are reset to their default values. The
-original call to malloc MUST have set digest_length to the default value. The
-behavior is unspecified if you violate this precondition.
-*/
-void
-Hacl_Hash_Blake2b_Simd256_reset_with_key(Hacl_Hash_Blake2b_Simd256_state_t *s, uint8_t *k);
-
-/**
- Specialized-purpose re-initialization function with no parameters
-and no key. This is what you want if you intend to use Blake2 as a hash
-function. The key length and digest length must have been set to their
-respective default values via your choice of malloc function (always true if you
-used `malloc`). All other parameters are reset to their default values. The
-behavior is unspecified if you violate this precondition.
-*/
-void Hacl_Hash_Blake2b_Simd256_reset(Hacl_Hash_Blake2b_Simd256_state_t *s);
-
-/**
   Update function; 0 = success, 1 = max length exceeded
 */
 Hacl_Streaming_Types_error_code
 Hacl_Hash_Blake2b_Simd256_update(
-  Hacl_Hash_Blake2b_Simd256_state_t *state,
+  void *state,
   uint8_t *chunk,
   uint32_t chunk_len
 );
@@ -173,55 +79,20 @@ For convenience, this function returns `digest_length`. When in doubt, callers
 can pass an array of size HACL_BLAKE2B_256_OUT_BYTES, then use the return value
 to see how many bytes were actually written.
 */
-uint8_t Hacl_Hash_Blake2b_Simd256_digest(Hacl_Hash_Blake2b_Simd256_state_t *s, uint8_t *dst);
+uint8_t Hacl_Hash_Blake2b_Simd256_digest(void *s, uint8_t *dst);
 
-Hacl_Hash_Blake2b_index Hacl_Hash_Blake2b_Simd256_info(Hacl_Hash_Blake2b_Simd256_state_t *s);
+Hacl_Hash_Blake2b_index Hacl_Hash_Blake2b_Simd256_info(void *s);
 
 /**
   Free state function when there is no key
 */
-void Hacl_Hash_Blake2b_Simd256_free(Hacl_Hash_Blake2b_Simd256_state_t *state);
+void Hacl_Hash_Blake2b_Simd256_free(void *state);
 
 /**
   Copying. This preserves all parameters.
 */
-Hacl_Hash_Blake2b_Simd256_state_t
-*Hacl_Hash_Blake2b_Simd256_copy(Hacl_Hash_Blake2b_Simd256_state_t *state);
-
-/**
-Write the BLAKE2b digest of message `input` using key `key` into `output`.
-
-@param output Pointer to `output_len` bytes of memory where the digest is written to.
-@param output_len Length of the to-be-generated digest with 1 <= `output_len` <= 64.
-@param input Pointer to `input_len` bytes of memory where the input message is read from.
-@param input_len Length of the input message.
-@param key Pointer to `key_len` bytes of memory where the key is read from.
-@param key_len Length of the key. Can be 0.
-*/
 void
-Hacl_Hash_Blake2b_Simd256_hash_with_key(
-  uint8_t *output,
-  uint32_t output_len,
-  uint8_t *input,
-  uint32_t input_len,
-  uint8_t *key,
-  uint32_t key_len
-);
-
-/**
-Write the BLAKE2b digest of message `input` using key `key` and
-parameters `params` into `output`. The `key` array must be of length
-`params.key_length`. The `output` array must be of length
-`params.digest_length`.
-*/
-void
-Hacl_Hash_Blake2b_Simd256_hash_with_key_and_params(
-  uint8_t *output,
-  uint8_t *input,
-  uint32_t input_len,
-  Hacl_Hash_Blake2b_blake2_params params,
-  uint8_t *key
-);
+*Hacl_Hash_Blake2b_Simd256_copy(void *state);
 
 #if defined(__cplusplus)
 }

--- a/Modules/_hacl/internal/Hacl_Hash_Blake2b_Simd256.h
+++ b/Modules/_hacl/internal/Hacl_Hash_Blake2b_Simd256.h
@@ -40,6 +40,130 @@ extern "C" {
 #include "../Hacl_Hash_Blake2b_Simd256.h"
 #include "libintvector.h"
 
+#define HACL_HASH_BLAKE2B_SIMD256_BLOCK_BYTES (128U)
+
+#define HACL_HASH_BLAKE2B_SIMD256_OUT_BYTES (64U)
+
+#define HACL_HASH_BLAKE2B_SIMD256_KEY_BYTES (64U)
+
+#define HACL_HASH_BLAKE2B_SIMD256_SALT_BYTES (16U)
+
+#define HACL_HASH_BLAKE2B_SIMD256_PERSONAL_BYTES (16U)
+
+typedef struct K____Lib_IntVector_Intrinsics_vec256___Lib_IntVector_Intrinsics_vec256__s
+{
+  Lib_IntVector_Intrinsics_vec256 *fst;
+  Lib_IntVector_Intrinsics_vec256 *snd;
+}
+K____Lib_IntVector_Intrinsics_vec256___Lib_IntVector_Intrinsics_vec256_;
+
+typedef struct Hacl_Hash_Blake2b_Simd256_block_state_t_s
+{
+  uint8_t fst;
+  uint8_t snd;
+  bool thd;
+  K____Lib_IntVector_Intrinsics_vec256___Lib_IntVector_Intrinsics_vec256_ f3;
+}
+Hacl_Hash_Blake2b_Simd256_block_state_t;
+
+typedef struct Hacl_Hash_Blake2b_Simd256_state_t_s
+{
+  Hacl_Hash_Blake2b_Simd256_block_state_t block_state;
+  uint8_t *buf;
+  uint64_t total_len;
+}
+Hacl_Hash_Blake2b_Simd256_state_t;
+
+/**
+ Specialized allocation function that picks default values for all
+parameters, except for the key_length. Further resettings of the state SHALL be
+done with `reset_with_key`, and SHALL feature the exact same key length `kk` as
+passed here. In other words, once you commit to a key length, the only way to
+change this parameter is to allocate a new object.
+
+The caller must satisfy the following requirements.
+- The key_length must not exceed 256 for S, 64 for B.
+
+*/
+Hacl_Hash_Blake2b_Simd256_state_t
+*Hacl_Hash_Blake2b_Simd256_malloc_with_key0(uint8_t *k, uint8_t kk);
+
+/**
+ Specialized allocation function that picks default values for all
+parameters, and has no key. Effectively, this is what you want if you intend to
+use Blake2 as a hash function. Further resettings of the state SHALL be done with `reset`.
+*/
+Hacl_Hash_Blake2b_Simd256_state_t *Hacl_Hash_Blake2b_Simd256_malloc(void);
+
+/**
+ General-purpose re-initialization function with parameters and
+key. You cannot change digest_length, key_length, or last_node, meaning those values in
+the parameters object must be the same as originally decided via one of the
+malloc functions. All other values of the parameter can be changed. The behavior
+is unspecified if you violate this precondition.
+*/
+void
+Hacl_Hash_Blake2b_Simd256_reset_with_key_and_params(
+  Hacl_Hash_Blake2b_Simd256_state_t *s,
+  Hacl_Hash_Blake2b_blake2_params *p,
+  uint8_t *k
+);
+
+/**
+ Specialized-purpose re-initialization function with no parameters,
+and a key. The key length must be the same as originally decided via your choice
+of malloc function. All other parameters are reset to their default values. The
+original call to malloc MUST have set digest_length to the default value. The
+behavior is unspecified if you violate this precondition.
+*/
+void
+Hacl_Hash_Blake2b_Simd256_reset_with_key(Hacl_Hash_Blake2b_Simd256_state_t *s, uint8_t *k);
+
+/**
+ Specialized-purpose re-initialization function with no parameters
+and no key. This is what you want if you intend to use Blake2 as a hash
+function. The key length and digest length must have been set to their
+respective default values via your choice of malloc function (always true if you
+used `malloc`). All other parameters are reset to their default values. The
+behavior is unspecified if you violate this precondition.
+*/
+void Hacl_Hash_Blake2b_Simd256_reset(Hacl_Hash_Blake2b_Simd256_state_t *s);
+
+/**
+Write the BLAKE2b digest of message `input` using key `key` into `output`.
+
+@param output Pointer to `output_len` bytes of memory where the digest is written to.
+@param output_len Length of the to-be-generated digest with 1 <= `output_len` <= 64.
+@param input Pointer to `input_len` bytes of memory where the input message is read from.
+@param input_len Length of the input message.
+@param key Pointer to `key_len` bytes of memory where the key is read from.
+@param key_len Length of the key. Can be 0.
+*/
+void
+Hacl_Hash_Blake2b_Simd256_hash_with_key(
+  uint8_t *output,
+  uint32_t output_len,
+  uint8_t *input,
+  uint32_t input_len,
+  uint8_t *key,
+  uint32_t key_len
+);
+
+/**
+Write the BLAKE2b digest of message `input` using key `key` and
+parameters `params` into `output`. The `key` array must be of length
+`params.key_length`. The `output` array must be of length
+`params.digest_length`.
+*/
+void
+Hacl_Hash_Blake2b_Simd256_hash_with_key_and_params(
+  uint8_t *output,
+  uint8_t *input,
+  uint32_t input_len,
+  Hacl_Hash_Blake2b_blake2_params params,
+  uint8_t *key
+);
+
 void
 Hacl_Hash_Blake2b_Simd256_init(Lib_IntVector_Intrinsics_vec256 *hash, uint32_t kk, uint32_t nn);
 

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -135,9 +135,7 @@ static inline bool has_simd256(cpu_flags *flags) {
 
 #include "_hacl/Hacl_Hash_Blake2b.h"
 #include "_hacl/Hacl_Hash_Blake2s.h"
-#if HACL_CAN_COMPILE_SIMD256
 #include "_hacl/Hacl_Hash_Blake2b_Simd256.h"
-#endif
 #if HACL_CAN_COMPILE_SIMD128
 #include "_hacl/Hacl_Hash_Blake2s_Simd128.h"
 #endif
@@ -358,7 +356,7 @@ typedef struct {
         Hacl_Hash_Blake2s_Simd128_state_t *blake2s_128_state;
 #endif
 #ifdef HACL_CAN_COMPILE_SIMD256
-        Hacl_Hash_Blake2b_Simd256_state_t *blake2b_256_state;
+        void *blake2b_256_state;
 #endif
     };
     blake2_impl impl;

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -40,7 +40,7 @@
 #endif
 
 #include <stdbool.h>
-
+#undef HACL_CAN_COMPILE_SIMD128
 // SIMD256 can't be compiled on macOS ARM64, and performance of SIMD128 isn't
 // great; but when compiling a universal2 binary, autoconf will set
 // HACL_CAN_COMPILE_SIMD128 and HACL_CAN_COMPILE_SIMD256 because they *can* be

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -100,7 +100,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>/Zm200  %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalIncludeDirectories>$(PySourcePath)Modules\_hacl\include;$(PySourcePath)Modules\_hacl\internal;$(PySourcePath)Python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(PySourcePath)Modules\_hacl\include;$(PySourcePath)Python;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="$(IncludeExternals)">$(zlibDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_USRDLL;Py_BUILD_CORE;Py_BUILD_CORE_BUILTIN;Py_ENABLE_SHARED;MS_DLL_ID="$(SysWinVer)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="$(IncludeExternals)">_Py_HAVE_ZLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
**Just a POC, because this is touching generated code.**

Limit the view of the `blake2module.c` to the internals of the SIMD* implementations by using `void *`.

For me this now works for clang-cl 18.1.8, which does not "allow to see" the needed intrinsics without compiling for the proper architecture. I just temporarily use `#undef HACL_CAN_COMPILE_SIMD128`, because I did the POC only for the SIMD256 case.

And `test_hashlib` is still green :)

And the fast SIMD256 path is used, if the host where the binary is running supports it, without the need of SIMD flags when compiling `blake2module.c`.

I've checked in a debugging session during running `test_hashlib`, that the `void *` "public" functions are still invoked, and that they work like before after casting back to `Hacl_Hash_Blake2b_Simd256_state_t *`.

<!-- gh-issue-number: gh-130213 -->
* Issue: gh-130213
<!-- /gh-issue-number -->
