### PR TITLE
gh-131204: Fix `difflib.HtmlDiff` may not use monospaced font

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1633,7 +1633,7 @@ _file_template = """
 
 _styles = """
         :root {color-scheme: light dark}
-        table.diff {font-family:Courier; border:medium;}
+        table.diff {font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace; border:medium}
         .diff_header {background-color:#e0e0e0}
         td.diff_header {text-align:right}
         .diff_next {background-color:#c0c0c0}

--- a/Lib/test/test_difflib_expect.html
+++ b/Lib/test/test_difflib_expect.html
@@ -10,7 +10,7 @@
     <title></title>
     <style type="text/css">
         :root {color-scheme: light dark}
-        table.diff {font-family:Courier; border:medium;}
+        table.diff {font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace; border:medium}
         .diff_header {background-color:#e0e0e0}
         td.diff_header {text-align:right}
         .diff_next {background-color:#c0c0c0}

--- a/Misc/NEWS.d/next/Library/2025-03-14-09-28-13.gh-issue-131204.wogNEX.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-14-09-28-13.gh-issue-131204.wogNEX.rst
@@ -1,1 +1,1 @@
-Fix :class:`difflib.HtmlDiff` may not use monospaced font
+Use monospace font from System Font Stack for cross-platform support in  :class:`difflib.HtmlDiff`.

--- a/Misc/NEWS.d/next/Library/2025-03-14-09-28-13.gh-issue-131204.wogNEX.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-14-09-28-13.gh-issue-131204.wogNEX.rst
@@ -1,0 +1,1 @@
+Fix :class:`difflib.HtmlDiff` may not use monospaced font


### PR DESCRIPTION
Fixes https://github.com/python/cpython/issues/131204.
<!-- gh-issue-number: gh-131204 -->
* Issue: gh-131204
<!-- /gh-issue-number -->
