### PR TITLE
gh-132159: Do not shadow user arguments in generated `__new__` by `@warnings.deprecated`

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -1653,6 +1653,25 @@ class DeprecatedTests(PyPublicAPITests):
         instance = Child(42)
         self.assertEqual(instance.a, 42)
 
+    def test_do_not_shadow_user_arguments(self):
+        new_called = False
+        new_called_cls = None
+
+        @deprecated("MyMeta will go away soon")
+        class MyMeta(type):
+            def __new__(mcs, name, bases, attrs, cls=None):
+                nonlocal new_called, new_called_cls
+                new_called = True
+                new_called_cls = cls
+                return super().__new__(mcs, name, bases, attrs)
+
+        with self.assertWarnsRegex(DeprecationWarning, "MyMeta will go away soon"):
+            class Foo(metaclass=MyMeta, cls='haha'):
+                pass
+
+        self.assertTrue(new_called)
+        self.assertEqual(new_called_cls, 'haha')
+
     def test_existing_init_subclass(self):
         @deprecated("C will go away soon")
         class C:

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -597,7 +597,7 @@ class deprecated:
             original_new = arg.__new__
 
             @functools.wraps(original_new)
-            def __new__(cls, *args, **kwargs):
+            def __new__(cls, /, *args, **kwargs):
                 if cls is arg:
                     warn(msg, category=category, stacklevel=stacklevel + 1)
                 if original_new is not object.__new__:

--- a/Misc/NEWS.d/next/Library/2025-04-06-16-12-49.gh-issue-132159.WvBfBm.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-06-16-12-49.gh-issue-132159.WvBfBm.rst
@@ -1,0 +1,1 @@
+Do not shadow user arguments in generated :meth:`!__new__` by decorator :class:`warnings.deprecated`. Patch by Xuehai Pan.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

Fixes #132159

cc @JelleZijlstra

<!-- gh-issue-number: gh-132159 -->
* Issue: gh-132159
<!-- /gh-issue-number -->
