### PR TITLE
gh-130524 Create WinGetpassTest class for improved coverage

### DIFF
--- a/Lib/test/test_getpass.py
+++ b/Lib/test/test_getpass.py
@@ -164,11 +164,11 @@ class UnixGetpassTest(unittest.TestCase):
 
 try:
     import msvcrt
-    msvcrt = True
+    msvcrt_available = True
 except ImportError:
-    msvcrt = False
+    msvcrt_available = False
 
-@unittest.skipUnless(msvcrt, 'tests require system with msvcrt (Windows)')
+@unittest.skipUnless(msvcrt_available, 'tests require system with msvcrt (Windows)')
 class WinGetpassTest(unittest.TestCase):
 
     def test_uses_msvcrt_directly(self):

--- a/Lib/test/test_getpass.py
+++ b/Lib/test/test_getpass.py
@@ -16,7 +16,6 @@ except ImportError:
 
 try:
     import msvcrt
-
 except ImportError:
     mscvrt = None
 

--- a/Lib/test/test_getpass.py
+++ b/Lib/test/test_getpass.py
@@ -13,11 +13,11 @@ try:
     import pwd
 except ImportError:
     pwd = None
-
 try:
     import msvcrt
 except ImportError:
     msvcrt = None
+
 
 @mock.patch('os.environ')
 class GetpassGetuserTest(unittest.TestCase):

--- a/Lib/test/test_getpass.py
+++ b/Lib/test/test_getpass.py
@@ -14,6 +14,12 @@ try:
 except ImportError:
     pwd = None
 
+try:
+    import msvcrt
+
+except ImportError:
+    mscvrt = None
+
 @mock.patch('os.environ')
 class GetpassGetuserTest(unittest.TestCase):
 
@@ -162,15 +168,8 @@ class UnixGetpassTest(unittest.TestCase):
             self.assertIn('Password:', stderr.getvalue())
 
 
-try:
-    import msvcrt
-except ImportError:
-    msvcrt_available = False
-else:
-    msvcrt_available = True
-
+@unittest.skipIf(msvcrt is None, 'tests require system with msvcrt (Windows)')
 @unittest.skipUnless(support.MS_WINDOWS, "Windows-specific tests")
-@unittest.skipUnless(msvcrt_available, 'tests require system with msvcrt (Windows)')
 class WinGetpassTest(unittest.TestCase):
 
     def test_uses_msvcrt_directly(self):
@@ -187,8 +186,10 @@ class WinGetpassTest(unittest.TestCase):
             mock_stream.flush.assert_called()
 
     def test_handles_backspace(self):
-        with mock.patch('msvcrt.getch') as getch, \
-             mock.patch('msvcrt.putch') as putch:
+        with (
+        	mock.patch('msvcrt.getch') as getch,
+            mock.patch('msvcrt.putch') as putch,
+		):
             getch.side_effect = [b'a', b'b', b'\b', b'c', b'\r']
             result = getpass.win_getpass()
             self.assertEqual(result, 'ac')

--- a/Lib/test/test_getpass.py
+++ b/Lib/test/test_getpass.py
@@ -168,6 +168,7 @@ try:
 except ImportError:
     msvcrt_available = False
 
+@unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
 @unittest.skipUnless(msvcrt_available, 'tests require system with msvcrt (Windows)')
 class WinGetpassTest(unittest.TestCase):
 

--- a/Lib/test/test_getpass.py
+++ b/Lib/test/test_getpass.py
@@ -17,7 +17,7 @@ except ImportError:
 try:
     import msvcrt
 except ImportError:
-    mscvrt = None
+    msvcrt = None
 
 @mock.patch('os.environ')
 class GetpassGetuserTest(unittest.TestCase):
@@ -185,16 +185,11 @@ class WinGetpassTest(unittest.TestCase):
             mock_stream.flush.assert_called()
 
     def test_handles_backspace(self):
