### PR TITLE
Revert "gh-128364: Fix flaky `test_timeout` test (gh-130724)"

### DIFF
--- a/Lib/test/test_concurrent_futures/test_wait.py
+++ b/Lib/test/test_concurrent_futures/test_wait.py
@@ -114,8 +114,9 @@ class WaitTests:
 
     def test_timeout(self):
         short_timeout = 0.050
+        long_timeout = short_timeout * 10
 
-        future = self.executor.submit(self.event.wait)
+        future = self.executor.submit(time.sleep, long_timeout)
 
         finished, pending = futures.wait(
                 [CANCELLED_AND_NOTIFIED_FUTURE,
@@ -130,9 +131,6 @@ class WaitTests:
                               SUCCESSFUL_FUTURE]),
                          finished)
         self.assertEqual(set([future]), pending)
-
-        # Set the event to allow the future to complete
-        self.event.set()
 
 
 class ThreadPoolWaitTests(ThreadPoolMixin, WaitTests, BaseTestCase):

--- a/Lib/test/test_concurrent_futures/util.py
+++ b/Lib/test/test_concurrent_futures/util.py
@@ -1,6 +1,5 @@
 import multiprocessing
 import sys
-import threading
 import time
 import unittest
 from concurrent import futures
@@ -47,14 +46,11 @@ class ExecutorMixin:
 
         self.t1 = time.monotonic()
         if hasattr(self, "ctx"):
-            self.manager = multiprocessing.Manager()
-            self.event = self.manager.Event()
             self.executor = self.executor_type(
                 max_workers=self.worker_count,
                 mp_context=self.get_context(),
                 **self.executor_kwargs)
         else:
-            self.event = threading.Event()
             self.executor = self.executor_type(
                 max_workers=self.worker_count,
                 **self.executor_kwargs)
@@ -62,9 +58,6 @@ class ExecutorMixin:
     def tearDown(self):
         self.executor.shutdown(wait=True)
         self.executor = None
-        if hasattr(self, "ctx"):
-            self.manager.shutdown()
-            self.manager = None
 
         dt = time.monotonic() - self.t1
         if support.verbose:


### PR DESCRIPTION
Change broke Android and iOS buildbots that do not have multiprocessing.

This reverts commit cfa0b1dc375e63cde28e61a47108c645b0e74834.


<!-- gh-issue-number: gh-128364 -->
* Issue: gh-128364
<!-- /gh-issue-number -->
