### PR TITLE
GH-131296: fix clang-cl warning on Windows in _wmimodule.cpp

### DIFF
--- a/PC/_wmimodule.cpp
+++ b/PC/_wmimodule.cpp
@@ -240,7 +240,6 @@ _wmi_exec_query_impl(PyObject *module, PyObject *query)
 
 /*[clinic end generated code]*/
 {
-    PyObject *result = NULL;
     HANDLE hThread = NULL;
     int err = 0;
     WCHAR buffer[8192];


### PR DESCRIPTION
I think this is a skip news?

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
