### PR TITLE
gh-91048: Chain some exceptions in _testexternalinspection.c

### DIFF
--- a/Modules/_testexternalinspection.c
+++ b/Modules/_testexternalinspection.c
@@ -65,7 +65,7 @@ _Py_RemoteDebug_GetAsyncioDebugAddress(proc_handle_t* handle)
         address = search_map_for_section(handle, "AsyncioDebug", "_asyncio.cpython");
     }
 #else
-    address = 0;
+    Py_UNREACHABLE();
 #endif
 
     return address;

--- a/Modules/_testexternalinspection.c
+++ b/Modules/_testexternalinspection.c
@@ -482,9 +482,6 @@ parse_task(
         return -1;
     }
 
-    uintptr_t refcnt;
-    read_ptr(handle, task_address + sizeof(Py_ssize_t), &refcnt);
-
     PyObject* result = PyList_New(0);
     if (result == NULL) {
         return -1;

--- a/Modules/_testexternalinspection.c
+++ b/Modules/_testexternalinspection.c
@@ -45,6 +45,15 @@ struct _Py_AsyncioModuleDebugOffsets {
     } asyncio_thread_state;
 };
 
+// Helper to chain exceptions and avoid repetitions
+static void
+chain_exceptions(PyObject *exception, const char *string)
+{
+    PyObject *exc = PyErr_GetRaisedException();
+    PyErr_SetString(exception, string);
+    _PyErr_ChainExceptions1(exc);
+}
+
 // Get the PyAsyncioDebug section address for any platform
 static uintptr_t
 _Py_RemoteDebug_GetAsyncioDebugAddress(proc_handle_t* handle)

--- a/Modules/_testexternalinspection.c
+++ b/Modules/_testexternalinspection.c
@@ -23,18 +23,6 @@
 #    define HAVE_PROCESS_VM_READV 0
 #endif
 
-#ifdef CHAIN_EXCEPTIONS
-#error "CHAIN_EXCEPTIONS should not be defined"
-#endif
-
-#define CHAIN_EXCEPTIONS(Type, Msg)                 \
-    do {                                            \
-        PyObject *exc = PyErr_GetRaisedException(); \
-        PyErr_SetString((Type), (Msg));             \
-        _PyErr_ChainExceptions1(exc);               \
-    } while(0)
-
-
 struct _Py_AsyncioModuleDebugOffsets {
     struct _asyncio_task_object {
         uint64_t size;
@@ -316,7 +304,7 @@ parse_task_name(
     if ((flags & Py_TPFLAGS_LONG_SUBCLASS)) {
         long res = read_py_long(handle, offsets, task_name_addr);
         if (res == -1) {
-            CHAIN_EXCEPTIONS(PyExc_RuntimeError, "Failed to get task name");
+            chain_exceptions(PyExc_RuntimeError, "Failed to get task name");
             return NULL;
         }
         return PyUnicode_FromFormat("Task-%d", res);
@@ -1181,13 +1169,13 @@ get_all_awaited_by(PyObject* self, PyObject* args)
     struct _Py_DebugOffsets local_debug_offsets;
 
     if (_Py_RemoteDebug_ReadDebugOffsets(handle, &runtime_start_addr, &local_debug_offsets)) {
-        CHAIN_EXCEPTIONS(PyExc_RuntimeError, "Failed to read debug offsets");
+        chain_exceptions(PyExc_RuntimeError, "Failed to read debug offsets");
         goto result_err;
     }
 
     struct _Py_AsyncioModuleDebugOffsets local_async_debug;
     if (read_async_debug(handle, &local_async_debug)) {
-        CHAIN_EXCEPTIONS(PyExc_RuntimeError, "Failed to read asyncio debug offsets");
+        chain_exceptions(PyExc_RuntimeError, "Failed to read asyncio debug offsets");
         goto result_err;
     }
 
@@ -1310,7 +1298,7 @@ get_stack_trace(PyObject* self, PyObject* args)
     struct _Py_DebugOffsets local_debug_offsets;
 
     if (_Py_RemoteDebug_ReadDebugOffsets(handle, &runtime_start_address, &local_debug_offsets)) {
-        CHAIN_EXCEPTIONS(PyExc_RuntimeError, "Failed to read debug offsets");
+        chain_exceptions(PyExc_RuntimeError, "Failed to read debug offsets");
         goto result_err;
     }
 
@@ -1381,13 +1369,13 @@ get_async_stack_trace(PyObject* self, PyObject* args)
     struct _Py_DebugOffsets local_debug_offsets;
 
     if (_Py_RemoteDebug_ReadDebugOffsets(handle, &runtime_start_address, &local_debug_offsets)) {
-        CHAIN_EXCEPTIONS(PyExc_RuntimeError, "Failed to read debug offsets");
+        chain_exceptions(PyExc_RuntimeError, "Failed to read debug offsets");
         goto result_err;
     }
 
     struct _Py_AsyncioModuleDebugOffsets local_async_debug;
     if (read_async_debug(handle, &local_async_debug)) {
-        CHAIN_EXCEPTIONS(PyExc_RuntimeError, "Failed to read asyncio debug offsets");
+        chain_exceptions(PyExc_RuntimeError, "Failed to read asyncio debug offsets");
         goto result_err;
     }
 
@@ -1409,7 +1397,7 @@ get_async_stack_trace(PyObject* self, PyObject* args)
         handle, runtime_start_address, &local_debug_offsets, &local_async_debug,
         &running_task_addr)
     ) {
-        CHAIN_EXCEPTIONS(PyExc_RuntimeError, "Failed to find running task");
+        chain_exceptions(PyExc_RuntimeError, "Failed to find running task");
         goto result_err;
     }
 
@@ -1424,7 +1412,7 @@ get_async_stack_trace(PyObject* self, PyObject* args)
         running_task_addr + local_async_debug.asyncio_task_object.task_coro,
         &running_coro_addr
     )) {
-        CHAIN_EXCEPTIONS(PyExc_RuntimeError, "Failed to read running task coro");
+        chain_exceptions(PyExc_RuntimeError, "Failed to read running task coro");
         goto result_err;
     }
 
