### PR TITLE
gh-81793: Skip tests for os.link() to symlink on Android

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1522,6 +1522,7 @@ class PosixTester(unittest.TestCase):
         os.close(os.pidfd_open(os.getpid(), 0))
 
     @unittest.skipUnless(hasattr(os, "link"), "test needs os.link()")
+    @support.skip_android_selinux('hard links to symbolic links')
     def test_link_follow_symlinks(self):
         default_follow = sys.platform.startswith(
             ('darwin', 'freebsd', 'netbsd', 'openbsd', 'dragonfly', 'sunos5'))


### PR DESCRIPTION


<!-- gh-issue-number: gh-81793 -->
* Issue: gh-81793
<!-- /gh-issue-number -->
