### PR TITLE
gh-131441: Add a set of asserts to test.test_capi.test_list

### DIFF
--- a/Lib/test/test_capi/test_list.py
+++ b/Lib/test/test_capi/test_list.py
@@ -62,6 +62,7 @@ class CAPITest(unittest.TestCase):
     def test_list_size(self):
         # Test PyList_Size()
         size = _testlimitedcapi.list_size
+        self.assertEqual(size([]), 0)
         self.assertEqual(size([1, 2]), 2)
         self.assertEqual(size(ListSubclass([1, 2])), 2)
         self.assertRaises(SystemError, size, UserList())
@@ -73,6 +74,7 @@ class CAPITest(unittest.TestCase):
     def test_list_get_size(self):
         # Test PyList_GET_SIZE()
         size = _testcapi.list_get_size
+        self.assertEqual(size([]), 0)
         self.assertEqual(size([1, 2]), 2)
         self.assertEqual(size(ListSubclass([1, 2])), 2)
         # CRASHES size(object())
@@ -287,6 +289,7 @@ class CAPITest(unittest.TestCase):
 
         self.assertEqual(list_reverse([]), [])
         self.assertEqual(list_reverse([2, 5, 10]), [10, 5, 2])
+        self.assertEqual(list_reverse(list_reverse([2, 5, 10])), [2, 5, 10])
 
         self.assertRaises(SystemError, reverse, ())
         self.assertRaises(SystemError, reverse, object())
@@ -296,6 +299,7 @@ class CAPITest(unittest.TestCase):
         # Test PyList_AsTuple()
         astuple = _testlimitedcapi.list_astuple
         self.assertEqual(astuple([]), ())
+        self.assertEqual(astuple([[]]), ([],))
         self.assertEqual(astuple([2, 5, 10]), (2, 5, 10))
 
         self.assertRaises(SystemError, astuple, ())


### PR DESCRIPTION
1. Assert 0-sized list for `PyList_Size()`.
2. Assert 0-sized list for `PyList_GET_SIZE()`.
3. Assert reverse of reverse for `PyList_Reverse()`.
4. Assert a list that contains one empty-list element for `PyList_AsTuple()`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131441 -->
* Issue: gh-131441
<!-- /gh-issue-number -->
