### PR TITLE
gh-80050: Update BufferedReader.read docs around non-blocking

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -571,7 +571,7 @@ I/O Base Classes
       Read and return up to *size* bytes. If the argument is omitted, ``None``,
       or negative read as much as possible.
 
-      The default implementation will use :py:func:`raw.readall` if available (
+      The default implementation will use ``raw.readall`` if available (
       which should implement :meth:`RawIOBase.readall`),
       otherwise will read in a loop until read returns ``None``, a size-zero
       ``bytes``, or a non-retryable error. For most streams this is to EOF, but

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -571,17 +571,18 @@ I/O Base Classes
       Read and return up to *size* bytes. If the argument is omitted, ``None``,
       or negative read as much as possible.
 
-      The default implementation will use ``raw.readall`` if available (
-      which should implement :meth:`RawIOBase.readall`),
-      otherwise will read in a loop until read returns ``None``, a size-zero
-      ``bytes``, or a non-retryable error. For most streams this is to EOF, but
-      for non-blocking streams more data may become available.
-
       Less bytes may be returned than requested. An empty :class:`bytes` object
       is returned if the stream is already at EOF. More than one read may be
       made, and calls may be retried if specific errors are encountered, see
       :meth:`os.read` and :pep:`475` for more details. Less than size bytes
       being returned does not imply that EOF is imminent.
+
+      When reading as much as possible the default implementation will use
+      ``raw.readall`` if available (which should implement
+      :meth:`RawIOBase.readall`), otherwise will read in a loop until read
+      returns ``None``, a size-zero :clss:`bytes`, or a non-retryable error. For
+      most streams this is to EOF, but for non-blocking streams more data may
+      become available.
 
       A :exc:`BlockingIOError` is raised if the underlying raw stream is in
       non blocking-mode, and has no data available at the moment.

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -580,7 +580,7 @@ I/O Base Classes
       When reading as much as possible the default implementation will use
       ``raw.readall`` if available (which should implement
       :meth:`RawIOBase.readall`), otherwise will read in a loop until read
-      returns ``None``, a size-zero :clss:`bytes`, or a non-retryable error. For
+      returns ``None``, a size-zero :class:`bytes`, or a non-retryable error. For
       most streams this is to EOF, but for non-blocking streams more data may
       become available.
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -568,15 +568,19 @@ I/O Base Classes
 
    .. method:: read(size=-1, /)
 
-      Read and return up to *size* bytes.  If the argument is omitted, ``None``,
-      or negative, data is read and returned until EOF is reached.  An empty
-      :class:`bytes` object is returned if the stream is already at EOF.
+      Read and return up to *size* bytes. If the argument is omitted, ``None``,
+      or negative read as much as possible.
 
-      If the argument is positive, and the underlying raw stream is not
-      interactive, multiple raw reads may be issued to satisfy the byte count
-      (unless EOF is reached first).  But for interactive raw streams, at most
-      one raw read will be issued, and a short result does not imply that EOF is
-      imminent.
+      Reading as much as possible will use :meth:`~raw.readall` if available,
+      otherwise will read in a loop until read returns ``None``, a size-zero
+      ``bytes``, or a non-retryable error. For most streams this is to EOF, but
+      for non-blocking streams more data may become available.
+
+      Less bytes may be returned than requested. An empty :class:`bytes` object
+      is returned if the stream is already at EOF. More than one read may be
+      made, and calls may be retried if specific errors are encountered, see
+      :meth:`os.read` and :pep:`475` for more details. Less than size bytes
+      being returned does not imply that EOF is imminent.
 
       A :exc:`BlockingIOError` is raised if the underlying raw stream is in
       non blocking-mode, and has no data available at the moment.
@@ -591,6 +595,11 @@ I/O Base Classes
 
       If *size* is ``-1`` (the default), an arbitrary number of bytes are
       returned (more than zero unless EOF is reached).
+
+      .. note::
+
+         When the underlying raw stream is non-blocking, a :exc:`BlockingIOError`
+         may be raised if a read operation cannot be completed immediately.
 
    .. method:: readinto(b, /)
 
@@ -737,14 +746,14 @@ than raw I/O does.
 
    .. method:: read1(size=-1, /)
 
-      In :class:`BytesIO`, this is the same as :meth:`~BufferedIOBase.read`.
+      In :class:`BytesIO`, this is the same as :meth:`io.BufferedIOBase.read`.
 
       .. versionchanged:: 3.7
          The *size* argument is now optional.
 
    .. method:: readinto1(b, /)
 
-      In :class:`BytesIO`, this is the same as :meth:`~BufferedIOBase.readinto`.
+      In :class:`BytesIO`, this is the same as :meth:`io.BufferedIOBase.readinto`.
 
       .. versionadded:: 3.5
 
@@ -767,33 +776,20 @@ than raw I/O does.
 
    .. method:: peek(size=0, /)
 
-      Return bytes from the stream without advancing the position.  At most one
-      single read on the raw stream is done to satisfy the call. The number of
-      bytes returned may be less or more than requested.
+      Return bytes from the stream without advancing the position. The number of
+      bytes returned may be less or more than requested. If the underlying raw
+      stream is non-blocking and the operation would block, returns empty bytes.
 
    .. method:: read(size=-1, /)
 
-      Read and return *size* bytes, or if *size* is not given or negative, until
-      EOF or if the read call would block in non-blocking mode.
-
-      .. note::
-
-         When the underlying raw stream is non-blocking, a :exc:`BlockingIOError`
-         may be raised if a read operation cannot be completed immediately.
+      In :class:`BufferedReader` this is the same as :meth:`io.BufferedIOBase.read`
 
    .. method:: read1(size=-1, /)
 
-      Read and return up to *size* bytes with only one call on the raw stream.
-      If at least one byte is buffered, only buffered bytes are returned.
-      Otherwise, one raw stream read call is made.
+      In :class:`BufferedReader` this is the same as :meth:`io.BufferedIOBase.read1`
 
       .. versionchanged:: 3.7
          The *size* argument is now optional.
-
-      .. note::
-
-         When the underlying raw stream is non-blocking, a :exc:`BlockingIOError`
-         may be raised if a read operation cannot be completed immediately.
 
 .. class:: BufferedWriter(raw, buffer_size=DEFAULT_BUFFER_SIZE)
 
@@ -856,7 +852,7 @@ than raw I/O does.
    :data:`DEFAULT_BUFFER_SIZE`.
 
    :class:`BufferedRWPair` implements all of :class:`BufferedIOBase`\'s methods
-   except for :meth:`~BufferedIOBase.detach`, which raises
+   except for :meth:`io.BufferedIOBase.detach`, which raises
    :exc:`UnsupportedOperation`.
 
    .. warning::
@@ -1006,8 +1002,8 @@ Text I/O
    If *line_buffering* is ``True``, :meth:`~IOBase.flush` is implied when a call to
    write contains a newline character or a carriage return.
 
-   If *write_through* is ``True``, calls to :meth:`~BufferedIOBase.write` are guaranteed
-   not to be buffered: any data written on the :class:`TextIOWrapper`
+   If *write_through* is ``True``, calls to :meth:`io.BufferedIOBase.write` are
+   guaranteed not to be buffered: any data written on the :class:`TextIOWrapper`
    object is immediately handled to its underlying binary *buffer*.
 
    .. versionchanged:: 3.3

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -571,7 +571,8 @@ I/O Base Classes
       Read and return up to *size* bytes. If the argument is omitted, ``None``,
       or negative read as much as possible.
 
-      Reading as much as possible will use :meth:`~raw.readall` if available,
+      The default implementation will use :py:func:`raw.readall` if available (
+      which should implement :meth:`RawIOBase.readall`),
       otherwise will read in a loop until read returns ``None``, a size-zero
       ``bytes``, or a non-retryable error. For most streams this is to EOF, but
       for non-blocking streams more data may become available.

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -573,14 +573,14 @@ I/O Base Classes
 
       Less bytes may be returned than requested. An empty :class:`bytes` object
       is returned if the stream is already at EOF. More than one read may be
-      made, and calls may be retried if specific errors are encountered, see
+      made and calls may be retried if specific errors are encountered, see
       :meth:`os.read` and :pep:`475` for more details. Less than size bytes
       being returned does not imply that EOF is imminent.
 
       When reading as much as possible the default implementation will use
       ``raw.readall`` if available (which should implement
       :meth:`RawIOBase.readall`), otherwise will read in a loop until read
-      returns ``None``, a size-zero :class:`bytes`, or a non-retryable error. For
+      returns ``None``, an empty :class:`bytes`, or a non-retryable error. For
       most streams this is to EOF, but for non-blocking streams more data may
       become available.
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -570,7 +570,7 @@ I/O Base Classes
       Read and return up to *size* bytes. If the argument is omitted, ``None``,
       or negative read as much as possible.
 
-      Less bytes may be returned than requested. An empty :class:`bytes` object
+      Fewer bytes may be returned than requested. An empty :class:`bytes` object
       is returned if the stream is already at EOF. More than one read may be
       made and calls may be retried if specific errors are encountered, see
       :meth:`os.read` and :pep:`475` for more details. Less than size bytes

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -592,11 +592,10 @@ I/O Base Classes
 
    .. method:: read1(size=-1, /)
 
-      Read and return up to *size* bytes, with at most one call to the
-      underlying raw stream's :meth:`~RawIOBase.read` (or
-      :meth:`~RawIOBase.readinto`) method. If *size* is ``-1`` or not provided,
-      the implementation will decide a size to use and at most one call will be
-      made.
+      Read and return up to *size* bytes, calilng :meth:`~raw.readinto`,
+      retrying if :py:const:`~errno.EINTR` is encountered per  :pep:`475`. If
+      *size* is ``-1`` or not provided, the implementation will choose an
+      arbitrary value for *size*.
 
       .. note::
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -592,7 +592,7 @@ I/O Base Classes
 
    .. method:: read1(size=-1, /)
 
