### PR TITLE
gh-102247: Improve documentation of http.HTTPStatus members update

### DIFF
--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -139,7 +139,8 @@ equal to the constant name (i.e. ``http.HTTPStatus.OK`` is also available as
 
 .. versionchanged:: 3.13
    Implemented RFC9110 naming for status constants. Old constant names are preserved for
-   backwards compatibility.
+   backwards compatibility: ``413 REQUEST_ENTITY_TOO_LARGE``, ``414 REQUEST_URI_TOO_LONG``,
+   ``416 REQUESTED_RANGE_NOT_SATISFIABLE`` and ``422 UNPROCESSABLE_ENTITY``.
 
 HTTP status category
 --------------------

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -904,16 +904,6 @@ glob
   (Contributed by Barney Gale in :gh:`72904`.)
 
 
-http
-----
-
-* :class:`http.HTTPStatus` was updated to use the names from :rfc:`9110`.
-  This RFC includes some HTTP statuses previously only used for WEBDAV
-  and assigns more generic names to them.
-  The old constants are preserved for backwards compatibility.
-  (Contributed by Michiel W. Beijen in :gh:`102247`.)
-
-
 importlib
 ---------
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -904,6 +904,16 @@ glob
   (Contributed by Barney Gale in :gh:`72904`.)
 
 
+http
+----
+
+* :class:`http.HTTPStatus` was updated to use the names from :rfc:`9110`.
+  This RFC includes some HTTP statuses previously only used for WEBDAV
+  and assigns more generic names to them.
+  The old constants are preserved for backwards compatibility.
+  (Contributed by Michiel W. Beijen in :gh:`102247`.)
+
+
 importlib
 ---------
 


### PR DESCRIPTION
Improves documentation for the renaming of `http.HTTPStatus` members done in https://github.com/python/cpython/pull/117611:

* Add old names to "Changed in..." notice in `http` module page (I hesitated to add a old -> new table, but it's probably too verbose)
* Add a mention in _What's New in 3.13_ page

I believe this should be backported to 3.13?

<!-- gh-issue-number: gh-102247 -->
* Issue: gh-102247
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133190.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->