### PR TITLE
Bump the HACL* revision.

### DIFF
--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -608,11 +608,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "c7fd386ae8b0430385ed0ba9a125ebf65c82840c"
+          "checksumValue": "c9651ef21479c4d8a3b04c5baa1902866dbb1cdf"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "e49ec69b37722c8809e55ddfc9eb17056be4438e087f9d9d4b6303309d49f6c7"
+          "checksumValue": "e039c82ba670606ca111573942baad800f75da467abbc74cd7d1fe175ebcdfaf"
         }
       ],
       "fileName": "Modules/_hacl/Lib_Memzero0.c"
@@ -1752,14 +1752,14 @@
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "502a0250fa08d2cbcc8b9e43831235a2c075de2eb180e7381ecb5d10b181971e"
+          "checksumValue": "02dfcf0c79d488b120d7f2c2a0f9206301c7927ed5106545e0b6f2aef88da76a"
         }
       ],
-      "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/cfbd2e5de9a4b053f18cbef2cae92c4f46f28e74.zip",
+      "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/7720f6d4fc0468a99d5ea6120976bcc271e42727.zip",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:hacl-star:hacl-star:cfbd2e5de9a4b053f18cbef2cae92c4f46f28e74:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:hacl-star:hacl-star:7720f6d4fc0468a99d5ea6120976bcc271e42727:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
@@ -1767,7 +1767,7 @@
       "name": "hacl-star",
       "originator": "Organization: HACL* Developers",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "cfbd2e5de9a4b053f18cbef2cae92c4f46f28e74"
+      "versionInfo": "7720f6d4fc0468a99d5ea6120976bcc271e42727"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-macholib",

--- a/Misc/sbom.spdx.json
+++ b/Misc/sbom.spdx.json
@@ -608,11 +608,11 @@
       "checksums": [
         {
           "algorithm": "SHA1",
-          "checksumValue": "80dae56879ed9bace476362ef251de48ce055a20"
+          "checksumValue": "c7fd386ae8b0430385ed0ba9a125ebf65c82840c"
         },
         {
           "algorithm": "SHA256",
-          "checksumValue": "da84b6287e9aa1fc52e819a8ca10e79b51263f1dda6b4528ed8c0c74a11fb0ea"
+          "checksumValue": "e49ec69b37722c8809e55ddfc9eb17056be4438e087f9d9d4b6303309d49f6c7"
         }
       ],
       "fileName": "Modules/_hacl/Lib_Memzero0.c"
@@ -1755,11 +1755,11 @@
           "checksumValue": "502a0250fa08d2cbcc8b9e43831235a2c075de2eb180e7381ecb5d10b181971e"
         }
       ],
-      "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/322f6d58290e0ed7f4ecb84fcce12917aa0f594b.zip",
+      "downloadLocation": "https://github.com/hacl-star/hacl-star/archive/cfbd2e5de9a4b053f18cbef2cae92c4f46f28e74.zip",
       "externalRefs": [
         {
           "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:hacl-star:hacl-star:322f6d58290e0ed7f4ecb84fcce12917aa0f594b:*:*:*:*:*:*:*",
+          "referenceLocator": "cpe:2.3:a:hacl-star:hacl-star:cfbd2e5de9a4b053f18cbef2cae92c4f46f28e74:*:*:*:*:*:*:*",
           "referenceType": "cpe23Type"
         }
       ],
@@ -1767,7 +1767,7 @@
       "name": "hacl-star",
       "originator": "Organization: HACL* Developers",
       "primaryPackagePurpose": "SOURCE",
