### PR TITLE
gh-130959: Reject whitespace in fractions, in pure Python `fromisoformat()`

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -436,6 +436,8 @@ def _parse_hh_mm_ss_ff(tstr):
             raise ValueError("Invalid microsecond separator")
         else:
             pos += 1
+            if not all(map(_is_ascii_digit, tstr[pos:])):
+                raise ValueError("Non-digit values in fraction")
 
             len_remainder = len_str - pos
 
@@ -447,9 +449,6 @@ def _parse_hh_mm_ss_ff(tstr):
             time_comps[3] = int(tstr[pos:(pos+to_parse)])
             if to_parse < 6:
                 time_comps[3] *= _FRACTION_CORRECTION[to_parse-1]
-            if (len_remainder > to_parse
-                    and not all(map(_is_ascii_digit, tstr[(pos+to_parse):]))):
-                raise ValueError("Non-digit values in unparsed fraction")
 
     return time_comps
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -3556,6 +3556,9 @@ class TestDateTime(TestDate):
             '9999-12-31T24:00:00.000000',  # Year is invalid after wrapping due to 24:00
             '2009-04-19T12:30Z12:00',      # Extra time zone info after Z
             '2009-04-19T12:30:45:334034',  # Invalid microsecond separator
+            '2009-04-19T12:30:45.400 +02:30',  # Space between ms and timezone (gh-130959)
+            '2009-04-19T12:30:45.400 ',        # Trailing space (gh-130959)
+            '2009-04-19T12:30:45. 400',        # Space before fraction (gh-130959)
         ]
 
         for bad_str in bad_strs:
@@ -4773,6 +4776,9 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
             '12:30,5',                  # Decimal mark at end of minute
             '12:30:45.123456Z12:00',    # Extra time zone info after Z
             '12:30:45:334034',          # Invalid microsecond separator
+            '12:30:45.400 +02:30',      # Space between ms and timezone (gh-130959)
+            '12:30:45.400 ',            # Trailing space (gh-130959)
+            '12:30:45. 400',            # Space before fraction (gh-130959)
         ]
 
         for bad_str in bad_strs:

--- a/Misc/NEWS.d/next/Library/2025-03-07-19-24-27.gh-issue-130959.xO8vVS.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-07-19-24-27.gh-issue-130959.xO8vVS.rst
@@ -1,3 +1,3 @@
-Fix pure Python implementation of ``time.fromisoformat()`` to reject times
+Fix pure-Python implementation of :func:`time.fromisoformat` to reject times
 with spaces in fractional part (for example, ``12:34:56.400 +02:00``), matching
-the C implementation.
+the C implementation. Patch by Michał Gorny.

--- a/Misc/NEWS.d/next/Library/2025-03-07-19-24-27.gh-issue-130959.xO8vVS.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-07-19-24-27.gh-issue-130959.xO8vVS.rst
@@ -1,0 +1,3 @@
+Fix pure Python implementation of ``time.fromisoformat()`` to reject times
+with spaces in fractional part (for example, ``12:34:56.400 ``), matching
+the C implementation.

--- a/Misc/NEWS.d/next/Library/2025-03-07-19-24-27.gh-issue-130959.xO8vVS.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-07-19-24-27.gh-issue-130959.xO8vVS.rst
@@ -1,3 +1,3 @@
-Fix pure-Python implementation of :func:`time.fromisoformat` to reject times
-with spaces in fractional part (for example, ``12:34:56.400 +02:00``), matching
-the C implementation. Patch by Michał Gorny.
+Fix pure-Python implementation of :func:`datetime.time.fromisoformat` to reject
+times with spaces in fractional part (for example, ``12:34:56.400 +02:00``),
+matching the C implementation. Patch by Michał Gorny.

--- a/Misc/NEWS.d/next/Library/2025-03-07-19-24-27.gh-issue-130959.xO8vVS.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-07-19-24-27.gh-issue-130959.xO8vVS.rst
@@ -1,3 +1,3 @@
 Fix pure Python implementation of ``time.fromisoformat()`` to reject times
-with spaces in fractional part (for example, ``12:34:56.400 ``), matching
+with spaces in fractional part (for example, ``12:34:56.400 +02:00``), matching
 the C implementation.


### PR DESCRIPTION
Fix the pure Python implementation of `fromisoformat()` to reject any non-digit characters, including whitespace, in the fractional part of time specification.  This makes the behavior consistent with the C implementation, and prevents incorrect parsing of these fractions (e.g. `.400 ` would be misinterpreted as `.04`).

<!-- gh-issue-number: gh-130959 -->
* Issue: gh-130959
<!-- /gh-issue-number -->
