### PR TITLE
gh-131238: Remove pycore_lock.h includes

### DIFF
--- a/Include/internal/pycore_ast_state.h
+++ b/Include/internal/pycore_ast_state.h
@@ -3,7 +3,7 @@
 #ifndef Py_INTERNAL_AST_STATE_H
 #define Py_INTERNAL_AST_STATE_H
 
-#include "pycore_lock.h"    // _PyOnceFlag
+#include "pycore_lock.h"          // _PyOnceFlag
 
 #ifdef __cplusplus
 extern "C" {

--- a/Include/internal/pycore_atexit.h
+++ b/Include/internal/pycore_atexit.h
@@ -1,8 +1,6 @@
 #ifndef Py_INTERNAL_ATEXIT_H
 #define Py_INTERNAL_ATEXIT_H
 
-#include "pycore_lock.h"        // PyMutex
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/Include/internal/pycore_brc.h
+++ b/Include/internal/pycore_brc.h
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include "pycore_llist.h"           // struct llist_node
-#include "pycore_lock.h"            // PyMutex
 #include "pycore_object_stack.h"    // _PyObjectStack
 
 #ifdef __cplusplus

--- a/Include/internal/pycore_ceval_state.h
+++ b/Include/internal/pycore_ceval_state.h
@@ -8,7 +8,6 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "pycore_lock.h"            // PyMutex
 #include "pycore_gil.h"             // struct _gil_runtime_state
 
 

--- a/Include/internal/pycore_code.h
+++ b/Include/internal/pycore_code.h
@@ -10,7 +10,6 @@ extern "C" {
 
 #include "pycore_structs.h"     // _Py_CODEUNIT
 #include "pycore_stackref.h"    // _PyStackRef
-#include "pycore_lock.h"        // PyMutex
 #include "pycore_backoff.h"     // _Py_BackoffCounter
 #include "pycore_tstate.h"      // _PyThreadStateImpl
 

--- a/Include/internal/pycore_codecs.h
+++ b/Include/internal/pycore_codecs.h
@@ -9,7 +9,6 @@ extern "C" {
 #endif
 
 #include "pycore_interp_structs.h" // struct codecs_state
-#include "pycore_lock.h"          // PyMutex
 
 /* Initialize codecs-related state for the given interpreter, including
    registering the first codec search function. Must be called before any other

--- a/Include/internal/pycore_critical_section.h
+++ b/Include/internal/pycore_critical_section.h
@@ -5,7 +5,7 @@
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "pycore_lock.h"        // PyMutex
+#include "pycore_lock.h"        // PyMutex_LockFast()
 #include "pycore_pystate.h"     // _PyThreadState_GET()
 #include <stdint.h>
 

--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -8,7 +8,6 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "pycore_lock.h"            // PyMutex
 #include "pycore_pyerrors.h"
 
 

--- a/Include/internal/pycore_function.h
+++ b/Include/internal/pycore_function.h
@@ -4,8 +4,6 @@
 extern "C" {
 #endif
 
-#include "pycore_lock.h"
-
 #ifndef Py_BUILD_CORE
 #  error "this header requires Py_BUILD_CORE define"
 #endif

--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -11,7 +11,6 @@ extern "C" {
 
 #include "pycore_hashtable.h"     // _Py_hashtable_t
 #include "pycore_interp_structs.h" // _import_state
-#include "pycore_lock.h"          // PyMutex
 
 extern int _PyImport_IsInitialized(PyInterpreterState *);
 

--- a/Include/internal/pycore_pymem.h
+++ b/Include/internal/pycore_pymem.h
@@ -2,7 +2,6 @@
 #define Py_INTERNAL_PYMEM_H
 
 #include "pycore_llist.h"           // struct llist_node
-#include "pycore_lock.h"            // PyMutex
 
 #ifdef __cplusplus
 extern "C" {

--- a/Include/internal/pycore_qsbr.h
+++ b/Include/internal/pycore_qsbr.h
@@ -11,7 +11,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "pycore_lock.h"        // PyMutex
 
 #ifdef __cplusplus
 extern "C" {

--- a/Include/internal/pycore_unicodeobject.h
+++ b/Include/internal/pycore_unicodeobject.h
@@ -8,7 +8,6 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "pycore_lock.h"          // PyMutex
 #include "pycore_fileutils.h"     // _Py_error_handler
 #include "pycore_ucnhash.h"       // _PyUnicode_Name_CAPI
 #include "pycore_global_objects.h"  // _Py_SINGLETON

--- a/Include/internal/pycore_weakref.h
+++ b/Include/internal/pycore_weakref.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 #include "pycore_critical_section.h" // Py_BEGIN_CRITICAL_SECTION()
-#include "pycore_lock.h"
+#include "pycore_lock.h"             // PyMutex_LockFlags()
 #include "pycore_object.h"           // _Py_REF_IS_MERGED()
 #include "pycore_pyatomic_ft_wrappers.h"
 

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -2368,7 +2368,7 @@ def write_internal_h_header(mod, f):
         #ifndef Py_INTERNAL_AST_STATE_H
         #define Py_INTERNAL_AST_STATE_H
 
-        #include "pycore_lock.h"    // _PyOnceFlag
+        #include "pycore_lock.h"          // _PyOnceFlag
 
         #ifdef __cplusplus
         extern "C" {


### PR DESCRIPTION
PyMutex type is now part of <Python.h>, it's no longer needed to include <pycore_lock.h> to get it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131238 -->
* Issue: gh-131238
<!-- /gh-issue-number -->
