### PR TITLE
gh-131316: handle NULL values returned by HACL* functions 

### DIFF
--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -415,7 +415,7 @@ new_Blake2Object(PyTypeObject *type)
 #define HACL_UPDATE(UPDATE_FUNC, STATE, BUF, LEN)               \
     do {                                                        \
         HACL_UPDATE_LOOP(UPDATE_FUNC, STATE, BUF, LEN);         \
-        assert((Py_ssize_t)(LEN) <= (Py_ssize_t)UINT32_MAX);    \
+        /* cast to uint32_t is now safe */                      \
         (void)UPDATE_FUNC(STATE, BUF, (uint32_t)LEN);           \
     } while (0)
 

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -395,26 +395,33 @@ new_Blake2Object(PyTypeObject *type)
  * 64 bits so we loop in <4gig chunks when needed. */
 
 #if PY_SSIZE_T_MAX > UINT32_MAX
-#define HACL_UPDATE_LOOP(update,state,buf,len) \
-  while (len > UINT32_MAX) { \
-    update(state, buf, UINT32_MAX); \
-    len -= UINT32_MAX; \
-    buf += UINT32_MAX; \
-  }
+#  define HACL_UPDATE_LOOP(UPDATE_FUNC, STATE, BUF, LEN)    \
+    do {                                                    \
+        while (LEN > UINT32_MAX) {                          \
+            (void)UPDATE_FUNC(STATE, BUF, UINT32_MAX);      \
+            LEN -= UINT32_MAX;                              \
+            BUF += UINT32_MAX;                              \
+        }                                                   \
+    } while (0)
 #else
-#define HACL_UPDATE_LOOP(update,state,buf,len)
+#  define HACL_UPDATE_LOOP(...)
 #endif
 
-#define HACL_UPDATE(update,state,buf,len) do { \
-  /* Note: we explicitly ignore the error code on the basis that it would take >
-   * 1 billion years to overflow the maximum admissible length for SHA2-256
-   * (namely, 2^61-1 bytes). */ \
-  HACL_UPDATE_LOOP(update,state,buf,len) \
-  /* Cast to uint32_t is safe: len <= UINT32_MAX at this point. */ \
-  update(state, buf, (uint32_t) len); \
-} while (0)
+/*
+ * Note: we explicitly ignore the error code on the basis that it would take
+ * more than 1 billion years to overflow the maximum admissible length for
+ * blake2b/2s (2^64 - 1).
+ */
+#define HACL_UPDATE(UPDATE_FUNC, STATE, BUF, LEN)               \
+    do {                                                        \
+        HACL_UPDATE_LOOP(UPDATE_FUNC, STATE, BUF, LEN);         \
+        assert((Py_ssize_t)(LEN) <= (Py_ssize_t)UINT32_MAX);    \
+        (void)UPDATE_FUNC(STATE, BUF, (uint32_t)LEN);           \
+    } while (0)
 
