### PR TITLE
gh-124703: Set return code to 1 when aborting process from pdb

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1834,7 +1834,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                     reply = 'y'
                     self.message('')
                 if reply == 'y' or reply == '':
-                    sys.exit(0)
+                    sys.exit(1)
                 elif reply.lower() == 'n':
                     return
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4453,7 +4453,7 @@ class PdbTestInline(unittest.TestCase):
             y
         """
 
-        stdout, stderr = self._run_script(script, commands)
+        stdout, stderr = self._run_script(script, commands, expected_returncode=1)
         self.assertIn("2", stdout)
         self.assertIn("Quit anyway", stdout)
         # Closing stdin will quit the debugger anyway so we need to confirm
@@ -4483,7 +4483,7 @@ class PdbTestInline(unittest.TestCase):
             y
         """
 
-        stdout, stderr = self._run_script(script, commands)
+        stdout, stderr = self._run_script(script, commands, expected_returncode=1)
         # Normal exit should not print anything to stderr
         self.assertEqual(stderr, "")
         # The quit prompt should be printed exactly once

--- a/Misc/NEWS.d/next/Library/2025-04-26-15-43-23.gh-issue-124703.jc5auS.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-26-15-43-23.gh-issue-124703.jc5auS.rst
@@ -1,0 +1,1 @@
+Set return code to ``1`` when aborting process from :mod:`pdb`.


### PR DESCRIPTION
As https://github.com/python/cpython/issues/124703#issuecomment-2832307498 mentioned, it's probably better to set the return code to something other than `0` when we abort the process from pdb. Logically it makes more sense, and the behavior is closer to what was before.

<!-- gh-issue-number: gh-124703 -->
* Issue: gh-124703
<!-- /gh-issue-number -->
