### PR TITLE
gh-130819: Update `tarfile.py#_create_gnu_long_header` to align with GNU Tar

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1708,6 +1708,15 @@ sysconfig
   (Contributed by Xuehai Pan in :gh:`131799`.)
 
 
+tarfile
+-------
+
+* Emit ``mode``, ``uname`` and ``gname`` fields for long paths in
+  :mod:`tarfile` archives, providing better bit-for-bit compatibility with GNU
+  :manpage:`tar(1)`.
+  (Contributed by Dahan Gong in :gh:`130820`.)
+
+
 threading
 ---------
 

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -895,6 +895,9 @@ class TarInfo(object):
         _link_target = None,
         )
 
+    _name_uid0 = None    # Cached uname of uid=0
+    _name_gid0 = None    # Cached gname of gid=0
+
     def __init__(self, name=""):
         """Construct a TarInfo object. name is the optional name
            of the member.
@@ -1202,6 +1205,13 @@ class TarInfo(object):
         info["type"] = type
         info["size"] = len(name)
         info["magic"] = GNU_MAGIC
+        info["mode"] = 0o100644
+        if cls._name_uid0 is None or cls._name_gid0 is None:
+            user_group_names = TarFile._get_user_group_names(0, 0, {}, {})
+            cls._name_uid0 = user_group_names[0] or ""
+            cls._name_gid0 = user_group_names[1] or ""
+        info["uname"] = cls._name_uid0
+        info["gname"] = cls._name_gid0
 
         # create extended header + name blocks.
         return cls._create_header(info, USTAR_FORMAT, encoding, errors) + \
@@ -2202,22 +2212,12 @@ class TarFile(object):
         tarinfo.type = type
         tarinfo.linkname = linkname
 
-        # Calls to pwd.getpwuid() and grp.getgrgid() tend to be expensive. To
-        # speed things up, cache the resolved usernames and group names.
-        if pwd:
-            if tarinfo.uid not in self._unames:
-                try:
-                    self._unames[tarinfo.uid] = pwd.getpwuid(tarinfo.uid)[0]
-                except KeyError:
-                    self._unames[tarinfo.uid] = ''
-            tarinfo.uname = self._unames[tarinfo.uid]
-        if grp:
-            if tarinfo.gid not in self._gnames:
-                try:
-                    self._gnames[tarinfo.gid] = grp.getgrgid(tarinfo.gid)[0]
-                except KeyError:
-                    self._gnames[tarinfo.gid] = ''
-            tarinfo.gname = self._gnames[tarinfo.gid]
+        uname, gname = TarFile._get_user_group_names(tarinfo.uid, tarinfo.gid,
+                                                     self._unames, self._gnames)
+        if uname is not None:
+            tarinfo.uname = uname
+        if gname is not None:
+            tarinfo.gname = gname
 
         if type in (CHRTYPE, BLKTYPE):
             if hasattr(os, "major") and hasattr(os, "minor"):
@@ -2559,6 +2559,29 @@ class TarFile(object):
             if not tarinfo.issym():
                 self.chmod(tarinfo, targetpath)
                 self.utime(tarinfo, targetpath)
+
+    def _get_user_group_names(uid, gid, unames_cache, gnames_cache):
+        # Calls to pwd.getpwuid() and grp.getgrgid() tend to be expensive.
+        # To speed things up, cache the resolved usernames and group names.
+        if pwd:
+            if uid not in unames_cache:
+                try:
+                    unames_cache[uid] = pwd.getpwuid(uid)[0]
+                except KeyError:
+                    unames_cache[uid] = ''
+            uname = unames_cache[uid]
+        else:
+            uname = None
+        if grp:
+            if gid not in gnames_cache:
+                try:
+                    gnames_cache[gid] = grp.getgrgid(gid)[0]
+                except KeyError:
+                    gnames_cache[gid] = ''
+            gname = gnames_cache[gid]
+        else:
+            gname = None
+        return uname, gname
 
     #--------------------------------------------------------------------------
     # Below are the different file methods. They are called via

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -665,6 +665,7 @@ Mikhail Golubev
 Marta Gómez Macías
 Guilherme Gonçalves
 Tiago Gonçalves
+Dahan Gong
 Chris Gonnerman
 Shelley Gooch
 David Goodger

--- a/Misc/NEWS.d/next/Library/2025-03-04-03-14-44.gh-issue-130819.Dphgb6.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-04-03-14-44.gh-issue-130819.Dphgb6.rst
@@ -1,0 +1,3 @@
+Emit ``mode``, ``uname`` and ``gname`` fields for long paths in
+:mod:`tarfile` archives, providing better bit-for-bit compatibility with GNU
+``tar(1)``.


### PR DESCRIPTION
The latest `tarfile` may still generate a file slightly different with the one made by GNU Tar, whenever a path name is longer than 100 bytes. So this PR tries to avoid the difference.

More details are in https://github.com/python/cpython/issues/130819 .

<!-- gh-issue-number: gh-130819 -->
* Issue: gh-130819
<!-- /gh-issue-number -->
