### PR TITLE
gh-133351: Fix Cmd completion for lines beginning with `! `

### DIFF
--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -273,7 +273,7 @@ class Cmd:
             endidx = readline.get_endidx() - stripped
             if begidx>0:
                 cmd, args, foo = self.parseline(line)
-                if cmd == '':
+                if cmd in ('', None):
                     compfunc = self.completedefault
                 else:
                     try:

--- a/Lib/test/test_cmd.py
+++ b/Lib/test/test_cmd.py
@@ -289,6 +289,31 @@ class CmdTestReadline(unittest.TestCase):
         self.assertIn(b'ab_completion_test', output)
         self.assertIn(b'tab completion success', output)
 
+    def test_bang_completion_without_do_shell(self):
+        script = textwrap.dedent("""
+            import cmd
+            class simplecmd(cmd.Cmd):
+                def completedefault(self, text, line, begidx, endidx):
+                    return ["hello"]
+
+                def default(self, line):
+                    if line == "! hello":
+                        print('tab completion success')
+                    else:
+                        print('tab completion failure')
+                    return True
+
+            simplecmd().cmdloop()
+        """)
+
+        # '! h' and complete 'ello' to '! hello'
+        input = b"! h\t\n"
+
+        output = run_pty(script, input)
+
+        self.assertIn(b'ello', output)
+        self.assertIn(b'tab completion success', output)
+
 def load_tests(loader, tests, pattern):
     tests.addTest(doctest.DocTestSuite())
     return tests


### PR DESCRIPTION
When a line begins with `!` and there's no `do_shell` method defined, `parsecmd` returns `None` as the `cmd`, which incorrectly leads to `None` being concatenated to `complete_` and triggering a `TypeError`.

Instead, recognize `None` as a sentinel that means we should call `completedefault`, as an empty string already is.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133351 -->
* Issue: gh-133351
<!-- /gh-issue-number -->
