### PR TITLE
gh-131955: Allow to disable internal string key caching for json.loads()

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -260,7 +260,7 @@ Basic Usage
 
 .. function:: load(fp, *, cls=None, object_hook=None, parse_float=None, \
                    parse_int=None, parse_constant=None, \
-                   object_pairs_hook=None, **kw)
+                   object_pairs_hook=None, cache_keys=True, **kw)
 
    Deserialize *fp* to a Python object
    using the :ref:`JSON-to-Python conversion table <json-to-py-table>`.
@@ -321,6 +321,11 @@ Basic Usage
       Default ``None``.
    :type parse_constant: :term:`callable` | None
 
+   :param bool cache_keys:
+      If set, then repeated keys will be re-used across dictionaries, leading
+      to lower memory usage, but worse performance.
+      Default ``True``.
+
    :raises JSONDecodeError:
       When the data being deserialized is not a valid JSON document.
 
@@ -345,7 +350,11 @@ Basic Usage
       conversion length limitation <int_max_str_digits>` to help avoid denial
       of service attacks.
 
-.. function:: loads(s, *, cls=None, object_hook=None, parse_float=None, parse_int=None, parse_constant=None, object_pairs_hook=None, **kw)
+   .. versionchanged:: next
+
+      * Added the optional *cache_keys* parameter.
+
+.. function:: loads(s, *, cls=None, object_hook=None, parse_float=None, parse_int=None, parse_constant=None, object_pairs_hook=None, cache_keys=True, **kw)
 
    Identical to :func:`load`, but instead of a file-like object,
    deserialize *s* (a :class:`str`, :class:`bytes` or :class:`bytearray`

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -272,7 +272,8 @@ def detect_encoding(b):
 
 
 def load(fp, *, cls=None, object_hook=None, parse_float=None,
-        parse_int=None, parse_constant=None, object_pairs_hook=None, **kw):
+        parse_int=None, parse_constant=None, object_pairs_hook=None,
+        cache_keys=True, **kw):
     """Deserialize ``fp`` (a ``.read()``-supporting file-like object containing
     a JSON document) to a Python object.
 
@@ -293,11 +294,13 @@ def load(fp, *, cls=None, object_hook=None, parse_float=None,
     return loads(fp.read(),
         cls=cls, object_hook=object_hook,
         parse_float=parse_float, parse_int=parse_int,
-        parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
+        parse_constant=parse_constant, object_pairs_hook=object_pairs_hook,
+        cache_keys=cache_keys, **kw)
 
 
 def loads(s, *, cls=None, object_hook=None, parse_float=None,
-        parse_int=None, parse_constant=None, object_pairs_hook=None, **kw):
+        parse_int=None, parse_constant=None, object_pairs_hook=None,
+        cache_keys=True, **kw):
     """Deserialize ``s`` (a ``str``, ``bytes`` or ``bytearray`` instance
     containing a JSON document) to a Python object.
 
@@ -326,6 +329,9 @@ def loads(s, *, cls=None, object_hook=None, parse_float=None,
     following strings: -Infinity, Infinity, NaN.
     This can be used to raise an exception if invalid JSON numbers
     are encountered.
+
+    if ``cache_keys`` is true, then repeated keys will be re-used across
+    dictionaries, leading to lower memory usage, but worse performance.
 
     To use a custom ``JSONDecoder`` subclass, specify it with the ``cls``
     kwarg; otherwise ``JSONDecoder`` is used.
@@ -356,4 +362,6 @@ def loads(s, *, cls=None, object_hook=None, parse_float=None,
         kw['parse_int'] = parse_int
     if parse_constant is not None:
         kw['parse_constant'] = parse_constant
+    if not cache_keys:
+        kw['cache_keys'] = cache_keys
     return cls(**kw).decode(s)

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -348,7 +348,8 @@ def loads(s, *, cls=None, object_hook=None, parse_float=None,
 
     if (cls is None and object_hook is None and
             parse_int is None and parse_float is None and
-            parse_constant is None and object_pairs_hook is None and not kw):
+            parse_constant is None and object_pairs_hook is None and
+            cache_keys and not kw):
         return _default_decoder.decode(s)
     if cls is None:
         cls = JSONDecoder

--- a/Lib/json/scanner.py
+++ b/Lib/json/scanner.py
@@ -18,6 +18,7 @@ def py_make_scanner(context):
     parse_string = context.parse_string
     match_number = NUMBER_RE.match
     strict = context.strict
+    cache_keys = context.cache_keys
     parse_float = context.parse_float
     parse_int = context.parse_int
     parse_constant = context.parse_constant
@@ -35,7 +36,7 @@ def py_make_scanner(context):
             return parse_string(string, idx + 1, strict)
         elif nextchar == '{':
             return parse_object((string, idx + 1), strict,
-                _scan_once, object_hook, object_pairs_hook, memo)
+                _scan_once, object_hook, object_pairs_hook, memo, cache_keys)
         elif nextchar == '[':
             return parse_array((string, idx + 1), _scan_once)
         elif nextchar == 'n' and string[idx:idx + 4] == 'null':

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -1,6 +1,7 @@
 import decimal
 from io import StringIO
 from collections import OrderedDict
+from functools import partial
 from test.test_json import PyTest, CTest
 from test import support
 
@@ -87,6 +88,19 @@ class TestDecode:
         self.check_keys_reuse(s, self.loads)
         decoder = self.json.decoder.JSONDecoder()
         self.check_keys_reuse(s, decoder.decode)
+        self.assertFalse(decoder.memo)
+
+    def check_no_keys_reuse(self, source, loads):
+        rval = loads(source)
+        (a, b), (c, d) = sorted(rval[0]), sorted(rval[1])
+        self.assertIsNot(a, c)
+        self.assertIsNot(b, d)
+
+    def test_no_keys_reuse(self):
+        s = '[{"a_key": 1, "b_\xe9": 2}, {"a_key": 3, "b_\xe9": 4}]'
+        self.check_no_keys_reuse(s, partial(self.loads, cache_keys=False))
+        decoder = self.json.decoder.JSONDecoder(cache_keys=False)
+        self.check_no_keys_reuse(s, decoder.decode)
         self.assertFalse(decoder.memo)
 
     def test_extra_data(self):

--- a/Misc/NEWS.d/next/Library/2025-04-01-07-18-10.gh-issue-131955.o-v72F.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-01-07-18-10.gh-issue-131955.o-v72F.rst
@@ -1,0 +1,1 @@
+Allow to disable internal string key caching for :func:`json.loads`.


### PR DESCRIPTION
### Benchmark:

<details><summary>script</summary>

```python
#mysys.py
import sys

