### PR TITLE
[3.13] Backport miscellaneous Android testbed changes

### DIFF
--- a/Android/README.md
+++ b/Android/README.md
@@ -143,10 +143,10 @@ stderr. Add the `-v` option to also show Gradle output, and non-Python logcat
 messages.
 
 Any other arguments on the `android.py test` command line will be passed through
-to `python -m test` – use `--` to separate them from android.py's own options.
+to `python -m test` – use `--` to separate them from android.py's own options.
 See the [Python Developer's
 Guide](https://devguide.python.org/testing/run-write-tests/) for common options
-– most of them will work on Android, except for those that involve subprocesses,
+– most of them will work on Android, except for those that involve subprocesses,
 such as `-j`.
 
 Every time you run `android.py test`, changes in pure-Python files in the

--- a/Android/testbed/app/build.gradle.kts
+++ b/Android/testbed/app/build.gradle.kts
@@ -75,13 +75,24 @@ for ((i, prefix) in prefixes.withIndex()) {
 
 
 android {
+    val androidEnvFile = file("../../android-env.sh").absoluteFile
+
     namespace = "org.python.testbed"
     compileSdk = 34
 
     defaultConfig {
         applicationId = "org.python.testbed"
-        minSdk = 21
+
+        minSdk = androidEnvFile.useLines {
+            for (line in it) {
+                """api_level:=(\d+)""".toRegex().find(line)?.let {
+                    return@useLines it.groupValues[1].toInt()
+                }
+            }
+            throw GradleException("Failed to find API level in $androidEnvFile")
+        }
         targetSdk = 34
+
         versionCode = 1
         versionName = "1.0"
 
@@ -101,7 +112,6 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    val androidEnvFile = file("../../android-env.sh").absoluteFile
     ndkVersion = androidEnvFile.useLines {
         for (line in it) {
             """ndk_version=(\S+)""".toRegex().find(line)?.let {

--- a/Android/testbed/app/src/main/c/main_activity.c
+++ b/Android/testbed/app/src/main/c/main_activity.c
@@ -34,9 +34,12 @@ typedef struct {
     int pipe[2];
 } StreamInfo;
 
+// The FILE member can't be initialized here because stdout and stderr are not
+// compile-time constants. Instead, it's initialized immediately before the
+// redirection.
 static StreamInfo STREAMS[] = {
-    {stdout, STDOUT_FILENO, ANDROID_LOG_INFO, "native.stdout", {-1, -1}},
-    {stderr, STDERR_FILENO, ANDROID_LOG_WARN, "native.stderr", {-1, -1}},
+    {NULL, STDOUT_FILENO, ANDROID_LOG_INFO, "native.stdout", {-1, -1}},
+    {NULL, STDERR_FILENO, ANDROID_LOG_WARN, "native.stderr", {-1, -1}},
     {NULL, -1, ANDROID_LOG_UNKNOWN, NULL, {-1, -1}},
 };
 
@@ -87,6 +90,8 @@ static char *redirect_stream(StreamInfo *si) {
 JNIEXPORT void JNICALL Java_org_python_testbed_PythonTestRunner_redirectStdioToLogcat(
     JNIEnv *env, jobject obj
 ) {
+    STREAMS[0].file = stdout;
+    STREAMS[1].file = stderr;
     for (StreamInfo *si = STREAMS; si->file; si++) {
         char *error_prefix;
         if ((error_prefix = redirect_stream(si))) {


### PR DESCRIPTION
#125946 made a few changes to the testbed as part of increasing the minimum Android version in Python 3.14. These will also work on the older Android version that Python 3.13 is built against, so we should backport them to avoid future merge conflicts.