### PR TITLE
gh-118761: Improve import time of ``annotationlib``

### DIFF
--- a/Lib/annotationlib/__init__.py
+++ b/Lib/annotationlib/__init__.py
@@ -2,7 +2,6 @@
 
 import builtins
 import enum
-import functools
 import keyword
 import sys
 import types
@@ -23,12 +22,16 @@ class _LazyImporter:
     def __getattr__(self, name):
         if name == "ast":
             import ast
-            setattr(self, "ast", ast)
+            self.ast = ast
             return ast
         elif name == "_Stringifier":
             from ._stringifier import _Stringifier
-            setattr(self, "_Stringifier", _Stringifier)
+            self._Stringifier = _Stringifier
             return _Stringifier
+        elif name == "functools":
+            import functools
+            self.functools = functools
+            return functools
         else:
             raise AttributeError(
                 f"{self.__class__.__name__!r} object has no attribute {name!r}"
@@ -588,7 +591,7 @@ def get_annotations(
             if hasattr(unwrap, "__wrapped__"):
                 unwrap = unwrap.__wrapped__
                 continue
-            if isinstance(unwrap, functools.partial):
+            if isinstance(unwrap, _laz.functools.partial):
                 unwrap = unwrap.func
                 continue
             break

--- a/Lib/annotationlib/__init__.py
+++ b/Lib/annotationlib/__init__.py
@@ -1,6 +1,5 @@
 """Helpers for introspecting and wrapping annotations."""
 
-import ast
 import builtins
 import enum
 import functools
@@ -20,6 +19,22 @@ __all__ = [
 ]
 
 
+class _LazyImporter:
+    def __getattr__(self, name):
+        if name == "ast":
+            import ast
+            setattr(self, "ast", ast)
+            return ast
+        elif name == "_Stringifier":
+            from ._stringifier import _Stringifier
+            setattr(self, "_Stringifier", _Stringifier)
+            return _Stringifier
+        else:
+            raise AttributeError(
+                f"{self.__class__.__name__!r} object has no attribute {name!r}"
+            )
+
+
 class Format(enum.IntEnum):
     VALUE = 1
     VALUE_WITH_FAKE_GLOBALS = 2
@@ -29,6 +44,7 @@ class Format(enum.IntEnum):
 
 _Union = None
 _sentinel = object()
+_laz = _LazyImporter()
 
 # Slots shared by ForwardRef and _Stringifier. The __forward__ names must be
 # preserved for compatibility with the old typing.ForwardRef class. The remaining
@@ -205,7 +221,7 @@ class ForwardRef:
         if self.__arg__ is not None:
             return self.__arg__
         if self.__ast_node__ is not None:
-            self.__arg__ = ast.unparse(self.__ast_node__)
+            self.__arg__ = _laz.ast.unparse(self.__ast_node__)
             return self.__arg__
         raise AssertionError(
             "Attempted to access '__forward_arg__' on an uninitialized ForwardRef"
@@ -265,206 +281,6 @@ class ForwardRef:
         return f"ForwardRef({self.__forward_arg__!r}{module_repr})"
 
 
-class _Stringifier:
-    # Must match the slots on ForwardRef, so we can turn an instance of one into an
-    # instance of the other in place.
-    __slots__ = _SLOTS
-
-    def __init__(
-        self,
-        node,
-        globals=None,
-        owner=None,
-        is_class=False,
-        cell=None,
-        *,
-        stringifier_dict,
-    ):
-        # Either an AST node or a simple str (for the common case where a ForwardRef
-        # represent a single name).
-        assert isinstance(node, (ast.AST, str))
-        self.__arg__ = None
-        self.__forward_evaluated__ = False
-        self.__forward_value__ = None
-        self.__forward_is_argument__ = False
-        self.__forward_is_class__ = is_class
-        self.__forward_module__ = None
-        self.__code__ = None
-        self.__ast_node__ = node
-        self.__globals__ = globals
-        self.__cell__ = cell
-        self.__owner__ = owner
-        self.__stringifier_dict__ = stringifier_dict
-
-    def __convert_to_ast(self, other):
-        if isinstance(other, _Stringifier):
-            if isinstance(other.__ast_node__, str):
-                return ast.Name(id=other.__ast_node__)
-            return other.__ast_node__
-        elif isinstance(other, slice):
-            return ast.Slice(
-                lower=(
-                    self.__convert_to_ast(other.start)
-                    if other.start is not None
-                    else None
-                ),
-                upper=(
-                    self.__convert_to_ast(other.stop)
-                    if other.stop is not None
-                    else None
-                ),
-                step=(
-                    self.__convert_to_ast(other.step)
-                    if other.step is not None
-                    else None
-                ),
-            )
-        else:
-            return ast.Constant(value=other)
-
-    def __get_ast(self):
-        node = self.__ast_node__
-        if isinstance(node, str):
-            return ast.Name(id=node)
-        return node
-
-    def __make_new(self, node):
-        stringifier = _Stringifier(
-            node,
-            self.__globals__,
-            self.__owner__,
-            self.__forward_is_class__,
-            stringifier_dict=self.__stringifier_dict__,
-        )
-        self.__stringifier_dict__.stringifiers.append(stringifier)
-        return stringifier
-
-    # Must implement this since we set __eq__. We hash by identity so that
-    # stringifiers in dict keys are kept separate.
-    def __hash__(self):
-        return id(self)
-
-    def __getitem__(self, other):
-        # Special case, to avoid stringifying references to class-scoped variables
-        # as '__classdict__["x"]'.
-        if self.__ast_node__ == "__classdict__":
-            raise KeyError
-        if isinstance(other, tuple):
-            elts = [self.__convert_to_ast(elt) for elt in other]
-            other = ast.Tuple(elts)
-        else:
-            other = self.__convert_to_ast(other)
-        assert isinstance(other, ast.AST), repr(other)
-        return self.__make_new(ast.Subscript(self.__get_ast(), other))
-
-    def __getattr__(self, attr):
-        return self.__make_new(ast.Attribute(self.__get_ast(), attr))
-
-    def __call__(self, *args, **kwargs):
-        return self.__make_new(
-            ast.Call(
-                self.__get_ast(),
-                [self.__convert_to_ast(arg) for arg in args],
-                [
-                    ast.keyword(key, self.__convert_to_ast(value))
-                    for key, value in kwargs.items()
-                ],
-            )
-        )
-
-    def __iter__(self):
-        yield self.__make_new(ast.Starred(self.__get_ast()))
-
-    def __repr__(self):
-        if isinstance(self.__ast_node__, str):
-            return self.__ast_node__
-        return ast.unparse(self.__ast_node__)
-
-    def __format__(self, format_spec):
-        raise TypeError("Cannot stringify annotation containing string formatting")
-
-    def _make_binop(op: ast.AST):
-        def binop(self, other):
-            return self.__make_new(
-                ast.BinOp(self.__get_ast(), op, self.__convert_to_ast(other))
-            )
-
-        return binop
-
-    __add__ = _make_binop(ast.Add())
-    __sub__ = _make_binop(ast.Sub())
-    __mul__ = _make_binop(ast.Mult())
-    __matmul__ = _make_binop(ast.MatMult())
-    __truediv__ = _make_binop(ast.Div())
-    __mod__ = _make_binop(ast.Mod())
-    __lshift__ = _make_binop(ast.LShift())
-    __rshift__ = _make_binop(ast.RShift())
-    __or__ = _make_binop(ast.BitOr())
-    __xor__ = _make_binop(ast.BitXor())
-    __and__ = _make_binop(ast.BitAnd())
-    __floordiv__ = _make_binop(ast.FloorDiv())
-    __pow__ = _make_binop(ast.Pow())
-
-    del _make_binop
-
-    def _make_rbinop(op: ast.AST):
-        def rbinop(self, other):
-            return self.__make_new(
-                ast.BinOp(self.__convert_to_ast(other), op, self.__get_ast())
-            )
-
-        return rbinop
-
-    __radd__ = _make_rbinop(ast.Add())
-    __rsub__ = _make_rbinop(ast.Sub())
-    __rmul__ = _make_rbinop(ast.Mult())
-    __rmatmul__ = _make_rbinop(ast.MatMult())
-    __rtruediv__ = _make_rbinop(ast.Div())
-    __rmod__ = _make_rbinop(ast.Mod())
-    __rlshift__ = _make_rbinop(ast.LShift())
-    __rrshift__ = _make_rbinop(ast.RShift())
-    __ror__ = _make_rbinop(ast.BitOr())
-    __rxor__ = _make_rbinop(ast.BitXor())
-    __rand__ = _make_rbinop(ast.BitAnd())
-    __rfloordiv__ = _make_rbinop(ast.FloorDiv())
-    __rpow__ = _make_rbinop(ast.Pow())
-
-    del _make_rbinop
-
-    def _make_compare(op):
-        def compare(self, other):
-            return self.__make_new(
-                ast.Compare(
-                    left=self.__get_ast(),
-                    ops=[op],
-                    comparators=[self.__convert_to_ast(other)],
-                )
-            )
-
-        return compare
-
-    __lt__ = _make_compare(ast.Lt())
-    __le__ = _make_compare(ast.LtE())
-    __eq__ = _make_compare(ast.Eq())
-    __ne__ = _make_compare(ast.NotEq())
-    __gt__ = _make_compare(ast.Gt())
-    __ge__ = _make_compare(ast.GtE())
-
-    del _make_compare
-
-    def _make_unary_op(op):
-        def unary_op(self):
-            return self.__make_new(ast.UnaryOp(op, self.__get_ast()))
-
-        return unary_op
-
-    __invert__ = _make_unary_op(ast.Invert())
-    __pos__ = _make_unary_op(ast.UAdd())
-    __neg__ = _make_unary_op(ast.USub())
-
-    del _make_unary_op
-
-
 class _StringifierDict(dict):
     def __init__(self, namespace, globals=None, owner=None, is_class=False):
         super().__init__(namespace)
@@ -475,7 +291,7 @@ class _StringifierDict(dict):
         self.stringifiers = []
 
     def __missing__(self, key):
-        fwdref = _Stringifier(
+        fwdref = _laz._Stringifier(
             key,
             globals=self.globals,
             owner=self.owner,
@@ -537,7 +353,7 @@ def call_annotate_function(annotate, format, *, owner=None, _is_evaluate=False):
                     name = freevars[i]
                 else:
                     name = "__cell__"
-                fwdref = _Stringifier(name, stringifier_dict=globals)
+                fwdref = _laz._Stringifier(name, stringifier_dict=globals)
                 new_closure.append(types.CellType(fwdref))
             closure = tuple(new_closure)
         else:
@@ -588,7 +404,7 @@ def call_annotate_function(annotate, format, *, owner=None, _is_evaluate=False):
                         name = freevars[i]
                     else:
                         name = "__cell__"
-                    fwdref = _Stringifier(
+                    fwdref = _laz._Stringifier(
                         name,
                         cell=cell,
                         owner=owner,

--- a/Lib/annotationlib/_stringifier.py
+++ b/Lib/annotationlib/_stringifier.py
@@ -1,0 +1,203 @@
+import ast
+
+from . import _SLOTS
+
+
+class _Stringifier:
+    # Must match the slots on ForwardRef, so we can turn an instance of one into an
+    # instance of the other in place.
+    __slots__ = _SLOTS
+
+    def __init__(
+        self,
+        node,
+        globals=None,
+        owner=None,
+        is_class=False,
+        cell=None,
+        *,
+        stringifier_dict,
+    ):
+        # Either an AST node or a simple str (for the common case where a ForwardRef
+        # represent a single name).
+        assert isinstance(node, (ast.AST, str))
+        self.__arg__ = None
+        self.__forward_evaluated__ = False
+        self.__forward_value__ = None
+        self.__forward_is_argument__ = False
+        self.__forward_is_class__ = is_class
+        self.__forward_module__ = None
+        self.__code__ = None
+        self.__ast_node__ = node
+        self.__globals__ = globals
+        self.__cell__ = cell
+        self.__owner__ = owner
+        self.__stringifier_dict__ = stringifier_dict
+
+    def __convert_to_ast(self, other):
+        if isinstance(other, _Stringifier):
+            if isinstance(other.__ast_node__, str):
+                return ast.Name(id=other.__ast_node__)
+            return other.__ast_node__
+        elif isinstance(other, slice):
+            return ast.Slice(
+                lower=(
+                    self.__convert_to_ast(other.start)
+                    if other.start is not None
+                    else None
+                ),
+                upper=(
+                    self.__convert_to_ast(other.stop)
+                    if other.stop is not None
+                    else None
+                ),
+                step=(
+                    self.__convert_to_ast(other.step)
+                    if other.step is not None
+                    else None
+                ),
+            )
+        else:
+            return ast.Constant(value=other)
+
+    def __get_ast(self):
+        node = self.__ast_node__
+        if isinstance(node, str):
+            return ast.Name(id=node)
+        return node
+
+    def __make_new(self, node):
+        stringifier = _Stringifier(
+            node,
+            self.__globals__,
+            self.__owner__,
+            self.__forward_is_class__,
+            stringifier_dict=self.__stringifier_dict__,
+        )
+        self.__stringifier_dict__.stringifiers.append(stringifier)
+        return stringifier
+
+    # Must implement this since we set __eq__. We hash by identity so that
+    # stringifiers in dict keys are kept separate.
+    def __hash__(self):
+        return id(self)
+
+    def __getitem__(self, other):
+        # Special case, to avoid stringifying references to class-scoped variables
+        # as '__classdict__["x"]'.
+        if self.__ast_node__ == "__classdict__":
+            raise KeyError
+        if isinstance(other, tuple):
+            elts = [self.__convert_to_ast(elt) for elt in other]
+            other = ast.Tuple(elts)
+        else:
+            other = self.__convert_to_ast(other)
+        assert isinstance(other, ast.AST), repr(other)
+        return self.__make_new(ast.Subscript(self.__get_ast(), other))
+
+    def __getattr__(self, attr):
+        return self.__make_new(ast.Attribute(self.__get_ast(), attr))
+
+    def __call__(self, *args, **kwargs):
+        return self.__make_new(
+            ast.Call(
+                self.__get_ast(),
+                [self.__convert_to_ast(arg) for arg in args],
+                [
+                    ast.keyword(key, self.__convert_to_ast(value))
+                    for key, value in kwargs.items()
+                ],
+            )
+        )
+
+    def __iter__(self):
+        yield self.__make_new(ast.Starred(self.__get_ast()))
+
+    def __repr__(self):
+        if isinstance(self.__ast_node__, str):
+            return self.__ast_node__
+        return ast.unparse(self.__ast_node__)
+
+    def __format__(self, format_spec):
+        raise TypeError("Cannot stringify annotation containing string formatting")
+
+    def _make_binop(op: ast.AST):
+        def binop(self, other):
+            return self.__make_new(
+                ast.BinOp(self.__get_ast(), op, self.__convert_to_ast(other))
+            )
+
+        return binop
+
+    __add__ = _make_binop(ast.Add())
+    __sub__ = _make_binop(ast.Sub())
+    __mul__ = _make_binop(ast.Mult())
+    __matmul__ = _make_binop(ast.MatMult())
+    __truediv__ = _make_binop(ast.Div())
+    __mod__ = _make_binop(ast.Mod())
+    __lshift__ = _make_binop(ast.LShift())
+    __rshift__ = _make_binop(ast.RShift())
+    __or__ = _make_binop(ast.BitOr())
+    __xor__ = _make_binop(ast.BitXor())
+    __and__ = _make_binop(ast.BitAnd())
+    __floordiv__ = _make_binop(ast.FloorDiv())
+    __pow__ = _make_binop(ast.Pow())
+
+    del _make_binop
+
+    def _make_rbinop(op: ast.AST):
+        def rbinop(self, other):
+            return self.__make_new(
+                ast.BinOp(self.__convert_to_ast(other), op, self.__get_ast())
+            )
+
+        return rbinop
+
+    __radd__ = _make_rbinop(ast.Add())
+    __rsub__ = _make_rbinop(ast.Sub())
+    __rmul__ = _make_rbinop(ast.Mult())
+    __rmatmul__ = _make_rbinop(ast.MatMult())
+    __rtruediv__ = _make_rbinop(ast.Div())
+    __rmod__ = _make_rbinop(ast.Mod())
+    __rlshift__ = _make_rbinop(ast.LShift())
+    __rrshift__ = _make_rbinop(ast.RShift())
+    __ror__ = _make_rbinop(ast.BitOr())
+    __rxor__ = _make_rbinop(ast.BitXor())
+    __rand__ = _make_rbinop(ast.BitAnd())
+    __rfloordiv__ = _make_rbinop(ast.FloorDiv())
+    __rpow__ = _make_rbinop(ast.Pow())
+
+    del _make_rbinop
+
+    def _make_compare(op):
+        def compare(self, other):
+            return self.__make_new(
+                ast.Compare(
+                    left=self.__get_ast(),
+                    ops=[op],
+                    comparators=[self.__convert_to_ast(other)],
+                )
+            )
+
+        return compare
+
+    __lt__ = _make_compare(ast.Lt())
+    __le__ = _make_compare(ast.LtE())
+    __eq__ = _make_compare(ast.Eq())
+    __ne__ = _make_compare(ast.NotEq())
+    __gt__ = _make_compare(ast.Gt())
+    __ge__ = _make_compare(ast.GtE())
+
+    del _make_compare
+
+    def _make_unary_op(op):
+        def unary_op(self):
+            return self.__make_new(ast.UnaryOp(op, self.__get_ast()))
+
+        return unary_op
+
+    __invert__ = _make_unary_op(ast.Invert())
+    __pos__ = _make_unary_op(ast.UAdd())
+    __neg__ = _make_unary_op(ast.USub())
+
+    del _make_unary_op


### PR DESCRIPTION
This PR converts `annotationlib.py` into a package with  `annotationlib/__init__.py` and `annotationlib/_stringifier.py`.

Discussed here: https://discuss.python.org/t/pep-749-implementing-pep-649/54974/63

This is done in order to move the definition of `_Stringifier` into a new submodule in order to defer the import of `ast` in the main module.

The outcome of this is that `ast` should only be imported if any of the following occur:

* `get_annotations(obj, format=Format.STRING)`[^1] is used and the output is not an empty dict
* `get_annotations(obj, format=Format.FORWARDREF)` is used and there are actually forward references
* `forwardref.__forward_arg__` is called and `forwardref.__ast_node__ is not None`

**Note**: I've used a class with a `__getattr__` method as a way of deferring imports in the current PR but I'd be happy to change that to something else if there's a more standard pattern.

My machine isn't a super stable benchmarking machine so take these only as rough estimates (they're slightly different to those posted in the discuss thread as it's a different run).

This branch:
```
import time: self [us] | cumulative | imported package
...
import time:       688 |        688 |     types
import time:      3373 |       4061 |   enum
import time:       306 |        306 |   keyword
import time:       906 |       5272 | annotationlib
```

Main:
```
import time: self [us] | cumulative | imported package
...
import time:      4032 |       4032 |     _ast
import time:      1605 |       5637 |   ast
import time:       432 |        432 |     types
import time:      2027 |       2459 |   enum
import time:       126 |        126 |       itertools
import time:       205 |        205 |       keyword
import time:        77 |         77 |         _operator
import time:       341 |        418 |       operator
import time:       210 |        210 |       reprlib
import time:       357 |        357 |       _collections
import time:      1415 |       2729 |     collections
import time:       217 |        217 |     _functools
import time:      1396 |       4341 |   functools
import time:      2198 |      14634 | annotationlib
```

[^1]: or any of the similar methods such as `call_annotate_function`

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
