### PR TITLE
[3.13] gh-132429: Fix support of Bluetooth sockets on NetBSD and DragonFly BSD

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-04-12-12-59-51.gh-issue-132429.OEIdlW.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-12-12-59-51.gh-issue-132429.OEIdlW.rst
@@ -1,0 +1,1 @@
+Fix support of Bluetooth sockets on NetBSD and DragonFly BSD.

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -122,6 +122,9 @@ typedef int socklen_t;
 #endif
 
 #ifdef HAVE_BLUETOOTH_H
+#ifdef __FreeBSD__
+#define L2CAP_SOCKET_CHECKED
+#endif
 #include <bluetooth.h>
 #endif
 
@@ -270,18 +273,22 @@ typedef union sock_addr {
     struct sockaddr_in6 in6;
     struct sockaddr_storage storage;
 #endif
-#if defined(HAVE_BLUETOOTH_H) && defined(__FreeBSD__)
-    struct sockaddr_l2cap bt_l2;
-    struct sockaddr_rfcomm bt_rc;
-    struct sockaddr_sco bt_sco;
-    struct sockaddr_hci bt_hci;
-#elif defined(HAVE_BLUETOOTH_BLUETOOTH_H)
+#if defined(MS_WINDOWS)
+    struct SOCKADDR_BTH_REDEF bt_rc;
+#elif defined(HAVE_BLUETOOTH_BLUETOOTH_H) // Linux
     struct sockaddr_l2 bt_l2;
     struct sockaddr_rc bt_rc;
     struct sockaddr_sco bt_sco;
     struct sockaddr_hci bt_hci;
-#elif defined(MS_WINDOWS)
-    struct SOCKADDR_BTH_REDEF bt_rc;
+#elif defined(HAVE_BLUETOOTH_H)
+# if defined(__FreeBSD__)
+    struct sockaddr_l2cap bt_l2;
+    struct sockaddr_rfcomm bt_rc;
+    struct sockaddr_sco bt_sco;
+    struct sockaddr_hci bt_hci;
+# else // NetBSD, DragonFly BSD
+    struct sockaddr_bt bt;
+# endif
 #endif
 #ifdef HAVE_NETPACKET_PACKET_H
     struct sockaddr_ll ll;


### PR DESCRIPTION
Also fix a compiler warning on FreeBSD.

(cherry picked from commit f2f86d3f459a89273ea22389bb57eed402908302)


<!-- gh-issue-number: gh-132429 -->
* Issue: gh-132429
<!-- /gh-issue-number -->
