### PR TITLE
GH-91048: Minor fixes for ``_remotedebugging`` & rename to ``_remote_debugging``

### DIFF
--- a/Lib/asyncio/tools.py
+++ b/Lib/asyncio/tools.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from itertools import count
 from enum import Enum
 import sys
-from _remotedebugging import get_all_awaited_by
+from _remote_debugging import get_all_awaited_by
 
 
 class NodeType(Enum):

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -20,7 +20,7 @@ try:
     from _remotedebugging import get_all_awaited_by
 except ImportError:
     raise unittest.SkipTest(
-        "Test only runs when _remotedebuggingmodule is available")
+        "Test only runs when _remotedebugging is available")
 
 def _make_test_script(script_dir, script_basename, source):
     to_return = make_script(script_dir, script_basename, source)

--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -14,13 +14,13 @@ import subprocess
 PROCESS_VM_READV_SUPPORTED = False
 
 try:
-    from _remotedebugging import PROCESS_VM_READV_SUPPORTED
-    from _remotedebugging import get_stack_trace
-    from _remotedebugging import get_async_stack_trace
-    from _remotedebugging import get_all_awaited_by
+    from _remote_debugging import PROCESS_VM_READV_SUPPORTED
+    from _remote_debugging import get_stack_trace
+    from _remote_debugging import get_async_stack_trace
+    from _remote_debugging import get_all_awaited_by
 except ImportError:
     raise unittest.SkipTest(
-        "Test only runs when _remotedebugging is available")
+        "Test only runs when _remote_debugging is available")
 
 def _make_test_script(script_dir, script_basename, source):
     to_return = make_script(script_dir, script_basename, source)

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1960,7 +1960,7 @@ def _supports_remote_attaching():
     PROCESS_VM_READV_SUPPORTED = False
 
     try:
-        from _remotedebugging import PROCESS_VM_READV_SUPPORTED
+        from _remote_debugging import PROCESS_VM_READV_SUPPORTED
     except ImportError:
         pass
 

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1960,7 +1960,7 @@ def _supports_remote_attaching():
     PROCESS_VM_READV_SUPPORTED = False
 
     try:
-        from _remotedebuggingmodule import PROCESS_VM_READV_SUPPORTED
+        from _remotedebugging import PROCESS_VM_READV_SUPPORTED
     except ImportError:
         pass
 

--- a/Modules/Setup
+++ b/Modules/Setup
@@ -284,7 +284,7 @@ PYTHONPATH=$(COREPYTHONPATH)
 
 #*shared*
 #_ctypes_test _ctypes/_ctypes_test.c
-#_remotedebugging _remotedebuggingmodule.c
+#_remote_debugging _remote_debugging_module.c
 #_testcapi _testcapimodule.c
 #_testimportmultiple _testimportmultiple.c
 #_testmultiphase _testmultiphase.c

--- a/Modules/Setup
+++ b/Modules/Setup
@@ -284,10 +284,10 @@ PYTHONPATH=$(COREPYTHONPATH)
 
 #*shared*
 #_ctypes_test _ctypes/_ctypes_test.c
+#_remotedebugging _remotedebuggingmodule.c
 #_testcapi _testcapimodule.c
 #_testimportmultiple _testimportmultiple.c
 #_testmultiphase _testmultiphase.c
-#_remotedebugging _remotedebuggingmodule.c
 #_testsinglephase _testsinglephase.c
 
 # ---

--- a/Modules/Setup.stdlib.in
+++ b/Modules/Setup.stdlib.in
@@ -33,7 +33,6 @@
 # Modules that should always be present (POSIX and Windows):
 @MODULE_ARRAY_TRUE@array arraymodule.c
 @MODULE__ASYNCIO_TRUE@_asyncio _asynciomodule.c
-@MODULE__REMOTEDEBUGGING_TRUE@_remotedebugging _remotedebuggingmodule.c
 @MODULE__BISECT_TRUE@_bisect _bisectmodule.c
 @MODULE__CSV_TRUE@_csv _csv.c
 @MODULE__HEAPQ_TRUE@_heapq _heapqmodule.c
