### PR TITLE
GH-125174: Make immortality "sticky"

### DIFF
--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -41,6 +41,10 @@ having all the lower 32 bits set, which will avoid the reference count to go
 beyond the refcount limit. Immortality checks for reference count decreases will
 be done by checking the bit sign flag in the lower 32 bits.
 
+To ensure that once an object becomes immortal, it remains immortal, the threshold
+for omitting increfs is much higher than for omitting decrefs. Consequently, once
+the refcount for an object exceeds _Py_IMMORTAL_MINIMUM_REFCNT it will gradually
+increase over time until it reaches _Py_IMMORTAL_INITIAL_REFCNT.
 */
 #define _Py_IMMORTAL_INITIAL_REFCNT (3UL << 30)
 #define _Py_STATIC_FLAG_BITS ((Py_ssize_t)(_Py_STATICALLY_ALLOCATED_FLAG | _Py_IMMORTAL_FLAGS))
@@ -287,7 +291,7 @@ static inline Py_ALWAYS_INLINE void Py_INCREF(PyObject *op)
     }
 #elif SIZEOF_VOID_P > 4
     PY_UINT32_T cur_refcnt = op->ob_refcnt;
-    if (cur_refcnt >= _Py_IMMORTAL_INITIAL_REFCNT) < 0) {
+    if (cur_refcnt >= _Py_IMMORTAL_INITIAL_REFCNT) {
         // the object is immortal
         _Py_INCREF_IMMORTAL_STAT_INC();
         return;

--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -287,7 +287,7 @@ static inline Py_ALWAYS_INLINE void Py_INCREF(PyObject *op)
     }
 #elif SIZEOF_VOID_P > 4
     PY_UINT32_T cur_refcnt = op->ob_refcnt;
-    if (((int32_t)cur_refcnt) < 0) {
+    if (cur_refcnt >= _Py_IMMORTAL_INITIAL_REFCNT) < 0) {
         // the object is immortal
         _Py_INCREF_IMMORTAL_STAT_INC();
         return;

--- a/Lib/test/test_bigmem.py
+++ b/Lib/test/test_bigmem.py
@@ -9,7 +9,8 @@ high memory limit to regrtest, with the -M option.
 """
 
 from test import support
-from test.support import bigmemtest, _1G, _2G, _4G
+from test.support import bigmemtest, _1G, _2G, _4G, import_helper
+_testcapi = import_helper.import_module('_testcapi')
 
 import unittest
 import operator
@@ -1255,6 +1256,24 @@ class DictTest(unittest.TestCase):
         # https://github.com/python/cpython/issues/102701
         d = dict.fromkeys(range(size))
         d[size] = 1
+
+
+class ImmortalityTest(unittest.TestCase):
+
+    @bigmemtest(size=_2G, memuse=pointer_size * 9/8)
+    def test_stickiness(self, size):
+        """Check that immortality is "sticky", so that
+           once an object is immortal it remains so."""
+        o1 = o2 = o3 = o4 = o5 = o6 = o7 = o8 = object()
+        l = [o1] * (size-20)
+        self.assertFalse(_testcapi.is_immortal(o1))
+        for _ in range(30):
+            l.append(l[0])
+        self.assertTrue(_testcapi.is_immortal(o1))
+        del o2, o3, o4, o5, o6, o7, o8
+        self.assertTrue(_testcapi.is_immortal(o1))
+        del l
+        self.assertTrue(_testcapi.is_immortal(o1))
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_bigmem.py
+++ b/Lib/test/test_bigmem.py
@@ -1264,6 +1264,9 @@ class ImmortalityTest(unittest.TestCase):
     def test_stickiness(self, size):
         """Check that immortality is "sticky", so that
            once an object is immortal it remains so."""
+        if size < _2G:
+            # Not enough memory to cause immortality on overflow
+            return
         o1 = o2 = o3 = o4 = o5 = o6 = o7 = o8 = object()
         l = [o1] * (size-20)
         self.assertFalse(_testcapi.is_immortal(o1))


### PR DESCRIPTION
Make immortality "sticky" by increasing the threshold for immortality in increfs, but leaving it the same for decrefs.

This way, no object will ever see more decrefs than increfs. Immortal objects may see more increfs than decrefs, but that's not a problem.

[Performance](https://github.com/faster-cpython/benchmarking-public/tree/main/results/bm-20250312-3.14.0a5+-2a08194) is neutral.

<!-- gh-issue-number: gh-125174 -->
* Issue: gh-125174
<!-- /gh-issue-number -->
