### PR TITLE
[3.13] Revert "gh-128231: Use `runcode()` return value for failing early (GH-129488) (#130513)"

### DIFF
--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -153,8 +153,6 @@ class Console(ABC):
 
 
 class InteractiveColoredConsole(code.InteractiveConsole):
-    STATEMENT_FAILED = object()
-
     def __init__(
         self,
         locals: dict[str, object] | None = None,
@@ -175,16 +173,6 @@ class InteractiveColoredConsole(code.InteractiveConsole):
                 colorize=self.can_colorize,
                 limit=traceback.BUILTIN_EXCEPTION_LIMIT)
         self.write(''.join(lines))
-
-    def runcode(self, code):
-        try:
-            exec(code, self.locals)
-        except SystemExit:
-            raise
-        except BaseException:
-            self.showtraceback()
-            return self.STATEMENT_FAILED
-        return None
 
     def runsource(self, source, filename="<input>", symbol="single"):
         try:
@@ -223,7 +211,5 @@ class InteractiveColoredConsole(code.InteractiveConsole):
             if code is None:
                 return True
 
-            result = self.runcode(code)
-            if result is self.STATEMENT_FAILED:
-                break
+            self.runcode(code)
         return False

--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -75,7 +75,7 @@ class AsyncIOInteractiveConsole(InteractiveColoredConsole):
                 self.write("\nKeyboardInterrupt\n")
             else:
                 self.showtraceback()
-            return self.STATEMENT_FAILED
+
 
 class REPLThread(threading.Thread):
 

--- a/Lib/test/test_pyrepl/test_interact.py
+++ b/Lib/test/test_pyrepl/test_interact.py
@@ -53,19 +53,6 @@ class TestSimpleInteract(unittest.TestCase):
         self.assertFalse(more)
         self.assertEqual(f.getvalue(), "1\n")
 
-    @force_not_colorized
-    def test_multiple_statements_fail_early(self):
-        console = InteractiveColoredConsole()
-        code = dedent("""\
-        raise Exception('foobar')
-        print('spam&eggs')
-        """)
-        f = io.StringIO()
-        with contextlib.redirect_stderr(f):
-            console.runsource(code)
-        self.assertIn('Exception: foobar', f.getvalue())
-        self.assertNotIn('spam&eggs', f.getvalue())
-
     def test_empty(self):
         namespace = {}
         code = ""

--- a/Lib/test/test_repl.py
+++ b/Lib/test/test_repl.py
@@ -294,15 +294,7 @@ class TestInteractiveModeSyntaxErrors(unittest.TestCase):
         self.assertEqual(traceback_lines, expected_lines)
 
 
-class TestAsyncioREPL(unittest.TestCase):
-    def test_multiple_statements_fail_early(self):
-        user_input = "1 / 0; print('afterwards')"
-        p = spawn_repl("-m", "asyncio")
-        p.stdin.write(user_input)
-        output = kill_python(p)
-        self.assertIn("ZeroDivisionError", output)
-        self.assertNotIn("afterwards", output)
-
+class TestAsyncioREPLContextVars(unittest.TestCase):
     def test_toplevel_contextvars_sync(self):
         user_input = dedent("""\
         from contextvars import ContextVar

--- a/Misc/NEWS.d/next/Library/2025-01-30-22-49-42.gh-issue-128231.SuEC18.rst
+++ b/Misc/NEWS.d/next/Library/2025-01-30-22-49-42.gh-issue-128231.SuEC18.rst
@@ -1,2 +1,0 @@
-Execution of multiple statements in the new REPL now stops immediately upon
-the first exception encountered. Patch by Bartosz Sławecki.


### PR DESCRIPTION
Re: https://github.com/python/cpython/pull/130513#issuecomment-2761188768

This reverts commit 8f6a9aa6aeb4fbbac186b7cb284f6301af5cbe36.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128231 -->
* Issue: gh-128231
<!-- /gh-issue-number -->
