### PR TITLE
gh-132354: document return value for `asyncio.Task.cancel`

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -1381,9 +1381,8 @@ Task Object
 
       Request the Task to be cancelled.
 
-      If the Task is already *done* or *cancelled*, return ``False``.
-      Otherwise, change the Task's state to *cancelled*,
-      schedule the callbacks, and return ``True``.
+      If the Task is already *done* or *cancelled*, return ``False``,
+      otherwise, return ``True``.
 
       The method arranges for a :exc:`CancelledError` exception to be thrown
       into the wrapped coroutine on the next cycle of the event loop.

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -1381,7 +1381,11 @@ Task Object
 
       Request the Task to be cancelled.
 
-      This arranges for a :exc:`CancelledError` exception to be thrown
+      If the Task is already *done* or *cancelled*, return ``False``.
+      Otherwise, change the Task's state to *cancelled*,
+      schedule the callbacks, and return ``True``.
+
+      The method arranges for a :exc:`CancelledError` exception to be thrown
       into the wrapped coroutine on the next cycle of the event loop.
 
       The coroutine then has a chance to clean up or even deny the

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1662,6 +1662,7 @@ Andreas Schawo
 Neil Schemenauer
 David Scherer
 Wolfgang Scherer
+Felix Scherz
 Hynek Schlawack
 Bob Schmertz
 Gregor Schmid

--- a/Misc/NEWS.d/next/Documentation/2025-04-10-20-41-53.gh-issue-132354.GN6DcP.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-04-10-20-41-53.gh-issue-132354.GN6DcP.rst
@@ -1,1 +1,0 @@
-Document return value for :func:`asyncio.Task.cancel`.

--- a/Misc/NEWS.d/next/Documentation/2025-04-10-20-41-53.gh-issue-132354.GN6DcP.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-04-10-20-41-53.gh-issue-132354.GN6DcP.rst
@@ -1,0 +1,1 @@
+Document return value for :func:`asyncio.Task.cancel`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Hi, this is intended to resolve #132354. I documented the return value, similar to `asyncio.Future.cancel`.

<!-- gh-issue-number: gh-132354 -->
* Issue: gh-132354
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132374.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->