### PR TITLE
gh-133046: Fix heading in `ast` module docstring

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -1,6 +1,6 @@
 """
     ast
-    ~~~
+    ---
 
     The `ast` module helps Python applications to process trees of the Python
     abstract syntax grammar.  The abstract syntax itself might change with


### PR DESCRIPTION
gh-133046: Fix ast module docstring markup for better rendering in VS Code

This PR updates the `ast` module docstring to use `---` instead of `~~~` for section headers. This change improves the docstring rendering in Visual Studio Code and similar tools, as discussed in issue #133046.

See: https://github.com/python/cpython/issues/133046