### PR TITLE
gh-130928: Fix error message during bytes formatting for the 'i' flag

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -5,6 +5,7 @@ the latter should be modernized).
 """
 
 import array
+import operator
 import os
 import re
 import sys
@@ -750,6 +751,8 @@ class BaseBytesTest:
         check(b'%i %*.*b', (10, 5, 3, b'abc',), b'10   abc')
         check(b'%i%b %*.*b', (10, b'3', 5, 3, b'abc',), b'103   abc')
         check(b'%c', b'a', b'a')
+
+        self.assertRaisesRegex(TypeError, '%i format: a real number is required, not complex', operator.mod, '%i', 2j)
 
     def test_imod(self):
         b = self.type2test(b'hello, %b!')

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -753,6 +753,7 @@ class BaseBytesTest:
         check(b'%c', b'a', b'a')
 
         self.assertRaisesRegex(TypeError, '%i format: a real number is required, not complex', operator.mod, '%i', 2j)
+        self.assertRaisesRegex(TypeError, '%d format: a real number is required, not complex', operator.mod, '%d', 2j)
 
     def test_imod(self):
         b = self.type2test(b'hello, %b!')

--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -283,6 +283,10 @@ class FormatTest(unittest.TestCase):
                         "%x format: an integer is required, not str")
         test_exc_common('%x', 3.14, TypeError,
                         "%x format: an integer is required, not float")
+        test_exc_common('%i', '1', TypeError,
+                        "%i format: a real number is required, not str")
+        test_exc_common('%i', b'1', TypeError,
+                        "%i format: a real number is required, not bytes")
 
     def test_str_format(self):
         testformat("%r", "\u0378", "'\\u0378'")  # non printable

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-09-09-03-24.gh-issue-130928.gP1yKv.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-09-09-03-24.gh-issue-130928.gP1yKv.rst
@@ -1,0 +1,2 @@
+Fix error message when formatting bytes using the ``'i'`` flag.
+Patch by Maxim Ageev.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -468,8 +468,6 @@ static PyObject *
 formatlong(PyObject *v, int flags, int prec, int type)
 {
     PyObject *result, *iobj;
-    if (type == 'i')
-        type = 'd';
     if (PyLong_Check(v))
         return _PyUnicode_FormatLong(v, flags & F_ALT, prec, type);
     if (PyNumber_Check(v)) {


### PR DESCRIPTION
Error output before correction:
```python
>>> b"%i" % "str"
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    b"%i" % "str"
    ~~~~~~^~~~~~~
TypeError: %d format: a real number is required, not str
```

Error output after correction:
```python
>>> b"%i" % "str"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    b"%i" % "str"
    ~~~~~~^~~~~~~
TypeError: %i format: a real number is required, not str
```


<!-- gh-issue-number: gh-130928 -->
* Issue: gh-130928
<!-- /gh-issue-number -->
