### PR TITLE
postpone <stdbool.h> inclusion after Python.h

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1,5 +1,3 @@
-#include <stdbool.h>
-
 #include "Python.h"
 #include "opcode.h"
 
@@ -19,6 +17,8 @@
 #include "pycore_tuple.h"         // _PyTuple_ITEMS()
 #include "pycore_uniqueid.h"      // _PyObject_AssignUniqueId()
 #include "clinic/codeobject.c.h"
+
+#include <stdbool.h>
 
 #define INITIAL_SPECIALIZED_CODE_SIZE 16
 

--- a/Python/assemble.c
+++ b/Python/assemble.c
@@ -1,5 +1,3 @@
-#include <stdbool.h>
-
 #include "Python.h"
 #include "pycore_code.h"            // write_location_entry_start()
 #include "pycore_compile.h"
@@ -8,6 +6,7 @@
 #include "pycore_opcode_metadata.h" // is_pseudo_target, _PyOpcode_Caches
 #include "pycore_symtable.h"        // _Py_SourceLocation
 
+#include <stdbool.h>
 
 #define DEFAULT_CODE_SIZE 128
 #define DEFAULT_LNOTAB_SIZE 16

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -14,8 +14,6 @@
  *
  */
 
-#include <stdbool.h>
-
 #include "Python.h"
 #include "pycore_ast.h"           // PyAST_Check, _PyAST_GetDocString()
 #include "pycore_compile.h"
@@ -24,6 +22,8 @@
 #include "pycore_setobject.h"     // _PySet_NextEntry()
 
 #include "cpython/code.h"
+
+#include <stdbool.h>
 
 #undef SUCCESS
 #undef ERROR

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -8,8 +8,6 @@
 
 /* TODO: Cull includes following phase split */
 
-#include <stdbool.h>
-
 #include "Python.h"
 
 #include "pycore_ast.h"           // PyAST_mod2obj()
@@ -28,6 +26,8 @@
 
 #include "errcode.h"              // E_EOF
 #include "marshal.h"              // PyMarshal_ReadLongFromFile()
+
+#include <stdbool.h>
 
 #ifdef MS_WINDOWS
 #  include "malloc.h"             // alloca()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
stdbool.h will cause <features.h> to be included before Python.h can define some macros to enable some additional features, causing multiple types not to be defined down the line

In my specific case, this was causing build failures when building python with `zig cc`