### PR TITLE
gh-131782: Fix cast to match type of `bits`.

### DIFF
--- a/Include/internal/pycore_stackref.h
+++ b/Include/internal/pycore_stackref.h
@@ -668,7 +668,7 @@ static inline int
 _Py_TryIncrefCompareStackRef(PyObject **src, PyObject *op, _PyStackRef *out)
 {
     if (_PyObject_HasDeferredRefcount(op)) {
-        *out = (_PyStackRef){ .bits = (intptr_t)op | Py_TAG_DEFERRED };
+        *out = (_PyStackRef){ .bits = (uintptr_t)op | Py_TAG_DEFERRED };
         return 1;
     }
     if (_Py_TryIncrefCompare(src, op)) {


### PR DESCRIPTION
Fixes compile error if `-Wc++11-narrowing` option is used.

<!-- gh-issue-number: gh-131782 -->
* Issue: gh-131782
<!-- /gh-issue-number -->
