### PR TITLE
gh-123503: Replace usages of `addinfourl` and `HTTPResponse` deprecated attributes with stable ones

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -300,7 +300,7 @@ class MockHeaders(dict):
 class MockResponse(io.StringIO):
     def __init__(self, code, msg, headers, data, url=None):
         io.StringIO.__init__(self, data)
-        self.code, self.msg, self.headers, self.url = code, msg, headers, url
+        self.status, self.msg, self.headers, self.url = code, msg, headers, url
 
     def info(self):
         return self.headers

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1006,7 +1006,7 @@ class AbstractBasicAuthHandler:
 
     def http_response(self, req, response):
         if hasattr(self.passwd, 'is_authenticated'):
-            if 200 <= response.code < 300:
+            if 200 <= response.status < 300:
                 self.passwd.update_authenticated(req.full_url, True)
             else:
                 self.passwd.update_authenticated(req.full_url, False)

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -594,7 +594,7 @@ class HTTPErrorProcessor(BaseHandler):
     handler_order = 1000  # after all other processing
 
     def http_response(self, request, response):
-        code, msg, hdrs = response.status, response.msg, response.info()
+        code, msg, hdrs = response.status, response.msg, response.headers
 
         # According to RFC 2616, "2xx" code indicates that the client's
         # request was successfully received, understood, and accepted.

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -210,7 +210,7 @@ def urlretrieve(url, filename=None, reporthook=None, data=None):
     url_type, path = _splittype(url)
 
     with contextlib.closing(urlopen(url, data)) as fp:
-        headers = fp.info()
+        headers = fp.headers
 
         # Just return the local path and the "headers" for file://
         # URLs. No sense in performing a copy unless requested.
@@ -594,7 +594,7 @@ class HTTPErrorProcessor(BaseHandler):
     handler_order = 1000  # after all other processing
 
     def http_response(self, request, response):
-        code, msg, hdrs = response.code, response.msg, response.info()
+        code, msg, hdrs = response.status, response.msg, response.info()
 
         # According to RFC 2616, "2xx" code indicates that the client's
         # request was successfully received, understood, and accepted.
@@ -1338,8 +1338,7 @@ class AbstractHTTPHandler(BaseHandler):
         # This line replaces the .msg attribute of the HTTPResponse
         # with .headers, because urllib clients expect the response to
         # have the reason in .msg.  It would be good to mark this
-        # attribute is deprecated and get then to use info() or
-        # .headers.
+        # attribute is deprecated and get then to use .headers.
         r.msg = r.reason
         return r
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1270,6 +1270,7 @@ Dustin J. Mitchell
 Gideon Mitchell
 Tim Mitchell
 Zubin Mithra
+Alexandr Mitin
 Florian Mladitsch
 Kevin Modzelewski
 Doug Moen

--- a/Misc/NEWS.d/next/Library/2025-04-17-18-13-46.gh-issue-123503.Qtuolv.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-17-18-13-46.gh-issue-123503.Qtuolv.rst
@@ -1,2 +1,0 @@
-Deprecated attributes `urllib.response.addinfourl.status` and `http.client.HTTPResponse.info()`
-have been replaced with their modern equivalents (`HTTPResponse.headers`) while maintaining backwards-compatibility.

--- a/Misc/NEWS.d/next/Library/2025-04-17-18-13-46.gh-issue-123503.Qtuolv.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-17-18-13-46.gh-issue-123503.Qtuolv.rst
@@ -1,1 +1,2 @@
-Replaced usage of deprecated attributes `addinfourl.status` and `HTTPResponse.info` with their modern equivalents.
+Deprecated attributes `urllib.response.addinfourl.status` and `http.client.HTTPResponse.info()`
+have been replaced with their modern equivalents (`HTTPResponse.headers`) while maintaining backwards-compatibility.

--- a/Misc/NEWS.d/next/Library/2025-04-17-18-13-46.gh-issue-123503.Qtuolv.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-17-18-13-46.gh-issue-123503.Qtuolv.rst
@@ -1,0 +1,1 @@
+Replaced usage of deprecated attributes `addinfourl.status` and `HTTPResponse.info` with their modern equivalents.

--- a/Misc/NEWS.d/next/Library/2025-04-17-18-37-26.gh-issue-123503.mfg0wD.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-17-18-37-26.gh-issue-123503.mfg0wD.rst
@@ -1,0 +1,1 @@
+Deprecated attributes urllib.response.addinfourl.status and http.client.HTTPResponse.info() have been replaced with their modern equivalents (HTTPResponse.headers) while maintaining backwards-compatibility.


### PR DESCRIPTION
I replaced deprecated features with the recommended current features(updated to the latest version)


<!-- gh-issue-number: gh-123503 -->
* Issue: gh-123503
<!-- /gh-issue-number -->