### PR TITLE
gh-129005: Move bytearray to use bytes as a buffer

### DIFF
--- a/Include/cpython/bytearrayobject.h
+++ b/Include/cpython/bytearrayobject.h
@@ -9,6 +9,7 @@ typedef struct {
     char *ob_bytes;        /* Physical backing buffer */
     char *ob_start;        /* Logical start inside ob_bytes */
     Py_ssize_t ob_exports; /* How many buffer exports */
+    PyObject *ob_bytes_head; /* bytes enabling zero-copy detach. */
 } PyByteArrayObject;
 
 PyAPI_DATA(char) _PyByteArray_empty_string[];

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1547,7 +1547,7 @@ class SizeofTest(unittest.TestCase):
         samples = [b'', b'u'*100000]
         for sample in samples:
             x = bytearray(sample)
-            check(x, vsize('n2Pi') + x.__alloc__())
+            check(x, vsize('n2PiP') + x.__alloc__())
         # bytearray_iterator
         check(iter(bytearray()), size('nP'))
         # bytes

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-25-20-31-36.gh-issue-129005.0KBps9.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-25-20-31-36.gh-issue-129005.0KBps9.rst
@@ -1,1 +1,1 @@
-Move :class:`bytearray` to use a buffer convertable to :class:`bytes` without copying.
+Move :class:`bytearray` to use a buffer convertible to :class:`bytes` without copying.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-25-20-31-36.gh-issue-129005.0KBps9.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-25-20-31-36.gh-issue-129005.0KBps9.rst
@@ -1,0 +1,1 @@
+Move :class:`bytearray` to use a buffer convertable to :class:`bytes` without copying.


### PR DESCRIPTION
1. Add `tp_new` to guarantee `ob_bytes_head` is always set, often to the empty bytes singleton.
2. `ob_alloc` information is now redundant, added assertion to validate that, would it make sense to deprecate?
3. There's a lot of `bytearray` code very similar to `bytes` code, more could likely be just proxied to the `bytes` now (Ex. construction from an object in `__new__`). Here just focusing on the swap as that enables optimizations.
4. If `bytearray` is passed a single-reference bytes it could potentially take "ownership" of it without copying the bytes, for now not implemented.

This enables adding [`bytearray._detach()`](https://github.com/python/cpython/commit/98f8483ae0071dbd6eff319b919b11be42dea894) which I plan to do in a separate PR.

## TODO
 - [ ] Single byte strings passed to PyBytes_FromStringAndSize returns immortal objects that shouldn't be mutated. Not sure how to best work around that. `_io.FileIO.readall()` can't run into that case as it never passes in a string to start with, just a size.

## Performance

```bash
# _io.FileIO.readall of a large file
./python -m test -M8g -uall test_largefile -m test.test_largefile.CLargeFileTest.test_large_read

# _pyio.FileIO.readall of a large file
./python -m test -M8g -uall test_largefile -m test.test_largefile.PyLargeFileTest.test_large_read
```

On my machine (AMD 64 bit Linux, Optimized build): 
`_io` takes: ~0.791s and uses ~2GB of RAM
`_pyio` current: ~1.073s and uses ~4GB of RAM
`_pyio` with `bytearray._detach`: ~0.887s and uses ~2GB of RAM

Perf checking no major swings in an optimized build: `./python -E -bb -Wd -m test -uall -M32G test_bytes test_capi.test_bytearray -vvv`

before: ~1.4s
after: ~1.4s

Previous discussion: https://discuss.python.org/t/add-zero-copy-conversion-of-bytearray-to-bytes-by-providing-bytes/79164

cc: @serhiy-storchaka @vstinner 

<!-- gh-issue-number: gh-129005 -->
* Issue: gh-129005
<!-- /gh-issue-number -->
