### PR TITLE
gh-133311: have MIMEImage respect policy.max_line_length

### DIFF
--- a/Misc/NEWS.d/next/133311.rst
+++ b/Misc/NEWS.d/next/133311.rst
@@ -1,0 +1,1 @@
+Fix email.mime.image.MIMEImage to respect policy.max_line_length (bpo-133311).

--- a/Misc/NEWS.d/next/Library/2025-05-02-23-35-26.gh-issue-133311.c36IjF.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-02-23-35-26.gh-issue-133311.c36IjF.rst
@@ -1,0 +1,1 @@
+Fix email.mime.image.MIMEImage to respect policy.max_line_length when Base64-encoding image payloads.


### PR DESCRIPTION
This patch updates Lib/email/mime/image.py so that MIMEImage honors the max_line_length setting from the provided EmailPolicy when Base64-encoding image payloads.

- Adds imports for base64 and textwrap.wrap
- Replaces the old `set_payload(_imagedata)` + `_encoder(self)` calls with an explicit Base64 encode, wrap to `policy.max_line_length` (default 76), and then calls `set_payload` with the wrapped text.
- Ensures CRLF line endings and proper headers are still applied by set_payload.

Fixes issue #133311: MIMEImage’s policy argument not taking effect.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133311 -->
* Issue: gh-133311
<!-- /gh-issue-number -->
