### PR TITLE
gh-132527: fix: include 'w' in error message for array typecodes

### DIFF
--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2873,7 +2873,7 @@ array_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         }
     }
     PyErr_SetString(PyExc_ValueError,
-        "bad typecode (must be b, B, u, h, H, i, I, l, L, q, Q, f or d)");
+        "bad typecode (must be b, B, u, h, H, i, I, l, L, q, Q, f, d or w)");
     return NULL;
 }
 


### PR DESCRIPTION


gh-132527:  Fix error message to include 'w' typecode in arraymodule.c

This PR fixes the ValueError message in `arraymodule.c`, adding `'w'` to the list of valid typecodes. `'w'` is currently a supported typecode, but it was missing from the error message when users tried to use it, causing confusion.

