### PR TITLE
gh-130421: Fix data race on timebase initialization

### DIFF
--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -23,6 +23,7 @@ extern "C" {
 #include "pycore_pymem.h"           // struct _pymem_allocators
 #include "pycore_pythread.h"        // struct _pythread_runtime_state
 #include "pycore_signal.h"          // struct _signals_runtime_state
+#include "pycore_time.h"            // struct _PyTime_runtime_state
 #include "pycore_tracemalloc.h"     // struct _tracemalloc_runtime_state
 #include "pycore_typeobject.h"      // struct _types_runtime_state
 #include "pycore_unicodeobject.h"   // struct _Py_unicode_runtime_state
@@ -168,6 +169,7 @@ typedef struct pyruntimestate {
     struct _Py_float_runtime_state float_state;
     struct _Py_unicode_runtime_state unicode_state;
     struct _types_runtime_state types;
+    struct _Py_time_runtime_state time;
 
 #if defined(__EMSCRIPTEN__) && defined(PY_CALL_TRAMPOLINE)
     // Used in "Python/emscripten_trampoline.c" to choose between type

--- a/Include/internal/pycore_time.h
+++ b/Include/internal/pycore_time.h
@@ -331,6 +331,18 @@ extern double _PyTimeFraction_Resolution(
     const _PyTimeFraction *frac);
 
 
+// --- _Py_time_runtime_state ------------------------------------------------
+
+struct _Py_time_runtime_state {
+#if defined(MS_WINDOWS) || defined(__APPLE__)
+    _PyTimeFraction base;
+#else
+    char _unused;
+#endif
+};
+
+extern PyStatus _PyTime_Init(struct _Py_time_runtime_state *state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -20,6 +20,7 @@
 #include "pycore_pystate.h"
 #include "pycore_runtime_init.h"  // _PyRuntimeState_INIT
 #include "pycore_stackref.h"      // Py_STACKREF_DEBUG
+#include "pycore_time.h"          // _PyTime_Init()
 #include "pycore_obmalloc.h"      // _PyMem_obmalloc_state_on_heap()
 #include "pycore_uniqueid.h"      // _PyObject_FinalizePerThreadRefcounts()
 
@@ -459,6 +460,11 @@ _PyRuntimeState_Init(_PyRuntimeState *runtime)
         // Preserve the cookie from the original runtime.
         memcpy(runtime->debug_offsets.cookie, _Py_Debug_Cookie, 8);
         assert(!runtime->_initialized);
+    }
+
+    PyStatus status = _PyTime_Init(&runtime->time);
+    if (_PyStatus_EXCEPTION(status)) {
+        return status;
     }
 
     if (gilstate_tss_init(runtime) != 0) {

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "pycore_initconfig.h"    // _PyStatus_ERR
 #include "pycore_time.h"          // PyTime_t
 #include "pycore_pystate.h"       // _Py_AssertHoldsTstate()
 
@@ -1048,7 +1049,7 @@ py_win_perf_counter_frequency(_PyTimeFraction *base)
     // * 10,000,000 (10 MHz): 100 ns resolution
     // * 3,579,545 Hz (3.6 MHz): 279 ns resolution
     if (_PyTimeFraction_Set(base, SEC_TO_NS, denom) < 0) {
-        return PyStatus_Error("invalid QueryPerformanceFrequency");
+        return _PyStatus_ERR("invalid QueryPerformanceFrequency");
     }
     return PyStatus_Ok();
 }
@@ -1108,7 +1109,7 @@ py_mach_timebase_info(_PyTimeFraction *base)
     // * (1000000000, 33333335) on PowerPC: ~30 ns
     // * (1000000000, 25000000) on PowerPC: 40 ns
     if (_PyTimeFraction_Set(base, numer, denom) < 0) {
-        return PyStatus_Error("invalid mach_timebase_info");
+        return _PyStatus_ERR("invalid mach_timebase_info");
     }
     return PyStatus_Ok();
 }

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -917,7 +917,7 @@ py_get_system_clock(PyTime_t *tp, _Py_clock_info_t *info, int raise_exc)
         // QueryPerformanceCounter() internally.
         info->implementation = "GetSystemTimePreciseAsFileTime()";
         info->monotonic = 0;
-        info->resolution = _PyTimeFraction_Resolution(&_PyRuntime.time.timebase);
+        info->resolution = _PyTimeFraction_Resolution(&_PyRuntime.time.base);
         info->adjustable = 1;
     }
 


### PR DESCRIPTION
Windows and macOS require precomputing a "timebase" in order to convert OS timestamps into nanoseconds. Retrieve and compute this value during runtime initialization to avoid data races when accessing the time.


<!-- gh-issue-number: gh-130421 -->
* Issue: gh-130421
<!-- /gh-issue-number -->
