### PR TITLE
gh-130655: Add a test for big-endian MO files in `gettext`

### DIFF
--- a/Lib/test/test_gettext.py
+++ b/Lib/test/test_gettext.py
@@ -115,6 +115,23 @@ GNU_MO_DATA_CORRUPT = base64.b64encode(bytes([
     0x62, 0x61, 0x72, 0x00,  # Message data
 ]))
 
+
+GNU_MO_DATA_BIG_ENDIAN = base64.b64encode(bytes([
+    0x95, 0x04, 0x12, 0xDE,  # Magic
+    0x00, 0x00, 0x00, 0x00,  # Version
+    0x00, 0x00, 0x00, 0x01,  # Message count
+    0x00, 0x00, 0x00, 0x1C,  # Message offset
+    0x00, 0x00, 0x00, 0x24,  # Translation offset
+    0x00, 0x00, 0x00, 0x00,  # Hash table size
+    0x00, 0x00, 0x00, 0x2C,  # Hash table offset
+    0x00, 0x00, 0x00, 0x03,  # 1st message length
+    0x00, 0x00, 0x00, 0x2C,  # 1st message offset
+    0x00, 0x00, 0x00, 0x03,  # 1st trans length
+    0x00, 0x00, 0x00, 0x30,  # 1st trans offset
+    0x66, 0x6F, 0x6F, 0x00,  # Message data
+    0x62, 0x61, 0x72, 0x00,  # Message data
+]))
+
 UMO_DATA = b'''\
 3hIElQAAAAADAAAAHAAAADQAAAAAAAAAAAAAAAAAAABMAAAABAAAAE0AAAAQAAAAUgAAAA8BAABj
 AAAABAAAAHMBAAAWAAAAeAEAAABhYsOeAG15Y29udGV4dMOeBGFiw54AUHJvamVjdC1JZC1WZXJz
@@ -142,6 +159,7 @@ MOFILE_BAD_MAGIC_NUMBER = os.path.join(LOCALEDIR, 'gettext_bad_magic_number.mo')
 MOFILE_BAD_MAJOR_VERSION = os.path.join(LOCALEDIR, 'gettext_bad_major_version.mo')
 MOFILE_BAD_MINOR_VERSION = os.path.join(LOCALEDIR, 'gettext_bad_minor_version.mo')
 MOFILE_CORRUPT = os.path.join(LOCALEDIR, 'gettext_corrupt.mo')
+MOFILE_BIG_ENDIAN = os.path.join(LOCALEDIR, 'gettext_big_endian.mo')
 UMOFILE = os.path.join(LOCALEDIR, 'ugettext.mo')
 MMOFILE = os.path.join(LOCALEDIR, 'metadata.mo')
 
@@ -168,6 +186,8 @@ class GettextBaseTest(unittest.TestCase):
             fp.write(base64.decodebytes(GNU_MO_DATA_BAD_MINOR_VERSION))
         with open(MOFILE_CORRUPT, 'wb') as fp:
             fp.write(base64.decodebytes(GNU_MO_DATA_CORRUPT))
+        with open(MOFILE_BIG_ENDIAN, 'wb') as fp:
+            fp.write(base64.decodebytes(GNU_MO_DATA_BIG_ENDIAN))
         with open(UMOFILE, 'wb') as fp:
             fp.write(base64.decodebytes(UMO_DATA))
         with open(MMOFILE, 'wb') as fp:
@@ -292,6 +312,12 @@ class GettextTestCase2(GettextBaseTest):
             self.assertEqual(exception.errno, 0)
             self.assertEqual(exception.strerror, "File is corrupt")
             self.assertEqual(exception.filename, MOFILE_CORRUPT)
+
+    def test_big_endian_file(self):
+        with open(MOFILE_BIG_ENDIAN, 'rb') as fp:
+            t = gettext.GNUTranslations(fp)
+
+        self.assertEqual(t.gettext('foo'), 'bar')
 
     def test_some_translations(self):
         eq = self.assertEqual


### PR DESCRIPTION
MO files can be stored either in little or big-endian format. Which is which is dictated by the file header.
All our test MO files are currently little-endian. We should have at least one test with big-endian as well.

<!-- gh-issue-number: gh-130655 -->
* Issue: gh-130655
<!-- /gh-issue-number -->
