### PR TITLE
gh-131490: Clarify defaultdict keyword argument behavior in docs

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -731,6 +731,11 @@ stack manipulations such as ``dup``, ``drop``, ``swap``, ``over``, ``pick``,
     will create a dict with a key of ``'default_factory'`` and a value of
     :class:`list`. Instead, call ``defaultdict(list)``.
 
+        >>> defaultdict(default_factory=list)
+        defaultdict(None, {'default_factory': <class 'list'>})
+        >>> defaultdict(list)
+        defaultdict(<class 'list'>, {})
+        >>>
 
     :class:`defaultdict` objects support the following method in addition to the
     standard :class:`dict` operations:

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -727,6 +727,10 @@ stack manipulations such as ``dup``, ``drop``, ``swap``, ``over``, ``pick``,
     as if they were passed to the :class:`dict` constructor, including keyword
     arguments.
 
+    Note that this means ``defaultdict(default_factory=list)`` (for example),
+    will create a dict with a key of ``'default_factory'`` and a value of
+    :class:`list`. Instead, call ``defaultdict(list)``.
+
 
     :class:`defaultdict` objects support the following method in addition to the
     standard :class:`dict` operations:

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2476,6 +2476,10 @@ a new value when a key is not present, in __getitem__ only.\n\
 A defaultdict compares equal to a dict with the same items.\n\
 All remaining arguments are treated the same as if they were\n\
 passed to the dict constructor, including keyword arguments.\n\
+\n\
+Note that this means defaultdict(default_factory=list) (for\n\
+example), will create a dict with a key of 'default_factory'\n\
+and a value of <class 'list'>. Instead, call defaultdict(list).\n\
 ");
 
 /* See comment in xxsubtype.c */


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131490 -->
* Issue: gh-131490
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131491.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->