### PR TITLE
gh-121468: Ensure PDB cleans up event loop policies after using asyncio.

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -13,6 +13,7 @@ import linecache
 import zipapp
 import zipfile
 
+from asyncio.events import _set_event_loop_policy
 from contextlib import ExitStack, redirect_stdout
 from io import StringIO
 from test import support
@@ -40,6 +41,10 @@ class PdbTestInput(object):
         sys.stdin = self.real_stdin
         if self.orig_trace:
             sys.settrace(self.orig_trace)
+
+        # To prevent a warning "test altered the execution environment" if
+        # asyncio features are used.
+        _set_event_loop_policy(None)
 
 
 def test_pdb_displayhook():

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -2155,7 +2155,7 @@ if not SKIP_CORO_TESTS:
             ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
 
             >>> def test_function():
-            ...     asyncio.run(test())
+            ...     asyncio.run(test(), loop_factory=asyncio.EventLoop)
 
             >>> with PdbTestInput([  # doctest: +ELLIPSIS
             ...     '$_asynctask',


### PR DESCRIPTION
#124367 added a PDB test that interacts with asyncio. Under some conditions, this can lead to a warning during test execution because the PDB test "alters the execution environment" by setting an event loop policy:

```
$ python.exe -m test  test_asyncio.test_unix_events test_pdb
Using random seed: 451824264
0:00:00 load avg: 15.60 Run 2 tests sequentially in a single process
0:00:00 load avg: 15.60 [1/2] test_asyncio.test_unix_events
0:00:00 load avg: 15.55 [1/2] test_asyncio.test_unix_events passed
0:00:00 load avg: 15.55 [2/2] test_pdb
Warning -- asyncio.events._event_loop_policy was modified by test_pdb
Warning --   Before: None
Warning --   After:  <asyncio.unix_events._UnixDefaultEventLoopPolicy object at 0x101d80190> 
0:00:08 load avg: 15.51 [2/2/1] test_pdb failed (env changed)

== Tests result: SUCCESS ==

1 test altered the execution environment (env changed):
    test_pdb

1 test OK.

Total duration: 8.1 sec
Total tests: run=282 skipped=2
Total test files: run=2/2 env_changed=1
Result: SUCCESS
```

This problem only manifests if you run the tests suite sequentially, or if an asyncio test is performed in the same process as the `test_pdb` test. iOS and Android tests are *always* run sequentially, so those platforms are hitting this problem reliably.

This fix ensures that `test_pdb` cleans up the event policy at the end of each test. The approach I've taken seems consistent with other "end of test cleanup" methods in `test_asyncio`.

<!-- gh-issue-number: gh-121468 -->
* Issue: gh-121468
<!-- /gh-issue-number -->
