### PR TITLE
Docs: standardize boolean constants in `stdtypes.rst`

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -828,7 +828,7 @@ empty string, all events are passed.
 
    .. method:: filter(record)
 
-      Is the specified record to be logged? Returns ``False`` for no, ``True`` for
+      Is the specified record to be logged? Returns false for no, true for
       yes. Filters can either modify log records in-place or return a completely
       different record instance which will replace the original
       log record in any future processing of the event.

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -828,7 +828,7 @@ empty string, all events are passed.
 
    .. method:: filter(record)
 
-      Is the specified record to be logged? Returns false for no, true for
+      Is the specified record to be logged? Returns ``False`` for no, ``True`` for
       yes. Filters can either modify log records in-place or return a completely
       different record instance which will replace the original
       log record in any future processing of the event.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2012,7 +2012,7 @@ expression support in the :mod:`re` module).
 
 .. method:: str.isprintable()
 
-   Return true if all characters in the string are printable, false if it
+   Return ``True`` if all characters in the string are printable, ``False`` if it
    contains at least one non-printable character.
 
    Here "printable" means the character is suitable for :func:`repr` to use in

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2371,7 +2371,7 @@ expression support in the :mod:`re` module).
 .. method:: str.swapcase()
 
    Return a copy of the string with uppercase characters converted to lowercase and
-   vice versa. Note that it is not necessarily ``True`` that
+   vice versa. Note that it is not necessarily true that
    ``s.swapcase().swapcase() == s``.
 
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2371,7 +2371,7 @@ expression support in the :mod:`re` module).
 .. method:: str.swapcase()
 
    Return a copy of the string with uppercase characters converted to lowercase and
-   vice versa. Note that it is not necessarily true that
+   vice versa. Note that it is not necessarily ``True`` that
    ``s.swapcase().swapcase() == s``.
 
 

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -237,7 +237,7 @@ See also the :ref:`formatspec` section.
 The *field_name* itself begins with an *arg_name* that is either a number or a
 keyword.  If it's a number, it refers to a positional argument, and if it's a keyword,
 it refers to a named keyword argument. An *arg_name* is treated as a number if
-a call to :meth:`str.isdecimal` on the string would return true.
+a call to :meth:`str.isdecimal` on the string would return ``True``.
 If the numerical arg_names in a format string
 are 0, 1, 2, ... in sequence, they can all be omitted (not just some)
 and the numbers 0, 1, 2, ... will be automatically inserted in that order.
@@ -858,7 +858,7 @@ these rules.  The methods of :class:`Template` are:
 
    .. method:: is_valid()
 
-      Returns false if the template has invalid placeholders that will cause
+      Returns ``False`` if the template has invalid placeholders that will cause
       :meth:`substitute` to raise :exc:`ValueError`.
 
       .. versionadded:: 3.11

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -237,7 +237,7 @@ See also the :ref:`formatspec` section.
 The *field_name* itself begins with an *arg_name* that is either a number or a
 keyword.  If it's a number, it refers to a positional argument, and if it's a keyword,
 it refers to a named keyword argument. An *arg_name* is treated as a number if
-a call to :meth:`str.isdecimal` on the string would return ``True``.
+a call to :meth:`str.isdecimal` on the string would return true.
 If the numerical arg_names in a format string
 are 0, 1, 2, ... in sequence, they can all be omitted (not just some)
 and the numbers 0, 1, 2, ... will be automatically inserted in that order.


### PR DESCRIPTION
Replaces lowercase `true`/`false` with standard boolean values `True`/`False`.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133325.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->