@@ -42,6 +41,7 @@
 @MODULE__PICKLE_TRUE@_pickle _pickle.c
 @MODULE__QUEUE_TRUE@_queue _queuemodule.c
 @MODULE__RANDOM_TRUE@_random _randommodule.c
+@MODULE__REMOTEDEBUGGING_TRUE@_remotedebugging _remotedebuggingmodule.c
 @MODULE__STRUCT_TRUE@_struct _struct.c
 
 # build supports subinterpreters

--- a/Modules/Setup.stdlib.in
+++ b/Modules/Setup.stdlib.in
@@ -41,7 +41,7 @@
 @MODULE__PICKLE_TRUE@_pickle _pickle.c
 @MODULE__QUEUE_TRUE@_queue _queuemodule.c
 @MODULE__RANDOM_TRUE@_random _randommodule.c
-@MODULE__REMOTEDEBUGGING_TRUE@_remotedebugging _remotedebuggingmodule.c
+@MODULE__REMOTE_DEBUGGING_TRUE@_remote_debugging _remote_debugging_module.c
 @MODULE__STRUCT_TRUE@_struct _struct.c
 
 # build supports subinterpreters

--- a/Modules/_remote_debugging_module.c
+++ b/Modules/_remote_debugging_module.c
@@ -1554,13 +1554,13 @@ static PyMethodDef methods[] = {
 
 static struct PyModuleDef module = {
     .m_base = PyModuleDef_HEAD_INIT,
-    .m_name = "_remotedebugging",
+    .m_name = "_remote_debugging",
     .m_size = -1,
     .m_methods = methods,
 };
 
 PyMODINIT_FUNC
-PyInit__remotedebugging(void)
+PyInit__remote_debugging(void)
 {
     PyObject* mod = PyModule_Create(&module);
     if (mod == NULL) {

--- a/PCbuild/_remote_debugging.vcxproj
+++ b/PCbuild/_remote_debugging.vcxproj
@@ -68,7 +68,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4D7C112F-3083-4D9E-9754-9341C14D9B39}</ProjectGuid>
-    <RootNamespace>_remotedebugging</RootNamespace>
+    <RootNamespace>_remote_debugging</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <SupportPGO>false</SupportPGO>
   </PropertyGroup>
@@ -93,7 +93,7 @@
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <ClCompile Include="..\Modules\_remotedebuggingmodule.c" />
+    <ClCompile Include="..\Modules\_remote_debugging_module.c" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\PC\python_nt.rc" />

--- a/PCbuild/_remote_debugging.vcxproj.filters
+++ b/PCbuild/_remote_debugging.vcxproj.filters
@@ -9,7 +9,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\Modules\_remotedebuggingmodule.c" />
+    <ClCompile Include="..\Modules\_remote_debugging_module.c" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\PC\python_nt.rc">

--- a/PCbuild/pcbuild.proj
+++ b/PCbuild/pcbuild.proj
@@ -66,7 +66,7 @@
     <!-- pyshellext.dll -->
     <Projects Include="pyshellext.vcxproj" />
     <!-- Extension modules -->
-    <ExtensionModules Include="_asyncio;_remotedebugging;_zoneinfo;_decimal;_elementtree;_multiprocessing;_overlapped;pyexpat;_queue;select;unicodedata;winsound;_uuid;_wmi" />
+    <ExtensionModules Include="_asyncio;_decimal;_elementtree;_multiprocessing;_overlapped;pyexpat;_queue;_remotedebugging;select;unicodedata;winsound;_uuid;_wmi;_zoneinfo" />
     <ExtensionModules Include="_ctypes" Condition="$(IncludeCTypes)" />
     <!-- Extension modules that require external sources -->
     <ExternalModules Include="_bz2;_lzma;_sqlite3" />

--- a/PCbuild/pcbuild.proj
+++ b/PCbuild/pcbuild.proj
@@ -66,7 +66,7 @@
     <!-- pyshellext.dll -->
     <Projects Include="pyshellext.vcxproj" />
     <!-- Extension modules -->
-    <ExtensionModules Include="_asyncio;_decimal;_elementtree;_multiprocessing;_overlapped;pyexpat;_queue;_remotedebugging;select;unicodedata;winsound;_uuid;_wmi;_zoneinfo" />
+    <ExtensionModules Include="_asyncio;_decimal;_elementtree;_multiprocessing;_overlapped;pyexpat;_queue;_remote_debugging;select;unicodedata;winsound;_uuid;_wmi;_zoneinfo" />
     <ExtensionModules Include="_ctypes" Condition="$(IncludeCTypes)" />
     <!-- Extension modules that require external sources -->
     <ExternalModules Include="_bz2;_lzma;_sqlite3" />

--- a/PCbuild/pcbuild.sln
+++ b/PCbuild/pcbuild.sln
@@ -81,7 +81,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_testclinic", "_testclinic.
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_testinternalcapi", "_testinternalcapi.vcxproj", "{900342D7-516A-4469-B1AD-59A66E49A25F}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_remotedebugging", "_remotedebugging.vcxproj", "{4D7C112F-3083-4D9E-9754-9341C14D9B39}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_remote_debugging", "_remote_debugging.vcxproj", "{4D7C112F-3083-4D9E-9754-9341C14D9B39}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_testimportmultiple", "_testimportmultiple.vcxproj", "{36D0C52C-DF4E-45D0-8BC7-E294C3ABC781}"
 EndProject

--- a/Python/stdlib_module_names.h
+++ b/Python/stdlib_module_names.h
@@ -71,6 +71,7 @@ static const char* _Py_stdlib_module_names[] = {
 "_pyrepl",
 "_queue",
 "_random",
+"_remote_debugging",
 "_scproxy",
 "_sha1",
 "_sha2",

--- a/Tools/build/generate_stdlib_module_names.py
+++ b/Tools/build/generate_stdlib_module_names.py
@@ -34,7 +34,6 @@ IGNORE = {
     '_testlimitedcapi',
     '_testmultiphase',
     '_testsinglephase',
-    '_remotedebugging',
     '_xxtestfuzz',
     'idlelib.idle_test',
     'test',

--- a/configure
+++ b/configure
@@ -692,8 +692,6 @@ MODULE__TKINTER_FALSE
 MODULE__TKINTER_TRUE
 MODULE__SQLITE3_FALSE
 MODULE__SQLITE3_TRUE
-MODULE__REMOTEDEBUGGING_FALSE
-MODULE__REMOTEDEBUGGING_TRUE
 MODULE_READLINE_FALSE
 MODULE_READLINE_TRUE
 MODULE__GDBM_FALSE
@@ -793,6 +791,8 @@ MODULE__STRUCT_FALSE
 MODULE__STRUCT_TRUE
 MODULE_SELECT_FALSE
 MODULE_SELECT_TRUE
+MODULE__REMOTE_DEBUGGING_FALSE
+MODULE__REMOTE_DEBUGGING_TRUE
 MODULE__RANDOM_FALSE
 MODULE__RANDOM_TRUE
 MODULE__QUEUE_FALSE
@@ -31072,7 +31072,7 @@ case $ac_sys_system in #(
 
 
     py_cv_module__ctypes_test=n/a
-    py_cv_module__remotedebugging=n/a
+    py_cv_module__remote_debugging=n/a
     py_cv_module__testimportmultiple=n/a
     py_cv_module__testmultiphase=n/a
     py_cv_module__testsinglephase=n/a
@@ -31389,6 +31389,28 @@ fi
 
   as_fn_append MODULE_BLOCK "MODULE__RANDOM_STATE=$py_cv_module__random$as_nl"
   if test "x$py_cv_module__random" = xyes
+then :
+
+
+
+
+fi
+
+
+        if test "$py_cv_module__remote_debugging" != "n/a"
+then :
+  py_cv_module__remote_debugging=yes
+fi
+   if test "$py_cv_module__remote_debugging" = yes; then
+  MODULE__REMOTE_DEBUGGING_TRUE=
+  MODULE__REMOTE_DEBUGGING_FALSE='#'
+else
+  MODULE__REMOTE_DEBUGGING_TRUE='#'
+  MODULE__REMOTE_DEBUGGING_FALSE=
+fi
+
+  as_fn_append MODULE_BLOCK "MODULE__REMOTE_DEBUGGING_STATE=$py_cv_module__remote_debugging$as_nl"
+  if test "x$py_cv_module__remote_debugging" = xyes
 then :
 
 
@@ -33132,46 +33154,6 @@ fi
 printf "%s\n" "$py_cv_module_readline" >&6; }
 
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for stdlib extension module _remotedebugging" >&5
-printf %s "checking for stdlib extension module _remotedebugging... " >&6; }
-        if test "$py_cv_module__remotedebugging" != "n/a"
-then :
-
-    if test "$TEST_MODULES" = yes
-then :
-  if true
-then :
-  py_cv_module__remotedebugging=yes
-else case e in #(
-  e) py_cv_module__remotedebugging=missing ;;
-esac
-fi
-else case e in #(
-  e) py_cv_module__remotedebugging=disabled ;;
-esac
-fi
-
-fi
-  as_fn_append MODULE_BLOCK "MODULE__REMOTEDEBUGGING_STATE=$py_cv_module__remotedebugging$as_nl"
-  if test "x$py_cv_module__remotedebugging" = xyes
-then :
-
-
-
-
-fi
-   if test "$py_cv_module__remotedebugging" = yes; then
-  MODULE__REMOTEDEBUGGING_TRUE=
-  MODULE__REMOTEDEBUGGING_FALSE='#'
-else
-  MODULE__REMOTEDEBUGGING_TRUE='#'
-  MODULE__REMOTEDEBUGGING_FALSE=
-fi
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $py_cv_module__remotedebugging" >&5
-printf "%s\n" "$py_cv_module__remotedebugging" >&6; }
-
-
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for stdlib extension module _sqlite3" >&5
 printf %s "checking for stdlib extension module _sqlite3... " >&6; }
         if test "$py_cv_module__sqlite3" != "n/a"
