### PR TITLE
[3.13] gh-132435: Test syntax warnings in a finally block (GH-132436)

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -1530,6 +1530,26 @@ class TestSpecifics(unittest.TestCase):
 
         self.assertEqual(len(caught), 2)
 
+    def test_compile_warning_in_finally(self):
+        # Ensure that warnings inside finally blocks are
+        # only emitted once despite the block being
+        # compiled twice (for normal execution and for
+        # exception handling).
+        source = textwrap.dedent("""
+            try:
+                pass
+            finally:
+                1 is 1
+        """)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("default")
+            compile(source, '<stdin>', 'exec')
+
+        self.assertEqual(len(caught), 1)
+        self.assertEqual(caught[0].category, SyntaxWarning)
+        self.assertIn("\"is\" with 'int' literal", str(caught[0].message))
+
 @requires_debug_ranges()
 class TestSourcePositions(unittest.TestCase):
     # Ensure that compiled code snippets have correct line and column numbers

--- a/Misc/NEWS.d/next/Core and Builtins/2025-04-13-10-34-27.gh-issue-131927.otp80n.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-04-13-10-34-27.gh-issue-131927.otp80n.rst
@@ -1,0 +1,3 @@
+Compiler warnings originating from the same module and line number are now
+only emitted once, matching the behaviour of warnings emitted from user
+code. This can also be configured with :mod:`warnings` filters.


### PR DESCRIPTION
(cherry picked from commit 887eabc5a74316708460120d60d0fa4f8bdf5960)

<!-- gh-issue-number: gh-132435 -->
* Issue: gh-132435
<!-- /gh-issue-number -->
