### PR TITLE
gh-127604: Don't rely on `dprintf()` for faulthandler C stacks

### DIFF
--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -132,6 +132,8 @@ PyAPI_FUNC(Py_ssize_t) _Py_write_noraise(
     const void *buf,
     size_t count);
 
+extern int _Py_fdprintf(int fd, const char *fmt, ...);
+
 #ifdef HAVE_READLINK
 extern int _Py_wreadlink(
     const wchar_t *path,

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -14,6 +14,7 @@
 #  include <windows.h>
 #  include <winioctl.h>             // FILE_DEVICE_* constants
 #  include "pycore_fileutils_windows.h" // FILE_STAT_BASIC_INFORMATION
+#  define fdopen _fdopen
 #  if defined(MS_WINDOWS_GAMES) && !defined(MS_WINDOWS_DESKTOP)
 #    define PATHCCH_ALLOW_LONG_PATHS 0x01
 #  else
@@ -2057,6 +2058,21 @@ Py_ssize_t
 _Py_write_noraise(int fd, const void *buf, size_t count)
 {
     return _Py_write_impl(fd, buf, count, 0);
+}
+
+int
+_Py_fdprintf(int fd, const char *fmt, ...)
+{
+    FILE *handle = fdopen(fd, "a");
+    va_list vargs;
+    va_start(vargs, fmt);
+    int res = vfprintf(handle, fmt, vargs);
+    va_end(vargs);
+    if (res != 0) {
+        return -1;
+    }
+
+    return 0;
 }
 
 #ifdef HAVE_READLINK

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -15,6 +15,7 @@
 #  include <winioctl.h>             // FILE_DEVICE_* constants
 #  include "pycore_fileutils_windows.h" // FILE_STAT_BASIC_INFORMATION
 #  define fdopen _fdopen
+#  define dup _dup
 #  if defined(MS_WINDOWS_GAMES) && !defined(MS_WINDOWS_DESKTOP)
 #    define PATHCCH_ALLOW_LONG_PATHS 0x01
 #  else
@@ -2063,7 +2064,8 @@ _Py_write_noraise(int fd, const void *buf, size_t count)
 int
 _Py_fdprintf(int fd, const char *fmt, ...)
 {
-    FILE *handle = fdopen(fd, "a");
+    int newfd = dup(fd);
+    FILE *handle = fdopen(newfd, "a");
     va_list vargs;
     va_start(vargs, fmt);
     int res = vfprintf(handle, fmt, vargs);

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -2068,6 +2068,7 @@ _Py_fdprintf(int fd, const char *fmt, ...)
     va_start(vargs, fmt);
     int res = vfprintf(handle, fmt, vargs);
     va_end(vargs);
+    fclose(handle);
     if (res != 0) {
         return -1;
     }

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -16,7 +16,6 @@
 #  include "pycore_fileutils_windows.h" // FILE_STAT_BASIC_INFORMATION
 #  define fdopen _fdopen
 #  define dup _dup
-#  define close _close
 #  if defined(MS_WINDOWS_GAMES) && !defined(MS_WINDOWS_DESKTOP)
 #    define PATHCCH_ALLOW_LONG_PATHS 0x01
 #  else
@@ -2079,7 +2078,6 @@ _Py_fdprintf(int fd, const char *fmt, ...)
     int res = vfprintf(handle, fmt, vargs);
     va_end(vargs);
     fclose(handle);
-    close(newfd);
     if (res != 0) {
         return -1;
     }

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -1210,7 +1210,7 @@ _Py_backtrace_symbols_fd(int fd, void *const *array, Py_ssize_t size)
             || info[i].dli_fname == NULL
             || info[i].dli_fname[0] == '\0'
         ) {
-            dprintf(fd, "  Binary file '<unknown>' [%p]\n", array[i]);
+            _Py_fdprintf(fd, "  Binary file '<unknown>' [%p]\n", array[i]);
             continue;
         }
 
@@ -1222,9 +1222,9 @@ _Py_backtrace_symbols_fd(int fd, void *const *array, Py_ssize_t size)
 
         if (info[i].dli_sname == NULL
             && info[i].dli_saddr == 0) {
-            dprintf(fd, "  Binary file \"%s\" [%p]\n",
-                    info[i].dli_fname,
-                    array[i]);
+            _Py_fdprintf(fd, "  Binary file \"%s\" [%p]\n",
+                         info[i].dli_fname,
+                         array[i]);
         }
         else {
             char sign;
@@ -1238,10 +1238,10 @@ _Py_backtrace_symbols_fd(int fd, void *const *array, Py_ssize_t size)
                 offset = info[i].dli_saddr - array[i];
             }
             const char *symbol_name = info[i].dli_sname != NULL ? info[i].dli_sname : "";
-            dprintf(fd, "  Binary file \"%s\", at %s%c%#tx [%p]\n",
-                    info[i].dli_fname,
-                    symbol_name,
-                    sign, offset, array[i]);
+            _Py_fdprintf(fd, "  Binary file \"%s\", at %s%c%#tx [%p]\n",
+                         info[i].dli_fname,
+                         symbol_name,
+                         sign, offset, array[i]);
         }
     }
 }


### PR DESCRIPTION
I thought it wasn't possible for a system to have glibc's `backtrace()` but not glibc's `dprintf()`. Apparently, I was wrong.
This uses `fdopen()`/`vfprintf()` instead, which should be portable across anything POSIX, and even Windows.

<!-- gh-issue-number: gh-127604 -->
* Issue: gh-127604
<!-- /gh-issue-number -->
