### PR TITLE
GH-128520: pathlib ABCs: fix `with_name()` handling of empty names

### DIFF
--- a/Lib/pathlib/types.py
+++ b/Lib/pathlib/types.py
@@ -133,9 +133,12 @@ class _JoinablePath(ABC):
     def with_name(self, name):
         """Return a new path with the file name changed."""
         split = self.parser.split
-        if split(name)[0]:
+        if not name or split(name)[0]:
             raise ValueError(f"Invalid name {name!r}")
-        return self.with_segments(split(str(self))[0], name)
+        parent, old_name = split(str(self))
+        if not old_name:
+            raise ValueError(f"{self!r} has an empty name")
+        return self.with_segments(parent, name)
 
     def with_stem(self, stem):
         """Return a new path with the stem changed."""

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -413,18 +413,12 @@ class PurePathTest(test_pathlib_abc.JoinablePathTest):
 
     def test_with_name_empty(self):
         P = self.cls
-        self.assertRaises(ValueError, P('').with_name, 'd.xml')
         self.assertRaises(ValueError, P('.').with_name, 'd.xml')
-        self.assertRaises(ValueError, P('/').with_name, 'd.xml')
-        self.assertRaises(ValueError, P('a/b').with_name, '')
         self.assertRaises(ValueError, P('a/b').with_name, '.')
 
     def test_with_stem_empty(self):
         P = self.cls
-        self.assertRaises(ValueError, P('').with_stem, 'd')
         self.assertRaises(ValueError, P('.').with_stem, 'd')
-        self.assertRaises(ValueError, P('/').with_stem, 'd')
-        self.assertRaises(ValueError, P('a/b').with_stem, '')
         self.assertRaises(ValueError, P('a/b').with_stem, '.')
 
     def test_is_reserved_deprecated(self):

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -680,6 +680,9 @@ class JoinablePathTest(unittest.TestCase):
         self.assertEqual(P('/a/b.py').with_name('d.xml'), P('/a/d.xml'))
         self.assertEqual(P('a/Dot ending.').with_name('d.xml'), P('a/d.xml'))
         self.assertEqual(P('/a/Dot ending.').with_name('d.xml'), P('/a/d.xml'))
+        self.assertRaises(ValueError, P('').with_name, 'd.xml')
+        self.assertRaises(ValueError, P('/').with_name, 'd.xml')
+        self.assertRaises(ValueError, P('a/b').with_name, '')
 
     @needs_windows
     def test_with_name_windows(self):
@@ -700,10 +703,7 @@ class JoinablePathTest(unittest.TestCase):
 
     def test_with_name_empty(self):
         P = self.cls
-        self.assertEqual(P('').with_name('d.xml'), P('d.xml'))
         self.assertEqual(P('.').with_name('d.xml'), P('d.xml'))
-        self.assertEqual(P('/').with_name('d.xml'), P('/d.xml'))
-        self.assertEqual(P('a/b').with_name(''), P('a/'))
         self.assertEqual(P('a/b').with_name('.'), P('a/.'))
 
     def test_with_name_seps(self):
@@ -721,6 +721,11 @@ class JoinablePathTest(unittest.TestCase):
         self.assertEqual(P('/a/b.tar.gz').with_stem('d'), P('/a/d.gz'))
         self.assertEqual(P('a/Dot ending.').with_stem('d'), P('a/d.'))
         self.assertEqual(P('/a/Dot ending.').with_stem('d'), P('/a/d.'))
+        self.assertRaises(ValueError, P('').with_stem, 'd')
+        self.assertRaises(ValueError, P('/').with_stem, 'd')
+        self.assertRaises(ValueError, P('a/b').with_stem, '')
+        self.assertRaises(ValueError, P('foo.gz').with_stem, '')
+        self.assertRaises(ValueError, P('/a/b/foo.gz').with_stem, '')
 
     @needs_windows
     def test_with_stem_windows(self):
@@ -741,13 +746,8 @@ class JoinablePathTest(unittest.TestCase):
 
     def test_with_stem_empty(self):
         P = self.cls
-        self.assertEqual(P('').with_stem('d'), P('d'))
         self.assertEqual(P('.').with_stem('d'), P('d'))
-        self.assertEqual(P('/').with_stem('d'), P('/d'))
-        self.assertEqual(P('a/b').with_stem(''), P('a/'))
         self.assertEqual(P('a/b').with_stem('.'), P('a/.'))
-        self.assertRaises(ValueError, P('foo.gz').with_stem, '')
-        self.assertRaises(ValueError, P('/a/b/foo.gz').with_stem, '')
 
     def test_with_stem_seps(self):
         P = self.cls


### PR DESCRIPTION
Raise `ValueError` from `pathlib.types._JoinablePath.with_name()` when given an empty name, or acting upon a path with an empty name. This behaviour matches `pathlib.PurePath.with_name()`.


<!-- gh-issue-number: gh-128520 -->
* Issue: gh-128520
<!-- /gh-issue-number -->
