### PR TITLE
gh-129965: Add more missing MIME types

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -958,15 +958,6 @@ mimetypes
   * :rfc:`5334`: Add Ogg media (``.oga``, ``.ogg`` and ``.ogx``)
   * :rfc:`6713`: Add gzip ``application/gzip`` (``.gz``)
   * :rfc:`9639`: Add FLAC ``audio/flac`` (``.flac``)
-  * De facto: Add WebM ``audio/webm`` (``.weba``)
-  * `ECMA-376
-    <https://ecma-international.org/publications-and-standards/standards/ecma-376/>`__:
-    Add ``.docx``, ``.pptx`` and ``.xlsx`` types
-  * `OASIS
-    <https://docs.oasis-open.org/office/v1.2/cs01/OpenDocument-v1.2-cs01-part1.html#Appendix_C>`__:
-    Add OpenDocument ``.odg``, ``.odp``, ``.ods`` and ``.odt`` types
-  * `W3C <https://www.w3.org/TR/epub-33/#app-media-type>`__:
-    Add EPUB ``application/epub+zip`` (``.epub``)
   * Add 7z ``application/x-7z-compressed`` (``.7z``)
   * Add Android Package ``application/vnd.android.package-archive`` (``.apk``)
     when not strict
@@ -979,6 +970,15 @@ mimetypes
   * Add RPM ``application/x-rpm`` (``.rpm``)
   * Add STL ``model/stl`` (``.stl``)
   * Add Windows Media Video ``video/x-ms-wmv`` (``.wmv``)
+  * De facto: Add WebM ``audio/webm`` (``.weba``)
+  * `ECMA-376
+    <https://ecma-international.org/publications-and-standards/standards/ecma-376/>`__:
+    Add ``.docx``, ``.pptx`` and ``.xlsx`` types
+  * `OASIS
+    <https://docs.oasis-open.org/office/v1.2/cs01/OpenDocument-v1.2-cs01-part1.html#Appendix_C>`__:
+    Add OpenDocument ``.odg``, ``.odp``, ``.ods`` and ``.odt`` types
+  * `W3C <https://www.w3.org/TR/epub-33/#app-media-type>`__:
+    Add EPUB ``application/epub+zip`` (``.epub``)
 
   (Contributed by Hugo van Kemenade in :gh:`129965`.)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -971,6 +971,7 @@ mimetypes
   * Add Android Package ``application/vnd.android.package-archive`` (``.apk``)
     when not strict
   * Add deb ``application/x-debian-package`` (``.deb``)
+  * Add glTF binary ``model/gltf-binary`` (``.glb``)
   * Add M4V ``video/x-m4v`` (``.m4v``)
   * Add PHP ``application/x-httpd-php`` (``.php``)
   * Add RAR ``application/vnd.rar`` (``.rar``)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -973,6 +973,7 @@ mimetypes
   * Add M4V ``video/x-m4v`` (``.m4v``)
   * Add PHP ``application/x-httpd-php`` (``.php``)
   * Add RAR ``application/vnd.rar`` (``.rar``)
+  * Add RPM ``application/x-rpm`` (``.rpm``)
 
   (Contributed by Hugo van Kemenade in :gh:`129965`.)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -970,6 +970,7 @@ mimetypes
   * Add 7z ``application/x-7z-compressed`` (``.7z``)
   * Add Android Package ``application/vnd.android.package-archive`` (``.apk``)
     when not strict
+  * Add deb ``application/x-debian-package`` (``.deb``)
   * Add M4V ``video/x-m4v`` (``.m4v``)
   * Add PHP ``application/x-httpd-php`` (``.php``)
   * Add RAR ``application/vnd.rar`` (``.rar``)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -966,6 +966,8 @@ mimetypes
     Add OpenDocument ``.odg``, ``.odp``, ``.ods`` and ``.odt`` types
   * `W3C <https://www.w3.org/TR/epub-33/#app-media-type>`__:
     Add EPUB ``application/epub+zip`` (``.epub``)
