### PR TITLE
gh-127785: Limit check labels github action permission

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -10,8 +10,7 @@ jobs:
     if: github.repository_owner == 'python'
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
+      pull-requests: read
     timeout-minutes: 10
 
     steps:
@@ -28,8 +27,7 @@ jobs:
     if: github.repository_owner == 'python'
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
+      pull-requests: read
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
The workflow checks for labels on pull requests using the `mheap/github-action-required-labels` action. Since this action only reads PR labels without modifying them, it does not require write permissions.

I tested it in my [test-repo/pull/11](https://github.com/shenxianpeng/test-repo/pull/11), removed `issues: write` and changed `pull-requests: write` to `pull-requests: read` to limit permissions, The workflow functioned as expected.

<!-- gh-issue-number: gh-127785 -->
* Issue: gh-127785
<!-- /gh-issue-number -->
