### PR TITLE
gh-59705: Fix solaris detection in test_set_name

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -2145,7 +2145,7 @@ class MiscTestCase(unittest.TestCase):
         if os_helper.TESTFN_UNENCODABLE:
             tests.append(os_helper.TESTFN_UNENCODABLE)
 
-        if sys.platform.startswith("solaris"):
+        if sys.platform.startswith("sunos"):
             encoding = "utf-8"
         else:
             encoding = sys.getfilesystemencoding()
@@ -2161,7 +2161,7 @@ class MiscTestCase(unittest.TestCase):
                     encoded = encoded.split(b'\0', 1)[0]
                 if truncate is not None:
                     encoded = encoded[:truncate]
-                if sys.platform.startswith("solaris"):
+                if sys.platform.startswith("sunos"):
                     expected = encoded.decode("utf-8", "surrogateescape")
                 else:
                     expected = os.fsdecode(encoded)


### PR DESCRIPTION
`sys.platform` on Solaris/Illumos starts with `"sunos"` rather than `"solaris"`.

<!-- gh-issue-number: gh-59705 -->
* Issue: gh-59705
<!-- /gh-issue-number -->
