### PR TITLE
gh-132399: ensure correct alignment of `PyInterpreterState` when UBSan is on

### DIFF
--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -748,6 +748,11 @@ struct _Py_unique_id_pool {
    The PyInterpreterState typedef is in Include/pytypedefs.h.
    */
 struct _is {
+    /* This structure is carefully allocated so that it's correctly aligned
+     * to avoid undefined behaviors during LOAD and STORE. The '_malloced'
+     * field stores the allocated pointer address that will later be freed.
+     */
+    uintptr_t _malloced;
 
     /* This struct contains the eval_breaker,
      * which is by far the hottest field in this struct

--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -748,16 +748,17 @@ struct _Py_unique_id_pool {
    The PyInterpreterState typedef is in Include/pytypedefs.h.
    */
 struct _is {
-    /* This structure is carefully allocated so that it's correctly aligned
-     * to avoid undefined behaviors during LOAD and STORE. The '_malloced'
-     * field stores the allocated pointer address that will later be freed.
-     */
-    uintptr_t _malloced;
 
     /* This struct contains the eval_breaker,
      * which is by far the hottest field in this struct
      * and should be placed at the beginning. */
     struct _ceval_state ceval;
+
+   /* This structure is carefully allocated so that it's correctly aligned
+     * to avoid undefined behaviors during LOAD and STORE. The '_malloced'
+     * field stores the allocated pointer address that will later be freed.
+     */
+    void *_malloced;
 
     PyInterpreterState *next;
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -664,17 +664,14 @@ extern "C" {
 #if defined(__has_feature)
 #  if __has_feature(undefined_behavior_sanitizer)
 #    define _Py_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined")))
-#    define _Py_HAS_UNDEFINED_BEHAVIOR_SANITIZER
 #  endif
 #endif
 #if !defined(_Py_NO_SANITIZE_UNDEFINED) && defined(__GNUC__) \
     && ((__GNUC__ >= 5) || (__GNUC__ == 4) && (__GNUC_MINOR__ >= 9))
 #  define _Py_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize_undefined))
-#  define _Py_HAS_UNDEFINED_BEHAVIOR_SANITIZER
 #endif
 #ifndef _Py_NO_SANITIZE_UNDEFINED
 #  define _Py_NO_SANITIZE_UNDEFINED
-#  undef _Py_HAS_UNDEFINED_BEHAVIOR_SANITIZER
 #endif
 
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -664,14 +664,17 @@ extern "C" {
 #if defined(__has_feature)
 #  if __has_feature(undefined_behavior_sanitizer)
 #    define _Py_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined")))
+#    define _Py_HAS_UNDEFINED_BEHAVIOR_SANITIZER
 #  endif
 #endif
 #if !defined(_Py_NO_SANITIZE_UNDEFINED) && defined(__GNUC__) \
     && ((__GNUC__ >= 5) || (__GNUC__ == 4) && (__GNUC_MINOR__ >= 9))
 #  define _Py_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize_undefined))
+#  define _Py_HAS_UNDEFINED_BEHAVIOR_SANITIZER
 #endif
 #ifndef _Py_NO_SANITIZE_UNDEFINED
 #  define _Py_NO_SANITIZE_UNDEFINED
+#  undef _Py_HAS_UNDEFINED_BEHAVIOR_SANITIZER
 #endif
 
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -573,7 +573,7 @@ _PyInterpreterState_Enable(_PyRuntimeState *runtime)
 #define RAW_ALIGN_PTR_OFFSET sizeof(void *)
 #endif
 
-static inline PyInterpreterState *
+static PyInterpreterState *
 alloc_interpreter(void)
 {
 #ifdef _Py_HAS_UNDEFINED_BEHAVIOR_SANITIZER

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -580,7 +580,7 @@ alloc_interpreter(void)
     }
     PyInterpreterState *interp = _Py_ALIGN_UP(mem, alignment);
     assert(_Py_IS_ALIGNED(interp, alignment));
-    interp->_malloced = (uintptr_t)mem;
+    interp->_malloced = mem;
     return interp;
 }
 
@@ -596,7 +596,7 @@ free_interpreter(PyInterpreterState *interp)
             interp->obmalloc = NULL;
         }
         assert(_Py_IS_ALIGNED(interp, _Alignof(PyInterpreterState)));
-        PyMem_RawFree((void *)interp->_malloced);
+        PyMem_RawFree(interp->_malloced);
     }
 }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -608,9 +608,7 @@ free_interpreter(PyInterpreterState *interp)
         assert(_Py_IS_ALIGNED(interp, _Alignof(PyInterpreterState)));
         char *mem_location = (char *)interp - RAW_ALIGN_PTR_OFFSET;
         void *mem = *((void **)mem_location);
-        if (mem != NULL) {
-            PyMem_RawFree(mem);
-        }
+        PyMem_RawFree(mem);
 #else
         PyMem_RawFree(interp);
 #endif


### PR DESCRIPTION
With that PR, the test suite passes for the free-threaded build with UBSan:

```sh
./configure --with-undefined-behavior-sanitizer --with-pydebug --prefix="$(pwd)/build" CC=clang LD=clang CFLAGS="-fsanitize=undefined -fno-sanitize-recover"  LDFLAGS="-fsanitize=undefined -fno-sanitize-recover" -q --disable-gil
./python -m test -j0
```

There is still one UB failure (fixed by #131605) but this is not specific to free-threading.

cc @colesbury

<!-- gh-issue-number: gh-132399 -->
* Issue: gh-132399
<!-- /gh-issue-number -->
