### PR TITLE
gh-130160: Convert `webbrowser` docs to use `.. option` directive

### DIFF
--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -40,14 +40,23 @@ a new tab, with the browser being brought to the foreground. The use of the
 :mod:`webbrowser` module on iOS requires the :mod:`ctypes` module. If
 :mod:`ctypes` isn't available, calls to :func:`.open` will fail.
 
+.. program:: webbrowser
+
 The script :program:`webbrowser` can be used as a command-line interface for the
 module. It accepts a URL as the argument. It accepts the following optional
 parameters:
 
-* ``-n``/``--new-window`` opens the URL in a new browser window, if possible.
-* ``-t``/``--new-tab`` opens the URL in a new browser page ("tab").
+.. option:: -n, --new-window
 
-The options are, naturally, mutually exclusive.  Usage example::
+   Opens the URL in a new browser window, if possible.
+
+.. option:: -t, --new-tab
+
+   Opens the URL in a new browser page ("tab").
+
+The options are, naturally, mutually exclusive.  Usage example:
+
+.. code-block:: bash
 
    python -m webbrowser -t "https://www.python.org"
 


### PR DESCRIPTION
Before: https://docs.python.org/3/library/webbrowser.html#module-webbrowser

<img width="829" alt="Снимок экрана 2025-02-24 в 10 56 51" src="https://github.com/user-attachments/assets/1a70a6fd-3369-43cc-a01a-fa6f4010f880" />


After:
<img width="842" alt="Снимок экрана 2025-02-24 в 10 57 54" src="https://github.com/user-attachments/assets/4ccf94d4-7252-4d97-811a-133fbd6ac183" />



<!-- gh-issue-number: gh-130160 -->
* Issue: gh-130160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130497.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->