### PR TITLE
GH-118761: Expose more core interpreter types in ``_types``

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -21,8 +21,8 @@ import unittest.mock
 import weakref
 import typing
 
-c_types = import_fresh_module("types", fresh=["_types"])
-py_types = import_fresh_module("types", blocked=["_types"])
+c_types = import_fresh_module('types', fresh=['_types'])
+py_types = import_fresh_module('types', blocked=['_types'])
 
 T = typing.TypeVar("T")
 

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -21,6 +21,8 @@ import unittest.mock
 import weakref
 import typing
 
+c_types = import_fresh_module("types", fresh=["_types"])
+py_types = import_fresh_module("types", blocked=["_types"])
 
 T = typing.TypeVar("T")
 
@@ -41,11 +43,22 @@ class TypesTests(unittest.TestCase):
         ignored = {'new_class', 'resolve_bases', 'prepare_class',
                    'get_original_bases', 'DynamicClassAttribute', 'coroutine'}
 
-        c_types = import_fresh_module('types', fresh=['_types'])
-        py_types = import_fresh_module('types', blocked=['_types'])
         for name in c_types.__all__:
             if name not in c_only_names | ignored:
                 self.assertIs(getattr(c_types, name), getattr(py_types, name))
+
+        all_names = ignored | {
+            'AsyncGeneratorType', 'BuiltinFunctionType', 'BuiltinMethodType',
+            'CapsuleType', 'CellType', 'ClassMethodDescriptorType', 'CodeType',
+            'CoroutineType', 'EllipsisType', 'FrameType', 'FunctionType',
+            'GeneratorType', 'GenericAlias', 'GetSetDescriptorType',
+            'LambdaType', 'MappingProxyType', 'MemberDescriptorType',
+            'MethodDescriptorType', 'MethodType', 'MethodWrapperType',
+            'ModuleType', 'NoneType', 'NotImplementedType', 'SimpleNamespace',
+            'TracebackType', 'UnionType', 'WrapperDescriptorType',
+        }
+        self.assertEqual(all_names, set(c_types.__all__))
+        self.assertEqual(all_names - c_only_names, set(py_types.__all__))
 
     def test_truth_values(self):
         if None: self.fail('None is true instead of false')

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -4,6 +4,8 @@ from test.support import (
     run_with_locale, cpython_only, no_rerun,
     MISSING_C_DOCSTRINGS,
 )
+from test.support.import_helper import import_fresh_module
+
 import collections.abc
 from collections import namedtuple, UserDict
 import copy
@@ -33,6 +35,17 @@ def clear_typing_caches():
 
 
 class TypesTests(unittest.TestCase):
