### PR TITLE
[3.12] GH-121970: Extract `pydoc_topics` into a new extension (GH-131256)

### DIFF
--- a/Doc/tools/extensions/pydoc_topics.py
+++ b/Doc/tools/extensions/pydoc_topics.py
@@ -143,7 +143,7 @@ class PydocTopicsBuilder(TextBuilder):
                 visitor = TextTranslator(document, builder=self)
                 document.walkabout(visitor)
                 body = "\n".join(map(str.rstrip, visitor.body.splitlines()))
-                self.topics[topic_label] = body
+                self.topics[topic_label] = body + "\n"
 
     def finish(self) -> None:
         topics_repr = "\n".join(


### PR DESCRIPTION
(cherry picked from commit c1a02f9101f0b2d9dc7cfb4b8be5193e7459a906)


<!-- gh-issue-number: gh-121970 -->
* Issue: gh-121970
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131512.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->