### PR TITLE
gettext: Remove outdated "TODO" comment

### DIFF
--- a/Lib/gettext.py
+++ b/Lib/gettext.py
@@ -41,9 +41,6 @@ internationalized, to the local language and cultural habits.
 #   to do binary searches and lazy initializations.  Or you might want to use
 #   the undocumented double-hash algorithm for .mo files with hash tables, but
 #   you'll need to study the GNU gettext code to do this.
-#
-# - Support Solaris .mo file formats.  Unfortunately, we've been unable to
-#   find this format documented anywhere.
 
 
 import operator


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
This was added by @warsaw 25 years ago in https://github.com/python/cpython/commit/33d8d705b88ca6fb227d75d9b7f5bf8efda1d0a7

As the comment mentions it is undocumented, so undocumented that I cannot find any reference to the term whatsoever. 

Furthermore (Oracle) Solairs is not a supported os so there is no reason to have this on our todo list.