### PR TITLE
gh-69619: Add whitespace term to glossary and reference in `stdtypes.rst`

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1445,15 +1445,15 @@ Glossary
 
    whitespace
       Characters that represent horizontal or vertical space.
-      In ASCII context, Python recognizes these characters as whitespace:
+      In an ASCII context, Python recognizes these characters as whitespace:
       ``' \t\n\v\f\r'`` (space, tab, newline, vertical tab, form feed, carriage return).
 
-      In Unicode context, whitespace characters are those
+      In a Unicode context, whitespace characters are the
       characters defined in the Unicode character database as "Other" or "Separator"
       and those with bidirectional property being one of "WS", "B", or "S".
 
-      This is used, for example, to :meth:`split <str.split>` or
-      :meth:`strip <str.strip>` strings.
+      This is used, for example, to :meth:`~str.split` or
+      :meth:`~str.strip` strings.
 
    Zen of Python
       Listing of Python design principles and philosophies that are helpful in

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1466,8 +1466,8 @@ Glossary
       <https://www.unicode.org/reports/tr44/>`_ as "Other" or "Separator"
       and those with bidirectional property being one of "WS," "B," or "S."
 
-      This is used, for example, to :meth:`~str.split` or
-      :meth:`~str.strip` strings.
+      For example, this is used to :meth:`~str.split` or :meth:`~str.strip`
+      strings.
 
    Zen of Python
       Listing of Python design principles and philosophies that are helpful in

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1446,11 +1446,25 @@ Glossary
    whitespace
       Characters that represent horizontal or vertical space.
       In an ASCII context, Python recognizes these characters as whitespace:
-      ``' \t\n\v\f\r'`` (space, tab, newline, vertical tab, form feed, carriage return).
+
+      +-----------+-----------------+
+      |  ``' '``  | space           |
+      +-----------+-----------------+
+      | ``'\t'``  | tab             |
+      +-----------+-----------------+
+      | ``'\n'``  | newline         |
+      +-----------+-----------------+
+      | ``'\v'``  | vertical tab    |
+      +-----------+-----------------+
+      | ``'\f'``  | form feed       |
+      +-----------+-----------------+
+      | ``'\r'``  | carriage return |
+      +-----------+-----------------+
 
       In a Unicode context, whitespace characters are the
-      characters defined in the Unicode character database as "Other" or "Separator"
-      and those with bidirectional property being one of "WS", "B", or "S".
+      characters defined in the `Unicode Character Database
+      <https://www.unicode.org/reports/tr44/>`_ as "Other" or "Separator"
+      and those with bidirectional property being one of "WS," "B," or "S."
 
       This is used, for example, to :meth:`~str.split` or
       :meth:`~str.strip` strings.

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1443,6 +1443,17 @@ Glossary
       A computer defined entirely in software.  Python's virtual machine
       executes the :term:`bytecode` emitted by the bytecode compiler.
 
+   whitespace
+      Characters that represent horizontal or vertical space.
+      In ASCII context, Python recognizes these characters as whitespace:
+      `` \t\n\v\f\r`` (space, tab, newline, vertical tab, form feed, carriage return).
+
+      In Unicode context, whitespace characters are those
+      characters defined in the Unicode character database as "Other" or "Separator"
+      and those with bidirectional property being one of "WS", "B", or "S".
+
+      This is used, for example, to :func:`split` or :func:`strip` strings.
+
    Zen of Python
       Listing of Python design principles and philosophies that are helpful in
       understanding and using the language.  The listing can be found by typing

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -1446,13 +1446,14 @@ Glossary
    whitespace
       Characters that represent horizontal or vertical space.
       In ASCII context, Python recognizes these characters as whitespace:
-      `` \t\n\v\f\r`` (space, tab, newline, vertical tab, form feed, carriage return).
+      ``' \t\n\v\f\r'`` (space, tab, newline, vertical tab, form feed, carriage return).
 
       In Unicode context, whitespace characters are those
       characters defined in the Unicode character database as "Other" or "Separator"
       and those with bidirectional property being one of "WS", "B", or "S".
 
-      This is used, for example, to :func:`split` or :func:`strip` strings.
+      This is used, for example, to :meth:`split <str.split>` or
+      :meth:`strip <str.strip>` strings.
 
    Zen of Python
       Listing of Python design principles and philosophies that are helpful in

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2092,8 +2092,9 @@ expression support in the :mod:`re` module).
 
    Return a copy of the string with leading characters removed.  The *chars*
    argument is a string specifying the set of characters to be removed.  If omitted
