### PR TITLE
Docs: fix some typos in `Doc/library`

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -130,7 +130,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
 .. data:: base_exec_prefix
 
-   Equivalent to :data:`exec_prefix`, but refering to the base Python installation.
+   Equivalent to :data:`exec_prefix`, but referring to the base Python installation.
 
    When running under :ref:`sys-path-init-virtual-environments`,
    :data:`exec_prefix` gets overwritten to the virtual environment prefix.
@@ -143,7 +143,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
 .. data:: base_prefix
 
-   Equivalent to :data:`prefix`, but refering to the base Python installation.
+   Equivalent to :data:`prefix`, but referring to the base Python installation.
 
    When running under :ref:`virtual environment <venv-def>`,
    :data:`prefix` gets overwritten to the virtual environment prefix.

--- a/Doc/library/sys_path_init.rst
+++ b/Doc/library/sys_path_init.rst
@@ -97,7 +97,7 @@ Please refer to :mod:`site`'s
 .. note::
 
    There are other ways how "virtual environments" could be implemented, this
-   documentation referes implementations based on the ``pyvenv.cfg`` mechanism,
+   documentation refers implementations based on the ``pyvenv.cfg`` mechanism,
    such as :mod:`venv`. Most virtual environment implementations follow the
    model set by :mod:`venv`, but there may be exotic implementations that
    diverge from it.

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -853,7 +853,7 @@ The :mod:`test.support` module defines the following functions:
 
 .. function:: linked_with_musl()
 
-   Return ``False`` if there is no evidence the interperter was compiled with
+   Return ``False`` if there is no evidence the interpreter was compiled with
    ``musl``, otherwise return a version triple, either ``(0, 0, 0)`` if the
    version is unknown, or the actual version if it is known.  Intended for use
    in ``skip`` decorators.  ``emscripten`` and ``wasi`` are assumed to be


### PR DESCRIPTION
Fix some spelling errors in `Doc/library/` using **codespell**.
In the future, I'm happy to run periodic checks with codespell every few weeks. If need, just let me know!

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132511.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->