### PR TITLE
gh-133079: Remove Py_C_RECURSION_LIMIT & PyThreadState.c_recursion_remaining

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2256,3 +2256,10 @@ Removed
 * Remove the private ``_Py_InitializeMain()`` function. It was a
   :term:`provisional API` added to Python 3.8 by :pep:`587`.
   (Contributed by Victor Stinner in :gh:`129033`.)
+
+* The undocumented APIs :c:macro:`!Py_C_RECURSION_LIMIT` and
+  :c:member:`!PyThreadState.c_recursion_remaining`, added in 3.13, are removed
+  without a deprecation period.
+  Please use :c:func:`Py_EnterRecursiveCall` to guard against runaway recursion
+  in C code.
+  (Removed in :gh:`133079`, see also :gh:`130396`.)

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -120,8 +120,6 @@ struct _ts {
 
     int py_recursion_remaining;
     int py_recursion_limit;
-
-    int c_recursion_remaining; /* Retained for backwards compatibility. Do not use */
     int recursion_headroom; /* Allow 50 more calls to handle any errors. */
 
     /* 'tracing' keeps track of the execution depth when tracing/profiling.
@@ -211,8 +209,6 @@ struct _ts {
     PyObject *threading_local_sentinel;
     _PyRemoteDebuggerSupport remote_debugger_support;
 };
-
-# define Py_C_RECURSION_LIMIT 5000
 
 /* other API */
 

--- a/Misc/NEWS.d/next/C_API/2025-04-28-13-27-48.gh-issue-133079.DJL2sK.rst
+++ b/Misc/NEWS.d/next/C_API/2025-04-28-13-27-48.gh-issue-133079.DJL2sK.rst
@@ -1,0 +1,3 @@
+The undocumented APIs :c:macro:`!Py_C_RECURSION_LIMIT` and
+:c:member:`!PyThreadState.c_recursion_remaining`, added in 3.13, are removed
+without a deprecation period.

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1533,7 +1533,6 @@ init_threadstate(_PyThreadStateImpl *_tstate,
 
     tstate->py_recursion_limit = interp->ceval.recursion_limit;
     tstate->py_recursion_remaining = interp->ceval.recursion_limit;
-    tstate->c_recursion_remaining = 2;
     tstate->exc_info = &tstate->exc_state;
 
     // PyGILState_Release must not try to delete this thread state.

--- a/Python/vm-state.md
+++ b/Python/vm-state.md
@@ -73,7 +73,8 @@ It will be more complex in the JIT.
 
 Another important piece of VM state is the **thread state**, held in `tstate`.
 The current frame pointer, `frame`, is always equal to `tstate->current_frame`.
-The thread state also holds the exception state (`tstate->exc_info`) and the recursion counters (`tstate->c_recursion_remaining` and `tstate->py_recursion_remaining`).
+The thread state also holds the exception state (`tstate->exc_info`) and
+recursion tracking data (`tstate->py_recursion_remaining`, `tstate->c_stack*`).
 
 The thread state is also used to access the **interpreter state** (`tstate->interp`), which is important since the "eval breaker" flags are stored there (`tstate->interp->ceval.eval_breaker`, an "atomic" variable), as well as the "PEP 523 function" (`tstate->interp->eval_frame`).
 The interpreter state also holds the optimizer state (`optimizer` and some counters).


### PR DESCRIPTION
Both were added in 3.13, are undocumented, and don't make sense in 3.14 due to changes in the stack overflow detection machinery (gh-112282).

PEP 387 exception for skipping a deprecation period: https://github.com/python/steering-council/issues/288

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133079 -->
* Issue: gh-133079
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133080.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->