### PR TITLE
gh-131741: Add documentation for Windows version detection change in `platform`

### DIFF
--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -811,6 +811,17 @@ pathlib
   :meth:`pathlib.Path.rglob` and :meth:`pathlib.PurePath.match` for matching
   the path's case sensitivity, allowing for more precise control over the matching process.
 
+platform
+--------
+
+* Add support for detecting Windows 11 and Windows Server releases past 2012.
+  Prior, lookups on Windows Server platforms newer than Windows Server 2012
+  and on Windows 11 would return `Windows-10`.
+  (Contributed by Steve Dower in :gh:`89545`.)
+
+* Add support for detecting Windows Server 2025.
+  (Contributed by Wulian233 in :gh:`127732`.)
+
 pdb
 ---
 

--- a/Doc/whatsnew/3.12.rst
+++ b/Doc/whatsnew/3.12.rst
@@ -815,12 +815,9 @@ platform
 --------
 
 * Add support for detecting Windows 11 and Windows Server releases past 2012.
-  Prior, lookups on Windows Server platforms newer than Windows Server 2012
-  and on Windows 11 would return `Windows-10`.
+  Previously, lookups on Windows Server platforms newer than Windows Server 2012
+  and on Windows 11 would return ``Windows-10``.
   (Contributed by Steve Dower in :gh:`89545`.)
-
-* Add support for detecting Windows Server 2025.
-  (Contributed by Wulian233 in :gh:`127732`.)
 
 pdb
 ---


### PR DESCRIPTION
Document the behavior change between 3.11 & 3.12, where `platform` now correctly detects Windows 11 and Windows Server releases past Windows Server 2012.


<!-- gh-issue-number: gh-131741 -->
* Issue: gh-131741
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131742.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->