### PR TITLE
gh-133367: Add missing options to `ast` CLI

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2574,7 +2574,7 @@ The following options are accepted:
 
 .. option:: --feature-version <version>
 
-   Minor version (int) or 3.x tuple (e.g., 3.10).
+   Python version in the format 3.x (e.g., 3.10).
 
    .. versionadded:: next
 
@@ -2587,7 +2587,7 @@ The following options are accepted:
 
 .. option:: --show-empty
 
-   Show empty lists and fields in dump output.
+   Show empty lists and fields that are ``None``.
 
    .. versionadded:: next
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2576,14 +2576,20 @@ The following options are accepted:
 
    Minor version (int) or 3.x tuple (e.g., 3.10).
 
+   .. versionadded:: next
+
 .. option:: -o <level>
             --optimize <level>
 
    Optimization level for parser.
 
+   .. versionadded:: next
+
 .. option:: --show-empty
 
    Show empty lists and fields in dump output.
+
+   .. versionadded:: next
 
 If :file:`infile` is specified its contents are parsed to AST and dumped
 to stdout.  Otherwise, the content is read from stdin.

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2574,9 +2574,10 @@ The following options are accepted:
 
 .. option:: --feature-version <version>
 
-   Python version in the format 3.x (e.g., 3.10).
+   Python version in the format 3.x (for example, 3.10).
 
    .. versionadded:: next
+
 
 .. option:: -o <level>
             --optimize <level>
@@ -2585,11 +2586,13 @@ The following options are accepted:
 
    .. versionadded:: next
 
+
 .. option:: --show-empty
 
    Show empty lists and fields that are ``None``.
 
    .. versionadded:: next
+
 
 If :file:`infile` is specified its contents are parsed to AST and dumped
 to stdout.  Otherwise, the content is read from stdin.

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1,4 +1,4 @@
-:mod:`!ast` --- Abstract Syntax Trees
+:mod:`!ast` --- Abstract syntax trees
 =====================================
 
 .. module:: ast
@@ -2156,7 +2156,7 @@ Async and await
    of :class:`ast.operator`, :class:`ast.unaryop`, :class:`ast.cmpop`,
    :class:`ast.boolop` and :class:`ast.expr_context`) on the returned tree
    will be singletons. Changes to one will be reflected in all other
-   occurrences of the same value (e.g. :class:`ast.Add`).
+   occurrences of the same value (for example, :class:`ast.Add`).
 
 
 :mod:`ast` helpers

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2588,7 +2588,7 @@ The following options are accepted:
 
 .. option:: --show-empty
 
-   Show empty lists and fields that are ``None``. Defaults to showing empty
+   Show empty lists and fields that are ``None``. Defaults to not showing empty
    objects.
 
    .. versionadded:: next

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2578,7 +2578,7 @@ The following options are accepted:
 
    .. versionadded:: next
 
-.. option:: -o <level>
+.. option:: -O <level>
             --optimize <level>
 
    Optimization level for parser.

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2578,14 +2578,12 @@ The following options are accepted:
 
    .. versionadded:: next
 
-
 .. option:: -o <level>
             --optimize <level>
 
    Optimization level for parser.
 
    .. versionadded:: next
-
 
 .. option:: --show-empty
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2574,20 +2574,22 @@ The following options are accepted:
 
 .. option:: --feature-version <version>
 
-   Python version in the format 3.x (for example, 3.10).
+   Python version in the format 3.x (for example, 3.10). Defaults to the
+   current version of the interpreter.
 
    .. versionadded:: next
 
 .. option:: -O <level>
             --optimize <level>
 
-   Optimization level for parser.
+   Optimization level for parser. Defaults to no optimization.
 
    .. versionadded:: next
 
 .. option:: --show-empty
 
-   Show empty lists and fields that are ``None``.
+   Show empty lists and fields that are ``None``. Defaults to showing empty
+   objects.
 
    .. versionadded:: next
 

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -29,7 +29,7 @@ compiled into a Python code object using the built-in :func:`compile` function.
 
 .. _abstract-grammar:
 
-Abstract Grammar
+Abstract grammar
 ----------------
 
 The abstract grammar is currently defined as follows:
@@ -2159,7 +2159,7 @@ Async and await
    occurrences of the same value (e.g. :class:`ast.Add`).
 
 
-:mod:`ast` Helpers
+:mod:`ast` helpers
 ------------------
 
 Apart from the node classes, the :mod:`ast` module defines these utility functions
@@ -2484,7 +2484,7 @@ and classes for traversing abstract syntax trees:
 
 .. _ast-compiler-flags:
 
-Compiler Flags
+Compiler flags
 --------------
 
 The following flags may be passed to :func:`compile` in order to change
@@ -2533,7 +2533,7 @@ effects on the compilation of a program:
 
 .. _ast-cli:
 
-Command-Line Usage
+Command-line usage
 ------------------
 
 .. versionadded:: 3.9
@@ -2571,6 +2571,19 @@ The following options are accepted:
             --indent <indent>
 
    Indentation of nodes in AST (number of spaces).
+
+.. option:: --feature-version <version>
+
+   Minor version (int) or 3.x tuple (e.g., 3.10).
+
+.. option:: -o <level>
+            --optimize <level>
+
+   Optimization level for parser.
+
+.. option:: --show-empty
+
+   Show empty lists and fields in dump output.
 
 If :file:`infile` is specified its contents are parsed to AST and dumped
 to stdout.  Otherwise, the content is read from stdin.

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -874,6 +874,7 @@ ast
   command-line interface.
   (Contributed by Semyon Moroz in :gh:`133367`.)
 
+
 bdb
 ---
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1991,6 +1991,10 @@ ast
   Use :attr:`!ast.Constant.value` instead.
   (Contributed by Alex Waygood in :gh:`119562`.)
 
+* Added new ``--feature-version``, ``--optimize``, ``--show-empty`` options to
+  command-line interface.
+  (Contributed by Semyon Moroz in :gh:`133367`.)
+
 asyncio
 -------
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -870,6 +870,10 @@ ast
   that the root node type is appropriate.
   (Contributed by Irit Katriel in :gh:`130139`.)
 
+* Add new ``--feature-version``, ``--optimize``, ``--show-empty`` options to
+  command-line interface.
+  (Contributed by Semyon Moroz in :gh:`133367`.)
+
 bdb
 ---
 
@@ -1990,10 +1994,6 @@ ast
 
   Use :attr:`!ast.Constant.value` instead.
   (Contributed by Alex Waygood in :gh:`119562`.)
-
-* Added new ``--feature-version``, ``--optimize``, ``--show-empty`` options to
-  command-line interface.
-  (Contributed by Semyon Moroz in :gh:`133367`.)
 
 asyncio
 -------

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -645,7 +645,7 @@ def main():
                         help='indentation of nodes (number of spaces)')
     parser.add_argument('--feature-version',
                         type=str, default=None, metavar='VERSION',
-                        help='minor version (int) or 3.x tuple (e.g., 3.10)')
+                        help='python version in the format 3.x (e.g., 3.10)')
     parser.add_argument('-o', '--optimize',
                         type=int, default=-1, metavar='LEVEL',
                         help='optimization level for parser (default -1)')
@@ -664,13 +664,13 @@ def main():
     # Process feature_version
     feature_version = None
     if args.feature_version:
-        if '.' in args.feature_version:
-            major_minor = tuple(map(int, args.feature_version.split('.', 1)))
-            if len(major_minor) != 2 or major_minor[0] != 3:
-                parser.error("--feature-version must be 3.x tuple (e.g., 3.10)")
-            feature_version = major_minor
-        else:
-            feature_version = int(args.feature_version)
+        try:
+            major, minor = map(int, args.feature_version.split('.', 1))
+        except ValueError:
+            parser.error('Invalid format for --feature-version; '
+                         'expected format 3.x (e.g., 3.10)')
+
+        feature_version = (major, minor)
 
     tree = parse(source, name, args.mode, type_comments=args.no_type_comments,
                  feature_version=feature_version, optimize=args.optimize)

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -643,6 +643,14 @@ def main():
                              'column offsets')
     parser.add_argument('-i', '--indent', type=int, default=3,
                         help='indentation of nodes (number of spaces)')
