### PR TITLE
GH-128520: pathlib ABCs tests: use explicit text encoding

### DIFF
--- a/Lib/test/test_pathlib/support/local_path.py
+++ b/Lib/test/test_pathlib/support/local_path.py
@@ -82,7 +82,7 @@ class LocalPathGround:
     readlink = staticmethod(os.readlink)
 
     def readtext(self, p):
-        with open(p, 'r') as f:
+        with open(p, 'r', encoding='utf-8') as f:
             return f.read()
 
     def readbytes(self, p):

--- a/Lib/test/test_pathlib/support/zip_path.py
+++ b/Lib/test/test_pathlib/support/zip_path.py
@@ -63,7 +63,7 @@ class ZipPathGround:
 
     def readtext(self, p):
         with p.zip_file.open(str(p), 'r') as f:
-            f = io.TextIOWrapper(f)
+            f = io.TextIOWrapper(f, encoding='utf-8')
             return f.read()
 
     def readbytes(self, p):

--- a/Lib/test/test_pathlib/test_read.py
+++ b/Lib/test/test_pathlib/test_read.py
@@ -32,7 +32,7 @@ class ReadTestBase:
 
     def test_open_r(self):
         p = self.root / 'fileA'
-        with magic_open(p, 'r') as f:
+        with magic_open(p, 'r', encoding='utf-8') as f:
             self.assertIsInstance(f, io.TextIOBase)
             self.assertEqual(f.read(), 'this is file A\n')
 
@@ -61,7 +61,7 @@ class ReadTestBase:
 
     def test_read_text(self):
         p = self.root / 'fileA'
-        self.assertEqual(p.read_text(), 'this is file A\n')
+        self.assertEqual(p.read_text(encoding='utf-8'), 'this is file A\n')
         q = self.root / 'abc'
         self.ground.create_file(q, b'\xe4bcdefg')
         self.assertEqual(q.read_text(encoding='latin-1'), 'äbcdefg')
@@ -81,11 +81,11 @@ class ReadTestBase:
         p = self.root / 'abc'
         self.ground.create_file(p, b'abcde\r\nfghlk\n\rmnopq')
         # Check that `\n` character change nothing
-        self.assertEqual(p.read_text(newline='\n'), 'abcde\r\nfghlk\n\rmnopq')
+        self.assertEqual(p.read_text(encoding='utf-8', newline='\n'), 'abcde\r\nfghlk\n\rmnopq')
         # Check that `\r` character replaces `\n`
-        self.assertEqual(p.read_text(newline='\r'), 'abcde\r\nfghlk\n\rmnopq')
+        self.assertEqual(p.read_text(encoding='utf-8', newline='\r'), 'abcde\r\nfghlk\n\rmnopq')
         # Check that `\r\n` character replaces `\n`
-        self.assertEqual(p.read_text(newline='\r\n'), 'abcde\r\nfghlk\n\rmnopq')
+        self.assertEqual(p.read_text(encoding='utf-8', newline='\r\n'), 'abcde\r\nfghlk\n\rmnopq')
 
     def test_iterdir(self):
         expected = ['dirA', 'dirB', 'dirC', 'fileA']

--- a/Lib/test/test_pathlib/test_write.py
+++ b/Lib/test/test_pathlib/test_write.py
@@ -31,7 +31,7 @@ class WriteTestBase:
 
     def test_open_w(self):
         p = self.root / 'fileA'
-        with magic_open(p, 'w') as f:
+        with magic_open(p, 'w', encoding='utf-8') as f:
             self.assertIsInstance(f, io.TextIOBase)
             f.write('this is file A\n')
         self.assertEqual(self.ground.readtext(p), 'this is file A\n')
@@ -70,7 +70,7 @@ class WriteTestBase:
         p.write_text('äbcdefg', encoding='latin-1')
         self.assertEqual(self.ground.readbytes(p), b'\xe4bcdefg')
         # Check that trying to write bytes does not truncate the file.
-        self.assertRaises(TypeError, p.write_text, b'somebytes')
+        self.assertRaises(TypeError, p.write_text, b'somebytes', encoding='utf-8')
         self.assertEqual(self.ground.readbytes(p), b'\xe4bcdefg')
 
     @unittest.skipIf(
@@ -86,23 +86,23 @@ class WriteTestBase:
     def test_write_text_with_newlines(self):
         # Check that `\n` character change nothing
         p = self.root / 'fileA'
-        p.write_text('abcde\r\nfghlk\n\rmnopq', newline='\n')
+        p.write_text('abcde\r\nfghlk\n\rmnopq', encoding='utf-8', newline='\n')
         self.assertEqual(self.ground.readbytes(p), b'abcde\r\nfghlk\n\rmnopq')
 
         # Check that `\r` character replaces `\n`
         p = self.root / 'fileB'
-        p.write_text('abcde\r\nfghlk\n\rmnopq', newline='\r')
+        p.write_text('abcde\r\nfghlk\n\rmnopq', encoding='utf-8', newline='\r')
         self.assertEqual(self.ground.readbytes(p), b'abcde\r\rfghlk\r\rmnopq')
 
         # Check that `\r\n` character replaces `\n`
         p = self.root / 'fileC'
-        p.write_text('abcde\r\nfghlk\n\rmnopq', newline='\r\n')
+        p.write_text('abcde\r\nfghlk\n\rmnopq', encoding='utf-8', newline='\r\n')
         self.assertEqual(self.ground.readbytes(p), b'abcde\r\r\nfghlk\r\n\rmnopq')
 
         # Check that no argument passed will change `\n` to `os.linesep`
         os_linesep_byte = bytes(os.linesep, encoding='ascii')
         p = self.root / 'fileD'
-        p.write_text('abcde\nfghlk\n\rmnopq')
+        p.write_text('abcde\nfghlk\n\rmnopq', encoding='utf-8')
         self.assertEqual(self.ground.readbytes(p),
                          b'abcde' + os_linesep_byte +
                          b'fghlk' + os_linesep_byte + b'\rmnopq')


### PR DESCRIPTION
Follow-up to fbffd70. Set `encoding='utf-8'` when reading and writing text in the tests for the private pathlib ABCs, which allows the tests to run under `-W error -X warn_default_encoding` conditions

<!-- gh-issue-number: gh-128520 -->
* Issue: gh-128520
<!-- /gh-issue-number -->
