### PR TITLE
gh-133261: Use __builtin_frame_address() on GCC 9 and older

### DIFF
--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -300,7 +300,7 @@ _Py_AssertHoldsTstateFunc(const char *func)
 #define _Py_AssertHoldsTstate()
 #endif
 
-#if !_Py__has_builtin(__builtin_frame_address) && !defined(_MSC_VER)
+#if !_Py__has_builtin(__builtin_frame_address) && !defined(__GNUC__) && !defined(_MSC_VER)
 static uintptr_t return_pointer_as_int(char* p) {
     return (uintptr_t)p;
 }
@@ -308,7 +308,7 @@ static uintptr_t return_pointer_as_int(char* p) {
 
 static inline uintptr_t
 _Py_get_machine_stack_pointer(void) {
-#if _Py__has_builtin(__builtin_frame_address)
+#if _Py__has_builtin(__builtin_frame_address) || defined(__GNUC__)
     return (uintptr_t)__builtin_frame_address(0);
 #elif defined(_MSC_VER)
     return (uintptr_t)_AddressOfReturnAddress();


### PR DESCRIPTION
GCC 9 and older don't have __has_builtin(), but have __builtin_frame_address() function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133261 -->
* Issue: gh-133261
<!-- /gh-issue-number -->
