### PR TITLE
gh-81793: Skip tests for os.link(follow_links=) on Android

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1549,10 +1549,6 @@ class PosixTester(unittest.TestCase):
             except NotImplementedError:
                 if os.link in os.supports_follow_symlinks or default_no_follow:
                     raise
-            except PermissionError:
-                if sys.platform == 'android':
-                    self.skipTest('Android blocks follow_symlinks with SELinux')
-                raise
             else:
                 self.addCleanup(os_helper.unlink, link)
                 self.assertEqual(posix.lstat(link), posix.lstat(symlink))
@@ -1565,10 +1561,6 @@ class PosixTester(unittest.TestCase):
             except NotImplementedError:
                 if os.link in os.supports_follow_symlinks or default_follow:
                     raise
-            except PermissionError:
-                if sys.platform == 'android':
-                    self.skipTest('Android blocks follow_symlinks with SELinux')
-                raise
             else:
                 self.addCleanup(os_helper.unlink, link)
                 self.assertEqual(posix.lstat(link), posix.lstat(orig))

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1549,6 +1549,10 @@ class PosixTester(unittest.TestCase):
             except NotImplementedError:
                 if os.link in os.supports_follow_symlinks or default_no_follow:
                     raise
+            except PermissionError:
+                if sys.platform == 'android':
+                    self.skipTest('Android blocks follow_symlinks with SELinux')
+                raise
             else:
                 self.addCleanup(os_helper.unlink, link)
                 self.assertEqual(posix.lstat(link), posix.lstat(symlink))
@@ -1561,6 +1565,10 @@ class PosixTester(unittest.TestCase):
             except NotImplementedError:
                 if os.link in os.supports_follow_symlinks or default_follow:
                     raise
+            except PermissionError:
+                if sys.platform == 'android':
+                    self.skipTest('Android blocks follow_symlinks with SELinux')
+                raise
             else:
                 self.addCleanup(os_helper.unlink, link)
                 self.assertEqual(posix.lstat(link), posix.lstat(orig))

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -573,7 +573,7 @@ extern char *ctermid_r(char *);
 #  define HAVE_FACCESSAT_RUNTIME 1
 #  define HAVE_FCHMODAT_RUNTIME 1
 #  define HAVE_FCHOWNAT_RUNTIME 1
-#ifdef __wasi__
+#if defined(__wasi__) || defined(__ANDROID__)
 #  define HAVE_LINKAT_RUNTIME 0
 # else
 #  define HAVE_LINKAT_RUNTIME 1


### PR DESCRIPTION


<!-- gh-issue-number: gh-81793 -->
* Issue: gh-81793
<!-- /gh-issue-number -->
