### PR TITLE
gh-110097: Fix flaky `test_timeout` in `test_concurrent_futures.test_process_pool`

### DIFF
--- a/Lib/test/test_concurrent_futures/executor.py
+++ b/Lib/test/test_concurrent_futures/executor.py
@@ -69,7 +69,9 @@ class ExecutorTest:
         else:
             self.fail('expected TimeoutError')
 
-        self.assertEqual([None, None], results)
+        # gh-110097: On heavily loaded systems, the launch of the worker may
+        # take longer than the specified timeout.
+        self.assertIn(results, ([None, None], [None], []))
 
     def test_shutdown_race_issue12456(self):
         # Issue #12456: race condition at shutdown where trying to post a


### PR DESCRIPTION
On heavily loaded systems, the launch of the workers to run `time.sleep(0)` can take longer than the five second timeout.


<!-- gh-issue-number: gh-110097 -->
* Issue: gh-110097
<!-- /gh-issue-number -->
