### PR TITLE
GH-131296: fix clang-cl warning on Windows in thread_nt.h

### DIFF
--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -289,6 +289,7 @@ PyThread_exit_thread(void)
     if (!initialized)
         exit(0);
     _endthreadex(0);
+    Py_UNREACHABLE();
 }
 
 void _Py_NO_RETURN


### PR DESCRIPTION
I think this is a skip news?

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
