### PR TITLE
gh-132385: Fix instance error suggestions potential exceptions in `traceback`

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4504,6 +4504,28 @@ class SuggestionFormattingTestBase:
         actual = self.get_suggestion(instance.foo)
         self.assertNotIn("self.blech", actual)
 
+    def test_unbound_local_error_with_side_effect(self):
+        # gh-132385
+        class A:
+            def __getattr__(self, key):
+                if key == 'foo':
+                    raise SystemExit('foo')
+                if key == 'spam':
+                    raise ValueError('spam')
+
+            def bar(self):
+                foo
+            def baz(self):
+                spam
+
+        suggestion = self.get_suggestion(A().bar)
+        self.assertNotIn('self.', suggestion)
+        self.assertIn("'foo'", suggestion)
+
+        suggestion = self.get_suggestion(A().baz)
+        self.assertNotIn('self.', suggestion)
+        self.assertIn("'spam'", suggestion)
+
     def test_unbound_local_error_does_not_match(self):
         def func():
             something = 3

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4509,7 +4509,7 @@ class SuggestionFormattingTestBase:
         class A:
             def __getattr__(self, key):
                 if key == 'foo':
-                    raise SystemExit('foo')
+                    raise AttributeError('foo')
                 if key == 'spam':
                     raise ValueError('spam')
 

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1532,7 +1532,11 @@ def _compute_suggestion_error(exc_value, tb, wrong_name):
         # has the wrong name as attribute
         if 'self' in frame.f_locals:
             self = frame.f_locals['self']
-            if hasattr(self, wrong_name):
+            try:
+                has_wrong_name = hasattr(self, wrong_name)
+            except BaseException:
+                has_wrong_name = False
+            if has_wrong_name:
                 return f"self.{wrong_name}"
 
     try:

--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -1534,7 +1534,7 @@ def _compute_suggestion_error(exc_value, tb, wrong_name):
             self = frame.f_locals['self']
             try:
                 has_wrong_name = hasattr(self, wrong_name)
-            except BaseException:
+            except Exception:
                 has_wrong_name = False
             if has_wrong_name:
                 return f"self.{wrong_name}"

--- a/Misc/NEWS.d/next/Library/2025-04-11-12-41-47.gh-issue-132385.86HoA7.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-11-12-41-47.gh-issue-132385.86HoA7.rst
@@ -1,0 +1,2 @@
+Fix instance error suggestions trigger potential exceptions
+in :meth:`object.__getattr__` in :mod:`traceback`.


### PR DESCRIPTION
It does not cover all side-effects, it will still evaluate `print`, etc.
But, it does not fail with exceptions at least.

<!-- gh-issue-number: gh-132385 -->
* Issue: gh-132385
<!-- /gh-issue-number -->
