### PR TITLE
gh-131952: Add color to the `json` CLI

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -789,7 +789,7 @@ json
   See the :ref:`JSON command-line interface <json-commandline>` documentation.
   (Contributed by Trey Hunner in :gh:`122873`.)
 
-* By default, the output of the `JSON command-line interface <json-commandline>`
+* By default, the output of the :ref:`JSON command-line interface <json-commandline>`
   is highlighted in color. This can be controlled via the
   :envvar:`PYTHON_COLORS` environment variable as well as the canonical
   |NO_COLOR|_ and |FORCE_COLOR|_ environment variables. See also

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -789,6 +789,12 @@ json
   See the :ref:`JSON command-line interface <json-commandline>` documentation.
   (Contributed by Trey Hunner in :gh:`122873`.)
 
+* By default, the output of the `JSON command-line interface <json-commandline>`
+  is highlighted in color. This can be controlled via the
+  :envvar:`PYTHON_COLORS` environment variable as well as the canonical
+  |NO_COLOR|_ and |FORCE_COLOR|_ environment variables. See also
+  :ref:`using-on-controlling-color`.
+  (Contributed by Tomas Roun in :gh:`131952`.)
 
 linecache
 ---------

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -10,7 +10,7 @@ import sys
 from _colorize import ANSIColors, can_colorize
 
 
