### PR TITLE
gh-132930: Include IDLE path in registry for PyManager packages

### DIFF
--- a/PC/layout/support/pymanager.py
+++ b/PC/layout/support/pymanager.py
@@ -188,7 +188,7 @@ def calculate_install_json(ns, *, for_embed=False, for_test=False):
         ],
     })
 
-    if TARGETW:
+    if TARGETW and STD_PEP514:
         STD_PEP514[0]["InstallPath"]["WindowedExecutablePath"] = f"%PREFIX%{TARGETW}"
 
     if ns.include_idle:
@@ -206,6 +206,8 @@ def calculate_install_json(ns, *, for_embed=False, for_test=False):
             "Icon": r"%PREFIX%Lib\idlelib\Icons\idle.ico",
             "IconIndex": 0,
         })
+        if STD_PEP514:
+            STD_PEP514[0]["InstallPath"]["IdlePath"] = f"%PREFIX%Lib\\idlelib\\idle.pyw"
 
     if ns.include_html_doc:
         STD_PEP514[0]["Help"]["Main Python Documentation"] = {


### PR DESCRIPTION
This is forward preparation for a future extension to PyManager to list all IDLE installs in .py file context menu (which needs a far more efficient search option than running `py`).

<!-- gh-issue-number: gh-132930 -->
* Issue: gh-132930
<!-- /gh-issue-number -->