-      Read and return up to *size* bytes, calilng :meth:`~raw.readinto`,
+      Read and return up to *size* bytes, calilng ``raw.readinto``,
       retrying if :py:const:`~errno.EINTR` is encountered per  :pep:`475`. If
       *size* is ``-1`` or not provided, the implementation will choose an
       arbitrary value for *size*.

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -823,8 +823,8 @@ than raw I/O does.
 
       Write the :term:`bytes-like object`, *b*, and return the
       number of bytes written.  When in non-blocking mode, a
-      :exc:`BlockingIOError` is raised if the buffer needs to be written out but
-      the raw stream blocks.
+      :exc:`BlockingIOError` with :attr:`BlockingIOError.characters_written` set
+      is raised if the buffer needs to be written out but the raw stream blocks.
 
 
 .. class:: BufferedRandom(raw, buffer_size=DEFAULT_BUFFER_SIZE)

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -584,8 +584,8 @@ I/O Base Classes
       most streams this is to EOF, but for non-blocking streams more data may
       become available.
 
-      The standard library :class:`io.BufferedReader` returns ``None`` if
-      reading would block and no data is available. Other implementations may
+      The standard library :class:`io.BufferedReader` returns ``None`` if the
+      stream is non-blocking and no data is available. Other implementations may
       return ``None`` or raise :exc:`BlockingIOError`.
 
    .. method:: read1(size=-1, /)

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -528,14 +528,13 @@ I/O Base Classes
    It inherits from :class:`IOBase`.
 
    The main difference with :class:`RawIOBase` is that methods :meth:`read`,
