### PR TITLE
gh-130740: Move some `stdbool.h` includes after `Python.h`

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-03-01-18-20-07.gh-issue-130738.nDFSHR.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-01-18-20-07.gh-issue-130738.nDFSHR.rst
@@ -1,0 +1,1 @@
+Ensure Python.h is included in most places, except when "pyconfig.h" is included before, or in platform specific contexts

--- a/Misc/NEWS.d/next/Build/2025-03-01-18-20-07.gh-issue-130738.nDFSHR.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-01-18-20-07.gh-issue-130738.nDFSHR.rst
@@ -1,1 +1,2 @@
-Ensure Python.h is included in most places, except when "pyconfig.h" is included before, or in platform specific contexts
+Ensure that `Python.h` is included before `stdbool.h` unless `pyconfig.h` is included
+or in some platform-specific contexts.

--- a/Misc/NEWS.d/next/Build/2025-03-01-18-20-07.gh-issue-130738.nDFSHR.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-01-18-20-07.gh-issue-130738.nDFSHR.rst
@@ -1,2 +1,0 @@
-Ensure that `Python.h` is included before `stdbool.h` unless `pyconfig.h` is included
-or in some platform-specific contexts.

--- a/Misc/NEWS.d/next/Build/2025-03-01-18-27-42.gh-issue-130740.nDFSHR.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-01-18-27-42.gh-issue-130740.nDFSHR.rst
@@ -1,0 +1,1 @@
+Ensure Python.h is included in most places, except when "pyconfig.h" is included before, or in platform specific contexts

--- a/Misc/NEWS.d/next/Build/2025-03-01-18-27-42.gh-issue-130740.nDFSHR.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-01-18-27-42.gh-issue-130740.nDFSHR.rst
@@ -1,1 +1,2 @@
-Ensure Python.h is included in most places, except when "pyconfig.h" is included before, or in platform specific contexts
+Ensure that `Python.h` is included before `stdbool.h` unless `pyconfig.h` is included
+or in some platform-specific contexts.

--- a/Misc/NEWS.d/next/Build/2025-03-01-18-27-42.gh-issue-130740.nDFSHR.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-01-18-27-42.gh-issue-130740.nDFSHR.rst
@@ -1,2 +1,2 @@
-Ensure that `Python.h` is included before `stdbool.h` unless `pyconfig.h` is included
+Ensure that ``Python.h`` is included before ``stdbool.h`` unless ``pyconfig.h`` is included
 or in some platform-specific contexts.

--- a/Misc/NEWS.d/next/Build/2025-03-01-18-27-42.gh-issue-130740.nDFSHR.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-01-18-27-42.gh-issue-130740.nDFSHR.rst
@@ -1,2 +1,2 @@
-Ensure that ``Python.h`` is included before ``stdbool.h`` unless ``pyconfig.h`` is included
-or in some platform-specific contexts.
+Ensure that ``Python.h`` is included before ``stdbool.h`` unless ``pyconfig.h``
+is included before or in some platform-specific contexts.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -22,7 +22,6 @@
 #  define Py_BUILD_CORE_MODULE 1
 #endif
 
-#include <stdbool.h>
 #include "Python.h"
 #include "pycore_hashtable.h"
 #include "pycore_strhex.h"               // _Py_strhex()
@@ -37,6 +36,7 @@
 #include <openssl/objects.h>
 #include <openssl/err.h>
 
+#include <stdbool.h>
 
 #ifndef OPENSSL_THREADS
 #  error "OPENSSL_THREADS is not defined, Python requires thread-safe OpenSSL"

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -1,5 +1,3 @@
-#include <stdbool.h>
-
 #include <Python.h>
 #include "pycore_bytesobject.h"   // _PyBytes_DecodeEscape()
 #include "pycore_unicodeobject.h" // _PyUnicode_DecodeUnicodeEscapeInternal()
@@ -7,6 +5,8 @@
 #include "lexer/state.h"
 #include "pegen.h"
 #include "string_parser.h"
+
+#include <stdbool.h>
 
 //// STRING HANDLING FUNCTIONS ////
 

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -12,8 +12,6 @@
  * objects.
  */
 
-#include <stdbool.h>
-
 #include "Python.h"
 #include "opcode.h"
 #include "pycore_ast.h"           // _PyAST_GetDocString()
@@ -31,6 +29,8 @@
 #define NEED_OPCODE_METADATA
 #include "pycore_opcode_metadata.h" // _PyOpcode_opcode_metadata, _PyOpcode_num_popped/pushed
 #undef NEED_OPCODE_METADATA
+
+#include <stdbool.h>
 
 #define COMP_GENEXP   0
 #define COMP_LISTCOMP 1

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1,6 +1,3 @@
-
-#include <stdbool.h>
-
 #include "Python.h"
 #include "opcode.h"
 #include "pycore_flowgraph.h"
@@ -11,6 +8,8 @@
 
 #include "pycore_opcode_utils.h"
 #include "pycore_opcode_metadata.h" // OPCODE_HAS_ARG, etc
+
+#include <stdbool.h>
 
 
 #undef SUCCESS

--- a/Python/index_pool.c
+++ b/Python/index_pool.c
@@ -1,9 +1,9 @@
-#include <stdbool.h>
-
 #include "Python.h"
 
 #include "pycore_index_pool.h"
 #include "pycore_lock.h"
+
+#include <stdbool.h>
 
 #ifdef Py_GIL_DISABLED
 

--- a/Python/instruction_sequence.c
+++ b/Python/instruction_sequence.c
@@ -5,8 +5,6 @@
  */
 
 
-#include <stdbool.h>
-
 #include "Python.h"
 
 #include "pycore_compile.h" // _PyCompile_EnsureArrayLargeEnough
@@ -21,6 +19,8 @@ typedef _Py_SourceLocation location;
 #define INITIAL_INSTR_SEQUENCE_LABELS_MAP_SIZE 10
 
 #include "clinic/instruction_sequence.c.h"
+
+#include <stdbool.h>
 
 #undef SUCCESS
 #undef ERROR


### PR DESCRIPTION
Except when "pyconfig.h" is included first, and for platform specific code such as android/emscripten

Following up from https://github.com/python/cpython/pull/130641#issuecomment-2692299464

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130740 -->
* Issue: gh-130740
<!-- /gh-issue-number -->
