### PR TITLE
gh-130715: Allowed turtle head shape rotation when it is set to an image

### DIFF
--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -873,9 +873,6 @@ class TransformableImage(object):
         self._transformMatrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
         self._item = screen._createimage(self._transformedImage)
 
-    def clone(self, *args, **kwargs):
-        return self.__class__(self._screen, self._originalImage, *args, **kwargs)
-
     def _transform_coordinates(self, x, y):
         m = self._transformMatrix
         return (m[0][0] * x + m[0][1] * y + m[0][2],
@@ -1009,6 +1006,11 @@ class TransformableImage(object):
             self._currentOrientation = orientation
             self._currentTilt = tilt
         self._screen._drawimage(self._item, position, self._transformedImage)
+
+    def stamp(self, position, orientation, tilt):
+        stamp = self.__class__(self._screen, self._originalImage)
+        stamp.draw(position, orientation, tilt)
+        return stamp
 
     def delete(self):
         self._screen._delete(self._item)
@@ -3331,8 +3333,7 @@ class RawTurtle(TPen, TNavigator):
                 screen._drawpoly(item, poly, fill=self._cc(fc),
                                  outline=self._cc(oc), width=self._outlinewidth, top=True)
         elif ttype == "transformable_image":
-            stitem = self.turtle._item.clone()
-            stitem.draw(self._position, self._orient, self._tilt)
+            stitem = self.turtle._item.stamp(self._position, self._orient, self._tilt)
         self.stampItems.append(stitem)
         self.undobuffer.push(("stamp", stitem))
         return stitem

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -965,22 +965,47 @@ class TransformableImage(object):
             bounding_box = self._get_new_bounding_box()
             offset_x = bounding_box["min_x"] * -1
             offset_y = bounding_box["min_y"] * -1
-            self._tkPhotoImage = TK.PhotoImage(width=bounding_box["width"], height=bounding_box["height"])
+            self._tkPhotoImage = TK.PhotoImage(width=bounding_box["width"],
+                                               height=bounding_box["height"])
 
             for new_y in range(bounding_box["height"]):
                 for new_x in range(bounding_box["width"]):
-                    original_x, original_y = self._transform_coordinates(new_x - offset_x, new_y - offset_y)
-
-                    if 0 <= original_x < self._originalImage.width() - 1 and 0 <= original_y < self._originalImage.height() - 1:
+                    original_x, original_y = self._transform_coordinates(
+                        new_x - offset_x, new_y - offset_y
+                    )
+                    if (
+                        0 <= original_x < self._originalImage.width() - 1
+                        and 0 <= original_y < self._originalImage.height() - 1
+                    ):
                         rgb = self._interpolate_color(original_x, original_y)
-                        is_transparent = self._originalImage.transparency_get(int(original_x), int(original_y))
-                        self._tkPhotoImage.put("#{:02x}{:02x}{:02x}".format(rgb[0], rgb[1], rgb[2]), (new_x, new_y))
-                        self._tkPhotoImage.transparency_set(new_x, new_y, is_transparent)
-                    elif 0 <= int(original_x) < self._originalImage.width() and 0 <= int(original_y) < self._originalImage.height():
-                        rgb = self._originalImage.get(int(original_x),int(original_y))
-                        is_transparent = self._originalImage.transparency_get(int(original_x), int(original_y))
-                        self._tkPhotoImage.put("#{:02x}{:02x}{:02x}".format(rgb[0], rgb[1], rgb[2]), (new_x, new_y))
-                        self._tkPhotoImage.transparency_set(new_x, new_y, is_transparent)
+                        is_transparent = self._originalImage.transparency_get(
+                            int(original_x), int(original_y)
+                        )
+                        self._tkPhotoImage.put(
+                            "#{:02x}{:02x}{:02x}".format(rgb[0], rgb[1], rgb[2]),
+                            (new_x, new_y),
+                        )
+                        self._tkPhotoImage.transparency_set(
+                            new_x, new_y, is_transparent
+                        )
+                    elif (
+                        0 <= int(original_x) < self._originalImage.width()
+                        and 0 <= int(original_y) < self._originalImage.height()
+                    ):
+                        rgb = self._originalImage.get(
+                            int(original_x), int(original_y)
+                        )
+                        is_transparent = self._originalImage.transparency_get(
+                            int(original_x), int(original_y)
+                        )
+                        self._tkPhotoImage.put(
+                            "#{:02x}{:02x}{:02x}".format(rgb[0], rgb[1], rgb[2]),
+                            (new_x, new_y),
+                        )
+                        self._tkPhotoImage.transparency_set(
+                            new_x, new_y, is_transparent
+                        )
+
             self._currentOrientation = orientation
             self._currentTilt = tilt
         self._screen._drawimage(self._item, position, self._tkPhotoImage)
@@ -1000,9 +1025,7 @@ class Shape(object):
         if type_ == "polygon":
             if isinstance(data, list):
                 data = tuple(data)
-        elif type_ == "image":
-            assert(isinstance(data, TK.PhotoImage))
-        elif type_ == "transformable_image":
+        elif type_ == "image" or type_ == "transformable_image":
             assert(isinstance(data, TK.PhotoImage))
         elif type_ == "compound":
             data = []
@@ -1241,8 +1264,8 @@ class TurtleScreen(TurtleScreenBase):
             of pairs of coordinates. Installs the corresponding
             polygon shape
         (4) name is an arbitrary string and shape is a
-            (compound or transformable_image) Shape object. Installs the corresponding
-            shape.
+            (compound) Shape object. Installs the corresponding
+            compound shape.
         To use a shape, you have to issue the command shape(shapename).
 
         call: register_shape("turtle.gif")
@@ -3326,7 +3349,6 @@ class RawTurtle(TPen, TNavigator):
             elif not isinstance(stampid, TransformableImage):
                 self.screen._delete(stampid)
             self.stampItems.remove(stampid)
-
         # Delete stampitem from undobuffer if necessary
         # if clearstamp is called directly.
         item = ("stamp", stampid)

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -867,11 +867,11 @@ class TransformableImage(object):
         self._screen = screen
         self._originalImage = image
         self._rotationCenter = (image.width() / 2, image.height() / 2)
-        self._tkPhotoImage = image.copy()
+        self._transformedImage = image.copy()
         self._currentOrientation = (1.0, 0)
         self._currentTilt = 0.0
         self._transformMatrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
-        self._item = screen._createimage(self._tkPhotoImage)
+        self._item = screen._createimage(self._transformedImage)
 
     def clone(self, *args, **kwargs):
         return self.__class__(self._screen, self._originalImage, *args, **kwargs)
@@ -965,7 +965,7 @@ class TransformableImage(object):
             bounding_box = self._get_new_bounding_box()
             offset_x = bounding_box["min_x"] * -1
             offset_y = bounding_box["min_y"] * -1
-            self._tkPhotoImage = TK.PhotoImage(width=bounding_box["width"],
+            self._transformedImage = TK.PhotoImage(width=bounding_box["width"],
                                                height=bounding_box["height"])
 
             for new_y in range(bounding_box["height"]):
@@ -981,11 +981,11 @@ class TransformableImage(object):
                         is_transparent = self._originalImage.transparency_get(
                             int(original_x), int(original_y)
                         )
-                        self._tkPhotoImage.put(
+                        self._transformedImage.put(
                             "#{:02x}{:02x}{:02x}".format(rgb[0], rgb[1], rgb[2]),
                             (new_x, new_y),
                         )
-                        self._tkPhotoImage.transparency_set(
+                        self._transformedImage.transparency_set(
                             new_x, new_y, is_transparent
                         )
                     elif (
@@ -998,17 +998,17 @@ class TransformableImage(object):
                         is_transparent = self._originalImage.transparency_get(
                             int(original_x), int(original_y)
                         )
-                        self._tkPhotoImage.put(
+                        self._transformedImage.put(
                             "#{:02x}{:02x}{:02x}".format(rgb[0], rgb[1], rgb[2]),
                             (new_x, new_y),
                         )
-                        self._tkPhotoImage.transparency_set(
+                        self._transformedImage.transparency_set(
                             new_x, new_y, is_transparent
                         )
 
             self._currentOrientation = orientation
             self._currentTilt = tilt
-        self._screen._drawimage(self._item, position, self._tkPhotoImage)
+        self._screen._drawimage(self._item, position, self._transformedImage)
 
     def delete(self):
         self._screen._delete(self._item)

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -2705,6 +2705,7 @@ class _TurtleImage(object):
 
     def _setshape(self, shapeIndex):
         screen = self.screen
+        self.shapeIndex = shapeIndex
         if self._type == "polygon" == screen._shapes[shapeIndex]._type:
             return
         if self._type == "image" == screen._shapes[shapeIndex]._type:
@@ -2715,11 +2716,8 @@ class _TurtleImage(object):
             for item in self._item:
                 screen._delete(item)
         elif self._type == "transformable_image":
-            del self._item
-
+            self._item.delete()
         self._type = screen._shapes[shapeIndex]._type
-        self.shapeIndex = shapeIndex
-
         if self._type == "polygon":
             self._item = screen._createpoly()
         elif self._type == "image":

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -1224,7 +1224,7 @@ class TurtleScreen(TurtleScreenBase):
         self._rescale(self.xscale/oldxscale, self.yscale/oldyscale)
         self.update()
 
-    def register_shape(self, name, shape=None):
+    def register_shape(self, name, shape=None, rotate_image_shape=False):
         """Adds a turtle shape to TurtleScreen's shapelist.
 
         Arguments:
@@ -1236,6 +1236,7 @@ class TurtleScreen(TurtleScreenBase):
             Installs the corresponding image shape.
             !! Image-shapes DO NOT rotate when turning the turtle,
             !! so they do not display the heading of the turtle!
+            !! unless rotate_image_shape is explicitly set to true
         (3) name is an arbitrary string and shape is a tuple
             of pairs of coordinates. Installs the corresponding
             polygon shape
@@ -1246,15 +1247,17 @@ class TurtleScreen(TurtleScreenBase):
 
         call: register_shape("turtle.gif")
         --or: register_shape("tri", ((0,0), (10,10), (-10,10)))
+        --or: register_shape("turtle.gif", rotate_image_shape=True)
 
         Example (for a TurtleScreen instance named screen):
         >>> screen.register_shape("triangle", ((5,-3),(0,5),(-5,-3)))
 
         """
+        image_shape_type = "transformable_image" if rotate_image_shape else "image"
         if shape is None:
-            shape = Shape("image", self._image(name))
+            shape = Shape(image_shape_type, self._image(name))
         elif isinstance(shape, str):
-            shape = Shape("image", self._image(shape))
+            shape = Shape(image_shape_type, self._image(shape))
         elif isinstance(shape, tuple):
             shape = Shape("polygon", shape)
         ## else shape assumed to be Shape-instance

--- a/Misc/NEWS.d/next/Library/2025-03-04-21-35-52.gh-issue-130715.4k4xhd.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-04-21-35-52.gh-issue-130715.4k4xhd.rst
@@ -1,0 +1,1 @@
+Turtle library - added optional rotate_image_shape parameter to addshape() method to allow turtle head rotation when shape is set to an image.


### PR DESCRIPTION
Turtle module allowed to rotate every custom head shape except for an image. 

Added rotate_image_shape parameter to addshape() method and mechanism that allows to rotate images, so that rotations are also possible when turtle shape is set to an image.

<!-- gh-issue-number: gh-130715 -->
* Issue: gh-130715
<!-- /gh-issue-number -->

Not sure if it's relevant, but I used llm assistant while working on code included in this PR.