### PR TITLE
gh-118761: Fix star-import of ``ast``

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -24,7 +24,6 @@
     :copyright: Copyright 2008 by Armin Ronacher.
     :license: Python License.
 """
-import sys
 from _ast import *
 
 
@@ -623,6 +622,7 @@ class Param(expr_context):
 
 def main():
     import argparse
+    import sys
 
     parser = argparse.ArgumentParser()
     parser.add_argument('infile', nargs='?', default='-',
@@ -655,7 +655,7 @@ if __name__ == '__main__':
 def __dir__():
     return {n for n in globals() if not n.startswith('_')} | {'unparse'}
 
-__all__ = tuple(__dir__() - {'sys'})  # don't include modules in __all__
+__all__ = tuple(__dir__())
 
 def __getattr__(name):
     if name == 'unparse':

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -653,8 +653,9 @@ if __name__ == '__main__':
     main()
 
 def __dir__():
-    dir_ = {n for n in globals() if not n.startswith('_') and n != 'sys'}
-    return sorted(dir_ | {'unparse'})
+    return {n for n in globals() if not n.startswith('_')} | {'unparse'}
+
+__all__ = tuple(__dir__() - {'sys'})  # don't include modules in __all__
 
 def __getattr__(name):
     if name == 'unparse':


### PR DESCRIPTION
cc @danielhollas 

I agree that removing 'sys' in `__dir__` is fragile, but we can now move the import to the `main()` function, which I missed initially.

A

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
