### PR TITLE
gh-131254: ensure that BROWSER is not set for `test_webbrowser` on macOS

### DIFF
--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -321,7 +321,13 @@ class MockPopenPipe:
 @unittest.skipUnless(sys.platform == "darwin", "macOS specific test")
 @requires_subprocess()
 class MacOSXOSAScriptTest(unittest.TestCase):
+
     def setUp(self):
+        # Ensure that 'BROWSER' is not set to 'open' or something else.
+        # See: https://github.com/python/cpython/issues/131254.
+        env = self.enterContext(os_helper.EnvironmentVarGuard())
+        env.unset("BROWSER")
+
         support.patch(self, os, "popen", self.mock_popen)
         self.browser = webbrowser.MacOSXOSAScript("default")
 

--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -326,8 +326,7 @@ class MacOSXOSAScriptTest(unittest.TestCase):
         # Ensure that 'BROWSER' is not set to 'open' or something else.
         # See: https://github.com/python/cpython/issues/131254.
         env = self.enterContext(os_helper.EnvironmentVarGuard())
-        if "BROWSER" in env:
-            env.unset("BROWSER")
+        env.unset("BROWSER")
 
         support.patch(self, os, "popen", self.mock_popen)
         self.browser = webbrowser.MacOSXOSAScript("default")

--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -326,7 +326,8 @@ class MacOSXOSAScriptTest(unittest.TestCase):
         # Ensure that 'BROWSER' is not set to 'open' or something else.
         # See: https://github.com/python/cpython/issues/131254.
         env = self.enterContext(os_helper.EnvironmentVarGuard())
-        env.unset("BROWSER")
+        if "BROWSER" in env:
+            env.unset("BROWSER")
 
         support.patch(self, os, "popen", self.mock_popen)
         self.browser = webbrowser.MacOSXOSAScript("default")


### PR DESCRIPTION
@smontanaro Can you confirm that this fixes your issue? I'll run the macOS build bots but those don't have a BROWSER set I think.

<!-- gh-issue-number: gh-131254 -->
* Issue: gh-131254
<!-- /gh-issue-number -->