-static void update(Blake2Object *self, uint8_t *buf, Py_ssize_t len) {
+static void
+update(Blake2Object *self, uint8_t *buf, Py_ssize_t len)
+{
     switch (self->impl) {
       // These need to be ifdef'd out otherwise it's an unresolved symbol at
       // link-time.
@@ -583,21 +590,41 @@ py_blake2b_or_s_new(PyTypeObject *type, PyObject *data, int digest_size,
 
     switch (self->impl) {
 #if HACL_CAN_COMPILE_SIMD256
-        case Blake2b_256:
+        case Blake2b_256: {
             self->blake2b_256_state = Hacl_Hash_Blake2b_Simd256_malloc_with_params_and_key(&params, last_node, key->buf);
+            if (self->blake2b_256_state == NULL) {
+                (void)PyErr_NoMemory();
+                goto error;
+            }
             break;
+        }
 #endif
 #if HACL_CAN_COMPILE_SIMD128
-        case Blake2s_128:
+        case Blake2s_128: {
             self->blake2s_128_state = Hacl_Hash_Blake2s_Simd128_malloc_with_params_and_key(&params, last_node, key->buf);
+            if (self->blake2s_128_state == NULL) {
+                (void)PyErr_NoMemory();
+                goto error;
+            }
             break;
+        }
 #endif
-        case Blake2b:
+        case Blake2b: {
             self->blake2b_state = Hacl_Hash_Blake2b_malloc_with_params_and_key(&params, last_node, key->buf);
+            if (self->blake2b_state == NULL) {
+                (void)PyErr_NoMemory();
+                goto error;
+            }
             break;
-        case Blake2s:
+        }
+        case Blake2s: {
             self->blake2s_state = Hacl_Hash_Blake2s_malloc_with_params_and_key(&params, last_node, key->buf);
+            if (self->blake2s_state == NULL) {
+                (void)PyErr_NoMemory();
+                goto error;
+            }
             break;
+        }
         default:
             Py_UNREACHABLE();
     }
@@ -610,7 +637,8 @@ py_blake2b_or_s_new(PyTypeObject *type, PyObject *data, int digest_size,
             Py_BEGIN_ALLOW_THREADS
             update(self, buf.buf, buf.len);
             Py_END_ALLOW_THREADS
-        } else {
+        }
+        else {
             update(self, buf.buf, buf.len);
         }
         PyBuffer_Release(&buf);
@@ -688,6 +716,53 @@ py_blake2s_new_impl(PyTypeObject *type, PyObject *data, int digest_size,
     return py_blake2b_or_s_new(type, data, digest_size, key, salt, person, fanout, depth, leaf_size, node_offset, node_depth, inner_size, last_node, usedforsecurity);
 }
 
+static int
+blake2_blake2b_copy_locked(Blake2Object *self, Blake2Object *cpy)
+{
+    switch (self->impl) {
+#if HACL_CAN_COMPILE_SIMD256
+        case Blake2b_256: {
+            cpy->blake2b_256_state = Hacl_Hash_Blake2b_Simd256_copy(self->blake2b_256_state);
+            if (cpy->blake2b_256_state == NULL) {
+                goto error;
+            }
+            break;
+        }
+#endif
+#if HACL_CAN_COMPILE_SIMD128
+        case Blake2s_128: {
+            cpy->blake2s_128_state = Hacl_Hash_Blake2s_Simd128_copy(self->blake2s_128_state);
+            if (cpy->blake2s_128_state == NULL) {
+                goto error;
+            }
+            break;
+        }
+#endif
+        case Blake2b: {
+            cpy->blake2b_state = Hacl_Hash_Blake2b_copy(self->blake2b_state);
+            if (cpy->blake2b_state == NULL) {
+                goto error;
+            }
+            break;
+        }
+        case Blake2s: {
+            cpy->blake2s_state = Hacl_Hash_Blake2s_copy(self->blake2s_state);
+            if (cpy->blake2s_state == NULL) {
+                goto error;
+            }
+            break;
+        }
+        default:
+            Py_UNREACHABLE();
+    }
+    cpy->impl = self->impl;
+    return 0;
+
+error:
+    (void)PyErr_NoMemory();
+    return -1;
+}
+
 /*[clinic input]
 _blake2.blake2b.copy
 
@@ -700,32 +775,18 @@ _blake2_blake2b_copy_impl(Blake2Object *self)
 {
     Blake2Object *cpy;
 
-    if ((cpy = new_Blake2Object(Py_TYPE(self))) == NULL)
+    if ((cpy = new_Blake2Object(Py_TYPE(self))) == NULL) {
         return NULL;
-
-    ENTER_HASHLIB(self);
-    switch (self->impl) {
-#if HACL_CAN_COMPILE_SIMD256
-        case Blake2b_256:
-            cpy->blake2b_256_state = Hacl_Hash_Blake2b_Simd256_copy(self->blake2b_256_state);
-            break;
-#endif
-#if HACL_CAN_COMPILE_SIMD128
-        case Blake2s_128:
-            cpy->blake2s_128_state = Hacl_Hash_Blake2s_Simd128_copy(self->blake2s_128_state);
-            break;
-#endif
-        case Blake2b:
-            cpy->blake2b_state = Hacl_Hash_Blake2b_copy(self->blake2b_state);
-            break;
-        case Blake2s:
-            cpy->blake2s_state = Hacl_Hash_Blake2s_copy(self->blake2s_state);
-            break;
-        default:
-            Py_UNREACHABLE();
     }
-    cpy->impl = self->impl;
+
+    int rc;
+    ENTER_HASHLIB(self);
+    rc = blake2_blake2b_copy_locked(self, cpy);
     LEAVE_HASHLIB(self);
+    if (rc < 0) {
+        Py_DECREF(cpy);
+        return NULL;
+    }
     return (PyObject *)cpy;
 }
 

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -719,6 +719,7 @@ py_blake2s_new_impl(PyTypeObject *type, PyObject *data, int digest_size,
 static int
 blake2_blake2b_copy_locked(Blake2Object *self, Blake2Object *cpy)
 {
+    assert(cpy != NULL);
     switch (self->impl) {
 #if HACL_CAN_COMPILE_SIMD256
         case Blake2b_256: {
@@ -773,13 +774,13 @@ static PyObject *
 _blake2_blake2b_copy_impl(Blake2Object *self)
 /*[clinic end generated code: output=622d1c56b91c50d8 input=e383c2d199fd8a2e]*/
 {
+    int rc;
     Blake2Object *cpy;
 
     if ((cpy = new_Blake2Object(Py_TYPE(self))) == NULL) {
         return NULL;
     }
 
-    int rc;
     ENTER_HASHLIB(self);
     rc = blake2_blake2b_copy_locked(self, cpy);
     LEAVE_HASHLIB(self);

--- a/Modules/md5module.c
+++ b/Modules/md5module.c
@@ -193,7 +193,7 @@ update(Hacl_Hash_MD5_state_t *state, uint8_t *buf, Py_ssize_t len)
         buf += UINT32_MAX;
     }
 #endif
-    assert(len <= (Py_ssize_t)UINT32_MAX);
+    /* cast to uint32_t is now safe */
     (void)Hacl_Hash_MD5_update(state, buf, (uint32_t)len);
 }
 

--- a/Modules/md5module.c
+++ b/Modules/md5module.c
@@ -121,12 +121,17 @@ MD5Type_copy_impl(MD5object *self, PyTypeObject *cls)
     MD5State *st = PyType_GetModuleState(cls);
 
     MD5object *newobj;
-    if ((newobj = newMD5object(st))==NULL)
+    if ((newobj = newMD5object(st)) == NULL) {
         return NULL;
+    }
 
     ENTER_HASHLIB(self);
     newobj->hash_state = Hacl_Hash_MD5_copy(self->hash_state);
     LEAVE_HASHLIB(self);
+    if (newobj->hash_state == NULL) {
+        Py_DECREF(self);
+        return PyErr_NoMemory();
+    }
     return (PyObject *)newobj;
 }
 
@@ -173,15 +178,23 @@ MD5Type_hexdigest_impl(MD5object *self)
     return PyUnicode_FromStringAndSize(digest_hex, sizeof(digest_hex));
 }
 
-static void update(Hacl_Hash_MD5_state_t *state, uint8_t *buf, Py_ssize_t len) {
+static void
+update(Hacl_Hash_MD5_state_t *state, uint8_t *buf, Py_ssize_t len)
+{
+    /*
+    * Note: we explicitly ignore the error code on the basis that it would
+    * take more than 1 billion years to overflow the maximum admissible length
+    * for MD5 (2^61 - 1).
+    */
 #if PY_SSIZE_T_MAX > UINT32_MAX
-  while (len > UINT32_MAX) {
-    Hacl_Hash_MD5_update(state, buf, UINT32_MAX);
-    len -= UINT32_MAX;
-    buf += UINT32_MAX;
-  }
+    while (len > UINT32_MAX) {
+        (void)Hacl_Hash_MD5_update(state, buf, UINT32_MAX);
+        len -= UINT32_MAX;
+        buf += UINT32_MAX;
+    }
 #endif
-  Hacl_Hash_MD5_update(state, buf, (uint32_t) len);
+    assert(len <= (Py_ssize_t)UINT32_MAX);
+    (void)Hacl_Hash_MD5_update(state, buf, (uint32_t)len);
 }
 
 /*[clinic input]
@@ -286,24 +299,27 @@ _md5_md5_impl(PyObject *module, PyObject *string, int usedforsecurity)
     MD5object *new;
     Py_buffer buf;
 
-    if (string)
+    if (string) {
         GET_BUFFER_VIEW_OR_ERROUT(string, &buf);
+    }
 
     MD5State *st = md5_get_state(module);
     if ((new = newMD5object(st)) == NULL) {
-        if (string)
+        if (string) {
             PyBuffer_Release(&buf);
+        }
         return NULL;
     }
 
     new->hash_state = Hacl_Hash_MD5_malloc();
-
-    if (PyErr_Occurred()) {
+    if (new->hash_state == NULL) {
         Py_DECREF(new);
-        if (string)
+        if (string) {
             PyBuffer_Release(&buf);
-        return NULL;
+        }
+        return PyErr_NoMemory();
     }
+
     if (string) {
         if (buf.len >= HASHLIB_GIL_MINSIZE) {
             /* We do not initialize self->lock here as this is the constructor
@@ -311,7 +327,8 @@ _md5_md5_impl(PyObject *module, PyObject *string, int usedforsecurity)
             Py_BEGIN_ALLOW_THREADS
             update(new->hash_state, buf.buf, buf.len);
             Py_END_ALLOW_THREADS
-        } else {
+        }
+        else {
             update(new->hash_state, buf.buf, buf.len);
         }
         PyBuffer_Release(&buf);

--- a/Modules/sha1module.c
+++ b/Modules/sha1module.c
@@ -98,7 +98,10 @@ static void
 SHA1_dealloc(PyObject *op)
 {
     SHA1object *ptr = _SHA1object_CAST(op);
-    Hacl_Hash_SHA1_free(ptr->hash_state);
+    if (ptr->hash_state != NULL) {
+        Hacl_Hash_SHA1_free(ptr->hash_state);
+        ptr->hash_state = NULL;
+    }
     PyTypeObject *tp = Py_TYPE(ptr);
     PyObject_GC_UnTrack(ptr);
     PyObject_GC_Del(ptr);

--- a/Modules/sha1module.c
+++ b/Modules/sha1module.c
@@ -123,12 +123,17 @@ SHA1Type_copy_impl(SHA1object *self, PyTypeObject *cls)
     SHA1State *st = _PyType_GetModuleState(cls);
 
     SHA1object *newobj;
-    if ((newobj = newSHA1object(st)) == NULL)
+    if ((newobj = newSHA1object(st)) == NULL) {
         return NULL;
+    }
 
     ENTER_HASHLIB(self);
     newobj->hash_state = Hacl_Hash_SHA1_copy(self->hash_state);
     LEAVE_HASHLIB(self);
+    if (newobj->hash_state == NULL) {
+        Py_DECREF(newobj);
+        return PyErr_NoMemory();
+    }
     return (PyObject *)newobj;
 }
 
@@ -166,15 +171,23 @@ SHA1Type_hexdigest_impl(SHA1object *self)
     return _Py_strhex((const char *)digest, SHA1_DIGESTSIZE);
 }
 
-static void update(Hacl_Hash_SHA1_state_t *state, uint8_t *buf, Py_ssize_t len) {
+static void
+update(Hacl_Hash_SHA1_state_t *state, uint8_t *buf, Py_ssize_t len)
+{
+    /*
+     * Note: we explicitly ignore the error code on the basis that it would
+     * take more than 1 billion years to overflow the maximum admissible length
+     * for SHA-1 (2^61 - 1).
+     */
 #if PY_SSIZE_T_MAX > UINT32_MAX
-  while (len > UINT32_MAX) {
-    Hacl_Hash_SHA1_update(state, buf, UINT32_MAX);
-    len -= UINT32_MAX;
-    buf += UINT32_MAX;
-  }
+    while (len > UINT32_MAX) {
+        (void)Hacl_Hash_SHA1_update(state, buf, UINT32_MAX);
+        len -= UINT32_MAX;
+        buf += UINT32_MAX;
+    }
 #endif
-  Hacl_Hash_SHA1_update(state, buf, (uint32_t) len);
+    assert(len <= (Py_ssize_t)UINT32_MAX);
+    (void)Hacl_Hash_SHA1_update(state, buf, (uint32_t)len);
 }
 
 /*[clinic input]
@@ -279,23 +292,26 @@ _sha1_sha1_impl(PyObject *module, PyObject *string, int usedforsecurity)
     SHA1object *new;
     Py_buffer buf;
 
-    if (string)
+    if (string) {
         GET_BUFFER_VIEW_OR_ERROUT(string, &buf);
+    }
 
     SHA1State *st = sha1_get_state(module);
     if ((new = newSHA1object(st)) == NULL) {
-        if (string)
+        if (string) {
             PyBuffer_Release(&buf);
+        }
         return NULL;
     }
 
     new->hash_state = Hacl_Hash_SHA1_malloc();
 
-    if (PyErr_Occurred()) {
+    if (new->hash_state == NULL) {
         Py_DECREF(new);
-        if (string)
+        if (string) {
             PyBuffer_Release(&buf);
-        return NULL;
+        }
+        return PyErr_NoMemory();
     }
     if (string) {
         if (buf.len >= HASHLIB_GIL_MINSIZE) {
@@ -304,7 +320,8 @@ _sha1_sha1_impl(PyObject *module, PyObject *string, int usedforsecurity)
             Py_BEGIN_ALLOW_THREADS
             update(new->hash_state, buf.buf, buf.len);
             Py_END_ALLOW_THREADS
-        } else {
+        }
+        else {
             update(new->hash_state, buf.buf, buf.len);
         }
         PyBuffer_Release(&buf);

--- a/Modules/sha1module.c
+++ b/Modules/sha1module.c
@@ -186,7 +186,7 @@ update(Hacl_Hash_SHA1_state_t *state, uint8_t *buf, Py_ssize_t len)
         buf += UINT32_MAX;
     }
 #endif
-    assert(len <= (Py_ssize_t)UINT32_MAX);
+    /* cast to uint32_t is now safe */
     (void)Hacl_Hash_SHA1_update(state, buf, (uint32_t)len);
 }
 

