### PR TITLE
[3.13] gh-132106: Ensure that running `logging.handlers.QueueListener…

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -1172,6 +1172,10 @@ possible, while any potentially slow operations (such as sending an email via
       This starts up a background thread to monitor the queue for
       LogRecords to process.
 
+      .. versionchanged:: next
+         Raises :exc:`RuntimeError` if called and the listener is already
+         running.
+
    .. method:: stop()
 
       Stops the listener.

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1545,6 +1545,9 @@ class QueueListener(object):
         This starts up a background thread to monitor the queue for
         LogRecords to process.
         """
+        if self._thread is not None:
+            raise RuntimeError("Listener already started")
+
         self._thread = t = threading.Thread(target=self._monitor)
         t.daemon = True
         t.start()

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4300,8 +4300,6 @@ class QueueHandlerTest(BaseTest):
         self.assertEqual(formatted_msg, log_record.msg)
         self.assertEqual(formatted_msg, log_record.message)
 
-    @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
-                         'logging.handlers.QueueListener required for this test')
     def test_queue_listener(self):
         handler = TestHandler(support.Matcher())
         listener = logging.handlers.QueueListener(self.queue, handler)
@@ -4336,40 +4334,18 @@ class QueueHandlerTest(BaseTest):
         self.assertTrue(handler.matches(levelno=logging.CRITICAL, message='6'))
         handler.close()
 
-    def test_queue_listener_context_manager(self):
-        handler = TestHandler(support.Matcher())
-        with logging.handlers.QueueListener(self.queue, handler) as listener:
-            self.assertIsInstance(listener, logging.handlers.QueueListener)
-            self.assertIsNotNone(listener._thread)
-        self.assertIsNone(listener._thread)
-
-        # doesn't hurt to call stop() more than once.
-        listener.stop()
-        self.assertIsNone(listener._thread)
-
-    def test_queue_listener_context_manager(self):
-        handler = TestHandler(support.Matcher())
-        with logging.handlers.QueueListener(self.queue, handler) as listener:
-            self.assertIsInstance(listener, logging.handlers.QueueListener)
-            self.assertIsNotNone(listener._thread)
-        self.assertIsNone(listener._thread)
-
         # doesn't hurt to call stop() more than once.
         listener.stop()
         self.assertIsNone(listener._thread)
 
     def test_queue_listener_multi_start(self):
         handler = TestHandler(support.Matcher())
-        with logging.handlers.QueueListener(self.queue, handler) as listener:
-            self.assertRaises(RuntimeError, listener.start)
-
-        with listener:
-            self.assertRaises(RuntimeError, listener.start)
-
+        listener = logging.handlers.QueueListener(self.queue, handler)
         listener.start()
+        self.assertRaises(RuntimeError, listener.start)
         listener.stop()
+        self.assertIsNone(listener._thread)
 
->>>>>>> 5863cd70b87... gh-132106: Ensure that running `logging.handlers.QueueListener` cannot be started again (GH-132444)
     def test_queue_listener_with_StreamHandler(self):
         # Test that traceback and stack-info only appends once (bpo-34334, bpo-46755).
         listener = logging.handlers.QueueListener(self.queue, self.root_hdlr)
@@ -4384,8 +4360,6 @@ class QueueHandlerTest(BaseTest):
         self.assertEqual(self.stream.getvalue().strip().count('Traceback'), 1)
         self.assertEqual(self.stream.getvalue().strip().count('Stack'), 1)
 
-    @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
-                         'logging.handlers.QueueListener required for this test')
     def test_queue_listener_with_multiple_handlers(self):
         # Test that queue handler format doesn't affect other handler formats (bpo-35726).
         self.que_hdlr.setFormatter(self.root_formatter)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4336,8 +4336,40 @@ class QueueHandlerTest(BaseTest):
         self.assertTrue(handler.matches(levelno=logging.CRITICAL, message='6'))
         handler.close()
 
-    @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
-                         'logging.handlers.QueueListener required for this test')
+    def test_queue_listener_context_manager(self):
+        handler = TestHandler(support.Matcher())
+        with logging.handlers.QueueListener(self.queue, handler) as listener:
+            self.assertIsInstance(listener, logging.handlers.QueueListener)
+            self.assertIsNotNone(listener._thread)
+        self.assertIsNone(listener._thread)
+
+        # doesn't hurt to call stop() more than once.
+        listener.stop()
+        self.assertIsNone(listener._thread)
+
+    def test_queue_listener_context_manager(self):
+        handler = TestHandler(support.Matcher())
+        with logging.handlers.QueueListener(self.queue, handler) as listener:
+            self.assertIsInstance(listener, logging.handlers.QueueListener)
+            self.assertIsNotNone(listener._thread)
+        self.assertIsNone(listener._thread)
+
+        # doesn't hurt to call stop() more than once.
+        listener.stop()
+        self.assertIsNone(listener._thread)
+
+    def test_queue_listener_multi_start(self):
+        handler = TestHandler(support.Matcher())
+        with logging.handlers.QueueListener(self.queue, handler) as listener:
+            self.assertRaises(RuntimeError, listener.start)
+
+        with listener:
+            self.assertRaises(RuntimeError, listener.start)
+
+        listener.start()
+        listener.stop()
+
+>>>>>>> 5863cd70b87... gh-132106: Ensure that running `logging.handlers.QueueListener` cannot be started again (GH-132444)
     def test_queue_listener_with_StreamHandler(self):
         # Test that traceback and stack-info only appends once (bpo-34334, bpo-46755).
         listener = logging.handlers.QueueListener(self.queue, self.root_hdlr)

--- a/Misc/NEWS.d/next/Library/2025-04-12-09-30-24.gh-issue-132106.OxUds3.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-12-09-30-24.gh-issue-132106.OxUds3.rst
@@ -1,0 +1,2 @@
+:meth:`QueueListener.start <logging.handlers.QueueListener.start>` now
+raises a :exc:`RuntimeError` if the listener is already started.


### PR DESCRIPTION
…` cannot be started again (GH-132444)
(cherry picked from commit 5863cd70b8782313b52bb8c71a4127d7ea4c50e9)

<!-- gh-issue-number: gh-132106 -->
* Issue: gh-132106
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132471.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->