### PR TITLE
gh-130453: pygettext: Allow overriding default keywords when using `--keyword`

### DIFF
--- a/Lib/test/test_tools/i18n_data/custom_keywords.pot
+++ b/Lib/test/test_tools/i18n_data/custom_keywords.pot
@@ -15,31 +15,37 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: custom_keywords.py:9 custom_keywords.py:10
+#: custom_keywords.py:10 custom_keywords.py:11
 msgid "bar"
 msgstr ""
 
-#: custom_keywords.py:12
+#: custom_keywords.py:13
 msgid "cat"
 msgid_plural "cats"
 msgstr[0] ""
 msgstr[1] ""
 
-#: custom_keywords.py:13
+#: custom_keywords.py:14
 msgid "dog"
 msgid_plural "dogs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: custom_keywords.py:15
+#: custom_keywords.py:16
 msgctxt "context"
 msgid "bar"
 msgstr ""
 
-#: custom_keywords.py:17
+#: custom_keywords.py:18
 msgctxt "context"
 msgid "cat"
 msgid_plural "cats"
+msgstr[0] ""
+msgstr[1] ""
+
+#: custom_keywords.py:34
+msgid "overridden"
+msgid_plural "default"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/Lib/test/test_tools/i18n_data/custom_keywords.py
+++ b/Lib/test/test_tools/i18n_data/custom_keywords.py
@@ -4,6 +4,7 @@ from gettext import (
     pgettext as pfoo,
     npgettext as npfoo,
     gettext as bar,
+    gettext as _,
 )
 
 foo('bar')
@@ -28,3 +29,6 @@ pfoo('context')
 # 'npfoo' requires at least 3 arguments
 npfoo('context')
 npfoo('context', 'cat')
+
+# --keyword should override the default keyword
+_('overridden', 'default')

--- a/Lib/test/test_tools/test_i18n.py
+++ b/Lib/test/test_tools/test_i18n.py
@@ -525,7 +525,7 @@ def extract_from_snapshots():
         'comments.py': ('--add-comments=i18n:',),
         'custom_keywords.py': ('--keyword=foo', '--keyword=nfoo:1,2',
                                '--keyword=pfoo:1c,2',
-                               '--keyword=npfoo:1c,2,3'),
+                               '--keyword=npfoo:1c,2,3', '--keyword=_:1,2'),
     }
 
     for filename, args in snapshots.items():

--- a/Misc/NEWS.d/next/Tools-Demos/2025-02-28-23-24-03.gh-issue-130453.EK0Vk_.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-02-28-23-24-03.gh-issue-130453.EK0Vk_.rst
@@ -1,0 +1,1 @@
+Make it possible to override default keywords in :program:`pygettext`.

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -729,12 +729,15 @@ def main():
 
     # calculate all keywords
     try:
-        options.keywords = dict(parse_spec(spec) for spec in options.keywords)
+        custom_keywords = dict(parse_spec(spec) for spec in options.keywords)
     except ValueError as e:
         print(e, file=sys.stderr)
         sys.exit(1)
+    options.keywords = {}
     if not no_default_keywords:
         options.keywords |= DEFAULTKEYWORDS
+    # custom keywords override default keywords
+    options.keywords |= custom_keywords
 
     # initialize list of strings to exclude
     if options.excludefilename:


### PR DESCRIPTION
Related comment: https://github.com/python/cpython/issues/130453#issuecomment-2681609260

Both babel and xgettext allow this. For example for `xgettext --keyword='_:1,2'` and this input file
```python
_('foo', 'foos', 1)
```
xgettext will extract

```po
msgid "foo"
msgid_plural "foos"
msgstr[0] ""
msgstr[1] ""
```

while pygettext will extract 

```po
msgid "foo"
msgstr ""
```

i.e. the default keyword takes precedence. It should be possible to use `--keyword` to override the default keyword (`_:1`) same as xgettext and babel.

<!-- gh-issue-number: gh-130453 -->
* Issue: gh-130453
<!-- /gh-issue-number -->
