### PR TITLE
GH-131770: increase assumed WASI stack size to 131072 (wasi-sdk default)

### DIFF
--- a/Lib/test/test_gettext.py
+++ b/Lib/test/test_gettext.py
@@ -485,6 +485,7 @@ class PluralFormsInternalTestCase(unittest.TestCase):
         s = ''.join([ str(f(x)) for x in range(200) ])
         eq(s, "01233333333444444444444444444444444444444444444444444444444444444444444444444444444444444444444444445553333333344444444444444444444444444444444444444444444444444444444444444444444444444444444444444444")
 
+    @support.skip_wasi_stack_overflow()
     def test_security(self):
         raises = self.assertRaises
         # Test for a dangerous expression

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2928,6 +2928,7 @@ while 1:
                     compile(source, "<string>", mode)
 
     @support.cpython_only
+    @support.skip_wasi_stack_overflow()
     def test_deep_invalid_rule(self):
         # Check that a very deep invalid rule in the PEG
         # parser doesn't have exponential backtracking.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -364,7 +364,7 @@ _Py_EnterRecursiveCallUnchecked(PyThreadState *tstate)
 #  define Py_C_STACK_SIZE 1600000
 #elif defined(__wasi__)
    /* Web assembly has two stacks, so this isn't really the stack depth */
-#  define Py_C_STACK_SIZE 80000
+#  define Py_C_STACK_SIZE 131072  // wasi-libc DEFAULT_STACK_SIZE
 #elif defined(__hppa__) || defined(__powerpc64__)
 #  define Py_C_STACK_SIZE 2000000
 #else


### PR DESCRIPTION
This fixes the parser stack overflow issues in the test suite source, at least, and makes it pass when using `--with-pydebug`.

https://github.com/WebAssembly/wasi-libc/blob/e9524a0980b9bb6bb92e87a41ed1055bdda5bb86/libc-top-half/musl/src/internal/pthread_impl.h#L220

<!-- gh-issue-number: gh-131770 -->
* Issue: gh-131770
<!-- /gh-issue-number -->
