### PR TITLE
GH-131498: Allow 'peek' variables to be modified

### DIFF
--- a/Include/internal/pycore_uop_metadata.h
+++ b/Include/internal/pycore_uop_metadata.h
@@ -1081,7 +1081,7 @@ int _PyUop_num_popped(int opcode, int oparg)
         case _CALL_KW_NON_PY:
             return 3 + oparg;
         case _MAKE_CALLARGS_A_TUPLE:
-            return 2;
+            return 0;
         case _MAKE_FUNCTION:
             return 1;
         case _SET_FUNCTION_ATTRIBUTE:

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -2047,12 +2047,6 @@
         }
 
         case _MAKE_CALLARGS_A_TUPLE: {
-            JitOptSymbol *tuple;
-            JitOptSymbol *kwargs_out;
-            tuple = sym_new_not_null(ctx);
-            kwargs_out = sym_new_not_null(ctx);
-            stack_pointer[-2] = tuple;
-            stack_pointer[-1] = kwargs_out;
             break;
         }
 

--- a/Tools/cases_generator/generators_common.py
+++ b/Tools/cases_generator/generators_common.py
@@ -500,9 +500,6 @@ class Emitter:
                         if tkn in local_stores:
                             for var in storage.inputs:
                                 if var.name == tkn.text:
-                                    if var.in_local or var.in_memory():
-                                        msg = f"Cannot assign to already defined input variable '{tkn.text}'"
-                                        raise analysis_error(msg, tkn)
                                     var.in_local = True
                                     var.memory_offset = None
                                     break

--- a/Tools/cases_generator/stack.py
+++ b/Tools/cases_generator/stack.py
@@ -283,7 +283,7 @@ class Stack:
         self.base_offset = self.logical_sp
 
     def push(self, var: Local) -> None:
-        assert(var not in self.variables)
+        assert(var not in self.variables), var
         self.variables.append(var)
         self.logical_sp = self.logical_sp.push(var.item)
 
@@ -325,6 +325,7 @@ class Stack:
             var_offset = var_offset.push(var.item)
 
     def flush(self, out: CWriter) -> None:
+        self._print(out)
         self.save_variables(out)
         self._save_physical_sp(out)
         out.start_line()
@@ -432,12 +433,14 @@ class Storage:
     stack: Stack
     inputs: list[Local]
     outputs: list[Local]
+    peeks: int
     check_liveness: bool
     spilled: int = 0
 
     @staticmethod
     def needs_defining(var: Local) -> bool:
         return (
+            not var.item.peek and
             not var.in_local and
             not var.is_array() and
             var.name != "unused"
@@ -454,7 +457,7 @@ class Storage:
         )
 
     def clear_inputs(self, reason:str) -> None:
