### PR TITLE
GH-133336: Remove reserved ``-J`` flag for Jython

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -670,6 +670,13 @@ Miscellaneous options
    .. versionchanged:: 3.10
       Removed the ``-X oldparser`` option.
 
+.. versionremoved:: next
+
+   :option:`!-J` is no longer reserved for use by Jython_,
+   and now has no special meaning.
+
+   .. _Jython: https://www.jython.org/
+
 .. _using-on-controlling-color:
 
 Controlling color
@@ -693,15 +700,6 @@ output. To control the color output only in the Python interpreter, the
 :envvar:`PYTHON_COLORS` environment variable can be used. This variable takes
 precedence over ``NO_COLOR``, which in turn takes precedence over
 ``FORCE_COLOR``.
-
-Options you shouldn't use
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. option:: -J
-
-   Reserved for use by Jython_.
-
-.. _Jython: https://www.jython.org/
 
 
 .. _using-on-envvars:

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -1747,7 +1747,7 @@ Interpreter Changes
 -------------------------------
 
 Two command-line options have been reserved for use by other Python
-implementations.  The :option:`-J` switch has been reserved for use by
+implementations.  The :option:`!-J` switch has been reserved for use by
 Jython for Jython-specific options, such as switches that are passed to
 the underlying JVM.  :option:`-X` has been reserved for options
 specific to a particular implementation of Python such as CPython,

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -805,6 +805,11 @@ Other language changes
   :keyword:`async with`).
   (Contributed by Bénédikt Tran in :gh:`128398`.)
 
+* :option:`-J` is no longer a reserved flag for Jython_,
+  and now has no special meaning.
+  (Contributed by Adam Turner in :gh:`133336`.)
+
+  .. _Jython: https://www.jython.org/
 
 .. _whatsnew314-pep765:
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -805,7 +805,7 @@ Other language changes
   :keyword:`async with`).
   (Contributed by Bénédikt Tran in :gh:`128398`.)
 
-* :option:`-J` is no longer a reserved flag for Jython_,
+* :option:`!-J` is no longer a reserved flag for Jython_,
   and now has no special meaning.
   (Contributed by Adam Turner in :gh:`133336`.)
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-05-15-33-35.gh-issue-133336.miffFi.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-05-15-33-35.gh-issue-133336.miffFi.rst
@@ -1,0 +1,2 @@
+:option:`!-J` is no longer reserved for use by Jython.
+Patch by Adam Turner.

--- a/Python/getopt.c
+++ b/Python/getopt.c
@@ -133,13 +133,6 @@ int _PyOS_GetOpt(Py_ssize_t argc, wchar_t * const *argv, int *longindex)
         return opt->val;
     }
 
-    if (option == 'J') {
-        if (_PyOS_opterr) {
-            fprintf(stderr, "-J is reserved for Jython\n");
-        }
-        return '_';
-    }
-
     if ((ptr = wcschr(SHORT_OPTS, option)) == NULL) {
         if (_PyOS_opterr) {
             fprintf(stderr, "Unknown option: -%c\n", (char)option);

--- a/Python/getopt.c
+++ b/Python/getopt.c
@@ -37,7 +37,7 @@ static const wchar_t *opt_ptr = L"";
 
 /* Python command line short and long options */
 
-#define SHORT_OPTS L"bBc:dEhiIJm:OPqRsStuvVW:xX:?"
+#define SHORT_OPTS L"bBc:dEhiIm:OPqRsStuvVW:xX:?"
 
 static const _PyOS_LongOption longopts[] = {
     /* name, has_arg, val (used in switch in initconfig.c) */


### PR DESCRIPTION
Currently `python -J` errors, so removing the reservation requires no deprecation period. cc @sobolevn.

A

<!-- gh-issue-number: gh-133336 -->
* Issue: gh-133336
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133444.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->