### PR TITLE
[3.13] gh-132011: Fix crash on invalid `CALL_LIST_APPEND` deoptimization (GH-132018)

### DIFF
--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -1,4 +1,5 @@
 import sys
+import textwrap
 from test import list_tests
 from test.support import cpython_only
 from test.support.script_helper import assert_python_ok

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-02-17-47-14.gh-issue-132011.dNh64H.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-02-17-47-14.gh-issue-132011.dNh64H.rst
@@ -1,0 +1,1 @@
+Fix crash when calling :meth:`!list.append` as an unbound method.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -3631,7 +3631,7 @@ dummy_func(
             assert(oparg == 1);
             PyInterpreterState *interp = tstate->interp;
             DEOPT_IF(callable != interp->callable_cache.list_append);
-            assert(self != NULL);
+            DEOPT_IF(self == NULL);
             DEOPT_IF(!PyList_Check(self));
             STAT_INC(CALL, hit);
             if (_PyList_AppendTakeRef((PyListObject *)self, arg) < 0) {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -1590,7 +1590,7 @@
             assert(oparg == 1);
             PyInterpreterState *interp = tstate->interp;
             DEOPT_IF(callable != interp->callable_cache.list_append, CALL);
-            assert(self != NULL);
+            DEOPT_IF(self == NULL, CALL);
             DEOPT_IF(!PyList_Check(self), CALL);
             STAT_INC(CALL, hit);
             if (_PyList_AppendTakeRef((PyListObject *)self, arg) < 0) {


### PR DESCRIPTION
(cherry picked from commit c0661df42ad20e488dbfa3e0fec22462833fc3d6)


<!-- gh-issue-number: gh-132011 -->
* Issue: gh-132011
<!-- /gh-issue-number -->
