### PR TITLE
[3.12] gh-130824: Add tests for NULL in PyLong_*AndOverflow functions (GH-130828)

### DIFF
--- a/Lib/test/test_capi/test_long.py
+++ b/Lib/test/test_capi/test_long.py
@@ -208,9 +208,8 @@ class LongTests(unittest.TestCase):
 
         self.assertEqual(func(min_val - 1), (-1, -1))
         self.assertEqual(func(max_val + 1), (-1, +1))
-
-        # CRASHES func(1.0)
-        # CRASHES func(NULL)
+        self.assertRaises(SystemError, func, None)
+        self.assertRaises(TypeError, func, 1.0)
 
     def test_long_aslong(self):
         # Test PyLong_AsLong() and PyLong_FromLong()

--- a/Modules/_testcapi/long.c
+++ b/Modules/_testcapi/long.c
@@ -629,8 +629,7 @@ pylong_aslongandoverflow(PyObject *module, PyObject *arg)
     int overflow = UNINITIALIZED_INT;
     long value = PyLong_AsLongAndOverflow(arg, &overflow);
     if (value == -1 && PyErr_Occurred()) {
-        // overflow can be 0 if a separate exception occurred
-        assert(overflow == -1 || overflow == 0);
+        assert(overflow == 0);
         return NULL;
     }
     return Py_BuildValue("li", value, overflow);
@@ -676,8 +675,7 @@ pylong_aslonglongandoverflow(PyObject *module, PyObject *arg)
     int overflow = UNINITIALIZED_INT;
     long long value = PyLong_AsLongLongAndOverflow(arg, &overflow);
     if (value == -1 && PyErr_Occurred()) {
-        // overflow can be 0 if a separate exception occurred
-        assert(overflow == -1 || overflow == 0);
+        assert(overflow == 0);
         return NULL;
     }
     return Py_BuildValue("Li", value, overflow);

--- a/Modules/_testcapi/long.c
+++ b/Modules/_testcapi/long.c
@@ -629,7 +629,8 @@ pylong_aslongandoverflow(PyObject *module, PyObject *arg)
     int overflow = UNINITIALIZED_INT;
     long value = PyLong_AsLongAndOverflow(arg, &overflow);
     if (value == -1 && PyErr_Occurred()) {
-        assert(overflow == -1);
+        // overflow can be 0 if a separate exception occurred
+        assert(overflow == -1 || overflow == 0);
         return NULL;
     }
     return Py_BuildValue("li", value, overflow);
@@ -675,7 +676,8 @@ pylong_aslonglongandoverflow(PyObject *module, PyObject *arg)
     int overflow = UNINITIALIZED_INT;
     long long value = PyLong_AsLongLongAndOverflow(arg, &overflow);
     if (value == -1 && PyErr_Occurred()) {
-        assert(overflow == -1);
+        // overflow can be 0 if a separate exception occurred
+        assert(overflow == -1 || overflow == 0);
         return NULL;
     }
     return Py_BuildValue("Li", value, overflow);


### PR DESCRIPTION
This backports commit: 90130807d9c5a55b2a64024f5dfbee4785b9a27c
and the fix-up: 63d25f8d0c4f4626fb9f1131402d95fdaca34a57

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130824 -->
* Issue: gh-130824
<!-- /gh-issue-number -->
