### PR TITLE
gh-132952: Improve Python startup time by ~12%

### DIFF
--- a/Lib/io.py
+++ b/Lib/io.py
@@ -53,7 +53,6 @@ __all__ = ["BlockingIOError", "open", "open_code", "IOBase", "RawIOBase",
 import _io
 import abc
 
-from _collections_abc import _check_methods
 from _io import (DEFAULT_BUFFER_SIZE, BlockingIOError, UnsupportedOperation,
                  open, open_code, FileIO, BytesIO, StringIO, BufferedReader,
                  BufferedWriter, BufferedRWPair, BufferedRandom,
@@ -126,6 +125,7 @@ class Reader(metaclass=abc.ABCMeta):
     @classmethod
     def __subclasshook__(cls, C):
         if cls is Reader:
+            from _collections_abc import _check_methods
             return _check_methods(C, "read")
         return NotImplemented
 
@@ -147,6 +147,7 @@ class Writer(metaclass=abc.ABCMeta):
     @classmethod
     def __subclasshook__(cls, C):
         if cls is Writer:
+            from _collections_abc import _check_methods
             return _check_methods(C, "write")
         return NotImplemented
 


### PR DESCRIPTION
This improves the time of a no-`site.py` startup by 12%, i.e.

```
python -c pass -S
```

I'm not strongly of the opinion this should be merged (hence the draft PR), since there are probably all kinds of other places where "lazy importing" could be used to improve startup time that don't improve readability.  On the other hand, it's a fairly large regression from 3.13.x that we may want to avoid.

<!-- gh-issue-number: gh-132952 -->
* Issue: gh-132952
<!-- /gh-issue-number -->
