### PR TITLE
gh-133516: Raise `ValueError` when constants `True`, `False` or `None` are used as an identifier after NFKC normalization

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -821,6 +821,12 @@ class AST_Tests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, f"identifier field can't represent '{constant}' constant"):
                 compile(expr, "<test>", "eval")
 
+    def test_constant_as_unicode_name(self):
+        for constant in b"Tru\xe1\xb5\x89", b"Fal\xc5\xbfe", b"N\xc2\xbane":
+            with self.assertRaises(ValueError,
+                msg="identifier must not be None, True or False after NFKC normalization"):
+                ast.parse(constant, mode="eval")
+
     def test_precedence_enum(self):
         class _Precedence(enum.IntEnum):
             """Precedence table that originated from python grammar."""

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -822,10 +822,15 @@ class AST_Tests(unittest.TestCase):
                 compile(expr, "<test>", "eval")
 
     def test_constant_as_unicode_name(self):
-        for constant in b"Tru\xe1\xb5\x89", b"Fal\xc5\xbfe", b"N\xc2\xbane":
+        constants = [
+            ("True", b"Tru\xe1\xb5\x89"),
+            ("False", b"Fal\xc5\xbfe"),
+            ("None", b"N\xc2\xbane"),
+        ]
+        for constant in constants:
             with self.assertRaisesRegex(ValueError,
-                "identifier must not be None, True or False after Unicode normalization \\(NKFC\\)"):
-                ast.parse(constant, mode="eval")
+                f"identifier field can't represent '{constant[0]}' constant"):
+                ast.parse(constant[1], mode="eval")
 
     def test_precedence_enum(self):
         class _Precedence(enum.IntEnum):

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -823,8 +823,8 @@ class AST_Tests(unittest.TestCase):
 
     def test_constant_as_unicode_name(self):
         for constant in b"Tru\xe1\xb5\x89", b"Fal\xc5\xbfe", b"N\xc2\xbane":
-            with self.assertRaises(ValueError,
-                msg="identifier must not be None, True or False after NFKC normalization"):
+            with self.assertRaisesRegex(ValueError,
+                "identifier must not be None, True or False after Unicode normalization \\(NKFC\\)"):
                 ast.parse(constant, mode="eval")
 
     def test_precedence_enum(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-06-15-01-41.gh-issue-133516.RqWVf2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-06-15-01-41.gh-issue-133516.RqWVf2.rst
@@ -1,2 +1,2 @@
 Raise :exc:`ValueError` when constants ``True``, ``False`` or ``None`` are
-used as an identifier after NFKC normalization
+used as an identifier after NFKC normalization.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-06-15-01-41.gh-issue-133516.RqWVf2.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-06-15-01-41.gh-issue-133516.RqWVf2.rst
@@ -1,0 +1,2 @@
+Raise :exc:`ValueError` when constants ``True``, ``False`` or ``None`` are
+used as an identifier after NFKC normalization

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -549,11 +549,13 @@ _PyPegen_new_identifier(Parser *p, const char *n)
         }
         id = id2;
     }
-    if (_PyUnicode_EqualToASCIIString(id, "None") ||
-        _PyUnicode_EqualToASCIIString(id, "True") ||
-        _PyUnicode_EqualToASCIIString(id, "False"))
+    if (_PyUnicode_EqualToASCIIString(id, "None")
+        || _PyUnicode_EqualToASCIIString(id, "True")
+        || _PyUnicode_EqualToASCIIString(id, "False"))
     {
-        PyErr_SetString(PyExc_ValueError, "identifier must not be None, True or False after Unicode normalization (NKFC)");
+        PyErr_SetString(PyExc_ValueError,
+                        "identifier must not be None, True or False "
+                        "after Unicode normalization (NKFC)");
         Py_DECREF(id);
         goto error;
     }

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -549,15 +549,20 @@ _PyPegen_new_identifier(Parser *p, const char *n)
         }
         id = id2;
     }
-    if (_PyUnicode_EqualToASCIIString(id, "None")
-        || _PyUnicode_EqualToASCIIString(id, "True")
-        || _PyUnicode_EqualToASCIIString(id, "False"))
-    {
-        PyErr_SetString(PyExc_ValueError,
-                        "identifier must not be None, True or False "
-                        "after Unicode normalization (NKFC)");
-        Py_DECREF(id);
-        goto error;
+    static const char * const forbidden[] = {
+        "None",
+        "True",
+        "False",
+        NULL
+    };
+    for (int i = 0; forbidden[i] != NULL; i++) {
+        if (_PyUnicode_EqualToASCIIString(id, forbidden[i])) {
+            PyErr_Format(PyExc_ValueError,
+                         "identifier field can't represent '%s' constant",
+                         forbidden[i]);
+            Py_DECREF(id);
+            goto error;
+        }
     }
     PyInterpreterState *interp = _PyInterpreterState_GET();
     _PyUnicode_InternImmortal(interp, &id);

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -553,7 +553,7 @@ _PyPegen_new_identifier(Parser *p, const char *n)
         _PyUnicode_EqualToASCIIString(id, "True") ||
         _PyUnicode_EqualToASCIIString(id, "False"))
     {
-        PyErr_SetString(PyExc_ValueError, "identifier must not be None, True or False after NFKC normalization");
+        PyErr_SetString(PyExc_ValueError, "identifier must not be None, True or False after Unicode normalization (NKFC)");
         Py_DECREF(id);
         goto error;
     }

--- a/Parser/pegen.c
+++ b/Parser/pegen.c
@@ -549,6 +549,14 @@ _PyPegen_new_identifier(Parser *p, const char *n)
         }
         id = id2;
     }
+    if (_PyUnicode_EqualToASCIIString(id, "None") ||
+        _PyUnicode_EqualToASCIIString(id, "True") ||
+        _PyUnicode_EqualToASCIIString(id, "False"))
+    {
+        PyErr_SetString(PyExc_ValueError, "identifier must not be None, True or False after NFKC normalization");
+        Py_DECREF(id);
+        goto error;
+    }
     PyInterpreterState *interp = _PyInterpreterState_GET();
     _PyUnicode_InternImmortal(interp, &id);
     if (_PyArena_AddPyObject(p->arena, id) < 0)


### PR DESCRIPTION
#133516 