--- a/Modules/sha2module.c
+++ b/Modules/sha2module.c
@@ -178,7 +178,10 @@ static void
 SHA256_dealloc(PyObject *op)
 {
     SHA256object *ptr = _SHA256object_CAST(op);
-    Hacl_Hash_SHA2_free_256(ptr->state);
+    if (ptr->state != NULL) {
+        Hacl_Hash_SHA2_free_256(ptr->state);
+        ptr->state = NULL;
+    }
     PyTypeObject *tp = Py_TYPE(ptr);
     PyObject_GC_UnTrack(ptr);
     PyObject_GC_Del(ptr);
@@ -189,7 +192,10 @@ static void
 SHA512_dealloc(PyObject *op)
 {
     SHA512object *ptr = _SHA512object_CAST(op);
-    Hacl_Hash_SHA2_free_512(ptr->state);
+    if (ptr->state != NULL) {
+        Hacl_Hash_SHA2_free_512(ptr->state);
+        ptr->state = NULL;
+    }
     PyTypeObject *tp = Py_TYPE(ptr);
     PyObject_GC_UnTrack(ptr);
     PyObject_GC_Del(ptr);
@@ -265,9 +271,8 @@ SHA256Type_copy_impl(SHA256object *self, PyTypeObject *cls)
         }
     }
 
