### PR TITLE
gh-119786: Fix _PyExecutorObject link at jit.md file

### DIFF
--- a/InternalDocs/jit.md
+++ b/InternalDocs/jit.md
@@ -22,7 +22,7 @@ It then calls the function `_PyOptimizer_Optimize()` in
 [`Python/optimizer.c`](../Python/optimizer.c), passing it the current
 [frame](frames.md) and instruction pointer. `_PyOptimizer_Optimize()`
 constructs an object of type
-[`_PyExecutorObject`](Include/internal/pycore_optimizer.h) which implements
+[`_PyExecutorObject`](../Include/internal/pycore_optimizer.h) which implements
 an optimized version of the instruction trace beginning at this jump.
 
 The optimizer determines where the trace ends, and the executor is set up


### PR DESCRIPTION
Now `_PyExecutorObject` link refers to the correct URL.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-119786 -->
* Issue: gh-119786
<!-- /gh-issue-number -->
