### PR TITLE
gh-132930: Fixes PEP 514 registration for PyManager packages on x64

### DIFF
--- a/PC/layout/support/pymanager.py
+++ b/PC/layout/support/pymanager.py
@@ -82,6 +82,8 @@ def calculate_install_json(ns, *, for_embed=False, for_test=False):
     ID_TAG = XY_ARCH_TAG
     # Tag shown in 'py list' output
     DISPLAY_TAG = f"{XY_TAG}-dev{TAG_ARCH}" if VER_SUFFIX else XY_ARCH_TAG
+    # Tag used for PEP 514 registration
+    SYS_WINVER = XY_TAG + (TAG_ARCH if TAG_ARCH != '-64' else '')
 
     DISPLAY_SUFFIX = ", ".join(i for i in DISPLAY_TAGS if i)
     if DISPLAY_SUFFIX:
@@ -146,25 +148,26 @@ def calculate_install_json(ns, *, for_embed=False, for_test=False):
                 {**base, "name": f"{prefix}{X_ARCH_TAG}.exe"},
             ])
 
-    STD_PEP514.append({
-        "kind": "pep514",
-        "Key": rf"{COMPANY}\{ID_TAG}",
-        "DisplayName": f"{DISPLAY_NAME} {DISPLAY_VERSION}",
-        "SupportUrl": "https://www.python.org/",
-        "SysArchitecture": SYS_ARCH,
-        "SysVersion": VER_DOT,
-        "Version": FULL_VERSION,
-        "InstallPath": {
-            "_": "%PREFIX%",
-            "ExecutablePath": f"%PREFIX%{TARGET}",
-            # WindowedExecutablePath is added below
-        },
-        "Help": {
-            "Online Python Documentation": {
-                "_": f"https://docs.python.org/{VER_DOT}/"
+    if SYS_WINVER:
+        STD_PEP514.append({
+            "kind": "pep514",
+            "Key": rf"{COMPANY}\{SYS_WINVER}",
+            "DisplayName": f"{DISPLAY_NAME} {DISPLAY_VERSION}",
+            "SupportUrl": "https://www.python.org/",
+            "SysArchitecture": SYS_ARCH,
+            "SysVersion": VER_DOT,
+            "Version": FULL_VERSION,
+            "InstallPath": {
+                "_": "%PREFIX%",
+                "ExecutablePath": f"%PREFIX%{TARGET}",
+                # WindowedExecutablePath is added below
             },
-        },
-    })
+            "Help": {
+                "Online Python Documentation": {
+                    "_": f"https://docs.python.org/{VER_DOT}/"
+                },
+            },
+        })
 
     STD_START.append({
         "kind": "start",


### PR DESCRIPTION


<!-- gh-issue-number: gh-132930 -->
* Issue: gh-132930
<!-- /gh-issue-number -->
