### PR TITLE
gh-131178: Update help message for `timeit` CLI

### DIFF
--- a/Lib/test/test_timeit.py
+++ b/Lib/test/test_timeit.py
@@ -297,9 +297,7 @@ class TestTimeit(unittest.TestCase):
     @unittest.skipIf(sys.flags.optimize >= 2, "need __doc__")
     def test_main_help(self):
         s = self.run_main(switches=['-h'])
-        # Note: It's not clear that the trailing space was intended as part of
-        # the help text, but since it's there, check for it.
-        self.assertEqual(s, timeit.__doc__ + ' ')
+        self.assertEqual(s, timeit.__doc__)
 
     def test_main_verbose(self):
         s = self.run_main(switches=['-v'])

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -44,7 +44,6 @@ Functions:
     timeit(string, string) -> float
     repeat(string, string) -> list
     default_timer() -> float
-
 """
 
 import gc
@@ -302,7 +301,7 @@ def main(args=None, *, _wrap_timer=None):
                 precision += 1
             verbose += 1
         if o in ("-h", "--help"):
-            print(__doc__, end=' ')
+            print(__doc__, end="")
             return 0
     setup = "\n".join(setup) or "pass"
 

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -44,6 +44,7 @@ Functions:
     timeit(string, string) -> float
     repeat(string, string) -> list
     default_timer() -> float
+
 """
 
 import gc

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -44,7 +44,6 @@ Functions:
     timeit(string, string) -> float
     repeat(string, string) -> list
     default_timer() -> float
-
 """
 
 import gc


### PR DESCRIPTION
I thought it was weird to have next end for the help message. The one who added test case also noticed this and commented it.
I didn't find where it could be useful and also unexpectedly, this is what it looks like when I run `./python -m timeit -h`:

| `main` branch | `PR` branch |
|--------|--------|
| ![Screenshot from 2025-03-16 15-39-11](https://github.com/user-attachments/assets/865e7136-525b-4444-b6b5-841357672a13) | ![Screenshot from 2025-03-16 15-38-56](https://github.com/user-attachments/assets/d1fe05ea-520b-4e7a-9e49-4e84c85d72cb) | 


<!-- gh-issue-number: gh-131178 -->
* Issue: gh-131178
<!-- /gh-issue-number -->
