### PR TITLE
Fixed keywords arguments of `subprocess.Popen.__init__` overriding by positional argumens of `subprocess.run`

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -551,6 +551,10 @@ def run(*popenargs,
         kwargs['stdout'] = PIPE
         kwargs['stderr'] = PIPE
 
+    # backward compatibility
+    if not isinstance(popenargs, os.PathLike) and len(popenargs) == 1:
+        popenargs = popenargs[0]
+
     with Popen(popenargs, **kwargs) as process:
         try:
             stdout, stderr = process.communicate(input, timeout=timeout)

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -551,7 +551,7 @@ def run(*popenargs,
         kwargs['stdout'] = PIPE
         kwargs['stderr'] = PIPE
 
-    with Popen(*popenargs, **kwargs) as process:
+    with Popen(popenargs, **kwargs) as process:
         try:
             stdout, stderr = process.communicate(input, timeout=timeout)
         except TimeoutExpired as exc:


### PR DESCRIPTION
Function `subprocess.run` passes process arguments to `subprocess.Popen.__init__` as vararg,
https://github.com/python/cpython/blob/bc26f95e8ff60ccca9818ca8522d2d0cde1b55fb/Lib/subprocess.py#L554
but constructor expects them as single iterable argument,
https://github.com/python/cpython/blob/bc26f95e8ff60ccca9818ca8522d2d0cde1b55fb/Lib/subprocess.py#L813-L821
so path to executable gets into `args`, first process argument gets into `bufsize`, second to `executable` and so on.

Example programm (tested on 3.8, but seems this part of code still not fixed):
```python
from subprocess import run
run("git", "status")
```
Error:
```
Traceback (most recent call last):
  File "<test programm>", line 2, in <module>
    run("git", "status")
  File "stdlib/subprocess.py", line 493, in run
    with Popen(*popenargs, **kwargs) as process:
  File "stdlib/subprocess.py", line 757, in __init__
    raise TypeError("bufsize must be an integer")
TypeError: bufsize must be an integer
```

-----

This PR provides fix of this error, but `subprocess.run` definition should be reviewed because in source, stubs and docs it has different signature (vararg/position of asterisc).
