### PR TITLE
gh-131860: Update bundled pip version to 24.0.

### DIFF
--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -12,7 +12,7 @@ from . import _bundled
 
 __all__ = ["version", "bootstrap"]
 _SETUPTOOLS_VERSION = "58.1.0"
-_PIP_VERSION = "23.0.1"
+_PIP_VERSION = "24.0"
 _PROJECTS = [
     ("setuptools", _SETUPTOOLS_VERSION, "py3"),
     ("pip", _PIP_VERSION, "py3"),


### PR DESCRIPTION
# gh-131860: Update bundled pip to address CVE-2023-5752

## Summary:
This PR updates the bundled version of pip in **CPython 3.9** to address **CVE-2023-5752**. The previous versions of pip included in these Python releases contained a security vulnerability that required users to manually update pip after creating a virtual environment.

## Changes made:
- Updated the bundled pip version in **CPython 3.9** to the latest secure release.

## Issue reference:
Closes [gh-131860](#131860) (Update pip to address CVE-2023-5752)