### PR TITLE
gh-131974: Fix usages of `locked_deref` in `ctypes`

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-04-01-09-20-32.gh-issue-131974.AIzshA.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-01-09-20-32.gh-issue-131974.AIzshA.rst
@@ -1,0 +1,2 @@
+Fix several thread-safety issues in :mod:`ctypes` on the :term:`free
+threaded <free threading>` build.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5686,7 +5686,7 @@ Pointer_subscript(PyObject *myself, PyObject *item)
             if (step == 1) {
                 PyObject *res;
                 LOCK_PTR(self);
-                wchar_t *ptr = *(void **)self;
+                wchar_t *ptr = *(wchar_t **)self->b_ptr;
                 res = PyUnicode_FromWideChar(ptr + start,
                                              len);
                 UNLOCK_PTR(self);
@@ -5696,7 +5696,7 @@ Pointer_subscript(PyObject *myself, PyObject *item)
             if (dest == NULL)
                 return PyErr_NoMemory();
             LOCK_PTR(self);
-            wchar_t *ptr = *(void **)self;
+            wchar_t *ptr = *(wchar_t **)self->b_ptr;
             for (cur = start, i = 0; i < len; cur += step, i++) {
                 dest[i] = ptr[cur];
             }

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5558,9 +5558,7 @@ static int
 copy_pointer_to_list_lock_held(PyObject *myself, PyObject *np, Py_ssize_t len,
                                Py_ssize_t start, Py_ssize_t step)
 {
-    Py_ssize_t i;
-    size_t cur;
-    for (cur = start, i = 0; i < len; cur += step, i++) {
+    for (size_t cur = start, Py_ssize_t i = 0; i < len; cur += step, i++) {
         PyObject *v = Pointer_item_lock_held(myself, cur);
         if (!v) {
             return -1;

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5555,9 +5555,10 @@ Pointer_new(PyTypeObject *type, PyObject *args, PyObject *kw)
 }
 
 static int
-copy_pointer_to_list_lock_held(PyObject *myself, PyObject *np, Py_ssize_t start, Py_ssize_t step)
+copy_pointer_to_list_lock_held(PyObject *myself, PyObject *np, Py_ssize_t len,
+                               Py_ssize_t start, Py_ssize_t step)
 {
-    Py_ssize_t i, len;
+    Py_ssize_t i;
     size_t cur;
     for (cur = start, i = 0; i < len; cur += step, i++) {
         PyObject *v = Pointer_item_lock_held(myself, cur);
@@ -5711,7 +5712,7 @@ Pointer_subscript(PyObject *myself, PyObject *item)
 
         int res;
         LOCK_PTR(self);
-        res = copy_pointer_to_list_lock_held(myself, np, start, step);
+        res = copy_pointer_to_list_lock_held(myself, np, len, start, step);
         UNLOCK_PTR(self);
         if (res < 0) {
             Py_DECREF(np);

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5558,7 +5558,9 @@ static int
 copy_pointer_to_list_lock_held(PyObject *myself, PyObject *np, Py_ssize_t len,
                                Py_ssize_t start, Py_ssize_t step)
 {
-    for (size_t cur = start, Py_ssize_t i = 0; i < len; cur += step, i++) {
+    Py_ssize_t i;
+    size_t cur;
+    for (cur = start, i = 0; i < len; cur += step, i++) {
         PyObject *v = Pointer_item_lock_held(myself, cur);
         if (!v) {
             return -1;

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5504,8 +5504,9 @@ Pointer_set_contents(PyObject *op, PyObject *value, void *closure)
         locked_deref_assign(self, dst->b_ptr);
         UNLOCK_PTR(dst);
     } else {
-        // We already hold the lock
+        LOCK_PTR(self);
         *((void **)self->b_ptr) = dst->b_ptr;
+        UNLOCK_PTR(self);
     }
 
     /*

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5499,10 +5499,14 @@ Pointer_set_contents(PyObject *op, PyObject *value, void *closure)
     }
 
     dst = (CDataObject *)value;
-    assert(dst != self); // XXX Can the user do this?
-    LOCK_PTR(dst);
-    locked_deref_assign(self, dst->b_ptr);
-    UNLOCK_PTR(dst);
+    if (dst != self) {
+        LOCK_PTR(dst);
+        locked_deref_assign(self, dst->b_ptr);
+        UNLOCK_PTR(dst);
+    } else {
+        // We already hold the lock
+        *((void **)self->b_ptr) = dst->b_ptr;
+    }
 
     /*
        A Pointer instance must keep the value it points to alive.  So, a


### PR DESCRIPTION
We need to hold the lock as long as we plan on using the pointer, not just when we dereference it.

<!-- gh-issue-number: gh-131974 -->
* Issue: gh-131974
<!-- /gh-issue-number -->
