### PR TITLE
[3.13] gh-131988: Fix a multithreaded scaling regression

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-01-19-25-05.gh-issue-131988.sbYLEs.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-01-19-25-05.gh-issue-131988.sbYLEs.rst
@@ -1,0 +1,2 @@
+Fix a performance regression that caused scaling bottlenecks in the free
+threaded build in 3.13.1 and 3.13.2.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1587,10 +1587,10 @@ new_threadstate(PyInterpreterState *interp, int whence)
 
     HEAD_UNLOCK(interp->runtime);
 #ifdef Py_GIL_DISABLED
-    if (id == 1) {
+    if (id > 1) {
         if (_Py_atomic_load_int(&interp->gc.immortalize) == 0) {
             // Immortalize objects marked as using deferred reference counting
-            // the first time a non-main thread is created.
+            // once a non-main thread is created, if we haven't already done so.
             _PyGC_ImmortalizeDeferredObjects(interp);
         }
     }


### PR DESCRIPTION
The 3.13 free threaded build immortalizes certain objects to avoid reference count contention. In gh-127114 the condition was unintentionally changed to happen when the first thread was created instead of the first non-main thread. The `interp->gc.immortalize` field is then cleared again during `_PyGC_Init()`.

Change the condition so that we check if we should immortalize objects using deferred reference counting whenever a non-main thread is created.


<!-- gh-issue-number: gh-131988 -->
* Issue: gh-131988
<!-- /gh-issue-number -->
