### PR TITLE
Update documention of stdlib `copy` to clear that list can also be shallow copied via `.copy()`

### DIFF
--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -72,8 +72,8 @@ file, socket, window, or any similar types.  It does "copy" functions and
 classes (shallow and deeply), by returning the original object unchanged; this
 is compatible with the way these are treated by the :mod:`pickle` module.
 
-Shallow copies of dictionaries can be made using :meth:`dict.copy`, and
-of lists by assigning a slice of the entire list, for example,
+Shallow copies of dictionaries and lists can be made using :meth:`dict.copy`. And
+of lists can also be made by assigning a slice of the entire list, for example,
 ``copied_list = original_list[:]``.
 
 .. index:: pair: module; pickle


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Update documention of stdlib `copy` to clear that list can also be shallow copied via `.copy()`

```py
a = [1,2]
b = a.copy()
b
```
this can work in recent versions of python 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131027.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->