### PR TITLE
gh-131181: Fix possible NULL pointer dereference in Modules/_ctypes/_ctypes.c

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2826,6 +2826,7 @@ PyCData_NewGetBuffer(PyObject *myself, Py_buffer *view, int flags)
     StgDictObject *item_dict = PyType_stgdict(item_type);
 
     if (view == NULL) return 0;
+    assert(dict);
 
     view->buf = self->b_ptr;
     view->obj = Py_NewRef(myself);
@@ -2862,7 +2863,10 @@ PyCData_reduce(PyObject *myself, PyObject *args)
 {
     CDataObject *self = (CDataObject *)myself;
 
-    if (PyObject_stgdict(myself)->flags & (TYPEFLAG_ISPOINTER|TYPEFLAG_HASPOINTER)) {
+    StgDictObject *stgdict = PyObject_stgdict(myself);
+    assert(stgdict);
+
+    if (stgdict->flags & (TYPEFLAG_ISPOINTER|TYPEFLAG_HASPOINTER)) {
         PyErr_SetString(PyExc_ValueError,
                         "ctypes objects containing pointers cannot be pickled");
         return NULL;


### PR DESCRIPTION
In the `PyCData_NewGetBuffer()` (file `Modules/_ctypes/_ctypes.c`), the `PyObject_stgdict()` is called, which may return NULL. 
Its result is assigned to `dict`, then `dict` is dereferenced (`view->format = dict->format ? dict->format : "B";`).
If `dict` is NULL, a null pointer dereference will occur, so a check for NULL need to be added.

Similarly, in the `PyCData_reduce()` (file `Modules/_ctypes/_ctypes.c`) `PyObject_stgdict(myself)` may return NULL, so need to check result to prevent null pointer dereferencing.

Commit dcaf33a41d5d220523d71c9b35bc08f5b8405dac (Author: @encukou) fixes this problems, but it is very large and probably difficult to backport, so I suggest adding `assert();` before the dereference. 

This needs to be added to branches 3.1 - 3.12.
Found by Linux Verification Center (linuxtesting.org) with SVACE.

<!-- gh-issue-number: gh-131181 -->
* Issue: gh-131181
<!-- /gh-issue-number -->
