### PR TITLE
GH-119866: Don't clear `frame->stackpointer` on release builds

### DIFF
--- a/Include/internal/pycore_interpframe.h
+++ b/Include/internal/pycore_interpframe.h
@@ -163,9 +163,9 @@ _PyFrame_GetLocalsArray(_PyInterpreterFrame *frame)
     return frame->localsplus;
 }
 
-/* Fetches the stack pointer, and sets stackpointer to NULL.
-   Having stackpointer == NULL ensures that invalid
-   values are not visible to the cycle GC. */
+// Fetches the stack pointer, and (on debug builds) sets stackpointer to NULL.
+// Having stackpointer == NULL makes it easier to catch missing stack pointer
+// spills/restores (which could expose invalid values to the GC) using asserts.
 static inline _PyStackRef*
 _PyFrame_GetStackPointer(_PyInterpreterFrame *frame)
 {

--- a/Include/internal/pycore_interpframe.h
+++ b/Include/internal/pycore_interpframe.h
@@ -171,7 +171,9 @@ _PyFrame_GetStackPointer(_PyInterpreterFrame *frame)
 {
     assert(frame->stackpointer != NULL);
     _PyStackRef *sp = frame->stackpointer;
+#ifndef NDEBUG
     frame->stackpointer = NULL;
+#endif
     return sp;
 }
 


### PR DESCRIPTION
This is only useful for asserts to make sure that we're spilling and restoring the stack pointer in all the right places. Removing these frequent stores makes the interpreter [0.7% faster](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20250325-3.14.0a6%2B-7b432e3/bm-20250325-linux-x86_64-brandtbucher-null_stack_pointer-3.14.0a6%2B-7b432e3-vs-base.svg) and the JIT [0.4% faster](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20250325-3.14.0a6%2B-7b432e3-JIT/bm-20250325-linux-x86_64-brandtbucher-null_stack_pointer-3.14.0a6%2B-7b432e3-vs-base.svg).

<!-- gh-issue-number: gh-119866 -->
* Issue: gh-119866
<!-- /gh-issue-number -->
