### PR TITLE
gh-131082: Add missing guards for WIN32_LEAN_AND_MEAN

### DIFF
--- a/Include/internal/pycore_condvar.h
+++ b/Include/internal/pycore_condvar.h
@@ -32,7 +32,7 @@
 
 /* include windows if it hasn't been done before */
 #ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>              // CRITICAL_SECTION
 

--- a/Include/internal/pycore_condvar.h
+++ b/Include/internal/pycore_condvar.h
@@ -31,7 +31,9 @@
 #define Py_HAVE_CONDVAR
 
 /* include windows if it hasn't been done before */
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>              // CRITICAL_SECTION
 
 /* options */

--- a/Include/internal/pycore_semaphore.h
+++ b/Include/internal/pycore_semaphore.h
@@ -10,7 +10,9 @@
 #include "pycore_pythread.h"      // _POSIX_SEMAPHORES
 
 #ifdef MS_WINDOWS
-#   define WIN32_LEAN_AND_MEAN
+#   ifndef WIN32_LEAN_AND_MEAN
+#       define WIN32_LEAN_AND_MEAN
+#   endif
 #   include <windows.h>
 #elif defined(HAVE_PTHREAD_H)
 #   include <pthread.h>

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -11,7 +11,9 @@
 #include "pycore_pystate.h"       // _PyInterpreterState_GetIDObject()
 
 #ifdef MS_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>        // SwitchToThread()
 #elif defined(HAVE_SCHED_H)
 #include <sched.h>          // sched_yield()

--- a/Modules/_interpchannelsmodule.c
+++ b/Modules/_interpchannelsmodule.c
@@ -12,7 +12,7 @@
 
 #ifdef MS_WINDOWS
 #ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>        // SwitchToThread()
 #elif defined(HAVE_SCHED_H)

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -23,7 +23,7 @@
 #include <stddef.h> /* For offsetof */
 
 #ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
 #include <fcntl.h>

--- a/Python/lock.c
+++ b/Python/lock.c
@@ -8,7 +8,9 @@
 #include "pycore_time.h"          // _PyTime_Add()
 
 #ifdef MS_WINDOWS
-#  define WIN32_LEAN_AND_MEAN
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
 #  include <windows.h>            // SwitchToThread()
 #elif defined(HAVE_SCHED_H)
 #  include <sched.h>              // sched_yield()

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -45,7 +45,9 @@ Data members:
 #endif
 
 #ifdef MS_WINDOWS
-#  define WIN32_LEAN_AND_MEAN
+#  ifndef WIN32_LEAN_AND_MEAN
+#    define WIN32_LEAN_AND_MEAN
+#  endif
 #  include <windows.h>
 #endif /* MS_WINDOWS */
 


### PR DESCRIPTION
This adds missing guards for the WIN32_LEAN_AND_MEAN macro. I am working on the xbox where the toolchain already adds this definition. This leads to warnings about the macro getting redefined.

I think this should be trivial enough to require no issue / news entry

<!-- gh-issue-number: gh-131082 -->
* Issue: gh-131082
<!-- /gh-issue-number -->
