### PR TITLE
gh-131357: Add a set of asserts to test.test_capi.test_bytearray

### DIFF
--- a/Lib/test/test_capi/test_bytearray.py
+++ b/Lib/test/test_capi/test_bytearray.py
@@ -20,6 +20,7 @@ class CAPITest(unittest.TestCase):
     def test_check(self):
         # Test PyByteArray_Check()
         check = _testlimitedcapi.bytearray_check
+        self.assertTrue(check(bytearray(b'')))
         self.assertTrue(check(bytearray(b'abc')))
         self.assertFalse(check(b'abc'))
         self.assertTrue(check(ByteArraySubclass(b'abc')))
@@ -33,6 +34,7 @@ class CAPITest(unittest.TestCase):
     def test_checkexact(self):
         # Test PyByteArray_CheckExact()
         check = _testlimitedcapi.bytearray_checkexact
+        self.assertTrue(check(bytearray(b'')))
         self.assertTrue(check(bytearray(b'abc')))
         self.assertFalse(check(b'abc'))
         self.assertFalse(check(ByteArraySubclass(b'abc')))
@@ -78,7 +80,7 @@ class CAPITest(unittest.TestCase):
     def test_size(self):
         # Test PyByteArray_Size()
         size = _testlimitedcapi.bytearray_size
-
+        self.assertEqual(size(bytearray(b'')), 0)
         self.assertEqual(size(bytearray(b'abc')), 3)
         self.assertEqual(size(ByteArraySubclass(b'abc')), 3)
 
@@ -89,7 +91,7 @@ class CAPITest(unittest.TestCase):
     def test_asstring(self):
         """Test PyByteArray_AsString()"""
         asstring = _testlimitedcapi.bytearray_asstring
-
+        self.assertEqual(asstring(bytearray(b''), 1), b'\0')
         self.assertEqual(asstring(bytearray(b'abc'), 4), b'abc\0')
         self.assertEqual(asstring(ByteArraySubclass(b'abc'), 4), b'abc\0')
         self.assertEqual(asstring(bytearray(b'abc\0def'), 8), b'abc\0def\0')
@@ -105,6 +107,7 @@ class CAPITest(unittest.TestCase):
         ba = bytearray(b'abc')
         self.assertEqual(concat(ba, b'def'), bytearray(b'abcdef'))
         self.assertEqual(ba, b'abc')
+        self.assertEqual(concat(ba, ba), bytearray(b'abcabc'))
 
         self.assertEqual(concat(b'abc', b'def'), bytearray(b'abcdef'))
         self.assertEqual(concat(b'a\0b', b'c\0d'), bytearray(b'a\0bc\0d'))


### PR DESCRIPTION
1. Assert empty bytearray object for `PyByteArray_Check`.
2. Assert empty bytearray object for `PyByteArray_CheckExact`.
3. Assert 0-size bytearray object for `PyByteArray_Size`.
4. Assert empty bytearray object for `PyByteArray_AsString`.
5. Assert concatenation of the bytearray object with itself for `PyByteArray_Concat`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131357 -->
* Issue: gh-131357
<!-- /gh-issue-number -->
