### PR TITLE
[3.13] gh-122179: Fix hashlib.file_digest and non-blocking I/O

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -270,7 +270,10 @@ a file or file-like object.
    *fileobj* must be a file-like object opened for reading in binary mode.
    It accepts file objects from  builtin :func:`open`, :class:`~io.BytesIO`
    instances, SocketIO objects from :meth:`socket.socket.makefile`, and
-   similar. The function may bypass Python's I/O and use the file descriptor
+   similar. *fileobj* must be opened in blocking mode, otherwise a
+   :exc:`BlockingIOError` may be raised.
+
+   The function may bypass Python's I/O and use the file descriptor
    from :meth:`~io.IOBase.fileno` directly. *fileobj* must be assumed to be
    in an unknown state after this function returns or raises. It is up to
    the caller to close *fileobj*.
@@ -298,6 +301,10 @@ a file or file-like object.
       True
 
    .. versionadded:: 3.11
+
+   .. versionchanged:: next
+      Now raises a :exc:`BlockingIOError` if the file is opened in blocking
+      mode. Previously, spurious null bytes were added to the digest.
 
 
 Key derivation

--- a/Lib/hashlib.py
+++ b/Lib/hashlib.py
@@ -231,6 +231,8 @@ def file_digest(fileobj, digest, /, *, _bufsize=2**18):
     view = memoryview(buf)
     while True:
         size = fileobj.readinto(buf)
+        if size is None:
+            raise BlockingIOError("I/O operation would block.")
         if size == 0:
             break  # EOF
         digestobj.update(view[:size])

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -1190,6 +1190,15 @@ class KDFTests(unittest.TestCase):
             with open(os_helper.TESTFN, "wb") as f:
                 hashlib.file_digest(f, "sha256")
 
+        class NonBlocking:
+            def readinto(self, buf):
+                return None
+            def readable(self):
+                return True
+
+        with self.assertRaises(BlockingIOError):
+            hashlib.file_digest(NonBlocking(), hashlib.sha256)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2024-07-23-17-08-41.gh-issue-122179.0jZm9h.rst
+++ b/Misc/NEWS.d/next/Library/2024-07-23-17-08-41.gh-issue-122179.0jZm9h.rst
@@ -1,0 +1,3 @@
+:func:`hashlib.file_digest` now raises :exc:`BlockingIOError` when no data
+is available during non-blocking I/O. Before, it added spurious null bytes
+to the digest.


### PR DESCRIPTION
* Fix hashlib.file_digest and non-blocking I/O
* Add documentation around this behavior
* Add versionchanged

(cherry picked from commit 2b47f46d7dc30d27b2486991fea4acd83553294b)

<!-- gh-issue-number: gh-122179 -->
* Issue: gh-122179
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132787.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->