### PR TITLE
gh-131736: only apply `security_level` workaround in `test_ssl` for security levels greater than 1

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -155,7 +155,8 @@ if is_ubuntu():
         for ctx in ctxs:
             if (
                 hasattr(ctx, "minimum_version") and
-                ctx.minimum_version <= ssl.TLSVersion.TLSv1_1
+                ctx.minimum_version <= ssl.TLSVersion.TLSv1_1 and
+                ctx.security_level > 1
             ):
                 ctx.set_ciphers("@SECLEVEL=1:ALL")
 else:

--- a/Misc/NEWS.d/next/Tests/2025-03-25-20-54-12.gh-issue-131736.firXbY.rst
+++ b/Misc/NEWS.d/next/Tests/2025-03-25-20-54-12.gh-issue-131736.firXbY.rst
@@ -1,1 +1,0 @@
-Only do seclevel workaround if seclevel greater than 1.

--- a/Misc/NEWS.d/next/Tests/2025-03-25-20-54-12.gh-issue-131736.firXbY.rst
+++ b/Misc/NEWS.d/next/Tests/2025-03-25-20-54-12.gh-issue-131736.firXbY.rst
@@ -1,0 +1,1 @@
+Only do seclevel workaround if seclevel greater than 1.


### PR DESCRIPTION
# Notes

Please see Issue #131736.

# Testing

- CPython CI
- built locally with AWS-LC, confirmed that relevant tests now work

<!-- gh-issue-number: gh-131736 -->
* Issue: gh-131736
<!-- /gh-issue-number -->
