### PR TITLE
gh-133073: avoid NULL + 0 arithmetic in `list_extend_*` functions

### DIFF
--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1315,9 +1315,15 @@ list_extend_set(PyListObject *self, PySetObject *other)
 {
     Py_ssize_t m = Py_SIZE(self);
     Py_ssize_t n = PySet_GET_SIZE(other);
-    if (list_resize(self, m + n) < 0) {
+    Py_ssize_t r = m + n;
+    if (r == 0) {
+        return 0;
+    }
+    if (list_resize(self, r) < 0) {
         return -1;
     }
+
+    assert(self->ob_item != NULL);
     /* populate the end of self with iterable's items */
     Py_ssize_t setpos = 0;
     Py_hash_t hash;
@@ -1327,7 +1333,7 @@ list_extend_set(PyListObject *self, PySetObject *other)
         FT_ATOMIC_STORE_PTR_RELEASE(*dest, key);
         dest++;
     }
-    Py_SET_SIZE(self, m + n);
+    Py_SET_SIZE(self, r);
     return 0;
 }
 
@@ -1337,10 +1343,15 @@ list_extend_dict(PyListObject *self, PyDictObject *dict, int which_item)
     // which_item: 0 for keys and 1 for values
     Py_ssize_t m = Py_SIZE(self);
     Py_ssize_t n = PyDict_GET_SIZE(dict);
-    if (list_resize(self, m + n) < 0) {
+    Py_ssize_t r = m + n;
+    if (r == 0) {
+        return 0;
+    }
+    if (list_resize(self, r) < 0) {
         return -1;
     }
 
+    assert(self->ob_item != NULL);
     PyObject **dest = self->ob_item + m;
     Py_ssize_t pos = 0;
     PyObject *keyvalue[2];
@@ -1351,7 +1362,7 @@ list_extend_dict(PyListObject *self, PyDictObject *dict, int which_item)
         dest++;
     }
 
-    Py_SET_SIZE(self, m + n);
+    Py_SET_SIZE(self, r);
     return 0;
 }
 
@@ -1360,10 +1371,15 @@ list_extend_dictitems(PyListObject *self, PyDictObject *dict)
 {
     Py_ssize_t m = Py_SIZE(self);
     Py_ssize_t n = PyDict_GET_SIZE(dict);
-    if (list_resize(self, m + n) < 0) {
+    Py_ssize_t r = m + n;
+    if (r == 0) {
+        return 0;
+    }
+    if (list_resize(self, r) < 0) {
         return -1;
     }
 
+    assert(self->ob_item != NULL);
     PyObject **dest = self->ob_item + m;
     Py_ssize_t pos = 0;
     Py_ssize_t i = 0;
@@ -1379,7 +1395,7 @@ list_extend_dictitems(PyListObject *self, PyDictObject *dict)
         i++;
     }
 
-    Py_SET_SIZE(self, m + n);
+    Py_SET_SIZE(self, r);
     return 0;
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133073 -->
* Issue: gh-133073
<!-- /gh-issue-number -->
