### PR TITLE
gh-131798: JIT: Propagate the result in `_BINARY_OP_SUBSCR_TUPLE_INT`

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1923,6 +1923,23 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertNotIn("_GUARD_TOS_INT", uops)
         self.assertIn("_CALL_LEN", uops)
 
+    def test_binary_op_subscr_tuple_int(self):
+        def testfunc(n):
+            x = 0
+            for _ in range(n):
+                y = (1, 2)
+                if y[0] == 1:  # _COMPARE_OP_INT + _GUARD_IS_TRUE_POP are removed
+                    x += 1
+            return x
+
+        res, ex = self._run_with_optimizer(testfunc, TIER2_THRESHOLD)
+        self.assertEqual(res, TIER2_THRESHOLD)
+        self.assertIsNotNone(ex)
+        uops = get_opnames(ex)
+        self.assertIn("_BINARY_OP_SUBSCR_TUPLE_INT", uops)
+        self.assertNotIn("_COMPARE_OP_INT", uops)
+        self.assertNotIn("_GUARD_IS_TRUE_POP", uops)
+
 
 def global_identity(x):
     return x

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-04-26-13-57-13.gh-issue-131798.Gt8CGE.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-04-26-13-57-13.gh-issue-131798.Gt8CGE.rst
@@ -1,0 +1,2 @@
+Propagate the return type of ``_BINARY_OP_SUBSCR_TUPLE_INT`` in JIT. Patch
+by Tomas Roun

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -376,8 +376,15 @@ dummy_func(void) {
             assert(PyLong_CheckExact(sym_get_const(ctx, right)));
             long index = PyLong_AsLong(sym_get_const(ctx, right));
             assert(index >= 0);
-            assert(index < sym_tuple_length(left));
-            res = sym_tuple_getitem(ctx, left, index);
+            int tuple_length = sym_tuple_length(left);
+            if (tuple_length == -1) {
+                // Unknown length
+                res = sym_new_not_null(ctx);
+            }
+            else {
+                assert(index < tuple_length);
+                res = sym_tuple_getitem(ctx, left, index);
+            }
         }
         else {
             res = sym_new_not_null(ctx);

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -370,6 +370,20 @@ dummy_func(void) {
         res = sym_new_type(ctx, &PyUnicode_Type);
     }
 
+    op(_BINARY_OP_SUBSCR_TUPLE_INT, (left, right -- res)) {
+        assert(sym_matches_type(left, &PyTuple_Type));
+        if (sym_is_const(ctx, right)) {
+            assert(PyLong_CheckExact(sym_get_const(ctx, right)));
+            long index = PyLong_AsLong(sym_get_const(ctx, right));
+            assert(index >= 0);
+            assert(index < sym_tuple_length(left));
+            res = sym_tuple_getitem(ctx, left, index);
+        }
+        else {
+            res = sym_new_not_null(ctx);
+        }
+    }
+
     op(_TO_BOOL, (value -- res)) {
         int already_bool = optimize_to_bool(this_instr, ctx, value, &res);
         if (!already_bool) {

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -370,20 +370,20 @@ dummy_func(void) {
         res = sym_new_type(ctx, &PyUnicode_Type);
     }
 
-    op(_BINARY_OP_SUBSCR_TUPLE_INT, (left, right -- res)) {
-        assert(sym_matches_type(left, &PyTuple_Type));
-        if (sym_is_const(ctx, right)) {
-            assert(PyLong_CheckExact(sym_get_const(ctx, right)));
-            long index = PyLong_AsLong(sym_get_const(ctx, right));
+    op(_BINARY_OP_SUBSCR_TUPLE_INT, (tuple_st, sub_st -- res)) {
+        assert(sym_matches_type(tuple_st, &PyTuple_Type));
+        if (sym_is_const(ctx, sub_st)) {
+            assert(PyLong_CheckExact(sym_get_const(ctx, sub_st)));
+            long index = PyLong_AsLong(sym_get_const(ctx, sub_st));
             assert(index >= 0);
-            int tuple_length = sym_tuple_length(left);
+            int tuple_length = sym_tuple_length(tuple_st);
             if (tuple_length == -1) {
                 // Unknown length
                 res = sym_new_not_null(ctx);
             }
             else {
                 assert(index < tuple_length);
-                res = sym_tuple_getitem(ctx, left, index);
+                res = sym_tuple_getitem(ctx, tuple_st, index);
             }
         }
         else {

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -627,8 +627,14 @@
                 assert(PyLong_CheckExact(sym_get_const(ctx, right)));
                 long index = PyLong_AsLong(sym_get_const(ctx, right));
                 assert(index >= 0);
-                assert(index < sym_tuple_length(left));
-                res = sym_tuple_getitem(ctx, left, index);
+                int tuple_length = sym_tuple_length(left);
+                if (tuple_length == -1) {
+                    res = sym_new_not_null(ctx);
+                }
+                else {
+                    assert(index < tuple_length);
+                    res = sym_tuple_getitem(ctx, left, index);
+                }
             }
             else {
                 res = sym_new_not_null(ctx);

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -617,23 +617,23 @@
         }
 
         case _BINARY_OP_SUBSCR_TUPLE_INT: {
-            JitOptSymbol *right;
-            JitOptSymbol *left;
+            JitOptSymbol *sub_st;
+            JitOptSymbol *tuple_st;
             JitOptSymbol *res;
-            right = stack_pointer[-1];
-            left = stack_pointer[-2];
-            assert(sym_matches_type(left, &PyTuple_Type));
-            if (sym_is_const(ctx, right)) {
-                assert(PyLong_CheckExact(sym_get_const(ctx, right)));
-                long index = PyLong_AsLong(sym_get_const(ctx, right));
+            sub_st = stack_pointer[-1];
+            tuple_st = stack_pointer[-2];
+            assert(sym_matches_type(tuple_st, &PyTuple_Type));
+            if (sym_is_const(ctx, sub_st)) {
+                assert(PyLong_CheckExact(sym_get_const(ctx, sub_st)));
+                long index = PyLong_AsLong(sym_get_const(ctx, sub_st));
                 assert(index >= 0);
-                int tuple_length = sym_tuple_length(left);
+                int tuple_length = sym_tuple_length(tuple_st);
                 if (tuple_length == -1) {
                     res = sym_new_not_null(ctx);
                 }
                 else {
                     assert(index < tuple_length);
-                    res = sym_tuple_getitem(ctx, left, index);
+                    res = sym_tuple_getitem(ctx, tuple_st, index);
                 }
             }
             else {

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -617,8 +617,22 @@
         }
 
         case _BINARY_OP_SUBSCR_TUPLE_INT: {
+            JitOptSymbol *right;
+            JitOptSymbol *left;
             JitOptSymbol *res;
-            res = sym_new_not_null(ctx);
+            right = stack_pointer[-1];
+            left = stack_pointer[-2];
+            assert(sym_matches_type(left, &PyTuple_Type));
+            if (sym_is_const(ctx, right)) {
+                assert(PyLong_CheckExact(sym_get_const(ctx, right)));
+                long index = PyLong_AsLong(sym_get_const(ctx, right));
+                assert(index >= 0);
+                assert(index < sym_tuple_length(left));
+                res = sym_tuple_getitem(ctx, left, index);
+            }
+            else {
+                res = sym_new_not_null(ctx);
+            }
             stack_pointer[-2] = res;
             stack_pointer += -1;
             assert(WITHIN_STACK_BOUNDS());


### PR DESCRIPTION
More context: https://github.com/python/cpython/pull/132851#discussion_r2059146672

This propagates the information about tuple elements after `_BINARY_OP_SUBSCR_TUPLE_INT` when the RHS is a constant.
For example in
```python
foo = (1, 2)
x = foo[0]  # _BINARY_OP_SUBSCR_TUPLE_INT
```
we can now deduce that `x` is `1`.

<!-- gh-issue-number: gh-131798 -->
* Issue: gh-131798
<!-- /gh-issue-number -->
