### PR TITLE
gh-130587: Invoke regen-token rst with rstfile as an argument

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1960,7 +1960,8 @@ regen-token:
 	# using Tools/build/generate_token.py
 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/build/generate_token.py rst \
 		$(srcdir)/Grammar/Tokens \
-		$(srcdir)/Doc/library/token-list.inc
+		$(srcdir)/Doc/library/token-list.inc \
+		$(srcdir)/Doc/library/token.rst
 	# Regenerate Include/internal/pycore_token.h from Grammar/Tokens
 	# using Tools/build/generate_token.py
 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/build/generate_token.py h \


### PR DESCRIPTION
This mitigates the issue we've bumped into in Fedora where we create special build directories for various types of builds and we can't deal with relative paths efficiently. I believe this was omitted incidentally in the original change.
Spotted in Python 3.14.0a7.

<!-- gh-issue-number: gh-130587 -->
* Issue: gh-130587
<!-- /gh-issue-number -->
