### PR TITLE
Add `profile-gen-stamp` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ Tools/unicode/data/
 /profile-clean-stamp
 /profile-run-stamp
 /profile-bolt-stamp
+/profile-gen-stamp
 /pybuilddir.txt
 /pyconfig.h
 /python-config


### PR DESCRIPTION
<img width="788" alt="Снимок экрана 2025-04-30 в 10 21 47" src="https://github.com/user-attachments/assets/5cbeeb24-ef9a-4d59-9c16-c13ba8b08df6" />

It is generated when compiled with `--enable-optimization` but is not ignored.