### PR TITLE
Lint: Use Ruff to format ``Tools/build/check_warnings.py``

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.6
+    rev: v0.11.8
     hooks:
       - id: ruff
         name: Run Ruff (lint) on Doc/
@@ -22,14 +22,14 @@ repos:
         name: Run Ruff (format) on Doc/
         args: [--check]
         files: ^Doc/
+      - id: ruff-format
+        name: Run Ruff (format) on Tools/build/check_warnings.py
+        args: [--check, --config=Tools/build/.ruff.toml]
+        files: ^Tools/build/check_warnings.py
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.1.0
     hooks:
-      - id: black
-        name: Run Black on Tools/build/check_warnings.py
-        files: ^Tools/build/check_warnings.py
-        args: [--line-length=79]
       - id: black
         name: Run Black on Tools/jit/
         files: ^Tools/jit/

--- a/Tools/build/.ruff.toml
+++ b/Tools/build/.ruff.toml
@@ -1,5 +1,13 @@
 extend = "../../.ruff.toml"  # Inherit the project-wide settings
 
+[per-file-target-version]
+"deepfreeze.py" = "py310"
+"stable_abi.py" = "py311"  # requires 'tomllib'
+
+[format]
+preview = true
+docstring-code-format = true
+
 [lint]
 select = [
     "C4",      # flake8-comprehensions
@@ -23,10 +31,6 @@ ignore = [
     "PYI025",  # Use `from collections.abc import Set as AbstractSet`
     "UP038",   # Use `X | Y` in `isinstance` call instead of `(X, Y)`
 ]
-
-[per-file-target-version]
-"deepfreeze.py" = "py310"
-"stable_abi.py" = "py311"  # requires 'tomllib'
 
 [lint.per-file-ignores]
 "{check_extension_modules,freeze_modules}.py" = [

--- a/Tools/build/check_warnings.py
+++ b/Tools/build/check_warnings.py
@@ -83,17 +83,13 @@ def extract_warnings_from_compiler_output(
     for i, line in enumerate(compiler_output.splitlines(), start=1):
         if match := compiled_regex.match(line):
             try:
-                compiler_warnings.append(
-                    {
-                        "file": match.group("file").removeprefix(path_prefix),
-                        "line": match.group("line"),
-                        "column": match.group("column"),
-                        "message": match.group("message"),
-                        "option": match.group("option")
-                        .lstrip("[")
-                        .rstrip("]"),
-                    }
-                )
+                compiler_warnings.append({
+                    "file": match.group("file").removeprefix(path_prefix),
+                    "line": match.group("line"),
+                    "column": match.group("column"),
+                    "message": match.group("message"),
+                    "option": match.group("option").lstrip("[").rstrip("]"),
+                })
             except AttributeError:
                 print(
                     f"Error parsing compiler output. "
@@ -151,7 +147,6 @@ def get_unexpected_warnings(
     """
     unexpected_warnings = {}
     for file in files_with_warnings.keys():
-
         rule = is_file_ignored(file, ignore_rules)
 
         if rule:
@@ -201,13 +196,11 @@ def get_unexpected_improvements(
             if rule.file_path not in files_with_warnings.keys():
                 unexpected_improvements.append((rule.file_path, rule.count, 0))
             elif len(files_with_warnings[rule.file_path]) < rule.count:
-                unexpected_improvements.append(
-                    (
-                        rule.file_path,
-                        rule.count,
-                        len(files_with_warnings[rule.file_path]),
-                    )
-                )
+                unexpected_improvements.append((
+                    rule.file_path,
+                    rule.count,
+                    len(files_with_warnings[rule.file_path]),
+                ))
 
     if unexpected_improvements:
         print("Unexpected improvements:")


### PR DESCRIPTION
Split out from #133123.

A