### PR TITLE
gh-130167: Minor `textwrap.dedent()` optimization

### DIFF
--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -432,26 +432,28 @@ def dedent(text):
     lines = text.split('\n')
 
     # Get length of leading whitespace, inspired by ``os.path.commonprefix()``.
-    l1 = None
-    l2 = None
+    val = False
     for i, line in enumerate(lines):
         # Compute min + max concurrently + normalize others
         if line and not line.isspace():
-            if l1 is None or line < l1:
-                l1 = line
-            if l2 is None or line > l2:
-                l2 = line
+            if val:
+                if line < l1:
+                    l1 = line
+                elif line > l2:
+                    l2 = line
+            else:
+               val = True
+               l1 = l2 = line 
+                
         else:
             lines[i] = ''
     
-    if l1 is None:
-        l1 = ''
+    if not val or not l1:
+        return '\n'.join(lines)
     
     for margin, c in enumerate(l1):
         if c != l2[margin] or c not in ' \t':
             break
-    else:
-        return '\n'.join(lines)
 
     return '\n'.join([line[margin:] for line in lines])
 

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -432,15 +432,28 @@ def dedent(text):
     lines = text.split('\n')
 
     # Get length of leading whitespace, inspired by ``os.path.commonprefix()``.
-    non_blank_lines = [l for l in lines if l and not l.isspace()]
-    l1 = min(non_blank_lines, default='')
-    l2 = max(non_blank_lines, default='')
-    margin = 0
+    l1 = None
+    l2 = None
+    for i, line in enumerate(lines):
+        # Compute min + max concurrently + normalize others
+        if line and not line.isspace():
+            if l1 is None or line < l1:
+                l1 = line
+            if l2 is None or line > l2:
+                l2 = line
+        else:
+            lines[i] = ''
+    
+    if l1 is None:
+        l1 = ''
+    
     for margin, c in enumerate(l1):
         if c != l2[margin] or c not in ' \t':
             break
+    else:
+        return '\n'.join(lines)
 
-    return '\n'.join([l[margin:] if not l.isspace() else '' for l in lines])
+    return '\n'.join([line[margin:] for line in lines])
 
 
 def indent(text, prefix, predicate=None):


### PR DESCRIPTION
Minor optimization to @AA-Turner  https://github.com/python/cpython/pull/131792 where you compute the min and max of the non_blank_lines simultaneously, removes additional use of `line.isspace()` as well.

| Benchmark                                   | raw     | new                   |
|---------------------------------------------|:-------:|:---------------------:|
| raw_text: "abc  \t"                         | 2.91 ms | 3.33 ms: 1.15x slower |
| raw_text: "    "                            | 4.31 ms | 4.17 ms: 1.03x faster |
| raw_text: " \t  abc"                        | 4.04 ms | 4.40 ms: 1.09x slower |
| raw_text: " \t  abc  \t  "                  | 4.08 ms | 4.40 ms: 1.08x slower |
| raw_text: 1000 spaces                       | 34.9 ms | 27.9 ms: 1.25x faster |
| Basic indented text with empty lines        | 1.88 us | 1.82 us: 1.03x faster |
| Text with mixed indentation and blank lines | 1.85 us | 1.79 us: 1.03x faster |
| No indentation (edge case)                  | 1.24 us | 1.14 us: 1.09x faster |
| Only blank lines                            | 958 ns  | 641 ns: 1.49x faster  |
| Edge case: No common prefix to remove       | 1.09 us | 993 ns: 1.10x faster  |
| Edge case: Single indented line             | 998 ns  | 855 ns: 1.17x faster  |
| Edge case: Single indented line only        | 631 ns  | 432 ns: 1.46x faster  |
| Edge case: Empty text                       | 89.3 ns | 81.0 ns: 1.10x faster |
| no_indent                                   | 2.57 us | 2.50 us: 1.03x faster |
| mixed                                       | 10.4 us | 10.9 us: 1.05x slower |
| large_text                                  | 77.7 us | 85.7 us: 1.10x slower |
| whitespace_only                             | 859 ns  | 599 ns: 1.43x faster  |
| Geometric mean                              | (ref)   | 1.08x faster          |

<!-- gh-issue-number: gh-130167 -->
* Issue: gh-130167
<!-- /gh-issue-number -->
