### PR TITLE
gh-130887: remove trailing jump in AArch64 JIT stencils

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-10-12-08-57.gh-issue-130887.f823Ih.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-10-12-08-57.gh-issue-130887.f823Ih.rst
@@ -1,0 +1,1 @@
+Optimize the AArch64 code generation for the JIT. Patch by Diego Russo


### PR DESCRIPTION
In order to keep the alignment of the code body, the removed jump and the 0 padding at the end of AArch64 JIT stencils have been replaced with nop instructions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130887 -->
* Issue: gh-130887
<!-- /gh-issue-number -->
