### PR TITLE
docs(http.server): mention exceptions for content length header

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -164,7 +164,8 @@ provides three different variants:
       capabilities for future requests. If set to
       ``'HTTP/1.1'``, the server will permit HTTP persistent connections;
       however, your server *must* then include an accurate ``Content-Length``
-      header (using :meth:`send_header`) in all of its responses to clients.
+      header (using :meth:`send_header`) in all of its responses to clients
+      (with a few exceptions, like the ``1xx`` and ``204`` status codes [#]_).
       For backwards compatibility, the setting defaults to ``'HTTP/1.0'``.
 
    .. attribute:: MessageClass
@@ -562,3 +563,8 @@ server to send nefarious control codes to your terminal.
 
 .. versionchanged:: 3.12
    Control characters are scrubbed in stderr logs.
+
+.. rubric:: Footnotes
+
+.. [#] Read more about the ``Content-Length`` header in the relevant RFC:
+   https://www.rfc-editor.org/rfc/rfc9110#section-8.6


### PR DESCRIPTION
This updates the documentation for `BaseHTTPRequestHandler.protocol_version`, where it incorrectly said that every response must contain a `Content-Length` header.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131541.org.readthedocs.build/en/131541/library/http.server.html#http.server.BaseHTTPRequestHandler.protocol_version

<!-- readthedocs-preview cpython-previews end -->