### PR TITLE
gh-132026: Ensure _MIPS_SIM has defined _ABI identifiers for comparison

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-04-02-21-08-36.gh-issue-132026.ptnR7T.rst
+++ b/Misc/NEWS.d/next/Build/2025-04-02-21-08-36.gh-issue-132026.ptnR7T.rst
@@ -1,2 +1,1 @@
-Use of undefined identifiers is removed for determining architecture
-specifics when building C code on MIPS architectures.
+Fix use of undefined identifiers in platform triplet detection on MIPS Linux platforms.

--- a/Misc/NEWS.d/next/Build/2025-04-02-21-08-36.gh-issue-132026.ptnR7T.rst
+++ b/Misc/NEWS.d/next/Build/2025-04-02-21-08-36.gh-issue-132026.ptnR7T.rst
@@ -1,0 +1,2 @@
+Use of undefined identifiers is removed for determining architecture
+specifics when building C code on MIPS architectures.

--- a/Misc/platform_triplet.c
+++ b/Misc/platform_triplet.c
@@ -57,21 +57,21 @@ PLATFORM_TRIPLET=arm-linux-androideabi
 #  endif
 #  if defined(_MIPS_SIM)
 #   if defined(__mips_hard_float)
-#    if _MIPS_SIM == _ABIO32
+#    if defined(_ABIO32) && _MIPS_SIM == _ABIO32
 #     define LIBC_MIPS gnu
-#    elif _MIPS_SIM == _ABIN32
+#    elif defined(_ABIN32) && _MIPS_SIM == _ABIN32
 #     define LIBC_MIPS gnuabin32
-#    elif _MIPS_SIM == _ABI64
+#    elif defined(_ABI64) && _MIPS_SIM == _ABI64
 #     define LIBC_MIPS gnuabi64
 #    else
 #     error unknown mips sim value
 #    endif
 #   else
-#    if _MIPS_SIM == _ABIO32
+#    if defined(_ABIO32) && _MIPS_SIM == _ABIO32
 #     define LIBC_MIPS gnusf
-#    elif _MIPS_SIM == _ABIN32
+#    elif defined(_ABIN32) && _MIPS_SIM == _ABIN32
 #     define LIBC_MIPS gnuabin32sf
-#    elif _MIPS_SIM == _ABI64
+#    elif defined(_ABI64) && _MIPS_SIM == _ABI64
 #     define LIBC_MIPS gnuabi64sf
 #    else
 #     error unknown mips sim value
@@ -107,21 +107,21 @@ PLATFORM_TRIPLET=arm-linux-androideabi
 #   endif
 #   if defined(_MIPS_SIM)
 #    if defined(__mips_hard_float)
-#     if _MIPS_SIM == _ABIO32
+#     if defined(_ABIO32) && _MIPS_SIM == _ABIO32
 #      define LIBC_MIPS musl
-#     elif _MIPS_SIM == _ABIN32
+#     elif defined(_ABIN32) && _MIPS_SIM == _ABIN32
 #      define LIBC_MIPS musln32
-#     elif _MIPS_SIM == _ABI64
+#     elif defined(_ABI64) && _MIPS_SIM == _ABI64
 #      define LIBC_MIPS musl
 #     else
 #      error unknown mips sim value
 #     endif
 #    else
-#     if _MIPS_SIM == _ABIO32
+#     if defined(_ABIO32) && _MIPS_SIM == _ABIO32
 #      define LIBC_MIPS muslsf
-#     elif _MIPS_SIM == _ABIN32
+#     elif defined(_ABIN32) && _MIPS_SIM == _ABIN32
 #      define LIBC_MIPS musln32sf
-#     elif _MIPS_SIM == _ABI64
+#     elif defined(_ABI64) && _MIPS_SIM == _ABI64
 #      define LIBC_MIPS muslsf
 #     else
 #      error unknown mips sim value


### PR DESCRIPTION
When building C code on a MIPS architecture, `_MIPS_SIM` is used to determine [architecture specifics](https://wiki.debian.org/ArchitectureSpecificsMemo#Summary). The value is expected to match either `_ABIO32`, `_ABIN32` or `_ABI64`.

In `gcc` [config/mips/mips.h](https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/config/mips/mips.h;h=616a275b918c34caf87f333f40e00866504156d7;hb=04696df09633baf97cdbbdd6e9929b9d472161d3#l560) these values are defined as compiler `builtin_define` inside of a switch/case. That means, mips64el and mips64 architectures know about `_ABI64` but don't know about `_ABIO32` and `_ABIN32`. In turn, when CPython tries to use them in comparison, they may be undefined identifiers.

In default compiler behavior, the undefined identifier will be evaluated as zero, and it will not match `_MIPS_SIM`. However, the issues pop up when `-Wundef` (or, even worse, `-Werror=undef`) compiler flag is enabled. Then suddenly it's visible as a warning or error.

<!-- gh-issue-number: gh-132026 -->
* Issue: gh-132026
<!-- /gh-issue-number -->
