### PR TITLE
GH-131035: use -flto=thin for clang-cl on Windows

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-03-10-10-52-25.gh-issue-131035.KF1w4j.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-10-10-52-25.gh-issue-131035.KF1w4j.rst
@@ -1,0 +1,2 @@
+Use ``-flto=thin`` for faster build times using clang-cl on Windows. Patch by
+Chris Eibl.

--- a/PCbuild/pyproject-clangcl.props
+++ b/PCbuild/pyproject-clangcl.props
@@ -41,7 +41,7 @@
       <AdditionalOptions>-Wno-deprecated-non-prototype -Wno-unused-label -Wno-pointer-sign -Wno-incompatible-pointer-types-discards-qualifiers -Wno-unused-function %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Platform)' == 'Win32'">-m32 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Platform)' == 'x64'">-m64 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="$(Configuration) != 'Debug'">-flto %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="$(Configuration) != 'Debug'">-flto=thin %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="$(SupportPGO) and $(Configuration) == 'PGInstrument'">-fprofile-instr-generate=$(_CLANG_PROFILE_PATH)$(TargetName)_%m.profraw %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="$(SupportPGO) and $(Configuration) == 'PGUpdate'">-fprofile-instr-use=$(OutDir)instrumented\profdata.profdata -Wno-profile-instr-unprofiled %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>


### PR DESCRIPTION
Faster build times, neutral wrt to pyperformance. For details please refer to https://github.com/python/cpython/issues/131035.

<!-- gh-issue-number: gh-131035 -->
* Issue: gh-131035
<!-- /gh-issue-number -->
