### PR TITLE
gh-130790: Remove references about unicode's readiness from comments

### DIFF
--- a/Include/cpython/unicodeobject.h
+++ b/Include/cpython/unicodeobject.h
@@ -212,22 +212,21 @@ static inline unsigned int PyUnicode_IS_READY(PyObject* Py_UNUSED(op)) {
 #define PyUnicode_IS_READY(op) PyUnicode_IS_READY(_PyObject_CAST(op))
 
 /* Return true if the string contains only ASCII characters, or 0 if not. The
-   string may be compact (PyUnicode_IS_COMPACT_ASCII) or not, but must be
-   ready. */
+   string may be compact (PyUnicode_IS_COMPACT_ASCII) or not. */
 static inline unsigned int PyUnicode_IS_ASCII(PyObject *op) {
     return _PyASCIIObject_CAST(op)->state.ascii;
 }
 #define PyUnicode_IS_ASCII(op) PyUnicode_IS_ASCII(_PyObject_CAST(op))
 
 /* Return true if the string is compact or 0 if not.
-   No type checks or Ready calls are performed. */
+   No type checks are performed. */
 static inline unsigned int PyUnicode_IS_COMPACT(PyObject *op) {
     return _PyASCIIObject_CAST(op)->state.compact;
 }
 #define PyUnicode_IS_COMPACT(op) PyUnicode_IS_COMPACT(_PyObject_CAST(op))
 
 /* Return true if the string is a compact ASCII string (use PyASCIIObject
-   structure), or 0 if not.  No type checks or Ready calls are performed. */
+   structure), or 0 if not.  No type checks are performed. */
 static inline int PyUnicode_IS_COMPACT_ASCII(PyObject *op) {
     return (_PyASCIIObject_CAST(op)->state.ascii && PyUnicode_IS_COMPACT(op));
 }