@@ -1454,7 +1442,7 @@ get_async_stack_trace(PyObject* self, PyObject* args)
         handle, runtime_start_address, &local_debug_offsets,
         &address_of_current_frame)
     ) {
-        CHAIN_EXCEPTIONS(PyExc_RuntimeError, "Failed to find running frame");
+        chain_exceptions(PyExc_RuntimeError, "Failed to find running frame");
         goto result_err;
     }
 
@@ -1470,7 +1458,7 @@ get_async_stack_trace(PyObject* self, PyObject* args)
         );
 
         if (res < 0) {
-            CHAIN_EXCEPTIONS(PyExc_RuntimeError, "Failed to parse async frame object");
+            chain_exceptions(PyExc_RuntimeError, "Failed to parse async frame object");
             goto result_err;
         }
 

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -372,7 +372,9 @@ search_map_for_section(proc_handle_t *handle, const char* secname, const char* s
 
     mach_port_t proc_ref = pid_to_task(handle->pid);
     if (proc_ref == 0) {
-        PyErr_SetString(PyExc_PermissionError, "Cannot get task for PID");
+        if (!PyErr_Occurred()) {
+            PyErr_SetString(PyExc_PermissionError, "Cannot get task for PID");
+        }
         return 0;
     }
 

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -342,6 +342,7 @@ search_section_in_file(const char* secname, char* path, uintptr_t base, mach_vm_
     munmap(map, fs.st_size);
     if (close(fd) != 0) {
         PyErr_SetFromErrno(PyExc_OSError);
+        result = 0;
     }
     return result;
 }
@@ -495,6 +496,7 @@ exit:
     }
     if (fd >= 0 && close(fd) != 0) {
         PyErr_SetFromErrno(PyExc_OSError);
+        result = 0;
     }
     return result;
 }
@@ -570,7 +572,10 @@ search_linux_map_for_section(proc_handle_t *handle, const char* secname, const c
     }
 
     PyMem_Free(line);
-    fclose(maps_file);
+    if (fclose(maps_file) != 0) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        retval = 0;
+    }
 
     return retval;
 }

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -699,7 +699,7 @@ _Py_RemoteDebug_GetPyRuntimeAddress(proc_handle_t* handle)
         address = search_map_for_section(handle, "PyRuntime", "python");
     }
 #else
-    address = 0;
+    Py_UNREACHABLE();
 #endif
 
     return address;

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -708,11 +708,6 @@ _Py_RemoteDebug_GetPyRuntimeAddress(proc_handle_t* handle)
         // TODO: Differentiate between not found and error
         PyErr_Clear();
         address = search_map_for_section(handle, "PyRuntime", "python");