+
+    def test_names(self):
+        c_only_names = {'CapsuleType'}
+        ignored = {'new_class', 'resolve_bases', 'prepare_class',
+                   'get_original_bases', 'DynamicClassAttribute', 'coroutine'}
+
+        c_types = import_fresh_module('types', fresh=['_types'])
+        py_types = import_fresh_module('types', blocked=['_types'])
+        for name in c_types.__all__:
+            if name not in c_only_names | ignored:
+                self.assertIs(getattr(c_types, name), getattr(py_types, name))
 
     def test_truth_values(self):
         if None: self.fail('None is true instead of false')

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -2,67 +2,78 @@
 Define names for built-in types that aren't directly accessible as a builtin.
 """
 
-import _types
-
 # Iterators in Python aren't a matter of type but of protocol.  A large
 # and changing number of builtin types implement *some* flavor of
 # iterator.  Don't check the type!  Use hasattr to check for both
 # "__iter__" and "__next__" attributes instead.
 
-def _f(): pass
-FunctionType = type(_f)
-LambdaType = type(lambda: None)         # Same as FunctionType
-CodeType = type(_f.__code__)
-MappingProxyType = type(type.__dict__)
-SimpleNamespace = _types.SimpleNamespace
-
-def _cell_factory():
-    a = 1
-    def f():
-        nonlocal a
-    return f.__closure__[0]
-CellType = type(_cell_factory())
-
-def _g():
-    yield 1
-GeneratorType = type(_g())
-
-async def _c(): pass
-_c = _c()
-CoroutineType = type(_c)
-_c.close()  # Prevent ResourceWarning
-
-async def _ag():
-    yield
-_ag = _ag()
-AsyncGeneratorType = type(_ag)
-
-class _C:
-    def _m(self): pass
-MethodType = type(_C()._m)
-
-BuiltinFunctionType = type(len)
-BuiltinMethodType = type([].append)     # Same as BuiltinFunctionType
-
-WrapperDescriptorType = type(object.__init__)
-MethodWrapperType = type(object().__str__)
-MethodDescriptorType = type(str.join)
-ClassMethodDescriptorType = type(dict.__dict__['fromkeys'])
-
-ModuleType = type(_types)
-
 try:
-    raise TypeError
-except TypeError as exc:
-    TracebackType = type(exc.__traceback__)
-    FrameType = type(exc.__traceback__.tb_frame)
+    from _types import *
+except ImportError:
+    import sys
 
-GetSetDescriptorType = type(FunctionType.__code__)
-MemberDescriptorType = type(FunctionType.__globals__)
+    def _f(): pass
+    FunctionType = type(_f)
+    LambdaType = type(lambda: None)         # Same as FunctionType
+    CodeType = type(_f.__code__)
+    MappingProxyType = type(type.__dict__)
+    SimpleNamespace = type(sys.implementation)
 
-CapsuleType = _types.CapsuleType
+    def _cell_factory():
+        a = 1
+        def f():
+            nonlocal a
+        return f.__closure__[0]
+    CellType = type(_cell_factory())
 
-del _types, _f, _g, _C, _c, _ag, _cell_factory  # Not for export
+    def _g():
+        yield 1
+    GeneratorType = type(_g())
+
+    async def _c(): pass
+    _c = _c()
+    CoroutineType = type(_c)
+    _c.close()  # Prevent ResourceWarning
+
+    async def _ag():
+        yield
+    _ag = _ag()
+    AsyncGeneratorType = type(_ag)
+
+    class _C:
+        def _m(self): pass
+    MethodType = type(_C()._m)
+
+    BuiltinFunctionType = type(len)
+    BuiltinMethodType = type([].append)     # Same as BuiltinFunctionType
+
+    WrapperDescriptorType = type(object.__init__)
+    MethodWrapperType = type(object().__str__)
+    MethodDescriptorType = type(str.join)
+    ClassMethodDescriptorType = type(dict.__dict__['fromkeys'])
+
+    ModuleType = type(sys)
+
+    try:
+        raise TypeError
+    except TypeError as exc:
+        TracebackType = type(exc.__traceback__)
+        FrameType = type(exc.__traceback__.tb_frame)
+
+    GetSetDescriptorType = type(FunctionType.__code__)
+    MemberDescriptorType = type(FunctionType.__globals__)
+
+    GenericAlias = type(list[int])
+    UnionType = type(int | str)
+
+    EllipsisType = type(Ellipsis)
+    NoneType = type(None)
+    NotImplementedType = type(NotImplemented)
+
+    # CapsuleType cannot be accessed from pure Python,
+    # so there is no fallback definition.
+
+    del sys, _f, _g, _C, _c, _ag, _cell_factory  # Not for export
 
 
 # Provide a PEP 3115 compliant mechanism for class creation
@@ -325,12 +336,5 @@ def coroutine(func):
         return coro
 
     return wrapped
-
-GenericAlias = type(list[int])
-UnionType = type(int | str)
-
-EllipsisType = type(Ellipsis)
-NoneType = type(None)
-NotImplementedType = type(NotImplemented)
 
 __all__ = [n for n in globals() if not n.startswith('_')]  # for pydoc

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -14,7 +14,7 @@ except ImportError:
 
     def _f(): pass
     FunctionType = type(_f)
-    LambdaType = type(lambda: None)         # Same as FunctionType
+    LambdaType = type(lambda: None)  # Same as FunctionType
     CodeType = type(_f.__code__)
     MappingProxyType = type(type.__dict__)
     SimpleNamespace = type(sys.implementation)
@@ -45,7 +45,7 @@ except ImportError:
     MethodType = type(_C()._m)
 
     BuiltinFunctionType = type(len)
-    BuiltinMethodType = type([].append)     # Same as BuiltinFunctionType
+    BuiltinMethodType = type([].append)  # Same as BuiltinFunctionType
 
     WrapperDescriptorType = type(object.__init__)
     MethodWrapperType = type(object().__str__)

--- a/Modules/_typesmodule.c
+++ b/Modules/_typesmodule.c
@@ -1,15 +1,95 @@
 /* _types module */
 
 #include "Python.h"
+#include "pycore_descrobject.h"   // _PyMethodWrapper_Type
 #include "pycore_namespace.h"     // _PyNamespace_Type
+#include "pycore_object.h"       // _PyNone_Type, _PyNotImplemented_Type
+#include "pycore_unionobject.h"  // _PyUnion_Type
 
 static int
 _types_exec(PyObject *m)
 {
+    if (PyModule_AddObjectRef(m, "AsyncGeneratorType", (PyObject *)&PyAsyncGen_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "BuiltinFunctionType", (PyObject *)&PyCFunction_Type) < 0) {
+        return -1;
+    }
+    // Same as BuiltinMethodType
+    if (PyModule_AddObjectRef(m, "BuiltinMethodType", (PyObject *)&PyCFunction_Type) < 0) {
+        return -1;
+    }
     if (PyModule_AddObjectRef(m, "CapsuleType", (PyObject *)&PyCapsule_Type) < 0) {
         return -1;
     }
+    if (PyModule_AddObjectRef(m, "CellType", (PyObject *)&PyCell_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "ClassMethodDescriptorType", (PyObject *)&PyClassMethodDescr_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "CodeType", (PyObject *)&PyCode_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "CoroutineType", (PyObject *)&PyCoro_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "EllipsisType", (PyObject *)&PyEllipsis_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "FrameType", (PyObject *)&PyFrame_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "FunctionType", (PyObject *)&PyFunction_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "GeneratorType", (PyObject *)&PyGen_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "GenericAlias", (PyObject *)&Py_GenericAliasType) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "GetSetDescriptorType", (PyObject *)&PyGetSetDescr_Type) < 0) {
+        return -1;
+    }
+    // Same as FunctionType
+    if (PyModule_AddObjectRef(m, "LambdaType", (PyObject *)&PyFunction_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MappingProxyType", (PyObject *)&PyDictProxy_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MemberDescriptorType", (PyObject *)&PyMemberDescr_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MethodDescriptorType", (PyObject *)&PyMethodDescr_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MethodType", (PyObject *)&PyMethod_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "MethodWrapperType", (PyObject *)&_PyMethodWrapper_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "ModuleType", (PyObject *)&PyModule_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "NoneType", (PyObject *)&_PyNone_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "NotImplementedType", (PyObject *)&_PyNotImplemented_Type) < 0) {
+        return -1;
+    }
     if (PyModule_AddObjectRef(m, "SimpleNamespace", (PyObject *)&_PyNamespace_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "TracebackType", (PyObject *)&PyTraceBack_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "UnionType", (PyObject *)&_PyUnion_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(m, "WrapperDescriptorType", (PyObject *)&PyWrapperDescr_Type) < 0) {
         return -1;
     }
     return 0;

--- a/Modules/_typesmodule.c
+++ b/Modules/_typesmodule.c
@@ -11,6 +11,7 @@ _types_exec(PyObject *m)
 {
 #define EXPORT_STATIC_TYPE(NAME, TYPE)                                   \
     do {                                                                 \
+        assert(PyUnstable_IsImmortal((PyObject *)&(TYPE)));              \
         if (PyModule_AddObjectRef(m, (NAME), (PyObject *)&(TYPE)) < 0) { \
             return -1;                                                   \
         }                                                                \

--- a/Modules/_typesmodule.c
+++ b/Modules/_typesmodule.c
@@ -19,7 +19,7 @@ _types_exec(PyObject *m)
 
     EXPORT_STATIC_TYPE("AsyncGeneratorType", PyAsyncGen_Type);
     EXPORT_STATIC_TYPE("BuiltinFunctionType", PyCFunction_Type);
-    // Same as BuiltinFunctionType
+    // BuiltinMethodType is the same as BuiltinFunctionType
     EXPORT_STATIC_TYPE("BuiltinMethodType", PyCFunction_Type);
     EXPORT_STATIC_TYPE("CapsuleType", PyCapsule_Type);
     EXPORT_STATIC_TYPE("CellType", PyCell_Type);
@@ -32,7 +32,7 @@ _types_exec(PyObject *m)
     EXPORT_STATIC_TYPE("GeneratorType", PyGen_Type);
     EXPORT_STATIC_TYPE("GenericAlias", Py_GenericAliasType);
     EXPORT_STATIC_TYPE("GetSetDescriptorType", PyGetSetDescr_Type);
-    // Same as FunctionType
+    // LambdaType is the same as FunctionType
     EXPORT_STATIC_TYPE("LambdaType", PyFunction_Type);
     EXPORT_STATIC_TYPE("MappingProxyType", PyDictProxy_Type);
     EXPORT_STATIC_TYPE("MemberDescriptorType", PyMemberDescr_Type);

--- a/Modules/_typesmodule.c
+++ b/Modules/_typesmodule.c
@@ -9,89 +9,43 @@
 static int
 _types_exec(PyObject *m)
 {
-    if (PyModule_AddObjectRef(m, "AsyncGeneratorType", (PyObject *)&PyAsyncGen_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "BuiltinFunctionType", (PyObject *)&PyCFunction_Type) < 0) {
-        return -1;
-    }
-    // Same as BuiltinMethodType
-    if (PyModule_AddObjectRef(m, "BuiltinMethodType", (PyObject *)&PyCFunction_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "CapsuleType", (PyObject *)&PyCapsule_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "CellType", (PyObject *)&PyCell_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "ClassMethodDescriptorType", (PyObject *)&PyClassMethodDescr_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "CodeType", (PyObject *)&PyCode_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "CoroutineType", (PyObject *)&PyCoro_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "EllipsisType", (PyObject *)&PyEllipsis_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "FrameType", (PyObject *)&PyFrame_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "FunctionType", (PyObject *)&PyFunction_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "GeneratorType", (PyObject *)&PyGen_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "GenericAlias", (PyObject *)&Py_GenericAliasType) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "GetSetDescriptorType", (PyObject *)&PyGetSetDescr_Type) < 0) {
-        return -1;
-    }
+#define EXPORT_STATIC_TYPE(NAME, TYPE)                                   \
+    do {                                                                 \
+        if (PyModule_AddObjectRef(m, (NAME), (PyObject *)&(TYPE)) < 0) { \
+            return -1;                                                   \
+        }                                                                \
+    } while (0)
+
+    EXPORT_STATIC_TYPE("AsyncGeneratorType", PyAsyncGen_Type);
+    EXPORT_STATIC_TYPE("BuiltinFunctionType", PyCFunction_Type);
+    // Same as BuiltinFunctionType
+    EXPORT_STATIC_TYPE("BuiltinMethodType", PyCFunction_Type);
+    EXPORT_STATIC_TYPE("CapsuleType", PyCapsule_Type);
+    EXPORT_STATIC_TYPE("CellType", PyCell_Type);
+    EXPORT_STATIC_TYPE("ClassMethodDescriptorType", PyClassMethodDescr_Type);
+    EXPORT_STATIC_TYPE("CodeType", PyCode_Type);
+    EXPORT_STATIC_TYPE("CoroutineType", PyCoro_Type);
+    EXPORT_STATIC_TYPE("EllipsisType", PyEllipsis_Type);
+    EXPORT_STATIC_TYPE("FrameType", PyFrame_Type);
+    EXPORT_STATIC_TYPE("FunctionType", PyFunction_Type);
+    EXPORT_STATIC_TYPE("GeneratorType", PyGen_Type);
+    EXPORT_STATIC_TYPE("GenericAlias", Py_GenericAliasType);
+    EXPORT_STATIC_TYPE("GetSetDescriptorType", PyGetSetDescr_Type);
     // Same as FunctionType
-    if (PyModule_AddObjectRef(m, "LambdaType", (PyObject *)&PyFunction_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "MappingProxyType", (PyObject *)&PyDictProxy_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "MemberDescriptorType", (PyObject *)&PyMemberDescr_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "MethodDescriptorType", (PyObject *)&PyMethodDescr_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "MethodType", (PyObject *)&PyMethod_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "MethodWrapperType", (PyObject *)&_PyMethodWrapper_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "ModuleType", (PyObject *)&PyModule_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "NoneType", (PyObject *)&_PyNone_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "NotImplementedType", (PyObject *)&_PyNotImplemented_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "SimpleNamespace", (PyObject *)&_PyNamespace_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "TracebackType", (PyObject *)&PyTraceBack_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "UnionType", (PyObject *)&_PyUnion_Type) < 0) {
-        return -1;
-    }
-    if (PyModule_AddObjectRef(m, "WrapperDescriptorType", (PyObject *)&PyWrapperDescr_Type) < 0) {
-        return -1;
-    }
+    EXPORT_STATIC_TYPE("LambdaType", PyFunction_Type);
+    EXPORT_STATIC_TYPE("MappingProxyType", PyDictProxy_Type);
+    EXPORT_STATIC_TYPE("MemberDescriptorType", PyMemberDescr_Type);
+    EXPORT_STATIC_TYPE("MethodDescriptorType", PyMethodDescr_Type);
+    EXPORT_STATIC_TYPE("MethodType", PyMethod_Type);
+    EXPORT_STATIC_TYPE("MethodWrapperType", _PyMethodWrapper_Type);
+    EXPORT_STATIC_TYPE("ModuleType", PyModule_Type);
+    EXPORT_STATIC_TYPE("NoneType", _PyNone_Type);
+    EXPORT_STATIC_TYPE("NotImplementedType", _PyNotImplemented_Type);
+    EXPORT_STATIC_TYPE("SimpleNamespace", _PyNamespace_Type);
+    EXPORT_STATIC_TYPE("TracebackType", PyTraceBack_Type);
+    EXPORT_STATIC_TYPE("UnionType", _PyUnion_Type);
+    EXPORT_STATIC_TYPE("WrapperDescriptorType", PyWrapperDescr_Type);
+#undef ADD_STATIC_TYPE
     return 0;
 }
 

--- a/Modules/_typesmodule.c
+++ b/Modules/_typesmodule.c
@@ -3,8 +3,8 @@
 #include "Python.h"
 #include "pycore_descrobject.h"   // _PyMethodWrapper_Type
 #include "pycore_namespace.h"     // _PyNamespace_Type
-#include "pycore_object.h"       // _PyNone_Type, _PyNotImplemented_Type
-#include "pycore_unionobject.h"  // _PyUnion_Type
+#include "pycore_object.h"        // _PyNone_Type, _PyNotImplemented_Type
+#include "pycore_unionobject.h"   // _PyUnion_Type
 
 static int
 _types_exec(PyObject *m)

--- a/Modules/_typesmodule.c
+++ b/Modules/_typesmodule.c
@@ -45,7 +45,7 @@ _types_exec(PyObject *m)
     EXPORT_STATIC_TYPE("TracebackType", PyTraceBack_Type);
     EXPORT_STATIC_TYPE("UnionType", _PyUnion_Type);
     EXPORT_STATIC_TYPE("WrapperDescriptorType", PyWrapperDescr_Type);
-#undef ADD_STATIC_TYPE
+#undef EXPORT_STATIC_TYPE
     return 0;
 }
 


### PR DESCRIPTION
This was discussed in #131969 (cc @ZeroIntensity), but deferred to get the smaller change in. This PR adds all of the core interpreter types currently exposed in the `types` module to `_typesmodule.c`. We then change the definition of `types.py` to prefer these, but if the `_types` module is not available, to use the pure-Python fallbacks.

Strictly, this isn't needed, as `_types` is a built-in module. I think it might be helpful to keep the pure Python definitions for other implementations (PyPy, etc), and perhaps as a quick reminder of what each type looks like. Open to thoughts on this, as it would clearly be simpler to replace everything with `from _types import *`.

I've initially categorised this under #118761, as this does provide a ~15% speed-up for me (1627µs to 1403µs).

A

<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
