### PR TITLE
gh-133517: Remove os.listdrive, os.listvolumes and os.listmounts in non windows desktop builds

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-05-06-14-44-55.gh-issue-133517.Ca6NgW.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-06-14-44-55.gh-issue-133517.Ca6NgW.rst
@@ -1,2 +1,2 @@
-Remove :func:`os.listdrives` and :func:`os.listvolumes` in non windows desktop builds
-since the underlying functionality
+Remove :func:`os.listdrives`, :func:`os.listvolumes` and :func:`os.listmounts`
+in non windows desktop builds since the underlying functionality

--- a/Misc/NEWS.d/next/Library/2025-05-06-14-44-55.gh-issue-133517.Ca6NgW.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-06-14-44-55.gh-issue-133517.Ca6NgW.rst
@@ -1,2 +1,2 @@
 Remove :func:`os.listdrives`, :func:`os.listvolumes` and :func:`os.listmounts`
-in non windows desktop builds since the underlying functionality
+in non Windows desktop builds since the underlying functionality is missing.

--- a/Misc/NEWS.d/next/Library/2025-05-06-14-44-55.gh-issue-133517.Ca6NgW.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-06-14-44-55.gh-issue-133517.Ca6NgW.rst
@@ -1,0 +1,1 @@
+Remove :func:`os.listdrives` in non windows desktop builds since they don't support this feature

--- a/Misc/NEWS.d/next/Library/2025-05-06-14-44-55.gh-issue-133517.Ca6NgW.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-06-14-44-55.gh-issue-133517.Ca6NgW.rst
@@ -1,1 +1,2 @@
-Remove :func:`os.listdrives` in non windows desktop builds since they don't support this feature
+Remove :func:`os.listdrives` and :func:`os.listvolumes` in non windows desktop builds
+since the underlying functionality

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1659,7 +1659,7 @@ exit:
     return return_value;
 }
 
-#if defined(MS_WINDOWS)
+#if defined(MS_WINDOWS_DESKTOP)
 
 PyDoc_STRVAR(os_listdrives__doc__,
 "listdrives($module, /)\n"

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1705,7 +1705,7 @@ os_listvolumes(PyObject *module, PyObject *Py_UNUSED(ignored))
     return os_listvolumes_impl(module);
 }
 
-#endif /* defined(MS_WINDOWS_APP) || defined(MS_WINDOWS_SYSTEM) */
+#endif /* (defined(MS_WINDOWS_APP) || defined(MS_WINDOWS_SYSTEM)) */
 
 #if defined(MS_WINDOWS)
 
@@ -13398,4 +13398,4 @@ os__emscripten_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__EMSCRIPTEN_DEBUGGER_METHODDEF
     #define OS__EMSCRIPTEN_DEBUGGER_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_DEBUGGER_METHODDEF) */
-/*[clinic end generated code: output=3a4edc65bb386975 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b2f101ce2b2cf700 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1707,7 +1707,7 @@ os_listvolumes(PyObject *module, PyObject *Py_UNUSED(ignored))
 
 #endif /* (defined(MS_WINDOWS_APP) || defined(MS_WINDOWS_SYSTEM)) */
 
-#if defined(MS_WINDOWS)
+#if (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM))
 
 PyDoc_STRVAR(os_listmounts__doc__,
 "listmounts($module, /, volume)\n"
@@ -1774,7 +1774,7 @@ exit:
     return return_value;
 }
 
-#endif /* defined(MS_WINDOWS) */
+#endif /* (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)) */
 
 #if defined(MS_WINDOWS)
 

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1683,7 +1683,7 @@ os_listdrives(PyObject *module, PyObject *Py_UNUSED(ignored))
 
 #endif /* (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)) */
 
-#if defined(MS_WINDOWS)
+#if defined(MS_WINDOWS_APP) || defined(MS_WINDOWS_SYSTEM)
 
 PyDoc_STRVAR(os_listvolumes__doc__,
 "listvolumes($module, /)\n"
@@ -1705,7 +1705,7 @@ os_listvolumes(PyObject *module, PyObject *Py_UNUSED(ignored))
     return os_listvolumes_impl(module);
 }
 
-#endif /* defined(MS_WINDOWS) */
+#endif /* defined(MS_WINDOWS_APP) || defined(MS_WINDOWS_SYSTEM) */
 
 #if defined(MS_WINDOWS)
 

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -13398,4 +13398,4 @@ os__emscripten_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__EMSCRIPTEN_DEBUGGER_METHODDEF
     #define OS__EMSCRIPTEN_DEBUGGER_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_DEBUGGER_METHODDEF) */
-/*[clinic end generated code: output=b2f101ce2b2cf700 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ae64df0389746258 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1683,7 +1683,7 @@ os_listdrives(PyObject *module, PyObject *Py_UNUSED(ignored))
 
 #endif /* (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)) */
 
-#if defined(MS_WINDOWS_APP) || defined(MS_WINDOWS_SYSTEM)
+#if (defined(MS_WINDOWS_APP) || defined(MS_WINDOWS_SYSTEM))
 
 PyDoc_STRVAR(os_listvolumes__doc__,
 "listvolumes($module, /)\n"

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1659,7 +1659,7 @@ exit:
     return return_value;
 }
 
-#if defined(MS_WINDOWS_DESKTOP) || defined(WINAPI_PARTITION_SYSTEM)
+#if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)
 
 PyDoc_STRVAR(os_listdrives__doc__,
 "listdrives($module, /)\n"
@@ -1681,7 +1681,7 @@ os_listdrives(PyObject *module, PyObject *Py_UNUSED(ignored))
     return os_listdrives_impl(module);
 }
 
