### PR TITLE
gh-118331: Fix `test_list.ListTest.test_no_memory` under trace refs build

### DIFF
--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -1,3 +1,4 @@
+import signal
 import sys
 import textwrap
 from test import list_tests, support
@@ -324,8 +325,12 @@ class ListTest(list_tests.CommonTest):
         _testcapi.set_nomemory(0)
         l = [None]
         """)
-        _, _, err = assert_python_failure("-c", code)
-        self.assertIn("MemoryError", err.decode("utf-8"))
+        rc, _, _ = assert_python_failure("-c", code)
+        if support.MS_WINDOWS:
+            # STATUS_ACCESS_VIOLATION
+            self.assertNotEqual(rc, 0xC0000005)
+        else:
+            self.assertNotEqual(rc, -int(signal.SIGSEGV))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Memory allocation ends up failing in _PyRefchainTrace(), which produces different output. Assert that we don't segfault, which is the thing we want to test and is less brittle than checking output.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118331 -->
* Issue: gh-118331
<!-- /gh-issue-number -->
