### PR TITLE
gh-133089: Use original timeout value for `TimeoutExpired` when the func `subprocess.run` is called with a timeout

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1525,6 +1525,30 @@ handling consistency are valid for these functions.
 Notes
 -----
 
+.. _subprocess-timeout-behavior:
+
+Timeout Behavior
+---------------
+
+When using the ``timeout`` parameter in functions like :func:`run`,
+:meth:`Popen.wait`, or :meth:`Popen.communicate`,
+users should be aware of the following behaviors:
+
+Process Creation Delay
+~~~~~~~~~~~~~~~~~~~~~
+
+The initial process creation itself cannot be interrupted on many platform APIs.
+This means that even when specifying a timeout, you are not guaranteed to see a timeout exception
+until at least after however long process creation takes.
+
+Extremely Small Timeout Values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Setting very small timeout values (such as a few milliseconds) may result
+in almost immediate :exc:`TimeoutExpired` exceptions because
+process creation and system scheduling inherently require time.
+
+
 .. _converting-argument-sequence:
 
 Converting an argument sequence to a string on Windows

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1528,21 +1528,21 @@ Notes
 .. _subprocess-timeout-behavior:
 
 Timeout Behavior
-----------------
+^^^^^^^^^^^^^^^^
 
 When using the ``timeout`` parameter in functions like :func:`run`,
 :meth:`Popen.wait`, or :meth:`Popen.communicate`,
 users should be aware of the following behaviors:
 
 Process Creation Delay
-~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^
 
 The initial process creation itself cannot be interrupted on many platform APIs.
 This means that even when specifying a timeout, you are not guaranteed to see a timeout exception
 until at least after however long process creation takes.
 
 Extremely Small Timeout Values
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Setting very small timeout values (such as a few milliseconds) may result
 in almost immediate :exc:`TimeoutExpired` exceptions because

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1534,10 +1534,6 @@ When using the ``timeout`` parameter in functions like :func:`run`,
 :meth:`Popen.wait`, or :meth:`Popen.communicate`,
 users should be aware of the following behaviors:
 
-When using the ``timeout`` parameter in functions like :func:`run`,
-:meth:`Popen.wait`, or :meth:`Popen.communicate`,
-users should be aware of the following behaviors:
-
 1. **Process Creation Delay**: The initial process creation itself cannot be interrupted
   on many platform APIs. This means that even when specifying a timeout, you are not
   guaranteed to see a timeout exception until at least after however long process

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1528,21 +1528,21 @@ Notes
 .. _subprocess-timeout-behavior:
 
 Timeout Behavior
----------------
+----------------
 
 When using the ``timeout`` parameter in functions like :func:`run`,
 :meth:`Popen.wait`, or :meth:`Popen.communicate`,
 users should be aware of the following behaviors:
 
 Process Creation Delay
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 The initial process creation itself cannot be interrupted on many platform APIs.
 This means that even when specifying a timeout, you are not guaranteed to see a timeout exception
 until at least after however long process creation takes.
 
 Extremely Small Timeout Values
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Setting very small timeout values (such as a few milliseconds) may result
 in almost immediate :exc:`TimeoutExpired` exceptions because

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1535,14 +1535,13 @@ When using the ``timeout`` parameter in functions like :func:`run`,
 users should be aware of the following behaviors:
 
 1. **Process Creation Delay**: The initial process creation itself cannot be interrupted
-  on many platform APIs. This means that even when specifying a timeout, you are not
-  guaranteed to see a timeout exception until at least after however long process
-  creation takes.
+   on many platform APIs. This means that even when specifying a timeout, you are not
+   guaranteed to see a timeout exception until at least after however long process
+   creation takes.
 
 2. **Extremely Small Timeout Values**: Setting very small timeout values (such as a few
-  milliseconds) may result in almost immediate :exc:`TimeoutExpired` exceptions because
-  process creation and system scheduling inherently require time.
-
+   milliseconds) may result in almost immediate :exc:`TimeoutExpired` exceptions because
+   process creation and system scheduling inherently require time.
 
 .. _converting-argument-sequence:
 

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -1534,19 +1534,18 @@ When using the ``timeout`` parameter in functions like :func:`run`,
 :meth:`Popen.wait`, or :meth:`Popen.communicate`,
 users should be aware of the following behaviors:
 
