### PR TITLE
gh-127117: ensure that `_initial_thread` is the last field of `PyInterpreterState` when `Py_STACKREF_DEBUG` is defined

### DIFF
--- a/Include/internal/pycore_interp_structs.h
+++ b/Include/internal/pycore_interp_structs.h
@@ -754,7 +754,7 @@ struct _is {
      * and should be placed at the beginning. */
     struct _ceval_state ceval;
 
-   /* This structure is carefully allocated so that it's correctly aligned
+    /* This structure is carefully allocated so that it's correctly aligned
      * to avoid undefined behaviors during LOAD and STORE. The '_malloced'
      * field stores the allocated pointer address that will later be freed.
      */
@@ -941,11 +941,6 @@ struct _is {
 
     Py_ssize_t _interactive_src_count;
 
-    /* the initial PyInterpreterState.threads.head */
-    _PyThreadStateImpl _initial_thread;
-    // _initial_thread should be the last field of PyInterpreterState.
-    // See https://github.com/python/cpython/issues/127117.
-
 #if !defined(Py_GIL_DISABLED) && defined(Py_STACKREF_DEBUG)
     uint64_t next_stackref;
     _Py_hashtable_t *open_stackrefs_table;
@@ -953,6 +948,11 @@ struct _is {
     _Py_hashtable_t *closed_stackrefs_table;
 #  endif
 #endif
+
+    /* the initial PyInterpreterState.threads.head */
+    _PyThreadStateImpl _initial_thread;
+    // _initial_thread should be the last field of PyInterpreterState.
+    // See https://github.com/python/cpython/issues/127117.
 };
 
 


### PR DESCRIPTION
Depending on the configuration, the last field is not `_initial_thread`. I also fixed a typo I left in the previous commit.

<!-- gh-issue-number: gh-127117 -->
* Issue: gh-127117
<!-- /gh-issue-number -->
