### PR TITLE
gh-130917: update timer and workload in test_signal

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -838,11 +838,11 @@ class ItimerTest(unittest.TestCase):
     def test_itimer_virtual(self):
         self.itimer = signal.ITIMER_VIRTUAL
         signal.signal(signal.SIGVTALRM, self.sig_vtalrm)
-        signal.setitimer(self.itimer, 0.3, 0.2)
+        signal.setitimer(self.itimer, 0.001, 0.001)
 
         for _ in support.busy_retry(support.LONG_TIMEOUT):
             # use up some virtual time by doing real work
-            _ = sum(i * i for i in range(10**5))
+            _ = pow(12345, 67890, 10000019)
             if signal.getitimer(self.itimer) == (0.0, 0.0):
                 # sig_vtalrm handler stopped this itimer
                 break
@@ -859,7 +859,7 @@ class ItimerTest(unittest.TestCase):
 
         for _ in support.busy_retry(support.LONG_TIMEOUT):
             # do some work
-            _ = sum(i * i for i in range(10**5))
+            _ = pow(12345, 67890, 10000019)
             if signal.getitimer(self.itimer) == (0.0, 0.0):
                 # sig_prof handler stopped this itimer
                 break

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -842,7 +842,7 @@ class ItimerTest(unittest.TestCase):
 
         for _ in support.busy_retry(support.LONG_TIMEOUT):
             # use up some virtual time by doing real work
-            _ = pow(12345, 67890, 10000019)
+            _ = sum(i * i for i in range(10**5))
             if signal.getitimer(self.itimer) == (0.0, 0.0):
                 # sig_vtalrm handler stopped this itimer
                 break
@@ -859,7 +859,7 @@ class ItimerTest(unittest.TestCase):
 
         for _ in support.busy_retry(support.LONG_TIMEOUT):
             # do some work
-            _ = pow(12345, 67890, 10000019)
+            _ = sum(i * i for i in range(10**5))
             if signal.getitimer(self.itimer) == (0.0, 0.0):
                 # sig_prof handler stopped this itimer
                 break


### PR DESCRIPTION
The workload to advance the virtual timeout is too lightweight for some platforms. As result the test goes in timeout as it never reaches the end of the timer.
By having a heavier workload and a shorter timer value, the virtual timer reaches the end rapidly and the SIGVTALRM is sent before the test LONG_TIMEOUT.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130917 -->
* Issue: gh-130917
<!-- /gh-issue-number -->
