### PR TITLE
gh-131423: Update to OpenSSL 3.0.16.

### DIFF
--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -208,7 +208,15 @@ def test_open(testfn):
             if not fn:
                 continue
             with assertRaises(RuntimeError):
-                fn(*args)
+                try:
+                    fn(*args)
+                except NotImplementedError:
+                    if fn == load_dh_params:
+                        # Not callable in some builds
+                        load_dh_params = None
+                        raise RuntimeError
+                    else:
+                        raise
 
     actual_mode = [(a[0], a[1]) for e, a in hook.seen if e == "open" and a[1]]
     actual_flag = [(a[0], a[2]) for e, a in hook.seen if e == "open" and not a[1]]

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -23,6 +23,7 @@ class AuditTest(unittest.TestCase):
         with subprocess.Popen(
             [sys.executable, "-X utf8", AUDIT_TESTS_PY, *args],
             encoding="utf-8",
+            errors="backslashreplace",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ) as p:

--- a/Misc/NEWS.d/next/Windows/2025-03-28-13-22-55.gh-issue-131423.vI-LqV.rst
+++ b/Misc/NEWS.d/next/Windows/2025-03-28-13-22-55.gh-issue-131423.vI-LqV.rst
@@ -1,0 +1,3 @@
+Update bundled version of OpenSSL to 3.0.16. The new build also disables
+uplink support, which may be relevant to embedders but has no impact on
+normal use.

--- a/Misc/externals.spdx.json
+++ b/Misc/externals.spdx.json
@@ -70,21 +70,21 @@
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "1550c87996a0858474a9dd179deab2c55eb73726b9a140b32865b02fd3d8a86b"
+          "checksumValue": "6bb739ecddbd2cfb6d255eb5898437a9b5739277dee931338d3275bac5d96ba2"
         }
       ],
-      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/openssl-3.0.15.tar.gz",
+      "downloadLocation": "https://github.com/python/cpython-source-deps/archive/refs/tags/openssl-3.0.16.tar.gz",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:openssl:openssl:3.0.15:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:openssl:openssl:3.0.16:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
       "licenseConcluded": "NOASSERTION",
       "name": "openssl",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "3.0.15"
+      "versionInfo": "3.0.16"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-sqlite",

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -73,6 +73,13 @@
 #  error "OPENSSL_THREADS is not defined, Python requires thread-safe OpenSSL"
 #endif
 
