### PR TITLE
gh-133439: Fix dot commands with trailing spaces are mistaken for multi-line sqlite statements in the sqlite3 command-line interface

### DIFF
--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -48,7 +48,7 @@ class SqliteInteractiveConsole(InteractiveConsole):
         Return True if more input is needed; buffering is done automatically.
         Return False if input is a complete statement ready for execution.
         """
-        source = source.strip()
+        source = source.rstrip()
         match source:
             case ".version":
                 print(f"{sqlite3.sqlite_version}")

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -48,18 +48,18 @@ class SqliteInteractiveConsole(InteractiveConsole):
         Return True if more input is needed; buffering is done automatically.
         Return False if input is a complete statement ready for execution.
         """
-        source = source.rstrip()
-        match source:
-            case ".version":
-                print(f"{sqlite3.sqlite_version}")
-            case ".help":
-                print("Enter SQL code and press enter.")
-            case ".quit":
-                sys.exit(0)
-            case _:
-                if not sqlite3.complete_statement(source):
-                    return True
-                execute(self._cur, source)
+        if source[0] == ".":
+            match source[1:].strip():
+                case "version":
+                    print(f"{sqlite3.sqlite_version}")
+                case "help":
+                    print("Enter SQL code and press enter.")
+                case "quit":
+                    sys.exit(0)
+        else:
+            if not sqlite3.complete_statement(source):
+                return True
+            execute(self._cur, source)
         return False
 
 

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -58,9 +58,9 @@ class SqliteInteractiveConsole(InteractiveConsole):
                     print("Enter SQL code and press enter.")
                 case "quit":
                     sys.exit(0)
-                case _:
-                    print('Error: unknown command or invalid arguments:  '
-                          f'"{source[1:].strip()}". Enter ".help" for help')
+                case _ as unknown:
+                    print("Error: unknown command or invalid arguments:  "
+                          f'"{unknown}". Enter ".help" for help')
         else:
             if not sqlite3.complete_statement(source):
                 return True

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -59,8 +59,9 @@ class SqliteInteractiveConsole(InteractiveConsole):
                 case "quit":
                     sys.exit(0)
                 case _ as unknown:
-                    print("Error: unknown command or invalid arguments:  "
-                          f'"{unknown}". Enter ".help" for help')
+                    if unknown:
+                        print("Error: unknown command or invalid arguments:"
+                              f'  "{unknown}". Enter ".help" for help')
         else:
             if not sqlite3.complete_statement(source):
                 return True

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -56,6 +56,8 @@ class SqliteInteractiveConsole(InteractiveConsole):
                     print("Enter SQL code and press enter.")
                 case "quit":
                     sys.exit(0)
+                case _:
+                    print('Error: unknown command or invalid arguments:  "spam". Enter ".help" for help')
         else:
             if not sqlite3.complete_statement(source):
                 return True

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -48,6 +48,7 @@ class SqliteInteractiveConsole(InteractiveConsole):
         Return True if more input is needed; buffering is done automatically.
         Return False if input is a complete statement ready for execution.
         """
+        source = source.strip()
         match source:
             case ".version":
                 print(f"{sqlite3.sqlite_version}")

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -58,10 +58,11 @@ class SqliteInteractiveConsole(InteractiveConsole):
                     print("Enter SQL code and press enter.")
                 case "quit":
                     sys.exit(0)
+                case "":
+                    pass
                 case _ as unknown:
-                    if unknown:
-                        print("Error: unknown command or invalid arguments:"
-                              f'  "{unknown}". Enter ".help" for help')
+                    self.write("Error: unknown command or invalid arguments:"
+                               f'  "{unknown}".\n')
         else:
             if not sqlite3.complete_statement(source):
                 return True

--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -48,6 +48,8 @@ class SqliteInteractiveConsole(InteractiveConsole):
         Return True if more input is needed; buffering is done automatically.
         Return False if input is a complete statement ready for execution.
         """
+        if not source or source.isspace():
+            return False
         if source[0] == ".":
             match source[1:].strip():
                 case "version":
@@ -57,7 +59,8 @@ class SqliteInteractiveConsole(InteractiveConsole):
                 case "quit":
                     sys.exit(0)
                 case _:
