### PR TITLE
gh-133256: Add _Py_NONSTRING macro

### DIFF
--- a/Include/internal/pycore_debug_offsets.h
+++ b/Include/internal/pycore_debug_offsets.h
@@ -59,7 +59,7 @@ extern "C" {
 
 
 typedef struct _Py_DebugOffsets {
-    char cookie[8];
+    char cookie[8] _Py_NONSTRING;
     uint64_t version;
     uint64_t free_threaded;
     // Runtime state offset;

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -685,4 +685,19 @@ extern "C" {
 #endif
 
 
+// _Py_NONSTRING: The nonstring variable attribute specifies that an object or
+// member declaration with type array of char, signed char, or unsigned char,
+// or pointer to such a type is intended to store character arrays that do not
+// necessarily contain a terminating NUL.
+//
+// Usage:
+//
+//   char name [8] _Py_NONSTRING;
+#if _Py__has_attribute(nonstring)
+#  define _Py_NONSTRING __attribute__((nonstring))
+#else
+#  define _Py_NONSTRING
+#endif
+
+
 #endif /* Py_PYPORT_H */

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -24,7 +24,7 @@
 
 #define GUARDSZ 8
 // NUL followed by random bytes.
-static const char guard[GUARDSZ] = "\x00\xfa\x69\xc4\x67\xa3\x6c\x58";
+static const char guard[GUARDSZ] _Py_NONSTRING = "\x00\xfa\x69\xc4\x67\xa3\x6c\x58";
 
 /*[clinic input]
 module fcntl


### PR DESCRIPTION
Fix GCC 15 compiler warnings such as:

    Modules/fcntlmodule.c:27:36: warning: initializer-string for
    array of 'char' truncates NUL terminator but destination lacks
    'nonstring' attribute (9 chars into 8 available)
    [-Wunterminated-string-initialization]
    static const char guard[GUARDSZ] = "\x00\xfa\x69\xc4\x67\xa3\x6c\x58";

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133256 -->
* Issue: gh-133256
<!-- /gh-issue-number -->
