### PR TITLE
gh-131675: mimalloc: fix mi_atomic_yield on 32-bit ARM

### DIFF
--- a/Include/internal/mimalloc/mimalloc/atomic.h
+++ b/Include/internal/mimalloc/mimalloc/atomic.h
@@ -338,8 +338,9 @@ static inline void mi_atomic_yield(void) {
   _mm_pause();
 }
 #elif (defined(__GNUC__) || defined(__clang__)) && \
-      (defined(__x86_64__) || defined(__i386__) || defined(__arm__) || \
-       defined(__aarch64__) || defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)) || defined(__POWERPC__)
+      (defined(__x86_64__) || defined(__i386__) || \
+       defined(__aarch64__) || defined(__arm__) || \
+       defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) || defined(__POWERPC__))
 #if defined(__x86_64__) || defined(__i386__)
 static inline void mi_atomic_yield(void) {
   __asm__ volatile ("pause" ::: "memory");
@@ -357,7 +358,7 @@ static inline void mi_atomic_yield(void) {
 static inline void mi_atomic_yield(void) {
   __asm__ volatile ("nop" ::: "memory");
 }
-#endif  // __ARM_ARCH >= 7
+#endif
 #elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) || defined(__POWERPC__)
 #ifdef __APPLE__
 static inline void mi_atomic_yield(void) {

--- a/Include/internal/mimalloc/mimalloc/atomic.h
+++ b/Include/internal/mimalloc/mimalloc/atomic.h
@@ -338,7 +338,7 @@ static inline void mi_atomic_yield(void) {
   _mm_pause();
 }
 #elif (defined(__GNUC__) || defined(__clang__)) && \
-      (defined(__x86_64__) || defined(__i386__) || defined(__arm__) || defined(__armel__) || defined(__ARMEL__) || \
+      (defined(__x86_64__) || defined(__i386__) || defined(__arm__) || \
        defined(__aarch64__) || defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)) || defined(__POWERPC__)
 #if defined(__x86_64__) || defined(__i386__)
 static inline void mi_atomic_yield(void) {
@@ -348,10 +348,16 @@ static inline void mi_atomic_yield(void) {
 static inline void mi_atomic_yield(void) {
   __asm__ volatile("wfe");
 }
-#elif (defined(__arm__) && __ARM_ARCH__ >= 7)
+#elif defined(__arm__)
+#if __ARM_ARCH >= 7
 static inline void mi_atomic_yield(void) {
   __asm__ volatile("yield" ::: "memory");
 }
+#else
+static inline void mi_atomic_yield(void) {
+  __asm__ volatile ("nop" ::: "memory");
+}
+#endif  // __ARM_ARCH >= 7
 #elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) || defined(__POWERPC__)
 #ifdef __APPLE__
 static inline void mi_atomic_yield(void) {
@@ -362,10 +368,6 @@ static inline void mi_atomic_yield(void) {
   __asm__ __volatile__ ("or 27,27,27" ::: "memory");
 }
 #endif
-#elif defined(__armel__) || defined(__ARMEL__)
-static inline void mi_atomic_yield(void) {
-  __asm__ volatile ("nop" ::: "memory");
-}
 #endif
 #elif defined(__sun)
 // Fallback for other archs

--- a/Misc/NEWS.d/next/Build/2025-03-27-01-21-50.gh-issue-131675.l2zfOO.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-27-01-21-50.gh-issue-131675.l2zfOO.rst
@@ -1,1 +1,1 @@
-Fix mimalloc library builds for 32bit ARM targets
+Fix mimalloc library builds for 32-bit ARM targets.

--- a/Misc/NEWS.d/next/Build/2025-03-27-01-21-50.gh-issue-131675.l2zfOO.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-27-01-21-50.gh-issue-131675.l2zfOO.rst
@@ -1,0 +1,1 @@
+Fix mimalloc library builds for 32bit ARM targets


### PR DESCRIPTION
Previously, `mi_atomic_yield` for 32-bit ARM:

  * Used a non-standard `__ARM_ARCH__` macro to determine if the compiler was targeting ARMv7+ in order to emit a `yield` instruction, however it was often not defined so fell through to an `__ARMEL__` branch

  * Had a logic gap in the #ifdef where an `__arm__` target would be expected to emit `mi_atomic_yield` but there was no condition to define a function for big-endian targets

Now, the standard ACLE __ARM_ARCH macro [1] [2] is used which GCC and Clang support.

The branching logic for `__ARMEL__` has been removed so if the target architecture supports v7+ instructions, a `yield` is emitted, otherwise a `nop` is emitted. This covers both big and little endian scenarios.

[1]: https://arm-software.github.io/acle/main/acle.html#arm-architecture-level
[2]: https://arm-software.github.io/acle/main/acle.html#mapping-of-object-build-attributes-to-predefines

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-131675 -->
* Issue: gh-131675
<!-- /gh-issue-number -->
