### PR TITLE
gh-130957: Use `sleeping_retry` in `test_free_reference`

### DIFF
--- a/Lib/test/test_concurrent_futures/executor.py
+++ b/Lib/test/test_concurrent_futures/executor.py
@@ -129,4 +129,7 @@ class ExecutorTest:
             wr = weakref.ref(obj)
             del obj
             support.gc_collect()  # For PyPy or other GCs.
-            self.assertIsNone(wr())
+
+            for _ in support.sleeping_retry(support.SHORT_TIMEOUT):
+                if wr() is None:
+                    break


### PR DESCRIPTION
The weak reference may not be immediately dead.


<!-- gh-issue-number: gh-130957 -->
* Issue: gh-130957
<!-- /gh-issue-number -->
