### PR TITLE
gh-130482: Add ability to specify name for `tkinter.OptionMenu` and `tkinter.ttk.OptionMenu`

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -856,6 +856,9 @@ tkinter
   arguments passed by keyword.
   (Contributed by Zhikang Yan in :gh:`126899`.)
 
+* Add ability to specify name for :class:`!tkinter.OptionMenu` and
+  :class:`!tkinter.ttk.OptionMenu`.
+  (Contributed by Zhikang Yan in :gh:`130482`.)
 
 turtle
 ------

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -354,6 +354,10 @@ class OptionMenuTest(MenubuttonTest, unittest.TestCase):
         with self.assertRaisesRegex(TclError, r"^unknown option -image$"):
             tkinter.OptionMenu(self.root, None, 'b', image='')
 
+    def test_specify_name(self):
+        widget = tkinter.OptionMenu(self.root, None, ':)', name="option_menu")
+        self.assertIs(self.root.nametowidget("option_menu"), widget)
+
 @add_configure_tests(IntegerSizeTests, StandardOptionsTests)
 class EntryTest(AbstractWidgetTest, unittest.TestCase):
     _rounds_pixels = (tk_version < (9, 0))

--- a/Lib/test/test_tkinter/test_widgets.py
+++ b/Lib/test/test_tkinter/test_widgets.py
@@ -356,7 +356,8 @@ class OptionMenuTest(MenubuttonTest, unittest.TestCase):
 
     def test_specify_name(self):
         widget = tkinter.OptionMenu(self.root, None, ':)', name="option_menu")
-        self.assertIs(self.root.nametowidget("option_menu"), widget)
+        self.assertEqual(str(widget), ".option_menu")
+        self.assertIs(self.root.children["option_menu"], widget)
 
 @add_configure_tests(IntegerSizeTests, StandardOptionsTests)
 class EntryTest(AbstractWidgetTest, unittest.TestCase):

--- a/Lib/test/test_ttk/test_extensions.py
+++ b/Lib/test/test_ttk/test_extensions.py
@@ -319,6 +319,11 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
         textvar.trace_remove("write", cb_name)
         optmenu.destroy()
 
+    def test_specify_name(self):
+        textvar = tkinter.StringVar(self.root)
+        widget = ttk.OptionMenu(self.root, textvar, ":)", name="option_menu_ex")
+        self.assertIs(self.root.nametowidget("option_menu_ex"), widget)
+
 
 class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):
 

--- a/Lib/test/test_ttk/test_extensions.py
+++ b/Lib/test/test_ttk/test_extensions.py
@@ -322,7 +322,8 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
     def test_specify_name(self):
         textvar = tkinter.StringVar(self.root)
         widget = ttk.OptionMenu(self.root, textvar, ":)", name="option_menu_ex")
-        self.assertIs(self.root.nametowidget("option_menu_ex"), widget)
+        self.assertEqual(str(widget), ".option_menu_ex")
+        self.assertIs(self.root.children["option_menu_ex"], widget)
 
 
 class DefaultRootTest(AbstractDefaultRootTest, unittest.TestCase):

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -4187,7 +4187,7 @@ class OptionMenu(Menubutton):
         keyword argument command."""
         kw = {"borderwidth": 2, "textvariable": variable,
               "indicatoron": 1, "relief": RAISED, "anchor": "c",
-              "highlightthickness": 2}
+              "highlightthickness": 2, "name": kwargs.pop("name", None)}
         Widget.__init__(self, master, "menubutton", kw)
         self.widgetName = 'tk_optionMenu'
         menu = self.__menu = Menu(self, name="menu", tearoff=0)

--- a/Lib/tkinter/ttk.py
+++ b/Lib/tkinter/ttk.py
@@ -1603,7 +1603,8 @@ class OptionMenu(Menubutton):
                 A callback that will be invoked after selecting an item.
         """
         kw = {'textvariable': variable, 'style': kwargs.pop('style', None),
-              'direction': kwargs.pop('direction', None)}
+              'direction': kwargs.pop('direction', None),
+              'name': kwargs.pop('name', None)}
         Menubutton.__init__(self, master, **kw)
         self['menu'] = tkinter.Menu(self, tearoff=False)
 

--- a/Misc/NEWS.d/next/Library/2025-02-24-12-22-51.gh-issue-130482.p2DrrL.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-24-12-22-51.gh-issue-130482.p2DrrL.rst
@@ -1,0 +1,2 @@
+Add ability to specify name for :class:`!tkinter.OptionMenu` and
+:class:`!tkinter.ttk.OptionMenu`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130482 -->
* Issue: gh-130482
<!-- /gh-issue-number -->
