### PR TITLE
gh-133351: Fix remote PDB's multi-line block tab completion

### DIFF
--- a/Lib/test/test_remote_pdb.py
+++ b/Lib/test/test_remote_pdb.py
@@ -531,6 +531,44 @@ class PdbClientTestCase(unittest.TestCase):
             expected_state={"state": "pdb"},
         )
 
+    def test_multiline_completion_in_pdb_state(self):
+        """Test requesting tab completions at a (Pdb) continuation prompt."""
+        # GIVEN
+        incoming = [
+            ("server", {"prompt": "(Pdb) ", "state": "pdb"}),
+            ("user", {"prompt": "(Pdb) ", "input": "if True:"}),
+            (
+                "user",
+                {
+                    "prompt": "...   ",
+                    "completion_request": {
+                        "line": "    b",
+                        "begidx": 4,
+                        "endidx": 5,
+                    },
+                    "input": "    bool()",
+                },
+            ),
+            ("server", {"completions": ["bin", "bool", "bytes"]}),
+            ("user", {"prompt": "...   ", "input": ""}),
+        ]
+        self.do_test(
+            incoming=incoming,
+            expected_outgoing=[
+                {
+                    "complete": {
+                        "text": "b",
+                        "line": "! b",
+                        "begidx": 2,
+                        "endidx": 3,
+                    }
+                },
+                {"reply": "if True:\n    bool()\n"},
+            ],
+            expected_completions=["bin", "bool", "bytes"],
+            expected_state={"state": "pdb"},
+        )
+
     def test_completion_in_interact_state(self):
         """Test requesting tab completions at a >>> prompt."""
         incoming = [

--- a/Misc/NEWS.d/next/Library/2025-05-04-13-46-20.gh-issue-133351.YsZls1.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-04-13-46-20.gh-issue-133351.YsZls1.rst
@@ -1,0 +1,3 @@
+Fix remote PDB to correctly request tab completions for Python expressions
+from the server when completing a continuation line of a multi-line Python
+block.


### PR DESCRIPTION
Provide extra context to the server so that it knows that we're requesting completions for a Python expression, rather than for PDB commands.


<!-- gh-issue-number: gh-133351 -->
* Issue: gh-133351
<!-- /gh-issue-number -->
