### PR TITLE
gh-130160: use `.. program::` directive for documenting `doctest` CLI

### DIFF
--- a/Doc/library/cmdline.rst
+++ b/Doc/library/cmdline.rst
@@ -13,7 +13,7 @@ The following modules have a command-line interface.
 * :mod:`cProfile`: see :ref:`profile <profile-cli>`
 * :ref:`difflib <difflib-interface>`
 * :ref:`dis <dis-cli>`
-* :mod:`doctest <doctest-cli>`
+* :ref:`doctest <doctest-cli>`
 * :mod:`!encodings.rot_13`
 * :mod:`ensurepip`
 * :mod:`filecmp`

--- a/Doc/library/cmdline.rst
+++ b/Doc/library/cmdline.rst
@@ -13,7 +13,7 @@ The following modules have a command-line interface.
 * :mod:`cProfile`: see :ref:`profile <profile-cli>`
 * :ref:`difflib <difflib-interface>`
 * :ref:`dis <dis-cli>`
-* :mod:`doctest`
+* :mod:`doctest <doctest-cli>`
 * :mod:`!encodings.rot_13`
 * :mod:`ensurepip`
 * :mod:`filecmp`

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -177,15 +177,8 @@ prohibit it by passing ``verbose=False``.  In either of those cases,
 ``sys.argv`` is not examined by :func:`testmod` (so passing ``-v`` or not
 has no effect).
 
-There is also a command line shortcut for running :func:`testmod`.  You can
-instruct the Python interpreter to run the doctest module directly from the
-standard library and pass the module name(s) on the command line::
-
-   python -m doctest -v example.py
-
-This will import :file:`example.py` as a standalone module and run
-:func:`testmod` on it.  Note that this may not work correctly if the file is
-part of a package and imports other submodules from that package.
+There is also a command line shortcut for running :func:`testmod`, see section
+:ref:`doctest-cli`.
 
 For more information on :func:`testmod`, see section :ref:`doctest-basic-api`.
 
@@ -248,16 +241,52 @@ Like :func:`testmod`, :func:`testfile`'s verbosity can be set with the
 ``-v`` command-line switch or with the optional keyword argument
 *verbose*.
 
-There is also a command line shortcut for running :func:`testfile`.  You can
-instruct the Python interpreter to run the doctest module directly from the
-standard library and pass the file name(s) on the command line::
-
-   python -m doctest -v example.txt
-
-Because the file name does not end with :file:`.py`, :mod:`doctest` infers that
-it must be run with :func:`testfile`, not :func:`testmod`.
+There is also a command line shortcut for running :func:`testfile`, see section
+:ref:`doctest-cli`.
 
 For more information on :func:`testfile`, see section :ref:`doctest-basic-api`.
+
+
+.. _doctest-cli:
+
+Command-line Usage
+------------------
+
+The :mod:`doctest` module can be invoked as a script from the command line:
+
+.. code-block:: bash
+
+   python -m doctest [-v] [-o OPTION] [-f] file [file ...]
+
+.. program:: doctest
+
+.. option:: -v, --verbose
+
+   Detailed report of all examples tried is printed to standard output,
+   along with assorted summaries at the end::
+
+      python -m doctest -v example.py
+
+   This will import :file:`example.py` as a standalone module and run
+   :func:`testmod` on it.  Note that this may not work correctly if the file is
+   part of a package and imports other submodules from that package.
+   If the file name does not end with :file:`.py`, :mod:`doctest` infers that
+   it must be run with :func:`testfile`, not :func:`testmod`::
+
+      python -m doctest -v example.txt
+
+.. option:: -o, --option <option>
+
+   Option flags control various aspects of doctest's behavior, see section
+   :ref:`doctest-options`.
+
+   .. versionadded:: 3.4
+
+.. option:: -f, --fail-fast
+
+   This is shorthand for ``-o FAIL_FAST``.
+
+   .. versionadded:: 3.4
 
 
 .. _doctest-how-it-works:
@@ -540,9 +569,6 @@ Symbolic names for the flags are supplied as module constants, which can be
 The names can also be used in :ref:`doctest directives <doctest-directives>`,
 and may be passed to the doctest command line interface via the ``-o`` option.
 
-.. versionadded:: 3.4
-   The ``-o`` command line option.
-
 The first group of options define test semantics, controlling aspects of how
 doctest decides whether actual output matches an example's expected output:
 
@@ -681,11 +707,6 @@ The second group of options controls how test failures are reported:
    the remaining examples. Thus, the number of failures reported will be at most
    1.  This flag may be useful during debugging, since examples after the first
    failure won't even produce debugging output.
-
-   The doctest command line accepts the option ``-f`` as a shorthand for ``-o
-   FAIL_FAST``.
-
-   .. versionadded:: 3.4
 
 
 .. data:: REPORTING_FLAGS

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -268,10 +268,11 @@ The :mod:`doctest` module can be invoked as a script from the command line:
       python -m doctest -v example.py
 
    This will import :file:`example.py` as a standalone module and run
-   :func:`testmod` on it.  Note that this may not work correctly if the file is
-   part of a package and imports other submodules from that package.
-   If the file name does not end with :file:`.py`, :mod:`doctest` infers that
-   it must be run with :func:`testfile`, not :func:`testmod`::
+   :func:`testmod` on it. Note that this may not work correctly if the
+   file is part of a package and imports other submodules from that package.
+
+   If the file name does not end with :file:`.py`, :mod:`!doctest` infers
+   that it must be run with :func:`testfile` instead::
 
       python -m doctest -v example.txt
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-130160 -->
* Issue: gh-130160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131034.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->