### PR TITLE
Update argparse.py: remove unused `metavar`

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -933,7 +933,6 @@ class _StoreConstAction(Action):
                  default=None,
                  required=False,
                  help=None,
-                 metavar=None,
                  deprecated=False):
         super(_StoreConstAction, self).__init__(
             option_strings=option_strings,


### PR DESCRIPTION
remove unused `metavar` of `_StoreConstAction.__init__`