### PR TITLE
annotationlib: Remove some unnecessary dict copies

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -720,11 +720,11 @@ def get_annotations(
             # For STRING, we try to call __annotate__
             ann = _get_and_call_annotate(obj, format)
             if ann is not None:
-                return ann
+                return dict(ann)
             # But if we didn't get it, we use __annotations__ instead.
             ann = _get_dunder_annotations(obj)
             if ann is not None:
-                 ann = annotations_to_string(ann)
+                 return annotations_to_string(ann)
         case Format.VALUE_WITH_FAKE_GLOBALS:
             raise ValueError("The VALUE_WITH_FAKE_GLOBALS format is for internal use only")
         case _:
@@ -832,22 +832,15 @@ def _get_and_call_annotate(obj, format):
         ann = call_annotate_function(annotate, format, owner=obj)
         if not isinstance(ann, dict):
             raise ValueError(f"{obj!r}.__annotate__ returned a non-dict")
-        return dict(ann)
+        return ann
     return None
 
 
 def _get_dunder_annotations(obj):
-    if isinstance(obj, type):
-        try:
-            ann = obj.__annotations__
-        except AttributeError:
-            # For static types, the descriptor raises AttributeError.
-            return None
-    else:
-        ann = getattr(obj, "__annotations__", None)
-        if ann is None:
-            return None
+    ann = getattr(obj, "__annotations__", None)
+    if ann is None:
+        return None
 
     if not isinstance(ann, dict):
         raise ValueError(f"{obj!r}.__annotations__ is neither a dict nor None")
-    return dict(ann)
+    return ann

--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -819,7 +819,10 @@ def value_to_string(value):
 
 
 def annotations_to_string(annotations):
-    """Convert an annotation dict containing values to approximately the STRING format."""
+    """Convert an annotation dict containing values to approximately the STRING format.
+
+    Always returns a fresh a dictionary.
+    """
     return {
         n: t if isinstance(t, str) else value_to_string(t)
         for n, t in annotations.items()
@@ -827,6 +830,10 @@ def annotations_to_string(annotations):
 
 
 def _get_and_call_annotate(obj, format):
+    """Get the __annotate__ function and call it.
+
+    May not return a fresh dictionary.
+    """
     annotate = get_annotate_function(obj)
     if annotate is not None:
         ann = call_annotate_function(annotate, format, owner=obj)
@@ -837,6 +844,10 @@ def _get_and_call_annotate(obj, format):
 
 
 def _get_dunder_annotations(obj):
+    """Return the annotations for an object, checking that it is a dictionary.
+
+    Does not return a fresh dictionary.
+    """
     ann = getattr(obj, "__annotations__", None)
     if ann is None:
         return None


### PR DESCRIPTION
We were copying the dictionary multiple times in a few cases. Once is enough.