+  * Add Android Package ``application/vnd.android.package-archive`` (``.apk``)
+    when not strict
   * Add PHP ``application/x-httpd-php`` (``.php``)
   * Add RAR ``application/vnd.rar`` (``.rar``)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -956,6 +956,7 @@ mimetypes
     and for ``.wav`` to ``audio/vnd.wave``
   * :rfc:`4337`: Add MPEG-4 ``audio/mp4`` (``.m4a``)
   * :rfc:`5334`: Add Ogg media (``.oga``, ``.ogg`` and ``.ogx``)
+  * :rfc:`6713`: Add gzip ``application/gzip`` (``.gz``)
   * :rfc:`9639`: Add FLAC ``audio/flac`` (``.flac``)
   * De facto: Add WebM ``audio/webm`` (``.weba``)
   * `ECMA-376

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -977,6 +977,7 @@ mimetypes
   * Add PHP ``application/x-httpd-php`` (``.php``)
   * Add RAR ``application/vnd.rar`` (``.rar``)
   * Add RPM ``application/x-rpm`` (``.rpm``)
+  * Add STL ``model/stl`` (``.stl``)
   * Add Windows Media Video ``video/x-ms-wmv`` (``.wmv``)
 
   (Contributed by Hugo van Kemenade in :gh:`129965`.)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -954,7 +954,7 @@ mimetypes
 
   * :rfc:`2361`: Change type for ``.avi`` to ``video/vnd.avi``
     and for ``.wav`` to ``audio/vnd.wave``
-  * :rfc:`4337`: Add MPEG-4 ``audio/mp4`` (``.m4a``))
+  * :rfc:`4337`: Add MPEG-4 ``audio/mp4`` (``.m4a``)
   * :rfc:`5334`: Add Ogg media (``.oga``, ``.ogg`` and ``.ogx``)
   * :rfc:`9639`: Add FLAC ``audio/flac`` (``.flac``)
   * De facto: Add WebM ``audio/webm`` (``.weba``)
@@ -968,6 +968,7 @@ mimetypes
     Add EPUB ``application/epub+zip`` (``.epub``)
   * Add Android Package ``application/vnd.android.package-archive`` (``.apk``)
     when not strict
+  * Add M4V ``video/x-m4v`` (``.m4v``)
   * Add PHP ``application/x-httpd-php`` (``.php``)
   * Add RAR ``application/vnd.rar`` (``.rar``)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -966,6 +966,7 @@ mimetypes
     Add OpenDocument ``.odg``, ``.odp``, ``.ods`` and ``.odt`` types
   * `W3C <https://www.w3.org/TR/epub-33/#app-media-type>`__:
     Add EPUB ``application/epub+zip`` (``.epub``)
+  * Add RAR ``application/vnd.rar`` (``.rar``)
 
   (Contributed by Hugo van Kemenade in :gh:`129965`.)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -972,6 +972,7 @@ mimetypes
     when not strict
   * Add deb ``application/x-debian-package`` (``.deb``)
   * Add glTF binary ``model/gltf-binary`` (``.glb``)
+  * Add glTF JSON/ASCII ``model/gltf+json`` (``.gltf``)
   * Add M4V ``video/x-m4v`` (``.m4v``)
   * Add PHP ``application/x-httpd-php`` (``.php``)
   * Add RAR ``application/vnd.rar`` (``.rar``)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -974,6 +974,7 @@ mimetypes
   * Add PHP ``application/x-httpd-php`` (``.php``)
   * Add RAR ``application/vnd.rar`` (``.rar``)
   * Add RPM ``application/x-rpm`` (``.rpm``)
+  * Add Windows Media Video ``video/x-ms-wmv`` (``.wmv``)
 
   (Contributed by Hugo van Kemenade in :gh:`129965`.)
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -966,6 +966,7 @@ mimetypes
     Add OpenDocument ``.odg``, ``.odp``, ``.ods`` and ``.odt`` types
   * `W3C <https://www.w3.org/TR/epub-33/#app-media-type>`__:
     Add EPUB ``application/epub+zip`` (``.epub``)
+  * Add PHP ``application/x-httpd-php`` (``.php``)
   * Add RAR ``application/vnd.rar`` (``.rar``)
 
   (Contributed by Hugo van Kemenade in :gh:`129965`.)

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -966,6 +966,7 @@ mimetypes
     Add OpenDocument ``.odg``, ``.odp``, ``.ods`` and ``.odt`` types
   * `W3C <https://www.w3.org/TR/epub-33/#app-media-type>`__:
     Add EPUB ``application/epub+zip`` (``.epub``)
