### PR TITLE
gh-131217: new repl display output from all statements, separated by ';'

### DIFF
--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -201,11 +201,9 @@ class InteractiveColoredConsole(code.InteractiveConsole):
         if tree.body:
             *_, last_stmt = tree.body
         for stmt in tree.body:
-            wrapper = ast.Interactive if stmt is last_stmt else ast.Module
-            the_symbol = symbol if stmt is last_stmt else "exec"
-            item = wrapper([stmt])
+            item = ast.Interactive([stmt])
             try:
-                code = self.compile.compiler(item, filename, the_symbol)
+                code = self.compile.compiler(item, filename, symbol)
                 linecache._register_code(code, source, filename)
             except SyntaxError as e:
                 if e.args[0] == "'await' outside function":

--- a/Lib/test/test_pyrepl/test_interact.py
+++ b/Lib/test/test_pyrepl/test_interact.py
@@ -51,7 +51,16 @@ class TestSimpleInteract(unittest.TestCase):
         with contextlib.redirect_stdout(f):
             more = console.push(code, filename="<stdin>", _symbol="single")  # type: ignore[call-arg]
         self.assertFalse(more)
-        self.assertEqual(f.getvalue(), "1\n")
+        self.assertEqual(f.getvalue(), "1\n1\n")
+
+        namespace = {}
+        code = "'foo';'bar'"
+        console = InteractiveColoredConsole(namespace, filename="<stdin>")
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            more = console.push(code, filename="<stdin>", _symbol="single")  # type: ignore[call-arg]
+        self.assertFalse(more)
+        self.assertEqual(f.getvalue(), "'foo'\n'bar'\n")
 
     @force_not_colorized
     def test_multiple_statements_fail_early(self):

--- a/Misc/NEWS.d/next/Library/2025-03-17-12-03-32.gh-issue-131217.ejHRzN.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-17-12-03-32.gh-issue-131217.ejHRzN.rst
@@ -1,0 +1,2 @@
+Fix new repl to display output from multiple statements, separated by ';'.
+Patch by Sergey B Kirpichev.


### PR DESCRIPTION
Was:
```pycon
>>> 1;2
2
```

Now:
```pycon
>>> 1;2
1
2
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131217 -->
* Issue: gh-131217
<!-- /gh-issue-number -->