-    int rc = 0;
     ENTER_HASHLIB(self);
-    rc = SHA256copy(self, newobj);
+    int rc = SHA256copy(self, newobj);
     LEAVE_HASHLIB(self);
     if (rc < 0) {
         Py_DECREF(newobj);
@@ -288,6 +293,7 @@ static PyObject *
 SHA512Type_copy_impl(SHA512object *self, PyTypeObject *cls)
 /*[clinic end generated code: output=66d2a8ef20de8302 input=f673a18f66527c90]*/
 {
+    int rc;
     SHA512object *newobj;
     sha2_state *state = _PyType_GetModuleState(cls);
 
@@ -302,7 +308,6 @@ SHA512Type_copy_impl(SHA512object *self, PyTypeObject *cls)
         }
     }
 
-    int rc = 0;
     ENTER_HASHLIB(self);
     rc = SHA512copy(self, newobj);
     LEAVE_HASHLIB(self);

--- a/Modules/sha2module.c
+++ b/Modules/sha2module.c
@@ -258,6 +258,7 @@ static PyObject *
 SHA256Type_copy_impl(SHA256object *self, PyTypeObject *cls)
 /*[clinic end generated code: output=fabd515577805cd3 input=3137146fcb88e212]*/
 {
+    int rc;
     SHA256object *newobj;
     sha2_state *state = _PyType_GetModuleState(cls);
     if (Py_IS_TYPE(self, state->sha256_type)) {
@@ -272,7 +273,7 @@ SHA256Type_copy_impl(SHA256object *self, PyTypeObject *cls)
     }
 
     ENTER_HASHLIB(self);
-    int rc = SHA256copy(self, newobj);
+    rc = SHA256copy(self, newobj);
     LEAVE_HASHLIB(self);
     if (rc < 0) {
         Py_DECREF(newobj);

--- a/Modules/sha2module.c
+++ b/Modules/sha2module.c
@@ -214,7 +214,7 @@ update_256(Hacl_Hash_SHA2_state_t_256 *state, uint8_t *buf, Py_ssize_t len)
         buf += UINT32_MAX;
     }
 #endif
-    assert(len <= (Py_ssize_t)UINT32_MAX);
+    /* cast to uint32_t is now safe */
     (void)Hacl_Hash_SHA2_update_256(state, buf, (uint32_t)len);
 }
 
