### PR TITLE
gh-130736: Fix asyncio test_shutdown_default_executor_timeout()

### DIFF
--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -249,7 +249,7 @@ class BaseEventLoopTests(test_utils.TestCase):
             with self.assertWarnsRegex(RuntimeWarning,
                                        "The executor did not finishing joining"):
                 self.loop.run_until_complete(
-                    self.loop.shutdown_default_executor(timeout=0.1))
+                    self.loop.shutdown_default_executor(timeout=0.01))
         finally:
             event.set()
 

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -233,20 +233,25 @@ class BaseEventLoopTests(test_utils.TestCase):
         self.assertIsNone(self.loop._default_executor)
 
     def test_shutdown_default_executor_timeout(self):
+        event = threading.Event()
+
         class DummyExecutor(concurrent.futures.ThreadPoolExecutor):
             def shutdown(self, wait=True, *, cancel_futures=False):
                 if wait:
-                    time.sleep(0.1)
+                    event.wait()
 
         self.loop._process_events = mock.Mock()
         self.loop._write_to_self = mock.Mock()
         executor = DummyExecutor()
         self.loop.set_default_executor(executor)
 
-        with self.assertWarnsRegex(RuntimeWarning,
-                                   "The executor did not finishing joining"):
-            self.loop.run_until_complete(
-                self.loop.shutdown_default_executor(timeout=0.01))
+        try:
+            with self.assertWarnsRegex(RuntimeWarning,
+                                       "The executor did not finishing joining"):
+                self.loop.run_until_complete(
+                    self.loop.shutdown_default_executor(timeout=0.1))
+        finally:
+            event.set()
 
     def test_call_soon(self):
         def cb():


### PR DESCRIPTION
Use a ridiculous small timeout (1 nanosecond) instead of 10 ms.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130736 -->
* Issue: gh-130736
<!-- /gh-issue-number -->
