### PR TITLE
GH-129149: Add fast paths to four more `PyLong_From*` functions

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-13-20-23-02.gh-issue-129149.z42wkm.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-13-20-23-02.gh-issue-129149.z42wkm.rst
@@ -1,3 +1,4 @@
-Add fast path for medium-size integers in :c:func:`PyLong_FromInt32`,
-:c:func:`PyLong_FromUInt32`, :c:func:`PyLong_FromInt64` and
+Add fast path for small and medium-size integers in
+:c:func:`PyLong_FromInt32`, :c:func:`PyLong_FromUInt32`,
+:c:func:`PyLong_FromInt64` and
 :c:func:`PyLong_FromUInt64`. Patch by Chris Eibl.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-13-20-23-02.gh-issue-129149.z42wkm.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-13-20-23-02.gh-issue-129149.z42wkm.rst
@@ -1,0 +1,3 @@
+Add fast path for medium-size integers in :c:func:`PyLong_FromInt32`,
+:c:func:`PyLong_FromUInt32`, :c:func:`PyLong_FromInt64` and
+:c:func:`PyLong_FromUInt64`. Patch by Chris Eibl.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6741,17 +6741,21 @@ PyUnstable_Long_CompactValue(const PyLongObject* op) {
 }
 
 
-PyObject* PyLong_FromInt32(int32_t value)
-{ return PyLong_FromNativeBytes(&value, sizeof(value), -1); }
+PyObject* PyLong_FromInt32(int32_t value) {
+    PYLONG_FROM_INT(uint32_t, int32_t, value);
+}
 
-PyObject* PyLong_FromUInt32(uint32_t value)
-{ return PyLong_FromUnsignedNativeBytes(&value, sizeof(value), -1); }
+PyObject* PyLong_FromUInt32(uint32_t value) {
+    PYLONG_FROM_UINT(uint32_t, value);
+}
 
-PyObject* PyLong_FromInt64(int64_t value)
-{ return PyLong_FromNativeBytes(&value, sizeof(value), -1); }
+PyObject* PyLong_FromInt64(int64_t value) {
+    PYLONG_FROM_INT(uint64_t, int64_t, value);
+}
 
-PyObject* PyLong_FromUInt64(uint64_t value)
-{ return PyLong_FromUnsignedNativeBytes(&value, sizeof(value), -1); }
+PyObject* PyLong_FromUInt64(uint64_t value) {
+    PYLONG_FROM_UINT(uint64_t, value);
+}
 
 #define LONG_TO_INT(obj, value, type_name) \
     do { \

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6741,19 +6741,23 @@ PyUnstable_Long_CompactValue(const PyLongObject* op) {
 }
 
 
-PyObject* PyLong_FromInt32(int32_t value) {
+PyObject* PyLong_FromInt32(int32_t value)
+{
     PYLONG_FROM_INT(uint32_t, int32_t, value);
 }
 
-PyObject* PyLong_FromUInt32(uint32_t value) {
+PyObject* PyLong_FromUInt32(uint32_t value)
+{
     PYLONG_FROM_UINT(uint32_t, value);
 }
 
-PyObject* PyLong_FromInt64(int64_t value) {
+PyObject* PyLong_FromInt64(int64_t value)
+{
     PYLONG_FROM_INT(uint64_t, int64_t, value);
 }
 
-PyObject* PyLong_FromUInt64(uint64_t value) {
+PyObject* PyLong_FromUInt64(uint64_t value)
+{
     PYLONG_FROM_UINT(uint64_t, value);
 }
 


### PR DESCRIPTION
Use the macro `PYLONG_FROM_INT` to implement `PyLong_FromInt32()` and `PyLong_FromInt64()`, and the macro `PYLONG_FROM_UINT` to implement `PyLong_FromUInt32()` and `PyLong_FromUInt64()`, because they have a fast path for small and medium-size integers.

before:
```
PyLong_FromInt32: some small ints
          -5:   228.22 ms
           0:   218.91 ms
         256:   214.52 ms
PyLong_FromInt32: some medium ints
 -1073741823:   313.45 ms
        1000:   196.13 ms
  1073741822:   305.81 ms
PyLong_FromInt32: some bigger ints
 -1073741824:   305.89 ms
  1073741824:   283.47 ms
```
after:
```
PyLong_FromInt32: some small ints
          -5:    21.09 ms
           0:    20.80 ms
         256:    20.27 ms
PyLong_FromInt32: some medium ints
 -1073741823:   100.03 ms
        1000:   101.13 ms
  1073741822:    98.36 ms
PyLong_FromInt32: some bigger ints
 -1073741824:   204.82 ms
  1073741824:   205.22 ms
```

Benchmark done like in https://github.com/python/cpython/pull/129301#issuecomment-2692297879.

<!-- gh-issue-number: gh-129149 -->
* Issue: gh-129149
<!-- /gh-issue-number -->