-                    print('Error: unknown command or invalid arguments:  "spam". Enter ".help" for help')
+                    print('Error: unknown command or invalid arguments:  '
+                          f'"{source[1:].strip()}". Enter ".help" for help')
         else:
             if not sqlite3.complete_statement(source):
                 return True

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -124,15 +124,21 @@ class InteractiveSession(unittest.TestCase):
         self.assertEqual(out.count(self.PS2), 0)
 
     def test_interact_dot_commands_unknown(self):
-        out, err = self.run_cli(commands=(".unknown_command", "."))
+        out, err = self.run_cli(commands=(".unknown_command"))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertEndsWith(out, self.PS1)
-        self.assertEqual(out.count(self.PS1), 3)
+        self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
+        self.assertIn("Error", err)
         # test "unknown_command" is pointed out in the error message
-        self.assertIn("unknown_command", out)
-        # test ignore empty dot command "." to mimic sqlite3 CLI
-        self.assertEqual(out.count('Error'), 1)
+        self.assertIn("unknown_command", err)
+
+    def test_interact_dot_commands_empty(self):
+        out, err = self.run_cli(commands=("."))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 2)
+        self.assertEqual(out.count(self.PS2), 0)
 
     def test_interact_dot_commands_with_whitespaces(self):
         out, err = self.run_cli(commands=(".version ", ". version"))

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -124,12 +124,15 @@ class InteractiveSession(unittest.TestCase):
         self.assertEqual(out.count(self.PS2), 0)
 
     def test_interact_dot_commands_unknown(self):
-        out, err = self.run_cli(commands=(".unknown_command",))
+        out, err = self.run_cli(commands=(".unknown_command", "."))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertEndsWith(out, self.PS1)
-        self.assertEqual(out.count(self.PS1), 2)
+        self.assertEqual(out.count(self.PS1), 3)
         self.assertEqual(out.count(self.PS2), 0)
-        self.assertIn('Error: unknown command or invalid arguments:  "unknown_command"', out)
+        # test "unknown_command" is pointed out in the error message
+        self.assertIn("unknown_command", out)
+        # test ignore empty dot command "." to mimic sqlite3 CLI
+        self.assertEqual(out.count('Error'), 1)
 
     def test_interact_dot_commands_with_whitespaces(self):
         out, err = self.run_cli(commands=(".version ", ". version"))

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -116,6 +116,15 @@ class InteractiveSession(unittest.TestCase):
         self.assertEqual(out.count(self.PS2), 0)
         self.assertIn(sqlite3.sqlite_version, out)
 
+    def test_interact_whitespace_stripping(self):
+        out, err = self.run_cli(commands=(" " + ".version" + " ",))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertIn(sqlite3.sqlite_version + "\n", out)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 2)
+        self.assertEqual(out.count(self.PS2), 0)
+        self.assertIn(sqlite3.sqlite_version, out)
+
     def test_interact_valid_sql(self):
         out, err = self.run_cli(commands=("SELECT 1;",))
         self.assertIn(self.MEMORY_DB_MSG, err)

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -117,7 +117,7 @@ class InteractiveSession(unittest.TestCase):
         self.assertIn(sqlite3.sqlite_version, out)
 
     def test_interact_whitespace_stripping(self):
-        out, err = self.run_cli(commands=(" " + ".version" + " ",))
+        out, err = self.run_cli(commands=(".version" + " ",))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertIn(sqlite3.sqlite_version + "\n", out)
         self.assertEndsWith(out, self.PS1)

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -124,7 +124,7 @@ class InteractiveSession(unittest.TestCase):
         self.assertEqual(out.count(self.PS2), 0)
 
     def test_interact_dot_commands_unknown(self):
-        out, err = self.run_cli(commands=(".unknown_command"))
+        out, err = self.run_cli(commands=(".unknown_command", ))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertEndsWith(out, self.PS1)
         self.assertEqual(out.count(self.PS1), 2)

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -116,12 +116,12 @@ class InteractiveSession(unittest.TestCase):
         self.assertEqual(out.count(self.PS2), 0)
         self.assertIn(sqlite3.sqlite_version, out)
 
-    def test_interact_whitespace_stripping(self):
-        out, err = self.run_cli(commands=(".version" + " ",))
+    def test_interact_dot_commands_whitespace(self):
+        out, err = self.run_cli(commands=(".version ", ". version"))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertIn(sqlite3.sqlite_version + "\n", out)
+        self.assertEqual(out.count(sqlite3.sqlite_version + "\n"), 2)
         self.assertEndsWith(out, self.PS1)
