### PR TITLE
gh-133196: Guard PEP 750 grammar with `CHECK_VERSION`

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -971,7 +971,12 @@ tstring_middle[expr_ty]:
     | tstring_replacement_field
     | t=TSTRING_MIDDLE { _PyPegen_constant_from_token(p, t) }
 tstring[expr_ty] (memo):
-    | a=TSTRING_START b=tstring_middle* c=TSTRING_END { _PyPegen_template_str(p, a, (asdl_expr_seq*)b, c) }
+    | a=TSTRING_START b=tstring_middle* c=TSTRING_END { 
+        CHECK_VERSION(
+            expr_ty, 
+            14, 
+            "t-strings are", 
+            _PyPegen_template_str(p, a, (asdl_expr_seq*)b, c)) }
 
 string[expr_ty]: s[Token*]=STRING { _PyPegen_constant_from_string(p, s) }
 strings[expr_ty] (memo): a[asdl_expr_seq*]=(fstring|string|tstring)+ { _PyPegen_concatenate_strings(p, a, EXTRA) }

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -675,6 +675,12 @@ class AST_Tests(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             ast.parse('(x := 0)', feature_version=(3, 7))
 
+    def test_pep750_tstring(self):
+        code = 't""'
+        ast.parse(code, feature_version=(3, 14))
+        with self.assertRaises(SyntaxError):
+            ast.parse(code, feature_version=(3, 13))
+
     def test_pep758_except_without_parens(self):
         code = textwrap.dedent("""
             try:

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -16860,7 +16860,7 @@ tstring_rule(Parser *p)
         )
         {
             D(fprintf(stderr, "%*c+ tstring[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "TSTRING_START tstring_middle* TSTRING_END"));
-            _res = _PyPegen_template_str ( p , a , ( asdl_expr_seq* ) b , c );
+            _res = CHECK_VERSION ( expr_ty , 14 , "t-strings are" , _PyPegen_template_str ( p , a , ( asdl_expr_seq* ) b , c ) );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;


### PR DESCRIPTION
No news, because this was never released.

<!-- gh-issue-number: gh-133196 -->
* Issue: gh-133196
<!-- /gh-issue-number -->
