### PR TITLE
Revert "gh-124715: Fix method_dealloc(): use PyObject_GC_UnTrack() (#133199)"

### DIFF
--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -244,7 +244,7 @@ static void
 method_dealloc(PyObject *self)
 {
     PyMethodObject *im = _PyMethodObject_CAST(self);
-    PyObject_GC_UnTrack(im);
+    _PyObject_GC_UNTRACK(im);
     if (im->im_weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject *)im);
     Py_DECREF(im->im_func);


### PR DESCRIPTION
This reverts commit 662dd294563ce86980c640ad67e3d460a72c9cb9.

The root issue was fixed by the commit f554237b8ef6c60df651ac17eb0ef0c095cef185.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-124715 -->
* Issue: gh-124715
<!-- /gh-issue-number -->
