### PR TITLE
gh-131261: expat/refresh.sh: Expand list of manual steps

### DIFF
--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -128,20 +128,6 @@
       "fileName": "Modules/expat/nametab.h"
     },
     {
-      "SPDXID": "SPDXRef-FILE-Modules-expat-refresh.sh",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "1834a0629524eee116cf84251464fb368423fd73"
-        },
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "a8e123d64c0c43fcc52e70c6573db071c3d007ecdad604fbc3a84beefe2ed3a1"
-        }
-      ],
-      "fileName": "Modules/expat/refresh.sh"
-    },
-    {
       "SPDXID": "SPDXRef-FILE-Modules-expat-siphash.h",
       "checksums": [
         {
@@ -1773,11 +1759,6 @@
     },
     {
       "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-nametab.h",
-      "relationshipType": "CONTAINS",
-      "spdxElementId": "SPDXRef-PACKAGE-expat"
-    },
-    {
-      "relatedSpdxElement": "SPDXRef-FILE-Modules-expat-refresh.sh",
       "relationshipType": "CONTAINS",
       "spdxElementId": "SPDXRef-PACKAGE-expat"
     },

--- a/Modules/expat/refresh.sh
+++ b/Modules/expat/refresh.sh
@@ -54,4 +54,13 @@ rm libexpat.tar.gz
 # Step 3: Add the namespacing include to expat_external.h
 sed -i 's/#define Expat_External_INCLUDED 1/&\n\n\/* Namespace external symbols to allow multiple libexpat version to\n   co-exist. \*\/\n#include "pyexpatns.h"/' expat_external.h
 
-echo "Updated; verify all is okay using git diff and git status."
+echo "
+Updated! next steps:
+- Verify all is okay:
+    git diff
+    git status
+- Regenerate the sbom file
+    make regen-sbom
+- Update warning count in Tools/build/.warningignore_macos
+    (use info from CI if not on a Mac)
+"

--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -60,7 +60,7 @@ PACKAGE_TO_FILES = {
         exclude=[
             "Modules/expat/expat_config.h",
             "Modules/expat/pyexpatns.h",
-            "Modules/_hacl/refresh.sh",
+            "Modules/expat/refresh.sh",
         ]
     ),
     "macholib": PackageFiles(


### PR DESCRIPTION
There's a few manual steps for updating expat; here's a list.
(This is a separate PR as it doesn't need backports.)

We could run `make regen-sbom` automatically, but it's probably better to do it after checking `git diff`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131261 -->
* Issue: gh-131261
<!-- /gh-issue-number -->
