### PR TITLE
Add tests for Bluetooth RFCOMM, HCI and SCO

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -2691,6 +2691,7 @@ class BasicBluetoothTest(unittest.TestCase):
             except OSError as err:
                 if sys.platform == 'win32' and err.winerror == 10050:
                     self.skipTest(str(err))
+                raise
             addr = s.getsockname()
             self.assertEqual(addr, (mock.ANY, channel))
             self.assertRegex(addr[0], r'(?i)[0-9a-f]{2}(?::[0-9a-f]{2}){4}')

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -2670,6 +2670,33 @@ class BasicBluetoothTest(unittest.TestCase):
             addr = f.getsockname()
             self.assertEqual(addr, (socket.BDADDR_ANY, psm))
 
+    def testBindRfcommSocket(self):
+        with socket.socket(socket.AF_BLUETOOTH, socket.SOCK_STREAM, socket.BTPROTO_RFCOMM) as s:
+            channel = 0
+            s.bind((socket.BDADDR_ANY, channel))
+            addr = s.getsockname()
+            self.assertEqual(addr, (socket.BDADDR_ANY, channel))
+
+    @unittest.skipUnless(hasattr(socket, 'BTPROTO_HCI'), 'Bluetooth HCI sockets required for this test')
+    def testBindHciSocket(self):
+        with socket.socket(socket.AF_BLUETOOTH, socket.SOCK_RAW, socket.BTPROTO_HCI) as s:
+            if sys.platform.startswith(('netbsd', 'dragonfly', 'freebsd')):
+                s.bind(socket.BDADDR_ANY.encode())
+                addr = s.getsockname()
+                self.assertEqual(addr, socket.BDADDR_ANY)
+            else:
+                dev = 0
+                s.bind((dev,))
+                addr = s.getsockname()
+                self.assertEqual(addr, dev)
+
+    @unittest.skipUnless(hasattr(socket, 'BTPROTO_SCO'), 'Bluetooth SCO sockets required for this test')
+    def testBindScoSocket(self):
+        with socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_SCO) as s:
+            s.bind(socket.BDADDR_ANY.encode())
+            addr = s.getsockname()
+            self.assertEqual(addr, socket.BDADDR_ANY)
+
 
 @unittest.skipUnless(HAVE_SOCKET_HYPERV,
                      'Hyper-V sockets required for this test.')


### PR DESCRIPTION
Test parsing and unparsing of address.

The tests expose some errors in implementation: the format of the returned address for HCI and SCO is not compatible with acceptable format.