### PR TITLE
gh-132176: Fix crash on `type()` when `tuple` subclass passed as `bases`

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1825,12 +1825,7 @@ class ClassCreationTests(unittest.TestCase):
         class TupleSubclass(tuple): pass
 
         typ = type("typ", TupleSubclass((int, object)), {})
-        self.assertTrue(issubclass(typ, int))
-        self.assertTrue(issubclass(typ, object))
-        self.assertFalse(issubclass(typ, tuple))
-        self.assertIsInstance(typ(), int)
-        self.assertIsInstance(typ(), object)
-        self.assertNotIsInstance(typ(), tuple)
+        self.assertEqual(typ.__bases__, (int, object))
 
 
 class SimpleNamespaceTests(unittest.TestCase):

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1819,6 +1819,19 @@ class ClassCreationTests(unittest.TestCase):
         with self.assertRaises(RuntimeWarning):
             type("SouthPonies", (Model,), {})
 
+    def test_tuple_subclass_as_bases(self):
+        # gh-132176: it used to crash on using
+        # tuple subclass for as base classes.
+        class TupleSubclass(tuple): pass
+
+        typ = type("typ", TupleSubclass((int, object)), {})
+        self.assertTrue(issubclass(typ, int))
+        self.assertTrue(issubclass(typ, object))
+        self.assertFalse(issubclass(typ, tuple))
+        self.assertIsInstance(typ(), int)
+        self.assertIsInstance(typ(), object)
+        self.assertNotIsInstance(typ(), tuple)
+
 
 class SimpleNamespaceTests(unittest.TestCase):
 

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1826,6 +1826,7 @@ class ClassCreationTests(unittest.TestCase):
 
         typ = type("typ", TupleSubclass((int, object)), {})
         self.assertEqual(typ.__bases__, (int, object))
+        self.assertEqual(type(typ.__bases__), TupleSubclass)
 
 
 class SimpleNamespaceTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-07-12-50-10.gh-issue-132176.PRDbkA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-07-12-50-10.gh-issue-132176.PRDbkA.rst
@@ -1,2 +1,0 @@
-Fix a crash when :func:`type` receives a :class:`tuple` subclass as the
-second *bases* argument.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-07-12-50-10.gh-issue-132176.PRDbkA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-07-12-50-10.gh-issue-132176.PRDbkA.rst
@@ -1,0 +1,2 @@
+Fix a crash when :func:`type` receives a :class:`tuple` subclass as the
+second *bases* argument.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -497,10 +497,11 @@ _PyType_GetBases(PyTypeObject *self)
 static inline void
 set_tp_bases(PyTypeObject *self, PyObject *bases, int initial)
 {
-    assert(PyTuple_CheckExact(bases));
+    assert(PyTuple_Check(bases));
     if (self->tp_flags & _Py_TPFLAGS_STATIC_BUILTIN) {
         // XXX tp_bases can probably be statically allocated for each
         // static builtin type.
+        assert(PyTuple_CheckExact(bases));
         assert(initial);
         assert(self->tp_bases == NULL);
         if (PyTuple_GET_SIZE(bases) == 0) {


### PR DESCRIPTION


<!-- gh-issue-number: gh-132176 -->
* Issue: gh-132176
<!-- /gh-issue-number -->
