### PR TITLE
gh-132493: Avoid eager import of annotationlib in typing (again)

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6338,7 +6338,7 @@ class InternalsTests(BaseTestCase):
             "inspect",
             "re",
             "contextlib",
-            # "annotationlib",  # TODO
+            "annotationlib",
         })
 
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3132,6 +3132,20 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaisesRegex(TypeError, only_classes_allowed):
             issubclass(1, BadPG)
 
+    def test_lazy_evaluation_with_subprotocols(self):
+        @runtime_checkable
+        class Base(Protocol):
+            x: int
+
+        class Child(Base, Protocol):
+            y: str
+
+        class Capybara:
+            x = 43
+
+        self.assertIsInstance(Capybara(), Base)
+        self.assertNotIsInstance(Capybara(), Child)
+
     def test_implicit_issubclass_between_two_protocols(self):
         @runtime_checkable
         class CallableMembersProto(Protocol):
@@ -3826,6 +3840,7 @@ class ProtocolTests(BaseTestCase):
             '_is_protocol', '_is_runtime_protocol', '__parameters__',
             '__init__', '__annotations__', '__subclasshook__', '__annotate__',
             '__annotations_cache__', '__annotate_func__',
+            '__protocol_attrs_cache__',
         }
         self.assertLessEqual(vars(NonP).keys(), vars(C).keys() | acceptable_extra_attrs)
         self.assertLessEqual(

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3149,7 +3149,7 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaisesRegex(TypeError, only_classes_allowed):
             issubclass(1, BadPG)
 
-    def test_lazy_evaluation_with_subprotocols(self):
+    def test_isinstance_against_superproto_doesnt_affect_subproto_instance(self):
         @runtime_checkable
         class Base(Protocol):
             x: int
@@ -3858,7 +3858,6 @@ class ProtocolTests(BaseTestCase):
             '_is_protocol', '_is_runtime_protocol', '__parameters__',
             '__init__', '__annotations__', '__subclasshook__', '__annotate__',
             '__annotations_cache__', '__annotate_func__',
-            '__protocol_attrs_cache__',
         }
         self.assertLessEqual(vars(NonP).keys(), vars(C).keys() | acceptable_extra_attrs)
         self.assertLessEqual(

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3137,6 +3137,7 @@ class ProtocolTests(BaseTestCase):
         class Base(Protocol):
             x: int
 
+        @runtime_checkable
         class Child(Base, Protocol):
             y: str
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4575,15 +4575,10 @@ class ProtocolTests(BaseTestCase):
             def __get__(self, instance, type):
                 raise CustomError
 
-        @runtime_checkable
-        class Commentable(Protocol):
-            evil = classproperty()
-
-        class Normal:
-            evil = None
-
         with self.assertRaises(TypeError) as cm:
-            isinstance(Normal(), Commentable)
+            @runtime_checkable
+            class Commentable(Protocol):
+                evil = classproperty()
 
         exc = cm.exception
         self.assertEqual(

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4542,10 +4542,15 @@ class ProtocolTests(BaseTestCase):
             def __get__(self, instance, type):
                 raise CustomError
 
+        @runtime_checkable
+        class Commentable(Protocol):
+            evil = classproperty()
+
+        class Normal:
+            evil = None
+
         with self.assertRaises(TypeError) as cm:
-            @runtime_checkable
-            class Commentable(Protocol):
-                evil = classproperty()
+            isinstance(Normal(), Commentable)
 
         exc = cm.exception
         self.assertEqual(

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1925,9 +1925,11 @@ class _ProtocolMeta(ABCMeta):
     # This metaclass is somewhat unfortunate,
     # but is necessary for several reasons...
     def __new__(mcls, name, bases, namespace, /, **kwargs):
+        is_protocol = False
         if name == "Protocol" and bases == (Generic,):
             pass
         elif Protocol in bases:
+            is_protocol = True
             for base in bases:
                 if not (
                     base in {object, Generic}
@@ -1942,7 +1944,8 @@ class _ProtocolMeta(ABCMeta):
                         f"got {base!r}"
                     )
         cls = super().__new__(mcls, name, bases, namespace, **kwargs)
-        cls.__protocol_attrs_cache__ = None
+        if is_protocol:
+            cls.__protocol_attrs_cache__ = None
         return cls
 
     def __subclasscheck__(cls, other):
@@ -2015,7 +2018,7 @@ class _ProtocolMeta(ABCMeta):
     def __non_callable_proto_members__(cls):
         # PEP 544 prohibits using issubclass()
         # with protocols that have non-method members.
-        non_callable_members = cls.__non_callable_proto_members_cache__
+        non_callable_members = cls.__non_callable_proto_members_cache__  # set by @runtime_checkable
         if non_callable_members is None:
             non_callable_members = set()
             for attr in cls.__protocol_attrs__:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2025,6 +2025,8 @@ def _proto_hook(cls, other):
 
             # ...or in annotations, if it is a sub-protocol.
             if issubclass(other, Generic) and getattr(other, "_is_protocol", False):
+                # We avoid the slower path through annotationlib here because in most
+                # cases it should be unnecessary.
                 try:
                     annos = base.__annotations__
                 except Exception:

--- a/Misc/NEWS.d/next/Library/2025-04-16-06-50-13.gh-issue-132493.XvnL7t.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-16-06-50-13.gh-issue-132493.XvnL7t.rst
@@ -1,1 +1,0 @@
-Speed up the creation of :class:`typing.Protocol` subclasses.

--- a/Misc/NEWS.d/next/Library/2025-04-16-06-50-13.gh-issue-132493.XvnL7t.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-16-06-50-13.gh-issue-132493.XvnL7t.rst
@@ -1,0 +1,1 @@
+Speed up the creation of :class:`typing.Protocol` subclasses.


### PR DESCRIPTION
gh-132494 made typing.py eagerly import annotationlib again because
typing contains several protocols. Avoid this by using annotationlib only if `.__annotations__` fails.

An earlier version of this PR instead made it so we compute the protocol attrs only when needed (generally on the first `isinstance()` call). That would make startup faster, but has some compatibility implications in cases where attributes get added to the class later, so I think this version is safer.

<!-- gh-issue-number: gh-132493 -->
* Issue: gh-132493
<!-- /gh-issue-number -->
