### PR TITLE
gh-131762: Fixed dereferencing the pointer 'parser_token->metadata' with a NULL value

### DIFF
--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -194,7 +194,7 @@ initialize_token(Parser *p, Token *parser_token, struct token *new_token, int to
     parser_token->metadata = NULL;
     if (new_token->metadata != NULL) {
         if (_PyArena_AddPyObject(p->arena, new_token->metadata) < 0) {
-            Py_DECREF(parser_token->metadata);
+            Py_DECREF(new_token->metadata);
             return -1;
         }
         parser_token->metadata = new_token->metadata;


### PR DESCRIPTION
Py_DECREF should be applied to the new_token->metadata.

<!-- gh-issue-number: gh-131762 -->
* Issue: gh-131762
<!-- /gh-issue-number -->
