### PR TITLE
gh-132388: remove outdated TODO comment in `test_hmac.py`

### DIFF
--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -980,8 +980,6 @@ class OpenSSLConstructorTestCase(ThroughOpenSSLAPIMixin,
         return _hashlib.UnsupportedDigestmodError
 
     def test_hmac_digest_digestmod_parameter(self):
-        # TODO(picnixz): remove default arguments in _hashlib.hmac_digest()
-        # since the return value is not a HMAC object but a bytes object.
         for value in [object, 'unknown', 1234, None]:
             with (
                 self.subTest(value=value),


### PR DESCRIPTION
I don't remember why I put it but I know that it's now outdated. Proof:

```c
/*[clinic input]
_hashlib.hmac_digest as _hashlib_hmac_singleshot

    key: Py_buffer
    msg: Py_buffer
    digest: object

Single-shot HMAC.
[clinic start generated code]*/
```

<!-- gh-issue-number: gh-132388 -->
* Issue: gh-132388
<!-- /gh-issue-number -->
