### PR TITLE
gh-130850 Refactor _close_self_pipe for conditional socket shutdown in asyncio/selector_events.py

### DIFF
--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -107,31 +107,28 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
             self._selector.close()
             self._selector = None
 
-    def _close_self_pipe(self):
-        self._remove_reader(self._ssock.fileno())
-        
-        # Handle shutdown and close for _ssock
-        if self._ssock:
-            try:
-                self._ssock.shutdown(socket.SHUT_RDWR)
-            except OSError as e:
-                # Log the error or handle it as necessary
-                print(f"Error shutting down _ssock: {e}")
-            finally:
-                self._ssock.close()
-                self._ssock = None
-        
-        # Handle shutdown and close for _csock
-        if self._csock:
-            try:
-                self._csock.shutdown(socket.SHUT_RDWR)
-            except OSError as e:
-                # Log the error or handle it as necessary
-                print(f"Error shutting down _csock: {e}")
-            finally:
-                self._csock.close()
-                self._csock = None
-    
+    def _close_self_pipe(self, shutdown=False):
+        if self._ssock is not None:
+            self._remove_reader(self._ssock.fileno())
+            if shutdown:
+                try:
+                    self._ssock.shutdown(socket.SHUT_RDWR)
+                except OSError as e:
+                    # Log the error with more context
+                    print(f"Error shutting down _ssock (fileno={self._ssock.fileno()}): {e}")
+            self._ssock.close()
+            self._ssock = None
+
+        if self._csock is not None:
+            if shutdown:
+                try:
+                    self._csock.shutdown(socket.SHUT_RDWR)
+                except OSError as e:
+                    # Log the error with more context
+                    print(f"Error shutting down _csock (fileno={self._csock.fileno()}): {e}")
+            self._csock.close()
+            self._csock = None
+
         self._internal_fds -= 1
 
 

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -132,7 +132,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
                 self._csock.close()
                 self._csock = None
     
-    self._internal_fds -= 1
+        self._internal_fds -= 1
 
 
 

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -108,6 +108,24 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
             self._selector = None
 
     def _close_self_pipe(self, shutdown=False):
+        """
+        Close the self-pipe used for waking up the event loop.
+    
+        This method ensures that the self-pipe is properly closed, releasing any associated resources.
+        It optionally shuts down the sockets before closing them if the `shutdown` parameter is set to True.
+    
+        Parameters:
+        shutdown (bool): If True, the method attempts to shut down the sockets before closing them.
+    
+        Raises:
+        OSError: If an error occurs during the socket shutdown process. The error is logged but not re-raised.
+    
+        Notes:
+        - The method first removes the reader from the event loop for the `_ssock` socket.
+        - If `shutdown` is True, the method attempts to shut down the `_ssock` and `_csock` sockets.
+          Any errors encountered during shutdown are logged.
+        - The sockets are closed, and the `_internal_fds` counter is decremented.
+        """
         if self._ssock is not None:
             self._remove_reader(self._ssock.fileno())
             if shutdown:

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -109,11 +109,32 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
 
     def _close_self_pipe(self):
         self._remove_reader(self._ssock.fileno())
-        self._ssock.close()
-        self._ssock = None
-        self._csock.close()
-        self._csock = None
-        self._internal_fds -= 1
+        
+        # Handle shutdown and close for _ssock
+        if self._ssock:
+            try:
+                self._ssock.shutdown(socket.SHUT_RDWR)
+            except OSError as e:
+                # Log the error or handle it as necessary
+                print(f"Error shutting down _ssock: {e}")
+            finally:
+                self._ssock.close()
+                self._ssock = None
+        
+        # Handle shutdown and close for _csock
+        if self._csock:
+            try:
+                self._csock.shutdown(socket.SHUT_RDWR)
+            except OSError as e:
+                # Log the error or handle it as necessary
+                print(f"Error shutting down _csock: {e}")
+            finally:
+                self._csock.close()
+                self._csock = None
+    
+    self._internal_fds -= 1
+
+
 
     def _make_self_pipe(self):
         # A self-socket, really. :-)

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -108,24 +108,6 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
             self._selector = None
 
     def _close_self_pipe(self, shutdown=False):
-        """
-        Close the self-pipe used for waking up the event loop.
-    
-        This method ensures that the self-pipe is properly closed, releasing any associated resources.
-        It optionally shuts down the sockets before closing them if the `shutdown` parameter is set to True.
-    
-        Parameters:
-        shutdown (bool): If True, the method attempts to shut down the sockets before closing them.
-    
-        Raises:
-        OSError: If an error occurs during the socket shutdown process. The error is logged but not re-raised.
-    
-        Notes:
-        - The method first removes the reader from the event loop for the `_ssock` socket.
-        - If `shutdown` is True, the method attempts to shut down the `_ssock` and `_csock` sockets.
-          Any errors encountered during shutdown are logged.
-        - The sockets are closed, and the `_internal_fds` counter is decremented.
-        """
         if self._ssock is not None:
             self._remove_reader(self._ssock.fileno())
             if shutdown:

