### PR TITLE
gh-117151: optimize algorithm to grow the buffer size for readall() on files

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-03-11-10-57-36.gh-issue-131052.QuKA1H.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-11-10-57-36.gh-issue-131052.QuKA1H.rst
@@ -1,0 +1,4 @@
+Optimize the algorithm to grow the buffer when reading a full file and the
+file size was unknown or changed since the file was opened. Increase
+exponentially and faster and in steps no smaller than 128 kB. This should
+improve I/O performance.

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -43,17 +43,8 @@
 #  include <windows.h>
 #endif
 
-#if BUFSIZ < (8*1024)
-#  define SMALLCHUNK (8*1024)
-#elif (BUFSIZ >= (2 << 25))
-#  error "unreasonable BUFSIZ > 64 MiB defined"
-#else
-#  define SMALLCHUNK BUFSIZ
-#endif
-
-/* Size at which a buffer is considered "large" and behavior should change to
-   avoid excessive memory allocation */
-#define LARGE_BUFFER_CUTOFF_SIZE 65536
+#define LARGE_BUFFER_CUTOFF_SIZE (4096*1024)
+#define SMALL_BUFFER_SIZE (128*1024)
 
 /*[clinic input]
 module _io
@@ -709,16 +700,20 @@ new_buffersize(fileio *self, size_t currentsize)
     size_t addend;
 
     /* Expand the buffer by an amount proportional to the current size,
-       giving us amortized linear-time behavior.  For bigger sizes, use a
-       less-than-double growth factor to avoid excessive allocation. */
+       giving us amortized linear-time behavior. This heuristic is only used
+       when the file size was unknown or changed since the file was opened.
+       For smaller sizes, use exponential growth to avoid many small reads.
+       For bigger sizes, use a less-than-double growth factor to avoid
+       excessive allocation.
+    */
     assert(currentsize <= PY_SSIZE_T_MAX);
     if (currentsize > LARGE_BUFFER_CUTOFF_SIZE)
         addend = currentsize >> 3;
     else
-        addend = 256 + currentsize;
-    if (addend < SMALLCHUNK)
+        addend = 3 * currentsize;
+    if (addend < SMALL_BUFFER_SIZE)
         /* Avoid tiny read() calls. */
-        addend = SMALLCHUNK;
+        addend = SMALL_BUFFER_SIZE;
     return addend + currentsize;
 }
 
@@ -743,7 +738,6 @@ _io_FileIO_readall_impl(fileio *self)
     Py_ssize_t bytes_read = 0;
     Py_ssize_t n;
     size_t bufsize;
-
     if (self->fd < 0) {
         return err_closed();
     }
@@ -756,7 +750,7 @@ _io_FileIO_readall_impl(fileio *self)
     }
     if (end <= 0) {
         /* Use a default size and resize as needed. */
-        bufsize = SMALLCHUNK;
+        bufsize = SMALL_BUFFER_SIZE;
     }
     else {
         /* This is probably a real file. */
@@ -777,7 +771,7 @@ _io_FileIO_readall_impl(fileio *self)
            then calls readall() to get the rest, which would result in allocating
            more than required. Guard against that for larger files where we expect
            the I/O time to dominate anyways while keeping small files fast. */
-        if (bufsize > LARGE_BUFFER_CUTOFF_SIZE) {
+        if (bufsize > SMALL_BUFFER_SIZE) {
             Py_BEGIN_ALLOW_THREADS
             _Py_BEGIN_SUPPRESS_IPH
 #ifdef MS_WINDOWS


### PR DESCRIPTION
continuing my PRs to optimize buffers.

file `readall()` sets the buffer to the filesize.
* in the happy path, the filesize matches the file and it can be read in one call (or multiple calls if large file), without any buffer extension.
* in the not happy path, the filesize could have changed or be unavailable. `new_buffersize` is used to grow the buffer gradually. we need to optimize that later case.

that `new_buffersize` function was written 16 years ago and had little optimization since. 
it's reading the file with a 8kB buffer to start with and increasing in steps of around 8kB, it's doing a lot of small inefficient writes.
it's increasing in steps of 12.5% after 65kB, which is still minuscule.

I spent some days looking into this function (as part of the attached ticket looking into optimizing buffers), the attached PR is what I could come up with to optimize the function.

considerations and gotcha:
* I am seeing buffers above some size (256kB or 512kB) have some microseconds of overhead. probably due to the OS allocating them differently with large page and zeroing them (there was another ticket raised about that). so the code is starting with a 128kB buffer to avoid that overhead. This may vary with the operating system.
* for small sizes, multiply the size by 4 on each step. we want to get into the MB range to do larger I/O.
* for larger sizes, increase the size by 12.5%, same as the existing code. this is required to avoid running out of memory when reading very large file. (for example try to read a 25GB file on a system with 32GB of memory, it will error out of memory if the buffer grows by 50% or even 25%). there is another old ticket about that from years
* the buffer is reallocated in place without copying the memory. it's actually not expensive to realloc() many times since there is no copy. This may vary with the operating system.

is it worth explaining all of that in comments? 
the existing code is sparse in explanation and I had to go through a fair amount of tickets and debugging to understand the history.

See code below to benchmark with different file sizes on your machine.
This PR is a draft to discuss the fix before I spend more time on it. and to get a CI build passing. 

```
import os
import time

os.system("touch file.txt")
os.system("truncate --size 0 file.txt")
f = open("file.txt", "rb")
os.system("dd if=/dev/urandom bs=1k count=1 >> file.txt")
os.system("dd if=/dev/urandom bs=50k count=1 >> file.txt")
os.system("dd if=/dev/urandom bs=150k count=1 >> file.txt")
os.system("dd if=/dev/urandom bs=1M count=1 >> file.txt")
#os.system("dd if=/dev/urandom bs=1k count=1 >> file.txt")
#os.system("dd if=/dev/urandom bs=2M count=1 >> file.txt")
#os.system("dd if=/dev/urandom bs=2M count=1 >> file.txt")
os.system("dd if=/dev/urandom bs=1k count=1 >> file.txt")
time.sleep(0.5)
start = time.perf_counter()
data = f.read()
end = time.perf_counter()
elapsed = end - start
f.close()
finalsize = os.path.getsize("file.txt")
print("read took {:3.09f} ms for {} bytes".format(elapsed * 1000.0, finalsize))
```


<!-- gh-issue-number: gh-117151 -->
* Issue: gh-117151
<!-- /gh-issue-number -->
