### PR TITLE
gh-132747: Fix `NULL` dereference when calling a method's `__get__` manually

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -653,6 +653,24 @@ class TypesTests(unittest.TestCase):
         self.assertIsInstance(int.from_bytes, types.BuiltinMethodType)
         self.assertIsInstance(int.__new__, types.BuiltinMethodType)
 
+    def test_method_descriptor_crash(self):
+        # gh-132747: The default __get__() implementation in C was unable
+        # to handle a second argument of None when called from Python
+        import _io
+        import io
+        import _queue
+
+        types = [
+            # (method, instance)
+            (_io.TextIOWrapper.write, io.StringIO()),
+            (_queue.SimpleQueue.put, _queue.SimpleQueue()),
+            (str.capitalize, "nobody expects the spanish inquisition")
+        ]
+
+        for method, instance in types:
+            with self.subTest(method=method, instance=instance):
+                method.__get__(instance)
+
     def test_ellipsis_type(self):
         self.assertIsInstance(Ellipsis, types.EllipsisType)
 

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -662,7 +662,7 @@ class TypesTests(unittest.TestCase):
 
         types = [
             # (method, instance)
-            (_io.TextIOWrapper.write, io.StringIO()),
+            (_io._TextIOBase.read, io.StringIO()),
             (_queue.SimpleQueue.put, _queue.SimpleQueue()),
             (str.capitalize, "nobody expects the spanish inquisition")
         ]

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -660,16 +660,17 @@ class TypesTests(unittest.TestCase):
         import io
         import _queue
 
-        types = [
+        to_check = [
             # (method, instance)
             (_io._TextIOBase.read, io.StringIO()),
             (_queue.SimpleQueue.put, _queue.SimpleQueue()),
             (str.capitalize, "nobody expects the spanish inquisition")
         ]
 
-        for method, instance in types:
+        for method, instance in to_check:
             with self.subTest(method=method, instance=instance):
-                method.__get__(instance)
+                bound = method.__get__(instance)
+                self.assertIsInstance(bound, types.BuiltinMethodType)
 
     def test_ellipsis_type(self):
         self.assertIsInstance(Ellipsis, types.EllipsisType)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-21-07-39-59.gh-issue-132747.L-cnej.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-21-07-39-59.gh-issue-132747.L-cnej.rst
@@ -1,0 +1,2 @@
+Fix a crash when calling :meth:`~object.__get__` of a :term:`method` with a
+:const:`None` second argument.

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -145,7 +145,7 @@ method_get(PyObject *self, PyObject *obj, PyObject *type)
         return NULL;
     }
     if (descr->d_method->ml_flags & METH_METHOD) {
-        if (PyType_Check(type)) {
+        if (type == NULL || PyType_Check(type)) {
             return PyCMethod_New(descr->d_method, obj, NULL, descr->d_common.d_type);
         } else {
             PyErr_Format(PyExc_TypeError,


### PR DESCRIPTION


<!-- gh-issue-number: gh-132747 -->
* Issue: gh-132747
<!-- /gh-issue-number -->
