### PR TITLE
gh-131127: Minimal build support on systems using LibreSSL

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-03-11-21-08-46.gh-issue-131127.whcVdY.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-11-21-08-46.gh-issue-131127.whcVdY.rst
@@ -1,0 +1,1 @@
+Systems using LibreSSL now successfully build.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4787,7 +4787,7 @@ _ssl__SSLContext_sni_callback_set_impl(PySSLContext *self, PyObject *value)
     return 0;
 }
 
-#if OPENSSL_VERSION_NUMBER < 0x30300000L
+#if OPENSSL_VERSION_NUMBER < 0x30300000L && !defined(LIBRESSL_VERSION_NUMBER)
 static X509_OBJECT *x509_object_dup(const X509_OBJECT *obj)
 {
     int ok;


### PR DESCRIPTION
I am aware PEP-644 states that LibreSSL is no longer supported, but I am hoping this simple `#ifdef` is not too muich to add [1].

[1] https://peps.python.org/pep-0644/


<!-- gh-issue-number: gh-131127 -->
* Issue: gh-131127
<!-- /gh-issue-number -->
