### PR TITLE
gh-130695: add count create/destroy refs to tracemalloc

### DIFF
--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -331,10 +331,12 @@ Functions
    :mod:`tracemalloc` module as a tuple: ``(current: int, peak: int)``.
 
 
-.. function:: get_traced_allocs()
+.. function:: get_traced_refs()
 
-   Get the current unit counts of allocated and deallocated memory blocks.
-   :mod:`tracemalloc` module as a tuple: ``(allocs: int, deallocs: int)``.
+   Get the current count of created and destroyed traced references.
+   :mod:`tracemalloc` module as a tuple: ``(created: int, destroyed: int)``.
+
+   .. versionadded:: next
 
 
 .. function:: reset_peak()

--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -299,7 +299,8 @@ Functions
 
 .. function:: clear_traces()
 
-   Clear traces of memory blocks allocated by Python.
+   Clear traces of memory blocks allocated and counts of created and destroyed
+   memory blocks by Python.
 
    See also :func:`stop`.
 
@@ -328,6 +329,12 @@ Functions
 
    Get the current size and peak size of memory blocks traced by the
    :mod:`tracemalloc` module as a tuple: ``(current: int, peak: int)``.
+
+
+.. function:: get_traced_refs()
+
+   Get the current count of created and destroyed memory blocks.
+   :mod:`tracemalloc` module as a tuple: ``(created: int, destroyed: int)``.
 
 
 .. function:: reset_peak()

--- a/Doc/library/tracemalloc.rst
+++ b/Doc/library/tracemalloc.rst
@@ -331,10 +331,10 @@ Functions
    :mod:`tracemalloc` module as a tuple: ``(current: int, peak: int)``.
 
 
-.. function:: get_traced_refs()
+.. function:: get_traced_allocs()
 
-   Get the current count of created and destroyed memory blocks.
-   :mod:`tracemalloc` module as a tuple: ``(created: int, destroyed: int)``.
+   Get the current unit counts of allocated and deallocated memory blocks.
+   :mod:`tracemalloc` module as a tuple: ``(allocs: int, deallocs: int)``.
 
 
 .. function:: reset_peak()

