### PR TITLE
gh-131647: fix 'sys.path_hooks is empty' warning in test_permission_e…

### DIFF
--- a/Lib/test/test_importlib/import_/test_path.py
+++ b/Lib/test/test_importlib/import_/test_path.py
@@ -158,11 +158,15 @@ class FinderTests:
     def test_permission_error_cwd(self):
         # gh-115911: Test that an unreadable CWD does not break imports, in
         # particular during early stages of interpreter startup.
+
+        def noop_hook(*args):
+            raise ImportError
+
         with (
             os_helper.temp_dir() as new_dir,
             os_helper.save_mode(new_dir),
             os_helper.change_cwd(new_dir),
-            util.import_state(path=['']),
+            util.import_state(path=[''], path_hooks=[noop_hook]),
         ):
             # chmod() is done here (inside the 'with' block) because the order
             # of teardown operations cannot be the reverse of setup order. See


### PR DESCRIPTION
…rror_cwd

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131647 -->
* Issue: gh-131647
<!-- /gh-issue-number -->
