### PR TITLE
GH-131296: fix clang-cl warning in tracemalloc.c

### DIFF
--- a/Python/tracemalloc.c
+++ b/Python/tracemalloc.c
@@ -53,7 +53,8 @@ typedef struct tracemalloc_traceback traceback_t;
 /* The maximum number of frames is either:
  - The maximum number of frames we can store in `traceback_t.nframe`
  - The maximum memory size_t we can allocate */
-static const unsigned long MAX_NFRAME = Py_MIN(UINT16_MAX, ((SIZE_MAX - sizeof(traceback_t)) / sizeof(frame_t) + 1));
+static const unsigned long MAX_NFRAME = (unsigned long)Py_MIN(
+    UINT16_MAX, ((SIZE_MAX - sizeof(traceback_t)) / sizeof(frame_t) + 1));
 
 
 #define tracemalloc_empty_traceback _PyRuntime.tracemalloc.empty_traceback


### PR DESCRIPTION
This one is really interesting. Only clang-cl issues it - not clang or GCC on Linux: https://godbolt.org/z/57oaaTcbT

Interestingly enough, clang-cl even emits this warning without any options given (i.e. the default warning level), on the not taken branch in `Py_MIN(x, y) (((x) > (y)) ? (y) : (x))`.

I had to use C++ on godbolt, because clang-cl is not available as C compiler, but I get the same error for that file when compiling the C file `tracemalloc.c` locally.

The fix is easy, although seeming very unneeded :(

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