--- a/Include/internal/pycore_tracemalloc.h
+++ b/Include/internal/pycore_tracemalloc.h
@@ -94,6 +94,12 @@ struct _tracemalloc_runtime_state {
     /* domain (unsigned int) => traces (_Py_hashtable_t).
        Protected by TABLES_LOCK(). */
     _Py_hashtable_t *domains;
+    /* Number of references created.
+       Protected by TABLES_LOCK(). */
+    size_t refs_created;
+    /* Number of references destroyed.
+       Protected by TABLES_LOCK() and sometimes modified atomically. */
+    size_t refs_destroyed;
 
     struct tracemalloc_traceback empty_traceback;
 
@@ -154,6 +160,9 @@ extern size_t _PyTraceMalloc_GetMemory(void);
 
 /* Get the current size and peak size of traced memory blocks as a 2-tuple */
 extern PyObject* _PyTraceMalloc_GetTracedMemory(void);
+
+/* Get the current number of references created and destroyed as a 2-tuple */
+extern PyObject* _PyTraceMalloc_GetTracedRefs(void);
 
 /* Set the peak size of traced memory blocks to the current size */
 extern void _PyTraceMalloc_ResetPeak(void);

--- a/Include/internal/pycore_tracemalloc.h
+++ b/Include/internal/pycore_tracemalloc.h
@@ -98,7 +98,7 @@ struct _tracemalloc_runtime_state {
        Protected by TABLES_LOCK(). */
     Py_ssize_t refs_created;
     /* Number of references destroyed.
-       Protected by TABLES_LOCK() and sometimes modified atomically. */
+       Protected by TABLES_LOCK(). */
     Py_ssize_t refs_destroyed;
 
     struct tracemalloc_traceback empty_traceback;

--- a/Include/internal/pycore_tracemalloc.h
+++ b/Include/internal/pycore_tracemalloc.h
@@ -94,12 +94,12 @@ struct _tracemalloc_runtime_state {
     /* domain (unsigned int) => traces (_Py_hashtable_t).
        Protected by TABLES_LOCK(). */
     _Py_hashtable_t *domains;
-    /* Number of allocations.
+    /* Number of references created.
        Protected by TABLES_LOCK(). */
-    Py_ssize_t allocations;
-    /* Number of deallocations.
+    Py_ssize_t refs_created;
+    /* Number of references destroyed.
        Protected by TABLES_LOCK() and sometimes modified atomically. */
-    Py_ssize_t deallocations;
+    Py_ssize_t refs_destroyed;
 
     struct tracemalloc_traceback empty_traceback;
 
@@ -162,7 +162,7 @@ extern size_t _PyTraceMalloc_GetMemory(void);
 extern PyObject* _PyTraceMalloc_GetTracedMemory(void);
 
 /* Get the current number of references created and destroyed as a 2-tuple */
-extern PyObject* _PyTraceMalloc_GetTracedAllocs(void);
+extern PyObject* _PyTraceMalloc_GetTracedRefs(void);
 
 /* Set the peak size of traced memory blocks to the current size */
 extern void _PyTraceMalloc_ResetPeak(void);

--- a/Include/internal/pycore_tracemalloc.h
+++ b/Include/internal/pycore_tracemalloc.h
@@ -94,12 +94,12 @@ struct _tracemalloc_runtime_state {
     /* domain (unsigned int) => traces (_Py_hashtable_t).
        Protected by TABLES_LOCK(). */
     _Py_hashtable_t *domains;
-    /* Number of references created.
+    /* Number of allocations.
        Protected by TABLES_LOCK(). */
-    size_t refs_created;
-    /* Number of references destroyed.
+    Py_ssize_t allocations;
+    /* Number of deallocations.
        Protected by TABLES_LOCK() and sometimes modified atomically. */
-    size_t refs_destroyed;
+    Py_ssize_t deallocations;
 
     struct tracemalloc_traceback empty_traceback;
 
@@ -162,7 +162,7 @@ extern size_t _PyTraceMalloc_GetMemory(void);
 extern PyObject* _PyTraceMalloc_GetTracedMemory(void);
 
 /* Get the current number of references created and destroyed as a 2-tuple */
-extern PyObject* _PyTraceMalloc_GetTracedRefs(void);
+extern PyObject* _PyTraceMalloc_GetTracedAllocs(void);
 
 /* Set the peak size of traced memory blocks to the current size */
 extern void _PyTraceMalloc_ResetPeak(void);

--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -1156,7 +1156,7 @@ class TestCAPI(unittest.TestCase):
         try:
             tracemalloc.clear_traces()
             f()
-            refs = tracemalloc.get_traced_allocs()
+            refs = tracemalloc.get_traced_refs()
             if refs == (1, 0):
                 warnings.warn("ceval Py_DECREF doesn't emit PyRefTracer_DESTROY in this build")
             else:
@@ -1164,7 +1164,7 @@ class TestCAPI(unittest.TestCase):
 
             tracemalloc.clear_traces()
             g()
-            refs = tracemalloc.get_traced_allocs()
+            refs = tracemalloc.get_traced_refs()
             if refs == (3, 2):
                 warnings.warn("ceval Py_DECREF doesn't emit PyRefTracer_DESTROY in this build")
             else:

--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -1156,7 +1156,7 @@ class TestCAPI(unittest.TestCase):
         try:
             tracemalloc.clear_traces()
             f()
-            refs = tracemalloc.get_traced_refs()
+            refs = tracemalloc.get_traced_allocs()
             if refs == (1, 0):
                 warnings.warn("ceval Py_DECREF doesn't emit PyRefTracer_DESTROY in this build")
             else:
@@ -1164,7 +1164,7 @@ class TestCAPI(unittest.TestCase):
 
             tracemalloc.clear_traces()
             g()
-            refs = tracemalloc.get_traced_refs()
+            refs = tracemalloc.get_traced_allocs()
             if refs == (3, 2):
                 warnings.warn("ceval Py_DECREF doesn't emit PyRefTracer_DESTROY in this build")
             else:

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-02-28-17-13-36.gh-issue-130695.WuCmBj.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-02-28-17-13-36.gh-issue-130695.WuCmBj.rst
@@ -1,0 +1,1 @@
+Add tracking of number of deallocations to :mod:`tracemalloc`.

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -169,7 +169,7 @@ _tracemalloc_get_traced_memory_impl(PyObject *module)
 
 
 /*[clinic input]
-_tracemalloc.get_traced_allocs
+_tracemalloc.get_traced_refs
 
 Get the current count of created and destroyed refs.
 
@@ -177,10 +177,10 @@ Returns a tuple: (created: int, destroyed: int).
 [clinic start generated code]*/
 
 static PyObject *
-_tracemalloc_get_traced_allocs_impl(PyObject *module)
-/*[clinic end generated code: output=cb84cbd781fab85f input=336f38d37a5830ef]*/
+_tracemalloc_get_traced_refs_impl(PyObject *module)
+/*[clinic end generated code: output=81d36fdeb3ffc362 input=d0652f2592733b0e]*/
 {
-    return _PyTraceMalloc_GetTracedAllocs();
+    return _PyTraceMalloc_GetTracedRefs();
 }
 
 
@@ -212,7 +212,7 @@ static PyMethodDef module_methods[] = {
     _TRACEMALLOC_GET_TRACEBACK_LIMIT_METHODDEF
     _TRACEMALLOC_GET_TRACEMALLOC_MEMORY_METHODDEF
     _TRACEMALLOC_GET_TRACED_MEMORY_METHODDEF
-    _TRACEMALLOC_GET_TRACED_ALLOCS_METHODDEF
+    _TRACEMALLOC_GET_TRACED_REFS_METHODDEF
     _TRACEMALLOC_RESET_PEAK_METHODDEF
     /* sentinel */
     {NULL, NULL}

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -169,7 +169,7 @@ _tracemalloc_get_traced_memory_impl(PyObject *module)
 
 
 /*[clinic input]
-_tracemalloc.get_traced_refs
+_tracemalloc.get_traced_allocs
 
 Get the current count of created and destroyed refs.
 
@@ -177,10 +177,10 @@ Returns a tuple: (created: int, destroyed: int).
 [clinic start generated code]*/
 
 static PyObject *
-_tracemalloc_get_traced_refs_impl(PyObject *module)
-/*[clinic end generated code: output=81d36fdeb3ffc362 input=d0652f2592733b0e]*/
+_tracemalloc_get_traced_allocs_impl(PyObject *module)
+/*[clinic end generated code: output=cb84cbd781fab85f input=336f38d37a5830ef]*/
 {
-    return _PyTraceMalloc_GetTracedRefs();
+    return _PyTraceMalloc_GetTracedAllocs();
 }
 
 
@@ -212,7 +212,7 @@ static PyMethodDef module_methods[] = {
     _TRACEMALLOC_GET_TRACEBACK_LIMIT_METHODDEF
     _TRACEMALLOC_GET_TRACEMALLOC_MEMORY_METHODDEF
     _TRACEMALLOC_GET_TRACED_MEMORY_METHODDEF
-    _TRACEMALLOC_GET_TRACED_REFS_METHODDEF
+    _TRACEMALLOC_GET_TRACED_ALLOCS_METHODDEF
     _TRACEMALLOC_RESET_PEAK_METHODDEF
     /* sentinel */
     {NULL, NULL}

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -167,6 +167,23 @@ _tracemalloc_get_traced_memory_impl(PyObject *module)
     return _PyTraceMalloc_GetTracedMemory();
 }
 
+
+/*[clinic input]
+_tracemalloc.get_traced_refs
+
+Get the current count of created and destroyed refs.
+
+Returns a tuple: (created: int, destroyed: int).
+[clinic start generated code]*/
+
+static PyObject *
+_tracemalloc_get_traced_refs_impl(PyObject *module)
+/*[clinic end generated code: output=81d36fdeb3ffc362 input=d0652f2592733b0e]*/
+{
+    return _PyTraceMalloc_GetTracedRefs();
+}
+
+
 /*[clinic input]
 _tracemalloc.reset_peak
 
@@ -195,6 +212,7 @@ static PyMethodDef module_methods[] = {
     _TRACEMALLOC_GET_TRACEBACK_LIMIT_METHODDEF
     _TRACEMALLOC_GET_TRACEMALLOC_MEMORY_METHODDEF
     _TRACEMALLOC_GET_TRACED_MEMORY_METHODDEF
+    _TRACEMALLOC_GET_TRACED_REFS_METHODDEF
     _TRACEMALLOC_RESET_PEAK_METHODDEF
     /* sentinel */
     {NULL, NULL}

--- a/Modules/clinic/_tracemalloc.c.h
+++ b/Modules/clinic/_tracemalloc.c.h
@@ -195,24 +195,24 @@ _tracemalloc_get_traced_memory(PyObject *module, PyObject *Py_UNUSED(ignored))
     return _tracemalloc_get_traced_memory_impl(module);
 }
 
-PyDoc_STRVAR(_tracemalloc_get_traced_allocs__doc__,
-"get_traced_allocs($module, /)\n"
+PyDoc_STRVAR(_tracemalloc_get_traced_refs__doc__,
+"get_traced_refs($module, /)\n"
 "--\n"
 "\n"
 "Get the current count of created and destroyed refs.\n"
 "\n"
 "Returns a tuple: (created: int, destroyed: int).");
 
-#define _TRACEMALLOC_GET_TRACED_ALLOCS_METHODDEF    \
-    {"get_traced_allocs", (PyCFunction)_tracemalloc_get_traced_allocs, METH_NOARGS, _tracemalloc_get_traced_allocs__doc__},
+#define _TRACEMALLOC_GET_TRACED_REFS_METHODDEF    \
+    {"get_traced_refs", (PyCFunction)_tracemalloc_get_traced_refs, METH_NOARGS, _tracemalloc_get_traced_refs__doc__},
 
 static PyObject *
-_tracemalloc_get_traced_allocs_impl(PyObject *module);
+_tracemalloc_get_traced_refs_impl(PyObject *module);
 
 static PyObject *
-_tracemalloc_get_traced_allocs(PyObject *module, PyObject *Py_UNUSED(ignored))
+_tracemalloc_get_traced_refs(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
-    return _tracemalloc_get_traced_allocs_impl(module);
+    return _tracemalloc_get_traced_refs_impl(module);
 }
 
 PyDoc_STRVAR(_tracemalloc_reset_peak__doc__,
@@ -234,4 +234,4 @@ _tracemalloc_reset_peak(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _tracemalloc_reset_peak_impl(module);
 }
-/*[clinic end generated code: output=9cb364916c67f0be input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7efbb9b4f08daab3 input=a9049054013a1b77]*/

--- a/Modules/clinic/_tracemalloc.c.h
+++ b/Modules/clinic/_tracemalloc.c.h
@@ -195,24 +195,24 @@ _tracemalloc_get_traced_memory(PyObject *module, PyObject *Py_UNUSED(ignored))
     return _tracemalloc_get_traced_memory_impl(module);
 }
 
-PyDoc_STRVAR(_tracemalloc_get_traced_refs__doc__,
-"get_traced_refs($module, /)\n"
+PyDoc_STRVAR(_tracemalloc_get_traced_allocs__doc__,
+"get_traced_allocs($module, /)\n"
 "--\n"
 "\n"
 "Get the current count of created and destroyed refs.\n"
 "\n"
 "Returns a tuple: (created: int, destroyed: int).");
 
-#define _TRACEMALLOC_GET_TRACED_REFS_METHODDEF    \
-    {"get_traced_refs", (PyCFunction)_tracemalloc_get_traced_refs, METH_NOARGS, _tracemalloc_get_traced_refs__doc__},
+#define _TRACEMALLOC_GET_TRACED_ALLOCS_METHODDEF    \
+    {"get_traced_allocs", (PyCFunction)_tracemalloc_get_traced_allocs, METH_NOARGS, _tracemalloc_get_traced_allocs__doc__},
 
 static PyObject *
-_tracemalloc_get_traced_refs_impl(PyObject *module);
+_tracemalloc_get_traced_allocs_impl(PyObject *module);
 
 static PyObject *
-_tracemalloc_get_traced_refs(PyObject *module, PyObject *Py_UNUSED(ignored))
+_tracemalloc_get_traced_allocs(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
-    return _tracemalloc_get_traced_refs_impl(module);
+    return _tracemalloc_get_traced_allocs_impl(module);
 }
 
 PyDoc_STRVAR(_tracemalloc_reset_peak__doc__,
@@ -234,4 +234,4 @@ _tracemalloc_reset_peak(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _tracemalloc_reset_peak_impl(module);
 }
-/*[clinic end generated code: output=7efbb9b4f08daab3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9cb364916c67f0be input=a9049054013a1b77]*/

--- a/Modules/clinic/_tracemalloc.c.h
+++ b/Modules/clinic/_tracemalloc.c.h
@@ -195,6 +195,26 @@ _tracemalloc_get_traced_memory(PyObject *module, PyObject *Py_UNUSED(ignored))
     return _tracemalloc_get_traced_memory_impl(module);
 }
 
+PyDoc_STRVAR(_tracemalloc_get_traced_refs__doc__,
+"get_traced_refs($module, /)\n"
+"--\n"
+"\n"
+"Get the current count of created and destroyed refs.\n"
+"\n"
+"Returns a tuple: (created: int, destroyed: int).");
+
+#define _TRACEMALLOC_GET_TRACED_REFS_METHODDEF    \
+    {"get_traced_refs", (PyCFunction)_tracemalloc_get_traced_refs, METH_NOARGS, _tracemalloc_get_traced_refs__doc__},
+
+static PyObject *
+_tracemalloc_get_traced_refs_impl(PyObject *module);
+
+static PyObject *
+_tracemalloc_get_traced_refs(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return _tracemalloc_get_traced_refs_impl(module);
+}
+
 PyDoc_STRVAR(_tracemalloc_reset_peak__doc__,
 "reset_peak($module, /)\n"
 "--\n"
@@ -214,4 +234,4 @@ _tracemalloc_reset_peak(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _tracemalloc_reset_peak_impl(module);
 }
-/*[clinic end generated code: output=9d4d884b156c2ddb input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7efbb9b4f08daab3 input=a9049054013a1b77]*/


### PR DESCRIPTION
Add a way to track the number of allocations and specifically DEALLOCATIONS in `tracemalloc`. For a concrete example of why this is needed see:

https://github.com/python/cpython/issues/130382

and

https://github.com/python/cpython/pull/130689

for the rationale for this PR.

<!-- gh-issue-number: gh-130695 -->
* Issue: gh-130695
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130696.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->