### PR TITLE
Docs: fix typo in `BEFORE_ASYNC_WITH` instruction

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -681,7 +681,7 @@ not have to be) the original ``STACK[-2]``.
    Resolves ``__aenter__`` and ``__aexit__`` from ``STACK[-1]``.
    Pushes ``__aexit__`` and result of ``__aenter__()`` to the stack::
 
-      STACK.extend((__aexit__, __aenter__())
+      STACK.extend((__aexit__, __aenter__()))
 
    .. versionadded:: 3.5
 


### PR DESCRIPTION
# Add a missing parentheses

      STACK.extend((__aexit__, __aenter__())
should STACK.extend((__aexit__, __aenter__())) 
Parentheses are missing

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132514.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->