### PR TITLE
gh-93096: Remove `-t` and `-v` flags from `pickle` cli

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -1906,10 +1906,6 @@ except ImportError:
     Pickler, Unpickler = _Pickler, _Unpickler
     dump, dumps, load, loads = _dump, _dumps, _load, _loads
 
-# Doctest
-def _test():
-    import doctest
-    return doctest.testmod()
 
 if __name__ == "__main__":
     import argparse
@@ -1918,24 +1914,15 @@ if __name__ == "__main__":
     parser.add_argument(
         'pickle_file',
         nargs='*', help='the pickle file')
-    parser.add_argument(
-        '-t', '--test', action='store_true',
-        help='run self-test suite')
-    parser.add_argument(
-        '-v', action='store_true',
-        help='run verbosely; only affects self-test run')
     args = parser.parse_args()
-    if args.test:
-        _test()
+    if not args.pickle_file:
+        parser.print_help()
     else:
-        if not args.pickle_file:
-            parser.print_help()
-        else:
-            import pprint
-            for fn in args.pickle_file:
-                if fn == '-':
-                    obj = load(sys.stdin.buffer)
-                else:
-                    with open(fn, 'rb') as f:
-                        obj = load(f)
-                pprint.pprint(obj)
+        import pprint
+        for fn in args.pickle_file:
+            if fn == '-':
+                obj = load(sys.stdin.buffer)
+            else:
+                with open(fn, 'rb') as f:
+                    obj = load(f)
+            pprint.pprint(obj)

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -700,7 +700,7 @@ class CompatPickleTests(unittest.TestCase):
 
 
 def load_tests(loader, tests, pattern):
-    tests.addTest(doctest.DocTestSuite())
+    tests.addTest(doctest.DocTestSuite(pickle))
     return tests
 
 

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -700,7 +700,7 @@ class CompatPickleTests(unittest.TestCase):
 
 
 def load_tests(loader, tests, pattern):
-    tests.addTest(doctest.DocTestSuite(pickle))
+    tests.addTest(doctest.DocTestSuite())
     return tests
 
 

--- a/Misc/NEWS.d/next/Library/2025-03-11-08-07-07.gh-issue-93096.DyPXUX.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-11-08-07-07.gh-issue-93096.DyPXUX.rst
@@ -1,0 +1,2 @@
+Removed undocumented ``-t`` and ``-v`` arguments of ``python -m pickle``.
+Use ``python -m doctest Lib/pickle.py -v`` instead. Patch by Semyon Moroz.


### PR DESCRIPTION
- [x] added load doctest to unittest
- [x] we still can run doctests using: `./python -m doctest Lib/pickle.py -v`

<!-- gh-issue-number: gh-93096 -->
* Issue: gh-93096
<!-- /gh-issue-number -->
