### PR TITLE
gh-131566: Skip `test_tracemalloc_track_race` under TSAN

### DIFF
--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -1114,6 +1114,7 @@ class TestCAPI(unittest.TestCase):
     @threading_helper.requires_working_threading()
     # gh-128679: Test crash on a debug build (especially on FreeBSD).
     @unittest.skipIf(support.Py_DEBUG, 'need release build')
+    @support.skip_if_sanitizer('gh-131566: race when setting allocator', thread=True)
     def test_tracemalloc_track_race(self):
         # gh-128679: Test fix for tracemalloc.stop() race condition
         _testcapi.tracemalloc_track_race()


### PR DESCRIPTION
The test has data race when setting the global "raw" memory allocator.


<!-- gh-issue-number: gh-131566 -->
* Issue: gh-131566
<!-- /gh-issue-number -->
