### PR TITLE
gh-132796: Closes SMTP connection on 421 during data in sendmail

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -886,7 +886,14 @@ class SMTP:
             # the server refused all our recipients
             self._rset()
             raise SMTPRecipientsRefused(senderrs)
-        (code, resp) = self.data(msg)
+        try:
+            (code, resp) = self.data(msg)
+        except SMTPDataError as ex:
+            if ex.smtp_code == 421:
+                self.close()
+            else: 
+                self._rset()
+            raise
         if code != 250:
             if code == 421:
                 self.close()

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -891,7 +891,7 @@ class SMTP:
         except SMTPDataError as ex:
             if ex.smtp_code == 421:
                 self.close()
-            else: 
+            else:
                 self._rset()
             raise
         if code != 250:

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -1259,6 +1259,10 @@ class SMTPSimTests(unittest.TestCase):
             smtp.sendmail('John', 'Sally', 'test message')
         self.assertIsNone(smtp.sock)
 
+    # The following 421 response tests for sendmail ensure that sendmail handles
+    # 421 respones correctly by closing the connection. sendmail has to take 
+    # care of this, as it wraps a mail transaction for users.
+
     # Issue 5713: make sure close, not rset, is called if we get a 421 error
     def test_421_from_mail_cmd(self):
         smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
@@ -1292,6 +1296,16 @@ class SMTPSimTests(unittest.TestCase):
         smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
                             timeout=support.LOOPBACK_TIMEOUT)
         smtp.noop()
+        with self.assertRaises(smtplib.SMTPDataError):
+            smtp.sendmail('John@foo.org', ['Sally@foo.org'], 'test message')
+        self.assertIsNone(smtp.sock)
+        self.assertEqual(self.serv._SMTPchannel.rcpt_count, 0)
+
+    def test_421_during_data_cmd(self):
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost',
+                            timeout=support.LOOPBACK_TIMEOUT)
+        smtp.noop()
+        self.serv._SMTPchannel.data_response = '421 closing'
         with self.assertRaises(smtplib.SMTPDataError):
             smtp.sendmail('John@foo.org', ['Sally@foo.org'], 'test message')
         self.assertIsNone(smtp.sock)

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -1260,7 +1260,7 @@ class SMTPSimTests(unittest.TestCase):
         self.assertIsNone(smtp.sock)
 
     # The following 421 response tests for sendmail ensure that sendmail handles
-    # 421 respones correctly by closing the connection. sendmail has to take 
+    # 421 respones correctly by closing the connection. sendmail has to take
     # care of this, as it wraps a mail transaction for users.
 
     # Issue 5713: make sure close, not rset, is called if we get a 421 error

--- a/Misc/NEWS.d/next/Library/2025-05-20-15-39-55.gh-issue-132796.UJXDBR.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-20-15-39-55.gh-issue-132796.UJXDBR.rst
@@ -1,0 +1,3 @@
+Improve handling of 421 SMTP responses in :meth:`smtplib.SMTP.sendmail` by
+covering a previously missing case in which 421 occurs while sending a DATA
+command.


### PR DESCRIPTION
Fixes a minor issue in smtlib.SMTP.sendmail that leads to SMTP client connections not being closed when a server responds with 421 during a DATA command. The existing 421 handling covers almost all cases, but as the DATA command method already handles some error response codes, the 421 is masked for sendmail.


<!-- gh-issue-number: gh-132796 -->
* Issue: gh-132796
<!-- /gh-issue-number -->
