### PR TITLE
gh-130843: add UUIDv7 timestamp recipes

### DIFF
--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -441,7 +441,8 @@ Here are some examples of typical usage of the :mod:`uuid` module::
    >>> u.time  # doctest: +SKIP
    1743936859822
    >>> # get UUIDv7 creation (local) time as a datetime object
-   >>> datetime.fromtimestamp(u.time / 1000)  # doctest: +SKIP
+   >>> import datetime as dt
+   >>> dt.datetime.fromtimestamp(u.time / 1000)  # doctest: +SKIP
    datetime.datetime(...)
 
 

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -436,7 +436,7 @@ Here are some examples of typical usage of the :mod:`uuid` module::
    >>> uuid.MAX
    UUID('ffffffff-ffff-ffff-ffff-ffffffffffff')
 
-   >>> # get UUIDv7 creation (local) time as a timestamp in millisecond
+   >>> # get UUIDv7 creation (local) time as a timestamp in milliseconds
    >>> u = uuid.uuid7()
    >>> u.time  # doctest: +SKIP
    1743936859822

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -121,8 +121,10 @@ which relays any information about the UUID's safety, using this enumeration:
      - The last 48 bits of the UUID. Only relevant to version 1.
 
    * - .. attribute:: UUID.time
-     - The 60-bit timestamp for version 1 and 6,
-       or the 48-bit timestamp for version 7.
+     - The 60-bit timestamp as a count of 100-nanosecond intervals since
+       Gregorian epoch (1582-10-15 00:00:00) for versions 1 and 6, or the
+       48-bit timestamp in milliseconds since Unix epoch (1970-01-01 00:00:00)
+       for version 7.
 
    * - .. attribute:: UUID.clock_seq
      - The 14-bit sequence number. Only relevant to versions 1 and 6.
@@ -433,6 +435,14 @@ Here are some examples of typical usage of the :mod:`uuid` module::
    >>> # get the Max UUID
    >>> uuid.MAX
    UUID('ffffffff-ffff-ffff-ffff-ffffffffffff')
+
+   >>> # get UUIDv7 creation (local) time as a timestamp in millisecond
+   >>> u = uuid.uuid7()
+   >>> u.time  # doctest: +SKIP
+   1743936859822
+   >>> # get UUIDv7 creation (local) time as a datetime object
+   >>> datetime.fromtimestamp(u.time / 1000)  # doctest: +SKIP
+   datetime.datetime(...)
 
 
 .. _uuid-cli-example:


### PR DESCRIPTION
Note: historically, Python (and [Rust](https://github.com/uuid-rs/uuid/blob/5fbd84355fb5348f25abe23d694c1004b0d74eb3/src/timestamp.rs#L50)) uses a local clock instead of querying exact UTC time. Now the RFC says:

> For systems that do not have UTC available but do have the local time, they may use that instead of UTC as long as they do so consistently throughout the system. However, this is not recommended since generating the UTC from local time only needs a time-zone offset.

So I think it's a good idea to indicate that we're actually using `time.time()` and not `time.gmtime()` when computing the timestamps. Both implementation choices are RFC compliant, and using a local time seems to be what other languages do (if I'm wrong, please correct me as I'm no Rust expert).

Note: if A in timezone $z_A$ generates a UUIDv7 at time $t_A$, and gives it to B in timezone $z_B$, then unless B knows $z_A$, they won't be able to know about $t_A$ as `u.time` would give the timestamp since Unix epoch with a "hidden" offset. But I'm not comfortable with Python being the only one that is actually generating UUIDv7 objects that are UTC-based and not local-time. For UUIDv1, I prefer not to change anything and UUIDv6 is meant to be compatible with UUIDv1, so I shouldn't change one without changing the other. UUIDv7 could be using UTC-based times (namely the timestamp would be extracted using `time.time_ns() - offset` but I don't know if Python should be the only one doing it...) 

<!-- gh-issue-number: gh-130843 -->
* Issue: gh-130843
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132154.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->