### PR TITLE
gh-131656: Solved the cross-interpreter support of `multiprocessing` module

### DIFF
--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -170,7 +170,10 @@ def get_preparation_data(name):
     if util._logger is not None:
         d['log_level'] = util._logger.getEffectiveLevel()
 
-    sys_path=sys.path.copy()
+    sys_path=[]
+    for path in sys.path:
+        if sys.base_prefix not in os.path.abspath(path):
+            sys_path.append(path) # For cross-interpreter support
     try:
         i = sys_path.index('')
     except ValueError:
@@ -226,10 +229,14 @@ def prepare(data):
         util.get_logger().setLevel(data['log_level'])
 
     if 'sys_path' in data:
-        sys.path = data['sys_path']
+        sys_path = data['sys_path'].copy()
+        for path in data['sys_path']:
+            if path in sys.path:
+                sys_path.remove(path)
+        sys.path.extend(sys_path)
 
     if 'sys_argv' in data:
-        sys.argv = data['sys_argv']
+        sys.argv = data['sys_argv'] # For cross-interpreter support
 
     if 'dir' in data:
         os.chdir(data['dir'])

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -233,10 +233,10 @@ def prepare(data):
         for path in data['sys_path']:
             if path in sys.path:
                 sys_path.remove(path)
-        sys.path.extend(sys_path)
+        sys.path.extend(sys_path) # For cross-interpreter support
 
     if 'sys_argv' in data:
-        sys.argv = data['sys_argv'] # For cross-interpreter support
+        sys.argv = data['sys_argv']
 
     if 'dir' in data:
         os.chdir(data['dir'])

--- a/Misc/NEWS.d/next/Library/2025-03-24-12-37-35.gh-issue-131656.7PiFWH.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-24-12-37-35.gh-issue-131656.7PiFWH.rst
@@ -1,0 +1,1 @@
+Fixed the cross-interpreter issue of subprocess module by modifying :func:`multiprocessing.spawn.prepare` and :func:`multiprocessing.spawn.get_preparation_data`. Contributed by pypy66.


### PR DESCRIPTION
The issue #131656 could be solved by slightly modifying the `prepare` and `get_preparation_data` functions from `multiprocessing.spawn` module, which is responsible for exchanging Python runtime states including `sys.path`.   
After modifying, my example code in #131656 successfully runs:

<img width="356" alt="console screen" src="https://github.com/user-attachments/assets/0381b2f2-4d19-4653-b308-5e34e3faefce" />


<!-- gh-issue-number: gh-131656 -->
* Issue: gh-131656
<!-- /gh-issue-number -->
