### PR TITLE
GH-131296: fix clang-cl warning on Windows in _winapi.c

### DIFF
--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -609,7 +609,7 @@ _winapi_CreateJunction_impl(PyObject *module, LPCWSTR src_path,
         /* overallocate by a few array elements */
         LUID_AND_ATTRIBUTES privs[4];
     } tp, previousTp;
-    int previousTpSize = 0;
+    DWORD previousTpSize = 0;
 
     /* Reparse data buffer */
     const USHORT prefix_len = 4;


### PR DESCRIPTION
I think this is a skip news?

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
