### PR TITLE
gh-130617 : fix time_clockid_converter on DragonFlyBSD

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -187,6 +187,8 @@ time_clockid_converter(PyObject *obj, clockid_t *p)
 {
 #ifdef _AIX
     long long clk_id = PyLong_AsLongLong(obj);
+#elif defined(__DragonFly__)
+    long clk_id = PyLong_AsLong(obj);
 #else
     int clk_id = PyLong_AsInt(obj);
 #endif


### PR DESCRIPTION
closed #130617


<!-- gh-issue-number: gh-130617 -->
* Issue: gh-130617
<!-- /gh-issue-number -->
