### PR TITLE
[3.12] gh-130461: Remove unnecessary usages of `.. index::` directives in Doc/library/uuid.rst (#130526)

### DIFF
--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -179,8 +179,6 @@ The :mod:`uuid` module defines the following functions:
       administered MAC addresses, since the former are guaranteed to be
       globally unique, while the latter are not.
 
-.. index:: single: getnode
-
 
 .. function:: uuid1(node=None, clock_seq=None)
 
@@ -189,8 +187,6 @@ The :mod:`uuid` module defines the following functions:
    *clock_seq* is given, it is used as the sequence number; otherwise a random
    14-bit sequence number is chosen.
 
-.. index:: single: uuid1
-
 
 .. function:: uuid3(namespace, name)
 
@@ -198,14 +194,10 @@ The :mod:`uuid` module defines the following functions:
    UUID) and a name (which is a :class:`bytes` object or a string
    that will be encoded using UTF-8).
 
-.. index:: single: uuid3
-
 
 .. function:: uuid4()
 
    Generate a random UUID.
-
-.. index:: single: uuid4
 
 
 .. function:: uuid5(namespace, name)
@@ -214,7 +206,19 @@ The :mod:`uuid` module defines the following functions:
    UUID) and a name (which is a :class:`bytes` object or a string
    that will be encoded using UTF-8).
 
-.. index:: single: uuid5
+.. function:: uuid8(a=None, b=None, c=None)
+
+   Generate a pseudo-random UUID according to
+   :rfc:`RFC 9562, §5.8 <9562#section-5.8>`.
+
+   When specified, the parameters *a*, *b* and *c* are expected to be
+   positive integers of 48, 12 and 62 bits respectively. If they exceed
+   their expected bit count, only their least significant bits are kept;
+   non-specified arguments are substituted for a pseudo-random integer of
+   appropriate size.
+
+   .. versionadded:: 3.14
+
 
 The :mod:`uuid` module defines the following namespace identifiers for use with
 :func:`uuid3` or :func:`uuid5`.

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -206,19 +206,6 @@ The :mod:`uuid` module defines the following functions:
    UUID) and a name (which is a :class:`bytes` object or a string
    that will be encoded using UTF-8).
 
-.. function:: uuid8(a=None, b=None, c=None)
-
-   Generate a pseudo-random UUID according to
-   :rfc:`RFC 9562, §5.8 <9562#section-5.8>`.
-
-   When specified, the parameters *a*, *b* and *c* are expected to be
-   positive integers of 48, 12 and 62 bits respectively. If they exceed
-   their expected bit count, only their least significant bits are kept;
-   non-specified arguments are substituted for a pseudo-random integer of
-   appropriate size.
-
-   .. versionadded:: 3.14
-
 
 The :mod:`uuid` module defines the following namespace identifiers for use with
 :func:`uuid3` or :func:`uuid5`.

--- a/Misc/NEWS.d/next/Library/2025-02-25-03-53-00.gh-issue-130461.asr2dg.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-25-03-53-00.gh-issue-130461.asr2dg.rst
@@ -1,0 +1,4 @@
+Remove ``.. index::`` directives from the :mod:`uuid` module documentation. These directives
+previously created entries in the general index for :func:`~uuid.getnode` as well as the
+:func:`~uuid.uuid1`, :func:`~uuid.uuid3`, :func:`~uuid.uuid4`, :func:`~uuid.uuid5`, and
+:func:`~uuid.uuid8` constructor functions.

--- a/Misc/NEWS.d/next/Library/2025-02-25-03-53-00.gh-issue-130461.asr2dg.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-25-03-53-00.gh-issue-130461.asr2dg.rst
@@ -1,4 +1,4 @@
 Remove ``.. index::`` directives from the :mod:`uuid` module documentation. These directives
 previously created entries in the general index for :func:`~uuid.getnode` as well as the
-:func:`~uuid.uuid1`, :func:`~uuid.uuid3`, :func:`~uuid.uuid4`, :func:`~uuid.uuid5`, and
-:func:`~uuid.uuid8` constructor functions.
+:func:`~uuid.uuid1`, :func:`~uuid.uuid3`, :func:`~uuid.uuid4`, and :func:`~uuid.uuid5`
+constructor functions.


### PR DESCRIPTION
Co-authored-by: Bénédikt Tran <10796600+picnixz@users.noreply.github.com>
(cherry picked from commit 85f1cc8d60b06d5b2af3e4da8e4f98171420dd91)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

fix: #130461 

<!-- gh-issue-number: gh-130461 -->
* Issue: gh-130461
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130546.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->