### PR TITLE
gh-132775: Add _PyImport_GetModulesRef() to the Internal C-API

### DIFF
--- a/Include/internal/pycore_import.h
+++ b/Include/internal/pycore_import.h
@@ -63,6 +63,7 @@ extern void _PyImport_SetDLOpenFlags(PyInterpreterState *interp, int new_val);
 
 extern PyObject * _PyImport_InitModules(PyInterpreterState *interp);
 extern PyObject * _PyImport_GetModules(PyInterpreterState *interp);
+extern PyObject * _PyImport_GetModulesRef(PyInterpreterState *interp);
 extern void _PyImport_ClearModules(PyInterpreterState *interp);
 
 extern void _PyImport_ClearModulesByIndex(PyInterpreterState *interp);

--- a/Python/import.c
+++ b/Python/import.c
@@ -153,6 +153,20 @@ _PyImport_GetModules(PyInterpreterState *interp)
     return MODULES(interp);
 }
 
+PyObject *
+_PyImport_GetModulesRef(PyInterpreterState *interp)
+{
+    _PyImport_AcquireLock(interp);
+    PyObject *modules = MODULES(interp);
+    if (modules == NULL) {
+        /* The interpreter hasn't been initialized yet. */
+        modules = Py_None;
+    }
+    Py_INCREF(modules);
+    _PyImport_ReleaseLock(interp);
+    return modules;
+}
+
 void
 _PyImport_ClearModules(PyInterpreterState *interp)
 {


### PR DESCRIPTION
This is the equivalent of `_PyImport_GetModules()` that incref's while the lock is held.

This is used by a later change related to pickle and handling `__main__`.

<!-- gh-issue-number: gh-132775 -->
* Issue: gh-132775
<!-- /gh-issue-number -->
