### PR TITLE
gh-130902 Add optional socket shutdown to close method of HTTPConnection class in http/client.py

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1492,7 +1492,7 @@ to sockets.
    operations on the socket object will fail. The remote end will receive no more data 
    (after queued data is flushed).
 
-   If the `shutdown` parameter is set to ``True``, the socket will first be 
+   If the ``shutdown`` parameter is set to ``True``, the socket will first be 
    shut down before closing, ensuring that no further data can be sent or received. 
    This is useful for properly releasing resources and preventing issues like lingering 
    connections or reset by peer (RST) errors in some network conditions. If the parameter is
@@ -1503,7 +1503,7 @@ to sockets.
    :keyword:`with` statement around them.
 
    .. versionadded:: 3.14
-      Added an optional `shutdown` parameter to allow explicit socket shutdown before closing.
+      Added an optional ``shutdown`` parameter to allow explicit socket shutdown before closing.
 
    .. versionchanged:: 3.6
       :exc:`OSError` is now raised if an error occurs when the underlying

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1512,8 +1512,9 @@ to sockets.
    .. note::
 
       :meth:`close` releases the resource associated with a connection 
-      but does not necessarily close the connection immediately. If you want to close the connection in a timely fashion,        call :meth:`shutdown` before :meth:`close`, or use this function with the shutdown parameter like this
-      ``socket.close(shutdown=True)``
+      but does not necessarily close the connection immediately. If you want to close the connection in a 
+      timely fashion, call :meth:`shutdown` before :meth:`close`, or
+      use this function with the shutdown parameter like this ``socket.close(shutdown=True)``
 
 
 .. method:: socket.connect(address)

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1489,17 +1489,17 @@ to sockets.
 
    Mark the socket closed. The underlying system resource (e.g., a file descriptor) is also
    closed when all file objects from :meth:`makefile` are closed. Once that happens, all future
-   operations on the socket object will fail. The remote end will receive no more data 
+   operations on the socket object will fail. The remote end will receive no more data
    (after queued data is flushed).
 
-   If the ``shutdown`` parameter is set to ``True``, the socket will first be 
-   shut down before closing, ensuring that no further data can be sent or received. 
-   This is useful for properly releasing resources and preventing issues like lingering 
+   If the ``shutdown`` parameter is set to ``True``, the socket will first be
+   shut down before closing, ensuring that no further data can be sent or received.
+   This is useful for properly releasing resources and preventing issues like lingering
    connections or reset by peer (RST) errors in some network conditions. If the parameter is
    ommited or set to false, the function will continue its normal behavior
 
-   Sockets are automatically closed when they are garbage-collected, but 
-   it is recommended to :meth:`close` them explicitly, or to use a 
+   Sockets are automatically closed when they are garbage-collected, but
+   it is recommended to :meth:`close` them explicitly, or to use a
    :keyword:`with` statement around them.
 
    .. versionadded:: 3.14
@@ -1511,8 +1511,8 @@ to sockets.
 
    .. note::
 
-      :meth:`close` releases the resource associated with a connection 
-      but does not necessarily close the connection immediately. If you want to close the connection in a 
+      :meth:`close` releases the resource associated with a connection
+      but does not necessarily close the connection immediately. If you want to close the connection in a
       timely fashion, call :meth:`shutdown` before :meth:`close`, or
       use this function with the shutdown parameter like this ``socket.close(shutdown=True)``
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1513,7 +1513,7 @@ to sockets.
 
       :meth:`close` releases the resource associated with a connection 
       but does not necessarily close the connection immediately. If you want to close the connection in a timely fashion,        call :meth:`shutdown` before :meth:`close`, or use this function with the shutdown parameter like this
-      ``socket.close(shutdown=True)
+      ``socket.close(shutdown=True)``
 
 
 .. method:: socket.connect(address)

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1494,7 +1494,7 @@ to sockets.
 
    If the ``shutdown`` parameter is set to ``True``, the socket will first be
    shut down before closing, ensuring that no further data can be sent or received.
-   This is useful for properly releasing resources and preventing issues like lingering
+   This is useful for properly releasing resources and preventing issues like persistent
    connections or reset by peer (RST) errors in some network conditions. If the parameter is
    ommited or set to false, the function will continue its normal behavior
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -1485,17 +1485,25 @@ to sockets.
    .. availability:: not WASI.
 
 