--- a/Misc/NEWS.d/next/Library/2025-03-05-01-03-59.gh-issue-130850.FmU_5n.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-05-01-03-59.gh-issue-130850.FmU_5n.rst
@@ -1,0 +1,8 @@
+================
+Type: Enhancement
+Title: Refactor _close_self_pipe for conditional socket shutdown in asyncio/selector_events.py``
+Issue: :gh:`130850`
+
+
+Detailed changes:
+Python's `asyncio` module has been enhanced with a refactored `_close_self_pipe` function in `selector_events.py`. This update introduces a `shutdown` parameter, allowing developers to choose between a graceful socket shutdown or a standard close operation, thereby offering greater control over socket management within asynchronous applications.

--- a/Misc/NEWS.d/next/Library/2025-03-05-01-03-59.gh-issue-130850.FmU_5n.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-05-01-03-59.gh-issue-130850.FmU_5n.rst
@@ -1,8 +1,6 @@
-================
 Type: Enhancement
-Title: Refactor _close_self_pipe for conditional socket shutdown in asyncio/selector_events.py``
+Title: Refactor :code:`_close_self_pipe` for conditional socket shutdown in :code:`asyncio/selector_events.py`
 Issue: :gh:`130850`
 
-
 Detailed changes:
-Python's `asyncio` module has been enhanced with a refactored `_close_self_pipe` function in `selector_events.py`. This update introduces a `shutdown` parameter, allowing developers to choose between a graceful socket shutdown or a standard close operation, thereby offering greater control over socket management within asynchronous applications.
+Python's :code:`asyncio` module has been enhanced with a refactored :code:`_close_self_pipe` function in :code:`selector_events.py`. This update introduces a :code:`shutdown` parameter, allowing developers to choose between a graceful socket shutdown or a standard close operation, thereby offering greater control over socket management within asynchronous applications.

--- a/Misc/NEWS.d/next/Library/2025-03-05-01-03-59.gh-issue-130850.FmU_5n.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-05-01-03-59.gh-issue-130850.FmU_5n.rst
@@ -1,6 +1,4 @@
-Type: Enhancement
-Title: Refactor :code:`_close_self_pipe` for conditional socket shutdown in :code:`asyncio/selector_events.py`
 Issue: :gh:`130850`
 
 Detailed changes:
-Python's :code:`asyncio` module has been enhanced with a refactored :code:`_close_self_pipe` function in :code:`selector_events.py`. This update introduces a :code:`shutdown` parameter, allowing developers to choose between a graceful socket shutdown or a standard close operation, thereby offering greater control over socket management within asynchronous applications.
+Modified :code:`_close_self_pipe` function in :code:`selector_events.py` in python/asyncio. This update introduces a :code:`shutdown` parameter, allowing for either a socket shutdown or the default socket close

--- a/Misc/NEWS.d/next/Library/2025-03-05-01-03-59.gh-issue-130850.FmU_5n.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-05-01-03-59.gh-issue-130850.FmU_5n.rst
@@ -1,4 +1,4 @@
-Issue: :gh:`130850`
+Issue: :gh:`130870`
 
 Detailed changes:
-Modified :code:`_close_self_pipe` function in :code:`selector_events.py` in python/asyncio. This update introduces a :code:`shutdown` parameter, allowing for either a socket shutdown or the default socket close
+This change improves the handling of ``GenericAlias`` and ``Union`` types in ``_eval_type``, ensuring that callable arguments for ``GenericAlias`` are unflattened and that ``Union`` types are properly evaluated.

--- a/Misc/NEWS.d/next/Library/2025-03-05-01-03-59.gh-issue-130850.FmU_5n.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-05-01-03-59.gh-issue-130850.FmU_5n.rst
@@ -1,4 +1,3 @@
-Issue: :gh:`130870`
+Issue: :gh:`130850`
 
-Detailed changes:
-This change improves the handling of ``GenericAlias`` and ``Union`` types in ``_eval_type``, ensuring that callable arguments for ``GenericAlias`` are unflattened and that ``Union`` types are properly evaluated.
+Detailed changes: Modified _close_self_pipe function in selector_events.py in python/asyncio. This update introduces a shutdown parameter, allowing for either a socket shutdown or the default socket close


### PR DESCRIPTION
Overview:

Fixes [#130850](https://github.com/python/cpython/issues/130850)

Conditional Socket Shutdown: The _close_self_pipe function now accepts an optional shutdown parameter. When shutdown=True is passed, the function performs a shutdown of the socket using socket.SHUT_RDWR. If shutdown=False (or if the parameter is omitted), the function proceeds with the original behavior, closing the socket without shutdown.

Error Handling Enhancements: Catches and llogs OSerrors

Testing:

- Test with shutdown=True: Simulates a scenario where a graceful shutdown is performed. The server initiates a shutdown, and the client performs a shutdown before closing the socket. 

- Test with shutdown=False (default): Simulates a standard socket closure without shutdown. Both the server and client close the socket without performing a shutdown.


<!-- gh-issue-number: gh-130850 -->
* Issue: gh-130850
<!-- /gh-issue-number -->
