### PR TITLE
gh-119180: Make the FORWARDREF format work with more kinds of runtime errors

### DIFF
--- a/Lib/annotationlib.py
+++ b/Lib/annotationlib.py
@@ -868,7 +868,7 @@ def get_annotations(
             # For FORWARDREF, we use __annotations__ if it exists
             try:
                 ann = _get_dunder_annotations(obj)
-            except NameError:
+            except Exception:
                 pass
             else:
                 if ann is not None:

--- a/Lib/test/test_annotationlib.py
+++ b/Lib/test/test_annotationlib.py
@@ -1053,6 +1053,21 @@ class TestGetAnnotations(unittest.TestCase):
             },
         )
 
+    def test_partial_evaluation_error(self):
+        def f(x: range[1]):
+            pass
+        with self.assertRaisesRegex(
+            TypeError, "type 'range' is not subscriptable"
+        ):
+            f.__annotations__
+
+        self.assertEqual(
+            get_annotations(f, format=Format.FORWARDREF),
+            {
+                "x": support.EqualToForwardRef("range[1]", owner=f),
+            },
+        )
+
     def test_partial_evaluation_cell(self):
         obj = object()
 

--- a/Misc/NEWS.d/next/Library/2025-05-04-15-39-25.gh-issue-119180.avZ3Hm.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-04-15-39-25.gh-issue-119180.avZ3Hm.rst
@@ -1,0 +1,3 @@
+Make :func:`annotationlib.get_annotations` succeed with the ``FORWARDREF``
+format if evaluating the annotations throws an exception other than
+:exc:`NameError` or :exc:`AttributeError`.


### PR DESCRIPTION
I should have done this in #132818 but didn't notice in time.

cc @DavidCEllis 

<!-- gh-issue-number: gh-119180 -->
* Issue: gh-119180
<!-- /gh-issue-number -->
