### PR TITLE
GH-130614: pathlib ABCs: support alternate separator in `full_match()`

### DIFF
--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -320,11 +320,11 @@ def translate(pat, *, recursive=False, include_hidden=False, seps=None):
 
 
 @functools.lru_cache(maxsize=512)
-def _compile_pattern(pat, sep, case_sensitive, recursive=True):
+def _compile_pattern(pat, seps, case_sensitive, recursive=True):
     """Compile given glob pattern to a re.Pattern object (observing case
     sensitivity)."""
     flags = re.NOFLAG if case_sensitive else re.IGNORECASE
-    regex = translate(pat, recursive=recursive, include_hidden=True, seps=sep)
+    regex = translate(pat, recursive=recursive, include_hidden=True, seps=seps)
     return re.compile(regex, flags=flags).match
 
 
@@ -360,8 +360,9 @@ class _GlobberBase:
 
     # High-level methods
 
-    def compile(self, pat):
-        return _compile_pattern(pat, self.sep, self.case_sensitive, self.recursive)
+    def compile(self, pat, altsep=None):
+        seps = (self.sep, altsep) if altsep else self.sep
+        return _compile_pattern(pat, seps, self.case_sensitive, self.recursive)
 
     def selector(self, parts):
         """Returns a function that selects from a given path, walking and

--- a/Lib/pathlib/types.py
+++ b/Lib/pathlib/types.py
@@ -14,7 +14,7 @@ from abc import ABC, abstractmethod
 from glob import _PathGlobber, _no_recurse_symlinks
 from pathlib import PurePath, Path
 from pathlib._os import magic_open, ensure_distinct_paths, copy_file
-from typing import Protocol, runtime_checkable
+from typing import Optional, Protocol, runtime_checkable
 
 
 def _explode_path(path):
@@ -44,6 +44,7 @@ class _PathParser(Protocol):
     """
 
     sep: str
+    altsep: Optional[str]
     def split(self, path: str) -> tuple[str, str]: ...
     def splitext(self, path: str) -> tuple[str, str]: ...
     def normcase(self, path: str) -> str: ...
@@ -223,7 +224,7 @@ class _JoinablePath(ABC):
         if case_sensitive is None:
             case_sensitive = self.parser.normcase('Aa') == 'Aa'
         globber = _PathGlobber(pattern.parser.sep, case_sensitive, recursive=True)
-        match = globber.compile(str(pattern))
+        match = globber.compile(str(pattern), altsep=pattern.parser.altsep)
         return match(str(self)) is not None
 
 


### PR DESCRIPTION
In `pathlib.types._JoinablePath.full_match()`, treat alternate path separators in the path and pattern as if they were primary separators. e.g. if the parser is `ntpath`, then `P(r'foo/bar\baz').full_match(r'*\*/*')` is true.

Testing will be covered by https://github.com/python/cpython/pull/130988.


<!-- gh-issue-number: gh-130614 -->
* Issue: gh-130614
<!-- /gh-issue-number -->
