### PR TITLE
Fix tz to `UTC` in `test_time` test

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -757,6 +757,7 @@ class TestStrftime4dyear(_TestStrftimeYear, _Test4dYear, unittest.TestCase):
 class TestPytime(unittest.TestCase):
     @skip_if_buggy_ucrt_strfptime
     @unittest.skipUnless(time._STRUCT_TM_ITEMS == 11, "needs tm_zone support")
+    @support.run_with_tz('UTC')
     def test_localtime_timezone(self):
 
         # Get the localtime and examine it for the offset and zone.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Currently on DST, this causes:

```
======================================================================
FAIL: test_localtime_timezone (test.test_time.TestPytime.test_localtime_timezone)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/stan/PycharmProjects/cpython/Lib/test/test_time.py", line 772, in test_localtime_timezone
    self.assertEqual(lt.tm_gmtoff, -[time.timezone, time.altzone][lt.tm_isdst])
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 3600 != 0

----------------------------------------------------------------------
Ran 63 tests in 2.938s

FAILED (failures=1, skipped=3)
test test_time failed
0:00:02 load avg: 1.87 [1/1/1] test_time failed (1 failure)

== Tests result: FAILURE ==

1 test failed:
    test_time

Total duration: 3.0 sec
Total tests: run=63 failures=1 skipped=3
Total test files: run=1/1 failed=1
Result: FAILURE
```