-Process Creation Delay
-^^^^^^^^^^^^^^^^^^^^^^
+When using the ``timeout`` parameter in functions like :func:`run`,
+:meth:`Popen.wait`, or :meth:`Popen.communicate`,
+users should be aware of the following behaviors:
 
-The initial process creation itself cannot be interrupted on many platform APIs.
-This means that even when specifying a timeout, you are not guaranteed to see a timeout exception
-until at least after however long process creation takes.
+1. **Process Creation Delay**: The initial process creation itself cannot be interrupted
+  on many platform APIs. This means that even when specifying a timeout, you are not
+  guaranteed to see a timeout exception until at least after however long process
+  creation takes.
 
-Extremely Small Timeout Values
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Setting very small timeout values (such as a few milliseconds) may result
-in almost immediate :exc:`TimeoutExpired` exceptions because
-process creation and system scheduling inherently require time.
+2. **Extremely Small Timeout Values**: Setting very small timeout values (such as a few
+  milliseconds) may result in almost immediate :exc:`TimeoutExpired` exceptions because
+  process creation and system scheduling inherently require time.
 
 
 .. _converting-argument-sequence:

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1235,8 +1235,10 @@ class Popen:
 
             finally:
                 self._communication_started = True
-
-            sts = self.wait(timeout=self._remaining_time(endtime))
+            try:
+                sts = self.wait(timeout=self._remaining_time(endtime))
+            except TimeoutExpired:
+                raise TimeoutExpired(self.args, timeout)
 
         return (stdout, stderr)
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1191,8 +1191,6 @@ class Popen:
         universal_newlines.
         """
 
-        timeout = None if timeout == 0 else timeout
-
         if self._communication_started and input:
             raise ValueError("Cannot send input after starting communication")
 
@@ -1270,7 +1268,6 @@ class Popen:
 
 
     def wait(self, timeout=None):
-        timeout = None if timeout == 0 else timeout
         """Wait for child process to terminate; returns self.returncode."""
         if timeout is not None:
             endtime = _time() + timeout
@@ -2034,7 +2031,7 @@ class Popen:
             if self.returncode is not None:
                 return self.returncode
 
-            if timeout is not None:
+            if timeout is not None and timeout > 0:
                 endtime = _time() + timeout
                 # Enter a busy loop if we have a timeout.  This busy loop was
                 # cribbed from Lib/threading.py in Thread.wait() at r71065.
@@ -2052,7 +2049,7 @@ class Popen:
                         finally:
                             self._waitpid_lock.release()
                     remaining = self._remaining_time(endtime)
-                    if remaining <= 0:
+                    if remaining < 0:
                         raise TimeoutExpired(self.args, timeout)
                     delay = min(delay * 2, remaining, .05)
                     time.sleep(delay)

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1191,6 +1191,8 @@ class Popen:
         universal_newlines.
         """
 
+        timeout = None if timeout == 0 else timeout
+
         if self._communication_started and input:
             raise ValueError("Cannot send input after starting communication")
 
@@ -1268,6 +1270,7 @@ class Popen:
 
 
     def wait(self, timeout=None):
+        timeout = None if timeout == 0 else timeout
         """Wait for child process to terminate; returns self.returncode."""
         if timeout is not None:
             endtime = _time() + timeout

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1237,8 +1237,9 @@ class Popen:
                 self._communication_started = True
             try:
                 sts = self.wait(timeout=self._remaining_time(endtime))
-            except TimeoutExpired:
-                raise TimeoutExpired(self.args, timeout)
+            except TimeoutExpired as exc:
+                exc.timeout = timeout
+                raise
 
         return (stdout, stderr)
 
@@ -2149,8 +2150,9 @@ class Popen:
                             self._fileobj2output[key.fileobj].append(data)
             try:
                 self.wait(timeout=self._remaining_time(endtime))
-            except TimeoutExpired:
-                raise TimeoutExpired(self.args, orig_timeout)
+            except TimeoutExpired as exc:
+                exc.timeout = orig_timeout
+                raise
 
             # All data exchanged.  Translate lists into strings.
             if stdout is not None:

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -162,6 +162,20 @@ class ProcessTestCase(BaseTestCase):
                           [sys.executable, "-c", "while True: pass"],
                           timeout=0.1)
 
