### PR TITLE
gh-127146: Fix Emscripten test suite when run with -uall

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1104,6 +1104,7 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             self.check_iter_pickle(f1, list(f2), proto)
 
     @support.skip_wasi_stack_overflow()
+    @support.skip_emscripten_stack_overflow()
     @support.requires_resource('cpu')
     def test_filter_dealloc(self):
         # Tests recursive deallocation of nested filter objects using the

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -411,10 +411,12 @@ class CAPITest(unittest.TestCase):
         for i in range(100):
             L = MyList((L,))
 
+    @support.skip_emscripten_stack_overflow()
     @support.requires_resource('cpu')
     def test_trashcan_python_class1(self):
         self.do_test_trashcan_python_class(list)
 
+    @support.skip_emscripten_stack_overflow()
     @support.requires_resource('cpu')
     def test_trashcan_python_class2(self):
         from _testcapi import MyList

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4519,6 +4519,7 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         o.whatever = Provoker(o)
         del o
 
+    @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     @support.requires_resource('cpu')
     def test_wrapper_segfault(self):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -1428,6 +1428,7 @@ class ExceptionTests(unittest.TestCase):
         self.assertIsInstance(exc, RecursionError, type(exc))
         self.assertIn("maximum recursion depth exceeded", str(exc))
 
+    @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()
     @cpython_only
     @support.requires_resource('cpu')

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -553,7 +553,7 @@ class IOTest(unittest.TestCase):
         for [test, abilities] in tests:
             with self.subTest(test):
                 if test == pipe_writer and not threading_helper.can_start_thread:
-                    skipTest()
+                    self.skipTest("Requires threading but threading not supported")
                 with test() as obj:
                     do_test(test, obj, abilities)
 

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1916,6 +1916,10 @@ class MakedirTests(unittest.TestCase):
         os.makedirs(path)
 
     @unittest.skipIf(
+        support.is_emscripten,
+        "Failing in the buildbot, but I can't reproduce. TODO: investigate this."
+    )
+    @unittest.skipIf(
         support.is_wasi,
         "WASI's umask is a stub."
     )

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -659,8 +659,8 @@ class TestSysConfig(unittest.TestCase, VirtualEnvironmentMixin):
             ignore_keys |= {'prefix', 'exec_prefix', 'base', 'platbase', 'installed_base', 'installed_platbase'}
 
         for key in ignore_keys:
-            json_config_vars.pop(key)
-            system_config_vars.pop(key)
+            json_config_vars.pop(key, None)
+            system_config_vars.pop(key, None)
 
         self.assertEqual(system_config_vars, json_config_vars)
 

--- a/configure
+++ b/configure
@@ -12951,13 +12951,6 @@ if test "$ac_cv_sizeof_off_t" -gt "$ac_cv_sizeof_long" -a \
 else
   have_largefile_support="no"
 fi
-case $ac_sys_system in #(
-  Emscripten) :
-    have_largefile_support="no"
- ;; #(
-  *) :
-     ;;
-esac
 if test "x$have_largefile_support" = xyes
 then :
 

--- a/configure.ac
+++ b/configure.ac
@@ -3158,10 +3158,6 @@ if test "$ac_cv_sizeof_off_t" -gt "$ac_cv_sizeof_long" -a \
 else
   have_largefile_support="no"
 fi
-dnl LFS does not work with Emscripten 3.1
-AS_CASE([$ac_sys_system],
-  [Emscripten], [have_largefile_support="no"]
-)
 AS_VAR_IF([have_largefile_support], [yes], [
   AC_DEFINE([HAVE_LARGEFILE_SUPPORT], [1],
   [Defined to enable large file support when an off_t is bigger than a long


### PR DESCRIPTION
Emscripten large file support works fine and is required for `testZip64LargeFile` to work.

And skip more stack overflows
@freakboy3742

<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
