### PR TITLE
gh-137855: `email.quoprimime` removing `re` import

### DIFF
--- a/Lib/email/quoprimime.py
+++ b/Lib/email/quoprimime.py
@@ -286,24 +286,19 @@ def header_decode(s):
     quoted-printable (like =?iso-8859-1?q?Hello_World?=) -- please use
     the high level email.header class for that functionality.
     """
-    s = s.replace('_', ' ')
-    
-    valid_hex = '0123456789ABCDEFabcdef'
-    
-    i = 0
     # Check for regex =[a-fA-F0-9]{2}
-    
     result = []
     
-    while i < len(s):
-        if s[i] == '=' and i + 2 < len(s):
+    max_s_check_len = s - 2
+    for i, c in enumerate(s):
+        if c == '=' and i < max_s_check_len:
             hex_part = s[i: i + 3]
             
-            if (hex_part[1] in valid_hex) and (hex_part[2] in valid_hex):
+            if (hex_part[1] in hexdigits) and (hex_part[2] in hexdigits):
                 result.append(unquote(hex_part))
                 i += 3
                 continue
-        result.append(s[i])
+        result.append(' ' if c == '_' else c)
         i += 1
     
     return ''.join(result)

--- a/Lib/email/quoprimime.py
+++ b/Lib/email/quoprimime.py
@@ -302,8 +302,7 @@ def header_decode(s):
 
     while i < s_len:
         if s[i] == '=' and i + 2 < s_len:
-            hex_str = s[i + 1:i + 3].lower()
-            if hex_str in _HEX_TO_CHAR:
+            if (hex_str := s[i + 1:i + 3].lower()) in _HEX_TO_CHAR:
                 if last_append < i:
                     result.append(s[last_append:i])
                 result.append(_HEX_TO_CHAR[hex_str])

--- a/Lib/email/quoprimime.py
+++ b/Lib/email/quoprimime.py
@@ -39,8 +39,6 @@ __all__ = [
     'unquote',
     ]
 
-import re
-
 from string import ascii_letters, digits, hexdigits
 
 CRLF = '\r\n'
@@ -280,14 +278,6 @@ def decode(encoded, eol=NL):
 body_decode = decode
 decodestring = decode
 
-
-
-def _unquote_match(match):
-    """Turn a match in the form =AB to the ASCII character with value 0xab"""
-    s = match.group(0)
-    return unquote(s)
-
-
 # Header decoding is done a bit differently
 def header_decode(s):
     """Decode a string encoded with RFC 2045 MIME header 'Q' encoding.
@@ -297,4 +287,23 @@ def header_decode(s):
     the high level email.header class for that functionality.
     """
     s = s.replace('_', ' ')
-    return re.sub(r'=[a-fA-F0-9]{2}', _unquote_match, s, flags=re.ASCII)
+    
+    valid_hex = '0123456789ABCDEFabcdef'
+    
+    i = 0
+    # Check for regex =[a-fA-F0-9]{2}
+    
+    result = []
+    
+    while i < len(s):
+        if s[i] == '=' and i + 2 < len(s):
+            hex_part = s[i: i + 3]
+            
+            if (hex_part[1] in valid_hex) and (hex_part[2] in valid_hex):
+                result.append(unquote(hex_part))
+                i += 3
+                continue
+        result.append(s[i])
+        i += 1
+    
+    return ''.join(result)

--- a/Lib/email/quoprimime.py
+++ b/Lib/email/quoprimime.py
@@ -279,11 +279,7 @@ body_decode = decode
 decodestring = decode
 
 
-_HEX_TO_CHAR = {}
-for i in range(256):
-    key_lower = f"{i:02x}"
-    char_val = chr(i)
-    _HEX_TO_CHAR[key_lower] = char_val
+_HEX_TO_CHAR = {f'{i:02x}': chr(i) for i in range(256)}
 
 # Header decoding is done a bit differently
 def header_decode(s):

--- a/Lib/email/quoprimime.py
+++ b/Lib/email/quoprimime.py
@@ -288,17 +288,17 @@ def header_decode(s):
     """
     # Check for regex =[a-fA-F0-9]{2}
     result = []
-    
-    max_s_check_len = s - 2
-    for i, c in enumerate(s):
-        if c == '=' and i < max_s_check_len:
-            hex_part = s[i: i + 3]
-            
-            if (hex_part[1] in hexdigits) and (hex_part[2] in hexdigits):
-                result.append(unquote(hex_part))
-                i += 3
-                continue
+
+    s_len = len(s)
+    i =0
+    while i < s_len:
+        c = s[i]
+
+        if c == '=' and i + 2 < s_len and s[i + 1] in hexdigits and s[i + 2] in hexdigits:
+            result.append(unquote(s[i: i + 3]))
+            i += 3
+            continue
         result.append(' ' if c == '_' else c)
         i += 1
