### PR TITLE
gh-132002: Fix crash of `ContextVar` on unhashable `str` subtype

### DIFF
--- a/Lib/test/test_context.py
+++ b/Lib/test/test_context.py
@@ -92,6 +92,15 @@ class ContextTest(unittest.TestCase):
             contextvars.Context(a=1)
         contextvars.Context(**{})
 
+    def test_context_new_unhashable_str_subclass(self):
+        # gh-132002: it used to crash on unhashable str subtypes.
+        class weird_str(str):
+            def __eq__(self, other):
+                pass
+
+        with self.assertRaisesRegex(TypeError, 'unhashable type'):
+            contextvars.ContextVar(weird_str())
+
     def test_context_typerrors_1(self):
         ctx = contextvars.Context()
 

--- a/Misc/NEWS.d/next/Library/2025-04-02-11-31-15.gh-issue-132002.TMsYvE.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-02-11-31-15.gh-issue-132002.TMsYvE.rst
@@ -1,0 +1,2 @@
+Fix crash when deallocating :class:`contextvars.ContextVar` with weird
+unahashable string names.

--- a/Python/context.c
+++ b/Python/context.c
@@ -880,7 +880,7 @@ contextvar_new(PyObject *name, PyObject *def)
 
     var->var_hash = contextvar_generate_hash(var, name);
     if (var->var_hash == -1) {
-        Py_DECREF(var);
+        PyObject_GC_Del(var);
         return NULL;
     }
 

--- a/Python/context.c
+++ b/Python/context.c
@@ -878,14 +878,7 @@ contextvar_new(PyObject *name, PyObject *def)
         return NULL;
     }
 
-    var->var_hash = contextvar_generate_hash(var, name);
-    if (var->var_hash == -1) {
-        PyObject_GC_Del(var);
-        return NULL;
-    }
-
     var->var_name = Py_NewRef(name);
-
     var->var_default = Py_XNewRef(def);
 
 #ifndef Py_GIL_DISABLED
@@ -893,6 +886,12 @@ contextvar_new(PyObject *name, PyObject *def)
     var->var_cached_tsid = 0;
     var->var_cached_tsver = 0;
 #endif
+
+    var->var_hash = contextvar_generate_hash(var, name);
+    if (var->var_hash == -1) {
+        Py_DECREF(var);
+        return NULL;
+    }
 
     if (_PyObject_GC_MAY_BE_TRACKED(name) ||
             (def != NULL && _PyObject_GC_MAY_BE_TRACKED(def)))


### PR DESCRIPTION


<!-- gh-issue-number: gh-132002 -->
* Issue: gh-132002
<!-- /gh-issue-number -->
