### PR TITLE
GH-130328: pasting in new REPL is slow on Windows

### DIFF
--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -633,7 +633,7 @@ class Reader:
 
     def refresh(self) -> None:
         """Recalculate and refresh the screen."""
-        if self.in_bracketed_paste and self.buffer and not self.buffer[-1] == "\n":
+        if self.paste_mode and self.buffer and not self.buffer[-1] == "\n":
             return
 
         # this call sets up self.cxy, so call it first.

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -633,7 +633,7 @@ class Reader:
 
     def refresh(self) -> None:
         """Recalculate and refresh the screen."""
-        if self.paste_mode and self.buffer and not self.buffer[-1] == "\n":
+        if self.in_bracketed_paste and self.buffer and not self.buffer[-1] == "\n":
             return
 
         # this call sets up self.cxy, so call it first.

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -109,6 +109,9 @@ CTRL_ACTIVE = 0x04 | 0x08
 WAIT_TIMEOUT = 0x102
 WAIT_FAILED = 0xFFFFFFFF
 
+# from winbase.h
+INFINITE = 0xFFFFFFFF
+
 
 class _error(Exception):
     pass
@@ -523,7 +526,11 @@ class WindowsConsole(Console):
 
     def wait(self, timeout: float | None) -> bool:
         """Wait for an event."""
-        ret = WaitForSingleObject(InHandle, int(timeout))
+        if timeout is None:
+            timeout = INFINITE
+        else:
+            timeout = int(timeout)
+        ret = WaitForSingleObject(InHandle, timeout)
         if ret == WAIT_FAILED:
             raise WinError(ctypes.get_last_error())
 

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -42,12 +42,15 @@ from .utils import wlen
 from .windows_eventqueue import EventQueue
 
 try:
-    from ctypes import GetLastError, WinDLL, windll, WinError  # type: ignore[attr-defined]
+    from ctypes import get_last_error, GetLastError, WinDLL, windll, WinError  # type: ignore[attr-defined]
 except:
     # Keep MyPy happy off Windows
     from ctypes import CDLL as WinDLL, cdll as windll
 
     def GetLastError() -> int:
+        return 42
+
+    def get_last_error() -> int:
         return 42
 
     class WinError(OSError):  # type: ignore[no-redef]
@@ -416,7 +419,7 @@ class WindowsConsole(Console):
         if not block:
             ret = WaitForSingleObject(InHandle, 0)
             if ret == WAIT_FAILED:
-                raise WinError(ctypes.get_last_error())
+                raise WinError(get_last_error())
             elif ret == WAIT_TIMEOUT:
                 return None
 
@@ -532,7 +535,7 @@ class WindowsConsole(Console):
             timeout = int(timeout)
         ret = WaitForSingleObject(InHandle, timeout)
         if ret == WAIT_FAILED:
-            raise WinError(ctypes.get_last_error())
+            raise WinError(get_last_error())
 
     def repaint(self) -> None:
         raise NotImplementedError("No repaint support")

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -416,12 +416,8 @@ class WindowsConsole(Console):
         return info.srWindow.Bottom  # type: ignore[no-any-return]
 
     def _read_input(self, block: bool = True) -> INPUT_RECORD | None:
-        if not block:
-            ret = WaitForSingleObject(InHandle, 0)
-            if ret == WAIT_FAILED:
-                raise WinError(get_last_error())
-            elif ret == WAIT_TIMEOUT:
-                return None
+        if not block and not self.wait(timeout=0):
+            return None
 
         rec = INPUT_RECORD()
         read = DWORD()
@@ -536,6 +532,9 @@ class WindowsConsole(Console):
         ret = WaitForSingleObject(InHandle, timeout)
         if ret == WAIT_FAILED:
             raise WinError(get_last_error())
+        elif ret == WAIT_TIMEOUT:
+            return False
+        return True
 
     def repaint(self) -> None:
         raise NotImplementedError("No repaint support")

