### PR TITLE
gh-111442: Correct names for all 0's and all 1's hosts in Address objects, and deprecate incorrect names.

### DIFF
--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -780,7 +780,8 @@ dictionaries.
    .. attribute:: subnet_router_anycast_address
 
       The Subnet-Router anycast address for the network, which is the first address
-      in the network.
+      in the network or None if the network is a /127 or /128, which do not have
+      a subnet router, as defined in IETF RFC 6164, section 8.
 
       .. versionadded:: next
 

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -563,7 +563,9 @@ dictionaries.
    .. attribute:: last_address
 
       The last address in the network, the address with all the host bits set.
-      This is the same as the broadcast_address for IPv4 networks.
+      This is the same as :attr:`broadcast_address` for IPv4 networks.
+      
+      .. versionadded:: next
 
    .. attribute:: broadcast_address
 

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -551,7 +551,9 @@ dictionaries.
    .. attribute:: first_address
 
       The first address in the network, the one with all the host bits cleared.
-      This is the same as the network_address for IPv4 networks.
+      This is the same as :attr:`network_address` for IPv4 networks.
+      
+      .. versionadded:: next
 
    .. attribute:: network_address
 

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -552,7 +552,7 @@ dictionaries.
 
       The first address in the network, the one with all the host bits cleared.
       This is the same as :attr:`network_address` for IPv4 networks.
-      
+
       .. versionadded:: next
 
    .. attribute:: network_address
@@ -564,7 +564,7 @@ dictionaries.
 
       The last address in the network, the address with all the host bits set.
       This is the same as :attr:`broadcast_address` for IPv4 networks.
-      
+
       .. versionadded:: next
 
    .. attribute:: broadcast_address
@@ -774,21 +774,21 @@ dictionaries.
 
       The first address in the network, the one with all the host bits cleared.
       This is the same as :attr:`subnet_router_anycast_address` for IPv6 networks.
-      
+
       .. versionadded:: next
 
    .. attribute:: subnet_router_anycast_address
 
       The Subnet-Router anycast address for the network, which is the first address
       in the network.
-      
+
       .. versionadded:: next
 
    .. attribute:: last_address
 
       The last address in the network, the one with all the host bits set.
       This has no special meaning for IPv6 networks.
-      
+
       .. versionadded:: next
 
    .. attribute:: hostmask
@@ -800,6 +800,22 @@ dictionaries.
    .. attribute:: with_hostmask
    .. attribute:: num_addresses
    .. attribute:: prefixlen
+   .. attribute:: network_address
+
+      The first address in the network. The name "network address" has meaning for IPv4 networks,
+      but not for IPv6, hence this use is deprecated.
+
+      .. deprecated:: next
+         Use :attr:`first_address` or :attr:`subnet_router_anycast_address` instead.
+
+   .. attribute:: broadcast_address
+
+      The last address in the network. The name "broadcast address" has meaning for IPv4 networks,
+      but not for IPv6, hence this use is deprecated.
+
+      .. deprecated:: next
+         Use :attr:`last_address` instead.
+
    .. method:: hosts()
 
       Returns an iterator over the usable hosts in the network.  The usable

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -781,6 +781,8 @@ dictionaries.
 
       The Subnet-Router anycast address for the network, which is the first address
       in the network.
+      
+      .. versionadded:: next
 
    .. attribute:: last_address
 

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -773,7 +773,9 @@ dictionaries.
    .. attribute:: first_address
 
       The first address in the network, the one with all the host bits cleared.
-      This is the same as the subnet_router_anycast_address for IPv6 networks.
+      This is the same as :attr:`subnet_router_anycast_address` for IPv6 networks.
+      
+      .. versionadded:: next
 
    .. attribute:: subnet_router_anycast_address
 

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -560,7 +560,7 @@ dictionaries.
       
    .. attribute:: broadcast_address
 
-      The broadcast address for the network. Packets sent to the broadcast
+      The same as :attr:`last_address` for IPv4 networks. Packets sent to this
       address should be received by every host on the network.
 
    .. attribute:: hostmask

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -788,6 +788,8 @@ dictionaries.
 
       The last address in the network, the one with all the host bits set.
       This has no special meaning for IPv6 networks.
+      
+      .. versionadded:: next
 
    .. attribute:: hostmask
    .. attribute:: netmask

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -553,6 +553,11 @@ dictionaries.
       The network address for the network. The network address and the
       prefix length together uniquely define a network.
 
+   .. attribute:: last_address
+
+      The last address in the network, the address with all the host bits set.
+      This is the same as the broadcast_address for IPv4 networks.
+      
    .. attribute:: broadcast_address
 
       The broadcast address for the network. Packets sent to the broadcast
@@ -757,7 +762,7 @@ dictionaries.
    .. attribute:: is_loopback
    .. attribute:: is_link_local
    .. attribute:: network_address
