### PR TITLE
gh-97517: Add hyperlink to format code information for strftime() and strptime() docstrings.

### DIFF
--- a/Lib/_pydatetime.py
+++ b/Lib/_pydatetime.py
@@ -1107,6 +1107,8 @@ class date:
         Format using strftime().
 
         Example: "%d/%m/%Y, %H:%M:%S"
+
+        `A list of supported format codes can be viewed here. <https://docs.python.org/3/library/datetime.html#format-codes>`_
         """
         return _wrap_strftime(self, format, self.timetuple())
 
@@ -1636,6 +1638,8 @@ class time:
     def strftime(self, format):
         """Format using strftime().  The date part of the timestamp passed
         to underlying strftime should not be used.
+
+        `A list of supported format codes can be viewed here. <https://docs.python.org/3/library/datetime.html#format-codes>`_
         """
         # The year must be >= 1000 else Python's strftime implementation
         # can raise a bogus exception.
@@ -2180,7 +2184,9 @@ class datetime(date):
 
     @classmethod
     def strptime(cls, date_string, format):
-        'string, format -> new datetime parsed from a string (like time.strptime()).'
+        """string, format -> new datetime parsed from a string (like time.strptime()).
+        
+        `A list of supported format codes can be viewed here. <https://docs.python.org/3/library/datetime.html#format-codes>`_"""
         import _strptime
         return _strptime._strptime_datetime_datetime(cls, date_string, format)
 


### PR DESCRIPTION
Fairly self-explanatory PR. Whenever I've used the datetime library, I've commonly had to open up the format code documentation in my web browser. This is just an inclusion of a link to the official python documentation so end users can more quickly/easily access this information. Plus it synergizes well with documentation extensions like VSCode's Docs View.

It might be worthwhile to port the full format code documentation, but I figured this would be a nice QoL addition without concern about how the documentation should be structured in the docstring.

<!-- gh-issue-number: gh-97517 -->
* Issue: gh-97517
<!-- /gh-issue-number -->
