### PR TITLE
gh-132558: allow `choices` to be specified as strings in presence of a `type` argument  

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -74,7 +74,7 @@ ArgumentParser objects
                           prefix_chars='-', fromfile_prefix_chars=None, \
                           argument_default=None, conflict_handler='error', \
                           add_help=True, allow_abbrev=True, exit_on_error=True, \
-                          suggest_on_error=False)
+                          suggest_on_error=False, convert_choices=False)
 
    Create a new :class:`ArgumentParser` object. All parameters should be passed
    as keyword arguments. Each parameter has its own more detailed description
@@ -118,6 +118,9 @@ ArgumentParser objects
 
    * suggest_on_error_ - Enables suggestions for mistyped argument choices
      and subparser names (default: ``False``)
+
+   * convert_choices_ - Runs the ``choices`` through the ``type`` callable
+     during checking (default: ``False``)
 
 
    .. versionchanged:: 3.5
@@ -610,6 +613,38 @@ keyword argument::
    >>> parser.suggest_on_error = True
 
 .. versionadded:: 3.14
+
+
+convert_choices
+^^^^^^^^^^^^^^^
+
+By default, when a user passes both a ``type`` and a ``choices`` argument, the
+``choices`` need to be specified in the target type, after conversion.
+This can cause confusing ``usage`` and ``help`` strings. If the user would like
+to specify ``choices`` in the same vocabulary as the end-user would enter them,
+this feature can be enabled by setting ``convert_choices`` to ``True``::
+
+   >>> parser = argparse.ArgumentParser(convert_choices=True)
+   >>> parser.add_argument('when',
+   ...                     choices=['mo', 'tu', 'we', 'th', 'fr', 'sa', 'su'],
+   ...                     type=to_dow)
+   >>> parser.print_help()
+   usage: example_broken.py [-h] [--days {mo,tu,we,th,fr,sa,su}]
+
+   options:
+     -h, --help            show this help message and exit
+     --days {mo,tu,we,th,fr,sa,su}
+
+
+If you're writing code that needs to be compatible with older Python versions
+and want to opportunistically use ``convert_choices`` when it's available, you
+can set it as an attribute after initializing the parser instead of using the
+keyword argument::
+
+   >>> parser = argparse.ArgumentParser()
+   >>> parser.convert_choices = True
+
+.. versionadded:: next
 
 
 The add_argument() method
@@ -1124,9 +1159,12 @@ if the argument was not one of the acceptable values::
    game.py: error: argument move: invalid choice: 'fire' (choose from 'rock',
    'paper', 'scissors')
 
-Note that inclusion in the *choices* sequence is checked after any type_
-conversions have been performed, so the type of the objects in the *choices*
-sequence should match the type_ specified.
+Note that, by default, inclusion in the *choices* sequence is checked after
+any type_ conversions have been performed, so the type of the objects in the
+*choices* sequence should match the type_ specified. This can lead to
+confusing ``usage`` messages. If you want to convert *choices* using type_
+before checking, set the ``convert_choices`` flag on :class:`~ArgumentParser`.
+
 
 Any sequence can be passed as the *choices* value, so :class:`list` objects,
 :class:`tuple` objects, and custom sequences are all supported.

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1777,7 +1777,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
             error info when an error occurs
         - suggest_on_error - Enables suggestions for mistyped argument choices
             and subparser names. (default: ``False``)