-   or ``None``, the *chars* argument defaults to removing whitespace.  The *chars*
-   argument is not a prefix; rather, all combinations of its values are stripped::
+   or ``None``, the *chars* argument defaults to removing :term:`whitespace`.
+   The *chars* argument is not a prefix; rather, all combinations of its values
+   are stripped::
 
       >>> '   spacious   '.lstrip()
       'spacious   '
@@ -2211,8 +2212,9 @@ expression support in the :mod:`re` module).
 
    Return a copy of the string with trailing characters removed.  The *chars*
    argument is a string specifying the set of characters to be removed.  If omitted
-   or ``None``, the *chars* argument defaults to removing whitespace.  The *chars*
-   argument is not a suffix; rather, all combinations of its values are stripped::
+   or ``None``, the *chars* argument defaults to removing :term:`whitespace`.
+   The *chars* argument is not a suffix; rather, all combinations of its values
+   are stripped::
 
       >>> '   spacious   '.rstrip()
       '   spacious'
@@ -2348,7 +2350,7 @@ expression support in the :mod:`re` module).
 
    Return a copy of the string with the leading and trailing characters removed.
    The *chars* argument is a string specifying the set of characters to be removed.
-   If omitted or ``None``, the *chars* argument defaults to removing whitespace.
+   If omitted or ``None``, the *chars* argument defaults to removing :term:`whitespace`.
    The *chars* argument is not a prefix or suffix; rather, all combinations of its
    values are stripped::
 
@@ -2735,7 +2737,7 @@ data and are closely related to string objects in a variety of other ways.
 
       This :class:`bytes` class method returns a bytes object, decoding the
       given string object.  The string must contain two hexadecimal digits per
-      byte, with ASCII whitespace being ignored.
+      byte, with :term:`ASCII whitespace <whitespace>` being ignored.
 
       >>> bytes.fromhex('2Ef0 F1f2  ')
       b'.\xf0\xf1\xf2'
@@ -2824,7 +2826,7 @@ objects.
 
       This :class:`bytearray` class method returns bytearray object, decoding
       the given string object.  The string must contain two hexadecimal digits
-      per byte, with ASCII whitespace being ignored.
+      per byte, with :term:`ASCII whitespace <whitespace>` being ignored.
 
       >>> bytearray.fromhex('2Ef0 F1f2  ')
       bytearray(b'.\xf0\xf1\xf2')
@@ -3243,8 +3245,8 @@ produce new objects.
    *chars* argument is a binary sequence specifying the set of byte values to
    be removed - the name refers to the fact this method is usually used with
    ASCII characters.  If omitted or ``None``, the *chars* argument defaults
-   to removing ASCII whitespace.  The *chars* argument is not a prefix;
-   rather, all combinations of its values are stripped::
+   to removing :term:`ASCII whitespace <whitespace>`.  The *chars* argument is
+   not a prefix; rather, all combinations of its values are stripped::
 
       >>> b'   spacious   '.lstrip()
       b'spacious   '
@@ -3287,8 +3289,8 @@ produce new objects.
    Split the binary sequence into subsequences of the same type, using *sep*
    as the delimiter string. If *maxsplit* is given, at most *maxsplit* splits
    are done, the *rightmost* ones.  If *sep* is not specified or ``None``,
-   any subsequence consisting solely of ASCII whitespace is a separator.
-   Except for splitting from the right, :meth:`rsplit` behaves like
+   any subsequence consisting solely of :term:`ASCII whitespace <whitespace>`
+   is a separator. Except for splitting from the right, :meth:`rsplit` behaves like
    :meth:`split` which is described in detail below.
 
 
@@ -3299,8 +3301,8 @@ produce new objects.
    *chars* argument is a binary sequence specifying the set of byte values to
    be removed - the name refers to the fact this method is usually used with
    ASCII characters.  If omitted or ``None``, the *chars* argument defaults to
-   removing ASCII whitespace.  The *chars* argument is not a suffix; rather,
-   all combinations of its values are stripped::
+   removing :term:`ASCII whitespace <whitespace>`.  The *chars* argument is not
+   a suffix; rather, all combinations of its values are stripped::
 
       >>> b'   spacious   '.rstrip()
       b'   spacious'
