### PR TITLE
Add link in importlib.metadata.version() docs

### DIFF
--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -268,8 +268,9 @@ Distribution versions
 
 .. function:: version(distribution_name)
 
-   Return the installed distribution package version for the named
-   distribution package.
+   Return the installed distribution package
+   `version <https://packaging.python.org/en/latest/specifications/core-metadata/#version>`__
+   for the named distribution package.
 
    Raises :exc:`PackageNotFoundError` if the named distribution
    package is not installed in the current Python environment.


### PR DESCRIPTION
Link the specification for the returned data makes it clearer what this is and what the format of the version string can be.

I see this as trivial enough to not create a separate issue, but can of course do if desired.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130739.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->