### PR TITLE
Fix PEP number in `ast_opt.c` for new `finally` check

### DIFF
--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -21,7 +21,7 @@ typedef struct {
     int ff_features;
     int syntax_check_only;
 
-    _Py_c_array_t cf_finally;       /* context for PEP 678 check */
+    _Py_c_array_t cf_finally;       /* context for PEP 765 check */
     int cf_finally_used;
 } _PyASTOptimizeState;
 


### PR DESCRIPTION
Saw a small typo while reading the source code, but it is quite important one: because this is a PEP number, which can confuse people.

- https://peps.python.org/pep-0678/
- https://peps.python.org/pep-0765/