### PR TITLE
GH-130614: pathlib ABCs: revise test suite for Posix path joining

### DIFF
--- a/Lib/test/test_pathlib/support/lexical_path.py
+++ b/Lib/test/test_pathlib/support/lexical_path.py
@@ -4,6 +4,7 @@ Simple implementation of JoinablePath, for use in pathlib tests.
 
 import os.path
 import pathlib.types
+import posixpath
 
 
 class LexicalPath(pathlib.types._JoinablePath):
@@ -31,3 +32,8 @@ class LexicalPath(pathlib.types._JoinablePath):
 
     def with_segments(self, *pathsegments):
         return type(self)(*pathsegments)
+
+
+class LexicalPosixPath(LexicalPath):
+    __slots__ = ()
+    parser = posixpath

--- a/Lib/test/test_pathlib/test_join_posix.py
+++ b/Lib/test/test_pathlib/test_join_posix.py
@@ -1,0 +1,49 @@
+"""
+Tests for Posix-flavoured pathlib.types._JoinablePath
+"""
+
+import os
+import unittest
+
+from pathlib import PurePosixPath, PosixPath
+from test.test_pathlib.support.lexical_path import LexicalPosixPath
+
+
+class JoinTestBase:
+    def test_join(self):
+        P = self.cls
+        p = P('//a')
+        pp = p.joinpath('b')
+        self.assertEqual(pp, P('//a/b'))
+        pp = P('/a').joinpath('//c')
+        self.assertEqual(pp, P('//c'))
+        pp = P('//a').joinpath('/c')
+        self.assertEqual(pp, P('/c'))
+
+    def test_div(self):
+        # Basically the same as joinpath().
+        P = self.cls
+        p = P('//a')
+        pp = p / 'b'
+        self.assertEqual(pp, P('//a/b'))
+        pp = P('/a') / '//c'
+        self.assertEqual(pp, P('//c'))
+        pp = P('//a') / '/c'
+        self.assertEqual(pp, P('/c'))
+
+
+class LexicalPosixPathJoinTest(JoinTestBase, unittest.TestCase):
+    cls = LexicalPosixPath
+
+
+class PurePosixPathJoinTest(JoinTestBase, unittest.TestCase):
+    cls = PurePosixPath
+
+
+if os.name != 'nt':
+    class PosixPathJoinTest(JoinTestBase, unittest.TestCase):
+        cls = PosixPath
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -108,17 +108,6 @@ class JoinablePathTest(unittest.TestCase):
         self._check_str_subclass('\\\\some\\share\\a')
         self._check_str_subclass('\\\\some\\share\\a\\b.txt')
 
-    @needs_posix
-    def test_join_posix(self):
-        P = self.cls
-        p = P('//a')
-        pp = p.joinpath('b')
-        self.assertEqual(pp, P('//a/b'))
-        pp = P('/a').joinpath('//c')
-        self.assertEqual(pp, P('//c'))
-        pp = P('//a').joinpath('/c')
-        self.assertEqual(pp, P('/c'))
-
     @needs_windows
     def test_join_windows(self):
         P = self.cls
@@ -156,18 +145,6 @@ class JoinablePathTest(unittest.TestCase):
         self.assertEqual(pp, P('//server/share'))
         pp = P('//./BootPartition').joinpath('Windows')
         self.assertEqual(pp, P('//./BootPartition/Windows'))
-
-    @needs_posix
-    def test_div_posix(self):
-        # Basically the same as joinpath().
-        P = self.cls
-        p = P('//a')
-        pp = p / 'b'
-        self.assertEqual(pp, P('//a/b'))
-        pp = P('/a') / '//c'
-        self.assertEqual(pp, P('//c'))
-        pp = P('//a') / '/c'
-        self.assertEqual(pp, P('/c'))
 
     @needs_windows
     def test_div_windows(self):


### PR DESCRIPTION
Test Posix-flavoured `pathlib.types._JoinablePath` in a dedicated test module. These tests cover `LexicalPosixPath`, `PurePosixPath` and `PosixPath`, where `LexicalPosixPath` is a simple implementation of `_JoinablePath` for use in tests.


<!-- gh-issue-number: gh-130614 -->
* Issue: gh-130614
<!-- /gh-issue-number -->
