### PR TITLE
gh-133363: Fix Cmd completion for lines beginning with `! `

### DIFF
--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -273,7 +273,7 @@ class Cmd:
             endidx = readline.get_endidx() - stripped
             if begidx>0:
                 cmd, args, foo = self.parseline(line)
-                if cmd == '':
+                if cmd in ('', None):
                     compfunc = self.completedefault
                 else:
                     try:

--- a/Lib/cmd.py
+++ b/Lib/cmd.py
@@ -273,7 +273,7 @@ class Cmd:
             endidx = readline.get_endidx() - stripped
             if begidx>0:
                 cmd, args, foo = self.parseline(line)
-                if cmd in ('', None):
+                if not cmd:
                     compfunc = self.completedefault
                 else:
                     try:

--- a/Lib/test/test_cmd.py
+++ b/Lib/test/test_cmd.py
@@ -289,6 +289,31 @@ class CmdTestReadline(unittest.TestCase):
         self.assertIn(b'ab_completion_test', output)
         self.assertIn(b'tab completion success', output)
 
+    def test_bang_completion_without_do_shell(self):
+        script = textwrap.dedent("""
+            import cmd
+            class simplecmd(cmd.Cmd):
+                def completedefault(self, text, line, begidx, endidx):
+                    return ["hello"]
+
+                def default(self, line):
+                    if line == "! hello":
+                        print('tab completion success')
+                    else:
+                        print('tab completion failure')
+                    return True
+
+            simplecmd().cmdloop()
+        """)
+
+        # '! h' and complete 'ello' to '! hello'
+        input = b"! h\t\n"
+
+        output = run_pty(script, input)
+
+        self.assertIn(b'ello', output)
+        self.assertIn(b'tab completion success', output)
+
 def load_tests(loader, tests, pattern):
     tests.addTest(doctest.DocTestSuite())
     return tests

--- a/Lib/test/test_cmd.py
+++ b/Lib/test/test_cmd.py
@@ -297,7 +297,7 @@ class CmdTestReadline(unittest.TestCase):
                     return ["hello"]
 
                 def default(self, line):
-                    if line == "! hello":
+                    if line.replace(" ", "") == "!hello":
                         print('tab completion success')
                     else:
                         print('tab completion failure')
@@ -306,13 +306,12 @@ class CmdTestReadline(unittest.TestCase):
             simplecmd().cmdloop()
         """)
 
-        # '! h' and complete 'ello' to '! hello'
-        input = b"! h\t\n"
-
-        output = run_pty(script, input)
-
-        self.assertIn(b'ello', output)
-        self.assertIn(b'tab completion success', output)
+        # '! h' or '!h' and complete 'ello' to 'hello'
+        for input in [b"! h\t\n", b"!h\t\n"]:
+            with self.subTest(input=input):
+                output = run_pty(script, input)
+                self.assertIn(b'hello', output)
+                self.assertIn(b'tab completion success', output)
 
 def load_tests(loader, tests, pattern):
     tests.addTest(doctest.DocTestSuite())

--- a/Misc/NEWS.d/next/Library/2025-05-03-21-55-33.gh-issue-133363.PTLnRP.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-03-21-55-33.gh-issue-133363.PTLnRP.rst
@@ -1,5 +1,3 @@
-The :class:`cmd.Cmd` class has been fixed to call the ``completedefault``
+The :class:`cmd.Cmd` class has been fixed to reliably call the ``completedefault``
 method whenever the ``do_shell`` method is not defined and tab completion is
-requested for a line beginning with ``!``. Previously ``completedefault``
-was called only if there were no spaces between the ``!`` and the cursor
-position where tab completion was attempted.
+requested for a line beginning with ``!``.

--- a/Misc/NEWS.d/next/Library/2025-05-03-21-55-33.gh-issue-133363.PTLnRP.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-03-21-55-33.gh-issue-133363.PTLnRP.rst
@@ -1,0 +1,5 @@
+The :class:`cmd.Cmd` class has been fixed to call the ``completedefault``
+method whenever the ``do_shell`` method is not defined and tab completion is
+requested for a line beginning with ``!``. Previously ``completedefault``
+was called only if there were no spaces between the ``!`` and the cursor
+position where tab completion was attempted.


### PR DESCRIPTION
When a line begins with `!` and there's no `do_shell` method defined, `parseline` returns `None` as the `cmd`, which incorrectly leads to `None` being concatenated to `complete_` and triggering a `TypeError`.

Instead, recognize `None` as a sentinel that means we should call `completedefault`, as an empty string already is.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133363 -->
* Issue: gh-133363
<!-- /gh-issue-number -->
