### PR TITLE
gh-131238: Move pycore_obmalloc.h include to pycore_runtime_structs.h

### DIFF
--- a/Include/internal/pycore_backoff.h
+++ b/Include/internal/pycore_backoff.h
@@ -10,7 +10,8 @@ extern "C" {
 #endif
 
 #include <assert.h>
-#include "pycore_structs.h" // _Py_BackoffCounter
+#include <stdbool.h>
+#include "pycore_structs.h"       // _Py_BackoffCounter
 
 /* 16-bit countdown counters using exponential backoff.
 

--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -1,3 +1,6 @@
+/* This file contains the struct definitions for interpreter state
+ * and other necessary structs */
+
 #ifndef Py_INTERNAL_INTERP_STRUCTS_H
 #define Py_INTERNAL_INTERP_STRUCTS_H
 #ifdef __cplusplus
@@ -11,9 +14,6 @@ extern "C" {
 #include "pycore_tstate.h"        // _PyThreadStateImpl
 #include "pycore_typedefs.h"      // _PyRuntimeState
 
-
-/* This file contains the struct definitions for interpreter state
- * and other necessary structs */
 
 #define CODE_MAX_WATCHERS 8
 #define CONTEXT_MAX_WATCHERS 8
@@ -247,13 +247,7 @@ struct _gc_runtime_state {
 #endif
 };
 
-#include "pycore_gil.h"
-
-/****** Thread state **************/
-#include "pytypedefs.h"
-#include "pystate.h"
-#include "pycore_tstate.h"
-
+#include "pycore_gil.h"           // struct _gil_runtime_state
 
 /**** Import ********/
 
@@ -327,8 +321,8 @@ struct _import_state {
 
 /********** Interpreter state **************/
 
-#include "pycore_object_state.h"
-#include "pycore_crossinterp.h"
+#include "pycore_object_state.h"  // struct _py_object_state
+#include "pycore_crossinterp.h"   // _PyXI_state_t
 
 
 struct _Py_long_state {
@@ -453,8 +447,8 @@ struct _py_func_state {
     struct _func_version_cache_item func_version_cache[FUNC_VERSION_CACHE_SIZE];
 };
 
-#include "pycore_dict_state.h"
-#include "pycore_exceptions.h"
+#include "pycore_dict_state.h"    // struct _Py_dict_state
+#include "pycore_exceptions.h"    // struct _Py_exc_state
 
 
 /****** type state *********/
@@ -635,7 +629,7 @@ struct _Py_unicode_ids {
     PyObject **array;
 };
 
-#include "pycore_ucnhash.h"
+#include "pycore_ucnhash.h"       // _PyUnicode_Name_CAPI
 
 struct _Py_unicode_state {
     struct _Py_unicode_fs_codec fs_codec;
@@ -653,8 +647,6 @@ struct callable_cache {
     PyObject *list_append;
     PyObject *object__getattribute__;
 };
-
-#include "pycore_obmalloc.h"
 
 /* Length of array of slotdef pointers used to store slots with the
    same __name__.  There should be at most MAX_EQUIV-1 slotdef entries with
@@ -696,7 +688,7 @@ struct _Py_interp_static_objects {
     } singletons;
 };
 
-#include "pycore_instruments.h"
+#include "pycore_instruments.h"   // PY_MONITORING_TOOL_IDS
 
 
 #ifdef Py_GIL_DISABLED
@@ -953,7 +945,6 @@ struct _is {
 #  endif
 #endif
 };
-
 
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_runtime_structs.h
+++ b/Include/internal/pycore_runtime_structs.h
@@ -1,14 +1,14 @@
+/* This file contains the struct definitions for the runtime, interpreter
+ * and thread states, plus all smaller structs contained therein */
+
 #ifndef Py_INTERNAL_RUNTIME_STRUCTS_H
 #define Py_INTERNAL_RUNTIME_STRUCTS_H
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* This file contains the struct definitions for the runtime, interpreter
- * and thread states, plus all smaller structs contained therein */
-
-#include "pycore_structs.h"
-#include "pycore_interp_structs.h"
+#include "pycore_interp_structs.h" // _PyGC_Head_UNUSED
+#include "pycore_obmalloc.h"      // struct _obmalloc_global_state
 
 /************ Runtime state ************/
 
@@ -58,17 +58,16 @@ struct pyhash_runtime_state {
     } urandom_cache;
 };
 
-#include "pycore_tracemalloc.h"
+#include "pycore_tracemalloc.h"   // struct _tracemalloc_runtime_state
 
 struct _fileutils_state {
     int force_ascii;
 };
 
-#include "pycore_debug_offsets.h"
-#include "pycore_signal.h"
-#include "pycore_faulthandler.h"
-#include "pycore_pythread.h"
-#include "pycore_ast.h"
+#include "pycore_debug_offsets.h" // _Py_DebugOffsets
+#include "pycore_signal.h"        // struct _signals_runtime_state
+#include "pycore_faulthandler.h"  // struct _faulthandler_runtime_state
+#include "pycore_ast.h"           // struct _expr
 
 #ifdef Py_DEBUG
 #define _PYPEGEN_NSTATISTICS 2000
@@ -109,7 +108,7 @@ struct _Py_cached_objects {
 #define _PY_NSMALLPOSINTS           257
 #define _PY_NSMALLNEGINTS           5
 
-#include "pycore_global_strings.h"
+#include "pycore_global_strings.h" // struct _Py_global_strings
 
 struct _Py_static_objects {
     struct {
@@ -308,7 +307,6 @@ struct pyruntimestate {
     // _main_interpreter should be the last field of _PyRuntimeState.
     // See https://github.com/python/cpython/issues/127117.
 };
-
 
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_structs.h
+++ b/Include/internal/pycore_structs.h
@@ -1,15 +1,13 @@
+/* This files contains various key structs that are widely used
+ * and do not depend on other headers. */
+
 #ifndef Py_INTERNAL_STRUCTS_H
 #define Py_INTERNAL_STRUCTS_H
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* This files contains various key structs that are widely used
- * and do not depend on other headers. */
-
-#include <stddef.h>
-#include <stdint.h>
-#include <stdbool.h>
+#include <stdint.h>      // uint16_t
 
 
 typedef struct {
@@ -54,7 +52,7 @@ typedef struct {
     PyObject *b_array[1];
 } PyHamtNode_Bitmap;
 
-#include "pycore_context.h"
+#include "pycore_context.h"       // _PyContextTokenMissing
 
 // Define this to get precise tracking of stackrefs.
 // #define Py_STACKREF_DEBUG 1


### PR DESCRIPTION
Move pycore_obmalloc.h include from pycore_interp_structs.h to pycore_runtime_structs.h.

Add also comment explaining the purpose of each include in pycore_interp_structs.h, pycore_runtime_structs.h and pycore_structs.h.

Remove <stdbool.h> and <stddef.h> from pycore_structs.h.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131238 -->
* Issue: gh-131238
<!-- /gh-issue-number -->
