### PR TITLE
gh-133259: Show path to python.sh script on successful build

### DIFF
--- a/Tools/wasm/wasi.py
+++ b/Tools/wasm/wasi.py
@@ -270,6 +270,10 @@ def make_wasi_python(context, working_dir):
 
     exec_script = working_dir / "python.sh"
     subprocess.check_call([exec_script, "--version"])
+    print(
+        f"🎉 Use '{exec_script.relative_to(context.init_dir)}' "
+        "to run CPython in wasmtime"
+    )
 
 
 def build_all(context):
@@ -348,6 +352,7 @@ def main():
                         help="The target triple for the WASI host build")
 
     context = parser.parse_args()
+    context.init_dir = pathlib.Path().absolute()
 
     dispatch = {"configure-build-python": configure_build_python,
                 "make-build-python": make_build_python,

--- a/Tools/wasm/wasi.py
+++ b/Tools/wasm/wasi.py
@@ -272,7 +272,7 @@ def make_wasi_python(context, working_dir):
     subprocess.check_call([exec_script, "--version"])
     print(
         f"🎉 Use '{exec_script.relative_to(context.init_dir)}' "
-        "to run CPython in wasmtime"
+        "to run CPython in wasm runtime"
     )
 
 


### PR DESCRIPTION
This is a slightly different solution than @brettcannon suggested.  At least on my machine, my CPython checkout is pretty deep, so it's nice to just show the path relative to the checkout.

<!-- gh-issue-number: gh-133259 -->
* Issue: gh-133259
<!-- /gh-issue-number -->
