### PR TITLE
gh-130941: Fix `configparser` parsing values with `allow_no_value` and `interpolation` set

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -541,7 +541,7 @@ class ExtendedInterpolation(Interpolation):
                 except (KeyError, NoSectionError, NoOptionError):
                     raise InterpolationMissingOptionError(
                         option, section, rawval, ":".join(path)) from None
-                if not v:
+                if v is None:
                     continue
                 if "$" in v:
                     self._interpolate_some(parser, opt, accum, v, sect,

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -541,6 +541,8 @@ class ExtendedInterpolation(Interpolation):
                 except (KeyError, NoSectionError, NoOptionError):
                     raise InterpolationMissingOptionError(
                         option, section, rawval, ":".join(path)) from None
+                if not v:
+                    continue
                 if "$" in v:
                     self._interpolate_some(parser, opt, accum, v, sect,
                                            dict(parser.items(sect, raw=True)),

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -1328,9 +1328,9 @@ class ConfigParserTestCaseNoValue(ConfigParserTestCase):
     allow_no_value = True
 
 
-class ConfigParserTestCaseNoValueAndInterpolation(ConfigParserTestCase):
-    allow_no_value = True
+class NoValueAndExtendedInterpolation(CfgParserTestCaseClass):
     interpolation = configparser.ExtendedInterpolation()
+    allow_no_value = True
 
     def test_interpolation_with_allow_no_value(self):
         config = textwrap.dedent("""
@@ -1342,6 +1342,31 @@ class ConfigParserTestCaseNoValueAndInterpolation(ConfigParserTestCase):
 
         self.assertIs(cf["dummy"]["a"], None)
         self.assertEqual(cf["dummy"]["b"], "")
+
+    def test_explicit_none(self):
+        config = textwrap.dedent("""
+            [dummy]
+            a = None
+            b = ${a}
+        """)
+        cf = self.fromstring(config)
+
+        self.assertEqual(cf["dummy"]["a"], "None")
+        self.assertEqual(cf["dummy"]["b"], "None")
+
+
+class ConfigParserNoValueAndExtendedInterpolationTest(
+    NoValueAndExtendedInterpolation,
+    unittest.TestCase,
+):
+    config_class = configparser.ConfigParser
+
+
+class RawConfigParserNoValueAndExtendedInterpolationTest(
+    NoValueAndExtendedInterpolation,
+    unittest.TestCase,
+):
+    config_class = configparser.RawConfigParser
 
 
 class ConfigParserTestCaseTrickyFile(CfgParserTestCaseClass, unittest.TestCase):

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -1328,6 +1328,22 @@ class ConfigParserTestCaseNoValue(ConfigParserTestCase):
     allow_no_value = True
 
 
+class ConfigParserTestCaseNoValueAndInterpolation(ConfigParserTestCase):
+    allow_no_value = True
+    interpolation = configparser.ExtendedInterpolation()
+
+    def test_interpolation_with_allow_no_value(self):
+        config = textwrap.dedent("""
+            [dummy]
+            a
+            b = ${a}
+        """)
+        cf = self.fromstring(config)
+
+        self.assertIs(cf["dummy"]["a"], None)
+        self.assertEqual(cf["dummy"]["b"], "")
+
+
 class ConfigParserTestCaseTrickyFile(CfgParserTestCaseClass, unittest.TestCase):
     config_class = configparser.ConfigParser
     delimiters = {'='}

--- a/Misc/NEWS.d/next/Library/2025-03-07-17-47-32.gh-issue-130941.7_GvhW.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-07-17-47-32.gh-issue-130941.7_GvhW.rst
@@ -1,0 +1,2 @@
+Fix :class:`configparser.ConfigParser` parsing empty interpolation with
+``allow_no_value`` set to ``True``.


### PR DESCRIPTION


<!-- gh-issue-number: gh-130941 -->
* Issue: gh-130941
<!-- /gh-issue-number -->
