### PR TITLE
gh-131296: Fix clang-cl warning on Windows in `posixmodule.c`

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4189,7 +4189,7 @@ posix_getcwd(int use_bytes)
     /* If the buffer is large enough, len does not include the
        terminating \0. If the buffer is too small, len includes
        the space needed for the terminator. */
-    if (len >= Py_ARRAY_LENGTH(wbuf)) {
+    if ((size_t)len >= Py_ARRAY_LENGTH(wbuf)) {
         if (len <= PY_SSIZE_T_MAX / sizeof(wchar_t)) {
             wbuf2 = PyMem_RawMalloc(len * sizeof(wchar_t));
         }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4189,8 +4189,8 @@ posix_getcwd(int use_bytes)
     /* If the buffer is large enough, len does not include the
        terminating \0. If the buffer is too small, len includes
        the space needed for the terminator. */
-    if ((size_t)len >= Py_ARRAY_LENGTH(wbuf)) {
-        if (len <= PY_SSIZE_T_MAX / sizeof(wchar_t)) {
+    if (len >= Py_ARRAY_LENGTH(wbuf)) {
+        if ((Py_ssize_t)len <= PY_SSIZE_T_MAX / sizeof(wchar_t)) {
             wbuf2 = PyMem_RawMalloc(len * sizeof(wchar_t));
         }
         else {


### PR DESCRIPTION
Only 1 warning in `posixmodule.c`
```
..\Modules\posixmodule.c(4193,17): warning : result of comparison of constant 4611686018427387903 with expression of ty
pe 'DWORD' (aka 'unsigned long') is always true [-Wtautological-constant-out-of-range-compare] 
```

Please add skip news label :)

<!-- gh-issue-number: gh-131296 -->
* Issue: gh-131296
<!-- /gh-issue-number -->
