### PR TITLE
gh-131331: rename `not` field to `invert` for C++ extension modules

### DIFF
--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -201,7 +201,7 @@ typedef struct _jit_opt_tuple {
 
 typedef struct {
     uint8_t tag;
-    bool not_;
+    bool invert;
     uint16_t value;
 } JitOptTruthiness;
 

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -201,7 +201,7 @@ typedef struct _jit_opt_tuple {
 
 typedef struct {
     uint8_t tag;
-    bool not;
+    bool not_;
     uint16_t value;
 } JitOptTruthiness;
 

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -113,7 +113,7 @@ _Py_uop_sym_is_const(JitOptContext *ctx, JitOptSymbol *sym)
         if (truthiness < 0) {
             return false;
         }
-        make_const(sym, (truthiness ^ sym->truthiness.not) ? Py_True : Py_False);
+        make_const(sym, (truthiness ^ sym->truthiness.not_) ? Py_True : Py_False);
         return true;
     }
     return false;
@@ -138,7 +138,7 @@ _Py_uop_sym_get_const(JitOptContext *ctx, JitOptSymbol *sym)
         if (truthiness < 0) {
             return NULL;
         }
-        PyObject *res = (truthiness ^ sym->truthiness.not) ? Py_True : Py_False;
+        PyObject *res = (truthiness ^ sym->truthiness.not_) ? Py_True : Py_False;
         make_const(sym, res);
         return res;
     }
@@ -289,7 +289,7 @@ _Py_uop_sym_set_const(JitOptContext *ctx, JitOptSymbol *sym, PyObject *const_val
             }
             JitOptSymbol *value = allocation_base(ctx) + sym->truthiness.value;
             PyTypeObject *type = _Py_uop_sym_get_type(value);
-            if (const_val == (sym->truthiness.not ? Py_False : Py_True)) {
+            if (const_val == (sym->truthiness.not_ ? Py_False : Py_True)) {
                 // value is truthy. This is only useful for bool:
                 if (type == &PyBool_Type) {
                     _Py_uop_sym_set_const(ctx, value, Py_True);
@@ -496,7 +496,7 @@ _Py_uop_sym_truthiness(JitOptContext *ctx, JitOptSymbol *sym)
             if (truthiness < 0) {
                 return truthiness;
             }
-            truthiness ^= sym->truthiness.not;
+            truthiness ^= sym->truthiness.not_;
             make_const(sym, truthiness ? Py_True : Py_False);
             return truthiness;
     }
@@ -590,8 +590,8 @@ JitOptSymbol *
 _Py_uop_sym_new_truthiness(JitOptContext *ctx, JitOptSymbol *value, bool truthy)
 {
     // It's clearer to invert this in the signature:
-    bool not = !truthy;
-    if (value->tag == JIT_SYM_TRUTHINESS_TAG && value->truthiness.not == not) {
+    bool not_ = !truthy;
+    if (value->tag == JIT_SYM_TRUTHINESS_TAG && value->truthiness.not_ == not_) {
         return value;
     }
     JitOptSymbol *res = sym_new(ctx);
@@ -601,11 +601,11 @@ _Py_uop_sym_new_truthiness(JitOptContext *ctx, JitOptSymbol *value, bool truthy)
     int truthiness = _Py_uop_sym_truthiness(ctx, value);
     if (truthiness < 0) {
         res->tag = JIT_SYM_TRUTHINESS_TAG;
-        res->truthiness.not = not;
+        res->truthiness.not_ = not_;
         res->truthiness.value = (uint16_t)(value - allocation_base(ctx));
     }
     else {
-        make_const(res, (truthiness ^ not) ? Py_True : Py_False);
+        make_const(res, (truthiness ^ not_) ? Py_True : Py_False);
     }
     return res;
 }

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -113,7 +113,7 @@ _Py_uop_sym_is_const(JitOptContext *ctx, JitOptSymbol *sym)
         if (truthiness < 0) {
             return false;
         }
-        make_const(sym, (truthiness ^ sym->truthiness.not_) ? Py_True : Py_False);
+        make_const(sym, (truthiness ^ sym->truthiness.invert) ? Py_True : Py_False);
         return true;
     }
     return false;
@@ -138,7 +138,7 @@ _Py_uop_sym_get_const(JitOptContext *ctx, JitOptSymbol *sym)
         if (truthiness < 0) {
             return NULL;
         }
-        PyObject *res = (truthiness ^ sym->truthiness.not_) ? Py_True : Py_False;
+        PyObject *res = (truthiness ^ sym->truthiness.invert) ? Py_True : Py_False;
         make_const(sym, res);
         return res;
     }
@@ -289,7 +289,7 @@ _Py_uop_sym_set_const(JitOptContext *ctx, JitOptSymbol *sym, PyObject *const_val
             }
             JitOptSymbol *value = allocation_base(ctx) + sym->truthiness.value;
             PyTypeObject *type = _Py_uop_sym_get_type(value);
-            if (const_val == (sym->truthiness.not_ ? Py_False : Py_True)) {
+            if (const_val == (sym->truthiness.invert ? Py_False : Py_True)) {
                 // value is truthy. This is only useful for bool:
                 if (type == &PyBool_Type) {
                     _Py_uop_sym_set_const(ctx, value, Py_True);
@@ -496,7 +496,7 @@ _Py_uop_sym_truthiness(JitOptContext *ctx, JitOptSymbol *sym)
             if (truthiness < 0) {
                 return truthiness;
             }
-            truthiness ^= sym->truthiness.not_;
+            truthiness ^= sym->truthiness.invert;
             make_const(sym, truthiness ? Py_True : Py_False);
             return truthiness;
     }
@@ -590,8 +590,8 @@ JitOptSymbol *
 _Py_uop_sym_new_truthiness(JitOptContext *ctx, JitOptSymbol *value, bool truthy)
 {
     // It's clearer to invert this in the signature:
-    bool not_ = !truthy;
-    if (value->tag == JIT_SYM_TRUTHINESS_TAG && value->truthiness.not_ == not_) {
+    bool invert = !truthy;
+    if (value->tag == JIT_SYM_TRUTHINESS_TAG && value->truthiness.invert == invert) {
         return value;
     }
     JitOptSymbol *res = sym_new(ctx);
@@ -601,11 +601,11 @@ _Py_uop_sym_new_truthiness(JitOptContext *ctx, JitOptSymbol *value, bool truthy)
     int truthiness = _Py_uop_sym_truthiness(ctx, value);
     if (truthiness < 0) {
         res->tag = JIT_SYM_TRUTHINESS_TAG;
-        res->truthiness.not_ = not_;
+        res->truthiness.invert = invert;
         res->truthiness.value = (uint16_t)(value - allocation_base(ctx));
     }
     else {
-        make_const(res, (truthiness ^ not_) ? Py_True : Py_False);
+        make_const(res, (truthiness ^ invert) ? Py_True : Py_False);
     }
     return res;
 }


### PR DESCRIPTION
cc @brandtbucher 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131331 -->
* Issue: gh-131331
<!-- /gh-issue-number -->
