### PR TITLE
gh-84481: Make ZipFile.data_offset more robust

### DIFF
--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -3363,7 +3363,7 @@ class TestDataOffsetZipWrite(unittest.TestCase):
                 raise OSError("Unimplemented!")
         with NoTellBytesIO() as fp:
             with zipfile.ZipFile(fp, "w") as zipfp:
-                self.assertIs(zipfp.data_offset, None)
+                self.assertIsNone(zipfp.data_offset)
 
 
 class EncodedMetadataTests(unittest.TestCase):

--- a/Lib/test/test_zipfile/test_core.py
+++ b/Lib/test/test_zipfile/test_core.py
@@ -3348,6 +3348,12 @@ class TestDataOffsetZipWrite(unittest.TestCase):
             with zipfile.ZipFile(fp, "w") as zipfp:
                 self.assertEqual(zipfp.data_offset, 16)
 
+    def test_data_offset_append_with_bad_zip(self):
+        with io.BytesIO() as fp:
+            fp.write(b"this is a prefix")
+            with zipfile.ZipFile(fp, "a") as zipfp:
+                self.assertEqual(zipfp.data_offset, 16)
+
     def test_data_offset_write_no_tell(self):
         # The initializer in ZipFile checks if tell raises AttributeError or
         # OSError when creating a file in write mode when deducing the offset

--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -1403,6 +1403,7 @@ class ZipFile:
         self._lock = threading.RLock()
         self._seekable = True
         self._writing = False
+        self._data_offset = None
 
         try:
             if mode == 'r':
@@ -1418,7 +1419,6 @@ class ZipFile:
                     self.fp = _Tellable(self.fp)
                     self.start_dir = 0
                     self._seekable = False
-                    self._data_offset = None
                 else:
                     # Some file-like objects can provide tell() but not seek()
                     try:
@@ -1439,6 +1439,7 @@ class ZipFile:
                     # even if no files are added to the archive
                     self._didModify = True
                     self.start_dir = self.fp.tell()
+                    self._data_offset = self.start_dir
             else:
                 raise ValueError("Mode must be 'r', 'w', 'x', or 'a'")
         except:


### PR DESCRIPTION
As pointed out by @picnixz, in append mode with a bad zip file, we append to the end of the file, and should set `.data_offset`.

I also added a test which should cover this scenario.

<!-- gh-issue-number: gh-84481 -->
* Issue: gh-84481
<!-- /gh-issue-number -->
