### PR TITLE
[3.13] gh-130604: Always run all matrix workflows in GitHub Actions (GH-130603)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,6 +230,7 @@ jobs:
     needs: build-context
     if: fromJSON(needs.build-context.outputs.run-windows-msi)
     strategy:
+      fail-fast: false
       matrix:
         arch:
         - x86
@@ -280,6 +281,7 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
     strategy:
+      fail-fast: false
       matrix:
         free-threading:
         - false
@@ -479,6 +481,7 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04]
     env:
@@ -542,6 +545,7 @@ jobs:
     needs: build-context
     if: needs.build-context.outputs.run-tests == 'true'
     strategy:
+      fail-fast: false
       matrix:
         free-threading:
         - false

--- a/.github/workflows/project-updater.yml
+++ b/.github/workflows/project-updater.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         include:
           # if an issue has any of these labels, it will be added


### PR DESCRIPTION
(cherry picked from commit fda056e64bdfcac3dd3d13eebda0a24994d83cb8)


<!-- gh-issue-number: gh-130604 -->
* Issue: gh-130604
<!-- /gh-issue-number -->
