### PR TITLE
gh-67766: Improve `struct.pack` out of range error messages

### DIFF
--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -55,7 +55,7 @@ The module defines the following exception and functions:
    Exception raised on various occasions; argument is a string describing what
    is wrong.
 
-   .. versionchanged::
+   .. versionchanged:: next
       Out of range errors are more descriptive specifying which argument resulted
       in the exception.
 

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -55,6 +55,10 @@ The module defines the following exception and functions:
    Exception raised on various occasions; argument is a string describing what
    is wrong.
 
+   .. versionchanged::
+      Out of range errors are more descriptive specifying which argument resulted
+      in the exception.
+
 
 .. function:: pack(format, v1, v2, ...)
 

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -55,10 +55,6 @@ The module defines the following exception and functions:
    Exception raised on various occasions; argument is a string describing what
    is wrong.
 
-   .. versionchanged:: next
-      Out of range errors are more descriptive specifying which argument resulted
-      in the exception.
-
 
 .. function:: pack(format, v1, v2, ...)
 

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -742,7 +742,7 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             else:
                 max_ = 2 ** (size * 8 - 1) - 1
                 min_ = -2 ** (size * 8 - 1)
-            error_msg = f"'{int_type}' format requires {min_} <= number <= {max_}"
+            error_msg = f"'{int_type}' format requires {min_} <= arg 1 <= {max_}"
             for number in [int(-1e50), min_ - 1, max_ + 1, int(1e50)]:
                 with self.subTest(format_str=fmt_str, number=number):
                     with self.assertRaisesRegex(struct.error, error_msg):

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -742,7 +742,7 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             else:
                 max_ = 2 ** (size * 8 - 1) - 1
                 min_ = -2 ** (size * 8 - 1)
-            error_msg = f"'{int_type}' format requires {min_} <= arg 1 <= {max_}"
+            error_msg = f"'{int_type}' format requires {min_} <= number <= {max_} (at item 1)"
             for number in [int(-1e50), min_ - 1, max_ + 1, int(1e50)]:
                 with self.subTest(format_str=fmt_str, number=number):
                     with self.assertRaisesRegex(struct.error, error_msg):

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -3,6 +3,7 @@ from itertools import combinations
 import array
 import gc
 import math
+import re
 import operator
 import unittest
 import struct
@@ -742,7 +743,7 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             else:
                 max_ = 2 ** (size * 8 - 1) - 1
                 min_ = -2 ** (size * 8 - 1)
-            error_msg = f"'{int_type}' format requires {min_} <= number <= {max_} (at item 1)"
+            error_msg = re.escape(f"'{int_type}' format requires {min_} <= number <= {max_} (at item 1)")
             for number in [int(-1e50), min_ - 1, max_ + 1, int(1e50)]:
                 with self.subTest(format_str=fmt_str, number=number):
                     with self.assertRaisesRegex(struct.error, error_msg):

--- a/Misc/NEWS.d/next/Library/2025-04-23-21-40-00.gh-issue-67766.0x8FFFF.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-23-21-40-00.gh-issue-67766.0x8FFFF.rst
@@ -1,0 +1,1 @@
+:func:`struct.pack` raises more informative errors when an argument is out of range.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1493,10 +1493,9 @@ lp_ulonglong(_structmodulestate *state, char *p, PyObject *v, const formatdef *f
     Py_DECREF(v);
     if (res < 0) {
         PyErr_Format(state->StructError,
-                     "'%c' format requires 0 <= number <= %llu (at item %zd)",
+                     "'%c' format requires 0 <= number <= %llu",
                      f->format,
-                     ULLONG_MAX,
-                     state->current_arg);
+                     ULLONG_MAX);
         return -1;
     }
     return res;

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -362,18 +362,18 @@ _range_error(_structmodulestate *state, const formatdef *f, int is_unsigned, Py_
     assert(f->size >= 1 && f->size <= SIZEOF_SIZE_T);
     if (is_unsigned)
         PyErr_Format(state->StructError,
-            "'%c' format requires 0 <= arg %zd <= %zu",
+            "'%c' format requires 0 <= number <= %zu (at item %zd)",
             f->format,
-            loc,
-            ulargest);
+            ulargest,
+            loc);
     else {
         const Py_ssize_t largest = (Py_ssize_t)(ulargest >> 1);
         PyErr_Format(state->StructError,
-            "'%c' format requires %zd <= arg %zd <= %zd",
+            "'%c' format requires %zd <= number <= %zd (at item %zd)",
             f->format,
             ~ largest,
-            loc,
-            largest);
+            largest,
+            loc);
     }
 
     return -1;
