### PR TITLE
[3.13] Revert "[3.13] gh-132921: Fix setuptools._distutils.dep_util deprecation (GH-132923) (#132926)"

### DIFF
--- a/Tools/peg_generator/pegen/build.py
+++ b/Tools/peg_generator/pegen/build.py
@@ -95,7 +95,7 @@ def compile_c_extension(
     import setuptools.logging
 
     from setuptools import Extension, Distribution
-    from setuptools.modified import newer_group
+    from setuptools._distutils.dep_util import newer_group
     from setuptools._distutils.ccompiler import new_compiler
     from setuptools._distutils.sysconfig import customize_compiler
 


### PR DESCRIPTION
This reverts commit 3776ade2e86010d638c538c5d3f225887d714478.

setuptools.modified module is not available on old setuptools versions.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-132921 -->
* Issue: gh-132921
<!-- /gh-issue-number -->
