### PR TITLE
Doc: Strip trailing whitespace in ``pydoc_topics``

### DIFF
--- a/Doc/tools/extensions/pydoc_topics.py
+++ b/Doc/tools/extensions/pydoc_topics.py
@@ -143,7 +143,8 @@ class PydocTopicsBuilder(TextBuilder):
                 document.append(doc_ids[label_id])
                 visitor = TextTranslator(document, builder=self)
                 document.walkabout(visitor)
-                self.topics[topic_label] = visitor.body
+                body = "\n".join(map(str.rstrip, visitor.body.splitlines()))
+                self.topics[topic_label] = body
 
     def finish(self) -> None:
         topics_repr = "\n".join(


### PR DESCRIPTION
In lieu of identifying the root cause, this should at least prevent further failures.

See discussion in https://github.com/python/cpython/pull/130441.

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130492.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->