### PR TITLE
gh-132835: Fix using a null pointer in mro_hierarchy

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1652,6 +1652,9 @@ mro_hierarchy(PyTypeObject *type, PyObject *temp)
         return res;
     }
     PyObject *new_mro = lookup_tp_mro(type);
+    if (new_mro == NULL) {
+        return -1;
+    }
 
     PyObject *tuple;
     if (old_mro != NULL) {


### PR DESCRIPTION
Fix for [gh-132835](https://github.com/python/cpython/issues/132835).