-   .. attribute:: broadcast_address
+   .. attribute:: last_address
    .. attribute:: hostmask
    .. attribute:: netmask
    .. attribute:: with_prefixlen

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -548,6 +548,11 @@ dictionaries.
       These attributes are true for the network as a whole if they are true
       for both the network address and the broadcast address.
 
+   .. attribute:: first_address
+
+      The first address in the network, the one with all the host bits cleared.
+      This is the same as the network_address for IPv4 networks.
+
    .. attribute:: network_address
 
       The network address for the network. The network address and the
@@ -761,8 +766,21 @@ dictionaries.
    .. attribute:: is_reserved
    .. attribute:: is_loopback
    .. attribute:: is_link_local
-   .. attribute:: network_address
+   .. attribute:: first_address
+
+      The first address in the network, the one with all the host bits cleared.
+      This is the same as the subnet_router_anycast_address for IPv6 networks.
+
+   .. attribute:: subnet_router_anycast_address
+
+      The Subnet-Router anycast address for the network, which is the first address
+      in the network.
+
    .. attribute:: last_address
+
+      The last address in the network, the one with all the host bits set.
+      This has no special meaning for IPv6 networks.
+
    .. attribute:: hostmask
    .. attribute:: netmask
    .. attribute:: with_prefixlen

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -562,7 +562,7 @@ dictionaries.
 
       The last address in the network, the address with all the host bits set.
       This is the same as the broadcast_address for IPv4 networks.
-      
+
    .. attribute:: broadcast_address
 
       The same as :attr:`last_address` for IPv4 networks. Packets sent to this

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -2383,7 +2383,6 @@ class IPv6Network(_BaseV6, _BaseNetwork):
         return self.last_address
 
 
-
 class _IPv6Constants:
 
     _linklocal_network = IPv6Network('fe80::/10')

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -2370,6 +2370,8 @@ class IPv6Network(_BaseV6, _BaseNetwork):
 
     @functools.cached_property
     def subnet_router_anycast_address(self):
+        if self._prefixlen == 127 or self._prefixlen == 128:
+            return None
         return self.first_address
 
     @functools.cached_property

--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -757,11 +757,11 @@ class _BaseNetwork(_IPAddressBase):
 
     @functools.cached_property
     def first_address(self):
-        return self._address_class(int(self.network_address))
+        return self._address_class(int(self.first_address))
 
     @functools.cached_property
     def last_address(self):
