### PR TITLE
[3.12] gh-130809: Fix `PyFrame_LocalsToFast` copying the wrong value

### DIFF
--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -709,6 +709,15 @@ class ListComprehensionTest(unittest.TestCase):
         self._check_in_scopes(code, {"x": 2, "y": [3]}, ns={"x": 3}, scopes=["class"])
         self._check_in_scopes(code, {"x": 2, "y": [2]}, ns={"x": 3}, scopes=["function", "module"])
 
+    def test_name_collision_locals(self):
+        code = """
+            x = 1
+            [x for x in [0]]
+            from abc import *
+            exec("b = 2")
+        """
+        self._check_in_scopes(code, {"b": 2, "x": 1}, scopes=["module"])
+
     def test_exception_locations(self):
         # The location of an exception raised from __init__ or
         # __next__ should should be the iterator expression

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -710,8 +710,9 @@ class ListComprehensionTest(unittest.TestCase):
         self._check_in_scopes(code, {"x": 2, "y": [2]}, ns={"x": 3}, scopes=["function", "module"])
 
     def test_name_collision_locals(self):
-        # GH-130809: The existence of a hidden fast from list comprehension should not cause
-        # frame.f_locals on module level to return a new dict every time it is accessed.
+        # GH-130809: The existence of a hidden fast from list comprehension
+        # should not cause frame.f_locals on module level to return a new dict
+        # every time it is accessed.
 
         code = """
             import sys

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -720,6 +720,7 @@ class ListComprehensionTest(unittest.TestCase):
             f_locals = frame.f_locals
             foo = 1
             [foo for foo in [0]]
+            # calls _PyFrame_LocalsToFast which triggers the issue
             from abc import *
             same_f_locals = frame.f_locals is f_locals
         """

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -711,12 +711,15 @@ class ListComprehensionTest(unittest.TestCase):
 
     def test_name_collision_locals(self):
         code = """
-            x = 1
-            [x for x in [0]]
+            import sys
+            frame = sys._getframe()
+            f_locals = frame.f_locals
+            foo = 1
+            [foo for foo in [0]]
             from abc import *
-            exec("b = 2")
+            assert frame.f_locals is f_locals
         """
-        self._check_in_scopes(code, {"b": 2, "x": 1}, scopes=["module"])
+        self._check_in_scopes(code, {"foo": 1}, scopes=["module"])
 
     def test_exception_locations(self):
         # The location of an exception raised from __init__ or

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -710,6 +710,9 @@ class ListComprehensionTest(unittest.TestCase):
         self._check_in_scopes(code, {"x": 2, "y": [2]}, ns={"x": 3}, scopes=["function", "module"])
 
     def test_name_collision_locals(self):
+        # GH-130809: The existence of a hidden fast from list comprehension should not cause
+        # frame.f_locals on module level to return a new dict every time it is accessed.
+
         code = """
             import sys
             frame = sys._getframe()
@@ -717,9 +720,9 @@ class ListComprehensionTest(unittest.TestCase):
             foo = 1
             [foo for foo in [0]]
             from abc import *
-            assert frame.f_locals is f_locals
+            same_f_locals = frame.f_locals is f_locals
         """
-        self._check_in_scopes(code, {"foo": 1}, scopes=["module"])
+        self._check_in_scopes(code, {"foo": 1, "same_f_locals": True}, scopes=["module"])
 
     def test_exception_locations(self):
         # The location of an exception raised from __init__ or

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-04-12-52-21.gh-issue-130809.fSXq60.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-04-12-52-21.gh-issue-130809.fSXq60.rst
@@ -1,2 +1,2 @@
-Fix an issue where modifications to locals could fail to persist when there
-is an inlined comprehension with colliding variable name.
+Fixed an issue where ``_PyFrame_LocalsToFast`` tries to write module level
+values to hidden fasts.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-04-12-52-21.gh-issue-130809.fSXq60.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-04-12-52-21.gh-issue-130809.fSXq60.rst
@@ -1,0 +1,2 @@
+Fix an issue where modifications to locals could fail to persist when there
+is an inlined comprehension with colliding variable name.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1399,14 +1399,17 @@ _PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear)
 
     PyObject *exc = PyErr_GetRaisedException();
     for (int i = 0; i < co->co_nlocalsplus; i++) {
-        /* Same test as in _PyFrame_GetLocals() above. */
-        PyObject *value; // borrowed reference
-        if (!frame_get_var(frame, co, i, &value)) {
+        _PyLocals_Kind kind = _PyLocals_GetKind(co->co_localspluskinds, i);
+
+        /* Same test as in PyFrame_FastToLocals() above. */
+        if (kind & CO_FAST_FREE && !(co->co_flags & CO_OPTIMIZED)) {
             continue;
         }
-
+        if (kind & CO_FAST_HIDDEN) {
+            continue;
+        }
         PyObject *name = PyTuple_GET_ITEM(co->co_localsplusnames, i);
-        _PyLocals_Kind kind = _PyLocals_GetKind(co->co_localspluskinds, i);
+        PyObject *value = PyObject_GetItem(locals, name);
         /* We only care about NULLs if clear is true. */
         if (value == NULL) {
             PyErr_Clear();
@@ -1452,6 +1455,7 @@ _PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear)
             }
             Py_XSETREF(fast[i], Py_NewRef(value));
         }
+        Py_XDECREF(value);
     }
     PyErr_SetRaisedException(exc);
 }

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1399,14 +1399,14 @@ _PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear)
 
     PyObject *exc = PyErr_GetRaisedException();
     for (int i = 0; i < co->co_nlocalsplus; i++) {
-        _PyLocals_Kind kind = _PyLocals_GetKind(co->co_localspluskinds, i);
-
-        /* Same test as in PyFrame_FastToLocals() above. */
-        if (kind & CO_FAST_FREE && !(co->co_flags & CO_OPTIMIZED)) {
+        /* Same test as in _PyFrame_GetLocals() above. */
+        PyObject *value; // borrowed reference
+        if (!frame_get_var(frame, co, i, &value)) {
             continue;
         }
+
         PyObject *name = PyTuple_GET_ITEM(co->co_localsplusnames, i);
-        PyObject *value = PyObject_GetItem(locals, name);
+        _PyLocals_Kind kind = _PyLocals_GetKind(co->co_localspluskinds, i);
         /* We only care about NULLs if clear is true. */
         if (value == NULL) {
             PyErr_Clear();
@@ -1452,7 +1452,6 @@ _PyFrame_LocalsToFast(_PyInterpreterFrame *frame, int clear)
             }
             Py_XSETREF(fast[i], Py_NewRef(value));
         }
-        Py_XDECREF(value);
     }
     PyErr_SetRaisedException(exc);
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Don't update hidden fast locals in `PyFrame_LocalsToFast`, to make sure we don't write the wrong value if there is a name collision.

<!-- gh-issue-number: gh-130809 -->
* Issue: gh-130809
<!-- /gh-issue-number -->
