### PR TITLE
gh-124878: Add temporary TSAN suppression for free_threadstate

### DIFF
--- a/Tools/tsan/suppressions.txt
+++ b/Tools/tsan/suppressions.txt
@@ -1,5 +1,8 @@
 # This file contains suppressions for the default (with GIL) build.
 # reference: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 
+# gh-124878: race condition when interpreter finalized while daemon thread runs
+race:free_threadstate
+
 # https://gist.github.com/mpage/daaf32b39180c1989572957b943eb665
 thread:pthread_create

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -10,7 +10,7 @@
 # These entries are for warnings that trigger in a library function, as called
 # by a CPython function.
 
-# https://gist.github.com/swtaarrs/08dfe7883b4c975c31ecb39388987a67
+# gh-124878: race condition when interpreter finalized while daemon thread runs
 race:free_threadstate
 
 # These warnings trigger directly in a CPython function.


### PR DESCRIPTION
The race condition with `free_threadstate` and daemon threads exists in both the free threading and default builds. We were missing a suppression in the default build.


<!-- gh-issue-number: gh-124878 -->
* Issue: gh-124878
<!-- /gh-issue-number -->
