### PR TITLE
gh-133505 Fixed link to PEP 784 in 3.14 What's New page

### DIFF
--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -276,7 +276,7 @@ As can be seen, the API is similar to the APIs of the :mod:`!lzma` and
 Victor Stinner, and Rogdham in :gh:`132983`)
 
 .. seealso::
-   :pep:`768`.
+   :pep:`784`.
 
 
 .. _whatsnew314-remote-pdb:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Changed link to PEP 784 in the Zstandard entry in the 3.14 What's New page.

Fixes #133505.


<!-- gh-issue-number: gh-133505 -->
* Issue: gh-133505
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133507.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->