### PR TITLE
Generate social media preview cards for the documentation

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -204,6 +204,7 @@ dist-html:
 	find dist -name 'python-$(DISTVERSION)-docs-html*' -exec rm -rf {} \;
 	$(MAKE) html
 	cp -pPR build/html dist/python-$(DISTVERSION)-docs-html
+	rm -rf dist/python-$(DISTVERSION)-docs-html/_images/social_previews/
 	tar -C dist -cf dist/python-$(DISTVERSION)-docs-html.tar python-$(DISTVERSION)-docs-html
 	bzip2 -9 -k dist/python-$(DISTVERSION)-docs-html.tar
 	(cd dist; zip -q -r -9 python-$(DISTVERSION)-docs-html.zip python-$(DISTVERSION)-docs-html)

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -73,7 +73,7 @@ build:
 		echo ""; \
 		exit 1; \
 	fi
-	$(SPHINXBUILD) $(ALLSPHINXOPTS)
+	$(SPHINXBUILD) $(ALLSPHINXOPTS) --tag create-social-cards
 	@echo
 
 .PHONY: html

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -73,7 +73,7 @@ build:
 		echo ""; \
 		exit 1; \
 	fi
-	$(SPHINXBUILD) $(ALLSPHINXOPTS) --tag create-social-cards
+	$(SPHINXBUILD) $(ALLSPHINXOPTS)
 	@echo
 
 .PHONY: html

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -624,7 +624,7 @@ stable_abi_file = 'data/stable_abi.dat'
 # Options for sphinxext-opengraph
 # -------------------------------
 
-ogp_site_url = 'https://docs.python.org/3/'
+ogp_canonical_url = 'https://docs.python.org/3/'
 ogp_site_name = 'Python documentation'
 ogp_social_cards = {  # Used when matplotlib is installed
     'image': '_static/og-image.png',

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -624,16 +624,19 @@ stable_abi_file = 'data/stable_abi.dat'
 # Options for sphinxext-opengraph
 # -------------------------------
 
-ogp_site_url = 'https://hugovk-cpython.readthedocs.io/en/ogp_social_cards/'
+ogp_site_url = 'https://docs.python.org/3/'
 ogp_site_name = 'Python documentation'
-# ogp_image = '_static/og-image.png'
-# ogp_custom_meta_tags = [
-#     '<meta property="og:image:width" content="200" />',
-#     '<meta property="og:image:height" content="200" />',
-#     '<meta name="theme-color" content="#3776ab" />',
-# ]
-
-ogp_social_cards = {
-    "image": "_static/og-image.png",
-    "line_color": "#3776ab",
+ogp_social_cards = {  # Used when matplotlib is installed
+    'image': '_static/og-image.png',
+    'line_color': '#3776ab',
 }
+ogp_custom_meta_tags = [
+    '<meta name="theme-color" content="#3776ab" />',
+]
+if 'create-social-cards' not in tags:  # noqa: F821
+    # Define a static preview image when not creating social cards
+    ogp_image = '_static/og-image.png'
+    ogp_custom_meta_tags += [
+        '<meta property="og:image:width" content="200" />',
+        '<meta property="og:image:height" content="200" />',
+    ]

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -624,11 +624,16 @@ stable_abi_file = 'data/stable_abi.dat'
 # Options for sphinxext-opengraph
 # -------------------------------
 
-ogp_site_url = 'https://docs.python.org/3/'
+ogp_site_url = 'https://hugovk-cpython.readthedocs.io/en/ogp_social_cards/'
 ogp_site_name = 'Python documentation'
-ogp_image = '_static/og-image.png'
-ogp_custom_meta_tags = [
-    '<meta property="og:image:width" content="200" />',
-    '<meta property="og:image:height" content="200" />',
-    '<meta name="theme-color" content="#3776ab" />',
-]
+# ogp_image = '_static/og-image.png'
+# ogp_custom_meta_tags = [
+#     '<meta property="og:image:width" content="200" />',
+#     '<meta property="og:image:height" content="200" />',
+#     '<meta name="theme-color" content="#3776ab" />',
+# ]
+
+ogp_social_cards = {
+    "image": "_static/og-image.png",
+    "line_color": "#3776ab",
+}

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -11,7 +11,7 @@ sphinx~=8.2.0
 
 blurb
 
-sphinxext-opengraph~=0.9.0
+sphinxext-opengraph~=0.10.0
 sphinx-notfound-page~=1.0.0
 
 # The theme used by the documentation is stored separately, so we need

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -19,3 +19,5 @@ sphinx-notfound-page~=1.0.0
 python-docs-theme>=2023.3.1,!=2023.7
 
 -c constraints.txt
+
+matplotlib

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -19,5 +19,3 @@ sphinx-notfound-page~=1.0.0
 python-docs-theme>=2023.3.1,!=2023.7
 
 -c constraints.txt
-
-matplotlib

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -11,7 +11,7 @@ sphinx~=8.2.0
 
 blurb
 
-sphinxext-opengraph[social-cards]~=0.10.0
+sphinxext-opengraph~=0.10.0
 sphinx-notfound-page~=1.0.0
 
 # The theme used by the documentation is stored separately, so we need

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -11,7 +11,7 @@ sphinx~=8.2.0
 
 blurb
 
-sphinxext-opengraph~=0.10.0
+sphinxext-opengraph[social-cards]~=0.10.0
 sphinx-notfound-page~=1.0.0
 
 # The theme used by the documentation is stored separately, so we need


### PR DESCRIPTION
Replaces #129120, requires https://github.com/python/docsbuild-scripts/pull/242, closes https://github.com/python/docsbuild-scripts/issues/147.

This generates a `Doc/build/html/_images/social_previews/` directory of ~500 `.png` images (one per page; ~40MB). Per Hugo's [comment in GH-129120](https://github.com/python/cpython/pull/129120#issuecomment-2604101850), it _removes_ HTML from the page head like:

```html
<meta property="og:image" content="https://docs.python.org/3/_static/og-image.png" />
<meta property="og:image:alt" content="Python documentation" />
...
<meta property="og:image:width" content="200" />
<meta property="og:image:height" content="200" />
```

And adds:

```html
<meta property="og:url" content="https://docs.python.org/3/library/mm.html" />
...
<meta property="og:image:width" content="1146" />
<meta property="og:image:height" content="600" />
<meta property="og:image" content="_images/social_previews/summary_library_mm_8b5ad9c4.png" />
<meta property="og:image:alt" content="The modules described in this chapter implement various algorithms or interfaces that are mainly useful for multimedia applications. They are available at th..." />
...
<meta name="twitter:card" content="summary_large_image" />
```

A




<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132101.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->