### PR TITLE
gh-131677: Fix flaky test_lru_cache_threaded3

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1934,8 +1934,7 @@ class TestLRU:
             time.sleep(.01)
             return 3 * x
         def test(i, x):
-            with self.subTest(thread=i):
-                self.assertEqual(f(x), 3 * x, i)
+            self.assertEqual(f(x), 3 * x, i)
         threads = [threading.Thread(target=test, args=(i, v))
                    for i, v in enumerate([1, 2, 2, 3, 2])]
         with threading_helper.start_threads(threads):


### PR DESCRIPTION
The call to `with self.subTest(...)` was not thread-safe.


<!-- gh-issue-number: gh-131677 -->
* Issue: gh-131677
<!-- /gh-issue-number -->