-# The string we are colorizing is a valid JSON,
+# The string we are colorizing is valid JSON,
 # so we can use a looser but simpler regex to match
 # the various parts, most notably strings and numbers,
 # where the regex given by the spec is much more complex.

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -31,9 +31,8 @@ _colors = {
 
 
 def _replace_match_callback(match):
-    for key in _colors:
+    for key, color in _colors.items():
         if m := match.group(key):
-            color = _colors[key]
             return f"{color}{m}{ANSIColors.RESET}"
     return match.group()
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -17,7 +17,6 @@ from _colorize import ANSIColors, can_colorize
 _color_pattern = re.compile(r'''
     (?P<key>"(\\.|[^"\\])*")(?=:)           |
     (?P<string>"(\\.|[^"\\])*")             |
-    (?P<number>NaN|-?Infinity|[0-9\-+.Ee]+) |
     (?P<boolean>true|false)                 |
     (?P<null>null)
 ''', re.VERBOSE)
@@ -26,7 +25,6 @@ _color_pattern = re.compile(r'''
 _colors = {
     'key': ANSIColors.INTENSE_BLUE,
     'string': ANSIColors.BOLD_GREEN,
-    'number': ANSIColors.BOLD_YELLOW,
     'boolean': ANSIColors.BOLD_CYAN,
     'null': ANSIColors.BOLD_CYAN,
 }

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -50,8 +50,6 @@ def main():
         dump_args['indent'] = None
         dump_args['separators'] = ',', ':'
 
-    with_colors = can_colorize()
-
     try:
         if options.infile == '-':
             infile = sys.stdin

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -83,10 +83,10 @@ def main():
 
 
 color_pattern = re.compile(r'''
-    (?P<string>"(.*?)")     |   # String
-    (?P<number>[\d\-+.Ee]+) |   # Number
-    (?P<boolean>true|false) |   # Boolean
-    (?P<null>null)              # Null
+    (?P<string>"(\\"|[^"])*?") |   # String
+    (?P<number>[\d\-+.Ee]+)    |   # Number
+    (?P<boolean>true|false)    |   # Boolean
+    (?P<null>null)                 # Null
 ''', re.VERBOSE)
 
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -83,10 +83,10 @@ def main():
 
 
 color_pattern = re.compile(r'''
-    (?P<string>"(\\"|[^"])*?") |   # String
-    (?P<number>[\d\-+.Ee]+)    |   # Number
-    (?P<boolean>true|false)    |   # Boolean
-    (?P<null>null)                 # Null
+    (?P<string>"(\\.|[^"\\])*?") |   # String
+    (?P<number>[\d\-+.Ee]+)      |   # Number
+    (?P<boolean>true|false)      |   # Boolean
+    (?P<null>null)                   # Null
 ''', re.VERBOSE)
 
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -25,10 +25,10 @@ _color_pattern = re.compile(r'''
 
 _colors = {
     'key': ANSIColors.INTENSE_BLUE,
-    'string': ANSIColors.GREEN,
+    'string': ANSIColors.INTENSE_GREEN,
     'number': ANSIColors.YELLOW,
-    'boolean': ANSIColors.CYAN,
-    'null': ANSIColors.CYAN,
+    'boolean': ANSIColors.INTENSE_CYAN,
+    'null': ANSIColors.INTENSE_CYAN,
 }
 
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -72,7 +72,7 @@ def main():
             outfile = open(options.outfile, 'w', encoding='utf-8')
         with outfile:
             for obj in objs:
-                if with_colors:
+                if can_colorize(file=outfile):
                     json_str = json.dumps(obj, **dump_args)
                     outfile.write(colorize_json(json_str))
                 else:

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -25,10 +25,10 @@ _color_pattern = re.compile(r'''
 
 _colors = {
     'key': ANSIColors.INTENSE_BLUE,
-    'string': ANSIColors.INTENSE_GREEN,
+    'string': ANSIColors.GREEN,
     'number': ANSIColors.YELLOW,
-    'boolean': ANSIColors.INTENSE_CYAN,
-    'null': ANSIColors.INTENSE_CYAN,
+    'boolean': ANSIColors.CYAN,
+    'null': ANSIColors.CYAN,
 }
 
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -83,10 +83,10 @@ def main():
 
 
 color_pattern = re.compile(r'''
-    (?P<string>"(\\.|[^"\\])*?") |   # String
-    (?P<number>[\d\-+.Ee]+)      |   # Number
-    (?P<boolean>true|false)      |   # Boolean
-    (?P<null>null)                   # Null
+    (?P<string>"(\\.|[^"\\])*?")           |   # String
+    (?P<number>NaN|-?Infinity|[\d\-+.Ee]+) |   # Number
+    (?P<boolean>true|false)                |   # Boolean
+    (?P<null>null)                             # Null
 ''', re.VERBOSE)
 
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -80,6 +80,10 @@ def main():
         raise SystemExit(e)
 
 
+# The string we are colorizing is a valid JSON,
+# so we can use a looser but simpler regex to match
+# the various parts, most notably strings and numbers,
+# where the regex given by the spec is much more complex.
 color_pattern = re.compile(r'''
     (?P<string>"(\\.|[^"\\])*")             |   # String
     (?P<number>NaN|-?Infinity|[0-9\-+.Ee]+) |   # Number

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -5,8 +5,8 @@ See `json.__main__` for a usage example (invocation as
 """
 import argparse
 import json
-import sys
 import re
+import sys
 from _colorize import ANSIColors, can_colorize
 
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -15,10 +15,10 @@ from _colorize import ANSIColors, can_colorize
 # the various parts, most notably strings and numbers,
 # where the regex given by the spec is much more complex.
 _color_pattern = re.compile(r'''
-    (?P<string>"(\\.|[^"\\])*")             |   # String
-    (?P<number>NaN|-?Infinity|[0-9\-+.Ee]+) |   # Number
-    (?P<boolean>true|false)                 |   # Boolean
-    (?P<null>null)                              # Null
+    (?P<string>"(\\.|[^"\\])*")             |
+    (?P<number>NaN|-?Infinity|[0-9\-+.Ee]+) |
+    (?P<boolean>true|false)                 |
+    (?P<null>null)
 ''', re.VERBOSE)
 
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -22,22 +22,24 @@ _color_pattern = re.compile(r'''
 ''', re.VERBOSE)
 
 
+_colors = {
+    'string': ANSIColors.GREEN,
+    'number': ANSIColors.YELLOW,
+    'boolean': ANSIColors.CYAN,
+    'null': ANSIColors.CYAN,
+}
+
+
+def _replace_match_callback(match):
+    for key in _colors:
+        if m := match.group(key):
+            color = _colors[key]
+            return f"{color}{m}{ANSIColors.RESET}"
+    return match.group()
+
+
 def _colorize_json(json_str):
-    colors = {
-        'string': ANSIColors.GREEN,
-        'number': ANSIColors.YELLOW,
-        'boolean': ANSIColors.CYAN,
-        'null': ANSIColors.CYAN,
-    }
-
-    def replace(match):
-        for key in colors:
-            if m := match.group(key):
-                color = colors[key]
-                return f"{color}{m}{ANSIColors.RESET}"
-        return match.group()
-
-    return re.sub(_color_pattern, replace, json_str)
+    return re.sub(_color_pattern, _replace_match_callback, json_str)
 
 
 def main():

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -83,7 +83,7 @@ def main():
 
 
 color_pattern = re.compile(r'''
-    (?P<string>"(\\.|[^"\\])*?")            |   # String
+    (?P<string>"(\\.|[^"\\])*")             |   # String
     (?P<number>NaN|-?Infinity|[0-9\-+.Ee]+) |   # Number
     (?P<boolean>true|false)                 |   # Boolean
     (?P<null>null)                              # Null

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -83,10 +83,10 @@ def main():
 
 
 color_pattern = re.compile(r'''
-    (?P<string>"(\\.|[^"\\])*?")           |   # String
-    (?P<number>NaN|-?Infinity|[\d\-+.Ee]+) |   # Number
-    (?P<boolean>true|false)                |   # Boolean
-    (?P<null>null)                             # Null
+    (?P<string>"(\\.|[^"\\])*?")            |   # String
+    (?P<number>NaN|-?Infinity|[0-9\-+.Ee]+) |   # Number
+    (?P<boolean>true|false)                 |   # Boolean
+    (?P<null>null)                              # Null
 ''', re.VERBOSE)
 
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -98,9 +98,9 @@ def colorize_json(json_str):
 
     def replace(match):
         for key in colors:
-            if match.group(key):
+            if m := match.group(key):
                 color = colors[key]
-                return f"{color}{match.group(key)}{ANSIColors.RESET}"
+                return f"{color}{m}{ANSIColors.RESET}"
         return match.group()
 
     return re.sub(color_pattern, replace, json_str)

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -14,7 +14,7 @@ from _colorize import ANSIColors, can_colorize
 # so we can use a looser but simpler regex to match
 # the various parts, most notably strings and numbers,
 # where the regex given by the spec is much more complex.
-color_pattern = re.compile(r'''
+_color_pattern = re.compile(r'''
     (?P<string>"(\\.|[^"\\])*")             |   # String
     (?P<number>NaN|-?Infinity|[0-9\-+.Ee]+) |   # Number
     (?P<boolean>true|false)                 |   # Boolean
@@ -22,7 +22,7 @@ color_pattern = re.compile(r'''
 ''', re.VERBOSE)
 
 
-def colorize_json(json_str):
+def _colorize_json(json_str):
     colors = {
         'string': ANSIColors.GREEN,
         'number': ANSIColors.YELLOW,
@@ -37,7 +37,7 @@ def colorize_json(json_str):
                 return f"{color}{m}{ANSIColors.RESET}"
         return match.group()
 
-    return re.sub(color_pattern, replace, json_str)
+    return re.sub(_color_pattern, replace, json_str)
 
 
 def main():
@@ -102,7 +102,7 @@ def main():
             for obj in objs:
                 if can_colorize(file=outfile):
                     json_str = json.dumps(obj, **dump_args)
-                    outfile.write(colorize_json(json_str))
+                    outfile.write(_colorize_json(json_str))
                 else:
                     json.dump(obj, outfile, **dump_args)
                 outfile.write('\n')

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -15,6 +15,7 @@ from _colorize import ANSIColors, can_colorize
 # the various parts, most notably strings and numbers,
 # where the regex given by the spec is much more complex.
 _color_pattern = re.compile(r'''
+    (?P<key>"(\\.|[^"\\])*")(?=:)           |
     (?P<string>"(\\.|[^"\\])*")             |
     (?P<number>NaN|-?Infinity|[0-9\-+.Ee]+) |
     (?P<boolean>true|false)                 |
@@ -23,6 +24,7 @@ _color_pattern = re.compile(r'''
 
 
 _colors = {
+    'key': ANSIColors.INTENSE_BLUE,
     'string': ANSIColors.GREEN,
     'number': ANSIColors.YELLOW,
     'boolean': ANSIColors.CYAN,

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -25,10 +25,10 @@ _color_pattern = re.compile(r'''
 
 _colors = {
     'key': ANSIColors.INTENSE_BLUE,
-    'string': ANSIColors.GREEN,
-    'number': ANSIColors.YELLOW,
-    'boolean': ANSIColors.CYAN,
-    'null': ANSIColors.CYAN,
+    'string': ANSIColors.BOLD_GREEN,
+    'number': ANSIColors.BOLD_YELLOW,
+    'boolean': ANSIColors.BOLD_CYAN,
+    'null': ANSIColors.BOLD_CYAN,
 }
 
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -10,6 +10,36 @@ import sys
 from _colorize import ANSIColors, can_colorize
 
 
+# The string we are colorizing is a valid JSON,
+# so we can use a looser but simpler regex to match
+# the various parts, most notably strings and numbers,
+# where the regex given by the spec is much more complex.
+color_pattern = re.compile(r'''
+    (?P<string>"(\\.|[^"\\])*")             |   # String
+    (?P<number>NaN|-?Infinity|[0-9\-+.Ee]+) |   # Number
+    (?P<boolean>true|false)                 |   # Boolean
+    (?P<null>null)                              # Null
+''', re.VERBOSE)
+
+
+def colorize_json(json_str):
+    colors = {
+        'string': ANSIColors.GREEN,
+        'number': ANSIColors.YELLOW,
+        'boolean': ANSIColors.CYAN,
+        'null': ANSIColors.CYAN,
+    }
+
+    def replace(match):
+        for key in colors:
+            if m := match.group(key):
+                color = colors[key]
+                return f"{color}{m}{ANSIColors.RESET}"
+        return match.group()
+
+    return re.sub(color_pattern, replace, json_str)
+
+
 def main():
     description = ('A simple command line interface for json module '
                    'to validate and pretty-print JSON objects.')
@@ -78,36 +108,6 @@ def main():
                 outfile.write('\n')
     except ValueError as e:
         raise SystemExit(e)
-
-
-# The string we are colorizing is a valid JSON,
-# so we can use a looser but simpler regex to match
-# the various parts, most notably strings and numbers,
-# where the regex given by the spec is much more complex.
-color_pattern = re.compile(r'''
-    (?P<string>"(\\.|[^"\\])*")             |   # String
-    (?P<number>NaN|-?Infinity|[0-9\-+.Ee]+) |   # Number
-    (?P<boolean>true|false)                 |   # Boolean
-    (?P<null>null)                              # Null
-''', re.VERBOSE)
-
-
-def colorize_json(json_str):
-    colors = {
-        'string': ANSIColors.GREEN,
-        'number': ANSIColors.YELLOW,
-        'boolean': ANSIColors.CYAN,
-        'null': ANSIColors.CYAN,
-    }
-
-    def replace(match):
-        for key in colors:
-            if m := match.group(key):
-                color = colors[key]
-                return f"{color}{m}{ANSIColors.RESET}"
-        return match.group()
-
-    return re.sub(color_pattern, replace, json_str)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -256,14 +256,14 @@ class TestMain(unittest.TestCase):
             ('null', b'\x1b[1;36mnull\x1b[0m'),
             ('true', b'\x1b[1;36mtrue\x1b[0m'),
             ('false', b'\x1b[1;36mfalse\x1b[0m'),
-            ('NaN', b'\x1b[1;33mNaN\x1b[0m'),
-            ('Infinity', b'\x1b[1;33mInfinity\x1b[0m'),
-            ('-Infinity', b'\x1b[1;33m-Infinity\x1b[0m'),
+            ('NaN', b'NaN'),
+            ('Infinity', b'Infinity'),
+            ('-Infinity', b'-Infinity'),
             ('"foo"', b'\x1b[1;32m"foo"\x1b[0m'),
             (r'" \"foo\" "', b'\x1b[1;32m" \\"foo\\" "\x1b[0m'),
             ('"α"', b'\x1b[1;32m"\\u03b1"\x1b[0m'),
-            ('123', b'\x1b[1;33m123\x1b[0m'),
-            ('-1.2345e+23', b'\x1b[1;33m-1.2345e+23\x1b[0m'),
+            ('123', b'123'),
+            ('-1.2345e+23', b'-1.2345e+23'),
             (r'{"\\": ""}',
              b'''\
 {
@@ -284,16 +284,16 @@ class TestMain(unittest.TestCase):
              b'''\
 {
     \x1b[94m"foo"\x1b[0m: \x1b[1;32m"bar"\x1b[0m,
-    \x1b[94m"baz"\x1b[0m: \x1b[1;33m1234\x1b[0m,
+    \x1b[94m"baz"\x1b[0m: 1234,
     \x1b[94m"qux"\x1b[0m: [
         \x1b[1;36mtrue\x1b[0m,
         \x1b[1;36mfalse\x1b[0m,
         \x1b[1;36mnull\x1b[0m
     ],
     \x1b[94m"xyz"\x1b[0m: [
-        \x1b[1;33mNaN\x1b[0m,
-        \x1b[1;33m-Infinity\x1b[0m,
-        \x1b[1;33mInfinity\x1b[0m
+        NaN,
+        -Infinity,
+        Infinity
     ]
 }'''),
         )

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -264,6 +264,9 @@ class TestMain(unittest.TestCase):
             ('null', b'\x1b[36mnull\x1b[0m'),
             ('true', b'\x1b[36mtrue\x1b[0m'),
             ('false', b'\x1b[36mfalse\x1b[0m'),
+            ('NaN', b'\x1b[33mNaN\x1b[0m'),
+            ('Infinity', b'\x1b[33mInfinity\x1b[0m'),
+            ('-Infinity', b'\x1b[33m-Infinity\x1b[0m'),
             ('"foo"', b'\x1b[32m"foo"\x1b[0m'),
             (r'" \"foo\" "', b'\x1b[32m" \\"foo\\" "\x1b[0m'),
             ('123', b'\x1b[33m123\x1b[0m'),
@@ -278,7 +281,13 @@ class TestMain(unittest.TestCase):
 {
     \x1b[32m"\\\\\\\\"\x1b[0m: \x1b[32m""\x1b[0m
 }'''),
-            ('{"foo": "bar", "baz": 1234, "qux": [true, false, null]}',
+            ('''\
+{
+    "foo": "bar",
+    "baz": 1234,
+    "qux": [true, false, null],
+    "xyz": [NaN, -Infinity, Infinity]
+}''',
              b'''\
 {
     \x1b[32m"foo"\x1b[0m: \x1b[32m"bar"\x1b[0m,
@@ -287,6 +296,11 @@ class TestMain(unittest.TestCase):
         \x1b[36mtrue\x1b[0m,
         \x1b[36mfalse\x1b[0m,
         \x1b[36mnull\x1b[0m
+    ],
+    \x1b[32m"xyz"\x1b[0m: [
+        \x1b[33mNaN\x1b[0m,
+        \x1b[33m-Infinity\x1b[0m,
+        \x1b[33mInfinity\x1b[0m
     ]
 }'''),
         )

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -320,3 +320,7 @@ class TestMain(unittest.TestCase):
 @support.requires_subprocess()
 class TestTool(TestMain):
     module = 'json.tool'
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -253,26 +253,26 @@ class TestMain(unittest.TestCase):
         cases = (
             ('{}', b'{}'),
             ('[]', b'[]'),
-            ('null', b'\x1b[36mnull\x1b[0m'),
-            ('true', b'\x1b[36mtrue\x1b[0m'),
-            ('false', b'\x1b[36mfalse\x1b[0m'),
-            ('NaN', b'\x1b[33mNaN\x1b[0m'),
-            ('Infinity', b'\x1b[33mInfinity\x1b[0m'),
-            ('-Infinity', b'\x1b[33m-Infinity\x1b[0m'),
-            ('"foo"', b'\x1b[32m"foo"\x1b[0m'),
-            (r'" \"foo\" "', b'\x1b[32m" \\"foo\\" "\x1b[0m'),
-            ('"α"', b'\x1b[32m"\\u03b1"\x1b[0m'),
-            ('123', b'\x1b[33m123\x1b[0m'),
-            ('-1.2345e+23', b'\x1b[33m-1.2345e+23\x1b[0m'),
+            ('null', b'\x1b[1;36mnull\x1b[0m'),
+            ('true', b'\x1b[1;36mtrue\x1b[0m'),
+            ('false', b'\x1b[1;36mfalse\x1b[0m'),
+            ('NaN', b'\x1b[1;33mNaN\x1b[0m'),
+            ('Infinity', b'\x1b[1;33mInfinity\x1b[0m'),
+            ('-Infinity', b'\x1b[1;33m-Infinity\x1b[0m'),
+            ('"foo"', b'\x1b[1;32m"foo"\x1b[0m'),
+            (r'" \"foo\" "', b'\x1b[1;32m" \\"foo\\" "\x1b[0m'),
+            ('"α"', b'\x1b[1;32m"\\u03b1"\x1b[0m'),
+            ('123', b'\x1b[1;33m123\x1b[0m'),
+            ('-1.2345e+23', b'\x1b[1;33m-1.2345e+23\x1b[0m'),
             (r'{"\\": ""}',
              b'''\
 {
-    \x1b[32m"\\\\"\x1b[0m: \x1b[32m""\x1b[0m
+    \x1b[94m"\\\\"\x1b[0m: \x1b[1;32m""\x1b[0m
 }'''),
             (r'{"\\\\": ""}',
              b'''\
 {
-    \x1b[32m"\\\\\\\\"\x1b[0m: \x1b[32m""\x1b[0m
+    \x1b[94m"\\\\\\\\"\x1b[0m: \x1b[1;32m""\x1b[0m
 }'''),
             ('''\
 {
@@ -283,17 +283,17 @@ class TestMain(unittest.TestCase):
 }''',
              b'''\
 {
-    \x1b[32m"foo"\x1b[0m: \x1b[32m"bar"\x1b[0m,
-    \x1b[32m"baz"\x1b[0m: \x1b[33m1234\x1b[0m,
-    \x1b[32m"qux"\x1b[0m: [
-        \x1b[36mtrue\x1b[0m,
-        \x1b[36mfalse\x1b[0m,
-        \x1b[36mnull\x1b[0m
+    \x1b[94m"foo"\x1b[0m: \x1b[1;32m"bar"\x1b[0m,
+    \x1b[94m"baz"\x1b[0m: \x1b[1;33m1234\x1b[0m,
+    \x1b[94m"qux"\x1b[0m: [
+        \x1b[1;36mtrue\x1b[0m,
+        \x1b[1;36mfalse\x1b[0m,
+        \x1b[1;36mnull\x1b[0m
     ],
-    \x1b[32m"xyz"\x1b[0m: [
-        \x1b[33mNaN\x1b[0m,
-        \x1b[33m-Infinity\x1b[0m,
-        \x1b[33mInfinity\x1b[0m
+    \x1b[94m"xyz"\x1b[0m: [
+        \x1b[1;33mNaN\x1b[0m,
+        \x1b[1;33m-Infinity\x1b[0m,
+        \x1b[1;33mInfinity\x1b[0m
     ]
 }'''),
         )

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -287,7 +287,9 @@ class TestMain(unittest.TestCase):
                     fp.write(input_)
                 _, stdout, _ = assert_python_ok('-m', self.module, infile,
                                                 PYTHON_COLORS='1')
-                self.assertEqual(stdout.strip(), expected)
+                stdout = stdout.replace(b'\r\n', b'\n')  # normalize line endings
+                stdout = stdout.strip()
+                self.assertEqual(stdout, expected)
 
 
 @support.requires_subprocess()

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -269,6 +269,7 @@ class TestMain(unittest.TestCase):
             ('-Infinity', b'\x1b[33m-Infinity\x1b[0m'),
             ('"foo"', b'\x1b[32m"foo"\x1b[0m'),
             (r'" \"foo\" "', b'\x1b[32m" \\"foo\\" "\x1b[0m'),
+            ('"α"', b'\x1b[32m"\\u03b1"\x1b[0m'),
             ('123', b'\x1b[33m123\x1b[0m'),
             ('-1.2345e+23', b'\x1b[33m-1.2345e+23\x1b[0m'),
             (r'{"\\": ""}',

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -268,6 +268,16 @@ class TestMain(unittest.TestCase):
             (r'" \"foo\" "', b'\x1b[32m" \\"foo\\" "\x1b[0m'),
             ('123', b'\x1b[33m123\x1b[0m'),
             ('-1.2345e+23', b'\x1b[33m-1.2345e+23\x1b[0m'),
+            (r'{"\\": ""}',
+             b'''\
+{
+    \x1b[32m"\\\\"\x1b[0m: \x1b[32m""\x1b[0m
+}'''),
+            (r'{"\\\\": ""}',
+             b'''\
+{
+    \x1b[32m"\\\\\\\\"\x1b[0m: \x1b[32m""\x1b[0m
+}'''),
             ('{"foo": "bar", "baz": 1234, "qux": [true, false, null]}',
              b'''\
 {

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -102,7 +102,6 @@ class TestMain(unittest.TestCase):
         self.assertEqual(process.stdout, self.expect)
         self.assertEqual(process.stderr, '')
 
-    @no_color
     def _create_infile(self, data=None):
         infile = os_helper.TESTFN
         with open(infile, "w", encoding="utf-8") as fp:
@@ -110,15 +109,14 @@ class TestMain(unittest.TestCase):
             fp.write(data or self.data)
         return infile
 
-    @no_color
     def test_infile_stdout(self):
         infile = self._create_infile()
-        rc, out, err = assert_python_ok('-m', self.module, infile)
+        rc, out, err = assert_python_ok('-m', self.module, infile,
+                                        PYTHON_COLORS='0')
         self.assertEqual(rc, 0)
         self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
         self.assertEqual(err, b'')
 
-    @no_color
     def test_non_ascii_infile(self):
         data = '{"msg": "\u3053\u3093\u306b\u3061\u306f"}'
         expect = textwrap.dedent('''\
@@ -128,17 +126,18 @@ class TestMain(unittest.TestCase):
         ''').encode()
 
         infile = self._create_infile(data)
-        rc, out, err = assert_python_ok('-m', self.module, infile)
+        rc, out, err = assert_python_ok('-m', self.module, infile,
+                                        PYTHON_COLORS='0')
 
         self.assertEqual(rc, 0)
         self.assertEqual(out.splitlines(), expect.splitlines())
         self.assertEqual(err, b'')
 
-    @no_color
     def test_infile_outfile(self):
         infile = self._create_infile()
         outfile = os_helper.TESTFN + '.out'
-        rc, out, err = assert_python_ok('-m', self.module, infile, outfile)
+        rc, out, err = assert_python_ok('-m', self.module, infile, outfile,
+                                        PYTHON_COLORS='0')
         self.addCleanup(os.remove, outfile)
         with open(outfile, "r", encoding="utf-8") as fp:
             self.assertEqual(fp.read(), self.expect)
@@ -146,10 +145,10 @@ class TestMain(unittest.TestCase):
         self.assertEqual(out, b'')
         self.assertEqual(err, b'')
 
-    @no_color
     def test_writing_in_place(self):
         infile = self._create_infile()
-        rc, out, err = assert_python_ok('-m', self.module, infile, infile)
+        rc, out, err = assert_python_ok('-m', self.module, infile, infile,
+                                        PYTHON_COLORS='0')
         with open(infile, "r", encoding="utf-8") as fp:
             self.assertEqual(fp.read(), self.expect)
         self.assertEqual(rc, 0)
@@ -163,17 +162,17 @@ class TestMain(unittest.TestCase):
         self.assertEqual(process.stdout, self.jsonlines_expect)
         self.assertEqual(process.stderr, '')
 
-    @no_color
     def test_help_flag(self):
-        rc, out, err = assert_python_ok('-m', self.module, '-h')
+        rc, out, err = assert_python_ok('-m', self.module, '-h',
+                                        PYTHON_COLORS='0')
         self.assertEqual(rc, 0)
         self.assertTrue(out.startswith(b'usage: '))
         self.assertEqual(err, b'')
 
-    @no_color
     def test_sort_keys_flag(self):
         infile = self._create_infile()
-        rc, out, err = assert_python_ok('-m', self.module, '--sort-keys', infile)
+        rc, out, err = assert_python_ok('-m', self.module, '--sort-keys', infile,
+                                        PYTHON_COLORS='0')
         self.assertEqual(rc, 0)
         self.assertEqual(out.splitlines(),
                          self.expect_without_sort_keys.encode().splitlines())
@@ -220,24 +219,23 @@ class TestMain(unittest.TestCase):
         self.assertEqual(process.stdout, expect)
         self.assertEqual(process.stderr, '')
 
-    @no_color
     def test_no_ensure_ascii_flag(self):
         infile = self._create_infile('{"key":"💩"}')
         outfile = os_helper.TESTFN + '.out'
         self.addCleanup(os.remove, outfile)
-        assert_python_ok('-m', self.module, '--no-ensure-ascii', infile, outfile)
+        assert_python_ok('-m', self.module, '--no-ensure-ascii', infile,
+                         outfile, PYTHON_COLORS='0')
         with open(outfile, "rb") as f:
             lines = f.read().splitlines()
         # asserting utf-8 encoded output file
         expected = [b'{', b'    "key": "\xf0\x9f\x92\xa9"', b"}"]
         self.assertEqual(lines, expected)
 
-    @no_color
     def test_ensure_ascii_default(self):
         infile = self._create_infile('{"key":"💩"}')
         outfile = os_helper.TESTFN + '.out'
         self.addCleanup(os.remove, outfile)
-        assert_python_ok('-m', self.module, infile, outfile)
+        assert_python_ok('-m', self.module, infile, outfile, PYTHON_COLORS='0')
         with open(outfile, "rb") as f:
             lines = f.read().splitlines()
         # asserting an ascii encoded output file

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -6,16 +6,8 @@ import unittest
 import subprocess
 
 from test import support
-from test.support import os_helper
+from test.support import force_not_colorized, os_helper
 from test.support.script_helper import assert_python_ok
-
-
-def no_color(func):
-    def inner(*args, **kwargs):
-        with os_helper.EnvironmentVarGuard() as env:
-            env['PYTHON_COLORS'] = '0'
-            return func(*args, **kwargs)
-    return inner
 
 
 @support.requires_subprocess()
@@ -95,7 +87,7 @@ class TestMain(unittest.TestCase):
     }
     """)
 
-    @no_color
+    @force_not_colorized
     def test_stdin_stdout(self):
         args = sys.executable, '-m', self.module
         process = subprocess.run(args, input=self.data, capture_output=True, text=True, check=True)
@@ -155,7 +147,7 @@ class TestMain(unittest.TestCase):
         self.assertEqual(out, b'')
         self.assertEqual(err, b'')
 
-    @no_color
+    @force_not_colorized
     def test_jsonlines(self):
         args = sys.executable, '-m', self.module, '--json-lines'
         process = subprocess.run(args, input=self.jsonlines_raw, capture_output=True, text=True, check=True)
@@ -178,7 +170,7 @@ class TestMain(unittest.TestCase):
                          self.expect_without_sort_keys.encode().splitlines())
         self.assertEqual(err, b'')
 
