### PR TITLE
GH-132445: Allowing to reset parameters of Wave_write

### DIFF
--- a/Doc/library/wave.rst
+++ b/Doc/library/wave.rst
@@ -198,10 +198,19 @@ Wave_write Objects
 
       Set the number of channels.
 
+      Raises an :exc:`wave.Error`, if the value is set after data was written.
+
+      .. versionchanged:: 3.14
+         :exc:`wave.Error` is not raised, if the value is the same.
 
    .. method:: setsampwidth(n)
 
       Set the sample width to *n* bytes.
+
+      Raises an :exc:`wave.Error`, if the value is set after data was written.
+
+      .. versionchanged:: 3.14
+         :exc:`wave.Error` is not raised, if the value is the same.
 
 
    .. method:: setframerate(n)
@@ -212,6 +221,11 @@ Wave_write Objects
          A non-integral input to this method is rounded to the nearest
          integer.
 
+      Raises an :exc:`wave.Error`, if the value is set after data was written.
+
+      .. versionchanged:: 3.14
+         :exc:`wave.Error` is not raised, if the value is the same.
+
 
    .. method:: setnframes(n)
 
@@ -219,12 +233,20 @@ Wave_write Objects
       of frames actually written is different (this update attempt will
       raise an error if the output stream is not seekable).
 
+      Raises an :exc:`wave.Error`, if the value is set after data was written.
+
+      .. versionchanged:: 3.14
+         :exc:`wave.Error` is not raised, if the value is the same.
 
    .. method:: setcomptype(type, name)
 
       Set the compression type and description. At the moment, only compression type
       ``NONE`` is supported, meaning no compression.
 
+      Raises an Error, if the value is set after data was written.
+
+      .. versionchanged:: 3.14
+         :exc:`wave.Error` is not raised, if the value is the same.
 
    .. method:: setparams(tuple)
 
@@ -232,6 +254,10 @@ Wave_write Objects
       compname)``, with values valid for the ``set*()`` methods.  Sets all
       parameters.
 
+      Raises an :exc:`wave.Error`, if the value is set after data was written.
+
+      .. versionchanged:: 3.14
+         :exc:`wave.Error` is not raised, if the value is the same.
 
    .. method:: tell()
 
@@ -257,6 +283,6 @@ Wave_write Objects
       .. versionchanged:: 3.4
          Any :term:`bytes-like object` is now accepted.
 
-      Note that it is invalid to set any parameters after calling :meth:`writeframes`
+      Note that it is invalid to change any parameters after calling :meth:`writeframes`
       or :meth:`writeframesraw`, and any attempt to do so will raise
-      :exc:`wave.Error`.
+      :exc:`wave.Error`, if the value is different from the current value.

--- a/Lib/test/test_wave.py
+++ b/Lib/test/test_wave.py
@@ -162,6 +162,39 @@ class MiscTestCase(unittest.TestCase):
                 with self.assertWarns(DeprecationWarning):
                     self.assertIsNone(writer.getmarkers())
 
+    def test_setters(self):
+        with io.BytesIO(b'') as tmpfile:
+            with wave.open(tmpfile, 'wb') as writer:
+                writer.setnchannels(1)
+                writer.setsampwidth(1)
+                writer.setframerate(1)
+                writer.setcomptype('NONE', 'not compressed')
+
+                # no errors, when chaning and nothing was written
+                writer.setnchannels(2)
+                writer.setsampwidth(2)
+                writer.setframerate(2)
+                writer.setcomptype('NONE', 'uncompressed')
+
+                # write some frames
+                writer.writeframes(b'\0' * 16)
+
+                # changeing now should result in an error
+                with self.assertRaises(wave.Error):
+                    writer.setnchannels(1)
+                with self.assertRaises(wave.Error):
+                    writer.setsampwidth(1)
+                with self.assertRaises(wave.Error):
+                    writer.setframerate(1)
+                with self.assertRaises(wave.Error):
+                    writer.setcomptype('NONE', 'other')
+
+                # same value, so it should not raise Error
+                writer.setnchannels(2)
+                writer.setsampwidth(2)
+                writer.setframerate(2)
+                writer.setcomptype('NONE', 'uncompressed')
+
 
 class WaveLowLevelTest(unittest.TestCase):
 

--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -478,7 +478,7 @@ class Wave_write:
     # User visible methods.
     #
     def setnchannels(self, nchannels):
-        if self._datawritten:
+        if self._datawritten and self._nchannels != nchannels:
             raise Error('cannot change parameters after starting to write')
         if nchannels < 1:
             raise Error('bad # of channels')
@@ -490,7 +490,7 @@ class Wave_write:
         return self._nchannels
 
     def setsampwidth(self, sampwidth):
-        if self._datawritten:
+        if self._datawritten and self._sampwidth != sampwidth:
             raise Error('cannot change parameters after starting to write')
         if sampwidth < 1 or sampwidth > 4:
             raise Error('bad sample width')
@@ -502,11 +502,12 @@ class Wave_write:
         return self._sampwidth
 
     def setframerate(self, framerate):
-        if self._datawritten:
+        rounded_framerate = int(round(framerate))
+        if self._datawritten and self._framerate != rounded_framerate:
             raise Error('cannot change parameters after starting to write')
-        if framerate <= 0:
+        if rounded_framerate <= 0:
             raise Error('bad frame rate')
-        self._framerate = int(round(framerate))
+        self._framerate = rounded_framerate
 
     def getframerate(self):
         if not self._framerate:
@@ -514,7 +515,7 @@ class Wave_write:
         return self._framerate
 
     def setnframes(self, nframes):
-        if self._datawritten:
+        if self._datawritten and self._nframes != nframes:
             raise Error('cannot change parameters after starting to write')
         self._nframes = nframes
 
@@ -522,7 +523,7 @@ class Wave_write:
         return self._nframeswritten
 
     def setcomptype(self, comptype, compname):
-        if self._datawritten:
+        if self._datawritten and (self._comptype != comptype or self._compname != compname):
             raise Error('cannot change parameters after starting to write')
         if comptype not in ('NONE',):
             raise Error('unsupported compression type')
@@ -537,8 +538,8 @@ class Wave_write:
 
     def setparams(self, params):
         nchannels, sampwidth, framerate, nframes, comptype, compname = params
-        if self._datawritten:
-            raise Error('cannot change parameters after starting to write')
+        # no check for value change required: either the properties have the same
+        # value or they throw the exception them selfs
         self.setnchannels(nchannels)
         self.setsampwidth(sampwidth)
         self.setframerate(framerate)

--- a/Misc/NEWS.d/next/Library/2025-04-30-18-12-53.gh-issue-132445.zPEifv.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-30-18-12-53.gh-issue-132445.zPEifv.rst
@@ -1,0 +1,1 @@
+:class:`Wave_write` setters don't raise an error anymore, if the value did not change after frames were written.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This allows to re-set a parameter of Wave_write to the same value without causing an `Error`. This allows to implemet repeated writes to a wav file without special care for the first write.


<!-- gh-issue-number: gh-132445 -->
* Issue: gh-132445
<!-- /gh-issue-number -->