+#ifdef FORCE_ASSERTS
+#ifdef NDEBUG
+#undef NDEBUG
+#define _DEBUG
+#endif
+#include <assert.h>
+#endif /* FORCE_ASSERTS */
 
 
 struct py_ssl_error_code {
@@ -4426,6 +4433,12 @@ _ssl__SSLContext_load_dh_params_impl(PySSLContext *self, PyObject *filepath)
 {
     FILE *f;
     DH *dh;
+
+#if defined(MS_WINDOWS) && defined(_DEBUG)
+    PyErr_SetString(PyExc_RuntimeError,
+                    "unable to load_dh_params on Windows debug build");
+    return NULL;
+#endif
 
     f = Py_fopen(filepath, "rb");
     if (f == NULL)

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4428,8 +4428,8 @@ _ssl__SSLContext_load_dh_params_impl(PySSLContext *self, PyObject *filepath)
     DH *dh;
 
 #if defined(MS_WINDOWS) && defined(_DEBUG)
-    PyErr_SetString(PyExc_RuntimeError,
-                    "unable to load_dh_params on Windows debug build");
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "load_dh_params: unavailable on Windows debug build");
     return NULL;
 #endif
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -73,13 +73,6 @@
 #  error "OPENSSL_THREADS is not defined, Python requires thread-safe OpenSSL"
 #endif
 
-#ifdef FORCE_ASSERTS
-#ifdef NDEBUG
-#undef NDEBUG
-#define _DEBUG
-#endif
-#include <assert.h>
-#endif /* FORCE_ASSERTS */
 
 
 struct py_ssl_error_code {

--- a/Modules/_ssl/debughelpers.c
+++ b/Modules/_ssl/debughelpers.c
@@ -174,6 +174,13 @@ _PySSLContext_set_keylog_filename(PyObject *op, PyObject *arg,
 {
     PySSLContext *self = PySSLContext_CAST(op);
     FILE *fp;
+
+#if defined(MS_WINDOWS) && defined(_DEBUG)
+    PyErr_SetString(PyExc_RuntimeError,
+                    "unable to set_keylog_filename on Windows debug build");
+    return -1;
+#endif
+
     /* Reset variables and callback first */
     SSL_CTX_set_keylog_callback(self->ctx, NULL);
     Py_CLEAR(self->keylog_filename);

--- a/Modules/_ssl/debughelpers.c
+++ b/Modules/_ssl/debughelpers.c
@@ -176,8 +176,8 @@ _PySSLContext_set_keylog_filename(PyObject *op, PyObject *arg,
     FILE *fp;
 
 #if defined(MS_WINDOWS) && defined(_DEBUG)
-    PyErr_SetString(PyExc_RuntimeError,
-                    "unable to set_keylog_filename on Windows debug build");
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "set_keylog_filename: unavailable on Windows debug build");
     return -1;
 #endif
 

--- a/PCbuild/_ssl.vcxproj
+++ b/PCbuild/_ssl.vcxproj
@@ -99,9 +99,6 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Modules\_ssl.c" />
-    <ClCompile Include="$(opensslIncludeDir)\applink.c">
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;$(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\PC\python_nt.rc" />

--- a/PCbuild/_ssl.vcxproj.filters
+++ b/PCbuild/_ssl.vcxproj.filters
@@ -12,9 +12,6 @@
     <ClCompile Include="..\Modules\_ssl.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="$(opensslIncludeDir)\applink.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\PC\python_nt.rc">

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -53,7 +53,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.8
 if NOT "%IncludeLibffiSrc%"=="false" set libraries=%libraries%  libffi-3.4.4
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-3.0.15
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-3.0.16
 set libraries=%libraries%                                       mpdecimal-4.0.0
 set libraries=%libraries%                                       sqlite-3.45.3.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.15.0
@@ -77,7 +77,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeLibffi%"=="false"  set binaries=%binaries% libffi-3.4.4
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-3.0.15
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-3.0.16.1
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.15.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/openssl.vcxproj
+++ b/PCbuild/openssl.vcxproj
@@ -67,47 +67,23 @@
 set VCINSTALLDIR=$(VCInstallDir)
 if not exist "$(IntDir.TrimEnd('\'))" mkdir "$(IntDir.TrimEnd('\'))"
 cd /D "$(IntDir.TrimEnd('\'))"
-$(Perl) "$(opensslDir)\configure" $(OpenSSLPlatform) no-asm
+$(Perl) "$(opensslDir)\configure" $(OpenSSLPlatform) no-asm no-uplink
 nmake
 </NMakeBuildCommandLine>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 
-  <Target Name="_PatchUplink" BeforeTargets="Build">
-    <PropertyGroup>
-      <Uplink>$(opensslDir)\ms\uplink.c</Uplink>
-      <BeforePatch>((h = GetModuleHandle(NULL)) == NULL)</BeforePatch>
-      <AfterPatch>((h = GetModuleHandleA("_ssl.pyd")) == NULL) if ((h = GetModuleHandleA("_ssl_d.pyd")) == NULL) if ((h = GetModuleHandle(NULL)) == NULL /*patched*/)</AfterPatch>
-    </PropertyGroup>
-    <Error Text="Cannot find $(Uplink)" Condition="!Exists($(Uplink))" />
-    <PropertyGroup>
-      <_Original>$([System.IO.File]::ReadAllText($(Uplink)))</_Original>
-      <_Patched>$(_Original.Replace($(BeforePatch), $(AfterPatch)))</_Patched>
-      <IsPatched>false</IsPatched>
-      <IsPatched Condition="$(_Patched) == $(_Original)">true</IsPatched>
-    </PropertyGroup>
-    <Message Text="$(Uplink) is already patched" Importance="normal" Condition="$(IsPatched)" />
-    <Message Text="Patching $(Uplink)" Importance="high" Condition="!$(IsPatched)" />
-    <WriteLinesToFile File="$(Uplink)"
-                      Lines="$(_Patched)"
-                      Overwrite="true"
-                      Encoding="ASCII"
-                      Condition="!$(IsPatched)" />
-  </Target>
-
   <Target Name="_CopyToOutput" AfterTargets="Build">
     <ItemGroup>
       <_Built Include="$(opensslDir)\LICENSE" />
       <_Built Include="$(IntDir)\libcrypto.lib;$(IntDir)\libcrypto-*.dll;$(IntDir)\libcrypto-*.pdb" />
       <_Built Include="$(IntDir)\libssl.lib;$(IntDir)\libssl-*.dll;$(IntDir)\libssl-*.pdb" />
-      <_AppLink Include="$(opensslDir)\ms\applink.c" />
       <_Include Include="$(opensslDir)\Include\openssl\*.h" />
       <_Include Include="$(IntDir)\include\openssl\*.h" />
     </ItemGroup>
     <MakeDir Directories="$(opensslOutDir)\include\openssl" />
     <Copy SourceFiles="@(_Built)" DestinationFolder="$(opensslOutDir)" />
-    <Copy SourceFiles="@(_AppLink)" DestinationFolder="$(opensslOutDir)\include" />
     <Copy SourceFiles="@(_Include)" DestinationFolder="$(opensslOutDir)\include\openssl" />
   </Target>
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -81,8 +81,8 @@
     <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
     <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
     <mpdecimalDir Condition="$(mpdecimalDir) == ''">$(ExternalsDir)\mpdecimal-4.0.0\</mpdecimalDir>
-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.15\</opensslDir>
-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.15\$(ArchName)\</opensslOutDir>
+    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.16\</opensslDir>
+    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.16.1\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.3.1\</zlibDir>


### PR DESCRIPTION
The bin tag is 3.0.16.1 because we rebuilt without uplink support to fix gh-131804.
This PR also prevents making calls that are now unsafe without uplink, and updates the tests to property interpret these failures as unsupported.
The PCbuild/openssl.vcxproj project is updated, even though it is not used by our own builds.

<!-- gh-issue-number: gh-131423 -->
* Issue: gh-131423
<!-- /gh-issue-number -->
