### PR TITLE
[3.13] gh-131645: fix ResourceWarnings in `test_asyncio.test_events` (#131646)

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1,6 +1,7 @@
 """Tests for events.py."""
 
 import concurrent.futures
+import contextlib
 import functools
 import io
 import multiprocessing
@@ -57,9 +58,9 @@ def _test_get_event_loop_new_process__sub_proc():
     async def doit():
         return 'hello'
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    return loop.run_until_complete(doit())
+    with contextlib.closing(asyncio.new_event_loop()) as loop:
+        asyncio.set_event_loop(loop)
+        return loop.run_until_complete(doit())
 
 
 class CoroLike:
@@ -2892,13 +2893,13 @@ class GetEventLoopTestsMixin:
     def test_get_running_loop_already_running(self):
         async def main():
             running_loop = asyncio.get_running_loop()
-            loop = asyncio.new_event_loop()
-            try:
-                loop.run_forever()
-            except RuntimeError:
-                pass
-            else:
-                self.fail("RuntimeError not raised")
+            with contextlib.closing(asyncio.new_event_loop()) as loop:
+                try:
+                    loop.run_forever()
+                except RuntimeError:
+                    pass
+                else:
+                    self.fail("RuntimeError not raised")
 
             self.assertIs(asyncio.get_running_loop(), running_loop)
 


### PR DESCRIPTION
(cherry picked from commit 71ce4acb25eb640a4582904172d2bb9600983f4c)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131645 -->
* Issue: gh-131645
<!-- /gh-issue-number -->
