### PR TITLE
gh-115810: Expose name attribute of `datetime.timezone`

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2421,6 +2421,10 @@ Class attributes:
 
    The UTC time zone, ``timezone(timedelta(0))``.
 
+.. attribute:: timezone.name
+
+   The name of the timezone if specified during creation. If no name is provided,
+   an empty string is returned.
 
 .. index::
    single: % (percent); datetime format

--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -2486,6 +2486,13 @@ class timezone(tzinfo):
         raise TypeError("tzname() argument must be a datetime instance"
                         " or None")
 
+    @property
+    def name(self):
+        """Return provided name otherwise empty string."""
+        if not self._name:
+            return ''
+        return self._name
+
     def dst(self, dt):
         if isinstance(dt, datetime) or dt is None:
             return None

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -348,6 +348,13 @@ class TestTimeZone(unittest.TestCase):
         with self.assertRaises(TypeError): self.EST.tzname('')
         with self.assertRaises(TypeError): self.EST.tzname(5)
 
+    def test_name_property(self):
+        tz_named = timezone(timedelta(hours=5), 'IST')
+        self.assertEqual(tz_named.name, 'IST')
+
+        tz_unnamed = timezone(timedelta(hours=0))
+        self.assertEqual(tz_unnamed.name, '')
+
     def test_fromutc(self):
         with self.assertRaises(ValueError):
             timezone.utc.fromutc(self.DT)

--- a/Misc/NEWS.d/next/Library/2025-03-13-20-21-00.gh-issue-115810.qwrb231.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-13-20-21-00.gh-issue-115810.qwrb231.rst
@@ -1,0 +1,2 @@
+Add ``name`` attribute to :class:`datetime.timezone` that returns the ``name``
+provided during creation else an empty string.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4374,6 +4374,16 @@ timezone_tzname(PyObject *op, PyObject *dt)
 }
 
 static PyObject *
+timezone_name(PyDateTime_TimeZone *self, void *closure)
+{
+    if (self->name == NULL) {
+        return PyUnicode_FromString("");
+    }
+    Py_INCREF(self->name);
+    return self->name;
+}
+
+static PyObject *
 timezone_utcoffset(PyObject *op, PyObject *dt)
 {
     if (_timezone_check_argument(dt, "utcoffset") == -1)
@@ -4440,6 +4450,13 @@ static PyMethodDef timezone_methods[] = {
     {NULL, NULL}
 };
 
+static PyGetSetDef timezone_getset[] = {
+    {"name", (getter)timezone_name, NULL,
+     PyDoc_STR("If name is specified when timezone is created, returns the name."), NULL},
+    {NULL}
+};
+
+
 static const char timezone_doc[] =
 PyDoc_STR("Fixed offset from UTC implementation of tzinfo.");
 
@@ -4473,7 +4490,7 @@ static PyTypeObject PyDateTime_TimeZoneType = {
     0,                                /* tp_iternext */
     timezone_methods,                 /* tp_methods */
     0,                                /* tp_members */
-    0,                                /* tp_getset */
+    timezone_getset,                  /* tp_getset */
     0,                                /* tp_base; filled in PyInit__datetime */
     0,                                /* tp_dict */
     0,                                /* tp_descr_get */


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Pretty sure the C implementation is right, but it definitely needs a good review to be sure.


<!-- gh-issue-number: gh-115810 -->
* Issue: gh-115810
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131210.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->