+    def test_timeout_exception(self):
+        try:
+            subprocess.run(['echo', 'hi'], timeout = -1)
+        except subprocess.TimeoutExpired as e:
+            self.assertIn("-1 seconds", str(e))
+        else:
+            self.fail("Expected TimeoutExpired exception not raised")
+        try:
+            subprocess.run(['echo', 'hi'], timeout = 0)
+        except subprocess.TimeoutExpired as e:
+            self.assertIn("0 seconds", str(e))
+        else:
+            self.fail("Expected TimeoutExpired exception not raised")
+
     def test_check_call_zero(self):
         # check_call() function with zero return code
         rc = subprocess.check_call(ZERO_RETURN_CMD)

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1660,8 +1660,6 @@ class RunFuncTestCase(BaseTestCase):
         # child.
         with self.assertRaises(subprocess.TimeoutExpired):
             self.run_python("while True: pass", timeout=0.0001)
-    def test_timeout_zero(self):
-        self.run_python("import time; time.sleep(0.1)", timeout=0)
 
     def test_capture_stdout(self):
         # capture stdout with zero return code

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1660,7 +1660,8 @@ class RunFuncTestCase(BaseTestCase):
         # child.
         with self.assertRaises(subprocess.TimeoutExpired):
             self.run_python("while True: pass", timeout=0.0001)
-
+    def test_timeout_zero(self):
+        self.run_python("import time; time.sleep(0.1)", timeout=0)
     def test_capture_stdout(self):
         # capture stdout with zero return code
         cp = self.run_python("print('BDFL')", stdout=subprocess.PIPE)

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1662,6 +1662,7 @@ class RunFuncTestCase(BaseTestCase):
             self.run_python("while True: pass", timeout=0.0001)
     def test_timeout_zero(self):
         self.run_python("import time; time.sleep(0.1)", timeout=0)
+
     def test_capture_stdout(self):
         # capture stdout with zero return code
         cp = self.run_python("print('BDFL')", stdout=subprocess.PIPE)

--- a/Misc/NEWS.d/next/Library/2025-04-29-02-23-04.gh-issue-133089.8Jy1ZS.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-29-02-23-04.gh-issue-133089.8Jy1ZS.rst
@@ -1,0 +1,2 @@
+Make :func:``subprocess.run``'s behavior is same with 'timeout=None' when
+the timeout is zero

--- a/Misc/NEWS.d/next/Library/2025-04-29-02-23-04.gh-issue-133089.8Jy1ZS.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-29-02-23-04.gh-issue-133089.8Jy1ZS.rst
@@ -1,2 +1,2 @@
-Make :func:`subprocess.run`'s behavior is same with 'timeout=None' when
-the timeout is zero
+Use origional timeout value for :exc:`TimeoutExpired`
+when the func :meth:`subprocess.run` is called with a timeout

--- a/Misc/NEWS.d/next/Library/2025-04-29-02-23-04.gh-issue-133089.8Jy1ZS.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-29-02-23-04.gh-issue-133089.8Jy1ZS.rst
@@ -1,2 +1,4 @@
-Use origional timeout value for :exc:`subprocess.TimeoutExpired`
+Use original timeout value for :exc:`subprocess.TimeoutExpired`
 when the func :meth:`subprocess.run` is called with a timeout
+instead of sometimes a confusing partial remaining time out value
+used internally on the final ``wait()``.

--- a/Misc/NEWS.d/next/Library/2025-04-29-02-23-04.gh-issue-133089.8Jy1ZS.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-29-02-23-04.gh-issue-133089.8Jy1ZS.rst
@@ -1,2 +1,2 @@
-Use origional timeout value for :exc:`TimeoutExpired`
+Use origional timeout value for :exc:`subprocess.TimeoutExpired`
 when the func :meth:`subprocess.run` is called with a timeout

--- a/Misc/NEWS.d/next/Library/2025-04-29-02-23-04.gh-issue-133089.8Jy1ZS.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-29-02-23-04.gh-issue-133089.8Jy1ZS.rst
@@ -1,2 +1,2 @@
-Make :func:``subprocess.run``'s behavior is same with 'timeout=None' when
+Make :func:`subprocess.run`'s behavior is same with 'timeout=None' when
 the timeout is zero


### PR DESCRIPTION
Fix #133089

<!-- gh-issue-number: gh-133089 -->
* Issue: gh-133089
<!-- /gh-issue-number -->
