### PR TITLE
GH-128520: pathlib ABCs: validate `magic_open()` arguments

### DIFF
--- a/Lib/pathlib/_os.py
+++ b/Lib/pathlib/_os.py
@@ -186,6 +186,12 @@ def magic_open(path, mode='r', buffering=-1, encoding=None, errors=None,
             pass
         else:
             return attr(path, buffering, encoding, errors, newline)
+    elif encoding is not None:
+        raise ValueError("binary mode doesn't take an encoding argument")
+    elif errors is not None:
+        raise ValueError("binary mode doesn't take an errors argument")
+    elif newline is not None:
+        raise ValueError("binary mode doesn't take a newline argument")
 
     try:
         attr = getattr(cls, f'__open_{mode}b__')

--- a/Lib/test/test_pathlib/test_read.py
+++ b/Lib/test/test_pathlib/test_read.py
@@ -39,6 +39,9 @@ class ReadTestBase:
         p = self.root / 'fileA'
         with magic_open(p, 'rb') as f:
             self.assertEqual(f.read(), b'this is file A\n')
+        self.assertRaises(ValueError, magic_open, p, 'rb', encoding='utf8')
+        self.assertRaises(ValueError, magic_open, p, 'rb', errors='strict')
+        self.assertRaises(ValueError, magic_open, p, 'rb', newline='')
 
     def test_read_bytes(self):
         p = self.root / 'fileA'

--- a/Lib/test/test_pathlib/test_write.py
+++ b/Lib/test/test_pathlib/test_write.py
@@ -41,6 +41,9 @@ class WriteTestBase:
             #self.assertIsInstance(f, io.BufferedWriter)
             f.write(b'this is file A\n')
         self.assertEqual(self.ground.readbytes(p), b'this is file A\n')
+        self.assertRaises(ValueError, magic_open, p, 'wb', encoding='utf8')
+        self.assertRaises(ValueError, magic_open, p, 'wb', errors='strict')
+        self.assertRaises(ValueError, magic_open, p, 'wb', newline='')
 
     def test_write_bytes(self):
         p = self.root / 'fileA'


### PR DESCRIPTION
When `pathlib._os.magic_open()` is called to open a path in binary mode, raise `ValueError` if any of the *encoding*, *errors* or *newline* arguments are given. This matches the `open()` built-in.


<!-- gh-issue-number: gh-128520 -->
* Issue: gh-128520
<!-- /gh-issue-number -->
