### PR TITLE
gh-69605: Add PyREPL import autocomplete feature to 'What's New'

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -2106,6 +2106,12 @@ Others
   integer must implement either :meth:`~object.__int__` or
   :meth:`~object.__index__`. (Contributed by Mark Dickinson in :gh:`119743`.)
 
+* The default :term:`interactive` shell now supports import autocompletion.
+  This means that typing ``import foo`` and pressing ``<tab>`` will suggest
+  modules starting with ``foo``. Similarly, typing ``from foo import b`` will
+  suggest submodules of ``foo`` starting with ``b``. Note that autocompletion
+  of module attributes is not currently supported.
+  (Contributed by Tomas Roun in :gh:`69605`.)
 
 CPython Bytecode Changes
 ========================


### PR DESCRIPTION
I wasn't sure where to put it so I slotted it under `Others`.

<!-- gh-issue-number: gh-69605 -->
* Issue: gh-69605
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133358.org.readthedocs.build/en/133358/whatsnew/3.14.html#others

<!-- readthedocs-preview cpython-previews end -->