### PR TITLE
GH-130614: pathlib ABCs: retain original separator in `with_name()`

### DIFF
--- a/Lib/pathlib/types.py
+++ b/Lib/pathlib/types.py
@@ -135,7 +135,9 @@ class _JoinablePath(ABC):
         split = self.parser.split
         if split(name)[0]:
             raise ValueError(f"Invalid name {name!r}")
-        return self.with_segments(split(str(self))[0], name)
+        path = str(self)
+        path = path.removesuffix(split(path)[1]) + name
+        return self.with_segments(path)
 
     def with_stem(self, stem):
         """Return a new path with the stem changed."""


### PR DESCRIPTION
In `pathlib.types._JoinablePath.with_name()`, retain any alternative path separator preceding the old name, rather stripping and replacing it with a primary separator. As a result, this method changes _only_ the name.

Testing will be covered by https://github.com/python/cpython/pull/130988.

<!-- gh-issue-number: gh-130614 -->
* Issue: gh-130614
<!-- /gh-issue-number -->
