### PR TITLE
Update cryptographic CODEOWNERS entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -107,12 +107,15 @@ Objects/exceptions.c          @iritkatriel
 # Hashing & cryptographic primitives
 **/*hashlib*                  @gpshead @tiran @picnixz
 **/*hashopenssl*              @gpshead @tiran @picnixz
-**/*pyhash*                   @gpshead @tiran
-**/sha*                       @gpshead @tiran @picnixz
-Modules/md5*                  @gpshead @tiran @picnixz
-**/*blake*                    @gpshead @tiran @picnixz
-Modules/_hacl/**              @gpshead
+**/*pyhash*                   @gpshead @tiran @picnixz
+Modules/*blake*               @gpshead @tiran @picnixz
+Modules/*md5*                 @gpshead @tiran @picnixz
+Modules/*sha*                 @gpshead @tiran @picnixz
+Modules/_hacl/**              @gpshead @picnixz
 **/*hmac*                     @gpshead @picnixz
+
+# libssl
+**/*ssl*                      @gpshead @picnixz
 
 # logging
 **/*logging*                  @vsajip

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1910,6 +1910,7 @@ Matias Torchinsky
 Sandro Tosi
 Richard Townsend
 David Townshend
+Bénédikt Tran
 Nathan Trapuzzano
 Laurence Tratt
 Alberto Trevino


### PR DESCRIPTION
I observed that I wasn't notified automatically when HACL* sources are touched so I'm adding myself to the codeowners.

Note that the `**/sha*` pattern also matched `Lib/multiprocessing/shared_memory.py`, but since Gregory is already an mp-expert, it was probably never noticed (and tiran is no more active). So I'm refining the pattern so that we're only picking up SHA-related files.

In addition, I'm adding an entry for SSL-related stuff (@gpshead I added you as well but feel free to edit the PR directly if you don't want to be notified for SSL-related changes). `**/*ssl*` picks up quite a lot of files but I think, possibly except for `Lib/asyncio/sslproto.py`, we should be considered code owners (or at least relevant people to tag when modifying such files):

```txt
Doc/library/ssl.rst
Lib/asyncio/sslproto.py
Lib/ssl.py
Lib/test/certdata/make_ssl_certs.py
Lib/test/certdata/ssl_cert.pem
Lib/test/certdata/ssl_key.passwd.pem
Lib/test/certdata/ssl_key.pem
Lib/test/ssl_servers.py
Lib/test/ssltests.py
Lib/test/test_asyncio/test_ssl.py
Lib/test/test_asyncio/test_sslproto.py
Lib/test/test_ssl.py
Misc/rhel7/openssl.pc
Modules/_hashopenssl.c
Modules/_ssl.c
Modules/_ssl.h
Modules/_ssl/cert.c
Modules/_ssl/clinic/cert.c.h
Modules/_ssl/debughelpers.c
Modules/_ssl/misc.c
Modules/_ssl_data_111.h
Modules/_ssl_data_300.h
Modules/_ssl_data_34.h
Modules/clinic/_hashopenssl.c.h
Modules/clinic/_ssl.c.h
PCbuild/_ssl.vcxproj
PCbuild/_ssl.vcxproj.filters
PCbuild/openssl.props
PCbuild/openssl.vcxproj
PCbuild/prepare_ssl.bat
PCbuild/prepare_ssl.py
Tools/ssl/make_ssl_data.py
Tools/ssl/multissltests.py
```

NB: I observed that I never added myself to ACKS, so I'm taking this commit as an opporunity as well.

NB2: the reason why we have `Modules/*sha*` and not `Modules/sha*` is to also be notified when clinic files are changed for whatever reasons (compare `git ls-files 'Modules/*sha*'` and `git ls-files 'Modules/sha*'`).