### PR TITLE
[3.13] gh-130794: Process interpreter QSBR queue in _PyMem_AbandonDelayed. (gh-130808)

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-03-20-33-44.gh-issue-130794.LwtGQc.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-03-20-33-44.gh-issue-130794.LwtGQc.rst
@@ -1,0 +1,2 @@
+Fix memory leak in the :term:`free threaded <free threading>` build when
+resizing a shared list or dictionary from multiple short-lived threads.

--- a/Python/qsbr.c
+++ b/Python/qsbr.c
@@ -161,6 +161,7 @@ bool
 _Py_qsbr_poll(struct _qsbr_thread_state *qsbr, uint64_t goal)
 {
     assert(_Py_atomic_load_int_relaxed(&_PyThreadState_GET()->state) == _Py_THREAD_ATTACHED);
+    assert(((_PyThreadStateImpl *)_PyThreadState_GET())->qsbr == qsbr);
 
     if (_Py_qbsr_goal_reached(qsbr, goal)) {
         return true;


### PR DESCRIPTION
This avoids a case where the interpreter's queue of memory to be freed could grow rapidly if there are many short lived threads.
(cherry picked from commit 2f6e0e9f7001769be746ee96356656d3ebdc7f96)


<!-- gh-issue-number: gh-130794 -->
* Issue: gh-130794
<!-- /gh-issue-number -->