-.. method:: socket.close()
+.. method:: socket.close(shutdown=False)
 
-   Mark the socket closed.  The underlying system resource (e.g. a file
-   descriptor) is also closed when all file objects from :meth:`makefile`
-   are closed.  Once that happens, all future operations on the socket
-   object will fail. The remote end will receive no more data (after
-   queued data is flushed).
+   Mark the socket closed. The underlying system resource (e.g., a file descriptor) is also
+   closed when all file objects from :meth:`makefile` are closed. Once that happens, all future
+   operations on the socket object will fail. The remote end will receive no more data 
+   (after queued data is flushed).
 
-   Sockets are automatically closed when they are garbage-collected, but
-   it is recommended to :meth:`close` them explicitly, or to use a
+   If the `shutdown` parameter is set to ``True``, the socket will first be 
+   shut down before closing, ensuring that no further data can be sent or received. 
+   This is useful for properly releasing resources and preventing issues like lingering 
+   connections or reset by peer (RST) errors in some network conditions. If the parameter is
+   ommited or set to false, the function will continue its normal behavior
+
+   Sockets are automatically closed when they are garbage-collected, but 
+   it is recommended to :meth:`close` them explicitly, or to use a 
    :keyword:`with` statement around them.
+
+   .. versionadded:: 3.14
+      Added an optional `shutdown` parameter to allow explicit socket shutdown before closing.
 
    .. versionchanged:: 3.6
       :exc:`OSError` is now raised if an error occurs when the underlying
@@ -1503,10 +1511,9 @@ to sockets.
 
    .. note::
 
-      :meth:`close` releases the resource associated with a connection but
-      does not necessarily close the connection immediately.  If you want
-      to close the connection in a timely fashion, call :meth:`shutdown`
-      before :meth:`close`.
+      :meth:`close` releases the resource associated with a connection 
+      but does not necessarily close the connection immediately. If you want to close the connection in a timely fashion,        call :meth:`shutdown` before :meth:`close`, or use this function with the shutdown parameter like this
+      ``socket.close(shutdown=True)
 
 
 .. method:: socket.connect(address)

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1040,8 +1040,7 @@ class HTTPConnection:
                 except OSError as e:
                     print(f"Response close error: {e}", file=sys.stderr)
                 except Exception as e:
-                    print(f"Unexpected error during response close: {e}", file=sys.stderr)
-    
+                    print(f"Unexpected error during response close: {e}", file=sys.stderr)    
     def send(self, data):
         """Send 'data' to the server.
         ``data`` can be a string object, a bytes object, an array object, a

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1013,6 +1013,10 @@ class HTTPConnection:
             self._tunnel()
 
     def close(self, shutdown=False):
+        """Close the connection to the HTTP server.
+        :param shutdown: If True, perform an explicit shutdown of the socket before closing. Defaults to False.
+        :type shutdown: bool, optional
+        """
         self.__state = _CS_IDLE
         try:
             sock = self.sock

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1040,7 +1040,8 @@ class HTTPConnection:
                 except OSError as e:
                     print(f"Response close error: {e}", file=sys.stderr)
                 except Exception as e:
-                    print(f"Unexpected error during response close: {e}", file=sys.stderr)    
+                    print(f"Unexpected error during response close: {e}", file=sys.stderr)
+                    
     def send(self, data):
         """Send 'data' to the server.
         ``data`` can be a string object, a bytes object, an array object, a

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1042,8 +1042,6 @@ class HTTPConnection:
                 except Exception as e:
                     print(f"Unexpected error during response close: {e}", file=sys.stderr)
     
-
-
     def send(self, data):
         """Send 'data' to the server.
         ``data`` can be a string object, a bytes object, an array object, a

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1041,7 +1041,7 @@ class HTTPConnection:
                     print(f"Response close error: {e}", file=sys.stderr)
                 except Exception as e:
                     print(f"Unexpected error during response close: {e}", file=sys.stderr)
-                    
+
     def send(self, data):
         """Send 'data' to the server.
         ``data`` can be a string object, a bytes object, an array object, a

--- a/Misc/NEWS.d/next/Library/2025-03-06-16-31-08.gh-issue-130902.mHAtcq.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-06-16-31-08.gh-issue-130902.mHAtcq.rst
@@ -1,4 +1,4 @@
 Issue: :gh:`130902`
 
 
