### PR TITLE
GH-133410: Use commit hashes for change detection

### DIFF
--- a/.github/workflows/reusable-context.yml
+++ b/.github/workflows/reusable-context.yml
@@ -97,6 +97,8 @@ jobs:
       run: python Tools/build/compute-changes.py
       env:
         GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        CCF_TARGET_REF: ${{ github.base_ref || github.event.repository.default_branch }}
+        CCF_HEAD_REF: ${{ github.event.pull_request.head.sha || github.sha }}
 
     - name: Compute hash for config cache key
       id: config-hash

--- a/Tools/build/compute-changes.py
+++ b/Tools/build/compute-changes.py
@@ -56,10 +56,10 @@ class Outputs:
 
 
 def compute_changes() -> None:
-    target_branch, head_branch = git_branches()
-    if target_branch and head_branch:
+    target_branch, head_ref = git_refs()
+    if target_branch and head_ref:
         # Getting changed files only makes sense on a pull request
-        files = get_changed_files(target_branch, head_branch)
+        files = get_changed_files(target_branch, head_ref)
         outputs = process_changed_files(files)
     else:
         # Otherwise, just run the tests
@@ -87,7 +87,7 @@ def compute_changes() -> None:
     write_github_output(outputs)
 
 
-def git_branches() -> tuple[str, str]:
+def git_refs() -> tuple[str, str]:
     target_ref = os.environ.get("CCF_TARGET_REF", "")
     target_ref = target_ref.removeprefix("refs/heads/")
     print(f"target ref: {target_ref!r}")

--- a/Tools/build/compute-changes.py
+++ b/Tools/build/compute-changes.py
@@ -59,9 +59,7 @@ def compute_changes() -> None:
     target_branch, head_branch = git_branches()
     if target_branch and head_branch:
         # Getting changed files only makes sense on a pull request
-        files = get_changed_files(
-            f"origin/{target_branch}", f"origin/{head_branch}"
-        )
+        files = get_changed_files(target_branch, head_branch)
         outputs = process_changed_files(files)
     else:
         # Otherwise, just run the tests
@@ -90,14 +88,14 @@ def compute_changes() -> None:
 
 
 def git_branches() -> tuple[str, str]:
-    target_branch = os.environ.get("GITHUB_BASE_REF", "")
-    target_branch = target_branch.removeprefix("refs/heads/")
-    print(f"target branch: {target_branch!r}")
+    target_ref = os.environ.get("CCF_TARGET_REF", "")
+    target_ref = target_ref.removeprefix("refs/heads/")
+    print(f"target ref: {target_ref!r}")
 
-    head_branch = os.environ.get("GITHUB_HEAD_REF", "")
-    head_branch = head_branch.removeprefix("refs/heads/")
-    print(f"head branch: {head_branch!r}")
-    return target_branch, head_branch
+    head_ref = os.environ.get("CCF_HEAD_REF", "")
+    head_ref = head_ref.removeprefix("refs/heads/")
+    print(f"head ref: {head_ref!r}")
+    return f"origin/{target_ref}", head_ref
 
 
 def get_changed_files(


### PR DESCRIPTION
As seen recently, if the pull-request branch on a fork repository has the same name as the target branch on the upstream repository, the branches shadow each other when set up by `@actions/checkout`, meaning that change detection passes with no changes having occured.

This changes to instead perform the `git diff` with the commit SHA of the head commit. This is slightly tricky due to what GitHub exposes, but in short, we always compare the tip of the PR branch (fork) against the default branch (upstream).

A

cc @JelleZijlstra 

<!-- gh-issue-number: gh-133410 -->
* Issue: gh-133410
<!-- /gh-issue-number -->
