### PR TITLE
gh-130363: add a test resource to mark tests that need an idle system

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -122,6 +122,9 @@ resources to test.  Currently only the following are defined:
 
     tzdata -         Run tests that require timezone data.
 
+    idle -           Run tests that require an otherwise idle system as
+                     they are sensitive to timing.
+
 To enable all resources except one, use '-uall,-<resource>'.  For
 example, to run all the tests except for the gui tests, give the
 option '-uall,-gui'.

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -33,7 +33,7 @@ EXIT_TIMEOUT = 120.0
 
 
 ALL_RESOURCES = ('audio', 'curses', 'largefile', 'network',
-                 'decimal', 'cpu', 'subprocess', 'urlfetch', 'gui', 'walltime')
+                 'decimal', 'cpu', 'subprocess', 'urlfetch', 'gui', 'walltime', 'idle')
 
 # Other resources excluded from --use=all:
 #

--- a/Misc/NEWS.d/next/Tests/2025-02-24-12-50-56.gh-issue-130363.zeM6ig.rst
+++ b/Misc/NEWS.d/next/Tests/2025-02-24-12-50-56.gh-issue-130363.zeM6ig.rst
@@ -1,0 +1,2 @@
+Add the ``idle`` resource for flagging tests that need an idle system as
+they're sensitive to timing.


### PR DESCRIPTION
Some tests are very sensitive to timing and will fail on a loaded system, typically because there are small windows for timeouts to trigger in.

Some of these are poorly implemented tests which can be improved, but others may genuinely have strict timing requirements.

Add a test resource so that these tests can be marked as such, and only ran when the system is known to be idle.

<!-- gh-issue-number: gh-130363 -->
* Issue: gh-130363
<!-- /gh-issue-number -->
