### PR TITLE
silence system utils tests in emscripten python.sh

### DIFF
--- a/Tools/wasm/emscripten/__main__.py
+++ b/Tools/wasm/emscripten/__main__.py
@@ -248,10 +248,10 @@ def configure_emscripten_python(context, working_dir):
 
             # Macs come with FreeBSD coreutils which doesn't have the -s option
             # so feature detect and work around it.
-            if which grealpath > /dev/null; then
+            if which grealpath > /dev/null 2>&1; then
                 # It has brew installed gnu core utils, use that
                 REALPATH="grealpath -s"
-            elif which realpath > /dev/null && realpath --version > /dev/null 2> /dev/null && realpath --version | grep GNU > /dev/null; then
+            elif which realpath > /dev/null 2>&1 && realpath --version > /dev/null 2>&1 && realpath --version | grep GNU > /dev/null 2>&1; then
                 # realpath points to GNU realpath so use it.
                 REALPATH="realpath -s"
             else


### PR DESCRIPTION
When running the generated `python.sh` an a system without `grealpath` (like Linux), `which` prints to stderr and pollutes the console with an unnecessary error message:

```
which: no grealpath in (<$PATH>)
Python 3.14.0a7+ 
Type "help", "copyright", "credits" or "license" for more information.
>>> 
``` 
where `<$PATH>` is the system path which may span multiple lines.

This PR redirects all output to /dev/null, since we're only interested in the return code anyways.