### PR TITLE
gh-132713: Fix repr(classmethod) race condition

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-25-09-05-47.gh-issue-132713.rHfLvU.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-25-09-05-47.gh-issue-132713.rHfLvU.rst
@@ -1,0 +1,2 @@
+Fix ``repr(classmethod)`` race condition: hold a strong reference to the
+callable while calling ``repr(classmethod)``. Patch by Victor Stinner.

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -1488,7 +1488,12 @@ static PyObject*
 cm_repr(PyObject *self)
 {
     classmethod *cm = _PyClassMethod_CAST(self);
-    return PyUnicode_FromFormat("<classmethod(%R)>", cm->cm_callable);
+    // gh-132713: Hold a strong reference since cm_init() can be called
+    // in parallel
+    PyObject *callable = Py_NewRef(cm->cm_callable);
+    PyObject *repr = PyUnicode_FromFormat("<classmethod(%R)>", callable);
+    Py_DECREF(callable);
+    return repr;
 }
 
 PyDoc_STRVAR(classmethod_doc,


### PR DESCRIPTION
Hold a strong reference to the callable while calling repr(classmethod).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-132713 -->
* Issue: gh-132713
<!-- /gh-issue-number -->
