### PR TITLE
gh-132719: Fix AMD64 FreeBSD14/15 3.x failures - `test_rlock_locked_2processes` used an unknown `Value`

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1589,6 +1589,7 @@ class _TestLock(BaseTestCase):
         rlock = self.RLock()
         event = self.Event()
         res = Value('b', 0)
+        res = self.Value('b', 0)
         # target is the same as for the test_lock_locked_2processes test.
         p = self.Process(target=self._test_lock_locked_2processes,
                          args=(rlock, event, res))

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1588,7 +1588,6 @@ class _TestLock(BaseTestCase):
 
         rlock = self.RLock()
         event = self.Event()
-        res = Value('b', 0)
         res = self.Value('b', 0)
         # target is the same as for the test_lock_locked_2processes test.
         p = self.Process(target=self._test_lock_locked_2processes,


### PR DESCRIPTION
### Description

Because the line 68 from https://github.com/python/cpython/blob/09b624b80f54e1f97812981cfff9fa374bd5360f/Lib/test/_test_multiprocessing.py#L66-L70 failed in **AMD64 FreeBSD14/15** buildbot.

the `res = Value('b', 0)` line of the `test_rlock_locked_2processes` raise an exception.

Change to `res = self.Value('b', 0)` as in `test_lock_locked_2processes` test.

### Linked PRs

See PR #132586

<!-- gh-issue-number: gh-132719 -->
* Issue: gh-132719
<!-- /gh-issue-number -->
