### PR TITLE
gh-121468: Fix the doctest failure for asyncio test on pdb

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2079,7 +2079,7 @@ if not SKIP_CORO_TESTS:
             > <doctest test.test_pdb.test_pdb_asynctask[1]>(2)test()
             -> import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
             (Pdb) $_asynctask
-            <Task pending name='Task-1' coro=<test() running at <doctest test.test_pdb.test_pdb_asynctask[1]>:2> ...
+            <Task pending name=... coro=<test() running at <doctest test.test_pdb.test_pdb_asynctask[1]>:2> ...
             (Pdb) continue
             """
 


### PR DESCRIPTION
In #124367, The doctest wrongly asserts the name of the task, where it does not hold for Android and iOS. We don't care about the name so use wildcard. 
https://buildbot.python.org/#/builders/1380/builds/2883/steps/10/logs/stdio

<!-- gh-issue-number: gh-121468 -->
* Issue: gh-121468
<!-- /gh-issue-number -->
