### PR TITLE
gh-133376: build: allow parser.c to be created if missing

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1948,7 +1948,7 @@ regen-pegen:
 		$(srcdir)/Grammar/python.gram \
 		$(srcdir)/Grammar/Tokens \
 		-o $(srcdir)/Parser/parser.c.new
-	$(UPDATE_FILE) $(srcdir)/Parser/parser.c $(srcdir)/Parser/parser.c.new
+	$(UPDATE_FILE) --create $(srcdir)/Parser/parser.c $(srcdir)/Parser/parser.c.new
 
 .PHONY: regen-ast
 regen-ast:


### PR DESCRIPTION

Previously, `regen-pegen` would fail if Parser/parser.c was deleted (e.g. due to merge conflicts), requiring a manual `touch` to proceed. This change passes `--create` to update_file.py to allow the file to be created automatically if it doesn't exist.

<!-- gh-issue-number: gh-133376 -->
* Issue: gh-133376
<!-- /gh-issue-number -->
