### PR TITLE
gh-132099: Harmonize Bluetooth address handling

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -158,9 +158,8 @@ created.  Socket addresses are represented as follows:
 
     - On Linux it accepts a tuple ``(device_id,)`` where ``device_id``
       is an integer specifying the number of the Bluetooth device.
-    - On FreeBSD, NetBSD and DragonFly BSD it accepts ``bdaddr`` where ``bdaddr``
-      is a :class:`bytes` object containing the Bluetooth address in a
-      string format. (ex. ``b'12:23:34:45:56:67'``)
+    - On FreeBSD, NetBSD and DragonFly BSD it accepts ``bdaddr``
+      where ``bdaddr`` is the Bluetooth address as a string.
 
     .. versionchanged:: 3.2
        NetBSD and DragonFlyBSD support added.
@@ -168,9 +167,9 @@ created.  Socket addresses are represented as follows:
     .. versionchanged:: 3.13.3
        FreeBSD support added.
 
-  - :const:`BTPROTO_SCO` accepts ``bdaddr`` where ``bdaddr`` is a
-    :class:`bytes` object containing the Bluetooth address in a
-    string format. (ex. ``b'12:23:34:45:56:67'``)
+  - :const:`BTPROTO_SCO` accepts ``bdaddr`` where ``bdaddr`` is
+    the Bluetooth address as a string or a :class:`bytes` object.
+    (ex. ``'12:23:34:45:56:67'`` or ``b'12:23:34:45:56:67'``)
 
     .. versionchanged:: next
        FreeBSD support added.

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -2681,6 +2681,8 @@ class BasicBluetoothTest(unittest.TestCase):
                 f.bind(socket.BDADDR_ANY)
             with self.assertRaises(OSError):
                 f.bind((socket.BDADDR_ANY.encode(), 0x1001))
+            with self.assertRaises(OSError):
+                f.bind(('\ud812', 0x1001))
 
     def testBindRfcommSocket(self):
         with socket.socket(socket.AF_BLUETOOTH, socket.SOCK_STREAM, socket.BTPROTO_RFCOMM) as s:
@@ -2713,13 +2715,15 @@ class BasicBluetoothTest(unittest.TestCase):
             with self.assertRaises(OSError):
                 s.bind((socket.BDADDR_ANY + '\0', channel))
             with self.assertRaises(OSError):
+                s.bind('\ud812')
+            with self.assertRaises(OSError):
                 s.bind(('invalid', channel))
 
     @unittest.skipUnless(hasattr(socket, 'BTPROTO_HCI'), 'Bluetooth HCI sockets required for this test')
     def testBindHciSocket(self):
         with socket.socket(socket.AF_BLUETOOTH, socket.SOCK_RAW, socket.BTPROTO_HCI) as s:
             if sys.platform.startswith(('netbsd', 'dragonfly', 'freebsd')):
-                s.bind(socket.BDADDR_ANY.encode())
+                s.bind(socket.BDADDR_ANY)
                 addr = s.getsockname()
                 self.assertEqual(addr, socket.BDADDR_ANY)
             else:
@@ -2738,14 +2742,17 @@ class BasicBluetoothTest(unittest.TestCase):
         with socket.socket(socket.AF_BLUETOOTH, socket.SOCK_RAW, socket.BTPROTO_HCI) as s:
             if sys.platform.startswith(('netbsd', 'dragonfly', 'freebsd')):
                 with self.assertRaises(OSError):
-                    s.bind(socket.BDADDR_ANY)
+                    s.bind(socket.BDADDR_ANY.encode())
                 with self.assertRaises(OSError):
-                    s.bind((socket.BDADDR_ANY.encode(),))
-                if sys.platform.startswith('freebsd'):
-                    with self.assertRaises(ValueError):
-                        s.bind(socket.BDADDR_ANY.encode() + b'\0')
-                    with self.assertRaises(ValueError):
-                        s.bind(socket.BDADDR_ANY.encode() + b' '*100)
+                    s.bind((socket.BDADDR_ANY,))
+                with self.assertRaises(OSError):
+                    s.bind(socket.BDADDR_ANY + '\0')
+                with self.assertRaises((ValueError, OSError)):
+                    s.bind(socket.BDADDR_ANY + ' '*100)
+                with self.assertRaises(OSError):
+                    s.bind('\ud812')
+                with self.assertRaises(OSError):
+                    s.bind('invalid')
                 with self.assertRaises(OSError):
                     s.bind(b'invalid')
             else:
@@ -2757,10 +2764,17 @@ class BasicBluetoothTest(unittest.TestCase):
                 with self.assertRaises(OSError):
                     s.bind(dev)
                 with self.assertRaises(OSError):
+                    s.bind(socket.BDADDR_ANY)
+                with self.assertRaises(OSError):
                     s.bind(socket.BDADDR_ANY.encode())
 
     @unittest.skipUnless(hasattr(socket, 'BTPROTO_SCO'), 'Bluetooth SCO sockets required for this test')
     def testBindScoSocket(self):
+        with socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_SCO) as s:
+            s.bind(socket.BDADDR_ANY)
+            addr = s.getsockname()
+            self.assertEqual(addr, socket.BDADDR_ANY)
+
         with socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_SCO) as s:
             s.bind(socket.BDADDR_ANY.encode())
             addr = s.getsockname()
@@ -2770,9 +2784,17 @@ class BasicBluetoothTest(unittest.TestCase):
     def testBadScoAddr(self):
         with socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_SCO) as s:
             with self.assertRaises(OSError):
-                s.bind(socket.BDADDR_ANY)
+                s.bind((socket.BDADDR_ANY,))
             with self.assertRaises(OSError):
                 s.bind((socket.BDADDR_ANY.encode(),))
+            with self.assertRaises(ValueError):
+                s.bind(socket.BDADDR_ANY + '\0')
+            with self.assertRaises(ValueError):
+                s.bind(socket.BDADDR_ANY.encode() + b'\0')
+            with self.assertRaises(UnicodeEncodeError):
+                s.bind('\ud812')
+            with self.assertRaises(OSError):
+                s.bind('invalid')
             with self.assertRaises(OSError):
                 s.bind(b'invalid')
 


### PR DESCRIPTION
Now all protocols always accept the Bluetooth address as string and getsockname() always returns the Bluetooth address as string.

* BTPROTO_SCO now accepts not only bytes, but str.
* BTPROTO_SCO now checks address for embedded null.
* On *BSD, BTPROTO_HCI now accepts str instead of bytes.
* On FreeBSD, getsockname() for BTPROTO_HCI now returns str instead of bytes.
* On NetBSD and DragonFly BDS, BTPROTO_HCI now checks address for embedded null.


<!-- gh-issue-number: gh-132099 -->
* Issue: gh-132099
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132486.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->