### PR TITLE
gh-133016: Fix a reference to removed `asyncio.futures.TimeoutError`

### DIFF
--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -28,7 +28,6 @@ except ImportError:  # pragma: no cover
 from asyncio import base_events
 from asyncio import events
 from asyncio import format_helpers
-from asyncio import futures
 from asyncio import tasks
 from asyncio.log import logger
 from test import support

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -104,7 +104,7 @@ def run_until(loop, pred, timeout=support.SHORT_TIMEOUT):
         loop.run_until_complete(tasks.sleep(delay))
         delay = max(delay * 2, 1.0)
     else:
-        raise futures.TimeoutError()
+        raise TimeoutError()
 
 
 def run_once(loop):

--- a/Misc/NEWS.d/next/Tests/2025-04-26-17-31-23.gh-issue-133016.YqvYed.rst
+++ b/Misc/NEWS.d/next/Tests/2025-04-26-17-31-23.gh-issue-133016.YqvYed.rst
@@ -1,0 +1,1 @@
+A reference to the removed ``asyncio.futures.TimeoutError`` is removed and replaced with just ``TimeoutError``.

--- a/Misc/NEWS.d/next/Tests/2025-04-26-17-31-23.gh-issue-133016.YqvYed.rst
+++ b/Misc/NEWS.d/next/Tests/2025-04-26-17-31-23.gh-issue-133016.YqvYed.rst
@@ -1,1 +1,0 @@
-A reference to the removed ``asyncio.futures.TimeoutError`` is removed and replaced with just ``TimeoutError``.


### PR DESCRIPTION
``asyncio.futures.TimeoutError`` no longer exists, so we use the builtin TimeoutError instead.

<!-- gh-issue-number: gh-133016 -->
* Issue: gh-133016
<!-- /gh-issue-number -->
