### PR TITLE
gh-114713: Revert gh-114731

### DIFF
--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -237,7 +237,6 @@ class ZoneInfoTest(TzPathUserMixin, ZoneInfoTestBase):
             "../zoneinfo/America/Los_Angeles",  # Traverses above TZPATH
             "America/../America/Los_Angeles",  # Not normalized
             "America/./Los_Angeles",
-            "",
         ]
 
         for bad_key in bad_keys:

--- a/Lib/zoneinfo/_tzpath.py
+++ b/Lib/zoneinfo/_tzpath.py
@@ -83,11 +83,6 @@ _TEST_PATH = os.path.normpath(os.path.join("_", "_"))[:-1]
 
 
 def _validate_tzfile_path(path, _base=_TEST_PATH):
-    if not path:
-        raise ValueError(
-            "ZoneInfo key must not be an empty string"
-        )
-
     if os.path.isabs(path):
         raise ValueError(
             f"ZoneInfo keys may not be absolute paths, got: {path}"

--- a/Misc/NEWS.d/next/Library/2025-03-09-01-09-12.gh-issue-114713.lkq9vZ.rst
+++ b/Misc/NEWS.d/next/Library/2025-03-09-01-09-12.gh-issue-114713.lkq9vZ.rst
@@ -1,1 +1,0 @@
-Handle case of an empty string passed to :class:`zoneinfo.ZoneInfo`.


### PR DESCRIPTION
Unfortunately, #114731 introduced a regression and `zoneinfo.ZoneInfo(None)` now raises a `ValueError` instead of `TypeError`, which may break some tests in 3rd party libraries (such as https://github.com/reagento/adaptix/).

Therefore, I'm reverting it before 3.14b1. The original issue isn't critical, and we can address it later.

<!-- gh-issue-number: gh-114713 -->
* Issue: gh-114713
<!-- /gh-issue-number -->
