### PR TITLE
gh-91156: Document how TextIOWrapper interacts with UTF-8 mode

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -965,7 +965,8 @@ Text I/O
    :class:`TextIOBase`.
 
    *encoding* gives the name of the encoding that the stream will be decoded or
-   encoded with.  It defaults to :func:`locale.getencoding`.
+   encoded with.  In :ref:`UTF-8 Mode <utf8-mode>`, this defaults to UTF-8.
+   Otherwise, it defaults to :func:`locale.getencoding`.
    ``encoding="locale"`` can be used to specify the current locale's encoding
    explicitly. See :ref:`io-text-encoding` for more information.
 


### PR DESCRIPTION
Previously discussed [here](https://discuss.python.org/t/confused-about-documentation-of-io-textiowrapper-encoding/21089). This will become more important when UTF-8 mode is made the default in Python 3.15.

<!-- gh-issue-number: gh-91156 -->
* Issue: gh-91156
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132885.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->