### PR TITLE
gh-130730: Fix flaky `test_active_children` test

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -589,13 +589,15 @@ class _TestProcess(BaseTestCase):
     def test_active_children(self):
         self.assertEqual(type(self.active_children()), list)
 
-        p = self.Process(target=time.sleep, args=(DELTA,))
+        event = self.Event()
+        p = self.Process(target=event.wait)
         self.assertNotIn(p, self.active_children())
 
         p.daemon = True
         p.start()
         self.assertIn(p, self.active_children())
 
+        event.set()
         p.join()
         self.assertNotIn(p, self.active_children())
 


### PR DESCRIPTION
Use an Event object instead of time.sleep().


<!-- gh-issue-number: gh-130730 -->
* Issue: gh-130730
<!-- /gh-issue-number -->
