### PR TITLE
gh-133017: Improve error message for invalid typecodes in `multiprocessing.{Array,Value}`

### DIFF
--- a/Lib/multiprocessing/sharedctypes.py
+++ b/Lib/multiprocessing/sharedctypes.py
@@ -42,7 +42,7 @@ def _new_value(type_):
     except TypeError as e:
         raise TypeError("bad typecode (must be a ctypes type or one of "
                         "c, b, B, u, h, H, i, I, l, L, q, Q, f or d)") from e
-    
+
     wrapper = heap.BufferWrapper(size)
     return rebuild_ctype(type_, wrapper, None)
 

--- a/Lib/multiprocessing/sharedctypes.py
+++ b/Lib/multiprocessing/sharedctypes.py
@@ -37,7 +37,12 @@ typecode_to_type = {
 #
 
 def _new_value(type_):
-    size = ctypes.sizeof(type_)
+    try:
+        size = ctypes.sizeof(type_)
+    except TypeError as e:
+        raise TypeError("bad typecode (must be a ctypes type or one of "
+                        "c, b, B, u, h, H, i, I, l, L, q, Q, f or d)") from e
+    
     wrapper = heap.BufferWrapper(size)
     return rebuild_ctype(type_, wrapper, None)
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2463,6 +2463,12 @@ class _TestValue(BaseTestCase):
         self.assertNotHasAttr(arr5, 'get_lock')
         self.assertNotHasAttr(arr5, 'get_obj')
 
+    @unittest.skipIf(c_int is None, "requires _ctypes")
+    def test_invalid_typecode(self):
+        with self.assertRaisesRegex(TypeError, 'bad typecode'):
+            self.Value('x', None)
+        with self.assertRaisesRegex(TypeError, 'bad typecode'):
+            self.RawValue('x', None)
 
 class _TestArray(BaseTestCase):
 
@@ -2543,6 +2549,12 @@ class _TestArray(BaseTestCase):
         self.assertNotHasAttr(arr5, 'get_lock')
         self.assertNotHasAttr(arr5, 'get_obj')
 
+    @unittest.skipIf(c_int is None, "requires _ctypes")
+    def test_invalid_typecode(self):
+        with self.assertRaisesRegex(TypeError, 'bad typecode'):
+            self.Array('x', [])
+        with self.assertRaisesRegex(TypeError, 'bad typecode'):
+            self.RawArray('x', [])
 #
 #
 #

--- a/Misc/NEWS.d/next/Library/2025-05-01-16-03-11.gh-issue-133017.k7RLQp.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-01-16-03-11.gh-issue-133017.k7RLQp.rst
@@ -1,4 +1,4 @@
-Improve the error message of :func:`multiprocessing.Array`,
-:func:`multiprocessing.RawArray`, :func:`multiprocessing.Value` and
-:func:`multiprocessing.RawValue` when an invalid typecode is passed. Patch
+Improve the error message of :func:`multiprocessing.sharedctypes.Array`,
+:func:`multiprocessing.sharedctypes.RawArray`, :func:`multiprocessing.sharedctypes.Value` and
+:func:`multiprocessing.sharedctypes.RawValue` when an invalid typecode is passed. Patch
 by Tomas Roun

--- a/Misc/NEWS.d/next/Library/2025-05-01-16-03-11.gh-issue-133017.k7RLQp.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-01-16-03-11.gh-issue-133017.k7RLQp.rst
@@ -1,0 +1,4 @@
+Improve the error message of :func:`multiprocessing.Array`,
+:func:`multiprocessing.RawArray`, :func:`multiprocessing.Value` and
+:func:`multiprocessing.RawValue` when an invalid typecode is passed. Patch
+by Tomas Roun


### PR DESCRIPTION
Changes the error message from the default ctypes error which rather cryptic to a more user-friendly error.

The error message follows the same structure as the one raised by `array.array`.

<!-- gh-issue-number: gh-133017 -->
* Issue: gh-133017
<!-- /gh-issue-number -->
