### PR TITLE
[3.13] gh-133122: Fix for test_type_lookup_mro_reference.

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -5177,10 +5177,15 @@ class MiscTests(unittest.TestCase):
 
         with self.assertWarnsRegex(RuntimeWarning, 'X'):
             X = type('X', (Base,), {MyKey(): 5})
+
+        # Note that the access below uses getattr() rather than normally
+        # accessing the attribute.  That is done to avoid the bytecode
+        # specializer activating on repeated runs of the test.
+
         # mykey is read from Base
-        self.assertEqual(X.mykey, 'from Base')
+        self.assertEqual(getattr(X, 'mykey'), 'from Base')
         # mykey2 is read from Base2 because MyKey.__eq__ has set __bases__
-        self.assertEqual(X.mykey2, 'from Base2')
+        self.assertEqual(getattr(X, 'mykey2'), 'from Base2')
 
 
 class PicklingTests(unittest.TestCase):


### PR DESCRIPTION
Change the unit test case to use `getattr()` so that we avoid the bytecode specializer optimizing the access.  The specializer will call the `__eq__` method before the unit test expects, causing it to fail.

In the 3.14 branch (gh-128164) the test is changed in a different way to avoid the same issue.


<!-- gh-issue-number: gh-133122 -->
* Issue: gh-133122
<!-- /gh-issue-number -->
