### PR TITLE
gh-132805 - annotationlib - Fix unions of real types and forward references.

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -400,7 +400,7 @@ class _Stringifier:
     def __or__(self, other):
         if self.__stringifier_dict__.create_unions:
             return types.UnionType[self, other]
-        
+
         return self.__make_new(
             ast.BinOp(self.__get_ast(), ast.BitOr(), self.__convert_to_ast(other))
         )
@@ -431,11 +431,11 @@ class _Stringifier:
     def __ror__(self, other):
         if self.__stringifier_dict__.create_unions:
             return types.UnionType[other, self]
-        
+
         return self.__make_new(
             ast.BinOp(self.__convert_to_ast(other), ast.BitOr(), self.__get_ast())
         )
-        
+
     del _make_rbinop
 
     def _make_compare(op):
@@ -585,10 +585,10 @@ def call_annotate_function(annotate, format, *, owner=None, _is_evaluate=False):
         namespace = {**annotate.__builtins__, **annotate.__globals__}
         is_class = isinstance(owner, type)
         globals = _StringifierDict(
-            namespace, 
-            annotate.__globals__, 
-            owner, 
-            is_class, 
+            namespace,
+            annotate.__globals__,
+            owner,
+            is_class,
             create_unions=True
         )
         if annotate.__closure__:

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -117,7 +117,7 @@ class TestForwardRefFormat(unittest.TestCase):
         alpha_anno = anno["alpha"]
         self.assertIsInstance(alpha_anno, Union)
         self.assertEqual(
-            typing.get_args(alpha_anno), 
+            typing.get_args(alpha_anno),
             (support.EqualToForwardRef("some", owner=f), support.EqualToForwardRef("obj", owner=f))
         )
 

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -936,6 +936,28 @@ class TestGetAnnotations(unittest.TestCase):
                         annotationlib.get_annotations(obj, format=format), {}
                     )
 
+    def test_union_forwardref(self):
+        # Test unions with '|' syntax equal unions with typing.Union[] with forwardrefs
+        class UnionForwardrefs:
+            pipe: str | undefined
+            union: Union[str, undefined]
+
+        annos = get_annotations(UnionForwardrefs, format=Format.FORWARDREF)
+
+        match = (
+            str,
+            support.EqualToForwardRef("undefined", is_class=True, owner=UnionForwardrefs)
+        )
+
+        self.assertEqual(
+            typing.get_args(annos["pipe"]),
+            typing.get_args(annos["union"])
+        )
+
+        self.assertEqual(typing.get_args(annos["pipe"]), match)
+        self.assertEqual(typing.get_args(annos["union"]), match)
+
+
     def test_pep695_generic_class_with_future_annotations(self):
         ann_module695 = inspect_stringized_annotations_pep695
         A_annotations = annotationlib.get_annotations(ann_module695.A, eval_str=True)


### PR DESCRIPTION
Potential fix for #132805 

This adds a `create_unions` parameter to `_StringifierDict` which - if set to `True` - creates unions between `_Stringifier` instances instead of trying to join them with `ast` methods. This is set to True only for `Format.FORWARDREF`, the behaviour is unchanged for `Format.STRING`.

<!-- gh-issue-number: gh-132805 -->
* Issue: gh-132805
<!-- /gh-issue-number -->
