### PR TITLE
[3.13] gh-131032: Add support.linked_to_musl() function (#131071)

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2767,3 +2767,22 @@ class BrokenIter:
         if self.iter_raises:
             1/0
         return self
+
+
+def linked_to_musl():
+    """
+    Test if the Python executable is linked to the musl C library.
+    """
+    if sys.platform != 'linux':
+        return False
+
+    import subprocess
+    exe = getattr(sys, '_base_executable', sys.executable)
+    cmd = ['ldd', exe]
+    try:
+        stdout = subprocess.check_output(cmd,
+                                         text=True,
+                                         stderr=subprocess.STDOUT)
+    except (OSError, subprocess.CalledProcessError):
+        return False
+    return ('musl' in stdout)

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -2712,8 +2712,9 @@ class FMATests(unittest.TestCase):
     # gh-73468: On some platforms, libc fma() doesn't implement IEE 754-2008
     # properly: it doesn't use the right sign when the result is zero.
     @unittest.skipIf(
-        sys.platform.startswith(("freebsd", "wasi", "netbsd"))
-        or (sys.platform == "android" and platform.machine() == "x86_64"),
+        sys.platform.startswith(("freebsd", "wasi", "netbsd", "emscripten"))
+        or (sys.platform == "android" and platform.machine() == "x86_64")
+        or support.linked_to_musl(),  # gh-131032
         f"this platform doesn't implement IEE 754-2008 properly")
     def test_fma_zero_result(self):
         nonnegative_finites = [0.0, 1e-300, 2.3, 1e300]

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -733,6 +733,10 @@ class TestSupport(unittest.TestCase):
         self.assertEqual(support.copy_python_src_ignore(path, os.listdir(path)),
                          ignored)
 
+    def test_linked_to_musl(self):
+        linked = support.linked_to_musl()
+        self.assertIsInstance(linked, bool)
+
     # XXX -follows a list of untested API
     # make_legacy_pyc
     # is_resource_enabled


### PR DESCRIPTION
Skip test_math.test_fma_zero_result() if Python is linked to the musl C library.

(cherry picked from commit 68922ace4dabb6635e6d5b51bbe6485ef2e9dad2)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131032 -->
* Issue: gh-131032
<!-- /gh-issue-number -->
