### PR TITLE
gh-132917: Fix data race detected by tsan

### DIFF
--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -2074,10 +2074,9 @@ gc_should_collect_mem_usage(GCState *gcstate)
         // clear the young object count so we don't check memory usage again
         // on the next call to gc_should_collect().
         PyMutex_Lock(&gcstate->mutex);
+        int young_count = _Py_atomic_exchange_int(&gcstate->young.count, 0);
         _Py_atomic_store_ssize_relaxed(&gcstate->deferred_count,
-                                       gcstate->deferred_count +
-                                           gcstate->young.count);
-        _Py_atomic_store_int(&gcstate->young.count, 0);
+                                       gcstate->deferred_count + young_count);
         PyMutex_Unlock(&gcstate->mutex);
         return false;
     }


### PR DESCRIPTION
Fix data race detected by tsan (https://github.com/python/cpython/actions/runs/14857021107/job/41712717208?pr=133502): young.count can be modified by other threads even while the gcstate is locked.

This is the simplest fix to (potentially) unblock beta 1, although this particular code path seems like it could just be an atomic swap followed by an atomic add, without having the lock at all.


<!-- gh-issue-number: gh-132917 -->
* Issue: gh-132917
<!-- /gh-issue-number -->
