### PR TITLE
gh-93096: Remove CLI interface for `difflib`

### DIFF
--- a/Doc/library/cmdline.rst
+++ b/Doc/library/cmdline.rst
@@ -11,7 +11,6 @@ The following modules have a command-line interface.
 * :mod:`code`
 * :ref:`compileall <compileall-cli>`
 * :mod:`cProfile`: see :ref:`profile <profile-cli>`
-* :ref:`difflib <difflib-interface>`
 * :ref:`dis <dis-cli>`
 * :mod:`doctest`
 * :mod:`!encodings.rot_13`

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -2060,10 +2060,3 @@ def restore(delta, which):
     for line in delta:
         if line[:2] in prefixes:
             yield line[2:]
-
-def _test():
-    import doctest, difflib
-    return doctest.testmod(difflib)
-
-if __name__ == "__main__":
-    _test()

--- a/Misc/NEWS.d/next/Library/2025-03-11-20-35-41.gh-issue-93096.Jdt_8a.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-11-20-35-41.gh-issue-93096.Jdt_8a.rst
@@ -1,0 +1,2 @@
+Removed undocumented CLI ``python -m difflib``. Use ``python -m doctest
+Lib/difflib.py -v`` instead. Patch by Semyon Moroz.


### PR DESCRIPTION
There was no true CLI, just the ability to run doctests.

And I think we have a little strange title for section about creating custom CLI with example (we already use similar titles for CLI docs sections):
![Screenshot from 2025-03-11 20-25-22](https://github.com/user-attachments/assets/b28cbf88-fa14-420e-bb7b-40c54138dbb9)

cc @vstinner 

<!-- gh-issue-number: gh-93096 -->
* Issue: gh-93096
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131099.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->