### PR TITLE
gh-132775: Add _PyCode_GetScriptXIData()

### DIFF
--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -191,6 +191,10 @@ PyAPI_FUNC(int) _PyCode_GetXIData(
         PyThreadState *,
         PyObject *,
         _PyXIData_t *);
+PyAPI_FUNC(int) _PyCode_GetScriptXIData(
+        PyThreadState *,
+        PyObject *,
+        _PyXIData_t *);
 
 
 /* using cross-interpreter data */

--- a/Include/internal/pycore_crossinterp.h
+++ b/Include/internal/pycore_crossinterp.h
@@ -195,6 +195,10 @@ PyAPI_FUNC(int) _PyCode_GetScriptXIData(
         PyThreadState *,
         PyObject *,
         _PyXIData_t *);
+PyAPI_FUNC(int) _PyCode_GetPureScriptXIData(
+        PyThreadState *,
+        PyObject *,
+        _PyXIData_t *);
 
 
 /* using cross-interpreter data */

--- a/Include/internal/pycore_pythonrun.h
+++ b/Include/internal/pycore_pythonrun.h
@@ -25,6 +25,7 @@ extern int _PyRun_InteractiveLoopObject(
     PyObject *filename,
     PyCompilerFlags *flags);
 
+extern int _PyObject_SupportedAsScript(PyObject *);
 extern const char* _Py_SourceAsString(
     PyObject *cmd,
     const char *funcname,

--- a/Lib/test/_code_definitions.py
+++ b/Lib/test/_code_definitions.py
@@ -1,4 +1,32 @@
 
+def simple_script():
+    assert True
+
+
+def complex_script():
+    obj = 'a string'
+    pickle = __import__('pickle')
+    def spam_minimal():
+        pass
+    spam_minimal()
+    data = pickle.dumps(obj)
+    res = pickle.loads(data)
+    assert res == obj, (res, obj)
+
+
+def script_with_globals():
+    obj1, obj2 = spam(42)
+    assert obj1 == 42
+    assert obj2 is None
+
+
+def script_with_explicit_empty_return():
+    return None
+
+
+def script_with_return():
+    return True
+
 
 def spam_minimal():
     # no arg defaults or kwarg defaults
@@ -141,6 +169,11 @@ ham_C_closure, *_ = eggs_closure_C(2)
 
 TOP_FUNCTIONS = [
     # shallow
+    simple_script,
+    complex_script,
+    script_with_globals,
+    script_with_explicit_empty_return,
+    script_with_return,
     spam_minimal,
     spam_with_builtins,
     spam_with_globals_and_builtins,
@@ -179,6 +212,10 @@ FUNCTIONS = [
 ]
 
 STATELESS_FUNCTIONS = [
+    simple_script,
+    complex_script,
+    script_with_explicit_empty_return,
+    script_with_return,
     spam,
     spam_minimal,
     spam_with_builtins,
@@ -200,8 +237,19 @@ STATELESS_FUNCTIONS = [
 ]
 STATELESS_CODE = [
     *STATELESS_FUNCTIONS,
+    script_with_globals,
     spam_with_globals_and_builtins,
     spam_full,
+]
+
+SCRIPT_FUNCTIONS = [
+    simple_script,
+    complex_script,
+    script_with_explicit_empty_return,
+    spam_minimal,
+    spam_with_builtins,
+    spam_with_inner_not_closure,
+    spam_with_inner_closure,
 ]
 
 

--- a/Lib/test/_code_definitions.py
+++ b/Lib/test/_code_definitions.py
@@ -242,7 +242,7 @@ STATELESS_CODE = [
     spam_full,
 ]
 
-SCRIPT_FUNCTIONS = [
+PURE_SCRIPT_FUNCTIONS = [
     simple_script,
     complex_script,
     script_with_explicit_empty_return,
@@ -250,6 +250,11 @@ SCRIPT_FUNCTIONS = [
     spam_with_builtins,
     spam_with_inner_not_closure,
     spam_with_inner_closure,
+]
+SCRIPT_FUNCTIONS = [
+    *PURE_SCRIPT_FUNCTIONS,
+    script_with_globals,
+    spam_with_globals_and_builtins,
 ]
 
 

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -673,6 +673,20 @@ class CodeTest(unittest.TestCase):
         VARKWARGS = CO_FAST_LOCAL | CO_FAST_ARG_VAR | CO_FAST_ARG_KW
 
         funcs = {
+            defs.simple_script: {},
+            defs.complex_script: {
+                'obj': CO_FAST_LOCAL,
+                'pickle': CO_FAST_LOCAL,
+                'spam_minimal': CO_FAST_LOCAL,
+                'data': CO_FAST_LOCAL,
+                'res': CO_FAST_LOCAL,
+            },
+            defs.script_with_globals: {
+                'obj1': CO_FAST_LOCAL,
+                'obj2': CO_FAST_LOCAL,
+            },
+            defs.script_with_explicit_empty_return: {},
+            defs.script_with_return: {},
             defs.spam_minimal: {},
             defs.spam_with_builtins: {
                 'x': CO_FAST_LOCAL,
@@ -898,6 +912,19 @@ class CodeTest(unittest.TestCase):
             }
 
         funcs = {
+            defs.simple_script: new_var_counts(),
+            defs.complex_script: new_var_counts(
+                purelocals=5,
+                globalvars=1,
+                attrs=2,
+            ),
+            defs.script_with_globals: new_var_counts(
+                purelocals=2,
+                globalvars=1,
+            ),
+            defs.script_with_explicit_empty_return: new_var_counts(),
+            defs.script_with_return: new_var_counts(),
+            defs.spam_minimal: new_var_counts(),
             defs.spam_minimal: new_var_counts(),
             defs.spam_with_builtins: new_var_counts(
                 purelocals=4,

--- a/Lib/test/test_crossinterp.py
+++ b/Lib/test/test_crossinterp.py
@@ -782,11 +782,13 @@ class PureShareableScriptTests(_GetXIDataTests):
             """,
     ]
     INVALID_SCRIPTS = [
-        '    pass',
-        '----',
+        '    pass',  # IndentationError
+        '----',  # SyntaxError
         """if True:
-            # do something
-            """,
+            def spam():
+                # no body
+            spam()
+            """,  # IndentationError
     ]
 
     def test_valid_str(self):

--- a/Lib/test/test_crossinterp.py
+++ b/Lib/test/test_crossinterp.py
@@ -758,9 +758,9 @@ class CodeTests(_GetXIDataTests):
         ])
 
 
-class ShareableScriptTests(_GetXIDataTests):
+class PureShareableScriptTests(_GetXIDataTests):
 
-    MODE = 'script'
+    MODE = 'script-pure'
 
     VALID_SCRIPTS = [
         '',
@@ -809,24 +809,34 @@ class ShareableScriptTests(_GetXIDataTests):
             *(s.encode('utf8') for s in self.INVALID_SCRIPTS),
         ])
 
-    def test_script_code(self):
+    def test_pure_script_code(self):
         self.assert_roundtrip_equal_not_identical([
-            *(f.__code__ for f in defs.SCRIPT_FUNCTIONS),
-            defs.script_with_globals.__code__,
+            *(f.__code__ for f in defs.PURE_SCRIPT_FUNCTIONS),
+        ])
+
+    def test_impure_script_code(self):
+        self.assert_not_shareable([
+            *(f.__code__ for f in defs.SCRIPT_FUNCTIONS
+              if f not in defs.PURE_SCRIPT_FUNCTIONS),
         ])
 
     def test_other_code(self):
         self.assert_not_shareable([
             *(f.__code__ for f in defs.FUNCTIONS
-              if f not in defs.SCRIPT_FUNCTIONS and
-                f is not defs.script_with_globals),
+              if f not in defs.SCRIPT_FUNCTIONS),
             *(f.__code__ for f in defs.FUNCTION_LIKE),
         ])
 
-    def test_script_function(self):
+    def test_pure_script_function(self):
         self.assert_roundtrip_not_equal([
-            *defs.SCRIPT_FUNCTIONS,
+            *defs.PURE_SCRIPT_FUNCTIONS,
         ], expecttype=types.CodeType)
+
+    def test_impure_script_function(self):
+        self.assert_not_shareable([
+            *(f for f in defs.SCRIPT_FUNCTIONS
+              if f not in defs.PURE_SCRIPT_FUNCTIONS),
+        ])
 
     def test_other_function(self):
         self.assert_not_shareable([
@@ -847,6 +857,23 @@ class ShareableScriptTests(_GetXIDataTests):
             {},
             object(),
         ])
+
+
+class ShareableScriptTests(PureShareableScriptTests):
+
+    MODE = 'script'
+
+    def test_impure_script_code(self):
+        self.assert_roundtrip_equal_not_identical([
+            *(f.__code__ for f in defs.SCRIPT_FUNCTIONS
+              if f not in defs.PURE_SCRIPT_FUNCTIONS),
+        ])
+
+    def test_impure_script_function(self):
+        self.assert_roundtrip_not_equal([
+            *(f for f in defs.SCRIPT_FUNCTIONS
+              if f not in defs.PURE_SCRIPT_FUNCTIONS),
+        ], expecttype=types.CodeType)
 
 
 class ShareableTypeTests(_GetXIDataTests):

--- a/Lib/test/test_crossinterp.py
+++ b/Lib/test/test_crossinterp.py
@@ -758,6 +758,97 @@ class CodeTests(_GetXIDataTests):
         ])
 
 
+class ShareableScriptTests(_GetXIDataTests):
+
+    MODE = 'script'
+
+    VALID_SCRIPTS = [
+        '',
+        'spam',
+        '# a comment',
+        'print("spam")',
+        'raise Exception("spam")',
+        """if True:
+            do_something()
+            """,
+        """if True:
+            def spam(x):
+                return x
+            class Spam:
+                def eggs(self):
+                    return 42
+            x = Spam().eggs()
+            raise ValueError(spam(x))
+            """,
+    ]
+    INVALID_SCRIPTS = [
+        '    pass',
+        '----',
+        """if True:
+            # do something
+            """,
+    ]
+
+    def test_valid_str(self):
+        self.assert_roundtrip_not_equal([
+            *self.VALID_SCRIPTS,
+        ], expecttype=types.CodeType)
+
+    def test_invalid_str(self):
+        self.assert_not_shareable([
+            *self.INVALID_SCRIPTS,
+        ])
+
+    def test_valid_bytes(self):
+        self.assert_roundtrip_not_equal([
+            *(s.encode('utf8') for s in self.VALID_SCRIPTS),
+        ], expecttype=types.CodeType)
+
+    def test_invalid_bytes(self):
+        self.assert_not_shareable([
+            *(s.encode('utf8') for s in self.INVALID_SCRIPTS),
+        ])
+
+    def test_script_code(self):
+        self.assert_roundtrip_equal_not_identical([
+            *(f.__code__ for f in defs.SCRIPT_FUNCTIONS),
+            defs.script_with_globals.__code__,
+        ])
+
+    def test_other_code(self):
+        self.assert_not_shareable([
+            *(f.__code__ for f in defs.FUNCTIONS
+              if f not in defs.SCRIPT_FUNCTIONS and
+                f is not defs.script_with_globals),
+            *(f.__code__ for f in defs.FUNCTION_LIKE),
+        ])
+
+    def test_script_function(self):
+        self.assert_roundtrip_not_equal([
+            *defs.SCRIPT_FUNCTIONS,
+        ], expecttype=types.CodeType)
+
+    def test_other_function(self):
+        self.assert_not_shareable([
+            *(f for f in defs.FUNCTIONS
+              if f not in defs.SCRIPT_FUNCTIONS),
+            *defs.FUNCTION_LIKE,
+        ])
+
+    def test_other_objects(self):
+        self.assert_not_shareable([
+            None,
+            True,
+            False,
+            Ellipsis,
+            NotImplemented,
+            (),
+            [],
+            {},
+            object(),
+        ])
+
+
 class ShareableTypeTests(_GetXIDataTests):
 
     MODE = 'xidata'

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -1994,6 +1994,11 @@ get_crossinterp_data(PyObject *self, PyObject *args, PyObject *kwargs)
             goto error;
         }
     }
