### PR TITLE
GH-132930: Display 'free-threaded' in pymanager builds

### DIFF
--- a/PC/layout/support/pymanager.py
+++ b/PC/layout/support/pymanager.py
@@ -39,6 +39,7 @@ def calculate_install_json(ns, *, for_embed=False, for_test=False):
     DISPLAY_NAME = "Python"
     TAG_SUFFIX = ""
     ALIAS_PREFIX = "python"
+    ALIAS_WPREFIX = "pythonw"
     FILE_PREFIX = "python-"
     FILE_SUFFIX = f"-{ns.arch}"
     DISPLAY_TAGS = [{

--- a/PC/layout/support/pymanager.py
+++ b/PC/layout/support/pymanager.py
@@ -82,7 +82,7 @@ def calculate_install_json(ns, *, for_embed=False, for_test=False):
     # Tag shown in 'py list' output
     DISPLAY_TAG = f"{XY_TAG}-dev{TAG_ARCH}" if VER_SUFFIX else XY_ARCH_TAG
 
-    DISPLAY_SUFFIX = ", ".join(filter(None, DISPLAY_TAGS))
+    DISPLAY_SUFFIX = ", ".join(i for i in DISPLAY_TAGS if i)
     if DISPLAY_SUFFIX:
         DISPLAY_SUFFIX = f" ({DISPLAY_SUFFIX})"
     DISPLAY_VERSION = f"{XYZ_VERSION}{VER_SUFFIX}{DISPLAY_SUFFIX}"

--- a/PC/layout/support/pymanager.py
+++ b/PC/layout/support/pymanager.py
@@ -39,7 +39,6 @@ def calculate_install_json(ns, *, for_embed=False, for_test=False):
     DISPLAY_NAME = "Python"
     TAG_SUFFIX = ""
     ALIAS_PREFIX = "python"
-    ALIAS_WPREFIX = "pythonw"
     FILE_PREFIX = "python-"
     FILE_SUFFIX = f"-{ns.arch}"
     DISPLAY_TAGS = [{
@@ -67,7 +66,7 @@ def calculate_install_json(ns, *, for_embed=False, for_test=False):
         TAG_SUFFIX = "t"
         TARGET = f"python{VER_MAJOR}.{VER_MINOR}t.exe"
         TARGETW = f"pythonw{VER_MAJOR}.{VER_MINOR}t.exe"
-        DISPLAY_TAGS.append("freethreaded")
+        DISPLAY_TAGS.append("free-threaded")
         FILE_SUFFIX = f"t-{ns.arch}"
 
     FULL_TAG = f"{VER_MAJOR}.{VER_MINOR}.{VER_MICRO}{VER_SUFFIX}{TAG_SUFFIX}"
@@ -82,7 +81,7 @@ def calculate_install_json(ns, *, for_embed=False, for_test=False):
     # Tag shown in 'py list' output
     DISPLAY_TAG = f"{XY_TAG}-dev{TAG_ARCH}" if VER_SUFFIX else XY_ARCH_TAG
 
-    DISPLAY_SUFFIX = ", ".join(i for i in DISPLAY_TAGS if i)
+    DISPLAY_SUFFIX = ", ".join(filter(None, DISPLAY_TAGS))
     if DISPLAY_SUFFIX:
         DISPLAY_SUFFIX = f" ({DISPLAY_SUFFIX})"
     DISPLAY_VERSION = f"{XYZ_VERSION}{VER_SUFFIX}{DISPLAY_SUFFIX}"


### PR DESCRIPTION
Currently, `py list` shows:

```
Tag                Name                                Managed By  Version   Alias
3.13t              Python 3.13.2 (free-threaded)       PythonCore  3.13.2    python3.13t.exe, python3t.exe, pythonw3.13t.exe...
3.14t-dev[-64]     Python 3.14.0a7 (freethreaded)      PythonCore  3.14.0a7  python3.14t-64.exe, python3.14t.exe, python3t-6...
```

(limiting only to nogil builds). As an aesthetic preference, but also to align with wider terminology, I suggest including the hyphen.

Also remove an unused constant, `ALIAS_WPREFIX`.

A

<!-- gh-issue-number: gh-132930 -->
* Issue: gh-132930
<!-- /gh-issue-number -->
