### PR TITLE
gh-127503: Improve tracebacks on Emscripten when there is a trap

### DIFF
--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -327,6 +327,7 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
             with self.assertRaises(RecursionError):
                 issubclass(Failure(), int)
 
+    @support.skip_emscripten_stack_overflow()
     def test_infinite_cycle_in_bases(self):
         """Regression test for bpo-30570."""
         class X:

--- a/Tools/wasm/emscripten/node_entry.mjs
+++ b/Tools/wasm/emscripten/node_entry.mjs
@@ -32,6 +32,8 @@ const thisProgramIndex = process.argv.findIndex((x) =>
 
 const settings = {
   preRun(Module) {
+    // Globally expose API object so we can access it if we raise on startup.
+    globalThis.Module = Module;
     mountDirectories(Module);
     Module.FS.chdir(process.cwd());
     Object.assign(Module.ENV, process.env);
@@ -45,4 +47,12 @@ const settings = {
   arguments: process.argv.slice(thisProgramIndex + 1),
 };
 
-await EmscriptenModule(settings);
+try {
+  await EmscriptenModule(settings);
+} catch(e) {
+  // Show JavaScript exception and traceback
+  console.warn(e);
+  // Show Python exception and traceback
+  Module.__Py_DumpTraceback(2, Module._PyGILState_GetThisThreadState());
+  process.exit(1);
+}

--- a/configure
+++ b/configure
@@ -9631,7 +9631,7 @@ fi
 
         as_fn_append LINKFORSHARED " -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"
     as_fn_append LINKFORSHARED " -sEXPORTED_RUNTIME_METHODS=FS,callMain,ENV"
-    as_fn_append LINKFORSHARED " -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET"
+    as_fn_append LINKFORSHARED " -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET,_PyGILState_GetThisThreadState,_Py_DumpTraceback"
     as_fn_append LINKFORSHARED " -sSTACK_SIZE=5MB"
 
     if test "x$enable_wasm_dynamic_linking" = xyes

--- a/configure
+++ b/configure
@@ -9631,7 +9631,7 @@ fi
 
         as_fn_append LINKFORSHARED " -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"
     as_fn_append LINKFORSHARED " -sEXPORTED_RUNTIME_METHODS=FS,callMain,ENV"
-    as_fn_append LINKFORSHARED " -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET,_PyGILState_GetThisThreadState,_Py_DumpTraceback"
+    as_fn_append LINKFORSHARED " -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET,_PyGILState_GetThisThreadState,__Py_DumpTraceback"
     as_fn_append LINKFORSHARED " -sSTACK_SIZE=5MB"
 
     if test "x$enable_wasm_dynamic_linking" = xyes

--- a/configure.ac
+++ b/configure.ac
@@ -2370,7 +2370,7 @@ AS_CASE([$ac_sys_system],
     dnl Include file system support
     AS_VAR_APPEND([LINKFORSHARED], [" -sFORCE_FILESYSTEM -lidbfs.js -lnodefs.js -lproxyfs.js -lworkerfs.js"])
     AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_RUNTIME_METHODS=FS,callMain,ENV"])
-    AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET"])
+    AS_VAR_APPEND([LINKFORSHARED], [" -sEXPORTED_FUNCTIONS=_main,_Py_Version,__PyRuntime,__PyEM_EMSCRIPTEN_COUNT_ARGS_OFFSET,_PyGILState_GetThisThreadState,__Py_DumpTraceback"])
     AS_VAR_APPEND([LINKFORSHARED], [" -sSTACK_SIZE=5MB"])
 
     AS_VAR_IF([enable_wasm_dynamic_linking], [yes], [


### PR DESCRIPTION
This PR solves two problems:
1. No Python traceback shown on segfault/trap
2. The JavaScript source line is shown

The JavaScript source line is super long and completely unenlightening, whereas the Python traceback is very helpful.


<!-- gh-issue-number: gh-127503 -->
* Issue: gh-127503
<!-- /gh-issue-number -->