-   :meth:`readinto` and :meth:`write` will try (respectively) to read as much
-   input as requested or to consume all given output, at the expense of
-   making perhaps more than one system call.
+   :meth:`readinto` and :meth:`write` will try (respectively) to read
+   as much input as requested or to emit all provided data.
 
-   In addition, those methods can raise :exc:`BlockingIOError` if the
-   underlying raw stream is in non-blocking mode and cannot take or give
-   enough data; unlike their :class:`RawIOBase` counterparts, they will
-   never return ``None``.
+   In addition, if the underlying raw stream is in non-blocking mode, when the
+   system returns would block :meth:`write` will raise :exc:`BlockingIOError`
+   with :attr:`BlockingIOError.characters_written` and :meth:`read` will return
+   data read so far or ``None`` if no data is available.
 
    Besides, the :meth:`read` method does not have a default
    implementation that defers to :meth:`readinto`.

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -584,25 +584,25 @@ I/O Base Classes
       most streams this is to EOF, but for non-blocking streams more data may
       become available.
 
-      The standard library :class:`io.BufferedReader` returns ``None`` if the
-      stream is non-blocking and no data is available. Other implementations may
-      return ``None`` or raise :exc:`BlockingIOError`.
+      .. note::
+
+         When the underlying raw stream is non-blocking, implementations may
+         either raise :exc:`BlockingIOError` or return ``None`` if no data is
+         available. :mod:`io` implementations return ``None``.
 
    .. method:: read1(size=-1, /)
 
       Read and return up to *size* bytes, with at most one call to the
       underlying raw stream's :meth:`~RawIOBase.read` (or
