### PR TITLE
gh-93696: Fixed the breakpoint display error for frozen modules

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1971,12 +1971,6 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         if last is None:
             last = first + 10
         filename = self.curframe.f_code.co_filename
-        # gh-93696: stdlib frozen modules provide a useful __file__
-        # this workaround can be removed with the closure of gh-89815
-        if filename.startswith("<frozen"):
-            tmp = self.curframe.f_globals.get("__file__")
-            if isinstance(tmp, str):
-                filename = tmp
         breaklist = self.get_file_breaks(filename)
         try:
             lines = linecache.getlines(filename, self.curframe.f_globals)

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4287,15 +4287,11 @@ def bœr():
 
         # verify that pdb found the source of the "frozen" function and it
         # shows the breakpoint at the correct line for both list and longlist
-        stdout, _ = self._run_pdb(["gh93696_host.py"], commands_list)
-        self.assertIn('x = "Sentinel string for gh-93696"', stdout, "Sentinel statement not found")
-        self.assertIn('4 B', stdout, "breakpoint not found")
-        self.assertIn('-> def func():', stdout, "stack entry not found")
-
-        stdout, _ = self._run_pdb(["gh93696_host.py"], commands_longlist)
-        self.assertIn('x = "Sentinel string for gh-93696"', stdout, "Sentinel statement not found")
-        self.assertIn('4 B', stdout, "breakpoint not found")
-        self.assertIn('-> def func():', stdout, "stack entry not found")
+        for commands in (commands_list, commands_longlist):
+            stdout, _ = self._run_pdb(["gh93696_host.py"], commands)
+            self.assertIn('x = "Sentinel string for gh-93696"', stdout, "Sentinel statement not found")
+            self.assertIn('4 B', stdout, "breakpoint not found")
+            self.assertIn('-> def func():', stdout, "stack entry not found")
 
     def test_empty_file(self):
         script = ''

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4260,11 +4260,20 @@ def bœr():
         mod = _create_fake_frozen_module()
         mod.func()
         """
-        commands = """
+        commands_list = """
             break 20
             continue
             step
+            break 4
             list
+            quit
+        """
+        commands_longlist = """
+            break 20
+            continue
+            step
+            break 4
+            longlist
             quit
         """
         with open('gh93696.py', 'w') as f:
@@ -4275,9 +4284,18 @@ def bœr():
 
         self.addCleanup(os_helper.unlink, 'gh93696.py')
         self.addCleanup(os_helper.unlink, 'gh93696_host.py')
-        stdout, stderr = self._run_pdb(["gh93696_host.py"], commands)
-        # verify that pdb found the source of the "frozen" function
+
+        # verify that pdb found the source of the "frozen" function and it
+        # shows the breakpoint at the correct line for both list and longlist
+        stdout, _ = self._run_pdb(["gh93696_host.py"], commands_list)
         self.assertIn('x = "Sentinel string for gh-93696"', stdout, "Sentinel statement not found")
+        self.assertIn('4 B', stdout, "breakpoint not found")
+        self.assertIn('-> def func():', stdout, "stack entry not found")
+
+        stdout, _ = self._run_pdb(["gh93696_host.py"], commands_longlist)
+        self.assertIn('x = "Sentinel string for gh-93696"', stdout, "Sentinel statement not found")
+        self.assertIn('4 B', stdout, "breakpoint not found")
+        self.assertIn('-> def func():', stdout, "stack entry not found")
 
     def test_empty_file(self):
         script = ''

--- a/Misc/NEWS.d/next/Library/2025-04-24-01-03-40.gh-issue-93696.kM-MBp.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-24-01-03-40.gh-issue-93696.kM-MBp.rst
@@ -1,0 +1,1 @@
+Fixed the breakpoint display error for frozen modules in :mod:`pdb`.


### PR DESCRIPTION
#93697 attempted to extract the actual file of a frozen module, but it only did it for `list`, not `longlist` or `where`. With #131638, we can get source code of frozen modules without any extra efforts, so we should remove this piece of code now.

Also, this code introduced a small error - it does not show breakpoints correctly. When we set breakpoints, we use the `co_filename` (`<frozen XXX>`) as the key. Breakpoints can't be found if the filename is converted to real file, so the `B` indicator will not be there.

Some extra tests were added.

<!-- gh-issue-number: gh-93696 -->
* Issue: gh-93696
<!-- /gh-issue-number -->
