### PR TITLE
gh-131798: Use `sym_new_type` instead of `sym_new_not_null` for `_BUILD_LIST`, `_BUILD_SLICE`, and `_BUILD_MAP`

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1686,7 +1686,7 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertEqual(res, TIER2_THRESHOLD)
         self.assertIsNotNone(ex)
         uops = get_opnames(ex)
-        self.assertEqual(uops.count("_GUARD_NOS_DICT"), 1)
+        self.assertEqual(uops.count("_GUARD_NOS_DICT"), 0)
         self.assertEqual(uops.count("_STORE_SUBSCR_DICT"), 1)
         self.assertEqual(uops.count("_BINARY_OP_SUBSCR_DICT"), 1)
 
@@ -1706,7 +1706,7 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertEqual(res, 2 * TIER2_THRESHOLD)
         self.assertIsNotNone(ex)
         uops = get_opnames(ex)
-        self.assertEqual(uops.count("_GUARD_NOS_LIST"), 1)
+        self.assertEqual(uops.count("_GUARD_NOS_LIST"), 0)
         self.assertEqual(uops.count("_STORE_SUBSCR_LIST_INT"), 1)
         self.assertEqual(uops.count("_GUARD_TOS_LIST"), 0)
         self.assertEqual(uops.count("_UNPACK_SEQUENCE_LIST"), 1)

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1678,7 +1678,7 @@ class TestUopsOptimization(unittest.TestCase):
             x = 0
             for _ in range(n):
                 d = {}
-                d["Spam"] = 1  # Guarded...
+                d["Spam"] = 1  # unguarded!
                 x += d["Spam"]  # ...unguarded!
             return x
 
@@ -1695,7 +1695,7 @@ class TestUopsOptimization(unittest.TestCase):
             x = 0
             for _ in range(n):
                 l = [0]
-                l[0] = 1  # Guarded...
+                l[0] = 1  # unguarded!
                 [a] = l  # ...unguarded!
                 b = l[0]  # ...unguarded!
                 if l:  # ...unguarded!

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-12-19-41-16.gh-issue-131798.JkSocg.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-12-19-41-16.gh-issue-131798.JkSocg.rst
@@ -1,0 +1,2 @@
+Use ``sym_new_type`` instead of ``sym_new_not_null`` for _BUILD_LIST,
+_BUILD_SET, _BUILD_MAP

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -928,7 +928,7 @@ dummy_func(void) {
     }
 
     op(_BUILD_MAP, (values[oparg*2] -- map)) {
-        map = sym_new_type(ctx, &PyMap_Type);
+        map = sym_new_type(ctx, &PyDict_Type);
     }
 
     op(_UNPACK_SEQUENCE_TWO_TUPLE, (seq -- val1, val0)) {

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -919,6 +919,18 @@ dummy_func(void) {
         tup = sym_new_tuple(ctx, oparg, values);
     }
 
+    op(_BUILD_LIST, (values[oparg] -- list)) {
+        list = sym_new_type(ctx, &PyList_Type);
+    }
+
+    op(_BUILD_SLICE, (values[oparg] -- slice)) {
+        slice = sym_new_type(ctx, &PySlice_Type);
+    }
+
+    op(_BUILD_MAP, (values[oparg*2] -- map)) {
+        map = sym_new_type(ctx, &PyMap_Type);
+    }
+
     op(_UNPACK_SEQUENCE_TWO_TUPLE, (seq -- val1, val0)) {
         val0 = sym_tuple_getitem(ctx, seq, 0);
         val1 = sym_tuple_getitem(ctx, seq, 1);

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1031,7 +1031,7 @@
 
         case _BUILD_LIST: {
             JitOptSymbol *list;
-            list = sym_new_not_null(ctx);
+            list = sym_new_type(ctx, &PyList_Type);
             stack_pointer[-oparg] = list;
             stack_pointer += 1 - oparg;
             assert(WITHIN_STACK_BOUNDS());
@@ -1061,7 +1061,7 @@
 
         case _BUILD_MAP: {
             JitOptSymbol *map;
-            map = sym_new_not_null(ctx);
+            map = sym_new_type(ctx, &PyMap_Type);
             stack_pointer[-oparg*2] = map;
             stack_pointer += 1 - oparg*2;
             assert(WITHIN_STACK_BOUNDS());
@@ -2092,7 +2092,7 @@
 
         case _BUILD_SLICE: {
             JitOptSymbol *slice;
-            slice = sym_new_not_null(ctx);
+            slice = sym_new_type(ctx, &PySlice_Type);
             stack_pointer[-oparg] = slice;
             stack_pointer += 1 - oparg;
             assert(WITHIN_STACK_BOUNDS());

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1061,7 +1061,7 @@
 
         case _BUILD_MAP: {
             JitOptSymbol *map;
-            map = sym_new_type(ctx, &PyMap_Type);
+            map = sym_new_type(ctx, &PyDict_Type);
             stack_pointer[-oparg*2] = map;
             stack_pointer += 1 - oparg*2;
             assert(WITHIN_STACK_BOUNDS());


### PR DESCRIPTION


<!-- gh-issue-number: gh-131798 -->
* Issue: gh-131798
<!-- /gh-issue-number -->
