### PR TITLE
gh-93096: Remove run block in `heapq`

### DIFF
--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -595,9 +595,3 @@ try:
     from _heapq import _heappop_max
 except ImportError:
     pass
-
-
-if __name__ == "__main__":
-
-    import doctest # pragma: no cover
-    print(doctest.testmod()) # pragma: no cover


### PR DESCRIPTION
we can use next command for doctests: `./python -m doctest Lib/heapq.py -v`

and we already loading doctest in next line:
https://github.com/python/cpython/blob/ebc24d54bcf554403e9bf4b590d5c1f49e648e0d/Lib/test/test_heapq.py#L30-L45

<!-- gh-issue-number: gh-93096 -->
* Issue: gh-93096
<!-- /gh-issue-number -->
