### PR TITLE
GH-132380: Add optimization for non-interned type lookup.

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-17-11-32-43.gh-issue-132380.eDaVzm.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-17-11-32-43.gh-issue-132380.eDaVzm.rst
@@ -1,0 +1,3 @@
+Add an optimized implementation of type lookup for names that are
+non-interned strings. This is only enabled for free-threaded builds since
+that kind of lookup can cause contention for the global type lock.


### PR DESCRIPTION
Add an optimized implementation of type lookup for names that are non-interned strings. This is only enabled for free-threaded builds since that kind of lookup can cause contention for the global type lock.

I benchmarked this with LibCST running on the numpy source code.  Summary of results:

| Config              | Time [s] | Description                                                         |
| ------------------- | -------- | ------------------------------------------------------------------- |
| Base                | 38.1     | Main branch of 3.13, free-threaded build                            |
| Non-interned lookup | 24.1     | With the version of this PR for 3.13 applied                        |
| GIL enabled         | 21.0     | This is free-threaded build with GIL=1, uses multi-process          |
| Python cache        | 27.2     | This is with pr1295, using a Python-based cache on top of getattr() |

<!-- gh-issue-number: gh-132380 -->
* Issue: gh-132380
<!-- /gh-issue-number -->

The backport to 3.13 of this is non-trivial and so I made a separate PR for it (GH-132651).  It is basically the same logic though.  This approach to avoid the contention might be preferred to GH-132381 since I think it should be more obviously safe.

[Benchmark results from pyperformance](https://github.com/facebookexperimental/free-threading-benchmarking/blob/main/results/bm-20250417-3.14.0a7%2B-d3f79e5-NOGIL/bm-20250417-vultr-x86_64-nascheme-gh_132380_tp_lookup_-3.14.0a7%2B-d3f79e5-vs-base.svg)
