### PR TITLE
gh-131885: Updates docs to make max and min iterable param positional only

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1222,7 +1222,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. function:: max(iterable, /, *, key=None)
               max(iterable, /, *, default, key=None)
-              max(arg1, arg2, *args, key=None)
+              max(arg1, arg2, /, *args, key=None)
 
    Return the largest item in an iterable or the largest of two or more
    arguments.
@@ -1260,7 +1260,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. function:: min(iterable, /, *, key=None)
               min(iterable, /, *, default, key=None)
-              min(arg1, arg2, *args, key=None)
+              min(arg1, arg2, /, *args, key=None)
 
    Return the smallest item in an iterable or the smallest of two or more
    arguments.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1220,8 +1220,8 @@ are always available.  They are listed here in alphabetical order.
       Added the *strict* parameter.
 
 
-.. function:: max(iterable, *, key=None)
-              max(iterable, *, default, key=None)
+.. function:: max(iterable, /, *, key=None)
+              max(iterable, /, *, default, key=None)
               max(arg1, arg2, *args, key=None)
 
    Return the largest item in an iterable or the largest of two or more

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1259,7 +1259,7 @@ are always available.  They are listed here in alphabetical order.
 
 
 .. function:: min(iterable, /, *, key=None)
-              min(iterable, *, default, key=None)
+              min(iterable, /, *, default, key=None)
               min(arg1, arg2, *args, key=None)
 
    Return the smallest item in an iterable or the smallest of two or more

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1258,7 +1258,7 @@ are always available.  They are listed here in alphabetical order.
    :ref:`typememoryview` for more information.
 
 
-.. function:: min(iterable, *, key=None)
+.. function:: min(iterable, /, *, key=None)
               min(iterable, *, default, key=None)
               min(arg1, arg2, *args, key=None)
 

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2019,7 +2019,7 @@ builtin_min(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *k
 }
 
 PyDoc_STRVAR(min_doc,
-"min(iterable, *[, default=obj, key=func]) -> value\n\
+"min(iterable, /, *[, default=obj, key=func]) -> value\n\
 min(arg1, arg2, *args, *[, key=func]) -> value\n\
 \n\
 With a single iterable argument, return its smallest item. The\n\
@@ -2036,7 +2036,7 @@ builtin_max(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *k
 }
 
 PyDoc_STRVAR(max_doc,
-"max(iterable, *[, default=obj, key=func]) -> value\n\
+"max(iterable, /, *[, default=obj, key=func]) -> value\n\
 max(arg1, arg2, *args, *[, key=func]) -> value\n\
 \n\
 With a single iterable argument, return its biggest item. The\n\

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2019,7 +2019,7 @@ builtin_min(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *k
 }
 
 PyDoc_STRVAR(min_doc,
-"min(iterable, /, *[, default=obj, key=func]) -> value\n\
+"min(iterable, *[, default=obj, key=func]) -> value\n\
 min(arg1, arg2, *args, *[, key=func]) -> value\n\
 \n\
 With a single iterable argument, return its smallest item. The\n\
@@ -2036,7 +2036,7 @@ builtin_max(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *k
 }
 
 PyDoc_STRVAR(max_doc,
-"max(iterable, /, *[, default=obj, key=func]) -> value\n\
+"max(iterable, *[, default=obj, key=func]) -> value\n\
 max(arg1, arg2, *args, *[, key=func]) -> value\n\
 \n\
 With a single iterable argument, return its biggest item. The\n\


### PR DESCRIPTION
This PR updates the documentation of `max` and `min` to match their implementation like how `sorted`'s implementation matches it's documentation. 

Sorted's function definition in the documentation is as follows:

`sorted(iterable, /, *, key=None, reverse=False)`

When attempted to call with `iterable` as a keyword argument, the following occurs:

```
>>> sorted(iterable=[1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: sorted expected 1 argument, got 0
```

However, looking at the documentation for `max`:

`max(iterable, *, key=None)`

And comparing to their implementation:

```
>>> max(iterable=[1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: max expected at least 1 argument, got 0
```

The same follows for `min`

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131868.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-131885 -->
* Issue: gh-131885
<!-- /gh-issue-number -->
