### PR TITLE
gh-60115: Support frozen modules for linecache.getline()

### DIFF
--- a/Doc/library/linecache.rst
+++ b/Doc/library/linecache.rst
@@ -30,7 +30,7 @@ The :mod:`linecache` module defines the following functions:
 
    .. index:: triple: module; search; path
 
-   If *filename* indicates a frozen module (starting with ``<frozen ``), the function
+   If *filename* indicates a frozen module (starting with ``'<frozen '``), the function
    will attepmt to get the real file name from ``module_globals['__file__']`` if
    *module_globals* is not ``None``.
 

--- a/Doc/library/linecache.rst
+++ b/Doc/library/linecache.rst
@@ -30,6 +30,10 @@ The :mod:`linecache` module defines the following functions:
 
    .. index:: triple: module; search; path
 
+   If *filename* indicates a frozen module (starting with ``<frozen ``), the function
+   will attepmt to get the real file name from ``module_globals['__file__']`` if
+   *module_globals* is not ``None``.
+
    If a file named *filename* is not found, the function first checks
    for a :pep:`302` ``__loader__`` in *module_globals*.
    If there is such a loader and it defines a ``get_source`` method,
@@ -37,6 +41,10 @@ The :mod:`linecache` module defines the following functions:
    (if ``get_source()`` returns ``None``, then ``''`` is returned).
    Finally, if *filename* is a relative filename,
    it is looked up relative to the entries in the module search path, ``sys.path``.
+
+   .. versionchanged:: 3.14
+
+      Support *filename* of frozen modules.
 
 
 .. function:: clearcache()

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -674,6 +674,13 @@ json
   (Contributed by Trey Hunner in :gh:`122873`.)
 
 
+linecache
+---------
+
+* :func:`linecache.getline` can retrieve source code for frozen modules.
+  (Contributed by Tian Gao in :gh:`131638`.)
+
+
 mimetypes
 ---------
 

--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -63,6 +63,16 @@ def _getlines_from_code(code):
     return []
 
 
+def _source_unavailable(filename):
+    """Return True if the source code is unavailable for such file name"""
+    return (
+        not filename
+        or (filename.startswith('<')
+            and filename.endswith('>')
+            and not filename.startswith('<frozen '))
+    )
+
+
 def checkcache(filename=None):
     """Discard cache entries that are out of date.
     (This is not checked upon each call!)"""
@@ -118,10 +128,17 @@ def updatecache(filename, module_globals=None):
     if filename in cache:
         if len(cache[filename]) != 1:
             cache.pop(filename, None)
-    if not filename or (filename.startswith('<') and filename.endswith('>')):
+    if _source_unavailable(filename):
         return []
 
-    fullname = filename
+    if filename.startswith('<frozen ') and module_globals is not None:
+        # This is a frozen module, so we need to use the filename
+        # from the module globals.
+        fullname = module_globals.get('__file__', None)
+        if fullname is None:
+            return []
+    else:
+        fullname = filename
     try:
         stat = os.stat(fullname)
     except OSError:

--- a/Lib/linecache.py
+++ b/Lib/linecache.py
@@ -64,7 +64,7 @@ def _getlines_from_code(code):
 
 
 def _source_unavailable(filename):
-    """Return True if the source code is unavailable for such file name"""
+    """Return True if the source code is unavailable for such file name."""
     return (
         not filename
         or (filename.startswith('<')
@@ -134,7 +134,7 @@ def updatecache(filename, module_globals=None):
     if filename.startswith('<frozen ') and module_globals is not None:
         # This is a frozen module, so we need to use the filename
         # from the module globals.
-        fullname = module_globals.get('__file__', None)
+        fullname = module_globals.get('__file__')
         if fullname is None:
             return []
     else:

--- a/Lib/test/test_linecache.py
+++ b/Lib/test/test_linecache.py
@@ -281,6 +281,19 @@ class LineCacheTests(unittest.TestCase):
         self.assertEqual(linecache.getlines(filename, module_globals),
                          ['source for x.y.z\n'])
 
+    def test_frozen(self):
+        filename = '<frozen fakemodule>'
+        module_globals = {'__file__': FILENAME}
+        empty = linecache.getlines(filename)
+        self.assertEqual(empty, [])
+        lines = linecache.getlines(filename, module_globals)
+        self.assertGreater(len(lines), 0)
+        lines_cached = linecache.getlines(filename)
+        self.assertEqual(lines, lines_cached)
+        linecache.clearcache()
+        empty = linecache.getlines(filename)
+        self.assertEqual(empty, [])
+
     def test_invalid_names(self):
         for name, desc in [
             ('\x00', 'NUL bytes filename'),

--- a/Misc/NEWS.d/next/Library/2025-03-23-18-39-07.gh-issue-60115.AWdcmq.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-23-18-39-07.gh-issue-60115.AWdcmq.rst
@@ -1,1 +1,1 @@
-Support frozen modules for :func:`linecache.getlines()`
+Support frozen modules for :func:`linecache.getlines`.

--- a/Misc/NEWS.d/next/Library/2025-03-23-18-39-07.gh-issue-60115.AWdcmq.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-23-18-39-07.gh-issue-60115.AWdcmq.rst
@@ -1,0 +1,1 @@
+Support frozen modules for :func:`linecache.getlines()`

--- a/Misc/NEWS.d/next/Library/2025-03-23-18-39-07.gh-issue-60115.AWdcmq.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-23-18-39-07.gh-issue-60115.AWdcmq.rst
@@ -1,1 +1,1 @@
-Support frozen modules for :func:`linecache.getlines`.
+Support frozen modules for :func:`linecache.getline`.


### PR DESCRIPTION
When we try to get source lines for frozen modules with `linecache.getlines()`, it will be rejected because frozen modules have file names starting with `<`. However, we can deal with that case, if we have `module_globals` - we can read `__file__` in `module_globals` to get the real file and read it.

`pdb` suffers from it when debugging frozen modules - `list` deals with it but stack entry and `ll` does not. I could fix it in pdb, but I think `linecache` could benefit from this change so it helps all users. This is also a pretty straighforward change, just convert the filename passed in to the actual file name and the rest is the same.

<!-- gh-issue-number: gh-60115 -->
* Issue: gh-60115
<!-- /gh-issue-number -->
