### PR TITLE
gh-129327: revise hashlib documentation to account for FIPS removing sha1

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -20,13 +20,12 @@
 
 --------------
 
-This module implements a common interface to many different secure hash and
-message digest algorithms.  Included are the FIPS secure hash algorithms SHA1,
-SHA224, SHA256, SHA384, SHA512, (defined in `the FIPS 180-4 standard`_),
-the SHA-3 series (defined in `the FIPS 202 standard`_) as well as RSA's MD5
-algorithm (defined in internet :rfc:`1321`).  The terms "secure hash" and
-"message digest" are interchangeable.  Older algorithms were called message
-digests.  The modern term is secure hash.
+This module implements a common interface to many different hash algorithms.
+Included are the FIPS secure hash algorithms SHA224, SHA256, SHA384, SHA512,
+(defined in `the FIPS 180-4 standard`_), the SHA-3 series (defined in `the FIPS
+202 standard`_) as well as the non-cryptographically-secure algorithms SHA1
+(`formerly part of FIPS`_) and RSA's MD5 algorithm (defined in internet
+:rfc:`1321`).
 
 .. note::
 
@@ -812,6 +811,7 @@ Domain Dedication 1.0 Universal:
 .. _the FIPS 180-4 standard: https://csrc.nist.gov/pubs/fips/180-4/upd1/final
 .. _the FIPS 202 standard: https://csrc.nist.gov/pubs/fips/202/final
 .. _HACL\* project: https://github.com/hacl-star/hacl-star
+.. _formerly part of FIPS: https://csrc.nist.gov/news/2023/decision-to-revise-fips-180-4
 
 
 .. _hashlib-seealso:

--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -23,9 +23,8 @@
 This module implements a common interface to many different hash algorithms.
 Included are the FIPS secure hash algorithms SHA224, SHA256, SHA384, SHA512,
 (defined in `the FIPS 180-4 standard`_), the SHA-3 series (defined in `the FIPS
-202 standard`_) as well as the non-cryptographically-secure algorithms SHA1
-(`formerly part of FIPS`_) and RSA's MD5 algorithm (defined in internet
-:rfc:`1321`).
+202 standard`_) as well as the legacy algorithms SHA1 (`formerly part of FIPS`_)
+and the MD5 algorithm (defined in internet :rfc:`1321`).
 
 .. note::
 

--- a/Misc/NEWS.d/next/Documentation/2025-01-27-01-21-55.gh-issue-129327.sv2NB1.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-01-27-01-21-55.gh-issue-129327.sv2NB1.rst
@@ -1,0 +1,3 @@
+Clarify that hashlib's SHA1 is no longer a FIPS secure algorithm. Clarify that
+hashlib has a mixture of cryptographically secure and non cryptographically
+secure hash algorithms. Patch by Eli Schwartz.

--- a/Misc/NEWS.d/next/Documentation/2025-01-27-01-21-55.gh-issue-129327.sv2NB1.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-01-27-01-21-55.gh-issue-129327.sv2NB1.rst
@@ -1,3 +1,0 @@
-Clarify that hashlib's SHA1 is no longer a FIPS secure algorithm. Clarify that
-hashlib has a mixture of cryptographically secure and non cryptographically
-secure hash algorithms. Patch by Eli Schwartz.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Finishes off #129334 with @gpshead 's suggestion

Also request: @picnixz @eli-schwartz 

<!-- gh-issue-number: gh-129327 -->
* Issue: gh-129327
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132729.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->