### PR TITLE
no issue: Document that sys._is_gil_enabled is CPython-specific

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1247,6 +1247,9 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
    .. versionadded:: 3.13
 
+   .. impl-detail::
+
+      It is not guaranteed to exist in all implementations of Python.
 
 .. function:: is_finalizing()
 


### PR DESCRIPTION
As discussed in https://discuss.python.org/t/environment-marker-for-free-threading/60007/22

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131748.org.readthedocs.build/en/131748/library/sys.html#sys._is_gil_enabled

<!-- readthedocs-preview cpython-previews end -->