### PR TITLE
gh-131936: Relax assertion in `_Py_CalculateSuggestions` 

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4629,6 +4629,8 @@ class MiscTest(unittest.TestCase):
         # gh-131936: _Py_CalculateSuggestions wanted exactly a list
         class MyList(list):
             def __getitem__(self, *_):
+                # _Py_CalculateSuggestions uses the list macros, so this
+                # shouldn't be a problem.
                 raise RuntimeError("evil")
 
         self.assertEqual(_suggestions._generate_suggestions(MyList(["spanish", "inquisition"]), "spani"),

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4621,10 +4621,20 @@ class MiscTest(unittest.TestCase):
         # Check that the C extension is available
         import _suggestions
 
-        self.assertEqual(_suggestions._generate_suggestions(["hello", "world"], "hell"),
-                         "hello")
-        self.assertEqual(_suggestions._generate_suggestions(["hovercraft"], "eels"),
-                         None)
+        self.assertEqual(
+            _suggestions._generate_suggestions(
+                ["hello", "world"],
+                "hell"
+            ),
+            "hello"
+        )
+        self.assertEqual(
+            _suggestions._generate_suggestions(
+                ["hovercraft"],
+                "eels"
+            ),
+            None
+        )
 
         # gh-131936: _Py_CalculateSuggestions wanted exactly a list
         class MyList(list):
@@ -4633,8 +4643,13 @@ class MiscTest(unittest.TestCase):
                 # shouldn't be a problem.
                 raise RuntimeError("evil")
 
-        self.assertEqual(_suggestions._generate_suggestions(MyList(["spanish", "inquisition"]), "spani"),
-                         "spanish")
+        self.assertEqual(
+            _suggestions._generate_suggestions(
+                MyList(["spanish", "inquisition"]),
+                "spani"
+            ),
+            "spanish"
+        )
 
 
 class TestColorizedTraceback(unittest.TestCase):

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4619,7 +4619,20 @@ class MiscTest(unittest.TestCase):
     @cpython_only
     def test_suggestions_extension(self):
         # Check that the C extension is available
-        import _suggestions  # noqa: F401
+        import _suggestions
+
+        self.assertEqual(_suggestions._generate_suggestions(["hello", "world"], "hell"),
+                         "hello")
+        self.assertEqual(_suggestions._generate_suggestions(["hovercraft"], "eels"),
+                         None)
+
+        # gh-131936: _Py_CalculateSuggestions wanted exactly a list
+        class MyList(list):
+            def __getitem__(self, *_):
+                raise RuntimeError("evil")
+
+        self.assertEqual(_suggestions._generate_suggestions(MyList(["spanish", "inquisition"]), "spani"),
+                         "spanish")
 
 
 class TestColorizedTraceback(unittest.TestCase):

--- a/Python/suggestions.c
+++ b/Python/suggestions.c
@@ -129,7 +129,7 @@ _Py_CalculateSuggestions(PyObject *dir,
                       PyObject *name)
 {
     assert(!PyErr_Occurred());
-    assert(PyList_CheckExact(dir));
+    assert(PyList_Check(dir));
 
     Py_ssize_t dir_size = PyList_GET_SIZE(dir);
     if (dir_size >= MAX_CANDIDATE_ITEMS) {


### PR DESCRIPTION
Another option is to validate that `_generate_suggestions` is given exactly a list, but I don't see why we should require that. I'm not adding a blurb entry because `_generate_suggestions` is solely internal.

<!-- gh-issue-number: gh-131936 -->
* Issue: gh-131936
<!-- /gh-issue-number -->
