### PR TITLE
gh-131666: mark `anext_awaitable.close` as a `METH_NOARGS` instead of `METH_VARARGS`

### DIFF
--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -1191,6 +1191,17 @@ class CoroutineTest(unittest.TestCase):
         _, result = run_async(g())
         self.assertIsNone(result.__context__)
 
+    def test_await_17(self):
+        # See https://github.com/python/cpython/issues/131666 for details.
+        class A:
+            async def __anext__(self):
+                raise StopAsyncIteration
+            def __aiter__(self):
+                return self
+
+        anext_awaitable = anext(A(), "a").__await__()
+        self.assertRaises(TypeError, anext_awaitable.close, 1)
+
     def test_with_1(self):
         class Manager:
             def __init__(self, name):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-24-14-56-00.gh-issue-131666.q0-a-b.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-24-14-56-00.gh-issue-131666.q0-a-b.rst
@@ -1,0 +1,1 @@
+Fix signature of ``anext_awaitable.close`` objects. Patch by Bénédikt Tran.

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -414,6 +414,8 @@ anextawaitable_proxy(anextawaitableobject *obj, char *meth, PyObject *arg)
     if (awaitable == NULL) {
         return NULL;
     }
+    // When specified, 'arg' may be a tuple (if coming from a METH_VARARGS
+    // method) or a single object (if coming from a METH_O method).
     PyObject *ret = arg == NULL
         ? PyObject_CallMethod(awaitable, meth, NULL)
         : PyObject_CallMethod(awaitable, meth, "O", arg);

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -408,7 +408,9 @@ anextawaitable_proxy(anextawaitableobject *obj, char *meth, PyObject *arg) {
     if (awaitable == NULL) {
         return NULL;
     }
-    PyObject *ret = PyObject_CallMethod(awaitable, meth, "O", arg);
+    PyObject *ret = arg == NULL
+        ? PyObject_CallMethod(awaitable, meth, NULL)
+        : PyObject_CallMethod(awaitable, meth, "O", arg);
     Py_DECREF(awaitable);
     if (ret != NULL) {
         return ret;
@@ -439,8 +441,8 @@ anextawaitable_throw(anextawaitableobject *obj, PyObject *arg) {
 
 
 static PyObject *
-anextawaitable_close(anextawaitableobject *obj, PyObject *arg) {
-    return anextawaitable_proxy(obj, "close", arg);
+anextawaitable_close(anextawaitableobject *obj, PyObject *Py_UNUSED(dummy)) {
+    return anextawaitable_proxy(obj, "close", NULL);
 }
 
 
@@ -466,7 +468,7 @@ PyDoc_STRVAR(close_doc,
 static PyMethodDef anextawaitable_methods[] = {
     {"send",(PyCFunction)anextawaitable_send, METH_O, send_doc},
     {"throw",(PyCFunction)anextawaitable_throw, METH_VARARGS, throw_doc},
-    {"close",(PyCFunction)anextawaitable_close, METH_VARARGS, close_doc},
+    {"close",(PyCFunction)anextawaitable_close, METH_NOARGS, close_doc},
     {NULL, NULL}        /* Sentinel */
 };
 


### PR DESCRIPTION
It's not really an issue because the underlying coroutine wrapper will raise a TypeError, so there won't be a different exception raised now. It's just that instead of "coroutine_wrapper.close taskes no argument", we have "anext_awaitable.close takes no argument".

<!-- gh-issue-number: gh-131666 -->
* Issue: gh-131666
<!-- /gh-issue-number -->
