### PR TITLE
Manpage formatting tweaks

### DIFF
--- a/Misc/python.man
+++ b/Misc/python.man
@@ -254,17 +254,30 @@ to
 
 The simplest settings apply a particular action unconditionally to all warnings
 emitted by a process (even those that are otherwise ignored by default):
-
-.nf
-  \-Wdefault  # Warn once per call location
-  \-Werror    # Convert to exceptions
-  \-Walways   # Warn every time
-  \-Wall      # Same as \-Walways
-  \-Wmodule   # Warn once per calling module
-  \-Wonce     # Warn once per Python process
-  \-Wignore   # Never warn
-.fi
-
+.RS
+.TP
+.B \-Wdefault
+Warn once per call location
+.TP
+.B \-Werror
+Convert to exceptions
+.TP
+.B \-Walways
+Warn every time
+.TP
+.B \-Wall
+Same as \-Walways
+.TP
+.B \-Wmodule
+Warn once per calling module
+.TP
+.B \-Wonce
+Warn once per Python process
+.TP
+.B \-Wignore
+Never warn
+.RE
+.IP
 The action names can be abbreviated as desired and the interpreter will resolve
 them to the appropriate action name. For example,
 .B \-Wi

--- a/Misc/python.man
+++ b/Misc/python.man
@@ -458,7 +458,7 @@ is an empty string; if
 is used,
 .I sys.argv[0]
 contains the string
-.RI ' \-c "' ."
+.RI ' \-c '.
 Note that options interpreted by the Python interpreter itself
 are not placed in
 .IR sys.argv .

--- a/Misc/python.man
+++ b/Misc/python.man
@@ -1,4 +1,4 @@
-.TH PYTHON "1"
+.TH PYTHON 1
 
 .\" To view this file while editing, run it through groff:
 .\"   groff -Tascii -man python.man | less
@@ -532,12 +532,12 @@ the \fB\-d\fP option. If set to an integer, it is equivalent to
 specifying \fB\-d\fP multiple times.
 .IP PYTHONEXECUTABLE
 If this environment variable is set,
-.IB sys.argv[0]
+.I sys.argv[0]
 will be set to its value instead of the value got through the C runtime. Only
 works on Mac OS X.
 .IP PYTHONFAULTHANDLER
 If this environment variable is set to a non-empty string,
-.IR faulthandler.enable()
+.I faulthandler.enable()
 is called at startup: install a handler for SIGSEGV, SIGFPE, SIGABRT, SIGBUS
 and SIGILL signals to dump the Python traceback.
 .IP
@@ -610,14 +610,14 @@ If this is set before running the interpreter, it overrides the encoding used
 for stdin/stdout/stderr, in the syntax
 .IB encodingname : errorhandler
 The
-.IB errorhandler
+.I errorhandler
 part is optional and has the same meaning as in str.encode. For stderr, the
-.IB errorhandler
+.I errorhandler
 part is ignored; the handler will always be \'backslashreplace\'.
 .IP PYTHONMALLOC
 Set the Python memory allocators and/or install debug hooks. The available
 memory allocators are
-.IR malloc
+.I malloc
 and
 .IR pymalloc .
 The available debug hooks are
@@ -627,7 +627,7 @@ and
 .IR pymalloc_debug .
 .IP
 When Python is compiled in debug mode, the default is
-.IR pymalloc_debug
+.I pymalloc_debug
 and the debug hooks are automatically used. Otherwise, the default is
 .IR pymalloc .
 .IP PYTHONMALLOCSTATS
@@ -708,14 +708,14 @@ Python memory allocations using the tracemalloc module.
 .IP
 The value of the variable is the maximum number of frames stored in a
 traceback of a trace. For example,
-.IB PYTHONTRACEMALLOC=1
+.I PYTHONTRACEMALLOC=1
 stores only the most recent frame.
 .IP PYTHONUNBUFFERED
 If this is set to a non-empty string it is equivalent to specifying
 the \fB\-u\fP option.
 .IP PYTHONUSERBASE
 Defines the user base directory, which is used to compute the path of the user
-.IR site\-packages
+.I site\-packages
 directory and installation paths for
 .IR "python \-m pip install \-\-user" .
 .IP PYTHONUTF8
@@ -751,17 +751,17 @@ This is equivalent to the \fB\-X presite=\fImodule\fR option.
 .SH AUTHOR
 The Python Software Foundation: https://www.python.org/psf/
 .SH INTERNET RESOURCES
-Main website:  https://www.python.org/
+Main website: https://www.python.org/
 .br
