### PR TITLE
gh-126895: fix readline module in free-threaded build

### DIFF
--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -433,34 +433,36 @@ class FreeThreadingTest(unittest.TestCase):
 
         self.check([completer_delims] * 100)
 
-    @threading_helper.reap_threads
-    @threading_helper.requires_working_threading()
-    def test_free_threading_doctest_difflib(self):
-        import doctest, difflib
+    # output causing this to fail
 
-        preserve_stdout = sys.stdout
-        COUNT = 40
-        funcs = []
-        results = [False] * COUNT
+    # @threading_helper.reap_threads
+    # @threading_helper.requires_working_threading()
+    # def test_free_threading_doctest_difflib(self):
+    #     import doctest, difflib
 
-        for i in range(COUNT):
-            def func(b, i=i):
-                try:
-                    doctest.testmod(difflib)
-                except RecursionError:
-                    results[i] = True
-                except Exception:
-                    pass
-                else:
-                    results[i] = True
+    #     preserve_stdout = sys.stdout
+    #     COUNT = 40
+    #     funcs = []
+    #     results = [False] * COUNT
 
-            funcs.append(func)
+    #     for i in range(COUNT):
+    #         def func(b, i=i):
+    #             try:
+    #                 doctest.testmod(difflib)
+    #             except RecursionError:
+    #                 results[i] = True
+    #             except Exception:
+    #                 pass
+    #             else:
+    #                 results[i] = True
 
-        self.check(funcs)
+    #         funcs.append(func)
 
-        sys.stdout = preserve_stdout
+    #     self.check(funcs)
 
-        self.assertTrue(all(results))
+    #     sys.stdout = preserve_stdout
+
+    #     self.assertTrue(all(results))
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -433,36 +433,21 @@ class FreeThreadingTest(unittest.TestCase):
 
         self.check([completer_delims] * 100)
 
-    # output causing this to fail
+    def test_free_threading_doctest_difflib(self):
+        code = textwrap.dedent("""
+            from threading import Thread
+            import doctest, difflib
 
-    # @threading_helper.reap_threads
-    # @threading_helper.requires_working_threading()
-    # def test_free_threading_doctest_difflib(self):
-    #     import doctest, difflib
+            def _test():
+                try:
+                    doctest.testmod(difflib)
+                except RecursionError:
+                    pass
 
-    #     preserve_stdout = sys.stdout
-    #     COUNT = 40
-    #     funcs = []
-    #     results = [False] * COUNT
-
-    #     for i in range(COUNT):
-    #         def func(b, i=i):
-    #             try:
-    #                 doctest.testmod(difflib)
-    #             except RecursionError:
-    #                 results[i] = True
-    #             except Exception:
-    #                 pass
-    #             else:
-    #                 results[i] = True
-
-    #         funcs.append(func)
-
-    #     self.check(funcs)
-
-    #     sys.stdout = preserve_stdout
-
-    #     self.assertTrue(all(results))
+            for x in range(40):
+                Thread(target=_test, args=()).start()
+        """)
+        assert_python_ok("-c", code)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2025-03-13-19-54-57.gh-issue-126895.eJP9l0.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-13-19-54-57.gh-issue-126895.eJP9l0.rst
@@ -1,0 +1,1 @@
+Fix :mod:`readline` in :term:`free-threaded <free threading>` build.

