### PR TITLE
gh-91349: Expose the crc32 function from the lzma library

### DIFF
--- a/Doc/library/lzma.rst
+++ b/Doc/library/lzma.rst
@@ -310,6 +310,23 @@ Compressing and decompressing data in memory
    *preset* and *filters* arguments.
 
 
+.. function:: crc32(data, value=0)
+
+   .. index::
+      single: Cyclic Redundancy Check
+      single: checksum; Cyclic Redundancy Check
+
+   Computes a CRC (Cyclic Redundancy Check) checksum of *data*. The
+   result is a positive integer, less than :math:`2^32`. If *value* is present, it is used
+   as the starting value of the checksum; otherwise, a default value of 0
+   is used.  Passing in *value* allows computing a running checksum over the
+   concatenation of several inputs.  The algorithm is not cryptographically
+   strong, and should not be used for authentication or digital signatures.  Since
+   the algorithm is designed for use as a checksum algorithm, it is not suitable
+   for use as a general hash algorithm.
+
+   .. versionadded:: next
+
 .. function:: decompress(data, format=FORMAT_AUTO, memlimit=None, filters=None)
 
    Decompress *data* (a :class:`bytes` object), returning the uncompressed data

--- a/Misc/NEWS.d/next/Library/2025-03-18-14-18-06.gh-issue-91349.Qrnmxt.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-18-14-18-06.gh-issue-91349.Qrnmxt.rst
@@ -1,0 +1,1 @@
+Expose the crc32 function from the lzma library as :func:`lzma.crc32`.

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -1587,10 +1587,40 @@ lzma_exec(PyObject *module)
     return 0;
 }
 
+/*[clinic input]
+_lzma.crc32 -> unsigned_int
+
+    data: Py_buffer
+    value: unsigned_int(bitwise=True) = 0
+        Starting value of the checksum.
+    /
+
+Compute a CRC-32 checksum of data.
+
+The returned checksum is an integer.
+[clinic start generated code]*/
+
+static unsigned int
+_lzma_crc32_impl(PyObject *module, Py_buffer *data, unsigned int value)
+/*[clinic end generated code: output=fca7916d796faf8b input=bb623a169c14534f]*/
+{
+    /* Releasing the GIL for very small buffers is inefficient
+       and may lower performance */
+    if (data->len > 1024*5) {
+        Py_BEGIN_ALLOW_THREADS
+        value = lzma_crc32(data->buf, (size_t)data->len, (uint32_t)value);
+        Py_END_ALLOW_THREADS
+    } else {
+        value = lzma_crc32(data->buf, (size_t)data->len, (uint32_t)value);
+    }
+    return value;
+}
+
 static PyMethodDef lzma_methods[] = {
     _LZMA_IS_CHECK_SUPPORTED_METHODDEF
     _LZMA__ENCODE_FILTER_PROPERTIES_METHODDEF
     _LZMA__DECODE_FILTER_PROPERTIES_METHODDEF
+    _LZMA_CRC32_METHODDEF
     {NULL}
 };
 

--- a/Modules/clinic/_lzmamodule.c.h
+++ b/Modules/clinic/_lzmamodule.c.h
@@ -333,4 +333,58 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=6386084cb43d2533 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(_lzma_crc32__doc__,
+"crc32($module, data, value=0, /)\n"
+"--\n"
+"\n"
+"Compute a CRC-32 checksum of data.\n"
+"\n"
+"  value\n"
+"    Starting value of the checksum.\n"
+"\n"
+"The returned checksum is an integer.");
+
+#define _LZMA_CRC32_METHODDEF    \
+    {"crc32", _PyCFunction_CAST(_lzma_crc32), METH_FASTCALL, _lzma_crc32__doc__},
+
+static unsigned int
+_lzma_crc32_impl(PyObject *module, Py_buffer *data, unsigned int value);
+
+static PyObject *
+_lzma_crc32(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    Py_buffer data = {NULL, NULL};
+    unsigned int value = 0;
+    unsigned int _return_value;
+
+    if (!_PyArg_CheckPositional("crc32", nargs, 1, 2)) {
+        goto exit;
+    }
+    if (PyObject_GetBuffer(args[0], &data, PyBUF_SIMPLE) != 0) {
+        goto exit;
+    }
+    if (nargs < 2) {
+        goto skip_optional;
+    }
+    value = (unsigned int)PyLong_AsUnsignedLongMask(args[1]);
+    if (value == (unsigned int)-1 && PyErr_Occurred()) {
+        goto exit;
+    }
+skip_optional:
+    _return_value = _lzma_crc32_impl(module, &data, value);
+    if ((_return_value == (unsigned int)-1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromUnsignedLong((unsigned long)_return_value);
+
+exit:
+    /* Cleanup for data */
+    if (data.obj) {
+       PyBuffer_Release(&data);
+    }
+
+    return return_value;
+}
+/*[clinic end generated code: output=b6591cb074aa87b6 input=a9049054013a1b77]*/


### PR DESCRIPTION
Hello,

This is a simple PR to expose the crc32 function from the lzma library.
The code and tests are very similar to the crc in binascii and zlib. I don't think it's too controversial.

I came across this while looking at compression libraries for https://github.com/python/cpython/issues/91349
crc32 is always available from the lzma library (xz-utils/liblzma.so). I think it should be exposed.
there are more hashing functions available (namely crc64) but they need compilation/runtime checks to verify whether they are available.

Regards.

<!-- gh-issue-number: gh-91349 -->
* Issue: gh-91349
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131721.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->