### PR TITLE
gh-133213: Add tests for `string.templatelib.TemplateIter`

### DIFF
--- a/Lib/test/test_string/test_templatelib.py
+++ b/Lib/test/test_string/test_templatelib.py
@@ -120,13 +120,14 @@ world"""
 
 
 class TemplateIterTests(unittest.TestCase):
-    def test_basic(self):
+    def test_abc(self):
         self.assertIsInstance(iter(t''), Iterable)
         self.assertIsInstance(iter(t''), Iterator)
 
     def test_final(self):
+        TemplateIter = type(iter(t''))
         with self.assertRaisesRegex(TypeError, 'is not an acceptable base type'):
-            class Sub(type(iter(t''))): ...
+            class Sub(TemplateIter): ...
 
     def test_iter(self):
         x = 1

--- a/Lib/test/test_string/test_templatelib.py
+++ b/Lib/test/test_string/test_templatelib.py
@@ -1,5 +1,6 @@
 import pickle
 import unittest
+from collections.abc import Iterator, Iterable
 from string.templatelib import Template, Interpolation
 
 from test.test_string._support import TStringBaseCase, fstring
@@ -116,6 +117,28 @@ world"""
                     self.assertEqual(unpickled.expression, interpolation.expression)
                     self.assertEqual(unpickled.conversion, interpolation.conversion)
                     self.assertEqual(unpickled.format_spec, interpolation.format_spec)
+
+
+class TemplateIterTests(unittest.TestCase):
+    def test_basic(self):
+        self.assertIsInstance(iter(t''), Iterable)
+        self.assertIsInstance(iter(t''), Iterator)
+
+    def test_final(self):
+        with self.assertRaisesRegex(TypeError, 'is not an acceptable base type'):
+            class Sub(type(iter(t''))): ...
+
+    def test_iter(self):
+        x = 1
+        res = list(iter(t'abc {x} yz'))
+
+        self.assertEqual(res[0], 'abc ')
+        self.assertIsInstance(res[1], Interpolation)
+        self.assertEqual(res[1].value, 1)
+        self.assertEqual(res[1].expression, 'x')
+        self.assertEqual(res[1].conversion, None)
+        self.assertEqual(res[1].format_spec, '')
+        self.assertEqual(res[2], ' yz')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I did not include `pickle` tests, because I found a problem with it. I will open a separate issue for that, it will require some C code modifications.

<!-- gh-issue-number: gh-133213 -->
* Issue: gh-133213
<!-- /gh-issue-number -->
