### PR TITLE
[3.12] gh-132969:  Fix exception/hang shutdown(wait=False) and a task exited abnormally

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -766,6 +766,10 @@ class ProcessPoolExecutor(_base.Executor):
                 self._executor_manager_thread_wakeup
 
     def _adjust_process_count(self):
+        # gh-132969
+        if self._processes is None:
+            return
+
         # if there's an idle process, we don't need to spawn a new one.
         if self._idle_worker_semaphore.acquire(blocking=False):
             return

--- a/Lib/test/test_concurrent_futures/test_shutdown.py
+++ b/Lib/test/test_concurrent_futures/test_shutdown.py
@@ -20,6 +20,16 @@ def sleep_and_print(t, msg):
     sys.stdout.flush()
 
 
+def failing_task_132969(n: int) -> int:
+    raise ValueError("failing task")
+
+
+def good_task_132969(n: int) -> int:
+    time.sleep(0.1 * n)
+    return n
+
+
+
 class ExecutorShutdownTest:
     def test_run_after_shutdown(self):
         self.executor.shutdown()
@@ -329,6 +339,43 @@ class ProcessPoolShutdownTest(ExecutorShutdownTest):
         # Make sure the results were all computed before the executor got
         # shutdown.
         assert all([r == abs(v) for r, v in zip(res, range(-5, 5))])
+
+    def _run_test_issue_132969(self, max_workers: int) -> int:
+        # max_workers=2 will repro exception
+        # max_workers=4 will repro exception and then hang
+
+        import multiprocessing as mp
+
+        # Repro conditions
+        #   max_tasks_per_child=1
+        #   a task ends abnormally
+        #   shutdown(wait=False) is called
+        executor = futures.ProcessPoolExecutor(
+                max_workers=max_workers,
+                max_tasks_per_child=1,
+                mp_context=mp.get_context("forkserver"))
+        f1 = executor.submit(good_task_132969, 1)
+        f2 = executor.submit(failing_task_132969, 2)
+        f3 = executor.submit(good_task_132969, 3)
+        result:int = 0
+        try:
+            result += f1.result()
+            result += f2.result()
+            result += f3.result()
+        except ValueError:
+            # stop processing results upon first exception
+            pass
+
+        executor.shutdown(wait=False)
+        return result
+
+    def test_shutdown_len_exception_132969(self):
+        result = self._run_test_issue_132969(2)
+        self.assertEqual(result, 1)
+
+    def test_shutdown_process_hang_132969(self):
+        result = self._run_test_issue_132969(4)
+        self.assertEqual(result, 1)
 
 
 create_executor_tests(globals(), ProcessPoolShutdownTest,

--- a/Misc/NEWS.d/next/Library/2025-04-30-18-01-47.gh-issue-132969.EagQ3G.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-30-18-01-47.gh-issue-132969.EagQ3G.rst
@@ -1,0 +1,1 @@
+Fixes error+hang when ProcessPoolExecutor shutdown called with wait=False and a task ended abnormally.


### PR DESCRIPTION
When shutdown is called with wait=False, the executor thread keeps running even after the ProcessPoolExecutor's state is reset. The executor then tries to replenish the worker processes pool resulting in an error and a potential hang when it comes across a worker that has died. Fixed the issue by having _adjust_process_count() return without doing anything if the ProcessPoolExecutor's state has been reset.

Added unit tests to validate two scenarios:
max_workers < num_tasks (exception)
max_workers > num_tasks (exception + hang)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-132969 -->
* Issue: gh-132969
<!-- /gh-issue-number -->
