### PR TITLE
gh-119786: add `JUMP_BACKWARD` macro to the Jumps section

### DIFF
--- a/InternalDocs/interpreter.md
+++ b/InternalDocs/interpreter.md
@@ -112,7 +112,7 @@ already points to the next instruction.
 Thus, jump instructions can be implemented by manipulating `next_instr`:
 
 - A jump forward (`JUMP_FORWARD`) sets `next_instr += oparg`.
-- A jump backward sets `next_instr -= oparg`.
+- A jump backward (`JUMP_BACKWARD`) sets `next_instr -= oparg`.
 
 ## Inline cache entries
 


### PR DESCRIPTION
The **Jumps** section in `interpreter.md` shows how to manipulate the `next_instr` offset **forward** and **backward**. However, the section uses the macro name for the forward (`JUMP_FORWARD`) at the first point, but it does not use the macro name for the backward point, so the `JUMP_BACKWARD`  macro name was added to the second point.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119786 -->
* Issue: gh-119786
<!-- /gh-issue-number -->
