### PR TITLE
gh-130920: Fix data race in STORE_SUBSCR_LIST_INT

### DIFF
--- a/Lib/test/test_free_threading/test_list.py
+++ b/Lib/test/test_free_threading/test_list.py
@@ -1,6 +1,6 @@
 import unittest
 
-from threading import Thread
+from threading import Thread, Barrier
 from unittest import TestCase
 
 from test.support import threading_helper
@@ -70,6 +70,20 @@ class TestList(TestCase):
         writer.join()
         for reader in readers:
             reader.join()
+
+    def test_store_list_int(self):
+        def copy_back_and_forth(b, l):
+            b.wait()
+            for _ in range(100):
+                l[0] = l[1]
+                l[1] = l[0]
+
+        l = [0, 1]
+        barrier = Barrier(NTHREAD)
+        threads = [Thread(target=copy_back_and_forth, args=(barrier, l))
+                   for _ in range(NTHREAD)]
+        with threading_helper.start_threads(threads):
+            pass
 
 
 if __name__ == "__main__":

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -1015,7 +1015,8 @@ dummy_func(
             STAT_INC(STORE_SUBSCR, hit);
 
             PyObject *old_value = PyList_GET_ITEM(list, index);
-            PyList_SET_ITEM(list, index, PyStackRef_AsPyObjectSteal(value));
+            FT_ATOMIC_STORE_PTR_RELEASE(_PyList_ITEMS(list)[index],
+                                        PyStackRef_AsPyObjectSteal(value));
             assert(old_value != NULL);
             UNLOCK_OBJECT(list);  // unlock before decrefs!
             PyStackRef_CLOSE_SPECIALIZED(sub_st, _PyLong_ExactDealloc);

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1522,7 +1522,8 @@
             }
             STAT_INC(STORE_SUBSCR, hit);
             PyObject *old_value = PyList_GET_ITEM(list, index);
-            PyList_SET_ITEM(list, index, PyStackRef_AsPyObjectSteal(value));
+            FT_ATOMIC_STORE_PTR_RELEASE(_PyList_ITEMS(list)[index],
+                                        PyStackRef_AsPyObjectSteal(value));
             assert(old_value != NULL);
             UNLOCK_OBJECT(list);  // unlock before decrefs!
             PyStackRef_CLOSE_SPECIALIZED(sub_st, _PyLong_ExactDealloc);

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -11259,7 +11259,8 @@
             }
             STAT_INC(STORE_SUBSCR, hit);
             PyObject *old_value = PyList_GET_ITEM(list, index);
-            PyList_SET_ITEM(list, index, PyStackRef_AsPyObjectSteal(value));
+            FT_ATOMIC_STORE_PTR_RELEASE(_PyList_ITEMS(list)[index],
+                                        PyStackRef_AsPyObjectSteal(value));
             assert(old_value != NULL);
             UNLOCK_OBJECT(list);  // unlock before decrefs!
             PyStackRef_CLOSE_SPECIALIZED(sub_st, _PyLong_ExactDealloc);


### PR DESCRIPTION
The write of the item to the list needs to use an atomic operation in the free threading build.


<!-- gh-issue-number: gh-130920 -->
* Issue: gh-130920
<!-- /gh-issue-number -->
