### PR TITLE
GH-127705: Handle trace refs in specialized decref

### DIFF
--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -420,6 +420,9 @@ static inline void _Py_DECREF_MORTAL_SPECIALIZED(const char *filename, int linen
         _Py_DECREF_DecRefTotal();
     }
     if (--op->ob_refcnt == 0) {
+#ifdef Py_TRACE_REFS
+        _Py_ForgetReference(op);
+#endif
         destruct(op);
     }
 }
@@ -464,6 +467,9 @@ static inline void Py_DECREF_MORTAL_SPECIALIZED(PyObject *op, destructor destruc
     assert(!_Py_IsStaticImmortal(op));
     _Py_DECREF_STAT_INC();
     if (--op->ob_refcnt == 0) {
+#ifdef Py_TRACE_REFS
+        _Py_ForgetReference(op);
+#endif
         destruct(op);
     }
 }


### PR DESCRIPTION
Adds a couple of `_Py_ForgetReference`s that were overlooked.

<!-- gh-issue-number: gh-127705 -->
* Issue: gh-127705
<!-- /gh-issue-number -->
