### PR TITLE
gh-103982: Set fold for result in `datetime.astimezone`

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -2115,7 +2115,13 @@ class datetime(date):
         utc = (self - myoffset).replace(tzinfo=tz)
 
         # Convert from UTC to tz's local time.
-        return tz.fromutc(utc)
+        result = tz.fromutc(utc)
+
+        # Set fold if there is discrepancy between timestamp and timezone.
+        if tz.utcoffset(result) != myoffset:
+            result = result.replace(fold=1)
+
+        return result
 
     # Ways to produce a string.
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6754,6 +6754,29 @@ datetime_astimezone(PyObject *op, PyObject *args, PyObject *kw)
         PyObject_CallMethodOneArg(tzinfo, &_Py_ID(fromutc), temp);
     Py_DECREF(temp);
 
+    /* Set fold if there is discrepancy between timestamp and timezone. */
+    if (result != NULL) {
+        offset = call_utcoffset(tzinfo, (PyObject *)result);
+        if (offset == NULL || offset == Py_None || !PyDelta_Check(offset)) {
+            Py_XDECREF(offset);
+            goto naive;
+        }
+
+        PyObject *myoffset = call_utcoffset(tzinfo, (PyObject *)self);
+        if (myoffset == NULL || myoffset == Py_None || !PyDelta_Check(myoffset)) {
+            Py_XDECREF(offset);
+            Py_XDECREF(myoffset);
+            return NULL;
+        }
+
+        if (delta_cmp(offset, myoffset) == 0) {
+            DATE_SET_FOLD(result, 1);
+        }
+
+        Py_XDECREF(myoffset);
+        Py_XDECREF(offset);
+    }
+
     return (PyObject *)result;
 }
 


### PR DESCRIPTION
Please take a close look at my C code as I have not worked much with the C implementation.

And I don't think this change needs a News entry because it's just a fix for an implicit behavior (but if you tell me, I'll add it)

**Note: many tests fail because they don't expect a result with `fold` or expect with `fold=0`**

<!-- gh-issue-number: gh-103982 -->
* Issue: gh-103982
<!-- /gh-issue-number -->
