### PR TITLE
update comment about LLVM bug relevant for `--with-tail-call-interp` performance

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -390,8 +390,9 @@ For further information on how to build Python, see
     `compiler bug <https://github.com/llvm/llvm-project/issues/106846>`_ found in
     Clang/LLVM 19, which causes the normal interpreter to be slower. We were unaware of this bug,
     resulting in inaccurate results. We sincerely apologize for
-    communicating results that were only accurate for certain versions of LLVM 19
-    and 20. At the time of writing, this bug has not yet been fixed in LLVM 19-21. Thus
+    communicating results that were only accurate for LLVM v19.1.x and v20.1.0. In the meantime,
+    the bug has been fixed in LLVM v20.1.1 and for the upcoming v21.1, but it will remain
+    unfixed for LLVM v19.1.x and v20.1.0. Thus
     any benchmarks with those versions of LLVM may produce inaccurate numbers.
     (Thanks to Nelson Elhage for bringing this to light.)
 


### PR DESCRIPTION
While reading the [release notes](https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-tail-call) for 3.14, I followed some links and noticed that the bug affecting the performance numbers for `--with-tail-call-interp` was fixed in LLVM v20.1.1 (https://github.com/llvm/llvm-project/commit/0412f708c380d8fefc2136bbcfbcb5d551fe5730) resp. on main (https://github.com/llvm/llvm-project/commit/dd21aacd76e36d4db157a5d7a7b5370d456426e6)

This to me seems to be trivial enough to not require an issue, but if preferred, I can open one of course.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132297.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->