### PR TITLE
Move `assert()` inside lock to avoid data race.

### DIFF
--- a/Python/legacy_tracing.c
+++ b/Python/legacy_tracing.c
@@ -582,10 +582,10 @@ _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
     if (_PySys_Audit(current_tstate, "sys.settrace", NULL) < 0) {
         return -1;
     }
-    assert(tstate->interp->sys_tracing_threads >= 0);
     // needs to be decref'd outside of the lock
     PyObject *old_traceobj;
     LOCK_SETUP();
+    assert(tstate->interp->sys_tracing_threads >= 0);
     Py_ssize_t tracing_threads = setup_tracing(tstate, func, arg, &old_traceobj);
     UNLOCK_SETUP();
     Py_XDECREF(old_traceobj);


### PR DESCRIPTION
We need to hold the lock to safely read the `tstate->interp->sys_tracing_threads` value.