### PR TITLE
gh-132106: Allow logging.handlers.QueueListener to be used as a context manager

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -589,16 +589,18 @@ An example of using these two classes follows (imports omitted)::
     que = queue.Queue(-1)  # no limit on size
     queue_handler = QueueHandler(que)
     handler = logging.StreamHandler()
+    listener = QueueListener(que, handler)
     root = logging.getLogger()
     root.addHandler(queue_handler)
     formatter = logging.Formatter('%(threadName)s: %(message)s')
     handler.setFormatter(formatter)
-    with QueueListener(que, handler) as listener:
-        # The log output will display the thread which generated
-        # the event (the main thread) rather than the internal
-        # thread which monitors the internal queue. This is what
-        # you want to happen.
-        root.warning('Look out!')
+    listener.start()
+    # The log output will display the thread which generated
+    # the event (the main thread) rather than the internal
+    # thread which monitors the internal queue. This is what
+    # you want to happen.
+    root.warning('Look out!')
+    listener.stop()
 
 which, when run, will produce:
 
@@ -623,6 +625,19 @@ which, when run, will produce:
    listener's constructor. When this is done, the listener compares the level
    of each message with the handler's level, and only passes a message to a
    handler if it's appropriate to do so.
+
+.. versionchanged:: next
+   The :class:`QueueListener` can be started (and stopped) via the
+   :keyword:`with` statement. For example:
+
+    .. code-block:: python
+
+        with QueueListener(que, handler) as listener:
+             # the queue listener automatically starts
+             # when the with block is entered
+             pass
+        # the queue listener automatically stops once
+        # the with block is exited
 
 .. _network-logging:
 

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -630,14 +630,14 @@ which, when run, will produce:
    The :class:`QueueListener` can be started (and stopped) via the
    :keyword:`with` statement. For example:
 
-    .. code-block:: python
+   .. code-block:: python
 
-        with QueueListener(que, handler) as listener:
-             # the queue listener automatically starts
-             # when the with block is entered
-             pass
-        # the queue listener automatically stops once
-        # the with block is exited
+      with QueueListener(que, handler) as listener:
+          # The queue listener automatically starts
+          # when the 'with' block is entered.
+          pass
+      # The queue listener automatically stops once
+      # the 'with' block is exited.
 
 .. _network-logging:
 

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -589,18 +589,16 @@ An example of using these two classes follows (imports omitted)::
     que = queue.Queue(-1)  # no limit on size
     queue_handler = QueueHandler(que)
     handler = logging.StreamHandler()
-    listener = QueueListener(que, handler)
     root = logging.getLogger()
     root.addHandler(queue_handler)
     formatter = logging.Formatter('%(threadName)s: %(message)s')
     handler.setFormatter(formatter)
