### PR TITLE
gh-124864: Extend smtplib documentation on ESMTP options format

### DIFF
--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -431,9 +431,11 @@ An :class:`SMTP` instance has the following methods:
    Send mail.  The required arguments are an :rfc:`822` from-address string, a list
    of :rfc:`822` to-address strings (a bare string will be treated as a list with 1
    address), and a message string.  The caller may pass a list of ESMTP options
-   (such as ``8bitmime``) to be used in ``MAIL FROM`` commands as *mail_options*.
+   (such as ``"8bitmime"``) to be used in ``MAIL FROM`` commands as *mail_options*.
    ESMTP options (such as ``DSN`` commands) that should be used with all ``RCPT``
-   commands can be passed as *rcpt_options*.  (If you need to use different ESMTP
+   commands can be passed as *rcpt_options*. Each option should be passed as a string
+   containing the full text of the option, including any potential key
+   (for instance, ``"NOTIFY=SUCCESS,FAILURE"``). (If you need to use different ESMTP
    options to different recipients you have to use the low-level methods such as
    :meth:`mail`, :meth:`rcpt` and :meth:`data` to send the message.)
 


### PR DESCRIPTION
This changes adds to the documentation that ESMTP options are to be passed as strings, even if the option is in key-value form. 

<!-- gh-issue-number: gh-124864 -->
* Issue: gh-124864
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132547.org.readthedocs.build/en/132547/library/smtplib.html#smtplib.SMTP.sendmail

<!-- readthedocs-preview cpython-previews end -->