### PR TITLE
GH-109564: add asyncio.Server state machine

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -318,7 +318,7 @@ class Server(events.AbstractServer):
 
     def _detach(self, transport):
         self._clients.discard(transport)
-        if self._state == _ServerState.CLOSED and len(self._clients) == 0:
+        if self._state == _ServerState.CLOSED and not self._clients:
             self._shutdown()
 
     def _shutdown(self):

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -344,7 +344,7 @@ class Server(events.AbstractServer):
         elif self._state == _ServerState.SERVING:
             return
         else:
-            raise RuntimeError(f'server {self!r} was already started and then closed')
+            raise RuntimeError('is closed')
 
         for sock in self._sockets:
             sock.listen(self._backlog)

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -325,7 +325,7 @@ class Server(events.AbstractServer):
         if self._state == _ServerState.CLOSED:
             self._state = _ServerState.SHUTDOWN
         elif self._state == _ServerState.SHUTDOWN:
-            # gh109564: the wakeup method has two possible call-sites,
+            # gh-109564: the wakeup method has two possible call-sites,
             # through an explicit call Server.close(), or indirectly through
             # Server._detach() by the last connected client.
             return

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -16,6 +16,7 @@ to modify the meaning of the API call itself.
 import collections
 import collections.abc
 import concurrent.futures
+import enum
 import errno
 import heapq
 import itertools
@@ -272,6 +273,23 @@ class _SendfileFallbackProtocol(protocols.Protocol):
             self._proto.resume_writing()
 
 