-    @no_color
+    @force_not_colorized
     def test_indent(self):
         input_ = '[1, 2]'
         expect = textwrap.dedent('''\
@@ -192,7 +184,7 @@ class TestMain(unittest.TestCase):
         self.assertEqual(process.stdout, expect)
         self.assertEqual(process.stderr, '')
 
-    @no_color
+    @force_not_colorized
     def test_no_indent(self):
         input_ = '[1,\n2]'
         expect = '[1, 2]\n'
@@ -201,7 +193,7 @@ class TestMain(unittest.TestCase):
         self.assertEqual(process.stdout, expect)
         self.assertEqual(process.stderr, '')
 
-    @no_color
+    @force_not_colorized
     def test_tab(self):
         input_ = '[1, 2]'
         expect = '[\n\t1,\n\t2\n]\n'
@@ -210,7 +202,7 @@ class TestMain(unittest.TestCase):
         self.assertEqual(process.stdout, expect)
         self.assertEqual(process.stderr, '')
 
-    @no_color
+    @force_not_colorized
     def test_compact(self):
         input_ = '[ 1 ,\n 2]'
         expect = '[1,2]\n'
@@ -242,8 +234,8 @@ class TestMain(unittest.TestCase):
         expected = [b'{', rb'    "key": "\ud83d\udca9"', b"}"]
         self.assertEqual(lines, expected)
 
+    @force_not_colorized
     @unittest.skipIf(sys.platform =="win32", "The test is failed with ValueError on Windows")
-    @no_color
     def test_broken_pipe_error(self):
         cmd = [sys.executable, '-m', self.module]
         proc = subprocess.Popen(cmd,

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -243,6 +243,7 @@ class TestMain(unittest.TestCase):
             ('true', b'\x1b[36mtrue\x1b[0m'),
             ('false', b'\x1b[36mfalse\x1b[0m'),
             ('"foo"', b'\x1b[32m"foo"\x1b[0m'),
+            (r'" \"foo\" "', b'\x1b[32m" \\"foo\\" "\x1b[0m'),
             ('123', b'\x1b[33m123\x1b[0m'),
             ('-1.2345e+23', b'\x1b[33m-1.2345e+23\x1b[0m'),
             ('{"foo": "bar", "baz": 1234, "qux": [true, false, null]}',

--- a/Misc/NEWS.d/next/Library/2025-04-05-16-05-34.gh-issue-131952.HX6gCX.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-05-16-05-34.gh-issue-131952.HX6gCX.rst
@@ -1,1 +1,1 @@
-Add color output to the :program:`json` CLI.
+Add color output to the :program:`json` CLI. Patch by Tomas Roun.

--- a/Misc/NEWS.d/next/Library/2025-04-05-16-05-34.gh-issue-131952.HX6gCX.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-05-16-05-34.gh-issue-131952.HX6gCX.rst
@@ -1,1 +1,1 @@
-Add color output to the :program:`json.tool` CLI.
+Add color output to the :program:`json` CLI.

--- a/Misc/NEWS.d/next/Library/2025-04-05-16-05-34.gh-issue-131952.HX6gCX.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-05-16-05-34.gh-issue-131952.HX6gCX.rst
@@ -1,0 +1,1 @@
+Add color output to the :program:`json.tool` CLI.


### PR DESCRIPTION
Example:

![image](https://github.com/user-attachments/assets/a7eb24e6-25e8-4704-8e24-63a1eb8661c8)

I'm open to changing the colors. For now it's green for strings, yellow for numbers and cyan for true/false/null.

<!-- gh-issue-number: gh-131952 -->
* Issue: gh-131952
<!-- /gh-issue-number -->
