### PR TITLE
gh-127081: use re-entrant variants of `get{proto,serv}by{name,port}`

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1297,6 +1297,10 @@ class GeneralModuleTests(unittest.TestCase):
         self.assertRaises(OverflowError, socket.getservbyport, -1)
         self.assertRaises(OverflowError, socket.getservbyport, 65536)
 
+    def testGetProtoByName(self):
+        self.assertEqual(socket.getprotobyname('tcp'), 6)
+        self.assertRaises(OSError, socket.getprotobyname, 'non-existent proto')
+
     def testDefaultTimeout(self):
         # Testing default timeout
         # The default timeout should initially be None

--- a/Misc/NEWS.d/next/Library/2025-04-17-00-14-41.gh-issue-127081.aEM3Hk.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-17-00-14-41.gh-issue-127081.aEM3Hk.rst
@@ -1,0 +1,2 @@
+Fix thread safety issues with getservbyname, getservbyport, and
+getprotobyname.

--- a/Misc/NEWS.d/next/Library/2025-04-21-01-00-47.gh-issue-127081.o56pE1.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-21-01-00-47.gh-issue-127081.o56pE1.rst
@@ -1,0 +1,3 @@
+Fix libc thread safety issues with :mod:`socket` by replacing
+``getservbyname``, ``getservbyport``, and ``getprotobyname`` with ``*_r``
+re-entrant versions.

--- a/configure
+++ b/configure
@@ -22615,6 +22615,129 @@ fi
 
 
 
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for getservbyname_r" >&5
+printf %s "checking for getservbyname_r... " >&6; }
+if test ${ac_cv_func_getservbyname_r+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <netdb.h>
+int
+main (void)
+{
+void *x=getservbyname_r
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ac_cv_func_getservbyname_r=yes
+else case e in #(
+  e) ac_cv_func_getservbyname_r=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+   ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getservbyname_r" >&5
+printf "%s\n" "$ac_cv_func_getservbyname_r" >&6; }
+  if test "x$ac_cv_func_getservbyname_r" = xyes
+then :
+
+printf "%s\n" "#define HAVE_GETSERVBYNAME_R 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for getservbyport_r" >&5
+printf %s "checking for getservbyport_r... " >&6; }
+if test ${ac_cv_func_getservbyport_r+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <netdb.h>
+int
+main (void)
+{
+void *x=getservbyport_r
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ac_cv_func_getservbyport_r=yes
+else case e in #(
+  e) ac_cv_func_getservbyport_r=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+   ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getservbyport_r" >&5
+printf "%s\n" "$ac_cv_func_getservbyport_r" >&6; }
+  if test "x$ac_cv_func_getservbyport_r" = xyes
+then :
+
+printf "%s\n" "#define HAVE_GETSERVBYPORT_R 1" >>confdefs.h
+
+fi
+
+
+
+
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for getprotobyname_r" >&5
+printf %s "checking for getprotobyname_r... " >&6; }
+if test ${ac_cv_func_getprotobyname_r+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <netdb.h>
+int
+main (void)
+{
+void *x=getprotobyname_r
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ac_cv_func_getprotobyname_r=yes
+else case e in #(
+  e) ac_cv_func_getprotobyname_r=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+   ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getprotobyname_r" >&5
+printf "%s\n" "$ac_cv_func_getprotobyname_r" >&6; }
+  if test "x$ac_cv_func_getprotobyname_r" = xyes
+then :
+
+printf "%s\n" "#define HAVE_GETPROTOBYNAME_R 1" >>confdefs.h
+
+fi
+
+
+
+
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -5395,6 +5395,9 @@ PY_CHECK_NETDB_FUNC([getservbyport])
 PY_CHECK_NETDB_FUNC([gethostbyname])
 PY_CHECK_NETDB_FUNC([gethostbyaddr])
 PY_CHECK_NETDB_FUNC([getprotobyname])
+PY_CHECK_NETDB_FUNC([getservbyname_r])
+PY_CHECK_NETDB_FUNC([getservbyport_r])
+PY_CHECK_NETDB_FUNC([getprotobyname_r])
 
 dnl PY_CHECK_SOCKET_FUNC(FUNCTION)
 AC_DEFUN([PY_CHECK_SOCKET_FUNC], [PY_CHECK_FUNC([$1], [

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -557,6 +557,9 @@
 /* Define if you have the 'getprotobyname' function. */
 #undef HAVE_GETPROTOBYNAME
 
+/* Define if you have the 'getprotobyname_r' function. */
+#undef HAVE_GETPROTOBYNAME_R
+
 /* Define to 1 if you have the 'getpwent' function. */
 #undef HAVE_GETPWENT
 
@@ -587,8 +590,14 @@
 /* Define if you have the 'getservbyname' function. */
 #undef HAVE_GETSERVBYNAME
 
+/* Define if you have the 'getservbyname_r' function. */
+#undef HAVE_GETSERVBYNAME_R
+
 /* Define if you have the 'getservbyport' function. */
 #undef HAVE_GETSERVBYPORT
+
+/* Define if you have the 'getservbyport_r' function. */
+#undef HAVE_GETSERVBYPORT_R
 
 /* Define to 1 if you have the 'getsid' function. */
 #undef HAVE_GETSID


### PR DESCRIPTION
Add configure tests and defines for getservbyname_r, getservbyport_r, and getprotobyname_r. Use these if available, otherwise fallback to the thread-unsafe variants.

Add a unit test to exercise getprotobyname, which is currently untested.

TODO:
 - Are there any platforms which define the unsafe variants but not the re-entrant ones? If not we can simplify the #ifdef hell somewhat.
 - Do the re-entrant functions have the same signature on all platforms?
 - These changes follow the existing code's practice: allocate a fixed-size (and overly large) buffer, and don't properly handle the error case if it is too small. Should this be fixed? If so should existing code also be fixed?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127081 -->
* Issue: gh-127081
<!-- /gh-issue-number -->
