### PR TITLE
gh-118761: Optimise import time for ``string``

### DIFF
--- a/Lib/string.py
+++ b/Lib/string.py
@@ -50,7 +50,6 @@ def capwords(s, sep=None):
 
 ####################################################################
 _sentinel_dict = {}
-_sentinel_flags = object()
 
 
 class _TemplatePattern:
@@ -71,7 +70,7 @@ class Template:
     # See https://bugs.python.org/issue31672
     idpattern = r'(?a:[_a-z][_a-z0-9]*)'
     braceidpattern = None
-    flags = _sentinel_flags  # default: re.IGNORECASE
+    flags = None  # default: re.IGNORECASE
 
     pattern = _TemplatePattern()  # use a descriptor to compile the pattern
 
@@ -99,7 +98,7 @@ class Template:
               (?P<invalid>)             # Other ill-formed delimiter exprs
             )
             """
-        if cls.flags is _sentinel_flags:
+        if cls.flags is None:
             cls.flags = re.IGNORECASE
         pat = cls.pattern = re.compile(pattern, cls.flags | re.VERBOSE)
         return pat

--- a/Lib/string.py
+++ b/Lib/string.py
@@ -57,6 +57,7 @@ class _TemplatePattern:
     def __get__(self, instance, cls=None):
         if cls is None:
             return self
+        # This descriptor is overwritten in ``_compile_pattern()``.
         return cls._compile_pattern()
 
 

--- a/Lib/string.py
+++ b/Lib/string.py
@@ -83,11 +83,8 @@ class Template:
     def _compile_pattern(cls):
         import re  # deferred import, for performance
 
-        cls_pattern = cls.__dict__.get('pattern')
-        if cls_pattern is not None and cls_pattern is not _TemplatePattern:
-            # Prefer a pattern defined on the class.
-            pattern = cls_pattern
-        else:
+        pattern = cls.__dict__.get('pattern', _TemplatePattern)
+        if pattern is _TemplatePattern:
             delim = re.escape(cls.delimiter)
             id = cls.idpattern
             bid = cls.braceidpattern or cls.idpattern

--- a/Lib/string.py
+++ b/Lib/string.py
@@ -53,11 +53,12 @@ _sentinel_dict = {}
 
 
 class _TemplatePattern:
+    # This descriptor is overwritten in ``Template._compile_pattern()``.
     def __get__(self, instance, cls=None):
         if cls is None:
             return self
-        # This descriptor is overwritten in ``_compile_pattern()``.
         return cls._compile_pattern()
+_TemplatePattern = _TemplatePattern()
 
 
 class Template:
@@ -72,7 +73,7 @@ class Template:
     braceidpattern = None
     flags = None  # default: re.IGNORECASE
 
-    pattern = _TemplatePattern()  # use a descriptor to compile the pattern
+    pattern = _TemplatePattern  # use a descriptor to compile the pattern
 
     def __init_subclass__(cls):
         super().__init_subclass__()
@@ -83,7 +84,7 @@ class Template:
         import re  # deferred import, for performance
 
         cls_pattern = cls.__dict__.get('pattern')
-        if cls_pattern and not isinstance(cls_pattern, _TemplatePattern):
+        if cls_pattern is not None and cls_pattern is not _TemplatePattern:
             # Prefer a pattern defined on the class.
             pattern = cls_pattern
         else:

--- a/Misc/NEWS.d/next/Library/2025-04-03-01-35-02.gh-issue-118761.VQcj70.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-03-01-35-02.gh-issue-118761.VQcj70.rst
@@ -1,0 +1,2 @@
+Improve import times by up to 27x for the :mod:`string` module.
+Patch by Adam Turner.


### PR DESCRIPTION
This PR achieves a 27x improvement in import time for the `string` module. The main improvement comes from replacing `Template.__init_subclass__()` (GH-16256) with a descriptor class, allowing lazy import of the `re` module.

Current:

```
import string: cumulative time
mean: 9162.100 µs
median: 9133.000 µs
stdev: 66.662
min: 9071
max: 9301
```

This PR:

```
import string: cumulative time
mean: 334.967 µs
median: 329.000 µs
stdev: 13.438
min: 316
max: 368
```

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
