### PR TITLE
gh-131525: Remove `_HashedSeq` wrapper from `lru_cache`

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -516,22 +516,6 @@ def _unwrap_partialmethod(func):
 
 _CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
 
-class _HashedSeq(list):
-    """ This class guarantees that hash() will be called no more than once
-        per element.  This is important because the lru_cache() will hash
-        the key multiple times on a cache miss.
-
-    """
-
-    __slots__ = 'hashvalue'
-
-    def __init__(self, tup, hash=hash):
-        self[:] = tup
-        self.hashvalue = hash(tup)
-
-    def __hash__(self):
-        return self.hashvalue
-
 def _make_key(args, kwds, typed,
              kwd_mark = (object(),),
              fasttypes = {int, str},
@@ -561,7 +545,7 @@ def _make_key(args, kwds, typed,
             key += tuple(type(v) for v in kwds.values())
     elif len(key) == 1 and type(key[0]) in fasttypes:
         return key[0]
-    return _HashedSeq(key)
+    return key
 
 def lru_cache(maxsize=128, typed=False):
     """Least-recently-used cache decorator.


### PR DESCRIPTION
As suggested in https://github.com/python/cpython/issues/131525#issuecomment-2741817521 this PR removes `_HashedSeq` wrapper from the Python-only `functools.lru_cache` implementation.  Since tuple hashes are now cached (#131529) this wrapper is not needed anymore.

I ran some very quick benchmarks with the following ipython script to check whether this change has an impact on the performance:
```python
from functools import lru_cache

@lru_cache(maxsize=1)
def foo(a, b, c, d, e):
    pass

%%timeit
foo(1, 2, 3, 4, 5)
foo(1, 2, 3, 4, 6)
```

In this toy benchmark with trivial hashes this change removes some overhead

version | pre #131529 | `main`
---|---|---
C implementation | 137 ns ± 2.51 ns | 139 ns ± 0.682 ns
Python only | 1.23 μs ± 35.2 ns | 1.23 μs ± 6.91 ns
Python only no `_HashedSeq` (this PR) | 788 ns ± 2.49 ns | 777 ns ± 5.12 ns

In an example where hashes are artificially slow this change would've caused a regression before #131529 but now performs equally well (4.14 s without tuple hash cashing vs 1.03 s with hash caching).

```python
class SlowInt:
    def __init__(self, val) -> None:
        self.val = val

    def __hash__(self):
        time.sleep(0.1)
        return hash(self.val)

%%timeit
foo(SlowInt(1), SlowInt(2), SlowInt(3), SlowInt(4), SlowInt(5))
foo(SlowInt(1), SlowInt(2), SlowInt(3), SlowInt(4), SlowInt(6))
```

I don't think a news entry is necessary since this only affects the Python only implementation, but let me know if I should still add one.



<!-- gh-issue-number: gh-131525 -->
* Issue: gh-131525
<!-- /gh-issue-number -->
