### PR TITLE
GH-132983: Use a standard autoconf version check for zstd

### DIFF
--- a/configure
+++ b/configure
@@ -22392,24 +22392,21 @@ printf "%s\n" "yes" >&6; }
         have_liblzma=yes
 fi
 
-have_libzstd=no
-
-
 
 pkg_failed=no
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libzstd" >&5
-printf %s "checking for libzstd... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libzstd >= 1.4.5" >&5
+printf %s "checking for libzstd >= 1.4.5... " >&6; }
 
 if test -n "$LIBZSTD_CFLAGS"; then
     pkg_cv_LIBZSTD_CFLAGS="$LIBZSTD_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libzstd") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.4.5\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.4.5") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_LIBZSTD_CFLAGS=`$PKG_CONFIG --cflags "libzstd" 2>/dev/null`
+  pkg_cv_LIBZSTD_CFLAGS=`$PKG_CONFIG --cflags "libzstd >= 1.4.5" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -22421,12 +22418,12 @@ if test -n "$LIBZSTD_LIBS"; then
     pkg_cv_LIBZSTD_LIBS="$LIBZSTD_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libzstd") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libzstd >= 1.4.5\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libzstd >= 1.4.5") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_LIBZSTD_LIBS=`$PKG_CONFIG --libs "libzstd" 2>/dev/null`
+  pkg_cv_LIBZSTD_LIBS=`$PKG_CONFIG --libs "libzstd >= 1.4.5" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -22447,9 +22444,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-                LIBZSTD_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libzstd" 2>&1`
+                LIBZSTD_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libzstd >= 1.4.5" 2>&1`
         else
-                LIBZSTD_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libzstd" 2>&1`
+                LIBZSTD_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libzstd >= 1.4.5" 2>&1`
         fi
         # Put the nasty error message in config.log where it belongs
         echo "$LIBZSTD_PKG_ERRORS" >&5
@@ -22473,7 +22470,8 @@ then :
 #define `printf "%s\n" "HAVE_$ac_header" | sed "$as_sed_cpp"` 1
 _ACEOF
 
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ZDICT_finalizeDictionary in -lzstd" >&5
+      py_check_lib_save_LIBS=$LIBS
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ZDICT_finalizeDictionary in -lzstd" >&5
 printf %s "checking for ZDICT_finalizeDictionary in -lzstd... " >&6; }
 if test ${ac_cv_lib_zstd_ZDICT_finalizeDictionary+y}
 then :
@@ -22518,51 +22516,13 @@ fi
 printf "%s\n" "$ac_cv_lib_zstd_ZDICT_finalizeDictionary" >&6; }
 if test "x$ac_cv_lib_zstd_ZDICT_finalizeDictionary" = xyes
 then :
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if libzstd is new enough" >&5
-printf %s "checking if libzstd is new enough... " >&6; }
-
-
-        if test "$cross_compiling" = yes
-then :
-  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See 'config.log' for more details" "$LINENO" 5; }
-else case e in #(
-  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include "zstd.h"
-int
-main (void)
-{
-
-      #if ZSTD_VERSION_NUMBER < 10405
-          exit(1);
-      #endif
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
-  py__zstd_too_old=no
-else case e in #(
-  e) py__zstd_too_old=yes ;;
-esac
-fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext ;;
-esac
-fi
-
-    have_libzstd=yes
-
+  have_libzstd=yes
 else case e in #(
   e) have_libzstd=no ;;
 esac
 fi
+
+LIBS=$py_check_lib_save_LIBS
 
 
 else case e in #(
@@ -22608,7 +22568,8 @@ then :
 #define `printf "%s\n" "HAVE_$ac_header" | sed "$as_sed_cpp"` 1
 _ACEOF
 
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ZDICT_finalizeDictionary in -lzstd" >&5
+      py_check_lib_save_LIBS=$LIBS
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ZDICT_finalizeDictionary in -lzstd" >&5
 printf %s "checking for ZDICT_finalizeDictionary in -lzstd... " >&6; }
 if test ${ac_cv_lib_zstd_ZDICT_finalizeDictionary+y}
 then :
@@ -22653,51 +22614,13 @@ fi
 printf "%s\n" "$ac_cv_lib_zstd_ZDICT_finalizeDictionary" >&6; }
 if test "x$ac_cv_lib_zstd_ZDICT_finalizeDictionary" = xyes
 then :
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if libzstd is new enough" >&5
-printf %s "checking if libzstd is new enough... " >&6; }
-
-
-        if test "$cross_compiling" = yes
-then :
-  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See 'config.log' for more details" "$LINENO" 5; }
-else case e in #(
-  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include "zstd.h"
-int
-main (void)
-{
-
-      #if ZSTD_VERSION_NUMBER < 10405
-          exit(1);
-      #endif
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
-  py__zstd_too_old=no
-else case e in #(
-  e) py__zstd_too_old=yes ;;
-esac
-fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext ;;
-esac
-fi
-
-    have_libzstd=yes
-
+  have_libzstd=yes
 else case e in #(
   e) have_libzstd=no ;;
 esac
 fi
