### PR TITLE
gh-43657: Add support for custom test case and runner in both DocTestSuite and DocFileSuite

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -1102,8 +1102,8 @@ from text files and modules with doctests:
    Optional argument *encoding* specifies an encoding that should be used to
    convert the file to unicode.
 
-   Optional argument *test_case* specifies the :class:`DocFileCase` class (or a
-   subclass) that should be used to create test cases. By default, :class:`DocFileCase`
+   Optional argument *test_case* specifies the :class:`!DocFileCase` class (or a
+   subclass) that should be used to create test cases. By default, :class:`!DocFileCase`
    is used. This allows for custom test case classes that can add additional behavior
    or attributes to the test cases.
 
@@ -1147,8 +1147,8 @@ from text files and modules with doctests:
    Optional arguments *setUp*, *tearDown*, and *optionflags* are the same as for
    function :func:`DocFileSuite` above.
 
-   Optional argument *test_case* specifies the :class:`DocTestCase` class (or a
-   subclass) that should be used to create test cases. By default, :class:`DocTestCase`
+   Optional argument *test_case* specifies the :class:`!DocTestCase` class (or a
+   subclass) that should be used to create test cases. By default, :class:`!DocTestCase`
    is used. This allows for custom test case classes that can add additional behavior
    or attributes to the test cases.
 

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -1038,7 +1038,7 @@ There are two main functions for creating :class:`unittest.TestSuite` instances
 from text files and modules with doctests:
 
 
-.. function:: DocFileSuite(*paths, module_relative=True, package=None, setUp=None, tearDown=None, globs=None, optionflags=0, parser=DocTestParser(), encoding=None)
+.. function:: DocFileSuite(*paths, module_relative=True, package=None, setUp=None, tearDown=None, globs=None, optionflags=0, parser=DocTestParser(), encoding=None, test_case=DocFileCase, runner=DocTestRunner)
 
    Convert doctest tests from one or more text files to a
    :class:`unittest.TestSuite`.
@@ -1102,11 +1102,24 @@ from text files and modules with doctests:
    Optional argument *encoding* specifies an encoding that should be used to
    convert the file to unicode.
 
+   Optional argument *test_case* specifies the :class:`DocFileCase` class (or a
+   subclass) that should be used to create test cases. By default, :class:`DocFileCase`
+   is used. This allows for custom test case classes that can add additional behavior
+   or attributes to the test cases.
+
+   Optional argument *runner* specifies the :class:`DocTestRunner` class (or a
+   subclass) that should be used to run the tests. By default, :class:`DocTestRunner`
+   is used.
+
    The global ``__file__`` is added to the globals provided to doctests loaded
    from a text file using :func:`DocFileSuite`.
 
+   .. versionchanged:: 3.13
+      Added *test_case* and *runner* parameters to support user specified test case
+      and runner in DocFileSuite.
 
-.. function:: DocTestSuite(module=None, globs=None, extraglobs=None, test_finder=None, setUp=None, tearDown=None, optionflags=0, checker=None)
+
+.. function:: DocTestSuite(module=None, globs=None, extraglobs=None, test_finder=None, setUp=None, tearDown=None, optionflags=0, checker=None, test_case=DocTestCase, runner=DocTestRunner)
 
    Convert doctest tests for a module to a :class:`unittest.TestSuite`.
 
@@ -1134,11 +1147,24 @@ from text files and modules with doctests:
    Optional arguments *setUp*, *tearDown*, and *optionflags* are the same as for
    function :func:`DocFileSuite` above.
 
+   Optional argument *test_case* specifies the :class:`DocTestCase` class (or a
+   subclass) that should be used to create test cases. By default, :class:`DocTestCase`
+   is used. This allows for custom test case classes that can add additional behavior
+   or attributes to the test cases.
+
+   Optional argument *runner* specifies the :class:`DocTestRunner` class (or a
+   subclass) that should be used to run the tests. By default, :class:`DocTestRunner`
+   is used.
+
    This function uses the same search technique as :func:`testmod`.
 
    .. versionchanged:: 3.5
       :func:`DocTestSuite` returns an empty :class:`unittest.TestSuite` if *module*
       contains no docstrings instead of raising :exc:`ValueError`.
+
+   .. versionchanged:: 3.13
+      Added *runner* and *test_case* parameters to support custom test runners
+      and test case classes in DocTestSuite.
 
 .. exception:: failureException
 

--- a/Lib/test/test_doctest/test_doctest.py
+++ b/Lib/test/test_doctest/test_doctest.py
@@ -2383,6 +2383,36 @@ def test_DocTestSuite():
        modified the test globals, which are a copy of the
        sample_doctest module dictionary.  The test globals are
        automatically cleared for us after a test.
