### PR TITLE
gh-132185: Avoid slow test_expanduser_pwd2 in test_posixpath

### DIFF
--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -359,7 +359,7 @@ class PosixPathTest(unittest.TestCase):
                      "no home directory on VxWorks")
     def test_expanduser_pwd2(self):
         pwd = import_helper.import_module('pwd')
-        for all_entry in get_attribute(pwd, 'getpwall')():
+        for all_entry in get_attribute(pwd, 'getpwall')()[:10]:
             name = all_entry.pw_name
 
             # gh-121200: pw_dir can be different between getpwall() and


### PR DESCRIPTION
On systems where `pwd.getpwall()` can return lots of entries, this test can end up being very slow, for no obvious benefit.


<!-- gh-issue-number: gh-132185 -->
* Issue: gh-132185
<!-- /gh-issue-number -->
