### PR TITLE
gh-132950: Skip test_remote_pdb if remote exec is disabled

### DIFF
--- a/Lib/test/test_remote_pdb.py
+++ b/Lib/test/test_remote_pdb.py
@@ -21,6 +21,10 @@ import pdb
 from pdb import _PdbServer, _PdbClient
 
 
+if not sys.is_remote_debug_enabled():
+    raise unittest.SkipTest('remote debugging is disabled')
+
+
 @contextmanager
 def kill_on_error(proc):
     """Context manager killing the subprocess if a Python exception is raised."""


### PR DESCRIPTION
Skip test_keyboard_interrupt() if remote execution is disabled.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-132950 -->
* Issue: gh-132950
<!-- /gh-issue-number -->