-Modifies the ``HTTPConnection.close`` of ``HTTPConnection`` to include an optional socket ``shutdown``, improving functionality with error handling.
+Modifies the :meth:`http.client.HTTPConnection.close` of :class:`http.client.HTTPConnection` to include an optional socket ``shutdown``, improving functionality with error handling.

--- a/Misc/NEWS.d/next/Library/2025-03-06-16-31-08.gh-issue-130902.mHAtcq.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-06-16-31-08.gh-issue-130902.mHAtcq.rst
@@ -1,4 +1,4 @@
 Issue: :gh:`130902`
 
 
-Modifies the :func:`HTTPConnection.close` of :class:`HTTPConnection` to include an optional socket ``shutdown``, improving functionality with error handling.
+Modifies the ``HTTPConnection.close`` of ``HTTPConnection`` to include an optional socket ``shutdown``, improving functionality with error handling.

--- a/Misc/NEWS.d/next/Library/2025-03-06-16-31-08.gh-issue-130902.mHAtcq.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-06-16-31-08.gh-issue-130902.mHAtcq.rst
@@ -1,4 +1,4 @@
 Issue: :gh:`130902`
 
 
-Modified close(self) method of HTTPConnection class to include an optional socket shutdown similar to gh-130850. Includes error handling. As mentioned, it adds an optional shutdown param to the close method, keeping existing programs working, but adding an extra feature to new programs that offers improvements.
+Modifies the :func:`HTTPConnection.close` of :class:`HTTPConnection` to include an optional socket ``shutdown``, improving functionality with error handling.

--- a/Misc/NEWS.d/next/Library/2025-03-06-16-31-08.gh-issue-130902.mHAtcq.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-06-16-31-08.gh-issue-130902.mHAtcq.rst
@@ -1,0 +1,4 @@
+Issue: :gh:`130902`
+
+
+Modified close(self) method of HTTPConnection class to include an optional socket shutdown similar to gh-130850. Includes error handling. As mentioned, it adds an optional shutdown param to the close method, keeping existing programs working, but adding an extra feature to new programs that offers improvements.


### PR DESCRIPTION
Similar to gh-130862 but for http library

This pr will close #130902 

Overview:
Based on #130902, I added an optional socket shutdown to HTTPConnection.close. The modified function, HTTPConnection.close has a new optional shutdown parameter defaulted to false.

Original function:

```python
  def close(self):
      """Close the connection to the HTTP server."""
      self.__state = _CS_IDLE
      try:
          sock = self.sock
          if sock:
              self.sock = None
              sock.close()   # close it manually... there may be other refs
      finally:
          response = self.__response
          if response:
              self.__response = None
              response.close()
```

Refactored function:

```python
def close(self, shutdown=False):
        self.__state = _CS_IDLE
        try:
            sock = self.sock
            if sock:
                self.sock = None
                if shutdown:
                    try:
                        sock.shutdown(socket.SHUT_RDWR)
                    except OSError as e:
                        print(f"Socket shutdown error: {e}", file=sys.stderr)
                    except Exception as e:
                        print(f"Unexpected error during socket shutdown: {e}", file=sys.stderr)
                try:
                    sock.close()
                except OSError as e:
                    print(f"Socket close error: {e}", file=sys.stderr)
                except Exception as e:
                    print(f"Unexpected error during socket close: {e}", file=sys.stderr)
        finally:
            response = self.__response
            if response:
                self.__response = None
                try:
                    response.close()
                except OSError as e:
                    print(f"Response close error: {e}", file=sys.stderr)
                except Exception as e:
                    print(f"Unexpected error during response close: {e}", file=sys.stderr)
```

This new change has some benefits such as:
- Ensures that all pending data is properly discarded before closing, particularly in scenarios where data might still be buffered.
- Prevents potential issues with lingering resources in some edge cases.
- Aligns with best practices for socket cleanup.
- Can help avoid RST (reset by peer) issues in some network conditions.

View #130902 for more information

I tested it against a custom test script:

```python
import sys
from unittest.mock import MagicMock
from http.client import HTTPConnection  # Replace with the actual module name
from io import StringIO

def test_close_with_shutdown():
    # Create a mock socket object
    mock_socket = MagicMock()
    mock_socket.close = MagicMock()
    mock_socket.shutdown = MagicMock()

    # Instantiate the HTTPConnection object
    connection = HTTPConnection('www.example.com')
    connection.sock = mock_socket

    # Redirect stderr to capture error messages
    original_stderr = sys.stderr
    sys.stderr = StringIO()

    try:
        # Call the close method with shutdown=True
        connection.close(shutdown=True)

        # Check that shutdown and close were called
        mock_socket.shutdown.assert_called_once_with(2)  # SHUT_RDWR
        mock_socket.close.assert_called_once()

        # Check that no error messages were written to stderr
        error_output = sys.stderr.getvalue()
        assert not error_output, f"Error messages were written to stderr: {error_output}"

    finally:
        # Restore original stderr
        sys.stderr = original_stderr

def test_close_without_shutdown():
    # Create a mock socket object
    mock_socket = MagicMock()
    mock_socket.close = MagicMock()
    mock_socket.shutdown = MagicMock()

    # Instantiate the HTTPConnection object
    connection = HTTPConnection('www.example.com')
    connection.sock = mock_socket

    # Redirect stderr to capture error messages
    original_stderr = sys.stderr
    sys.stderr = StringIO()

    try:
        # Call the close method with shutdown=False
        connection.close(shutdown=False)

        # Check that shutdown was not called, but close was
        mock_socket.shutdown.assert_not_called()
        mock_socket.close.assert_called_once()

        # Check that no error messages were written to stderr
        error_output = sys.stderr.getvalue()
        assert not error_output, f"Error messages were written to stderr: {error_output}"

    finally:
        # Restore original stderr
        sys.stderr = original_stderr

def test_close_shutdown_error():
    # Create a mock socket object that raises an OSError on shutdown
    mock_socket = MagicMock()
    mock_socket.close = MagicMock()
    mock_socket.shutdown = MagicMock(side_effect=OSError("Shutdown error"))

    # Instantiate the HTTPConnection object
    connection = HTTPConnection('www.example.com')
    connection.sock = mock_socket

    # Redirect stderr to capture error messages
    original_stderr = sys.stderr
    sys.stderr = StringIO()

    try:
        # Call the close method with shutdown=True
        connection.close(shutdown=True)

        # Check that shutdown and close were called
        mock_socket.shutdown.assert_called_once_with(2)  # SHUT_RDWR
        mock_socket.close.assert_called_once()

        # Check that the error message was written to stderr
        error_output = sys.stderr.getvalue()
        assert "Socket shutdown error: Shutdown error" in error_output, f"Expected error message not found: {error_output}"

    finally:
        # Restore original stderr
        sys.stderr = original_stderr

def test_close_unexpected_error():
    # Create a mock socket object that raises an unexpected exception on shutdown
    mock_socket = MagicMock()
    mock_socket.close = MagicMock()
    mock_socket.shutdown = MagicMock(side_effect=Exception("Unexpected error"))

    # Instantiate the HTTPConnection object
    connection = HTTPConnection('www.example.com')
    connection.sock = mock_socket

    # Redirect stderr to capture error messages
    original_stderr = sys.stderr
    sys.stderr = StringIO()

    try:
        # Call the close method with shutdown=True
        connection.close(shutdown=True)

        # Check that shutdown and close were called
        mock_socket.shutdown.assert_called_once_with(2)  # SHUT_RDWR
        mock_socket.close.assert_called_once()

        # Check that the error message was written to stderr
        error_output = sys.stderr.getvalue()
        assert "Unexpected error during socket shutdown: Unexpected error" in error_output, f"Expected error message not found: {error_output}"

    finally:
        # Restore original stderr
        sys.stderr = original_stderr

if __name__ == '__main__':
    test_close_with_shutdown()
    test_close_without_shutdown()
    test_close_shutdown_error()
    test_close_unexpected_error()
    print("All tests passed.")
```
And it passed successfully:

```shell
PS C:\Users\---\Documents\GitHub\cpython> .\PCbuild\amd64\python_d.exe test.py
All tests passed.
PS C:\Users\---\Documents\GitHub\cpython> 
```


<!-- gh-issue-number: gh-130902 -->
* Issue: gh-130902
<!-- /gh-issue-number -->