-        - convert_choices - Runs the ``choices`` through the ``type`` function
+        - convert_choices - Runs the ``choices`` through the ``type`` callable
             during checking. (default: ``False``)
     """
 
@@ -2593,11 +2593,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
             action.type and
             all(isinstance(choice, str) for choice in choices)
         ):
-            try:
-                typed_choices = [action.type(v) for v in choices]
-            except Exception:
-                # We use a blanket catch here, because type is user provided.
-                pass
+            typed_choices = [action.type(v) for v in choices]
 
         if value not in choices and value not in typed_choices:
             args = {'value': arg_string,

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1935,7 +1935,7 @@ class TestFileTypeRB(TempDirMixin, ParserTestCase):
     ]
 
 class TestChoices(ParserTestCase):
-    """Test the original behavior"""
+    """Test integer choices without conversion."""
     def to_dow(arg):
         days = ["mo", "tu", "we", "th", "fr", "sa", "su"]
         if arg in days:

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1934,6 +1934,46 @@ class TestFileTypeRB(TempDirMixin, ParserTestCase):
         ('-x - -', NS(x=eq_bstdin, spam=eq_bstdin)),
     ]
 
+class TestChoices(ParserTestCase):
+    """Test the original behavior"""
+    def to_dow(arg):
+        days = ["mo", "tu", "we", "th", "fr", "sa", "su"]
+        if arg in days:
+            return days.index(arg) + 1
+        else:
+            return None
+
+    argument_signatures = [
+        Sig('when',
+            type=to_dow, choices=[1, 2, 3, 4, 5, 6, 7],
+        )
+    ]
+    failures = ['now', '1']
+    successes = [
+        ('mo', NS(when=1)),
+        ('su', NS(when=7)),
+    ]
+
+class TestTypedChoices(TestChoices):
+    """Test a set of string choices that convert to weekdays"""
+
+    parser_signature = Sig(convert_choices=True)
+    argument_signatures = [
+        Sig('when',
+            type=TestChoices.to_dow, choices=["mo", "tu", "we" , "th", "fr", "sa", "su"],
+        )
+    ]
+
+class TestTypedChoicesNoFlag(TestChoices):
+    """Without the feature flag we fail"""
+    argument_signatures = [
+        Sig('when',
+            type=TestChoices.to_dow, choices=["mo", "tu", "we" , "th", "fr", "sa", "su"],
+        )
+    ]
+    failures = ['mo']
+    successes = []
+
 
 class WFile(object):
     seen = set()
@@ -5466,6 +5506,39 @@ class TestHelpMetavarTypeFormatter(HelpTestCase):
           -c SOME FLOAT
         '''
     version = ''
+
+
+class TestHelpTypedChoices(HelpTestCase):
+    from datetime import date, timedelta
+    def to_date(arg):
+        if arg == "today":
+            return date.today()
+        elif arg == "tomorrow":
+            return date.today() + timedelta(days=1).date()
+        else:
+            return None
+
+    parser_signature = Sig(prog='PROG', convert_choices=True)
+    argument_signatures = [
+        Sig('when',
+            type=to_date,
+            choices=["today", "tomorrow"]
+        ),
+    ]
+
+    usage = '''\
+usage: PROG [-h] {today,tomorrow}
+        '''
+    help = usage + '''\
+
+positional arguments:
+  {today,tomorrow}
+
+options:
+  -h, --help        show this help message and exit
+        '''
+    version = ''
+
 
 
 class TestHelpUsageLongSubparserCommand(TestCase):

--- a/Misc/NEWS.d/next/Library/2025-04-20-12-52-20.gh-issue-132558.MoFGmw.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-20-12-52-20.gh-issue-132558.MoFGmw.rst
@@ -1,0 +1,2 @@
+:mod:`argparse` now allows `choices` to be entered as strings and calls
+convert on the available choices during checking.

--- a/Misc/NEWS.d/next/Library/2025-04-20-12-52-20.gh-issue-132558.MoFGmw.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-20-12-52-20.gh-issue-132558.MoFGmw.rst
@@ -1,2 +1,3 @@
-:mod:`argparse` now allows `choices` to be entered as strings and calls
-convert on the available choices during checking.
+:mod:`argparse` Add option ``convert_choices`` to :class:`ArgumentParser`. Combined with ``type``, allows  ``choices``
+to be entered as strings and converted during argument checking.
+


### PR DESCRIPTION
As a motivating example, consider the following program:
```
import argparse

parser = argparse.ArgumentParser()

day_names = ["mo", "tu", "we", "th", "fr", "sa", "su"]
days = [1, 2, 3, 4, 5, 6, 7]

def name_day(value):
    return day_names.index(value) + 1

parser.add_argument(
    '--day',
    type=name_day,
    choices=days,
)
parser.parse_args()
```

This gives the following usage string:
```
usage: example.py [-h] [--day {1,2,3,4,5,6,7}]
```

With the proposed pull request, the program can be rewritten as follows:
```
import argparse

parser = argparse.ArgumentParser()

day_names = ["mo", "tu", "we", "th", "fr", "sa", "su"]

def name_day(value):
    return day_names.index(value) + 1

parser.add_argument(
    '--day',
    type=name_day,
    choices=days,
)
parser.parse_args()
```
With the following usage string:
```
usage: example_new.py [-h] [--days {mo,tu,we,th,fr,sa,su}]
```

I took care to ensure backward compatibility including by adding a feature flag for the behavior. The feature flag should not be necessary, but because the argparse library is so flexible, it better to be safe than sorry. 


<!-- gh-issue-number: gh-132558 -->
* Issue: gh-132558
<!-- /gh-issue-number -->
