### PR TITLE
[3.10] gh-127257: ssl: Raise OSError for ERR_LIB_SYS (GH-127361) (GH-127905)

### DIFF
--- a/Misc/NEWS.d/next/Library/2024-11-28-14-14-46.gh-issue-127257.n6-jU9.rst
+++ b/Misc/NEWS.d/next/Library/2024-11-28-14-14-46.gh-issue-127257.n6-jU9.rst
@@ -1,0 +1,2 @@
+In :mod:`ssl`, system call failures that OpenSSL reports using
+``ERR_LIB_SYS`` are now raised as :exc:`OSError`.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -656,6 +656,11 @@ PySSL_SetError(PySSLSocket *sslsock, int ret, const char *filename, int lineno)
                     errstr = "Some I/O error occurred";
                 }
             } else {
+                if (ERR_GET_LIB(e) == ERR_LIB_SYS) {
+                    // A system error is being reported; reason is set to errno
+                    errno = ERR_GET_REASON(e);
+                    return PyErr_SetFromErrno(PyExc_OSError);
+                }
                 p = PY_SSL_ERROR_SYSCALL;
             }
             break;
@@ -681,6 +686,11 @@ PySSL_SetError(PySSLSocket *sslsock, int ret, const char *filename, int lineno)
                 errstr = "EOF occurred in violation of protocol";
             }
 #endif
+            if (ERR_GET_LIB(e) == ERR_LIB_SYS) {
+                // A system error is being reported; reason is set to errno
+                errno = ERR_GET_REASON(e);
+                return PyErr_SetFromErrno(PyExc_OSError);
+            }
             break;
         }
         default:


### PR DESCRIPTION
gh-127257: ssl: Raise OSError for ERR_LIB_SYS (GH-127361)

From the ERR_raise manpage:

    ERR_LIB_SYS

        This "library code" indicates that a system error is
        being reported.  In this case, the reason code given
        to `ERR_raise()` and `ERR_raise_data()` *must* be
        `errno(3)`.

This PR only handles ERR_LIB_SYS for the high-lever error types SSL_ERROR_SYSCALL and SSL_ERROR_SSL, i.e., not the ones where OpenSSL indicates it has some more information about the issue. (cherry picked from commit f4b31edf2d9d72878dab1f66a36913b5bcc848ec)

Co-authored-by: Petr Viktorin <encukou@gmail.com>
(cherry picked from commit 7f707fa6c67d0bfa9bbc1a9f344b932789659397)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
