### PR TITLE
gh-131151: Refactor use of lookup_maybe_method to propagate lookup errors

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-13-16-21-09.gh-issue-131151.KaIHys.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-13-16-21-09.gh-issue-131151.KaIHys.rst
@@ -1,8 +1,8 @@
-Change the handling of errors raised from descriptor :meth:`__get__`
+Change the handling of errors raised from descriptor ``__get__``
 accessing some special (dunder) methods.
 
-* Raising :class:`AttributeError` from :meth:`__get__`  will continue to treat the method *as though it was not defined*, and special methods that had a fallback will continue to fallback.
+* Raising ``AttributeError`` from ``__get__``  will continue to treat the method *as though it was not defined*, and special methods that had a fallback will continue to fallback.
 * Other errors will be propagated as-is.
-* Directly affects :meth:`__eq__` (and other comparisons), :meth:`__hash__`, :meth:`__repr__`, :meth:`__iter__`.
-* :meth:`__del__` will report as un-raisable.
-* May affect :meth:`__contains__`, :meth:`__bool__`, :meth:`__await__`, :meth:`__aiter__`, :meth:`__anext__`.
+* Directly affects ``__eq__`` (and other comparisons), ``__hash__``, ``__repr__``, ``__iter__``.
+* ``__del__`` will report as un-raisable.
+* May affect ``__contains__``, ``__bool__``, ``__await__``, ``__aiter__``, ``__anext__``.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-13-16-21-09.gh-issue-131151.KaIHys.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-13-16-21-09.gh-issue-131151.KaIHys.rst
@@ -1,0 +1,8 @@
+Change the handling of errors raised from descriptor :meth:`__get__`
+accessing some special (dunder) methods.
+
+* Raising :class:`AttributeError` from :meth:`__get__`  will continue to treat the method *as though it was not defined*, and special methods that had a fallback will continue to fallback.
+* Other errors will be propagated as-is.
+* Directly affects :meth:`__eq__` (and other comparisons), :meth:`__hash__`, :meth:`__repr__`, :meth:`__iter__`.
+* :meth:`__del__` will report as un-raisable.
+* May affect :meth:`__contains__`, :meth:`__bool__`, :meth:`__await__`, :meth:`__aiter__`, :meth:`__anext__`.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2814,8 +2814,9 @@ static PyObject *
 lookup_maybe_method(PyObject *self, PyObject *attr, int *unbound, PyObject* exc_ignored)
 {
     PyObject *res = _PyType_LookupRef(Py_TYPE(self), attr);
+    assert(!PyErr_Occurred());
+
     if (res == NULL) {
-        assert(!PyErr_Occurred());
         Py_RETURN_NOTIMPLEMENTED;
     }
 
@@ -2829,7 +2830,7 @@ lookup_maybe_method(PyObject *self, PyObject *attr, int *unbound, PyObject* exc_
         if (f != NULL) {
             Py_SETREF(res, f(res, self, (PyObject *)(Py_TYPE(self))));
 
-            assert(!!res || PyErr_Occurred());
+            assert((!res)^(!PyErr_Occurred()));
 
             if(res == NULL && exc_ignored && PyErr_ExceptionMatches(exc_ignored)){
                 // TODO: even though the docs say check before calling PyErr_ExceptionMatches,
@@ -2918,6 +2919,7 @@ vectorcall_maybe(PyThreadState *tstate, PyObject *name,
 
     int unbound;
     PyObject *self = args[0];
+    // TODO: PyExc_AttributeError shouldn't be ignored in this case for some reason?
     PyObject *func = lookup_maybe_method(self, name, &unbound, PyExc_AttributeError);
     if (func == NULL || func == Py_NotImplemented) {
         return func;


### PR DESCRIPTION
* lookup_maybe_method changed to accept ignorable exception type
* lookup_maybe_method returning NULL now indicates exception should not be ignored
* lookup_maybe_method returns NotImplemented otherwise if lookup failed
* logic updated in callers of lookup_maybe_method to reconcile exceptions and fallbacks

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131151 -->
* Issue: gh-131151
<!-- /gh-issue-number -->
