### PR TITLE
Docs HTML: Remove self-closing tags

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -631,12 +631,12 @@ ogp_social_cards = {  # Used when matplotlib is installed
     'line_color': '#3776ab',
 }
 ogp_custom_meta_tags = [
-    '<meta name="theme-color" content="#3776ab" />',
+    '<meta name="theme-color" content="#3776ab">',
 ]
 if 'create-social-cards' not in tags:  # noqa: F821
     # Define a static preview image when not creating social cards
     ogp_image = '_static/og-image.png'
     ogp_custom_meta_tags += [
-        '<meta property="og:image:width" content="200" />',
-        '<meta property="og:image:height" content="200" />',
+        '<meta property="og:image:width" content="200">',
+        '<meta property="og:image:height" content="200">',
     ]

--- a/Doc/includes/email-alternative.py
+++ b/Doc/includes/email-alternative.py
@@ -36,7 +36,7 @@ msg.add_alternative("""\
             recette
         </a> sera sûrement un très bon repas.
     </p>
-    <img src="cid:{asparagus_cid}" />
+    <img src="cid:{asparagus_cid}">
   </body>
 </html>
 """.format(asparagus_cid=asparagus_cid[1:-1]), subtype='html')

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -10,30 +10,30 @@
   <p><strong>{% trans %}Documentation sections:{% endtrans %}</strong></p>
   <table class="contentstable" align="center"><tr>
     <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("whatsnew/" + version) }}">{% trans %}What's new in Python {{ version }}?{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("whatsnew/" + version) }}">{% trans %}What's new in Python {{ version }}?{% endtrans %}</a><br>
          <span class="linkdescr"> {% trans whatsnew_index=pathto("whatsnew/index") %}Or <a href="{{ whatsnew_index }}">all "What's new" documents since Python 2.0</a>{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("tutorial/index") }}">{% trans %}Tutorial{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("tutorial/index") }}">{% trans %}Tutorial{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Start here: a tour of Python's syntax and features{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("library/index") }}">{% trans %}Library reference{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("library/index") }}">{% trans %}Library reference{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Standard library and builtins{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("reference/index") }}">{% trans %}Language reference{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("reference/index") }}">{% trans %}Language reference{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Syntax and language elements{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("using/index") }}">{% trans %}Python setup and usage{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("using/index") }}">{% trans %}Python setup and usage{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}How to install, configure, and use Python{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("howto/index") }}">{% trans %}Python HOWTOs{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("howto/index") }}">{% trans %}Python HOWTOs{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}In-depth topic manuals{% endtrans %}</span></p>
     </td><td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("installing/index") }}">{% trans %}Installing Python modules{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("installing/index") }}">{% trans %}Installing Python modules{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Third-party modules and PyPI.org{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("distributing/index") }}">{% trans %}Distributing Python modules{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("distributing/index") }}">{% trans %}Distributing Python modules{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Publishing modules for use by other people{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("extending/index") }}">{% trans %}Extending and embedding{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("extending/index") }}">{% trans %}Extending and embedding{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}For C/C++ programmers{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("c-api/index") }}">{% trans %}Python's C API{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("c-api/index") }}">{% trans %}Python's C API{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}C API reference{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("faq/index") }}">{% trans %}FAQs{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("faq/index") }}">{% trans %}FAQs{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Frequently asked questions (with answers!){% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("deprecations/index") }}">{% trans %}Deprecations{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("deprecations/index") }}">{% trans %}Deprecations{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Deprecated functionality{% endtrans %}</span></p>
     </td></tr>
   </table>
@@ -41,16 +41,16 @@
   <p><strong>{% trans %}Indices, glossary, and search:{% endtrans %}</strong></p>
   <table class="contentstable" align="center"><tr>
     <td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("py-modindex") }}">{% trans %}Global module index{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("py-modindex") }}">{% trans %}Global module index{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}All modules and libraries{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("genindex") }}">{% trans %}General index{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("genindex") }}">{% trans %}General index{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}All functions, classes, and terms{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("glossary") }}">{% trans %}Glossary{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("glossary") }}">{% trans %}Glossary{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Terms explained{% endtrans %}</span></p>
     </td><td width="50%">
-      <p class="biglink"><a class="biglink" href="{{ pathto("search") }}">{% trans %}Search page{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("search") }}">{% trans %}Search page{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Search this documentation{% endtrans %}</span></p>
-      <p class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{% trans %}Complete table of contents{% endtrans %}</a><br/>
+      <p class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{% trans %}Complete table of contents{% endtrans %}</a><br>
          <span class="linkdescr">{% trans %}Lists all sections and subsections{% endtrans %}</span></p>
     </td></tr>
   </table>

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -29,7 +29,7 @@
     {% if builder == "html" and enable_analytics %}
       <script defer data-domain="docs.python.org" src="https://plausible.io/js/script.js"></script>
     {% endif %}
-    <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html" />
+    <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html">
     {% if builder != "htmlhelp" %}
       {% if pagename == 'whatsnew/changelog' and not embedded %}
       <script type="text/javascript" src="{{ pathto('_static/changelog_search.js', 1) }}"></script>{% endif %}


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

> _Self-closing tags (`<tag />`) do not exist in HTML._
> 
> If a trailing `/` (slash) character is present in the start tag of an HTML element, HTML parsers ignore that slash character. This is especially important to remember for elements such as [`<script>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script) or [`<ul>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul) that do require a closing tag. In these cases, adding a trailing slash in the start tag does not close the element. Instead, the trailing slash is ignored, and the element is treated as open until an explicit closing tag is encountered or until the parser implicitly closes the element based on the HTML structure and parsing rules. For example, in the case of `<div/>Some text`, browsers interpret this as `<div>Some text</div>`, treating the slash as ignored and considering the div element to encapsulate the text that follows.

https://developer.mozilla.org/en-US/docs/Glossary/Void_element#self-closing_tags

Let's omit them: they're ignored, could be misleading (give the false impression they do something when they do not) and are ugly (IMO).



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132220.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->