-      "versionInfo": "322f6d58290e0ed7f4ecb84fcce12917aa0f594b"
+      "versionInfo": "cfbd2e5de9a4b053f18cbef2cae92c4f46f28e74"
     },
     {
       "SPDXID": "SPDXRef-PACKAGE-macholib",

--- a/Modules/_hacl/Lib_Memzero0.c
+++ b/Modules/_hacl/Lib_Memzero0.c
@@ -10,6 +10,20 @@
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <AvailabilityMacros.h>
+// memset_s is available from macOS 10.9, iOS 7, watchOS 2, and on all tvOS and visionOS versions.
+#  if (defined(MAC_OS_X_VERSION_MIN_REQUIRED) && (MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9))
+#    define APPLE_HAS_MEMSET_S 1
+#  elif (defined(IPHONE_OS_VERSION_MIN_REQUIRED) && (IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
+#    define APPLE_HAS_MEMSET_S 1
+#  elif (defined(TARGET_OS_TV) && TARGET_OS_TV)
+#    define APPLE_HAS_MEMSET_S 1
+#  elif (defined(WATCH_OS_VERSION_MIN_REQUIRED) && (WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
+#    define APPLE_HAS_MEMSET_S 1
+#  elif (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
+#    define APPLE_HAS_MEMSET_S 1
+#  else
+#    define APPLE_HAS_MEMSET_S 0
+#  endif
 #endif
 
 #if (defined(__APPLE__) && defined(__MACH__)) || defined(__linux__) || defined(__OpenBSD__)
@@ -41,7 +55,7 @@ void Lib_Memzero0_memzero0(void *dst, uint64_t len) {
 
   #ifdef _WIN32
     SecureZeroMemory(dst, len_);
-  #elif defined(__APPLE__) && defined(__MACH__) && defined(MAC_OS_X_VERSION_MIN_REQUIRED) && (MAC_OS_X_VERSION_MIN_REQUIRED >= 1090)
+  #elif defined(__APPLE__) && defined(__MACH__) && APPLE_HAS_MEMSET_S
     memset_s(dst, len_, 0, len_);
   #elif (defined(__linux__) && !defined(LINUX_NO_EXPLICIT_BZERO)) || defined(__FreeBSD__) || defined(__OpenBSD__)
     explicit_bzero(dst, len_);
@@ -52,7 +66,7 @@ void Lib_Memzero0_memzero0(void *dst, uint64_t len) {
     #warning "Your platform does not support any safe implementation of memzero -- consider a pull request!"
     volatile unsigned char *volatile dst_ = (volatile unsigned char *volatile) dst;
     size_t i = 0U;
-    while (i < len)
+    while (i < len_)
       dst_[i++] = 0U;
   #endif
 }

--- a/Modules/_hacl/Lib_Memzero0.c
+++ b/Modules/_hacl/Lib_Memzero0.c
@@ -13,11 +13,11 @@
 // memset_s is available from macOS 10.9, iOS 7, watchOS 2, and on all tvOS and visionOS versions.
 #  if (defined(MAC_OS_X_VERSION_MIN_REQUIRED) && (MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9))
 #    define APPLE_HAS_MEMSET_S 1
-#  elif (defined(IPHONE_OS_VERSION_MIN_REQUIRED) && (IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
+#  elif (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0))
 #    define APPLE_HAS_MEMSET_S 1
 #  elif (defined(TARGET_OS_TV) && TARGET_OS_TV)
 #    define APPLE_HAS_MEMSET_S 1
-#  elif (defined(WATCH_OS_VERSION_MIN_REQUIRED) && (WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
+#  elif (defined(__WATCH_OS_VERSION_MIN_REQUIRED) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_2_0))
 #    define APPLE_HAS_MEMSET_S 1
 #  elif (defined(TARGET_OS_VISION) && TARGET_OS_VISION)
 #    define APPLE_HAS_MEMSET_S 1

--- a/Modules/_hacl/refresh.sh
+++ b/Modules/_hacl/refresh.sh
@@ -22,7 +22,7 @@ fi
 
 # Update this when updating to a new version after verifying that the changes
 # the update brings in are good.
-expected_hacl_star_rev=322f6d58290e0ed7f4ecb84fcce12917aa0f594b
+expected_hacl_star_rev=cfbd2e5de9a4b053f18cbef2cae92c4f46f28e74
 
 hacl_dir="$(realpath "$1")"
 cd "$(dirname "$0")"

--- a/Modules/_hacl/refresh.sh
+++ b/Modules/_hacl/refresh.sh
@@ -22,7 +22,7 @@ fi
 
 # Update this when updating to a new version after verifying that the changes
 # the update brings in are good.
-expected_hacl_star_rev=cfbd2e5de9a4b053f18cbef2cae92c4f46f28e74
+expected_hacl_star_rev=7720f6d4fc0468a99d5ea6120976bcc271e42727
 
 hacl_dir="$(realpath "$1")"
 cd "$(dirname "$0")"


### PR DESCRIPTION
Bumps the HACL* revision to include updated Apple platform identification code.

This causes iOS to use an known-safe implementation of `memzero_s`, silencing the last build warning on iOS.

/cc @msprotz 