### PR TITLE
gh-130080: Remove unnecessary memset for `_PyASTOptimizeState` initializing 

### DIFF
--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -940,11 +940,11 @@ _PyAST_Optimize(mod_ty mod, PyArena *arena, PyObject *filename, int optimize,
                 int ff_features, int syntax_check_only)
 {
     _PyASTOptimizeState state;
-    memset(&state, 0, sizeof(_PyASTOptimizeState));
     state.filename = filename;
     state.optimize = optimize;
     state.ff_features = ff_features;
     state.syntax_check_only = syntax_check_only;
+    state.cf_finally_used = 0;
     if (_Py_CArray_Init(&state.cf_finally, sizeof(ControlFlowInFinallyContext), 20) < 0) {
         return -1;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

I believe this `memset` is unnecessary as all of the struct fields (except for `cf_finally_used`) are initialized explicitly anyway. Therefore removing it and initializing `cf_finally_used` explicitly as well.

<!-- gh-issue-number: gh-130080 -->
* Issue: gh-130080
<!-- /gh-issue-number -->
