### PR TITLE
gh-133371: Don't optimize `LOAD_FAST` instructions whose local is killed by `DELETE_FAST`

### DIFF
--- a/Include/internal/pycore_magic_number.h
+++ b/Include/internal/pycore_magic_number.h
@@ -276,6 +276,7 @@ Known values:
     Python 3.14a7 3621 (Optimize LOAD_FAST opcodes into LOAD_FAST_BORROW)
     Python 3.14a7 3622 (Store annotations in different class dict keys)
     Python 3.14a7 3623 (Add BUILD_INTERPOLATION & BUILD_TEMPLATE opcodes)
+    Python 3.14b1 3624 (Don't optimize LOAD_FAST when local is killed by DELETE_FAST)
 
     Python 3.15 will start with 3650
 
@@ -288,7 +289,7 @@ PC/launcher.c must also be updated.
 
 */
 
-#define PYC_MAGIC_NUMBER 3623
+#define PYC_MAGIC_NUMBER 3624
 /* This is equivalent to converting PYC_MAGIC_NUMBER to 2 bytes
    (little-endian) and then appending b'\r\n'. */
 #define PYC_MAGIC_NUMBER_TOKEN \

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -2472,6 +2472,13 @@ class OptimizeLoadFastTestCase(DirectCfgOptimizerTests):
         ]
         self.check(insts, insts)
 
+        insts = [
+            ("LOAD_FAST", 0, 1),
+            ("DELETE_FAST", 0, 2),
+            ("POP_TOP", None, 3),
+        ]
+        self.check(insts, insts)
+
     def test_unoptimized_if_aliased(self):
         insts = [
             ("LOAD_FAST", 0, 1),

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -1,4 +1,5 @@
 import dis
+import gc
 from itertools import combinations, product
 import opcode
 import sys
@@ -2612,6 +2613,22 @@ class OptimizeLoadFastTestCase(DirectCfgOptimizerTests):
             ("RETURN_VALUE", None, 7)
         ]
         self.cfg_optimization_test(insts, expected, consts=[None])
+
+    def test_del_in_finally(self):
+        # This loads `obj` onto the stack, executes `del obj`, then returns the
+        # `obj` from the stack. See gh-133371 for more details.
+        def create_obj():
+            obj = [42]
+            try:
+                return obj
+            finally:
+                del obj
+
+        obj = create_obj()
+        # The crash in the linked issue happens while running GC during
+        # interpreter finalization, so run it here manually.
+        gc.collect()
+        self.assertEqual(obj, [42])
 
 
 

--- a/Python/flowgraph.c
+++ b/Python/flowgraph.c
@@ -2795,6 +2795,11 @@ optimize_load_fast(cfg_builder *g)
             assert(opcode != EXTENDED_ARG);
             switch (opcode) {
                 // Opcodes that load and store locals
+                case DELETE_FAST: {
+                    kill_local(instr_flags, &refs, oparg);
+                    break;
+                }
+
                 case LOAD_FAST: {
                     PUSH_REF(i, oparg);
                     break;


### PR DESCRIPTION
In certain cases it's possible for locals loaded by `LOAD_FAST` instructions to be on the stack when the local is killed by `DELETE_FAST`. These `LOAD_FAST` instructions should not be optimized into `LOAD_FAST_BORROW` as the strong reference in the frame is killed while there is still a reference on the stack.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133371 -->
* Issue: gh-133371
<!-- /gh-issue-number -->
