### PR TITLE
gh-105499: typing: Remove an unused function

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -363,18 +363,6 @@ def _deduplicate_unhashable(unhashable_params):
             new_unhashable.append(t)
     return new_unhashable
 
-def _compare_args_orderless(first_args, second_args):
-    first_unhashable = _deduplicate_unhashable(first_args)
-    second_unhashable = _deduplicate_unhashable(second_args)
-    t = list(second_unhashable)
-    try:
-        for elem in first_unhashable:
-            t.remove(elem)
-    except ValueError:
-        return False
-    return not t
-
-
 def _flatten_literal_params(parameters):
     """Internal helper for Literal creation: flatten Literals among parameters."""
     params = []

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -354,14 +354,11 @@ def _deduplicate(params, *, unhashable_fallback=False):
         if not unhashable_fallback:
             raise
         # Happens for cases like `Annotated[dict, {'x': IntValidator()}]`
-        return _deduplicate_unhashable(params)
-
-def _deduplicate_unhashable(unhashable_params):
-    new_unhashable = []
-    for t in unhashable_params:
-        if t not in new_unhashable:
-            new_unhashable.append(t)
-    return new_unhashable
+        new_unhashable = []
+        for t in params:
+            if t not in new_unhashable:
+                new_unhashable.append(t)
+        return new_unhashable
 
 def _flatten_literal_params(parameters):
     """Internal helper for Literal creation: flatten Literals among parameters."""

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -29,12 +29,7 @@ import functools
 import operator
 import sys
 import types
-from types import (
-    WrapperDescriptorType,
-    MethodWrapperType,
-    MethodDescriptorType,
-    GenericAlias,
-)
+from types import GenericAlias
 import warnings
 
 from _typing import (


### PR DESCRIPTION
Leftover from #105511 I believe. GitHub code search found no usages other
than copies of typing.py and lists of stdlib functions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
