### PR TITLE
GH-131296: fix clang-cl warning on Windows in pegen.h

### DIFF
--- a/Parser/pegen.h
+++ b/Parser/pegen.h
@@ -170,7 +170,7 @@ void *_PyPegen_raise_error_known_location(Parser *p, PyObject *errtype,
 void _Pypegen_set_syntax_error(Parser* p, Token* last_token);
 void _Pypegen_stack_overflow(Parser *p);
 
-Py_LOCAL_INLINE(void *)
+static inline void *
 RAISE_ERROR_KNOWN_LOCATION(Parser *p, PyObject *errtype,
                            Py_ssize_t lineno, Py_ssize_t col_offset,
                            Py_ssize_t end_lineno, Py_ssize_t end_col_offset,


### PR DESCRIPTION
Fix `warning : fastcall calling convention is not supported on variadic function [-Wignored-attributes]`.
This warning is seen 7 times in a row: https://github.com/python/cpython/actions/runs/14006628024/job/39221297660#step:4:239

For 32bit builds of `pythoncore`, we'd see this another 7 times (and in case of PGO we'd triple up to 21 warnings).

MSVC seems to silently ignore it https://devblogs.microsoft.com/oldnewthing/20131128-00/?p=2543.

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
