### PR TITLE
gh-132474: optimize rounding of int's for large negative ndigits

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-16-10-00-52.gh-issue-132474.fERfiC.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-16-10-00-52.gh-issue-132474.fERfiC.rst
@@ -1,0 +1,2 @@
+Optimize rounding speed of :class:`int`'s for large (by magnitude) negative
+``ndigits``, when result is zero.  Patch by Sergey B Kirpichev.

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6225,6 +6225,8 @@ int___round___impl(PyObject *self, PyObject *o_ndigits)
      * definition of the _PyLong_Frexp() we have
      * abs(self) < 10*10**(log10(2)*e) < 10**(e/3 + 1). */
     (void)_PyLong_Frexp((PyLongObject *)self, &e);
+    assert(e >= 0);
+    assert(!PyErr_Occurred());
 
     if (e/3 + 2 < n) {
         Py_DECREF(ndigits);

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -6212,6 +6212,25 @@ int___round___impl(PyObject *self, PyObject *o_ndigits)
         return long_long(self);
     }
 
+    int64_t n, e;
+
+    if (PyLong_AsInt64(ndigits, &n) < 0) {
+        Py_DECREF(ndigits);
+        return NULL;
+    }
+    n = -n;
+
+    /* A quick exit, if the result is zero.
+     * We start from criteria abs(self) < 10**(n - 1).  Then, from
+     * definition of the _PyLong_Frexp() we have
+     * abs(self) < 10*10**(log10(2)*e) < 10**(e/3 + 1). */
+    (void)_PyLong_Frexp((PyLongObject *)self, &e);
+
+    if (e/3 + 2 < n) {
+        Py_DECREF(ndigits);
+        return _PyLong_GetZero();
+    }
+
     /* result = self - divmod_near(self, 10 ** -ndigits)[1] */
     PyObject *temp = (PyObject*)long_neg((PyLongObject*)ndigits);
     Py_SETREF(ndigits, temp);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-132474 -->
* Issue: gh-132474
<!-- /gh-issue-number -->

-----------

Benchmark 1 (``0`` coming for ``ndigits <= -5``):
| Benchmark          | ref     | patch                |
|--------------------|:-------:|:--------------------:|
| round(17000, -1)   | 515 ns  | 573 ns: 1.11x slower |
| round(17000, -2)   | 495 ns  | 545 ns: 1.10x slower |
| round(17000, -3)   | 565 ns  | 592 ns: 1.05x slower |
| round(17000, -4)   | 674 ns  | 708 ns: 1.05x slower |
| round(17000, -5)   | 560 ns  | 635 ns: 1.13x slower |
| round(17000, -6)   | 564 ns  | 616 ns: 1.09x slower |
| round(17000, -7)   | 608 ns  | 647 ns: 1.06x slower |
| round(17000, -8)   | 563 ns  | 233 ns: 2.42x faster |
| round(17000, -9)   | 612 ns  | 240 ns: 2.55x faster |
| round(17000, -10)  | 663 ns  | 232 ns: 2.86x faster |
| round(17000, -20)  | 979 ns  | 233 ns: 4.21x faster |
| round(17000, -50)  | 1.47 us | 233 ns: 6.30x faster |
| round(17000, -100) | 1.95 us | 234 ns: 8.33x faster |
| Geometric mean     | (ref)   | 1.81x faster         |

Benchmark 2 (here ``round(2**d, -5) != 0`` for ``d>=20``):
| Benchmark         | ref    | patch                |
|-------------------|:------:|:--------------------:|
| round(2**5, -5)   | 527 ns | 232 ns: 2.27x faster |
| round(2**7, -5)   | 531 ns | 233 ns: 2.28x faster |
| round(2**10, -5)  | 557 ns | 621 ns: 1.11x slower |
| round(2**15, -5)  | 558 ns | 623 ns: 1.12x slower |
| round(2**20, -5)  | 672 ns | 730 ns: 1.09x slower |
| round(2**25, -5)  | 753 ns | 784 ns: 1.04x slower |
| round(2**30, -5)  | 811 ns | 843 ns: 1.04x slower |
| round(2**50, -5)  | 797 ns | 830 ns: 1.04x slower |
| round(2**100, -5) | 871 ns | 912 ns: 1.05x slower |
| Geometric mean    | (ref)  | 1.14x faster         |

<details>

```py
# bench1.py
import pyperf
runner = pyperf.Runner()
d = 17000
for n in list(range(1, 11)) + [20, 50, 100]:
    n = -n
    s = f"round({d}, {n})"
    runner.bench_func(s, round, d, n)
```

```py
# bench2.py
import math
import pyperf
runner = pyperf.Runner()
n = -5
for d in [5, 7, 10, 15, 20, 25, 30, 50, 100]:
    x = 1<<d
    s = f"round(2**{d}, {n})"
    runner.bench_func(s, round, x, n)
```

</details>

- issue thread has several other variants for cutoff
- here is gmpy2 code (recently corrected): https://github.com/aleaxit/gmpy/blob/e58796a9f53787cdc28db895ec7bb6aaaed7b778/src/gmpy2_mpz_misc.c#L270-L272
