### PR TITLE
GH-128520: pathlib ABCs: add `JoinablePath.__vfspath__()`

### DIFF
--- a/Lib/glob.py
+++ b/Lib/glob.py
@@ -358,6 +358,12 @@ class _GlobberBase:
         """
         raise NotImplementedError
 
+    @staticmethod
+    def stringify_path(path):
+        """Converts the path to a string object
+        """
+        raise NotImplementedError
+
     # High-level methods
 
     def compile(self, pat, altsep=None):
@@ -466,8 +472,9 @@ class _GlobberBase:
         select_next = self.selector(parts)
 
         def select_recursive(path, exists=False):
-            match_pos = len(str(path))
-            if match is None or match(str(path), match_pos):
+            path_str = self.stringify_path(path)
+            match_pos = len(path_str)
+            if match is None or match(path_str, match_pos):
                 yield from select_next(path, exists)
             stack = [path]
             while stack:
@@ -489,7 +496,7 @@ class _GlobberBase:
                         pass
 
                     if is_dir or not dir_only:
-                        entry_path_str = str(entry_path)
+                        entry_path_str = self.stringify_path(entry_path)
                         if dir_only:
                             entry_path = self.concat_path(entry_path, self.sep)
                         if match is None or match(entry_path_str, match_pos):
@@ -529,19 +536,6 @@ class _StringGlobber(_GlobberBase):
             entries = list(scandir_it)
         return ((entry, entry.name, entry.path) for entry in entries)
 
-
-class _PathGlobber(_GlobberBase):
-    """Provides shell-style pattern matching and globbing for pathlib paths.
-    """
-
     @staticmethod
-    def lexists(path):
-        return path.info.exists(follow_symlinks=False)
-
-    @staticmethod
-    def scandir(path):
-        return ((child.info, child.name, child) for child in path.iterdir())
-
-    @staticmethod
-    def concat_path(path, text):
-        return path.with_segments(str(path) + text)
+    def stringify_path(path):
+        return path  # Already a string.

--- a/Lib/pathlib/__init__.py
+++ b/Lib/pathlib/__init__.py
@@ -28,8 +28,9 @@ except ImportError:
 
 from pathlib._os import (
     PathInfo, DirEntryInfo,
+    magic_open, vfspath,
     ensure_different_files, ensure_distinct_paths,
-    copyfile2, copyfileobj, magic_open, copy_info,
+    copyfile2, copyfileobj, copy_info,
 )
 
 
@@ -1164,12 +1165,12 @@ class Path(PurePath):
         # os.symlink() incorrectly creates a file-symlink on Windows. Avoid
         # this by passing *target_is_dir* to os.symlink() on Windows.
         def _copy_from_symlink(self, source, preserve_metadata=False):
-            os.symlink(str(source.readlink()), self, source.info.is_dir())
+            os.symlink(vfspath(source.readlink()), self, source.info.is_dir())
             if preserve_metadata:
                 copy_info(source.info, self, follow_symlinks=False)
     else:
         def _copy_from_symlink(self, source, preserve_metadata=False):
-            os.symlink(str(source.readlink()), self)
+            os.symlink(vfspath(source.readlink()), self)
             if preserve_metadata:
                 copy_info(source.info, self, follow_symlinks=False)
 

--- a/Lib/pathlib/_os.py
+++ b/Lib/pathlib/_os.py
@@ -215,24 +215,18 @@ def vfspath(path):
     Return the string representation of a virtual path object.
     """
     try:
-        path_str = os.fspath(path)
+        return os.fsdecode(path)
     except TypeError:
         pass
-    else:
-        if isinstance(path_str, str):
-            return path_str
 
     path_type = type(path)
     try:
-        path_str = path_type.__vfspath__(path)
+        return path_type.__vfspath__(path)
     except AttributeError:
-        if hasattr(path_type, '__fspath__'):
+        if hasattr(path_type, '__vfspath__'):
             raise
-    else:
-        if isinstance(path_str, str):
-            return path_str
 
