### PR TITLE
GH-131798: Skip `self`/`NULL` checks for some known non-methods

### DIFF
--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -550,6 +550,58 @@ class TestCallCache(TestBase):
         with self.assertRaises(TypeError):
             instantiate()
 
+    def test_call_specialized_non_method_on_class(self):
+        class C:
+            pass
+        o = C()
+        for callable in (isinstance, len, str, tuple, type):
+            setattr(C, callable.__name__, callable)
+        for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+            self.assertIs(o.isinstance("Spam", str), True)
+            self.assertEqual(o.len("Spam"), 4)
+            self.assertEqual(o.str("Spam"), "Spam")
+            self.assertEqual(o.tuple("Spam"), ("S", "p", "a", "m"))
+            self.assertIs(o.type("Spam"), str)
+
+    def test_call_specialized_non_method_on_instance(self):
+        class C:
+            pass
+        o = C()
+        for callable in (isinstance, len, str, tuple, type):
+            setattr(o, callable.__name__, callable)
+        for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+            self.assertIs(o.isinstance("Spam", str), True)
+            self.assertEqual(o.len("Spam"), 4)
+            self.assertEqual(o.str("Spam"), "Spam")
+            self.assertEqual(o.tuple("Spam"), ("S", "p", "a", "m"))
+            self.assertIs(o.type("Spam"), str)
+
+    def test_call_specialized_method_on_class(self):
+        class C:
+            pass
+        o = C()
+        for callable in (isinstance, len, str, tuple, type):
+            setattr(C, callable.__name__, types.MethodType(callable, "Spam"))
+        for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+            self.assertIs(o.isinstance(str), True)
+            self.assertEqual(o.len(), 4)
+            self.assertEqual(o.str(), "Spam")
+            self.assertEqual(o.tuple(), ("S", "p", "a", "m"))
+            self.assertIs(o.type(), str)
+
+    def test_call_specialized_method_on_instance(self):
+        class C:
+            pass
+        o = C()
+        for callable in (isinstance, len, str, tuple, type):
+            setattr(o, callable.__name__, types.MethodType(callable, "Spam"))
+        for _ in range(_testinternalcapi.SPECIALIZATION_THRESHOLD):
+            self.assertIs(o.isinstance(str), True)
+            self.assertEqual(o.len(), 4)
+            self.assertEqual(o.str(), "Spam")
+            self.assertEqual(o.tuple(), ("S", "p", "a", "m"))
+            self.assertIs(o.type(), str)
+
 
 def make_deferred_ref_count_obj():
     """Create an object that uses deferred reference counting.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-08-08-59-25.gh-issue-131798.WrcdVS.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-08-08-59-25.gh-issue-131798.WrcdVS.rst
@@ -1,0 +1,2 @@
+Remove some unnecessary checks for some non-method :opcode:`CALL`
+specializations.


### PR DESCRIPTION
`CALL_TYPE_1`, `CALL_STR_1`, `CALL_TUPLE_1`, `CALL_LEN`, and `CALL_ISINSTANCE` will never call a method descriptor, which means that we can just assert that `self_or_null` is `NULL` instead of checking and "adjusting" the arguments each time.

`CALL_BUILTIN_CLASS` should never call a method descriptor, but I'm not sure that we can gurantee it. So I've just made this a `DEOPT_IF` instead.

<!-- gh-issue-number: gh-131798 -->
* Issue: gh-131798
<!-- /gh-issue-number -->
