### PR TITLE
gh-105499: Defer "import warnings" in typing

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -30,7 +30,6 @@ import operator
 import sys
 import types
 from types import GenericAlias
-import warnings
 
 from _typing import (
     _idfunc,
@@ -1626,14 +1625,17 @@ class _TupleType(_SpecialGenericAlias, _root=True):
 
 class _UnionGenericAliasMeta(type):
     def __instancecheck__(self, inst: object) -> bool:
+        import warnings
         warnings._deprecated("_UnionGenericAlias", remove=(3, 17))
         return isinstance(inst, Union)
 
     def __subclasscheck__(self, inst: type) -> bool:
+        import warnings
         warnings._deprecated("_UnionGenericAlias", remove=(3, 17))
         return issubclass(inst, Union)
 
     def __eq__(self, other):
+        import warnings
         warnings._deprecated("_UnionGenericAlias", remove=(3, 17))
         if other is _UnionGenericAlias or other is Union:
             return True
@@ -1650,6 +1652,7 @@ class _UnionGenericAlias(metaclass=_UnionGenericAliasMeta):
 
     """
     def __new__(cls, self_cls, parameters, /, *, name=None):
+        import warnings
         warnings._deprecated("_UnionGenericAlias", remove=(3, 17))
         return Union[parameters]
 


### PR DESCRIPTION
A bunch of other warnings in typing.py were already deferred, but
I added a few non-lazy ones.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-105499 -->
* Issue: gh-105499
<!-- /gh-issue-number -->
