### PR TITLE
gh-89708: use fds when possible in contextlib.chdir

### DIFF
--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -1400,23 +1400,23 @@ class TestChdir(unittest.TestCase):
                     os.chdir('a')
                     count += 1
 
-                self.assertTrue(count > 0)
+                self.assertGreater(count, 0)
                 os.mkdir('a')
                 with chdir('a'):
-                    self.assertTrue(len(os.getcwd()) > path_max)
+                    self.assertGreater(len(os.getcwd()), path_max)
 
     @unittest.skipUnless(chdir._supports_fd(),
                          "chdir requires fd support for deleted dir")
     def test_original_path_deleted(self):
         original = os.getcwd()
         dir = tempfile.TemporaryDirectory()
+        self.addCleanup(dir.cleanup)
         try:
             os.chdir(dir.name)
             with chdir(original):
                 dir.cleanup()
         finally:
             os.chdir(original)
-            dir.cleanup()
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -1366,9 +1366,7 @@ class TestChdir(unittest.TestCase):
         target = self.make_relative_path('non_existent_directory')
         self.assertNotEqual(old_cwd, target)
         ctx = chdir(target)
-        with self.assertRaises(OSError):
-            with ctx:
-                self.fail("chdir should have raised an exception")
+        self.assertRaises(OSError, ctx.__enter__)
         self.assertFalse(ctx._old_cwd)
         self.assertEqual(os.getcwd(), old_cwd)
 

--- a/Misc/NEWS.d/next/Library/2025-04-26-12-10-32.gh-issue-89708.haEUh3.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-26-12-10-32.gh-issue-89708.haEUh3.rst
@@ -1,0 +1,3 @@
+Use fds in contextlib.chdir where supported. This fixes bugs if the original
+working directory is greater than PATH_MAX and/or is deleted before the
+context manager exits.

--- a/Misc/NEWS.d/next/Library/2025-04-26-12-10-32.gh-issue-89708.haEUh3.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-26-12-10-32.gh-issue-89708.haEUh3.rst
@@ -1,3 +1,3 @@
-Use fds in contextlib.chdir where supported. This fixes bugs if the original
-working directory is greater than PATH_MAX and/or is deleted before the
-context manager exits.
+Use file descriptors in :func:`contextlib.chdir` when possible to prevent
+issues when the original working directory is concurrently deleted or when its
+path length is longer than the maximum allowed by the host platform.


### PR DESCRIPTION
This fixes two failure modes: original directories that are longer than PATH_MAX or that were deleted. Use this safer mode when possible, falling back to the existing mode if fds cannot be used.


<!-- gh-issue-number: gh-89708 -->
* Issue: gh-89708
<!-- /gh-issue-number -->