-        if (address == 0) {
-            PyObject *exc = PyErr_GetRaisedException();
-            PyErr_SetString(PyExc_RuntimeError, "Failed to find the PyRuntime section in the process.");
-            _PyErr_ChainExceptions1(exc);
-        }
     }
 #else
     Py_UNREACHABLE();

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -688,14 +688,18 @@ _Py_RemoteDebug_GetPyRuntimeAddress(proc_handle_t* handle)
     address = search_windows_map_for_section(handle, "PyRuntime", L"python");
     if (address == 0) {
         // Error out: 'python' substring covers both executable and DLL
+        PyObject *exc = PyErr_GetRaisedException();
         PyErr_SetString(PyExc_RuntimeError, "Failed to find the PyRuntime section in the process.");
+        _PyErr_ChainExceptions1(exc);
     }
 #elif defined(__linux__)
     // On Linux, search for 'python' in executable or DLL
     address = search_linux_map_for_section(handle, "PyRuntime", "python");
     if (address == 0) {
         // Error out: 'python' substring covers both executable and DLL
+        PyObject *exc = PyErr_GetRaisedException();
         PyErr_SetString(PyExc_RuntimeError, "Failed to find the PyRuntime section in the process.");
+        _PyErr_ChainExceptions1(exc);
     }
 #elif defined(__APPLE__) && TARGET_OS_OSX
     // On macOS, try libpython first, then fall back to python
@@ -704,6 +708,11 @@ _Py_RemoteDebug_GetPyRuntimeAddress(proc_handle_t* handle)
         // TODO: Differentiate between not found and error
         PyErr_Clear();
         address = search_map_for_section(handle, "PyRuntime", "python");
+        if (address == 0) {
+            PyObject *exc = PyErr_GetRaisedException();
+            PyErr_SetString(PyExc_RuntimeError, "Failed to find the PyRuntime section in the process.");
+            _PyErr_ChainExceptions1(exc);
+        }
     }
 #else
     Py_UNREACHABLE();

--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -109,6 +109,15 @@ _Py_RemoteDebug_CleanupProcHandle(proc_handle_t *handle) {
     handle->pid = 0;
 }
 
+// Helper to chain exceptions and avoid repetitions
+static void
+chain_exceptions(PyObject *exception, const char *string)
+{
+    PyObject *exc = PyErr_GetRaisedException();
+    PyErr_SetString(exception, string);
+    _PyErr_ChainExceptions1(exc);
+}
+
 #if defined(__APPLE__) && TARGET_OS_OSX
 
 static uintptr_t
@@ -688,18 +697,14 @@ _Py_RemoteDebug_GetPyRuntimeAddress(proc_handle_t* handle)
     address = search_windows_map_for_section(handle, "PyRuntime", L"python");
     if (address == 0) {
         // Error out: 'python' substring covers both executable and DLL
-        PyObject *exc = PyErr_GetRaisedException();
-        PyErr_SetString(PyExc_RuntimeError, "Failed to find the PyRuntime section in the process.");
-        _PyErr_ChainExceptions1(exc);
+        chain_exceptions(PyExc_RuntimeError, "Failed to find the PyRuntime section in the process.");
     }
 #elif defined(__linux__)
     // On Linux, search for 'python' in executable or DLL
     address = search_linux_map_for_section(handle, "PyRuntime", "python");
     if (address == 0) {
         // Error out: 'python' substring covers both executable and DLL
-        PyObject *exc = PyErr_GetRaisedException();
-        PyErr_SetString(PyExc_RuntimeError, "Failed to find the PyRuntime section in the process.");
-        _PyErr_ChainExceptions1(exc);
+        chain_exceptions(PyExc_RuntimeError, "Failed to find the PyRuntime section in the process.");
     }
 #elif defined(__APPLE__) && TARGET_OS_OSX
     // On macOS, try libpython first, then fall back to python


### PR DESCRIPTION
1. Added extra Py_UNREACHABLE calls on unsupported platforms
2. Remove unused refcnt read
3. Set result to 0 if fd closing failed
4. Chain some exceptions to get more info if failed

<!-- gh-issue-number: gh-91048 -->
* Issue: gh-91048
<!-- /gh-issue-number -->
