### PR TITLE
gh-131379: Fix assertionError in __move_tall when scrolling through REPL history

### DIFF
--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -256,7 +256,9 @@ class UnixConsole(Console):
 
         # we make sure the cursor is on the screen, and that we're
         # using all of the screen if we can
-        if cy < offset:
+        if len(screen) < height:
+            offset = 0
+        elif cy < offset:
             offset = cy
         elif cy >= offset + height:
             offset = cy - height + 1


### PR DESCRIPTION
In REPL, when the screen height is sufficient to accommodate all content, set the screen offset to 0

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131379 -->
* Issue: gh-131379
<!-- /gh-issue-number -->