@@ -233,7 +233,7 @@ update_512(Hacl_Hash_SHA2_state_t_512 *state, uint8_t *buf, Py_ssize_t len)
         buf += UINT32_MAX;
     }
 #endif
-    assert(len <= (Py_ssize_t)UINT32_MAX);
+    /* cast to uint32_t is now safe */
     (void)Hacl_Hash_SHA2_update_512(state, buf, (uint32_t)len);
 }
 

--- a/Modules/sha3module.c
+++ b/Modules/sha3module.c
@@ -98,7 +98,7 @@ sha3_update(Hacl_Hash_SHA3_state_t *state, uint8_t *buf, Py_ssize_t len)
         buf += UINT32_MAX;
     }
 #endif
-    assert(len <= (Py_ssize_t)UINT32_MAX);
+    /* cast to uint32_t is now safe */
     (void)Hacl_Hash_SHA3_update(state, buf, (uint32_t)len);
 }
 

--- a/Modules/sha3module.c
+++ b/Modules/sha3module.c
@@ -83,18 +83,23 @@ newSHA3object(PyTypeObject *type)
     return newobj;
 }
 
-static void sha3_update(Hacl_Hash_SHA3_state_t *state, uint8_t *buf, Py_ssize_t len) {
-  /* Note: we explicitly ignore the error code on the basis that it would take >
-   * 1 billion years to hash more than 2^64 bytes. */
+static void
+sha3_update(Hacl_Hash_SHA3_state_t *state, uint8_t *buf, Py_ssize_t len)
+{
+  /*
+   * Note: we explicitly ignore the error code on the basis that it would
+   * take more than 1 billion years to overflow the maximum admissible length
+   * for SHA-3 (2^64 - 1).
+   */
 #if PY_SSIZE_T_MAX > UINT32_MAX
-  while (len > UINT32_MAX) {
-    Hacl_Hash_SHA3_update(state, buf, UINT32_MAX);
-    len -= UINT32_MAX;
-    buf += UINT32_MAX;
-  }
+    while (len > UINT32_MAX) {
+        (void)Hacl_Hash_SHA3_update(state, buf, UINT32_MAX);
+        len -= UINT32_MAX;
+        buf += UINT32_MAX;
+    }
 #endif
-  /* Cast to uint32_t is safe: len <= UINT32_MAX at this point. */
-  Hacl_Hash_SHA3_update(state, buf, (uint32_t) len);
+    assert(len <= (Py_ssize_t)UINT32_MAX);
+    (void)Hacl_Hash_SHA3_update(state, buf, (uint32_t)len);
 }
 
 /*[clinic input]
@@ -123,18 +128,29 @@ py_sha3_new_impl(PyTypeObject *type, PyObject *data, int usedforsecurity)
 
     if (type == state->sha3_224_type) {
         self->hash_state = Hacl_Hash_SHA3_malloc(Spec_Hash_Definitions_SHA3_224);
-    } else if (type == state->sha3_256_type) {
+    }
+    else if (type == state->sha3_256_type) {
         self->hash_state = Hacl_Hash_SHA3_malloc(Spec_Hash_Definitions_SHA3_256);
-    } else if (type == state->sha3_384_type) {
+    }
+    else if (type == state->sha3_384_type) {
         self->hash_state = Hacl_Hash_SHA3_malloc(Spec_Hash_Definitions_SHA3_384);
-    } else if (type == state->sha3_512_type) {
+    }
+    else if (type == state->sha3_512_type) {
         self->hash_state = Hacl_Hash_SHA3_malloc(Spec_Hash_Definitions_SHA3_512);
-    } else if (type == state->shake_128_type) {
+    }
+    else if (type == state->shake_128_type) {
         self->hash_state = Hacl_Hash_SHA3_malloc(Spec_Hash_Definitions_Shake128);
-    } else if (type == state->shake_256_type) {
+    }
+    else if (type == state->shake_256_type) {
         self->hash_state = Hacl_Hash_SHA3_malloc(Spec_Hash_Definitions_Shake256);
-    } else {
+    }
+    else {
         PyErr_BadInternalCall();
+        goto error;
+    }
+
+    if (self->hash_state == NULL) {
+        (void)PyErr_NoMemory();
         goto error;
     }
 
@@ -146,7 +162,8 @@ py_sha3_new_impl(PyTypeObject *type, PyObject *data, int usedforsecurity)
             Py_BEGIN_ALLOW_THREADS
             sha3_update(self->hash_state, buf.buf, buf.len);
             Py_END_ALLOW_THREADS
-        } else {
+        }
+        else {
             sha3_update(self->hash_state, buf.buf, buf.len);
         }
     }
@@ -155,7 +172,7 @@ py_sha3_new_impl(PyTypeObject *type, PyObject *data, int usedforsecurity)
 
     return (PyObject *)self;
 
-  error:
+error:
     if (self) {
         Py_DECREF(self);
     }
@@ -217,6 +234,10 @@ _sha3_sha3_224_copy_impl(SHA3object *self)
     ENTER_HASHLIB(self);
     newobj->hash_state = Hacl_Hash_SHA3_copy(self->hash_state);
     LEAVE_HASHLIB(self);
+    if (newobj->hash_state == NULL) {
+        Py_DECREF(newobj);
+        return PyErr_NoMemory();
+    }
     return (PyObject *)newobj;
 }
 
@@ -232,10 +253,10 @@ _sha3_sha3_224_digest_impl(SHA3object *self)
 /*[clinic end generated code: output=fd531842e20b2d5b input=5b2a659536bbd248]*/
 {
     unsigned char digest[SHA3_MAX_DIGESTSIZE];
-    // This function errors out if the algorithm is Shake. Here, we know this
+    // This function errors out if the algorithm is SHAKE. Here, we know this
     // not to be the case, and therefore do not perform error checking.
     ENTER_HASHLIB(self);
-    Hacl_Hash_SHA3_digest(self->hash_state, digest);
+    (void)Hacl_Hash_SHA3_digest(self->hash_state, digest);
     LEAVE_HASHLIB(self);
     return PyBytes_FromStringAndSize((const char *)digest,
         Hacl_Hash_SHA3_hash_len(self->hash_state));
@@ -254,7 +275,7 @@ _sha3_sha3_224_hexdigest_impl(SHA3object *self)
 {
     unsigned char digest[SHA3_MAX_DIGESTSIZE];
     ENTER_HASHLIB(self);
-    Hacl_Hash_SHA3_digest(self->hash_state, digest);
+    (void)Hacl_Hash_SHA3_digest(self->hash_state, digest);
     LEAVE_HASHLIB(self);
     return _Py_strhex((const char *)digest,
         Hacl_Hash_SHA3_hash_len(self->hash_state));
@@ -465,13 +486,13 @@ _SHAKE_digest(PyObject *op, unsigned long digestlen, int hex)
      * - the output length is zero -- we follow the existing behavior and return
      *   an empty digest, without raising an error */
     if (digestlen > 0) {
-        Hacl_Hash_SHA3_squeeze(self->hash_state, digest, digestlen);
+        (void)Hacl_Hash_SHA3_squeeze(self->hash_state, digest, digestlen);
     }
     if (hex) {
         result = _Py_strhex((const char *)digest, digestlen);
-    } else {
-        result = PyBytes_FromStringAndSize((const char *)digest,
-                                           digestlen);
+    }
+    else {
+        result = PyBytes_FromStringAndSize((const char *)digest, digestlen);
     }
     PyMem_Free(digest);
     return result;


### PR DESCRIPTION
In a follow-up PR I'd like to move all `UPDATE` functions in a single helper. The construction is always the same and it would help the HMAC PR as well (I've done it out there).

More generally, I'd like to have the same construction for MD5/SHA1/SHA2/SHA3 as they really share common code. I don't know how much I can change the code so that it looks better, which is why I didn't change anything here.

We had a discussion on the blake2 PR concerning the cosmetics of blake2module and I think we can definitely improve how it's currently structured, because the functions become quite ugly. But that'd be another issue.

cc @msprotz @chris-eibl 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131316 -->
* Issue: gh-131316
<!-- /gh-issue-number -->
