### PR TITLE
gh-130806: emit ResourceWarning if GzipFile unclosed

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -193,6 +193,11 @@ class GzipFile(_compression.BaseStream):
 
         """
 
+        # Ensure attributes exist at __del__
+        self.mode = None
+        self.fileobj = None
+        self._buffer = None
+
         if mode and ('t' in mode or 'U' in mode):
             raise ValueError("Invalid mode: {!r}".format(mode))
         if mode and 'b' not in mode:
@@ -358,7 +363,7 @@ class GzipFile(_compression.BaseStream):
 
     def close(self):
         fileobj = self.fileobj
-        if fileobj is None or self._buffer.closed:
+        if fileobj is None or self._buffer is None or self._buffer.closed:
             return
         try:
             if self.mode == WRITE:
@@ -435,6 +440,13 @@ class GzipFile(_compression.BaseStream):
         self._check_not_closed()
         return self._buffer.readline(size)
 
+    def __del__(self):
+        if self.mode == WRITE and not self.closed:
+            import warnings
+            warnings.warn("unclosed GzipFile",
+                          ResourceWarning, source=self, stacklevel=2)
+
+        return super().__del__()
 
 def _read_exact(fp, n):
     '''Read exactly *n* bytes from `fp`

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -363,7 +363,9 @@ class GzipFile(_compression.BaseStream):
 
     def close(self):
         fileobj = self.fileobj
-        if fileobj is None or self._buffer is None or self._buffer.closed:
+        if fileobj is None:
+            return
+        if self._buffer is None or self._buffer.closed:
             return
         try:
             if self.mode == WRITE:
@@ -446,7 +448,7 @@ class GzipFile(_compression.BaseStream):
             warnings.warn("unclosed GzipFile",
                           ResourceWarning, source=self, stacklevel=2)
 
-        return super().__del__()
+        super().__del__()
 
 def _read_exact(fp, n):
     '''Read exactly *n* bytes from `fp`

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -9,6 +9,7 @@ import os
 import struct
 import sys
 import unittest
+import warnings
 from subprocess import PIPE, Popen
 from test.support import catch_unraisable_exception
 from test.support import import_helper
@@ -867,9 +868,10 @@ class TestGzip(BaseTest):
         # fileobj would be closed before the GzipFile as the result of a
         # reference loop. See issue gh-129726
         with catch_unraisable_exception() as cm:
-            gzip.GzipFile(fileobj=io.BytesIO(), mode="w")
-            gc.collect()
-            self.assertIsNone(cm.unraisable)
+            with self.assertWarns(ResourceWarning):
+                gzip.GzipFile(fileobj=io.BytesIO(), mode="w")
+                gc.collect()
+                self.assertIsNone(cm.unraisable)
 
 
 class TestOpen(BaseTest):

--- a/Misc/NEWS.d/next/Library/2025-03-05-20-02-21.gh-issue-130806.o0l2FJ.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-05-20-02-21.gh-issue-130806.o0l2FJ.rst
@@ -1,0 +1,2 @@
+Deleting :class:`gzip.GzipFile` before it is closed now emits a
+:exc:`ResourceWarning`.


### PR DESCRIPTION
This may indicate accidental data loss, the `crc` and `size` fields of the GzipFile are only written on close.

Ways to make sure all data is written:
1. Use the [file-like object](https://docs.python.org/3/glossary.html#term-file-object) as a [“With Statement Context Manager”](https://docs.python.org/3/reference/datamodel.html#context-managers).
   - All objects which [inherit](https://docs.python.org/3/tutorial/classes.html#inheritance) from [IOBase](https://docs.python.org/3/library/io.html#io.IOBase) support this.
   - [`BufferedIOBase`](https://docs.python.org/3/library/io.html#io.BufferedIOBase), [`BufferedWriter`](https://docs.python.org/3/library/io.html#io.BufferedWriter), and [`GzipFile`](https://docs.python.org/3/library/gzip.html#gzip.GzipFile) all support this.
   - Ensures `.close()` is called in both exception and regular cases.
1. Ensure [`.close()`](https://docs.python.org/3/library/io.html#io.IOBase.close) is always called which flushes data before closing.
1. If the underlying stream needs to be kept open, use [`.detach()`](https://docs.python.org/3/library/io.html#io.BufferedIOBase.detach)

Since at least 3.12 flushing has been necessary in GzipFile (see gh-105808 which was a release blocker), this makes that more visible. Users have been encountering as they upgrade to 3.12 (ex. gh-129726).

<!-- gh-issue-number: gh-130806 -->
* Issue: gh-130806
<!-- /gh-issue-number -->
