### PR TITLE
gh-130973: Add missing options at doc for `pickletools`

### DIFF
--- a/Doc/library/pickletools.rst
+++ b/Doc/library/pickletools.rst
@@ -75,6 +75,14 @@ Command line options
    When more than one pickle file are specified, print given preamble
    before each disassembly.
 
+.. option:: -t, --test
+
+   Run self-test suite.
+
+.. option:: -v
+
+   Run verbosely; only affects self-test run.
+
 
 
 Programmatic Interface


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Add missing options `-t` and `-v` at doc for `pickletools`


<!-- gh-issue-number: gh-130973 -->
* Issue: gh-130973
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130974.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->