### PR TITLE
gh-91205: fix bug in shutil.copytree with relative links and ignore_dangling_symlinks=True

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -569,6 +569,10 @@ def _copytree(entries, src, dst, symlinks, ignore, copy_function,
                     os.symlink(linkto, dstname)
                     copystat(srcobj, dstname, follow_symlinks=not symlinks)
                 else:
+                    # if the link is not to an absolute path it is relative to
+                    # the source (see gh-91205)
+                    if not os.path.isabs(linkto):
+                        linkto = os.path.join(os.path.dirname(srcname), linkto)
                     # ignore dangling symlink if the flag is on
                     if not os.path.exists(linkto) and ignore_dangling_symlinks:
                         continue

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1079,22 +1079,23 @@ class TestCopyTree(BaseTest, unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     def test_copytree_relative_symlink(self):
-        # Ensure valid relative symlinks are copied regardless of the value of
-        # the ignore_dangling_symlinks flag (see gh-91205)
+        # gh-91205: Ensure valid relative symlinks are copied regardless of the
+        # value of the ``ignore_dangling_symlinks`` flag.
         src_dir = self.mkdtemp()
-        a_dir = os.path.join(src_dir, 'a')
-        a_file = os.path.join(a_dir, 'a.txt')
-        b_dir = os.path.join(a_dir, 'b')
-        os.mkdir(a_dir)
-        os.mkdir(b_dir)
-        create_file(os.path.join(a_dir, 'a.txt'))
-        os.symlink(os.path.join("..", 'a.txt'), os.path.join(b_dir, 'a.txt'))
+        dir_a = os.path.join(src_dir, 'a')
+        dir_a_dir_b = os.path.join(dir_a, 'b')
+        os.mkdir(dir_a)
+        os.mkdir(dir_a_dir_b)
+        create_file(os.path.join(dir_a, 'a.txt'))
+        # create a symlink from src/a/b/a.txt to ../a.txt
+        os.symlink(os.path.join(os.pardir, 'a.txt'),
+                   os.path.join(dir_a_dir_b, 'a.txt'))
 
         for ignore_dangling_symlinks in (True, False):
             with self.subTest(ignore_dangling_symlinks=ignore_dangling_symlinks):
                 dst_dir = os.path.join(self.mkdtemp(), 'x')
                 shutil.copytree(
-                    b_dir, dst_dir, symlinks=False,
+                    dir_a_dir_b, dst_dir, symlinks=False,
                     ignore_dangling_symlinks=ignore_dangling_symlinks)
                 self.assertIn('a.txt', os.listdir(dst_dir))
                 self.assertFalse(

--- a/Misc/NEWS.d/next/Library/2025-04-26-13-44-46.gh-issue-91205.kYPo51.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-26-13-44-46.gh-issue-91205.kYPo51.rst
@@ -1,2 +1,2 @@
-Fix bug in :mod:`shutil`.``copytree`` where symbolic links to relative paths
-were skipped when the ``ignore_dangling_symlinks`` flag is given.
+Avoid skipping symbolic links to relative paths in :func:`shutil.copytree` when
+``ignore_dangling_symlinks=True`` and ``symlinks=False``.

--- a/Misc/NEWS.d/next/Library/2025-04-26-13-44-46.gh-issue-91205.kYPo51.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-26-13-44-46.gh-issue-91205.kYPo51.rst
@@ -1,0 +1,2 @@
+Fix bug in :mod:`shutil`.``copytree`` where symbolic links to relative paths
+were skipped when the ``ignore_dangling_symlinks`` flag is given.


### PR DESCRIPTION
Fix bug where `shutil.copytree` was skipping copying the contents of symbolic links to relative paths when the `ignore_dangling_symlinks` flag was set.


<!-- gh-issue-number: gh-91205 -->
* Issue: gh-91205
<!-- /gh-issue-number -->
