### PR TITLE
gh-133167: Fix compilation process with `--enable-optimizations` and `--without-docstrings`

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1332,8 +1332,8 @@ MISSING_C_DOCSTRINGS = (check_impl_detail() and
                         sys.platform != 'win32' and
                         not sysconfig.get_config_var('WITH_DOC_STRINGS'))
 
-HAVE_DOCSTRINGS = (_check_docstrings.__doc__ is not None and
-                   not MISSING_C_DOCSTRINGS)
+HAVE_PY_DOCSTRINGS = _check_docstrings.__doc__ is not None
+HAVE_DOCSTRINGS = (HAVE_PY_DOCSTRINGS and not MISSING_C_DOCSTRINGS)
 
 requires_docstrings = unittest.skipUnless(HAVE_DOCSTRINGS,
                                           "test requires docstrings")

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2952,7 +2952,7 @@ class TestSingleDispatch(unittest.TestCase):
                 self.assertEqual(meth.__qualname__, prefix + meth.__name__)
                 self.assertEqual(meth.__doc__,
                                  ('My function docstring'
-                                  if support.HAVE_DOCSTRINGS
+                                  if support.HAVE_PY_DOCSTRINGS
                                   else None))
                 self.assertEqual(meth.__annotations__['arg'], int)
 
@@ -3107,7 +3107,7 @@ class TestSingleDispatch(unittest.TestCase):
             with self.subTest(meth=meth):
                 self.assertEqual(meth.__doc__,
                                  ('My function docstring'
-                                  if support.HAVE_DOCSTRINGS
+                                  if support.HAVE_PY_DOCSTRINGS
                                   else None))
                 self.assertEqual(meth.__annotations__['arg'], int)
 
@@ -3584,7 +3584,7 @@ class TestCachedProperty(unittest.TestCase):
     def test_doc(self):
         self.assertEqual(CachedCostItem.cost.__doc__,
                          ("The cost of the item."
-                          if support.HAVE_DOCSTRINGS
+                          if support.HAVE_PY_DOCSTRINGS
                           else None))
 
     def test_module(self):

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -636,6 +636,7 @@ class OperatorTestCase:
             if dunder:
                 self.assertIs(dunder, orig)
 
+    @support.requires_docstrings
     def test_attrgetter_signature(self):
         operator = self.module
         sig = inspect.signature(operator.attrgetter)
@@ -643,6 +644,7 @@ class OperatorTestCase:
         sig = inspect.signature(operator.attrgetter('x', 'z', 'y'))
         self.assertEqual(str(sig), '(obj, /)')
 
+    @support.requires_docstrings
     def test_itemgetter_signature(self):
         operator = self.module
         sig = inspect.signature(operator.itemgetter)
@@ -650,6 +652,7 @@ class OperatorTestCase:
         sig = inspect.signature(operator.itemgetter(2, 3, 5))
         self.assertEqual(str(sig), '(obj, /)')
 
+    @support.requires_docstrings
     def test_methodcaller_signature(self):
         operator = self.module
         sig = inspect.signature(operator.methodcaller)

--- a/Misc/NEWS.d/next/Build/2025-04-30-10-23-18.gh-issue-133167.E0jrYJ.rst
+++ b/Misc/NEWS.d/next/Build/2025-04-30-10-23-18.gh-issue-133167.E0jrYJ.rst
@@ -1,0 +1,2 @@
+Fix compilation process with ``--enable-optimizations`` and
+``--without-docstrings``.


### PR DESCRIPTION


<!-- gh-issue-number: gh-133167 -->
* Issue: gh-133167
<!-- /gh-issue-number -->
