### PR TITLE
GH-131033: Enable the optimizing macros UNLIKELY and LIKELY for clang-cl on Windows

### DIFF
--- a/Modules/expat/expat_external.h
+++ b/Modules/expat/expat_external.h
@@ -112,14 +112,14 @@
 #  define XMLIMPORT
 #endif
 
-#if defined(__GNUC__)                                                          \
+#if defined(__clang__) || defined(__GNUC__)                                    \
     && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 96))
 #  define XML_ATTR_MALLOC __attribute__((__malloc__))
 #else
 #  define XML_ATTR_MALLOC
 #endif
 
-#if defined(__GNUC__)                                                          \
+#if defined(__clang__) || defined(__GNUC__)                                    \
     && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
 #  define XML_ATTR_ALLOC_SIZE(x) __attribute__((__alloc_size__(x)))
 #else

--- a/Modules/expat/expat_external.h
+++ b/Modules/expat/expat_external.h
@@ -112,14 +112,14 @@
 #  define XMLIMPORT
 #endif
 
-#if defined(__clang__) || defined(__GNUC__)                                    \
+#if defined(__GNUC__)                                                          \
     && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 96))
 #  define XML_ATTR_MALLOC __attribute__((__malloc__))
 #else
 #  define XML_ATTR_MALLOC
 #endif
 
-#if defined(__clang__) || defined(__GNUC__)                                    \
+#if defined(__GNUC__)                                                          \
     && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
 #  define XML_ATTR_ALLOC_SIZE(x) __attribute__((__alloc_size__(x)))
 #else

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1455,7 +1455,7 @@ PyObject_Free(void *ptr)
 }
 
 
-/* If we're using GCC, use __builtin_expect() to reduce overhead of
+/* Use __builtin_expect() where available to reduce overhead of
    the valgrind checks */
 #if (defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 2))) && defined(__OPTIMIZE__)
 #  define UNLIKELY(value) __builtin_expect((value), 0)

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1457,7 +1457,7 @@ PyObject_Free(void *ptr)
 
 /* If we're using GCC, use __builtin_expect() to reduce overhead of
    the valgrind checks */
-#if defined(__GNUC__) && (__GNUC__ > 2) && defined(__OPTIMIZE__)
+#if (defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 2))) && defined(__OPTIMIZE__)
 #  define UNLIKELY(value) __builtin_expect((value), 0)
 #  define LIKELY(value) __builtin_expect((value), 1)
 #else


### PR DESCRIPTION
Maybe a skip news?

Performance neutral, see https://github.com/python/cpython/issues/131033.

<!-- gh-issue-number: gh-131033 -->
* Issue: gh-131033
<!-- /gh-issue-number -->
