### PR TITLE
gh-131507: Refactor screen and cursor position calculations

### DIFF
--- a/Lib/_pyrepl/types.py
+++ b/Lib/_pyrepl/types.py
@@ -1,8 +1,10 @@
 from collections.abc import Callable, Iterator
 
-Callback = Callable[[], object]
-SimpleContextManager = Iterator[None]
-KeySpec = str  # like r"\C-c"
-CommandName = str  # like "interrupt"
-EventTuple = tuple[CommandName, str]
-Completer = Callable[[str, int], str | None]
+type Callback = Callable[[], object]
+type SimpleContextManager = Iterator[None]
+type KeySpec = str  # like r"\C-c"
+type CommandName = str  # like "interrupt"
+type EventTuple = tuple[CommandName, str]
+type Completer = Callable[[str, int], str | None]
+type CharBuffer = list[str]
+type CharWidths = list[int]

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -2,6 +2,9 @@ import re
 import unicodedata
 import functools
 
+from .types import CharBuffer, CharWidths
+from .trace import trace
+
 ANSI_ESCAPE_SEQUENCE = re.compile(r"\x1b\[[ -@]*[A-~]")
 ZERO_WIDTH_BRACKET = re.compile(r"\x01.*?\x02")
 ZERO_WIDTH_TRANS = str.maketrans({"\x01": "", "\x02": ""})
@@ -36,3 +39,39 @@ def unbracket(s: str, including_content: bool = False) -> str:
     if including_content:
         return ZERO_WIDTH_BRACKET.sub("", s)
     return s.translate(ZERO_WIDTH_TRANS)
+
+
+def disp_str(buffer: str) -> tuple[CharBuffer, CharWidths]:
+    r"""Decompose the input buffer into a printable variant.
+
+    Returns a tuple of two lists:
+    - the first list is the input buffer, character by character;
+    - the second list is the visible width of each character in the input
+      buffer.
+
+    Examples:
+    >>> utils.disp_str("a = 9")
+    (['a', ' ', '=', ' ', '9'], [1, 1, 1, 1, 1])
+    """
+    chars: CharBuffer = []
+    char_widths: CharWidths = []
+
+    if not buffer:
+        return chars, char_widths
+
+    for c in buffer:
+        if c == "\x1a":  # CTRL-Z on Windows
+            chars.append(c)
+            char_widths.append(2)
+        elif ord(c) < 128:
+            chars.append(c)
+            char_widths.append(1)
+        elif unicodedata.category(c).startswith("C"):
+            c = r"\u%04x" % ord(c)
+            chars.append(c)
+            char_widths.append(len(c))
+        else:
+            chars.append(c)
+            char_widths.append(str_width(c))
+    trace("disp_str({buffer}) = {s}, {b}", buffer=repr(buffer), s=chars, b=char_widths)
+    return chars, char_widths


### PR DESCRIPTION
This is based off #131509.

I changed a bunch of variable names to make things more obvious in `calc_screen()` and `pos2xy()`. Plus very mild refactoring once the better names make it obvious which things are the same. It is helpful to me at least.

The one actual change here is moving `disp_str()` to `_pyrepl.utils` because this is where syntax highlighting will live as well. With that move comes a slight performance optimization that will become functionally important later: `disp_str()` no longer repacks the list of characters into a string (that is later only iterated on anyway in `calc_screen()`). Additionally, our version of `disp_str()` never had the behavior presented in the docstring, so I replaced it with something more sensible.

That's about it. Tests prove no functional change.

<!-- gh-issue-number: gh-131507 -->
* Issue: gh-131507
<!-- /gh-issue-number -->
