### PR TITLE
gh-129817: Use `_PyType_HasFeature()` to check tp_flags.

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -810,7 +810,7 @@ static inline PyObject **
 _PyObject_GET_WEAKREFS_LISTPTR(PyObject *op)
 {
     if (PyType_Check(op) &&
-            ((PyTypeObject *)op)->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
+            _PyType_HasFeature((PyTypeObject *)op, _Py_TPFLAGS_STATIC_BUILTIN)) {
         PyInterpreterState *interp = _PyInterpreterState_GET();
         managed_static_type_state *state = _PyStaticType_GetState(
                                                 interp, (PyTypeObject *)op);
@@ -837,7 +837,7 @@ static inline PyWeakReference **
 _PyObject_GET_WEAKREFS_LISTPTR_FROM_OFFSET(PyObject *op)
 {
     assert(!PyType_Check(op) ||
-            ((PyTypeObject *)op)->tp_flags & Py_TPFLAGS_HEAPTYPE);
+            _PyType_HasFeature((PyTypeObject *)op, Py_TPFLAGS_HEAPTYPE));
     Py_ssize_t offset = Py_TYPE(op)->tp_weaklistoffset;
     return (PyWeakReference **)((char *)op + offset);
 }
@@ -935,7 +935,7 @@ typedef union {
 static inline PyManagedDictPointer *
 _PyObject_ManagedDictPointer(PyObject *obj)
 {
-    assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+    assert(_PyType_HasFeature(Py_TYPE(obj), Py_TPFLAGS_MANAGED_DICT));
     return (PyManagedDictPointer *)((char *)obj + MANAGED_DICT_OFFSET);
 }
 
@@ -951,8 +951,8 @@ _PyObject_InlineValues(PyObject *obj)
 {
     PyTypeObject *tp = Py_TYPE(obj);
     assert(tp->tp_basicsize > 0 && (size_t)tp->tp_basicsize % sizeof(PyObject *) == 0);
-    assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
-    assert(Py_TYPE(obj)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+    assert(_PyType_HasFeature(Py_TYPE(obj), Py_TPFLAGS_INLINE_VALUES));
+    assert(_PyType_HasFeature(Py_TYPE(obj), Py_TPFLAGS_MANAGED_DICT));
     return (PyDictValues *)((char *)obj + tp->tp_basicsize);
 }
 

--- a/Include/internal/pycore_typeobject.h
+++ b/Include/internal/pycore_typeobject.h
@@ -10,6 +10,7 @@ extern "C" {
 
 #include "pycore_moduleobject.h"  // PyModuleObject
 #include "pycore_lock.h"          // PyMutex
+#include "pycore_pyatomic_ft_wrappers.h" // FT_ATOMIC_LOAD_ULONG_RELAXED
 
 
 /* state */
@@ -207,7 +208,7 @@ static inline void *
 _PyType_GetModuleState(PyTypeObject *type)
 {
     assert(PyType_Check(type));
-    assert(type->tp_flags & Py_TPFLAGS_HEAPTYPE);
+    assert((FT_ATOMIC_LOAD_ULONG_RELAXED(type->tp_flags) & Py_TPFLAGS_HEAPTYPE));
     PyHeapTypeObject *et = (PyHeapTypeObject *)type;
     assert(et->ht_module);
     PyModuleObject *mod = (PyModuleObject *)(et->ht_module);

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -1911,7 +1911,7 @@ get_tlbc_id(PyObject *Py_UNUSED(module), PyObject *obj)
 static PyObject *
 has_inline_values(PyObject *self, PyObject *obj)
 {
-    if ((Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES) &&
+    if (_PyType_HasFeature(Py_TYPE(obj), Py_TPFLAGS_INLINE_VALUES) &&
         _PyObject_InlineValues(obj)->valid) {
         Py_RETURN_TRUE;
     }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1484,7 +1484,7 @@ PyObject **
 _PyObject_ComputedDictPointer(PyObject *obj)
 {
     PyTypeObject *tp = Py_TYPE(obj);
-    assert((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0);
+    assert(!_PyType_HasFeature(tp, Py_TPFLAGS_MANAGED_DICT));
 
     Py_ssize_t dictoffset = tp->tp_dictoffset;
     if (dictoffset == 0) {
@@ -1518,11 +1518,11 @@ _PyObject_ComputedDictPointer(PyObject *obj)
 PyObject **
 _PyObject_GetDictPtr(PyObject *obj)
 {
-    if ((Py_TYPE(obj)->tp_flags & Py_TPFLAGS_MANAGED_DICT) == 0) {
+    if (!_PyType_HasFeature(Py_TYPE(obj), Py_TPFLAGS_MANAGED_DICT)) {
         return _PyObject_ComputedDictPointer(obj);
     }
     PyDictObject *dict = _PyObject_GetManagedDict(obj);
-    if (dict == NULL && Py_TYPE(obj)->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (dict == NULL && _PyType_HasFeature(Py_TYPE(obj), Py_TPFLAGS_INLINE_VALUES)) {
         dict = _PyObject_MaterializeManagedDict(obj);
         if (dict == NULL) {
             PyErr_Clear();
@@ -1598,7 +1598,7 @@ _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
         }
     }
     PyObject *dict, *attr;
-    if ((tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) &&
+    if (_PyType_HasFeature(tp, Py_TPFLAGS_INLINE_VALUES) &&
          _PyObject_TryGetInstanceAttribute(obj, name, &attr)) {
         if (attr != NULL) {
             *method = attr;
@@ -1607,7 +1607,7 @@ _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
         }
         dict = NULL;
     }
-    else if ((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT)) {
+    else if (_PyType_HasFeature(tp, Py_TPFLAGS_MANAGED_DICT)) {
         dict = (PyObject *)_PyObject_GetManagedDict(obj);
     }
     else {
@@ -1700,7 +1700,7 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
         }
     }
     if (dict == NULL) {
-        if ((tp->tp_flags & Py_TPFLAGS_INLINE_VALUES)) {
+        if (_PyType_HasFeature(tp, Py_TPFLAGS_INLINE_VALUES)) {
             if (PyUnicode_CheckExact(name) &&
                 _PyObject_TryGetInstanceAttribute(obj, name, &res)) {
                 if (res != NULL) {
@@ -1715,7 +1715,7 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
                 }
             }
         }
-        else if ((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT)) {
+        else if (_PyType_HasFeature(tp, Py_TPFLAGS_MANAGED_DICT)) {
             dict = (PyObject *)_PyObject_GetManagedDict(obj);
         }
         else {
@@ -1816,12 +1816,12 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
     if (dict == NULL) {
         PyObject **dictptr;
 
-        if ((tp->tp_flags & Py_TPFLAGS_INLINE_VALUES)) {
+        if (_PyType_HasFeature(tp, Py_TPFLAGS_INLINE_VALUES)) {
             res = _PyObject_StoreInstanceAttribute(obj, name, value);
             goto error_check;
         }
 
-        if ((tp->tp_flags & Py_TPFLAGS_MANAGED_DICT)) {
+        if (_PyType_HasFeature(tp, Py_TPFLAGS_MANAGED_DICT)) {
             PyManagedDictPointer *managed_dict = _PyObject_ManagedDictPointer(obj);
             dictptr = (PyObject **)&managed_dict->dict;
         }

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2204,7 +2204,7 @@ dummy_func(
         op(_CHECK_MANAGED_OBJECT_HAS_VALUES, (owner -- owner)) {
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
             assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_INLINE_VALUES));
             DEOPT_IF(!FT_ATOMIC_LOAD_UINT8(_PyObject_InlineValues(owner_o)->valid));
         }
 
@@ -2264,7 +2264,7 @@ dummy_func(
 
         op(_LOAD_ATTR_WITH_HINT, (hint/1, owner -- attr)) {
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+            assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_MANAGED_DICT));
             PyDictObject *dict = _PyObject_GetManagedDict(owner_o);
             DEOPT_IF(dict == NULL);
             assert(PyDict_CheckExact((PyObject *)dict));
@@ -2414,7 +2414,7 @@ dummy_func(
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
 
             assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_INLINE_VALUES));
             if (_PyObject_GetManagedDict(owner_o) ||
                     !FT_ATOMIC_LOAD_UINT8(_PyObject_InlineValues(owner_o)->valid)) {
                 UNLOCK_OBJECT(owner_o);
@@ -2448,7 +2448,7 @@ dummy_func(
 
         op(_STORE_ATTR_WITH_HINT, (hint/1, value, owner --)) {
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+            assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_MANAGED_DICT));
             PyDictObject *dict = _PyObject_GetManagedDict(owner_o);
             DEOPT_IF(dict == NULL);
             DEOPT_IF(!LOCK_OBJECT(dict));
@@ -2919,12 +2919,12 @@ dummy_func(
         }
 
         inst(MATCH_MAPPING, (subject -- subject, res)) {
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
+            int match = _PyType_HasFeature(PyStackRef_TYPE(subject), Py_TPFLAGS_MAPPING);
             res = match ? PyStackRef_True : PyStackRef_False;
         }
 
         inst(MATCH_SEQUENCE, (subject -- subject, res)) {
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
+            int match = _PyType_HasFeature(PyStackRef_TYPE(subject), Py_TPFLAGS_SEQUENCE);
             res = match ? PyStackRef_True : PyStackRef_False;
         }
 
@@ -3328,7 +3328,7 @@ dummy_func(
 
         op(_GUARD_DORV_VALUES_INST_ATTR_FROM_DICT, (owner -- owner)) {
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_INLINE_VALUES));
             PyDictValues *ivs = _PyObject_InlineValues(owner_o);
             DEOPT_IF(!FT_ATOMIC_LOAD_UINT8(ivs->valid));
         }
@@ -3841,7 +3841,7 @@ dummy_func(
             PyTypeObject *tp = (PyTypeObject *)callable_o;
             DEOPT_IF(FT_ATOMIC_LOAD_UINT32_RELAXED(tp->tp_version_tag) != type_version);
             assert(tp->tp_new == PyBaseObject_Type.tp_new);
-            assert(tp->tp_flags & Py_TPFLAGS_HEAPTYPE);
+            assert(_PyType_HasFeature(tp, Py_TPFLAGS_HEAPTYPE));
             assert(tp->tp_alloc == PyType_GenericAlloc);
             PyHeapTypeObject *cls = (PyHeapTypeObject *)callable_o;
             PyFunctionObject *init_func = (PyFunctionObject *)FT_ATOMIC_LOAD_PTR_ACQUIRE(cls->_spec_cache.init);

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -475,7 +475,7 @@ _excinfo_init_type_from_exception(struct _excinfo_type *info, PyObject *exc)
     PyObject *strobj = NULL;
 
     PyTypeObject *type = Py_TYPE(exc);
-    if (type->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
+    if (_PyType_HasFeature(type, _Py_TPFLAGS_STATIC_BUILTIN)) {
         assert(_Py_IsImmortal((PyObject *)type));
         info->builtin = type;
     }
@@ -560,12 +560,11 @@ _excinfo_init_type_from_object(struct _excinfo_type *info, PyObject *exctype)
 
     return 0;
 }
-
 static void
 _excinfo_clear_type(struct _excinfo_type *info)
 {
     if (info->builtin != NULL) {
-        assert(info->builtin->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN);
+        assert(_PyType_HasFeature(info->builtin, _Py_TPFLAGS_STATIC_BUILTIN));
         assert(_Py_IsImmortal((PyObject *)info->builtin));
     }
     if (info->name != NULL) {

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -134,7 +134,7 @@ _xidregistry_unlock(dlregistry_t *registry)
 static inline dlregistry_t *
 _get_xidregistry_for_type(dlcontext_t *ctx, PyTypeObject *cls)
 {
-    if (cls->tp_flags & Py_TPFLAGS_HEAPTYPE) {
+    if (_PyType_HasFeature(cls, Py_TPFLAGS_HEAPTYPE)) {
         return &ctx->local->registry;
     }
     return &ctx->global->registry;
@@ -157,7 +157,7 @@ _xidregistry_find_type(dlregistry_t *xidregistry, PyTypeObject *cls)
             }
             assert(PyType_Check(registered));
             assert(cur->cls == (PyTypeObject *)registered);
-            assert(cur->cls->tp_flags & Py_TPFLAGS_HEAPTYPE);
+            assert(_PyType_HasFeature(cur->cls, Py_TPFLAGS_HEAPTYPE));
             Py_DECREF(registered);
         }
         if (cur->cls == cls) {
@@ -200,7 +200,7 @@ _xidregistry_add_type(dlregistry_t *xidregistry,
         .refcount = 1,
         .getdata = getdata,
     };
-    if (cls->tp_flags & Py_TPFLAGS_HEAPTYPE) {
+    if (_PyType_HasFeature(cls, Py_TPFLAGS_HEAPTYPE)) {
         // XXX Assign a callback to clear the entry from the registry?
         newhead->weakref = PyWeakref_NewRef((PyObject *)cls, NULL);
         if (newhead->weakref == NULL) {

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -3080,7 +3080,7 @@
             owner = stack_pointer[-1];
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
             assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_INLINE_VALUES));
             if (!FT_ATOMIC_LOAD_UINT8(_PyObject_InlineValues(owner_o)->valid)) {
                 UOP_STAT_INC(uopcode, miss);
                 JUMP_TO_JUMP_TARGET();
@@ -3170,7 +3170,7 @@
             owner = stack_pointer[-1];
             uint16_t hint = (uint16_t)CURRENT_OPERAND0();
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+            assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_MANAGED_DICT));
             PyDictObject *dict = _PyObject_GetManagedDict(owner_o);
             if (dict == NULL) {
                 UOP_STAT_INC(uopcode, miss);
@@ -3332,7 +3332,7 @@
             owner = stack_pointer[-1];
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
             assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_INLINE_VALUES));
             if (_PyObject_GetManagedDict(owner_o) ||
                 !FT_ATOMIC_LOAD_UINT8(_PyObject_InlineValues(owner_o)->valid)) {
                 UNLOCK_OBJECT(owner_o);
@@ -3379,7 +3379,7 @@
             value = stack_pointer[-2];
             uint16_t hint = (uint16_t)CURRENT_OPERAND0();
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+            assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_MANAGED_DICT));
             PyDictObject *dict = _PyObject_GetManagedDict(owner_o);
             if (dict == NULL) {
                 UOP_STAT_INC(uopcode, miss);
@@ -3974,7 +3974,7 @@
             _PyStackRef subject;
             _PyStackRef res;
             subject = stack_pointer[-1];
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
+            int match = _PyType_HasFeature(PyStackRef_TYPE(subject), Py_TPFLAGS_MAPPING);
             res = match ? PyStackRef_True : PyStackRef_False;
             stack_pointer[0] = res;
             stack_pointer += 1;
@@ -3986,7 +3986,7 @@
             _PyStackRef subject;
             _PyStackRef res;
             subject = stack_pointer[-1];
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
+            int match = _PyType_HasFeature(PyStackRef_TYPE(subject), Py_TPFLAGS_SEQUENCE);
             res = match ? PyStackRef_True : PyStackRef_False;
             stack_pointer[0] = res;
             stack_pointer += 1;
@@ -4405,7 +4405,7 @@
             _PyStackRef owner;
             owner = stack_pointer[-1];
             PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-            assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+            assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_INLINE_VALUES));
             PyDictValues *ivs = _PyObject_InlineValues(owner_o);
             if (!FT_ATOMIC_LOAD_UINT8(ivs->valid)) {
                 UOP_STAT_INC(uopcode, miss);
@@ -5164,7 +5164,7 @@
                 JUMP_TO_JUMP_TARGET();
             }
             assert(tp->tp_new == PyBaseObject_Type.tp_new);
-            assert(tp->tp_flags & Py_TPFLAGS_HEAPTYPE);
+            assert(_PyType_HasFeature(tp, Py_TPFLAGS_HEAPTYPE));
             assert(tp->tp_alloc == PyType_GenericAlloc);
             PyHeapTypeObject *cls = (PyHeapTypeObject *)callable_o;
             PyFunctionObject *init_func = (PyFunctionObject *)FT_ATOMIC_LOAD_PTR_ACQUIRE(cls->_spec_cache.init);

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -2281,7 +2281,7 @@ _PyObject_GC_New(PyTypeObject *tp)
         return NULL;
     }
     _PyObject_Init(op, tp);
-    if (tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (_PyType_HasFeature(tp, Py_TPFLAGS_INLINE_VALUES)) {
         _PyObject_InitInlineValues(op, tp);
     }
     return op;

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -2566,7 +2566,7 @@ _PyObject_GC_New(PyTypeObject *tp)
         return NULL;
     }
     _PyObject_Init(op, tp);
-    if (tp->tp_flags & Py_TPFLAGS_INLINE_VALUES) {
+    if (_PyType_HasFeature(tp, Py_TPFLAGS_INLINE_VALUES)) {
         _PyObject_InitInlineValues(op, tp);
     }
     return op;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1500,7 +1500,7 @@
                     JUMP_TO_PREDICTED(CALL);
                 }
                 assert(tp->tp_new == PyBaseObject_Type.tp_new);
-                assert(tp->tp_flags & Py_TPFLAGS_HEAPTYPE);
+                assert(_PyType_HasFeature(tp, Py_TPFLAGS_HEAPTYPE));
                 assert(tp->tp_alloc == PyType_GenericAlloc);
                 PyHeapTypeObject *cls = (PyHeapTypeObject *)callable_o;
                 PyFunctionObject *init_func = (PyFunctionObject *)FT_ATOMIC_LOAD_PTR_ACQUIRE(cls->_spec_cache.init);
@@ -7946,7 +7946,7 @@
             {
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
                 assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-                assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+                assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_INLINE_VALUES));
                 if (!FT_ATOMIC_LOAD_UINT8(_PyObject_InlineValues(owner_o)->valid)) {
                     UPDATE_MISS_STATS(LOAD_ATTR);
                     assert(_PyOpcode_Deopt[opcode] == (LOAD_ATTR));
@@ -8125,7 +8125,7 @@
             // _GUARD_DORV_VALUES_INST_ATTR_FROM_DICT
             {
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-                assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+                assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_INLINE_VALUES));
                 PyDictValues *ivs = _PyObject_InlineValues(owner_o);
                 if (!FT_ATOMIC_LOAD_UINT8(ivs->valid)) {
                     UPDATE_MISS_STATS(LOAD_ATTR);
@@ -8311,7 +8311,7 @@
             // _GUARD_DORV_VALUES_INST_ATTR_FROM_DICT
             {
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-                assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+                assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_INLINE_VALUES));
                 PyDictValues *ivs = _PyObject_InlineValues(owner_o);
                 if (!FT_ATOMIC_LOAD_UINT8(ivs->valid)) {
                     UPDATE_MISS_STATS(LOAD_ATTR);
@@ -8544,7 +8544,7 @@
             {
                 uint16_t hint = read_u16(&this_instr[4].cache);
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-                assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+                assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_MANAGED_DICT));
                 PyDictObject *dict = _PyObject_GetManagedDict(owner_o);
                 if (dict == NULL) {
                     UPDATE_MISS_STATS(LOAD_ATTR);
@@ -9739,7 +9739,7 @@
             _PyStackRef subject;
             _PyStackRef res;
             subject = stack_pointer[-1];
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
+            int match = _PyType_HasFeature(PyStackRef_TYPE(subject), Py_TPFLAGS_MAPPING);
             res = match ? PyStackRef_True : PyStackRef_False;
             stack_pointer[0] = res;
             stack_pointer += 1;
@@ -9758,7 +9758,7 @@
             _PyStackRef subject;
             _PyStackRef res;
             subject = stack_pointer[-1];
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
+            int match = _PyType_HasFeature(PyStackRef_TYPE(subject), Py_TPFLAGS_SEQUENCE);
             res = match ? PyStackRef_True : PyStackRef_False;
             stack_pointer[0] = res;
             stack_pointer += 1;
@@ -10689,7 +10689,7 @@
             {
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
                 assert(Py_TYPE(owner_o)->tp_dictoffset < 0);
-                assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_INLINE_VALUES);
+                assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_INLINE_VALUES));
                 if (_PyObject_GetManagedDict(owner_o) ||
                     !FT_ATOMIC_LOAD_UINT8(_PyObject_InlineValues(owner_o)->valid)) {
                     UNLOCK_OBJECT(owner_o);
@@ -10808,7 +10808,7 @@
                 value = stack_pointer[-2];
                 uint16_t hint = read_u16(&this_instr[4].cache);
                 PyObject *owner_o = PyStackRef_AsPyObjectBorrow(owner);
-                assert(Py_TYPE(owner_o)->tp_flags & Py_TPFLAGS_MANAGED_DICT);
+                assert(_PyType_HasFeature(Py_TYPE(owner_o), Py_TPFLAGS_MANAGED_DICT));
                 PyDictObject *dict = _PyObject_GetManagedDict(owner_o);
                 if (dict == NULL) {
                     UPDATE_MISS_STATS(STORE_ATTR);


### PR DESCRIPTION
In the free-threaded build, an atomic load is needed to safely read `tp_flags`, avoiding data races.  Replace bit tests on `tp->tp_flags` with calls to `_PyType_HasFeature()`.  When multiple bits are being returned as a result of the test, use `PyType_GetFlags()`.

I think some of these flag tests can safely be a normal load rather than an atomic load.  However, it seems better to consistently use `_PyType_HasFeature()` unless we are sure there is no data race possible.

Implementation notes:
- this is unfortunately quite a lot of code churn because there are a lot of places we read `tp_flags` directly.  I used this command to find all the places: `rg -tc -- '->tp_flags \&' ` and then used editor macros to make the changes.
- the flag test expression and `_PyType_HasFeature()` are not always equivalent since the function only returns 0 and 1 while the test expression might care about individual bits.  I wrote a replacement `_PyType_HasFeature` function that checks how many bits are being passed as the feature and then ensured that only one bit is set.  I then manually fixed or confirmed cases were this wasn't so.  So, I'm fairly sure using `_PyType_HasFeature()` as this PR does is correct in all cases.
- I haven't done a performance comparison on a weakly ordered CPU (e.g. ARM).  It's possible this change could negatively impact performance.  I'll schedule a pyperformance comparison and link it here.

Related PRs: gh-120210 gh-127588


<!-- gh-issue-number: gh-129817 -->
* Issue: gh-129817
<!-- /gh-issue-number -->
