### PR TITLE
Remove `print` from `test_monitoring.py`

### DIFF
--- a/Lib/test/test_monitoring.py
+++ b/Lib/test/test_monitoring.py
@@ -1733,7 +1733,6 @@ class TestBranchConsistency(MonitoringTestBase, unittest.TestCase):
             for (src, left, right) in test_func.__code__.co_branches():
                 lefts.add((src, left))
                 rights.add((src, right))
-            print(event_list)
             for event in event_list:
                 way, _, src, dest = event
                 if "left" in way:


### PR DESCRIPTION
Before:

```
» ./python.exe -m test test_monitoring
Using random seed: 921836869
0:00:00 load avg: 1.52 Run 1 test sequentially in a single process
0:00:00 load avg: 1.52 [1/1] test_monitoring
[('branch left', 'foo', 10, 16), ('branch left', 'foo', 10, 16), ('branch left', 'foo', 10, 16), ('branch left', 'foo', 10, 16), ('branch right', 'foo', 10, 40)]
[('branch left', 'foo', 36, 40), ('branch left', 'foo', 36, 40), ('branch right', 'foo', 36, 52)]
[('branch left', 'func', 40, 46), ('branch left', 'func', 124, 130)]
[('branch left', 'func', 28, 32), ('branch right', 'func', 44, 58), ('branch left', 'func', 28, 32), ('branch left', 'func', 44, 50), ('branch right', 'func', 28, 70)]
[('branch left', 'whilefunc', 10, 16), ('branch left', 'whilefunc', 10, 16), ('branch left', 'whilefunc', 10, 16), ('branch right', 'whilefunc', 10, 38)]
0:00:00 load avg: 1.52 [1/1] test_monitoring passed

== Tests result: SUCCESS ==

1 test OK.

Total duration: 101 ms
Total tests: run=86
Total test files: run=1/1
Result: SUCCESS
                 
```

After:

```
» ./python.exe -m test test_monitoring                     
Using random seed: 1417341001
0:00:00 load avg: 1.71 Run 1 test sequentially in a single process
0:00:00 load avg: 1.71 [1/1] test_monitoring
0:00:00 load avg: 1.71 [1/1] test_monitoring passed

== Tests result: SUCCESS ==

1 test OK.

Total duration: 102 ms
Total tests: run=86
Total test files: run=1/1
Result: SUCCESS
                 
```

Looks like it was left here after a debugging of https://github.com/python/cpython/pull/130847 

I am pretty sure that it should not print anything by default. In case you want to have that, I can add `if support.verbose` check there.