### PR TITLE
gh-97907: use cancellation error from child if possible

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -844,6 +844,7 @@ def gather(*coros_or_futures, return_exceptions=False):
             # All futures are done; create a list of results
             # and set it to the 'outer' future.
             results = []
+            cancelled_child = None
 
             for fut in children:
                 if fut.cancelled():
@@ -853,6 +854,8 @@ def gather(*coros_or_futures, return_exceptions=False):
                     # to 'results' instead of raising it, don't bother
                     # setting __context__.  This also lets us preserve
                     # calling '_make_cancelled_error()' at most once.
+                    if cancelled_child is None:
+                        cancelled_child = fut
                     res = exceptions.CancelledError(
                         '' if fut._cancel_message is None else
                         fut._cancel_message)
@@ -863,10 +866,15 @@ def gather(*coros_or_futures, return_exceptions=False):
                 results.append(res)
 
             if outer._cancel_requested:
+                # If one or more children were cancelled, raise the exception
+                # from the first of those encountered, otherwise use the last
+                # child. See issue gh-97907.
+                if cancelled_child is None:
+                    cancelled_child = fut
                 # If gather is being cancelled we must propagate the
                 # cancellation regardless of *return_exceptions* argument.
                 # See issue 32684.
-                exc = fut._make_cancelled_error()
+                exc = cancelled_child._make_cancelled_error()
                 outer.set_exception(exc)
             else:
                 outer.set_result(results)

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2418,6 +2418,27 @@ class BaseTaskTests:
                         'raised by inner task to the gather() caller.'
                     )
 
+    def test_cancel_gather_3(self):
+        loop = asyncio.new_event_loop()
+        self.addCleanup(loop.close)
+        barrier = asyncio.Barrier(2)
+
+        async def f1():
+            await barrier.wait()
+            await asyncio.sleep(1)
+
+        async def f2():
+            return 42
+
+        async def main():
+            gfut = asyncio.gather(f2(), f1(), f2(), return_exceptions=True)
+            await barrier.wait()
+            gfut.cancel("my message")
+            await gfut
+
+        with self.assertRaisesRegex(asyncio.CancelledError, "my message"):
+            loop.run_until_complete(main())
+
     def test_exception_traceback(self):
         # See http://bugs.python.org/issue28843
 

--- a/Misc/NEWS.d/next/Library/2025-05-01-21-13-23.gh-issue-97907.MFyz5K.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-01-21-13-23.gh-issue-97907.MFyz5K.rst
@@ -1,0 +1,2 @@
+Ensure cancellation error is raised by :func:`asncio.gather` using the error
+from a cancelled child, if there is one.

--- a/Misc/NEWS.d/next/Library/2025-05-01-21-13-23.gh-issue-97907.MFyz5K.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-01-21-13-23.gh-issue-97907.MFyz5K.rst
@@ -1,2 +1,2 @@
-Ensure cancellation error is raised by :func:`asncio.gather` using the error
+Ensure cancellation error is raised by :func:`asyncio.gather` using the error
 from a cancelled child, if there is one.


### PR DESCRIPTION
At present when cancelling the result of an :func:`asncio.gather` call, the last child is used to create the cancellation error. If that was not cancelled but another child was, its cancellation message and traceback will be lost.

Fix this by using the cancellation error from the first of the children to be cancelled, if any, falling back to the last child only if none have been.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-97907 -->
* Issue: gh-97907
<!-- /gh-issue-number -->
