### PR TITLE
gh-131170: fix duplicated sections in frames.md file

### DIFF
--- a/InternalDocs/frames.md
+++ b/InternalDocs/frames.md
@@ -49,9 +49,8 @@ as the arguments on the stack are (usually) already in the correct
 location for the parameters. However, it requires the VM to maintain
 an extra pointer for the locals, which can hurt performance.
 
-### Generators and Coroutines
+### Specials
 
-Generators and coroutines contain a `_PyInterpreterFrame`
 The specials section contains the following pointers:
 
 * Globals dict


### PR DESCRIPTION
In the "frames.md" file at InternalDocs, I have changed the first duplicated title to **Specials** and removed the unnecessary content under the **Specials** section.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131170 -->
* Issue: gh-131170
<!-- /gh-issue-number -->
