### PR TITLE
gh-131878: Fix input of unicode characters with two or more code points in the REPL on Windows in vt mode

### DIFF
--- a/Lib/_pyrepl/base_eventqueue.py
+++ b/Lib/_pyrepl/base_eventqueue.py
@@ -69,13 +69,13 @@ class BaseEventQueue:
         trace('added event {event}', event=event)
         self.events.append(event)
 
-    def push(self, char: int | bytes) -> None:
+    def push(self, char: bytes) -> None:
         """
         Processes a character by updating the buffer and handling special key mappings.
         """
-        ord_char = char if isinstance(char, int) else ord(char)
-        char = bytes(bytearray((ord_char,)))
-        self.buf.append(ord_char)
+        assert isinstance(char, bytes)
+        assert len(char) == 1
+        self.buf.extend(char)
         if char in self.keymap:
             if self.keymap is self.compiled_keymap:
                 # sanity check, buffer is empty when a special key comes

--- a/Lib/_pyrepl/base_eventqueue.py
+++ b/Lib/_pyrepl/base_eventqueue.py
@@ -69,19 +69,13 @@ class BaseEventQueue:
         trace('added event {event}', event=event)
         self.events.append(event)
 
-    def push(self, char: int | bytes | str) -> None:
+    def push(self, char: int | bytes) -> None:
         """
         Processes a character by updating the buffer and handling special key mappings.
         """
         ord_char = char if isinstance(char, int) else ord(char)
-        if ord_char > 255:
-            assert isinstance(char, str)
-            char = bytes(char.encode(self.encoding, "replace"))
-            self.buf.extend(char)
-        else:
-            char = bytes(bytearray((ord_char,)))
-            self.buf.append(ord_char)
-
+        char = bytes(bytearray((ord_char,)))
+        self.buf.append(ord_char)
         if char in self.keymap:
             if self.keymap is self.compiled_keymap:
                 # sanity check, buffer is empty when a special key comes

--- a/Lib/_pyrepl/base_eventqueue.py
+++ b/Lib/_pyrepl/base_eventqueue.py
@@ -96,7 +96,7 @@ class BaseEventQueue:
             self.keymap = self.compiled_keymap
             self.insert(Event('key', '\033', bytearray(b'\033')))
             for _c in self.flush_buf()[1:]:
-                self.push(_c)
+                self.push(_c.to_bytes())
 
         else:
             try:

--- a/Lib/_pyrepl/console.py
+++ b/Lib/_pyrepl/console.py
@@ -99,13 +99,6 @@ class Console(ABC):
         ...
 
     @abstractmethod
-    def push_char(self, char: int | bytes) -> None:
-        """
-        Push a character to the console event queue.
-        """
-        ...
-
-    @abstractmethod
     def beep(self) -> None: ...
 
     @abstractmethod

--- a/Lib/_pyrepl/reader.py
+++ b/Lib/_pyrepl/reader.py
@@ -733,10 +733,6 @@ class Reader:
             self.do_cmd(cmd)
             return True
 