+class _ServerState(enum.Enum):
+    """This tracks the state of Server.
+
+    -[in]->INITIALIZED -[ss]-> SERVING -[cl]-> CLOSED -[wk]*-> SHUTDOWN
+
+    - in: Server.__init__()
+    - ss: Server._start_serving()
+    - cl: Server.close()
+    - wk: Server._wakeup()  *only called if number of clients == 0
+    """
+
+    INITIALIZED = "initialized"
+    SERVING = "serving"
+    CLOSED = "closed"
+    SHUTDOWN = "shutdown"
+
+
 class Server(events.AbstractServer):
 
     def __init__(self, loop, sockets, protocol_factory, ssl_context, backlog,
@@ -287,22 +305,34 @@ class Server(events.AbstractServer):
         self._ssl_context = ssl_context
         self._ssl_handshake_timeout = ssl_handshake_timeout
         self._ssl_shutdown_timeout = ssl_shutdown_timeout
-        self._serving = False
+        self._state = _ServerState.INITIALIZED
         self._serving_forever_fut = None
 
     def __repr__(self):
         return f'<{self.__class__.__name__} sockets={self.sockets!r}>'
 
     def _attach(self, transport):
-        assert self._sockets is not None
+        if self._state != _ServerState.SERVING:
+            raise RuntimeError("server is not serving, cannot attach transport")
         self._clients.add(transport)
 
     def _detach(self, transport):
         self._clients.discard(transport)
-        if len(self._clients) == 0 and self._sockets is None:
+        if self._state == _ServerState.CLOSED and len(self._clients) == 0:
             self._wakeup()
 
     def _wakeup(self):
+        match self._state:
+            case _ServerState.SHUTDOWN:
+                # gh109564: the wakeup method has two possible call-sites,
+                # through an explicit call Server.close(), or indirectly through
+                # Server._detach() by the last connected client.
+                return
+            case _ServerState.INITIALIZED | _ServerState.SERVING:
+                raise RuntimeError("cannot wakeup server before closing")
+            case _ServerState.CLOSED:
+                self._state = _ServerState.SHUTDOWN
+
         waiters = self._waiters
         self._waiters = None
         for waiter in waiters:
@@ -310,9 +340,14 @@ class Server(events.AbstractServer):
                 waiter.set_result(None)
 
     def _start_serving(self):
-        if self._serving:
-            return
-        self._serving = True
+        match self._state:
+            case _ServerState.SERVING:
+                return
+            case _ServerState.CLOSED | _ServerState.SHUTDOWN:
+                raise RuntimeError(f'server {self!r} is closed')
+            case _ServerState.INITIALIZED:
+                self._state = _ServerState.SERVING
+
         for sock in self._sockets:
             sock.listen(self._backlog)
             self._loop._start_serving(
@@ -324,7 +359,7 @@ class Server(events.AbstractServer):
         return self._loop
 
     def is_serving(self):
-        return self._serving
+        return self._state == _ServerState.SERVING
 
     @property
     def sockets(self):
@@ -333,6 +368,13 @@ class Server(events.AbstractServer):
         return tuple(trsock.TransportSocket(s) for s in self._sockets)
 
     def close(self):
+        match self._state:
+            case _ServerState.CLOSED | _ServerState.SHUTDOWN:
+                # Shutdown state can only be reached after closing.
+                return
+            case _:
+                self._state = _ServerState.CLOSED
+
         sockets = self._sockets
         if sockets is None:
             return
@@ -340,8 +382,6 @@ class Server(events.AbstractServer):
 
         for sock in sockets:
             self._loop._stop_serving(sock)
-
-        self._serving = False
 
         if (self._serving_forever_fut is not None and
                 not self._serving_forever_fut.done()):
@@ -369,8 +409,6 @@ class Server(events.AbstractServer):
         if self._serving_forever_fut is not None:
             raise RuntimeError(
                 f'server {self!r} is already being awaited on serve_forever()')
-        if self._sockets is None:
-            raise RuntimeError(f'server {self!r} is closed')
 
         self._start_serving()
         self._serving_forever_fut = self._loop.create_future()
@@ -407,7 +445,7 @@ class Server(events.AbstractServer):
         # from two places: self.close() and self._detach(), but only
         # when both conditions have become true. To signal that this
         # has happened, self._wakeup() sets self._waiters to None.
-        if self._waiters is None:
+        if self._state == _ServerState.SHUTDOWN:
             return
         waiter = self._loop.create_future()
         self._waiters.append(waiter)

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -330,7 +330,7 @@ class Server(events.AbstractServer):
             # Server._detach() by the last connected client.
             return
         else:
-            raise RuntimeError(f"server {self!r} can only wakeup waiters after closing")
+            raise RuntimeError(f"server {self!r} must be closed before shutdown")
 
         waiters = self._waiters
         self._waiters = None

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -366,7 +366,7 @@ class Server(events.AbstractServer):
         return tuple(trsock.TransportSocket(s) for s in self._sockets)
 
     def close(self):
-        if self._state == _ServerState.CLOSED or self._state == _ServerState.SHUTDOWN:
+        if self._state in {_ServerState.CLOSED, _ServerState.SHUTDOWN}:
             return
         else:
             self._state = _ServerState.CLOSED

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -344,7 +344,7 @@ class Server(events.AbstractServer):
         elif self._state == _ServerState.SERVING:
             return
         else:
-            raise RuntimeError(f'server {self!r} is closed')
+            raise RuntimeError(f'server {self!r} was already started and then closed')
 
         for sock in self._sockets:
             sock.listen(self._backlog)

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -63,7 +63,11 @@ class _ProactorBasePipeTransport(transports._FlowControlMixin,
         self._called_connection_lost = False
         self._eof_written = False
         if self._server is not None:
-            self._server._attach(self)
+            if self._server.is_serving():
+                self._server._attach(self)
+            else:
+                self.abort()
+                return
         self._loop.call_soon(self._protocol.connection_made, self)
         if waiter is not None:
             # only wake up the waiter when connection_made() has been called

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -62,12 +62,8 @@ class _ProactorBasePipeTransport(transports._FlowControlMixin,
         self._closing = False  # Set when close() called.
         self._called_connection_lost = False
         self._eof_written = False
-        if self._server is not None:
-            if self._server.is_serving():
-                self._server._attach(self)
-            else:
-                self.abort()
-                return
+        if self._server is not None and self._server.is_serving():
+            self._server._attach(self)
         self._loop.call_soon(self._protocol.connection_made, self)
         if waiter is not None:
             # only wake up the waiter when connection_made() has been called

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -795,7 +795,12 @@ class _SelectorTransport(transports._FlowControlMixin,
         self._paused = False  # Set when pause_reading() called
 
         if self._server is not None:
-            self._server._attach(self)
+            if self._server.is_serving():
+                self._server._attach(self)
+            else:
+                self.abort()
+                return
+
         loop._transports[self._sock_fd] = self
 
     def __repr__(self):

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -794,12 +794,8 @@ class _SelectorTransport(transports._FlowControlMixin,
         self._closing = False  # Set when close() called.
         self._paused = False  # Set when pause_reading() called
 
-        if self._server is not None:
-            if self._server.is_serving():
-                self._server._attach(self)
-            else:
-                self.abort()
-                return
+        if self._server is not None and self._server.is_serving():
+            self._server._attach(self)
 
         loop._transports[self._sock_fd] = self
 

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -66,7 +66,7 @@ class BaseStartServer(func_tests.FunctionalTestCaseMixin):
         self.assertIsNone(srv._waiters)
         self.assertFalse(srv.is_serving())
 
-        with self.assertRaisesRegex(RuntimeError, r'started and then closed'):
+        with self.assertRaisesRegex(RuntimeError, r'is closed'):
             self.loop.run_until_complete(srv.serve_forever())
 
 
@@ -119,7 +119,7 @@ class SelectorStartServerTests(BaseStartServer, unittest.TestCase):
             self.assertIsNone(srv._waiters)
             self.assertFalse(srv.is_serving())
 
-            with self.assertRaisesRegex(RuntimeError, r'started and then closed'):
+            with self.assertRaisesRegex(RuntimeError, r'is closed'):
                 self.loop.run_until_complete(srv.serve_forever())
 
 
@@ -215,7 +215,7 @@ class TestServer2(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
         self.assertTrue(task.done())
 
-        with self.assertRaisesRegex(RuntimeError, r'started and then closed'):
+        with self.assertRaisesRegex(RuntimeError, r'is closed'):
             await srv.start_serving()
 
     async def test_abort_clients(self):

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -4,7 +4,6 @@ import socket
 import time
 import threading
 import unittest
-from unittest.mock import Mock
 
 from test.support import socket_helper
 from test.test_asyncio import utils as test_utils

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -272,29 +272,6 @@ class TestServer2(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
         self.assertTrue(task.done())
 
-    async def test_close_before_transport_attach(self):
-        proto = Mock()
-        loop = asyncio.get_running_loop()
-        srv = await loop.create_server(lambda *_: proto, socket_helper.HOSTv4, 0)
-
-        await srv.start_serving()
-        addr = srv.sockets[0].getsockname()
-
-        # Create a connection to the server but close the server before the
-        # socket transport for the connection is created and attached
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.connect(addr)
-        await asyncio.sleep(0)  # loop select reader
-        await asyncio.sleep(0)  # accept conn 1
-        srv.close()
-
-        # Ensure the protocol is given an opportunity to handle this event
-        # gh109564: the transport would be unclosed and will cause a loop
-        # exception due to a double-call to Server._wakeup
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        proto.connection_lost.assert_called()
-
 
 # Test the various corner cases of Unix server socket removal
 class UnixServerCleanupTests(unittest.IsolatedAsyncioTestCase):

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -66,7 +66,7 @@ class BaseStartServer(func_tests.FunctionalTestCaseMixin):
         self.assertIsNone(srv._waiters)
         self.assertFalse(srv.is_serving())
 
-        with self.assertRaisesRegex(RuntimeError, r'is closed'):
+        with self.assertRaisesRegex(RuntimeError, r'started and then closed'):
             self.loop.run_until_complete(srv.serve_forever())
 
 
@@ -119,7 +119,7 @@ class SelectorStartServerTests(BaseStartServer, unittest.TestCase):
             self.assertIsNone(srv._waiters)
             self.assertFalse(srv.is_serving())
 
-            with self.assertRaisesRegex(RuntimeError, r'is closed'):
+            with self.assertRaisesRegex(RuntimeError, r'started and then closed'):
                 self.loop.run_until_complete(srv.serve_forever())
 
 
@@ -215,7 +215,7 @@ class TestServer2(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(0)
         self.assertTrue(task.done())
 
-        with self.assertRaisesRegex(RuntimeError, r'is closed'):
+        with self.assertRaisesRegex(RuntimeError, r'started and then closed'):
             await srv.start_serving()
 
     async def test_abort_clients(self):

--- a/Misc/NEWS.d/next/Library/2025-03-09-23-10-39.gh-issue-109564.r9rnIB.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-09-23-10-39.gh-issue-109564.r9rnIB.rst
@@ -1,0 +1,1 @@
+Fix race condition in :meth:`asyncio.Server.close`. Patch by Jamie Phan.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Supersedes #126660 and implements a state machine as suggested by this comment: https://github.com/python/cpython/pull/126660#pullrequestreview-2441159034

## Analysis

<img width="1119" alt="image" src="https://github.com/user-attachments/assets/f00d3f5a-502c-4d3e-97c5-3b9b25b7b684" />


## Addressed issues

This addresses two issues raised in GH-109564:

1. A transport will first check if a server is closed before attempting to attach. This will prevent raising an `AssertionError` (changed to a `RuntimeError` here)
2. When a connection is accepted by `BaseSelectorEventLoop._accept_connection` but is not handled in `BaseSelectorEventLoop._accept_connection2`, then it will fail to correctly construct and raise an `"unclosed transport"` `ResourceWarning` on `__del__`; this will raise an error as it will call `Server._detach` -> `Server._wakeup` after close and attempt to access the `Server._waiters=None` attribute.

These errors can be seen in the new test `test_close_before_transport_attach` against `main`:

```
0:00:00 load avg: 2.05 [1/1] test_asyncio.test_server
Error on transport creation for incoming connection
handle_traceback: Handle created at (most recent call last):
  File "cpython/Lib/unittest/async_case.py", line 120, in _callMaybeAsync
    return self._asyncioRunner.run(
  File "cpython/Lib/asyncio/runners.py", line 127, in run
    return self._loop.run_until_complete(task)
  File "cpython/Lib/asyncio/base_events.py", line 706, in run_until_complete
    self.run_forever()
  File "cpython/Lib/asyncio/base_events.py", line 677, in run_forever
    self._run_once()
  File "cpython/Lib/asyncio/base_events.py", line 2029, in _run_once
    handle._run()
  File "cpython/Lib/asyncio/events.py", line 98, in _run
    self._context.run(self._callback, *self._args)
  File "cpython/Lib/asyncio/selector_events.py", line 215, in _accept_connection
    self.create_task(accept)
  File "cpython/Lib/asyncio/base_events.py", line 470, in create_task
    task = tasks.Task(coro, loop=self, **kwargs)
protocol: <Mock id='4354243424'>
Traceback (most recent call last):
  File "cpython/Lib/asyncio/selector_events.py", line 234, in _accept_connection2
    transport = self._make_socket_transport(
        conn, protocol, waiter=waiter, extra=extra,
        server=server)
  File "cpython/Lib/asyncio/selector_events.py", line 72, in _make_socket_transport
    return _SelectorSocketTransport(self, sock, protocol, waiter,
                                    extra, server)
  File "cpython/Lib/asyncio/selector_events.py", line 941, in __init__
    super().__init__(loop, sock, protocol, extra, server)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "cpython/Lib/asyncio/selector_events.py", line 799, in __init__
    self._server._attach(self)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "cpython/Lib/asyncio/base_events.py", line 297, in _attach
    assert self._sockets is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
Warning -- Unraisable exception
Exception ignored while calling deallocator <function _SelectorTransport.__del__ at 0x1037d1900>:
Traceback (most recent call last):
  File "cpython/Lib/asyncio/selector_events.py", line 881, in __del__
    self._server._detach(self)
  File "cpython/Lib/asyncio/base_events.py", line 303, in _detach
    self._wakeup()
  File "cpython/Lib/asyncio/base_events.py", line 308, in _wakeup
    for waiter in waiters:
TypeError: 'NoneType' object is not iterable
test test_asyncio.test_server failed -- Traceback (most recent call last):
  File "cpython/Lib/asyncio/runners.py", line 127, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "cpython/Lib/asyncio/base_events.py", line 719, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "cpython/Lib/test/test_asyncio/test_server.py", line 293, in test_close_before_transport_attach
    proto.connection_lost.assert_called()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "cpython/Lib/unittest/mock.py", line 949, in assert_called
    raise AssertionError(msg)
AssertionError: Expected 'connection_lost' to have been called.

0:00:00 load avg: 2.05 [1/1/1] test_asyncio.test_server failed (1 failure)
```