### PR TITLE
GH-131291: fix building python_uwp.cpp with clang-cl

### DIFF
--- a/PC/python_uwp.cpp
+++ b/PC/python_uwp.cpp
@@ -10,6 +10,10 @@
 
 #include <string>
 
+#if defined(__clang__)
+#define _SILENCE_CLANG_COROUTINE_MESSAGE
+#endif
+
 #include <appmodel.h>
 #include <winrt\Windows.ApplicationModel.h>
 #include <winrt\Windows.Storage.h>


### PR DESCRIPTION
For details please refer to https://github.com/python/cpython/issues/131291.

I think this is a skip news.