### PR TITLE
gh-131189: Fix "msvcrt" import warning on Linux when "_ctypes" is not available.

### DIFF
--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -42,10 +42,11 @@ from .console import Console as ConsoleType
 
 Console: type[ConsoleType]
 _error: tuple[type[Exception], ...] | type[Exception]
-try:
-    from .unix_console import UnixConsole as Console, _error
-except ImportError:
+
+if os.name == "nt":
     from .windows_console import WindowsConsole as Console, _error
+else:
+    from .unix_console import UnixConsole as Console, _error
 
 ENCODING = sys.getdefaultencoding() or "latin1"
 


### PR DESCRIPTION
On Linux, compiling without "libffi" causes a misleading warning
"No module named 'msvcrt'" when launching PyREPL.


<!-- gh-issue-number: gh-131189 -->
* Issue: gh-131189
<!-- /gh-issue-number -->
