### PR TITLE
gh-132470: Prevent crash in ctypes.CField when `byte_size` is incorrect

### DIFF
--- a/Lib/test/test_ctypes/test_struct_fields.py
+++ b/Lib/test/test_ctypes/test_struct_fields.py
@@ -75,8 +75,8 @@ class FieldsTestBase(StructCheckMixin):
                                     'ctypes state is not initialized'):
             class Subclass(BrokenStructure): ...
 
-    def test_invalid_byte_size_raises(self):
-        with self.assertRaises(ValueError) as cm:
+    def test_invalid_byte_size_raises_gh132470(self):
+        with self.assertRaisesRegex(ValueError, r"does not match type size"):
             CField(
                 name="a",
                 type=c_byte,
@@ -85,8 +85,6 @@ class FieldsTestBase(StructCheckMixin):
                 index=1,
                 _internal_use=True
             )
-
-            self.assertIn("does not match type size", str(cm.exception))
 
     def test_max_field_size_gh126937(self):
         # Classes for big structs should be created successfully.

--- a/Lib/test/test_ctypes/test_struct_fields.py
+++ b/Lib/test/test_ctypes/test_struct_fields.py
@@ -80,7 +80,7 @@ class FieldsTestBase(StructCheckMixin):
             CField(
                 name="a",
                 type=c_byte,
-                byte_size=2, # Wrong size: c_byte is only 1 byte
+                byte_size=2,  # Wrong size: c_byte is only 1 byte
                 byte_offset=2,
                 index=1,
                 _internal_use=True

--- a/Lib/test/test_ctypes/test_struct_fields.py
+++ b/Lib/test/test_ctypes/test_struct_fields.py
@@ -1,6 +1,6 @@
 import unittest
 import sys
-from ctypes import Structure, Union, sizeof, c_char, c_int, CField
+from ctypes import Structure, Union, sizeof, c_byte, c_char, c_int, CField
 from ._support import Py_TPFLAGS_IMMUTABLETYPE, StructCheckMixin
 
 
@@ -74,6 +74,19 @@ class FieldsTestBase(StructCheckMixin):
         with self.assertRaisesRegex(TypeError,
                                     'ctypes state is not initialized'):
             class Subclass(BrokenStructure): ...
+
+    def test_invalid_byte_size_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            CField(
+                name="a",
+                type=c_byte,
+                byte_size=2, # Wrong size: c_byte is only 1 byte
+                byte_offset=2,
+                index=1,
+                _internal_use=True
+            )
+
+            self.assertIn("does not match type size", str(cm.exception))
 
     def test_max_field_size_gh126937(self):
         # Classes for big structs should be created successfully.

--- a/Misc/NEWS.d/next/C_API/2025-04-13-20-52-39.gh-issue-132470.UqBQjN.rst
+++ b/Misc/NEWS.d/next/C_API/2025-04-13-20-52-39.gh-issue-132470.UqBQjN.rst
@@ -1,14 +1,2 @@
-Creating a ctypes.CField with a byte_size that does not match the actual
-type size now raises a ValueError instead of crashing the interpreter. #
-Please enter the relevant GitHub issue number here: #
-
-# # Uncomment one of these "section:" lines to specify which section # this
-entry should go in in Misc/NEWS.d. # #.. section: Security #.. section: Core
-and Builtins #.. section: Library #.. section: Documentation #.. section:
-Tests #.. section: Build #.. section: Windows #.. section: macOS #..
-section: IDLE #.. section: Tools/Demos #.. section: C API
-
-# Write your Misc/NEWS.d entry below.  It should be a simple ReST paragraph.
-# Don't start with "- Issue #<n>: " or "- gh-issue-<n>: " or that sort of
-stuff.
-###########################################################################
+Creating a :class:`ctypes.CField` with a *byte_size* that does not match the actual
+type size now raises a :exc:`ValueError` instead of crashing the interpreter.

--- a/Misc/NEWS.d/next/C_API/2025-04-13-20-52-39.gh-issue-132470.UqBQjN.rst
+++ b/Misc/NEWS.d/next/C_API/2025-04-13-20-52-39.gh-issue-132470.UqBQjN.rst
@@ -1,0 +1,14 @@
+Creating a ctypes.CField with a byte_size that does not match the actual
+type size now raises a ValueError instead of crashing the interpreter. #
+Please enter the relevant GitHub issue number here: #
+
+# # Uncomment one of these "section:" lines to specify which section # this
+entry should go in in Misc/NEWS.d. # #.. section: Security #.. section: Core
+and Builtins #.. section: Library #.. section: Documentation #.. section:
+Tests #.. section: Build #.. section: Windows #.. section: macOS #..
+section: IDLE #.. section: Tools/Demos #.. section: C API
+
+# Write your Misc/NEWS.d entry below.  It should be a simple ReST paragraph.
+# Don't start with "- Issue #<n>: " or "- gh-issue-<n>: " or that sort of
+stuff.
+###########################################################################

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -99,7 +99,12 @@ PyCField_new_impl(PyTypeObject *type, PyObject *name, PyObject *proto,
                      "type of field %R must be a C type", name);
         goto error;
     }
-    assert(byte_size == info->size);
+    if (byte_size != info->size) {
+        PyErr_Format(PyExc_ValueError,
+                     "byte size of field %R (%zd) does not match type size (%zd)",
+                     name, byte_size, info->size);
+        goto error;
+    }
 
     Py_ssize_t bitfield_size = 0;
     Py_ssize_t bit_offset = 0;


### PR DESCRIPTION

When creating a ctypes.CField with an incorrect byte_size (e.g., using byte_size=2 for ctypes.c_byte), the code would previously abort due to the failed assertion byte_size == info->size.

This commit replaces the assertion with a proper error handling mechanism that raises a ValueError when byte_size does not match the expected type size. This prevents the crash and provides a more informative error message to the us




<!-- gh-issue-number: gh-132470 -->
* Issue: gh-132470
<!-- /gh-issue-number -->
