### PR TITLE
gh-130567: fix strxfrm memory allocation

### DIFF
--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -371,6 +371,17 @@ class TestEnUSCollation(BaseLocalizedTest, TestCollation):
     def test_strxfrm_with_diacritic(self):
         self.assertLess(locale.strxfrm('à'), locale.strxfrm('b'))
 
+    @unittest.skipIf(sys.platform.startswith('aix'),
+                     'bpo-29972: broken test on AIX')
+    @unittest.skipIf(
+        is_emscripten or is_wasi,
+        "musl libc issue on Emscripten/WASI, bpo-46390"
+    )
+    @unittest.skipIf(sys.platform.startswith("netbsd"),
+                     "gh-124108: NetBSD doesn't support UTF-8 for LC_COLLATE")
+    def test_strxfrm_non_latin_1(self):
+        self.assertLess(locale.strxfrm('s'), locale.strxfrm('š'))
+
 
 class NormalizeTest(unittest.TestCase):
     def check(self, localename, expected):


### PR DESCRIPTION
The posix specification does not define that wcsxfrm should return needed buffer size, it just says:

If the value returned is n or more, the contents of the array pointed to by ws1 are unspecified.

Therefore double the allocation when the original call has failed. It might also make sense to increase the allocation repeatedly, but that would make the code more complex.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130567 -->
* Issue: gh-130567
<!-- /gh-issue-number -->
