### PR TITLE
gh-132064: Make annotationlib use __annotate__ if only it is present

### DIFF
--- a/Doc/library/annotationlib.rst
+++ b/Doc/library/annotationlib.rst
@@ -322,12 +322,17 @@ Functions
 
    The *format* parameter controls the format in which annotations are returned,
    and must be a member of the :class:`Format` enum or its integer equivalent.
-   For the VALUE format, the :attr:`~object.__annotations__` is tried first; if it
-   does not exist, the :attr:`~object.__annotate__` function is called. The
-   FORWARDREF format uses :attr:`~object.__annotations__` if it exists and can be
-   evaluated, and otherwise falls back to calling the :attr:`~object.__annotate__` function.
-   The SOURCE format tries :attr:`~object.__annotate__` first, and falls back to
-   using :attr:`~object.__annotations__`, stringified using :func:`annotations_to_string`.
+   The different formats work as follows:
+
+   * VALUE: :attr:`!object.__annotations__` is tried first; if that does not exist,
+     the :attr:`!object.__annotate__` function is called if it exists.
+   * FORWARDREF: If :attr:`!object.__annotations__` exists and can be evaluated successfully,
+     it is used; otherwise, the :attr:`!object.__annotate__` function is called. If it
+     does not exist either, :attr:`!object.__annotations__` is tried again and any error
+     from accessing it is re-raised.
+   * STRING: If :attr:`!object.__annotate__` exists, it is called first;
+     otherwise, :attr:`!object.__annotations__` is used and stringified
+     using :func:`annotations_to_string`.
 
    Returns a dict. :func:`!get_annotations` returns a new dict every time
    it's called; calling it twice on the same object will return two

--- a/Doc/library/annotationlib.rst
+++ b/Doc/library/annotationlib.rst
@@ -317,11 +317,17 @@ Functions
    Compute the annotations dict for an object.
 
    *obj* may be a callable, class, module, or other object with
-   :attr:`~object.__annotate__` and :attr:`~object.__annotations__` attributes.
-   Passing in an object of any other type raises :exc:`TypeError`.
+   :attr:`~object.__annotate__` or :attr:`~object.__annotations__` attributes.
+   Passing any other object raises :exc:`TypeError`.
 
    The *format* parameter controls the format in which annotations are returned,
    and must be a member of the :class:`Format` enum or its integer equivalent.
+   For the VALUE format, the :attr:`~object.__annotations__` is tried first; if it
+   does not exist, the :attr:`~object.__annotate__` function is called. The
+   FORWARDREF format uses :attr:`~object.__annotations__` if it exists and can be
+   evaluated, and otherwise falls back to calling the :attr:`~object.__annotate__` function.
+   The SOURCE format tries :attr:`~object.__annotate__` first, and falls back to
+   using :attr:`~object.__annotations__`, stringified using :func:`annotations_to_string`.
 
    Returns a dict. :func:`!get_annotations` returns a new dict every time
    it's called; calling it twice on the same object will return two

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -740,7 +740,7 @@ def get_annotations(
             raise ValueError(f"Unsupported format {format!r}")
 
     if ann is None:
-        if isinstance(obj, type):
+        if isinstance(obj, type) or callable(obj):
             return {}
         raise TypeError(f"{obj!r} does not have annotations")
 

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -906,6 +906,18 @@ class TestGetAnnotations(unittest.TestCase):
             {"x": "int"},
         )
 
+    def test_no_annotations(self):
+        class CustomClass:
+            pass
+
+        for format in Format:
+            if format == Format.VALUE_WITH_FAKE_GLOBALS:
+                continue
+            for obj in (None, 1, object(), CustomClass()):
+                with self.subTest(format=format, obj=obj):
+                    with self.assertRaises(TypeError):
+                        annotationlib.get_annotations(obj, format=format)
+
     def test_pep695_generic_class_with_future_annotations(self):
         ann_module695 = inspect_stringized_annotations_pep695
         A_annotations = annotationlib.get_annotations(ann_module695.A, eval_str=True)

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -910,6 +910,10 @@ class TestGetAnnotations(unittest.TestCase):
         class CustomClass:
             pass
 
+        class MyCallable:
+            def __call__(self):
+                pass
+
         for format in Format:
             if format == Format.VALUE_WITH_FAKE_GLOBALS:
                 continue
@@ -917,6 +921,13 @@ class TestGetAnnotations(unittest.TestCase):
                 with self.subTest(format=format, obj=obj):
                     with self.assertRaises(TypeError):
                         annotationlib.get_annotations(obj, format=format)
+
+            # Callables and types with no annotations return an empty dict
+            for obj in (int, len, MyCallable()):
+                with self.subTest(format=format, obj=obj):
+                    self.assertEqual(
+                        annotationlib.get_annotations(obj, format=format), {}
+                    )
 
     def test_pep695_generic_class_with_future_annotations(self):
         ann_module695 = inspect_stringized_annotations_pep695

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -885,6 +885,27 @@ class TestGetAnnotations(unittest.TestCase):
             annotationlib.get_annotations(hb, format=Format.STRING), {"x": str}
         )
 
+    def test_only_annotate(self):
+        def f(x: int):
+            pass
+
+        class OnlyAnnotate:
+            @property
+            def __annotate__(self):
+                return f.__annotate__
+
+        oa = OnlyAnnotate()
+        self.assertEqual(
+            annotationlib.get_annotations(oa, format=Format.VALUE), {"x": int}
+        )
+        self.assertEqual(
+            annotationlib.get_annotations(oa, format=Format.FORWARDREF), {"x": int}
+        )
+        self.assertEqual(
+            annotationlib.get_annotations(oa, format=Format.STRING),
+            {"x": "int"},
+        )
+
     def test_pep695_generic_class_with_future_annotations(self):
         ann_module695 = inspect_stringized_annotations_pep695
         A_annotations = annotationlib.get_annotations(ann_module695.A, eval_str=True)

--- a/Misc/NEWS.d/next/Library/2025-04-06-21-17-14.gh-issue-132064.ktPwDM.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-06-21-17-14.gh-issue-132064.ktPwDM.rst
@@ -1,0 +1,4 @@
+:func:`annotationlib.get_annotations` now uses the ``__annotate__``
+attribute if it is present, even if ``__annotations__`` is not present.
+Additionally, the function now raises a :py:exc:`TypeError` if it is passed
+an object that does not have any annotatins.


### PR DESCRIPTION
Fixes #132064. Non-function objects for which `update_wrapper()` was used end up with only `__annotate__`, not `__annotations__`. It seems sensible for `get_annotations()` to support this case, and that also fixes the issue that was reported.

While implementing this I noticed a discrepancy between the docs and behavior of `get_annotations()`. The documentation said that the function would raise on unsupported objects; in fact it returned an empty dictionary, except if `eval_str=True`. I made it consistently raise a TypeError in this case instead, consistent with the docs.

<!-- gh-issue-number: gh-132064 -->
* Issue: gh-132064
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132195.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->