### PR TITLE
gh-111178: Fix PyCMethod API

### DIFF
--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -24,7 +24,7 @@ typedef PyObject *(*PyCFunctionFastWithKeywords) (PyObject *,
                                                   PyObject *const *, Py_ssize_t,
                                                   PyObject *);
 typedef PyObject *(*PyCMethod)(PyObject *, PyTypeObject *, PyObject *const *,
-                               size_t, PyObject *);
+                               Py_ssize_t, PyObject *);
 
 // For backwards compatibility. `METH_FASTCALL` was added to the stable API in
 // 3.10 alongside `_PyCFunctionFastWithKeywords` and `_PyCFunctionFast`.

--- a/Misc/NEWS.d/next/C_API/2025-03-12-08-29-23.gh-issue-111178.Jny_YJ.rst
+++ b/Misc/NEWS.d/next/C_API/2025-03-12-08-29-23.gh-issue-111178.Jny_YJ.rst
@@ -1,0 +1,2 @@
+Fix :c:type:`PyCMethod` API: replace ``size_t nargs`` with ``Py_ssize_t nargs``
+in :c:type:`PyCMethod`. Patch by Victor Stinner.


### PR DESCRIPTION
Replace "size_t nargs" with "Py_ssize_t nargs" in PyCMethod.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111178 -->
* Issue: gh-111178
<!-- /gh-issue-number -->
