### PR TITLE
gh-132882: Fix copying of unions with members that do not support __or__

### DIFF
--- a/Lib/copyreg.py
+++ b/Lib/copyreg.py
@@ -31,8 +31,8 @@ def pickle_complex(c):
 pickle(complex, pickle_complex, complex)
 
 def pickle_union(obj):
-    import functools, operator
-    return functools.reduce, (operator.or_, obj.__args__)
+    import typing, operator
+    return operator.getitem, (typing.Union, obj.__args__)
 
 pickle(type(int | str), pickle_union)
 

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5283,10 +5283,12 @@ class GenericTests(BaseTestCase):
                   Tuple[Any, Any], Node[T], Node[int], Node[Any], typing.Iterable[T],
                   typing.Iterable[Any], typing.Iterable[int], typing.Dict[int, str],
                   typing.Dict[T, Any], ClassVar[int], ClassVar[List[T]], Tuple['T', 'T'],
-                  Union['T', int], List['T'], typing.Mapping['T', int]]
+                  Union['T', int], List['T'], typing.Mapping['T', int],
+                  Union[b"x", b"y"]]
         for t in things + [Any]:
-            self.assertEqual(t, copy(t))
-            self.assertEqual(t, deepcopy(t))
+            with self.subTest(thing=t):
+                self.assertEqual(t, copy(t))
+                self.assertEqual(t, deepcopy(t))
 
     def test_immutability_by_copy_and_pickle(self):
         # Special forms like Union, Any, etc., generic aliases to containers like List,

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -5284,8 +5284,8 @@ class GenericTests(BaseTestCase):
                   typing.Iterable[Any], typing.Iterable[int], typing.Dict[int, str],
                   typing.Dict[T, Any], ClassVar[int], ClassVar[List[T]], Tuple['T', 'T'],
                   Union['T', int], List['T'], typing.Mapping['T', int],
-                  Union[b"x", b"y"]]
-        for t in things + [Any]:
+                  Union[b"x", b"y"], Any]
+        for t in things:
             with self.subTest(thing=t):
                 self.assertEqual(t, copy(t))
                 self.assertEqual(t, deepcopy(t))

--- a/Misc/NEWS.d/next/Library/2025-04-24-09-10-04.gh-issue-132882.6zoyp5.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-24-09-10-04.gh-issue-132882.6zoyp5.rst
@@ -1,0 +1,2 @@
+Fix copying of :class:`typing.Union` objects containing objects that do not
+support the ``|`` operator.


### PR DESCRIPTION


<!-- gh-issue-number: gh-132882 -->
* Issue: gh-132882
<!-- /gh-issue-number -->
