### PR TITLE
gh-124111: Update macOS installer to use Tcl/Tk 8.6.16.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -264,10 +264,10 @@ def library_recipes():
             tk_patches = ['backport_gh71383_fix.patch', 'tk868_on_10_8_10_9.patch', 'backport_gh110950_fix.patch']
 
         else:
-            tcl_tk_ver='8.6.15'
-            tcl_checksum='861e159753f2e2fbd6ec1484103715b0be56be3357522b858d3cbb5f893ffef1'
+            tcl_tk_ver='8.6.16'
+            tcl_checksum='91cb8fa61771c63c262efb553059b7c7ad6757afa5857af6265e4b0bdc2a14a5'
 
-            tk_checksum='550969f35379f952b3020f3ab7b9dd5bfd11c1ef7c9b7c6a75f5c49aca793fec'
+            tk_checksum='be9f94d3575d4b3099d84bc3c10de8994df2d7aa405208173c709cc404a7e5fe'
             tk_patches = []
 
 

--- a/Misc/NEWS.d/next/macOS/2025-04-06-23-39-47.gh-issue-124111.2JI7iE.rst
+++ b/Misc/NEWS.d/next/macOS/2025-04-06-23-39-47.gh-issue-124111.2JI7iE.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use Tcl/Tk 8.6.16.


### PR DESCRIPTION


<!-- gh-issue-number: gh-124111 -->
* Issue: gh-124111
<!-- /gh-issue-number -->
