### PR TITLE
gh-88932 socketserver.shutdown: Connect to server socket to wake up the loop

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -230,7 +230,7 @@ Server Objects
       will return.
 
 
-   .. method:: serve_forever(poll_interval=0.5)
+   .. method:: serve_forever(poll_interval=30)
 
       Handle requests until an explicit :meth:`shutdown` request.  Poll for
       shutdown every *poll_interval* seconds.
@@ -243,6 +243,9 @@ Server Objects
       .. versionchanged:: 3.3
          Added ``service_actions`` call to the ``serve_forever`` method.
 
+      .. versionchanged:: 3.14
+         Default of *poll_interval* is now ``30`` instead of ``0.5``.
+
 
    .. method:: service_actions()
 
@@ -252,12 +255,16 @@ Server Objects
 
       .. versionadded:: 3.3
 
-   .. method:: shutdown()
+   .. method:: shutdown(write_to_self=True)
 
       Tell the :meth:`serve_forever` loop to stop and wait until it does.
+      If *write_to_self* is True, :meth:`write_to_self` called
+      and the loop will wake up immediately if server is not closed.
       :meth:`shutdown` must be called while :meth:`serve_forever` is running in a
       different thread otherwise it will deadlock.
 
+      .. versionchanged:: 3.14
+         Added ``write_to_self`` parameter.
 
    .. method:: server_close()
 
@@ -397,6 +404,14 @@ Server Objects
       be processed, and if it's :const:`False`, the request will be denied.  This
       function can be overridden to implement access controls for a server. The
       default implementation always returns :const:`True`.
+
+
+   .. method:: write_to_self()
+
+      Connect to the server's socket and send null byte.
+      May be overriden.
+
+      .. versionadded:: 3.14
 
 
    .. versionchanged:: 3.6

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -273,7 +273,7 @@ class SocketServerTest(unittest.TestCase):
             def serve_forever(self, poll_interval=poll_interval) -> None:
                 try:
                     super().serve_forever(poll_interval)
-                except OSError:
+                except ValueError:
                     # In case server was closed before select() was called
                     return
 

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -273,7 +273,7 @@ class SocketServerTest(unittest.TestCase):
             def serve_forever(self, poll_interval=poll_interval) -> None:
                 try:
                     super().serve_forever(poll_interval)
-                except ValueError:
+                except (ValueError, OSError):
                     # In case server was closed before select() was called
                     return
 

--- a/Misc/NEWS.d/next/Library/2025-02-28-10-56-25.gh-issue-88932.QVit76.rst
+++ b/Misc/NEWS.d/next/Library/2025-02-28-10-56-25.gh-issue-88932.QVit76.rst
@@ -1,0 +1,2 @@
+Add socketserver.BaseServer.write_to_self method, and call it from BaseServer.shutdown().
+Now serve_forever() loop wakes up immediately after shutdown() is called.


### PR DESCRIPTION
I have tried to finish [solution](https://github.com/encukou/cpython/commit/1ab0ed9345bcab9a0ce71870c1242e7c7c92cd53) with os.pipe, but found that on Windows, select() available only for socket file descriptors. So I came up with a different approach: connect to server's socket and send some data (I chose zero byte).

<!-- gh-issue-number: gh-88932 -->
* Issue: gh-88932
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130680.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->