### PR TITLE
gh-131430: Fix crashes on an empty DELETE_WORD_BACKWARDS (^W) followed by CLEAR_TO_START (^K)

### DIFF
--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -66,7 +66,7 @@ class KillCommand(Command):
         b = r.buffer
         text = b[start:end]
         del b[start:end]
-        if is_kill(r.last_command):
+        if is_kill(r.last_command) and r.kill_ring:
             if start < r.pos:
                 r.kill_ring[-1] = text + r.kill_ring[-1]
             else:

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -4,6 +4,7 @@ import rlcompleter
 from textwrap import dedent
 from unittest import TestCase
 from unittest.mock import MagicMock
+from _pyrepl.readline import multiline_input
 from test.support import force_colorized_test_class, force_not_colorized_test_class
 
 from .support import handle_all_events, handle_events_narrow_console
@@ -357,6 +358,59 @@ class TestReader(ScreenEqualMixin, TestCase):
         reader, _ = handle_all_events(events)
         reader.setpos_from_xy(8, 0)
         self.assertEqual(reader.pos, 7)
+
+    def test_empty_line_control_w_k(self):
+        """Test that Control-W followed by Control-K on an empty line doesn't crash."""
+        events = itertools.chain(
+            [
+                Event(evt="key", data="\x17", raw=bytearray(b"\x17")),  # Control-W
+                Event(evt="key", data="\x0b", raw=bytearray(b"\x0b")),  # Control-K
+            ],
+        )
+        reader, _ = handle_all_events(events)
+        self.assert_screen_equal(reader, "", clean=True)
+        self.assertEqual(reader.pos, 0)
+
+    def test_control_w_delete_word(self):
+        """Test Control-W delete word"""
+        def test_with_text(text: str, expected: list[str], before_pos: int, after_pos: int):
+            events = itertools.chain(
+                code_to_events(text) if len(text) else [],
+                [Event(evt="key", data="left", raw=bytearray(b"\x1b[D"))] * (len(text) - before_pos),  # Move cursor to specified position
+                [
+                    Event(evt="key", data="\x17", raw=bytearray(b"\x17")), # Control-W
+                ],
+            )
+            reader, _ = handle_all_events(events)
+            self.assertEqual(reader.screen, expected)
+            self.assertEqual(reader.pos, after_pos)
+
+        test_with_text("", [], 0, 0)
+        test_with_text("a", [""], 1, 0)
+        test_with_text("abc", [""], 3, 0)
+        test_with_text("abc def", ["def"], 4, 0)
+        test_with_text("abc def", ["abc "], 7, 4)
+        test_with_text("def xxx():xxx\n    ", ["def xxx():"], 18, 10)
+
+    def test_control_k_delete_to_eol(self):
+        """Test Control-K delete from cursor to end of line"""
+        def test_with_text(text: str, pos: int, expected: list[str]):
+            events = itertools.chain(
+                code_to_events(text) if len(text) else [],
+                [Event(evt="key", data="left", raw=bytearray(b"\x1b[D"))] * (len(text) - pos),  # Move cursor to specified position
+                [
+                    Event(evt="key", data="\x0b", raw=bytearray(b"\x0b")),  # Control-K
+                ],
+            )
+            reader, _ = handle_all_events(events)
+            self.assertEqual(reader.screen, expected)
+            self.assertEqual(reader.pos, pos)
+
+        test_with_text("", 0, [""])
+        test_with_text("a", 0, [""])
+        test_with_text("abc", 1, ["a"])
+        test_with_text("abc def", 4, ["abc "])
+        test_with_text("def xxx():xxx\n    pass", 10, ["def xxx():", "    pass"])
 
 @force_colorized_test_class
 class TestReaderInColor(ScreenEqualMixin, TestCase):

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -361,12 +361,10 @@ class TestReader(ScreenEqualMixin, TestCase):
 
     def test_empty_line_control_w_k(self):
         """Test that Control-W followed by Control-K on an empty line doesn't crash."""
-        events = itertools.chain(
-            [
-                Event(evt="key", data="\x17", raw=bytearray(b"\x17")),  # Control-W
-                Event(evt="key", data="\x0b", raw=bytearray(b"\x0b")),  # Control-K
-            ],
-        )
+        events = [
+            Event(evt="key", data="\x17", raw=bytearray(b"\x17")),  # Control-W
+            Event(evt="key", data="\x0b", raw=bytearray(b"\x0b")),  # Control-K
+        ]
         reader, _ = handle_all_events(events)
         self.assert_screen_equal(reader, "", clean=True)
         self.assertEqual(reader.pos, 0)
@@ -375,7 +373,7 @@ class TestReader(ScreenEqualMixin, TestCase):
         """Test Control-W delete word"""
         def test_with_text(text: str, expected: list[str], before_pos: int, after_pos: int):
             events = itertools.chain(
-                code_to_events(text) if len(text) else [],
+                code_to_events(text),
                 [Event(evt="key", data="left", raw=bytearray(b"\x1b[D"))] * (len(text) - before_pos),  # Move cursor to specified position
                 [
                     Event(evt="key", data="\x17", raw=bytearray(b"\x17")), # Control-W

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -384,7 +384,7 @@ class TestReader(ScreenEqualMixin, TestCase):
             with self.subTest(text=text, before_pos=before_pos):
                 events = itertools.chain(
                     code_to_events(text),
-                    [Event(evt="key", data="left", raw=bytearray(b"\x1b[D"))] * (len(text) - before_pos),  # Move cursor to specified position
+                    [Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))] * (len(text) - before_pos),  # Move cursor to specified position
                     [
                         Event(evt="key", data="\x17", raw=bytearray(b"\x17")), # Control-W
                     ],
@@ -407,7 +407,7 @@ class TestReader(ScreenEqualMixin, TestCase):
             with self.subTest(text=text, pos=pos):
                 events = itertools.chain(
                     code_to_events(text),
-                    [Event(evt="key", data="left", raw=bytearray(b"\x1b[D"))] * (len(text) - pos),  # Move cursor to specified position
+                    [Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))] * (len(text) - pos),  # Move cursor to specified position
                     [
                         Event(evt="key", data="\x0b", raw=bytearray(b"\x0b")),  # Control-K
                     ],

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-11-06-44-10.gh-issue-131430.wbtIcQ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-11-06-44-10.gh-issue-131430.wbtIcQ.rst
@@ -1,3 +1,2 @@
-Fix crashes on an empty DELETE_WORD_BACKWARDS (^W) followed by
-CLEAR_TO_START (^K). Added comprehensive test cases for both Control-W and
-Control-K functionality.
+Fix PyREPL crash on an empty DELETE_WORD_BACKWARDS (^W) followed by
+CLEAR_TO_START (^K).

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-11-06-44-10.gh-issue-131430.wbtIcQ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-11-06-44-10.gh-issue-131430.wbtIcQ.rst
@@ -1,0 +1,3 @@
+Fix crashes on an empty DELETE_WORD_BACKWARDS (^W) followed by
+CLEAR_TO_START (^K). Added comprehensive test cases for both Control-W and
+Control-K functionality.


### PR DESCRIPTION
Add the handling of kill_range null detection, which is a left closed and right open interval. When end start<=1, it means that no operation has been done and should be skipped; The original writing only handled the case of end==start.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131430 -->
* Issue: gh-131430
<!-- /gh-issue-number -->
