### PR TITLE
gh-82987: Stop on calling frame unconditionally for inline breakpoints

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -246,7 +246,8 @@ access further features, you have to do this yourself:
       Added the *mode* argument.
 
    .. versionchanged:: 3.14
-      *skip* will be ignored if inline breakpoints like :func:`breakpoint` or :func:`set_trace` are used.
+      Inline breakpoints like :func:`breakpoint` or :func:`pdb.set_trace` will
+      always stop the program at calling frame, ignoring the *skip* pattern (if any).
 
    .. method:: run(statement, globals=None, locals=None)
                runeval(expression, globals=None, locals=None)

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -245,6 +245,9 @@ access further features, you have to do this yourself:
    .. versionadded:: 3.14
       Added the *mode* argument.
 
+   .. versionchanged:: 3.14
+      *skip* will be ignored if inline breakpoints like :func:`breakpoint` or :func:`set_trace` are used.
+
    .. method:: run(statement, globals=None, locals=None)
                runeval(expression, globals=None, locals=None)
                runcall(function, *args, **kwds)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -709,6 +709,11 @@ pdb
   the quit and call :func:`sys.exit`, instead of raising :exc:`bdb.BdbQuit`.
   (Contributed by Tian Gao in :gh:`124704`.)
 
+* :mod:`pdb` will always stop on calling frames when inline breakpoints like
+  :func:`breakpoint` or :func:`pdb.set_trace` are used, ignoring the ``skip``
+  pattern (if any).
+  (Contributed by Tian Gao in :gh:`130493`.)
+
 
 pickle
 ------

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -709,9 +709,9 @@ pdb
   the quit and call :func:`sys.exit`, instead of raising :exc:`bdb.BdbQuit`.
   (Contributed by Tian Gao in :gh:`124704`.)
 
-* :mod:`pdb` will always stop on calling frames when inline breakpoints like
-  :func:`breakpoint` or :func:`pdb.set_trace` are used, ignoring the ``skip``
-  pattern (if any).
+* Inline breakpoints like :func:`breakpoint` or :func:`pdb.set_trace` will
+  always stop the program at calling frame, ignoring the ``skip`` pattern
+  (if any).
   (Contributed by Tian Gao in :gh:`130493`.)
 
 

--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -215,10 +215,13 @@ class Bdb:
         If the debugger stops on the current opcode, invoke
         self.user_opcode(). Raise BdbQuit if self.quitting is set.
         Return self.trace_dispatch to continue tracing in this scope.
+
+        Opcode event will always trigger the user calback. For now the only
+        opcode event is from an inline set_trace() and we want to stop there
+        unconditionally.
         """
-        if self.stop_here(frame) or self.break_here(frame):
-            self.user_opcode(frame)
-            if self.quitting: raise BdbQuit
+        self.user_opcode(frame)
+        if self.quitting: raise BdbQuit
         return self.trace_dispatch
 
     # Normally derived classes don't override the following

--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -216,7 +216,7 @@ class Bdb:
         self.user_opcode(). Raise BdbQuit if self.quitting is set.
         Return self.trace_dispatch to continue tracing in this scope.
 
-        Opcode event will always trigger the user calback. For now the only
+        Opcode event will always trigger the user callback. For now the only
         opcode event is from an inline set_trace() and we want to stop there
         unconditionally.
         """

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4341,6 +4341,28 @@ class PdbTestInline(unittest.TestCase):
         # The quit prompt should be printed exactly twice
         self.assertEqual(stdout.count("Quit anyway"), 2)
 
+    def test_set_trace_with_skip(self):
+        """GH-82897
+        Inline set_trace() should break unconditionally. This example is a
+        bit oversimplified, but as `pdb.set_trace()` uses the previous Pdb
+        instance, it's possible that we had a previous pdb instance with
+        skip values when we use `pdb.set_trace()` - it would be confusing
+        to users when such inline breakpoints won't break immediately.
+        """
+        script = textwrap.dedent("""
+            import pdb
+            def foo():
+                x = 40 + 2
+                pdb.Pdb(skip=['__main__']).set_trace()
+            foo()
+        """)
+        commands = """
+            p x
+            c
+        """
+        stdout, _ = self._run_script(script, commands)
+        self.assertIn("42", stdout)
+
 
 @support.requires_subprocess()
 class PdbTestReadline(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2025-02-24-01-49-11.gh-issue-82987.vHfQlG.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-24-01-49-11.gh-issue-82987.vHfQlG.rst
@@ -1,0 +1,1 @@
+:mod:`pdb` will always stop on calling frames when inline breakpoints like :func:`breakpoint` or :func:`pdb.set_trace` are used, regardless of whether the module matches ``skip`` pattern.

--- a/Misc/NEWS.d/next/Library/2025-02-24-01-49-11.gh-issue-82987.vHfQlG.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-24-01-49-11.gh-issue-82987.vHfQlG.rst
@@ -1,1 +1,1 @@
-:mod:`pdb` will always stop on calling frames when inline breakpoints like :func:`breakpoint` or :func:`pdb.set_trace` are used, ignoring the ``skip`` pattern (if any).
+Inline breakpoints like :func:`breakpoint` or :func:`pdb.set_trace` will always stop the program at calling frame, ignoring the ``skip`` pattern (if any).

--- a/Misc/NEWS.d/next/Library/2025-02-24-01-49-11.gh-issue-82987.vHfQlG.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-24-01-49-11.gh-issue-82987.vHfQlG.rst
@@ -1,1 +1,1 @@
-:mod:`pdb` will always stop on calling frames when inline breakpoints like :func:`breakpoint` or :func:`pdb.set_trace` are used, regardless of whether the module matches ``skip`` pattern.
+:mod:`pdb` will always stop on calling frames when inline breakpoints like :func:`breakpoint` or :func:`pdb.set_trace` are used, ignoring the ``skip`` pattern (if any).


### PR DESCRIPTION
The testing code
```python
import pdb
def foo():
    x = 40 + 2
    pdb.Pdb(skip=['__main__']).set_trace()
foo()
```

seems a bit silly, but this is a real issue because we use the *last instance* of pdb for inline breakpoints now.

So if we instantiate a debugger like `p = pdb.Pdb(skip=["django.*"])` somewhere, and we set an inline breakpoint in Django with an innocent `breakpoint()`, it still won't stop inside Django modules.

Overall I think it's reasonable that we *always* stop for inline breakpoints. The implementation I chose is to remove the condition for `opcode` events which also makes sense. For now that event is exclusively used by inline breakpoints. Even if we add instruction level debugging in the future, I think the only useful command is "step instruction". It's hard to imagine instruction level breakpoints or something like `until instruction`. Always trigger user function for opcode seems like an okay solution.

<!-- gh-issue-number: gh-82987 -->
* Issue: gh-82987
<!-- /gh-issue-number -->