-    
+
     return ''.join(result)

--- a/Lib/email/quoprimime.py
+++ b/Lib/email/quoprimime.py
@@ -294,11 +294,15 @@ def header_decode(s):
     the high level email.header class for that functionality.
     """
     # Check for regex =[a-fA-F0-9]{2}
+    s = s.replace("_", " ")
+    
+    if '=' not in s:
+        return s
+    
     result = []
     s_len = len(s)
     i = 0
     last_append = 0
-    s = s.replace("_", " ")
 
     while i < s_len:
         if s[i] == '=' and i + 2 < s_len:
@@ -310,9 +314,6 @@ def header_decode(s):
                 last_append = i
                 continue
         i += 1
-
-    if last_append == 0:
-        return s
 
     if last_append < s_len:
         result.append(s[last_append:])

--- a/Lib/email/quoprimime.py
+++ b/Lib/email/quoprimime.py
@@ -295,7 +295,7 @@ def header_decode(s):
     if '=' not in s:
         return s
     
-    result = []
+    result = ''
     s_len = len(s)
     i = 0
     last_append = 0
@@ -304,14 +304,14 @@ def header_decode(s):
         if s[i] == '=' and i + 2 < s_len:
             if (hex_str := s[i + 1:i + 3].lower()) in _HEX_TO_CHAR:
                 if last_append < i:
-                    result.append(s[last_append:i])
-                result.append(_HEX_TO_CHAR[hex_str])
+                    result += s[last_append:i]
+                result += _HEX_TO_CHAR[hex_str]
                 i += 3
                 last_append = i
                 continue
         i += 1
 
     if last_append < s_len:
-        result.append(s[last_append:])
+        result += s[last_append:]
 
-    return ''.join(result)
+    return result

--- a/Lib/email/quoprimime.py
+++ b/Lib/email/quoprimime.py
@@ -292,9 +292,7 @@ def header_decode(s):
     s_len = len(s)
     i =0
     while i < s_len:
-        c = s[i]
-
-        if c == '=' and i + 2 < s_len and s[i + 1] in hexdigits and s[i + 2] in hexdigits:
+        if (c := s[i]) == '=' and i + 2 < s_len and s[i + 1] in hexdigits and s[i + 2] in hexdigits:
             result.append(unquote(s[i: i + 3]))
             i += 3
             continue

--- a/Misc/NEWS.d/next/Library/2025-04-03-04-40-15.gh-issue-130167.Tc5zLB.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-03-04-40-15.gh-issue-130167.Tc5zLB.rst
@@ -1,2 +1,0 @@
-Improved import time of :mod:`email.quoprimime` module by 60%. Patch by
-Marius-Juston

--- a/Misc/NEWS.d/next/Library/2025-04-03-04-40-15.gh-issue-130167.Tc5zLB.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-03-04-40-15.gh-issue-130167.Tc5zLB.rst
@@ -1,0 +1,2 @@
+Improved import time of :mod:`email.quoprimime` module by 60%. Patch by
+Marius-Juston


### PR DESCRIPTION
This pull request removes the `re` module from the `email.quoprimime`, thus increasing the import speed from `5676` us to `3669` us (a 60% import speed increase );

From

```shell
marius@DESKTOP-IOUM5DH:~/cpython$ ./python -X importtime -c "import email.quoprimime"
import time: self [us] | cumulative | imported package
import time:        88 |         88 |   _io
import time:        19 |         19 |   marshal
import time:       143 |        143 |   posix
import time:       332 |        580 | _frozen_importlib_external
import time:        42 |         42 |   time
import time:       125 |        166 | zipimport
import time:        25 |         25 |     _codecs
import time:       290 |        315 |   codecs
import time:       190 |        190 |   encodings.aliases
import time:       417 |        921 | encodings
import time:        90 |         90 | encodings.utf_8
import time:        44 |         44 | _signal
import time:        22 |         22 |     _abc
import time:        93 |        114 |   abc
import time:       484 |        484 |   _collections_abc
import time:       136 |        733 | io
import time:        22 |         22 |       _stat
import time:        59 |         80 |     stat
import time:        31 |         31 |       errno
import time:        43 |         43 |       genericpath
import time:        87 |        160 |     posixpath
import time:       283 |        523 |   os
import time:        50 |         50 |   _sitebuiltins
import time:        86 |         86 |   sitecustomize
import time:        30 |         30 |   usercustomize
import time:       216 |        902 | site
import time:       114 |        114 | linecache
import time:       203 |        203 |   email
import time:        22 |         22 |     _string
import time:       140 |        140 |         types
import time:       795 |        935 |       enum
import time:        34 |         34 |         _sre
import time:       130 |        130 |           re._constants
import time:       181 |        311 |         re._parser
import time:        49 |         49 |         re._casefix
import time:       198 |        591 |       re._compiler
import time:        57 |         57 |           itertools
import time:        75 |         75 |           keyword
import time:        41 |         41 |             _operator
import time:       153 |        194 |           operator
import time:        98 |         98 |           reprlib
import time:        32 |         32 |           _collections
import time:       553 |       1006 |         collections
import time:        30 |         30 |         _functools
import time:       346 |       1381 |       functools
import time:        95 |         95 |       copyreg
import time:       311 |       3311 |     re
import time:       365 |       3697 |   string
import time:      1777 |       5676 | email.quoprimime
```

To 
```shell
marius@DESKTOP-IOUM5DH:~/cpython$ ./python -X importtime -c "import email.quoprimime"
import time: self [us] | cumulative | imported package
import time:        89 |         89 |   _io
import time:        18 |         18 |   marshal
import time:       130 |        130 |   posix
import time:       305 |        541 | _frozen_importlib_external
import time:        37 |         37 |   time
import time:       115 |        152 | zipimport
import time:        24 |         24 |     _codecs
import time:       273 |        296 |   codecs
import time:       175 |        175 |   encodings.aliases
import time:       387 |        857 | encodings
import time:        83 |         83 | encodings.utf_8
import time:        40 |         40 | _signal
import time:        16 |         16 |     _abc
import time:        88 |        103 |   abc
import time:       422 |        422 |   _collections_abc
import time:       125 |        649 | io
import time:        20 |         20 |       _stat
import time:        54 |         73 |     stat
import time:        29 |         29 |       errno
import time:        39 |         39 |       genericpath
import time:        81 |        148 |     posixpath
import time:       269 |        490 |   os
import time:        48 |         48 |   _sitebuiltins
import time:        80 |         80 |   sitecustomize
import time:        28 |         28 |   usercustomize
import time:       199 |        842 | site
import time:       106 |        106 | linecache
import time:       189 |        189 |   email
import time:        18 |         18 |     _string
import time:       124 |        124 |         types
import time:       667 |        791 |       enum
import time:        33 |         33 |         _sre
import time:       130 |        130 |           re._constants
import time:       177 |        307 |         re._parser
import time:        49 |         49 |         re._casefix
import time:       179 |        566 |       re._compiler
import time:        58 |         58 |           itertools
import time:        74 |         74 |           keyword
import time:        36 |         36 |             _operator
import time:       148 |        183 |           operator
import time:        96 |         96 |           reprlib
import time:        31 |         31 |           _collections
import time:       494 |        934 |         collections
import time:        27 |         27 |         _functools
import time:       315 |       1274 |       functools
import time:        87 |         87 |       copyreg
import time:       284 |       3000 |     re
import time:       297 |       3314 |   string
import time:       168 |       3669 | email.quoprimime
```

 however, the new implementation does increase the compute time 


```python
TEST_CASES = {
    "empty": "Dracula",
    "empty_medium": "Dracula"* 10,
    "empty_long": "Dracula"* 100,
    "short": "Hello=20World=21",
    "medium": "This_is_a_test=3F=3D=2E" * 10,
    "long": "Some_long_text_with_encoding=20" * 100,
    "mixed": "A=2Equick=20brown=5Ffox=21=3F" * 50,
    "edge_case_short": "=20=21=3F=2E=5F",
    "edge_case_long": "=20=21=3F=2E=5F" * 200
}
```

| Benchmark       | regex   | non_regex              |
|-----------------|:-------:|:----------------------:|
| empty           | 284 ns  | 382 ns: 1.34x slower   |
| empty_medium    | 302 ns  | 2.99 us: 9.91x slower  |
| empty_long      | 371 ns  | 28.6 us: 77.20x slower |
| short           | 731 ns  | 902 ns: 1.23x slower   |
| medium          | 6.24 us | 11.8 us: 1.89x slower  |
| long            | 25.5 us | 137 us: 5.37x slower   |
| mixed           | 57.0 us | 71.5 us: 1.25x slower  |
| edge_case_short | 1.36 us | 916 ns: 1.48x faster   |
| edge_case_long  | 178 us  | 160 us: 1.11x faster   |
| Geometric mean  | (ref)   | 2.78x slower           |

So it is very possible that this is not worth it.

Issues:

<!-- gh-issue-number: gh-130167 -->
* gh-130167
* gh-118761
<!-- /gh-issue-number -->

<!-- gh-issue-number: gh-137855 -->
* Issue: gh-137855
<!-- /gh-issue-number -->
