### PR TITLE
gh-120144: Disable the CALL event when possible to achieve zero overhead pdb

### DIFF
--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -342,7 +342,12 @@ class Bdb:
             self.botframe = frame.f_back # (CT) Note that this may also be None!
             return self.trace_dispatch
         if not (self.stop_here(frame) or self.break_anywhere(frame)):
-            # No need to trace this function
+            # We already know there's no breakpoint in this function
+            # If it's a next/until/return command, we don't need any CALL event
+            # and we don't need to set the f_trace on any new frame.
+            # If it's a step command, it must either hit stop_here, or skip the
+            # whole module. Either way, we don't need the CALL event here.
+            self.disable_current_event()
             return # None
         # Ignore call events in generator except when stepping.
         if self.stopframe and frame.f_code.co_flags & GENERATOR_AND_COROUTINE_FLAGS:

--- a/Misc/NEWS.d/next/Library/2025-03-18-02-11-33.gh-issue-120144.dBLFkI.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-18-02-11-33.gh-issue-120144.dBLFkI.rst
@@ -1,0 +1,1 @@
+Disable ``CALL`` event in :mod:`bdb` in ``monitoring`` backend when we don't need any new events on the code object to get a better performance.


### PR DESCRIPTION
This is one line of well-thought code :)

We basically solved the debugger overhead in a big loop by disabling LINE events, the one (major) thing left was recursive calls - or rather, calls in general. We won't prevent CALL events from happening for every unrelated call because that would require a much larger change, but we can disable CALL events after we hit it once.

Notice that CALL event has a two effects which made it a bit more complicated:
1. It could be the event that the user actually wants (only happens in `step`)
2. It returns the local trace function that enables all the other events on this *code object* (not function/frame).

No 2. makes it a bit challenging and much more rewarding.

We need to make sure we don't need any *new* events on this code object, before we can disable the CALL event.

First of all, if there's any breakpoint on the code object, we can't do that. But we already have check for that where the code was added.

Then we'll realize, if it's a `next`, `until` or `return` - it will just work fine, because they all rely on events on *existing* frame and code objects. It's impossible for those commands to stop at a new frame.

The only command that could stop at a new frame, is `step` - but if it's a step, it would either
* hit `stop_here()` already on this specific `CALL` event so we can't reach to this point
* or skip this function because of specified `skip` argument, which means it won't stop in this function in the future

So really, we don't need to care about anything. If we don't need to trace this function now, we won't need any *new* events for this code object in the future (until the user interaction), so we can simply disable the CALL event.

This basically gives us a zero overhead debugger. There's no observable overhead for the recursive fib implementation.

<!-- gh-issue-number: gh-120144 -->
* Issue: gh-120144
<!-- /gh-issue-number -->
