### PR TITLE
gh-129666: Revert "gh-129666: Add C11/C++11 to docs and `-pedantic-errors` to GCC/clang test_c[pp]ext tests (GH-130686)"

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -30,16 +30,6 @@ familiar with writing an extension before  attempting to embed Python in a real
 application.
 
 
-Language version compatibility
-==============================
-
-Python's C API is compatible with C11 and C++11 versions of C and C++.
-
-This is a lower limit: the C API does not require features from later
-C/C++ versions.
-You do *not* need to enable your compiler's "c11 mode".
-
-
 Coding standards
 ================
 

--- a/Lib/test/test_cext/__init__.py
+++ b/Lib/test/test_cext/__init__.py
@@ -38,9 +38,6 @@ class TestExt(unittest.TestCase):
 
     @unittest.skipIf(support.MS_WINDOWS, "MSVC doesn't support /std:c99")
     def test_build_c99(self):
-        # In public docs, we say C API is compatible with C11. However,
-        # in practice we do maintain C99 compatibility in public headers.
-        # Please ask the C API WG before adding a new C11-only feature.
         self.check_build('_test_c99_cext', std='c99')
 
     @support.requires_gil_enabled('incompatible with Free Threading')

--- a/Lib/test/test_cext/extension.c
+++ b/Lib/test/test_cext/extension.c
@@ -58,23 +58,10 @@ _testcext_exec(
     return 0;
 }
 
-// Converting from function pointer to void* has undefined behavior, but
-// works on all known platforms, and CPython's module and type slots currently
-// need it.
-// (GCC doesn't have a narrower category for this than -Wpedantic.)
-_Py_COMP_DIAG_PUSH
-#if defined(__GNUC__)
-#pragma GCC diagnostic ignored "-Wpedantic"
-#elif defined(__clang__)
-#pragma clang diagnostic ignored "-Wpedantic"
-#endif
-
 static PyModuleDef_Slot _testcext_slots[] = {
     {Py_mod_exec, (void*)_testcext_exec},
     {0, NULL}
 };
-
-_Py_COMP_DIAG_POP
 
 
 PyDoc_STRVAR(_testcext_doc, "C test extension.");

--- a/Lib/test/test_cext/setup.py
+++ b/Lib/test/test_cext/setup.py
@@ -21,9 +21,6 @@ if not support.MS_WINDOWS:
 
         # gh-120593: Check the 'const' qualifier
         '-Wcast-qual',
-
-        # Ask for strict(er) compliance with the standard
-        '-pedantic-errors',
     ]
     if not support.Py_GIL_DISABLED:
         CFLAGS.append(

--- a/Lib/test/test_cppext/__init__.py
+++ b/Lib/test/test_cppext/__init__.py
@@ -29,9 +29,6 @@ class TestCPPExt(unittest.TestCase):
         self.check_build('_testcppext')
 
     def test_build_cpp03(self):
-        # In public docs, we say C API is compatible with C++11. However,
-        # in practice we do maintain C++03 compatibility in public headers.
-        # Please ask the C API WG before adding a new C++11-only feature.
         self.check_build('_testcpp03ext', std='c++03')
 
     @unittest.skipIf(support.MS_WINDOWS, "MSVC doesn't support /std:c++11")

--- a/Lib/test/test_cppext/extension.cpp
+++ b/Lib/test/test_cppext/extension.cpp
@@ -161,23 +161,10 @@ private:
 
 int VirtualPyObject::instance_count = 0;
 
-// Converting from function pointer to void* has undefined behavior, but
-// works on all known platforms, and CPython's module and type slots currently
-// need it.
-// (GCC doesn't have a narrower category for this than -Wpedantic.)
-_Py_COMP_DIAG_PUSH
-#if defined(__GNUC__)
-#pragma GCC diagnostic ignored "-Wpedantic"
-#elif defined(__clang__)
-#pragma clang diagnostic ignored "-Wpedantic"
-#endif
-
 PyType_Slot VirtualPyObject_Slots[] = {
     {Py_tp_free, (void*)VirtualPyObject::dealloc},
     {0, _Py_NULL},
 };
-
-_Py_COMP_DIAG_POP
 
 PyType_Spec VirtualPyObject_Spec = {
     /* .name */ STR(MODULE_NAME) ".VirtualPyObject",
@@ -254,20 +241,11 @@ _testcppext_exec(PyObject *module)
     return 0;
 }
 
-// Need to ignore "-Wpedantic" warnings; see VirtualPyObject_Slots above
-_Py_COMP_DIAG_PUSH
-#if defined(__GNUC__)
-#pragma GCC diagnostic ignored "-Wpedantic"
-#elif defined(__clang__)
-#pragma clang diagnostic ignored "-Wpedantic"
-#endif
-
 static PyModuleDef_Slot _testcppext_slots[] = {
     {Py_mod_exec, reinterpret_cast<void*>(_testcppext_exec)},
     {0, _Py_NULL}
 };
 
-_Py_COMP_DIAG_POP
 
 PyDoc_STRVAR(_testcppext_doc, "C++ test extension.");
 

--- a/Lib/test/test_cppext/setup.py
+++ b/Lib/test/test_cppext/setup.py
@@ -18,14 +18,6 @@ if not support.MS_WINDOWS:
         # a C++ extension using the Python C API does not emit C++ compiler
         # warnings
         '-Werror',
-
-        # Ask for strict(er) compliance with the standard.
-        '-pedantic-errors',
-
-        # But allow C++11 features for -std=C++03. We use:
-        # - `long long` (-Wno-c++11-long-long)
-        # - comma at end of `enum` lists (no narrower GCC option exists)
-        '-Wno-c++11-extensions',
     ]
 else:
     # MSVC compiler flags


### PR DESCRIPTION
The change broke buildbots.

This reverts commit 003e6d2b9776c07147a9c628eb028fd2ac3f0008.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129666 -->
* Issue: gh-129666
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130688.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->