### PR TITLE
gh-131423: Update macOS installer to use OpenSSL 3.0.16.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -246,9 +246,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 3.0.15",
-              url="https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz",
-              checksum='23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533',
+              name="OpenSSL 3.0.16",
+              url="https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz",
+              checksum='57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2025-04-06-23-24-00.gh-issue-131423.4UcBKy.rst
+++ b/Misc/NEWS.d/next/macOS/2025-04-06-23-24-00.gh-issue-131423.4UcBKy.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use OpenSSL 3.0.16. Patch by Bénédikt Tran.


### PR DESCRIPTION
Patch by Bénédikt Tran.

<!-- gh-issue-number: gh-131423 -->
* Issue: gh-131423
<!-- /gh-issue-number -->