-        with (
-        	mock.patch('msvcrt.getch') as getch,
-            mock.patch('msvcrt.putch') as putch,
-		):
+        with mock.patch('msvcrt.getch') as getch, \
+                mock.patch('msvcrt.putch') as putch:
             getch.side_effect = [b'a', b'b', b'\b', b'c', b'\r']
             result = getpass.win_getpass()
             self.assertEqual(result, 'ac')
-            # Verify putch was called to handle the backspace (erase character)
-            # The exact sequence depends on the implementation, but should include
-            # calls to handle the backspace character
             putch.assert_any_call(b'\b')
 
     def test_handles_ctrl_c(self):
@@ -214,8 +209,7 @@ class WinGetpassTest(unittest.TestCase):
 
     def test_falls_back_to_fallback_if_msvcrt_raises(self):
         with mock.patch('msvcrt.getch') as getch, \
-             mock.patch('getpass.fallback_getpass') as fallback:
-            # Make getch raise an exception to trigger the fallback
+                mock.patch('getpass.fallback_getpass') as fallback:
             getch.side_effect = RuntimeError("Simulated msvcrt failure")
             mock_stream = mock.Mock(spec=StringIO)
             getpass.win_getpass(stream=mock_stream)

--- a/Lib/test/test_getpass.py
+++ b/Lib/test/test_getpass.py
@@ -164,11 +164,12 @@ class UnixGetpassTest(unittest.TestCase):
 
 try:
     import msvcrt
-    msvcrt_available = True
 except ImportError:
     msvcrt_available = False
+else:
+    msvcrt_available = True
 
-@unittest.skipUnless(WIN32, "skipped on non-Windows platforms")
+@unittest.skipUnless(support.MS_WINDOWS, "Windows-specific tests")
 @unittest.skipUnless(msvcrt_available, 'tests require system with msvcrt (Windows)')
 class WinGetpassTest(unittest.TestCase):
 

--- a/Lib/test/test_getpass.py
+++ b/Lib/test/test_getpass.py
@@ -167,8 +167,7 @@ class UnixGetpassTest(unittest.TestCase):
             self.assertIn('Password:', stderr.getvalue())
 
 
-@unittest.skipIf(msvcrt is None, 'tests require system with msvcrt (Windows)')
-@unittest.skipUnless(support.MS_WINDOWS, "Windows-specific tests")
+@unittest.skipUnless(msvcrt, 'tests require system with msvcrt')
 class WinGetpassTest(unittest.TestCase):
 
     def test_uses_msvcrt_directly(self):

--- a/Lib/test/test_getpass.py
+++ b/Lib/test/test_getpass.py
@@ -168,7 +168,7 @@ try:
 except ImportError:
     msvcrt_available = False
 
-@unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+@unittest.skipUnless(WIN32, "skipped on non-Windows platforms")
 @unittest.skipUnless(msvcrt_available, 'tests require system with msvcrt (Windows)')
 class WinGetpassTest(unittest.TestCase):
 

--- a/Lib/test/test_getpass.py
+++ b/Lib/test/test_getpass.py
@@ -202,8 +202,7 @@ class WinGetpassTest(unittest.TestCase):
             # Simulate typing 'a' then Ctrl+C (ASCII value 3)
             getch.side_effect = [b'a', b'\x03']
             # Verify that KeyboardInterrupt is raised
-            with self.assertRaises(KeyboardInterrupt):
-                getpass.win_getpass()
+            self.assertRaises(KeyboardInterrupt, getpass.win_getpass)
 
     def test_flushes_stream_after_input(self):
         with mock.patch('msvcrt.getch') as getch:


### PR DESCRIPTION
## Improved Getpass coverage for Windows 

I followed the same pattern as the Unix tests, the new class tests the core functionality of `win_getpass` using `msvcrt.getch` for input, verifies proper handling of special characters including keyboard interrupt, ensures stream flushing works correctly, and a test for `fallback_getpass()` to test the `mscvrt`  fallback mechanism when the primary method fails.

<!-- gh-issue-number: gh-130524 -->
* Issue: gh-130524
<!-- /gh-issue-number -->
