### PR TITLE
gh-127833: lexical analysis: Add backticks to BOM example

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -99,7 +99,7 @@ which is recognized by Bram Moolenaar's VIM.
 
 If no encoding declaration is found, the default encoding is UTF-8.  If the
 implicit or explicit encoding of a file is UTF-8, an initial UTF-8 byte-order
-mark (b'\xef\xbb\xbf') is ignored rather than being a syntax error.
+mark (``b'\xef\xbb\xbf'``) is ignored rather than being a syntax error.
 
 If an encoding is declared, the encoding name must be recognized by Python
 (see :ref:`standard-encodings`). The


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Issue is used for other lexical analysis changes (links and expanding section)

logging-cookbook already does this:

![image](https://github.com/user-attachments/assets/5da786d9-cbed-4cf5-85b0-73f74bf9883f)


<!-- gh-issue-number: gh-127833 -->
* Issue: gh-127833
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132407.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->