+
+       We can also provide a custom test case class:
+
+         >>> class CustomDocTestCase(doctest.DocTestCase):
+         ...     def __init__(self, test, **options):
+         ...         super().__init__(test, **options)
+         ...         self.custom_attr = "custom_value"
+         ...     def runTest(self):
+         ...         self.assertEqual(self.custom_attr, "custom_value")
+         ...         super().runTest()
+
+         >>> suite = doctest.DocTestSuite('test.test_doctest.sample_doctest',
+         ...                              test_case=CustomDocTestCase)
+         >>> result = suite.run(unittest.TestResult())
+         >>> result
+         <unittest.result.TestResult run=9 errors=0 failures=4>
+
+       We can also provide both a custom test case class and a custom runner class:
+
+         >>> class CustomDocTestRunner(doctest.DocTestRunner):
+         ...     def __init__(self, **options):
+         ...         super().__init__(**options)
+         ...         self.custom_attr = "custom_runner"
+         >>> suite = doctest.DocTestSuite('test.test_doctest.sample_doctest',
+         ...                              test_case=CustomDocTestCase,
+         ...                              runner=CustomDocTestRunner)
+         >>> result = suite.run(unittest.TestResult())
+         >>> result
+         <unittest.result.TestResult run=9 errors=0 failures=4>
+
        """
 
 def test_DocFileSuite():
@@ -2542,6 +2572,38 @@ def test_DocFileSuite():
          ...                              encoding='utf-8')
          >>> suite.run(unittest.TestResult())
          <unittest.result.TestResult run=3 errors=0 failures=2>
+
+       We can also provide a custom test case class:
+
+         >>> class CustomDocTestCase(doctest.DocFileCase):
+         ...     def __init__(self, test, **options):
+         ...         super().__init__(test, **options)
+         ...         self.custom_attr = "custom_value"
+         ...     def runTest(self):
+         ...         self.assertEqual(self.custom_attr, "custom_value")
+         ...         super().runTest()
+
+         >>> suite = doctest.DocFileSuite('test_doctest.txt',
+         ...                              globs={'favorite_color': 'blue'},
+         ...                              test_case=CustomDocTestCase)
+         >>> result = suite.run(unittest.TestResult())
+         >>> result
+         <unittest.result.TestResult run=1 errors=0 failures=0>
+
+       We can also provide both a custom test case class and a custom runner class:
+
+         >>> class CustomDocTestRunner(doctest.DocTestRunner):
+         ...     def __init__(self, **options):
+         ...         super().__init__(**options)
+         ...         self.custom_attr = "custom_runner"
+
+         >>> suite = doctest.DocFileSuite('test_doctest.txt',
+         ...                              globs={'favorite_color': 'blue'},
+         ...                              test_case=CustomDocTestCase,
+         ...                              runner=CustomDocTestRunner)
+         >>> result = suite.run(unittest.TestResult())
+         >>> result
+         <unittest.result.TestResult run=1 errors=0 failures=0>
 
        """
 

--- a/Misc/NEWS.d/next/Library/2025-04-30-12-01-45.gh-issue-43657.YzJLCZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-30-12-01-45.gh-issue-43657.YzJLCZ.rst
@@ -1,0 +1,1 @@
+Allow custom test case and runner for  DocTestSuite and DocFileSuite

--- a/Misc/NEWS.d/next/Library/2025-04-30-12-01-45.gh-issue-43657.YzJLCZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-30-12-01-45.gh-issue-43657.YzJLCZ.rst
@@ -1,1 +1,1 @@
-Allow custom test case and runner for  DocTestSuite and DocFileSuite
+Add support for custom test case and runner classes in :func:`doctest.DocTestSuite` and :func:`doctest.DocFileSuite`. This allows users to extend doctest functionality by providing their own test case and runner implementations through the new ``test_case`` and ``runner`` parameters.


### PR DESCRIPTION
allow users to extend the doctest functionality by providing their own test case and runner implementations, default behavior of `DocTestSuite` and `DocFileSuite` has _not_ been changed

* Added new parameters to `DocTestSuite` and `DocFileSuite`:
    - `test_case`: Optional parameter to specify a custom `DocTestCase`/`DocFileCase` class
    - `runner`: Optional parameter to specify a custom `DocTestRunner` class
* Added test cases for custom test case and runner classes
* Updated documentation in Doc/library/doctest.rst to reflect these changes


<!-- gh-issue-number: gh-43657 -->
* Issue: gh-43657
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133203.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->