### PR TITLE
gh-130379: Fix incorrect zipapp logic to avoid including the target in itself

### DIFF
--- a/Lib/test/test_zipapp.py
+++ b/Lib/test/test_zipapp.py
@@ -102,7 +102,7 @@ class ZipAppTest(unittest.TestCase):
             self.assertEqual(len(z.namelist()), 2)
             self.assertIn('__main__.py', z.namelist())
             self.assertIn('test.py', z.namelist())
-        
+
     def test_create_archive_filter_exclude_dir(self):
         # Test packing a directory and using a filter to exclude a
         # subdirectory (ensures that the path supplied to include

--- a/Lib/test/test_zipapp.py
+++ b/Lib/test/test_zipapp.py
@@ -89,6 +89,20 @@ class ZipAppTest(unittest.TestCase):
             self.assertIn('test.py', z.namelist())
             self.assertNotIn('test.pyc', z.namelist())
 
+    def test_create_archive_self_insertion(self):
+        # When creating an archive, we shouldn't
+        # include the archive in the lis of files to add.
+        source = self.tmpdir
+        (source / '__main__.py').touch()
+        (source / 'test.py').touch()
+        target = self.tmpdir / 'target.pyz'
+
+        zipapp.create_archive(source, target)
+        with zipfile.ZipFile(target, 'r') as z:
+            self.assertEqual(len(z.namelist()), 2)
+            self.assertIn('__main__.py', z.namelist())
+            self.assertIn('test.py', z.namelist())
+        
     def test_create_archive_filter_exclude_dir(self):
         # Test packing a directory and using a filter to exclude a
         # subdirectory (ensures that the path supplied to include

--- a/Lib/test/test_zipapp.py
+++ b/Lib/test/test_zipapp.py
@@ -91,7 +91,7 @@ class ZipAppTest(unittest.TestCase):
 
     def test_create_archive_self_insertion(self):
         # When creating an archive, we shouldn't
-        # include the archive in the lis of files to add.
+        # include the archive in the list of files to add.
         source = self.tmpdir
         (source / '__main__.py').touch()
         (source / 'test.py').touch()
@@ -102,6 +102,16 @@ class ZipAppTest(unittest.TestCase):
             self.assertEqual(len(z.namelist()), 2)
             self.assertIn('__main__.py', z.namelist())
             self.assertIn('test.py', z.namelist())
+
+    def test_target_overwrites_source_file(self):
+        # The target cannot be one of the files to add.
+        source = self.tmpdir
+        (source / '__main__.py').touch()
+        target = source / 'target.pyz'
+        target.touch()
+
+        with self.assertRaises(zipapp.ZipAppError):
+            zipapp.create_archive(source, target)
 
     def test_create_archive_filter_exclude_dir(self):
         # Test packing a directory and using a filter to exclude a

--- a/Lib/zipapp.py
+++ b/Lib/zipapp.py
@@ -147,10 +147,9 @@ def create_archive(source, target=None, interpreter=None, main=None,
     # thorough checks don't provide enough value to justify the extra
     # cost.
 
-    # https://github.com/python/cpython/issues/104527 tracks making
-    # the zipfile module catch writing an archive to itself at a
-    # lower level, which could help here in cases that our check
-    # doesn't catch.
+    # If target is a file-like object, it will simply fail to compare
+    # equal to any of the entries in files_to_add, so there's no need
+    # to add a special check for that.
     if target in files_to_add:
         raise ZipAppError(
             f"The target archive {target} overwrites one of the source files.")

--- a/Misc/NEWS.d/next/Library/2025-02-24-14-46-20.gh-issue-130379.lsef7A.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-24-14-46-20.gh-issue-130379.lsef7A.rst
@@ -1,0 +1,1 @@
+The zipapp module now calculates the list of files to be added to the archive before creating the archive. This avoids accidentally including the target when it is being created in the source directory.


### PR DESCRIPTION
The change in https://github.com/python/cpython/pull/106076 was intended to ensure that zipapp would not include the target file in the list of files that get included in the target. However the logic to do that was flawed, and expensive. This PR changes the approach to generate the list of files to add *before* creating the target, so there is no possibility of the target being included in the first place.

<!-- gh-issue-number: gh-130379 -->
* Issue: gh-130379
<!-- /gh-issue-number -->
