### PR TITLE
GH-131296: fix clang-cl warning on Windows in semaphore.c

### DIFF
--- a/Modules/_multiprocessing/semaphore.c
+++ b/Modules/_multiprocessing/semaphore.c
@@ -65,7 +65,7 @@ class _multiprocessing.SemLock "SemLockObject *" "&_PyMp_SemLockType"
 #define SEM_UNLINK(name) 0
 
 static int
-_GetSemaphoreValue(HANDLE handle, long *value)
+_GetSemaphoreValue(HANDLE handle, int *value)
 {
     long previous;
 


### PR DESCRIPTION
I think this is a skip news?

Fixes https://github.com/python/cpython/actions/runs/14006628024/job/39221297660#step:4:259

```
..\Modules\_multiprocessing\semaphore.c(636,36): warning : incompatible pointer types passing 'int *' 
to parameter of type 'long *' [-Wincompatible-pointer-types] [D:\a\cpython\cpython\PCbuild\_multiprocessing.vcxproj]
..\Modules\_multiprocessing\semaphore.c(668,36): warning : incompatible pointer types passing 'int *'
to parameter of type 'long *' [-Wincompatible-pointer-types] 
```

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
