### PR TITLE
gh-130160: use `.. program::` directive for documenting `pdb` CLI

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -82,7 +82,7 @@ example:
 
 .. code-block:: bash
 
-   python -m pdb [-h] [-c command] (-m module | pyfile) [args ...]
+   python -m pdb [-c command] (-m module | pyfile) [args ...]
 
 When invoked as a module, pdb will automatically enter post-mortem debugging if
 the program being debugged exits abnormally.  After post-mortem debugging (or

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -78,9 +78,7 @@ The debugger's prompt is ``(Pdb)``, which is the indicator that you are in debug
 .. program:: pdb
 
 You can also invoke :mod:`pdb` from the command line to debug other scripts.  For
-example:
-
-.. code-block:: bash
+example::
 
    python -m pdb [-c command] (-m module | pyfile) [args ...]
 

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -75,10 +75,14 @@ The debugger's prompt is ``(Pdb)``, which is the indicator that you are in debug
    arguments of the ``p`` command.
 
 
-You can also invoke :mod:`pdb` from the command line to debug other scripts.  For
-example::
+.. program:: pdb
 
-   python -m pdb myscript.py
+You can also invoke :mod:`pdb` from the command line to debug other scripts.  For
+example:
+
+.. code-block:: bash
+
+   python -m pdb [-h] [-c command] (-m module | pyfile) [args ...]
 
 When invoked as a module, pdb will automatically enter post-mortem debugging if
 the program being debugged exits abnormally.  After post-mortem debugging (or
@@ -86,14 +90,21 @@ after normal exit of the program), pdb will restart the program.  Automatic
 restarting preserves pdb's state (such as breakpoints) and in most cases is more
 useful than quitting the debugger upon program's exit.
 
-.. versionchanged:: 3.2
-   Added the ``-c`` option to execute commands as if given
-   in a :file:`.pdbrc` file; see :ref:`debugger-commands`.
+.. option:: -c, --command <command>
 
-.. versionchanged:: 3.7
-   Added the ``-m`` option to execute modules similar to the way
-   ``python -m`` does. As with a script, the debugger will pause execution just
-   before the first line of the module.
+   To execute commands as if given in a :file:`.pdbrc` file; see
+   :ref:`debugger-commands`.
+
+   .. versionchanged:: 3.2
+      Added the ``-c`` option.
+
+.. option:: -m <module>
+
+   To execute modules similar to the way ``python -m`` does. As with a script,
+   the debugger will pause execution just before the first line of the module.
+
+   .. versionchanged:: 3.7
+      Added the ``-m`` option.
 
 Typical usage to execute a statement under control of the debugger is::
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-130160 -->
* Issue: gh-130160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--130996.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->