-        self.assertEqual(out.count(self.PS1), 2)
+        self.assertEqual(out.count(self.PS1), 3)
         self.assertEqual(out.count(self.PS2), 0)
         self.assertIn(sqlite3.sqlite_version, out)
 

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -116,15 +116,28 @@ class InteractiveSession(unittest.TestCase):
         self.assertEqual(out.count(self.PS2), 0)
         self.assertIn(sqlite3.sqlite_version, out)
 
-    def test_interact_dot_commands(self):
-        # test dot commands with whitespaces and unknow dot commands
-        out, err = self.run_cli(commands=(".version ", ". version", ".spam"))
+    def test_interact_empty_source(self):
+        out, err = self.run_cli(commands=("", " "))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 3)
+        self.assertEqual(out.count(self.PS2), 0)
+
+    def test_interact_dot_commands_unknown(self):
+        out, err = self.run_cli(commands=(".unknown_command",))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 2)
+        self.assertEqual(out.count(self.PS2), 0)
+        self.assertIn('Error: unknown command or invalid arguments:  "unknown_command"', out)
+
+    def test_interact_dot_commands_with_whitespaces(self):
+        out, err = self.run_cli(commands=(".version ", ". version"))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertEqual(out.count(sqlite3.sqlite_version + "\n"), 2)
         self.assertEndsWith(out, self.PS1)
-        self.assertEqual(out.count(self.PS1), 4)
+        self.assertEqual(out.count(self.PS1), 3)
         self.assertEqual(out.count(self.PS2), 0)
-        self.assertIn("Error", out)
 
     def test_interact_valid_sql(self):
         out, err = self.run_cli(commands=("SELECT 1;",))

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -116,14 +116,15 @@ class InteractiveSession(unittest.TestCase):
         self.assertEqual(out.count(self.PS2), 0)
         self.assertIn(sqlite3.sqlite_version, out)
 
-    def test_interact_dot_commands_whitespace(self):
-        out, err = self.run_cli(commands=(".version ", ". version"))
+    def test_interact_dot_commands(self):
+        # test dot commands with whitespaces and unknow dot commands
+        out, err = self.run_cli(commands=(".version ", ". version", ".spam"))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertEqual(out.count(sqlite3.sqlite_version + "\n"), 2)
         self.assertEndsWith(out, self.PS1)
-        self.assertEqual(out.count(self.PS1), 3)
+        self.assertEqual(out.count(self.PS1), 4)
         self.assertEqual(out.count(self.PS2), 0)
-        self.assertIn(sqlite3.sqlite_version, out)
+        self.assertIn("Error", out)
 
     def test_interact_valid_sql(self):
         out, err = self.run_cli(commands=("SELECT 1;",))

--- a/Misc/NEWS.d/next/Library/2025-05-05-22-11-24.gh-issue-133439.LpmyFz.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-05-22-11-24.gh-issue-133439.LpmyFz.rst
@@ -1,0 +1,2 @@
+fix dot commands with trailing spaces are mistaken for multi-line sqlite
+statements in the sqlite3 command-line interface

--- a/Misc/NEWS.d/next/Library/2025-05-05-22-11-24.gh-issue-133439.LpmyFz.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-05-22-11-24.gh-issue-133439.LpmyFz.rst
@@ -1,2 +1,2 @@
-fix dot commands with trailing spaces are mistaken for multi-line SQL
-statements in the sqlite3 command-line interface
+Fix dot commands with trailing spaces are mistaken for multi-line SQL
+statements in the sqlite3 command-line interface.

--- a/Misc/NEWS.d/next/Library/2025-05-05-22-11-24.gh-issue-133439.LpmyFz.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-05-22-11-24.gh-issue-133439.LpmyFz.rst
@@ -1,2 +1,2 @@
-fix dot commands with trailing spaces are mistaken for multi-line sqlite
+fix dot commands with trailing spaces are mistaken for multi-line SQL
 statements in the sqlite3 command-line interface


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Issue: [sqlite3 CLI does not recognize dot commands with trailing spaces #133439](https://github.com/python/cpython/issues/133439)


<!-- gh-issue-number: gh-133439 -->
* Issue: gh-133439
<!-- /gh-issue-number -->
