### PR TITLE
gh-63882: Use `self.assert*` in `test_minidom`

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -155,7 +155,7 @@ class MinidomTest(unittest.TestCase):
     def testInsertBeforeFragment(self):
         dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()
         dom.documentElement.insertBefore(frag, None)
-        self.assertEqual(tuple(dom.documentElement.childNodes),
+        self.assertTupleEqual(tuple(dom.documentElement.childNodes),
                      (orig, c1, c2, c3),
                      "insertBefore(<fragment>, None)")
         frag.unlink()
@@ -221,9 +221,9 @@ class MinidomTest(unittest.TestCase):
         attrs = elem.attributes
         attrs["foo"] = "bar"
         a = attrs.item(0)
-        self.assertTrue(a.ownerDocument is dom,
+        self.assertIs(a.ownerDocument, dom,
                 "NamedNodeMap.__setitem__() sets ownerDocument")
-        self.assertTrue(a.ownerElement is elem,
+        self.assertIs(a.ownerElement, elem,
                 "NamedNodeMap.__setitem__() sets ownerElement")
         self.assertEqual(a.value, "bar",
                 "NamedNodeMap.__setitem__() sets value")
@@ -234,9 +234,9 @@ class MinidomTest(unittest.TestCase):
 
     def testNonZero(self):
         dom = parse(tstfile)
-        self.assertTrue(dom)# should not be zero
+        self.assertTrue(dom)  # should not be zero
         dom.appendChild(dom.createComment("foo"))
-        self.assertTrue(not dom.childNodes[-1].childNodes)
+        self.assertFalse(dom.childNodes[-1].childNodes)
         dom.unlink()
 
     def testUnlink(self):
@@ -758,7 +758,7 @@ class MinidomTest(unittest.TestCase):
                     "]>\n"
                     "<doc attr='value'/>")
         doc2 = doc.cloneNode(1)
-        self.assertTrue(not (doc.isSameNode(doc2) or doc2.isSameNode(doc)),
+        self.assertFalse((doc.isSameNode(doc2) or doc2.isSameNode(doc)),
                 "testCloneDocumentDeep: document objects not distinct")
         self.assertEqual(len(doc.childNodes), len(doc2.childNodes),
                 "testCloneDocumentDeep: wrong number of Document children")
@@ -766,14 +766,14 @@ class MinidomTest(unittest.TestCase):
                 "testCloneDocumentDeep: documentElement not an ELEMENT_NODE")
         self.assertTrue(doc2.documentElement.ownerDocument.isSameNode(doc2),
             "testCloneDocumentDeep: documentElement owner is not new document")
-        self.assertTrue(not doc.documentElement.isSameNode(doc2.documentElement),
+        self.assertFalse(doc.documentElement.isSameNode(doc2.documentElement),
                 "testCloneDocumentDeep: documentElement should not be shared")
         if doc.doctype is not None:
             # check the doctype iff the original DOM maintained it
             self.assertEqual(doc2.doctype.nodeType, Node.DOCUMENT_TYPE_NODE,
                     "testCloneDocumentDeep: doctype not a DOCUMENT_TYPE_NODE")
             self.assertTrue(doc2.doctype.ownerDocument.isSameNode(doc2))
-            self.assertTrue(not doc.doctype.isSameNode(doc2.doctype))
+            self.assertFalse(doc.doctype.isSameNode(doc2.doctype))
 
     def testCloneDocumentTypeDeepOk(self):
         doctype = create_nonempty_doctype()
@@ -863,8 +863,8 @@ class MinidomTest(unittest.TestCase):
         attr = doc.documentElement.getAttributeNode("attr")
         self.assertNotEqual(attr, None)
         clone = attr.cloneNode(deep)
-        self.assertTrue(not clone.isSameNode(attr))
-        self.assertTrue(not attr.isSameNode(clone))
+        self.assertFalse(clone.isSameNode(attr))
+        self.assertFalse(attr.isSameNode(clone))
         self.assertIs(clone.ownerElement, None,
                 testName + ": ownerElement should be None")
         self.confirm(clone.ownerDocument.isSameNode(attr.ownerDocument),
@@ -1559,9 +1559,9 @@ class MinidomTest(unittest.TestCase):
         a3.value = "v"
         e.setAttributeNode(a3)
         self.assertTrue(e.isSameNode(doc.getElementById("w")))
-        self.assertTrue(not a1.isId)
+        self.assertFalse(a1.isId)
         self.assertTrue(a2.isId)
-        self.assertTrue(not a3.isId)
+        self.assertFalse(a3.isId)
         self.assertIs(doc.getElementById("v"), None)
         # renaming an attribute should not affect its ID-ness:
         doc.renameNode(a2, xml.dom.EMPTY_NAMESPACE, "an")
@@ -1595,9 +1595,9 @@ class MinidomTest(unittest.TestCase):
         a3.value = "v"
         e.setAttributeNode(a3)
         self.assertTrue(e.isSameNode(doc.getElementById("w")))
-        self.assertTrue(not a1.isId)
+        self.assertFalse(a1.isId)
         self.assertTrue(a2.isId)
-        self.assertTrue(not a3.isId)
+        self.assertFalse(a3.isId)
         self.assertIs(doc.getElementById("v"), None)
         # renaming an attribute should not affect its ID-ness:
         doc.renameNode(a2, xml.dom.EMPTY_NAMESPACE, "an")

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -163,7 +163,7 @@ class MinidomTest(unittest.TestCase):
 
         dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()
         dom.documentElement.insertBefore(frag, orig)
-        self.assertEqual(tuple(dom.documentElement.childNodes),
+        self.assertTupleEqual(tuple(dom.documentElement.childNodes),
                      (c1, c2, c3, orig),
                      "insertBefore(<fragment>, orig)")
         frag.unlink()
@@ -179,7 +179,7 @@ class MinidomTest(unittest.TestCase):
     def testAppendChildFragment(self):
         dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()
         dom.documentElement.appendChild(frag)
-        self.assertEqual(tuple(dom.documentElement.childNodes),
+        self.assertTupleEqual(tuple(dom.documentElement.childNodes),
                      (orig, c1, c2, c3),
                      "appendChild(<fragment>)")
         frag.unlink()
@@ -189,7 +189,7 @@ class MinidomTest(unittest.TestCase):
         dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()
         dom.documentElement.replaceChild(frag, orig)
         orig.unlink()
-        self.assertEqual(tuple(dom.documentElement.childNodes), (c1, c2, c3),
+        self.assertTupleEqual(tuple(dom.documentElement.childNodes), (c1, c2, c3),
                 "replaceChild(<fragment>)")
         frag.unlink()
         dom.unlink()
@@ -262,9 +262,9 @@ class MinidomTest(unittest.TestCase):
         el.setAttribute("spam", "jam2")
         self.assertEqual(el.toxml(), '<abc spam="jam2"/>', "testAAA")
         a = el.getAttributeNode("spam")
-        self.assertTrue(a.ownerDocument is dom,
+        self.assertIs(a.ownerDocument, dom,
                 "setAttribute() sets ownerDocument")
-        self.assertTrue(a.ownerElement is dom.documentElement,
+        self.assertIs(a.ownerElement, dom.documentElement,
                 "setAttribute() sets ownerElement")
         dom.unlink()
 

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -813,7 +813,7 @@ class MinidomTest(unittest.TestCase):
     def testCloneDocumentTypeDeepNotOk(self):
         doc = create_doc_with_doctype()
         clone = doc.doctype.cloneNode(1)
-        self.assertIsNone(clone, "testCloneDocumentTypeDeepNotOk")
+        self.assertIsNone(clone)
 
     def testCloneDocumentTypeShallowOk(self):
         doctype = create_nonempty_doctype()

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -57,7 +57,7 @@ class MinidomTest(unittest.TestCase):
 
     def checkWholeText(self, node, s):
         t = node.wholeText
-        self.confirm(t == s, "looking for %r, found %r" % (s, t))
+        self.assertEqual(t, s, "looking for %r, found %r" % (s, t))
 
     def testDocumentAsyncAttr(self):
         doc = Document()
@@ -68,13 +68,13 @@ class MinidomTest(unittest.TestCase):
         with open(tstfile, 'rb') as file:
             dom = parse(file)
             dom.unlink()
-            self.confirm(isinstance(dom, Document))
+            self.assertIsInstance(dom, Document)
 
     def testParseFromTextFile(self):
         with open(tstfile, 'r', encoding='iso-8859-1') as file:
             dom = parse(file)
             dom.unlink()
-            self.confirm(isinstance(dom, Document))
+            self.assertIsInstance(dom, Document)
 
     def testAttrModeSetsParamsAsAttrs(self):
         attr = Attr("qName", "namespaceURI", "localName", "prefix")
@@ -92,7 +92,7 @@ class MinidomTest(unittest.TestCase):
 
     def testGetElementsByTagName(self):
         dom = parse(tstfile)
-        self.confirm(dom.getElementsByTagName("LI") == \
+        self.assertEqual(dom.getElementsByTagName("LI"),
                 dom.documentElement.getElementsByTagName("LI"))
         dom.unlink()
 
@@ -102,32 +102,32 @@ class MinidomTest(unittest.TestCase):
         elem = root.childNodes[0]
         nelem = dom.createElement("element")
         root.insertBefore(nelem, elem)
-        self.confirm(len(root.childNodes) == 2
-                and root.childNodes.length == 2
+        self.confirm(len(root.childNodes), 2
+                and root.childNodes.length, 2
                 and root.childNodes[0] is nelem
                 and root.childNodes.item(0) is nelem
                 and root.childNodes[1] is elem
                 and root.childNodes.item(1) is elem
                 and root.firstChild is nelem
                 and root.lastChild is elem
-                and root.toxml() == "<doc><element/><foo/></doc>"
+                and root.toxml(), "<doc><element/><foo/></doc>"
                 , "testInsertBefore -- node properly placed in tree")
         nelem = dom.createElement("element")
         root.insertBefore(nelem, None)
-        self.confirm(len(root.childNodes) == 3
-                and root.childNodes.length == 3
+        self.confirm(len(root.childNodes), 3
+                and root.childNodes.length, 3
                 and root.childNodes[1] is elem
                 and root.childNodes.item(1) is elem
                 and root.childNodes[2] is nelem
                 and root.childNodes.item(2) is nelem
                 and root.lastChild is nelem
                 and nelem.previousSibling is elem
-                and root.toxml() == "<doc><element/><foo/><element/></doc>"
+                and root.toxml(), "<doc><element/><foo/><element/></doc>"
                 , "testInsertBefore -- node properly placed in tree")
         nelem2 = dom.createElement("bar")
         root.insertBefore(nelem2, nelem)
-        self.confirm(len(root.childNodes) == 4
-                and root.childNodes.length == 4
+        self.confirm(len(root.childNodes), 4
+                and root.childNodes.length, 4
                 and root.childNodes[2] is nelem2
                 and root.childNodes.item(2) is nelem2
                 and root.childNodes[3] is nelem
@@ -155,7 +155,7 @@ class MinidomTest(unittest.TestCase):
     def testInsertBeforeFragment(self):
         dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()
         dom.documentElement.insertBefore(frag, None)
-        self.confirm(tuple(dom.documentElement.childNodes) ==
+        self.assertEqual(tuple(dom.documentElement.childNodes),
                      (orig, c1, c2, c3),
                      "insertBefore(<fragment>, None)")
         frag.unlink()
@@ -163,7 +163,7 @@ class MinidomTest(unittest.TestCase):
 
         dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()
         dom.documentElement.insertBefore(frag, orig)
-        self.confirm(tuple(dom.documentElement.childNodes) ==
+        self.assertEqual(tuple(dom.documentElement.childNodes),
                      (c1, c2, c3, orig),
                      "insertBefore(<fragment>, orig)")
         frag.unlink()
@@ -172,14 +172,14 @@ class MinidomTest(unittest.TestCase):
     def testAppendChild(self):
         dom = parse(tstfile)
         dom.documentElement.appendChild(dom.createComment("Hello"))
-        self.confirm(dom.documentElement.childNodes[-1].nodeName == "#comment")
-        self.confirm(dom.documentElement.childNodes[-1].data == "Hello")
+        self.assertEqual(dom.documentElement.childNodes[-1].nodeName, "#comment")
+        self.assertEqual(dom.documentElement.childNodes[-1].data, "Hello")
         dom.unlink()
 
     def testAppendChildFragment(self):
         dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()
         dom.documentElement.appendChild(frag)
-        self.confirm(tuple(dom.documentElement.childNodes) ==
+        self.assertEqual(tuple(dom.documentElement.childNodes),
                      (orig, c1, c2, c3),
                      "appendChild(<fragment>)")
         frag.unlink()
@@ -189,7 +189,7 @@ class MinidomTest(unittest.TestCase):
         dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()
         dom.documentElement.replaceChild(frag, orig)
         orig.unlink()
-        self.confirm(tuple(dom.documentElement.childNodes) == (c1, c2, c3),
+        self.assertEqual(tuple(dom.documentElement.childNodes), (c1, c2, c3),
                 "replaceChild(<fragment>)")
         frag.unlink()
         dom.unlink()
@@ -221,22 +221,22 @@ class MinidomTest(unittest.TestCase):
         attrs = elem.attributes
         attrs["foo"] = "bar"
         a = attrs.item(0)
-        self.confirm(a.ownerDocument is dom,
+        self.assertTrue(a.ownerDocument is dom,
                 "NamedNodeMap.__setitem__() sets ownerDocument")
-        self.confirm(a.ownerElement is elem,
+        self.assertTrue(a.ownerElement is elem,
                 "NamedNodeMap.__setitem__() sets ownerElement")
-        self.confirm(a.value == "bar",
+        self.assertEqual(a.value, "bar",
                 "NamedNodeMap.__setitem__() sets value")
-        self.confirm(a.nodeValue == "bar",
+        self.assertEqual(a.nodeValue, "bar",
                 "NamedNodeMap.__setitem__() sets nodeValue")
         elem.unlink()
         dom.unlink()
 
     def testNonZero(self):
         dom = parse(tstfile)
-        self.confirm(dom)# should not be zero
+        self.assertTrue(dom)# should not be zero
         dom.appendChild(dom.createComment("foo"))
-        self.confirm(not dom.childNodes[-1].childNodes)
+        self.assertTrue(not dom.childNodes[-1].childNodes)
         dom.unlink()
 
     def testUnlink(self):
@@ -253,18 +253,18 @@ class MinidomTest(unittest.TestCase):
     def testElement(self):
         dom = Document()
         dom.appendChild(dom.createElement("abc"))
-        self.confirm(dom.documentElement)
+        self.assertTrue(dom.documentElement)
         dom.unlink()
 
     def testAAA(self):
         dom = parseString("<abc/>")
         el = dom.documentElement
         el.setAttribute("spam", "jam2")
-        self.confirm(el.toxml() == '<abc spam="jam2"/>', "testAAA")
+        self.assertEqual(el.toxml(), '<abc spam="jam2"/>', "testAAA")
         a = el.getAttributeNode("spam")
-        self.confirm(a.ownerDocument is dom,
+        self.assertTrue(a.ownerDocument is dom,
                 "setAttribute() sets ownerDocument")
-        self.confirm(a.ownerElement is dom.documentElement,
+        self.assertTrue(a.ownerElement is dom.documentElement,
                 "setAttribute() sets ownerElement")
         dom.unlink()
 
@@ -273,7 +273,7 @@ class MinidomTest(unittest.TestCase):
         el = dom.documentElement
         el.setAttribute("spam", "jam")
         el.setAttribute("spam", "jam2")
-        self.confirm(el.toxml() == '<abc spam="jam2"/>', "testAAB")
+        self.assertEqual(el.toxml(), '<abc spam="jam2"/>', "testAAB")
         dom.unlink()
 
     def testAddAttr(self):
@@ -281,31 +281,31 @@ class MinidomTest(unittest.TestCase):
         child = dom.appendChild(dom.createElement("abc"))
 
         child.setAttribute("def", "ghi")
-        self.confirm(child.getAttribute("def") == "ghi")
-        self.confirm(child.attributes["def"].value == "ghi")
+        self.assertEqual(child.getAttribute("def"),"ghi")
+        self.assertEqual(child.attributes["def"].value, "ghi")
 
         child.setAttribute("jkl", "mno")
-        self.confirm(child.getAttribute("jkl") == "mno")
-        self.confirm(child.attributes["jkl"].value == "mno")
+        self.assertEqual(child.getAttribute("jkl"), "mno")
+        self.assertEqual(child.attributes["jkl"].value, "mno")
 
-        self.confirm(len(child.attributes) == 2)
+        self.assertEqual(len(child.attributes), 2)
 
         child.setAttribute("def", "newval")
-        self.confirm(child.getAttribute("def") == "newval")
-        self.confirm(child.attributes["def"].value == "newval")
+        self.assertEqual(child.getAttribute("def"), "newval")
+        self.assertEqual(child.attributes["def"].value, "newval")
 
-        self.confirm(len(child.attributes) == 2)
+        self.assertEqual(len(child.attributes), 2)
         dom.unlink()
 
     def testDeleteAttr(self):
         dom = Document()
         child = dom.appendChild(dom.createElement("abc"))
 
-        self.confirm(len(child.attributes) == 0)
+        self.assertEqual(len(child.attributes), 0)
         child.setAttribute("def", "ghi")
-        self.confirm(len(child.attributes) == 1)
+        self.assertEqual(len(child.attributes), 1)
         del child.attributes["def"]
-        self.confirm(len(child.attributes) == 0)
+        self.assertEqual(len(child.attributes), 0)
         dom.unlink()
 
     def testRemoveAttr(self):
@@ -313,10 +313,10 @@ class MinidomTest(unittest.TestCase):
         child = dom.appendChild(dom.createElement("abc"))
 
         child.setAttribute("def", "ghi")
-        self.confirm(len(child.attributes) == 1)
+        self.assertEqual(len(child.attributes), 1)
         self.assertRaises(xml.dom.NotFoundErr, child.removeAttribute, "foo")
         child.removeAttribute("def")
-        self.confirm(len(child.attributes) == 0)
+        self.assertEqual(len(child.attributes), 0)
         dom.unlink()
 
     def testRemoveAttrNS(self):
@@ -328,21 +328,21 @@ class MinidomTest(unittest.TestCase):
         child.setAttributeNS("http://www.python.org", "python:abcattr", "foo")
         self.assertRaises(xml.dom.NotFoundErr, child.removeAttributeNS,
             "foo", "http://www.python.org")
-        self.confirm(len(child.attributes) == 2)
+        self.assertEqual(len(child.attributes), 2)
         child.removeAttributeNS("http://www.python.org", "abcattr")
-        self.confirm(len(child.attributes) == 1)
+        self.assertEqual(len(child.attributes), 1)
         dom.unlink()
 
     def testRemoveAttributeNode(self):
         dom = Document()
         child = dom.appendChild(dom.createElement("foo"))
         child.setAttribute("spam", "jam")
-        self.confirm(len(child.attributes) == 1)
+        self.assertEqual(len(child.attributes), 1)
         node = child.getAttributeNode("spam")
         self.assertRaises(xml.dom.NotFoundErr, child.removeAttributeNode,
             None)
         self.assertIs(node, child.removeAttributeNode(node))
-        self.confirm(len(child.attributes) == 0
+        self.assertEqual(len(child.attributes), 0
                 and child.getAttributeNode("spam") is None)
         dom2 = Document()
         child2 = dom2.appendChild(dom2.createElement("foo"))
@@ -355,13 +355,13 @@ class MinidomTest(unittest.TestCase):
         dom = Document()
         child = dom.appendChild(dom.createElement("foo"))
         child.setAttribute("spam", "jam")
-        self.confirm(child.hasAttribute("spam"))
+        self.assertTrue(child.hasAttribute("spam"))
 
     def testChangeAttr(self):
         dom = parseString("<abc/>")
         el = dom.documentElement
         el.setAttribute("spam", "jam")
-        self.confirm(len(el.attributes) == 1)
+        self.assertEqual(len(el.attributes), 1)
         el.setAttribute("spam", "bam")
         # Set this attribute to be an ID and make sure that doesn't change
         # when changing the value:
@@ -444,7 +444,7 @@ class MinidomTest(unittest.TestCase):
     def get_empty_nodelist_from_elements_by_tagName_ns_helper(self, doc, nsuri,
                                                               lname):
         nodelist = doc.getElementsByTagNameNS(nsuri, lname)
-        self.confirm(len(nodelist) == 0)
+        self.assertEqual(len(nodelist), 0)
 
     def testGetEmptyNodeListFromElementsByTagNameNS(self):
         doc = parseString('<doc/>')
@@ -468,7 +468,7 @@ class MinidomTest(unittest.TestCase):
         el = dom.appendChild(dom.createElement("abc"))
         string1 = repr(el)
         string2 = str(el)
-        self.confirm(string1 == string2)
+        self.assertEqual(string1, string2)
         dom.unlink()
 
     def testElementReprAndStrUnicode(self):
@@ -476,7 +476,7 @@ class MinidomTest(unittest.TestCase):
         el = dom.appendChild(dom.createElement("abc"))
         string1 = repr(el)
         string2 = str(el)
-        self.confirm(string1 == string2)
+        self.assertEqual(string1, string2)
         dom.unlink()
 
     def testElementReprAndStrUnicodeNS(self):
@@ -485,15 +485,15 @@ class MinidomTest(unittest.TestCase):
             dom.createElementNS("http://www.slashdot.org", "slash:abc"))
         string1 = repr(el)
         string2 = str(el)
-        self.confirm(string1 == string2)
-        self.confirm("slash:abc" in string1)
+        self.assertEqual(string1, string2)
+        self.assertIn("slash:abc", string1)
         dom.unlink()
 
     def testAttributeRepr(self):
         dom = Document()
         el = dom.appendChild(dom.createElement("abc"))
         node = el.setAttribute("abc", "def")
-        self.confirm(str(node) == repr(node))
+        self.assertEqual(str(node), repr(node))
         dom.unlink()
 
     def testTextNodeRepr(self): pass
@@ -503,7 +503,7 @@ class MinidomTest(unittest.TestCase):
         dom = parseString(str)
         domstr = dom.toxml()
         dom.unlink()
-        self.confirm(str == domstr)
+        self.assertEqual(str, domstr)
 
     def test_toxml_quote_text(self):
         dom = Document()
@@ -550,7 +550,7 @@ class MinidomTest(unittest.TestCase):
         dom = parseString(str)
         domstr = dom.toprettyxml(newl="\r\n")
         dom.unlink()
-        self.confirm(domstr == str.replace("\n", "\r\n"))
+        self.assertEqual(domstr, str.replace("\n", "\r\n"))
 
     def test_toprettyxml_with_text_nodes(self):
         # see issue #4147, text nodes are not indented
@@ -643,7 +643,7 @@ class MinidomTest(unittest.TestCase):
         attrs = e.attributes
         a1 = e.getAttributeNode("a")
         a2 = attrs.removeNamedItem("a")
-        self.confirm(a1.isSameNode(a2))
+        self.assertEqual(a1.isSameNode(a2))
         self.assertRaises(xml.dom.NotFoundErr, attrs.removeNamedItem, "a")
 
     def testRemoveNamedItemNS(self):
@@ -652,7 +652,7 @@ class MinidomTest(unittest.TestCase):
         attrs = e.attributes
         a1 = e.getAttributeNodeNS("http://xml.python.org/", "b")
         a2 = attrs.removeNamedItemNS("http://xml.python.org/", "b")
-        self.confirm(a1.isSameNode(a2))
+        self.assertTrue(a1.isSameNode(a2))
         self.assertRaises(xml.dom.NotFoundErr, attrs.removeNamedItemNS,
                           "http://xml.python.org/", "b")
 
@@ -695,7 +695,7 @@ class MinidomTest(unittest.TestCase):
         keys2 = list(attrs2.keys())
         keys1.sort()
         keys2.sort()
-        self.confirm(keys1 == keys2, "clone of element has same attribute keys")
+        self.assertEqual(keys1, keys2, "clone of element has same attribute keys")
         for i in range(len(keys1)):
             a1 = attrs1.item(i)
             a2 = attrs2.item(i)
@@ -705,7 +705,7 @@ class MinidomTest(unittest.TestCase):
                     and a1.namespaceURI == a2.namespaceURI
                     and a1.localName == a2.localName
                     , "clone of attribute node has proper attribute values")
-            self.confirm(a2.ownerElement is e2,
+            self.assertIs(a2.ownerElement, e2,
                     "clone of attribute node correctly owned")
 
     def _setupCloneElement(self, deep):
@@ -746,7 +746,7 @@ class MinidomTest(unittest.TestCase):
                     "]>\n"
                     "<doc attr='value'/>")
         doc2 = doc.cloneNode(0)
-        self.confirm(doc2 is None,
+        self.assertIs(doc2, None,
                 "testCloneDocumentShallow:"
                 " shallow cloning of documents makes no sense!")
 
@@ -758,22 +758,22 @@ class MinidomTest(unittest.TestCase):
                     "]>\n"
                     "<doc attr='value'/>")
         doc2 = doc.cloneNode(1)
-        self.confirm(not (doc.isSameNode(doc2) or doc2.isSameNode(doc)),
+        self.assertTrue(not (doc.isSameNode(doc2) or doc2.isSameNode(doc)),
                 "testCloneDocumentDeep: document objects not distinct")
-        self.confirm(len(doc.childNodes) == len(doc2.childNodes),
+        self.assertEqual(len(doc.childNodes), len(doc2.childNodes),
                 "testCloneDocumentDeep: wrong number of Document children")
-        self.confirm(doc2.documentElement.nodeType == Node.ELEMENT_NODE,
+        self.assertEqual(doc2.documentElement.nodeType, Node.ELEMENT_NODE,
                 "testCloneDocumentDeep: documentElement not an ELEMENT_NODE")
-        self.confirm(doc2.documentElement.ownerDocument.isSameNode(doc2),
+        self.assertEqual(doc2.documentElement.ownerDocument.isSameNode(doc2),
             "testCloneDocumentDeep: documentElement owner is not new document")
-        self.confirm(not doc.documentElement.isSameNode(doc2.documentElement),
+        self.assertTrue(not doc.documentElement.isSameNode(doc2.documentElement),
                 "testCloneDocumentDeep: documentElement should not be shared")
         if doc.doctype is not None:
             # check the doctype iff the original DOM maintained it
-            self.confirm(doc2.doctype.nodeType == Node.DOCUMENT_TYPE_NODE,
+            self.assertEqual(doc2.doctype.nodeType, Node.DOCUMENT_TYPE_NODE,
                     "testCloneDocumentDeep: doctype not a DOCUMENT_TYPE_NODE")
-            self.confirm(doc2.doctype.ownerDocument.isSameNode(doc2))
-            self.confirm(not doc.doctype.isSameNode(doc2.doctype))
+            self.assertTrue(doc2.doctype.ownerDocument.isSameNode(doc2))
+            self.assertTrue(not doc.doctype.isSameNode(doc2.doctype))
 
     def testCloneDocumentTypeDeepOk(self):
         doctype = create_nonempty_doctype()
@@ -812,7 +812,7 @@ class MinidomTest(unittest.TestCase):
     def testCloneDocumentTypeDeepNotOk(self):
         doc = create_doc_with_doctype()
         clone = doc.doctype.cloneNode(1)
-        self.confirm(clone is None, "testCloneDocumentTypeDeepNotOk")
+        self.assertIs(clone, None, "testCloneDocumentTypeDeepNotOk")
 
     def testCloneDocumentTypeShallowOk(self):
         doctype = create_nonempty_doctype()
@@ -831,7 +831,7 @@ class MinidomTest(unittest.TestCase):
     def testCloneDocumentTypeShallowNotOk(self):
         doc = create_doc_with_doctype()
         clone = doc.doctype.cloneNode(0)
-        self.confirm(clone is None, "testCloneDocumentTypeShallowNotOk")
+        self.assertIs(clone, None, "testCloneDocumentTypeShallowNotOk")
 
     def check_import_document(self, deep, testName):
         doc1 = parseString("<doc/>")
@@ -863,14 +863,14 @@ class MinidomTest(unittest.TestCase):
         attr = doc.documentElement.getAttributeNode("attr")
         self.assertNotEqual(attr, None)
         clone = attr.cloneNode(deep)
-        self.confirm(not clone.isSameNode(attr))
-        self.confirm(not attr.isSameNode(clone))
-        self.confirm(clone.ownerElement is None,
+        self.assertTrue(not clone.isSameNode(attr))
+        self.assertTrue(not attr.isSameNode(clone))
+        self.assertIs(clone.ownerElement, None,
                 testName + ": ownerElement should be None")
-        self.confirm(clone.ownerDocument.isSameNode(attr.ownerDocument),
+        self.assertEqual(clone.ownerDocument.isSameNode(attr.ownerDocument),
                 testName + ": ownerDocument does not match")
-        self.confirm(clone.specified,
-                testName + ": cloned attribute must have specified == True")
+        self.assertEqual(clone.specified,
+                testName + ": cloned attribute must have specified, True")
 
     def testCloneAttributeShallow(self):
         self.check_clone_attribute(0, "testCloneAttributeShallow")
@@ -1142,7 +1142,7 @@ class MinidomTest(unittest.TestCase):
         node = doc.documentElement
         node.childNodes[1].nodeValue = ""
         node.normalize()
-        self.confirm(node.childNodes[-1].nextSibling is None,
+        self.assertIS(node.childNodes[-1].nextSibling, None,
                      "Final child's .nextSibling should be None")
 
     def testSiblings(self):
@@ -1235,16 +1235,16 @@ class MinidomTest(unittest.TestCase):
     def testUserData(self):
         dom = Document()
         n = dom.createElement('e')
-        self.confirm(n.getUserData("foo") is None)
+        self.assertIs(n.getUserData("foo"), None)
         n.setUserData("foo", None, None)
-        self.confirm(n.getUserData("foo") is None)
+        self.assertIs(n.getUserData("foo"), None)
         n.setUserData("foo", 12, 12)
         n.setUserData("bar", 13, 13)
-        self.confirm(n.getUserData("foo") == 12)
-        self.confirm(n.getUserData("bar") == 13)
+        self.assertEqual(n.getUserData("foo"), 12)
+        self.assertEqual(n.getUserData("bar"), 13)
         n.setUserData("foo", None, None)
-        self.confirm(n.getUserData("foo") is None)
-        self.confirm(n.getUserData("bar") == 13)
+        self.assertIs(n.getUserData("foo"), None)
+        self.assertEqual(n.getUserData("bar"), 13)
 
         handler = self.UserDataHandler()
         n.setUserData("bar", 12, handler)
@@ -1434,10 +1434,10 @@ class MinidomTest(unittest.TestCase):
         doc = parseString("<doc><e/></doc>")
         elem = doc.documentElement
         e = elem.firstChild
-        self.confirm(e.parentNode is elem, "Before replaceChild()")
+        self.assertIs(e.parentNode, elem, "Before replaceChild()")
         # Check that replacing a child with itself leaves the tree unchanged
         elem.replaceChild(e, e)
-        self.confirm(e.parentNode is elem, "After replaceChild()")
+        self.assertIs(e.parentNode, elem, "After replaceChild()")
 
     def testReplaceWholeText(self):
         def setup():
@@ -1454,13 +1454,13 @@ class MinidomTest(unittest.TestCase):
         text = text1.replaceWholeText("new content")
         self.checkWholeText(text, "new content")
         self.checkWholeText(text2, "d")
-        self.confirm(len(elem.childNodes) == 3)
+        self.assertEqual(len(elem.childNodes), 3)
 
         doc, elem, text1, splitter, text2 = setup()
         text = text2.replaceWholeText("new content")
         self.checkWholeText(text, "new content")
         self.checkWholeText(text1, "cab")
-        self.confirm(len(elem.childNodes) == 5)
+        self.assertEqual(len(elem.childNodes), 5)
 
         doc, elem, text1, splitter, text2 = setup()
         text = text1.replaceWholeText("")
@@ -1558,11 +1558,11 @@ class MinidomTest(unittest.TestCase):
         a3 = doc.createAttributeNS(NS1, "a1")
         a3.value = "v"
         e.setAttributeNode(a3)
-        self.confirm(e.isSameNode(doc.getElementById("w")))
-        self.confirm(not a1.isId)
-        self.confirm(a2.isId)
-        self.confirm(not a3.isId)
-        self.confirm(doc.getElementById("v") is None)
+        self.assertTrue(e.isSameNode(doc.getElementById("w")))
+        self.assertTrue(not a1.isId)
+        self.assertTrue(a2.isId)
+        self.assertTrue(not a3.isId)
+        self.assertIs(doc.getElementById("v"), None)
         # renaming an attribute should not affect its ID-ness:
         doc.renameNode(a2, xml.dom.EMPTY_NAMESPACE, "an")
         self.confirm(e.isSameNode(doc.getElementById("w"))
@@ -1594,11 +1594,11 @@ class MinidomTest(unittest.TestCase):
         a3 = doc.createAttributeNS(NS1, "a1")
         a3.value = "v"
         e.setAttributeNode(a3)
-        self.confirm(e.isSameNode(doc.getElementById("w")))
-        self.confirm(not a1.isId)
-        self.confirm(a2.isId)
-        self.confirm(not a3.isId)
-        self.confirm(doc.getElementById("v") is None)
+        self.assertTrue(e.isSameNode(doc.getElementById("w")))
+        self.assertTrue(not a1.isId)
+        self.assertTrue(a2.isId)
+        self.assertTrue(not a3.isId)
+        self.assertIs(doc.getElementById("v"), None)
         # renaming an attribute should not affect its ID-ness:
         doc.renameNode(a2, xml.dom.EMPTY_NAMESPACE, "an")
         self.confirm(e.isSameNode(doc.getElementById("w"))
@@ -1663,7 +1663,7 @@ class MinidomTest(unittest.TestCase):
         doc = parseString("<element xmlns=''>\n"
                           "<foo/>\n</element>")
         doc2 = parseString(doc.toxml())
-        self.confirm(doc2.namespaceURI == xml.dom.EMPTY_NAMESPACE)
+        self.assertEqual(doc2.namespaceURI, xml.dom.EMPTY_NAMESPACE)
 
     def testExceptionOnSpacesInXMLNSValue(self):
         with self.assertRaises((ValueError, ExpatError)):
@@ -1679,7 +1679,7 @@ class MinidomTest(unittest.TestCase):
         num_children_before = len(doc.childNodes)
         doc.removeChild(doc.childNodes[0])
         num_children_after = len(doc.childNodes)
-        self.assertTrue(num_children_after == num_children_before - 1)
+        self.assertEqual(num_children_after, num_children_before - 1)
 
     def testProcessingInstructionNameError(self):
         # wrong variable in .nodeValue property will

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -102,32 +102,32 @@ class MinidomTest(unittest.TestCase):
         elem = root.childNodes[0]
         nelem = dom.createElement("element")
         root.insertBefore(nelem, elem)
-        self.confirm(len(root.childNodes), 2
-                and root.childNodes.length, 2
+        self.confirm(len(root.childNodes) == 2
+                and root.childNodes.length == 2
                 and root.childNodes[0] is nelem
                 and root.childNodes.item(0) is nelem
                 and root.childNodes[1] is elem
                 and root.childNodes.item(1) is elem
                 and root.firstChild is nelem
                 and root.lastChild is elem
-                and root.toxml(), "<doc><element/><foo/></doc>"
+                and root.toxml() == "<doc><element/><foo/></doc>"
                 , "testInsertBefore -- node properly placed in tree")
         nelem = dom.createElement("element")
         root.insertBefore(nelem, None)
-        self.confirm(len(root.childNodes), 3
-                and root.childNodes.length, 3
+        self.confirm(len(root.childNodes) == 3
+                and root.childNodes.length == 3
                 and root.childNodes[1] is elem
                 and root.childNodes.item(1) is elem
                 and root.childNodes[2] is nelem
                 and root.childNodes.item(2) is nelem
                 and root.lastChild is nelem
                 and nelem.previousSibling is elem
-                and root.toxml(), "<doc><element/><foo/><element/></doc>"
+                and root.toxml() == "<doc><element/><foo/><element/></doc>"
                 , "testInsertBefore -- node properly placed in tree")
         nelem2 = dom.createElement("bar")
         root.insertBefore(nelem2, nelem)
-        self.confirm(len(root.childNodes), 4
-                and root.childNodes.length, 4
+        self.confirm(len(root.childNodes) == 4
+                and root.childNodes.length == 4
                 and root.childNodes[2] is nelem2
                 and root.childNodes.item(2) is nelem2
                 and root.childNodes[3] is nelem
@@ -643,7 +643,7 @@ class MinidomTest(unittest.TestCase):
         attrs = e.attributes
         a1 = e.getAttributeNode("a")
         a2 = attrs.removeNamedItem("a")
-        self.assertEqual(a1.isSameNode(a2))
+        self.assertTrue(a1.isSameNode(a2))
         self.assertRaises(xml.dom.NotFoundErr, attrs.removeNamedItem, "a")
 
     def testRemoveNamedItemNS(self):
@@ -764,7 +764,7 @@ class MinidomTest(unittest.TestCase):
                 "testCloneDocumentDeep: wrong number of Document children")
         self.assertEqual(doc2.documentElement.nodeType, Node.ELEMENT_NODE,
                 "testCloneDocumentDeep: documentElement not an ELEMENT_NODE")
-        self.assertEqual(doc2.documentElement.ownerDocument.isSameNode(doc2),
+        self.assertTrue(doc2.documentElement.ownerDocument.isSameNode(doc2),
             "testCloneDocumentDeep: documentElement owner is not new document")
         self.assertTrue(not doc.documentElement.isSameNode(doc2.documentElement),
                 "testCloneDocumentDeep: documentElement should not be shared")
@@ -867,10 +867,10 @@ class MinidomTest(unittest.TestCase):
         self.assertTrue(not attr.isSameNode(clone))
         self.assertIs(clone.ownerElement, None,
                 testName + ": ownerElement should be None")
-        self.assertEqual(clone.ownerDocument.isSameNode(attr.ownerDocument),
+        self.confirm(clone.ownerDocument.isSameNode(attr.ownerDocument),
                 testName + ": ownerDocument does not match")
-        self.assertEqual(clone.specified,
-                testName + ": cloned attribute must have specified, True")
+        self.confirm(clone.specified,
+                testName + ": cloned attribute must have specified == True")
 
     def testCloneAttributeShallow(self):
         self.check_clone_attribute(0, "testCloneAttributeShallow")
@@ -1142,7 +1142,7 @@ class MinidomTest(unittest.TestCase):
         node = doc.documentElement
         node.childNodes[1].nodeValue = ""
         node.normalize()
-        self.assertIS(node.childNodes[-1].nextSibling, None,
+        self.assertIs(node.childNodes[-1].nextSibling, None,
                      "Final child's .nextSibling should be None")
 
     def testSiblings(self):

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -281,7 +281,7 @@ class MinidomTest(unittest.TestCase):
         child = dom.appendChild(dom.createElement("abc"))
 
         child.setAttribute("def", "ghi")
-        self.assertEqual(child.getAttribute("def"),"ghi")
+        self.assertEqual(child.getAttribute("def"), "ghi")
         self.assertEqual(child.attributes["def"].value, "ghi")
 
         child.setAttribute("jkl", "mno")
@@ -342,7 +342,7 @@ class MinidomTest(unittest.TestCase):
         self.assertRaises(xml.dom.NotFoundErr, child.removeAttributeNode,
             None)
         self.assertIs(node, child.removeAttributeNode(node))
-        self.assertEqual(len(child.attributes), 0
+        self.confirm(len(child.attributes) == 0
                 and child.getAttributeNode("spam") is None)
         dom2 = Document()
         child2 = dom2.appendChild(dom2.createElement("foo"))
@@ -695,7 +695,8 @@ class MinidomTest(unittest.TestCase):
         keys2 = list(attrs2.keys())
         keys1.sort()
         keys2.sort()
-        self.assertEqual(keys1, keys2, "clone of element has same attribute keys")
+        self.assertEqual(keys1, keys2,
+                    "clone of element has same attribute keys")
         for i in range(len(keys1)):
             a1 = attrs1.item(i)
             a2 = attrs2.item(i)
@@ -746,7 +747,7 @@ class MinidomTest(unittest.TestCase):
                     "]>\n"
                     "<doc attr='value'/>")
         doc2 = doc.cloneNode(0)
-        self.assertIs(doc2, None,
+        self.assertIsNone(doc2,
                 "testCloneDocumentShallow:"
                 " shallow cloning of documents makes no sense!")
 
@@ -812,7 +813,7 @@ class MinidomTest(unittest.TestCase):
     def testCloneDocumentTypeDeepNotOk(self):
         doc = create_doc_with_doctype()
         clone = doc.doctype.cloneNode(1)
-        self.assertIs(clone, None, "testCloneDocumentTypeDeepNotOk")
+        self.assertIsNone(clone, "testCloneDocumentTypeDeepNotOk")
 
     def testCloneDocumentTypeShallowOk(self):
         doctype = create_nonempty_doctype()
@@ -831,7 +832,7 @@ class MinidomTest(unittest.TestCase):
     def testCloneDocumentTypeShallowNotOk(self):
         doc = create_doc_with_doctype()
         clone = doc.doctype.cloneNode(0)
-        self.assertIs(clone, None, "testCloneDocumentTypeShallowNotOk")
+        self.assertIsNone(clone)
 
     def check_import_document(self, deep, testName):
         doc1 = parseString("<doc/>")
@@ -861,11 +862,11 @@ class MinidomTest(unittest.TestCase):
     def check_clone_attribute(self, deep, testName):
         doc = parseString("<doc attr='value'/>")
         attr = doc.documentElement.getAttributeNode("attr")
-        self.assertNotEqual(attr, None)
+        self.assertIsNotNone(attr)
         clone = attr.cloneNode(deep)
         self.assertFalse(clone.isSameNode(attr))
         self.assertFalse(attr.isSameNode(clone))
-        self.assertIs(clone.ownerElement, None,
+        self.assertIsNone(clone.ownerElement,
                 testName + ": ownerElement should be None")
         self.confirm(clone.ownerDocument.isSameNode(attr.ownerDocument),
                 testName + ": ownerDocument does not match")
@@ -1142,7 +1143,7 @@ class MinidomTest(unittest.TestCase):
         node = doc.documentElement
         node.childNodes[1].nodeValue = ""
         node.normalize()
-        self.assertIs(node.childNodes[-1].nextSibling, None,
+        self.assertIsNone(node.childNodes[-1].nextSibling,
                      "Final child's .nextSibling should be None")
 
     def testSiblings(self):
@@ -1235,15 +1236,15 @@ class MinidomTest(unittest.TestCase):
     def testUserData(self):
         dom = Document()
         n = dom.createElement('e')
-        self.assertIs(n.getUserData("foo"), None)
+        self.assertIsNone(n.getUserData("foo"))
         n.setUserData("foo", None, None)
-        self.assertIs(n.getUserData("foo"), None)
+        self.assertIsNone(n.getUserData("foo"))
         n.setUserData("foo", 12, 12)
         n.setUserData("bar", 13, 13)
         self.assertEqual(n.getUserData("foo"), 12)
         self.assertEqual(n.getUserData("bar"), 13)
         n.setUserData("foo", None, None)
-        self.assertIs(n.getUserData("foo"), None)
+        self.assertIsNone(n.getUserData("foo"))
         self.assertEqual(n.getUserData("bar"), 13)
 
         handler = self.UserDataHandler()
@@ -1562,7 +1563,7 @@ class MinidomTest(unittest.TestCase):
         self.assertFalse(a1.isId)
         self.assertTrue(a2.isId)
         self.assertFalse(a3.isId)
-        self.assertIs(doc.getElementById("v"), None)
+        self.assertIsNone(doc.getElementById("v"))
         # renaming an attribute should not affect its ID-ness:
         doc.renameNode(a2, xml.dom.EMPTY_NAMESPACE, "an")
         self.confirm(e.isSameNode(doc.getElementById("w"))
@@ -1598,7 +1599,7 @@ class MinidomTest(unittest.TestCase):
         self.assertFalse(a1.isId)
         self.assertTrue(a2.isId)
         self.assertFalse(a3.isId)
-        self.assertIs(doc.getElementById("v"), None)
+        self.assertIsNone(doc.getElementById("v"))
         # renaming an attribute should not affect its ID-ness:
         doc.renameNode(a2, xml.dom.EMPTY_NAMESPACE, "an")
         self.confirm(e.isSameNode(doc.getElementById("w"))


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Replaces all single line asserts, all the old confirms that have multiple lines will be in another pr as the diff is harder to view.

Once raised in https://github.com/python/cpython/issues/63882#issuecomment-1093635369:

> In fact, having looked at the test module in a bit more detail, it's in pretty sore need of an overall modernization. 

And also a few times in https://github.com/python/cpython/pull/132879

Request: @picnixz , @hugovk , @zware 

<!-- gh-issue-number: gh-63882 -->
* Issue: gh-63882
<!-- /gh-issue-number -->