--- a/Modules/clinic/readline.c.h
+++ b/Modules/clinic/readline.c.h
@@ -299,7 +299,9 @@ readline_set_startup_hook(PyObject *module, PyObject *const *args, Py_ssize_t na
     }
     function = args[0];
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = readline_set_startup_hook_impl(module, function);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -337,7 +339,9 @@ readline_set_pre_input_hook(PyObject *module, PyObject *const *args, Py_ssize_t 
     }
     function = args[0];
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = readline_set_pre_input_hook_impl(module, function);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -602,7 +606,9 @@ readline_set_completer(PyObject *module, PyObject *const *args, Py_ssize_t nargs
     }
     function = args[0];
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = readline_set_completer_impl(module, function);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -791,4 +797,4 @@ readline_redisplay(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef READLINE_CLEAR_HISTORY_METHODDEF
     #define READLINE_CLEAR_HISTORY_METHODDEF
 #endif /* !defined(READLINE_CLEAR_HISTORY_METHODDEF) */
-/*[clinic end generated code: output=69d8c8e4a86e5e68 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=88d9812b6caa2102 input=a9049054013a1b77]*/

--- a/Modules/clinic/readline.c.h
+++ b/Modules/clinic/readline.c.h
@@ -2,6 +2,7 @@
 preserve
 [clinic start generated code]*/
 
+#include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
 #include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
 PyDoc_STRVAR(readline_parse_and_bind__doc__,
@@ -12,6 +13,21 @@ PyDoc_STRVAR(readline_parse_and_bind__doc__,
 
 #define READLINE_PARSE_AND_BIND_METHODDEF    \
     {"parse_and_bind", (PyCFunction)readline_parse_and_bind, METH_O, readline_parse_and_bind__doc__},
+
+static PyObject *
+readline_parse_and_bind_impl(PyObject *module, PyObject *string);
+
+static PyObject *
+readline_parse_and_bind(PyObject *module, PyObject *string)
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = readline_parse_and_bind_impl(module, string);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
 
 PyDoc_STRVAR(readline_read_init_file__doc__,
 "read_init_file($module, filename=None, /)\n"
@@ -41,7 +57,9 @@ readline_read_init_file(PyObject *module, PyObject *const *args, Py_ssize_t narg
     }
     filename_obj = args[0];
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = readline_read_init_file_impl(module, filename_obj);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -75,7 +93,9 @@ readline_read_history_file(PyObject *module, PyObject *const *args, Py_ssize_t n
     }
     filename_obj = args[0];
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = readline_read_history_file_impl(module, filename_obj);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -238,7 +258,9 @@ readline_set_completion_display_matches_hook(PyObject *module, PyObject *const *
     }
     function = args[0];
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = readline_set_completion_display_matches_hook_impl(module, function);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -382,6 +404,21 @@ PyDoc_STRVAR(readline_set_completer_delims__doc__,
 #define READLINE_SET_COMPLETER_DELIMS_METHODDEF    \
     {"set_completer_delims", (PyCFunction)readline_set_completer_delims, METH_O, readline_set_completer_delims__doc__},
 
+static PyObject *
+readline_set_completer_delims_impl(PyObject *module, PyObject *string);
+
+static PyObject *
+readline_set_completer_delims(PyObject *module, PyObject *string)
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = readline_set_completer_delims_impl(module, string);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
 PyDoc_STRVAR(readline_remove_history_item__doc__,
 "remove_history_item($module, pos, /)\n"
 "--\n"
@@ -404,7 +441,9 @@ readline_remove_history_item(PyObject *module, PyObject *arg)
     if (entry_number == -1 && PyErr_Occurred()) {
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = readline_remove_history_item_impl(module, entry_number);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -444,7 +483,9 @@ readline_replace_history_item(PyObject *module, PyObject *const *args, Py_ssize_
         goto exit;
     }
     line = args[1];
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = readline_replace_history_item_impl(module, entry_number, line);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -458,6 +499,21 @@ PyDoc_STRVAR(readline_add_history__doc__,
 
 #define READLINE_ADD_HISTORY_METHODDEF    \
     {"add_history", (PyCFunction)readline_add_history, METH_O, readline_add_history__doc__},
+
+static PyObject *
+readline_add_history_impl(PyObject *module, PyObject *string);
+
+static PyObject *
+readline_add_history(PyObject *module, PyObject *string)
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = readline_add_history_impl(module, string);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
 
 PyDoc_STRVAR(readline_set_auto_history__doc__,
 "set_auto_history($module, enabled, /)\n"
@@ -503,7 +559,13 @@ readline_get_completer_delims_impl(PyObject *module);
 static PyObject *
 readline_get_completer_delims(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
-    return readline_get_completer_delims_impl(module);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = readline_get_completer_delims_impl(module);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(readline_set_completer__doc__,
@@ -582,7 +644,9 @@ readline_get_history_item(PyObject *module, PyObject *arg)
     if (idx == -1 && PyErr_Occurred()) {
         goto exit;
     }
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = readline_get_history_item_impl(module, idx);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -603,7 +667,13 @@ readline_get_current_history_length_impl(PyObject *module);
 static PyObject *
 readline_get_current_history_length(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
-    return readline_get_current_history_length_impl(module);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = readline_get_current_history_length_impl(module);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 PyDoc_STRVAR(readline_get_line_buffer__doc__,
@@ -621,7 +691,13 @@ readline_get_line_buffer_impl(PyObject *module);
 static PyObject *
 readline_get_line_buffer(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
-    return readline_get_line_buffer_impl(module);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = readline_get_line_buffer_impl(module);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 #if defined(HAVE_RL_COMPLETION_APPEND_CHARACTER)
@@ -641,7 +717,13 @@ readline_clear_history_impl(PyObject *module);
 static PyObject *
 readline_clear_history(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
-    return readline_clear_history_impl(module);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = readline_clear_history_impl(module);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 #endif /* defined(HAVE_RL_COMPLETION_APPEND_CHARACTER) */
@@ -654,6 +736,21 @@ PyDoc_STRVAR(readline_insert_text__doc__,
 
 #define READLINE_INSERT_TEXT_METHODDEF    \
     {"insert_text", (PyCFunction)readline_insert_text, METH_O, readline_insert_text__doc__},
+
+static PyObject *
+readline_insert_text_impl(PyObject *module, PyObject *string);
+
+static PyObject *
+readline_insert_text(PyObject *module, PyObject *string)
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = readline_insert_text_impl(module, string);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
 
 PyDoc_STRVAR(readline_redisplay__doc__,
 "redisplay($module, /)\n"
@@ -670,7 +767,13 @@ readline_redisplay_impl(PyObject *module);
 static PyObject *
 readline_redisplay(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
-    return readline_redisplay_impl(module);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(module);
+    return_value = readline_redisplay_impl(module);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 #ifndef READLINE_APPEND_HISTORY_FILE_METHODDEF
@@ -684,4 +787,4 @@ readline_redisplay(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef READLINE_CLEAR_HISTORY_METHODDEF
     #define READLINE_CLEAR_HISTORY_METHODDEF
 #endif /* !defined(READLINE_CLEAR_HISTORY_METHODDEF) */
-/*[clinic end generated code: output=358ab465285c7949 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=00d8f14f21c1d274 input=a9049054013a1b77]*/

--- a/Modules/clinic/readline.c.h
+++ b/Modules/clinic/readline.c.h
@@ -129,7 +129,9 @@ readline_write_history_file(PyObject *module, PyObject *const *args, Py_ssize_t 
     }
     filename_obj = args[0];
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = readline_write_history_file_impl(module, filename_obj);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -171,7 +173,9 @@ readline_append_history_file(PyObject *module, PyObject *const *args, Py_ssize_t
     }
     filename_obj = args[1];
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(module);
     return_value = readline_append_history_file_impl(module, nelements, filename_obj);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -787,4 +791,4 @@ readline_redisplay(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef READLINE_CLEAR_HISTORY_METHODDEF
     #define READLINE_CLEAR_HISTORY_METHODDEF
 #endif /* !defined(READLINE_CLEAR_HISTORY_METHODDEF) */
-/*[clinic end generated code: output=00d8f14f21c1d274 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=69d8c8e4a86e5e68 input=a9049054013a1b77]*/

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -199,6 +199,7 @@ disable_bracketed_paste(void)
 /* Exported function to send one line to readline's init file parser */
 
 /*[clinic input]
+@critical_section module
 readline.parse_and_bind
 
     string: object
@@ -208,8 +209,8 @@ Execute the init line provided in the string argument.
 [clinic start generated code]*/
 
 static PyObject *
-readline_parse_and_bind(PyObject *module, PyObject *string)
-/*[clinic end generated code: output=1a1ede8afb9546c1 input=8a28a00bb4d61eec]*/
+readline_parse_and_bind_impl(PyObject *module, PyObject *string)
+/*[clinic end generated code: output=828d9b6630d434f5 input=e89aac7c7a98067b]*/
 {
     char *copy;
     PyObject *encoded = encode(string);
@@ -233,6 +234,7 @@ readline_parse_and_bind(PyObject *module, PyObject *string)
 /* Exported function to parse a readline init file */
 
 /*[clinic input]
+@critical_section module
 readline.read_init_file
 
     filename as filename_obj: object = None
@@ -245,7 +247,7 @@ The default filename is the last filename used.
 
 static PyObject *
 readline_read_init_file_impl(PyObject *module, PyObject *filename_obj)
-/*[clinic end generated code: output=8e059b676142831e input=4c80c473e448139d]*/
+/*[clinic end generated code: output=8e059b676142831e input=496974ffe38b85db]*/
 {
     PyObject *filename_bytes;
     if (filename_obj != Py_None) {
@@ -264,6 +266,7 @@ readline_read_init_file_impl(PyObject *module, PyObject *filename_obj)
 /* Exported function to load a readline history file */
 
 /*[clinic input]
+@critical_section module
 readline.read_history_file
 
     filename as filename_obj: object = None
@@ -276,7 +279,7 @@ The default filename is ~/.history.
 
 static PyObject *
 readline_read_history_file_impl(PyObject *module, PyObject *filename_obj)
-/*[clinic end generated code: output=66a951836fb54fbb input=3d29d755b7e6932e]*/
+/*[clinic end generated code: output=66a951836fb54fbb input=2eaa52b2bbf6fb83]*/
 {
     PyObject *filename_bytes;
     if (filename_obj != Py_None) {
@@ -438,6 +441,7 @@ set_hook(const char *funcname, PyObject **hook_var, PyObject *function)
 }
 
 /*[clinic input]
+@critical_section module
 readline.set_completion_display_matches_hook
 
     function: object = None
@@ -453,7 +457,7 @@ once each time matches need to be displayed.
 static PyObject *
 readline_set_completion_display_matches_hook_impl(PyObject *module,
                                                   PyObject *function)
-/*[clinic end generated code: output=516e5cb8db75a328 input=4f0bfd5ab0179a26]*/
+/*[clinic end generated code: output=516e5cb8db75a328 input=5fddfa5edb69582c]*/
 {
     readlinestate *state = get_readline_state(module);
     PyObject *result = set_hook("completion_display_matches_hook",
@@ -573,6 +577,7 @@ readline_get_endidx_impl(PyObject *module)
 /* Set the tab-completion word-delimiters that readline uses */
 
 /*[clinic input]
+@critical_section module
 readline.set_completer_delims
 
     string: object
@@ -582,8 +587,8 @@ Set the word delimiters for completion.
 [clinic start generated code]*/
 
 static PyObject *
-readline_set_completer_delims(PyObject *module, PyObject *string)
-/*[clinic end generated code: output=4305b266106c4f1f input=ae945337ebd01e20]*/
+readline_set_completer_delims_impl(PyObject *module, PyObject *string)
+/*[clinic end generated code: output=017e48e9704a2f64 input=4fd8ec0db0dbdae5]*/
 {
     char *break_chars;
     PyObject *encoded = encode(string);
@@ -612,7 +617,7 @@ readline_set_completer_delims(PyObject *module, PyObject *string)
         return PyErr_NoMemory();
 }
 
-/* _py_free_history_entry: Utility function to free a history entry. */
+/* _py_free_history_entry_lock_held: Utility function to free a history entry. */
 
 #if defined(RL_READLINE_VERSION) && RL_READLINE_VERSION >= 0x0500
 
@@ -622,7 +627,7 @@ readline_set_completer_delims(PyObject *module, PyObject *string)
    takes care of the timestamp. */
 
 static void
-_py_free_history_entry(HIST_ENTRY *entry)
+_py_free_history_entry_lock_held(HIST_ENTRY *entry)
 {
     histdata_t data = free_history_entry(entry);
     free(data);
@@ -633,7 +638,7 @@ _py_free_history_entry(HIST_ENTRY *entry)
 /* No free_history_entry function;  free everything manually. */
 
 static void
-_py_free_history_entry(HIST_ENTRY *entry)
+_py_free_history_entry_lock_held(HIST_ENTRY *entry)
 {
     if (entry->line)
         free((void *)entry->line);
@@ -645,6 +650,7 @@ _py_free_history_entry(HIST_ENTRY *entry)
 #endif
 
 /*[clinic input]
+@critical_section module
 readline.remove_history_item
 
     pos as entry_number: int
@@ -655,7 +661,7 @@ Remove history item given by its zero-based position.
 
 static PyObject *
 readline_remove_history_item_impl(PyObject *module, int entry_number)
-/*[clinic end generated code: output=ab114f029208c7e8 input=f248beb720ff1838]*/
+/*[clinic end generated code: output=ab114f029208c7e8 input=1abf7add5c28f23c]*/
 {
     HIST_ENTRY *entry;
 
@@ -672,11 +678,12 @@ readline_remove_history_item_impl(PyObject *module, int entry_number)
         return NULL;
     }
     /* free memory allocated for the history entry */
-    _py_free_history_entry(entry);
+    _py_free_history_entry_lock_held(entry);
     Py_RETURN_NONE;
 }
 
 /*[clinic input]
+@critical_section module
 readline.replace_history_item
 
     pos as entry_number: int
@@ -691,7 +698,7 @@ pos is zero-based.
 static PyObject *
 readline_replace_history_item_impl(PyObject *module, int entry_number,
                                    PyObject *line)
-/*[clinic end generated code: output=f8cec2770ca125eb input=368bb66fe5ee5222]*/
+/*[clinic end generated code: output=f8cec2770ca125eb input=743ab534c4ac22f4]*/
 {
     PyObject *encoded;
     HIST_ENTRY *old_entry;
@@ -716,13 +723,14 @@ readline_replace_history_item_impl(PyObject *module, int entry_number,
         return NULL;
     }
     /* free memory allocated for the old history entry */
-    _py_free_history_entry(old_entry);
+    _py_free_history_entry_lock_held(old_entry);
     Py_RETURN_NONE;
 }
 
 /* Add a line to the history buffer */
 
 /*[clinic input]
+@critical_section module
 readline.add_history
 
     string: object
@@ -732,8 +740,8 @@ Add an item to the history buffer.
 [clinic start generated code]*/
 
 static PyObject *
-readline_add_history(PyObject *module, PyObject *string)
-/*[clinic end generated code: output=b107b7e8106e803d input=e57c1cf6bc68d7e3]*/
+readline_add_history_impl(PyObject *module, PyObject *string)
+/*[clinic end generated code: output=89047062042ac344 input=9679efa5b99bc972]*/
 {
     PyObject *encoded = encode(string);
     if (encoded == NULL) {
@@ -770,6 +778,7 @@ readline_set_auto_history_impl(PyObject *module,
 /* Get the tab-completion word-delimiters that readline uses */
 
 /*[clinic input]
+@critical_section module
 readline.get_completer_delims
 
 Get the word delimiters for completion.
@@ -777,7 +786,7 @@ Get the word delimiters for completion.
 
 static PyObject *
 readline_get_completer_delims_impl(PyObject *module)
-/*[clinic end generated code: output=6b060280fa68ef43 input=e36eb14fb8a1f08a]*/
+/*[clinic end generated code: output=6b060280fa68ef43 input=e30288e365692aa8]*/
 {
     return decode(rl_completer_word_break_characters);
 }
@@ -828,7 +837,7 @@ readline_get_completer_impl(PyObject *module)
  * See issue #8065.*/
 
 static int
-_py_get_history_length(void)
+_py_get_history_length_lock_held(void)
 {
     HISTORY_STATE *hist_st = history_get_history_state();
     int length = hist_st->length;
@@ -844,6 +853,7 @@ _py_get_history_length(void)
 /* Exported function to get any element of history */
 
 /*[clinic input]
+@critical_section module
 readline.get_history_item
 
     index as idx: int
@@ -854,7 +864,7 @@ Return the current contents of history item at one-based index.
 
 static PyObject *
 readline_get_history_item_impl(PyObject *module, int idx)
-/*[clinic end generated code: output=83d3e53ea5f34b3d input=8adf5c80e6c7ff2b]*/
+/*[clinic end generated code: output=83d3e53ea5f34b3d input=55ad7d4510969b16]*/
 {
     HIST_ENTRY *hist_ent;
 
@@ -863,7 +873,7 @@ readline_get_history_item_impl(PyObject *module, int idx)
          * use 0-based indexes, while readline and newer
          * versions of libedit use 1-based indexes.
          */
-        int length = _py_get_history_length();
+        int length = _py_get_history_length_lock_held();
 
         idx = idx - 1 + libedit_history_start;
 
@@ -887,6 +897,7 @@ readline_get_history_item_impl(PyObject *module, int idx)
 /* Exported function to get current length of history */
 
 /*[clinic input]
+@critical_section module
 readline.get_current_history_length
 
 Return the current (not the maximum) length of history.
@@ -894,14 +905,15 @@ Return the current (not the maximum) length of history.
 
 static PyObject *
 readline_get_current_history_length_impl(PyObject *module)
-/*[clinic end generated code: output=436b294f12ba1e3f input=9cb3f431a68d071f]*/
+/*[clinic end generated code: output=436b294f12ba1e3f input=b093b842cdbf4313]*/
 {
-    return PyLong_FromLong((long)_py_get_history_length());
+    return PyLong_FromLong((long)_py_get_history_length_lock_held());
 }
 
 /* Exported function to read the current line buffer */
 
 /*[clinic input]
+@critical_section module
 readline.get_line_buffer
 
 Return the current contents of the line buffer.
@@ -909,7 +921,7 @@ Return the current contents of the line buffer.
 
 static PyObject *
 readline_get_line_buffer_impl(PyObject *module)
-/*[clinic end generated code: output=d22f9025ecad80e4 input=5f5fbc0d12c69412]*/
+/*[clinic end generated code: output=d22f9025ecad80e4 input=b7cfd10cfb4713ed]*/
 {
     return decode(rl_line_buffer);
 }
@@ -919,6 +931,7 @@ readline_get_line_buffer_impl(PyObject *module)
 /* Exported function to clear the current history */
 
 /*[clinic input]
+@critical_section module
 readline.clear_history
 
 Clear the current readline history.
@@ -926,7 +939,7 @@ Clear the current readline history.
 
 static PyObject *
 readline_clear_history_impl(PyObject *module)
-/*[clinic end generated code: output=1f2dbb0dfa5d5ebb input=208962c4393f5d16]*/
+/*[clinic end generated code: output=1f2dbb0dfa5d5ebb input=3b3732c56bbcf587]*/
 {
     clear_history();
     Py_RETURN_NONE;
@@ -937,6 +950,7 @@ readline_clear_history_impl(PyObject *module)
 /* Exported function to insert text into the line buffer */
 
 /*[clinic input]
+@critical_section module
 readline.insert_text
 
     string: object
@@ -946,8 +960,8 @@ Insert text into the line buffer at the cursor position.
 [clinic start generated code]*/
 
 static PyObject *
-readline_insert_text(PyObject *module, PyObject *string)
-/*[clinic end generated code: output=23d792821d320c19 input=bc96c3c848d5ccb5]*/
+readline_insert_text_impl(PyObject *module, PyObject *string)
+/*[clinic end generated code: output=4bf4e176f68750e0 input=d279c09ba6502577]*/
 {
     PyObject *encoded = encode(string);
     if (encoded == NULL) {
@@ -961,6 +975,7 @@ readline_insert_text(PyObject *module, PyObject *string)
 /* Redisplay the line buffer */
 
 /*[clinic input]
+@critical_section module
 readline.redisplay
 
 Change what's displayed on the screen to reflect contents of the line buffer.
@@ -968,7 +983,7 @@ Change what's displayed on the screen to reflect contents of the line buffer.
 
 static PyObject *
 readline_redisplay_impl(PyObject *module)
-/*[clinic end generated code: output=a8b9725827c3c34b input=b485151058d75edc]*/
+/*[clinic end generated code: output=a8b9725827c3c34b input=8bf90322518dc0e2]*/
 {
     rl_redisplay();
     Py_RETURN_NONE;
@@ -1286,7 +1301,7 @@ setup_readline(readlinestate *mod_state)
     {
         add_history("2");
         HIST_ENTRY *old_entry = replace_history_entry(1, "X", NULL);
-        _py_free_history_entry(old_entry);
+        _py_free_history_entry_lock_held(old_entry);
         HIST_ENTRY *item = history_get(libedit_history_start);
         if (item && item->line && strcmp(item->line, "X")) {
             libedit_append_replace_history_offset = 0;
@@ -1487,7 +1502,7 @@ call_readline(FILE *sys_stdin, FILE *sys_stdout, const char *prompt)
     n = strlen(p);
     if (should_auto_add_history && n > 0) {
         const char *line;
-        int length = _py_get_history_length();
+        int length = _py_get_history_length_lock_held();
         if (length > 0) {
             HIST_ENTRY *hist_ent;
             if (using_libedit_emulation) {

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -447,7 +447,7 @@ set_hook(const char *funcname, PyObject **hook_var, PyObject *function)
 }
 
 /*[clinic input]
-@critical_section module
+@critical_section
 readline.set_completion_display_matches_hook
 
     function: object = None
@@ -463,7 +463,7 @@ once each time matches need to be displayed.
 static PyObject *
 readline_set_completion_display_matches_hook_impl(PyObject *module,
                                                   PyObject *function)
-/*[clinic end generated code: output=516e5cb8db75a328 input=5fddfa5edb69582c]*/
+/*[clinic end generated code: output=516e5cb8db75a328 input=ea4191e4a07d28d3]*/
 {
     readlinestate *state = get_readline_state(module);
     PyObject *result = set_hook("completion_display_matches_hook",
@@ -485,6 +485,7 @@ readline_set_completion_display_matches_hook_impl(PyObject *module,
 }
 
 /*[clinic input]
+@critical_section
 readline.set_startup_hook
 
     function: object = None
@@ -498,7 +499,7 @@ before readline prints the first prompt.
 
 static PyObject *
 readline_set_startup_hook_impl(PyObject *module, PyObject *function)
-/*[clinic end generated code: output=02cd0e0c4fa082ad input=7783b4334b26d16d]*/
+/*[clinic end generated code: output=02cd0e0c4fa082ad input=11fce34992f1125e]*/
 {
     readlinestate *state = get_readline_state(module);
     return set_hook("startup_hook", &state->startup_hook,
@@ -510,6 +511,7 @@ readline_set_startup_hook_impl(PyObject *module, PyObject *function)
 /* Set pre-input hook */
 
 /*[clinic input]
+@critical_section
 readline.set_pre_input_hook
 
     function: object = None
@@ -524,7 +526,7 @@ characters.
 
 static PyObject *
 readline_set_pre_input_hook_impl(PyObject *module, PyObject *function)
-/*[clinic end generated code: output=fe1a96505096f464 input=4f3eaeaf7ce1fdbe]*/
+/*[clinic end generated code: output=fe1a96505096f464 input=96d3d5ff4a0c7c28]*/
 {
     readlinestate *state = get_readline_state(module);
     return set_hook("pre_input_hook", &state->pre_input_hook,
@@ -800,6 +802,7 @@ readline_get_completer_delims_impl(PyObject *module)
 /* Set the completer function */
 
 /*[clinic input]
+@critical_section
 readline.set_completer
 
     function: object = None
@@ -814,7 +817,7 @@ It should return the next possible completion starting with 'text'.
 
 static PyObject *
 readline_set_completer_impl(PyObject *module, PyObject *function)
-/*[clinic end generated code: output=171a2a60f81d3204 input=51e81e13118eb877]*/
+/*[clinic end generated code: output=171a2a60f81d3204 input=97f539d8d0bfcb95]*/
 {
     readlinestate *state = get_readline_state(module);
     return set_hook("completer", &state->completer, function);

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -211,7 +211,7 @@ Execute the init line provided in the string argument.
 
 static PyObject *
 readline_parse_and_bind_impl(PyObject *module, PyObject *string)
-/*[clinic end generated code: output=828d9b6630d434f5 input=e89aac7c7a98067b]*/
+/*[clinic end generated code: output=828d9b6630d434f5 input=cefdc0f9f62f9fcc]*/
 {
     char *copy;
     PyObject *encoded = encode(string);
@@ -248,7 +248,7 @@ The default filename is the last filename used.
 
 static PyObject *
 readline_read_init_file_impl(PyObject *module, PyObject *filename_obj)
-/*[clinic end generated code: output=8e059b676142831e input=496974ffe38b85db]*/
+/*[clinic end generated code: output=8e059b676142831e input=62b767adfab6cc15]*/
 {
     PyObject *filename_bytes;
     if (filename_obj != Py_None) {
@@ -280,7 +280,7 @@ The default filename is ~/.history.
 
 static PyObject *
 readline_read_history_file_impl(PyObject *module, PyObject *filename_obj)
-/*[clinic end generated code: output=66a951836fb54fbb input=2eaa52b2bbf6fb83]*/
+/*[clinic end generated code: output=66a951836fb54fbb input=5d86fd7813172a67]*/
 {
     PyObject *filename_bytes;
     if (filename_obj != Py_None) {
@@ -313,7 +313,7 @@ The default filename is ~/.history.
 
 static PyObject *
 readline_write_history_file_impl(PyObject *module, PyObject *filename_obj)
-/*[clinic end generated code: output=fbcad13d8ef59ae6 input=28a8e062fe363703]*/
+/*[clinic end generated code: output=fbcad13d8ef59ae6 input=34aaada95120cfaa]*/
 {
     PyObject *filename_bytes;
     const char *filename;
@@ -356,7 +356,7 @@ The default filename is ~/.history.
 static PyObject *
 readline_append_history_file_impl(PyObject *module, int nelements,
                                   PyObject *filename_obj)
-/*[clinic end generated code: output=5df06fc9da56e4e4 input=784b774db3a4b7c5]*/
+/*[clinic end generated code: output=5df06fc9da56e4e4 input=78a6061a8d3a0275]*/
 {
     if (nelements < 0)
     {
@@ -594,7 +594,7 @@ Set the word delimiters for completion.
 
 static PyObject *
 readline_set_completer_delims_impl(PyObject *module, PyObject *string)
-/*[clinic end generated code: output=017e48e9704a2f64 input=4fd8ec0db0dbdae5]*/
+/*[clinic end generated code: output=017e48e9704a2f64 input=6c87bb1cbed7fcf1]*/
 {
     char *break_chars;
     PyObject *encoded = encode(string);
@@ -667,7 +667,7 @@ Remove history item given by its zero-based position.
 
 static PyObject *
 readline_remove_history_item_impl(PyObject *module, int entry_number)
-/*[clinic end generated code: output=ab114f029208c7e8 input=1abf7add5c28f23c]*/
+/*[clinic end generated code: output=ab114f029208c7e8 input=847d7cc7e7c25852]*/
 {
     HIST_ENTRY *entry;
 
@@ -704,7 +704,7 @@ pos is zero-based.
 static PyObject *
 readline_replace_history_item_impl(PyObject *module, int entry_number,
                                    PyObject *line)
-/*[clinic end generated code: output=f8cec2770ca125eb input=743ab534c4ac22f4]*/
+/*[clinic end generated code: output=f8cec2770ca125eb input=b44c8dcdc2dd87fe]*/
 {
     PyObject *encoded;
     HIST_ENTRY *old_entry;
@@ -747,7 +747,7 @@ Add an item to the history buffer.
 
 static PyObject *
 readline_add_history_impl(PyObject *module, PyObject *string)
-/*[clinic end generated code: output=89047062042ac344 input=9679efa5b99bc972]*/
+/*[clinic end generated code: output=89047062042ac344 input=faa7053b8612513b]*/
 {
     PyObject *encoded = encode(string);
     if (encoded == NULL) {
@@ -792,7 +792,7 @@ Get the word delimiters for completion.
 
 static PyObject *
 readline_get_completer_delims_impl(PyObject *module)
-/*[clinic end generated code: output=6b060280fa68ef43 input=e30288e365692aa8]*/
+/*[clinic end generated code: output=6b060280fa68ef43 input=80583cdf8176bcdd]*/
 {
     return decode(rl_completer_word_break_characters);
 }
@@ -870,7 +870,7 @@ Return the current contents of history item at one-based index.
 
 static PyObject *
 readline_get_history_item_impl(PyObject *module, int idx)
-/*[clinic end generated code: output=83d3e53ea5f34b3d input=55ad7d4510969b16]*/
+/*[clinic end generated code: output=83d3e53ea5f34b3d input=2835b50c7bde705f]*/
 {
     HIST_ENTRY *hist_ent;
 
@@ -911,7 +911,7 @@ Return the current (not the maximum) length of history.
 
 static PyObject *
 readline_get_current_history_length_impl(PyObject *module)
-/*[clinic end generated code: output=436b294f12ba1e3f input=b093b842cdbf4313]*/
+/*[clinic end generated code: output=436b294f12ba1e3f input=22e9fd0abbc2fd8d]*/
 {
     return PyLong_FromLong((long)_py_get_history_length_lock_held());
 }
@@ -927,7 +927,7 @@ Return the current contents of the line buffer.
 
 static PyObject *
 readline_get_line_buffer_impl(PyObject *module)
-/*[clinic end generated code: output=d22f9025ecad80e4 input=b7cfd10cfb4713ed]*/
+/*[clinic end generated code: output=d22f9025ecad80e4 input=8e02e0fe081feece]*/
 {
     return decode(rl_line_buffer);
 }
@@ -945,7 +945,7 @@ Clear the current readline history.
 
 static PyObject *
 readline_clear_history_impl(PyObject *module)
-/*[clinic end generated code: output=1f2dbb0dfa5d5ebb input=3b3732c56bbcf587]*/
+/*[clinic end generated code: output=1f2dbb0dfa5d5ebb input=b2c6b11551593053]*/
 {
     clear_history();
     Py_RETURN_NONE;
@@ -967,7 +967,7 @@ Insert text into the line buffer at the cursor position.
 
 static PyObject *
 readline_insert_text_impl(PyObject *module, PyObject *string)
-/*[clinic end generated code: output=4bf4e176f68750e0 input=d279c09ba6502577]*/
+/*[clinic end generated code: output=4bf4e176f68750e0 input=2f401f4316df33c2]*/
 {
     PyObject *encoded = encode(string);
     if (encoded == NULL) {
@@ -989,7 +989,7 @@ Change what's displayed on the screen to reflect contents of the line buffer.
 
 static PyObject *
 readline_redisplay_impl(PyObject *module)
-/*[clinic end generated code: output=a8b9725827c3c34b input=8bf90322518dc0e2]*/
+/*[clinic end generated code: output=a8b9725827c3c34b input=5895fd014615ff58]*/
 {
     rl_redisplay();
     Py_RETURN_NONE;


### PR DESCRIPTION
This is nothing more than adding `@critical_section` to functions which use the readline library. It is not thread-safe (because readline is not thread-safe), but it doesn't crash like before.

The test `test_free_threading_doctest_difflib` is probably overkill, but included at first to show that it works. Can comment out or remove as desired.

Also, without `test_free_threading_doctest_difflib` (that uses stuff which is not free-thread safe), `test_readline` fails without crashing with `--parallel-threads`, where previously it crashed. Also without it doesn't complain when tested with TSAN.

Subinterpreters are not an issue because `readline` just doesn't load in them: `module readline does not support loading in subinterpreters`

<!-- gh-issue-number: gh-126895 -->
* Issue: gh-126895
<!-- /gh-issue-number -->
