### PR TITLE
gh-74028: update `whatsnew/3.14.rst` post gh-125663

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -459,18 +459,19 @@ concurrent.futures
   ways to terminate or kill all living worker processes in the given pool.
   (Contributed by Charles Machalow in :gh:`130849`.)
 
-contextvars
------------
-
-* Support context manager protocol by :class:`contextvars.Token`.
-  (Contributed by Andrew Svetlov in :gh:`129889`.)
-
 * Add the optional ``buffersize`` parameter to
   :meth:`concurrent.futures.Executor.map` to limit the number of submitted
   tasks whose results have not yet been yielded. If the buffer is full,
   iteration over the *iterables* pauses until a result is yielded from the
   buffer.
   (Contributed by Enzo Bonnal and Josh Rosenberg in :gh:`74028`.)
+
+
+contextvars
+-----------
+
+* Support context manager protocol by :class:`contextvars.Token`.
+  (Contributed by Andrew Svetlov in :gh:`129889`.)
 
 
 ctypes


### PR DESCRIPTION
Following up on #125663, a conflict resolution has resulted in the mixing of items in 3.14.rst.

cc @picnixz 🙏🏻 

<!-- gh-issue-number: gh-74028 -->
* Issue: gh-74028
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131214.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->