### PR TITLE
gh-128481: indicate that the default value for `FrameSummary.end_lineno` changed in 3.13

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -551,6 +551,9 @@ in a :ref:`traceback <traceback-objects>`.
       The last line number of the source code for this frame.
       By default, it is set to ``lineno`` and indexation starts from 1.
 
+      .. versionchanged:: 3.13
+         The default value changed from ``None`` to ``lineno``.
+
    .. attribute:: FrameSummary.colno
 
       The column number of the source code for this frame.


### PR DESCRIPTION
Passing `end_lineno=None` to `FrameSummary` in Python 3.13 changed compared to Python 3.12.

3.14: https://github.com/python/cpython/blob/051f0e5683fec3840fa7fc99723741dd2d701eae/Lib/traceback.py#L307

3.13: https://github.com/python/cpython/blob/8edf17f260121357f323359d19cda8dd77bf5558/Lib/traceback.py#L307

3.12: https://github.com/python/cpython/blob/c19294436242dff8efa912425af9adcda97b1015/Lib/traceback.py#L285



<!-- gh-issue-number: gh-128481 -->
* Issue: gh-128481
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130755.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->