### PR TITLE
[3.11] gh-106883: Make test_current_frames_exceptions_deadlock faster

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -518,10 +518,12 @@ class SysModuleTest(unittest.TestCase):
         NUM_OBJECTS = 1000
         NUM_THREADS = 10
 
-        # 40 seconds should be enough for the test to be executed: if it
-        # is more than 40 seconds it means that the process is in deadlock
-        # hence the test fails
-        TIMEOUT = 40
+        # 160 seconds should be enough for the test to be executed: if it
+        # is more than 160 seconds it means that the process is in deadlock
+        # hence the test fails.
+        # The timeout is high because on older platforms it takes some time
+        # for the test to be executed when CPython is built with debug flags.
+        TIMEOUT = 160
 
         # Test the sys._current_frames and sys._current_exceptions calls
         pid = os.fork()

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -477,6 +477,7 @@ class SysModuleTest(unittest.TestCase):
     @threading_helper.reap_threads
     @threading_helper.requires_working_threading()
     @support.requires_fork()
+    @support.requires_resource('cpu')
     def test_current_frames_exceptions_deadlock(self):
         """
         Reproduce the bug raised in GH-106883 and GH-116969.
@@ -515,21 +516,14 @@ class SysModuleTest(unittest.TestCase):
 
         # The number of objects should be big enough to increase the
         # chances to call the GC.
-        NUM_OBJECTS = 1000
-        NUM_THREADS = 10
-
-        # 160 seconds should be enough for the test to be executed: if it
-        # is more than 160 seconds it means that the process is in deadlock
-        # hence the test fails.
-        # The timeout is high because on older platforms it takes some time
-        # for the test to be executed when CPython is built with debug flags.
-        TIMEOUT = 160
+        NUM_OBJECTS = 100
+        NUM_THREADS = 2
 
         # Test the sys._current_frames and sys._current_exceptions calls
         pid = os.fork()
         if pid:  # parent process
             try:
-                support.wait_process(pid, exitcode=0, timeout=TIMEOUT)
+                support.wait_process(pid, exitcode=0, timeout=support.SHORT_TIMEOUT)
             except KeyboardInterrupt:
                 # When pressing CTRL-C kill the deadlocked process
                 os.kill(pid, signal.SIGTERM)


### PR DESCRIPTION
On some platforms the test test_current_frames_exceptions_deadlock goes in timeout when CPython is built with debug.
The execution time of the test is about 4x and the current timeout is not enough to complete the test.

Make the test test_current_frames_exceptions_deadlock faster by decrementing the number of threads to the bare minimum and the number of objects by one order of magnitude.
These conditions are enough for a deadlock to happen.
Make use of support.SHORT_TIMEOUT which is 30 seconds by default.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106883 -->
* Issue: gh-106883
<!-- /gh-issue-number -->
