### PR TITLE
Fix grammar typo in `Doc/c-api/arg.rst`

### DIFF
--- a/Doc/c-api/arg.rst
+++ b/Doc/c-api/arg.rst
@@ -5,7 +5,7 @@
 Parsing arguments and building values
 =====================================
 
-These functions are useful when creating your own extensions functions and
+These functions are useful when creating your own extension functions and
 methods.  Additional information and examples are available in
 :ref:`extending-index`.
 


### PR DESCRIPTION
Fix typo: 'extensions functions'  -> 'extension functions' in documentation.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130741.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->