### PR TITLE
gh-132171: Fix `_interpreters.run_string` crash on string subclass

### DIFF
--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -746,6 +746,12 @@ class RunStringTests(TestBase):
         with self.assertRaises(TypeError):
             _interpreters.run_string(self.id, b'print("spam")')
 
+    def test_str_subclass_string(self):
+        class StrSubclass(str): pass
+
+        output = _run_output(self.id, StrSubclass('print(1 + 2)'))
+        self.assertEqual(output, '3\n')
+
     def test_with_shared(self):
         r, w = os.pipe()
 

--- a/Misc/NEWS.d/next/Library/2025-04-06-23-09-21.gh-issue-132171.zZqvfn.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-06-23-09-21.gh-issue-132171.zZqvfn.rst
@@ -1,0 +1,1 @@
+Fix crash of ``_interpreters.run_string`` on string subclasses.

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -330,7 +330,7 @@ get_code_str(PyObject *arg, Py_ssize_t *len_p, PyObject **bytes_p, int *flags_p)
     int flags = 0;
 
     if (PyUnicode_Check(arg)) {
-        assert(PyUnicode_CheckExact(arg)
+        assert(PyUnicode_Check(arg)
                && (check_code_str((PyUnicodeObject *)arg) == NULL));
         codestr = PyUnicode_AsUTF8AndSize(arg, &len);
         if (codestr == NULL) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-132171 -->
* Issue: gh-132171
<!-- /gh-issue-number -->