-    raise TypeError("expected str, os.PathLike[str] or JoinablePath "
+    raise TypeError("expected str, bytes, os.PathLike or JoinablePath "
                     "object, not " + path_type.__name__)
 
 

--- a/Lib/test/test_pathlib/support/lexical_path.py
+++ b/Lib/test/test_pathlib/support/lexical_path.py
@@ -9,9 +9,10 @@ import posixpath
 from . import is_pypi
 
 if is_pypi:
-    from pathlib_abc import _JoinablePath
+    from pathlib_abc import vfspath, _JoinablePath
 else:
     from pathlib.types import _JoinablePath
+    from pathlib._os import vfspath
 
 
 class LexicalPath(_JoinablePath):
@@ -22,20 +23,20 @@ class LexicalPath(_JoinablePath):
         self._segments = pathsegments
 
     def __hash__(self):
-        return hash(str(self))
+        return hash(vfspath(self))
 
     def __eq__(self, other):
         if not isinstance(other, LexicalPath):
             return NotImplemented
-        return str(self) == str(other)
+        return vfspath(self) == vfspath(other)
 
-    def __str__(self):
+    def __vfspath__(self):
         if not self._segments:
             return ''
         return self.parser.join(*self._segments)
 
     def __repr__(self):
-        return f'{type(self).__name__}({str(self)!r})'
+        return f'{type(self).__name__}({vfspath(self)!r})'
 
     def with_segments(self, *pathsegments):
         return type(self)(*pathsegments)

--- a/Lib/test/test_pathlib/support/local_path.py
+++ b/Lib/test/test_pathlib/support/local_path.py
@@ -97,7 +97,7 @@ class LocalPathInfo(PathInfo):
     __slots__ = ('_path', '_exists', '_is_dir', '_is_file', '_is_symlink')
 
     def __init__(self, path):
-        self._path = str(path)
+        self._path = os.fspath(path)
         self._exists = None
         self._is_dir = None
         self._is_file = None
@@ -139,13 +139,11 @@ class ReadableLocalPath(_ReadablePath, LexicalPath):
     Simple implementation of a ReadablePath class for local filesystem paths.
     """
     __slots__ = ('info',)
+    __fspath__ = LexicalPath.__vfspath__
 
     def __init__(self, *pathsegments):
         super().__init__(*pathsegments)
         self.info = LocalPathInfo(self)
-
-    def __fspath__(self):
-        return str(self)
 
     def __open_rb__(self, buffering=-1):
         return open(self, 'rb')
@@ -163,9 +161,7 @@ class WritableLocalPath(_WritablePath, LexicalPath):
     """
 
     __slots__ = ()
-
-    def __fspath__(self):
-        return str(self)
+    __fspath__ = LexicalPath.__vfspath__
 
     def __open_wb__(self, buffering=-1):
         return open(self, 'wb')

--- a/Lib/test/test_pathlib/test_join_windows.py
+++ b/Lib/test/test_pathlib/test_join_windows.py
@@ -9,6 +9,12 @@ from .support import is_pypi
 from .support.lexical_path import LexicalWindowsPath
 
 
+if is_pypi:
+    from pathlib_abc import vfspath
+else:
+    from pathlib._os import vfspath
+
+
 class JoinTestBase:
     def test_join(self):
         P = self.cls
@@ -70,17 +76,17 @@ class JoinTestBase:
         self.assertEqual(p / './dd:s', P(r'C:/a/b\./dd:s'))
         self.assertEqual(p / 'E:d:s', P('E:d:s'))
 
-    def test_str(self):
+    def test_vfspath(self):
         p = self.cls(r'a\b\c')
-        self.assertEqual(str(p), 'a\\b\\c')
+        self.assertEqual(vfspath(p), 'a\\b\\c')
         p = self.cls(r'c:\a\b\c')
-        self.assertEqual(str(p), 'c:\\a\\b\\c')
+        self.assertEqual(vfspath(p), 'c:\\a\\b\\c')
         p = self.cls('\\\\a\\b\\')
-        self.assertEqual(str(p), '\\\\a\\b\\')
+        self.assertEqual(vfspath(p), '\\\\a\\b\\')
         p = self.cls(r'\\a\b\c')
-        self.assertEqual(str(p), '\\\\a\\b\\c')
+        self.assertEqual(vfspath(p), '\\\\a\\b\\c')
         p = self.cls(r'\\a\b\c\d')
-        self.assertEqual(str(p), '\\\\a\\b\\c\\d')
+        self.assertEqual(vfspath(p), '\\\\a\\b\\c\\d')
 
     def test_parts(self):
         P = self.cls

--- a/Lib/test/test_pathlib/test_join_windows.py
+++ b/Lib/test/test_pathlib/test_join_windows.py
@@ -8,7 +8,6 @@ import unittest
 from .support import is_pypi
 from .support.lexical_path import LexicalWindowsPath
 
-
 if is_pypi:
     from pathlib_abc import vfspath
 else:


### PR DESCRIPTION
In the abstract interface of `JoinablePath`, replace `__str__()` with `__vfspath__()`. This frees user implementations of `JoinablePath` to implement `__str__()` however they like (or not at all.)

Also add `pathlib._os.vfspath()`, which calls `__fspath__()` or `__vfspath__()`. This will be exported as a public function in the pathlib-abc PyPI package.

Some related discussion here: https://discuss.python.org/t/protocol-for-virtual-filesystem-paths/82753


<!-- gh-issue-number: gh-128520 -->
* Issue: gh-128520
<!-- /gh-issue-number -->
