### PR TITLE
gh-117657: Fix TSAN data race in _PyEval_SetTrace assertion

### DIFF
--- a/Python/legacy_tracing.c
+++ b/Python/legacy_tracing.c
@@ -594,10 +594,10 @@ _PyEval_SetTrace(PyThreadState *tstate, Py_tracefunc func, PyObject *arg)
     if (_PySys_Audit(current_tstate, "sys.settrace", NULL) < 0) {
         return -1;
     }
-    assert(tstate->interp->sys_tracing_threads >= 0);
     // needs to be decref'd outside of the lock
     PyObject *old_traceobj;
     LOCK_SETUP();
+    assert(tstate->interp->sys_tracing_threads >= 0);
     Py_ssize_t tracing_threads = setup_tracing(tstate, func, arg, &old_traceobj);
     UNLOCK_SETUP();
     Py_XDECREF(old_traceobj);


### PR DESCRIPTION
The `sys_tracing_threads` variable should be read inside LOCK_SETUP().


<!-- gh-issue-number: gh-117657 -->
* Issue: gh-117657
<!-- /gh-issue-number -->
