### PR TITLE
Replace link to historical PEP with current document on typing.python…

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2771,7 +2771,7 @@ types.
 
       .. versionadded:: 3.13
 
-   See the `TypedDict <https://typing.python.org/en/latest/spec/typeddict.html#typeddict>`_ in the typing documentation for more examples and detailed rules.
+   See the `TypedDict <https://typing.python.org/en/latest/spec/typeddict.html#typeddict>`_ section in the typing documentation for more examples and detailed rules.
 
    .. versionadded:: 3.8
 

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -2771,7 +2771,7 @@ types.
 
       .. versionadded:: 3.13
 
-   See :pep:`589` for more examples and detailed rules of using ``TypedDict``.
+   See the `TypedDict <https://typing.python.org/en/latest/spec/typeddict.html#typeddict>`_ in the typing documentation for more examples and detailed rules.
 
    .. versionadded:: 3.8
 


### PR DESCRIPTION
Replace link to historical PEP with current document on typing.python.org

Discussion at https://discuss.python.org/t/links-to-historical-peps/80810

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131096.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->