### PR TITLE
gh-132983: Add What's New entry for PEP 784 implementation

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -267,10 +267,12 @@ Here's an example of using the new module to compress some data:
 
 As can be seen, the API is similar to the APIs of the :mod:`!lzma` and :mod:`!bz2` modules.
 
-See :pep:`784` for more details.
-
 (Contributed by Emma Harper Smith, Adam Turner, Gregory P. Smith, Tomas R., Victor Stinner, and
 Rogdham in :gh:`132983`)
+
+.. seealso::
+   :pep:`768`.
+
 
 .. _whatsnew314-remote-pdb:
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -238,17 +238,17 @@ See :pep:`768` for more details.
 PEP 784: Adding Zstandard to the standard library
 -------------------------------------------------
 
-The new ``compression`` package contains modules ``compression.lzma``, ``compression.bz2``,
-``compression.gzip`` and ``compression.zlib`` which re-export the :mod:`lzma`, :mod:`bz2`,
+The new ``compression`` package contains modules :mod:`!compression.lzma`, :mod:`!compression.bz2`,
+:mod:`!compression.gzip` and :mod:`!compression.zlib` which re-export the :mod:`lzma`, :mod:`bz2`,
 :mod:`gzip` and :mod:`zlib` modules respectively. The new import names under ``compression`` are
 the canonical names for importing these compression modules going forward. However, the existing
 modules names have not been deprecated. Any deprecation or removal of the existing compression modules
 will occur no sooner than 5 years after the release of 3.14.
 
-The new ``compression.zstd`` module provides compression and decompression APIs for the
+The new :mod:`!compression.zstd` module provides compression and decompression APIs for the
 Zstandard format via bindings to `Meta's zstd library <https://facebook.github.io/zstd/>`__.
 Zstandard is a widely adopted, highly efficient, and fast compression format. In addition to the APIs
-introduced in ``compression.zstd``, support for reading and writing Zstandard compressed archives
+introduced in :mod:`!compression.zstd`, support for reading and writing Zstandard compressed archives
 has been added to the :mod:`tarfile`, :mod:`zipfile`, and :mod:`shutil` modules.
 
 Here's an example of using the new module to compress some data:

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -238,18 +238,22 @@ See :pep:`768` for more details.
 PEP 784: Adding Zstandard to the standard library
 -------------------------------------------------
 
-The new ``compression`` package contains modules :mod:`!compression.lzma`, :mod:`!compression.bz2`,
-:mod:`!compression.gzip` and :mod:`!compression.zlib` which re-export the :mod:`lzma`, :mod:`bz2`,
-:mod:`gzip` and :mod:`zlib` modules respectively. The new import names under ``compression`` are
-the canonical names for importing these compression modules going forward. However, the existing
-modules names have not been deprecated. Any deprecation or removal of the existing compression modules
-will occur no sooner than five years after the release of 3.14.
+The new ``compression`` package contains modules :mod:`!compression.lzma`,
+:mod:`!compression.bz2`, :mod:`!compression.gzip` and :mod:`!compression.zlib`
+which re-export the :mod:`lzma`, :mod:`bz2`, :mod:`gzip` and :mod:`zlib`
+modules respectively. The new import names under ``compression`` are the
+canonical names for importing these compression modules going forward. However,
+the existing modules names have not been deprecated. Any deprecation or removal
+of the existing compression modules will occur no sooner than five years after
+the release of 3.14.
 
-The new :mod:`!compression.zstd` module provides compression and decompression APIs for the
-Zstandard format via bindings to `Meta's zstd library <https://facebook.github.io/zstd/>`__.
-Zstandard is a widely adopted, highly efficient, and fast compression format. In addition to the APIs
-introduced in :mod:`!compression.zstd`, support for reading and writing Zstandard compressed archives
-has been added to the :mod:`tarfile`, :mod:`zipfile`, and :mod:`shutil` modules.
+The new :mod:`!compression.zstd` module provides compression and decompression
+APIs for the Zstandard format via bindings to `Meta's zstd library
+<https://facebook.github.io/zstd/>`__. Zstandard is a widely adopted, highly
+efficient, and fast compression format. In addition to the APIs introduced in
+:mod:`!compression.zstd`, support for reading and writing Zstandard compressed
+archives has been added to the :mod:`tarfile`, :mod:`zipfile`, and
+:mod:`shutil` modules.
 
 Here's an example of using the new module to compress some data:
 
@@ -265,10 +269,11 @@ Here's an example of using the new module to compress some data:
     ratio = len(compressed) / len(data)
     print(f"Achieved compression ratio of {ratio}")
 
-As can be seen, the API is similar to the APIs of the :mod:`!lzma` and :mod:`!bz2` modules.
+As can be seen, the API is similar to the APIs of the :mod:`!lzma` and
+:mod:`!bz2` modules.
 