+  * Add 7z ``application/x-7z-compressed`` (``.7z``)
   * Add Android Package ``application/vnd.android.package-archive`` (``.apk``)
     when not strict
   * Add M4V ``video/x-m4v`` (``.m4v``)

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -660,6 +660,7 @@ def _default_mime_types():
     # Please sort these too
     common_types = _common_types_default = {
         '.rtf' : 'application/rtf',
+        '.apk' : 'application/vnd.android.package-archive',
         '.midi': 'audio/midi',
         '.mid' : 'audio/midi',
         '.jpg' : 'image/jpg',

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -651,6 +651,7 @@ def _default_mime_types():
         '.qt'     : 'video/quicktime',
         '.webm'   : 'video/webm',
         '.avi'    : 'video/vnd.avi',
+        '.m4v'    : 'video/x-m4v',
         '.movie'  : 'video/x-sgi-movie',
         }
 

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -519,6 +519,7 @@ def _default_mime_types():
         '.cdf'    : 'application/x-netcdf',
         '.nc'     : 'application/x-netcdf',
         '.p12'    : 'application/x-pkcs12',
+        '.php'    : 'application/x-httpd-php',
         '.pfx'    : 'application/x-pkcs12',
         '.ram'    : 'application/x-pn-realaudio',
         '.pyc'    : 'application/x-python-code',

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -507,6 +507,7 @@ def _default_mime_types():
         '.docx'   : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         '.rar'    : 'application/vnd.rar',
         '.wasm'   : 'application/wasm',
+        '.7z'     : 'application/x-7z-compressed',
         '.bcpio'  : 'application/x-bcpio',
         '.cpio'   : 'application/x-cpio',
         '.csh'    : 'application/x-csh',

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -512,6 +512,7 @@ def _default_mime_types():
         '.bcpio'  : 'application/x-bcpio',
         '.cpio'   : 'application/x-cpio',
         '.csh'    : 'application/x-csh',
+        '.deb'    : 'application/x-debian-package',
         '.dvi'    : 'application/x-dvi',
         '.gtar'   : 'application/x-gtar',
         '.hdf'    : 'application/x-hdf',

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -619,6 +619,7 @@ def _default_mime_types():
         '.nws'    : 'message/rfc822',
         '.gltf'   : 'model/gltf+json',
         '.glb'    : 'model/gltf-binary',
+        '.stl'    : 'model/stl',
         '.css'    : 'text/css',
         '.csv'    : 'text/csv',
         '.html'   : 'text/html',

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -617,6 +617,7 @@ def _default_mime_types():
         '.mht'    : 'message/rfc822',
         '.mhtml'  : 'message/rfc822',
         '.nws'    : 'message/rfc822',
+        '.glb'    : 'model/gltf-binary',
         '.css'    : 'text/css',
         '.csv'    : 'text/csv',
         '.html'   : 'text/html',

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -617,6 +617,7 @@ def _default_mime_types():
         '.mht'    : 'message/rfc822',
         '.mhtml'  : 'message/rfc822',
         '.nws'    : 'message/rfc822',
+        '.gltf'   : 'model/gltf+json',
         '.glb'    : 'model/gltf-binary',
         '.css'    : 'text/css',
         '.csv'    : 'text/csv',

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -655,6 +655,7 @@ def _default_mime_types():
         '.webm'   : 'video/webm',
         '.avi'    : 'video/vnd.avi',
         '.m4v'    : 'video/x-m4v',
+        '.wmv'    : 'video/x-ms-wmv',
         '.movie'  : 'video/x-sgi-movie',
         }
 

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -526,6 +526,7 @@ def _default_mime_types():
         '.ram'    : 'application/x-pn-realaudio',
         '.pyc'    : 'application/x-python-code',
         '.pyo'    : 'application/x-python-code',
+        '.rpm'    : 'application/x-rpm',
         '.sh'     : 'application/x-sh',
         '.shar'   : 'application/x-shar',
         '.swf'    : 'application/x-shockwave-flash',

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -466,6 +466,7 @@ def _default_mime_types():
         '.js'     : 'text/javascript',
         '.mjs'    : 'text/javascript',
         '.epub'   : 'application/epub+zip',
