### PR TITLE
gh-127146: Fix Emscripten build with --pydebug

### DIFF
--- a/Tools/wasm/emscripten/web_example/wasm_assets.py
+++ b/Tools/wasm/emscripten/web_example/wasm_assets.py
@@ -91,13 +91,6 @@ OMIT_MODULE_FILES = {
     "_zoneinfo": ["zoneinfo/"],
 }
 
-SYSCONFIG_NAMES = (
-    "_sysconfigdata__emscripten_wasm32-emscripten",
-    "_sysconfigdata__emscripten_wasm32-emscripten",
-    "_sysconfigdata__wasi_wasm32-wasi",
-    "_sysconfigdata__wasi_wasm64-wasi",
-)
-
 
 def get_builddir(args: argparse.Namespace) -> pathlib.Path:
     """Get builddir path from pybuilddir.txt"""
@@ -110,8 +103,6 @@ def get_sysconfigdata(args: argparse.Namespace) -> pathlib.Path:
     """Get path to sysconfigdata relative to build root"""
     assert isinstance(args.builddir, pathlib.Path)
     data_name: str = sysconfig._get_sysconfigdata_name()  # type: ignore[attr-defined]
-    if not data_name.startswith(SYSCONFIG_NAMES):
-        raise ValueError(f"Invalid sysconfig data name '{data_name}'.", SYSCONFIG_NAMES)
     filename = data_name + ".py"
     return args.builddir / filename
 


### PR DESCRIPTION
The deleted logic checks that the sysconfigdata is in a short list, and the list does not allow the `d` ABI flag to be present so it fails if we build with `--with-pydebug`. I removed the check because I don't think it is helpful.



<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