-#endif /* defined(MS_WINDOWS_DESKTOP) || defined(WINAPI_PARTITION_SYSTEM) */
+#endif /* defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM) */
 
 #if defined(MS_WINDOWS)
 

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1659,7 +1659,7 @@ exit:
     return return_value;
 }
 
-#if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)
+#if (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM))
 
 PyDoc_STRVAR(os_listdrives__doc__,
 "listdrives($module, /)\n"
@@ -1681,7 +1681,7 @@ os_listdrives(PyObject *module, PyObject *Py_UNUSED(ignored))
     return os_listdrives_impl(module);
 }
 
-#endif /* defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM) */
+#endif /* (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)) */
 
 #if defined(MS_WINDOWS)
 
@@ -13398,4 +13398,4 @@ os__emscripten_debugger(PyObject *module, PyObject *Py_UNUSED(ignored))
 #ifndef OS__EMSCRIPTEN_DEBUGGER_METHODDEF
     #define OS__EMSCRIPTEN_DEBUGGER_METHODDEF
 #endif /* !defined(OS__EMSCRIPTEN_DEBUGGER_METHODDEF) */
-/*[clinic end generated code: output=f7b5635e0b948be4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3a4edc65bb386975 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1681,7 +1681,7 @@ os_listdrives(PyObject *module, PyObject *Py_UNUSED(ignored))
     return os_listdrives_impl(module);
 }
 
-#endif /* defined(MS_WINDOWS) */
+#endif /* defined(MS_WINDOWS_DESKTOP) */
 
 #if defined(MS_WINDOWS)
 

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1659,7 +1659,7 @@ exit:
     return return_value;
 }
 
-#if defined(MS_WINDOWS_DESKTOP)
+#if defined(MS_WINDOWS_DESKTOP) || defined(WINAPI_PARTITION_SYSTEM)
 
 PyDoc_STRVAR(os_listdrives__doc__,
 "listdrives($module, /)\n"
@@ -1681,7 +1681,7 @@ os_listdrives(PyObject *module, PyObject *Py_UNUSED(ignored))
     return os_listdrives_impl(module);
 }
 
-#endif /* defined(MS_WINDOWS_DESKTOP) */
+#endif /* defined(MS_WINDOWS_DESKTOP) || defined(WINAPI_PARTITION_SYSTEM) */
 
 #if defined(MS_WINDOWS)
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4698,7 +4698,7 @@ os_listdir_impl(PyObject *module, path_t *path)
 }
 
 
-#if defined(MS_WINDOWS_DESKTOP) || defined(WINAPI_PARTITION_SYSTEM)
+#if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)
 
 /*[clinic input]
 os.listdrives
@@ -4747,7 +4747,7 @@ os_listdrives_impl(PyObject *module)
     return result;
 }
 
-#endif /* MS_WINDOWS_DESKTOP || WINAPI_PARTITION_SYSTEM */
+#endif /* MS_WINDOWS_DESKTOP || MS_WINDOWS_SYSTEM */
 
 #ifdef MS_WINDOWS
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4698,7 +4698,7 @@ os_listdir_impl(PyObject *module, path_t *path)
 }
 
 
-#ifdef MS_WINDOWS
+#ifdef MS_WINDOWS_DESKTOP
 
 /*[clinic input]
 os.listdrives

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4698,7 +4698,7 @@ os_listdir_impl(PyObject *module, path_t *path)
 }
 
 
-#ifdef MS_WINDOWS_DESKTOP
+#if defined(MS_WINDOWS_DESKTOP) || defined(WINAPI_PARTITION_SYSTEM)
 
 /*[clinic input]
 os.listdrives
@@ -4746,6 +4746,10 @@ os_listdrives_impl(PyObject *module)
     }
     return result;
 }
+
+#endif /* MS_WINDOWS_DESKTOP || WINAPI_PARTITION_SYSTEM */
+
+#ifdef MS_WINDOWS
 
 /*[clinic input]
 os.listvolumes

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4749,7 +4749,7 @@ os_listdrives_impl(PyObject *module)
 
 #endif /* MS_WINDOWS_DESKTOP || MS_WINDOWS_SYSTEM */
 
-#ifdef MS_WINDOWS
+#if defined(MS_WINDOWS_APP) || defined(MS_WINDOWS_SYSTEM)
 
 /*[clinic input]
 os.listvolumes
@@ -4812,6 +4812,9 @@ os_listvolumes_impl(PyObject *module)
     return result;
 }
 
+#endif /* MS_WINDOWS_APP || MS_WINDOWS_SYSTEM */
+
+#ifdef MS_WINDOWS
 
 /*[clinic input]
 os.listmounts

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4814,7 +4814,7 @@ os_listvolumes_impl(PyObject *module)
 
 #endif /* MS_WINDOWS_APP || MS_WINDOWS_SYSTEM */
 
-#ifdef MS_WINDOWS
+#if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)
 
 /*[clinic input]
 os.listmounts
@@ -4895,6 +4895,9 @@ exit:
     return result;
 }
 
+#endif /* MS_WINDOWS_DESKTOP || MS_WINDOWS_SYSTEM */
+
+#ifdef MS_WINDOWS
 
 /*[clinic input]
 os._path_isdevdrive


### PR DESCRIPTION


<!-- gh-issue-number: gh-133517 -->
* Issue: gh-133517
<!-- /gh-issue-number -->