+        '.gz'     : 'application/gzip',
         '.json'   : 'application/json',
         '.webmanifest': 'application/manifest+json',
         '.doc'    : 'application/msword',

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -505,6 +505,7 @@ def _default_mime_types():
         '.pptx'   : 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
         '.xlsx'   : 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         '.docx'   : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        '.rar'    : 'application/vnd.rar',
         '.wasm'   : 'application/wasm',
         '.bcpio'  : 'application/x-bcpio',
         '.cpio'   : 'application/x-cpio',

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -226,6 +226,7 @@ class MimeTypesTestCase(unittest.TestCase):
             for mime_type, ext in (
                 ("application/epub+zip", ".epub"),
                 ("application/octet-stream", ".bin"),
+                ("application/gzip", ".gz"),
                 ("application/ogg", ".ogx"),
                 ("application/postscript", ".ps"),
                 ("application/vnd.apple.mpegurl", ".m3u"),

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -7,7 +7,6 @@ import unittest.mock
 from platform import win32_edition
 from test import support
 from test.support import os_helper
-from test.support.script_helper import run_python_until_end
 
 try:
     import _winapi
@@ -240,6 +239,7 @@ class MimeTypesTestCase(unittest.TestCase):
                 ("application/vnd.openxmlformats-officedocument.presentationml.presentation", ".pptx"),
                 ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ".xlsx"),
                 ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx"),
+                ("application/vnd.rar", ".rar"),
                 ("application/x-texinfo", ".texi"),
                 ("application/x-troff", ".roff"),
                 ("application/xml", ".xsl"),

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -275,6 +275,7 @@ class MimeTypesTestCase(unittest.TestCase):
                 ("message/rfc822", ".eml"),
                 ("model/gltf+json", ".gltf"),
                 ("model/gltf-binary", ".glb"),
+                ("model/stl", ".stl"),
                 ("text/html", ".html"),
                 ("text/plain", ".txt"),
                 ("text/rtf", ".rtf"),

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -243,6 +243,7 @@ class MimeTypesTestCase(unittest.TestCase):
                 ("application/vnd.rar", ".rar"),
                 ("application/x-7z-compressed", ".7z"),
                 ("application/x-httpd-php", ".php"),
+                ("application/x-rpm", ".rpm"),
                 ("application/x-texinfo", ".texi"),
                 ("application/x-troff", ".roff"),
                 ("application/xml", ".xsl"),

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -242,6 +242,7 @@ class MimeTypesTestCase(unittest.TestCase):
                 ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx"),
                 ("application/vnd.rar", ".rar"),
                 ("application/x-7z-compressed", ".7z"),
+                ("application/x-debian-package", ".deb"),
                 ("application/x-httpd-php", ".php"),
                 ("application/x-rpm", ".rpm"),
                 ("application/x-texinfo", ".texi"),

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -240,6 +240,7 @@ class MimeTypesTestCase(unittest.TestCase):
                 ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ".xlsx"),
                 ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx"),
                 ("application/vnd.rar", ".rar"),
+                ("application/x-httpd-php", ".php"),
                 ("application/x-texinfo", ".texi"),
                 ("application/x-troff", ".roff"),
                 ("application/xml", ".xsl"),

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -240,6 +240,7 @@ class MimeTypesTestCase(unittest.TestCase):
                 ("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ".xlsx"),
                 ("application/vnd.openxmlformats-officedocument.wordprocessingml.document", ".docx"),
                 ("application/vnd.rar", ".rar"),
+                ("application/x-7z-compressed", ".7z"),
                 ("application/x-httpd-php", ".php"),
                 ("application/x-texinfo", ".texi"),
                 ("application/x-troff", ".roff"),

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -279,6 +279,7 @@ class MimeTypesTestCase(unittest.TestCase):
                 ("video/ogg", ".ogv"),
                 ("video/quicktime", ".mov"),
                 ("video/vnd.avi", ".avi"),
+                ("video/x-m4v", ".m4v"),
             ):
                 with self.subTest(mime_type=mime_type, ext=ext):
                     self.assertEqual(mimetypes.guess_extension(mime_type), ext)

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -273,6 +273,7 @@ class MimeTypesTestCase(unittest.TestCase):
                 ("image/webp", ".webp"),
                 ("image/wmf", ".wmf"),
                 ("message/rfc822", ".eml"),
