### PR TITLE
[3.12] gh-129296: Fix `pythread.h` include paths (#129320)

### DIFF
--- a/Include/cpython/pythread.h
+++ b/Include/cpython/pythread.h
@@ -21,7 +21,7 @@ PyAPI_FUNC(int) _PyThread_at_fork_reinit(PyThread_type_lock *lock);
     */
 #   define NATIVE_TSS_KEY_T     unsigned long
 #elif defined(HAVE_PTHREAD_STUBS)
-#   include "cpython/pthread_stubs.h"
+#   include "pthread_stubs.h"
 #   define NATIVE_TSS_KEY_T     pthread_key_t
 #else
 #   error "Require native threads. See https://bugs.python.org/issue31370"


### PR DESCRIPTION
Use relative includes in Include/cpython/pythread.h for pthread_stubs.h.

(cherry picked from commit 3a974e39d54902699f360bc4db2fd351a6baf3ef)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129296 -->
* Issue: gh-129296
<!-- /gh-issue-number -->
