### PR TITLE
[3.13] gh-132673: Fix crash with zero-alignment in a `ctypes.Structure`

### DIFF
--- a/Lib/test/test_ctypes/test_aligned_structures.py
+++ b/Lib/test/test_ctypes/test_aligned_structures.py
@@ -1,7 +1,7 @@
 from ctypes import (
     c_char, c_uint32, c_uint16, c_ubyte, c_byte, alignment, sizeof,
     BigEndianStructure, LittleEndianStructure,
-    BigEndianUnion, LittleEndianUnion,
+    BigEndianUnion, LittleEndianUnion, Structure
 )
 import struct
 import unittest
@@ -280,6 +280,41 @@ class TestAlignedStructures(unittest.TestCase):
             self.assertEqual(main.b.x, 2)
             self.assertEqual(main.b.y, 3)
             self.assertEqual(main.c, 4)
+
+    def test_negative_align(self):
+        for base in (Structure, LittleEndianStructure, BigEndianStructure):
+            with (
+                self.subTest(base=base),
+                self.assertRaisesRegex(
+                    ValueError,
+                    '_align_ must be a non-negative integer',
+                )
+            ):
+                class MyStructure(base):
+                    _align_ = -1
+                    _fields_ = []
+
+    def test_zero_align_no_fields(self):
+        for base in (Structure, LittleEndianStructure, BigEndianStructure):
+            with self.subTest(base=base):
+                class MyStructure(base):
+                    _align_ = 0
+                    _fields_ = []
+
+                self.assertEqual(alignment(MyStructure), 1)
+                self.assertEqual(alignment(MyStructure()), 1)
+
+    def test_zero_align_with_fields(self):
+        for base in (Structure, LittleEndianStructure, BigEndianStructure):
+            with self.subTest(base=base):
+                class MyStructure(base):
+                    _align_ = 0
+                    _fields_ = [
+                        ("x", c_ubyte),
+                    ]
+
+                self.assertEqual(alignment(MyStructure), 1)
+                self.assertEqual(alignment(MyStructure()), 1)
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2025-04-18-12-45-18.gh-issue-132673.P7Z3F1.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-18-12-45-18.gh-issue-132673.P7Z3F1.rst
@@ -1,0 +1,2 @@
+Fix crash when using ``_align_ = 0`` and ``_fields_ = []`` in a
+:class:`ctypes.Structure`.

--- a/Misc/NEWS.d/next/Library/2025-04-18-12-45-18.gh-issue-132673.P7Z3F1.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-18-12-45-18.gh-issue-132673.P7Z3F1.rst
@@ -1,2 +1,2 @@
-Fix crash when using ``_align_ = 0`` and ``_fields_ = []`` in a
+Fix a crash when using ``_align_ = 0`` and ``_fields_ = []`` in a
 :class:`ctypes.Structure`.

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -383,7 +383,7 @@ PyCStructUnionType_update_stginfo(PyObject *type, PyObject *fields, int isStruct
         size = 0;
         align = 0;
         union_size = 0;
-        total_align = forced_alignment;
+        total_align = forced_alignment != 0 ? forced_alignment : 1;
         stginfo->ffi_type_pointer.type = FFI_TYPE_STRUCT;
         stginfo->ffi_type_pointer.elements = PyMem_New(ffi_type *, len + 1);
         if (stginfo->ffi_type_pointer.elements == NULL) {
@@ -570,6 +570,7 @@ PyCStructUnionType_update_stginfo(PyObject *type, PyObject *fields, int isStruct
     }
 
     /* Adjust the size according to the alignment requirements */
+    assert(total_align != 0);
     aligned_size = ((size + total_align - 1) / total_align) * total_align;
 
     if (isStruct) {

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -383,7 +383,7 @@ PyCStructUnionType_update_stginfo(PyObject *type, PyObject *fields, int isStruct
         size = 0;
         align = 0;
         union_size = 0;
-        total_align = forced_alignment != 0 ? forced_alignment : 1;
+        total_align = forced_alignment == 0 ? 1 : forced_alignment;
         stginfo->ffi_type_pointer.type = FFI_TYPE_STRUCT;
         stginfo->ffi_type_pointer.elements = PyMem_New(ffi_type *, len + 1);
         if (stginfo->ffi_type_pointer.elements == NULL) {


### PR DESCRIPTION
Fixes the crash on a C level. I reused the test cases from gh-132676.

<!-- gh-issue-number: gh-132673 -->
* Issue: gh-132673
<!-- /gh-issue-number -->
