### PR TITLE
gh-132106: Ensure that running `logging.handlers.QueueListener` cannot be started again

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -1186,6 +1186,10 @@ possible, while any potentially slow operations (such as sending an email via
       This starts up a background thread to monitor the queue for
       LogRecords to process.
 
+      .. versionchanged:: next
+         Raises :exc:`RuntimeError` if called and the listener is already
+         running.
+
    .. method:: stop()
 
       Stops the listener.

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -819,6 +819,10 @@ logging.handlers
   manager protocol, allowing it to be used in a :keyword:`with` statement.
   (Contributed by Charles Machalow in :gh:`132106`.)
 
+* :meth:`~logging.handlers.QueueListener.start` will raise a :exc:`RuntimeError`
+  if the listener is already started.
+  (Contributed by Charles Machalow in :gh:`132106`.)
+
 
 mimetypes
 ---------

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -819,8 +819,8 @@ logging.handlers
   manager protocol, allowing it to be used in a :keyword:`with` statement.
   (Contributed by Charles Machalow in :gh:`132106`.)
 
-* :meth:`~logging.handlers.QueueListener.start` will raise a :exc:`RuntimeError`
-  if the listener is already started.
+* :meth:`QueueListener.start <logging.handlers.QueueListener.start>` now
+  raises a :exc:`RuntimeError` if the listener is already started.
   (Contributed by Charles Machalow in :gh:`132106`.)
 
 

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1561,6 +1561,9 @@ class QueueListener(object):
         This starts up a background thread to monitor the queue for
         LogRecords to process.
         """
+        if self._thread is not None:
+            raise RuntimeError("Listener already started")
+
         self._thread = t = threading.Thread(target=self._monitor)
         t.daemon = True
         t.start()

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4356,6 +4356,17 @@ class QueueHandlerTest(BaseTest):
         listener.stop()
         self.assertIsNone(listener._thread)
 
+    def test_queue_listener_multi_start(self):
+        handler = TestHandler(support.Matcher())
+        with logging.handlers.QueueListener(self.queue, handler) as listener:
+            self.assertRaises(RuntimeError, listener.start)
+
+        with listener:
+            self.assertRaises(RuntimeError, listener.start)
+
+        listener.start()
+        listener.stop()
+
     def test_queue_listener_with_StreamHandler(self):
         # Test that traceback and stack-info only appends once (bpo-34334, bpo-46755).
         listener = logging.handlers.QueueListener(self.queue, self.root_hdlr)

--- a/Misc/NEWS.d/next/Library/2025-04-12-09-30-24.gh-issue-132106.OxUds3.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-12-09-30-24.gh-issue-132106.OxUds3.rst
@@ -1,0 +1,2 @@
+:meth:`~logging.handlers.QueueListener.start` will raise a
+:exc:`RuntimeError` if the listener is already started.

--- a/Misc/NEWS.d/next/Library/2025-04-12-09-30-24.gh-issue-132106.OxUds3.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-12-09-30-24.gh-issue-132106.OxUds3.rst
@@ -1,2 +1,2 @@
-:meth:`~logging.handlers.QueueListener.start` will raise a
-:exc:`RuntimeError` if the listener is already started.
+:meth:`QueueListener.start <logging.handlers.QueueListener.start>` now
+raises a :exc:`RuntimeError` if the listener is already started.


### PR DESCRIPTION
gh-132106 - Make it so start can't be called again while running
Helps prevents a thread leak


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132444.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->