### PR TITLE
gh-133183: Include IPHONEOS_DEPLOYMENT_TARGET in iOS shim targets.

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-04-30-11-07-53.gh-issue-133183.zCKUeQ.rst
+++ b/Misc/NEWS.d/next/Build/2025-04-30-11-07-53.gh-issue-133183.zCKUeQ.rst
@@ -1,0 +1,2 @@
+iOS compiler shims now include ``IPHONEOS_DEPLOYMENT_TARGET`` in target
+triples, ensuring that SDK version minimums are honored.

--- a/iOS/Resources/bin/arm64-apple-ios-clang
+++ b/iOS/Resources/bin/arm64-apple-ios-clang
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} clang -target arm64-apple-ios "$@"
+xcrun --sdk iphoneos${IOS_SDK_VERSION} clang -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET} "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-clang++
+++ b/iOS/Resources/bin/arm64-apple-ios-clang++
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} clang++ -target arm64-apple-ios "$@"
+xcrun --sdk iphoneos${IOS_SDK_VERSION} clang++ -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET} "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-cpp
+++ b/iOS/Resources/bin/arm64-apple-ios-cpp
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphoneos${IOS_SDK_VERSION} clang -target arm64-apple-ios -E "$@"
+xcrun --sdk iphoneos${IOS_SDK_VERSION} clang -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET} -E "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-clang
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-clang
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target arm64-apple-ios-simulator "$@"
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-clang++
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-clang++
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target arm64-apple-ios-simulator "$@"
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator "$@"

--- a/iOS/Resources/bin/arm64-apple-ios-simulator-cpp
+++ b/iOS/Resources/bin/arm64-apple-ios-simulator-cpp
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target arm64-apple-ios-simulator -E "$@"
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target arm64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator -E "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-clang
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-clang
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target x86_64-apple-ios-simulator "$@"
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target x86_64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-clang++
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-clang++
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target x86_64-apple-ios-simulator "$@"
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang++ -target x86_64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator "$@"

--- a/iOS/Resources/bin/x86_64-apple-ios-simulator-cpp
+++ b/iOS/Resources/bin/x86_64-apple-ios-simulator-cpp
@@ -1,2 +1,2 @@
 #!/bin/sh
-xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target x86_64-apple-ios-simulator -E "$@"
+xcrun --sdk iphonesimulator${IOS_SDK_VERSION} clang -target x86_64-apple-ios${IPHONEOS_DEPLOYMENT_TARGET}-simulator -E "$@"


### PR DESCRIPTION
Ensures that `IPHONEOS_DEPLOYMENT_TARGET` is included in the target triple used by the iOS compiler shims.

This is needed to ensure that an environment-provided `IPHONEOS_DEPLOYMENT_TARGET` isn't ignored (or superseded) by the "no min SDK version" implied by `-target arm64-apple-ios` et al. 

<!-- gh-issue-number: gh-133183 -->
* Issue: gh-133183
<!-- /gh-issue-number -->
