### PR TITLE
gh-128041: Fix incorrect bullet placement

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -437,17 +437,16 @@ concurrent.futures
 
   (Contributed by Gregory P. Smith in :gh:`84559`.)
 
+* Add :meth:`concurrent.futures.ProcessPoolExecutor.terminate_workers` and
+  :meth:`concurrent.futures.ProcessPoolExecutor.kill_workers` as
+  ways to terminate or kill all living worker processes in the given pool.
+  (Contributed by Charles Machalow in :gh:`130849`.)
 
 contextvars
 -----------
 
 * Support context manager protocol by :class:`contextvars.Token`.
   (Contributed by Andrew Svetlov in :gh:`129889`.)
-
-* Add :meth:`concurrent.futures.ProcessPoolExecutor.terminate_workers` and
-  :meth:`concurrent.futures.ProcessPoolExecutor.kill_workers` as
-  ways to terminate or kill all living worker processes in the given pool.
-  (Contributed by Charles Machalow in :gh:`130849`.)
 
 
 ctypes


### PR DESCRIPTION
This wound up in the wrong section upon a rebase/merge

Move this bullet from contextvars -> concurrent.futures

Related to: https://github.com/python/cpython/issues/128041

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130900.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-128041 -->
* Issue: gh-128041
<!-- /gh-issue-number -->
