### PR TITLE
gh-133131: Discover an appropriate iOS simulator rather than hard-coding iPhone SE 3rd gen

### DIFF
--- a/Misc/NEWS.d/next/Tests/2025-04-29-14-56-37.gh-issue-133131.1pchjl.rst
+++ b/Misc/NEWS.d/next/Tests/2025-04-29-14-56-37.gh-issue-133131.1pchjl.rst
@@ -1,0 +1,2 @@
+The iOS testbed will now select the most recently released "SE-class" device
+for testing if a device isn't explicitly specified.


### PR DESCRIPTION
With the release of the iPhone 16e, Xcode 16.3 has been released; this release no longer contains an iPhone SE (3rd generation) simulator by default. 

This PR modifies the iOS testbed to search for "SE-class" deployment candidates, rather than hard-coding the iPhone SE as the deployment target if no simulator image is specified.

<!-- gh-issue-number: gh-133131 -->
* Issue: gh-133131
<!-- /gh-issue-number -->
