### PR TITLE
gh-128540: launch default browser more often on Linux

### DIFF
--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -74,9 +74,11 @@ The following functions are defined:
 
    Returns ``True`` if a browser was successfully launched, ``False`` otherwise.
 
-   Note that on some platforms, trying to open a filename using this function,
+   Note that on some platforms, trying to open a filename (``'./path.html'``) using this function,
    may work and start the operating system's associated program.  However, this
    is neither supported nor portable.
+   ``'file://...'`` URLs, on the other hand, should work and consistently
+   launch a browser.
 
    .. audit-event:: webbrowser.open url webbrowser.open
 
@@ -200,6 +202,14 @@ Notes:
 
 .. versionchanged:: 3.13
    Support for iOS has been added.
+
+.. versionadded:: next
+   Support for launching the XDG default browser via ``gtk-launch`` or ``gio launch`` on POSIX systems,
+   and ``exo-open`` in XFCE environments.
+
+.. versionchanged:: next
+   ``file://`` URLs should now open more reliably in browsers on all platforms,
+   instead of opening the default application associated with the file type.
 
 Here are some simple examples::
 

--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -205,7 +205,8 @@ Notes:
 
 .. versionadded:: next
    Support for launching the XDG default browser via ``gtk-launch`` or ``gio launch`` on POSIX systems,
-   and ``exo-open`` in XFCE environments.
+   ``exo-open`` in XFCE environments,
+   and ``kioclient exec`` in KDE environments.
 
 .. versionchanged:: next
    ``file://`` URLs should now open more reliably in browsers on all platforms,

--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -65,6 +65,25 @@ class GenericBrowserCommandTest(CommandTestMixin, unittest.TestCase):
                    options=[],
                    arguments=[URL])
 
+    def test_supports_file(self):
+        self._test('open',
+                   args=["file:///tmp/file"],
+                   options=[],
+                   arguments=["file:///tmp/file"])
+
+    def test_not_supports_file(self):
+        popen = PopenMock()
+        support.patch(self, subprocess, 'Popen', popen)
+        browser = self.browser_class("open")
+        browser._supports_file = False
+        assert not browser.open("file:///some/file")
+        assert subprocess.Popen.call_count == 0
+        url = "https://some-url"
+        browser.open(url)
+        assert subprocess.Popen.call_count == 1
+        popen_args = subprocess.Popen.call_args[0][0]
+        self.assertEqual(popen_args, ["open", url])
+
 
 class BackgroundBrowserCommandTest(CommandTestMixin, unittest.TestCase):
 
@@ -74,6 +93,25 @@ class BackgroundBrowserCommandTest(CommandTestMixin, unittest.TestCase):
         self._test('open',
                    options=[],
                    arguments=[URL])
+
+    def test_supports_file(self):
+        self._test('open',
+                   args=["file:///tmp/file"],
+                   options=[],
+                   arguments=["file:///tmp/file"])
+
+    def test_not_supports_file(self):
+        popen = PopenMock()
+        support.patch(self, subprocess, 'Popen', popen)
+        browser = self.browser_class("open")
+        browser._supports_file = False
+        assert not browser.open("file:///some/file")
+        assert subprocess.Popen.call_count == 0
+        url = "https://some-url"
+        browser.open(url)
+        assert subprocess.Popen.call_count == 1
+        popen_args = subprocess.Popen.call_args[0][0]
+        self.assertEqual(popen_args, ["open", url])
 
 
 class ChromeCommandTest(CommandTestMixin, unittest.TestCase):

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -168,7 +168,7 @@ class GenericBrowser(BaseBrowser):
     """Class for all browsers started with a command
        and without remote functionality."""
 
-    def __init__(self, name, /, _supports_file=True):
+    def __init__(self, name, *, _supports_file=True):
         if isinstance(name, str):
             self.name = name
             self.args = ["%s"]

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -501,9 +501,12 @@ def register_X_browsers():
 
     # The default KDE browser
     if (("KDE" in xdg_desktop or
-         "KDE_FULL_SESSION" in os.environ) and
-            shutil.which("kfmclient")):
-        register("kfmclient", Konqueror, Konqueror("kfmclient"))
+         "KDE_FULL_SESSION" in os.environ):
+        if shutil.which("kioclient"):
+            # launch URL with http[s] handler
+            register("kioclient", None, BackgroundBrowser(["kioclient", "exec", "%s", "x-scheme-handler/https"]))
+        if shutil.which("kfmclient")):
+            register("kfmclient", Konqueror, Konqueror("kfmclient"))
 
     # The default XFCE browser
     if "XFCE" in xdg_desktop and shutil.which("exo-open"):

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -168,7 +168,7 @@ class GenericBrowser(BaseBrowser):
     """Class for all browsers started with a command
        and without remote functionality."""
 
