### PR TITLE
[3.13] gh-132909: handle overflow for 'K' format in `do_mkvalue` (GH-132911)

### DIFF
--- a/Doc/c-api/arg.rst
+++ b/Doc/c-api/arg.rst
@@ -639,6 +639,8 @@ Building values
    ``L`` (:class:`int`) [long long]
       Convert a C :c:expr:`long long` to a Python integer object.
 
+   .. _capi-py-buildvalue-format-K:
+
    ``K`` (:class:`int`) [unsigned long long]
       Convert a C :c:expr:`unsigned long long` to a Python integer object.
 

--- a/Misc/NEWS.d/next/C API/2025-04-25-11-39-24.gh-issue-132909.JC3n_l.rst
+++ b/Misc/NEWS.d/next/C API/2025-04-25-11-39-24.gh-issue-132909.JC3n_l.rst
@@ -1,0 +1,2 @@
+Fix an overflow when handling the :ref:`K <capi-py-buildvalue-format-K>` format
+in :c:func:`Py_BuildValue`. Patch by Bénédikt Tran.

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -320,7 +320,8 @@ do_mkvalue(const char **p_format, va_list *p_va)
             return PyLong_FromLongLong((long long)va_arg(*p_va, long long));
 
         case 'K':
-            return PyLong_FromUnsignedLongLong((long long)va_arg(*p_va, unsigned long long));
+            return PyLong_FromUnsignedLongLong(
+                va_arg(*p_va, unsigned long long));
 
         case 'u':
         {


### PR DESCRIPTION
(cherry picked from commit 3fa024dec32e2ff86baf3dd7e14a0b314855327c)

<!-- gh-issue-number: gh-132909 -->
* Issue: gh-132909
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--132932.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->