### PR TITLE
GH-131296: fix clang-cl warning on Windows in overlapped.c

### DIFF
--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -1811,13 +1811,6 @@ _overlapped_Overlapped_WSASendTo_impl(OverlappedObject *self, HANDLE handle,
     }
 }
 
-
-
-PyDoc_STRVAR(
-    Overlapped_WSARecvFrom_doc,
-    "RecvFile(handle, size, flags) -> Overlapped[(message, (host, port))]\n\n"
-    "Start overlapped receive");
-
 /*[clinic input]
 _overlapped.Overlapped.WSARecvFrom
 


### PR DESCRIPTION
I think this is a skip news?

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
