### PR TITLE
gh-122029: Do not unpack method for legacy tracing anymore

### DIFF
--- a/Lib/test/test_sys_setprofile.py
+++ b/Lib/test/test_sys_setprofile.py
@@ -511,6 +511,26 @@ class TestEdgeCases(unittest.TestCase):
             ]
         )
 
+        # Test CALL_FUNCTION_EX
+        events = []
+        sys.setprofile(lambda frame, event, args: events.append(event))
+        # Not important, we only want to trigger INSTRUMENTED_CALL_KW
+        args = (1,)
+        B().f(*args, key=lambda x: 0)
+        sys.setprofile(None)
+        # The last c_call is the call to sys.setprofile
+        # INSTRUMENTED_CALL_FUNCTION_EX has different behavior than the other
+        # instrumented call bytecodes, it does not unpack the callable before
+        # calling it. This is probably not ideal because it's not consistent,
+        # but at least we get a consistent call stack (no unmatched c_call).
+        self.assertEqual(
+            events,
+            ['call', 'return',
+             'call', 'return',
+             'c_call'
+            ]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_sys_setprofile.py
+++ b/Lib/test/test_sys_setprofile.py
@@ -516,7 +516,8 @@ class TestEdgeCases(unittest.TestCase):
         sys.setprofile(lambda frame, event, args: events.append(event))
         # Not important, we only want to trigger INSTRUMENTED_CALL_KW
         args = (1,)
-        B().f(*args, key=lambda x: 0)
+        m = B().f
+        m(*args, key=lambda x: 0)
         sys.setprofile(None)
         # The last c_call is the call to sys.setprofile
         # INSTRUMENTED_CALL_FUNCTION_EX has different behavior than the other

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-05-21-52-20.gh-issue-122029.d_z93q.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-05-21-52-20.gh-issue-122029.d_z93q.rst
@@ -1,0 +1,1 @@
+:func:`sys.setprofile` and :func:`sys.settrace` will not generate a ``c_call`` event for ``INSTRUMENTED_CALL_FUNCTION_EX`` if the callable is a method with a C function wrapped, because we do not generate ``c_return`` event in such case.

--- a/Python/legacy_tracing.c
+++ b/Python/legacy_tracing.c
@@ -121,19 +121,6 @@ sys_profile_call_or_return(
         Py_DECREF(meth);
         return res;
     }
-    else if (Py_TYPE(callable) == &PyMethod_Type) {
-        // CALL instruction will grab the function from the method,
-        // so if the function is a C function, the return event will
-        // be emitted. However, CALL event happens before CALL
-        // instruction, so we need to handle this case here.
-        PyObject* func = PyMethod_GET_FUNCTION(callable);
-        if (func == NULL) {
-            return NULL;
-        }
-        if (PyCFunction_Check(func)) {
-            return call_profile_func(self, func);
-        }
-    }
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
`INSTRUMENTED_CALL` and `INSTRUMENTED_CALL_KW` now unpack the method before monitoring, so they are not affected by this change. The bytecode that this affects is `INSTRUMENTED_CALL_FUNCTION_EX`.

For `INSTRUMENTED_CALL_FUNCTION_EX`, we do not unpack the callable, instead, we use `PyObject_Call` directly on the callable. Because of this, `sys.monitoring` does not know this eventually calls into a C function, because the callable is a Python method, so `c_return` event will not be generated.

With the current code, because we unpack the method in `sys.setprofile`, we will generate an unmatched `c_call`, which is horrible.

The ideal result is probably have a consistent result for all three bytecodes, but that requires some refactoring for `CALL_FUNCTION_EX` which @markshannon was kind of against. If we can't achieve that, we should at least generated paired events - so we don't have a `c_call` without its `c_return`. That's why I removed the unpack code for legacy tracing.

<!-- gh-issue-number: gh-122029 -->
* Issue: gh-122029
<!-- /gh-issue-number -->
