### PR TITLE
gh-131281: fix compile error due to `BINARY_SUBSCR`

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -878,6 +878,7 @@ dummy_func(
             assert(res_o != NULL);
             res = PyStackRef_FromPyObjectNew(res_o);
 #endif
+            STAT_INC(BINARY_OP, hit);
             DECREF_INPUTS();
         }
 

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -878,7 +878,6 @@ dummy_func(
             assert(res_o != NULL);
             res = PyStackRef_FromPyObjectNew(res_o);
 #endif
-            STAT_INC(BINARY_SUBSCR, hit);
             DECREF_INPUTS();
         }
 

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1253,6 +1253,7 @@
             assert(res_o != NULL);
             res = PyStackRef_FromPyObjectNew(res_o);
             #endif
+            STAT_INC(BINARY_OP, hit);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             _PyStackRef tmp = list_st;
             list_st = res;

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -1253,7 +1253,6 @@
             assert(res_o != NULL);
             res = PyStackRef_FromPyObjectNew(res_o);
             #endif
-            STAT_INC(BINARY_SUBSCR, hit);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             _PyStackRef tmp = list_st;
             list_st = res;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -702,7 +702,6 @@
             assert(res_o != NULL);
             res = PyStackRef_FromPyObjectNew(res_o);
             #endif
-            STAT_INC(BINARY_SUBSCR, hit);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             _PyStackRef tmp = list_st;
             list_st = res;

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -702,6 +702,7 @@
             assert(res_o != NULL);
             res = PyStackRef_FromPyObjectNew(res_o);
             #endif
+            STAT_INC(BINARY_OP, hit);
             _PyFrame_SetStackPointer(frame, stack_pointer);
             _PyStackRef tmp = list_st;
             list_st = res;


### PR DESCRIPTION
Make `STAT_INC` record `BINARY_OP` instead of `BINARY_SUBSCR`, which is replaced by #129700 

<!-- gh-issue-number: gh-131281 -->
* Issue: gh-131281
<!-- /gh-issue-number -->
