### PR TITLE
gh-130604: Always run all matrix workflows in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,6 +185,7 @@ jobs:
     needs: build-context
     if: fromJSON(needs.build-context.outputs.run-windows-msi)
     strategy:
+      fail-fast: false
       matrix:
         arch:
         - x86
@@ -236,6 +237,7 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
     strategy:
+      fail-fast: false
       matrix:
         bolt:
         - false
@@ -452,6 +454,7 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04]
     env:
@@ -515,6 +518,7 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
     strategy:
+      fail-fast: false
       matrix:
         free-threading:
         - false

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -139,6 +139,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
+      fail-fast: false
       matrix:
         llvm:
           - 19

--- a/.github/workflows/project-updater.yml
+++ b/.github/workflows/project-updater.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         include:
           # if an issue has any of these labels, it will be added


### PR DESCRIPTION
Most GHA matricies have `fail-fast: false` but not all. Notably, the thread-sanitizer workflow, which is required for merge but auto-cancels if any of the matrix jobs fails, requiring a full re-run of both jobs.

A

<!-- gh-issue-number: gh-130604 -->
* Issue: gh-130604
<!-- /gh-issue-number -->