def _getsizeof(obj, seen=None):
    if (obj_id := id(obj)) in seen:
        return 0
    size = sys.getsizeof(obj)
    seen.add(obj_id)
    if isinstance(obj, dict):
        size += sum([_getsizeof(k, seen) + _getsizeof(v, seen) for k, v in obj.items()])
    elif isinstance(obj, list):
        size += sum(_getsizeof(v, seen) for v in obj)
    return size

def getsizeof(obj):
    size = _getsizeof(obj, set())
    for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
        if size < 1024:
            break
        size /= 1024
    return f"{size:.2f} {unit}"
```

```bat
::json_cache_keys.bat
@echo off
echo 100 repeated keys
call main\python            -m timeit -s "import json; s = json.dumps([{'abc': 0}] * 100)" "json.loads(s)"
call json_cache_keys\python -m timeit -s "import json; s = json.dumps([{'abc': 0}] * 100)" "json.loads(s, cache_keys=False)"
echo 10,000 repeated keys
call main\python            -m timeit -s "import json; s = json.dumps([{'abc': 0}] * 10_000)" "json.loads(s)"
call json_cache_keys\python -m timeit -s "import json; s = json.dumps([{'abc': 0}] * 10_000)" "json.loads(s, cache_keys=False)"
echo 1,000,000 repeated keys
call main\python            -m timeit -s "import json; s = json.dumps([{'abc': 0}] * 1_000_000)" "json.loads(s)"
call json_cache_keys\python -m timeit -s "import json; s = json.dumps([{'abc': 0}] * 1_000_000)" "json.loads(s, cache_keys=False)"

