### PR TITLE
gh-130814: Enhance documentation for Python C API type objects

### DIFF
--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -2,8 +2,8 @@
 
 .. _type-structs:
 
-Type Objects
-============
+Type Object Structures
+======================
 
 Perhaps one of the most important structures of the Python object system is the
 structure that defines a new type: the :c:type:`PyTypeObject` structure.  Type

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1225,6 +1225,7 @@ Jeff McNeil
 Craig McPheeters
 Corvin McPherson
 Lambert Meertens
+Rihaan Meher
 Bill van Melle
 Lucas Prado Melo
 Ezio Melotti

--- a/Misc/NEWS.d/next/Documentation/2025-03-04-01-23-42.gh-issue-130814.Tp3Ct1.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-03-04-01-23-42.gh-issue-130814.Tp3Ct1.rst
@@ -1,0 +1,7 @@
+================
+Type: Improvement
+Title: Enhance documentation for Python C API type objects
+Issue: bpo-130814
+
+Detailed changes:
+- Clarified the title of the page

--- a/Misc/NEWS.d/next/Documentation/2025-03-04-01-23-42.gh-issue-130814.Tp3Ct1.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-03-04-01-23-42.gh-issue-130814.Tp3Ct1.rst
@@ -1,7 +1,0 @@
-================
-Type: Improvement
-Title: Enhance documentation for Python C API type objects
-Issue: :gh:`130814`
-
-Detailed changes:
-- Clarified the title of the page

--- a/Misc/NEWS.d/next/Documentation/2025-03-04-01-23-42.gh-issue-130814.Tp3Ct1.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-03-04-01-23-42.gh-issue-130814.Tp3Ct1.rst
@@ -1,7 +1,7 @@
 ================
 Type: Improvement
 Title: Enhance documentation for Python C API type objects
-Issue: bpo-130814
+Issue: :gh:`130814`
 
 Detailed changes:
 - Clarified the title of the page


### PR DESCRIPTION
Update from 


```rst
Type Objects
============
```
to

```rst
Type Object Structures
======================
```

Based on issue [#130814](https://github.com/python/cpython/issues/130814) 




<!-- gh-issue-number: gh-130814 -->
* Issue: gh-130814
<!-- /gh-issue-number -->
