### PR TITLE
Docs: fix shell command formatting

### DIFF
--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -53,7 +53,7 @@ In some cases, IDLE might not be included in your Python installation.
 
 * For SUSE and OpenSUSE users::
 
-   sudo zypper in python3-idle
+   sudo zypper install python3-idle
 
 * For Alpine Linux users::
 


### PR DESCRIPTION
replace "zypper in" with "zypper install" to avoid incorrect highlighting

this is done instead of pull request #131295

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131310.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->