### PR TITLE
Remove unused assignment in HTMLParser

### DIFF
--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -226,9 +226,6 @@ class HTMLParser(_markupbase.ParserBase):
                 if match:
                     # match.group() will contain at least 2 chars
                     if end and match.group() == rawdata[i:]:
-                        k = match.end()
-                        if k <= i:
-                            k = n
                         i = self.updatepos(i, i + 1)
                     # incomplete
                     break


### PR DESCRIPTION
The assignment to k is never used, because the block breaks.

Code originally introduced in https://github.com/python/cpython/commit/b579dba1195df97f87ba868a5987f18fb7509bff

Discovered while porting this library to a different language.

