### PR TITLE
gh-128002: fix tsan race in closing socket in test_ssl

### DIFF
--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -1849,15 +1849,13 @@ class TestThreadedServer(SocketThread):
                     pass
         finally:
             super().stop()
-
-    def run(self):
-        try:
-            with self._sock:
-                self._sock.setblocking(False)
-                self._run()
-        finally:
+            self._sock.close()
             self._s1.close()
             self._s2.close()
+
+    def run(self):
+        self._sock.setblocking(False)
+        self._run()
 
     def _run(self):
         while self._active:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128002 -->
* Issue: gh-128002
<!-- /gh-issue-number -->


This fixes the tsan data race detected of closing of socket.

<details>

```console
env TSAN_OPTIONS="halt_on_error=1" ./python -m test test_asyncio.test_ssl -m test_create_connection_memory_lea
k -F -j 24 -v
== CPython 3.14.0a6+ experimental free-threading build (heads/main:a936af924ef, Mar 18 2025, 08:23:31) [GCC 13.3.0]
== Linux-5.15.167.4-microsoft-standard-WSL2-x86_64-with-glibc2.39 little-endian
== Python build: free_threading release TSAN
== cwd: /home/realkumaraditya/cpython/build/test_python_worker_16074æ
== CPU count: 12
== encodings: locale=UTF-8 FS=utf-8
== resources: all test resources are disabled, use -u option to unskip tests
== sanitizers: thread
== TSAN_OPTIONS='halt_on_error=1'

Using random seed: 1660520254
0:00:00 load avg: 1.24 Run tests in parallel using 24 worker processes
0:00:19 load avg: 8.61 [  1/1] test_asyncio.test_ssl worker non-zero exit code (Exit code 66)
test_create_connection_memory_leak (test.test_asyncio.test_ssl.TestSSL.test_create_connection_memory_leak) ... ==================
WARNING: ThreadSanitizer: data race (pid=16127)
  Write of size 8 at 0x72b000000120 by thread T1:
    #0 close ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1818 (libtsan.so.2+0x54741) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 _socket_socket_close_impl Modules/socketmodule.c:3444 (_socket.cpython-314t-x86_64-linux-gnu.so+0x679f) (BuildId: 7f0d127af95929d8aaa1a4545fb9e0d6cc040c59)
    #2 _socket_socket_close Modules/clinic/socketmodule.c.h:28 (_socket.cpython-314t-x86_64-linux-gnu.so+0x679f)
    #3 method_vectorcall_NOARGS Objects/descrobject.c:447 (python+0x16e66c) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #4 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x14f921) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #5 PyObject_Vectorcall Objects/call.c:327 (python+0x14f921)
    #6 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #7 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #8 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #9 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #10 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x1557f8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #11 method_vectorcall Objects/classobject.c:72 (python+0x1557f8)
    #12 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #13 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #14 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #15 thread_run Modules/_threadmodule.c:352 (python+0x537935) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #16 pythread_wrapper Python/thread_pthread.h:242 (python+0x46f499) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)

  Previous read of size 8 at 0x72b000000120 by main thread:
    #0 send ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:6755 (libtsan.so.2+0x7af7b) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 sock_send_impl Modules/socketmodule.c:4463 (_socket.cpython-314t-x86_64-linux-gnu.so+0xd679) (BuildId: 7f0d127af95929d8aaa1a4545fb9e0d6cc040c59)
    #2 sock_call_ex Modules/socketmodule.c:996 (_socket.cpython-314t-x86_64-linux-gnu.so+0xd679)
    #3 sock_call Modules/socketmodule.c:1048 (_socket.cpython-314t-x86_64-linux-gnu.so+0xd872) (BuildId: 7f0d127af95929d8aaa1a4545fb9e0d6cc040c59)
    #4 sock_send Modules/socketmodule.c:4489 (_socket.cpython-314t-x86_64-linux-gnu.so+0xd872)
    #5 method_vectorcall_VARARGS Objects/descrobject.c:324 (python+0x16edc3) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #6 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x14f921) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #7 PyObject_Vectorcall Objects/call.c:327 (python+0x14f921)
    #8 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #9 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #10 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #11 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #12 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x15567d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #13 method_vectorcall Objects/classobject.c:94 (python+0x15567d)
    #14 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #15 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #16 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #17 _PyEval_EvalFrameDefault Python/generated_cases.c.h:2424 (python+0x8f52d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #18 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #19 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #20 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #21 _PyObject_VectorcallDictTstate Objects/call.c:135 (python+0x151d9e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #22 _PyObject_Call_Prepend Objects/call.c:504 (python+0x1520b3) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #23 slot_tp_call Objects/typeobject.c:10061 (python+0x27af43) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #24 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #25 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #26 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #27 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #28 _PyEval_EvalFrameDefault Python/generated_cases.c.h:3837 (python+0x8bba6) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #29 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #30 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #31 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #32 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x15567d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #33 method_vectorcall Objects/classobject.c:94 (python+0x15567d)
    #34 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #35 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #36 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #37 _PyEval_EvalFrameDefault Python/generated_cases.c.h:2424 (python+0x8f52d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #38 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #39 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #40 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #41 _PyObject_VectorcallDictTstate Objects/call.c:135 (python+0x151d9e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #42 _PyObject_Call_Prepend Objects/call.c:504 (python+0x1520b3) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #43 slot_tp_call Objects/typeobject.c:10061 (python+0x27af43) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #44 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #45 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #46 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #47 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #48 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #49 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #50 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #51 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #52 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x15567d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #53 method_vectorcall Objects/classobject.c:94 (python+0x15567d)
    #54 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #55 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #56 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #57 _PyEval_EvalFrameDefault Python/generated_cases.c.h:2424 (python+0x8f52d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #58 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #59 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #60 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #61 _PyObject_VectorcallDictTstate Objects/call.c:135 (python+0x151d9e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #62 _PyObject_Call_Prepend Objects/call.c:504 (python+0x1520b3) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #63 slot_tp_call Objects/typeobject.c:10061 (python+0x27af43) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #64 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #65 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #66 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #67 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #68 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #69 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x381d04) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #70 _PyEval_Vector Python/ceval.c:1903 (python+0x381d04)
    #71 PyEval_EvalCode Python/ceval.c:831 (python+0x381d04)
    #72 builtin_exec_impl Python/bltinmodule.c:1156 (python+0x36f006) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #73 builtin_exec Python/clinic/bltinmodule.c.h:560 (python+0x36f006)
    #74 cfunction_vectorcall_FASTCALL_KEYWORDS Objects/methodobject.c:452 (python+0x203bd9) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #75 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x14f921) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #76 PyObject_Vectorcall Objects/call.c:327 (python+0x14f921)
    #77 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #78 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #79 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #80 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #81 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #82 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #83 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #84 pymain_run_module Modules/main.c:337 (python+0x48ee2c) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #85 pymain_run_python Modules/main.c:673 (python+0x48fb8c) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #86 Py_RunMain Modules/main.c:760 (python+0x491042) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #87 pymain_main Modules/main.c:790 (python+0x491042)
    #88 Py_BytesMain Modules/main.c:814 (python+0x491042)
    #89 main Programs/python.c:15 (python+0x85ce2) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)

  Location is file descriptor 9 created by main thread at:
    #0 socketpair ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1785 (libtsan.so.2+0x58bb3) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 socket_socketpair Modules/socketmodule.c:6414 (_socket.cpython-314t-x86_64-linux-gnu.so+0xe498) (BuildId: 7f0d127af95929d8aaa1a4545fb9e0d6cc040c59)
    #2 cfunction_call Objects/methodobject.c:562 (python+0x203e2f) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #3 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #4 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #5 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #6 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #7 _PyEval_EvalFrameDefault Python/generated_cases.c.h:3837 (python+0x8bba6) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #8 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #9 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #10 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #11 _PyObject_VectorcallDictTstate Objects/call.c:135 (python+0x151d9e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #12 _PyObject_Call_Prepend Objects/call.c:504 (python+0x15201e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #13 slot_tp_init Objects/typeobject.c:10307 (python+0x27b10b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #14 type_call Objects/typeobject.c:2257 (python+0x261fb5) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #15 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #16 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #17 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #18 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #19 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #20 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #21 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #22 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #23 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x15567d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #24 method_vectorcall Objects/classobject.c:94 (python+0x15567d)
    #25 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #26 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #27 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #28 _PyEval_EvalFrameDefault Python/generated_cases.c.h:2424 (python+0x8f52d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #29 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #30 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #31 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #32 _PyObject_VectorcallDictTstate Objects/call.c:135 (python+0x151d9e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #33 _PyObject_Call_Prepend Objects/call.c:504 (python+0x1520b3) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #34 slot_tp_call Objects/typeobject.c:10061 (python+0x27af43) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #35 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #36 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #37 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #38 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #39 _PyEval_EvalFrameDefault Python/generated_cases.c.h:3837 (python+0x8bba6) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #40 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #41 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #42 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #43 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x15567d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #44 method_vectorcall Objects/classobject.c:94 (python+0x15567d)
    #45 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #46 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #47 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #48 _PyEval_EvalFrameDefault Python/generated_cases.c.h:2424 (python+0x8f52d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #49 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #50 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #51 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #52 _PyObject_VectorcallDictTstate Objects/call.c:135 (python+0x151d9e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #53 _PyObject_Call_Prepend Objects/call.c:504 (python+0x1520b3) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #54 slot_tp_call Objects/typeobject.c:10061 (python+0x27af43) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #55 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #56 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #57 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #58 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #59 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #60 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #61 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #62 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #63 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x15567d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #64 method_vectorcall Objects/classobject.c:94 (python+0x15567d)
    #65 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #66 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #67 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #68 _PyEval_EvalFrameDefault Python/generated_cases.c.h:2424 (python+0x8f52d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #69 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #70 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #71 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #72 _PyObject_VectorcallDictTstate Objects/call.c:135 (python+0x151d9e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #73 _PyObject_Call_Prepend Objects/call.c:504 (python+0x1520b3) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #74 slot_tp_call Objects/typeobject.c:10061 (python+0x27af43) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #75 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #76 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #77 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #78 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #79 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #80 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x381d04) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #81 _PyEval_Vector Python/ceval.c:1903 (python+0x381d04)
    #82 PyEval_EvalCode Python/ceval.c:831 (python+0x381d04)
    #83 builtin_exec_impl Python/bltinmodule.c:1156 (python+0x36f006) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #84 builtin_exec Python/clinic/bltinmodule.c.h:560 (python+0x36f006)
    #85 cfunction_vectorcall_FASTCALL_KEYWORDS Objects/methodobject.c:452 (python+0x203bd9) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #86 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x14f921) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #87 PyObject_Vectorcall Objects/call.c:327 (python+0x14f921)
    #88 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #89 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #90 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #91 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #92 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #93 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #94 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #95 pymain_run_module Modules/main.c:337 (python+0x48ee2c) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #96 pymain_run_python Modules/main.c:673 (python+0x48fb8c) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #97 Py_RunMain Modules/main.c:760 (python+0x491042) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #98 pymain_main Modules/main.c:790 (python+0x491042)
    #99 Py_BytesMain Modules/main.c:814 (python+0x491042)
    #100 main Programs/python.c:15 (python+0x85ce2) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)

  Thread T1 'test-server' (tid=16293, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 38097064631f7912bd33117a9c83d08b42e15571)
    #1 do_start_joinable_thread Python/thread_pthread.h:289 (python+0x46f92e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #2 PyThread_start_joinable_thread Python/thread_pthread.h:313 (python+0x46f92e)
    #3 ThreadHandle_start Modules/_threadmodule.c:437 (python+0x538cb8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #4 do_start_new_thread Modules/_threadmodule.c:1822 (python+0x538cb8)
    #5 thread_PyThread_start_joinable_thread Modules/_threadmodule.c:1945 (python+0x5395d1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #6 cfunction_call Objects/methodobject.c:551 (python+0x203dd6) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #7 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #8 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #9 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #10 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #11 _PyEval_EvalFrameDefault Python/generated_cases.c.h:2744 (python+0x8d7cd) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #12 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #13 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #14 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #15 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x15567d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #16 method_vectorcall Objects/classobject.c:94 (python+0x15567d)
    #17 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #18 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #19 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #20 _PyEval_EvalFrameDefault Python/generated_cases.c.h:2424 (python+0x8f52d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #21 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #22 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #23 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #24 _PyObject_VectorcallDictTstate Objects/call.c:135 (python+0x151d9e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #25 _PyObject_Call_Prepend Objects/call.c:504 (python+0x1520b3) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #26 slot_tp_call Objects/typeobject.c:10061 (python+0x27af43) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #27 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #28 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #29 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #30 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #31 _PyEval_EvalFrameDefault Python/generated_cases.c.h:3837 (python+0x8bba6) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #32 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #33 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #34 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #35 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x15567d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #36 method_vectorcall Objects/classobject.c:94 (python+0x15567d)
    #37 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #38 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #39 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #40 _PyEval_EvalFrameDefault Python/generated_cases.c.h:2424 (python+0x8f52d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #41 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #42 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #43 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #44 _PyObject_VectorcallDictTstate Objects/call.c:135 (python+0x151d9e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #45 _PyObject_Call_Prepend Objects/call.c:504 (python+0x1520b3) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #46 slot_tp_call Objects/typeobject.c:10061 (python+0x27af43) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #47 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #48 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #49 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #50 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #51 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #52 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #53 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #54 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #55 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x15567d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #56 method_vectorcall Objects/classobject.c:94 (python+0x15567d)
    #57 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #58 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #59 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #60 _PyEval_EvalFrameDefault Python/generated_cases.c.h:2424 (python+0x8f52d) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #61 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #62 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #63 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #64 _PyObject_VectorcallDictTstate Objects/call.c:135 (python+0x151d9e) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #65 _PyObject_Call_Prepend Objects/call.c:504 (python+0x1520b3) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #66 slot_tp_call Objects/typeobject.c:10061 (python+0x27af43) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #67 _PyObject_MakeTpCall Objects/call.c:242 (python+0x14ea92) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #68 _PyObject_VectorcallTstate Include/internal/pycore_call.h:166 (python+0x14fa18) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #69 _PyObject_VectorcallTstate Include/internal/pycore_call.h:153 (python+0x14fa18)
    #70 PyObject_Vectorcall Objects/call.c:327 (python+0x14fa18)
    #71 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #72 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x381d04) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #73 _PyEval_Vector Python/ceval.c:1903 (python+0x381d04)
    #74 PyEval_EvalCode Python/ceval.c:831 (python+0x381d04)
    #75 builtin_exec_impl Python/bltinmodule.c:1156 (python+0x36f006) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #76 builtin_exec Python/clinic/bltinmodule.c.h:560 (python+0x36f006)
    #77 cfunction_vectorcall_FASTCALL_KEYWORDS Objects/methodobject.c:452 (python+0x203bd9) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #78 _PyObject_VectorcallTstate Include/internal/pycore_call.h:168 (python+0x14f921) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #79 PyObject_Vectorcall Objects/call.c:327 (python+0x14f921)
    #80 _PyEval_EvalFrameDefault Python/generated_cases.c.h:1375 (python+0x8bfa8) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #81 _PyEval_EvalFrame Include/internal/pycore_ceval.h:116 (python+0x382348) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #82 _PyEval_Vector Python/ceval.c:1903 (python+0x382348)
    #83 _PyFunction_Vectorcall Objects/call.c:413 (python+0x14fd3b) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #84 _PyVectorcall_Call Objects/call.c:273 (python+0x152137) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #85 _PyObject_Call Objects/call.c:348 (python+0x1526f1) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #86 PyObject_Call Objects/call.c:373 (python+0x1526f1)
    #87 pymain_run_module Modules/main.c:337 (python+0x48ee2c) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #88 pymain_run_python Modules/main.c:673 (python+0x48fb8c) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #89 Py_RunMain Modules/main.c:760 (python+0x491042) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)
    #90 pymain_main Modules/main.c:790 (python+0x491042)
    #91 Py_BytesMain Modules/main.c:814 (python+0x491042)
    #92 main Programs/python.c:15 (python+0x85ce2) (BuildId: 53ed23022782f7933a3af0cc0267268b7d97fe42)

SUMMARY: ThreadSanitizer: data race Modules/socketmodule.c:3444 in _socket_socket_close_impl
==================
Kill <WorkerThread #1 running test=test_asyncio.test_ssl pid=16124 time=19.8 sec> process group
Kill <WorkerThread #3 running test=test_asyncio.test_ssl pid=16125 time=19.9 sec> process group
Kill <WorkerThread #4 running test=test_asyncio.test_ssl pid=16126 time=19.9 sec> process group
Kill <WorkerThread #5 running test=test_asyncio.test_ssl pid=16129 time=20.0 sec> process group
Kill <WorkerThread #8 running test=test_asyncio.test_ssl pid=16135 time=20.0 sec> process group
Kill <WorkerThread #9 running test=test_asyncio.test_ssl pid=16140 time=20.0 sec> process group
Kill <WorkerThread #11 running test=test_asyncio.test_ssl pid=16138 time=19.9 sec> process group
Kill <WorkerThread #14 running test=test_asyncio.test_ssl pid=16142 time=19.9 sec> process group
Kill <WorkerThread #16 running test=test_asyncio.test_ssl pid=16148 time=19.7 sec> process group
Kill <WorkerThread #18 running test=test_asyncio.test_ssl pid=16152 time=19.6 sec> process group
Kill <WorkerThread #19 running test=test_asyncio.test_ssl pid=16156 time=19.6 sec> process group
Kill <WorkerThread #20 running test=test_asyncio.test_ssl pid=16155 time=19.6 sec> process group
Kill <WorkerThread #22 running test=test_asyncio.test_ssl pid=16159 time=19.5 sec> process group
Kill <WorkerThread #24 running test=test_asyncio.test_ssl pid=16160 time=19.4 sec> process group

```

</details>
