### PR TITLE
GH-131296: fix clang-cl warning on Windows in pytime.c

### DIFF
--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -915,7 +915,7 @@ py_get_system_clock(PyTime_t *tp, _Py_clock_info_t *info, int raise_exc)
     /* 11,644,473,600,000,000,000: number of nanoseconds between
        the 1st january 1601 and the 1st january 1970 (369 years + 89 leap
        days). */
-    PyTime_t ns = large.QuadPart * 100 - 11644473600000000000;
+    PyTime_t ns = (large.QuadPart - 116444736000000000) * 100;
     *tp = ns;
     if (info) {
         // GetSystemTimePreciseAsFileTime() is implemented using


### PR DESCRIPTION
This line
https://github.com/python/cpython/blob/0ce056d26552363c4b3d01fbcadd6569cd5eb5e7/Python/pytime.c#L918
produces 
```
..\Python\pytime.c(918,42): warning : integer literal is too large to be represented in a signed integer type,
interpreting as unsigned [-Wimplicitly-unsigned-literal]
```` 
Let's convert it to
```c
PyTime_t ns = (large.QuadPart - 116444736000000000) * 100;
``` 
which produces no warning but the exact same code: https://godbolt.org/z/r97Yadj5s

I think this is a skip news.

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
