### PR TITLE
DOC: fix formatting of shell commands

### DIFF
--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -44,26 +44,26 @@ In some cases, IDLE might not be included in your Python installation.
 
 * For Debian and Ubuntu users:
 
-.. code-block:: shell
+.. code-block:: shell-session
 
    sudo apt update
    sudo apt install idle
 
 * For Fedora, RHEL, and CentOS users:
 
-.. code-block:: shell
+.. code-block:: shell-session
 
    sudo dnf install python3-idle
 
 * For SUSE and OpenSUSE users:
 
-.. code-block:: shell
+.. code-block:: shell-session
 
    sudo zypper in python3-idle
 
 * For Alpine Linux users:
 
-.. code-block:: shell
+.. code-block:: shell-session
 
    sudo apk add python3-idle
 

--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -42,20 +42,28 @@ Installing IDLE
 
 In some cases, IDLE might not be included in your Python installation.
 
-* For Debian and Ubuntu users::
+* For Debian and Ubuntu users:
+
+.. code-block:: shell
 
    sudo apt update
    sudo apt install idle
 
-* For Fedora, RHEL, and CentOS users::
+* For Fedora, RHEL, and CentOS users:
+
+.. code-block:: shell
 
    sudo dnf install python3-idle
 
-* For SUSE and OpenSUSE users::
+* For SUSE and OpenSUSE users:
+
+.. code-block:: shell
 
    sudo zypper in python3-idle
 
-* For Alpine Linux users::
+* For Alpine Linux users:
+
+.. code-block:: shell
 
    sudo apk add python3-idle
 


### PR DESCRIPTION
"sudo zypper in python3-idle" gets highlighted as Python code. specifically "in" is highlighted in green. Since this is a shell command it needs to be formatted as such.
![Screenshot 2025-03-15 13 09 14](https://github.com/user-attachments/assets/57c81cb2-9265-49b5-bcff-1667826ab1d0)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131295.org.readthedocs.build/en/131295/using/unix.html

<!-- readthedocs-preview cpython-previews end -->