### PR TITLE
gh-118761: Use `enum._simple_enum` for `annotationlib.Format`

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -20,7 +20,8 @@ __all__ = [
 ]
 
 
-class Format(enum.IntEnum):
+@enum._simple_enum(enum.IntEnum)
+class Format:
     VALUE = 1
     VALUE_WITH_FAKE_GLOBALS = 2
     FORWARDREF = 3

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -3,6 +3,7 @@
 import annotationlib
 import builtins
 import collections
+import enum
 import functools
 import itertools
 import pickle
@@ -50,6 +51,14 @@ class TestFormat(unittest.TestCase):
 
         self.assertEqual(Format.STRING.value, 4)
         self.assertEqual(Format.STRING, 4)
+
+    def test_simple_enum(self):
+        class Format(enum.IntEnum):
+            VALUE = 1
+            VALUE_WITH_FAKE_GLOBALS = 2
+            FORWARDREF = 3
+            STRING = 4
+        enum._test_simple_enum(Format, annotationlib.Format)
 
 
 class TestForwardRefFormat(unittest.TestCase):


### PR DESCRIPTION
We can use the internal `_simple_enum` class decorator here, for slight faster enum creation. I don't think there's any good way to entirely avoid/defer the `enum` import, though.

A

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
