### PR TITLE
[3.13] gh-130804: Fix support of typing unicode chars in pyrepl (GH-130805)

### DIFF
--- a/Lib/_pyrepl/base_eventqueue.py
+++ b/Lib/_pyrepl/base_eventqueue.py
@@ -69,13 +69,19 @@ class BaseEventQueue:
         trace('added event {event}', event=event)
         self.events.append(event)
 
-    def push(self, char: int | bytes) -> None:
+    def push(self, char: int | bytes | str) -> None:
         """
         Processes a character by updating the buffer and handling special key mappings.
         """
         ord_char = char if isinstance(char, int) else ord(char)
-        char = bytes(bytearray((ord_char,)))
-        self.buf.append(ord_char)
+        if ord_char > 255:
+            assert isinstance(char, str)
+            char = bytes(char.encode(self.encoding, "replace"))
+            self.buf.extend(char)
+        else:
+            char = bytes(bytearray((ord_char,)))
+            self.buf.append(ord_char)
+
         if char in self.keymap:
             if self.keymap is self.compiled_keymap:
                 # sanity check, buffer is empty when a special key comes

--- a/Lib/test/test_pyrepl/test_eventqueue.py
+++ b/Lib/test/test_pyrepl/test_eventqueue.py
@@ -123,6 +123,13 @@ class EventQueueTestBase:
         self.assertEqual(eq.events[2].evt, "key")
         self.assertEqual(eq.events[2].data, "Z")
 
+    def test_push_unicode_character(self):
+        eq = self.make_eventqueue()
+        eq.keymap = {}
+        eq.push("ч")
+        self.assertEqual(eq.events[0].evt, "key")
+        self.assertEqual(eq.events[0].data, "ч")
+
 
 @unittest.skipIf(support.MS_WINDOWS, "No Unix event queue on Windows")
 class TestUnixEventQueue(EventQueueTestBase, unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2025-03-10-21-46-37.gh-issue-130804.0PpcTx.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-03-10-21-46-37.gh-issue-130804.0PpcTx.rst
@@ -1,0 +1,1 @@
+Fix support of unicode characters on Windows in the new REPL.


### PR DESCRIPTION
(cherry picked from commit 7c98b0674daa3e4eb3e8f35afb61a0dba61d1780)


<!-- gh-issue-number: gh-130804 -->
* Issue: gh-130804
<!-- /gh-issue-number -->
