### PR TITLE
Doc: Make codeblock in tutorial translateable

### DIFF
--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -145,7 +145,9 @@ Python can manipulate text (represented by type :class:`str`, so-called
 "strings") as well as numbers.  This includes characters "``!``", words
 "``rabbit``", names "``Paris``", sentences "``Got your back.``", etc.
 "``Yay! :)``". They can be enclosed in single quotes (``'...'``) or double
-quotes (``"..."``) with the same result [#]_::
+quotes (``"..."``) with the same result [#]_.
+
+.. code-block:: pycon
 
    >>> 'spam eggs'  # single quotes
    'spam eggs'

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -145,7 +145,7 @@ Python can manipulate text (represented by type :class:`str`, so-called
 "strings") as well as numbers.  This includes characters "``!``", words
 "``rabbit``", names "``Paris``", sentences "``Got your back.``", etc.
 "``Yay! :)``". They can be enclosed in single quotes (``'...'``) or double
-quotes (``"..."``) with the same result [#]_.
+quotes (``"..."``) with the same result [#]_.::
 
    >>> 'spam eggs'  # single quotes
    'spam eggs'

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -145,7 +145,7 @@ Python can manipulate text (represented by type :class:`str`, so-called
 "strings") as well as numbers.  This includes characters "``!``", words
 "``rabbit``", names "``Paris``", sentences "``Got your back.``", etc.
 "``Yay! :)``". They can be enclosed in single quotes (``'...'``) or double
-quotes (``"..."``) with the same result [#]_.::
+quotes (``"..."``) with the same result [#]_::
 
    >>> 'spam eggs'  # single quotes
    'spam eggs'


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

This is otherwise untranslatable at the moment due to a bug in Sphinx which has had no development for quite a while.

https://github.com/python/cpython/pull/123852
https://github.com/sphinx-doc/sphinx/issues/12871

It was presumably an accident as the rest of file uses literal-blocks. This is also a fairly important block in the tutorial :-)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131353.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->