### PR TITLE
gh-130727: Retry test_wmi on TimeoutError

### DIFF
--- a/Lib/test/test_wmi.py
+++ b/Lib/test/test_wmi.py
@@ -3,7 +3,8 @@
 
 import time
 import unittest
-from test.support import import_helper, requires_resource, LOOPBACK_TIMEOUT
+from test import support
+from test.support import import_helper
 
 
 # Do this first so test will be skipped if module doesn't exist
@@ -12,15 +13,16 @@ _wmi = import_helper.import_module('_wmi', required_on=['win'])
 
 def wmi_exec_query(query):
     # gh-112278: WMI maybe slow response when first call.
-    try:
-        return _wmi.exec_query(query)
-    except BrokenPipeError:
-        pass
-    except WindowsError as e:
-        if e.winerror != 258:
-            raise
-    time.sleep(LOOPBACK_TIMEOUT)
-    return _wmi.exec_query(query)
+    for _ in support.sleeping_retry(support.LONG_TIMEOUT):
+        try:
+            return _wmi.exec_query(query)
+        except BrokenPipeError:
+            pass
+            # retry on pipe error
+        except WindowsError as exc:
+            if exc.winerror != 258:
+                raise
+            # retry on timeout
 
 
 class WmiTests(unittest.TestCase):
@@ -58,7 +60,7 @@ class WmiTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             wmi_exec_query("not select, just in case someone tries something")
 
-    @requires_resource('cpu')
+    @support.requires_resource('cpu')
     def test_wmi_query_overflow(self):
         # Ensure very big queries fail
         # Test multiple times to ensure consistency


### PR DESCRIPTION
Use sleeping_retry() in test_wmi to retry multiple times on TimeoutError. Wait up to LONG_TIMEOUT seconds (5 minutes by default).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130727 -->
* Issue: gh-130727
<!-- /gh-issue-number -->
