### PR TITLE
gh-131032: Fix math.fma(x, y, z) zero sign

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -2806,6 +2806,13 @@ class FMATests(unittest.TestCase):
         self.assertIsPositiveZero(math.fma(-tiny, -tiny, -0.0))
         self.assertIsNegativeZero(math.fma(-tiny, tiny, -0.0))
 
+    # gh-73468: On some platforms, libc fma() doesn't implement IEE 754-2008
+    # properly: it doesn't use the right sign when the result is zero.
+    @unittest.skipIf(
+        sys.platform.startswith(("freebsd", "netbsd", "emscripten"))
+        or (sys.platform == "android" and platform.machine() == "x86_64"),
+        f"this platform doesn't implement IEE 754-2008 properly")
+    def test_fma_zero_result2(self):
         # Corner case where rounding the multiplication would
         # give the wrong result.
         x = float.fromhex('0x1p-500')

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -2765,12 +2765,6 @@ class FMATests(unittest.TestCase):
                 self.assertEqual(math.fma(-b, -math.inf, c), math.inf)
                 self.assertEqual(math.fma(-b, math.inf, c), -math.inf)
 
-    # gh-73468: On some platforms, libc fma() doesn't implement IEE 754-2008
-    # properly: it doesn't use the right sign when the result is zero.
-    @unittest.skipIf(
-        sys.platform.startswith(("freebsd", "wasi", "netbsd", "emscripten"))
-        or (sys.platform == "android" and platform.machine() == "x86_64"),
-        f"this platform doesn't implement IEE 754-2008 properly")
     def test_fma_zero_result(self):
         nonnegative_finites = [0.0, 1e-300, 2.3, 1e300]
 

--- a/Misc/NEWS.d/next/Library/2025-03-12-08-14-54.gh-issue-131032.kpSzWI.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-12-08-14-54.gh-issue-131032.kpSzWI.rst
@@ -1,0 +1,2 @@
+Fix :func:`math.fma(x, y, z) <math.fma>` zero sign: fix the result sign when
+*z* is zero. Patch by Victor Stinner and Sergey B Kirpichev.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2353,11 +2353,9 @@ math_fma_impl(PyObject *module, double x, double y, double z)
         // Emscripten, musl C library), libc fma() doesn't implement
         // IEEE 754-2008 properly: it doesn't use the right sign when the
         // result is zero.
-        if (x && y) {
-            r = x * y;
-        }
-        else {
-            r = copysign(1, z) == 1 ? x*y + z : x*y;
+        r = x * y;
+        if ((!x || !y) && copysign(1, z) == 1) {
+            r += z;
         }
     }
 


### PR DESCRIPTION
Fix result sign when z is zero.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131032 -->
* Issue: gh-131032
<!-- /gh-issue-number -->
