### PR TITLE
docs: Fix typo in context_aware_warnings flag

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -603,7 +603,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
           :envvar:`PYTHON_THREAD_INHERIT_CONTEXT`
 
       * - .. attribute:: flags.context_aware_warnings
-        - :option:`-X thread_inherit_context <-X>` and
+        - :option:`-X context_aware_warnings <-X>` and
           :envvar:`PYTHON_CONTEXT_AWARE_WARNINGS`
 
 


### PR DESCRIPTION
Fix a typo in `Docs/library/sys.rst`.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132340.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->