### PR TITLE
gh-129098: avoid using content of `_pyrepl/__main__.py` when reporting tracebacks

### DIFF
--- a/Lib/_pyrepl/__main__.py
+++ b/Lib/_pyrepl/__main__.py
@@ -1,6 +1,10 @@
 # Important: don't add things to this module, as they will end up in the REPL's
 # default globals.  Use _pyrepl.main instead.
 
+# Avoid caching this file by linecache and incorrectly report tracebacks.
+# See https://github.com/python/cpython/issues/129098.
+__spec__ = __loader__ = None
+
 if __name__ == "__main__":
     from .main import interactive_console as __pyrepl_interactive_console
     __pyrepl_interactive_console()

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -11,9 +11,9 @@ import tempfile
 from unittest import TestCase, skipUnless, skipIf
 from unittest.mock import patch
 from test.support import force_not_colorized, make_clean_env
-from test.support import SHORT_TIMEOUT
+from test.support import SHORT_TIMEOUT, STDLIB_DIR
 from test.support.import_helper import import_module
-from test.support.os_helper import unlink
+from test.support.os_helper import EnvironmentVarGuard, unlink
 
 from .support import (
     FakeConsole,
@@ -1215,6 +1215,31 @@ class TestMain(ReplTestCase):
         self.assertNotIn("True", output)
         self.assertNotIn("Exception", output)
         self.assertNotIn("Traceback", output)
+
+    @force_not_colorized
+    def test_no_pyrepl_source_in_exc(self):
+        # Avoid using _pyrepl/__main__.py in traceback reports
+        # See https://github.com/python/cpython/issues/129098.
+        pyrepl_main_file = os.path.join(STDLIB_DIR, "_pyrepl", "__main__.py")
+        self.assertTrue(os.path.exists(pyrepl_main_file), pyrepl_main_file)
+        with open(pyrepl_main_file) as fp:
+            excluded_lines = fp.readlines()
+        excluded_lines = list(filter(None, map(str.strip, excluded_lines)))
+
+        for filename in ['?', 'unknown-filename', '<foo>', '<...>']:
+            self._test_no_pyrepl_source_in_exc(filename, excluded_lines)
+
+    def _test_no_pyrepl_source_in_exc(self, filename, excluded_lines):
+        with EnvironmentVarGuard() as env, self.subTest(filename=filename):
+            env.unset("PYTHON_BASIC_REPL")
+            commands = (f"eval(compile('spam', {filename!r}, 'eval'))\n"
+                        f"exit()\n")
+            output, _ = self.run_repl(commands, env=env)
+            self.assertIn("Traceback (most recent call last)", output)
+            self.assertIn("NameError: name 'spam' is not defined", output)
+            for line in excluded_lines:
+                with self.subTest(line=line):
+                    self.assertNotIn(line, output)
 
     @force_not_colorized
     def test_bad_sys_excepthook_doesnt_crash_pyrepl(self):

--- a/Misc/NEWS.d/next/Library/2025-03-01-12-37-08.gh-issue-129098.eJ2-6L.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-01-12-37-08.gh-issue-129098.eJ2-6L.rst
@@ -1,0 +1,2 @@
+Fix REPL traceback reporting when using :func:`compile` with an inexisting
+file. Patch by Bénédikt Tran.


### PR DESCRIPTION
~~I don't know how to test this :)~~

<!-- gh-issue-number: gh-129098 -->
* Issue: gh-129098
<!-- /gh-issue-number -->
