### PR TITLE
Mention the "context manager" keyword in concurrent.futures documentation

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -94,10 +94,10 @@ Executor Objects
       executor has started running will be completed prior to this method
       returning. The remaining futures are cancelled.
 
-      You can avoid having to call this method explicitly if you use the
-      :keyword:`with` statement, which will shutdown the :class:`Executor`
-      (waiting as if :meth:`Executor.shutdown` were called with *wait* set to
-      ``True``)::
+      You can avoid having to call this method explicitly if you use the executor
+      as a :term:`context manager` via the  :keyword:`with` statement,
+      which will shutdown the :class:`Executor` (waiting as if
+      :meth:`Executor.shutdown` were called with *wait* set to ``True``)::
 
          import shutil
          with ThreadPoolExecutor(max_workers=4) as e:

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -95,9 +95,9 @@ Executor Objects
       returning. The remaining futures are cancelled.
 
       You can avoid having to call this method explicitly if you use the executor
-      as a :term:`context manager` via the  :keyword:`with` statement,
-      which will shutdown the :class:`Executor` (waiting as if
-      :meth:`Executor.shutdown` were called with *wait* set to ``True``)::
+      as a :term:`context manager` via the  :keyword:`with` statement, which
+      will shutdown the :class:`Executor` (waiting as if :meth:`Executor.shutdown`
+      were called with *wait* set to ``True``)::
 
          import shutil
          with ThreadPoolExecutor(max_workers=4) as e:


### PR DESCRIPTION
I was searching for context manager-related part part of this documentation and I couldn't find anything because the words "context manager" weren't actually used anywhere.

I think this will help with discoverability of this feature.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130976.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->