@@ -319,7 +318,7 @@ static inline void PyUnicode_WRITE(int kind, void *data,
                     (index), _Py_STATIC_CAST(Py_UCS4, value))
 
 /* Read a code point from the string's canonical representation.  No checks
-   or ready calls are performed. */
+   are performed. */
 static inline Py_UCS4 PyUnicode_READ(int kind,
                                      const void *data, Py_ssize_t index)
 {

--- a/Include/internal/pycore_traceback.h
+++ b/Include/internal/pycore_traceback.h
@@ -66,8 +66,7 @@ extern const char* _Py_DumpTracebackThreads(
 /* Write a Unicode object into the file descriptor fd. Encode the string to
    ASCII using the backslashreplace error handler.
 
-   Do nothing if text is not a Unicode object. The function accepts Unicode
-   string which is not ready (PyUnicode_WCHAR_KIND).
+   Do nothing if text is not a Unicode object.
 
    This function is signal safe. */
 extern void _Py_DumpASCII(int fd, PyObject *text);

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -358,7 +358,7 @@ _PyIncrementalNewlineDecoder_decode(PyObject *myself,
         out = PyUnicode_DATA(modified);
         PyUnicode_WRITE(kind, out, 0, '\r');
         memcpy(out + kind, PyUnicode_DATA(output), kind * output_len);
-        Py_SETREF(output, modified); /* output remains ready */
+        Py_SETREF(output, modified);
         self->pendingcr = 0;
         output_len++;
     }
@@ -1818,7 +1818,6 @@ textiowrapper_get_decoded_chars(textio *self, Py_ssize_t n)
     if (self->decoded_chars == NULL)
         return Py_GetConstant(Py_CONSTANT_EMPTY_STR);
 
-    /* decoded_chars is guaranteed to be "ready". */
     avail = (PyUnicode_GET_LENGTH(self->decoded_chars)
              - self->decoded_chars_used);
 

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -591,7 +591,7 @@ nfd_nfkd(PyObject *self, PyObject *input, int k)
     PyMem_Free(output);
     if (!result)
         return NULL;
-    /* result is guaranteed to be ready, as it is compact. */
+
     kind = PyUnicode_KIND(result);
     data = PyUnicode_DATA(result);
 
@@ -655,7 +655,7 @@ nfc_nfkc(PyObject *self, PyObject *input, int k)
     result = nfd_nfkd(self, input, k);
     if (!result)
         return NULL;
-    /* result will be "ready". */
+
     kind = PyUnicode_KIND(result);
     data = PyUnicode_DATA(result);
     len = PyUnicode_GET_LENGTH(result);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -49,7 +49,6 @@ class object "PyObject *" "&PyBaseObject_Type"
                 ((Py_ssize_t)(name)) >> 3)
 #define MCACHE_CACHEABLE_NAME(name)                             \
         PyUnicode_CheckExact(name) &&                           \
-        PyUnicode_IS_READY(name) &&                             \
         (PyUnicode_GET_LENGTH(name) <= MCACHE_MAX_ATTR_SIZE)
 
 #define NEXT_GLOBAL_VERSION_TAG _PyRuntime.types.next_version_tag

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15952,7 +15952,6 @@ _PyUnicode_ClearInterned(PyInterpreterState *interp)
     Py_ssize_t pos = 0;
     PyObject *s, *ignored_value;
     while (PyDict_Next(interned, &pos, &s, &ignored_value)) {
-        assert(PyUnicode_IS_READY(s));
         int shared = 0;
         switch (PyUnicode_CHECK_INTERNED(s)) {
         case SSTATE_INTERNED_IMMORTAL:

--- a/Parser/lexer/lexer.c
+++ b/Parser/lexer/lexer.c
@@ -309,7 +309,6 @@ verify_end_of_number(struct tok_state *tok, int c, const char *kind) {
 }
 
 /* Verify that the identifier follows PEP 3131.
-   All identifier strings are guaranteed to be "ready" unicode objects.
  */
 static int
 verify_identifier(struct tok_state *tok)

--- a/Parser/lexer/lexer.c
+++ b/Parser/lexer/lexer.c
@@ -308,8 +308,7 @@ verify_end_of_number(struct tok_state *tok, int c, const char *kind) {
     return 1;
 }
 
-/* Verify that the identifier follows PEP 3131.
- */
+/* Verify that the identifier follows PEP 3131. */
 static int
 verify_identifier(struct tok_state *tok)
 {

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -509,7 +509,6 @@ _PyPegen_new_identifier(Parser *p, const char *n)
     if (!id) {
         goto error;
     }
-    /* PyUnicode_DecodeUTF8 should always return a ready string. */
     assert(PyUnicode_IS_READY(id));
     /* Check whether there are non-ASCII characters in the
        identifier; if so, normalize to NFKC. */

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -509,7 +509,6 @@ _PyPegen_new_identifier(Parser *p, const char *n)
     if (!id) {
         goto error;
     }
-    assert(PyUnicode_IS_READY(id));
     /* Check whether there are non-ASCII characters in the
        identifier; if so, normalize to NFKC. */
     if (!PyUnicode_IS_ASCII(id))

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -1256,7 +1256,6 @@ _PyCodec_SurrogatePassUnicodeEncodeError(PyObject *exc)
 
     unsigned char *outp = (unsigned char *)PyBytes_AsString(res);
     for (Py_ssize_t i = start; i < end; i++) {
-        /* object is guaranteed to be "ready" */
         Py_UCS4 ch = PyUnicode_READ_CHAR(obj, i);
         if (!Py_UNICODE_IS_SURROGATE(ch)) {
             /* Not a surrogate, fail with original exception */

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -867,7 +867,6 @@ format_string_internal(PyObject *value, const InternalFormatSpec *format,
     int result = -1;
     Py_UCS4 maxchar;
 
-    assert(PyUnicode_IS_READY(value));
     len = PyUnicode_GET_LENGTH(value);
 
     /* sign is not allowed on strings */

--- a/Python/tracemalloc.c
+++ b/Python/tracemalloc.c
@@ -249,14 +249,6 @@ tracemalloc_get_frame(_PyInterpreterFrame *pyframe, frame_t *frame)
 #endif
         return;
     }
-    if (!PyUnicode_IS_READY(filename)) {
-        /* Don't make a Unicode string ready to avoid reentrant calls
-           to tracemalloc_alloc() or tracemalloc_realloc() */
-#ifdef TRACE_DEBUG
-        tracemalloc_error("filename is not a ready unicode string");
-#endif
-        return;
-    }
 
     /* intern the filename */
     _Py_hashtable_entry_t *entry;


### PR DESCRIPTION
And remove calls to `PyUnicode_IS_READY`

<!-- gh-issue-number: gh-130790 -->
* Issue: gh-130790
<!-- /gh-issue-number -->
