### PR TITLE
Fix test_pyrepl.TestDumbTerminal if PYTHON_BASIC_REPL set.

### DIFF
--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1059,6 +1059,7 @@ class TestPasteEvent(TestCase):
 class TestDumbTerminal(ReplTestCase):
     def test_dumb_terminal_exits_cleanly(self):
         env = os.environ.copy()
+        env.pop('PYTHON_BASIC_REPL', None)
         env.update({"TERM": "dumb"})
         output, exit_code = self.run_repl("exit()\n", env=env)
         self.assertEqual(exit_code, 0)


### PR DESCRIPTION
Most of the tests that care already adjust PYTHON_BASIC_REPL as needed,
but this one doesn't, and it fails if the developer has the variable set.
