### PR TITLE
Docs: fix some typos in docfiles(.rst .md)

### DIFF
--- a/InternalDocs/parser.md
+++ b/InternalDocs/parser.md
@@ -97,7 +97,7 @@ Consequences of the ordered choice operator
 -------------------------------------------
 
 Although PEG may look like EBNF, its meaning is quite different. The fact
-that the alternatives are ordered in a PEG grammer (which is at the core of
+that the alternatives are ordered in a PEG grammar (which is at the core of
 how PEG parsers work) has deep consequences, other than removing ambiguity.
 
 If a rule has two alternatives and the first of them succeeds, the second one is

--- a/Misc/NEWS.d/3.14.0a1.rst
+++ b/Misc/NEWS.d/3.14.0a1.rst
@@ -3586,7 +3586,7 @@ atomic types.
 
 Add *doc* parameter to :func:`dataclasses.field`, so it can be stored and
 shown as a documentation / metadata. If ``@dataclass(slots=True)`` is used,
-then the supplied string is availabl in the :attr:`~object.__slots__` dict.
+then the supplied string is available in the :attr:`~object.__slots__` dict.
 Otherwise, the supplied string is only available in the corresponding
 :class:`dataclasses.Field` object.
 
@@ -4184,7 +4184,7 @@ display REPL ``help()``.
 .. nonce: aFqNAB
 .. section: Core and Builtins
 
-Fix reading and decoding a line from the source file witn non-UTF-8 encoding
+Fix reading and decoding a line from the source file with non-UTF-8 encoding
 for syntax errors raised in the compiler.
 
 ..

--- a/Misc/NEWS.d/3.14.0a2.rst
+++ b/Misc/NEWS.d/3.14.0a2.rst
@@ -310,7 +310,7 @@ same manner as :data:`sys.path` is configured in workers before executing
 work items.
 
 This bug caused some forkserver module preloading to silently fail to
-preload. This manifested as a performance degration in child processes when
+preload. This manifested as a performance degradation in child processes when
 the ``sys.path`` was required due to additional repeated work in every
 worker.
 

--- a/Misc/NEWS.d/3.14.0a4.rst
+++ b/Misc/NEWS.d/3.14.0a4.rst
@@ -649,7 +649,7 @@ searching the Python interpreter directory.
 .. section: Core and Builtins
 
 We now use the location of the ``libpython`` runtime library used in the
-current proccess to determine :data:`sys.base_prefix` on all platforms
+current process to determine :data:`sys.base_prefix` on all platforms
 implementing the `dladdr
 <https://pubs.opengroup.org/onlinepubs/9799919799/functions/dladdr.html>`_
 function defined by the UNIX standard — this includes Linux, Android, macOS,

--- a/Misc/NEWS.d/3.14.0a6.rst
+++ b/Misc/NEWS.d/3.14.0a6.rst
@@ -160,7 +160,7 @@ Use monospace font from System Font Stack for cross-platform support in
 .. nonce: 3sBFv2
 .. section: Library
 
-Improve perfomance of :attr:`uuid.UUID.hex` and :meth:`uuid.UUID.__str__
+Improve performance of :attr:`uuid.UUID.hex` and :meth:`uuid.UUID.__str__
 <object.__str__>`.
 
 ..
@@ -535,7 +535,7 @@ the correct type, when called with optimize=False.
 
 Forbid the use of colon (":") as a fractional component separator and other
 improvements to the consistency of error raising between the C and Python
-implementaitons of :meth:`datetime.time.fromisoformat` and
+implementations of :meth:`datetime.time.fromisoformat` and
 :meth:`datetime.datetime.fromisoformat`. Patch by Semyon Moroz.
 
 ..
@@ -1109,7 +1109,7 @@ Fix two more :class:`bytearray` functions for :term:`free threading`.
 
 Use tagged references (``_PyStackRef``) for the default build as well as for
 the free-threading build. This has a small negative performance impact
-short-term but will enable larger speedups in the future and signficantly
+short-term but will enable larger speedups in the future and significantly
 reduce maintenance costs by allowing a single implementation of tagged
 references in the future.
 
@@ -1209,7 +1209,7 @@ is called concurrently with ``set.clear()``.
 .. section: Core and Builtins
 
 The internal (evaluation) stack is now spilled to memory whenever execution
-esacpes from the interpreter or JIT compiled code. This should have no
+escapes from the interpreter or JIT compiled code. This should have no
 observable effect in either Python or builtin extensions, but will allow
 various important optimizations in the future.
 

--- a/Tools/wasm/README.md
+++ b/Tools/wasm/README.md
@@ -53,7 +53,7 @@ export EM_COMPILER_WRAPPER=ccache
 
 #### Compile and build Python interpreter
 
-You can use `python Tools/wasm/emscripten` to compile and build targetting
+You can use `python Tools/wasm/emscripten` to compile and build targeting
 Emscripten. You can do everything at once with:
 ```shell
 python Tools/wasm/emscripten build


### PR DESCRIPTION
Fix some typos in docfiles(.rst .md) using codespell.