### PR TITLE
gh-131670: Fix crash in `anext()` when `__anext__` is sync and raises

### DIFF
--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -1169,6 +1169,25 @@ class AsyncGenAsyncioTest(unittest.TestCase):
 
         self.loop.run_until_complete(run())
 
+    def test_sync_anext_raises_exception(self):
+        # See: https://github.com/python/cpython/issues/131670
+        msg = 'custom'
+        for exc in [
+            StopAsyncIteration(msg),
+            StopIteration(msg),
+            ValueError(msg),
+            Exception(msg),
+        ]:
+            with self.subTest(exc=exc):
+                class A:
+                    def __anext__(self):
+                        raise exc
+
+                with self.assertRaisesRegex(type(exc), msg):
+                    anext(A())
+                with self.assertRaisesRegex(type(exc), msg):
+                    anext(A(), 1)
+
     def test_async_gen_asyncio_anext_stopiteration(self):
         async def foo():
             try:

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -1172,20 +1172,21 @@ class AsyncGenAsyncioTest(unittest.TestCase):
     def test_sync_anext_raises_exception(self):
         # See: https://github.com/python/cpython/issues/131670
         msg = 'custom'
-        for exc in [
-            StopAsyncIteration(msg),
-            StopIteration(msg),
-            ValueError(msg),
-            Exception(msg),
+        for exc_type in [
+            StopAsyncIteration,
+            StopIteration,
+            ValueError,
+            Exception,
         ]:
+            exc = exc_type(msg)
             with self.subTest(exc=exc):
                 class A:
                     def __anext__(self):
                         raise exc
 
-                with self.assertRaisesRegex(type(exc), msg):
+                with self.assertRaisesRegex(exc_type, msg):
                     anext(A())
-                with self.assertRaisesRegex(type(exc), msg):
+                with self.assertRaisesRegex(exc_type, msg):
                     anext(A(), 1)
 
     def test_async_gen_asyncio_anext_stopiteration(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-24-19-38-53.gh-issue-131670.IffOZj.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-24-19-38-53.gh-issue-131670.IffOZj.rst
@@ -1,0 +1,2 @@
+Fix :func:`anext` failing on sync :meth:`~object.__anext__` that raises
+:exc:`StopAsyncIteration`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-24-19-38-53.gh-issue-131670.IffOZj.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-24-19-38-53.gh-issue-131670.IffOZj.rst
@@ -1,2 +1,1 @@
-Fix :func:`anext` failing on sync :meth:`~object.__anext__` that raises
-:exc:`StopAsyncIteration`.
+Fix :func:`anext` failing on sync :meth:`~object.__anext__` raising an exception.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1837,6 +1837,9 @@ builtin_anext_impl(PyObject *module, PyObject *aiterator,
     }
 
     awaitable = (*t->tp_as_async->am_anext)(aiterator);
+    if (awaitable == NULL) {
+        return NULL;
+    }
     if (default_value == NULL) {
         return awaitable;
     }


### PR DESCRIPTION


<!-- gh-issue-number: gh-131670 -->
* Issue: gh-131670
<!-- /gh-issue-number -->
