### PR TITLE
gh-132139: 3.14 what's new: elaborate on why you can no longer set `Union` attributes

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1131,7 +1131,7 @@ typing
     this raised :exc:`TypeError`.
   - The ``__args__`` attribute of :class:`typing.Union` objects is no longer writable.
   - It is no longer possible to set any attributes on :class:`typing.Union` objects.
-    This only ever worked for dunder attributes on previous versions, was never 
+    This only ever worked for dunder attributes on previous versions, was never
     documented to work, and was subtly broken in many cases.
 
   (Contributed by Jelle Zijlstra in :gh:`105499`.)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1130,8 +1130,9 @@ typing
     For example, ``isinstance(int | str, typing.Union)`` will return ``True``; previously
     this raised :exc:`TypeError`.
   - The ``__args__`` attribute of :class:`typing.Union` objects is no longer writable.
-  - It is no longer possible to set arbitrary dunder attributes on :class:`typing.Union`
-    objects.
+  - It is no longer possible to set any attributes on :class:`typing.Union` objects.
+    This only ever worked for dunder attributes on previous versions, was never 
+    documented to work, and was subtly broken in many cases.
 
   (Contributed by Jelle Zijlstra in :gh:`105499`.)
 


### PR DESCRIPTION
Explain in a bit more depth why we think this is an acceptable change to make without a deprecation period (I agree it is)

<!-- gh-issue-number: gh-132139 -->
* Issue: gh-132139
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132157.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->