### PR TITLE
gh-93096: Update and document `pickletools` CLI

### DIFF
--- a/Doc/library/pickletools.rst
+++ b/Doc/library/pickletools.rst
@@ -75,6 +75,10 @@ Command line options
    When more than one pickle file are specified, print given preamble
    before each disassembly.
 
+.. option:: pickle_file
+
+   A pickle file to read, or ``-`` to indicate reading from standard input.
+
 
 
 Programmatic Interface

--- a/Doc/library/pickletools.rst
+++ b/Doc/library/pickletools.rst
@@ -19,7 +19,7 @@ ordinary users of the :mod:`pickle` module probably won't find the
 
 .. _pickletools-cli:
 
-Command line usage
+Command-line usage
 ------------------
 
 .. versionadded:: 3.2
@@ -48,7 +48,7 @@ For example, with a tuple ``(1, 2)`` pickled in file ``x.pickle``:
         9: .    STOP
     highest protocol among opcodes = 2
 
-Command line options
+Command-line options
 ^^^^^^^^^^^^^^^^^^^^
 
 .. program:: pickletools
@@ -72,7 +72,7 @@ Command line options
 
 .. option:: -p, --preamble=<preamble>
 
-   When more than one pickle file are specified, print given preamble
+   When more than one pickle file is specified, print given preamble
    before each disassembly.
 
 .. option:: pickle_file
@@ -81,7 +81,7 @@ Command line options
 
 
 
-Programmatic Interface
+Programmatic interface
 ----------------------
 
 

--- a/Lib/pickletools.py
+++ b/Lib/pickletools.py
@@ -2845,7 +2845,7 @@ if __name__ == "__main__":
         description='disassemble one or more pickle files')
     parser.add_argument(
         'pickle_file',
-        nargs='*', help='the pickle file')
+        nargs='+', help='the pickle file')
     parser.add_argument(
         '-o', '--output',
         help='the file where the output should be written')
@@ -2863,26 +2863,23 @@ if __name__ == "__main__":
         help='if more than one pickle file is specified, print this before'
         ' each disassembly')
     args = parser.parse_args()
-    if not args.pickle_file:
-        parser.print_help()
+    annotate = 30 if args.annotate else 0
+    memo = {} if args.memo else None
+    if args.output is None:
+        output = sys.stdout
     else:
-        annotate = 30 if args.annotate else 0
-        memo = {} if args.memo else None
-        if args.output is None:
-            output = sys.stdout
-        else:
-            output = open(args.output, 'w')
-        try:
-            for arg in args.pickle_file:
-                if len(args.pickle_file) > 1:
-                    name = '<stdin>' if arg == '-' else arg
-                    preamble = args.preamble.format(name=name)
-                    output.write(preamble + '\n')
-                if arg == '-':
-                    dis(sys.stdin.buffer, output, memo, args.indentlevel, annotate)
-                else:
-                    with open(arg, 'rb') as f:
-                        dis(f, output, memo, args.indentlevel, annotate)
-        finally:
-            if output is not sys.stdout:
-                output.close()
+        output = open(args.output, 'w')
+    try:
+        for arg in args.pickle_file:
+            if len(args.pickle_file) > 1:
+                name = '<stdin>' if arg == '-' else arg
+                preamble = args.preamble.format(name=name)
+                output.write(preamble + '\n')
+            if arg == '-':
+                dis(sys.stdin.buffer, output, memo, args.indentlevel, annotate)
+            else:
+                with open(arg, 'rb') as f:
+                    dis(f, output, memo, args.indentlevel, annotate)
+    finally:
+        if output is not sys.stdout:
+            output.close()


### PR DESCRIPTION
@hugovk what do you think about setting the same behavior as we did in `pickle`?

I changed `nargs` from `*` to `+` and I added `pickle_file` as option to docs

<!-- gh-issue-number: gh-93096 -->
* Issue: gh-93096
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131273.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->