### PR TITLE
gh-132320: random._randbelow fix

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -245,7 +245,7 @@ class Random(_random.Random):
     def _randbelow_with_getrandbits(self, n):
         "Return a random int in the range [0,n).  Defined for n > 0."
 
-        k = n.bit_length()
+        k = (n - 1).bit_length()
         r = self.getrandbits(k)  # 0 <= r < 2**k
         while r >= n:
             r = self.getrandbits(k)

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -813,7 +813,7 @@ class MersenneTwister_TestBasicOps(TestBasicOps, unittest.TestCase):
         self.gen.seed(1234567)
         # If randrange uses getrandbits, it should pick getrandbits(100)
         # when called with a 100-bits stop argument.
-        self.assertEqual(self.gen.randrange(2**99),
+        self.assertEqual(self.gen.randrange(2**99 + 1),
                          97904845777343510404718956115)
 
     def test_randbelow_logic(self, _log=log, int=int):

--- a/Misc/NEWS.d/next/Library/2025-04-09-14-59-52.gh-issue-132320.qa1OoM.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-09-14-59-52.gh-issue-132320.qa1OoM.rst
@@ -1,0 +1,1 @@
+20-30% performance improvement when generating integers lower than some power of 2. E.g. :func:`!random.randint(0, 2**32-1)`


### PR DESCRIPTION
```bash
PYEXE1='main/python.exe'
PYEXE2='new/python.exe'

$PYEXE1 -m timeit -s 'from random import randint' 'randint(0, 2 - 1)'    # 298 nsec
$PYEXE2 -m timeit -s 'from random import randint' 'randint(0, 2 - 1)'    # 218 nsec

$PYEXE1 -m timeit -s 'from random import randint' 'randint(0, 2**32 - 1)'    # 519 nsec
$PYEXE2 -m timeit -s 'from random import randint' 'randint(0, 2**32 - 1)'    # 357 nsec

$PYEXE1 -m timeit -s 'from random import randint' 'randint(0, 2**128 - 1)'    # 819 nsec
$PYEXE2 -m timeit -s 'from random import randint' 'randint(0, 2**128 - 1)'    # 670 nsec
```

<!-- gh-issue-number: gh-132320 -->
* Issue: gh-132320
<!-- /gh-issue-number -->
