### PR TITLE
gh-124666: Improve thread cleanup in test_android

### DIFF
--- a/Lib/test/test_android.py
+++ b/Lib/test/test_android.py
@@ -38,31 +38,41 @@ class TestAndroidOutput(unittest.TestCase):
             for line in self.logcat_process.stdout:
                 self.logcat_queue.put(line.rstrip("\n"))
             self.logcat_process.stdout.close()
+
         self.logcat_thread = Thread(target=logcat_thread)
         self.logcat_thread.start()
 
-        from ctypes import CDLL, c_char_p, c_int
-        android_log_write = getattr(CDLL("liblog.so"), "__android_log_write")
-        android_log_write.argtypes = (c_int, c_char_p, c_char_p)
-        ANDROID_LOG_INFO = 4
+        try:
+            from ctypes import CDLL, c_char_p, c_int
+            android_log_write = getattr(CDLL("liblog.so"), "__android_log_write")
+            android_log_write.argtypes = (c_int, c_char_p, c_char_p)
+            ANDROID_LOG_INFO = 4
 
-        # Separate tests using a marker line with a different tag.
-        tag, message = "python.test", f"{self.id()} {time()}"
-        android_log_write(
-            ANDROID_LOG_INFO, tag.encode("UTF-8"), message.encode("UTF-8"))
-        self.assert_log("I", tag, message, skip=True, timeout=5)
+            # Separate tests using a marker line with a different tag.
+            tag, message = "python.test", f"{self.id()} {time()}"
+            android_log_write(
+                ANDROID_LOG_INFO, tag.encode("UTF-8"), message.encode("UTF-8"))
+            self.assert_log("I", tag, message, skip=True)
+        except:
+            # If setUp throws an exception, tearDown is not automatically
+            # called. Avoid leaving a dangling thread which would keep the
+            # Python process alive indefinitely.
+            self.tearDown()
+            raise
 
     def assert_logs(self, level, tag, expected, **kwargs):
         for line in expected:
             self.assert_log(level, tag, line, **kwargs)
 
-    def assert_log(self, level, tag, expected, *, skip=False, timeout=0.5):
-        deadline = time() + timeout
+    def assert_log(self, level, tag, expected, *, skip=False):
+        deadline = time() + LOOPBACK_TIMEOUT
         while True:
             try:
                 line = self.logcat_queue.get(timeout=(deadline - time()))
             except queue.Empty:
-                self.fail(f"line not found: {expected!r}")
+                raise self.failureException(
+                    f"line not found: {expected!r}"
+                ) from None
             if match := re.fullmatch(fr"(.)/{tag}: (.*)", line):
                 try:
                     self.assertEqual(level, match[1])
@@ -76,6 +86,9 @@ class TestAndroidOutput(unittest.TestCase):
         self.logcat_process.terminate()
         self.logcat_process.wait(LOOPBACK_TIMEOUT)
         self.logcat_thread.join(LOOPBACK_TIMEOUT)
+
+        # Avoid an irrelevant warning about threading._dangling.
+        self.logcat_thread = None
 
     @contextmanager
     def unbuffered(self, stream):


### PR DESCRIPTION
The hanging buildbot in #124666 was caused by a leftover thread created in the test's `setUp` method. It was supposed to be cleaned up by `tearDown`, but that isn't called automatically when `setUp` fails.

I still don't know why the underlying test failure was happening, but I've increased all the timeouts to `LOOPBACK_TIMEOUT` (10 seconds) in case that makes a difference.

Also cleaned up a couple of other test failure logging issues.

<!-- gh-issue-number: gh-124666 -->
* Fixes gh-124666
<!-- /gh-issue-number -->
