### PR TITLE
gh-127604: Optimize -ldl usage on platforms that use dlopen for libFFI.

### DIFF
--- a/configure
+++ b/configure
@@ -15350,7 +15350,17 @@ fi
 
     if test "x$ac_cv_lib_dl_dlopen" = xyes
 then :
-  as_fn_append LIBFFI_LIBS " -ldl"
+
+    if test "x$ac_cv_require_ldl" = xyes
+then :
+
+else case e in #(
+  e)
+      as_fn_append LIBFFI_LIBS " -ldl"
+     ;;
+esac
+fi
+
 fi
 
   save_CFLAGS=$CFLAGS

--- a/configure
+++ b/configure
@@ -2313,70 +2313,6 @@ fi
 
 } # ac_fn_c_try_run
 
-# ac_fn_c_check_func LINENO FUNC VAR
-# ----------------------------------
-# Tests whether FUNC exists, setting the cache variable VAR accordingly
-ac_fn_c_check_func ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
-printf %s "checking for $2... " >&6; }
-if eval test \${$3+y}
-then :
-  printf %s "(cached) " >&6
-else case e in #(
-  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-/* Define $2 to an innocuous variant, in case <limits.h> declares $2.
-   For example, HP-UX 11i <limits.h> declares gettimeofday.  */
-#define $2 innocuous_$2
-
-/* System header to define __stub macros and hopefully few prototypes,
-   which can conflict with char $2 (void); below.  */
-
-#include <limits.h>
-#undef $2
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char $2 (void);
-/* The GNU C library defines this for functions which it implements
-    to always fail with ENOSYS.  Some functions are actually named
-    something starting with __ and the normal name is an alias.  */
-#if defined __stub_$2 || defined __stub___$2
-choke me
-#endif
-
-int
-main (void)
-{
-return $2 ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  eval "$3=yes"
-else case e in #(
-  e) eval "$3=no" ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext ;;
-esac
-fi
-eval ac_res=\$$3
-	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-printf "%s\n" "$ac_res" >&6; }
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-
-} # ac_fn_c_check_func
-
 # ac_fn_c_check_type LINENO TYPE VAR INCLUDES
 # -------------------------------------------
 # Tests whether TYPE exists after having included INCLUDES, setting cache
@@ -2630,6 +2566,70 @@ rm -f conftest.val
   as_fn_set_status $ac_retval
 
 } # ac_fn_c_compute_int
+
+# ac_fn_c_check_func LINENO FUNC VAR
+# ----------------------------------
+# Tests whether FUNC exists, setting the cache variable VAR accordingly
+ac_fn_c_check_func ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+printf %s "checking for $2... " >&6; }
+if eval test \${$3+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+/* Define $2 to an innocuous variant, in case <limits.h> declares $2.
+   For example, HP-UX 11i <limits.h> declares gettimeofday.  */
+#define $2 innocuous_$2
+
+/* System header to define __stub macros and hopefully few prototypes,
+   which can conflict with char $2 (void); below.  */
+
+#include <limits.h>
+#undef $2
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char $2 (void);
+/* The GNU C library defines this for functions which it implements
+    to always fail with ENOSYS.  Some functions are actually named
+    something starting with __ and the normal name is an alias.  */
+#if defined __stub_$2 || defined __stub___$2
+choke me
+#endif
+
+int
+main (void)
+{
+return $2 ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  eval "$3=yes"
+else case e in #(
+  e) eval "$3=no" ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext ;;
+esac
+fi
+eval ac_res=\$$3
+	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+printf "%s\n" "$ac_res" >&6; }
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_func
 
 # ac_fn_check_decl LINENO SYMBOL VAR INCLUDES EXTRA-OPTIONS FLAG-VAR
 # ------------------------------------------------------------------
@@ -11877,43 +11877,6 @@ fi
 fi
 
 
-# for faulthandler
-       for ac_header in execinfo.h link.h dlfcn.h
-do :
-  as_ac_Header=`printf "%s\n" "ac_cv_header_$ac_header" | sed "$as_sed_sh"`
-ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
-if eval test \"x\$"$as_ac_Header"\" = x"yes"
-then :
-  cat >>confdefs.h <<_ACEOF
-#define `printf "%s\n" "HAVE_$ac_header" | sed "$as_sed_cpp"` 1
-_ACEOF
-
-
-  for ac_func in backtrace dladdr1
-do :
-  as_ac_var=`printf "%s\n" "ac_cv_func_$ac_func" | sed "$as_sed_sh"`
-ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
-if eval test \"x\$"$as_ac_var"\" = x"yes"
-then :
-  cat >>confdefs.h <<_ACEOF
-#define `printf "%s\n" "HAVE_$ac_func" | sed "$as_sed_cpp"` 1
-_ACEOF
-
-    # dladdr1 requires -ldl
-    ac_cv_require_ldl=yes
-
-fi
-
-done
-
-fi
-
-done
-if test "x$ac_cv_require_ldl" = xyes
-then :
-  as_fn_append LDFLAGS " -ldl"
-fi
-
 # bluetooth/bluetooth.h has been known to not compile with -std=c99.
 # http://permalink.gmane.org/gmane.linux.bluez.kernel/22294
 SAVE_CFLAGS=$CFLAGS
@@ -14014,6 +13977,54 @@ fi
     # Dynamic linking for HP-UX
 
 
