### PR TITLE
GH-127381: pathlib ABCs: remove `case_sensitive` argument

### DIFF
--- a/Lib/test/test_pathlib/test_join.py
+++ b/Lib/test/test_pathlib/test_join.py
@@ -130,11 +130,6 @@ class JoinTestBase:
         self.assertFalse(P('a/b/c.py').full_match('**/a/b/c./**'))
         self.assertFalse(P('a/b/c.py').full_match('/a/b/c.py/**'))
         self.assertFalse(P('a/b/c.py').full_match('/**/a/b/c.py'))
-        # Case-sensitive flag
-        self.assertFalse(P('A.py').full_match('a.PY', case_sensitive=True))
-        self.assertTrue(P('A.py').full_match('a.PY', case_sensitive=False))
-        self.assertFalse(P('c:/a/B.Py').full_match('C:/A/*.pY', case_sensitive=True))
-        self.assertTrue(P('/a/b/c.py').full_match('/A/*/*.Py', case_sensitive=False))
         # Matching against empty path
         self.assertFalse(P('').full_match('*'))
         self.assertTrue(P('').full_match('**'))

--- a/Lib/test/test_pathlib/test_pathlib_abc.py
+++ b/Lib/test/test_pathlib/test_pathlib_abc.py
@@ -709,18 +709,6 @@ class ReadablePathTest(JoinablePathTest):
         p = P(self.base)
         self.assertEqual(list(p.glob("")), [p.joinpath("")])
 
-    def test_glob_case_sensitive(self):
-        P = self.cls
-        def _check(path, pattern, case_sensitive, expected):
-            actual = {str(q) for q in path.glob(pattern, case_sensitive=case_sensitive)}
-            expected = {str(P(self.base, q)) for q in expected}
-            self.assertEqual(actual, expected)
-        path = P(self.base)
-        _check(path, "DIRB/FILE*", True, [])
-        _check(path, "DIRB/FILE*", False, ["dirB/fileB"])
-        _check(path, "dirb/file*", True, [])
-        _check(path, "dirb/file*", False, ["dirB/fileB"])
-
     def test_info_exists(self):
         p = self.cls(self.base)
         self.assertTrue(p.info.exists())


### PR DESCRIPTION
Remove the *case_sensitive* argument from `_JoinablePath.full_match()` and `_ReadablePath.glob()`. Using a non-native case sensitivity forces the use of "case-pedantic" globbing, where we `iterdir()` even for non-wildcard pattern segments. But it's hard to know when to enable this mode, as case-sensitivity can vary by directory, so `_PathParser.normcase()` doesn't always give the full picture. The `Path.glob()` implementation is forced to make an educated guess, but we can avoid the issue in the ABCs by dropping the *case_sensitive* argument.

(I probably shouldn't have added this argument in `Path.glob()` in the first place!)

Also drop support for `_ReadablePath.glob(recurse_symlinks=False)`, which makes recursive globbing much slower.

No change to the public `pathlib` classes.

<!-- gh-issue-number: gh-127381 -->
* Issue: gh-127381
<!-- /gh-issue-number -->
