### PR TITLE
[3.13] Generate social media preview cards for the documentation (GH-132101)

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -204,6 +204,7 @@ dist-html:
 	find dist -name 'python-$(DISTVERSION)-docs-html*' -exec rm -rf {} \;
 	$(MAKE) html
 	cp -pPR build/html dist/python-$(DISTVERSION)-docs-html
+	rm -rf dist/python-$(DISTVERSION)-docs-html/_images/social_previews/
 	tar -C dist -cf dist/python-$(DISTVERSION)-docs-html.tar python-$(DISTVERSION)-docs-html
 	bzip2 -9 -k dist/python-$(DISTVERSION)-docs-html.tar
 	(cd dist; zip -q -r -9 python-$(DISTVERSION)-docs-html.zip python-$(DISTVERSION)-docs-html)

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -616,11 +616,19 @@ stable_abi_file = 'data/stable_abi.dat'
 # Options for sphinxext-opengraph
 # -------------------------------
 
-ogp_site_url = 'https://docs.python.org/3/'
+ogp_canonical_url = 'https://docs.python.org/3/'
 ogp_site_name = 'Python documentation'
-ogp_image = '_static/og-image.png'
+ogp_social_cards = {  # Used when matplotlib is installed
+    'image': '_static/og-image.png',
+    'line_color': '#3776ab',
+}
 ogp_custom_meta_tags = [
-    '<meta property="og:image:width" content="200">',
-    '<meta property="og:image:height" content="200">',
     '<meta name="theme-color" content="#3776ab">',
 ]
+if 'create-social-cards' not in tags:  # noqa: F821
+    # Define a static preview image when not creating social cards
+    ogp_image = '_static/og-image.png'
+    ogp_custom_meta_tags += [
+        '<meta property="og:image:width" content="200">',
+        '<meta property="og:image:height" content="200">',
+    ]

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -11,7 +11,7 @@ sphinx~=8.2.0
 
 blurb
 
-sphinxext-opengraph~=0.9.0
+sphinxext-opengraph~=0.10.0
 sphinx-notfound-page~=1.0.0
 
 # The theme used by the documentation is stored separately, so we need


### PR DESCRIPTION
(cherry picked from commit 561965fa5c8314dee5b86586ffa16c1f369d1fa2)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132344.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->