### PR TITLE
gh-132912: Use SHORT_TIMEOUT in test_remote_pdb

### DIFF
--- a/Lib/test/test_remote_pdb.py
+++ b/Lib/test/test_remote_pdb.py
@@ -12,7 +12,7 @@ import unittest
 import unittest.mock
 from contextlib import contextmanager
 from pathlib import Path
-from test.support import is_wasi, os_helper
+from test.support import is_wasi, os_helper, SHORT_TIMEOUT
 from test.support.os_helper import temp_dir, TESTFN, unlink
 from typing import Dict, List, Optional, Tuple, Union, Any
 
@@ -414,7 +414,7 @@ class PdbConnectTestCase(unittest.TestCase):
             self._send_command(client_file, "c")
 
             # Wait for process to finish
-            stdout, _ = process.communicate(timeout=5)
+            stdout, _ = process.communicate(timeout=SHORT_TIMEOUT)
 
             # Check if we got the expected output
             self.assertIn("Function returned: 42", stdout)
@@ -457,7 +457,7 @@ class PdbConnectTestCase(unittest.TestCase):
 
             # Continue to end
             self._send_command(client_file, "c")
-            stdout, _ = process.communicate(timeout=5)
+            stdout, _ = process.communicate(timeout=SHORT_TIMEOUT)
 
             self.assertIn("Function returned: 42", stdout)
             self.assertEqual(process.returncode, 0)
@@ -466,7 +466,7 @@ class PdbConnectTestCase(unittest.TestCase):
         """Test that sending keyboard interrupt breaks into pdb."""
         synchronizer_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         synchronizer_sock.bind(('127.0.0.1', 0))  # Let OS assign port
-        synchronizer_sock.settimeout(5)
+        synchronizer_sock.settimeout(SHORT_TIMEOUT)
         synchronizer_sock.listen(1)
         self.addCleanup(synchronizer_sock.close)
         sync_port = synchronizer_sock.getsockname()[1]
@@ -521,7 +521,7 @@ class PdbConnectTestCase(unittest.TestCase):
             # Continue to end
             self._send_command(client_file, "iterations = 0")
             self._send_command(client_file, "c")
-            stdout, _ = process.communicate(timeout=5)
+            stdout, _ = process.communicate(timeout=SHORT_TIMEOUT)
             self.assertIn("Function returned: 42", stdout)
             self.assertEqual(process.returncode, 0)
 
@@ -539,7 +539,7 @@ class PdbConnectTestCase(unittest.TestCase):
             client_file.flush()
 
             # The process should complete normally after receiving EOF
-            stdout, stderr = process.communicate(timeout=5)
+            stdout, stderr = process.communicate(timeout=SHORT_TIMEOUT)
 
             # Verify process completed correctly
             self.assertIn("Function returned: 42", stdout)
@@ -589,7 +589,7 @@ class PdbConnectTestCase(unittest.TestCase):
             self.assertIn('protocol version', message['message'])
 
             # The process should complete normally
-            stdout, stderr = process.communicate(timeout=5)
+            stdout, stderr = process.communicate(timeout=SHORT_TIMEOUT)
 
             # Verify the process completed successfully
             self.assertIn("Test result: True", stdout)
@@ -631,7 +631,7 @@ class PdbConnectTestCase(unittest.TestCase):
             # Continue execution to finish the program
             self._send_command(client_file, "c")
 
-            stdout, stderr = process.communicate(timeout=5)
+            stdout, stderr = process.communicate(timeout=SHORT_TIMEOUT)
             self.assertIn("Function returned: 42", stdout)
             self.assertEqual(process.returncode, 0)
 
@@ -689,7 +689,7 @@ class PdbConnectTestCase(unittest.TestCase):
             # Continue execution to finish
             self._send_command(client_file, "c")
 
-            stdout, stderr = process.communicate(timeout=5)
+            stdout, stderr = process.communicate(timeout=SHORT_TIMEOUT)
             self.assertIn("Function returned: 42", stdout)
             self.assertEqual(process.returncode, 0)
 


### PR DESCRIPTION
Replace hardcoded timeout of 5 seconds with SHORT_TIMEOUT.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-132912 -->
* Issue: gh-132912
<!-- /gh-issue-number -->
