### PR TITLE
gh-109981: Resolve situation on iOS regarding fd_count.

### DIFF
--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -657,7 +657,7 @@ def fd_count():
     """
     if sys.platform.startswith(('linux', 'android', 'freebsd', 'emscripten')):
         fd_path = "/proc/self/fd"
-    elif sys.platform == "darwin":
+    elif support.is_apple:
         fd_path = "/dev/fd"
     else:
         fd_path = None

--- a/Misc/NEWS.d/next/Tests/2025-04-23-02-23-37.gh-issue-109981.IX3k8p.rst
+++ b/Misc/NEWS.d/next/Tests/2025-04-23-02-23-37.gh-issue-109981.IX3k8p.rst
@@ -1,5 +1,3 @@
-Use ``/dev/fd`` on other Apple platforms, in addition to macOS, to determine
-the number of open files in ``test.support.os_helper.fd_count`` to avoid a crash
-with "guarded" file descriptors when probing for open files.
-
-The text for this entry is adapted from the previous one fixing the issue for macOS.
+The test helper that counts the list of open file descriptors now uses the
+optimised ``/dev/fd`` approach on all Apple platforms, not just macOS.
+This avoids crashes caused by guarded file descriptors.

--- a/Misc/NEWS.d/next/Tests/2025-04-23-02-23-37.gh-issue-109981.IX3k8p.rst
+++ b/Misc/NEWS.d/next/Tests/2025-04-23-02-23-37.gh-issue-109981.IX3k8p.rst
@@ -1,0 +1,5 @@
+Use ``/dev/fd`` on other Apple platforms, in addition to macOS, to determine
+the number of open files in ``test.support.os_helper.fd_count`` to avoid a crash
+with "guarded" file descriptors when probing for open files.
+
+The text for this entry is adapted from the previous one fixing the issue for macOS.


### PR DESCRIPTION
macOS Sonoma seems to have issues with support.fd_count, at gh-109981. However, after experimenting using macOS Sonoma on an attempt to support visionOS unofficially through another project, the simulator is hard-crashing, leading to the conclusion that this probably applies on all Apple platforms. Hence this patch.

@freakboy3742 (since he supports stuff for iOS)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
