### PR TITLE
gh-133300: argparse: make `suggest_on_error` a keyword-only parameter

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -74,7 +74,7 @@ ArgumentParser objects
                           prefix_chars='-', fromfile_prefix_chars=None, \
                           argument_default=None, conflict_handler='error', \
                           add_help=True, allow_abbrev=True, exit_on_error=True, \
-                          suggest_on_error=False, color=False)
+                          *, suggest_on_error=False, color=False)
 
    Create a new :class:`ArgumentParser` object. All parameters should be passed
    as keyword arguments. Each parameter has its own more detailed description

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1886,8 +1886,8 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
                  add_help=True,
                  allow_abbrev=True,
                  exit_on_error=True,
-                 suggest_on_error=False,
                  *,
+                 suggest_on_error=False,
                  color=False,
                  ):
         superinit = super(ArgumentParser, self).__init__

--- a/Misc/NEWS.d/next/Library/2025-05-02-17-23-41.gh-issue-133300.oAh1P2.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-02-17-23-41.gh-issue-133300.oAh1P2.rst
@@ -1,0 +1,2 @@
+Make :class:`argparse.ArgumentParser`'s ``suggest_on_error`` a keyword-only
+parameter. Patch by Hugo van Kemenade.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133300 -->
* Issue: gh-133300
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133302.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->