### PR TITLE
[3.13] gh-132713: Fix repr(list) race condition (#132801)

### DIFF
--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -116,6 +116,19 @@ class ListTest(list_tests.CommonTest):
         with self.assertRaises((MemoryError, OverflowError)):
             lst *= size
 
+    def test_repr_mutate(self):
+        class Obj:
+            @staticmethod
+            def __repr__():
+                try:
+                    mylist.pop()
+                except IndexError:
+                    pass
+                return 'obj'
+
+        mylist = [Obj() for _ in range(5)]
+        self.assertEqual(repr(mylist), '[obj, obj, obj]')
+
     def test_repr_large(self):
         # Check the repr of large list objects
         def check(n):

--- a/Misc/NEWS.d/next/Core and Builtins/2025-04-22-16-38-43.gh-issue-132713.mBWTSZ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-04-22-16-38-43.gh-issue-132713.mBWTSZ.rst
@@ -1,0 +1,2 @@
+Fix ``repr(list)`` race condition: hold a strong reference to the item while
+calling ``repr(item)``. Patch by Victor Stinner.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -585,6 +585,7 @@ list_repr_impl(PyListObject *v)
 {
     PyObject *s;
     _PyUnicodeWriter writer;
+    PyObject *item = NULL;
     Py_ssize_t i = Py_ReprEnter((PyObject*)v);
     if (i != 0) {
         return i > 0 ? PyUnicode_FromString("[...]") : NULL;
@@ -601,12 +602,19 @@ list_repr_impl(PyListObject *v)
     /* Do repr() on each element.  Note that this may mutate the list,
        so must refetch the list size on each iteration. */
     for (i = 0; i < Py_SIZE(v); ++i) {
+        item = list_get_item_ref(v, i);
+        if (item == NULL) {
+            // List truncated while iterating on it
+            PyErr_Clear();
+            break;
+        }
+
         if (i > 0) {
             if (_PyUnicodeWriter_WriteASCIIString(&writer, ", ", 2) < 0)
                 goto error;
         }
 
-        s = PyObject_Repr(v->ob_item[i]);
+        s = PyObject_Repr(item);
         if (s == NULL)
             goto error;
 
@@ -615,6 +623,7 @@ list_repr_impl(PyListObject *v)
             goto error;
         }
         Py_DECREF(s);
+        Py_CLEAR(item);
     }
 
     writer.overallocate = 0;
@@ -625,6 +634,7 @@ list_repr_impl(PyListObject *v)
     return _PyUnicodeWriter_Finish(&writer);
 
 error:
+    Py_XDECREF(item);
     _PyUnicodeWriter_Dealloc(&writer);
     Py_ReprLeave((PyObject *)v);
     return NULL;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -602,12 +602,8 @@ list_repr_impl(PyListObject *v)
     /* Do repr() on each element.  Note that this may mutate the list,
        so must refetch the list size on each iteration. */
     for (i = 0; i < Py_SIZE(v); ++i) {
-        item = list_get_item_ref(v, i);
-        if (item == NULL) {
-            // List truncated while iterating on it
-            PyErr_Clear();
-            break;
-        }
+        /* Hold a strong reference since repr(item) can mutate the list */
+        item = Py_NewRef(v->ob_item[i]);
 
         if (i > 0) {
             if (_PyUnicodeWriter_WriteASCIIString(&writer, ", ", 2) < 0)


### PR DESCRIPTION
Hold a strong reference to the item while calling repr(item).

(cherry picked from commit a4ea80d52394bafffb2257abbe815c7ffdb003a3)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-132713 -->
* Issue: gh-132713
<!-- /gh-issue-number -->
