### PR TITLE
Lint: Create a project-wide ``.ruff.toml`` settings file

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -8,5 +8,5 @@ line-length = 79
 
 # Enable automatic fixes by default.
 # To override this, use ``fix = false`` in a subdirectory's config file
-# or ``--no-fix`` on the CLI
+# or ``--no-fix`` on the command line.
 fix = true

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -6,9 +6,6 @@ target-version = "py310"
 # PEP 8
 line-length = 79
 
-# Nicer diagnostic output
-output-format = "full"
-
 # Enable automatic fixes by default.
 # To override this, use ``fix = false`` in a subdirectory's config file
 # or ``--no-fix`` on the CLI

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -9,5 +9,7 @@ line-length = 79
 # Nicer diagnostic output
 output-format = "full"
 
-# Enable automatic fixes (use ``fix = false`` or ``--no-fix`` to override)
+# Enable automatic fixes by default.
+# To override this, use ``fix = false`` in a subdirectory's config file
+# or ``--no-fix`` on the CLI
 fix = true

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,13 @@
+# Default settings for Ruff in CPython
+
+# PYTHON_FOR_REGEN
+target-version = "py310"
+
+# PEP 8
+line-length = 79
+
+# Nicer diagnostic output
+output-format = "full"
+
+# Enable automatic fixes (use ``fix = false`` or ``--no-fix`` to override)
+fix = true

--- a/Doc/.ruff.toml
+++ b/Doc/.ruff.toml
@@ -1,7 +1,6 @@
+extend = "../.ruff.toml"  # Inherit the project-wide settings
+
 target-version = "py312"  # Align with the version in oldest_supported_sphinx
-fix = true
-output-format = "full"
-line-length = 79
 extend-exclude = [
     "includes/*",
     # Temporary exclusions:

--- a/Lib/test/.ruff.toml
+++ b/Lib/test/.ruff.toml
@@ -1,4 +1,5 @@
-fix = true
+extend = "../../.ruff.toml"  # Inherit the project-wide settings
+
 extend-exclude = [
     # Excluded (run with the other AC files in its own separate ruff job in pre-commit)
     "test_clinic.py",

--- a/Tools/build/.ruff.toml
+++ b/Tools/build/.ruff.toml
@@ -1,6 +1,4 @@
-target-version = "py310"
-fix = true
-line-length = 79
+extend = "../../.ruff.toml"  # Inherit the project-wide settings
 
 [lint]
 select = [

--- a/Tools/clinic/.ruff.toml
+++ b/Tools/clinic/.ruff.toml
@@ -1,5 +1,4 @@
-target-version = "py310"
-fix = true
+extend = "../../.ruff.toml"  # Inherit the project-wide settings
 
 [lint]
 select = [


### PR DESCRIPTION
We have some settings that are replicated in every `.ruff.toml`. It's somewhat useful to centralise, so that we keep consistency throughout the project.

I've set `target-version` as 3.10 as that seems most common (inspired by PYTHON_FOR_REGEN?), but I'd have no objections to requiring something more recent.

I believe we need the `extend` lines, unless there's some way to get Ruff to automatically look in parent/project root directories (cc @AlexWaygood).

A

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133124.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->