### PR TITLE
gh-133357: Fix `SyntaxError` carret location on invalid starred exprs

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -1500,7 +1500,10 @@ invalid_kvpair:
 invalid_starred_expression_unpacking:
     | a='*' expression '=' b=expression { RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "cannot assign to iterable argument unpacking") }
 invalid_starred_expression:
-    | '*' { RAISE_SYNTAX_ERROR("Invalid star expression") }
+    | a='*' { 
+        RAISE_SYNTAX_ERROR_KNOWN_LOCATION(
+            a, 
+            "invalid star expression") } 
 
 invalid_fstring_replacement_field:
     | '{' a='=' { RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "f-string: valid expression required before '='") }

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2320,22 +2320,22 @@ A[*(1:2)]
     >>> A[*(1:2)]
     Traceback (most recent call last):
         ...
-    SyntaxError: Invalid star expression
+    SyntaxError: invalid star expression
     >>> A[*(1:2)] = 1
     Traceback (most recent call last):
         ...
-    SyntaxError: Invalid star expression
+    SyntaxError: invalid star expression
     >>> del A[*(1:2)]
     Traceback (most recent call last):
         ...
-    SyntaxError: Invalid star expression
+    SyntaxError: invalid star expression
 
 A[*:] and A[:*]
 
     >>> A[*:]
     Traceback (most recent call last):
         ...
-    SyntaxError: Invalid star expression
+    SyntaxError: invalid star expression
     >>> A[:*]
     Traceback (most recent call last):
         ...
@@ -2346,7 +2346,7 @@ A[*]
     >>> A[*]
     Traceback (most recent call last):
         ...
-    SyntaxError: Invalid star expression
+    SyntaxError: invalid star expression
 
 A[**]
 
@@ -2623,23 +2623,23 @@ Invalid expressions in type scopes:
 
     >>> f(**x, *)
     Traceback (most recent call last):
-    SyntaxError: Invalid star expression
+    SyntaxError: invalid star expression
 
     >>> f(x, *:)
     Traceback (most recent call last):
-    SyntaxError: Invalid star expression
+    SyntaxError: invalid star expression
 
     >>> f(x, *)
     Traceback (most recent call last):
-    SyntaxError: Invalid star expression
+    SyntaxError: invalid star expression
 
     >>> f(x = 5, *)
     Traceback (most recent call last):
-    SyntaxError: Invalid star expression
+    SyntaxError: invalid star expression
 
     >>> f(x = 5, *:)
     Traceback (most recent call last):
-    SyntaxError: Invalid star expression
+    SyntaxError: invalid star expression
 """
 
 import re

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -2438,6 +2438,14 @@ case(34)
             lineno=3
         )
 
+    def test_carret_location_invalid_star_expr(self):
+        with self.assertRaises(SyntaxError) as cm:
+            compile("A[*]", "<string>", "exec")
+        e = cm.exception
+        self.assertEqual(e.msg, "invalid star expression")
+        self.assertEqual(e.text.strip(), "A[*]")
+        self.assertEqual(e.offset, 3)
+
     @support.cpython_only
     def test_syntax_error_on_deeply_nested_blocks(self):
         # This raises a SyntaxError, it used to raise a SystemError. Context

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-05-19-42-11.gh-issue-133357.moEEdA.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-05-19-42-11.gh-issue-133357.moEEdA.rst
@@ -1,0 +1,2 @@
+Fix the location of the :exc:`SyntaxError` carret on invalid starred
+expressions.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -26067,13 +26067,13 @@ invalid_starred_expression_rule(Parser *p)
             return NULL;
         }
         D(fprintf(stderr, "%*c> invalid_starred_expression[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'*'"));
-        Token * _literal;
+        Token * a;
         if (
-            (_literal = _PyPegen_expect_token(p, 16))  // token='*'
+            (a = _PyPegen_expect_token(p, 16))  // token='*'
         )
         {
             D(fprintf(stderr, "%*c+ invalid_starred_expression[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'*'"));
-            _res = RAISE_SYNTAX_ERROR ( "Invalid star expression" );
+            _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "invalid star expression" );
             if (_res == NULL && PyErr_Occurred()) {
                 p->error_indicator = 1;
                 p->level--;


### PR DESCRIPTION
I went with the simplest possible change:
<img width="788" alt="Снимок экрана 2025-05-05 в 19 40 47" src="https://github.com/user-attachments/assets/2bb94aa6-4808-45ae-a0c4-538fd3d5811a" />

Now carret always points to the star itself.

Why?

1. Because `RAISE_SYNTAX_ERROR_KNOWN_RANGE` requires the second argument, it is rather hard to match. Because simple `a='*' b=expression` does not work. Because, for example, `(1:2)` is not a valid `expression` it is a `slice` in `()`. 
2. Changing `starred_expressions` also seems rather hard:

```ebnf
starred_expression[expr_ty]:
    | invalid_starred_expression_unpacking
    | '*' a=expression { _PyAST_Starred(a, Load, EXTRA) }
    | invalid_starred_expression
```

So, I decided to keep it simple.

<!-- gh-issue-number: gh-133357 -->
* Issue: gh-133357
<!-- /gh-issue-number -->
