### PR TITLE
[3.13] gh-130070: Fix `exec(<string>, closure=<non-None>)` unexpected path (GH-130071)

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -974,8 +974,24 @@ class BuiltinTest(unittest.TestCase):
             three_freevars.__code__,
             three_freevars.__globals__,
             closure=my_closure)
+        my_closure = tuple(my_closure)
+
+        # should fail: anything passed to closure= isn't allowed
+        # when the source is a string
+        self.assertRaises(TypeError,
+            exec,
+            "pass",
+            closure=int)
+
+        # should fail: correct closure= argument isn't allowed
+        # when the source is a string
+        self.assertRaises(TypeError,
+            exec,
+            "pass",
+            closure=my_closure)
 
         # should fail: closure tuple with one non-cell-var
+        my_closure = list(my_closure)
         my_closure[0] = int
         my_closure = tuple(my_closure)
         self.assertRaises(TypeError,

--- a/Misc/NEWS.d/next/Core and Builtins/2025-02-13-05-09-31.gh-issue-130070.C8c9gK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-02-13-05-09-31.gh-issue-130070.C8c9gK.rst
@@ -1,0 +1,1 @@
+Fixed an assertion error for :func:`exec` passed a string ``source`` and a non-``None`` ``closure``. Patch by Bartosz Sławecki.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1154,6 +1154,7 @@ builtin_exec_impl(PyObject *module, PyObject *source, PyObject *globals,
         if (closure != NULL) {
             PyErr_SetString(PyExc_TypeError,
                 "closure can only be used when source is a code object");
+            goto error;
         }
         PyObject *source_copy;
         const char *str;


### PR DESCRIPTION
Fixed an assertion error (so, it could be reproduced only in builds with assertions enabled) for `exec` when the `source` argument is a string and the `closure` argument is not `None`.

Co-authored-by: sobolevn <mail@sobolevn.me>
(cherry picked from commit 954b2cf031fb84ff3386251d5c45281f47229003)


<!-- gh-issue-number: gh-130070 -->
* Issue: gh-130070
<!-- /gh-issue-number -->