echo 100 different keys
call main\python            -m timeit -s "import json; s = json.dumps([{str(i): 0} for i in range(100)])" "json.loads(s)"
call json_cache_keys\python -m timeit -s "import json; s = json.dumps([{str(i): 0} for i in range(100)])" "json.loads(s, cache_keys=False)"
echo 10,000 different keys
call main\python            -m timeit -s "import json; s = json.dumps([{str(i): 0} for i in range(10_000)])" "json.loads(s)"
call json_cache_keys\python -m timeit -s "import json; s = json.dumps([{str(i): 0} for i in range(10_000)])" "json.loads(s, cache_keys=False)"
echo 1,000,000 different keys
call main\python            -m timeit -s "import json; s = json.dumps([{str(i): 0} for i in range(1_000_000)])" "json.loads(s)"
call json_cache_keys\python -m timeit -s "import json; s = json.dumps([{str(i): 0} for i in range(1_000_000)])" "json.loads(s, cache_keys=False)"

echo ### memory ###

echo 100 repeated keys
call main\python            -c "import json, mysys; print(mysys.getsizeof(json.loads(json.dumps([{'abc': 0}] * 100))))"
call json_cache_keys\python -c "import json, mysys; print(mysys.getsizeof(json.loads(json.dumps([{'abc': 0}] * 100), cache_keys=False)))"
echo 10,000 repeated keys
call main\python            -c "import json, mysys; print(mysys.getsizeof(json.loads(json.dumps([{'abc': 0}] * 10_000))))"
call json_cache_keys\python -c "import json, mysys; print(mysys.getsizeof(json.loads(json.dumps([{'abc': 0}] * 10_000), cache_keys=False)))"
echo 1,000,000 repeated keys
call main\python            -c "import json, mysys; print(mysys.getsizeof(json.loads(json.dumps([{'abc': 0}] * 1_000_000))))"
call json_cache_keys\python -c "import json, mysys; print(mysys.getsizeof(json.loads(json.dumps([{'abc': 0}] * 1_000_000), cache_keys=False)))"
```
</details>

```none
100 repeated keys
10000 loops, best of 5: 25.5 usec per loop # before
10000 loops, best of 5: 26.3 usec per loop # after
# -> 1.03x faster (no difference)
10,000 repeated keys
100 loops, best of 5: 2.56 msec per loop # before
100 loops, best of 5: 2.3 msec per loop # after
# -> 1.11x faster
1,000,000 repeated keys
1 loop, best of 5: 359 msec per loop # before
1 loop, best of 5: 385 msec per loop # after
# -> 1.07x SLOWER

100 different keys
10000 loops, best of 5: 27.8 usec per loop # before
10000 loops, best of 5: 26.4 usec per loop # after
# -> 1.05x faster
10,000 different keys
100 loops, best of 5: 2.93 msec per loop # before
100 loops, best of 5: 2.33 msec per loop # after
# -> 1.26x faster
1,000,000 different keys
1 loop, best of 5: 676 msec per loop # before
1 loop, best of 5: 392 msec per loop # after
# -> 1.72x faster

### memory ###

100 repeated keys
18.94 KB # before
23.19 KB # after
# -> 1.22x more memory
10,000 repeated keys
1.84 MB # before
2.26 MB # after
# -> 1.23x more memory
1,000,000 repeated keys
183.53 MB # before
225.50 MB # after
# -> 1.23x more memory
```

<!-- gh-issue-number: gh-131955 -->
* Issue: gh-131955
<!-- /gh-issue-number -->