-    def push_char(self, char: int | bytes) -> None:
-        self.console.push_char(char)
-        self.handle1(block=False)
-
     def readline(self, startup_hook: Callback | None = None) -> str:
         """Read a line.  The implementation of this method also shows
         how to drive Reader if you want more control over the event

--- a/Lib/_pyrepl/unix_console.py
+++ b/Lib/_pyrepl/unix_console.py
@@ -380,7 +380,7 @@ class UnixConsole(Console):
             signal.signal(signal.SIGWINCH, self.old_sigwinch)
             del self.old_sigwinch
 
-    def push_char(self, char: int | bytes) -> None:
+    def push_char(self, char: bytes) -> None:
         """
         Push a character to the console event queue.
         """

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -468,7 +468,9 @@ class WindowsConsole(Console):
                 return None
             elif self.__vt_support:
                 # If virtual terminal is enabled, scanning VT sequences
-                self.event_queue.push(rec.Event.KeyEvent.uChar.UnicodeChar)
+                for char in raw_key.encode(self.event_queue.encoding,
+                                           "replace"):
+                    self.event_queue.push(char.to_bytes())
                 continue
 
             if key_event.dwControlKeyState & ALT_ACTIVE:

--- a/Lib/_pyrepl/windows_console.py
+++ b/Lib/_pyrepl/windows_console.py
@@ -481,12 +481,6 @@ class WindowsConsole(Console):
             return Event(evt="key", data=key, raw=raw_key)
         return self.event_queue.get()
 
-    def push_char(self, char: int | bytes) -> None:
-        """
-        Push a character to the console event queue.
-        """
-        raise NotImplementedError("push_char not supported on Windows")
-
     def beep(self) -> None:
         self.__write("\x07")
 

--- a/Lib/test/test_pyrepl/support.py
+++ b/Lib/test/test_pyrepl/support.py
@@ -149,9 +149,6 @@ class FakeConsole(Console):
     def set_cursor_vis(self, visible: bool) -> None:
         pass
 
-    def push_char(self, char: int | bytes) -> None:
-        pass
-
     def beep(self) -> None:
         pass
 

--- a/Lib/test/test_pyrepl/test_eventqueue.py
+++ b/Lib/test/test_pyrepl/test_eventqueue.py
@@ -122,13 +122,6 @@ class EventQueueTestBase:
         self.assertEqual(eq.events[2].evt, "key")
         self.assertEqual(eq.events[2].data, "Z")
 
-    def test_push_unicode_character(self):
-        eq = self.make_eventqueue()
-        eq.keymap = {}
-        eq.push("ч")
-        self.assertEqual(eq.events[0].evt, "key")
-        self.assertEqual(eq.events[0].data, "ч")
-
 
 @unittest.skipIf(support.MS_WINDOWS, "No Unix event queue on Windows")
 class TestUnixEventQueue(EventQueueTestBase, unittest.TestCase):

--- a/Lib/test/test_pyrepl/test_eventqueue.py
+++ b/Lib/test/test_pyrepl/test_eventqueue.py
@@ -53,7 +53,7 @@ class EventQueueTestBase:
         mock_keymap.compile_keymap.return_value = {"a": "b"}
         eq = self.make_eventqueue()
         eq.keymap = {b"a": "b"}
-        eq.push("a")
+        eq.push(b"a")
         mock_keymap.compile_keymap.assert_called()
         self.assertEqual(eq.events[0].evt, "key")
         self.assertEqual(eq.events[0].data, "b")
@@ -63,7 +63,7 @@ class EventQueueTestBase:
         mock_keymap.compile_keymap.return_value = {"a": "b"}
         eq = self.make_eventqueue()
         eq.keymap = {b"c": "d"}
-        eq.push("a")
+        eq.push(b"a")
         mock_keymap.compile_keymap.assert_called()
         self.assertEqual(eq.events[0].evt, "key")
         self.assertEqual(eq.events[0].data, "a")
@@ -73,13 +73,13 @@ class EventQueueTestBase:
         mock_keymap.compile_keymap.return_value = {"a": "b"}
         eq = self.make_eventqueue()
         eq.keymap = {b"a": {b"b": "c"}}
-        eq.push("a")
+        eq.push(b"a")
         mock_keymap.compile_keymap.assert_called()
         self.assertTrue(eq.empty())
-        eq.push("b")
+        eq.push(b"b")
         self.assertEqual(eq.events[0].evt, "key")
         self.assertEqual(eq.events[0].data, "c")
-        eq.push("d")
+        eq.push(b"d")
         self.assertEqual(eq.events[1].evt, "key")
         self.assertEqual(eq.events[1].data, "d")
 
@@ -88,32 +88,32 @@ class EventQueueTestBase:
         mock_keymap.compile_keymap.return_value = {"a": "b"}
         eq = self.make_eventqueue()
         eq.keymap = {b"a": {b"b": "c"}}
-        eq.push("a")
+        eq.push(b"a")
         mock_keymap.compile_keymap.assert_called()
         self.assertTrue(eq.empty())
         eq.flush_buf()
-        eq.push("\033")
+        eq.push(b"\033")
         self.assertEqual(eq.events[0].evt, "key")
         self.assertEqual(eq.events[0].data, "\033")
-        eq.push("b")
+        eq.push(b"b")
         self.assertEqual(eq.events[1].evt, "key")
         self.assertEqual(eq.events[1].data, "b")
 
     def test_push_special_key(self):
         eq = self.make_eventqueue()
         eq.keymap = {}
-        eq.push("\x1b")
-        eq.push("[")
-        eq.push("A")
+        eq.push(b"\x1b")
+        eq.push(b"[")
+        eq.push(b"A")
         self.assertEqual(eq.events[0].evt, "key")
         self.assertEqual(eq.events[0].data, "\x1b")
 
     def test_push_unrecognized_escape_sequence(self):
         eq = self.make_eventqueue()
         eq.keymap = {}
-        eq.push("\x1b")
-        eq.push("[")
-        eq.push("Z")
+        eq.push(b"\x1b")
+        eq.push(b"[")
+        eq.push(b"Z")
         self.assertEqual(len(eq.events), 3)
         self.assertEqual(eq.events[0].evt, "key")
         self.assertEqual(eq.events[0].data, "\x1b")

--- a/Lib/test/test_pyrepl/test_eventqueue.py
+++ b/Lib/test/test_pyrepl/test_eventqueue.py
@@ -122,6 +122,20 @@ class EventQueueTestBase:
         self.assertEqual(eq.events[2].evt, "key")
         self.assertEqual(eq.events[2].data, "Z")
 
+    def test_push_unicode_character_two_bytes(self):
+        eq = self.make_eventqueue()
+        eq.keymap = {}
+
+        encoded_bytes = "ч".encode(eq.encoding, "replace")
+        self.assertEqual(len(encoded_bytes), 2)
+        eq.push(encoded_bytes[0].to_bytes())
+        self.assertEqual(eq.get(), None)
+
+        eq.push(encoded_bytes[1].to_bytes())
+        e = eq.get()
+        self.assertEqual(e.evt, "key")
+        self.assertEqual(e.data, "ч")
+
 
 @unittest.skipIf(support.MS_WINDOWS, "No Unix event queue on Windows")
 class TestUnixEventQueue(EventQueueTestBase, unittest.TestCase):


### PR DESCRIPTION
https://github.com/python/cpython/pull/133030/commits/ab8efa72d5dc5fe5ecf587da0f1bec5b49e68eeb is the fix on top of the reverted https://github.com/python/cpython/pull/130805.

https://github.com/python/cpython/pull/133030/commits/49078f3114308f3a8b0fd6ecf03c8616a71b1b06 shows how I'd like to only accept bytes of length=1 in `BaseEventQueue.push()`.

Only the tests used the `int` code path somewhat non-transparent by using strings which got converted to due to `else ord(char)` to bytes of length=1 again:

```python
        ord_char = char if isinstance(char, int) else ord(char)
        char = bytes(bytearray((ord_char,)))
```

Maybe too much churn, thus just a draft.

<!-- gh-issue-number: gh-131878 -->
* Issue: gh-131878
<!-- /gh-issue-number -->
