### PR TITLE
gh-133210: Fix `test_rlcompleter` in `--without-doc-strings` mode

### DIFF
--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -56,14 +56,16 @@ class TestRlcompleter(unittest.TestCase):
         self.assertEqual(self.stdcompleter.attr_matches('tuple.foospamegg'), [])
 
         def create_expected_for_none():
+            if not MISSING_C_DOCSTRINGS:
+                parentheses = ('__init_subclass__', '__class__')
+            else:
+                # When `--without-doc-strings` is used, `__class__`
+                # won't have a known signature.
+                parentheses = ('__init_subclass__',)
+
             items = set()
             for x in dir(None):
-                if (
-                    x == '__init_subclass__'
-                    # When `--without-doc-strings` is used, `__class__`
-                    # won't have a known signature.
-                    or (x == '__class__' and not MISSING_C_DOCSTRINGS)
-                ):
+                if x in parentheses:
                     items.add(f'None.{x}()')
                 elif x == '__doc__':
                     items.add(f'None.{x}')

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -54,11 +54,24 @@ class TestRlcompleter(unittest.TestCase):
                          ['str.{}('.format(x) for x in dir(str)
                           if x.startswith('s')])
         self.assertEqual(self.stdcompleter.attr_matches('tuple.foospamegg'), [])
-        expected = sorted({'None.%s%s' % (x,
-                                          '()' if x in ('__init_subclass__', '__class__')
-                                          else '' if x == '__doc__'
-                                          else '(')
-                           for x in dir(None)})
+
+        def create_expected_for_none():
+            items = set()
+            for x in dir(None):
+                if (
+                    x == '__init_subclass__'
+                    # When `--without-doc-strings` is used, `__class__`
+                    # won't have a known signature.
+                    or (x == '__class__' and not MISSING_C_DOCSTRINGS)
+                ):
+                    items.add(f'None.{x}()')
+                elif x == '__doc__':
+                    items.add(f'None.{x}')
+                else:
+                    items.add(f'None.{x}(')
+            return sorted(items)
+
+        expected = create_expected_for_none()
         self.assertEqual(self.stdcompleter.attr_matches('None.'), expected)
         self.assertEqual(self.stdcompleter.attr_matches('None._'), expected)
         self.assertEqual(self.stdcompleter.attr_matches('None.__'), expected)


### PR DESCRIPTION
This line affects the tests results: https://github.com/python/cpython/blob/ac56f8cc8d36ed65228d7eaa245569f66ad16d2b/Lib/rlcompleter.py#L106

<!-- gh-issue-number: gh-133210 -->
* Issue: gh-133210
<!-- /gh-issue-number -->
