### PR TITLE
Add psfhosted Plausible instance to analytics

### DIFF
--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -28,6 +28,7 @@
 {% block extrahead %}
     {% if builder == "html" and enable_analytics %}
       <script defer data-domain="docs.python.org" src="https://plausible.io/js/script.js"></script>
+      <script defer data-domain="docs.python.org" src="https://analytics.python.org/js/script.js"></script>
     {% endif %}
     <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html">
     {% if builder != "htmlhelp" %}


### PR DESCRIPTION
I'm evaluating the self-hosted option on the psf infrastructure.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132252.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->