-(Contributed by Emma Harper Smith, Adam Turner, Gregory P. Smith, Tomas R., Victor Stinner, and
-Rogdham in :gh:`132983`)
+(Contributed by Emma Harper Smith, Adam Turner, Gregory P. Smith, Tomas R.,
+Victor Stinner, and Rogdham in :gh:`132983`)
 
 .. seealso::
    :pep:`768`.

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -71,6 +71,7 @@ Summary -- release highlights
 * :ref:`PEP 761: Discontinuation of PGP signatures <whatsnew314-pep761>`
 * :ref:`PEP 765: Disallow return/break/continue that exit a finally block <whatsnew314-pep765>`
 * :ref:`PEP 768: Safe external debugger interface for CPython <whatsnew314-pep768>`
+* :ref:`PEP 784: Adding Zstandard to the standard library <whatsnew314-pep784>`
 * :ref:`A new type of interpreter <whatsnew314-tail-call>`
 * :ref:`Syntax highlighting in PyREPL <whatsnew314-pyrepl-highlighting>`,
   and color output in :ref:`unittest <whatsnew314-color-unittest>`,
@@ -232,6 +233,44 @@ See :pep:`768` for more details.
 
 (Contributed by Pablo Galindo Salgado, Matt Wozniski, and Ivona Stojanovic in :gh:`131591`.)
 
+.. _whatsnew314-pep784:
+
+PEP 784: Adding Zstandard to the standard library
+-------------------------------------------------
+
+The new ``compression`` package contains modules ``compression.lzma``, ``compression.bz2``,
+``compression.gzip`` and ``compression.zlib`` which re-export the :mod:`lzma`, :mod:`bz2`,
+:mod:`gzip` and :mod:`zlib` modules respectively. The new import names under ``compression`` are
+the canonical names for importing these compression modules going forward. However, the existing
+modules names have not been deprecated. Any deprecation or removal of the existing compression modules
+will occur no sooner than 5 years after the release of 3.14.
+
+The new ``compression.zstd`` module provides compression and decompression APIs for the
+Zstandard format via bindings to `Meta's zstd library <https://facebook.github.io/zstd/>`__.
+Zstandard is a widely adopted, highly efficient, and fast compression format. In addition to the APIs
+introduced in ``compression.zstd``, support for reading and writing Zstandard compressed archives
+has been added to the :mod:`tarfile`, :mod:`zipfile`, and :mod:`shutil` modules.
+
+Here's an example of using the new module to compress some data:
+
+.. code-block:: python
+
+    from compression import zstd
+    import math
+
+    data = str(math.pi).encode() * 20
+
+    compressed = zstd.compress(data)
+
+    ratio = len(compressed) / len(data)
+    print(f"Achieved compression ratio of {ratio}")
+
+As can be seen, the API is similar to the APIs of the :mod:`!lzma` and :mod:`!bz2` modules.
+
+See :pep:`784` for more details.
+
+(Contributed by Emma Harper Smith, Adam Turner, Gregory P. Smith, Tomas R., Victor Stinner, and
+Rogdham in :gh:`132983`)
 
 .. _whatsnew314-remote-pdb:
 

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -272,7 +272,7 @@ Here's an example of using the new module to compress some data:
 As can be seen, the API is similar to the APIs of the :mod:`!lzma` and
 :mod:`!bz2` modules.
 
-(Contributed by Emma Harper Smith, Adam Turner, Gregory P. Smith, Tomas R.,
+(Contributed by Emma Harper Smith, Adam Turner, Gregory P. Smith, Tomas Roun,
 Victor Stinner, and Rogdham in :gh:`132983`)
 
 .. seealso::
@@ -953,7 +953,7 @@ ast
   (Contributed by Irit Katriel in :gh:`123958`.)
 
 * The ``repr()`` output for AST nodes now includes more information.
-  (Contributed by Tomas R in :gh:`116022`.)
+  (Contributed by Tomas Roun in :gh:`116022`.)
 
 * :func:`ast.parse`, when called with an AST as input, now always verifies
   that the root node type is appropriate.

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -243,7 +243,7 @@ The new ``compression`` package contains modules :mod:`!compression.lzma`, :mod:
 :mod:`gzip` and :mod:`zlib` modules respectively. The new import names under ``compression`` are
 the canonical names for importing these compression modules going forward. However, the existing
 modules names have not been deprecated. Any deprecation or removal of the existing compression modules
-will occur no sooner than 5 years after the release of 3.14.
+will occur no sooner than five years after the release of 3.14.
 
 The new :mod:`!compression.zstd` module provides compression and decompression APIs for the
 Zstandard format via bindings to `Meta's zstd library <https://facebook.github.io/zstd/>`__.


### PR DESCRIPTION
Hopefully this is located correctly. I also wasn't sure if I should use ``module\`\` or `:mod:`. I think since there aren't docs yet the former looks a bit better.

Since the implementation was split across several PRs, I linked to the implementation issue, hopefully that makes sense.

<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133495.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->