### PR TITLE
GH-131296: fix clang-cl warnings on Windows in sqlite3

### DIFF
--- a/PCbuild/sqlite3.vcxproj
+++ b/PCbuild/sqlite3.vcxproj
@@ -100,6 +100,7 @@
       <AdditionalIncludeDirectories>$(sqlite3Dir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>SQLITE_ENABLE_MATH_FUNCTIONS;SQLITE_ENABLE_FTS4;SQLITE_ENABLE_FTS5;SQLITE_ENABLE_RTREE;SQLITE_OMIT_AUTOINIT;SQLITE_API=__declspec(dllexport);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level1</WarningLevel>
+      <AdditionalOptions Condition="$(PlatformToolset) == 'ClangCL'">%(AdditionalOptions) -Wno-unused</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>SQLITE_VERSION=$(SqliteVersion);SQLITE_MAJOR_VERSION=$(SqliteMajorVersion);SQLITE_MINOR_VERSION=$(SqliteMinorVersion);SQLITE_MICRO_VERSION=$(SqliteMicroVersion);SQLITE_PATCH_VERSION=$(SqlitePatchVersion);%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
This will fix three "unused warnings" in sqlite3:

```
sqlite3.c(33958,8): warning : variable 'bRc' set but not used [-Wunused-but-set-variable]
sqlite3.c(67016,9): warning : unused variable 'mExpect' [-Wunused-variable]
sqlite3.c(46795,35): warning : unused variable 'sqlite3_os_type' [-Wunused-variable]
```

I think this is a skip news?


<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
