### PR TITLE
GH-129817: thread safety for tp_flags

### DIFF
--- a/Include/cpython/object.h
+++ b/Include/cpython/object.h
@@ -284,6 +284,15 @@ typedef struct _heaptypeobject {
     struct _specialization_cache _spec_cache; // For use by the specializer.
 #ifdef Py_GIL_DISABLED
     Py_ssize_t unique_id;  // ID used for per-thread refcounting
+
+    // Used to store type flags that can be toggled after the type
+    // structure has been potentially exposed to other threads (i.e. after
+    // type_ready()).  We need to use atomic loads and stores for these
+    // flags, unlike for tp_flags.  The set of flags allowed to be toggled are
+    // POST_READY_FLAGS.  They are toggled with type_set_flags_with_mask() and
+    // need to be tested with _PyType_HasFeatureSafe(), in order to avoid data
+    // races.
+    unsigned long ht_flags;
 #endif
     /* here are optional user slots, followed by the members. */
 } PyHeapTypeObject;

--- a/Include/internal/pycore_call.h
+++ b/Include/internal/pycore_call.h
@@ -9,6 +9,7 @@ extern "C" {
 #endif
 
 #include "pycore_pystate.h"       // _PyThreadState_GET()
+#include "pycore_object.h"  // _PyType_HaveFeatureSafe()
 
 /* Suggested size (number of positional arguments) for arrays of PyObject*
    allocated on a C stack to avoid allocating memory on the heap memory. Such
@@ -116,7 +117,7 @@ _PyVectorcall_FunctionInline(PyObject *callable)
     assert(callable != NULL);
 
     PyTypeObject *tp = Py_TYPE(callable);
-    if (!PyType_HasFeature(tp, Py_TPFLAGS_HAVE_VECTORCALL)) {
+    if (!_PyType_HasFeatureSafe(tp, Py_TPFLAGS_HAVE_VECTORCALL)) {
         return NULL;
     }
     assert(PyCallable_Check(callable));

--- a/Include/object.h
+++ b/Include/object.h
@@ -774,11 +774,7 @@ PyType_HasFeature(PyTypeObject *type, unsigned long feature)
     // PyTypeObject is opaque in the limited C API
     flags = PyType_GetFlags(type);
 #else
-#   ifdef Py_GIL_DISABLED
-        flags = _Py_atomic_load_ulong_relaxed(&type->tp_flags);
-#   else
-        flags = type->tp_flags;
-#   endif
+    flags = type->tp_flags;
 #endif
     return ((flags & feature) != 0);
 }

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1750,6 +1750,7 @@ class SizeofTest(unittest.TestCase):
         s = vsize(fmt)
         check(int, s)
         typeid = 'n' if support.Py_GIL_DISABLED else ''
+        ht_flags = 'l' if support.Py_GIL_DISABLED else ''
         # class
         s = vsize(fmt +                 # PyTypeObject
                   '4P'                  # PyAsyncMethods
@@ -1760,6 +1761,7 @@ class SizeofTest(unittest.TestCase):
                   '7P'
                   '1PIP'                # Specializer cache
                   + typeid              # heap type id (free-threaded only)
+                  + ht_flags
                   )
         class newstyleclass(object): pass
         # Separate block for PyDictKeysObject with 8 keys and 5 entries

--- a/Modules/_testcapi/vectorcall.c
+++ b/Modules/_testcapi/vectorcall.c
@@ -3,6 +3,7 @@
 
 #include "parts.h"
 #include "clinic/vectorcall.c.h"
+#include "pycore_object.h" // _PyType_HasFeatureSafe()
 
 
 #include <stddef.h>                 // offsetof
@@ -255,7 +256,7 @@ static int
 _testcapi_has_vectorcall_flag_impl(PyObject *module, PyTypeObject *type)
 /*[clinic end generated code: output=3ae8d1374388c671 input=8eee492ac548749e]*/
 {
-    return PyType_HasFeature(type, Py_TPFLAGS_HAVE_VECTORCALL);
+    return _PyType_HasFeatureSafe(type, Py_TPFLAGS_HAVE_VECTORCALL);
 }
 
 static PyMethodDef TestMethods[] = {

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2919,12 +2919,12 @@ dummy_func(
         }
 
         inst(MATCH_MAPPING, (subject -- subject, res)) {
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
+            int match = _PyType_HasFeatureSafe(PyStackRef_TYPE(subject), Py_TPFLAGS_MAPPING);
             res = match ? PyStackRef_True : PyStackRef_False;
         }
 
         inst(MATCH_SEQUENCE, (subject -- subject, res)) {
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
+            int match = _PyType_HasFeatureSafe(PyStackRef_TYPE(subject), Py_TPFLAGS_SEQUENCE);
             res = match ? PyStackRef_True : PyStackRef_False;
         }
 

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -3974,7 +3974,7 @@
             _PyStackRef subject;
             _PyStackRef res;
             subject = stack_pointer[-1];
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
+            int match = _PyType_HasFeatureSafe(PyStackRef_TYPE(subject), Py_TPFLAGS_MAPPING);
             res = match ? PyStackRef_True : PyStackRef_False;
             stack_pointer[0] = res;
             stack_pointer += 1;
@@ -3986,7 +3986,7 @@
             _PyStackRef subject;
             _PyStackRef res;
             subject = stack_pointer[-1];
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
+            int match = _PyType_HasFeatureSafe(PyStackRef_TYPE(subject), Py_TPFLAGS_SEQUENCE);
             res = match ? PyStackRef_True : PyStackRef_False;
             stack_pointer[0] = res;
             stack_pointer += 1;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -9739,7 +9739,7 @@
             _PyStackRef subject;
             _PyStackRef res;
             subject = stack_pointer[-1];
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_MAPPING;
+            int match = _PyType_HasFeatureSafe(PyStackRef_TYPE(subject), Py_TPFLAGS_MAPPING);
             res = match ? PyStackRef_True : PyStackRef_False;
             stack_pointer[0] = res;
             stack_pointer += 1;
@@ -9758,7 +9758,7 @@
             _PyStackRef subject;
             _PyStackRef res;
             subject = stack_pointer[-1];
-            int match = PyStackRef_TYPE(subject)->tp_flags & Py_TPFLAGS_SEQUENCE;
+            int match = _PyType_HasFeatureSafe(PyStackRef_TYPE(subject), Py_TPFLAGS_SEQUENCE);
             res = match ? PyStackRef_True : PyStackRef_False;
             stack_pointer[0] = res;
             stack_pointer += 1;

--- a/Tools/cases_generator/analyzer.py
+++ b/Tools/cases_generator/analyzer.py
@@ -650,6 +650,7 @@ NON_ESCAPING_FUNCTIONS = (
     "_PyTuple_FromStackRefStealOnSuccess",
     "_PyTuple_ITEMS",
     "_PyType_HasFeature",
+    "_PyType_HasFeatureSafe",
     "_PyType_NewManagedObject",
     "_PyUnicode_Equal",
     "_PyUnicode_JoinArray",


### PR DESCRIPTION
Note: this PR needs a bit more polish before it becomes non-draft.  I added Sam and Matt to the reviewers in case they have some initial feedback on this approach.

Use a separate structure member in `PyHeapTypeObject`, `ht_flags`, to store a copy of the type flags.  That allows safe toggling of some of the flags after the type has been initialized and potentially exposed to other threads.

We would prefer to not use an atomic load whenever `tp_flags` is read.  That causes a lot of code churn (see gh-130892) and potentially some performance hit on platforms with weak memory ordering.  Instead, we would like to use a normal load and only set the flags before the type has been exposed to other threads.  That's mostly the case except for the flags listed below.

The following type flags cause issues in that they may be toggled after the type is initially created and exposed:

- `Py_TPFLAGS_SEQUENCE` and `Py_TPFLAGS_MAPPING`.   Set by the `_abc_register` function.  It seems there is no way to toggle these flags off once set.
-  `Py_TPFLAGS_IS_ABSTRACT`.  Toggled by assigning a non-empty set to `__abstractmethods__`
- `Py_TPFLAGS_HAVE_VECTORCALL`.  Toggled off (no way to turn back on) by assigning `__call__` to the type.

This PR does the following (only to the free-threaded build, the default build continues to work the same):

- Add a new member to `PyHeapTypeObject`, `ht_flags`.  This member only exists in the free-threaded build.
- Copy the `tp_flags` value into `ht_flags` when `type_ready()` completes.
-  If one of the above flags is toggled after type initialization, toggle it in `ht_flags`.  Use atomic operations to read and write it.
- Use `_PyType_HasFeatureSafe()` to test the above flags.  That function uses an atomic load.

This approach causes a bit of extra complication since we have to check `Py_TPFLAGS_HEAPTYPE` first to know where to look at the flags.  For non-heap types, they are in `tp_flags` always.  This could be avoided by adding an additional member to `PyTypeObject`.  However, I think the `Py_TPFLAGS_HEAPTYPE` check should be cheap enough and putting it in `PyHeapTypeObject` ensures that extension types don't get confused by it.

Note that since all non-heap types are immutable, it is not possible to toggle type flags for them (at least, CPython itself doesn't do so).  Also note that this change can break extensions that manipulate `tp_flags` directly or directly tests them, rather than using functions.

<!-- gh-issue-number: gh-129817 -->
* Issue: gh-129817
<!-- /gh-issue-number -->
