### PR TITLE
gh-130080: do not fold match case constants in unoptimized AST

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -3238,6 +3238,18 @@ class ASTOptimiziationTests(unittest.TestCase):
                 values = get_match_case_values(case.pattern)
                 self.assertListEqual(constants, values)
 
+    def test_match_case_not_folded_in_unoptimized_ast(self):
+        src = textwrap.dedent("""
+            match a:
+                case 1+2j:
+                    pass
+            """)
+
+        unfolded = "MatchValue(value=BinOp(left=Constant(value=1), op=Add(), right=Constant(value=2j))"
+        folded = "MatchValue(value=Constant(value=(1+2j)))"
+        for optval in (0, 1, 2):
+            self.assertIn(folded if optval else unfolded, ast.dump(ast.parse(src, optimize=optval)))
+
 
 if __name__ == '__main__':
     if len(sys.argv) > 1 and sys.argv[1] == '--snapshot-update':

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -824,6 +824,9 @@ astfold_withitem(withitem_ty node_, PyArena *ctx_, _PyASTOptimizeState *state)
 static int
 fold_const_match_patterns(expr_ty node, PyArena *ctx_, _PyASTOptimizeState *state)
 {
+    if (state->syntax_check_only) {
+        return 1;
+    }
     switch (node->kind)
     {
         case UnaryOp_kind:


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/python/cpython/pull/130087.



<!-- gh-issue-number: gh-130080 -->
* Issue: gh-130080
<!-- /gh-issue-number -->