@@ -3352,7 +3354,8 @@ produce new objects.
       [b'1', b'2', b'3<4']
 
    If *sep* is not specified or is ``None``, a different splitting algorithm
-   is applied: runs of consecutive ASCII whitespace are regarded as a single
+   is applied: runs of consecutive :term:`ASCII whitespace <whitespace>` are
+   regarded as a single
    separator, and the result will contain no empty strings at the start or
    end if the sequence has leading or trailing whitespace.  Consequently,
    splitting an empty sequence or a sequence consisting solely of ASCII
@@ -3376,8 +3379,8 @@ produce new objects.
    removed. The *chars* argument is a binary sequence specifying the set of
    byte values to be removed - the name refers to the fact this method is
    usually used with ASCII characters.  If omitted or ``None``, the *chars*
-   argument defaults to removing ASCII whitespace. The *chars* argument is
-   not a prefix or suffix; rather, all combinations of its values are
+   argument defaults to removing :term:`ASCII whitespace <whitespace>`. The *chars*
+   argument is not a prefix or suffix; rather, all combinations of its values are
    stripped::
 
       >>> b'   spacious   '.strip()
@@ -3519,10 +3522,8 @@ place, and instead produce new objects.
 .. method:: bytes.isspace()
             bytearray.isspace()
 
-   Return ``True`` if all bytes in the sequence are ASCII whitespace and the
-   sequence is not empty, ``False`` otherwise.  ASCII whitespace characters are
-   those byte values in the sequence ``b' \t\n\r\x0b\f'`` (space, tab, newline,
-   carriage return, vertical tab, form feed).
+   Return ``True`` if all bytes in the sequence are :term:`ASCII whitespace <whitespace>`
+   and the sequence is not empty, ``False`` otherwise.
 
 
 .. method:: bytes.istitle()

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2350,9 +2350,9 @@ expression support in the :mod:`re` module).
 
    Return a copy of the string with the leading and trailing characters removed.
    The *chars* argument is a string specifying the set of characters to be removed.
-   If omitted or ``None``, the *chars* argument defaults to removing :term:`whitespace`.
-   The *chars* argument is not a prefix or suffix; rather, all combinations of its
-   values are stripped::
+   If omitted or ``None``, the *chars* argument defaults to removing
+   :term:`whitespace`. The *chars* argument is not a prefix or suffix; rather,
+   all combinations of its values are stripped::
 
       >>> '   spacious   '.strip()
       'spacious'
@@ -3290,8 +3290,8 @@ produce new objects.
    as the delimiter string. If *maxsplit* is given, at most *maxsplit* splits
    are done, the *rightmost* ones.  If *sep* is not specified or ``None``,
    any subsequence consisting solely of :term:`ASCII whitespace <whitespace>`
-   is a separator. Except for splitting from the right, :meth:`rsplit` behaves like
-   :meth:`split` which is described in detail below.
+   is a separator. Except for splitting from the right, :meth:`rsplit` behaves
+   like :meth:`split` which is described in detail below.
 
 
 .. method:: bytes.rstrip([chars])
@@ -3379,9 +3379,9 @@ produce new objects.
    removed. The *chars* argument is a binary sequence specifying the set of
    byte values to be removed - the name refers to the fact this method is
    usually used with ASCII characters.  If omitted or ``None``, the *chars*
-   argument defaults to removing :term:`ASCII whitespace <whitespace>`. The *chars*
-   argument is not a prefix or suffix; rather, all combinations of its values are
-   stripped::
+   argument defaults to removing :term:`ASCII whitespace <whitespace>`.
+   The *chars* argument is not a prefix or suffix; rather, all combinations of
+   its values are stripped::
 
       >>> b'   spacious   '.strip()
       b'spacious'

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -3522,8 +3522,9 @@ place, and instead produce new objects.
 .. method:: bytes.isspace()
             bytearray.isspace()
 
-   Return ``True`` if all bytes in the sequence are :term:`ASCII whitespace <whitespace>`
-   and the sequence is not empty, ``False`` otherwise.
+   Return ``True`` if all bytes in the sequence are
+   :term:`ASCII whitespace <whitespace>` and the sequence is not empty,
+   ``False`` otherwise.
 
 
 .. method:: bytes.istitle()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Continues: #14753

Remainder of files will be split into smaller prs. Included just stdtypes here.

<!-- gh-issue-number: gh-69619 -->
* Issue: gh-69619
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132568.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->