### PR TITLE
gh-111178: Skip undefined behavior checks in _PyPegen_lookahead()

### DIFF
--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -406,11 +406,14 @@ _PyPegen_lookahead_with_int(int positive, Token *(func)(Parser *, int), Parser *
     return (res != NULL) == positive;
 }
 
-int
+// gh-111178: Use _Py_NO_SANITIZE_UNDEFINED to disable sanitizer checks on
+// undefined behavior (UBsan) in this function, rather than changing 'func'
+// callback API.
+int _Py_NO_SANITIZE_UNDEFINED
 _PyPegen_lookahead(int positive, void *(func)(Parser *), Parser *p)
 {
     int mark = p->mark;
-    void *res = (void*)func(p);
+    void *res = func(p);
     p->mark = mark;
     return (res != NULL) == positive;
 }


### PR DESCRIPTION
For example, expression_rule() return type is 'expr_ty', whereas _PyPegen_lookahead() uses 'void*'.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-111178 -->
* Issue: gh-111178
<!-- /gh-issue-number -->
