### PR TITLE
gh-129204: Add _PYTHON_SUBPROCESS_USE_POSIX_SPAWN environment knob

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -715,6 +715,9 @@ def _use_posix_spawn():
         # os.posix_spawn() is not available
         return False
 
+    if ((_env := os.environ.get('_PYTHON_SUBPROCESS_USE_POSIX_SPAWN')) in ('0', '1')):
+        return bool(int(_env))
+
     if sys.platform in ('darwin', 'sunos5'):
         # posix_spawn() is a syscall on both macOS and Solaris,
         # and properly reports errors

--- a/Misc/NEWS.d/next/Library/2025-04-06-19-25-12.gh-issue-129204.sAVFO6.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-06-19-25-12.gh-issue-129204.sAVFO6.rst
@@ -1,0 +1,2 @@
+Introduce new `_PYTHON_SUBPROCESS_USE_POSIX_SPAWN` environment variable knob in
+:mod:`subprocess` to control the use of :func:`os.posix_spawn`.

--- a/Misc/NEWS.d/next/Library/2025-04-06-19-25-12.gh-issue-129204.sAVFO6.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-06-19-25-12.gh-issue-129204.sAVFO6.rst
@@ -1,2 +1,2 @@
-Introduce new `_PYTHON_SUBPROCESS_USE_POSIX_SPAWN` environment variable knob in
+Introduce new ``_PYTHON_SUBPROCESS_USE_POSIX_SPAWN`` environment variable knob in
 :mod:`subprocess` to control the use of :func:`os.posix_spawn`.


### PR DESCRIPTION
Add support for disabling the use of `posix_spawn` via a variable in the process environment.

While it was previously possible to toggle this by modifying the value of `subprocess._USE_POSIX_SPAWN`, this required either patching CPython or modifying it within the interpreter instance which is not always possible, such as when running applications or scripts not under a user's control.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-129204 -->
* Issue: gh-129204
<!-- /gh-issue-number -->
