### PR TITLE
gh-130932: Fix incorrect exception handling in _PyModule_IsPossiblyShadowing

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -1185,6 +1185,27 @@ except ImportError as e:
             for line in lines:
                 self.assertRegex(line, rb"cannot import name 'Fraction' from 'fractions' \(.*\)")
 
+    def test_script_shadowing_stdlib_cwd_failure(self):
+        with os_helper.temp_dir() as tmp:
+            subtmp = os.path.join(tmp, "subtmp")
+            os.mkdir(subtmp)
+            with open(os.path.join(subtmp, "main.py"), "w", encoding='utf-8') as f:
+                f.write(f"""
+import sys
+assert sys.path[0] == ''
+
+import os
+import shutil
+shutil.rmtree(os.getcwd())
+
+os.does_not_exist
+""")
+            # Use -c to ensure sys.path[0] is ""
+            popen = script_helper.spawn_python("-c", "import main", cwd=subtmp)
+            stdout, stderr = popen.communicate()
+            expected_error = rb"AttributeError: module 'os' has no attribute 'does_not_exist'"
+            self.assertRegex(stdout, expected_error)
+
     def test_script_shadowing_stdlib_sys_path_modification(self):
         script_errors = [
             (

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -1185,6 +1185,7 @@ except ImportError as e:
             for line in lines:
                 self.assertRegex(line, rb"cannot import name 'Fraction' from 'fractions' \(.*\)")
 
+    @unittest.skipIf(sys.platform == 'win32', 'Cannot delete cwd on Windows')
     def test_script_shadowing_stdlib_cwd_failure(self):
         with os_helper.temp_dir() as tmp:
             subtmp = os.path.join(tmp, "subtmp")

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-06-22-56-02.gh-issue-130932.QVHaKT.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-06-22-56-02.gh-issue-130932.QVHaKT.rst
@@ -1,0 +1,1 @@
+Fix incorrect exception handling in ``_PyModule_IsPossiblyShadowing``

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -921,7 +921,9 @@ _PyModule_IsPossiblyShadowing(PyObject *origin)
     if (sys_path_0[0] == L'\0') {
         // if sys.path[0] == "", treat it as if it were the current directory
         if (!_Py_wgetcwd(sys_path_0_buf, MAXPATHLEN)) {
-            return -1;
+            // If we failed to getcwd, don't raise an exception and instead
+            // let the caller proceed assuming no shadowing
+            return 0;
         }
         sys_path_0 = sys_path_0_buf;
     }


### PR DESCRIPTION
Without the change in moduleobject.c, we sometimes end up returning NULL from `_Py_module_getattro_impl` without an exception raised.
```
./python.exe -m unittest test.test_import.ImportTests.test_script_shadowing_stdlib_cwd_failure
...
Assertion failed: (PyErr_Occurred()), function _PyObject_SetAttributeErrorContext, file object.c, line 1253.
```

I chose to not raise an exception here because I think it would be confusing for module attribute access to start raising something other than AttributeError if e.g. the cwd goes away

<!-- gh-issue-number: gh-130932 -->
* Issue: gh-130932
<!-- /gh-issue-number -->
