### PR TITLE
[3.12] gh-130151: Fix reference leaks in `_hashlib.hmac_{new,digest}` (GH-130152)

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-02-15-12-36-49.gh-issue-130151.3IFumF.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-15-12-36-49.gh-issue-130151.3IFumF.rst
@@ -1,0 +1,2 @@
+Fix reference leaks in :func:`!_hashlib.hmac_new` and
+:func:`!_hashlib.hmac_digest`. Patch by Bénédikt Tran.


### PR DESCRIPTION
(cherry picked from commit 071820113f11b8f6a21f98652d0840e10268114c)


<!-- gh-issue-number: gh-130151 -->
* Issue: gh-130151
<!-- /gh-issue-number -->
