### PR TITLE
typing: Modernize type annotations on IO classes

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -3477,7 +3477,7 @@ class IO(Generic[AnyStr]):
         pass
 
     @abstractmethod
-    def readlines(self, hint: int = -1) -> List[AnyStr]:
+    def readlines(self, hint: int = -1) -> list[AnyStr]:
         pass
 
     @abstractmethod
@@ -3493,7 +3493,7 @@ class IO(Generic[AnyStr]):
         pass
 
     @abstractmethod
-    def truncate(self, size: int = None) -> int:
+    def truncate(self, size: int | None = None) -> int:
         pass
 
     @abstractmethod
@@ -3505,11 +3505,11 @@ class IO(Generic[AnyStr]):
         pass
 
     @abstractmethod
-    def writelines(self, lines: List[AnyStr]) -> None:
+    def writelines(self, lines: list[AnyStr]) -> None:
         pass
 
     @abstractmethod
-    def __enter__(self) -> 'IO[AnyStr]':
+    def __enter__(self) -> IO[AnyStr]:
         pass
 
     @abstractmethod
@@ -3523,11 +3523,11 @@ class BinaryIO(IO[bytes]):
     __slots__ = ()
 
     @abstractmethod
-    def write(self, s: Union[bytes, bytearray]) -> int:
+    def write(self, s: bytes | bytearray) -> int:
         pass
 
     @abstractmethod
-    def __enter__(self) -> 'BinaryIO':
+    def __enter__(self) -> BinaryIO:
         pass
 
 
@@ -3548,7 +3548,7 @@ class TextIO(IO[str]):
 
     @property
     @abstractmethod
-    def errors(self) -> Optional[str]:
+    def errors(self) -> str | None:
         pass
 
     @property
@@ -3562,7 +3562,7 @@ class TextIO(IO[str]):
         pass
 
     @abstractmethod
-    def __enter__(self) -> 'TextIO':
+    def __enter__(self) -> TextIO:
         pass
 
 


### PR DESCRIPTION
Remove unnecessary strings, use of Union[], use of List[], and reliance
on implicit Optional.

These type annotations are not actually used for anything but I feel
we should set a good example.
