### PR TITLE
gh-132185: Speed up expanduser() test with large password database

### DIFF
--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -363,7 +363,8 @@ class PosixPathTest(unittest.TestCase):
         pwd = import_helper.import_module('pwd')
         getpwall = support.get_attribute(pwd, 'getpwall')
         names = [entry.pw_name for entry in getpwall()]
-        if not support.is_resource_enabled('cpu') and len(names) > 100:
+        maxusers = 10000 if support.is_resource_enabled('cpu') else 100
+        if len(names) > maxusers:
             # Select random names, half of them with non-ASCII name,
             # if evailable.
             random.shuffle(names)

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -363,7 +363,6 @@ class PosixPathTest(unittest.TestCase):
         pwd = import_helper.import_module('pwd')
         getpwall = support.get_attribute(pwd, 'getpwall')
         names = [entry.pw_name for entry in getpwall()]
-        names = [(n+'x')[:-1] for n in names for i in range(1000)]
         maxusers = 2000 if support.is_resource_enabled('cpu') else 100
         if len(names) > maxusers:
             # Select random names, half of them with non-ASCII name,

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -363,7 +363,7 @@ class PosixPathTest(unittest.TestCase):
         pwd = import_helper.import_module('pwd')
         getpwall = support.get_attribute(pwd, 'getpwall')
         names = [entry.pw_name for entry in getpwall()]
-        maxusers = 2000 if support.is_resource_enabled('cpu') else 100
+        maxusers = 1000 if support.is_resource_enabled('cpu') else 100
         if len(names) > maxusers:
             # Select random names, half of them with non-ASCII name,
             # if available.

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -363,13 +363,14 @@ class PosixPathTest(unittest.TestCase):
         pwd = import_helper.import_module('pwd')
         getpwall = support.get_attribute(pwd, 'getpwall')
         names = [entry.pw_name for entry in getpwall()]
-        maxusers = 10000 if support.is_resource_enabled('cpu') else 100
+        names = [(n+'x')[:-1] for n in names for i in range(1000)]
+        maxusers = 2000 if support.is_resource_enabled('cpu') else 100
         if len(names) > maxusers:
             # Select random names, half of them with non-ASCII name,
             # if evailable.
             random.shuffle(names)
             names.sort(key=lambda name: name.isascii())
-            del names[50:-50]
+            del names[maxusers//2:-maxusers//2]
         for name in names:
             # gh-121200: pw_dir can be different between getpwall() and
             # getpwnam(), so use getpwnam() pw_dir as expanduser() does.

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -366,7 +366,7 @@ class PosixPathTest(unittest.TestCase):
         maxusers = 2000 if support.is_resource_enabled('cpu') else 100
         if len(names) > maxusers:
             # Select random names, half of them with non-ASCII name,
-            # if evailable.
+            # if available.
             random.shuffle(names)
             names.sort(key=lambda name: name.isascii())
             del names[maxusers//2:-maxusers//2]

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -1,12 +1,14 @@
 import inspect
 import os
 import posixpath
+import random
 import sys
 import unittest
 from posixpath import realpath, abspath, dirname, basename
+from test import support
 from test import test_genericpath
-from test.support import get_attribute, import_helper
-from test.support import cpython_only, os_helper
+from test.support import import_helper
+from test.support import os_helper
 from test.support.os_helper import FakePath
 from unittest import mock
 
@@ -285,7 +287,7 @@ class PosixPathTest(unittest.TestCase):
         self.assertFalse(posixpath.isjunction(ABSTFN))
 
     @unittest.skipIf(sys.platform == 'win32', "Fast paths are not for win32")
-    @cpython_only
+    @support.cpython_only
     def test_fast_paths_in_use(self):
         # There are fast paths of these functions implemented in posixmodule.c.
         # Confirm that they are being used, and not the Python fallbacks
@@ -359,16 +361,22 @@ class PosixPathTest(unittest.TestCase):
                      "no home directory on VxWorks")
     def test_expanduser_pwd2(self):
         pwd = import_helper.import_module('pwd')
-        for all_entry in get_attribute(pwd, 'getpwall')():
-            name = all_entry.pw_name
-
+        getpwall = support.get_attribute(pwd, 'getpwall')
+        names = [entry.pw_name for entry in getpwall()]
+        if not support.is_resource_enabled('cpu') and len(names) > 100:
+            # Select random names, half of them with non-ASCII name,
+            # if evailable.
+            random.shuffle(names)
+            names.sort(key=lambda name: name.isascii())
+            del names[50:-50]
+        for name in names:
             # gh-121200: pw_dir can be different between getpwall() and
             # getpwnam(), so use getpwnam() pw_dir as expanduser() does.
             entry = pwd.getpwnam(name)
             home = entry.pw_dir
             home = home.rstrip('/') or '/'
 
-            with self.subTest(all_entry=all_entry, entry=entry):
+            with self.subTest(name=name, pw_dir=entry.pw_dir):
                 self.assertEqual(posixpath.expanduser('~' + name), home)
                 self.assertEqual(posixpath.expanduser(os.fsencode('~' + name)),
                                  os.fsencode(home))


### PR DESCRIPTION
Use only random selected entries if the "cpu" resource is not enabled.


<!-- gh-issue-number: gh-132185 -->
* Issue: gh-132185
<!-- /gh-issue-number -->
