### PR TITLE
GH-131916: Add `pathlib.PurePath.segments`

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -298,6 +298,30 @@ property:
 
    (note how the drive and local root are regrouped in a single part)
 
+To access the arguments given to the path initializer, use the following
+property:
+
+.. attribute:: PurePath.segments
+
+   A tuple of giving access to the path's initializer arguments::
+
+      >>> p = PurePath('/usr', 'bin/python3')
+      >>> p.segments
+      ('/usr', 'bin/python3')
+
+      >>> p = PurePath('/usr', PurePath('bin', 'python3'))
+      >>> p.segments
+      ('/usr', 'bin', 'python3')
+
+   (note how nested path objects have their segments merged)
+
+   .. note::
+
+      Paths with different segments compare equal if their normalized string
+      representation is the same.
+
+   .. versionadded:: next
+
 
 Methods and properties
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -315,11 +315,6 @@ property:
 
    (note how nested path objects have their segments merged)
 
-   .. note::
-
-      Paths with different segments compare equal if their normalized string
-      representation is the same.
-
    .. versionadded:: next
 
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -812,6 +812,11 @@ os
 pathlib
 -------
 
+* Add :meth:`pathlib.PurePath.segments` attribute that stores the original
+  arguments given to the path object initializer.
+
+  (Contributed by Barney Gale in :gh:`131916`.)
+
 * Add methods to :class:`pathlib.Path` to recursively copy or move files and
   directories:
 

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -182,7 +182,7 @@ class PurePath:
             return NotImplemented
 
     def __reduce__(self):
-        return self.__class__, tuple(self._raw_paths)
+        return self.__class__, self.segments
 
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.as_posix())
@@ -328,19 +328,19 @@ class PurePath:
         return str(self).replace(self.parser.sep, '/')
 
     @property
+    def segments(self):
+        """Sequence of raw path segments supplied to the path initializer.
+        """
+        return tuple(self._raw_paths)
+
+    @property
     def _raw_path(self):
         paths = self._raw_paths
         if len(paths) == 1:
             return paths[0]
         elif paths:
-            # Join path segments from the initializer.
-            path = self.parser.join(*paths)
-            # Cache the joined path.
-            paths.clear()
-            paths.append(path)
-            return path
+            return self.parser.join(*paths)
         else:
-            paths.append('')
             return ''
 
     @property

--- a/Lib/test/test_pathlib/support/lexical_path.py
+++ b/Lib/test/test_pathlib/support/lexical_path.py
@@ -15,11 +15,11 @@ else:
 
 
 class LexicalPath(_JoinablePath):
-    __slots__ = ('_segments',)
+    __slots__ = ('segments',)
     parser = os.path
 
     def __init__(self, *pathsegments):
-        self._segments = pathsegments
+        self.segments = pathsegments
 
     def __hash__(self):
         return hash(str(self))
@@ -28,11 +28,6 @@ class LexicalPath(_JoinablePath):
         if not isinstance(other, LexicalPath):
             return NotImplemented
         return str(self) == str(other)
-
-    def __str__(self):
-        if not self._segments:
-            return ''
-        return self.parser.join(*self._segments)
 
     def __repr__(self):
         return f'{type(self).__name__}({str(self)!r})'

--- a/Lib/test/test_pathlib/support/zip_path.py
+++ b/Lib/test/test_pathlib/support/zip_path.py
@@ -230,11 +230,11 @@ class ReadableZipPath(_ReadablePath):
     Simple implementation of a ReadablePath class for .zip files.
     """
 
-    __slots__ = ('_segments', 'zip_file')
+    __slots__ = ('segments', 'zip_file')
     parser = posixpath
 
     def __init__(self, *pathsegments, zip_file):
-        self._segments = pathsegments
+        self.segments = pathsegments
         self.zip_file = zip_file
         if not isinstance(zip_file.filelist, ZipFileList):
             zip_file.filelist = ZipFileList(zip_file)
@@ -246,11 +246,6 @@ class ReadableZipPath(_ReadablePath):
         if not isinstance(other, ReadableZipPath):
             return NotImplemented
         return str(self) == str(other) and self.zip_file is other.zip_file
-
-    def __str__(self):
-        if not self._segments:
-            return ''
-        return self.parser.join(*self._segments)
 
     def __repr__(self):
         return f'{type(self).__name__}({str(self)!r}, zip_file={self.zip_file!r})'
@@ -293,11 +288,11 @@ class WritableZipPath(_WritablePath):
     Simple implementation of a WritablePath class for .zip files.
     """
 
