### PR TITLE
Remove trailing whitespace from python.gram

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -79,7 +79,7 @@ _PyPegen_parse(Parser *p)
 # ~
 #   Commit to the current alternative, even if it fails to parse.
 # &&e
-#   Eager parse e. The parser will not backtrack and will immediately 
+#   Eager parse e. The parser will not backtrack and will immediately
 #   fail with SyntaxError if e cannot be parsed.
 #
 
@@ -659,7 +659,7 @@ type_alias[stmt_ty]:
 # Type parameter declaration
 # --------------------------
 
-type_params[asdl_type_param_seq*]: 
+type_params[asdl_type_param_seq*]:
     | invalid_type_params
     | '[' t=type_param_seq ']' {
         CHECK_VERSION(asdl_type_param_seq *, 12, "Type parameter lists are", t) }
@@ -1339,13 +1339,13 @@ invalid_group:
 invalid_import:
     | a='import' ','.dotted_name+ 'from' dotted_name {
         RAISE_SYNTAX_ERROR_STARTING_FROM(a, "Did you mean to use 'from ... import ...' instead?") }
-    | 'import' token=NEWLINE { 
+    | 'import' token=NEWLINE {
         RAISE_SYNTAX_ERROR_STARTING_FROM(token, "Expected one or more names after 'import'") }
 
 invalid_import_from_targets:
     | import_from_as_names ',' NEWLINE {
         RAISE_SYNTAX_ERROR("trailing comma not allowed without surrounding parentheses") }
-    | token=NEWLINE { 
+    | token=NEWLINE {
         RAISE_SYNTAX_ERROR_STARTING_FROM(token, "Expected one or more names after 'import'") }
 
 invalid_with_stmt:
@@ -1484,5 +1484,5 @@ invalid_factor:
 invalid_type_params:
     | '[' token=']' {
         RAISE_SYNTAX_ERROR_STARTING_FROM(
-            token, 
+            token,
             "Type parameter list cannot be empty")}


### PR DESCRIPTION
The intention is to solve "trailing whitespace" warning by sphinx-lint when running against translation files.

`Grammar/python.gram` is [included by Doc/reference/grammar.rst](https://github.com/python/cpython/blob/32d87a88994c131a9f3857d01ae7c07918577a55/Doc/reference/grammar.rst?plain=1). So running Sphinx `gettext` builder (`make -C Doc gettext`) results in the whole grammar content being extracted to translation files (`Doc/build/gettext/reference/grammar.pot` will be generated and used as the template for translation files).

In the current situation, running sphinx-lint against translation files and having the grammar content simply copied and pasted into the translation (msgstr) will cause warnings like this:

```
reference/grammar.po:145: trailing whitespace (trailing-whitespace)
reference/grammar.po:706: trailing whitespace (trailing-whitespace)
reference/grammar.po:1373: trailing whitespace (trailing-whitespace)
reference/grammar.po:1379: trailing whitespace (trailing-whitespace)
reference/grammar.po:1503: trailing whitespace (trailing-whitespace)
```