### PR TITLE
[tests] test_subprocess maybe avoid a timeout race condition?

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -164,13 +164,13 @@ class ProcessTestCase(BaseTestCase):
 
     def test_timeout_exception(self):
         try:
-            subprocess.run(['echo', 'hi'], timeout = -1)
+            subprocess.run([sys.executable, '-c', 'import time;time.sleep(9)'], timeout = -1)
         except subprocess.TimeoutExpired as e:
             self.assertIn("-1 seconds", str(e))
         else:
             self.fail("Expected TimeoutExpired exception not raised")
         try:
-            subprocess.run(['echo', 'hi'], timeout = 0)
+            subprocess.run([sys.executable, '-c', 'import time;time.sleep(9)'], timeout = 0)
         except subprocess.TimeoutExpired as e:
             self.assertIn("0 seconds", str(e))
         else:


### PR DESCRIPTION
The few buildbot failures on https://github.com/python/cpython/pull/133103 are possibly just due to racing a child process launch and exit?