+                ("model/gltf+json", ".gltf"),
                 ("model/gltf-binary", ".glb"),
                 ("text/html", ".html"),
                 ("text/plain", ".txt"),

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -283,6 +283,7 @@ class MimeTypesTestCase(unittest.TestCase):
                 ("video/quicktime", ".mov"),
                 ("video/vnd.avi", ".avi"),
                 ("video/x-m4v", ".m4v"),
+                ("video/x-ms-wmv", ".wmv"),
             ):
                 with self.subTest(mime_type=mime_type, ext=ext):
                     self.assertEqual(mimetypes.guess_extension(mime_type), ext)

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -273,6 +273,7 @@ class MimeTypesTestCase(unittest.TestCase):
                 ("image/webp", ".webp"),
                 ("image/wmf", ".wmf"),
                 ("message/rfc822", ".eml"),
+                ("model/gltf-binary", ".glb"),
                 ("text/html", ".html"),
                 ("text/plain", ".txt"),
                 ("text/rtf", ".rtf"),

--- a/Misc/NEWS.d/next/Library/2025-04-23-18-35-09.gh-issue-129965.nj7Fx2.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-23-18-35-09.gh-issue-129965.nj7Fx2.rst
@@ -1,0 +1,3 @@
+Add MIME types for ``.7z``, ``.apk``, ``.deb``, ``.glb``, ``.gltf``,
+``.gz``, ``.m4v``, ``.php``, ``.rar``, ``.rpm``, ``.stl`` and ``.wmv``.
+Patch by Hugo van Kemenade.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Based on the last list here:

```console
❯ uv run --python python3.14 --with content-types https://raw.githubusercontent.com/mikeckennedy/content-types/refs/heads/main/samples/compare_to_builtin.py
Compare types in mimetypes vs content-types.
There are 6 types where mimetypes and content-types disagree
mimetypes: .avi video/vnd.avi, content-types: .avi video/x-msvideo
mimetypes: .dll application/octet-stream, content-types: .dll application/x-msdownload
mimetypes: .exe application/octet-stream, content-types: .exe application/x-msdownload
mimetypes: .obj application/octet-stream, content-types: .obj model/obj
mimetypes: .wav audio/vnd.wave, content-types: .wav audio/wav
mimetypes: .xml text/xml, content-types: .xml application/xml

There are 14 types in mimetypes that are not in content-types
.emf : image/emf
.eot : application/vnd.ms-fontobject
.fits: image/fits
.g3  : image/g3fax
.jp2 : image/jp2
.jpm : image/jpm
.jpx : image/jpx
.mk3d: video/matroska-3d
.mka : audio/matroska
.mkv : video/matroska
.ogx : application/ogg
.t38 : image/t38
.tfx : image/tiff-fx
.wmf : image/wmf

There are 14 types in content-types that are not in mimetypes
.7z    -> application/x-7z-compressed
.apk   -> application/vnd.android.package-archive
.deb   -> application/x-debian-package
.glb   -> model/gltf-binary
.gltf  -> model/gltf+json
.gz    -> application/gzip
.m4v   -> video/mp4
.map   -> application/json
.php   -> application/x-httpd-php
.rar   -> application/vnd.rar
.rpm   -> application/x-rpm
.stl   -> model/stl
.tgz   -> application/gzip
.wmv   -> video/x-ms-wmv
```

---

I used the MIME types from the following sources.

From https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types

* `application/x-httpd-php`

From Wikipedia:

* `application/vnd.android.package-archive` (added to non-strict list because not in IANA or `x-` prefix)
* `application/x-7z-compressed`
* `video/x-m4v`

From https://mimetype.io

* `application/x-debian-package`
* `application/x-rpm`

From https://learn.microsoft.com/en-us/previous-versions/windows/desktop/wmp/file-name-extensions

* `video/x-ms-wmv`

All the rest from https://www.iana.org/assignments/media-types/media-types.xhtml

---

I didn't add these because they're not in IANA or MDN, and I didn't find any authoritative sources:

```
.map   -> application/json
.tgz   -> application/gzip
```

<!-- gh-issue-number: gh-129965 -->
* Issue: gh-129965
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132845.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->