### PR TITLE
gh-132983: Install compression package contents

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2503,6 +2503,8 @@ maninstall:	altmaninstall
 XMLLIBSUBDIRS=  xml xml/dom xml/etree xml/parsers xml/sax
 LIBSUBDIRS=	asyncio \
 		collections \
+		compression compression/bz2 compression/gzip \
+		compression/lzma compression/zlib compression/_common \
 		concurrent concurrent/futures \
 		csv \
 		ctypes ctypes/macholib \


### PR DESCRIPTION
This fixes a buildbot failure for running tests on installed Python.

Changes in this PR:
- Add makefile installer configuration for the `compression.*` packages.

------

<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->
