### PR TITLE
gh-130824: Add tests for `NULL` in `PyLong_*AndOverflow` functions

### DIFF
--- a/Lib/test/test_capi/test_long.py
+++ b/Lib/test/test_capi/test_long.py
@@ -211,8 +211,7 @@ class LongTests(unittest.TestCase):
 
         self.assertEqual(func(min_val - 1), (-1, -1))
         self.assertEqual(func(max_val + 1), (-1, +1))
-        with self.assertRaises(SystemError):
-            func(None)
+        self.assertRaises(SystemError, func, None)
 
         # CRASHES func(1.0)
 

--- a/Lib/test/test_capi/test_long.py
+++ b/Lib/test/test_capi/test_long.py
@@ -212,8 +212,7 @@ class LongTests(unittest.TestCase):
         self.assertEqual(func(min_val - 1), (-1, -1))
         self.assertEqual(func(max_val + 1), (-1, +1))
         self.assertRaises(SystemError, func, None)
-
-        # CRASHES func(1.0)
+        self.assertRaises(TypeError, func, 1.0)
 
     def test_long_asint(self):
         # Test PyLong_AsInt()

--- a/Lib/test/test_capi/test_long.py
+++ b/Lib/test/test_capi/test_long.py
@@ -211,9 +211,10 @@ class LongTests(unittest.TestCase):
 
         self.assertEqual(func(min_val - 1), (-1, -1))
         self.assertEqual(func(max_val + 1), (-1, +1))
+        with self.assertRaises(SystemError):
+            func(None)
 
         # CRASHES func(1.0)
-        # CRASHES func(NULL)
 
     def test_long_asint(self):
         # Test PyLong_AsInt()

--- a/Modules/_testlimitedcapi/long.c
+++ b/Modules/_testlimitedcapi/long.c
@@ -672,6 +672,7 @@ pylong_aslonglongandoverflow(PyObject *module, PyObject *arg)
     int overflow = UNINITIALIZED_INT;
     long long value = PyLong_AsLongLongAndOverflow(arg, &overflow);
     if (value == -1 && PyErr_Occurred()) {
+        // overflow can be 0 if a seperate exception occurred
         assert(overflow == -1 || overflow == 0);
         return NULL;
     }

--- a/Modules/_testlimitedcapi/long.c
+++ b/Modules/_testlimitedcapi/long.c
@@ -625,7 +625,8 @@ pylong_aslongandoverflow(PyObject *module, PyObject *arg)
     int overflow = UNINITIALIZED_INT;
     long value = PyLong_AsLongAndOverflow(arg, &overflow);
     if (value == -1 && PyErr_Occurred()) {
-        assert(overflow == -1);
+        // overflow can be 0 if a seperate exception occurred
+        assert(overflow == -1 || overflow == 0);
         return NULL;
     }
     return Py_BuildValue("li", value, overflow);
@@ -671,7 +672,7 @@ pylong_aslonglongandoverflow(PyObject *module, PyObject *arg)
     int overflow = UNINITIALIZED_INT;
     long long value = PyLong_AsLongLongAndOverflow(arg, &overflow);
     if (value == -1 && PyErr_Occurred()) {
-        assert(overflow == -1);
+        assert(overflow == -1 || overflow == 0);
         return NULL;
     }
     return Py_BuildValue("Li", value, overflow);

--- a/Modules/_testlimitedcapi/long.c
+++ b/Modules/_testlimitedcapi/long.c
@@ -625,7 +625,7 @@ pylong_aslongandoverflow(PyObject *module, PyObject *arg)
     int overflow = UNINITIALIZED_INT;
     long value = PyLong_AsLongAndOverflow(arg, &overflow);
     if (value == -1 && PyErr_Occurred()) {
-        // overflow can be 0 if a seperate exception occurred
+        // overflow can be 0 if a separate exception occurred
         assert(overflow == -1 || overflow == 0);
         return NULL;
     }
@@ -672,7 +672,7 @@ pylong_aslonglongandoverflow(PyObject *module, PyObject *arg)
     int overflow = UNINITIALIZED_INT;
     long long value = PyLong_AsLongLongAndOverflow(arg, &overflow);
     if (value == -1 && PyErr_Occurred()) {
-        // overflow can be 0 if a seperate exception occurred
+        // overflow can be 0 if a separate exception occurred
         assert(overflow == -1 || overflow == 0);
         return NULL;
     }


### PR DESCRIPTION
It crashed before because the assertion didn't realize that `overflow` would be 0 and not -1 in `SystemError` cases.

<!-- gh-issue-number: gh-130824 -->
* Issue: gh-130824
<!-- /gh-issue-number -->
