### PR TITLE
gh-90120: Specify UTF-8 encoding in `PyModule_AddString{Constant,Macro}` docs

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -633,7 +633,7 @@ state:
 
    Add a string constant to *module* as *name*.  This convenience function can be
    used from the module's initialization function.  The string *value* must be
-   ``NULL``-terminated.
+   ``NULL``-terminated and UTF-8 encoded.
    Return ``-1`` with an exception set on error, ``0`` on success.
 
    This is a convenience function that calls

--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -651,7 +651,13 @@ state:
 
 .. c:macro:: PyModule_AddStringMacro(module, macro)
 
-   Add a string constant to *module*.
+   Add a string constant to *module*. The name and the value are taken from
+   *macro*. For example ``PyModule_AddStrMacro(module, STRINGLIB_TYPE_NAME)``
+   adds the string constant *STRINGLIB_TYPE_NAME* with the value of
+   *STRINGLIB_TYPE_NAME* to *module*. The string *value* must be
+   ``NULL``-terminated and UTF-8 encoded.
+   Return ``-1`` with an exception set on error, ``0`` on success.
+
 
 .. c:function:: int PyModule_AddType(PyObject *module, PyTypeObject *type)
 


### PR DESCRIPTION
This is my first commit(s) and PR to `cpython`, thought I'd pick up some docs updates first 📝😄 

Issue: https://github.com/python/cpython/issues/90120


<!-- gh-issue-number: gh-90120 -->
* Issue: gh-90120
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131597.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->