### PR TITLE
gh-87135: test_threading: Wait on thread, not an Event it sets

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1219,18 +1219,18 @@ class ThreadTests(BaseTestCase):
             import threading
             done = threading.Event()
 
-            def loop():
+            def set_event():
                 done.set()
-
 
             class Cycle:
                 def __init__(self):
                     self.self_ref = self
-                    self.thr = threading.Thread(target=loop, daemon=True)
+                    self.thr = threading.Thread(target=set_event, daemon=True)
                     self.thr.start()
-                    done.wait()
+                    self.thr.join()
 
                 def __del__(self):
+                    assert done.is_set()
                     assert not self.thr.is_alive()
                     self.thr.join()
                     assert not self.thr.is_alive()


### PR DESCRIPTION
Sorry for this mistake!
When the event is set the thread might not be done yet. This should fix newly-flaky refleak buildbots.


This is a fix-up for commit 4ebbfcf30e0e2d87ff6036d4d1de0f6f0ef7c46a


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-87135 -->
* Issue: gh-87135
<!-- /gh-issue-number -->
