### PR TITLE
gh-99668: Add OpenSSF Scorecard GitHub Action and badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,46 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '24 7 * * 4'
+  push:
+    branches: [ "main" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/Misc/NEWS.d/next/Security/2025-02-23-22-30-01.gh-issue-99668.KlKXwO.rst
+++ b/Misc/NEWS.d/next/Security/2025-02-23-22-30-01.gh-issue-99668.KlKXwO.rst
@@ -1,0 +1,3 @@
+Add OpenSSF Scorecard GitHub Action which performs dozens of automated
+checks to ensure the project's security posture is solid and badge which
+shows OpenSSF Scorecard score.

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ This is Python version 3.14.0 alpha 5
    :alt: CPython build status on Azure DevOps
    :target: https://dev.azure.com/python/cpython/_build/latest?definitionId=4&branchName=main
 
+.. image:: https://api.scorecard.dev/projects/github.com/python/cpython/badge
+   :alt: OpenSSF Scorecard
+   :target: https://scorecard.dev/viewer/?uri=github.com/python/cpython
+
 .. image:: https://img.shields.io/badge/discourse-join_chat-brightgreen.svg
    :alt: Python Discourse chat
    :target: https://discuss.python.org/


### PR DESCRIPTION
Add OpenSSF Scorecard GitHub Action which performs dozens of automated
checks to ensure the project's security posture is solid and badge which
shows OpenSSF Scorecard score: https://scorecard.dev/viewer/?uri=github.com/python/cpython

<!-- gh-issue-number: gh-99668 -->
* Issue: gh-99668
<!-- /gh-issue-number -->
