### PR TITLE
gh-128540: lookup default webbrowser on macOS

### DIFF
--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -1,3 +1,4 @@
+import io
 import os
 import re
 import shlex
@@ -5,6 +6,7 @@ import subprocess
 import sys
 import unittest
 import webbrowser
+from functools import partial
 from test import support
 from test.support import import_helper
 from test.support import is_apple_mobile
@@ -299,6 +301,69 @@ class IOSBrowserTest(unittest.TestCase):
 
     def test_open_new_tab(self):
         self._test('open_new_tab')
+
+
+class MockPopenPipe:
+    def __init__(self, cmd, mode):
+        self.cmd = cmd
+        self.mode = mode
+        self.pipe = io.StringIO()
+        self._closed = False
+
+    def write(self, buf):
+        self.pipe.write(buf)
+
+    def close(self):
+        self._closed = True
+        return None
+
+
+@unittest.skipUnless(sys.platform == "darwin", "macOS specific test")
+@requires_subprocess()
+class MacOSXOSAScriptTest(unittest.TestCase):
+    def setUp(self):
+        support.patch(self, os, "popen", self.mock_popen)
+        self.browser = webbrowser.MacOSXOSAScript("default")
+
+    def mock_popen(self, cmd, mode):
+        self.popen_pipe = MockPopenPipe(cmd, mode)
+        return self.popen_pipe
+
+    def test_default(self):
+        browser = webbrowser.get()
+        assert isinstance(browser, webbrowser.MacOSXOSAScript)
+        self.assertEqual(browser.name, "default")
+
+    def test_default_open(self):
+        url = "https://python.org"
+        self.browser.open(url)
+        self.assertTrue(self.popen_pipe._closed)
+        self.assertEqual(self.popen_pipe.cmd, "osascript")
+        script = self.popen_pipe.pipe.getvalue()
+        self.assertEqual(script.strip(), f'open location "{url}"')
+
+    def test_url_quote(self):
+        self.browser.open('https://python.org/"quote"')
+        script = self.popen_pipe.pipe.getvalue()
+        self.assertEqual(
+            script.strip(), 'open location "https://python.org/%22quote%22"'
+        )
+
+    def test_default_browser_lookup(self):
+        url = "file:///tmp/some-file.html"
+        self.browser.open(url)
+        script = self.popen_pipe.pipe.getvalue()
+        # doesn't actually test the browser lookup works,
+        # just that the branch is taken
+        self.assertIn("URLForApplicationToOpenURL", script)
+        self.assertIn(f'open location "{url}"', script)
+
+    def test_explicit_browser(self):
+        browser = webbrowser.MacOSXOSAScript("safari")
+        browser.open("https://python.org")
+        script = self.popen_pipe.pipe.getvalue()
+        self.assertIn('tell application "safari"', script)
+        self.assertIn('open location "https://python.org"', script)
 
 
 class BrowserRegistrationTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/macOS/2025-02-25-10-25-27.gh-issue-128540.QDz3OL.rst
+++ b/Misc/NEWS.d/next/macOS/2025-02-25-10-25-27.gh-issue-128540.QDz3OL.rst
@@ -1,0 +1,2 @@
+Ensure web browser is launched by {func}`webbrowser.open` on macOS, even for
+``file://`` URLs.

--- a/Misc/NEWS.d/next/macOS/2025-02-25-10-25-27.gh-issue-128540.QDz3OL.rst
+++ b/Misc/NEWS.d/next/macOS/2025-02-25-10-25-27.gh-issue-128540.QDz3OL.rst
@@ -1,2 +1,2 @@
-Ensure web browser is launched by {func}`webbrowser.open` on macOS, even for
+Ensure web browser is launched by :func:`webbrowser.open` on macOS, even for
 ``file://`` URLs.


### PR DESCRIPTION
ensures web browser is launched on mac, even for URLs that are not http[s]. Only does the lookup for non-http URLs, limiting the impact of the change.

I'm not sure what level of testing is appropriate, but I added some basic exercise for MacOSXOSAScript. The subprocess is mocked, so the correctness of the applescript still itself isn't tested at all.

Addresses gh-128540 on macOS only. I'll open separate PRs per platform, as recommended by @ned-deily.

More discussion in https://discuss.python.org/t/support-for-file-urls-in-webbrowser-open/81612

Backported implementation in https://pypi.org/project/webbrowser-open/