### PR TITLE
Fix a typo in code module test

### DIFF
--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -50,9 +50,9 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         self.infunc.side_effect = EOFError('Finished')
         self.console.interact()
         self.assertEqual(self.sysmod.ps2, '... ')
-        self.sysmod.ps1 = 'custom2> '
+        self.sysmod.ps2 = 'custom2> '
         self.console.interact()
-        self.assertEqual(self.sysmod.ps1, 'custom2> ')
+        self.assertEqual(self.sysmod.ps2, 'custom2> ')
 
     def test_console_stderr(self):
         self.infunc.side_effect = ["'antioch'", "", EOFError('Finished')]


### PR DESCRIPTION
I'm 99% sure this is not intended in https://github.com/python/cpython/commit/5a4bbcd479ce86f68bbe12bc8c16e3447f32e13a. 