### PR TITLE
GH-131729: Consider in-memory state when merging storage and stack

### DIFF
--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -3933,6 +3933,7 @@
                 PyStackRef_CLOSE(tmp);
                 stack_pointer = _PyFrame_GetStackPointer(frame);
             }
+            stack_pointer[-1] = b;
             break;
         }
 
@@ -4116,6 +4117,7 @@
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
+            stack_pointer[-1] = iter;
             break;
         }
 

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -6009,6 +6009,7 @@
                     stack_pointer = _PyFrame_GetStackPointer(frame);
                 }
             }
+            stack_pointer[-1] = iter;
             DISPATCH();
         }
 

--- a/Tools/cases_generator/stack.py
+++ b/Tools/cases_generator/stack.py
@@ -378,6 +378,8 @@ class Stack:
             if self_var.memory_offset is not None:
                 if self_var.memory_offset != other_var.memory_offset:
                     raise StackError(f"Mismatched stack depths for {self_var.name}: {self_var.memory_offset} and {other_var.memory_offset}")
+            elif other_var.memory_offset is None:
+                self_var.memory_offset = None
 
 
 def stacks(inst: Instruction | PseudoInstruction) -> Iterator[StackEffect]:
@@ -601,6 +603,11 @@ class Storage:
         if len(self.outputs) != len(other.outputs):
             var = self.outputs[0] if len(self.outputs) > len(other.outputs) else other.outputs[0]
             raise StackError(f"'{var.name}' is set on some paths, but not all")
+        for var, other_var in zip(self.outputs, other.outputs):
+            if var.memory_offset is None:
+                other_var.memory_offset = None
+            elif other_var.memory_offset is None:
+                var.memory_offset = None
         self.stack.merge(other.stack, out)
         self.sanity_check()
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/python/cpython/pull/131732

<!-- gh-issue-number: gh-131729 -->
* Issue: gh-131729
<!-- /gh-issue-number -->
