### PR TITLE
gh-122029: Move monitoring after method expand for CALL_KW

### DIFF
--- a/Lib/test/test_sys_setprofile.py
+++ b/Lib/test/test_sys_setprofile.py
@@ -493,6 +493,24 @@ class TestEdgeCases(unittest.TestCase):
         # The last c_call is the call to sys.setprofile
         self.assertEqual(events, ['c_call', 'c_return', 'c_call'])
 
+        class B:
+            f = classmethod(max)
+        events = []
+        sys.setprofile(lambda frame, event, args: events.append(event))
+        # Not important, we only want to trigger INSTRUMENTED_CALL_KW
+        B().f(1, key=lambda x: 0)
+        sys.setprofile(None)
+        # The last c_call is the call to sys.setprofile
+        self.assertEqual(
+            events,
+            ['c_call',
+             'call', 'return',
+             'call', 'return',
+             'c_return',
+             'c_call'
+            ]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-23-20-48-31.gh-issue-122029.iW8GvA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-23-20-48-31.gh-issue-122029.iW8GvA.rst
@@ -1,0 +1,1 @@
+``INSTRUMENTED_CALL_KW`` will expand the method before monitoring to reflect the actual behavior more accurately.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -4509,8 +4509,8 @@ dummy_func(
         macro(INSTRUMENTED_CALL_KW) =
             counter/1 +
             unused/2 +
-            _MONITOR_CALL_KW +
             _MAYBE_EXPAND_METHOD_KW +
+            _MONITOR_CALL_KW +
             _DO_CALL_KW;
 
         op(_CHECK_IS_NOT_PY_CALLABLE_KW, (callable[1], unused[1], unused[oparg], kwnames -- callable[1], unused[1], unused[oparg], kwnames)) {


### PR DESCRIPTION
Per discussion in https://github.com/python/cpython/issues/122029#issuecomment-2245302063, we should monitor what really happened for C code. We expanded the possible method first for `CALL`, but not for `CALL_KW`. We should do the same for `CALL_KW`. We can potentially remove the temp patch in legacy tracing for unpacking methods later.

`CALL_FUNCTION_EX` is another story and to make the PR easy to review, we are dealing with `CALL_KW` only in this PR. This should be a very non-intrusive change.

<!-- gh-issue-number: gh-122029 -->
* Issue: gh-122029
<!-- /gh-issue-number -->
