### PR TITLE
gh-117657: Skip some tests when running with TSAN

### DIFF
--- a/Lib/test/test__interpchannels.py
+++ b/Lib/test/test__interpchannels.py
@@ -6,7 +6,7 @@ import threading
 import time
 import unittest
 
-from test.support import import_helper
+from test.support import import_helper, skip_if_sanitizer
 
 _channels = import_helper.import_module('_interpchannels')
 from test.support.interpreters import _crossinterp
@@ -365,6 +365,7 @@ class ChannelIDTests(TestBase):
         #self.assertIsNot(got, obj)
 
 
+@skip_if_sanitizer('gh-129824: race on _waiting_release', thread=True)
 class ChannelTests(TestBase):
 
     def test_create_cid(self):

--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -365,6 +365,7 @@ class CreateTests(TestBase):
 
         self.assertEqual(len(seen), 100)
 
+    @support.skip_if_sanitizer('gh-129824: race on tp_flags', thread=True)
     def test_in_thread(self):
         lock = threading.Lock()
         id = None

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1411,6 +1411,7 @@ class TestPendingCalls(unittest.TestCase):
                 self.assertNotIn(task.requester_tid, runner_tids)
 
     @requires_subinterpreters
+    @support.skip_if_sanitizer("gh-129824: race on assign_version_tag", thread=True)
     def test_isolated_subinterpreter(self):
         # We exercise the most important permutations.
 

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -227,6 +227,7 @@ class FaultHandlerTests(unittest.TestCase):
             func='faulthandler_fatal_error_thread',
             py_fatal_error=True)
 
+    @support.skip_if_sanitizer("TSAN itercepts SIGABRT", thread=True)
     def test_sigabrt(self):
         self.check_fatal_error("""
             import faulthandler
@@ -238,6 +239,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == 'win32',
                      "SIGFPE cannot be caught on Windows")
+    @support.skip_if_sanitizer("TSAN itercepts SIGFPE", thread=True)
     def test_sigfpe(self):
         self.check_fatal_error("""
             import faulthandler
@@ -249,6 +251,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(_testcapi is None, 'need _testcapi')
     @unittest.skipUnless(hasattr(signal, 'SIGBUS'), 'need signal.SIGBUS')
+    @support.skip_if_sanitizer("TSAN itercepts SIGBUS", thread=True)
     @skip_segfault_on_android
     def test_sigbus(self):
         self.check_fatal_error("""
@@ -263,6 +266,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(_testcapi is None, 'need _testcapi')
     @unittest.skipUnless(hasattr(signal, 'SIGILL'), 'need signal.SIGILL')
+    @support.skip_if_sanitizer("TSAN itercepts SIGILL", thread=True)
     @skip_segfault_on_android
     def test_sigill(self):
         self.check_fatal_error("""


### PR DESCRIPTION
The subinterpreter tests have data races (see gh-129824).

TSAN attempts to intercept some of the fatal signals, which can lead to bogus reports. We could possibly handle these via TSAN_OPTIONS, but it's simpler to just skip those tests -- they're not multithreaded anyways.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