-Documentation:  https://docs.python.org/
+Documentation: https://docs.python.org/
 .br
-Developer resources:  https://devguide.python.org/
+Developer resources: https://devguide.python.org/
 .br
-Downloads:  https://www.python.org/downloads/
+Downloads: https://www.python.org/downloads/
 .br
-Module repository:  https://pypi.org/
+Module repository: https://pypi.org/
 .br
-Newsgroups:  comp.lang.python, comp.lang.python.announce
+Newsgroups: comp.lang.python, comp.lang.python.announce
 .SH LICENSING
 Python is distributed under an Open Source license.  See the file
 "LICENSE" in the Python source distribution for information on terms &

--- a/Misc/python.man
+++ b/Misc/python.man
@@ -162,7 +162,7 @@ compilation options).
 Ignore environment variables like PYTHONPATH and PYTHONHOME that modify
 the behavior of the interpreter.
 .TP
-.B \-h ", " \-? ", "\-\-help
+.BR \-h ", " \-? ", " \-\-help
 Prints the usage for the interpreter executable and exits.
 .TP
 .B "\-\-help\-env"
@@ -170,7 +170,6 @@ Prints help about Python-specific environment variables and exits.
 .TP
 .B "\-\-help\-xoptions"
 Prints help about implementation-specific \fB\-X\fP options and exits.
-.TP
 .TP
 .B "\-\-help\-all"
 Prints complete usage information and exits.
@@ -243,7 +242,7 @@ twice, print a message for each file that is checked for when
 searching for a module.  Also provides information on module cleanup
 at exit.
 .TP
-.B \-V ", " \-\-version
+.BR \-V ", " \-\-version
 Prints the Python version number of the executable and exits.  When given
 twice, print more information about the build.
 
@@ -256,22 +255,24 @@ to
 The simplest settings apply a particular action unconditionally to all warnings
 emitted by a process (even those that are otherwise ignored by default):
 
-  -Wdefault  # Warn once per call location
-  -Werror    # Convert to exceptions
-  -Walways   # Warn every time
-  -Wall      # Same as -Walways
-  -Wmodule   # Warn once per calling module
-  -Wonce     # Warn once per Python process
-  -Wignore   # Never warn
+.nf
+  \-Wdefault  # Warn once per call location
+  \-Werror    # Convert to exceptions
+  \-Walways   # Warn every time
+  \-Wall      # Same as \-Walways
+  \-Wmodule   # Warn once per calling module
+  \-Wonce     # Warn once per Python process
+  \-Wignore   # Never warn
+.fi
 
 The action names can be abbreviated as desired and the interpreter will resolve
 them to the appropriate action name. For example,
 .B \-Wi
 is the same as
-.B \-Wignore .
+.BR \-Wignore .
 
 The full form of argument is:
-.IB action:message:category:module:lineno
+.IB action : message : category : module : lineno
 
 Empty fields match all values; trailing empty fields may be omitted. For
 example
@@ -457,7 +458,7 @@ is an empty string; if
 is used,
 .I sys.argv[0]
 contains the string
-.I '\-c'.
+.RI ' \-c "' ."
 Note that options interpreted by the Python interpreter itself
 are not placed in
 .IR sys.argv .
@@ -584,8 +585,8 @@ purpose is to allow repeatable hashing, such as for selftests for the
 interpreter itself, or to allow a cluster of python processes to share hash
 values.
 
-The integer must be a decimal number in the range [0,4294967295].  Specifying
-the value 0 will disable hash randomization.
+The integer must be a decimal number in the range [0,4\|294\|967\|295].
+Specifying the value 0 will disable hash randomization.
 .IP PYTHONHOME
 Change the location of the standard Python libraries.  By default, the
 libraries are searched in ${prefix}/lib/python<version> and
@@ -607,7 +608,7 @@ This is equivalent to the \fB\-X int_max_str_digits=\fINUMBER\fR option.
 .IP PYTHONIOENCODING
 If this is set before running the interpreter, it overrides the encoding used
 for stdin/stdout/stderr, in the syntax
-.IB encodingname ":" errorhandler
+.IB encodingname : errorhandler
 The
 .IB errorhandler
 part is optional and has the same meaning as in str.encode. For stderr, the


### PR DESCRIPTION
Following on from GH-132291 this is the second part of the patch from https://bugs.debian.org/1101406

This tweaks the formatting of a few bits of the manpage.

For those who don't speak roff, here are some rendering diffs: https://gist.github.com/stefanor/da32324f80e36f27819ba22ae0ab2098