### PR TITLE
gh-130605: Temporarily disable test_concurrent_futures in TSAN CI job

### DIFF
--- a/Lib/test/libregrtest/tsan.py
+++ b/Lib/test/libregrtest/tsan.py
@@ -6,7 +6,7 @@ TSAN_TESTS = [
     'test_capi.test_mem',
     'test_capi.test_pyatomic',
     'test_code',
-    'test_concurrent_futures',
+    # 'test_concurrent_futures',  # gh-130605: too many data races
     'test_enum',
     'test_functools',
     'test_httpservers',


### PR DESCRIPTION
There are a number of data races in the default build without suppressions that are exposed by this test. Disable the test for now under TSAN until we have suppressions or fix the data races.


<!-- gh-issue-number: gh-130605 -->
* Issue: gh-130605
<!-- /gh-issue-number -->
