### PR TITLE
gh-131591: Reset RemoteDebuggerSuupport state after fork

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-22-19-00-03.gh-issue-131591.CdEqBr.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-22-19-00-03.gh-issue-131591.CdEqBr.rst
@@ -1,1 +1,1 @@
-Reset ``_PyRemoteDebuggerSupport`` after os.fork
+Reset any :pep:`768` remote debugging pending call in children after :func:`os.fork` calls.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-22-19-00-03.gh-issue-131591.CdEqBr.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-22-19-00-03.gh-issue-131591.CdEqBr.rst
@@ -1,0 +1,1 @@
+Reset ``_PyRemoteDebuggerSupport`` after os.fork

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -678,6 +678,14 @@ PyOS_AfterFork_Parent(void)
 }
 
 void
+PyRemoteDebugCall_Reset(PyThreadState *tstate)
+{
+    tstate->remote_debugger_support.debugger_pending_call = 0;
+    memset(tstate->remote_debugger_support.debugger_script_path, 0, MAX_SCRIPT_PATH_SIZE);
+}
+
+
+void
 PyOS_AfterFork_Child(void)
 {
     PyStatus status;
@@ -709,6 +717,8 @@ PyOS_AfterFork_Child(void)
     if (_PyStatus_EXCEPTION(status)) {
         goto fatal_error;
     }
+
+    PyRemoteDebugCall_Reset(tstate);
 
     // Remove the dead thread states. We "start the world" once we are the only
     // thread state left to undo the stop the world call in `PyOS_BeforeFork`.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -677,7 +677,7 @@ PyOS_AfterFork_Parent(void)
     run_at_forkers(interp->after_forkers_parent, 0);
 }
 
-void
+static void
 PyRemoteDebugCall_Reset(PyThreadState *tstate)
 {
     tstate->remote_debugger_support.debugger_pending_call = 0;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -678,7 +678,7 @@ PyOS_AfterFork_Parent(void)
 }
 
 static void
-PyRemoteDebugCall_Reset(PyThreadState *tstate)
+reset_remotedebug_data(PyThreadState *tstate)
 {
     tstate->remote_debugger_support.debugger_pending_call = 0;
     memset(tstate->remote_debugger_support.debugger_script_path, 0, MAX_SCRIPT_PATH_SIZE);
@@ -718,7 +718,7 @@ PyOS_AfterFork_Child(void)
         goto fatal_error;
     }
 
-    PyRemoteDebugCall_Reset(tstate);
+    reset_remotedebug_data(tstate);
 
     // Remove the dead thread states. We "start the world" once we are the only
     // thread state left to undo the stop the world call in `PyOS_BeforeFork`.


### PR DESCRIPTION
FYI I think  we need to reset process _PyRemoteDebuggerSupport state after `os.fork`. Otherwise, the child process may inherit the `pendding_call == 1` state

<!-- gh-issue-number: gh-131591 -->
* Issue: gh-131591
<!-- /gh-issue-number -->
