### PR TITLE
gh-132777: Fix Error Message for Duplicates in generate_global_scripts.py

### DIFF
--- a/Tools/build/generate_global_objects.py
+++ b/Tools/build/generate_global_objects.py
@@ -438,7 +438,7 @@ def get_identifiers_and_strings() -> 'tuple[set[str], dict[str, str]]':
             if string not in strings:
                 strings[string] = name
             elif name != strings[string]:
-                raise ValueError(f'string mismatch for {name!r} ({string!r} != {strings[name]!r}')
+                raise ValueError(f'name mismatch for string {string!r} ({name!r} != {strings[string]!r}')
     overlap = identifiers & set(strings.keys())
     if overlap:
         raise ValueError(


### PR DESCRIPTION
The fstring would actually raise a KeyError, which we fix.  We also adjust the text to be correct.

<!-- gh-issue-number: gh-132777 -->
* Issue: gh-132777
<!-- /gh-issue-number -->
