### PR TITLE
GH-131296: fix clang-cl parentheses warnings on Windows

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -6111,7 +6111,7 @@ _ssl_enum_certificates_impl(PyObject *module, const char *store_name)
         return PyErr_SetFromWindowsErr(GetLastError());
     }
 
-    while (pCertCtx = CertEnumCertificatesInStore(hCollectionStore, pCertCtx)) {
+    while ((pCertCtx = CertEnumCertificatesInStore(hCollectionStore, pCertCtx))) {
         cert = PyBytes_FromStringAndSize((const char*)pCertCtx->pbCertEncoded,
                                             pCertCtx->cbCertEncoded);
         if (!cert) {
@@ -6210,7 +6210,7 @@ _ssl_enum_crls_impl(PyObject *module, const char *store_name)
         return PyErr_SetFromWindowsErr(GetLastError());
     }
 
-    while (pCrlCtx = CertEnumCRLsInStore(hCollectionStore, pCrlCtx)) {
+    while ((pCrlCtx = CertEnumCRLsInStore(hCollectionStore, pCrlCtx))) {
         crl = PyBytes_FromStringAndSize((const char*)pCrlCtx->pbCrlEncoded,
                                             pCrlCtx->cbCrlEncoded);
         if (!crl) {

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5372,7 +5372,7 @@ _testFileExistsByName(LPCWSTR path, BOOL followLinks)
                                      sizeof(info)))
     {
         if (!(info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) ||
-            !followLinks && IsReparseTagNameSurrogate(info.ReparseTag))
+            (!followLinks && IsReparseTagNameSurrogate(info.ReparseTag)))
         {
             return TRUE;
         }

--- a/PC/launcher2.c
+++ b/PC/launcher2.c
@@ -2760,7 +2760,7 @@ process(int argc, wchar_t ** argv)
     // We searched earlier, so if we didn't find anything, now we react
     exitCode = searchExitCode;
     // If none found, and if permitted, install it
-    if (exitCode == RC_NO_PYTHON && isEnvVarSet(L"PYLAUNCHER_ALLOW_INSTALL") ||
+    if (((exitCode == RC_NO_PYTHON) && isEnvVarSet(L"PYLAUNCHER_ALLOW_INSTALL")) ||
         isEnvVarSet(L"PYLAUNCHER_ALWAYS_INSTALL")) {
         exitCode = installEnvironment(&search);
         if (!exitCode) {


### PR DESCRIPTION
I think this is a skip news?

This might seem unneeded, but in the Linux code base, the same warning levels are active, but do not fire.
IMHO, it is better to have these warnings active in the Windows code base, too, and fix them.

[Every mainstream compiler warns on this suspicious-looking code.](https://quuxplusone.github.io/blog/2020/09/02/wparentheses/#what-is-a-suppression-mechanism)

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