--- a/Misc/NEWS.d/next/Library/2025-04-24-18-07-49.gh-issue-130328.z7CN8z.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-24-18-07-49.gh-issue-130328.z7CN8z.rst
@@ -1,0 +1,1 @@
+Speedup pasting in ``PyREPL`` on Windows. Fix by Chris Eibl.


### PR DESCRIPTION
The reason why pasting is so slow on Windows (especially in the legacy console case where virtual terminal mode - and thus bracketed paste - is disabled):

https://github.com/python/cpython/blob/9f5994b94cb6b8526bcb8fa29a99656dc403e25e/Lib/_pyrepl/reader.py#L702-L706

and

https://github.com/python/cpython/blob/9f5994b94cb6b8526bcb8fa29a99656dc403e25e/Lib/_pyrepl/windows_console.py#L523-L532

It is interesting, that `msvcrt.kbhit()` returns True in case of pasting, but if that weren't the case, we'd hit the 100ms timeout and would be even way slower. However,  `msvcrt.kbhit()` is very slow in case of the legacy console, and it is called at least twice as often, because we get a key up and a key down event - but only a key down event in the virtual terminal case. If the pasted input contains upper case letters, we additionally get a "shift key pressed" event - so in the worst case, `msvcrt.kbhit()` gets called 3 times more often (and each call is slower).

Output of `python.bat -m cProfile -m _pyrepl` when pasting the "test value" given in the OP for a legacy console:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     50/1    0.010    0.000   17.202   17.202 {built-in method builtins.exec}
        1    0.000    0.000   17.202   17.202 <frozen runpy>:201(run_module)
        1    0.000    0.000   17.199   17.199 <frozen runpy>:65(_run_code)
        1    0.000    0.000   17.199   17.199 __main__.py:1(<module>)
        1    0.000    0.000   17.112   17.112 main.py:24(interactive_console)
        1    0.000    0.000   17.112   17.112 simple_interact.py:99(run_multiline_interactive_console)
        5    0.000    0.000   17.111    3.422 readline.py:375(multiline_input)
        5    0.004    0.001   17.111    3.422 reader.py:741(readline)
     3090    0.036    0.000   17.103    0.006 reader.py:694(handle1)
     6210    0.013    0.000   13.714    0.002 windows_console.py:523(wait)
     6236   13.433    0.002   13.433    0.002 {built-in method msvcrt.kbhit}
``` 

Here the relevant line in case of virtual terminal:
``` 
  3270    0.554    0.000    0.554    0.000 {built-in method msvcrt.kbhit}
``` 

The fix is to use [WaitForSingleObject](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject)
```python
    def wait(self, timeout: float | None) -> bool:
        """Wait for an event."""
        ret = WaitForSingleObject(InHandle, int(timeout))
        if ret == WAIT_FAILED:
            raise WinError(ctypes.get_last_error())
``` 
which speeds up especially the legacy console (times in seconds):

| | legacy terminal | virtual terminal |
|--------|--------|-----|
| before| 15.6 | 0.89|
| after | 1.8|  0.26 |


Note, see also https://github.com/python/cpython/pull/132440#issuecomment-2817168234:
- legacy terminal: manually start `cmd.exe`. Timings gotten by pasting
``` 
import time
t1 = time.time()
<"test value" given in the OP>
print(time.time() - t1)
```
- virtual terminal: power shell via Windows terminal. Timings gotton by temporarily patching `commands.py`:
```python
import time
class enable_bracketed_paste(Command):
    def do(self) -> None:
        self.reader.bp_begin = time.perf_counter()
        self.reader.paste_mode = True
        self.reader.in_bracketed_paste = True

class disable_bracketed_paste(Command):
    def do(self) -> None:
        print("bracketed_paste took %5.2f s" % (time.perf_counter() - self.reader.bp_begin, ))
        self.reader.paste_mode = False
        self.reader.in_bracketed_paste = False
        self.reader.dirty = True

``` 


<!-- gh-issue-number: gh-130328 -->
* Issue: gh-130328
<!-- /gh-issue-number -->
