### PR TITLE
gh-133210: Fix `test_descr` in `--without-doc-strings` mode

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1589,7 +1589,7 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         cm = classmethod(f)
         cm_dict = {'__doc__': (
                        "f docstring"
-                       if support.HAVE_DOCSTRINGS
+                       if support.HAVE_PY_DOCSTRINGS
                        else None
                     ),
                    '__module__': __name__,


### PR DESCRIPTION
I tested that all 4 commands now work:
- `make clean && ./configure --with-pydebug --without-doc-strings && make && ./python.exe -OO -m test test_descr`
- `make clean && ./configure --with-pydebug --without-doc-strings && make && ./python.exe -m test test_descr`
- `make clean && ./configure --with-pydebug && make && ./python.exe -OO -m test test_descr`
- `make clean && ./configure --with-pydebug && make && ./python.exe -m test test_descr`

<img width="788" alt="Снимок экрана 2025-05-02 в 15 36 58" src="https://github.com/user-attachments/assets/7b7354f9-ffe0-447e-a419-8cc615289c80" />


<!-- gh-issue-number: gh-133210 -->
* Issue: gh-133210
<!-- /gh-issue-number -->