+    else if (strcmp(mode, "script-pure") == 0) {
+        if (_PyCode_GetPureScriptXIData(tstate, obj, xidata) != 0) {
+            goto error;
+        }
+    }
     else {
         PyErr_Format(PyExc_ValueError, "unsupported mode %R", modeobj);
         goto error;

--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -1989,6 +1989,11 @@ get_crossinterp_data(PyObject *self, PyObject *args, PyObject *kwargs)
             goto error;
         }
     }
+    else if (strcmp(mode, "script") == 0) {
+        if (_PyCode_GetScriptXIData(tstate, obj, xidata) != 0) {
+            goto error;
+        }
+    }
     else {
         PyErr_Format(PyExc_ValueError, "unsupported mode %R", modeobj);
         goto error;

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -846,6 +846,7 @@ get_script_xidata(PyThreadState *tstate, PyObject *obj, int pure,
     }
     else {
         const char *filename = "<script>";
+        int optimize = 0;
         PyCompilerFlags cf = _PyCompilerFlags_INIT;
         cf.cf_flags = PyCF_SOURCE_IS_UTF8;
         PyObject *ref = NULL;
@@ -858,7 +859,8 @@ get_script_xidata(PyThreadState *tstate, PyObject *obj, int pure,
             }
             goto error;
         }
-        code = Py_CompileStringExFlags(script, filename, Py_file_input, &cf, 0);
+        code = Py_CompileStringExFlags(
+                    script, filename, Py_file_input, &cf, optimize);
         Py_XDECREF(ref);
         if (code == NULL) {
             goto error;

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -851,9 +851,7 @@ get_script_xidata(PyThreadState *tstate, PyObject *obj, int pure,
         PyObject *ref = NULL;
         const char *script = _Py_SourceAsString(obj, "???", "???", &cf, &ref);
         if (script == NULL) {
-            if (!PyBytes_Check(obj) && !PyUnicode_Check(obj)
-                && !PyByteArray_Check(obj) && !PyObject_CheckBuffer(obj))
-            {
+            if (!_PyObject_SupportedAsScript(obj)) {
                 // We discard the raised exception.
                 _PyErr_Format(tstate, PyExc_TypeError,
                               "unsupported script %R", obj);

--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -865,8 +865,10 @@ get_script_xidata(PyThreadState *tstate, PyObject *obj, int pure,
         if (code == NULL) {
             goto error;
         }
+        // Compiled text can't have args or any return statements,
+        // nor be a closure.  It can use globals though.
         if (!pure) {
-            // It can't be a closure.
+            // We don't need to check for globals either.
             checked = 1;
         }
     }

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1524,6 +1524,26 @@ Py_CompileStringExFlags(const char *str, const char *filename_str, int start,
     return co;
 }
 
+int
+_PyObject_SupportedAsScript(PyObject *cmd)
+{
+    if (PyUnicode_Check(cmd)) {
+        return 1;
+    }
+    else if (PyBytes_Check(cmd)) {
+        return 1;
+    }
+    else if (PyByteArray_Check(cmd)) {
+        return 1;
+    }
+    else if (PyObject_CheckBuffer(cmd)) {
+        return 1;
+    }
+    else {
+        return 0;
+    }
+}
+
 const char *
 _Py_SourceAsString(PyObject *cmd, const char *funcname, const char *what, PyCompilerFlags *cf, PyObject **cmd_copy)
 {


### PR DESCRIPTION
This converts functions, code, str, bytes, bytearray, and memoryview objects to PyCodeObject,
and ensure that the object looks like a script.  That means no args, no return, and no closure.
`_PyCode_GetPureScriptXIData()` takes it a step further and ensures there are no globals.

<!-- gh-issue-number: gh-132775 -->
* Issue: gh-132775
<!-- /gh-issue-number -->
