### PR TITLE
gh-129964: Fix JIT crash on Windows on Arm

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-05-15-19-21.gh-issue-129964.jqu89w.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-05-15-19-21.gh-issue-129964.jqu89w.rst
@@ -1,0 +1,1 @@
+Fix JIT crash on Windows on Arm. Patch by Diego Russo and Brandt Bucher.

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -499,7 +499,7 @@ def get_target(host: str) -> _COFF | _ELF | _MachO:
     if re.fullmatch(r"aarch64-apple-darwin.*", host):
         target = _MachO(host, alignment=8, prefix="_")
     elif re.fullmatch(r"aarch64-pc-windows-msvc", host):
-        args = ["-fms-runtime-lib=dll"]
+        args = ["-fms-runtime-lib=dll", "-fplt"]
         target = _COFF(host, alignment=8, args=args)
     elif re.fullmatch(r"aarch64-.*-linux-gnu", host):
         args = [


### PR DESCRIPTION
Updating to clang-19 change the code generation of the JIT stencils. This caused some addresses of symbols to be far away hence it was impossible to reach them out.
Enabling the -fplt restores the behaviour that we had with clang-18.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129964 -->
* Issue: gh-129964
<!-- /gh-issue-number -->