+
+LIBS=$py_check_lib_save_LIBS
 
 
 else case e in #(
@@ -22726,47 +22649,7 @@ else
         LIBZSTD_LIBS=$pkg_cv_LIBZSTD_LIBS
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if libzstd is new enough" >&5
-printf %s "checking if libzstd is new enough... " >&6; }
-
-
-        if test "$cross_compiling" = yes
-then :
-  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See 'config.log' for more details" "$LINENO" 5; }
-else case e in #(
-  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include "zstd.h"
-int
-main (void)
-{
-
-      #if ZSTD_VERSION_NUMBER < 10405
-          exit(1);
-      #endif
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
-  py__zstd_too_old=no
-else case e in #(
-  e) py__zstd_too_old=yes ;;
-esac
-fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext ;;
-esac
-fi
-
-    have_libzstd=yes
-
+        have_libzstd=yes
 fi
 
 
@@ -33375,7 +33258,7 @@ printf %s "checking for stdlib extension module _zstd... " >&6; }
         if test "$py_cv_module__zstd" != "n/a"
 then :
 
-    if test "$py__zstd_too_old" = no
+    if true
 then :
   if test "$have_libzstd" = yes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -5386,32 +5386,14 @@ PKG_CHECK_MODULES([LIBLZMA], [liblzma], [have_liblzma=yes], [
   ])
 ])
 
-have_libzstd=no
-AC_DEFUN([TEST_ZSTD_VERSION],[
-  AC_MSG_CHECKING([if libzstd is new enough])
-
-  dnl TODO(emmatyping): check if we can set a C define for the minimum version
-  dnl to re-use here and in the header compile check
-
-  dnl This is checked when both a package is found and we do fallback searches
-  dnl If you update the minimum version here, you should update the compile
-  dnl check in Modules/_zstd/_zstdmodule.h
-  AC_RUN_IFELSE([AC_LANG_PROGRAM([@%:@include "zstd.h"], [
-      #if ZSTD_VERSION_NUMBER < 10405
-          exit(1);
-      #endif
-    ])], [py__zstd_too_old=no], [py__zstd_too_old=yes])
-  dnl Important to record that we have libzstd
-  have_libzstd=yes
-])
-
-PKG_CHECK_MODULES([LIBZSTD], [libzstd], [TEST_ZSTD_VERSION()], [
+dnl zstd 1.4.5 added ZDICT_finalizeDictionary
+PKG_CHECK_MODULES([LIBZSTD], [libzstd >= 1.4.5], [have_libzstd=yes], [
   WITH_SAVE_ENV([
     CPPFLAGS="$CPPFLAGS $LIBZSTD_CFLAGS"
     LIBS="$LIBS $LIBZSTD_LIBS"
     AC_CHECK_HEADERS([zstd.h zdict.h], [
-      AC_CHECK_LIB([zstd], [ZDICT_finalizeDictionary],
-       [TEST_ZSTD_VERSION()], [have_libzstd=no])
+      PY_CHECK_LIB([zstd], [ZDICT_finalizeDictionary],
+                   [have_libzstd=yes], [have_libzstd=no])
     ], [have_libzstd=no])
     AS_VAR_IF([have_libzstd], [yes], [
       LIBZSTD_CFLAGS=${LIBZSTD_CFLAGS-""}
@@ -8072,7 +8054,7 @@ PY_STDLIB_MOD([_bz2], [], [test "$have_bzip2" = yes],
   [$BZIP2_CFLAGS], [$BZIP2_LIBS])
 PY_STDLIB_MOD([_lzma], [], [test "$have_liblzma" = yes],
   [$LIBLZMA_CFLAGS], [$LIBLZMA_LIBS])
-PY_STDLIB_MOD([_zstd], [test "$py__zstd_too_old" = no], [test "$have_libzstd" = yes],
+PY_STDLIB_MOD([_zstd], [], [test "$have_libzstd" = yes],
   [$LIBZSTD_CFLAGS], [$LIBZSTD_LIBS])
 
 dnl OpenSSL bindings


### PR DESCRIPTION
cc @ned-deily, it seems that this works & is simpler? I'll run buildbots.

A

<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->
