### PR TITLE
gh-118761: Add helper to ensure that lazy imports are actually lazy

### DIFF
--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -24,6 +24,7 @@ from typing import (
 )
 
 from test import support
+from test.support import import_helper
 from test.test_inspect import inspect_stock_annotations
 from test.test_inspect import inspect_stringized_annotations
 from test.test_inspect import inspect_stringized_annotations_2
@@ -1367,3 +1368,9 @@ class ForwardRefTests(unittest.TestCase):
 class TestAnnotationLib(unittest.TestCase):
     def test__all__(self):
         support.check__all__(self, annotationlib)
+
+    def test_lazy_imports(self):
+        import_helper.ensure_lazy_imports("annotationlib", [
+            "typing",
+            "warnings",
+        ])

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1370,7 +1370,7 @@ class TestAnnotationLib(unittest.TestCase):
         support.check__all__(self, annotationlib)
 
     def test_lazy_imports(self):
-        import_helper.ensure_lazy_imports("annotationlib", [
+        import_helper.ensure_lazy_imports("annotationlib", {
             "typing",
             "warnings",
-        ])
+        })

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6318,13 +6318,13 @@ class InternalsTests(BaseTestCase):
         self.assertEqual(cm.filename, __file__)
 
     def test_lazy_import(self):
-        import_helper.ensure_lazy_imports("typing", [
+        import_helper.ensure_lazy_imports("typing", {
             "warnings",
             "inspect",
             "re",
             "contextlib",
             # "annotationlib",  # TODO
-        ])
+        })
 
 
 @lru_cache()

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6317,6 +6317,15 @@ class InternalsTests(BaseTestCase):
             typing._collect_parameters
         self.assertEqual(cm.filename, __file__)
 
+    def test_lazy_import(self):
+        import_helper.ensure_lazy_imports("typing", [
+            "warnings",
+            "inspect",
+            "re",
+            "contextlib",
+            # "annotationlib",  # TODO
+        ])
+
 
 @lru_cache()
 def cached_func(x, y):


### PR DESCRIPTION
This ensures that if we jump through some hoops to make sure something is imported
lazily, we don't regress on importing it.

I recently already accidentally made typing import warnings and annotationlib eagerly.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-118761 -->
* Issue: gh-118761
<!-- /gh-issue-number -->
