### PR TITLE
gh-132099: Accept an integer as the address for BTPROTO_HCI on Linux

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -156,8 +156,9 @@ created.  Socket addresses are represented as follows:
 
   - :const:`BTPROTO_HCI` accepts a format that depends on your OS.
 
-    - On Linux it accepts a tuple ``(device_id, [channel])`` where ``device_id``
-      is an integer specifying the number of the Bluetooth device,
+    - On Linux it accepts an integer ``device_id`` or a tuple
+      ``(device_id, [channel])`` where ``device_id``
+      is specifies the number of the Bluetooth device,
       and ``channel`` is an optional integer specifying the HCI channel
       (:const:`HCI_CHANNEL_RAW` by default).
     - On FreeBSD, NetBSD and DragonFly BSD it accepts ``bdaddr``
@@ -171,6 +172,7 @@ created.  Socket addresses are represented as follows:
 
     .. versionchanged:: next
        Added ``channel`` field.
+       ``device_id`` not packed in a tuple is now accepted.
 
   - :const:`BTPROTO_SCO` accepts ``bdaddr`` where ``bdaddr`` is
     the Bluetooth address as a string or a :class:`bytes` object.

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -158,7 +158,7 @@ created.  Socket addresses are represented as follows:
 
     - On Linux it accepts an integer ``device_id`` or a tuple
       ``(device_id, [channel])`` where ``device_id``
-      is specifies the number of the Bluetooth device,
+      specifies the number of the Bluetooth device,
       and ``channel`` is an optional integer specifying the HCI channel
       (:const:`HCI_CHANNEL_RAW` by default).
     - On FreeBSD, NetBSD and DragonFly BSD it accepts ``bdaddr``

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -2745,6 +2745,12 @@ class BasicBluetoothTest(unittest.TestCase):
                 addr = s.getsockname()
                 self.assertEqual(addr, dev)
 
+            with (self.subTest('integer'),
+                  socket.socket(socket.AF_BLUETOOTH, socket.SOCK_RAW, socket.BTPROTO_HCI) as s):
+                s.bind(dev)
+                addr = s.getsockname()
+                self.assertEqual(addr, dev)
+
             with (self.subTest('channel=HCI_CHANNEL_RAW'),
                   socket.socket(socket.AF_BLUETOOTH, socket.SOCK_RAW, socket.BTPROTO_HCI) as s):
                 channel = socket.HCI_CHANNEL_RAW
@@ -2789,8 +2795,6 @@ class BasicBluetoothTest(unittest.TestCase):
                     s.bind(())
                 with self.assertRaises(OSError):
                     s.bind((dev, socket.HCI_CHANNEL_RAW, 0, 0))
-                with self.assertRaises(OSError):
-                    s.bind(dev)
                 with self.assertRaises(OSError):
                     s.bind(socket.BDADDR_ANY)
                 with self.assertRaises(OSError):

--- a/Misc/NEWS.d/next/Library/2025-04-14-20-38-43.gh-issue-132099.0l0LlK.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-14-20-38-43.gh-issue-132099.0l0LlK.rst
@@ -1,0 +1,3 @@
+The Bluetooth socket with the :data:`~socket.BTPROTO_HCI` protocol on Linux
+now accepts an address in the format of an integer ``device_id``, not only a
+tuple  ``(device_id,)``.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2147,7 +2147,12 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
 #if defined(HAVE_BLUETOOTH_BLUETOOTH_H)
             unsigned short dev;
             unsigned short channel = HCI_CHANNEL_RAW;
-            if (!PyArg_ParseTuple(args, "H|H", &dev, &channel)) {
+            if (PyLong_Check(args)) {
+                if (!PyArg_Parse(args, "H", &dev)) {
+                    return 0;
+                }
+            }
+            else if (!PyArg_ParseTuple(args, "H|H", &dev, &channel)) {
                 PyErr_Format(PyExc_OSError,
                              "%s(): wrong format", caller);
                 return 0;


### PR DESCRIPTION
Previously only an integer packed in a tuple was accepted, while getsockname() could return a raw integer.
Now the result of getsockname() is always acceptable as an address.


<!-- gh-issue-number: gh-132099 -->
* Issue: gh-132099
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132525.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->