### PR TITLE
GH-123599: Match `file:` URL hostname against machine hostname in urllib

### DIFF
--- a/Doc/library/urllib.request.rst
+++ b/Doc/library/urllib.request.rst
@@ -199,9 +199,9 @@ The :mod:`urllib.request` module defines the following functions:
 
    .. versionchanged:: next
       This function calls :func:`socket.gethostbyname` if the URL authority
-      isn't empty or ``localhost``. If the authority resolves to a local IP
-      address then it is discarded; otherwise, on Windows a UNC path is
-      returned (as before), and on other platforms a
+      isn't empty, ``localhost``, or the machine hostname. If the authority
+      resolves to a local IP address then it is discarded; otherwise, on
+      Windows a UNC path is returned (as before), and on other platforms a
       :exc:`~urllib.error.URLError` is raised.
 
    .. versionchanged:: next

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1483,6 +1483,7 @@ class FileHandler(BaseHandler):
     file_open = open_local_file
 
 def _is_local_authority(authority):
+    # Compare hostnames
     if not authority or authority == 'localhost':
         return True
     try:
@@ -1492,6 +1493,7 @@ def _is_local_authority(authority):
     else:
         if authority == hostname:
             return True
+    # Compare IP addresses
     try:
         address = socket.gethostbyname(authority)
     except (socket.gaierror, AttributeError):

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1486,6 +1486,13 @@ def _is_local_authority(authority):
     if not authority or authority == 'localhost':
         return True
     try:
+        hostname = socket.gethostname()
+    except socket.gaierror:
+        pass
+    else:
+        if authority == hostname:
+            return True
+    try:
         address = socket.gethostbyname(authority)
     except (socket.gaierror, AttributeError):
         return False

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1487,7 +1487,7 @@ def _is_local_authority(authority):
         return True
     try:
         hostname = socket.gethostname()
-    except socket.gaierror:
+    except (socket.gaierror, AttributeError):
         pass
     else:
         if authority == hostname:


### PR DESCRIPTION
In `_is_local_authority()`, return early if the authority matches the machine hostname from `socket.gethostname()`, rather than resolving the names and matching IP addresses.


<!-- gh-issue-number: gh-123599 -->
* Issue: gh-123599
<!-- /gh-issue-number -->
