### PR TITLE
[3.12] gh-130618: Fix parser error when using lambdas inside f-strings (GH-130638)

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -2030,6 +2030,18 @@ class GrammarTests(unittest.TestCase):
         with self.assertRaises(Done):
             foo().send(None)
 
+    def test_complex_lambda(self):
+        def test1(foo, bar):
+            return ""
+
+        def test2():
+            return f"{test1(
+                foo=lambda: '、、、、、、、、、、、、、、、、、',
+                bar=lambda: 'abcdefghijklmnopqrstuvwxyz 123456789 123456789',
+            )}"
+
+        self.assertEqual(test2(), "")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-27-15-07-06.gh-issue-130618.JTcsRB.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-27-15-07-06.gh-issue-130618.JTcsRB.rst
@@ -1,0 +1,3 @@
+Fix a bug that was causing ``UnicodeDecodeError`` or ``SystemError`` to be
+raised when using f-strings with ``lambda`` expressions with non-ASCII
+characters. Patch by Pablo Galindo

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -479,8 +479,11 @@ static int update_fstring_expr(struct tok_state *tok, char cur) {
     break;
   case '}':
   case '!':
-  case ':':
     tok_mode->last_expr_end = strlen(tok->start);
+  case ':':
+    if (tok_mode->last_expr_end == -1) {
+        tok_mode->last_expr_end = strlen(tok->start);
+    }
     break;
   default:
     Py_UNREACHABLE();


### PR DESCRIPTION
…

(cherry picked from commit e06bebb87e1b33f7251196e1ddb566f528c3fc98)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130618 -->
* Issue: gh-130618
<!-- /gh-issue-number -->
