### PR TITLE
gh-111178: Fix getsockaddrarg() undefined behavior

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-03-28-11-26-31.gh-issue-131668.tcS4xS.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-28-11-26-31.gh-issue-131668.tcS4xS.rst
@@ -1,0 +1,1 @@
+:mod:`socket`: Fix code parsing AF_BLUETOOTH socket addresses.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2044,10 +2044,9 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             struct sockaddr_l2 *addr = &addrbuf->bt_l2;
             memset(addr, 0, sizeof(struct sockaddr_l2));
             _BT_L2_MEMB(addr, family) = AF_BLUETOOTH;
-            _BT_L2_MEMB(addr, bdaddr_type) = BDADDR_BREDR;
             int psm;
             int cid = _BT_L2_MEMB(addr, cid);
-            unsigned char bdaddr_type = _BT_L2_MEMB(addr, bdaddr_type);
+            unsigned char bdaddr_type = BDADDR_BREDR;
             if (!PyArg_ParseTuple(args, "si|iB", &straddr,
                                   &psm,
                                   &cid,

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2107,6 +2107,21 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             straddr = PyBytes_AS_STRING(args);
             if (setbdaddr(straddr, &_BT_HCI_MEMB(addr, bdaddr)) < 0)
                 return 0;
+#elif defined(__FreeBSD__)
+            _BT_HCI_MEMB(addr, family) = AF_BLUETOOTH;
+            if (!PyBytes_Check(args)) {
+                PyErr_Format(PyExc_OSError, "%s: "
+                             "wrong node format", caller);
+                return 0;
+            }
+            const char *straddr = PyBytes_AS_STRING(args);
+            size_t len = PyBytes_GET_SIZE(args);
+            if (len >= sizeof(_BT_HCI_MEMB(addr, node))) {
+                PyErr_Format(PyExc_OSError, "%s: "
+                             "node too long", caller);
+                return 0;
+            }
+            strcpy(_BT_HCI_MEMB(addr, node), straddr);
 #else  /* __NetBSD__ || __DragonFly__ */
             _BT_HCI_MEMB(addr, family) = AF_BLUETOOTH;
             unsigned short dev = _BT_HCI_MEMB(addr, dev);

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2045,14 +2045,21 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             memset(addr, 0, sizeof(struct sockaddr_l2));
             _BT_L2_MEMB(addr, family) = AF_BLUETOOTH;
             _BT_L2_MEMB(addr, bdaddr_type) = BDADDR_BREDR;
+            int psm;
+            int cid = _BT_L2_MEMB(addr, cid);
+            unsigned char bdaddr_type = _BT_L2_MEMB(addr, bdaddr_type);
             if (!PyArg_ParseTuple(args, "si|iB", &straddr,
-                                  &_BT_L2_MEMB(addr, psm),
-                                  &_BT_L2_MEMB(addr, cid),
-                                  &_BT_L2_MEMB(addr, bdaddr_type))) {
+                                  &psm,
+                                  &cid,
+                                  &bdaddr_type)) {
                 PyErr_Format(PyExc_OSError,
                              "%s(): wrong format", caller);
                 return 0;
             }
+            _BT_L2_MEMB(addr, psm) = psm;
+            _BT_L2_MEMB(addr, cid) = cid;
+            _BT_L2_MEMB(addr, bdaddr_type) = bdaddr_type;
+
             if (setbdaddr(straddr, &_BT_L2_MEMB(addr, bdaddr)) < 0)
                 return 0;
 

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2044,10 +2044,10 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             struct sockaddr_l2 *addr = &addrbuf->bt_l2;
             memset(addr, 0, sizeof(struct sockaddr_l2));
             _BT_L2_MEMB(addr, family) = AF_BLUETOOTH;
-            int psm;
-            int cid = 0;
+            unsigned short psm;
+            unsigned short cid = 0;
             unsigned char bdaddr_type = BDADDR_BREDR;
-            if (!PyArg_ParseTuple(args, "si|iB", &straddr,
+            if (!PyArg_ParseTuple(args, "sH|HB", &straddr,
                                   &psm,
                                   &cid,
                                   &bdaddr_type)) {
@@ -2071,12 +2071,15 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             const char *straddr;
             struct sockaddr_rc *addr = &addrbuf->bt_rc;
             _BT_RC_MEMB(addr, family) = AF_BLUETOOTH;
-            if (!PyArg_ParseTuple(args, "si", &straddr,
-                                  &_BT_RC_MEMB(addr, channel))) {
+            uint8_t channel = _BT_RC_MEMB(addr, channel);
+            if (!PyArg_ParseTuple(args, "sB", &straddr,
+                                  &channel)) {
                 PyErr_Format(PyExc_OSError,
                              "%s(): wrong format", caller);
                 return 0;
             }
+            _BT_RC_MEMB(addr, channel) = channel;
+
             if (setbdaddr(straddr, &_BT_RC_MEMB(addr, bdaddr)) < 0)
                 return 0;
 
@@ -2100,11 +2103,13 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
                 return 0;
 #else  /* __NetBSD__ || __DragonFly__ */
             _BT_HCI_MEMB(addr, family) = AF_BLUETOOTH;
-            if (!PyArg_ParseTuple(args, "i", &_BT_HCI_MEMB(addr, dev))) {
+            unsigned short dev = _BT_HCI_MEMB(addr, dev);
+            if (!PyArg_ParseTuple(args, "H", &dev)) {
                 PyErr_Format(PyExc_OSError,
                              "%s(): wrong format", caller);
                 return 0;
             }
+            _BT_HCI_MEMB(addr, dev) = dev;
 #endif /* !(__NetBSD__ || __DragonFly__) */
             *len_ret = sizeof *addr;
             return 1;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2071,13 +2071,19 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             const char *straddr;
             struct sockaddr_rc *addr = &addrbuf->bt_rc;
             _BT_RC_MEMB(addr, family) = AF_BLUETOOTH;
+#ifdef MS_WINDOWS
+            unsigned long channel = _BT_RC_MEMB(addr, channel);
+#           define FORMAT_CHANNEL "k"
+#else
             unsigned char channel = _BT_RC_MEMB(addr, channel);
-            if (!PyArg_ParseTuple(args, "sB", &straddr,
-                                  &channel)) {
-                PyErr_Format(PyExc_OSError,
-                             "%s(): wrong format", caller);
+#           define FORMAT_CHANNEL "B"
+#endif
+            if (!PyArg_ParseTuple(args, "s" FORMAT_CHANNEL,
+                                  &straddr, &channel)) {
+                PyErr_Format(PyExc_OSError, "%s(): wrong format", caller);
                 return 0;
             }
+#undef FORMAT_CHANNEL
             _BT_RC_MEMB(addr, channel) = channel;
 
             if (setbdaddr(straddr, &_BT_RC_MEMB(addr, bdaddr)) < 0)

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2071,7 +2071,7 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             const char *straddr;
             struct sockaddr_rc *addr = &addrbuf->bt_rc;
             _BT_RC_MEMB(addr, family) = AF_BLUETOOTH;
-            uint8_t channel = _BT_RC_MEMB(addr, channel);
+            unsigned char channel = _BT_RC_MEMB(addr, channel);
             if (!PyArg_ParseTuple(args, "sB", &straddr,
                                   &channel)) {
                 PyErr_Format(PyExc_OSError,

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2045,7 +2045,7 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             memset(addr, 0, sizeof(struct sockaddr_l2));
             _BT_L2_MEMB(addr, family) = AF_BLUETOOTH;
             int psm;
-            int cid = _BT_L2_MEMB(addr, cid);
+            int cid = 0;
             unsigned char bdaddr_type = BDADDR_BREDR;
             if (!PyArg_ParseTuple(args, "si|iB", &straddr,
                                   &psm,

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2076,10 +2076,10 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             struct sockaddr_rc *addr = &addrbuf->bt_rc;
             _BT_RC_MEMB(addr, family) = AF_BLUETOOTH;
 #ifdef MS_WINDOWS
-            unsigned long channel = _BT_RC_MEMB(addr, channel);
+            unsigned long channel;
 #           define FORMAT_CHANNEL "k"
 #else
-            unsigned char channel = _BT_RC_MEMB(addr, channel);
+            unsigned char channel;
 #           define FORMAT_CHANNEL "B"
 #endif
             if (!PyArg_ParseTuple(args, "s" FORMAT_CHANNEL,

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2121,12 +2121,12 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             const char *straddr = PyBytes_AS_STRING(args);
             size_t len = PyBytes_GET_SIZE(args);
             if (strlen(straddr) != len) {
-                PyErr_Format(PyExc_OSError, "%s: "
+                PyErr_Format(PyExc_ValueError, "%s: "
                              "node contains embedded null character", caller);
                 return 0;
             }
             if (len > sizeof(_BT_HCI_MEMB(addr, node))) {
-                PyErr_Format(PyExc_OSError, "%s: "
+                PyErr_Format(PyExc_ValueError, "%s: "
                              "node too long", caller);
                 return 0;
             }

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2132,7 +2132,7 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             }
             strncpy(_BT_HCI_MEMB(addr, node), straddr,
                     sizeof(_BT_HCI_MEMB(addr, node)));
-#else  /* __NetBSD__ || __DragonFly__ */
+#else
             _BT_HCI_MEMB(addr, family) = AF_BLUETOOTH;
             unsigned short dev = _BT_HCI_MEMB(addr, dev);
             if (!PyArg_ParseTuple(args, "H", &dev)) {
@@ -2141,7 +2141,7 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
                 return 0;
             }
             _BT_HCI_MEMB(addr, dev) = dev;
-#endif /* !(__NetBSD__ || __DragonFly__) */
+#endif
             *len_ret = sizeof *addr;
             return 1;
         }


### PR DESCRIPTION
Don't pass direct references to sockaddr members since their type may not match PyArg_ParseTuple() types. Instead, use temporary 'int' and 'unsigned char' variables, and update sockaddr members afterwards.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111178 -->
* Issue: gh-111178
<!-- /gh-issue-number -->
