### PR TITLE
gh-129463: Remove two attributes from ForwardRef equality

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -225,8 +225,6 @@ class ForwardRef:
             # because dictionaries are not hashable.
             and self.__globals__ is other.__globals__
             and self.__forward_is_class__ == other.__forward_is_class__
-            and self.__code__ == other.__code__
-            and self.__ast_node__ == other.__ast_node__
             and self.__cell__ == other.__cell__
             and self.__owner__ == other.__owner__
         )
@@ -237,8 +235,6 @@ class ForwardRef:
             self.__forward_module__,
             id(self.__globals__),  # dictionaries are not hashable, so hash by identity
             self.__forward_is_class__,
-            self.__code__,
-            self.__ast_node__,
             self.__cell__,
             self.__owner__,
         ))

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6529,6 +6529,13 @@ class ForwardRefTests(BaseTestCase):
         self.assertEqual(X | "x", Union[X, "x"])
         self.assertEqual("x" | X, Union["x", X])
 
+    def test_multiple_ways_to_create(self):
+        X1 = Union["X"]
+        self.assertIsInstance(X1, ForwardRef)
+        X2 = ForwardRef("X")
+        self.assertIsInstance(X2, ForwardRef)
+        self.assertEqual(X1, X2)
+
 
 class InternalsTests(BaseTestCase):
     def test_deprecation_for_no_type_params_passed_to__evaluate(self):

--- a/Misc/NEWS.d/next/Library/2025-04-08-10-45-22.gh-issue-129463.b1qEP3.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-08-10-45-22.gh-issue-129463.b1qEP3.rst
@@ -1,0 +1,3 @@
+Comparison of :class:`annotationlib.ForwardRef` objects no longer uses the
+internal ``__code__`` and ``__ast_node__`` attributes, which are used as
+caches.


### PR DESCRIPTION
* `__code__` is created on demand in the `__forward_code__` property
* `__ast_node__` is used together with `__arg__` to compute `__forward_arg__`, which is already used by itself in the comparison

<!-- gh-issue-number: gh-129463 -->
* Issue: gh-129463
<!-- /gh-issue-number -->
