### PR TITLE
gh-132637: Fix positional predicates in xpath when a default namespace is provided

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -3168,6 +3168,47 @@ class ElementFindTest(unittest.TestCase):
         self.assertRaisesRegex(SyntaxError, 'XPath', e.find, './tag[last()-0]')
         self.assertRaisesRegex(SyntaxError, 'XPath', e.find, './tag[last()+1]')
 
+    def test_find_xpath_namespaces(self):
+        LINEAR_XML = '''
+        <body xmlns="X">
+            <tag class='a'/>
+            <tag class='b'/>
+            <tag class='c'/>
+            <tag class='d'/>
+        </body>'''
+        e = ET.XML(LINEAR_XML)
+        nsmap = {"": "X"}
+
+        # Test for numeric indexing and last()
+        self.assertEqual(
+            e.find('./tag[1]', namespaces=nsmap).attrib['class'], 'a',
+        )
+        self.assertEqual(
+            e.find('./tag[2]', namespaces=nsmap).attrib['class'], 'b',
+        )
+        self.assertEqual(
+            e.find('./tag[last()]', namespaces=nsmap).attrib['class'], 'd',
+        )
+        self.assertEqual(
+            e.find('./tag[last()-1]', namespaces=nsmap).attrib['class'], 'c',
+        )
+        self.assertEqual(
+            e.find('./tag[last()-2]', namespaces=nsmap).attrib['class'], 'b',
+        )
+
+        self.assertRaisesRegex(
+            SyntaxError, 'XPath', e.find, './tag[0]', namespaces=nsmap,
+        )
+        self.assertRaisesRegex(
+            SyntaxError, 'XPath', e.find, './tag[-1]', namespaces=nsmap,
+        )
+        self.assertRaisesRegex(
+            SyntaxError, 'XPath', e.find, './tag[last()-0]', namespaces=nsmap,
+        )
+        self.assertRaisesRegex(
+            SyntaxError, 'XPath', e.find, './tag[last()+1]', namespaces=nsmap,
+        )
+
     def test_findall(self):
         e = ET.XML(SAMPLE_XML)
         e[2] = ET.XML(SAMPLE_SECTION)
@@ -3306,6 +3347,21 @@ class ElementFindTest(unittest.TestCase):
         nsmap = {'xx': 'X', '': 'Y'}
         self.assertEqual(len(root.findall(".//xx:b", namespaces=nsmap)), 2)
         self.assertEqual(len(root.findall(".//b", namespaces=nsmap)), 1)
+
+    def test_findall_default_nsmap_position_predicate(self):
+        root = ET.XML('''
+            <a xmlns="default" xmlns:x="X" xmlns:y="Y">
+                <x:b><c/></x:b>
+                <b/>
+                <b/>
+                <c><x:b/><b/></c><y:b/>
+            </a>''')
+        nsmap = {'': 'default'}
+        first_b = root[1]
+        last_b = root[2]
+        self.assertEqual(len(root.findall(".//b[1]", namespaces=nsmap)), 2)
+        self.assertEqual(root.findall(".//b[1]", namespaces=nsmap)[0], first_b)
+        self.assertEqual(root.findall(".//b[last()]", namespaces=nsmap)[0], last_b)
 
     def test_findall_wildcard(self):
         root = ET.XML('''

--- a/Misc/NEWS.d/next/Library/2025-04-23-11-57-05.gh-issue-132637.i5a8nM.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-23-11-57-05.gh-issue-132637.i5a8nM.rst
@@ -1,0 +1,3 @@
+Fix ``xml.etree.ElementPath.xpath_tokenizer`` to correctly handle
+positional predicates when a default namespace is provided in the
+``namespaces`` argument.


### PR DESCRIPTION
xpaths with a positional predicate (`.//b[1]`) would fail when the namespaces argument of `find()` or `findall()` supplied a default namespace.

This was due to `xpath_tokenizer()` erroneously prepending the default namespace to these positional predicates. `.//b[1]` would have a positional predicate of `{the-supplied-default-namespace}1` and `.//b[last()]` would be `{the-supplied-default-namespace}last()`. The integer case would cause the xpath not to match the intended elements and the `last()` predicate would raise an exception as the xpath function `{the-supplied-default-namespace}last()` is not supported (because it doesn't exist).

This PR fixes the issue by altering the regex that parses the xpath expression to pick out `last()` explicitly as that is the only function that is supported in Python's imlementation and we only know that it is a function, rather than a tag name, when we reach `()` so it was easier to grab `last` and `()` together which were previously parsed separately (the generator still returns them separately for compatibility).

We also test if the tag is a number possibly preceded by a `-` or `+` and exclude prepending the namespace in those cases.

Ultimately a comment in the code suggests the proper fix:

https://github.com/python/cpython/blob/b5bf8c80a921679b23548453565f6fd1f79901f2/Lib/xml/etree/ElementPath.py#L228-L229

but despite the known preferences of some contributors, replacing this regex parser with a real parser seems unlikely at this time.


<!-- gh-issue-number: gh-132637 -->
* Issue: gh-132637
<!-- /gh-issue-number -->