+    parser.add_argument('--feature-version',
+                        type=str, default=None, metavar='VERSION',
+                        help='minor version (int) or 3.x tuple (e.g., 3.10)')
+    parser.add_argument('-o', '--optimize',
+                        type=int, default=-1, metavar='LEVEL',
+                        help='optimization level for parser (default -1)')
+    parser.add_argument('--show-empty', default=False, action='store_true',
+                        help='show empty lists and fields in dump output')
     args = parser.parse_args()
 
     if args.infile == '-':
@@ -652,8 +660,22 @@ def main():
         name = args.infile
         with open(args.infile, 'rb') as infile:
             source = infile.read()
-    tree = parse(source, name, args.mode, type_comments=args.no_type_comments)
-    print(dump(tree, include_attributes=args.include_attributes, indent=args.indent))
+
+    # Process feature_version
+    feature_version = None
+    if args.feature_version:
+        if '.' in args.feature_version:
+            major_minor = tuple(map(int, args.feature_version.split('.', 1)))
+            if len(major_minor) != 2 or major_minor[0] != 3:
+                parser.error("--feature-version must be 3.x tuple (e.g., 3.10)")
+            feature_version = major_minor
+        else:
+            feature_version = int(args.feature_version)
+
+    tree = parse(source, name, args.mode, type_comments=args.no_type_comments,
+                 feature_version=feature_version, optimize=args.optimize)
+    print(dump(tree, include_attributes=args.include_attributes,
+               indent=args.indent, show_empty=args.show_empty))
 
 if __name__ == '__main__':
     main()

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -645,7 +645,8 @@ def main(args=None):
                         help='indentation of nodes (number of spaces)')
     parser.add_argument('--feature-version',
                         type=str, default=None, metavar='VERSION',
-                        help='python version in the format 3.x (e.g., 3.10)')
+                        help='Python version in the format 3.x '
+                             '(for example, 3.10)')
     parser.add_argument('-O', '--optimize',
                         type=int, default=-1, metavar='LEVEL',
                         help='optimization level for parser (default -1)')
@@ -668,7 +669,7 @@ def main(args=None):
             major, minor = map(int, args.feature_version.split('.', 1))
         except ValueError:
             parser.error('Invalid format for --feature-version; '
-                         'expected format 3.x (e.g., 3.10)')
+                         'expected format 3.x (for example, 3.10)')
 
         feature_version = (major, minor)
 

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -646,7 +646,7 @@ def main():
     parser.add_argument('--feature-version',
                         type=str, default=None, metavar='VERSION',
                         help='python version in the format 3.x (e.g., 3.10)')
