### PR TITLE
gh-118761: Cover the import time optimisations in What's New

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1085,6 +1085,7 @@ Optimizations
   (Contributed by Adam Turner, Bénédikt Tran, Chris Markiewicz, Eli Schwartz,
   Hugo van Kemenade, Jelle Zijlstra, and others in :gh:`118761`.)
 
+
 asyncio
 -------
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1076,6 +1076,15 @@ zipinfo
 Optimizations
 =============
 
+* The import time for several standard library modules has been improved,
+  including :mod:`ast`, :mod:`asyncio`, :mod:`base64`, :mod:`cmd`, :mod:`csv`,
+  :mod:`gettext`, :mod:`importlib.util`, :mod:`locale`, :mod:`mimetypes`,
+  :mod:`optparse`, :mod:`pickle`, :mod:`pprint`, :mod:`pstats`, :mod:`socket`,
+  :mod:`subprocess`, :mod:`threading`, :mod:`tomllib`, and :mod:`zipfile`.
+
+  (Contributed by Adam Turner, Bénédikt Tran, Chris Markiewicz, Eli Schwartz,
+  Hugo van Kemenade, Jelle Zijlstra, and others in :gh:`118761`.)
+
 asyncio
 -------
 


### PR DESCRIPTION
I think I've covered all of the modules, let me know if I've missed anything.

A

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132035.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->