### PR TITLE
GH-130396: Include stack margin for debug windows builds

### DIFF
--- a/Include/pythonrun.h
+++ b/Include/pythonrun.h
@@ -28,7 +28,7 @@ PyAPI_DATA(int) (*PyOS_InputHook)(void);
 #if defined(_Py_ADDRESS_SANITIZER) || defined(_Py_THREAD_SANITIZER)
 #  define PYOS_STACK_MARGIN 4096
 #elif defined(Py_DEBUG) && defined(WIN32)
-#  define PYOS_STACK_MARGIN 3072
+#  define PYOS_STACK_MARGIN 4096
 #elif defined(__wasi__)
    /* Web assembly has two stacks, so this isn't really a size */
 #  define PYOS_STACK_MARGIN 500


### PR DESCRIPTION
This might only be necessary on Windows debug free-threading builds, but it is simpler and harmless to do this for any Windows debug build.

<!-- gh-issue-number: gh-130396 -->
* Issue: gh-130396
<!-- /gh-issue-number -->
