### PR TITLE
Docs: fix typos in `Doc`

### DIFF
--- a/Doc/howto/remote_debugging.rst
+++ b/Doc/howto/remote_debugging.rst
@@ -110,7 +110,7 @@ file format structures from the binary file on disk. The ELF header contains a
 pointer to the section header table. Each section header contains metadata about
 a section including its name (stored in a separate string table), offset, and
 size. To find a specific section like .PyRuntime, you need to walk through these
-headers and match the section name. The section header then provdes the offset
+headers and match the section name. The section header then provides the offset
 where that section exists in the file, which can be used to calculate its
 runtime address when the binary is loaded into memory.
 

--- a/Doc/library/importlib.metadata.rst
+++ b/Doc/library/importlib.metadata.rst
@@ -297,7 +297,7 @@ Distribution files
    package is not installed in the current Python environment.
 
    Returns :const:`None` if the distribution is found but the installation
-   database records reporting the files associated with the distribuion package
+   database records reporting the files associated with the distribution package
    are missing.
 
 .. class:: PackagePath


### PR DESCRIPTION
Fix 2 typos in `Doc/howto/remote_debugging.rst` and `Doc/library/importlib.metadata.rst`.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132927.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->