### PR TITLE
gh-132769: Refactor possible read-out-of-bounds in `lexer.c`

### DIFF
--- a/Parser/lexer/lexer.c
+++ b/Parser/lexer/lexer.c
@@ -140,7 +140,7 @@ set_fstring_expr(struct tok_state* tok, struct token *token, char c) {
         for (i = 0, j = 0; i < input_length; i++) {
             if (tok_mode->last_expr_buffer[i] == '#') {
                 // Skip characters until newline or end of string
-                while (tok_mode->last_expr_buffer[i] != '\0' && i < input_length) {
+                while (i < input_length && tok_mode->last_expr_buffer[i] != '\0') {
                     if (tok_mode->last_expr_buffer[i] == '\n') {
                         result[j++] = tok_mode->last_expr_buffer[i];
                         break;


### PR DESCRIPTION
I don't really think that this is an actual problem, but this makes static analysis happy.
I also think that it might be a potential problem in some future case.

<!-- gh-issue-number: gh-132769 -->
* Issue: gh-132769
<!-- /gh-issue-number -->
