### PR TITLE
gh-132461: Fix crash in OrderedDict.setdefault when key has unstable hash

### DIFF
--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1033,7 +1033,11 @@ OrderedDict_setdefault_impl(PyODictObject *self, PyObject *key,
         if (result == NULL) {
             if (PyErr_Occurred())
                 return NULL;
-            assert(_odict_find_node(self, key) == NULL);
+            if (_odict_find_node(self, key) != NULL) {
+                PyErr_SetString(PyExc_RuntimeError,
+                    "OrderedDict key appears to change its hash value over time");
+                return NULL;
+            }
             if (PyODict_SetItem((PyObject *)self, key, default_value) >= 0) {
                 result = Py_NewRef(default_value);
             }


### PR DESCRIPTION
Replaced assertion with a runtime check in OrderedDict_setdefault_impl to gracefully handle keys with changing hash values. If such a key is detected, a TypeError is raised instead of aborting the interpreter.


<!-- gh-issue-number: gh-132461 -->
* Issue: gh-132461
<!-- /gh-issue-number -->
