### PR TITLE
gh-111178: Skip tests which require deep stack if UBsan

### DIFF
--- a/Lib/test/mapping_tests.py
+++ b/Lib/test/mapping_tests.py
@@ -624,6 +624,7 @@ class TestHashMappingProtocol(TestMappingProtocol):
 
     @support.skip_wasi_stack_overflow()
     @support.skip_emscripten_stack_overflow()
+    @support.skip_if_sanitizer("requires deep stack", ub=True)
     def test_repr_deep(self):
         d = self._empty_mapping()
         for i in range(support.exceeds_recursion_limit()):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2078,7 +2078,7 @@ class TestLRU:
 
     @support.skip_on_s390x
     @unittest.skipIf(support.is_wasi, "WASI has limited C stack")
-    @support.skip_if_sanitizer("requires deep stack", thread=True)
+    @support.skip_if_sanitizer("requires deep stack", ub=True, thread=True)
     @support.skip_emscripten_stack_overflow()
     def test_lru_recursion(self):
 


### PR DESCRIPTION
If Python is built with Undefined Behavior sanitizer, skip test_repr_deep() of test_userdict and test_lru_recursion() of test_functools.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111178 -->
* Issue: gh-111178
<!-- /gh-issue-number -->