-    listener.start()
-    # The log output will display the thread which generated
-    # the event (the main thread) rather than the internal
-    # thread which monitors the internal queue. This is what
-    # you want to happen.
-    root.warning('Look out!')
-    listener.stop()
+    with QueueListener(que, handler) as listener:
+        # The log output will display the thread which generated
+        # the event (the main thread) rather than the internal
+        # thread which monitors the internal queue. This is what
+        # you want to happen.
+        root.warning('Look out!')
 
 which, when run, will produce:
 

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -1186,10 +1186,6 @@ possible, while any potentially slow operations (such as sending an email via
       This starts up a background thread to monitor the queue for
       LogRecords to process.
 
-      .. versionchanged:: next
-         Raises :exc:`RuntimeError` if called and the listener is already
-         running.
-
    .. method:: stop()
 
       Stops the listener.

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -1152,6 +1152,8 @@ possible, while any potentially slow operations (such as sending an email via
       :class:`QueueListener` can now be used as a context manager via
       :keyword:`with`. When entering the context, the listener is started. When
       exiting the context, the listener is stopped.
+      :meth:`~contextmanager.__enter__` returns the
+      :class:`QueueListener` object.
 
    .. method:: dequeue(block)
 
@@ -1183,6 +1185,10 @@ possible, while any potentially slow operations (such as sending an email via
 
       This starts up a background thread to monitor the queue for
       LogRecords to process.
+
+      .. versionchanged:: next
+         Raises :exc:`RuntimeError` if called and the listener is already
+         running.
 
    .. method:: stop()
 

--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -1148,6 +1148,11 @@ possible, while any potentially slow operations (such as sending an email via
    .. versionchanged:: 3.5
       The ``respect_handler_level`` argument was added.
 
+   .. versionchanged:: next
+      :class:`QueueListener` can now be used as a context manager via
+      :keyword:`with`. When entering the context, the listener is started. When
+      exiting the context, the listener is stopped.
+
    .. method:: dequeue(block)
 
       Dequeues a record and return it, optionally blocking.

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -791,7 +791,7 @@ logging.handlers
 
 * :class:`logging.handlers.QueueListener` now implements the context
   manager protocol, allowing it to be used in a :keyword:`with` statement.
-  (Contributed by Charles Machalow in :gh:`TBD`.)
+  (Contributed by Charles Machalow in :gh:`132107`.)
 
 
 mimetypes

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -786,6 +786,14 @@ linecache
   (Contributed by Tian Gao in :gh:`131638`.)
 
 
+logging.handlers
+----------------
+
+* :class:`logging.handlers.QueueListener` now implements the context
+  manager protocol, allowing it to be used in a :keyword:`with` statement.
+  (Contributed by Charles Machalow in :gh:`TBD`.)
+
+
 mimetypes
 ---------
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -791,7 +791,7 @@ logging.handlers
 
 * :class:`logging.handlers.QueueListener` now implements the context
   manager protocol, allowing it to be used in a :keyword:`with` statement.
-  (Contributed by Charles Machalow in :gh:`132107`.)
+  (Contributed by Charles Machalow in :gh:`132106`.)
 
 
 mimetypes

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1532,6 +1532,19 @@ class QueueListener(object):
         self._thread = None
         self.respect_handler_level = respect_handler_level
 
+    def __enter__(self):
+        """
+        For use as a context manager. Starts the listener.
+        """
+        self.start()
+        return self
+
+    def __exit__(self, *args):
+        """
+        For use as a context manager. Stops the listener.
+        """
+        self.stop()
+
     def dequeue(self, block):
         """
         Dequeue a record and return it, optionally blocking.

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1561,8 +1561,6 @@ class QueueListener(object):
         This starts up a background thread to monitor the queue for
         LogRecords to process.
         """
-        if self._thread is not None:
-            raise RuntimeError("Listener already started")
         self._thread = t = threading.Thread(target=self._monitor)
         t.daemon = True
         t.start()

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1561,6 +1561,8 @@ class QueueListener(object):
         This starts up a background thread to monitor the queue for
         LogRecords to process.
         """
+        if self._thread is not None:
+            raise RuntimeError("Listener already started")
         self._thread = t = threading.Thread(target=self._monitor)
         t.daemon = True
         t.start()

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4362,19 +4362,6 @@ class QueueHandlerTest(BaseTest):
 
     @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
                          'logging.handlers.QueueListener required for this test')
-    def test_queue_listener_multi_start(self):
-        handler = TestHandler(support.Matcher())
-        with logging.handlers.QueueListener(self.queue, handler) as listener:
-            self.assertRaises(RuntimeError, listener.start)
-
-        with listener:
-            self.assertRaises(RuntimeError, listener.start)
-
-        listener.start()
-        listener.stop()
-
-    @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
-                         'logging.handlers.QueueListener required for this test')
     def test_queue_listener_with_StreamHandler(self):
         # Test that traceback and stack-info only appends once (bpo-34334, bpo-46755).
         listener = logging.handlers.QueueListener(self.queue, self.root_hdlr)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4349,6 +4349,18 @@ class QueueHandlerTest(BaseTest):
 
     @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
                          'logging.handlers.QueueListener required for this test')
+    def test_queue_listener_context_manager(self):
+        handler = TestHandler(support.Matcher())
+        with logging.handlers.QueueListener(self.queue, handler) as listener:
+            self.assertIsNotNone(listener._thread)
+        self.assertIsNone(listener._thread)
+
+        # doesn't hurt to call stop() more than once.
+        listener.stop()
+        self.assertIsNone(listener._thread)
+
+    @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
+                         'logging.handlers.QueueListener required for this test')
     def test_queue_listener_with_StreamHandler(self):
         # Test that traceback and stack-info only appends once (bpo-34334, bpo-46755).
         listener = logging.handlers.QueueListener(self.queue, self.root_hdlr)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4311,8 +4311,6 @@ class QueueHandlerTest(BaseTest):
         self.assertEqual(formatted_msg, log_record.msg)
         self.assertEqual(formatted_msg, log_record.message)
 
-    @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
-                         'logging.handlers.QueueListener required for this test')
     def test_queue_listener(self):
         handler = TestHandler(support.Matcher())
         listener = logging.handlers.QueueListener(self.queue, handler)
@@ -4347,8 +4345,6 @@ class QueueHandlerTest(BaseTest):
         self.assertTrue(handler.matches(levelno=logging.CRITICAL, message='6'))
         handler.close()
 
-    @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
-                         'logging.handlers.QueueListener required for this test')
     def test_queue_listener_context_manager(self):
         handler = TestHandler(support.Matcher())
         with logging.handlers.QueueListener(self.queue, handler) as listener:
@@ -4360,8 +4356,6 @@ class QueueHandlerTest(BaseTest):
         listener.stop()
         self.assertIsNone(listener._thread)
 
-    @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
-                         'logging.handlers.QueueListener required for this test')
     def test_queue_listener_with_StreamHandler(self):
         # Test that traceback and stack-info only appends once (bpo-34334, bpo-46755).
         listener = logging.handlers.QueueListener(self.queue, self.root_hdlr)
@@ -4376,8 +4370,6 @@ class QueueHandlerTest(BaseTest):
         self.assertEqual(self.stream.getvalue().strip().count('Traceback'), 1)
         self.assertEqual(self.stream.getvalue().strip().count('Stack'), 1)
 
-    @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
-                         'logging.handlers.QueueListener required for this test')
     def test_queue_listener_with_multiple_handlers(self):
         # Test that queue handler format doesn't affect other handler formats (bpo-35726).
         self.que_hdlr.setFormatter(self.root_formatter)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4352,6 +4352,7 @@ class QueueHandlerTest(BaseTest):
     def test_queue_listener_context_manager(self):
         handler = TestHandler(support.Matcher())
         with logging.handlers.QueueListener(self.queue, handler) as listener:
+            self.assertIsIsintance(listener, logging.handlers.QueueListener)
             self.assertIsNotNone(listener._thread)
         self.assertIsNone(listener._thread)
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4352,13 +4352,26 @@ class QueueHandlerTest(BaseTest):
     def test_queue_listener_context_manager(self):
         handler = TestHandler(support.Matcher())
         with logging.handlers.QueueListener(self.queue, handler) as listener:
-            self.assertIsIsintance(listener, logging.handlers.QueueListener)
+            self.assertIsInstance(listener, logging.handlers.QueueListener)
             self.assertIsNotNone(listener._thread)
         self.assertIsNone(listener._thread)
 
         # doesn't hurt to call stop() more than once.
         listener.stop()
         self.assertIsNone(listener._thread)
+
+    @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
+                         'logging.handlers.QueueListener required for this test')
+    def test_queue_listener_multi_start(self):
+        handler = TestHandler(support.Matcher())
+        with logging.handlers.QueueListener(self.queue, handler) as listener:
+            self.assertRaises(RuntimeError, listener.start)
+
+        with listener:
+            self.assertRaises(RuntimeError, listener.start)
+
+        listener.start()
+        listener.stop()
 
     @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
                          'logging.handlers.QueueListener required for this test')

--- a/Misc/NEWS.d/next/Library/2025-04-05-02-22-49.gh-issue-132106.XMjhQJ.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-05-02-22-49.gh-issue-132106.XMjhQJ.rst
@@ -1,0 +1,2 @@
+:class:`logging.handlers.QueueListener` now implements the context
+manager protocol, allowing it to be used in a :keyword:`with` statement.


### PR DESCRIPTION
<!-- gh-issue-number: gh-132106 -->
* Issue: gh-132106
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132107.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->