-        return self._address_class(int(self.network_address) |
+        return self._address_class(int(self.first_address) |
                                    int(self.hostmask))
 
     @property
@@ -1563,7 +1563,7 @@ class IPv4Network(_BaseV4, _BaseNetwork):
 
         """
         return (not (self.first_address in IPv4Network('100.64.0.0/10') and
-                    self.broadcast_address in IPv4Network('100.64.0.0/10')) and
+                    self.last_address in IPv4Network('100.64.0.0/10')) and
                 not self.is_private)
 
     @functools.cached_property
@@ -2373,12 +2373,12 @@ class IPv6Network(_BaseV6, _BaseNetwork):
         return self.first_address
 
     @functools.cached_property
-    @warnings.deprecated("IPv6 has no network addresses, use first_address or subnet_router_anycast_address instead.")
+    @warnings.deprecated("IPv6 has no network addresses, consider using first_address or subnet_router_anycast_address instead.")
     def network_address(self):
         return self.first_address
 
     @functools.cached_property
-    @warnings.deprecated("IPv6 has no broadcast addresses, use last_address instead for the address with all the host bits set.")
+    @warnings.deprecated("IPv6 has no broadcast addresses, consider using last_address instead.")
     def broadcast_address(self):
         return self.last_address
 

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -2754,7 +2754,7 @@ class IpaddrUnitTest(unittest.TestCase):
         ipv6_address2 = ipaddress.IPv6Interface("2001:658:22a:cafe:200:0:0:2")
         self.assertNotEqual(ipv6_address1.__hash__(), ipv6_address2.__hash__())
 
-    def test_ipv6_network_address_deprecation(self):
+    def testV6NetworkAddressDeprecation(self):
         network = ipaddress.IPv6Network('2001:658:22a:cafe::/64')
         with self.assertWarns(DeprecationWarning) as warn:
             addr = network.network_address
@@ -2765,7 +2765,7 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertIn("IPv6 has no network addresses", str(warn.warning))
         self.assertIn("consider using first_address or subnet_router_anycast_address instead", str(warn.warning))
 
-    def test_ipv6_broadcast_address_deprecation(self):
+    def testV6NetworkBroadcastAddressDeprecation(self):
         network = ipaddress.IPv6Network('2001:658:22a:cafe::/64')
         with self.assertWarns(DeprecationWarning) as warn:
             addr = network.broadcast_address
@@ -2775,13 +2775,13 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertIn("IPv6 has no broadcast addresses", str(warn.warning))
         self.assertIn("consider using last_address instead", str(warn.warning))
 
-    def test_ipv4_first_address(self):
+    def testV4NetworkFirstAddress(self):
         network = ipaddress.IPv4Network('192.0.2.0/24')
         addr = network.first_address
         self.assertEqual(addr, ipaddress.IPv4Address("192.0.2.0"))
         self.assertEqual(int(addr), 3221225984)
 
-    def test_ipv4_last_address(self):
+    def testV6NetworkLastAddress(self):
         network = ipaddress.IPv4Network('192.0.2.0/24')
         addr = network.last_address
         self.assertEqual(addr, ipaddress.IPv4Address("192.0.2.255"))

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -2787,6 +2787,21 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(addr, ipaddress.IPv4Address("192.0.2.255"))
         self.assertEqual(int(addr), 3221226239)
 
+    def testV6NetworkSubnetRouterAnycastAddress(self):
+        network = ipaddress.IPv6Network('2001:658:22a:cafe::/64')
+        addr = network.subnet_router_anycast_address
+        self.assertEqual(addr, ipaddress.IPv6Address("2001:658:22a:cafe::"))
+        self.assertEqual(int(addr), 42540616829182469433403647294022090752)
+
+    def testV6NetworkSubnetRouterAnycastAddressWithPrefix127(self):
+        network = ipaddress.IPv6Network('2001:658:22a:cafe::/127')
+        addr = network.subnet_router_anycast_address
+        self.assertIsNone(addr)
+
+    def testV6NetworkSubnetRouterAnycastAddressWithPrefix128(self):
+        network = ipaddress.IPv6Network('2001:658:22a:cafe::/128')
+        addr = network.subnet_router_anycast_address
+        self.assertIsNone(addr)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -1402,6 +1402,16 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(self.ipv4_network.supernet().prefixlen, 23)
         self.assertEqual(str(self.ipv4_network.supernet().network_address),
                          '1.2.2.0')
+        self.assertEqual(int(self.ipv6_network.broadcast_address),
+                          42540616829182469451850391367731642367)
+        self.assertEqual(str(self.ipv6_network.broadcast_address),
+                          '2001:658:22a:cafe:ffff:ffff:ffff:ffff')
+        self.assertEqual(int(self.ipv6_scoped_network.broadcast_address),
+                          42540616829182469451850391367731642367)
+        self.assertEqual(str(self.ipv6_scoped_network.broadcast_address),
+                          '2001:658:22a:cafe:ffff:ffff:ffff:ffff')
+
+        self.assertEqual(self.ipv4_network.supernet(new_prefix=22).prefixlen, 22)
         self.assertEqual(
             ipaddress.IPv4Interface('0.0.0.0/0').network.supernet(),
             ipaddress.IPv4Network('0.0.0.0/0'))
@@ -2030,9 +2040,9 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertTrue(ipaddress.ip_interface('::1%scope/80') >
                         ipaddress.ip_interface('::1/64'))
         self.assertTrue(ipaddress.ip_interface('::2%scope/64') >
-                        ipaddress.ip_interface('::1/64'))
+                        ipaddress.ip_interface('::1%scope/64'))
         self.assertTrue(ipaddress.ip_interface('::1%scope/64') >
-                        ipaddress.ip_interface('::2/48'))
+                        ipaddress.ip_interface('::2%scope/48'))
 
         self.assertFalse(ipaddress.ip_interface('::1/64') ==
                         ipaddress.ip_interface('::1%scope/64'))
@@ -2744,6 +2754,26 @@ class IpaddrUnitTest(unittest.TestCase):
         ipv6_address2 = ipaddress.IPv6Interface("2001:658:22a:cafe:200:0:0:2")
         self.assertNotEqual(ipv6_address1.__hash__(), ipv6_address2.__hash__())
 
+    def test_ipv6_network_address_deprecation(self):
+        network = ipaddress.IPv6Network('2001:658:22a:cafe::/64')
+        with self.assertWarns(DeprecationWarning) as warn:
+            addr = network.network_address
+            self.assertEqual(str(addr), "2001:658:22a:cafe::")
+            self.assertEqual(int(addr), 42540616829182469433403647294022090752)
+            self.assertEqual(addr, network.first_address)
+            self.assertEqual(addr, network.subnet_router_anycast_address)
+        self.assertIn("IPv6 has no network addresses", str(warn.warning))
+        self.assertIn("consider using first_address or subnet_router_anycast_address instead", str(warn.warning))
+
+    def test_ipv6_broadcast_address_deprecation(self):
+        network = ipaddress.IPv6Network('2001:658:22a:cafe::/64')
+        with self.assertWarns(DeprecationWarning) as warn:
+            addr = network.broadcast_address
+            self.assertEqual(str(addr), "2001:658:22a:cafe:ffff:ffff:ffff:ffff")
+            self.assertEqual(int(addr), 42540616829182469451850391367731642367)
+            self.assertEqual(addr, network.last_address)
+        self.assertIn("IPv6 has no broadcast addresses", str(warn.warning))
+        self.assertIn("consider using last_address instead", str(warn.warning))
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -1393,16 +1393,6 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(int(self.ipv4_network.broadcast_address), 16909311)
         self.assertEqual(str(self.ipv4_network.broadcast_address), '1.2.3.255')
 
-        self.assertEqual(int(self.ipv6_network.broadcast_address),
-                         42540616829182469451850391367731642367)
-        self.assertEqual(str(self.ipv6_network.broadcast_address),
-                         '2001:658:22a:cafe:ffff:ffff:ffff:ffff')
-
-        self.assertEqual(int(self.ipv6_scoped_network.broadcast_address),
-                         42540616829182469451850391367731642367)
-        self.assertEqual(str(self.ipv6_scoped_network.broadcast_address),
-                         '2001:658:22a:cafe:ffff:ffff:ffff:ffff')
-
     def testGetPrefixlen(self):
         self.assertEqual(self.ipv4_interface.network.prefixlen, 24)
         self.assertEqual(self.ipv6_interface.network.prefixlen, 64)
@@ -2708,21 +2698,13 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(self.ipv6_interface.network.network_address,
                          ipaddress.IPv6Address('2001:658:22a:cafe::'))
 
-        self.assertEqual(
-            self.ipv6_network.broadcast_address,
-            ipaddress.IPv6Address('2001:658:22a:cafe:ffff:ffff:ffff:ffff'))
         self.assertEqual(self.ipv6_network.hostmask,
                          ipaddress.IPv6Address('::ffff:ffff:ffff:ffff'))
-        self.assertEqual(
-            self.ipv6_interface.network.broadcast_address,
-            ipaddress.IPv6Address('2001:658:22a:cafe:ffff:ffff:ffff:ffff'))
         self.assertEqual(self.ipv6_interface.network.hostmask,
                          ipaddress.IPv6Address('::ffff:ffff:ffff:ffff'))
 
         # V6 - check we're cached
-        self.assertIn('broadcast_address', self.ipv6_network.__dict__)
         self.assertIn('hostmask', self.ipv6_network.__dict__)
-        self.assertIn('broadcast_address', self.ipv6_interface.network.__dict__)
         self.assertIn('hostmask', self.ipv6_interface.network.__dict__)
 
     def testTeredo(self):

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -2775,5 +2775,18 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertIn("IPv6 has no broadcast addresses", str(warn.warning))
         self.assertIn("consider using last_address instead", str(warn.warning))
 
+    def test_ipv4_first_address(self):
+        network = ipaddress.IPv4Network('192.0.2.0/24')
+        addr = network.first_address
+        self.assertEqual(addr, ipaddress.IPv4Address("192.0.2.0"))
+        self.assertEqual(int(addr), 3221225984)
+
+    def test_ipv4_last_address(self):
+        network = ipaddress.IPv4Network('192.0.2.0/24')
+        addr = network.last_address
+        self.assertEqual(addr, ipaddress.IPv4Address("192.0.2.255"))
+        self.assertEqual(int(addr), 3221226239)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -687,6 +687,7 @@ Fabian Groffen
 Linus Groh
 Eric Groo
 Daniel Andrade Groppe
+David Groves
 Dag Gruneau
 Filip Gruszczyński
 Andrii Grynenko

--- a/Misc/NEWS.d/next/Library/2025-04-11-21-01-53.gh-issue-111442.40zGdE.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-11-21-01-53.gh-issue-111442.40zGdE.rst
@@ -1,0 +1,4 @@
+Remove broadcast from IPv6Networks, as IPv6 does not have broadcasts in the
+same way IPv4 does. Internally last_address is now used instead of
+broadcast_address, and broadcast_address now aliases to last_address for
+IPv4Networks.


### PR DESCRIPTION
Use the correct langauge for the all 0's and all 1's addresses in networking.

For example, IPv6Networks don't have a network or a broadcast address. While the subnet_router_anycast address has all the host bits set to 0, you would expect to see packets on the wire addressed to it, where in IPv4 you would not expect to see packets addressed to the network_address. The all 1's host address in IPv6 has no special meaning.

This change deprecates the use of network_address or broadcast_address for IPv6Networks, and introduces the subnet_router_anycast_address property.

Internally, it does this by changing most previous occurances in the NetworkBase class for network_address to first_address and broadcast_address to last_address, and using the address family specific names in each address families class.

<!-- gh-issue-number: gh-111442 -->
* Issue: gh-111442
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132421.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->