@@ -34291,6 +34273,10 @@ if test -z "${MODULE__RANDOM_TRUE}" && test -z "${MODULE__RANDOM_FALSE}"; then
   as_fn_error $? "conditional \"MODULE__RANDOM\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
+if test -z "${MODULE__REMOTE_DEBUGGING_TRUE}" && test -z "${MODULE__REMOTE_DEBUGGING_FALSE}"; then
+  as_fn_error $? "conditional \"MODULE__REMOTE_DEBUGGING\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
 if test -z "${MODULE_SELECT_TRUE}" && test -z "${MODULE_SELECT_FALSE}"; then
   as_fn_error $? "conditional \"MODULE_SELECT\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
@@ -34473,10 +34459,6 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${MODULE_READLINE_TRUE}" && test -z "${MODULE_READLINE_FALSE}"; then
   as_fn_error $? "conditional \"MODULE_READLINE\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${MODULE__REMOTEDEBUGGING_TRUE}" && test -z "${MODULE__REMOTEDEBUGGING_FALSE}"; then
-  as_fn_error $? "conditional \"MODULE__REMOTEDEBUGGING\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${MODULE__SQLITE3_TRUE}" && test -z "${MODULE__SQLITE3_FALSE}"; then

--- a/configure
+++ b/configure
@@ -654,8 +654,6 @@ MODULE__XXTESTFUZZ_FALSE
 MODULE__XXTESTFUZZ_TRUE
 MODULE_XXSUBTYPE_FALSE
 MODULE_XXSUBTYPE_TRUE