-      :meth:`~RawIOBase.readinto`) method.  This can be useful if you are
-      implementing your own buffering on top of a :class:`BufferedIOBase`
-      object.
-
-      If *size* is ``-1`` (the default), an arbitrary number of bytes are
-      returned (more than zero unless EOF is reached).
+      :meth:`~RawIOBase.readinto`) method. If *size* is ``-1`` or not provided,
+      the implementation will decide a size to use and at most one call will be
+      made.
 
       .. note::
 
-         When the underlying raw stream is non-blocking, a :exc:`BlockingIOError`
-         may be raised if a read operation cannot be completed immediately.
+         When the underlying raw stream is non-blocking, implementations may
+         either raise :exc:`BlockingIOError` or return ``None`` if no data is
+         available. :mod:`io` implementations return ``None``.
 
    .. method:: readinto(b, /)
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -584,8 +584,9 @@ I/O Base Classes
       most streams this is to EOF, but for non-blocking streams more data may
       become available.
 
-      A :exc:`BlockingIOError` is raised if the underlying raw stream is in
-      non blocking-mode, and has no data available at the moment.
+      The standard library :class:`io.BufferedReader` returns ``None`` if
+      reading would block and no data is available. Other implementations may
+      return ``None`` or raise :exc:`BlockingIOError`.
 
    .. method:: read1(size=-1, /)
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -592,10 +592,10 @@ I/O Base Classes
 
    .. method:: read1(size=-1, /)
 
-      Read and return up to *size* bytes, calilng ``raw.readinto``,
-      retrying if :py:const:`~errno.EINTR` is encountered per  :pep:`475`. If
-      *size* is ``-1`` or not provided, the implementation will choose an
-      arbitrary value for *size*.
+      Read and return up to *size* bytes, calling :meth:`~RawIOBase.readinto`
+      which may retry if :py:const:`~errno.EINTR` is encountered per
+      :pep:`475`. If *size* is ``-1`` or not provided, the implementation will
+      choose an arbitrary value for *size*.
 
       .. note::
 
@@ -748,14 +748,14 @@ than raw I/O does.
 
    .. method:: read1(size=-1, /)
 
-      In :class:`BytesIO`, this is the same as :meth:`io.BufferedIOBase.read`.
+      In :class:`BytesIO`, this is the same as :meth:`~BufferedIOBase.read`.
 
       .. versionchanged:: 3.7
          The *size* argument is now optional.
 
    .. method:: readinto1(b, /)
 
-      In :class:`BytesIO`, this is the same as :meth:`io.BufferedIOBase.readinto`.
+      In :class:`BytesIO`, this is the same as :meth:`~BufferedIOBase.readinto`.
 
       .. versionadded:: 3.5
 
@@ -854,7 +854,7 @@ than raw I/O does.
    :data:`DEFAULT_BUFFER_SIZE`.
 
    :class:`BufferedRWPair` implements all of :class:`BufferedIOBase`\'s methods
-   except for :meth:`io.BufferedIOBase.detach`, which raises
+   except for :meth:`~BufferedIOBase.detach`, which raises
    :exc:`UnsupportedOperation`.
 
    .. warning::
@@ -1004,8 +1004,8 @@ Text I/O
    If *line_buffering* is ``True``, :meth:`~IOBase.flush` is implied when a call to
    write contains a newline character or a carriage return.
 
-   If *write_through* is ``True``, calls to :meth:`io.BufferedIOBase.write` are
-   guaranteed not to be buffered: any data written on the :class:`TextIOWrapper`
+   If *write_through* is ``True``, calls to :meth:`~BufferedIOBase.write` are guaranteed
+   not to be buffered: any data written on the :class:`TextIOWrapper`
    object is immediately handled to its underlying binary *buffer*.
 
    .. versionchanged:: 3.3


### PR DESCRIPTION
Synchronize `io.BufferedReader` and `io.BufferedIOBase` documentation with the current implementation. Focused on behavior around non-blocking streams.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-80050 -->
* Issue: gh-80050
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130653.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->