### PR TITLE
[GH-133419] fix test_external_inspection race assert

### DIFF
--- a/Lib/test/test_external_inspection.py
+++ b/Lib/test/test_external_inspection.py
@@ -59,8 +59,7 @@ class TestGetStackTrace(unittest.TestCase):
                 foo()
 
             def foo():
-                sock.sendall(b"ready")
-                time.sleep(1000)
+                sock.sendall(b"ready"); time.sleep(1000)  # same line number
 
             bar()
             """
@@ -96,10 +95,10 @@ class TestGetStackTrace(unittest.TestCase):
                 p.wait(timeout=SHORT_TIMEOUT)
 
             expected_stack_trace = [
-                ("foo", script_name, 15),
+                ("foo", script_name, 14),
                 ("baz", script_name, 11),
                 ("bar", script_name, 9),
-                ("<module>", script_name, 17),
+                ("<module>", script_name, 16),
             ]
             self.assertEqual(stack_trace, expected_stack_trace)
 


### PR DESCRIPTION
either line could be where the inspection finds the foo() function as after ready is sent, the process may not have made progress onto the next line yet.  "solve" by putting the statements on the same line.  simpler than asserting for multiple possible line values.

Fixes #133419.
Closes #133419.

<!-- gh-issue-number: gh-133419 -->
* Issue: gh-133419
<!-- /gh-issue-number -->
