### PR TITLE
GH-127705: Don't call _Py_ForgetReference before _Py_Dealloc

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -445,9 +445,6 @@ static inline void Py_DECREF_MORTAL(const char *filename, int lineno, PyObject *
         _Py_DECREF_DecRefTotal();
     }
     if (--op->ob_refcnt == 0) {
-#ifdef Py_TRACE_REFS
-        _Py_ForgetReference(op);
-#endif
         _Py_Dealloc(op);
     }
 }


### PR DESCRIPTION
Should fix the reftracer build bots.

<!-- gh-issue-number: gh-127705 -->
* Issue: gh-127705
<!-- /gh-issue-number -->
