### PR TITLE
gh-96531: tempfile.TemporaryFile should honour write-only mode

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -651,6 +651,9 @@ else:
         prefix, suffix, dir, output_type = _sanitize_params(prefix, suffix, dir)
 
         flags = _bin_openflags
+        if "r" not in mode and "+" not in mode:
+            flags = (flags & ~_os.O_RDWR) | _os.O_WRONLY
+
         if _O_TMPFILE_WORKS:
             fd = None
             def opener(*args):

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -57,6 +57,12 @@ _bin_openflags = _text_openflags
 if hasattr(_os, 'O_BINARY'):
     _bin_openflags |= _os.O_BINARY
 
+def _get_bin_openflags(mode):
+    if "r" in mode or "+" in mode:
+        return _bin_openflags
+    else:
+        return (_bin_openflags & ~_os.O_RDWR) | _os.O_WRONLY
+
 if hasattr(_os, 'TMP_MAX'):
     TMP_MAX = _os.TMP_MAX
 else:
@@ -583,7 +589,7 @@ def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
 
     prefix, suffix, dir, output_type = _sanitize_params(prefix, suffix, dir)
 
-    flags = _bin_openflags
+    flags = _get_bin_openflags(mode)
 
     # Setting O_TEMPORARY in the flags causes the OS to delete
     # the file when it is closed.  This is only supported by Windows.
@@ -650,10 +656,7 @@ else:
 
         prefix, suffix, dir, output_type = _sanitize_params(prefix, suffix, dir)
 
-        flags = _bin_openflags
-        if "r" not in mode and "+" not in mode:
-            flags = (flags & ~_os.O_RDWR) | _os.O_WRONLY
-
+        flags = _get_bin_openflags(mode)
         if _O_TMPFILE_WORKS:
             fd = None
             def opener(*args):

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -952,7 +952,7 @@ class BaseTemporaryFileTestCases:
 
         flags = spy.call_args[0][1]
         self.assertEqual(flags & os.O_RDONLY, 0x0)
-        self.assertEqual(flags & os.O_RDWR, 0x0)
+        self.assertNotEqual(flags & os.O_RDWR, os.O_RDWR)
         self.assertEqual(flags & os.O_WRONLY, os.O_WRONLY)
         self.assertEqual(flags & os.O_EXCL, os.O_EXCL)
 

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -940,14 +940,30 @@ class TestMktemp(BaseTestCase):
 # We test _TemporaryFileWrapper by testing NamedTemporaryFile.
 
 
-class TestNamedTemporaryFile(BaseTestCase):
+class BaseTemporaryFileTestCases:
+    def test_wronly_mode(self):
+        with mock.patch('os.open', wraps=os.open) as spy:
+            with self.do_create(mode='wb') as fileobj:
+                fileobj.write(b'abc')
+                fileobj.seek(0)
+                self.assertRaises(io.UnsupportedOperation, fileobj.read)
+                with self.assertRaises(OSError):
+                    os.read(fileobj.fileno(), 1)
+
+        flags = spy.call_args[0][1]
+        self.assertEqual(flags & os.O_RDONLY, 0x0)
+        self.assertEqual(flags & os.O_RDWR, 0x0)
+        self.assertEqual(flags & os.O_WRONLY, os.O_WRONLY)
+        self.assertEqual(flags & os.O_EXCL, os.O_EXCL)
+
+class TestNamedTemporaryFile(BaseTestCase, BaseTemporaryFileTestCases):
     """Test NamedTemporaryFile()."""
 
-    def do_create(self, dir=None, pre="", suf="", delete=True):
+    def do_create(self, dir=None, pre="", suf="", delete=True, mode='w+b'):
         if dir is None:
             dir = tempfile.gettempdir()
         file = tempfile.NamedTemporaryFile(dir=dir, prefix=pre, suffix=suf,
-                                           delete=delete)
+                                           delete=delete, mode=mode)
 
         self.nameCheck(file.name, dir, pre, suf)
         return file
@@ -1519,8 +1535,11 @@ class TestSpooledTemporaryFile(BaseTestCase):
 
 if tempfile.NamedTemporaryFile is not tempfile.TemporaryFile:
 
-    class TestTemporaryFile(BaseTestCase):
+    class TestTemporaryFile(BaseTestCase, BaseTemporaryFileTestCases):
         """Test TemporaryFile()."""
+
+        def do_create(self, *args, **kwargs):
+            return tempfile.TemporaryFile(*args, **kwargs)
 
         def test_basic(self):
             # TemporaryFile can create files
@@ -1564,21 +1583,6 @@ if tempfile.NamedTemporaryFile is not tempfile.TemporaryFile:
             roundtrip("abdc\n", "w+")
             roundtrip("\u039B", "w+", encoding="utf-16")
             roundtrip("foo\r\n", "w+", newline="")
-
-        def test_wronly_mode(self):
-            with mock.patch('os.open', wraps=os.open) as spy:
-                with tempfile.TemporaryFile(mode='wb') as fileobj:
-                    fileobj.write(b'abc')
-                    fileobj.seek(0)
-                    self.assertRaises(io.UnsupportedOperation, fileobj.read)
-                    with self.assertRaises(OSError):
-                        os.read(fileobj.fileno(), 1)
-
-            flags = spy.call_args[0][1]
-            self.assertEqual(flags & os.O_RDONLY, 0x0)
-            self.assertEqual(flags & os.O_RDWR, 0x0)
-            self.assertEqual(flags & os.O_WRONLY, os.O_WRONLY)
-            self.assertEqual(flags & os.O_EXCL, os.O_EXCL)
 
         def test_bad_mode(self):
             dir = tempfile.mkdtemp()

--- a/Misc/NEWS.d/next/Library/2025-05-01-16-10-47.gh-issue-96531.4WHMzW.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-01-16-10-47.gh-issue-96531.4WHMzW.rst
@@ -1,0 +1,3 @@
+When using ``O_TMPFILE``, open :class:`tempfile.TemporaryFile` file descriptors
+with ``O_WRONLY`` and not ``O_RDWR`` when a write-only mode is given. This will
+prevent low-level reads on their underlying file descriptor.

--- a/Misc/NEWS.d/next/Library/2025-05-01-16-10-47.gh-issue-96531.4WHMzW.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-01-16-10-47.gh-issue-96531.4WHMzW.rst
@@ -1,3 +1,3 @@
-When using ``O_TMPFILE``, open :class:`tempfile.TemporaryFile` file descriptors
-with ``O_WRONLY`` and not ``O_RDWR`` when a write-only mode is given. This will
-prevent low-level reads on their underlying file descriptor.
+Use the ``O_WRONLY`` flag instead of ``O_RDWR`` when opening file descriptors
+for :class:`tempfile.TemporaryFile` and :class:`tempfile.NamedTemporaryFile`
+objects created with a write-only mode).


### PR DESCRIPTION
If the `O_TMPFILE` is available and works `tempfile.TemporaryFile` will always open the temporary file as readable, even if the mode is write only.

Fix this by masking off `O_RDWR` and setting `O_WRONLY` if "r" or "+" is not specified in the mode.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-96531 -->
* Issue: gh-96531
<!-- /gh-issue-number -->
