### PR TITLE
Remove redundant check in assert(...) macro

### DIFF
--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -330,8 +330,7 @@ get_code_str(PyObject *arg, Py_ssize_t *len_p, PyObject **bytes_p, int *flags_p)
     int flags = 0;
 
     if (PyUnicode_Check(arg)) {
-        assert(PyUnicode_Check(arg)
-               && (check_code_str((PyUnicodeObject *)arg) == NULL));
+        assert(check_code_str((PyUnicodeObject *)arg) == NULL);
         codestr = PyUnicode_AsUTF8AndSize(arg, &len);
         if (codestr == NULL) {
             return NULL;


### PR DESCRIPTION
The check is already happening in the if condition, so we can remove the one in assert(...) macro.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
