### PR TITLE
[3.13] gh-124878: Add temporary TSAN suppression for free_threadstate (gh-130602)

### DIFF
--- a/Tools/tsan/suppressions.txt
+++ b/Tools/tsan/suppressions.txt
@@ -3,5 +3,8 @@
 race:get_allocator_unlocked
 race:set_allocator_unlocked
 
+# gh-124878: race condition when interpreter finalized while daemon thread runs
+race:free_threadstate
+
 # https://gist.github.com/mpage/daaf32b39180c1989572957b943eb665
 thread:pthread_create

--- a/Tools/tsan/suppressions_free_threading.txt
+++ b/Tools/tsan/suppressions_free_threading.txt
@@ -17,7 +17,8 @@ race:set_allocator_unlocked
 
 # https://gist.github.com/swtaarrs/8e0e365e1d9cecece3269a2fb2f2b8b8
 race:sock_recv_impl
-# https://gist.github.com/swtaarrs/08dfe7883b4c975c31ecb39388987a67
+
+# gh-124878: race condition when interpreter finalized while daemon thread runs
 race:free_threadstate
 
 


### PR DESCRIPTION
The race condition with `free_threadstate` and daemon threads exists in both the free threading and default builds. We were missing a suppression in the default build.
(cherry picked from commit cc17307faaa248535c65f6a7668e06dc8ef04575)


<!-- gh-issue-number: gh-124878 -->
* Issue: gh-124878
<!-- /gh-issue-number -->
