### PR TITLE
gh-132139: Document that you can no longer set attributes on unions

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1130,6 +1130,8 @@ typing
     For example, ``isinstance(int | str, typing.Union)`` will return ``True``; previously
     this raised :exc:`TypeError`.
   - The ``__args__`` attribute of :class:`typing.Union` objects is no longer writable.
+  - It is no longer possible to set arbitrary dunder attributes on :class:`typing.Union`
+    objects.
 
   (Contributed by Jelle Zijlstra in :gh:`105499`.)
 


### PR DESCRIPTION
Closes #132139.


<!-- gh-issue-number: gh-132139 -->
* Issue: gh-132139
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132146.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->