### PR TITLE
gh-93096: Remove `-t` and `-v` flags from `pickletools` cli

### DIFF
--- a/Lib/pickletools.py
+++ b/Lib/pickletools.py
@@ -2838,9 +2838,6 @@ __test__ = {'disassembler_test': _dis_test,
             'disassembler_memo_test': _memo_test,
            }
 
-def _test():
-    import doctest
-    return doctest.testmod()
 
 if __name__ == "__main__":
     import argparse
@@ -2865,36 +2862,27 @@ if __name__ == "__main__":
         '-p', '--preamble', default="==> {name} <==",
         help='if more than one pickle file is specified, print this before'
         ' each disassembly')
-    parser.add_argument(
-        '-t', '--test', action='store_true',
-        help='run self-test suite')
-    parser.add_argument(
-        '-v', action='store_true',
-        help='run verbosely; only affects self-test run')
     args = parser.parse_args()
-    if args.test:
-        _test()
+    if not args.pickle_file:
+        parser.print_help()
     else:
-        if not args.pickle_file:
-            parser.print_help()
+        annotate = 30 if args.annotate else 0
+        memo = {} if args.memo else None
+        if args.output is None:
+            output = sys.stdout
         else:
-            annotate = 30 if args.annotate else 0
-            memo = {} if args.memo else None
-            if args.output is None:
-                output = sys.stdout
-            else:
-                output = open(args.output, 'w')
-            try:
-                for arg in args.pickle_file:
-                    if len(args.pickle_file) > 1:
-                        name = '<stdin>' if arg == '-' else arg
-                        preamble = args.preamble.format(name=name)
-                        output.write(preamble + '\n')
-                    if arg == '-':
-                        dis(sys.stdin.buffer, output, memo, args.indentlevel, annotate)
-                    else:
-                        with open(arg, 'rb') as f:
-                            dis(f, output, memo, args.indentlevel, annotate)
-            finally:
-                if output is not sys.stdout:
-                    output.close()
+            output = open(args.output, 'w')
+        try:
+            for arg in args.pickle_file:
+                if len(args.pickle_file) > 1:
+                    name = '<stdin>' if arg == '-' else arg
+                    preamble = args.preamble.format(name=name)
+                    output.write(preamble + '\n')
+                if arg == '-':
+                    dis(sys.stdin.buffer, output, memo, args.indentlevel, annotate)
+                else:
+                    with open(arg, 'rb') as f:
+                        dis(f, output, memo, args.indentlevel, annotate)
+        finally:
+            if output is not sys.stdout:
+                output.close()

--- a/Misc/NEWS.d/next/Library/2025-03-10-14-44-04.gh-issue-93096.kmt59U.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-10-14-44-04.gh-issue-93096.kmt59U.rst
@@ -1,0 +1,3 @@
+Removed undocumented ``-t`` and ``-v`` arguments of ``python -m
+pickletools``. Use ``python -m doctest Lib/pickletools.py -v`` instead.
+Patch by Semyon Moroz.


### PR DESCRIPTION
I'm also going to send a similar PR for the `pickle` module (for same flags)

And I'm not sure if I should send a separate PR or I can add it here


<!-- gh-issue-number: gh-93096 -->
* Issue: gh-93096
<!-- /gh-issue-number -->
