### PR TITLE
gh-130317: Fix strict aliasing in PyFloat_Pack8()

### DIFF
--- a/Modules/_testcapi/float.c
+++ b/Modules/_testcapi/float.c
@@ -182,8 +182,12 @@ _testcapi_float_set_snan(PyObject *module, PyObject *obj)
     uint64_t v;
     memcpy(&v, &d, 8);
     v &= ~(1ULL << 51); /* make sNaN */
-    memcpy(&d, &v, 8);
-    return PyFloat_FromDouble(d);
+
+    // gh-130317: Work around 32-bit compilers which clear sNaN flag
+    // when calling PyFloat_FromDouble(). Set ob_fval using memcpy().
+    PyObject *res = PyFloat_FromDouble(0.0);
+    memcpy(&((PyFloatObject *)res)->ob_fval, &v, 8);
+    return res;
 }
 
 static PyMethodDef test_methods[] = {

--- a/Modules/_testcapi/float.c
+++ b/Modules/_testcapi/float.c
@@ -183,8 +183,7 @@ _testcapi_float_set_snan(PyObject *module, PyObject *obj)
     memcpy(&v, &d, 8);
     v &= ~(1ULL << 51); /* make sNaN */
 
-    // gh-130317: Work around 32-bit compilers which clear sNaN flag
-    // when calling PyFloat_FromDouble(). Set ob_fval using memcpy().
+    // gh-130317: memcpy() is needed to preserve the sNaN flag on x86 (32-bit)
     PyObject *res = PyFloat_FromDouble(0.0);
     memcpy(&((PyFloatObject *)res)->ob_fval, &v, 8);
     return res;

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -2197,12 +2197,10 @@ PyFloat_Pack4(double x, char *data, int le)
 
             memcpy(&v, &x, 8);
             if ((v & (1ULL << 51)) == 0) {
-                union float_val {
-                    float f;
-                    uint32_t u32;
-                } *py = (union float_val *)&y;
-
-                py->u32 &= ~(1 << 22); /* make sNaN */
+                uint32_t u32;
+                memcpy(&u32, &y, 4);
+                u32 &= ~(1 << 22); /* make sNaN */
+                memcpy(&y, &u32, 4);
             }
         }
 
@@ -2340,7 +2338,9 @@ PyFloat_Pack8(double x, char *data, int le)
         return -1;
     }
     else {
-        const unsigned char *s = (unsigned char*)&x;
+        unsigned char as_bytes[8];
+        memcpy(as_bytes, &x, 8);
+        const unsigned char *s = as_bytes;
         int i, incr = 1;
 
         if ((double_format == ieee_little_endian_format && !le)


### PR DESCRIPTION
* Fix strict aliasing in PyFloat_Pack8() and PyFloat_Pack4()
* Fix _testcapi.float_set_snan() on x86 (32-bit).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-130317 -->
* Issue: gh-130317
<!-- /gh-issue-number -->