-    def __init__(self, name):
+    def __init__(self, name, /, _supports_file=True):
         if isinstance(name, str):
             self.name = name
             self.args = ["%s"]
@@ -177,9 +177,20 @@ class GenericBrowser(BaseBrowser):
             self.name = name[0]
             self.args = name[1:]
         self.basename = os.path.basename(self.name)
+        # whether it supports file:// URLs
+        # set to False for generic openers like xdg-open,
+        # which do not launch webbrowsers reliably
+        self._supports_file = _supports_file
 
     def open(self, url, new=0, autoraise=True):
         sys.audit("webbrowser.open", url)
+
+        if not self._supports_file:
+            # skip me for `file://` URLs for generic openers (e.g. xdg-open)
+            proto, _sep, _rest = url.partition(":")
+            if _sep and proto.lower() == "file":
+                return False
+
         cmdline = [self.name] + [arg.replace("%s", url)
                                  for arg in self.args]
         try:
@@ -197,6 +208,12 @@ class BackgroundBrowser(GenericBrowser):
        background."""
 
     def open(self, url, new=0, autoraise=True):
+        if not self._supports_file:
+            # skip me for `file://` URLs for generic openers (e.g. xdg-open)
+            proto, _sep, _rest = url.partition(":")
+            if _sep and proto.lower() == "file":
+                return False
+
         cmdline = [self.name] + [arg.replace("%s", url)
                                  for arg in self.args]
         sys.audit("webbrowser.open", url)
@@ -415,19 +432,64 @@ class Edge(UnixBrowser):
 # Platform support for Unix
 #
 
+
+def _locate_xdg_desktop(name: str) -> str | None:
+    """Locate .desktop file by name
+
+    Returns absolute path to .desktop file found on $XDG_DATA search path
+    or None if no matching .desktop file is found.
+
+    Needed for `gio launch` support.
+    """
+    if not name.endswith(".desktop"):
+        # ensure it ends in .desktop
+        name += ".desktop"
+    xdg_data_home = os.environ.get("XDG_DATA_HOME") or os.path.expanduser(
+        "~/.local/share"
+    )
+    xdg_data_dirs = os.environ.get("XDG_DATA_DIRS") or "/usr/local/share/:/usr/share/"
+    all_data_dirs = [xdg_data_home]
+    all_data_dirs.extend(xdg_data_dirs.split(os.pathsep))
+    for data_dir in all_data_dirs:
+        desktop_path = os.path.join(data_dir, "applications", name)
+        if os.path.exists(desktop_path):
+            return desktop_path
+    return None
+
 # These are the right tests because all these Unix browsers require either
 # a console terminal or an X display to run.
 
 def register_X_browsers():
 
+    # use gtk-launch to launch preferred browser by name, if found
+    # this should be _before_ xdg-open, which doesn't necessarily launch a browser
+    if _os_preferred_browser and shutil.which("gtk-launch"):
+        register(
+            "gtk-launch",
+            None,
+            BackgroundBrowser(["gtk-launch", _os_preferred_browser, "%s"]),
+        )
+
     # use xdg-open if around
     if shutil.which("xdg-open"):
-        register("xdg-open", None, BackgroundBrowser("xdg-open"))
+        # `xdg-open` does NOT guarantee a browser is launched,
+        # so skip it for `file://`
+        register("xdg-open", None, BackgroundBrowser("xdg-open", _supports_file=False))
 
-    # Opens an appropriate browser for the URL scheme according to
+
+    # Opens the default application for the URL scheme according to
     # freedesktop.org settings (GNOME, KDE, XFCE, etc.)
     if shutil.which("gio"):
-        register("gio", None, BackgroundBrowser(["gio", "open", "--", "%s"]))
+        if _os_preferred_browser:
+            absolute_browser = _locate_xdg_desktop(_os_preferred_browser)
+            if absolute_browser:
+                register(
+                    "gio-launch",
+                    None,
+                    BackgroundBrowser(["gio", "launch", absolute_browser, "%s"]),
+                )
+        # `gio open` does NOT guarantee a browser is launched
+        register("gio", None, BackgroundBrowser(["gio", "open", "--", "%s"], _supports_file=False))
 
     xdg_desktop = os.getenv("XDG_CURRENT_DESKTOP", "").split(":")
 
@@ -435,13 +497,21 @@ def register_X_browsers():
     if (("GNOME" in xdg_desktop or
          "GNOME_DESKTOP_SESSION_ID" in os.environ) and
             shutil.which("gvfs-open")):
-        register("gvfs-open", None, BackgroundBrowser("gvfs-open"))
+        register("gvfs-open", None, BackgroundBrowser("gvfs-open", _supports_file=False))
 
     # The default KDE browser
     if (("KDE" in xdg_desktop or
          "KDE_FULL_SESSION" in os.environ) and
             shutil.which("kfmclient")):
         register("kfmclient", Konqueror, Konqueror("kfmclient"))
+
+    # The default XFCE browser
+    if "XFCE" in xdg_desktop and shutil.which("exo-open"):
+        register(
+            "exo-open",
+            None,
+            BackgroundBrowser(["exo-open", "--launch", "WebBrowser", "%s"]),
+        )
 
     # Common symbolic link for the default X11 browser
     if shutil.which("x-www-browser"):

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -502,12 +502,12 @@ def register_X_browsers():
         register("gvfs-open", None, BackgroundBrowser("gvfs-open", _supports_file=False))
 
     # The default KDE browser
-    if (("KDE" in xdg_desktop or
+    if ("KDE" in xdg_desktop or
          "KDE_FULL_SESSION" in os.environ):
         if shutil.which("kioclient"):
             # launch URL with http[s] handler
             register("kioclient", None, BackgroundBrowser(["kioclient", "exec", "%s", "x-scheme-handler/https"]))
-        if shutil.which("kfmclient")):
+        if shutil.which("kfmclient"):
             register("kfmclient", Konqueror, Konqueror("kfmclient"))
 
     # The default XFCE browser

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -461,14 +461,16 @@ def _locate_xdg_desktop(name: str) -> str | None:
 
 def register_X_browsers():
 
-    # use gtk-launch to launch preferred browser by name, if found
+    # use gtk[4]-launch to launch preferred browser by name, if found
     # this should be _before_ xdg-open, which doesn't necessarily launch a browser
-    if _os_preferred_browser and shutil.which("gtk-launch"):
-        register(
-            "gtk-launch",
-            None,
-            BackgroundBrowser(["gtk-launch", _os_preferred_browser, "%s"]),
-        )
+    if _os_preferred_browser:
+        for gtk_launch in ("gtk4-launch", "gtk-launch"):
+            if shutil.which(gtk_launch):
+                register(
+                    gtk_launch,
+                    None,
+                    BackgroundBrowser([gtk_launch, _os_preferred_browser, "%s"]),
+                )
 
     # use xdg-open if around
     if shutil.which("xdg-open"):

--- a/Misc/NEWS.d/next/Library/2025-02-24-13-55-54.gh-issue-128540.Pc4Pa4.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-24-13-55-54.gh-issue-128540.Pc4Pa4.rst
@@ -1,0 +1,6 @@
+:func:`webbrowser.open` should launch default webbrowsers for URLs that are
+not ``http[s]://`` more often (especially ``file://``,
+where the default application by file type was often launched, instead of a browser).
+This works by adding support for ``gtk-launch`` and ``gio
+launch``,
+and making sure generic application launchers like ``xdg-open`` are not used for ``file://`` URLs.


### PR DESCRIPTION
especially for file:// URLs

- add support for `gtk-launch` and `gio launch` if default browser is found via `xdg-settings`, since these allow launching a `.desktop` by name (`gio launch` requires an absolute path, so an implementation of searching XDG_DATA is included, while `gtk-launch` searches XDG_DATA path itself and only needs a name)
- add support for `exo-open --target WebBrowser` on XFCE (nice: it allows specifying that a browser should be launched)
- explicitly prevent non-browser launchers like `xdg-open`, `gvfs-open`, `gio open` from launching `file://` URLs, since those open applications associated by file type instead of browsers.

Addresses gh-128540 on linux, etc.

gh-50920: addressed by adding support for `exo-open --launch WebBrowser` on XFCE (only identified via the standard XDG_CURRENT_DESKTOP, which seems appropriate in 2025)

For users where `xdg-settings get default-web-browser` returned an _exact_ match to one of the known browsers, there is no change in behavior. For users with `gtk-launch` or `gio launch`, any `.desktop` should work (e.g. the `google-chrome-work` example in gh-108172), not just those in the hardcoded list.

Note that _unlike_ the mac and Windows implementations, this opts out of `file://` URLs for generic launchers instead of opting them in for `http[s]`. This only has an effect on other URLs, like `ssh://`, for which behavior is still undocumented. But it is easy enough to make the switch from `_supports_file` to `_http_only` (or `_supported_protocols`)

Questions:

- should `gtk-launch` be gnome specific?
- should `gio launch` be included, since it requires implementing a search of $XDG_DATA paths (aside: is there a standard call for resolving a .desktop file?)?
- should `xdg-open` and friends should be skipped for file URLs, since it does the wrong thing and is top priority in most cases?
- should `xdg-open` and friends be restricted to http[s] URLs to avoid launching non-browsers for custom URLs, as is done on mac/Windows and when the default browser is successfully recognized on linux?

Links:

- More discussion in https://discuss.python.org/t/support-for-file-urls-in-webbrowser-open/81612
- Backported implementation for testing in https://pypi.org/project/webbrowser-open/
- macOS counterpart: gh-130535
- Windows counterpart: gh-130538


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130541.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->