### PR TITLE
GH-131296: fix clang-cl warning on Windows in socketmodule.h

### DIFF
--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -18,6 +18,10 @@
  */
 #ifdef AF_BTH
 # include <ws2bth.h>
+# ifdef __clang__
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wpragma-pack"
+# endif
 # include <pshpack1.h>
 
 /*
@@ -51,7 +55,10 @@ struct SOCKADDR_BTH_REDEF {
 
 };
 # include <poppack.h>
-#endif
+# ifdef __clang__
+#  pragma clang diagnostic pop
+# endif
+#endif /* AF_BTH */
 
 /* Windows 'supports' CMSG_LEN, but does not follow the POSIX standard
  * interface at all, so there is no point including the code that


### PR DESCRIPTION
I think this is a skip news?

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
