### PR TITLE
Remove unused import

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -33,7 +33,7 @@ import copy
 import datetime
 import re
 import time
-import urllib.parse, urllib.request
+import urllib.parse
 import threading as _threading
 import http.client  # only for the default HTTP port
 from calendar import timegm

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1,5 +1,3 @@
-import importlib.abc
-import importlib.util
 import os
 import platform
 import re

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -43,7 +43,6 @@ import socket
 import io
 import re
 import email.utils
-import email.message
 import email.generator
 import base64
 import hmac

--- a/Lib/test/test_asyncio/functional.py
+++ b/Lib/test/test_asyncio/functional.py
@@ -1,5 +1,4 @@
 import asyncio
-import asyncio.events
 import contextlib
 import os
 import pprint

--- a/Lib/test/test_concurrent_futures/test_thread_pool.py
+++ b/Lib/test/test_concurrent_futures/test_thread_pool.py
@@ -1,7 +1,5 @@
 import contextlib
 import multiprocessing as mp
-import multiprocessing.process
-import multiprocessing.util
 import os
 import threading
 import unittest


### PR DESCRIPTION
I noticed that test_selector_events.py and asyncio/selector_event.py both have 

```python
try:
    import ssl
except ImportError:
    ssl = None
```

where the ssl module is never used, should these be removed? Removing the one in test_selector_event.py causes no problems in the tests; however removing the one in asyncio/selector_event.py causes a single error:

```python
test test.test_asyncio.test_selector_events failed -- Traceback (most recent call last):
  File "/home/marius/cpython/Lib/unittest/mock.py", line 1424, in patched
    with self.decoration_helper(patched,
         ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
                                args,
                                ^^^^^
                                keywargs) as (newargs, newkeywargs):
                                ^^^^^^^^^
  File "/home/marius/cpython/Lib/contextlib.py", line 141, in __enter__
    return next(self.gen)
  File "/home/marius/cpython/Lib/unittest/mock.py", line 1406, in decoration_helper
    arg = exit_stack.enter_context(patching)
  File "/home/marius/cpython/Lib/contextlib.py", line 530, in enter_context
    result = _enter(cm)
  File "/home/marius/cpython/Lib/unittest/mock.py", line 1498, in __enter__
    original, local = self.get_original()
                      ~~~~~~~~~~~~~~~~~^^
  File "/home/marius/cpython/Lib/unittest/mock.py", line 1468, in get_original
    raise AttributeError(
        "%s does not have the attribute %r" % (target, name)
    )
AttributeError: <module 'asyncio.selector_events' from '/home/marius/cpython/Lib/asyncio/selector_events.py'> does not have the attribute 'ssl'
```

While looking through I also saw in mailbox.py there is the 

```python
class Mailbox:
    """A group of messages in a particular place."""

    def __init__(self, path, factory=None, create=True):
        """Initialize a Mailbox instance."""
        self._path = os.path.abspath(os.path.expanduser(path))
        self._factory = factory
```

where the variable `create` is never used, this could most likely be removed?