### PR TITLE
gh-130940: Modify default behavior of `PyConfig.use_system_logger` to enable on iOS

### DIFF
--- a/Doc/c-api/init_config.rst
+++ b/Doc/c-api/init_config.rst
@@ -505,6 +505,10 @@ Configuration Options
      - :c:member:`use_hash_seed <PyConfig.use_hash_seed>`
      - ``bool``
      - Read-only
+   * - ``"use_system_logger"``
+     - :c:member:`use_system_logger <PyConfig.use_system_logger>`
+     - ``bool``
+     - Read-only
    * - ``"user_site_directory"``
      - :c:member:`user_site_directory <PyConfig.user_site_directory>`
      - ``bool``
@@ -1927,9 +1931,10 @@ PyConfig
 
       Only available on macOS 10.12 and later, and on iOS.
 
-      Default: ``0`` (don't use system log).
+      Default: ``0`` (don't use the system log) on macOS; ``1`` on iOS (use the
+      system log).
 
-      .. versionadded:: 3.13.2
+      .. versionadded:: 3.14
 
    .. c:member:: int user_site_directory
 

--- a/Doc/using/ios.rst
+++ b/Doc/using/ios.rst
@@ -297,7 +297,7 @@ To add Python to an iOS Xcode project:
    * Writing bytecode (:c:member:`PyConfig.write_bytecode`) is *disabled*;
    * Signal handlers (:c:member:`PyConfig.install_signal_handlers`) are *enabled*;
    * System logging (:c:member:`PyConfig.use_system_logger`) is *enabled*
-     (optional, but strongly recommended);
+     (optional, but strongly recommended; this is enabled by default);
    * ``PYTHONHOME`` for the interpreter is configured to point at the
      ``python`` subfolder of your app's bundle; and
    * The ``PYTHONPATH`` for the interpreter includes:

--- a/Misc/NEWS.d/next/Library/2025-03-13-07-06-22.gh-issue-130940.i5cUI5.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-13-07-06-22.gh-issue-130940.i5cUI5.rst
@@ -1,0 +1,2 @@
+The behavior of ``PyConfig.use_system_logger`` was modified to be enabled by
+default on iOS. It remains disabled by default on macOS.

--- a/Python/initconfig.c
+++ b/Python/initconfig.c
@@ -25,6 +25,15 @@
 #  endif
 #endif
 
+#ifdef __APPLE__
+/* Enable system log by default on non-macOS Apple platforms */
+#  if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+#define USE_SYSTEM_LOGGER_DEFAULT 1;
+#  else
+#define USE_SYSTEM_LOGGER_DEFAULT 0;
+#  endif
+#endif
+
 #include "config_common.h"
 
 /* --- PyConfig setters ------------------------------------------- */
@@ -1017,7 +1026,7 @@ _PyConfig_InitCompatConfig(PyConfig *config)
     config->code_debug_ranges = 1;
     config->cpu_count = -1;
 #ifdef __APPLE__
-    config->use_system_logger = 0;
+    config->use_system_logger = USE_SYSTEM_LOGGER_DEFAULT;
 #endif
 #ifdef Py_GIL_DISABLED
     config->enable_gil = _PyConfig_GIL_DEFAULT;
@@ -1049,7 +1058,7 @@ config_init_defaults(PyConfig *config)
     config->legacy_windows_stdio = 0;
 #endif
 #ifdef __APPLE__
-    config->use_system_logger = 0;
+    config->use_system_logger = USE_SYSTEM_LOGGER_DEFAULT;
 #endif
 }
 
@@ -1086,7 +1095,7 @@ PyConfig_InitIsolatedConfig(PyConfig *config)
     config->legacy_windows_stdio = 0;
 #endif
 #ifdef __APPLE__
-    config->use_system_logger = 0;
+    config->use_system_logger = USE_SYSTEM_LOGGER_DEFAULT;
 #endif
 }
 


### PR DESCRIPTION
#127592 added the `PyConfig.use_system_logger` configuration flag; this was backported to 3.13 in #127754.

This introduced an ABI breakage in 3.13.2; the flag will be removed from 3.13 by #131129. 

However, the functional effect of the flag is *required* on iOS so that the logs generated by the simulator can be observed at all. As a general rule, there's very little reason you'd *not* want stdout and stderr routed to the system log on iOS - every BeeWare app, for example, includes [std-nslog](https://github.com/beeware/std-nslog), which implements effectively the same behavior.

To allow for this, #131129 modifies the behavior on iOS to *always* use the system logger for stdout/stderr. This PR ensures that behaviour will be consistent by default between 3.13 and 3.14 - use of the system log is enabled by default on iOS, and disabled by default on macOS. 

<!-- gh-issue-number: gh-130940 -->
* Issue: gh-130940
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131172.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->