### PR TITLE
fix some typos in python files

### DIFF
--- a/Lib/sysconfig/__init__.py
+++ b/Lib/sysconfig/__init__.py
@@ -375,7 +375,7 @@ def _get_sysconfigdata():
 
 
 def _installation_is_relocated():
-    """Is the Python installation running from a different prefix than what was targetted when building?"""
+    """Is the Python installation running from a different prefix than what was targeted when building?"""
     if os.name != 'posix':
         raise NotImplementedError('sysconfig._installation_is_relocated() is currently only supported on POSIX')
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2956,7 +2956,7 @@ class BrokenIter:
 
 def in_systemd_nspawn_sync_suppressed() -> bool:
     """
-    Test whether the test suite is runing in systemd-nspawn
+    Test whether the test suite is running in systemd-nspawn
     with ``--suppress-sync=true``.
 
     This can be used to skip tests that rely on ``fsync()`` calls

--- a/Lib/test/test_build_details.py
+++ b/Lib/test/test_build_details.py
@@ -11,7 +11,7 @@ from test.support import is_android, is_apple_mobile, is_emscripten, is_wasi
 class FormatTestsBase:
     @property
     def contents(self):
-        """Install details file contents. Should be overriden by subclasses."""
+        """Install details file contents. Should be overridden by subclasses."""
         raise NotImplementedError
 
     @property

--- a/Lib/test/test_memoryview.py
+++ b/Lib/test/test_memoryview.py
@@ -738,7 +738,7 @@ class OtherTest(unittest.TestCase):
 @support.requires_resource("cpu")
 class RacingTest(unittest.TestCase):
     def test_racing_getbuf_and_releasebuf(self):
-        """Repeatly access the memoryview for racing."""
+        """Repeatedly access the memoryview for racing."""
         try:
             from multiprocessing.managers import SharedMemoryManager
         except ImportError:

--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -554,7 +554,7 @@ class TestCallCache(TestBase):
 def make_deferred_ref_count_obj():
     """Create an object that uses deferred reference counting.
 
-    Only objects that use deferred refence counting may be stored in inline
+    Only objects that use deferred reference counting may be stored in inline
     caches in free-threaded builds. This constructs a new class named Foo,
     which uses deferred reference counting.
     """


### PR DESCRIPTION
Fix some typos of document strings in python files.