### PR TITLE
gh-129210: GC optimisations for case where no objects being collected have finalizers

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-16-12-02-26.gh-issue-129210.a5uLpE.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-16-12-02-26.gh-issue-129210.a5uLpE.rst
@@ -1,2 +1,2 @@
-Optimise garbage collection in case where objects to collect have
+Optimise garbage collection in case where no objects to collect have
 finalizers, and hence cannot be resurrected.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-16-12-02-26.gh-issue-129210.a5uLpE.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-16-12-02-26.gh-issue-129210.a5uLpE.rst
@@ -1,0 +1,2 @@
+Optimise garbage collection in case where objects to collect have
+finalizers, and hence cannot be resurrected.

--- a/Python/gc.c
+++ b/Python/gc.c
@@ -1073,6 +1073,7 @@ handle_legacy_finalizers(PyThreadState *tstate,
 /* Run first-time finalizers (if any) on all the objects in collectable.
  * Note that this may remove some (or even all) of the objects from the
  * list, due to refcounts falling to 0.
+ * Return 1 if any finalizers were run.
  */
 static int
 finalize_garbage(PyThreadState *tstate, PyGC_Head *collectable)

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1592,6 +1592,7 @@ debug_cycle(const char *msg, PyObject *op)
 /* Run first-time finalizers (if any) on all the objects in collectable.
  * Note that this may remove some (or even all) of the objects from the
  * list, due to refcounts falling to 0.
+ * Return 1 if any finalizers were run.
  */
 static int
 finalize_garbage(struct collection_state *state)

--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1593,11 +1593,12 @@ debug_cycle(const char *msg, PyObject *op)
  * Note that this may remove some (or even all) of the objects from the
  * list, due to refcounts falling to 0.
  */
-static void
+static int
 finalize_garbage(struct collection_state *state)
 {
     // NOTE: the unreachable worklist holds a strong reference to the object
     // to prevent it from being deallocated while we are holding on to it.
+    int finalizer_run = 0;
     PyObject *op;
     WORKSTACK_FOR_EACH(&state->unreachable, op) {
         if (!_PyGC_FINALIZED(op)) {
@@ -1605,10 +1606,12 @@ finalize_garbage(struct collection_state *state)
             if (finalize != NULL) {
                 _PyGC_SET_FINALIZED(op);
                 finalize(op);
+                finalizer_run = 1;
                 assert(!_PyErr_Occurred(_PyThreadState_GET()));
             }
         }
     }
+    return finalizer_run;
 }
 
 // Break reference cycles by clearing the containers involved.
@@ -2009,11 +2012,13 @@ gc_collect_internal(PyInterpreterState *interp, struct collection_state *state, 
     // Call weakref callbacks and finalizers after unpausing other threads to
     // avoid potential deadlocks.
     call_weakref_callbacks(state);
-    finalize_garbage(state);
+    int check_resurrected = finalize_garbage(state);
 
-    // Handle any objects that may have resurrected after the finalization.
     _PyEval_StopTheWorld(interp);
-    err = handle_resurrected_objects(state);
+    // Handle any objects that may have resurrected after finalization, if any
+    if (check_resurrected) {
+        err = handle_resurrected_objects(state);
+    }
     // Clear free lists in all threads
     _PyGC_ClearAllFreeLists(interp);
     _PyEval_StartTheWorld(interp);


### PR DESCRIPTION
If no objects being collected have finalizers, they will not be able to be resurrected. This lets us avoid some repeated work we would otherwise have to do.

<!-- gh-issue-number: gh-129210 -->
* Issue: gh-129210
<!-- /gh-issue-number -->
