### PR TITLE
Minor doc edit: Make multinomial() the first math example

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -1009,6 +1009,12 @@ The following recipes have a more mathematical flavor:
 
 .. testcode::
 
+   def multinomial(*counts):
+       "Number of distinct arrangements of a multiset."
+       # Counter('abracadabra').values() → 5 2 2 1 1
+       # multinomial(5, 2, 2, 1, 1) → 83160
+       return prod(map(comb, accumulate(counts), counts))
+
    def powerset(iterable):
        "Subsequences of the iterable from shortest to longest."
        # powerset([1,2,3]) → () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)
@@ -1126,12 +1132,6 @@ The following recipes have a more mathematical flavor:
        for prime in set(factor(n)):
            n -= n // prime
        return n
-
-   def multinomial(*counts):
-       "Number of distinct arrangements of a multiset."
-       # Counter('abracadabra').values() → 5 2 2 1 1
-       # multinomial(5, 2, 2, 1, 1) → 83160
-       return prod(map(comb, accumulate(counts), counts))
 
 
 .. doctest::


### PR DESCRIPTION
Move `multinomial()` to the top of the math recipes because it nicely demonstrates a data pipeline, because of its brevity, and because it is more approachable that some of the recipes that follow.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132697.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->