### PR TITLE
GH-131473: add missing  %(AdditionalOptions) for Hacl_Hash_Blake2b_Simd{128|256}.c

### DIFF
--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -441,11 +441,11 @@
     <ClCompile Include="..\Modules\_hacl\Hacl_Hash_Blake2s.c" />
     <ClCompile Include="..\Modules\_hacl\Hacl_Hash_Blake2b_Simd256.c" Condition="'$(Platform)' == 'x64'">
       <PreprocessorDefinitions>HACL_CAN_COMPILE_VEC256;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/arch:AVX2</AdditionalOptions>
+      <AdditionalOptions>/arch:AVX2 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ClCompile Include="..\Modules\_hacl\Hacl_Hash_Blake2s_Simd128.c" Condition="'$(Platform)' == 'x64'">
       <PreprocessorDefinitions>HACL_CAN_COMPILE_VEC128;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/arch:AVX</AdditionalOptions>
+      <AdditionalOptions>/arch:AVX %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ClCompile Include="..\Modules\_heapqmodule.c" />
     <ClCompile Include="..\Modules\_json.c" />


### PR DESCRIPTION
... in pythoncore.vcxproj to fix clang-cl debug and release builds on Windows when `PreferredToolArchitecture` is not given.

Furthermore, this will ensure that all the other clang options will be inherited.

Won't help "enough" for PGO builds, though. For details please refer to the issue.

<!-- gh-issue-number: gh-131473 -->
* Issue: gh-131473
<!-- /gh-issue-number -->
