### PR TITLE
gh-131878: Handle top level exceptions in new pyrepl and prevent of closing it

### DIFF
--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -159,7 +159,7 @@ def run_multiline_interactive_console(
             console.write("\nMemoryError\n")
             console.resetbuffer()
         except SystemExit:
-            break
+            raise
         except:
             console.showtraceback()
             console.resetbuffer()

--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -158,3 +158,8 @@ def run_multiline_interactive_console(
         except MemoryError:
             console.write("\nMemoryError\n")
             console.resetbuffer()
+        except SystemExit:
+            break
+        except:
+            console.showtraceback()
+            console.resetbuffer()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-03-30-19-58-14.gh-issue-131878.uxM26H.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-03-30-19-58-14.gh-issue-131878.uxM26H.rst
@@ -1,0 +1,1 @@
+Handle uncaught exceptions in the main input loop for the new REPL.


### PR DESCRIPTION
Working on gh-131878 I saw a code paths that swallows exceptions. I propose not to swallow them and bubble it up to main input loop and handle there.

