### PR TITLE
gh-132246: Add PEP 688 to C Buffer Protocol docs

### DIFF
--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -67,7 +67,7 @@ resource leaks.
 .. versionadded:: 3.12
 
    Buffer protocol is now accessible in Python, see
-   :ref:`python-buffer-protocol` and :class:`memoryview`
+   :ref:`python-buffer-protocol` and :class:`memoryview`.
 
 .. _buffer-structure:
 

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -26,17 +26,19 @@ characteristic of being backed by a possibly large memory buffer.  It is
 then desirable, in some situations, to access that buffer directly and
 without intermediate copying.
 
-Python provides such a facility at the C level in the form of the :ref:`buffer
-protocol <bufferobjects>`.  This protocol has two sides:
+Python provides such a facility at the C and Python level in the form of the
+:ref:`buffer protocol <bufferobjects>`.  This protocol has two sides:
 
 .. index:: single: PyBufferProcs (C type)
 
 - on the producer side, a type can export a "buffer interface" which allows
   objects of that type to expose information about their underlying buffer.
-  This interface is described in the section :ref:`buffer-structs`;
+  This interface is described in the section :ref:`buffer-structs`; for
+  Python see :ref:`python-buffer-protocol`.
 
 - on the consumer side, several means are available to obtain a pointer to
-  the raw underlying data of an object (for example a method parameter).
+  the raw underlying data of an object (for example a method parameter). For
+  Python see :class:`memoryview`.
 
 Simple objects such as :class:`bytes` and :class:`bytearray` expose their
 underlying buffer in byte-oriented form.  Other forms are possible; for example,
@@ -62,6 +64,10 @@ In both cases, :c:func:`PyBuffer_Release` must be called when the buffer
 isn't needed anymore.  Failure to do so could lead to various issues such as
 resource leaks.
 
+.. versionadded:: 3.12
+
+   Buffer protocol is now accessible in Python, see
+   :ref:`python-buffer-protocol` and :class:`memoryview`
 
 .. _buffer-structure:
 

--- a/Doc/c-api/buffer.rst
+++ b/Doc/c-api/buffer.rst
@@ -66,7 +66,7 @@ resource leaks.
 
 .. versionadded:: 3.12
 
-   Buffer protocol is now accessible in Python, see
+   The buffer protocol is now accessible in Python, see
    :ref:`python-buffer-protocol` and :class:`memoryview`.
 
 .. _buffer-structure:


### PR DESCRIPTION
`memoryview` is older (at least PEP-3118), but it's the Python equivalent to the C buffer acquisition methods so included it in the versionadded note.

<!-- gh-issue-number: gh-132246 -->
* Issue: gh-132246
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132249.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->