### PR TITLE
gh-132296: Use thread-state reference counting to fix `PyEval_SetTraceAllThreads`

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -296,6 +296,9 @@ _Py_AssertHoldsTstateFunc(const char *func)
 #define _Py_AssertHoldsTstate()
 #endif
 
+void _PyThreadState_Decref(PyThreadState *tstate);
+void _PyThreadState_Incref(PyThreadState *tstate);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Misc/NEWS.d/next/C_API/2025-04-08-22-08-05.gh-issue-132296.n0hZYY.rst
+++ b/Misc/NEWS.d/next/C_API/2025-04-08-22-08-05.gh-issue-132296.n0hZYY.rst
@@ -1,0 +1,2 @@
+Fix a crash when using :c:func:`PyEval_SetTrace` on the :term:`free threaded
+<free threading>` build.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2474,11 +2474,9 @@ PyEval_SetTraceAllThreads(Py_tracefunc func, PyObject *arg)
     HEAD_UNLOCK(runtime);
 
     while (ts != NULL) {
-        /*
         if (_PyEval_SetTrace(ts, func, arg) < 0) {
             PyErr_FormatUnraisable("Exception ignored in PyEval_SetTraceAllThreads");
         }
-        */
         HEAD_LOCK(runtime);
         PyThreadState *old = ts;
         ts = PyThreadState_Next(ts);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1485,7 +1485,7 @@ decref_threadstate(_PyThreadStateImpl *tstate)
     }
 }
 
-static void
+void
 _PyThreadState_Decref(PyThreadState *tstate)
 {
     assert(tstate != NULL);
@@ -1493,7 +1493,7 @@ _PyThreadState_Decref(PyThreadState *tstate)
     decref_threadstate(tstate);
 }
 
-static void
+void
 _PyThreadState_Incref(PyThreadState *tstate)
 {
     assert(tstate != NULL);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1485,6 +1485,22 @@ decref_threadstate(_PyThreadStateImpl *tstate)
     }
 }
 
+static void
+_PyThreadState_Decref(PyThreadState *tstate)
+{
+    assert(tstate != NULL);
+    _PyThreadStateImpl *impl = (_PyThreadStateImpl *)tstate;
+    decref_threadstate(tstate);
+}
+
+static void
+_PyThreadState_Incref(PyThreadState *tstate)
+{
+    assert(tstate != NULL);
+    _PyThreadStateImpl *impl = (_PyThreadStateImpl *)tstate;
+    _Py_atomic_add_ssize(&impl->refcount, 1);
+}
+
 /* Get the thread state to a minimal consistent state.
    Further init happens in pylifecycle.c before it can be used.
    All fields not initialized here are expected to be zeroed out,

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1490,7 +1490,7 @@ _PyThreadState_Decref(PyThreadState *tstate)
 {
     assert(tstate != NULL);
     _PyThreadStateImpl *impl = (_PyThreadStateImpl *)tstate;
-    decref_threadstate(tstate);
+    decref_threadstate(impl);
 }
 
 void

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1898,7 +1898,7 @@ PyThreadState_Delete(PyThreadState *tstate)
     _Py_EnsureTstateNotNULL(tstate);
     tstate_verify_not_active(tstate);
     tstate_delete_common(tstate, 0);
-    free_threadstate((_PyThreadStateImpl *)tstate);
+    decref_threadstate((_PyThreadStateImpl *)tstate);
 }
 
 
@@ -1911,7 +1911,7 @@ _PyThreadState_DeleteCurrent(PyThreadState *tstate)
 #endif
     current_fast_clear(tstate->interp->runtime);
     tstate_delete_common(tstate, 1);  // release GIL as part of call
-    free_threadstate((_PyThreadStateImpl *)tstate);
+    decref_threadstate((_PyThreadStateImpl *)tstate);
 }
 
 void


### PR DESCRIPTION
This extends the `refcount` field to affect `PyThreadState_Delete` and friends, letting us keep a thread state alive for slightly longer. This mechanism is far from being robust, because we're still not preventing the thread state from being cleared or other bad things, but it's a really nice start.

We *could* go the route of letting the reference count field prevent any finalization happening to the thread state, but I want to hear opinions on this approach first.

<!-- gh-issue-number: gh-132296 -->
* Issue: gh-132296
<!-- /gh-issue-number -->