-    __slots__ = ('_segments', 'zip_file')
+    __slots__ = ('segments', 'zip_file')
     parser = posixpath
 
     def __init__(self, *pathsegments, zip_file):
-        self._segments = pathsegments
+        self.segments = pathsegments
         self.zip_file = zip_file
 
     def __hash__(self):
@@ -307,11 +302,6 @@ class WritableZipPath(_WritablePath):
         if not isinstance(other, WritableZipPath):
             return NotImplemented
         return str(self) == str(other) and self.zip_file is other.zip_file
-
-    def __str__(self):
-        if not self._segments:
-            return ''
-        return self.parser.join(*self._segments)
 
     def __repr__(self):
         return f'{type(self).__name__}({str(self)!r}, zip_file={self.zip_file!r})'

--- a/Lib/test/test_pathlib/test_join.py
+++ b/Lib/test/test_pathlib/test_join.py
@@ -31,6 +31,14 @@ class JoinTestBase:
         P('a/b/c')
         P('/a/b/c')
 
+    def test_segments(self):
+        P = self.cls
+        self.assertEqual(P().segments, ())
+        self.assertEqual(P('a', 'b', 'c').segments, ('a', 'b', 'c'))
+        self.assertEqual(P('/a', 'b', 'c').segments, ('/a', 'b', 'c'))
+        self.assertEqual(P('a/b/c').segments, ('a/b/c',))
+        self.assertEqual(P('/a/b/c').segments, ('/a/b/c',))
+
     def test_with_segments(self):
         class P(self.cls):
             def __init__(self, *pathsegments, session_id):

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -256,6 +256,15 @@ class PurePathTest(unittest.TestCase):
         check('a/./.',    '', '', ['a'])
         check('/a/b',     '', sep, ['a', 'b'])
 
+    def test_segments_nested(self):
+        P = self.cls
+        P(FakePath("a/b/c"))
+        self.assertEqual(P(P('a')).segments, ('a',))
+        self.assertEqual(P(P('a'), 'b').segments, ('a', 'b'))
+        self.assertEqual(P(P('a'), P('b')).segments, ('a', 'b'))
+        self.assertEqual(P(P('a'), P('b'), P('c')).segments, ('a', 'b', 'c'))
+        self.assertEqual(P(P('./a:b')).segments, ('./a:b',))
+
     def test_empty_path(self):
         # The empty path points to '.'
         p = self.cls('')
@@ -1176,17 +1185,6 @@ class PathTest(PurePathTest):
                                                  dir=os.getcwd()))
         self.addCleanup(os_helper.rmtree, d)
         return d
-
-    def test_matches_writablepath_docstrings(self):
-        path_names = {name for name in dir(pathlib.types._WritablePath) if name[0] != '_'}
-        for attr_name in path_names:
-            if attr_name == 'parser':
-                # On Windows, Path.parser is ntpath, but WritablePath.parser is
-                # posixpath, and so their docstrings differ.
-                continue
-            our_attr = getattr(self.cls, attr_name)
-            path_attr = getattr(pathlib.types._WritablePath, attr_name)
-            self.assertEqual(our_attr.__doc__, path_attr.__doc__)
 
     def test_concrete_class(self):
         if self.cls is pathlib.Path:

--- a/Misc/NEWS.d/next/Library/2025-03-30-20-25-58.gh-issue-131916.p8bRiF.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-30-20-25-58.gh-issue-131916.p8bRiF.rst
@@ -1,0 +1,2 @@
+Add :attr:`pathlib.PurePath.segments`, which stores the flattened path
+segments given to the path object initializer.


### PR DESCRIPTION
Add `pathlib.PurePath.segments` attribute, which stores the flattened path segments given to the path object initializer.

In the pathlib ABCs, add `JoinablePath.segments` as an abstract attribute, and convert `JoinablePath.__str__()` from an abstract method to a mixin method that joins `self.segments`.


<!-- gh-issue-number: gh-131916 -->
* Issue: gh-131916
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--131917.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->