### PR TITLE
gh-130660: Revert sys.ps1 and sys.ps2 after code.interact

### DIFF
--- a/Lib/code.py
+++ b/Lib/code.py
@@ -218,12 +218,14 @@ class InteractiveConsole(InteractiveInterpreter):
 
         """
         try:
-            sys.ps1
+            _ps1 = sys.ps1
         except AttributeError:
+            _ps1 = None
             sys.ps1 = ">>> "
         try:
-            sys.ps2
+            _ps2 = sys.ps2
         except AttributeError:
+            _ps2 = None
             sys.ps2 = "... "
         cprt = 'Type "help", "copyright", "credits" or "license" for more information.'
         if banner is None:
@@ -286,6 +288,12 @@ class InteractiveConsole(InteractiveInterpreter):
 
             if _quit is not None:
                 builtins.quit = _quit
+
+            if _ps1 is None:
+                del sys.ps1
+
+            if _ps2 is None:
+                del sys.ps2
 
             if exitmsg is None:
                 self.write('now exiting %s...\n' % self.__class__.__name__)

--- a/Lib/code.py
+++ b/Lib/code.py
@@ -218,15 +218,18 @@ class InteractiveConsole(InteractiveInterpreter):
 
         """
         try:
-            _ps1 = sys.ps1
+            sys.ps1
+            delete_ps1_after = False
         except AttributeError:
-            _ps1 = None
             sys.ps1 = ">>> "
+            delete_ps1_after = True
         try:
             _ps2 = sys.ps2
+            delete_ps2_after = False
         except AttributeError:
-            _ps2 = None
             sys.ps2 = "... "
+            delete_ps2_after = True
+
         cprt = 'Type "help", "copyright", "credits" or "license" for more information.'
         if banner is None:
             self.write("Python %s on %s\n%s\n(%s)\n" %
@@ -289,10 +292,10 @@ class InteractiveConsole(InteractiveInterpreter):
             if _quit is not None:
                 builtins.quit = _quit
 
-            if _ps1 is None:
+            if delete_ps1_after:
                 del sys.ps1
 
-            if _ps2 is None:
+            if delete_ps2_after:
                 del sys.ps2
 
             if exitmsg is None:

--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -47,7 +47,7 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         self.console.interact()
         output = ''.join(''.join(call[1]) for call in self.stdout.method_calls)
         self.assertIn('>>> ', output)
-        self.assertFalse(hasattr(self.sysmod, 'ps1'))
+        self.assertNotHasAttr(self.sysmod, 'ps1')
 
         self.infunc.side_effect = [
             "import code",
@@ -69,7 +69,7 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         self.console.interact()
         output = ''.join(''.join(call[1]) for call in self.stdout.method_calls)
         self.assertIn('... ', output)
-        self.assertFalse(hasattr(self.sysmod, 'ps2'))
+        self.assertNotHasAttr(self.sysmod, 'ps2')
 
         self.infunc.side_effect = [
             "import code",

--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -39,19 +39,47 @@ class TestInteractiveConsole(unittest.TestCase, MockSys):
         self.mock_sys()
 
     def test_ps1(self):
-        self.infunc.side_effect = EOFError('Finished')
+        self.infunc.side_effect = [
+            "import code",
+            "code.sys.ps1",
+            EOFError('Finished')
+        ]
         self.console.interact()
-        self.assertEqual(self.sysmod.ps1, '>>> ')
+        output = ''.join(''.join(call[1]) for call in self.stdout.method_calls)
+        self.assertIn('>>> ', output)
+        self.assertFalse(hasattr(self.sysmod, 'ps1'))
+
+        self.infunc.side_effect = [
+            "import code",
+            "code.sys.ps1",
+            EOFError('Finished')
+        ]
         self.sysmod.ps1 = 'custom1> '
         self.console.interact()
+        output = ''.join(''.join(call[1]) for call in self.stdout.method_calls)
+        self.assertIn('custom1> ', output)
         self.assertEqual(self.sysmod.ps1, 'custom1> ')
 
     def test_ps2(self):
-        self.infunc.side_effect = EOFError('Finished')
+        self.infunc.side_effect = [
+            "import code",
+            "code.sys.ps2",
+            EOFError('Finished')
+        ]
         self.console.interact()
-        self.assertEqual(self.sysmod.ps2, '... ')
+        output = ''.join(''.join(call[1]) for call in self.stdout.method_calls)
+        self.assertIn('... ', output)
+        self.assertFalse(hasattr(self.sysmod, 'ps2'))
+
+        self.infunc.side_effect = [
+            "import code",
+            "code.sys.ps2",
+            EOFError('Finished')
+        ]
         self.sysmod.ps2 = 'custom2> '
         self.console.interact()
+        output = ''.join(''.join(call[1]) for call in self.stdout.method_calls)
+        self.assertIn('custom2> ', output)
         self.assertEqual(self.sysmod.ps2, 'custom2> ')
 
     def test_console_stderr(self):

--- a/Misc/NEWS.d/next/Library/2025-02-28-01-10-14.gh-issue-130660.VIThEz.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-28-01-10-14.gh-issue-130660.VIThEz.rst
@@ -1,0 +1,1 @@
+``sys.ps1`` and ``sys.ps2`` are now restored after :func:`code.interact` call.


### PR DESCRIPTION
I'd consider this as a bug fix as the current behavior does not match what we documented. However, it's a behavior that has been in the code base for a while (in a relatively dark corner), so I'm still open to suggestions.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130660 -->
* Issue: gh-130660
<!-- /gh-issue-number -->
