### PR TITLE
GH-125515: Remove two unused error branches.

### DIFF
--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5296,18 +5296,6 @@ dummy_func(
             assert(tstate->tracing || eval_breaker == FT_ATOMIC_LOAD_UINTPTR_ACQUIRE(_PyFrame_GetCode(frame)->_co_instrumentation_version));
         }
 
-        label(pop_4_error) {
-            stack_pointer -= 4;
-            assert(WITHIN_STACK_BOUNDS());
-            goto error;
-        }
-
-        label(pop_3_error) {
-            stack_pointer -= 3;
-            assert(WITHIN_STACK_BOUNDS());
-            goto error;
-        }
-
         label(pop_2_error) {
             stack_pointer -= 2;
             assert(WITHIN_STACK_BOUNDS());

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -12134,20 +12134,6 @@ JUMP_TO_LABEL(error);
 #endif /* Py_TAIL_CALL_INTERP */
         /* BEGIN LABELS */
 
-        LABEL(pop_4_error)
-        {
-            stack_pointer -= 4;
-            assert(WITHIN_STACK_BOUNDS());
-            JUMP_TO_LABEL(error);
-        }
-
-        LABEL(pop_3_error)
-        {
-            stack_pointer -= 3;
-            assert(WITHIN_STACK_BOUNDS());
-            JUMP_TO_LABEL(error);
-        }
-
         LABEL(pop_2_error)
         {
             stack_pointer -= 2;

--- a/Python/opcode_targets.h
+++ b/Python/opcode_targets.h
@@ -260,8 +260,6 @@ static void *opcode_targets[256] = {
 #else /* Py_TAIL_CALL_INTERP */
 static py_tail_call_funcptr INSTRUCTION_TABLE[256];
 
-Py_PRESERVE_NONE_CC static PyObject *_TAIL_CALL_pop_4_error(TAIL_CALL_PARAMS);
-Py_PRESERVE_NONE_CC static PyObject *_TAIL_CALL_pop_3_error(TAIL_CALL_PARAMS);
 Py_PRESERVE_NONE_CC static PyObject *_TAIL_CALL_pop_2_error(TAIL_CALL_PARAMS);
 Py_PRESERVE_NONE_CC static PyObject *_TAIL_CALL_pop_1_error(TAIL_CALL_PARAMS);
 Py_PRESERVE_NONE_CC static PyObject *_TAIL_CALL_error(TAIL_CALL_PARAMS);


### PR DESCRIPTION
Removes two unused error handling branches from the generated bytecode handling; these were raising unreachable code warnings on macOS.

<!-- gh-issue-number: gh-125515 -->
* Issue: gh-125515
<!-- /gh-issue-number -->
