### PR TITLE
gh-132386: Fix a crash when passing a dict subclass to `exec`

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1636,6 +1636,16 @@ class TestSpecifics(unittest.TestCase):
                     pass
             [[]]
 
+    def test_globals_dict_subclass(self):
+        # gh-132386
+        class WeirdDict(dict):
+            pass
+
+        ns = {}
+        exec('def foo(): return a', WeirdDict(), ns)
+
+        self.assertRaises(NameError, ns['foo'])
+
 class TestBooleanExpression(unittest.TestCase):
     class Value:
         def __init__(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-11-18-46-37.gh-issue-132386.pMBFTe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-11-18-46-37.gh-issue-132386.pMBFTe.rst
@@ -1,0 +1,2 @@
+Fix crash when passing a dict subclass as the ``globals`` parameter to
+:func:`exec`.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3312,6 +3312,8 @@ _PyEval_LoadGlobalStackRef(PyObject *globals, PyObject *builtins, PyObject *name
                 _PyEval_FormatExcCheckArg(
                             PyThreadState_GET(), PyExc_NameError,
                             NAME_ERROR_MSG, name);
+                *writeto = PyStackRef_NULL;
+                return;
             }
         }
         *writeto = PyStackRef_FromPyObjectSteal(res);


### PR DESCRIPTION
This issue boils down to a different branch being taken in `_PyEval_LoadGlobalStackRef` when a dict subclass is passed to `exec` globals. There is one case where the stack ref is not set to `PyStackRef_NULL` which causes the abort.

<!-- gh-issue-number: gh-132386 -->
* Issue: gh-132386
<!-- /gh-issue-number -->
