### PR TITLE
gh-131753: Set copyright date 2001-present

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ This is Python version 3.14.0 alpha 6
    :target: https://discuss.python.org/
 
 
-Copyright © 2001 Python Software Foundation.  All rights reserved.
+Copyright © 2001-present Python Software Foundation.  All rights reserved.
 
 See the end of this file for further copyright and license information.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
#131753

I find it rather confusing that the copyright date is labeled 2001.
I know that the Python Foundation WAS first formed in 2001, but not saying 2001-2025 or 2001-present (like I have noticed you DO in your docs in the bottom little copyright section.

Relatively small change, just really confused me and it was the first thing I saw when browsing the repositories code. 

Not too important, so I guess I'll just leave this here for consideration. 

Ping me regarding the PR if you want, I will respond within 48 hours (most likely).

 It's a rather simple mistake and I thought I'd just try clear it up. 