### PR TITLE
gh-132915: Fix compiler warning in fcntlmodule.c

### DIFF
--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -24,7 +24,7 @@
 
 #define GUARDSZ 8
 // NUL followed by random bytes.
-static const char guard[GUARDSZ] = "\x00\xfa\x69\xc4\x67\xa3\x6c\x58";
+static const char guard[GUARDSZ+1] = "\x00\xfa\x69\xc4\x67\xa3\x6c\x58";
 
 /*[clinic input]
 module fcntl


### PR DESCRIPTION
Fix the warning:

    Modules/fcntlmodule.c:27:36: warning: initializer-string for
    array of 'char' truncates NUL terminator but destination lacks
    'nonstring' attribute (9 chars into 8 available)
    [-Wunterminated-string-initialization]
    static const char guard[GUARDSZ] = "\x00\xfa\x69\xc4\x67\xa3\x6c\x58";

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-132915 -->
* Issue: gh-132915
<!-- /gh-issue-number -->