-MODULE__REMOTEDEBUGGING_FALSE
-MODULE__REMOTEDEBUGGING_TRUE
 MODULE__TESTSINGLEPHASE_FALSE
 MODULE__TESTSINGLEPHASE_TRUE
 MODULE__TESTMULTIPHASE_FALSE
@@ -694,6 +692,8 @@ MODULE__TKINTER_FALSE
 MODULE__TKINTER_TRUE
 MODULE__SQLITE3_FALSE
 MODULE__SQLITE3_TRUE
+MODULE__REMOTEDEBUGGING_FALSE
+MODULE__REMOTEDEBUGGING_TRUE
 MODULE_READLINE_FALSE
 MODULE_READLINE_TRUE
 MODULE__GDBM_FALSE
@@ -33132,6 +33132,46 @@ fi
 printf "%s\n" "$py_cv_module_readline" >&6; }
 
 
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for stdlib extension module _remotedebugging" >&5
+printf %s "checking for stdlib extension module _remotedebugging... " >&6; }
+        if test "$py_cv_module__remotedebugging" != "n/a"
+then :
+
+    if test "$TEST_MODULES" = yes
+then :
+  if true
+then :
+  py_cv_module__remotedebugging=yes
+else case e in #(
+  e) py_cv_module__remotedebugging=missing ;;
+esac
+fi
+else case e in #(
+  e) py_cv_module__remotedebugging=disabled ;;
+esac
+fi
+
+fi
+  as_fn_append MODULE_BLOCK "MODULE__REMOTEDEBUGGING_STATE=$py_cv_module__remotedebugging$as_nl"
+  if test "x$py_cv_module__remotedebugging" = xyes
+then :
+
+
+
+
+fi
+   if test "$py_cv_module__remotedebugging" = yes; then
+  MODULE__REMOTEDEBUGGING_TRUE=
+  MODULE__REMOTEDEBUGGING_FALSE='#'
+else
+  MODULE__REMOTEDEBUGGING_TRUE='#'
+  MODULE__REMOTEDEBUGGING_FALSE=
+fi
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $py_cv_module__remotedebugging" >&5
+printf "%s\n" "$py_cv_module__remotedebugging" >&6; }
+
+
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for stdlib extension module _sqlite3" >&5
 printf %s "checking for stdlib extension module _sqlite3... " >&6; }
         if test "$py_cv_module__sqlite3" != "n/a"
