### PR TITLE
gh-132121: Always escape non-printable characters in `pygettext`

### DIFF
--- a/Lib/test/test_tools/i18n_data/ascii-escapes.pot
+++ b/Lib/test/test_tools/i18n_data/ascii-escapes.pot
@@ -41,7 +41,7 @@ msgstr ""
 
 #. some characters in the 128-255 range
 #: escapes.py:20
-msgid "   ÿ"
+msgid "\302\200 \302\240 ÿ"
 msgstr ""
 
 #. some characters >= 256 encoded as 2, 3 and 4 bytes, respectively

--- a/Misc/NEWS.d/next/Tools-Demos/2025-04-05-14-52-36.gh-issue-132121.QNoDih.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-04-05-14-52-36.gh-issue-132121.QNoDih.rst
@@ -1,0 +1,1 @@
+Always escape non-printable Unicode characters in :program:`pygettext`.

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -190,12 +190,10 @@ def make_escapes(pass_nonascii):
         # Allow non-ascii characters to pass through so that e.g. 'msgid
         # "Höhe"' would not result in 'msgid "H\366he"'.  Otherwise we
         # escape any character outside the 32..126 range.
-        mod = 128
         escape = escape_ascii
     else:
-        mod = 256
         escape = escape_nonascii
-    escapes = [r"\%03o" % i for i in range(mod)]
+    escapes = [r"\%03o" % i for i in range(256)]
     for i in range(32, 127):
         escapes[i] = chr(i)
     escapes[ord('\\')] = r'\\'
@@ -206,7 +204,15 @@ def make_escapes(pass_nonascii):
 
 
 def escape_ascii(s, encoding):
-    return ''.join(escapes[ord(c)] if ord(c) < 128 else c for c in s)
+    escaped = ''
+    for c in s:
+        if ord(c) < 128:
+            escaped += escapes[ord(c)]
+        elif c.isprintable():
+            escaped += c
+        else:
+            escaped += escape_nonascii(c, encoding)
+    return escaped
 
 
 def escape_nonascii(s, encoding):

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -204,15 +204,9 @@ def make_escapes(pass_nonascii):
 
 
 def escape_ascii(s, encoding):
-    escaped = ''
-    for c in s:
-        if ord(c) < 128:
-            escaped += escapes[ord(c)]
-        elif c.isprintable():
-            escaped += c
-        else:
-            escaped += escape_nonascii(c, encoding)
-    return escaped
+    return ''.join(escapes[ord(c)] if ord(c) < 128 else c
+                   if c.isprintable() else escape_nonascii(c, encoding)
+                   for c in s)
 
 
 def escape_nonascii(s, encoding):


### PR DESCRIPTION
Pretty much the title, all non-printable characters are always escaped regardless whether `--escape` is passed or not.

<!-- gh-issue-number: gh-132121 -->
* Issue: gh-132121
<!-- /gh-issue-number -->
