### PR TITLE
gh-121249: fix naming of struct tagPyCArgObject members

### DIFF
--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -489,14 +489,14 @@ struct tagPyCArgObject {
         int i;
         long l;
         long long q;
-        long double D;
+        long double g;
         double d;
         float f;
         void *p;
 #if defined(Py_HAVE_C_COMPLEX) && defined(Py_FFI_SUPPORT_C_COMPLEX)
-        double complex C;
-        float complex E;
-        long double complex F;
+        double complex D;
+        float complex F;
+        long double complex G;
 #endif
     } value;
     PyObject *obj;


### PR DESCRIPTION
It seems, no code actually uses these names, only sizes of the unnamed union members are important.  Though, I think it's good to be here consistent wrt type codes ('g' for long double, etc).

This amends 85f89cb3e6.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-121249 -->
* Issue: gh-121249
<!-- /gh-issue-number -->
