### PR TITLE
gh-87790: fix precision_with_grouping in formatting mini-language

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -326,7 +326,7 @@ The general form of a *standard format specifier* is:
    sign: "+" | "-" | " "
    width_and_precision: [`width_with_grouping`][`precision_with_grouping`]
    width_with_grouping: [`width`][`grouping`]
-   precision_with_grouping: "." [`precision`][`grouping`]
+   precision_with_grouping: "." (`precision` [`grouping`] | `grouping`)
    width: `~python-grammar:digit`+
    precision: `~python-grammar:digit`+
    grouping: "," | "_"


### PR DESCRIPTION
The 'type' field can't immediately follow to the dot. This amends f39a07b.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132205.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-87790 -->
* Issue: gh-87790
<!-- /gh-issue-number -->
