### PR TITLE
GH-131296: fix clang-cl warnings on Windows in blake2module.c

### DIFF
--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -92,10 +92,10 @@ void detect_cpu_features(cpu_flags *flags) {
     ebx7 = info7[1];
     ecx7 = info7[2];
     edx7 = info7[3];
-#else
+#endif
     (void) eax1; (void) ebx1; (void) ecx1; (void) edx1;
     (void) eax7; (void) ebx7; (void) ecx7; (void) edx7;
-#endif
+
 
     flags->avx = (ecx1 & ECX_AVX) != 0;
 


### PR DESCRIPTION
Fix
```
1>..\Modules\blake2module.c(77,9): warning : variable 'eax1' set but not used [-Wunused-but-set-variable]
1>..\Modules\blake2module.c(77,19): warning : variable 'ebx1' set but not used [-Wunused-but-set-variable]
1>..\Modules\blake2module.c(78,9): warning : variable 'eax7' set but not used [-Wunused-but-set-variable]
1>..\Modules\blake2module.c(78,29): warning : variable 'ecx7' set but not used [-Wunused-but-set-variable]
1>..\Modules\blake2module.c(78,39): warning : variable 'edx7' set but not used [-Wunused-but-set-variable]
```
we see them two (non-PGO) or three times, because the `_freeze_module` compiles blake2module.c, too.

I think this is a skip news.

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
