### PR TITLE
Fixed a typo in the `PCbuild/readme.txt` about PGO clang-cl

### DIFF
--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -70,7 +70,7 @@ You can also use a specific version of clang-cl downloaded from
 https://github.com/llvm/llvm-project/releases, e.g.
 clang+llvm-18.1.8-x86_64-pc-windows-msvc.tar.xz.
 Given you have extracted that to <my-clang-dir>, you can use it like so
-build.bat --pgo "/p:PlatformToolset=ClangCL" "/p:LLVMInstallDir=<my-clang-dir> "/p:LLVMToolsVersion=18"
+build.bat --pgo "/p:PlatformToolset=ClangCL" "/p:LLVMInstallDir=<my-clang-dir>" "/p:LLVMToolsVersion=18"
 
 Setting LLVMToolsVersion to the major version is enough, although you
 can be specific and use 18.1.8 in the above example, too.


### PR DESCRIPTION
I think we could add skip-news and skip-issue labels.

I copied the command in the readme, but it didn't work. The part of the path is missing one `"`

![屏幕截图 2025-04-28 211156](https://github.com/user-attachments/assets/0b15f86b-cef7-40ff-ae2a-004fdb9755f1)