@@ -33877,46 +33917,6 @@ fi
 printf "%s\n" "$py_cv_module__testsinglephase" >&6; }
 
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for stdlib extension module _remotedebugging" >&5
-printf %s "checking for stdlib extension module _remotedebugging... " >&6; }
-        if test "$py_cv_module__remotedebugging" != "n/a"
-then :
-
-    if test "$TEST_MODULES" = yes
-then :
-  if true
-then :
-  py_cv_module__remotedebugging=yes
-else case e in #(
-  e) py_cv_module__remotedebugging=missing ;;
-esac
-fi
-else case e in #(
-  e) py_cv_module__remotedebugging=disabled ;;
-esac
-fi
-
-fi
-  as_fn_append MODULE_BLOCK "MODULE__REMOTEDEBUGGING_STATE=$py_cv_module__remotedebugging$as_nl"
-  if test "x$py_cv_module__remotedebugging" = xyes
-then :
-
-
-
-
-fi
-   if test "$py_cv_module__remotedebugging" = yes; then
-  MODULE__REMOTEDEBUGGING_TRUE=
-  MODULE__REMOTEDEBUGGING_FALSE='#'
-else
-  MODULE__REMOTEDEBUGGING_TRUE='#'
-  MODULE__REMOTEDEBUGGING_FALSE=
-fi
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $py_cv_module__remotedebugging" >&5
-printf "%s\n" "$py_cv_module__remotedebugging" >&6; }
-
-
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for stdlib extension module xxsubtype" >&5
 printf %s "checking for stdlib extension module xxsubtype... " >&6; }
         if test "$py_cv_module_xxsubtype" != "n/a"
@@ -34475,6 +34475,10 @@ if test -z "${MODULE_READLINE_TRUE}" && test -z "${MODULE_READLINE_FALSE}"; then
   as_fn_error $? "conditional \"MODULE_READLINE\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
