### PR TITLE
Docs: Migrate entirely to PSF hosted plausible for analytics

### DIFF
--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -27,8 +27,7 @@
 
 {% block extrahead %}
     {% if builder == "html" and enable_analytics %}
-      <script defer data-domain="docs.python.org" src="https://plausible.io/js/script.js"></script>
-      <script defer data-domain="docs.python.org" src="https://analytics.python.org/js/script.js"></script>
+      <script defer data-domain="docs.python.org" src="https://analytics.python.org/js/script.outbound-links.js"></script>
     {% endif %}
     <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html">
     {% if builder != "htmlhelp" %}


### PR DESCRIPTION
I also updated the script to enable tracking of outbound link clicks, which may be nice to have.

Analytics can still be viewed publicly at https://analytics.python.org/docs.python.org.

~~The only discrepency I have encountered comparing the analytics data between the two is that hosted plausible seems to count more Unique visitors. I'm unsure why... but for our purposes it isn't really important, as we are mainly tracking what pages/languages are being viewed.~~ edit: this is now fixed, just needed to map Fastly-Client-IP header to the X-Plausible-IP header. I'll reset stats and re-import to clear things up.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132648.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->