### PR TITLE
[3.13] gh-130740: Move some `stdbool.h` includes after `Python.h` (#130738)

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-03-01-18-27-42.gh-issue-130740.nDFSHR.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-01-18-27-42.gh-issue-130740.nDFSHR.rst
@@ -1,0 +1,2 @@
+Ensure that ``Python.h`` is included before ``stdbool.h`` unless ``pyconfig.h``
+is included before or in some platform-specific contexts.

--- a/Modules/_blake2/blake2b_impl.c
+++ b/Modules/_blake2/blake2b_impl.c
@@ -17,9 +17,10 @@
 #  define Py_BUILD_CORE_MODULE 1
 #endif
 
-#include <stdbool.h>
 #include "Python.h"
 #include "pycore_strhex.h"       // _Py_strhex()
+
+#include <stdbool.h>
 
 #include "../hashlib.h"
 #include "blake2module.h"

--- a/Modules/_blake2/blake2s_impl.c
+++ b/Modules/_blake2/blake2s_impl.c
@@ -17,9 +17,10 @@
 #  define Py_BUILD_CORE_MODULE 1
 #endif
 
-#include <stdbool.h>
 #include "Python.h"
 #include "pycore_strhex.h"       // _Py_strhex()
+
+#include <stdbool.h>
 
 #include "../hashlib.h"
 #include "blake2module.h"

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -22,7 +22,6 @@
 #  define Py_BUILD_CORE_MODULE 1
 #endif
 
-#include <stdbool.h>
 #include "Python.h"
 #include "pycore_hashtable.h"
 #include "pycore_pyhash.h"               // _Py_HashBytes()
@@ -38,6 +37,7 @@
 #include <openssl/objects.h>
 #include <openssl/err.h>
 
+#include <stdbool.h>
 
 #ifndef OPENSSL_THREADS
 #  error "OPENSSL_THREADS is not defined, Python requires thread-safe OpenSSL"

--- a/Parser/string_parser.c
+++ b/Parser/string_parser.c
@@ -1,5 +1,3 @@
-#include <stdbool.h>
-
 #include <Python.h>
 #include "pycore_bytesobject.h"   // _PyBytes_DecodeEscape()
 #include "pycore_unicodeobject.h" // _PyUnicode_DecodeUnicodeEscapeInternal()
@@ -7,6 +5,8 @@
 #include "lexer/state.h"
 #include "pegen.h"
 #include "string_parser.h"
+
+#include <stdbool.h>
 
 //// STRING HANDLING FUNCTIONS ////
 

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -1,6 +1,3 @@
-
-#include <stdbool.h>
-
 #include "Python.h"
 #include "pycore_flowgraph.h"
 #include "pycore_compile.h"
@@ -8,6 +5,8 @@
 
 #include "pycore_opcode_utils.h"
 #include "pycore_opcode_metadata.h" // OPCODE_HAS_ARG, etc
+
+#include <stdbool.h>
 
 
 #undef SUCCESS

--- a/Python/instruction_sequence.c
+++ b/Python/instruction_sequence.c
@@ -5,8 +5,6 @@
  */
 
 
-#include <stdbool.h>
-
 #include "Python.h"
 
 #include "pycore_compile.h" // _PyCompile_EnsureArrayLargeEnough
@@ -21,6 +19,8 @@ typedef _Py_SourceLocation location;
 #define INITIAL_INSTR_SEQUENCE_LABELS_MAP_SIZE 10
 
 #include "clinic/instruction_sequence.c.h"
+
+#include <stdbool.h>
 
 #undef SUCCESS
 #undef ERROR


### PR DESCRIPTION
Move some `#include <stdbool.h>` after `#include "Python.h"` when `pyconfig.h` is not included first and when we are in a platform-agnostic context. This is to avoid having features defined by `stdbool.h` before those decided by `Python.h`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130740 -->
* Issue: gh-130740
<!-- /gh-issue-number -->
