### PR TITLE
InternalDocs: Fix outdated struct references in frames.md

### DIFF
--- a/InternalDocs/frames.md
+++ b/InternalDocs/frames.md
@@ -11,7 +11,7 @@ of three conceptual sections:
   previous frame, etc.
 
 The definition of the `_PyInterpreterFrame` struct is in
-[Include/internal/pycore_frame.h](../Include/internal/pycore_frame.h).
+[Include/internal/pycore_interpframe_structs.h](../Include/internal/pycore_interpframe_structs.h).
 
 # Allocation
 
@@ -21,8 +21,8 @@ of reference, most frames are allocated contiguously in a per-thread stack
 (see `_PyThreadState_PushFrame` in [Python/pystate.c](../Python/pystate.c)).
 
 Frames of generators and coroutines are embedded in the generator and coroutine
-objects, so are not allocated in the per-thread stack. See `PyGenObject` in
-[Include/internal/pycore_genobject.h](../Include/internal/pycore_genobject.h).
+objects, so are not allocated in the per-thread stack. See `_PyGenObject` in
+[Include/internal/pycore_interpframe_structs.h](../Include/internal/pycore_interpframe_structs.h).
 
 ## Layout
 


### PR DESCRIPTION
Update references to PyInterpreterFrame and PyGenObject structs in InternalDocs

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
