### PR TITLE
GH-127705: Fix _Py_RefcntAdd to handle objects becoming immortal

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -135,14 +135,39 @@ static inline void _Py_RefcntAdd(PyObject* op, Py_ssize_t n)
         _Py_INCREF_IMMORTAL_STAT_INC();
         return;
     }
+#ifndef Py_GIL_DISABLED
     Py_ssize_t refcnt = _Py_REFCNT(op);
     Py_ssize_t new_refcnt = refcnt + n;
     if (new_refcnt >= (Py_ssize_t)_Py_IMMORTAL_MINIMUM_REFCNT) {
         new_refcnt = _Py_IMMORTAL_INITIAL_REFCNT;
     }
-    Py_SET_REFCNT(op, new_refcnt);
-#ifdef Py_REF_DEBUG
+#  if SIZEOF_VOID_P > 4
+    op->ob_refcnt = (PY_UINT32_T)new_refcnt;
+#  else
+    op->ob_refcnt = new_refcnt;
+#  endif
+#  ifdef Py_REF_DEBUG
     _Py_AddRefTotal(_PyThreadState_GET(), new_refcnt - refcnt);
+#  endif
+#else
+    if (_Py_IsOwnedByCurrentThread(op)) {
+        uint32_t local = op->ob_ref_local;
+        Py_ssize_t refcnt = (Py_ssize_t)local + n;
+#  if PY_SSIZE_T_MAX > UINT32_MAX
+        if (refcnt > (Py_ssize_t)UINT32_MAX) {
+            // Make the object immortal if the 32-bit local reference count
+            // would overflow.
+            refcnt = _Py_IMMORTAL_REFCNT_LOCAL;
+        }
+#  endif
+        _Py_atomic_store_uint32_relaxed(&op->ob_ref_local, (uint32_t)refcnt);
+    }
+    else {
+        _Py_atomic_add_ssize(&op->ob_ref_shared, (n << _Py_REF_SHARED_SHIFT));
+    }
+#  ifdef Py_REF_DEBUG
+    _Py_AddRefTotal(_PyThreadState_GET(), n);
+#  endif
 #endif
     // Although the ref count was increased by `n` (which may be greater than 1)
     // it is only a single increment (i.e. addition) operation, so only 1 refcnt

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -42,7 +42,8 @@ beyond the refcount limit. Immortality checks for reference count decreases will
 be done by checking the bit sign flag in the lower 32 bits.
 
 */
-#define _Py_IMMORTAL_INITIAL_REFCNT (3UL << 30)
+#define _Py_IMMORTAL_INITIAL_REFCNT (3ULL << 30)
+#define _Py_IMMORTAL_MINIMUM_REFCNT (1ULL << 31)
 #define _Py_STATIC_FLAG_BITS ((Py_ssize_t)(_Py_STATICALLY_ALLOCATED_FLAG | _Py_IMMORTAL_FLAGS))
 #define _Py_STATIC_IMMORTAL_INITIAL_REFCNT (((Py_ssize_t)_Py_IMMORTAL_INITIAL_REFCNT) | (_Py_STATIC_FLAG_BITS << 48))
 

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -158,6 +158,9 @@ static inline void Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
         return;
     }
 #ifndef Py_GIL_DISABLED
+    if (refcnt >= (Py_ssize_t)_Py_IMMORTAL_MINIMUM_REFCNT) {
+        refcnt = _Py_IMMORTAL_INITIAL_REFCNT;
+    }
 #if SIZEOF_VOID_P > 4
     ob->ob_refcnt = (PY_UINT32_T)refcnt;
 #else

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -158,9 +158,6 @@ static inline void Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt) {
         return;
     }
 #ifndef Py_GIL_DISABLED
-    if (refcnt >= (Py_ssize_t)_Py_IMMORTAL_MINIMUM_REFCNT) {
-        refcnt = _Py_IMMORTAL_INITIAL_REFCNT;
-    }
 #if SIZEOF_VOID_P > 4
     ob->ob_refcnt = (PY_UINT32_T)refcnt;
 #else

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15982,7 +15982,7 @@ _PyUnicode_ClearInterned(PyInterpreterState *interp)
         case SSTATE_INTERNED_MORTAL:
             // Restore 2 references held by the interned dict; these will
             // be decref'd by clear_interned_dict's PyDict_Clear.
-            Py_SET_REFCNT(s, Py_REFCNT(s) + 2);
+            _Py_RefcntAdd(s, 2);
 #ifdef Py_REF_DEBUG
             /* let's be pedantic with the ref total */
             _Py_IncRefTotal(_PyThreadState_GET());


### PR DESCRIPTION
Account for immortality when doing bulk increfs.
This should get the bigmem buildbot passing.

This is not a complete fix for the underlying issue, but the complete fix will need performance testing which could take a while.

<!-- gh-issue-number: gh-127705 -->
* Issue: gh-127705
<!-- /gh-issue-number -->
