### PR TITLE
[3.12] gh-130160: use `.. program::` directive for documenting `webbrowser` CLI (GH-130995)

### DIFF
--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -33,13 +33,6 @@ allow the remote browser to maintain its own windows on the display.  If remote
 browsers are not available on Unix, the controlling process will launch a new
 browser and wait.
 
-On iOS, the :envvar:`BROWSER` environment variable, as well as any arguments
-controlling autoraise, browser preference, and new tab/window creation will be
-ignored. Web pages will *always* be opened in the user's preferred browser, in
-a new tab, with the browser being brought to the foreground. The use of the
-:mod:`webbrowser` module on iOS requires the :mod:`ctypes` module. If
-:mod:`ctypes` isn't available, calls to :func:`.open` will fail.
-
 .. program:: webbrowser
 
 The script :program:`webbrowser` can be used as a command-line interface for the

--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -33,11 +33,30 @@ allow the remote browser to maintain its own windows on the display.  If remote
 browsers are not available on Unix, the controlling process will launch a new
 browser and wait.
 
+On iOS, the :envvar:`BROWSER` environment variable, as well as any arguments
+controlling autoraise, browser preference, and new tab/window creation will be
+ignored. Web pages will *always* be opened in the user's preferred browser, in
+a new tab, with the browser being brought to the foreground. The use of the
+:mod:`webbrowser` module on iOS requires the :mod:`ctypes` module. If
+:mod:`ctypes` isn't available, calls to :func:`.open` will fail.
+
+.. program:: webbrowser
+
 The script :program:`webbrowser` can be used as a command-line interface for the
 module. It accepts a URL as the argument. It accepts the following optional
-parameters: ``-n`` opens the URL in a new browser window, if possible;
-``-t`` opens the URL in a new browser page ("tab"). The options are,
-naturally, mutually exclusive.  Usage example::
+parameters:
+
+.. option:: -n, --new-window
+
+   Opens the URL in a new browser window, if possible.
+
+.. option:: -t, --new-tab
+
+   Opens the URL in a new browser tab.
+
+The options are, naturally, mutually exclusive.  Usage example:
+
+.. code-block:: bash
 
    python -m webbrowser -t "https://www.python.org"
 


### PR DESCRIPTION
use `.. program::` directive for documenting `webbrowser` CLI
(cherry picked from commit [92e5f82](https://github.com/python/cpython/commit/92e5f826ace1eab29920a0a3487a3cac7eeab925))
 
Co-authored-by: donBarbos [donbarbos@proton.me](mailto:donbarbos@proton.me)



<!-- gh-issue-number: gh-130160 -->
* Issue: gh-130160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131004.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->