### PR TITLE
gh-133194: Fix regression with PEP 758 parsing on older `feature_version`

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -443,26 +443,30 @@ try_stmt[stmt_ty]:
 
 except_block[excepthandler_ty]:
     | invalid_except_stmt_indent
+    | 'except' e=expression ':' b=block {
+        _PyAST_ExceptHandler(e, NULL, b, EXTRA) }
+    | 'except' e=expression 'as' t=NAME ':' b=block {
+        _PyAST_ExceptHandler(e, ((expr_ty) t)->v.Name.id, b, EXTRA) }
     | 'except' e=expressions ':' b=block {
         CHECK_VERSION(
             excepthandler_ty, 
             14, 
-            "except expressions without parentheses", 
-            _PyAST_ExceptHandler(e,  NULL, b, EXTRA)) }
-    | 'except' e=expression 'as' t=NAME  ':' b=block {
-        _PyAST_ExceptHandler(e, ((expr_ty) t)->v.Name.id, b, EXTRA) }
+            "except expressions without parentheses are", 
+            _PyAST_ExceptHandler(e, NULL, b, EXTRA)) }
     | 'except' ':' b=block { _PyAST_ExceptHandler(NULL, NULL, b, EXTRA) }
     | invalid_except_stmt
 except_star_block[excepthandler_ty]:
     | invalid_except_star_stmt_indent
+    | 'except' '*' e=expression ':' b=block {
+        _PyAST_ExceptHandler(e, NULL, b, EXTRA) }
+    | 'except' '*' e=expression 'as' t=NAME ':' b=block {
+        _PyAST_ExceptHandler(e, ((expr_ty) t)->v.Name.id, b, EXTRA) }
     | 'except' '*' e=expressions ':' b=block {
         CHECK_VERSION(
             excepthandler_ty, 
             14, 
-            "except expressions without parentheses", 
+            "except expressions without parentheses are", 
             _PyAST_ExceptHandler(e,  NULL, b, EXTRA)) }
