### PR TITLE
Use Windows ARM64 hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 self-hosted-runner:
-  labels: ["windows-aarch64"]
+  # Pending https://github.com/rhysd/actionlint/issues/533
+  labels: ["windows-11-arm"]
 
 config-variables: null
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,28 +156,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - windows-latest
         arch:
           - x64
+          - Win32
+          - arm64
         free-threading:
           - false
           - true
-        include:
-          # Forks don't have access to Windows on Arm runners. These jobs are skipped below:
-          - os: ${{ github.repository_owner == 'python' && 'windows-aarch64' || 'windows-latest' }}
-            arch: arm64
-            free-threading: false
-          # Forks don't have access to Windows on Arm runners. These jobs are skipped below:
-          - os: ${{ github.repository_owner == 'python' && 'windows-aarch64' || 'windows-latest' }}
-            arch: arm64
-            free-threading: true
-          - os: windows-latest
-            arch: Win32
-            free-threading: false
+        exclude:
+          # Skip Win32 on free-threaded builds
+          - { arch: Win32, free-threading: true }
     uses: ./.github/workflows/reusable-windows.yml
     with:
-      os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       free-threading: ${{ matrix.free-threading }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,18 +179,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-        - windows-latest
         arch:
         - x86
         - x64
-        include:
-          # Forks don't have access to Windows on Arm runners. These jobs are skipped below:
-          - os: ${{ github.repository_owner == 'python' && 'windows-aarch64' || 'windows-latest' }}
-            arch: arm64
+        - arm64
     uses: ./.github/workflows/reusable-windows-msi.yml
     with:
-      os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
 
   build-macos:

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -96,7 +96,6 @@ jobs:
           python-version: '3.11'
 
       - name: Windows
-        # Forks don't have access to Windows on Arm runners. Skip those:
         if: runner.os == 'Windows'
         run: |
           choco install llvm --allow-downgrade --no-progress --version ${{ matrix.llvm }}.1.0

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -74,8 +74,7 @@ jobs:
             runner: windows-latest
           - target: aarch64-pc-windows-msvc/msvc
             architecture: ARM64
-            # Forks don't have access to Windows on Arm runners. These jobs are skipped below:
-            runner: ${{ github.repository_owner == 'python' && 'windows-aarch64' || 'windows-latest' }}
+            runner: windows-11-arm
           - target: x86_64-apple-darwin/clang
             architecture: x86_64
             runner: macos-13
@@ -98,7 +97,7 @@ jobs:
 
       - name: Windows
         # Forks don't have access to Windows on Arm runners. Skip those:
-        if: runner.os == 'Windows' && (matrix.architecture != 'ARM64' || github.repository_owner == 'python')
+        if: runner.os == 'Windows'
         run: |
           choco install llvm --allow-downgrade --no-progress --version ${{ matrix.llvm }}.1.0
           ./PCbuild/build.bat --experimental-jit ${{ matrix.debug && '-d' || '' }} -p ${{ matrix.architecture }}

--- a/.github/workflows/reusable-windows-msi.yml
+++ b/.github/workflows/reusable-windows-msi.yml
@@ -3,10 +3,6 @@ name: Reusable Windows MSI
 on:
   workflow_call:
     inputs:
-      os:
-        description: OS to run on
-        required: true
-        type: string
       arch:
         description: CPU architecture
         required: true
@@ -21,7 +17,7 @@ env:
 jobs:
   build:
     name: installer for ${{ inputs.arch }}
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
     timeout-minutes: 60
     env:
       ARCH: ${{ inputs.arch }}
@@ -31,7 +27,5 @@ jobs:
       with:
         persist-credentials: false
     - name: Build CPython installer
-      # Forks don't have access to Windows on Arm runners. Skip those:
-      if: inputs.arch != 'arm64' || github.repository_owner == 'python'
       run: ./Tools/msi/build.bat --doc -"${ARCH}"
       shell: bash

--- a/.github/workflows/reusable-windows.yml
+++ b/.github/workflows/reusable-windows.yml
@@ -3,10 +3,6 @@ name: Reusable Windows
 on:
   workflow_call:
     inputs:
-      os:
-        description: OS to run on
-        required: true
-        type: string
       arch:
         description: CPU architecture
         required: true
@@ -25,7 +21,7 @@ env:
 jobs:
   build:
     name: Build and test (${{ inputs.arch }})
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
     timeout-minutes: 60
     env:
       ARCH: ${{ inputs.arch }}
@@ -37,8 +33,6 @@ jobs:
       if: inputs.arch != 'Win32'
       run: echo "::add-matcher::.github/problem-matchers/msvc.json"
     - name: Build CPython
-      # Forks don't have access to Windows on Arm runners. Skip those:
-      if: inputs.arch != 'arm64' || github.repository_owner == 'python'
       run: >-
         .\\PCbuild\\build.bat
         -e -d -v
@@ -46,12 +40,8 @@ jobs:
         ${{ fromJSON(inputs.free-threading) && '--disable-gil' || '' }}
       shell: bash
     - name: Display build info
-      # Forks don't have access to Windows on Arm runners. Skip those:
-      if: inputs.arch != 'arm64' || github.repository_owner == 'python'
       run: .\\python.bat -m test.pythoninfo
     - name: Tests
-      # Forks don't have access to Windows on Arm runners. Skip those:
-      if: inputs.arch != 'arm64' || github.repository_owner == 'python'
       run: >-
         .\\PCbuild\\rt.bat
         -p "${ARCH}"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
These are now in "public preview" for public repos:

https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/

To use them, we use `runs-on: windows-11-arm` instead of `windows-latest`.

This means we can test ARM64 for both upstream and forks, and simplify the CI config.
