### PR TITLE
gh-130932: cwd cannot be removed on Solaris/Illumos

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -1186,6 +1186,7 @@ except ImportError as e:
                 self.assertRegex(line, rb"cannot import name 'Fraction' from 'fractions' \(.*\)")
 
     @unittest.skipIf(sys.platform == 'win32', 'Cannot delete cwd on Windows')
+    @unittest.skipIf(sys.platform == 'sunos5', 'Cannot delete cwd on Solaris/Illumos')
     def test_script_shadowing_stdlib_cwd_failure(self):
         with os_helper.temp_dir() as tmp:
             subtmp = os.path.join(tmp, "subtmp")


### PR DESCRIPTION
Recently introduced **test_script_shadowing_stdlib_cwd_failure** (#130934) fails on Solaris/Illumos, because, similarly to Windows, cwd cannot be removed. Instead, it fails with `OSError: [Errno 22] Invalid argument`.

```
======================================================================
FAIL: test_script_shadowing_stdlib_cwd_failure (test.test_import.ImportTests.test_script_shadowing_stdlib_cwd_failure)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builds/jkulik/permanent/buildbot-worker/worker/python-main.ulx-0-oracle-solaris-trunk-amd64/build/components/python/pythonmain/cpython-main/Lib/test/test_import/__init__.py", line 1208, in test_script_shadowing_stdlib_cwd_failure
    self.assertRegex(stdout, expected_error)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Regex didn't match: b"AttributeError: module 'os' has no attribute 'does_not_exist'" not found in b'Traceback (most recent call last):\n  File "<string>", line 1, in <module>\n    import main\n  File "/tmp/test_python_2l_0nt7c/tmp_zo8bxtz/subtmp/main.py", line 7, in <module>\n  File "/builds/jkulik/permanent/buildbot-worker/worker/python-main.ulx-0-oracle-solaris-trunk-amd64/build/components/python/pythonmain/cpython-main/Lib/shutil.py", line 845, in rmtree\n    _rmtree_impl(path, dir_fd, onexc)\n    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^\n  File "/builds/jkulik/permanent/buildbot-worker/worker/python-main.ulx-0-oracle-solaris-trunk-amd64/build/components/python/pythonmain/cpython-main/Lib/shutil.py", line 714, in _rmtree_safe_fd\n    _rmtree_safe_fd_step(stack, onexc)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^\n  File "/builds/jkulik/permanent/buildbot-worker/worker/python-main.ulx-0-oracle-solaris-trunk-amd64/build/components/python/pythonmain/cpython-main/Lib/shutil.py", line 795, in _rmtree_safe_fd_step\n    onexc(func, path, err)\n    ~~~~~^^^^^^^^^^^^^^^^^\n  File "/builds/jkulik/permanent/buildbot-worker/worker/python-main.ulx-0-oracle-solaris-trunk-amd64/build/components/python/pythonmain/cpython-main/Lib/shutil.py", line 746, in _rmtree_safe_fd_step\n    os.rmdir(name, dir_fd=dirfd)\n    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^\nOSError: [Errno 22] Invalid argument: \'/tmp/test_python_2l_0nt7c/tmp_zo8bxtz/subtmp\'\n'
```

<!-- gh-issue-number: gh-130932 -->
* Issue: gh-130932
<!-- /gh-issue-number -->
