### PR TITLE
gh-107369: Optimise ``textwrap.indent()``

### DIFF
--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -451,19 +451,20 @@ def indent(text, prefix, predicate=None):
     it will default to adding 'prefix' to all non-empty lines that do not
     consist solely of whitespace characters.
     """
-    if predicate is None:
-        # str.splitlines(True) doesn't produce empty string.
-        #  ''.splitlines(True) => []
-        #  'foo\n'.splitlines(True) => ['foo\n']
-        # So we can use just `not s.isspace()` here.
-        predicate = lambda s: not s.isspace()
-
     prefixed_lines = []
-    for line in text.splitlines(True):
-        if predicate(line):
-            prefixed_lines.append(prefix)
-        prefixed_lines.append(line)
-
+    if predicate is None:
+        # str.splitlines(keepends=True) doesn't produce the empty string,
+        # so we need to use `str.isspace()` rather than a truth test.
+        # Inlining the predicate leads to a ~30% performance improvement.
+        for line in text.splitlines(True):
+            if not line.isspace():
+                prefixed_lines.append(prefix)
+            prefixed_lines.append(line)
+    else:
+        for line in text.splitlines(True):
+            if predicate(line):
+                prefixed_lines.append(prefix)
+            prefixed_lines.append(line)
     return ''.join(prefixed_lines)
 
 

--- a/Misc/NEWS.d/next/Library/2025-03-31-02-06-57.gh-issue-107369.8M-HVz.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-31-02-06-57.gh-issue-107369.8M-HVz.rst
@@ -1,0 +1,2 @@
+Improved performance of :func:`textwrap.dedent` by an average of ~1.3x.
+Patch by Adam Turner.


### PR DESCRIPTION
Follow-up to #131919, I noticed there was opportunity for improvement here too, a ~30% speed-up.

| Benchmark | textwrap        | new                   |
|-----------|:---------------:|:---------------------:|
| indent    | 3.59 ms         | 2.81 ms: 1.28x faster |

Benchmarked by indenting the contents of `Objects/unicodeobject.c`.

A

<!-- gh-issue-number: gh-107369 -->
* Issue: gh-107369
<!-- /gh-issue-number -->
