### PR TITLE
gh-132776: Minor Fixes for XIBufferViewType

### DIFF
--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -76,7 +76,7 @@ is_running_main(PyInterpreterState *interp)
 // XXX Release when the original interpreter is destroyed.
 
 typedef struct {
-    PyObject_HEAD
+    PyObject base;
     Py_buffer *view;
     int64_t interpid;
 } XIBufferViewObject;
@@ -100,8 +100,9 @@ xibufferview_from_buffer(PyTypeObject *cls, Py_buffer *view, int64_t interpid)
         PyMem_RawFree(copied);
         return NULL;
     }
-    PyObject_Init((PyObject *)self, cls);
+    PyObject_Init(&self->base, cls);
     *self = (XIBufferViewObject){
+        .base = self->base,
         .view = copied,
         .interpid = interpid,
     };

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -104,13 +104,15 @@ xibufferview_dealloc(PyObject *op)
 {
     XIBufferViewObject *self = XIBufferViewObject_CAST(op);
     PyInterpreterState *interp = _PyInterpreterState_LookUpID(self->interpid);
-    /* If the interpreter is no longer alive then we have problems,
-       since other objects may be using the buffer still. */
-    assert(interp != NULL);
-
-    if (_PyBuffer_ReleaseInInterpreterAndRawFree(interp, self->view) < 0) {
-        // XXX Emit a warning?
+    if (interp == NULL) {
+        /* That interpreter is alrady dead. */
         PyErr_Clear();
+    }
+    else {
+        if (_PyBuffer_ReleaseInInterpreterAndRawFree(interp, self->view) < 0) {
+            // XXX Emit a warning?
+            PyErr_Clear();
+        }
     }
 
     PyTypeObject *tp = Py_TYPE(self);

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -84,18 +84,27 @@ typedef struct {
 #define XIBufferViewObject_CAST(op) ((XIBufferViewObject *)(op))
 
 static PyObject *
-xibufferview_from_xid(PyTypeObject *cls, _PyXIData_t *data)
+xibufferview_from_buffer(PyTypeObject *cls, Py_buffer *view, int64_t interpid)
 {
-    assert(_PyXIData_DATA(data) != NULL);
-    assert(_PyXIData_OBJ(data) == NULL);
-    assert(_PyXIData_INTERPID(data) >= 0);
+    assert(interpid >= 0);
+
+    Py_buffer *copied = PyMem_RawMalloc(sizeof(Py_buffer));
+    if (copied == NULL) {
+        return NULL;
+    }
+    /* This steals the view->obj reference  */
+    *copied = *view;
+
     XIBufferViewObject *self = PyObject_Malloc(sizeof(XIBufferViewObject));
     if (self == NULL) {
+        PyMem_RawFree(copied);
         return NULL;
     }
     PyObject_Init((PyObject *)self, cls);
-    self->view = (Py_buffer *)_PyXIData_DATA(data);
-    self->interpid = _PyXIData_INTERPID(data);
+    *self = (XIBufferViewObject){
+        .view = copied,
+        .interpid = interpid,
+    };
     return (PyObject *)self;
 }
 
@@ -103,15 +112,22 @@ static void
 xibufferview_dealloc(PyObject *op)
 {
     XIBufferViewObject *self = XIBufferViewObject_CAST(op);
-    PyInterpreterState *interp = _PyInterpreterState_LookUpID(self->interpid);
-    if (interp == NULL) {
-        /* That interpreter is alrady dead. */
-        PyErr_Clear();
-    }
-    else {
-        if (_PyBuffer_ReleaseInInterpreterAndRawFree(interp, self->view) < 0) {
-            // XXX Emit a warning?
+
+    if (self->view != NULL) {
+        PyInterpreterState *interp =
+                        _PyInterpreterState_LookUpID(self->interpid);
+        if (interp == NULL) {
+            /* The interpreter is no longer alive. */
             PyErr_Clear();
+            PyMem_RawFree(self->view);
+        }
+        else {
+            if (_PyBuffer_ReleaseInInterpreterAndRawFree(interp,
+                                                         self->view) < 0)
+            {
+                // XXX Emit a warning?
+                PyErr_Clear();
+            }
         }
     }
 
@@ -157,14 +173,28 @@ static PyType_Spec XIBufferViewType_spec = {
 
 static PyTypeObject * _get_current_xibufferview_type(void);
 
+
+struct xibuffer {
+    Py_buffer view;
+    int used;
+};
+
 static PyObject *
 _memoryview_from_xid(_PyXIData_t *data)
 {
+    assert(_PyXIData_DATA(data) != NULL);
+    assert(_PyXIData_OBJ(data) == NULL);
+    assert(_PyXIData_INTERPID(data) >= 0);
+    struct xibuffer *view = (struct xibuffer *)_PyXIData_DATA(data);
+    assert(!view->used);
+
     PyTypeObject *cls = _get_current_xibufferview_type();
     if (cls == NULL) {
         return NULL;
     }
-    PyObject *obj = xibufferview_from_xid(cls, data);
+
+    PyObject *obj = xibufferview_from_buffer(
+                        cls, &view->view, _PyXIData_INTERPID(data));
     if (obj == NULL) {
         return NULL;
     }
@@ -173,21 +203,34 @@ _memoryview_from_xid(_PyXIData_t *data)
         Py_DECREF(obj);
         return NULL;
     }
+    view->used = 1;
     return res;
 }
 
-static int
-_memoryview_shared(PyThreadState *tstate, PyObject *obj, _PyXIData_t *data)
+static void
+_pybuffer_shared_free(void* data)
 {
-    Py_buffer *view = PyMem_RawMalloc(sizeof(Py_buffer));
+    struct xibuffer *view = (struct xibuffer *)data;
+    if (!view->used) {
+        PyBuffer_Release(&view->view);
+    }
+    PyMem_RawFree(data);
+}
+
+static int
+_pybuffer_shared(PyThreadState *tstate, PyObject *obj, _PyXIData_t *data)
+{
+    struct xibuffer *view = PyMem_RawMalloc(sizeof(struct xibuffer));
     if (view == NULL) {
         return -1;
     }
-    if (PyObject_GetBuffer(obj, view, PyBUF_FULL_RO) < 0) {
+    view->used = 0;
+    if (PyObject_GetBuffer(obj, &view->view, PyBUF_FULL_RO) < 0) {
         PyMem_RawFree(view);
         return -1;
     }
     _PyXIData_Init(data, tstate->interp, view, NULL, _memoryview_from_xid);
+    data->free = _pybuffer_shared_free;
     return 0;
 }
 
@@ -208,7 +251,7 @@ register_memoryview_xid(PyObject *mod, PyTypeObject **p_state)
     *p_state = cls;
 
     // Register XID for the builtin memoryview type.
-    if (ensure_xid_class(&PyMemoryView_Type, _memoryview_shared) < 0) {
+    if (ensure_xid_class(&PyMemoryView_Type, _pybuffer_shared) < 0) {
         return -1;
     }
     // We don't ever bother un-registering memoryview.

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -168,7 +168,12 @@ _memoryview_from_xid(_PyXIData_t *data)
     if (obj == NULL) {
         return NULL;
     }
-    return PyMemoryView_FromObject(obj);
+    PyObject *res = PyMemoryView_FromObject(obj);
+    if (res == NULL) {
+        Py_DECREF(obj);
+        return NULL;
+    }
+    return res;
 }
 
 static int


### PR DESCRIPTION
This change covers the following:

* dealloc: no cleanup if no buffer set
* dealloc: handle already-destroyed interpreter correctly
* handle errors in _memoryview_from_xid() correctly
* clean up the buffer if the xidata is never used

<!-- gh-issue-number: gh-132776 -->
* Issue: gh-132776
<!-- /gh-issue-number -->
