### PR TITLE
enum: remove unused function

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -150,18 +150,6 @@ def bin(num, max_bits=None):
             digits = (sign[-1] * max_bits + digits)[-max_bits:]
     return "%s %s" % (sign, digits)
 
-def _dedent(text):
-    """
-    Like textwrap.dedent.  Rewritten because we cannot import textwrap.
-    """
-    lines = text.split('\n')
-    for i, ch in enumerate(lines[0]):
-        if ch != ' ':
-            break
-    for j, l in enumerate(lines):
-        lines[j] = l[i:]
-    return '\n'.join(lines)
-
 class _not_given:
     def __repr__(self):
         return('<not given>')


### PR DESCRIPTION
`_dedent` in enum was added in this PR.

https://github.com/python/cpython/pull/30582/files#diff-e5dd6e444e4e6c2cdeb8edf271d057f9da52f7b406dcd8b655dc396fb013bd03

But it is not used now.