### PR TITLE
GH-127705: Adds the missing bits from #131198

### DIFF
--- a/Include/refcount.h
+++ b/Include/refcount.h
@@ -387,42 +387,6 @@ static inline void Py_DECREF(PyObject *op)
 #define Py_DECREF(op) Py_DECREF(_PyObject_CAST(op))
 
 #elif defined(Py_REF_DEBUG)
-static inline void Py_DECREF_MORTAL(const char *filename, int lineno, PyObject *op)
-{
-    if (op->ob_refcnt <= 0) {
-        _Py_NegativeRefcount(filename, lineno, op);
-    }
-    _Py_DECREF_STAT_INC();
-    assert(!_Py_IsStaticImmortal(op));
-    if (!_Py_IsImmortal(op)) {
-        _Py_DECREF_DecRefTotal();
-    }
-    if (--op->ob_refcnt == 0) {
-        _Py_Dealloc(op);
-    }
-}
-#define Py_DECREF_MORTAL(op) Py_DECREF_MORTAL(__FILE__, __LINE__, _PyObject_CAST(op))
-
-
-
-static inline void _Py_DECREF_MORTAL_SPECIALIZED(const char *filename, int lineno, PyObject *op, destructor destruct)
-{
-    if (op->ob_refcnt <= 0) {
-        _Py_NegativeRefcount(filename, lineno, op);
-    }
-    _Py_DECREF_STAT_INC();
-    assert(!_Py_IsStaticImmortal(op));
-    if (!_Py_IsImmortal(op)) {
-        _Py_DECREF_DecRefTotal();
-    }
-    if (--op->ob_refcnt == 0) {
-#ifdef Py_TRACE_REFS
-        _Py_ForgetReference(op);
-#endif
-        destruct(op);
-    }
-}
-#define Py_DECREF_MORTAL_SPECIALIZED(op, destruct) _Py_DECREF_MORTAL_SPECIALIZED(__FILE__, __LINE__, op, destruct)
 
 static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
 {
@@ -448,28 +412,6 @@ static inline void Py_DECREF(const char *filename, int lineno, PyObject *op)
 #define Py_DECREF(op) Py_DECREF(__FILE__, __LINE__, _PyObject_CAST(op))
 
 #else
-static inline void Py_DECREF_MORTAL(PyObject *op)
-{
-    assert(!_Py_IsStaticImmortal(op));
-    _Py_DECREF_STAT_INC();
-    if (--op->ob_refcnt == 0) {
-        _Py_Dealloc(op);
-    }
-}
-#define Py_DECREF_MORTAL(op) Py_DECREF_MORTAL(_PyObject_CAST(op))
-
-static inline void Py_DECREF_MORTAL_SPECIALIZED(PyObject *op, destructor destruct)
-{
-    assert(!_Py_IsStaticImmortal(op));
-    _Py_DECREF_STAT_INC();
-    if (--op->ob_refcnt == 0) {
-#ifdef Py_TRACE_REFS
-        _Py_ForgetReference(op);
-#endif
-        destruct(op);
-    }
-}
-#define Py_DECREF_MORTAL_SPECIALIZED(op, destruct) Py_DECREF_MORTAL_SPECIALIZED(_PyObject_CAST(op), destruct)
 
 static inline Py_ALWAYS_INLINE void Py_DECREF(PyObject *op)
 {


### PR DESCRIPTION
Now that https://github.com/python/cpython/issues/131238 is mostly done, we can move this code to where it belongs and add the missing calls to `_PyReftracerTrack`

<!-- gh-issue-number: gh-127705 -->
* Issue: gh-127705
<!-- /gh-issue-number -->
