### PR TITLE
gh-127081: lock non-re-entrant `*pwent` calls

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-04-21-00-58-04.gh-issue-127081.3DCl92.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-21-00-58-04.gh-issue-127081.3DCl92.rst
@@ -1,0 +1,2 @@
+Fix libc thread safety issues with :mod:`pwd` by locking access to
+``getpwall``.

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -9,7 +9,6 @@
 
 #include "Python.h"
 #include "posixmodule.h"
-#include "listobject.h"           // PyList_Size/PyList_GetItem
 
 #include <errno.h>                // ERANGE
 #include <pwd.h>                  // getpwuid()

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -326,15 +326,12 @@ done:
 #ifdef Py_GIL_DISABLED
     PyMutex_Unlock(&getpwall_mutex);
 #endif
-    /* Deferred decref on entries created above and added to the list */
-    Py_ssize_t n = PyList_Size(d);
-    for (Py_ssize_t i = 0; i < n; ++i) {
-        PyObject *entry = PyList_GetItem(d, i);
-        Py_DECREF(entry);
+    /* Deferred decref on entries created above and added to the list. */
+    Py_ssize_t n = PyList_GET_SIZE(d);
+    while (--n >= 0) {
+        Py_DECREF(PyList_GET_ITEM(d, n));
     }
     if (failure) {
-        /* If there was a failure we might have created an entry but not added
-         * it: dec-ref that, if it exists, before clearing the list. */
         Py_XDECREF(orphan);
         Py_CLEAR(d);
     }

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -301,18 +301,28 @@ pwd_getpwall_impl(PyObject *module)
     struct passwd *p;
     if ((d = PyList_New(0)) == NULL)
         return NULL;
+
+#ifdef Py_GIL_DISABLED
+    static PyMutex getpwall_mutex = {0};
+    PyMutex_Lock(&getpwall_mutex);
+#endif
     setpwent();
+
     while ((p = getpwent()) != NULL) {
         PyObject *v = mkpwent(module, p);
         if (v == NULL || PyList_Append(d, v) != 0) {
             Py_XDECREF(v);
-            Py_DECREF(d);
-            endpwent();
-            return NULL;
+            Py_CLEAR(d);
+            goto done;
         }
         Py_DECREF(v);
     }
+
+done:
     endpwent();
+#ifdef Py_GIL_DISABLED
+    PyMutex_Unlock(&getpwall_mutex);
+#endif
     return d;
 }
 #endif

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -327,9 +327,9 @@ done:
     PyMutex_Unlock(&getpwall_mutex);
 #endif
     /* Deferred decref on entries created above and added to the list. */
-    Py_ssize_t n = PyList_GET_SIZE(d);
+    Py_ssize_t n = PyList_Size(d);
     while (--n >= 0) {
-        Py_DECREF(PyList_GET_ITEM(d, n));
+        Py_DECREF(PyList_GetItem(d, n));
     }
     if (failure) {
         Py_XDECREF(orphan);


### PR DESCRIPTION
The libc setpwent, getpwent, and endpwent functions are not thread-safe. Protect them with mutexs in free-threading builds.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127081 -->
* Issue: gh-127081
<!-- /gh-issue-number -->