-    | 'except' '*' e=expression 'as' t=NAME ':' b=block {
-        _PyAST_ExceptHandler(e, ((expr_ty) t)->v.Name.id, b, EXTRA) }
     | invalid_except_star_stmt
 finally_block[asdl_stmt_seq*]:
     | invalid_finally_stmt

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -692,6 +692,63 @@ class AST_Tests(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             ast.parse(code, feature_version=(3, 13))
 
+    def test_pep758_except_with_single_expr(self):
+        single_expr = textwrap.dedent("""
+            try:
+                ...
+            except{0} TypeError:
+                ...
+        """)
+
+        single_expr_with_as = textwrap.dedent("""
+            try:
+                ...
+            except{0} TypeError as exc:
+                ...
+        """)
+
+        single_tuple_expr = textwrap.dedent("""
+            try:
+                ...
+            except{0} (TypeError,):
+                ...
+        """)
+
+        single_tuple_expr_with_as = textwrap.dedent("""
+            try:
+                ...
+            except{0} (TypeError,) as exc:
+                ...
+        """)
+
+        single_parens_expr = textwrap.dedent("""
+            try:
+                ...
+            except{0} (TypeError):
+                ...
+        """)
+
+        single_parens_expr_with_as = textwrap.dedent("""
+            try:
+                ...
+            except{0} (TypeError) as exc:
+                ...
+        """)
+
+        for code in [
+            single_expr,
+            single_expr_with_as,
+            single_tuple_expr,
+            single_tuple_expr_with_as,
+            single_parens_expr,
+            single_parens_expr_with_as,
+        ]:
+            for star in [True, False]:
+                code = code.format('*' if star else '')
+                with self.subTest(code=code, star=star):
+                    ast.parse(code, feature_version=(3, 14))
+                    ast.parse(code, feature_version=(3, 13))
+
     def test_pep758_except_star_without_parens(self):
         code = textwrap.dedent("""
             try:

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -21,54 +21,54 @@ static KeywordToken *reserved_keywords[] = {
     (KeywordToken[]) {{NULL, -1}},
     (KeywordToken[]) {{NULL, -1}},
     (KeywordToken[]) {
-        {"if", 680},
-        {"as", 678},
-        {"in", 693},
-        {"or", 586},
-        {"is", 594},
+        {"if", 682},
+        {"as", 680},
+        {"in", 695},
+        {"or", 588},
+        {"is", 596},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"del", 623},
-        {"def", 697},
-        {"for", 692},
-        {"try", 654},
-        {"and", 587},
-        {"not", 701},
+        {"del", 625},
+        {"def", 699},
+        {"for", 694},
+        {"try", 656},
+        {"and", 589},
+        {"not", 703},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"from", 631},
+        {"from", 633},
         {"pass", 526},
-        {"with", 645},
-        {"elif", 685},
-        {"else", 684},
-        {"None", 621},
-        {"True", 620},
+        {"with", 647},
+        {"elif", 687},
+        {"else", 686},
+        {"None", 623},
+        {"True", 622},
         {NULL, -1},
     },
     (KeywordToken[]) {
         {"raise", 525},
-        {"yield", 585},
+        {"yield", 587},
         {"break", 527},
-        {"async", 696},
-        {"class", 699},
-        {"while", 687},
-        {"False", 622},
-        {"await", 595},
+        {"async", 698},
+        {"class", 701},
+        {"while", 689},
+        {"False", 624},
+        {"await", 597},
         {NULL, -1},
     },
     (KeywordToken[]) {
         {"return", 522},
-        {"import", 632},
+        {"import", 634},
         {"assert", 532},
         {"global", 529},
-        {"except", 675},
-        {"lambda", 619},
+        {"except", 677},
+        {"lambda", 621},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"finally", 671},
+        {"finally", 673},
         {NULL, -1},
     },
     (KeywordToken[]) {
@@ -1740,7 +1740,7 @@ simple_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'del' del_stmt"));
         stmt_ty del_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 623)  // token='del'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 625)  // token='del'
             &&
             (del_stmt_var = del_stmt_rule(p))  // del_stmt
         )
@@ -1761,7 +1761,7 @@ simple_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'yield' yield_stmt"));
         stmt_ty yield_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 585)  // token='yield'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 587)  // token='yield'
             &&
             (yield_stmt_var = yield_stmt_rule(p))  // yield_stmt
         )
@@ -1936,7 +1936,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'if' if_stmt"));
         stmt_ty if_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 680)  // token='if'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 682)  // token='if'
             &&
             (if_stmt_var = if_stmt_rule(p))  // if_stmt
         )
@@ -2020,7 +2020,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'try' try_stmt"));
         stmt_ty try_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 654)  // token='try'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 656)  // token='try'
             &&
             (try_stmt_var = try_stmt_rule(p))  // try_stmt
         )
@@ -2041,7 +2041,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'while' while_stmt"));
         stmt_ty while_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 687)  // token='while'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 689)  // token='while'
             &&
             (while_stmt_var = while_stmt_rule(p))  // while_stmt
         )
@@ -3209,7 +3209,7 @@ del_stmt_rule(Parser *p)
         Token * _keyword;
         asdl_expr_seq* a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 623))  // token='del'
+            (_keyword = _PyPegen_expect_token(p, 625))  // token='del'
             &&
             (a = del_targets_rule(p))  // del_targets
             &&
@@ -3498,7 +3498,7 @@ import_name_rule(Parser *p)
         Token * _keyword;
         asdl_alias_seq* a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 632))  // token='import'
+            (_keyword = _PyPegen_expect_token(p, 634))  // token='import'
             &&
             (a = dotted_as_names_rule(p))  // dotted_as_names
         )
@@ -3567,13 +3567,13 @@ import_from_rule(Parser *p)
         expr_ty b;
         asdl_alias_seq* c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 631))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 633))  // token='from'
             &&
             (a = _loop0_18_rule(p))  // (('.' | '...'))*
             &&
             (b = dotted_name_rule(p))  // dotted_name
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 632))  // token='import'
+            (_keyword_1 = _PyPegen_expect_token(p, 634))  // token='import'
             &&
             (c = import_from_targets_rule(p))  // import_from_targets
         )
@@ -3611,11 +3611,11 @@ import_from_rule(Parser *p)
         asdl_seq * a;
         asdl_alias_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 631))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 633))  // token='from'
             &&
             (a = _loop1_19_rule(p))  // (('.' | '...'))+
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 632))  // token='import'
+            (_keyword_1 = _PyPegen_expect_token(p, 634))  // token='import'
             &&
             (b = import_from_targets_rule(p))  // import_from_targets
         )
@@ -4402,7 +4402,7 @@ class_def_raw_rule(Parser *p)
         asdl_stmt_seq* c;
         void *t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 699))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='class'
             &&
             (a = _PyPegen_name_token(p))  // NAME
             &&
@@ -4569,7 +4569,7 @@ function_def_raw_rule(Parser *p)
         void *t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 697))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='def'
             &&
             (n = _PyPegen_name_token(p))  // NAME
             &&
@@ -4630,9 +4630,9 @@ function_def_raw_rule(Parser *p)
         void *t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 696))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 697))  // token='def'
+            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='def'
             &&
             (n = _PyPegen_name_token(p))  // NAME
             &&
@@ -5970,7 +5970,7 @@ if_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         stmt_ty c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6015,7 +6015,7 @@ if_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6110,7 +6110,7 @@ elif_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         stmt_ty c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 685))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 687))  // token='elif'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6155,7 +6155,7 @@ elif_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 685))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 687))  // token='elif'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6236,7 +6236,7 @@ else_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 684))  // token='else'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='else'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -6315,7 +6315,7 @@ while_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 687))  // token='while'
+            (_keyword = _PyPegen_expect_token(p, 689))  // token='while'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6415,11 +6415,11 @@ for_stmt_rule(Parser *p)
         expr_ty t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 692))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
             &&
             (t = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 693))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 695))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -6477,13 +6477,13 @@ for_stmt_rule(Parser *p)
         expr_ty t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 696))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 692))  // token='for'
+            (_keyword_1 = _PyPegen_expect_token(p, 694))  // token='for'
             &&
             (t = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_2 = _PyPegen_expect_token(p, 693))  // token='in'
+            (_keyword_2 = _PyPegen_expect_token(p, 695))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -6612,7 +6612,7 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 645))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 647))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -6663,7 +6663,7 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 645))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 647))  // token='with'
             &&
             (a = (asdl_withitem_seq*)_gather_35_rule(p))  // ','.with_item+
             &&
@@ -6712,9 +6712,9 @@ with_stmt_rule(Parser *p)
         asdl_withitem_seq* a;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 696))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 645))  // token='with'
+            (_keyword_1 = _PyPegen_expect_token(p, 647))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -6764,9 +6764,9 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 696))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 645))  // token='with'
+            (_keyword_1 = _PyPegen_expect_token(p, 647))  // token='with'
             &&
             (a = (asdl_withitem_seq*)_gather_35_rule(p))  // ','.with_item+
             &&
@@ -6852,7 +6852,7 @@ with_item_rule(Parser *p)
         if (
             (e = expression_rule(p))  // expression
             &&
-            (_keyword = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (t = star_target_rule(p))  // star_target
             &&
@@ -6977,7 +6977,7 @@ try_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         asdl_stmt_seq* f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 654))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7021,7 +7021,7 @@ try_stmt_rule(Parser *p)
         asdl_excepthandler_seq* ex;
         void *f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 654))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7069,7 +7069,7 @@ try_stmt_rule(Parser *p)
         asdl_excepthandler_seq* ex;
         void *f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 654))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7112,8 +7112,9 @@ try_stmt_rule(Parser *p)
 
 // except_block:
 //     | invalid_except_stmt_indent
-//     | 'except' expressions ':' block
+//     | 'except' expression ':' block
 //     | 'except' expression 'as' NAME ':' block
+//     | 'except' expressions ':' block
 //     | 'except' ':' block
 //     | invalid_except_stmt
 static excepthandler_ty
@@ -7156,27 +7157,27 @@ except_block_rule(Parser *p)
         D(fprintf(stderr, "%*c%s except_block[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_except_stmt_indent"));
     }
-    { // 'except' expressions ':' block
+    { // 'except' expression ':' block
         if (p->error_indicator) {
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> except_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' expressions ':' block"));
+        D(fprintf(stderr, "%*c> except_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' expression ':' block"));
         Token * _keyword;
         Token * _literal;
         asdl_stmt_seq* b;
         expr_ty e;
         if (
-            (_keyword = _PyPegen_expect_token(p, 675))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
             &&
-            (e = expressions_rule(p))  // expressions
+            (e = expression_rule(p))  // expression
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
             (b = block_rule(p))  // block
         )
         {
-            D(fprintf(stderr, "%*c+ except_block[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except' expressions ':' block"));
+            D(fprintf(stderr, "%*c+ except_block[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except' expression ':' block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
                 p->level--;
@@ -7186,7 +7187,7 @@ except_block_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( excepthandler_ty , 14 , "except expressions without parentheses" , _PyAST_ExceptHandler ( e , NULL , b , EXTRA ) );
+            _res = _PyAST_ExceptHandler ( e , NULL , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;
@@ -7196,7 +7197,7 @@ except_block_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s except_block[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'except' expressions ':' block"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'except' expression ':' block"));
     }
     { // 'except' expression 'as' NAME ':' block
         if (p->error_indicator) {
@@ -7211,11 +7212,11 @@ except_block_rule(Parser *p)
         expr_ty e;
         expr_ty t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 675))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (e = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (t = _PyPegen_name_token(p))  // NAME
             &&
@@ -7246,6 +7247,48 @@ except_block_rule(Parser *p)
         D(fprintf(stderr, "%*c%s except_block[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'except' expression 'as' NAME ':' block"));
     }
+    { // 'except' expressions ':' block
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> except_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' expressions ':' block"));
+        Token * _keyword;
+        Token * _literal;
+        asdl_stmt_seq* b;
+        expr_ty e;
+        if (
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            &&
+            (e = expressions_rule(p))  // expressions
+            &&
+            (_literal = _PyPegen_expect_token(p, 11))  // token=':'
+            &&
+            (b = block_rule(p))  // block
+        )
+        {
+            D(fprintf(stderr, "%*c+ except_block[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except' expressions ':' block"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                p->level--;
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = CHECK_VERSION ( excepthandler_ty , 14 , "except expressions without parentheses are" , _PyAST_ExceptHandler ( e , NULL , b , EXTRA ) );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s except_block[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'except' expressions ':' block"));
+    }
     { // 'except' ':' block
         if (p->error_indicator) {
             p->level--;
@@ -7256,7 +7299,7 @@ except_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 675))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -7312,8 +7355,9 @@ except_block_rule(Parser *p)
 
 // except_star_block:
 //     | invalid_except_star_stmt_indent
-//     | 'except' '*' expressions ':' block
+//     | 'except' '*' expression ':' block
 //     | 'except' '*' expression 'as' NAME ':' block
+//     | 'except' '*' expressions ':' block
 //     | invalid_except_star_stmt
 static excepthandler_ty
 except_star_block_rule(Parser *p)
@@ -7355,30 +7399,30 @@ except_star_block_rule(Parser *p)
         D(fprintf(stderr, "%*c%s except_star_block[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_except_star_stmt_indent"));
     }
-    { // 'except' '*' expressions ':' block
+    { // 'except' '*' expression ':' block
         if (p->error_indicator) {
             p->level--;
             return NULL;
         }
-        D(fprintf(stderr, "%*c> except_star_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' '*' expressions ':' block"));
+        D(fprintf(stderr, "%*c> except_star_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' '*' expression ':' block"));
         Token * _keyword;
         Token * _literal;
         Token * _literal_1;
         asdl_stmt_seq* b;
         expr_ty e;
         if (
-            (_keyword = _PyPegen_expect_token(p, 675))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
-            (e = expressions_rule(p))  // expressions
+            (e = expression_rule(p))  // expression
             &&
             (_literal_1 = _PyPegen_expect_token(p, 11))  // token=':'
             &&
             (b = block_rule(p))  // block
         )
         {
-            D(fprintf(stderr, "%*c+ except_star_block[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except' '*' expressions ':' block"));
+            D(fprintf(stderr, "%*c+ except_star_block[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except' '*' expression ':' block"));
             Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
             if (_token == NULL) {
                 p->level--;
@@ -7388,7 +7432,7 @@ except_star_block_rule(Parser *p)
             UNUSED(_end_lineno); // Only used by EXTRA macro
             int _end_col_offset = _token->end_col_offset;
             UNUSED(_end_col_offset); // Only used by EXTRA macro
-            _res = CHECK_VERSION ( excepthandler_ty , 14 , "except expressions without parentheses" , _PyAST_ExceptHandler ( e , NULL , b , EXTRA ) );
+            _res = _PyAST_ExceptHandler ( e , NULL , b , EXTRA );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;
@@ -7398,7 +7442,7 @@ except_star_block_rule(Parser *p)
         }
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s except_star_block[%d-%d]: %s failed!\n", p->level, ' ',
-                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'except' '*' expressions ':' block"));
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'except' '*' expression ':' block"));
     }
     { // 'except' '*' expression 'as' NAME ':' block
         if (p->error_indicator) {
@@ -7414,13 +7458,13 @@ except_star_block_rule(Parser *p)
         expr_ty e;
         expr_ty t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 675))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
             (e = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (t = _PyPegen_name_token(p))  // NAME
             &&
@@ -7450,6 +7494,51 @@ except_star_block_rule(Parser *p)
         p->mark = _mark;
         D(fprintf(stderr, "%*c%s except_star_block[%d-%d]: %s failed!\n", p->level, ' ',
                   p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'except' '*' expression 'as' NAME ':' block"));
+    }
+    { // 'except' '*' expressions ':' block
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> except_star_block[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except' '*' expressions ':' block"));
+        Token * _keyword;
+        Token * _literal;
+        Token * _literal_1;
+        asdl_stmt_seq* b;
+        expr_ty e;
+        if (
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            &&
+            (_literal = _PyPegen_expect_token(p, 16))  // token='*'
+            &&
+            (e = expressions_rule(p))  // expressions
+            &&
+            (_literal_1 = _PyPegen_expect_token(p, 11))  // token=':'
+            &&
+            (b = block_rule(p))  // block
+        )
+        {
+            D(fprintf(stderr, "%*c+ except_star_block[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except' '*' expressions ':' block"));
+            Token *_token = _PyPegen_get_last_nonnwhitespace_token(p);
+            if (_token == NULL) {
+                p->level--;
+                return NULL;
+            }
+            int _end_lineno = _token->end_lineno;
+            UNUSED(_end_lineno); // Only used by EXTRA macro
+            int _end_col_offset = _token->end_col_offset;
+            UNUSED(_end_col_offset); // Only used by EXTRA macro
+            _res = CHECK_VERSION ( excepthandler_ty , 14 , "except expressions without parentheses are" , _PyAST_ExceptHandler ( e , NULL , b , EXTRA ) );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s except_star_block[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'except' '*' expressions ':' block"));
     }
     if (p->call_invalid_rules) { // invalid_except_star_stmt
         if (p->error_indicator) {
@@ -7518,7 +7607,7 @@ finally_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 671))  // token='finally'
+            (_keyword = _PyPegen_expect_token(p, 673))  // token='finally'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7826,7 +7915,7 @@ guard_rule(Parser *p)
         Token * _keyword;
         expr_ty guard;
         if (
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
             &&
             (guard = named_expression_rule(p))  // named_expression
         )
@@ -8021,7 +8110,7 @@ as_pattern_rule(Parser *p)
         if (
             (pattern = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (target = pattern_capture_target_rule(p))  // pattern_capture_target
         )
@@ -8455,7 +8544,7 @@ literal_pattern_rule(Parser *p)
         D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'None'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 621))  // token='None'
+            (_keyword = _PyPegen_expect_token(p, 623))  // token='None'
         )
         {
             D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'None'"));
@@ -8488,7 +8577,7 @@ literal_pattern_rule(Parser *p)
         D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'True'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 620))  // token='True'
+            (_keyword = _PyPegen_expect_token(p, 622))  // token='True'
         )
         {
             D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'True'"));
@@ -8521,7 +8610,7 @@ literal_pattern_rule(Parser *p)
         D(fprintf(stderr, "%*c> literal_pattern[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'False'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 622))  // token='False'
+            (_keyword = _PyPegen_expect_token(p, 624))  // token='False'
         )
         {
             D(fprintf(stderr, "%*c+ literal_pattern[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'False'"));
@@ -8649,7 +8738,7 @@ literal_expr_rule(Parser *p)
         D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'None'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 621))  // token='None'
+            (_keyword = _PyPegen_expect_token(p, 623))  // token='None'
         )
         {
             D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'None'"));
@@ -8682,7 +8771,7 @@ literal_expr_rule(Parser *p)
         D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'True'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 620))  // token='True'
+            (_keyword = _PyPegen_expect_token(p, 622))  // token='True'
         )
         {
             D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'True'"));
@@ -8715,7 +8804,7 @@ literal_expr_rule(Parser *p)
         D(fprintf(stderr, "%*c> literal_expr[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'False'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 622))  // token='False'
+            (_keyword = _PyPegen_expect_token(p, 624))  // token='False'
         )
         {
             D(fprintf(stderr, "%*c+ literal_expr[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'False'"));
@@ -11318,11 +11407,11 @@ expression_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 684))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 686))  // token='else'
             &&
             (c = expression_rule(p))  // expression
         )
@@ -11426,9 +11515,9 @@ yield_expr_rule(Parser *p)
         Token * _keyword_1;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 585))  // token='yield'
+            (_keyword = _PyPegen_expect_token(p, 587))  // token='yield'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 631))  // token='from'
+            (_keyword_1 = _PyPegen_expect_token(p, 633))  // token='from'
             &&
             (a = expression_rule(p))  // expression
         )
@@ -11464,7 +11553,7 @@ yield_expr_rule(Parser *p)
         Token * _keyword;
         void *a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 585))  // token='yield'
+            (_keyword = _PyPegen_expect_token(p, 587))  // token='yield'
             &&
             (a = star_expressions_rule(p), !p->error_indicator)  // star_expressions?
         )
@@ -12204,7 +12293,7 @@ inversion_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 701))  // token='not'
+            (_keyword = _PyPegen_expect_token(p, 703))  // token='not'
             &&
             (a = inversion_rule(p))  // inversion
         )
@@ -12858,9 +12947,9 @@ notin_bitwise_or_rule(Parser *p)
         Token * _keyword_1;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 701))  // token='not'
+            (_keyword = _PyPegen_expect_token(p, 703))  // token='not'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 693))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 695))  // token='in'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -12906,7 +12995,7 @@ in_bitwise_or_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 693))  // token='in'
+            (_keyword = _PyPegen_expect_token(p, 695))  // token='in'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -12953,9 +13042,9 @@ isnot_bitwise_or_rule(Parser *p)
         Token * _keyword_1;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 594))  // token='is'
+            (_keyword = _PyPegen_expect_token(p, 596))  // token='is'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 701))  // token='not'
+            (_keyword_1 = _PyPegen_expect_token(p, 703))  // token='not'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -13001,7 +13090,7 @@ is_bitwise_or_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 594))  // token='is'
+            (_keyword = _PyPegen_expect_token(p, 596))  // token='is'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -14317,7 +14406,7 @@ await_primary_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 595))  // token='await'
+            (_keyword = _PyPegen_expect_token(p, 597))  // token='await'
             &&
             (a = primary_rule(p))  // primary
         )
@@ -14861,7 +14950,7 @@ atom_rule(Parser *p)
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'True'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 620))  // token='True'
+            (_keyword = _PyPegen_expect_token(p, 622))  // token='True'
         )
         {
             D(fprintf(stderr, "%*c+ atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'True'"));
@@ -14894,7 +14983,7 @@ atom_rule(Parser *p)
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'False'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 622))  // token='False'
+            (_keyword = _PyPegen_expect_token(p, 624))  // token='False'
         )
         {
             D(fprintf(stderr, "%*c+ atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'False'"));
@@ -14927,7 +15016,7 @@ atom_rule(Parser *p)
         D(fprintf(stderr, "%*c> atom[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'None'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 621))  // token='None'
+            (_keyword = _PyPegen_expect_token(p, 623))  // token='None'
         )
         {
             D(fprintf(stderr, "%*c+ atom[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'None'"));
@@ -15195,7 +15284,7 @@ lambdef_rule(Parser *p)
         void *a;
         expr_ty b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 619))  // token='lambda'
+            (_keyword = _PyPegen_expect_token(p, 621))  // token='lambda'
             &&
             (a = lambda_params_rule(p), !p->error_indicator)  // lambda_params?
             &&
@@ -17562,13 +17651,13 @@ for_if_clause_rule(Parser *p)
         expr_ty b;
         asdl_expr_seq* c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 696))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 692))  // token='for'
+            (_keyword_1 = _PyPegen_expect_token(p, 694))  // token='for'
             &&
             (a = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_2 = _PyPegen_expect_token(p, 693))  // token='in'
+            (_keyword_2 = _PyPegen_expect_token(p, 695))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -17607,11 +17696,11 @@ for_if_clause_rule(Parser *p)
         expr_ty b;
         asdl_expr_seq* c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 692))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
             &&
             (a = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 693))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 695))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -20912,11 +21001,11 @@ expression_without_invalid_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 684))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 686))  // token='else'
             &&
             (c = expression_rule(p))  // expression
         )
@@ -21216,7 +21305,7 @@ invalid_expression_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
@@ -21249,11 +21338,11 @@ invalid_expression_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 684))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 686))  // token='else'
             &&
             _PyPegen_lookahead(0, (void *(*)(Parser *)) expression_rule, p)
         )
@@ -21285,11 +21374,11 @@ invalid_expression_rule(Parser *p)
         if (
             (a = (stmt_ty)_tmp_116_rule(p))  // pass_stmt | break_stmt | continue_stmt
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 684))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 686))  // token='else'
             &&
             (c = simple_stmt_rule(p))  // simple_stmt
         )
@@ -21318,7 +21407,7 @@ invalid_expression_rule(Parser *p)
         Token * a;
         Token * b;
         if (
-            (a = _PyPegen_expect_token(p, 619))  // token='lambda'
+            (a = _PyPegen_expect_token(p, 621))  // token='lambda'
             &&
             (_opt_var = lambda_params_rule(p), !p->error_indicator)  // lambda_params?
             &&
@@ -21351,7 +21440,7 @@ invalid_expression_rule(Parser *p)
         Token * a;
         Token * b;
         if (
-            (a = _PyPegen_expect_token(p, 619))  // token='lambda'
+            (a = _PyPegen_expect_token(p, 621))  // token='lambda'
             &&
             (_opt_var = lambda_params_rule(p), !p->error_indicator)  // lambda_params?
             &&
@@ -21822,7 +21911,7 @@ invalid_del_stmt_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 623))  // token='del'
+            (_keyword = _PyPegen_expect_token(p, 625))  // token='del'
             &&
             (a = star_expressions_rule(p))  // star_expressions
         )
@@ -23258,7 +23347,7 @@ invalid_with_item_rule(Parser *p)
         if (
             (expression_var = expression_rule(p))  // expression
             &&
-            (_keyword = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -23308,13 +23397,13 @@ invalid_for_if_clause_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         void *_tmp_135_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 696), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 692))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
             &&
             (_tmp_135_var = _tmp_135_rule(p))  // bitwise_or ((',' bitwise_or))* ','?
             &&
-            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 693)  // token='in'
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 695)  // token='in'
         )
         {
             D(fprintf(stderr, "%*c+ invalid_for_if_clause[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'? 'for' (bitwise_or ((',' bitwise_or))* ','?) !'in'"));
@@ -23360,9 +23449,9 @@ invalid_for_target_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty a;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 696), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 692))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
             &&
             (a = star_expressions_rule(p))  // star_expressions
         )
@@ -23492,11 +23581,11 @@ invalid_import_rule(Parser *p)
         Token * a;
         expr_ty dotted_name_var;
         if (
-            (a = _PyPegen_expect_token(p, 632))  // token='import'
+            (a = _PyPegen_expect_token(p, 634))  // token='import'
             &&
             (_gather_137_var = _gather_137_rule(p))  // ','.dotted_name+
             &&
-            (_keyword = _PyPegen_expect_token(p, 631))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 633))  // token='from'
             &&
             (dotted_name_var = dotted_name_rule(p))  // dotted_name
         )
@@ -23523,7 +23612,7 @@ invalid_import_rule(Parser *p)
         Token * _keyword;
         Token * token;
         if (
-            (_keyword = _PyPegen_expect_token(p, 632))  // token='import'
+            (_keyword = _PyPegen_expect_token(p, 634))  // token='import'
             &&
             (token = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
@@ -23572,7 +23661,7 @@ invalid_dotted_as_name_rule(Parser *p)
         if (
             (dotted_name_var = dotted_name_rule(p))  // dotted_name
             &&
-            (_keyword = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             _PyPegen_lookahead(0, (void *(*)(Parser *)) _tmp_138_rule, p)
             &&
@@ -23623,7 +23712,7 @@ invalid_import_from_as_name_rule(Parser *p)
         if (
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
-            (_keyword = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             _PyPegen_lookahead(0, (void *(*)(Parser *)) _tmp_138_rule, p)
             &&
@@ -23749,9 +23838,9 @@ invalid_with_stmt_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 696), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 645))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 647))  // token='with'
             &&
             (_gather_140_var = _gather_140_rule(p))  // ','.(expression ['as' star_target])+
             &&
@@ -23787,9 +23876,9 @@ invalid_with_stmt_rule(Parser *p)
         UNUSED(_opt_var_1); // Silence compiler warnings
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 696), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 645))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 647))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -23849,9 +23938,9 @@ invalid_with_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 696), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 645))  // token='with'
+            (a = _PyPegen_expect_token(p, 647))  // token='with'
             &&
             (_gather_140_var = _gather_140_rule(p))  // ','.(expression ['as' star_target])+
             &&
@@ -23892,9 +23981,9 @@ invalid_with_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 696), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 645))  // token='with'
+            (a = _PyPegen_expect_token(p, 647))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -23957,7 +24046,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 654))  // token='try'
+            (a = _PyPegen_expect_token(p, 656))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -23989,7 +24078,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* block_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 654))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24028,7 +24117,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * b;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 654))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24036,7 +24125,7 @@ invalid_try_stmt_rule(Parser *p)
             &&
             (_loop1_37_var = _loop1_37_rule(p))  // except_block+
             &&
-            (a = _PyPegen_expect_token(p, 675))  // token='except'
+            (a = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (b = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -24075,7 +24164,7 @@ invalid_try_stmt_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         Token * a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 654))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24083,7 +24172,7 @@ invalid_try_stmt_rule(Parser *p)
             &&
             (_loop1_38_var = _loop1_38_rule(p))  // except_star_block+
             &&
-            (a = _PyPegen_expect_token(p, 675))  // token='except'
+            (a = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (_opt_var = _tmp_145_rule(p), !p->error_indicator)  // [expression ['as' NAME]]
             &&
@@ -24140,7 +24229,7 @@ invalid_except_stmt_rule(Parser *p)
         expr_ty expressions_var;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 675))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -24148,7 +24237,7 @@ invalid_except_stmt_rule(Parser *p)
             &&
             (expressions_var = expressions_rule(p))  // expressions
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -24180,7 +24269,7 @@ invalid_except_stmt_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 675))  // token='except'
+            (a = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
@@ -24211,7 +24300,7 @@ invalid_except_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 675))  // token='except'
+            (a = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
@@ -24240,11 +24329,11 @@ invalid_except_stmt_rule(Parser *p)
         expr_ty a;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 675))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (a = expression_rule(p))  // expression
         )
@@ -24300,7 +24389,7 @@ invalid_except_star_stmt_rule(Parser *p)
         expr_ty expressions_var;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 675))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -24310,7 +24399,7 @@ invalid_except_star_stmt_rule(Parser *p)
             &&
             (expressions_var = expressions_rule(p))  // expressions
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -24343,7 +24432,7 @@ invalid_except_star_stmt_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 675))  // token='except'
+            (a = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -24377,7 +24466,7 @@ invalid_except_star_stmt_rule(Parser *p)
         void *_tmp_146_var;
         Token * a;
         if (
-            (a = _PyPegen_expect_token(p, 675))  // token='except'
+            (a = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -24409,13 +24498,13 @@ invalid_except_star_stmt_rule(Parser *p)
         expr_ty a;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 675))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (a = expression_rule(p))  // expression
         )
@@ -24462,7 +24551,7 @@ invalid_finally_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 671))  // token='finally'
+            (a = _PyPegen_expect_token(p, 673))  // token='finally'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24518,7 +24607,7 @@ invalid_except_stmt_indent_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 675))  // token='except'
+            (a = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
@@ -24554,7 +24643,7 @@ invalid_except_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 675))  // token='except'
+            (a = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24610,7 +24699,7 @@ invalid_except_star_stmt_indent_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 675))  // token='except'
+            (a = _PyPegen_expect_token(p, 677))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -24849,7 +24938,7 @@ invalid_as_pattern_rule(Parser *p)
         if (
             (or_pattern_var = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (a = _PyPegen_expect_soft_keyword(p, "_"))  // soft_keyword='"_"'
         )
@@ -24879,7 +24968,7 @@ invalid_as_pattern_rule(Parser *p)
         if (
             (or_pattern_var = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (a = expression_rule(p))  // expression
         )
@@ -25031,7 +25120,7 @@ invalid_if_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -25062,7 +25151,7 @@ invalid_if_stmt_rule(Parser *p)
         expr_ty a_1;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 680))  // token='if'
+            (a = _PyPegen_expect_token(p, 682))  // token='if'
             &&
             (a_1 = named_expression_rule(p))  // named_expression
             &&
@@ -25117,7 +25206,7 @@ invalid_elif_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 685))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 687))  // token='elif'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -25148,7 +25237,7 @@ invalid_elif_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 685))  // token='elif'
+            (a = _PyPegen_expect_token(p, 687))  // token='elif'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -25201,7 +25290,7 @@ invalid_else_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 684))  // token='else'
+            (a = _PyPegen_expect_token(p, 686))  // token='else'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -25234,13 +25323,13 @@ invalid_else_stmt_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* block_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 684))  // token='else'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='else'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
             (block_var = block_rule(p))  // block
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 685))  // token='elif'
+            (_keyword_1 = _PyPegen_expect_token(p, 687))  // token='elif'
         )
         {
             D(fprintf(stderr, "%*c+ invalid_else_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'else' ':' block 'elif'"));
@@ -25287,7 +25376,7 @@ invalid_while_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 687))  // token='while'
+            (_keyword = _PyPegen_expect_token(p, 689))  // token='while'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -25318,7 +25407,7 @@ invalid_while_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 687))  // token='while'
+            (a = _PyPegen_expect_token(p, 689))  // token='while'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -25377,13 +25466,13 @@ invalid_for_stmt_rule(Parser *p)
         expr_ty star_expressions_var;
         expr_ty star_targets_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 696), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 692))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
             &&
             (star_targets_var = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 693))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 695))  // token='in'
             &&
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
             &&
@@ -25418,13 +25507,13 @@ invalid_for_stmt_rule(Parser *p)
         expr_ty star_expressions_var;
         expr_ty star_targets_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 696), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 692))  // token='for'
+            (a = _PyPegen_expect_token(p, 694))  // token='for'
             &&
             (star_targets_var = star_targets_rule(p))  // star_targets
             &&
-            (_keyword = _PyPegen_expect_token(p, 693))  // token='in'
+            (_keyword = _PyPegen_expect_token(p, 695))  // token='in'
             &&
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
             &&
@@ -25490,9 +25579,9 @@ invalid_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 696), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 697))  // token='def'
+            (a = _PyPegen_expect_token(p, 699))  // token='def'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -25549,9 +25638,9 @@ invalid_def_raw_rule(Parser *p)
         asdl_stmt_seq* block_var;
         expr_ty name_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 696), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 697))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='def'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -25615,7 +25704,7 @@ invalid_class_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 699))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='class'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -25654,7 +25743,7 @@ invalid_class_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 699))  // token='class'
+            (a = _PyPegen_expect_token(p, 701))  // token='class'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -26914,7 +27003,7 @@ invalid_arithmetic_rule(Parser *p)
             &&
             (_tmp_153_var = _tmp_153_rule(p))  // '+' | '-' | '*' | '/' | '%' | '//' | '@'
             &&
-            (a = _PyPegen_expect_token(p, 701))  // token='not'
+            (a = _PyPegen_expect_token(p, 703))  // token='not'
             &&
             (b = inversion_rule(p))  // inversion
         )
@@ -26963,7 +27052,7 @@ invalid_factor_rule(Parser *p)
         if (
             (_tmp_154_var = _tmp_154_rule(p))  // '+' | '-' | '~'
             &&
-            (a = _PyPegen_expect_token(p, 701))  // token='not'
+            (a = _PyPegen_expect_token(p, 703))  // token='not'
             &&
             (b = factor_rule(p))  // factor
         )
@@ -27310,7 +27399,7 @@ _tmp_5_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_5[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'import'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 632))  // token='import'
+            (_keyword = _PyPegen_expect_token(p, 634))  // token='import'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_5[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'import'"));
@@ -27329,7 +27418,7 @@ _tmp_5_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_5[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'from'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 631))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 633))  // token='from'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_5[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'from'"));
@@ -27367,7 +27456,7 @@ _tmp_6_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_6[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'def'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 697))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='def'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_6[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'def'"));
@@ -27405,7 +27494,7 @@ _tmp_6_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_6[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 696))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_6[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -27443,7 +27532,7 @@ _tmp_7_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_7[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'class'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 699))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 701))  // token='class'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_7[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'class'"));
@@ -27500,7 +27589,7 @@ _tmp_8_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_8[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'with'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 645))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 647))  // token='with'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_8[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'with'"));
@@ -27519,7 +27608,7 @@ _tmp_8_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_8[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 696))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_8[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -27557,7 +27646,7 @@ _tmp_9_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_9[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'for'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 692))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_9[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'for'"));
@@ -27576,7 +27665,7 @@ _tmp_9_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_9[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 696))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_9[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -27801,7 +27890,7 @@ _tmp_13_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 631))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 633))  // token='from'
             &&
             (z = expression_rule(p))  // expression
         )
@@ -28323,7 +28412,7 @@ _tmp_22_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (z = _PyPegen_name_token(p))  // NAME
         )
@@ -33838,7 +33927,7 @@ _tmp_111_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_111[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'True'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 620))  // token='True'
+            (_keyword = _PyPegen_expect_token(p, 622))  // token='True'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_111[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'True'"));
@@ -33857,7 +33946,7 @@ _tmp_111_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_111[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'False'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 622))  // token='False'
+            (_keyword = _PyPegen_expect_token(p, 624))  // token='False'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_111[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'False'"));
@@ -33876,7 +33965,7 @@ _tmp_111_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_111[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'None'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 621))  // token='None'
+            (_keyword = _PyPegen_expect_token(p, 623))  // token='None'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_111[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'None'"));
@@ -34087,7 +34176,7 @@ _tmp_115_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_115[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'else'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 684))  // token='else'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='else'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_115[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'else'"));
@@ -34334,7 +34423,7 @@ _tmp_118_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_118[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'True'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 620))  // token='True'
+            (_keyword = _PyPegen_expect_token(p, 622))  // token='True'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_118[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'True'"));
@@ -34353,7 +34442,7 @@ _tmp_118_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_118[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'None'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 621))  // token='None'
+            (_keyword = _PyPegen_expect_token(p, 623))  // token='None'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_118[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'None'"));
@@ -34372,7 +34461,7 @@ _tmp_118_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_118[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'False'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 622))  // token='False'
+            (_keyword = _PyPegen_expect_token(p, 624))  // token='False'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_118[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'False'"));
@@ -35826,7 +35915,7 @@ _tmp_143_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_143[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 675))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_143[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except'"));
@@ -35845,7 +35934,7 @@ _tmp_143_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_143[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'finally'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 671))  // token='finally'
+            (_keyword = _PyPegen_expect_token(p, 673))  // token='finally'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_143[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'finally'"));
@@ -36843,7 +36932,7 @@ _tmp_159_rule(Parser *p)
         Token * _keyword;
         expr_ty c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 586))  // token='or'
+            (_keyword = _PyPegen_expect_token(p, 588))  // token='or'
             &&
             (c = conjunction_rule(p))  // conjunction
         )
@@ -36889,7 +36978,7 @@ _tmp_160_rule(Parser *p)
         Token * _keyword;
         expr_ty c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 587))  // token='and'
+            (_keyword = _PyPegen_expect_token(p, 589))  // token='and'
             &&
             (c = inversion_rule(p))  // inversion
         )
@@ -37068,7 +37157,7 @@ _tmp_163_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
             &&
             (z = disjunction_rule(p))  // disjunction
         )
@@ -37726,7 +37815,7 @@ _tmp_176_rule(Parser *p)
         Token * _keyword;
         expr_ty star_target_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 678))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
             &&
             (star_target_var = star_target_rule(p))  // star_target
         )


### PR DESCRIPTION
My previous change was not quite correct in two ways:
- minor: missing "are" in the exception message
- major: it stopped allowing parsing valid code like `except TypeError:` with older `feature_version`s :(

I added a lot more tests and fixed the problem (hopefully)! Reviews are highly appreciated 🙏  

Fixes https://github.com/python/cpython/pull/133195
Fixes https://github.com/python/cpython/issues/133194
cc @cdce8p

<!-- gh-issue-number: gh-133194 -->
* Issue: gh-133194
<!-- /gh-issue-number -->