-    parser.add_argument('-o', '--optimize',
+    parser.add_argument('-O', '--optimize',
                         type=int, default=-1, metavar='LEVEL',
                         help='optimization level for parser (default -1)')
     parser.add_argument('--show-empty', default=False, action='store_true',

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -3272,6 +3272,9 @@ class CommandLineTests(unittest.TestCase):
             ('--no-type-comments', '--no-type-comments'),
             ('-a', '--include-attributes'),
             ('-i=4', '--indent=4'),
+            ('--feature-version=3.13', '--feature-version=3.13'),
+            ('-O=-1', '--optimize=-1'),
+            ('--show-empty', '--show-empty'),
         )
         self.set_source('''
             print(1, 2, 3)
@@ -3389,7 +3392,7 @@ class CommandLineTests(unittest.TestCase):
                 self.check_output(source, expect, flag)
 
     def test_indent_flag(self):
-        # test 'python -m ast -i/--indent'
+        # test 'python -m ast -i/--indent 0'
         source = 'pass'
         expect = '''
             Module(
@@ -3399,6 +3402,96 @@ class CommandLineTests(unittest.TestCase):
         for flag in ('-i=0', '--indent=0'):
             with self.subTest(flag=flag):
                 self.check_output(source, expect, flag)
+
+    def test_feature_version_flag(self):
+        # test 'python -m ast --feature-version 3.9/3.10'
+        source = '''
+            match x:
+                case 1:
+                    pass
+        '''
+        expect = '''
+            Module(
+               body=[
+                  Match(
+                     subject=Name(id='x', ctx=Load()),
+                     cases=[
+                        match_case(
+                           pattern=MatchValue(
+                              value=Constant(value=1)),
+                           body=[
+                              Pass()])])])
+        '''
+        self.check_output(source, expect, '--feature-version=3.10')
+        with self.assertRaises(SyntaxError):
+            self.invoke_ast('--feature-version=3.9')
+
+    def test_no_optimize_flag(self):
+        # test 'python -m ast -O/--optimize -1/0'
+        source = '''
+            match a:
+                case 1+2j:
+                    pass
+        '''
+        expect = '''
+            Module(
+               body=[
+                  Match(
+                     subject=Name(id='a', ctx=Load()),
+                     cases=[
+                        match_case(
+                           pattern=MatchValue(
+                              value=BinOp(
+                                 left=Constant(value=1),
+                                 op=Add(),
+                                 right=Constant(value=2j))),
+                           body=[
+                              Pass()])])])
+        '''
+        for flag in ('-O=-1', '--optimize=-1', '-O=0', '--optimize=0'):
+            with self.subTest(flag=flag):
+                self.check_output(source, expect, flag)
+
+    def test_optimize_flag(self):
+        # test 'python -m ast -O/--optimize 1/2'
+        source = '''
+            match a:
+                case 1+2j:
+                    pass
+        '''
+        expect = '''
+            Module(
+               body=[
+                  Match(
+                     subject=Name(id='a', ctx=Load()),
+                     cases=[
+                        match_case(
+                           pattern=MatchValue(
+                              value=Constant(value=(1+2j))),
+                           body=[
+                              Pass()])])])
+        '''
+        for flag in ('-O=1', '--optimize=1', '-O=2', '--optimize=2'):
+            with self.subTest(flag=flag):
+                self.check_output(source, expect, flag)
+
+    def test_show_empty_flag(self):
+        # test 'python -m ast --show-empty'
+        source = 'print(1, 2, 3)'
+        expect = '''
+            Module(
+               body=[
+                  Expr(
+                     value=Call(
+                        func=Name(id='print', ctx=Load()),
+                        args=[
+                           Constant(value=1),
+                           Constant(value=2),
+                           Constant(value=3)],
+                        keywords=[]))],
+               type_ignores=[])
+        '''
+        self.check_output(source, expect, '--show-empty')
 
 
 class ASTOptimiziationTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2025-05-04-13-40-05.gh-issue-133367.E5nl2u.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-04-13-40-05.gh-issue-133367.E5nl2u.rst
@@ -1,2 +1,2 @@
-Add ``--feature-version``, ``--optimize``, ``--show-empty`` flags for
+Add ``--feature-version``, ``--optimize``, ``--show-empty`` options for
 :mod:`ast` command-line interface. Patch by Semyon Moroz.

--- a/Misc/NEWS.d/next/Library/2025-05-04-13-40-05.gh-issue-133367.E5nl2u.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-04-13-40-05.gh-issue-133367.E5nl2u.rst
@@ -1,2 +1,2 @@
-Add ``--feature-version``, ``--optimize``, ``--show-empty`` options for
-:mod:`ast` command-line interface. Patch by Semyon Moroz.
+Add the ``--feature-version``, ``--optimize``, and ``--show-empty`` options
+to the :mod:`ast` command-line interface. Patch by Semyon Moroz.

--- a/Misc/NEWS.d/next/Library/2025-05-04-13-40-05.gh-issue-133367.E5nl2u.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-04-13-40-05.gh-issue-133367.E5nl2u.rst
@@ -1,0 +1,2 @@
+Add ``--feature-version``, ``--optimize``, ``--show-empty`` flags for
+:mod:`ast` command-line interface. Patch by Semyon Moroz.


### PR DESCRIPTION
I wasn't sure about adding whatsnew entry but I added it so we can remote it

*Headings were corrected according to the [devguide](https://devguide.python.org/documentation/style-guide/#capitalization)

cc @sobolevn 

<!-- gh-issue-number: gh-133367 -->
* Issue: gh-133367
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133369.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->