-        while self.inputs:
+        while len(self.inputs) > self.peeks:
             tos = self.inputs.pop()
             if self.is_live(tos) and self.check_liveness:
                 raise StackError(
@@ -464,14 +467,14 @@ class Storage:
 
     def clear_dead_inputs(self) -> None:
         live = ""
-        while self.inputs:
+        while len(self.inputs) > self.peeks:
             tos = self.inputs[-1]
             if self.is_live(tos):
                 live = tos.name
                 break
             self.inputs.pop()
             self.stack.drop(tos.item, self.check_liveness)
-        for var in self.inputs:
+        for var in self.inputs[self.peeks:]:
             if not self.is_live(var):
                 raise StackError(
                     f"Input '{var.name}' is not live, but '{live}' is"
@@ -493,8 +496,8 @@ class Storage:
                     f"Expected '{undefined}' to be defined before '{out.name}'"
             else:
                 undefined = out.name
-        while self.outputs and not self.needs_defining(self.outputs[0]):
-            out = self.outputs.pop(0)
+        while len(self.outputs) > self.peeks and not self.needs_defining(self.outputs[0]):
+            out = self.outputs.pop(self.peeks)
             self.stack.push(out)
 
     def locals_cached(self) -> bool:
@@ -541,12 +544,9 @@ class Storage:
             local = stack.pop(input, out)
             if input.peek:
                 peeks.append(local)
-            else:
-                inputs.append(local)
+            inputs.append(local)
         inputs.reverse()
         peeks.reverse()
-        for peek in peeks:
-            stack.push(peek)
         offset = stack.logical_sp - stack.physical_sp
         for ouput in uop.stack.outputs:
             if ouput.is_array() and ouput.used and not ouput.peek:
@@ -555,8 +555,8 @@ class Storage:
             offset = offset.push(ouput)
         for var in inputs:
             stack.push(var)
-        outputs = [ Local.undefined(var) for var in uop.stack.outputs if not var.peek ]
-        return Storage(stack, inputs, outputs, check_liveness)
+        outputs = peeks + [ Local.undefined(var) for var in uop.stack.outputs if not var.peek ]
+        return Storage(stack, inputs, outputs, len(peeks), check_liveness)
 
     @staticmethod
     def copy_list(arg: list[Local]) -> list[Local]:
@@ -568,7 +568,7 @@ class Storage:
         inputs = [ variables[var.name] for var in self.inputs]
         assert [v.name for v in inputs] == [v.name for v in self.inputs], (inputs, self.inputs)
         return Storage(
-            new_stack, inputs, self.copy_list(self.outputs),
+            new_stack, inputs, self.copy_list(self.outputs), self.peeks,
             self.check_liveness, self.spilled
         )
 
@@ -602,6 +602,8 @@ class Storage:
             other.clear_dead_inputs()
         if len(self.inputs) != len(other.inputs) and self.check_liveness:
             diff = self.inputs[-1] if len(self.inputs) > len(other.inputs) else other.inputs[-1]
+            self._print(out)
+            other._print(out)
             raise StackError(f"Unmergeable inputs. Differing state of '{diff.name}'")
         for var, other_var in zip(self.inputs, other.inputs):
             if var.in_local != other_var.in_local:
@@ -624,11 +626,11 @@ class Storage:
         if self.spilled:
             raise StackError(f"Unbalanced stack spills")
         self.clear_inputs("at the end of the micro-op")
-        if self.inputs and self.check_liveness:
+        if len(self.inputs) > self.peeks and self.check_liveness:
             raise StackError(f"Input variable '{self.inputs[-1].name}' is still live")
         self._push_defined_outputs()
         if self.outputs:
-            for out in self.outputs:
+            for out in self.outputs[self.peeks:]:
                 if self.needs_defining(out):
                     raise StackError(f"Output variable '{self.outputs[0].name}' is not defined")
                 self.stack.push(out)
@@ -640,6 +642,10 @@ class Storage:
         inputs = ", ".join([var.compact_str() for var in self.inputs])
         outputs = ", ".join([var.compact_str() for var in self.outputs])
         return f"{stack_comment[:-2]}{next_line}inputs: {inputs} outputs: {outputs}*/"
+
+    def _print(self, out: CWriter) -> None:
+        if PRINT_STACKS:
+            out.emit(self.as_comment() + "\n")
 
     def close_inputs(self, out: CWriter) -> None:
 

--- a/Tools/cases_generator/tier1_generator.py
+++ b/Tools/cases_generator/tier1_generator.py
@@ -204,7 +204,7 @@ def generate_tier1_labels(
     # Emit tail-callable labels as function defintions
     for name, label in analysis.labels.items():
         emitter.emit(f"LABEL({name})\n")
-        storage = Storage(Stack(), [], [], False)
+        storage = Storage(Stack(), [], [], 0, False)
         if label.spilled:
             storage.spilled = 1
         emitter.emit_tokens(label, storage, None)


### PR DESCRIPTION
This PR lifts the restriction on the modification of input and "peek" variables.

This restriction was supposed to help avoid reference leaks, but actually just makes it annoying and inefficient to change values on the stack.
Plus, we have a better way to detect leaks on the stack: `Py_STACKREF_DEBUG`.

Doing this allows us to clean up some code and, more importantly for TOS caching, turn some arrays back into scalars.

This PR modifies `SWAP` and `_MAKE_CALLARGS_A_TUPLE` to demonstrate the simplification.
We can make further simplifications, but I'll save those for an other PR for ease of review.


<!-- gh-issue-number: gh-131498 -->
* Issue: gh-131498
<!-- /gh-issue-number -->