@@ -747,11 +747,11 @@ np_longlong(_structmodulestate *state, char *p, PyObject *v, const formatdef *f)
     if (get_longlong(state, v, &x) < 0) {
         if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
             PyErr_Format(state->StructError,
-                         "'%c' format requires %lld <= arg %zd <= %lld",
+                         "'%c' format requires %lld <= number <= %lld (at item %zd)",
                          f->format,
                          LLONG_MIN,
-                         state->current_arg,
-                         LLONG_MAX);
+                         LLONG_MAX,
+                         state->current_arg);
         }
         return -1;
     }
@@ -766,10 +766,10 @@ np_ulonglong(_structmodulestate *state, char *p, PyObject *v, const formatdef *f
     if (get_ulonglong(state, v, &x) < 0) {
         if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
             PyErr_Format(state->StructError,
-                         "'%c' format requires 0 <= arg %zd <= %llu",
+                         "'%c' format requires 0 <= number <= %llu (at item %zd)",
                          f->format,
-                         state->current_arg,
-                         ULLONG_MAX);
+                         ULLONG_MAX,
+                         state->current_arg);
         }
         return -1;
     }
@@ -1132,11 +1132,11 @@ bp_longlong(_structmodulestate *state, char *p, PyObject *v, const formatdef *f)
     Py_DECREF(v);
     if (res < 0) {
         PyErr_Format(state->StructError,
-                     "'%c' format requires %lld <= arg %zd <= %lld",
+                     "'%c' format requires %lld <= number <= %lld (at item %zd)",
                      f->format,
                      LLONG_MIN,
-                     state->current_arg,
-                     LLONG_MAX);
+                     LLONG_MAX,
+                     state->current_arg);
         return -1;
     }
     return res;
@@ -1158,10 +1158,10 @@ bp_ulonglong(_structmodulestate *state, char *p, PyObject *v, const formatdef *f
     Py_DECREF(v);
     if (res < 0) {
         PyErr_Format(state->StructError,
-                     "'%c' format requires 0 <= arg %zd <= %llu",
+                     "'%c' format requires 0 <= number <= %llu (at item %zd)",
                      f->format,
-                     state->current_arg,
-                     ULLONG_MAX);
+                     ULLONG_MAX,
+                     state->current_arg);
         return -1;
     }
     return res;
@@ -1467,11 +1467,11 @@ lp_longlong(_structmodulestate *state, char *p, PyObject *v, const formatdef *f)
     Py_DECREF(v);
     if (res < 0) {
         PyErr_Format(state->StructError,
-                     "'%c' format requires %lld <= arg %zd <= %lld",
+                     "'%c' format requires %lld <= number <= %lld (at item %zd)",
                      f->format,
                      LLONG_MIN,
-                     state->current_arg,
-                     LLONG_MAX);
+                     LLONG_MAX,
+                     state->current_arg);
         return -1;
     }
     return res;
@@ -1493,9 +1493,10 @@ lp_ulonglong(_structmodulestate *state, char *p, PyObject *v, const formatdef *f
     Py_DECREF(v);
     if (res < 0) {
         PyErr_Format(state->StructError,
-                     "'%c' format requires 0 <= number <= %llu",
+                     "'%c' format requires 0 <= number <= %llu (at item %zd)",
                      f->format,
-                     ULLONG_MAX);
+                     ULLONG_MAX,
+                     state->current_arg);
         return -1;
     }
     return res;

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2201,8 +2201,8 @@ s_pack_internal(PyStructObject *soself, PyObject *const *args, int offset,
         char *res = buf + code->offset;
         Py_ssize_t j = code->repeat;
         while (j--) {
-            state->current_arg = i + 1;
             PyObject *v = args[i++];
+            state->current_arg = i;
             if (e->format == 's') {
                 Py_ssize_t n;
                 int isstring;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-67766 -->
* Issue: gh-67766
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132857.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->