### PR TITLE
gh-133153: Use rlcompleter for pdb's interact command

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1157,6 +1157,22 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             state += 1
         return matches
 
+    @contextmanager
+    def _enable_rlcompleter(self, ns):
+        try:
+            import readline
+        except ImportError:
+            yield
+            return
+
+        try:
+            old_completer = readline.get_completer()
+            completer = Completer(ns)
+            readline.set_completer(completer.complete)
+            yield
+        finally:
+            readline.set_completer(old_completer)
+
     # Pdb meta commands, only intended to be used internally by pdb
 
     def _pdbcmd_print_frame_status(self, arg):
@@ -2242,9 +2258,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         contains all the (global and local) names found in the current scope.
         """
         ns = {**self.curframe.f_globals, **self.curframe.f_locals}
-        console = _PdbInteractiveConsole(ns, message=self.message)
-        console.interact(banner="*pdb interact start*",
-                         exitmsg="*exit from pdb interact command*")
+        with self._enable_rlcompleter(ns):
+            console = _PdbInteractiveConsole(ns, message=self.message)
+            console.interact(banner="*pdb interact start*",
+                             exitmsg="*exit from pdb interact command*")
 
     def do_alias(self, arg):
         """alias [name [command]]
@@ -2749,14 +2766,18 @@ class _PdbServer(Pdb):
             self.error(f"Ignoring invalid message from client: {msg}")
 
     def _complete_any(self, text, line, begidx, endidx):
-        if begidx == 0:
-            return self.completenames(text, line, begidx, endidx)
-
-        cmd = self.parseline(line)[0]
-        if cmd:
-            compfunc = getattr(self, "complete_" + cmd, self.completedefault)
-        else:
+        # If we're in 'interact' mode, we need to use the default completer
+        if self._interact_state:
             compfunc = self.completedefault
+        else:
+            if begidx == 0:
+                return self.completenames(text, line, begidx, endidx)
+
+            cmd = self.parseline(line)[0]
+            if cmd:
+                compfunc = getattr(self, "complete_" + cmd, self.completedefault)
+            else:
+                compfunc = self.completedefault
         return compfunc(text, line, begidx, endidx)
 
     def cmdloop(self, intro=None):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4867,6 +4867,11 @@ class PdbTestReadline(unittest.TestCase):
         input += b"disp\t\n"
         # 'value' should still work
         input += b"val\t + 'al'\n"
+        # Let's define a function to test <tab>
+        input += b"def f():\n"
+        input += b"\treturn 42\n"
+        input += b"\n"
+        input += b"f() * 2\n"
         # Exit interact mode
         input += b"exit()\n"
         # continue
@@ -4876,6 +4881,7 @@ class PdbTestReadline(unittest.TestCase):
 
         self.assertIn(b"'disp' is not defined", output)
         self.assertIn(b'special', output)
+        self.assertIn(b'84', output)
 
 
 def load_tests(loader, tests, pattern):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4855,6 +4855,28 @@ class PdbTestReadline(unittest.TestCase):
         self.assertIn(b'4', output)
         self.assertNotIn(b'Error', output)
 
+    def test_interact_completion(self):
+        script = textwrap.dedent("""
+            value = "speci"
+            import pdb; pdb.Pdb().set_trace()
+        """)
+
+        # Enter interact mode
+        input = b"interact\n"
+        # Should fail to complete 'display' because that's a pdb command
+        input += b"disp\t\n"
+        # 'value' should still work
+        input += b"val\t + 'al'\n"
+        # Exit interact mode
+        input += b"exit()\n"
+        # continue
+        input += b"c\n"
+
+        output = run_pty(script, input)
+
+        self.assertIn(b"'disp' is not defined", output)
+        self.assertIn(b'special', output)
+
 
 def load_tests(loader, tests, pattern):
     from test import test_pdb

--- a/Misc/NEWS.d/next/Library/2025-04-29-23-20-52.gh-issue-133153.M-w9yC.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-29-23-20-52.gh-issue-133153.M-w9yC.rst
@@ -1,1 +1,1 @@
-Do not complete :mod:`pdb commands in ``interact`` mode of :mod:`pdb`.
+Do not complete :mod:`pdb` commands in ``interact`` mode of :mod:`pdb`.

--- a/Misc/NEWS.d/next/Library/2025-04-29-23-20-52.gh-issue-133153.M-w9yC.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-29-23-20-52.gh-issue-133153.M-w9yC.rst
@@ -1,0 +1,1 @@
+Do not complete :mod:`pdb commands in ``interact`` mode of :mod:`pdb`.


### PR DESCRIPTION
`interact` now uses the completion function of `pdb`, which lists pdb commands. It should simply use the `rlcompleter`.

<!-- gh-issue-number: gh-133153 -->
* Issue: gh-133153
<!-- /gh-issue-number -->
