### PR TITLE
gh-123471: Make concurrent iteration over itertools.repeat safe under free-threading

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-03-14-14-18-49.gh-issue-123471.sduBKk.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-14-14-18-49.gh-issue-123471.sduBKk.rst
@@ -1,0 +1,1 @@
+Make concurrent iterations over :class:`itertools.repeat` safe under free-threading.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3634,9 +3634,10 @@ repeat_next(PyObject *op)
     if (cnt == 0) {
         return NULL;
     }
-    cnt--;
-    assert(cnt >=0);
-    FT_ATOMIC_STORE_SSIZE_RELAXED(ro->cnt, cnt);
+    if (cnt > 0) {
+        cnt--;
+        FT_ATOMIC_STORE_SSIZE_RELAXED(ro->cnt, cnt);
+    }
     return Py_NewRef(ro->element);
 }
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3630,10 +3630,13 @@ static PyObject *
 repeat_next(PyObject *op)
 {
     repeatobject *ro = repeatobject_CAST(op);
-    if (ro->cnt == 0)
+    Py_ssize_t cnt = FT_ATOMIC_LOAD_SSIZE_RELAXED(ro->cnt);
+    if (cnt == 0) {
         return NULL;
-    if (ro->cnt > 0)
-        ro->cnt--;
+    }
+    cnt--;
+    assert(cnt >=0);
+    FT_ATOMIC_STORE_SSIZE_RELAXED(ro->cnt, cnt);
     return Py_NewRef(ro->element);
 }
 


### PR DESCRIPTION

If needed we can add a unit test similar to the one in https://github.com/python/cpython/pull/131212/files

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-123471 -->
* Issue: gh-123471
<!-- /gh-issue-number -->
