### PR TITLE
gh-132285: Fix that `__annotate__` is not deleted when `__annotations__` is deleted

### DIFF
--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -824,8 +824,8 @@ class TestGetAnnotations(unittest.TestCase):
         del A.__annotations__
         called = False
 
-        self.assertEqual(A.__annotations__, {'a': int})
-        self.assertTrue(called)
+        self.assertEqual(A.__annotations__, {})
+        self.assertFalse(called)
 
     def test_non_dict_annotations(self):
         class WeirdAnnotations:

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -809,6 +809,24 @@ class TestGetAnnotations(unittest.TestCase):
             {"x": "int"},
         )
 
+    def test_del_annotations(self):
+        # gh-132285
+        called = False
+        class A:
+            def __annotate__(format):
+                nonlocal called
+                called = True
+                return {'a': int}
+
+        self.assertEqual(A.__annotations__, {'a': int})
+        self.assertTrue(called)
+
+        del A.__annotations__
+        called = False
+
+        self.assertEqual(A.__annotations__, {'a': int})
+        self.assertTrue(called)
+
     def test_non_dict_annotations(self):
         class WeirdAnnotations:
             @property

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -809,24 +809,6 @@ class TestGetAnnotations(unittest.TestCase):
             {"x": "int"},
         )
 
-    def test_del_annotations(self):
-        # gh-132285
-        called = False
-        class A:
-            def __annotate__(format):
-                nonlocal called
-                called = True
-                return {'a': int}
-
-        self.assertEqual(A.__annotations__, {'a': int})
-        self.assertTrue(called)
-
-        del A.__annotations__
-        called = False
-
-        self.assertEqual(A.__annotations__, {})
-        self.assertFalse(called)
-
     def test_non_dict_annotations(self):
         class WeirdAnnotations:
             @property

--- a/Lib/test/test_type_annotations.py
+++ b/Lib/test/test_type_annotations.py
@@ -57,6 +57,26 @@ class TypeAnnotationTests(unittest.TestCase):
         del C.__annotations__
         self.assertFalse("__annotations__" in C.__dict__)
 
+    def test_del_annotations_and_annotate(self):
+        # gh-132285
+        called = False
+        class A:
+            def __annotate__(format):
+                nonlocal called
+                called = True
+                return {'a': int}
+
+        self.assertEqual(A.__annotations__, {'a': int})
+        self.assertTrue(called)
+        self.assertTrue(A.__annotate__)
+
+        del A.__annotations__
+        called = False
+
+        self.assertEqual(A.__annotations__, {})
+        self.assertFalse(called)
+        self.assertIs(A.__annotate__, None)
+
     def test_descriptor_still_works(self):
         class C:
             def __init__(self, name=None, bases=None, d=None):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-09-12-37-31.gh-issue-132286.1ZdsOa.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-09-12-37-31.gh-issue-132286.1ZdsOa.rst
@@ -1,0 +1,2 @@
+Fix that :attr:`type.__annotate__` was not deleted, when
+:attr:`type.__annotations__` was deleted.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2066,8 +2066,7 @@ type_set_annotations(PyObject *tp, PyObject *value, void *Py_UNUSED(closure))
     if (result < 0) {
         Py_DECREF(dict);
         return -1;
-    }
-    else if (result == 0) {
+    } else {  // result can be 0 or 1
         if (PyDict_Pop(dict, &_Py_ID(__annotate__), NULL) < 0) {
             PyType_Modified(type);
             Py_DECREF(dict);


### PR DESCRIPTION


<!-- gh-issue-number: gh-132285 -->
* Issue: gh-132285
<!-- /gh-issue-number -->
