### PR TITLE
gh-124397: Add itertools.serialize (name tbd)

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -56,6 +56,7 @@ Iterator                        Arguments                       Results         
 :func:`groupby`                 iterable[, key]                 sub-iterators grouped by value of key(v)            ``groupby(['A','B','DEF'], len) → (1, A B) (3, DEF)``
 :func:`islice`                  seq, [start,] stop [, step]     elements from seq[start:stop:step]                  ``islice('ABCDEFG', 2, None) → C D E F G``
 :func:`pairwise`                iterable                        (p[0], p[1]), (p[1], p[2])                          ``pairwise('ABCDEFG') → AB BC CD DE EF FG``
+:func:`serialize`               iterable                        p0, p1, p2, ...                                     ``serialize([1,4,6]) → 1 4 6``
 :func:`starmap`                 func, seq                       func(\*seq[0]), func(\*seq[1]), ...                 ``starmap(pow, [(2,5), (3,2), (10,3)]) → 32 9 1000``
 :func:`takewhile`               predicate, seq                  seq[0], seq[1], until predicate fails               ``takewhile(lambda x: x<5, [1,4,6,3,8]) → 1 4``
 :func:`tee`                     it, n                           it1, it2, ... itn  splits one iterator into n       ``tee('ABC', 2) → A B C, A B C``
@@ -648,6 +649,19 @@ loops that truncate the stream.
       >>> list(map(pow, range(10), repeat(2)))
       [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
 
+.. function:: serialize(iterable)
+
+   Make an iterator thread-safe. [TBD]
+
+   Roughly equivalent to::
+
+        class serialize(Iterator):
+            def __init__(self, it):
+                self._it = iter(it)
+                self._lock = Lock()
+            def __next__(self):
+                with self._lock:
+                    return next(self._it)
 
 .. function:: starmap(function, iterable)
 

--- a/Lib/test/test_free_threading/test_itertools_serialize.py
+++ b/Lib/test/test_free_threading/test_itertools_serialize.py
@@ -1,0 +1,82 @@
+import unittest
+from threading import Thread, Barrier
+from itertools import serialize
+from test.support import threading_helper
+
+
+threading_helper.requires_working_threading(module=True)
+
+class non_atomic_iterator:
+
+    def __init__(self, it):
+        self.it = iter(it)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        a = next(self.it)
+        b = next(self.it)
+        return a, b
+
+def count():
+    i = 0
+    while True:
+        i += 1
+        yield i
+
+class SerializeThreading(unittest.TestCase):
+
+    @threading_helper.reap_threads
+    def test_serialize(self):
+        number_of_threads = 10
+        number_of_iterations = 10
+        barrier = Barrier(number_of_threads)
+        def work(it):
+            while True:
+                try:
+                    a, b = next(it)
+                    assert a + 1 == b
+                except StopIteration:
+                    break
+
+        data = tuple(range(400))
+        for it in range(number_of_iterations):
+            serialize_iterator = serialize(non_atomic_iterator(data,))
+            worker_threads = []
+            for ii in range(number_of_threads):
+                worker_threads.append(
+                    Thread(target=work, args=[serialize_iterator]))
+
+            with threading_helper.start_threads(worker_threads):
+                pass
+
+            barrier.reset()
+
+    @threading_helper.reap_threads
+    def test_serialize_generator(self):
+        number_of_threads = 5
+        number_of_iterations = 4
+        barrier = Barrier(number_of_threads)
+        def work(it):
+            barrier.wait()
+            for _ in range(1_000):
+                try:
+                    next(it)
+                except StopIteration:
+                    break
+
+        for it in range(number_of_iterations):
+            generator = serialize(count())
+            worker_threads = []
+            for ii in range(number_of_threads):
+                worker_threads.append(
+                    Thread(target=work, args=[generator]))
+
+            with threading_helper.start_threads(worker_threads):
+                pass
+
+            barrier.reset()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -2331,6 +2331,19 @@ class TestVariousIteratorArgs(unittest.TestCase):
             self.assertRaises(TypeError, tee, N(s))
             self.assertRaises(ZeroDivisionError, list, tee(E(s))[0])
 
+    def test_serialize(self):
+        for s in ("123", "", range(1000), ('do', 1.2), range(2000,2200,5)):
+            for g in (G, I, Ig, S, L, R):
+                seq = list(g(s))
+                expected = seq
+                actual = list(serialize(g(s)))
+                self.assertEqual(actual, expected)
+            self.assertRaises(TypeError, serialize, X(s))
+            self.assertRaises(TypeError, serialize, N(s))
+            self.assertRaises(ZeroDivisionError, list, serialize(E(s)))
+        for arg in [1, True, sys]:
+            self.assertRaises(TypeError, serialize, arg)
+
 class LengthTransparency(unittest.TestCase):
 
     def test_repeat(self):

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -965,4 +965,34 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=999758202a532e0a input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(itertools_serialize__doc__,
+"serialize(iterable, /)\n"
+"--\n"
+"\n"
+"Make an iterator thread-safe [tbd]");
+
+static PyObject *
+itertools_serialize_impl(PyTypeObject *type, PyObject *iterable);
+
+static PyObject *
+itertools_serialize(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyTypeObject *base_tp = clinic_state()->serialize_type;
+    PyObject *iterable;
+
+    if ((type == base_tp || type->tp_init == base_tp->tp_init) &&
+        !_PyArg_NoKeywords("serialize", kwargs)) {
+        goto exit;
+    }
+    if (!_PyArg_CheckPositional("serialize", PyTuple_GET_SIZE(args), 1, 1)) {
+        goto exit;
+    }
+    iterable = PyTuple_GET_ITEM(args, 0);
+    return_value = itertools_serialize_impl(type, iterable);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=5f9393576be897be input=a9049054013a1b77]*/


### PR DESCRIPTION
Add `itertools.serialize` to make a non-threadsafe iterator thread-safe. 

- [ ] Bikeshedding on the naming ([thread](https://discuss.python.org/t/name-for-new-itertools-object-to-make-iterators-thread-safe/90394) at discuss.python.org)
- [ ] Update documentation
- [ ] Add method to make generator function thread-safe (probably a followup PR)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124397 -->
* Issue: gh-124397
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133272.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->