+if test -z "${MODULE__REMOTEDEBUGGING_TRUE}" && test -z "${MODULE__REMOTEDEBUGGING_FALSE}"; then
+  as_fn_error $? "conditional \"MODULE__REMOTEDEBUGGING\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
 if test -z "${MODULE__SQLITE3_TRUE}" && test -z "${MODULE__SQLITE3_FALSE}"; then
   as_fn_error $? "conditional \"MODULE__SQLITE3\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
@@ -34549,10 +34553,6 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${MODULE__TESTSINGLEPHASE_TRUE}" && test -z "${MODULE__TESTSINGLEPHASE_FALSE}"; then
   as_fn_error $? "conditional \"MODULE__TESTSINGLEPHASE\" was never defined.
-Usually this means the macro was only invoked conditionally." "$LINENO" 5
-fi
-if test -z "${MODULE__REMOTEDEBUGGING_TRUE}" && test -z "${MODULE__REMOTEDEBUGGING_FALSE}"; then
-  as_fn_error $? "conditional \"MODULE__REMOTEDEBUGGING\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${MODULE_XXSUBTYPE_TRUE}" && test -z "${MODULE_XXSUBTYPE_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -8077,6 +8077,7 @@ PY_STDLIB_MOD([_gdbm],
  PY_STDLIB_MOD([readline],
   [], [test "$with_readline" != "no"],
   [$READLINE_CFLAGS], [$READLINE_LIBS])
+PY_STDLIB_MOD([_remotedebugging], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([_sqlite3],
   [test "$have_sqlite3" = "yes"],
   [test "$have_supported_sqlite3" = "yes"],
@@ -8119,7 +8120,6 @@ PY_STDLIB_MOD([_testbuffer], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([_testimportmultiple], [test "$TEST_MODULES" = yes], [test "$ac_cv_func_dlopen" = yes])
 PY_STDLIB_MOD([_testmultiphase], [test "$TEST_MODULES" = yes], [test "$ac_cv_func_dlopen" = yes])
 PY_STDLIB_MOD([_testsinglephase], [test "$TEST_MODULES" = yes], [test "$ac_cv_func_dlopen" = yes])
-PY_STDLIB_MOD([_remotedebugging], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([xxsubtype], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([_xxtestfuzz], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([_ctypes_test],

--- a/configure.ac
+++ b/configure.ac
@@ -7755,7 +7755,7 @@ AS_CASE([$ac_sys_system],
     dnl (see Modules/Setup.stdlib.in).
     PY_STDLIB_MOD_SET_NA(
       [_ctypes_test],
-      [_remotedebugging],
+      [_remote_debugging],
       [_testimportmultiple],
       [_testmultiphase],
       [_testsinglephase],
@@ -7849,6 +7849,7 @@ PY_STDLIB_MOD_SIMPLE([_pickle])
 PY_STDLIB_MOD_SIMPLE([_posixsubprocess])
 PY_STDLIB_MOD_SIMPLE([_queue])
 PY_STDLIB_MOD_SIMPLE([_random])
+PY_STDLIB_MOD_SIMPLE([_remote_debugging])
 PY_STDLIB_MOD_SIMPLE([select])
 PY_STDLIB_MOD_SIMPLE([_struct])
 PY_STDLIB_MOD_SIMPLE([_types])
@@ -8077,7 +8078,6 @@ PY_STDLIB_MOD([_gdbm],
  PY_STDLIB_MOD([readline],
   [], [test "$with_readline" != "no"],
   [$READLINE_CFLAGS], [$READLINE_LIBS])
-PY_STDLIB_MOD([_remotedebugging], [test "$TEST_MODULES" = yes])
 PY_STDLIB_MOD([_sqlite3],
   [test "$have_sqlite3" = "yes"],
   [test "$have_supported_sqlite3" = "yes"],


### PR DESCRIPTION
cc @pablogsal, a few minor things I spotted after the rename in #133284.

Btw, would you support adding an underscore to the module name? I keep reading it as 'remoted ...', and `_remote_debugging` would better match the C files.

A

<!-- gh-issue-number: gh-91048 -->
* Issue: gh-91048
<!-- /gh-issue-number -->
