### PR TITLE
gh-131296: Fix Windows build warnings

### DIFF
--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -1293,8 +1293,8 @@ fileio_get_mode(PyObject *op, void *closure)
 static PyObject *
 fileio_get_blksize(PyObject *op, void *closure)
 {
-    fileio *self = PyFileIO_CAST(op);
 #ifdef HAVE_STRUCT_STAT_ST_BLKSIZE
+    fileio *self = PyFileIO_CAST(op);
     if (self->stat_atopen != NULL && self->stat_atopen->st_blksize > 1) {
         return PyLong_FromLong(self->stat_atopen->st_blksize);
     }

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -331,7 +331,6 @@ _io__WindowsConsoleIO___init___impl(winconsoleio *self, PyObject *nameobj,
     int ret = 0;
     int rwa = 0;
     int fd = -1;
-    int fd_is_own = 0;
     HANDLE handle = NULL;
 
 #ifndef NDEBUG

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -406,7 +406,6 @@ faulthandler_exc_handler(struct _EXCEPTION_POINTERS *exc_info)
 {
     const int fd = fatal_error.fd;
     DWORD code = exc_info->ExceptionRecord->ExceptionCode;
-    DWORD flags = exc_info->ExceptionRecord->ExceptionFlags;
 
     if (faulthandler_ignore_exception(code)) {
         /* ignore the exception: call the next exception handler */

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5696,7 +5696,6 @@ os_mkdir_impl(PyObject *module, path_t *path, int mode, int dir_fd)
     int result;
 #ifdef MS_WINDOWS
     int error = 0;
-    int pathError = 0;
     SECURITY_ATTRIBUTES secAttr = { sizeof(secAttr) };
     SECURITY_ATTRIBUTES *pSecAttr = NULL;
 #endif

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -31,8 +31,6 @@ static BOOL clinic_HKEY_converter(winreg_state *st, PyObject *ob, void *p);
 static PyObject *PyHKEY_FromHKEY(winreg_state *st, HKEY h);
 static BOOL PyHKEY_Close(winreg_state *st, PyObject *obHandle);
 
-static char errNotAHandle[] = "Object is not a handle";
-
 /* The win32api module reports the function name that failed,
    but this concept is not in the Python core.
    Hopefully it will one day, and in the meantime I don't
@@ -2074,7 +2072,7 @@ static struct PyMethodDef winreg_methods[] = {
     WINREG_SAVEKEY_METHODDEF
     WINREG_SETVALUE_METHODDEF
     WINREG_SETVALUEEX_METHODDEF
-    NULL,
+    {NULL},
 };
 
 #define ADD_INT(VAL) do {                               \

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -55,7 +55,9 @@ int _Py_open_cloexec_works = -1;
 
 // mbstowcs() and mbrtowc() errors
 static const size_t DECODE_ERROR = ((size_t)-1);
+#ifdef HAVE_MBRTOWC
 static const size_t INCOMPLETE_CHARACTER = (size_t)-2;
+#endif
 
 
 static int
@@ -129,6 +131,7 @@ is_valid_wide_char(wchar_t ch)
         // Reject lone surrogate characters
         return 0;
     }
+#if SIZEOF_WCHAR_T > 2
     if (ch > MAX_UNICODE) {
         // bpo-35883: Reject characters outside [U+0000; U+10ffff] range.
         // The glibc mbstowcs() UTF-8 decoder does not respect the RFC 3629,
@@ -136,6 +139,7 @@ is_valid_wide_char(wchar_t ch)
         // https://sourceware.org/bugzilla/show_bug.cgi?id=2373
         return 0;
     }
+#endif
     return 1;
 }
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2531,7 +2531,9 @@ sys__is_gil_enabled_impl(PyObject *module)
 }
 
 
+#ifndef MS_WINDOWS
 static PerfMapState perf_map_state;
+#endif
 
 PyAPI_FUNC(int) PyUnstable_PerfMapState_Init(void) {
 #ifndef MS_WINDOWS


### PR DESCRIPTION
Fix the following warnings:

* Modules\_io\fileio.c(1296,13): unused variable 'self'
* Modules\_io\winconsoleio.c(334,9): unused variable 'fd_is_own'
* Modules\faulthandler.c(409,11): unused variable 'flags'
* Modules\posixmodule.c(5699,9): unused variable 'pathError'
* PC\winreg.c(2077,5): suggest braces around initialization of subobject
* PC\winreg.c(34,13): unused variable 'errNotAHandle'
* Python\fileutils.c(132,12): result of comparison of constant 1114111 with expression of type 'wchar_t' (aka 'unsigned short') is always false
* Python\fileutils.c(58,21): unused variable 'INCOMPLETE_CHARACTER'
* Python\sysmodule.c(2534,21): unused variable 'perf_map_state'

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