+       for ac_header in execinfo.h link.h dlfcn.h
+do :
+  as_ac_Header=`printf "%s\n" "ac_cv_header_$ac_header" | sed "$as_sed_sh"`
+ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"
+then :
+  cat >>confdefs.h <<_ACEOF
+#define `printf "%s\n" "HAVE_$ac_header" | sed "$as_sed_cpp"` 1
+_ACEOF
+
+
+  for ac_func in backtrace dladdr1
+do :
+  as_ac_var=`printf "%s\n" "ac_cv_func_$ac_func" | sed "$as_sed_sh"`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"
+then :
+  cat >>confdefs.h <<_ACEOF
+#define `printf "%s\n" "HAVE_$ac_func" | sed "$as_sed_cpp"` 1
+_ACEOF
+
+    # dladdr1 requires -ldl
+    ac_cv_require_ldl=yes
+
+fi
+
+done
+
+fi
+
+done
+
+if test "x$ac_cv_require_ldl" = xyes
+then :
+
+  if test "x$ac_cv_lib_dl_dlopen" = xyes
+then :
+
+else case e in #(
+  e)
+    as_fn_append LDFLAGS " -ldl"
+   ;;
+esac
+fi
+
+fi
+
+
 
 
 
@@ -15350,17 +15361,7 @@ fi
 
     if test "x$ac_cv_lib_dl_dlopen" = xyes
 then :
-
-    if test "x$ac_cv_require_ldl" = xyes
-then :
-
-else case e in #(
-  e)
-      as_fn_append LIBFFI_LIBS " -ldl"
-     ;;
-esac
-fi
-
+  as_fn_append LIBFFI_LIBS " -ldl"
 fi
 
   save_CFLAGS=$CFLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -4045,7 +4045,11 @@ AS_VAR_IF([have_libffi], [yes], [
   AC_SUBST([MODULE__CTYPES_MALLOC_CLOSURE])
 
   dnl HAVE_LIBDL: for dlopen, see gh-76828
-  AS_VAR_IF([ac_cv_lib_dl_dlopen], [yes], [AS_VAR_APPEND([LIBFFI_LIBS], [" -ldl"])])
+  AS_VAR_IF([ac_cv_lib_dl_dlopen], [yes], [
+    AS_VAR_IF([ac_cv_require_ldl], [yes], [], [
+      AS_VAR_APPEND([LIBFFI_LIBS], [" -ldl"])
+    ])
+  ])
 
   WITH_SAVE_ENV([
     CFLAGS="$CFLAGS $LIBFFI_CFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -2985,15 +2985,6 @@ AC_CHECK_HEADERS([ \
 AC_HEADER_DIRENT
 AC_HEADER_MAJOR
 
-# for faulthandler
-AC_CHECK_HEADERS([execinfo.h link.h dlfcn.h], [
-  AC_CHECK_FUNCS([backtrace dladdr1], [
-    # dladdr1 requires -ldl
-    ac_cv_require_ldl=yes
-  ])
-])
-AS_VAR_IF([ac_cv_require_ldl], [yes], [AS_VAR_APPEND([LDFLAGS], [" -ldl"])])
-
 # bluetooth/bluetooth.h has been known to not compile with -std=c99.
 # http://permalink.gmane.org/gmane.linux.bluez.kernel/22294
 SAVE_CFLAGS=$CFLAGS
@@ -3715,6 +3706,22 @@ AC_CHECK_LIB([dl], [dlopen])       # Dynamic linking for SunOS/Solaris and SYSV
 AC_CHECK_LIB([dld], [shl_load])    # Dynamic linking for HP-UX
 
 
+dnl for faulthandler
+AC_CHECK_HEADERS([execinfo.h link.h dlfcn.h], [
+  AC_CHECK_FUNCS([backtrace dladdr1], [
+    # dladdr1 requires -ldl
+    ac_cv_require_ldl=yes
+  ])
+])
+
+dnl only add -ldl to LDFLAGS if it isn't already part of LIBS (GH-133081)
+AS_VAR_IF([ac_cv_require_ldl], [yes], [
+  AS_VAR_IF([ac_cv_lib_dl_dlopen], [yes], [], [
+    AS_VAR_APPEND([LDFLAGS], [" -ldl"])
+  ])
+])
+
+
 dnl check for uuid dependencies
 AH_TEMPLATE([HAVE_UUID_H], [Define to 1 if you have the <uuid.h> header file.])
 AH_TEMPLATE([HAVE_UUID_UUID_H], [Define to 1 if you have the <uuid/uuid.h> header file.])
@@ -4045,11 +4052,7 @@ AS_VAR_IF([have_libffi], [yes], [
   AC_SUBST([MODULE__CTYPES_MALLOC_CLOSURE])
 
   dnl HAVE_LIBDL: for dlopen, see gh-76828
-  AS_VAR_IF([ac_cv_lib_dl_dlopen], [yes], [
-    AS_VAR_IF([ac_cv_require_ldl], [yes], [], [
-      AS_VAR_APPEND([LIBFFI_LIBS], [" -ldl"])
-    ])
-  ])
+  AS_VAR_IF([ac_cv_lib_dl_dlopen], [yes], [AS_VAR_APPEND([LIBFFI_LIBS], [" -ldl"])])
 
   WITH_SAVE_ENV([
     CFLAGS="$CFLAGS $LIBFFI_CFLAGS"


### PR DESCRIPTION
#133040 modified the handling of `-ldl`, resulting in multiple copies of `-ldl` being included in link commands. 

#133071 modified this handling to minimise a lot of those usages; but on platforms that use `dlopen()` (macOS and iOS), there was still some duplicated use. This PR cleans up that usage.

<!-- gh-issue-number: gh-127604 -->
* Issue: gh-127604
<!-- /gh-issue-number -->
