### PR TITLE
[3.13] gh-130940: Remove PyConfig.use_system_logger

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -1271,17 +1271,6 @@ PyConfig
 
       Default: ``1`` in Python config and ``0`` in isolated config.
 
-   .. c:member:: int use_system_logger
-
-      If non-zero, ``stdout`` and ``stderr`` will be redirected to the system
-      log.
-
-      Only available on macOS 10.12 and later, and on iOS.
-
-      Default: ``0`` (don't use system log).
-
-      .. versionadded:: 3.13.2
-
    .. c:member:: int user_site_directory
 
       If non-zero, add the user site directory to :data:`sys.path`.

--- a/Doc/using/ios.rst
+++ b/Doc/using/ios.rst
@@ -296,8 +296,6 @@ To add Python to an iOS Xcode project:
    * Buffered stdio (:c:member:`PyConfig.buffered_stdio`) is *disabled*;
    * Writing bytecode (:c:member:`PyConfig.write_bytecode`) is *disabled*;
    * Signal handlers (:c:member:`PyConfig.install_signal_handlers`) are *enabled*;
-   * System logging (:c:member:`PyConfig.use_system_logger`) is *enabled*
-     (optional, but strongly recommended);
    * ``PYTHONHOME`` for the interpreter is configured to point at the
      ``python`` subfolder of your app's bundle; and
    * The ``PYTHONPATH`` for the interpreter includes:

--- a/Include/cpython/initconfig.h
+++ b/Include/cpython/initconfig.h
@@ -179,9 +179,6 @@ typedef struct PyConfig {
     int use_frozen_modules;
     int safe_path;
     int int_max_str_digits;
-#ifdef __APPLE__
-    int use_system_logger;
-#endif
 
     int cpu_count;
 #ifdef Py_GIL_DISABLED

--- a/Lib/test/test_apple.py
+++ b/Lib/test/test_apple.py
@@ -1,10 +1,10 @@
 import unittest
 from _apple_support import SystemLog
-from test.support import is_apple
+from test.support import is_apple_mobile
 from unittest.mock import Mock, call
 
-if not is_apple:
-    raise unittest.SkipTest("Apple-specific")
+if not is_apple_mobile:
+    raise unittest.SkipTest("iOS-specific")
 
 
 # Test redirection of stdout and stderr to the Apple system log.

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -627,8 +627,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         CONFIG_COMPAT.update({
             'legacy_windows_stdio': 0,
         })
-    if support.is_apple:
-        CONFIG_COMPAT['use_system_logger'] = False
 
     CONFIG_PYTHON = dict(CONFIG_COMPAT,
         _config_init=API_PYTHON,

--- a/Misc/NEWS.d/next/Library/2025-03-12-11-53-32.gh-issue-130940.81K1Tg.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-12-11-53-32.gh-issue-130940.81K1Tg.rst
@@ -1,4 +1,4 @@
-The ``PyConfig.use_system_logger`` attribute, introduced in Python 3.12.2, has
+The ``PyConfig.use_system_logger`` attribute, introduced in Python 3.13.2, has
 been removed. The introduction of this attribute inadvertently introduced an
 ABI breakage on macOS and iOS. The use of the system logger is now enabled
 by default on iOS, and disabled by default on macOS.

--- a/Misc/NEWS.d/next/Library/2025-03-12-11-53-32.gh-issue-130940.81K1Tg.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-12-11-53-32.gh-issue-130940.81K1Tg.rst
@@ -1,0 +1,4 @@
+The ``PyConfig.use_system_logger`` attribute, introduced in Python 3.12.2, has
+been removed. The introduction of this attribute inadvertently introduced an
+ABI breakage on macOS and iOS. The use of the system logger is now enabled
+by default on iOS, and disabled by default on macOS.

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -130,9 +130,6 @@ static const PyConfigSpec PYCONFIG_SPEC[] = {
 #ifdef Py_DEBUG
     SPEC(run_presite, WSTR_OPT),
 #endif
-#ifdef __APPLE__
-    SPEC(use_system_logger, BOOL),
-#endif
 
     {NULL, 0, 0},
 };
@@ -751,9 +748,6 @@ config_check_consistency(const PyConfig *config)
     assert(config->cpu_count != 0);
     // config->use_frozen_modules is initialized later
     // by _PyConfig_InitImportConfig().
-#ifdef __APPLE__
-    assert(config->use_system_logger >= 0);
-#endif
 #ifdef Py_STATS
     assert(config->_pystats >= 0);
 #endif
@@ -856,9 +850,6 @@ _PyConfig_InitCompatConfig(PyConfig *config)
     config->_is_python_build = 0;
     config->code_debug_ranges = 1;
     config->cpu_count = -1;
-#ifdef __APPLE__
-    config->use_system_logger = 0;
-#endif
 #ifdef Py_GIL_DISABLED
     config->enable_gil = _PyConfig_GIL_DEFAULT;
 #endif
@@ -886,9 +877,6 @@ config_init_defaults(PyConfig *config)
     config->pathconfig_warnings = 1;
 #ifdef MS_WINDOWS
     config->legacy_windows_stdio = 0;
-#endif
-#ifdef __APPLE__
-    config->use_system_logger = 0;
 #endif
 }
 
@@ -924,9 +912,6 @@ PyConfig_InitIsolatedConfig(PyConfig *config)
     config->pathconfig_warnings = 0;
 #ifdef MS_WINDOWS
     config->legacy_windows_stdio = 0;
-#endif
-#ifdef __APPLE__
-    config->use_system_logger = 0;
 #endif
 }
 

--- a/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
+++ b/iOS/testbed/iOSTestbedTests/iOSTestbedTests.m
@@ -53,8 +53,6 @@
     // Enforce UTF-8 encoding for stderr, stdout, file-system encoding and locale.
     // See https://docs.python.org/3/library/os.html#python-utf-8-mode.
     preconfig.utf8_mode = 1;
-    // Use the system logger for stdout/err
-    config.use_system_logger = 1;
     // Don't buffer stdio. We want output to appears in the log immediately
     config.buffered_stdio = 0;
     // Don't write bytecode; we can't modify the app bundle


### PR DESCRIPTION
Pull request #127754 is a backport of #127592 to the 3.13 branch. However, this PR included a new attribute (`use_system_logger`) in PyConfig, which broke ABI compatibility on Apple platforms (macOS and iOS).

This was not detected because ABI compatibility checks are only performed on Linux, and the inclusion of the flag was gated with `__APPLE__` preprocessor handling.

On macOS, removing the flag is no problem - it's a new feature, but an entirely optional one that would only be enabled by someone that has built (or updated) an app that embeds Python 3.13.2.

However, on iOS, the behavior enabled by this flag is required on iOS so that the logs generated by the simulator can be observed at all. More generally, there's very little reason that you'd *not* want stdout and stderr routed to the system log - every BeeWare app, for example, includes [std-nslog](https://github.com/beeware/std-nslog), which implements effectively the same behavior.

This PR:
* Removes the `use_system_logger` attribute from PyConfig.
* Hard-codes the use of the system logger on iOS *only*. 

This is, strictly, a change of behavior for 3.13 on iOS, unless you view "the output of Python's stdout/stderr is now visible in the app logs" as a bug that is resolved by this PR. My inclination is that this is such a signficant quality of life for iOS developers that it warrants being treated as a bugfix/improvement - but I wanted to flag the change in the strictest interpretation.

In an upcoming PR, I'll rework the introduction of the flag on the 3.14 branch to use the new PyInitConfig API (avoiding the ABI incompatibility), making the default value "enabled" on iOS, and "disabled" on macOS.


<!-- gh-issue-number: gh-130940 -->
* Issue: gh-130940
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131129.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->