### PR TITLE
gh-131798: JIT: Narrow the return type of `_BINARY_OP_SUBSCR_STR_INT` to `str`

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1648,17 +1648,16 @@ class TestUopsOptimization(unittest.TestCase):
 
     def test_binary_subcsr_str_int_narrows_to_str(self):
         def testfunc(n):
-            x = 0
+            x = []
             s = "foo"
-            z = ""
             for _ in range(n):
                 y = s[0]       # _BINARY_OP_SUBSCR_STR_INT
                 z = "bar" + y  # (_GUARD_TOS_UNICODE) + _BINARY_OP_ADD_UNICODE
-                x += 1
+                x.append(z)
             return x
 
         res, ex = self._run_with_optimizer(testfunc, TIER2_THRESHOLD)
-        self.assertEqual(res, TIER2_THRESHOLD)
+        self.assertEqual(res, ["barf"] * TIER2_THRESHOLD)
         self.assertIsNotNone(ex)
         uops = get_opnames(ex)
         self.assertIn("_BINARY_OP_SUBSCR_STR_INT", uops)

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1646,6 +1646,27 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertIn("_TO_BOOL_STR", uops)
         self.assertNotIn("_GUARD_TOS_UNICODE", uops)
 
+    def test_binary_subcsr_str_int_narrows_to_str(self):
+        def testfunc(n):
+            x = 0
+            s = "foo"
+            z = ""
+            for _ in range(n):
+                y = s[0]       # _BINARY_OP_SUBSCR_STR_INT
+                z = "bar" + y  # (_GUARD_TOS_UNICODE) + _BINARY_OP_ADD_UNICODE
+                x += 1
+            return x
+
+        res, ex = self._run_with_optimizer(testfunc, TIER2_THRESHOLD)
+        self.assertEqual(res, TIER2_THRESHOLD)
+        self.assertIsNotNone(ex)
+        uops = get_opnames(ex)
+        self.assertIn("_BINARY_OP_SUBSCR_STR_INT", uops)
+        # _BINARY_OP_SUBSCR_STR_INT narrows the result to 'str' so
+        # the unicode guard before _BINARY_OP_ADD_UNICODE is removed.
+        self.assertNotIn("_GUARD_TOS_UNICODE", uops)
+        self.assertIn("_BINARY_OP_ADD_UNICODE", uops)
+
 
 def global_identity(x):
     return x

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-06-13-17-10.gh-issue-131798.uMrfha.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-06-13-17-10.gh-issue-131798.uMrfha.rst
@@ -1,0 +1,2 @@
+Allow the JIT to remove unicode guards after ``_BINARY_OP_SUBSCR_STR_INT``
+by setting the return type to string.

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -366,6 +366,10 @@ dummy_func(void) {
         ctx->done = true;
     }
 
+    op(_BINARY_OP_SUBSCR_STR_INT, (left, right -- res)) {
+        res = sym_new_type(ctx, &PyUnicode_Type);
+    }
+
     op(_TO_BOOL, (value -- res)) {
         int already_bool = optimize_to_bool(this_instr, ctx, value, &res);
         if (!already_bool) {

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -569,7 +569,7 @@
 
         case _BINARY_OP_SUBSCR_STR_INT: {
             JitOptSymbol *res;
-            res = sym_new_not_null(ctx);
+            res = sym_new_type(ctx, &PyUnicode_Type);
             stack_pointer[-2] = res;
             stack_pointer += -1;
             assert(WITHIN_STACK_BOUNDS());


### PR DESCRIPTION
I tested this by finding another instruction which contains a unicode guard, in this case `BINARY_OP_ADD_UNICODE` and checking that the guard is removed if one of the operands is the result of `_BINARY_OP_SUBSCR_STR_INT`. Let me know if there's a better way to test this!

I also noticed that some other uops like `_BINARY_OP_ADD_UNICODE` check if the operands are constants. Should we add it here as well? I don't know if we gain much from that though, code like `'foo'[0]` is not very common.

<!-- gh-issue-number: gh-131798 -->
* Issue: gh-131798
<!-- /gh-issue-number -->
