### PR TITLE
gh-130167: Improve speed of `_pydecimal._all_zeros` and `_pydecimal._exact_half` by replacing `re`

### DIFF
--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -6078,7 +6078,14 @@ _parser = re.compile(r"""        # A numeric string consists of:
 
 # Checks for regex 0*$
 def _all_zeros(d_int, prec=0):
-    return '0' in d_int and d_int.endswith((len(d_int) - prec) * '0')
+    i = prec
+    len_d = len(d_int)
+    
+    while i < len_d:
+        if d_int[i] != '0':
+            return False
+        i += 1
+    return True
 
 # Checks for regex 50*$ 
 def _exact_half(d_int, prec=0):

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -6080,7 +6080,9 @@ _parser = re.compile(r"""        # A numeric string consists of:
 def _all_zeros(d_int,prec=0):
     return '0' in d_int and d_int.endswith((len(d_int) - prec) * '0')
 
-_exact_half = re.compile('50*$').match
+# Checks for regex 50*$ 
+def _exact_half(d_int, prec=0):
+    return len(d_int) >= prec and d_int[prec - 1] == '5' and d_int.endswith(max(len(d_int) - prec - 1, 0) * '0')
 
 ##### PEP3101 support functions ##############################################
 # The functions in this section have little to do with the Decimal

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -6089,7 +6089,16 @@ def _all_zeros(d_int, prec=0):
 
 # Checks for regex 50*$ 
 def _exact_half(d_int, prec=0):
-    return len(d_int) >= prec + 1 and d_int[prec] == '5' and d_int.endswith( (len(d_int) - prec - 1) * '0')
+    len_d = len(d_int)
+    i = prec + 1
+    
+    if len_d >= i and d_int[prec] == '5':
+        while i < len_d:
+            if d_int[i] != '0':
+                return False
+            i += 1
+        return True
+    return False
 
 ##### PEP3101 support functions ##############################################
 # The functions in this section have little to do with the Decimal

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -6082,7 +6082,7 @@ def _all_zeros(d_int, prec=0):
 
 # Checks for regex 50*$ 
 def _exact_half(d_int, prec=0):
-    return len(d_int) >= prec + 1 and d_int[prec] == '5' and d_int.endswith(max(len(d_int) - prec - 1, 0) * '0')
+    return len(d_int) >= prec + 1 and d_int[prec] == '5' and d_int.endswith( (len(d_int) - prec - 1) * '0')
 
 ##### PEP3101 support functions ##############################################
 # The functions in this section have little to do with the Decimal

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -6082,7 +6082,7 @@ def _all_zeros(d_int,prec=0):
 
 # Checks for regex 50*$ 
 def _exact_half(d_int, prec=0):
-    return len(d_int) >= prec and d_int[prec - 1] == '5' and d_int.endswith(max(len(d_int) - prec - 1, 0) * '0')
+    return len(d_int) >= prec + 1 and d_int[prec] == '5' and d_int.endswith(max(len(d_int) - prec - 1, 0) * '0')
 
 ##### PEP3101 support functions ##############################################
 # The functions in this section have little to do with the Decimal

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -6076,7 +6076,10 @@ _parser = re.compile(r"""        # A numeric string consists of:
     \Z
 """, re.VERBOSE | re.IGNORECASE).match
 
-_all_zeros = re.compile('0*$').match
+# Checks for regex 0*$
+def _all_zeros(d_int,prec=0):
+    return '0' in d_int and d_int.endswith((len(d_int) - prec) * '0')
+
 _exact_half = re.compile('50*$').match
 
 ##### PEP3101 support functions ##############################################

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -6077,7 +6077,7 @@ _parser = re.compile(r"""        # A numeric string consists of:
 """, re.VERBOSE | re.IGNORECASE).match
 
 # Checks for regex 0*$
-def _all_zeros(d_int,prec=0):
+def _all_zeros(d_int, prec=0):
     return '0' in d_int and d_int.endswith((len(d_int) - prec) * '0')
 
 # Checks for regex 50*$ 

--- a/Misc/NEWS.d/next/Library/2025-04-04-04-07-16.gh-issue-130167.XigAlq.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-04-04-07-16.gh-issue-130167.XigAlq.rst
@@ -1,2 +1,2 @@
 Improved performance of :func:`_pydecimal._all_zeros` by an average of
-~1.7x and :func:`_pydecimal._exact_half` by ~1.27x. Patch by Marius Juston
+~1.7x and :func:`_pydecimal._exact_half` by ~1.38x. Patch by Marius Juston

--- a/Misc/NEWS.d/next/Library/2025-04-04-04-07-16.gh-issue-130167.XigAlq.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-04-04-07-16.gh-issue-130167.XigAlq.rst
@@ -1,2 +1,2 @@
 Improved performance of :func:`_pydecimal._all_zeros` by an average of
-~1.7x. Patch by Marius Juston
+~1.7x and :func:`_pydecimal._exact_half` by ~1.27x. Patch by Marius Juston

--- a/Misc/NEWS.d/next/Library/2025-04-04-04-07-16.gh-issue-130167.XigAlq.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-04-04-07-16.gh-issue-130167.XigAlq.rst
@@ -1,0 +1,2 @@
+Improved performance of :func:`_pydecimal._all_zeros` by an average of
+~1.7x. Patch by Marius Juston


### PR DESCRIPTION
Benchmark for all zeros


| Benchmark      | regex_decimal | non_regex_ends_fast_decimal |
|----------------|:-------------:|:---------------------------:|
| exact          | 230 ns        | 83.5 ns: 2.76x faster       |
| No zeros 1     | 199 ns        | 83.9 ns: 2.38x faster       |
| No zeros 10    | 207 ns        | 84.1 ns: 2.46x faster       |
| No zeros 100   | 206 ns        | 86.4 ns: 2.38x faster       |
| No zeros 1000  | 201 ns        | 94.1 ns: 2.13x faster       |
| Mixed 1        | 204 ns        | 169 ns: 1.21x faster        |
| Mixed 10       | 200 ns        | 170 ns: 1.18x faster        |
| Mixed 100      | 208 ns        | 175 ns: 1.19x faster        |
| Mixed 1000     | 198 ns        | 231 ns: 1.17x slower        |
| Zero 1         | 231 ns        | 150 ns: 1.54x faster        |
| Zero 10        | 237 ns        | 180 ns: 1.32x faster        |
| Zero 100       | 287 ns        | 185 ns: 1.55x faster        |
| Zero 1000      | 783 ns        | 245 ns: 3.20x faster        |
| Geometric mean | (ref)         | 1.72x faster                |


Benchmark for exact half

| Benchmark      | half_regex | half_non_regex_correct |
|----------------|:----------:|:----------------------:|
| exact          | 176 ns     | 97.1 ns: 1.81x faster  |
| No half 1      | 178 ns     | 124 ns: 1.44x faster   |
| No half 10     | 177 ns     | 125 ns: 1.42x faster   |
| No half 100    | 177 ns     | 125 ns: 1.42x faster   |
| No half 1000   | 180 ns     | 126 ns: 1.42x faster   |
| Mixed 1         | 177 ns     | 126 ns: 1.41x faster   |
| Mixed 10        | 177 ns     | 124 ns: 1.42x faster   |
| Mixed 100       | 178 ns     | 125 ns: 1.42x faster   |
| Mixed 1000      | 177 ns     | 127 ns: 1.39x faster   |
| Half 1        | 232 ns     | 230 ns: 1.01x faster   |
| Half 10       | 235 ns     | 269 ns: 1.14x slower   |
| Half 100      | 288 ns     | 268 ns: 1.08x faster   |
| Half 1000     | 780 ns     | 338 ns: 2.31x faster   |
| Geometric mean | (ref)      | 1.38x faster           |


The tests benchmarks
```python
import pyperf

def setup_tests_zero():
    names = [
        ('exact', Decimal('3.5')._int)
    ]

    for i in [1, 10, 100, 1000]:
        names.append((f'No zeros {i}', Decimal('3.1' + '12' * i)._int))

    for i in [1, 10, 100, 1000]:
        names.append((f'Mixed {i}', Decimal('3.12' + '0' * i)._int))
        
    for i in [1, 10, 100, 1000]:
        names.append((f'Zero {i}', Decimal('3.1' + '0' * i)._int))
        
    return names

def setup_tests_half():
    names = [
        ('exact', Decimal('3.5')._int)
    ]

    for i in [1, 10, 100, 1000]:
        names.append((f'No half {i}', Decimal('3.1' + '12' * i)._int))

    for i in [1, 10, 100, 1000]:
        names.append((f'Mixed {i}', Decimal('3.5' + '0' * i)._int))
        
    for i in [1, 10, 100, 1000]:
        names.append((f'Half {i}', Decimal('3.15' + '0' * i)._int))
        
    return names

method = ''
benchmark_method = 'half'

benchmark = setup_tests_half if benchmark_method == 'half' else set 

func = _round_down if method == 'regex' else _is_all_zeros

runner = pyperf.Runner()

for n, v in benchmark():
    # print(func(v))
    runner.bench_func(n, func, v)
```

<!-- gh-issue-number: gh-130167 -->
* Issue: gh-130167
<!-- /gh-issue-number -->
