### PR TITLE
`unittest.mock` test and coverage fixup

### DIFF
--- a/Lib/test/test_unittest/testmock/testhelpers.py
+++ b/Lib/test/test_unittest/testmock/testhelpers.py
@@ -1080,7 +1080,7 @@ class SpecSignatureTest(unittest.TestCase):
         class WithMethod:
             a: int
             def b(self) -> int:
-                return 1
+                return 1  # pragma: no cover
 
         for mock in [
             create_autospec(WithMethod, instance=True),

--- a/Lib/test/test_unittest/testmock/testmock.py
+++ b/Lib/test/test_unittest/testmock/testmock.py
@@ -316,7 +316,7 @@ class MockTest(unittest.TestCase):
         passed to the wrapped object and the return_value is returned instead.
         """
         def my_func():
-            return None
+            return None  # pragma: no cover
         func_mock = create_autospec(spec=my_func, wraps=my_func)
         return_value = "explicit return value"
         func_mock.return_value = return_value

--- a/Lib/test/test_unittest/testmock/testpatch.py
+++ b/Lib/test/test_unittest/testmock/testpatch.py
@@ -748,7 +748,7 @@ class PatchTest(unittest.TestCase):
     def test_exit_idempotent(self):
         patcher = patch(foo_name, 'bar', 3)
         with patcher:
-            patcher.stop()
+            patcher.__exit__(None, None, None)
 
 
     def test_second_start_failure(self):


### PR DESCRIPTION
"no coverage" markers for two functions that will never be called along with a test fixup that was missing the path it intended to cover.

These were highlighted by [coverage checking in the rolling backport](https://github.com/testing-cabal/mock/pull/513).