### PR TITLE
gh-132893: Minor edits to the statistics module PR

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -810,8 +810,7 @@ def register(*kernels):
 @register('normal', 'gauss')
 def normal_kernel():
     sqrt2pi = sqrt(2 * pi)
-    sqrt2 = sqrt(2)
-    neg_sqrt2 = -sqrt2
+    neg_sqrt2 = -sqrt(2)
     pdf = lambda t: exp(-1/2 * t * t) / sqrt2pi
     cdf = lambda t: 1/2 * erfc(t / neg_sqrt2)
     invcdf = lambda t: _normal_dist_inv_cdf(t, 0.0, 1.0)

--- a/Misc/NEWS.d/next/Library/2025-04-24-21-22-46.gh-issue-132893.KFuxZ2.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-24-21-22-46.gh-issue-132893.KFuxZ2.rst
@@ -1,1 +1,1 @@
-Improved the accuracy of ``statistics.NormalDist.cdf`` for negative inputs.
+Improved ``statistics.NormalDist.cdf`` accuracy for inputs smaller than the mean.

--- a/Misc/NEWS.d/next/Library/2025-04-24-21-22-46.gh-issue-132893.KFuxZ2.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-24-21-22-46.gh-issue-132893.KFuxZ2.rst
@@ -1,1 +1,1 @@
-Improved ``statistics.NormalDist.cdf`` accuracy for inputs smaller than the mean.
+Improved :meth:`statistics.NormalDist.cdf` accuracy for inputs smaller than the mean.


### PR DESCRIPTION
* The Misc/NEWS entry was inaccurate. For `statistics.NormalDist.cdf`, the noticeable improvement was for any *x* positive or negative that is below the mean.

* Eliminate a temporary variable that was only used once.

<!-- gh-issue-number: gh-132893 -->
* Issue: gh-132893
<!-- /gh-issue-number -->
