### PR TITLE
gh-106670: Fix a typo in pdb's exceptions command

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -769,7 +769,7 @@ can be overridden by the local file.
    When using ``pdb.pm()``  or ``Pdb.post_mortem(...)`` with a chained exception
    instead of a traceback, it allows the user to move between the
    chained exceptions using ``exceptions`` command to list exceptions, and
-   ``exception <number>`` to switch to that exception.
+   ``exceptions <number>`` to switch to that exception.
 
 
    Example::


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-106670 -->
* Issue: gh-106670
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132277.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->