### PR TITLE
GH-126367: `url2pathname()`: handle NTFS alternate data streams

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -182,7 +182,9 @@ The :mod:`urllib.request` module defines the following functions:
       'C:\\Program Files'
 
    .. versionchanged:: 3.14
-      Windows drive letters are no longer converted to uppercase.
+      Windows drive letters are no longer converted to uppercase, and ``:``
+      characters not following a drive letter no longer cause an
+      :exc:`OSError` exception to be raised on Windows.
 
 
 .. function:: getproxies()

--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -31,7 +31,7 @@ def url2pathname(url):
             url = url[1:]
         if url[1:2] == '|':
             # Older URLs use a pipe after a drive letter
-            url = url.replace('|', ':', 1)
+            url = url[:1] + ':' + url[2:]
     return urllib.parse.unquote(url.replace('/', '\\'))
 
 def pathname2url(p):

--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -26,7 +26,7 @@ def url2pathname(url):
         # Skip past extra slash before UNC drive in URL path.
         url = url[1:]
     else:
-        if url[:1] == '/' and url[2:3] in ':|':
+        if url[:1] == '/' and url[2:3] in (':', '|'):
             # Skip past extra slash before DOS drive in URL path.
             url = url[1:]
         if url[1:2] == '|':

--- a/Lib/nturl2path.py
+++ b/Lib/nturl2path.py
@@ -14,7 +14,7 @@ def url2pathname(url):
     #   ///C:/foo/bar/spam.foo
     # become
     #   C:\foo\bar\spam.foo
-    import string, urllib.parse
+    import urllib.parse
     if url[:3] == '///':
         # URL has an empty authority section, so the path begins on the third
         # character.
@@ -25,19 +25,14 @@ def url2pathname(url):
     if url[:3] == '///':
         # Skip past extra slash before UNC drive in URL path.
         url = url[1:]
-    # Windows itself uses ":" even in URLs.
-    url = url.replace(':', '|')
-    if not '|' in url:
-        # No drive specifier, just convert slashes
-        # make sure not to convert quoted slashes :-)
-        return urllib.parse.unquote(url.replace('/', '\\'))
-    comp = url.split('|')
-    if len(comp) != 2 or comp[0][-1] not in string.ascii_letters:
-        error = 'Bad URL: ' + url
-        raise OSError(error)
-    drive = comp[0][-1]
-    tail = urllib.parse.unquote(comp[1].replace('/', '\\'))
-    return drive + ':' + tail
+    else:
+        if url[:1] == '/' and url[2:3] in ':|':
+            # Skip past extra slash before DOS drive in URL path.
+            url = url[1:]
+        if url[1:2] == '|':
+            # Older URLs use a pipe after a drive letter
+            url = url.replace('|', ':', 1)
+    return urllib.parse.unquote(url.replace('/', '\\'))
 
 def pathname2url(p):
     """OS-specific conversion from a file system path to a relative URL

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1484,6 +1484,7 @@ class Pathname_Tests(unittest.TestCase):
                          'test specific to Windows pathnames.')
     def test_url2pathname_win(self):
         fn = urllib.request.url2pathname
+        self.assertEqual(fn('/'), '\\')
         self.assertEqual(fn('/C:/'), 'C:\\')
         self.assertEqual(fn("///C|"), 'C:')
         self.assertEqual(fn("///C:"), 'C:')

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1502,8 +1502,10 @@ class Pathname_Tests(unittest.TestCase):
         self.assertEqual(fn('/C|/path/to/file'), 'C:\\path\\to\\file')
         self.assertEqual(fn('///C|/path/to/file'), 'C:\\path\\to\\file')
         self.assertEqual(fn("///C|/foo/bar/spam.foo"), 'C:\\foo\\bar\\spam.foo')
-        # Non-ASCII drive letter
-        self.assertRaises(IOError, fn, "///\u00e8|/")
+        # Colons in URI
+        self.assertEqual(fn('///\u00e8|/'), '\u00e8:\\')
+        self.assertEqual(fn('//host/share/spam.txt:eggs'), '\\\\host\\share\\spam.txt:eggs')
+        self.assertEqual(fn('///c:/spam.txt:eggs'), 'c:\\spam.txt:eggs')
         # UNC paths
         self.assertEqual(fn('//server/path/to/file'), '\\\\server\\path\\to\\file')
         self.assertEqual(fn('////server/path/to/file'), '\\\\server\\path\\to\\file')

--- a/Misc/NEWS.d/next/Library/2025-03-18-19-52-49.gh-issue-126367.PRxnuu.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-18-19-52-49.gh-issue-126367.PRxnuu.rst
@@ -1,0 +1,3 @@
+Fix issue where :func:`urllib.request.url2pathname` raised :exc:`OSError`
+when given a Windows URI containing a colon character not following a drive
+letter, such as before an NTFS alternate data stream.


### PR DESCRIPTION
Adjust `url2pathname()` to decode embedded colon characters in Windows URIs, rather than bailing out with an `OSError`.


<!-- gh-issue-number: gh-126367 -->
* Issue: gh-126367
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131428.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->