### PR TITLE
gh-128982: Revert "#128982: Substitute regular expression in http.cookiejar.join_header_words for an efficient alternative (GH-128983)" and add tests

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -448,7 +448,7 @@ def join_header_words(lists):
         attr = []
         for k, v in pairs:
             if v is not None:
-                if not v.isalnum() and '_' not in v:
+                if not re.search(r"^\w+$", v):
                     v = HEADER_JOIN_ESCAPE_RE.sub(r"\\\1", v)  # escape " and \
                     v = '"%s"' % v
                 k = "%s=%s" % (k, v)

--- a/Misc/NEWS.d/next/Library/2025-01-18-11-40-11.gh-issue-128982.557lS5.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-18-11-40-11.gh-issue-128982.557lS5.rst
@@ -1,2 +1,0 @@
-Improve the performance of :func:`!http.cookiejar.join_header_words` by up
-to 35%. Patch by Bénédikt Tran.


### PR DESCRIPTION
Revert "#128982: Substitute regular expression in http.cookiejar.join_header_words for an efficient alternative (GH-128983)"

This reverts commit 56e190068177855266f32a7efa329d145b279f94.


Add additional tests.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128982 -->
* Issue: gh-128982
<!-- /gh-issue-number -->
