### PR TITLE
gh-131121: Fix `_Py_atomic_store_char_relaxed` memory order

### DIFF
--- a/Include/cpython/pyatomic_gcc.h
+++ b/Include/cpython/pyatomic_gcc.h
@@ -519,7 +519,7 @@ _Py_atomic_store_ullong_relaxed(unsigned long long *obj,
 
 static inline void
 _Py_atomic_store_char_relaxed(char *obj, char value)
-{ __atomic_store_n(obj, value, __ATOMIC_RELEASE); }
+{ __atomic_store_n(obj, value, __ATOMIC_RELAXED); }
 
 static inline void
 _Py_atomic_store_uchar_relaxed(unsigned char *obj, unsigned char value)


### PR DESCRIPTION


<!-- gh-issue-number: gh-131121 -->
* Issue: gh-131121
<!-- /gh-issue-number -->
