### PR TITLE
gh-130956: emit AArch64 trampolines only for long jumps

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-10-12-05-45.gh-issue-130956.f823Ih.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-10-12-05-45.gh-issue-130956.f823Ih.rst
@@ -1,0 +1,1 @@
+Optimize the AArch64 code generation for the JIT. Patch by Diego Russo

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -430,6 +430,17 @@ void patch_aarch64_trampoline(unsigned char *location, int ordinal, jit_state *s
 void
 patch_aarch64_trampoline(unsigned char *location, int ordinal, jit_state *state)
 {
+
+    uint64_t value = (uintptr_t)symbols_map[ordinal];
+    int64_t range = value - (uintptr_t)location;
+
+    // If we are in range of 28 signed bits, we patch the instruction with
+    // the address of the symbol.
+    if (range >= -(1 << 27) && range < (1 << 27)) {
+        patch_aarch64_26r(location, (uintptr_t)value);
+        return;
+    }
+
     // Masking is done modulo 32 as the mask is stored as an array of uint32_t
     const uint32_t symbol_mask = 1 << (ordinal % 32);
     const uint32_t trampoline_mask = state->trampolines.mask[ordinal / 32];
@@ -445,7 +456,6 @@ patch_aarch64_trampoline(unsigned char *location, int ordinal, jit_state *state)
     uint32_t *p = (uint32_t*)(state->trampolines.mem + index * TRAMPOLINE_SIZE);
     assert((size_t)(index + 1) * TRAMPOLINE_SIZE <= state->trampolines.size);
 
-    uint64_t value = (uintptr_t)symbols_map[ordinal];
 
     /* Generate the trampoline
        0: 58000048      ldr     x8, 8

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -507,6 +507,7 @@ def get_target(host: str) -> _COFF | _ELF | _MachO:
             # On aarch64 Linux, intrinsics were being emitted and this flag
             # was required to disable them.
             "-mno-outline-atomics",
+            "-fplt",
         ]
         target = _ELF(host, alignment=8, args=args)
     elif re.fullmatch(r"i686-pc-windows-msvc", host):

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -507,7 +507,6 @@ def get_target(host: str) -> _COFF | _ELF | _MachO:
             # On aarch64 Linux, intrinsics were being emitted and this flag
             # was required to disable them.
             "-mno-outline-atomics",
-            "-fplt",
         ]
         target = _ELF(host, alignment=8, args=args)
     elif re.fullmatch(r"i686-pc-windows-msvc", host):


### PR DESCRIPTION
Emit the AArch64 trampoline only if the address is more than 27 bits range.
Enable the PLT for Linux AArch64: without it no trampolines are emitted at all and symbols are referenced via the GOT.



<!-- gh-issue-number: gh-130956 -->
* Issue: gh-130956
<!-- /gh-issue-number -->
