### PR TITLE
speedup test_pyrepl

### DIFF
--- a/Lib/test/test_pyrepl/test_unix_console.py
+++ b/Lib/test/test_pyrepl/test_unix_console.py
@@ -23,6 +23,7 @@ def unix_console(events, **kwargs):
     height = kwargs.get("height", 25)
     width = kwargs.get("width", 80)
     console.getheightwidth = MagicMock(side_effect=lambda: (height, width))
+    console.wait = MagicMock()
 
     console.prepare()
     for key, val in kwargs.items():

--- a/Lib/test/test_pyrepl/test_windows_console.py
+++ b/Lib/test/test_pyrepl/test_windows_console.py
@@ -31,6 +31,7 @@ class WindowsConsoleTests(TestCase):
     def console(self, events, **kwargs) -> Console:
         console = WindowsConsole()
         console.get_event = MagicMock(side_effect=events)
+        console.wait = MagicMock()
         console._scroll = MagicMock()
         console._hide_cursor = MagicMock()
         console._show_cursor = MagicMock()


### PR DESCRIPTION
Speedup `test_pyrepl` by speeding up `test_unix_console.py` / `test_windows_console.py`. Especially in case of Windows, almost all the time is spent there, and these tests are unnecessarily slow because they are not mocking `wait`:

https://github.com/python/cpython/blob/d134bd272f90bfc2dfb55b126d4552c996251fc1/Lib/_pyrepl/unix_console.py#L419-L427

https://github.com/python/cpython/blob/d134bd272f90bfc2dfb55b126d4552c996251fc1/Lib/_pyrepl/windows_console.py#L523-L532

The tables show the times in seconds.

Linux 64bit debug build (only tested in WSL):
- `./python -m test -u curses test_pyrepl`
- `./python -m test -u curses test_pyrepl.test_unix_console`

|  | test_pyrepl | test_unix_console |
|--------|--------|--------|
| before | 17.7 | 10.8 |
| after |  7.4 | 0.2 | 

Windows 64bit debug build:
- `python.bat -m test test_pyrepl`
- `python.bat -m test test_pyrepl.test_windows_console`

|  | test_pyrepl | test_windows_console |
|--------|--------|--------|
| before | 19.1 | 16.5 |
| after |  3.7 | 1.0 | 

I've marked as skipped news - and think this is also a skip issue?