### PR TITLE
gh-132608: Fix a sample code coloring for ast.While

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1190,7 +1190,7 @@ Control flow
 
    .. doctest::
 
-        >> print(ast.dump(ast.parse("""
+        >>> print(ast.dump(ast.parse("""
         ... while x:
         ...    ...
         ... else:


### PR DESCRIPTION
Fixes #132608. I added a `>` character.

I executed `make venv` and `make html` according to [Building the documentation](https://devguide.python.org/documentation/start-documenting/#introduction), then I confirmed that the sample code for `ast.While` is colored correctly now:

![image](https://github.com/user-attachments/assets/1277111c-a1cf-41ec-921a-d41be995f5cd)


<!-- gh-issue-number: gh-132608 -->
* Issue: gh-132608
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132609.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->