### PR TITLE
gh-131798: JIT: Narrow the return type of _BINARY_SLICE to original container type

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1942,6 +1942,23 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertNotIn("_COMPARE_OP_INT", uops)
         self.assertNotIn("_GUARD_IS_TRUE_POP", uops)
 
+    def test_binary_slice(self):
+        def testfunc(n):
+            a = [1, 2, 3, 4]
+            x = 1
+            y = 3
+            for _ in range(n):
+                b = a[x: y]
+                assert b == [2, 3]
+        _, ex = self._run_with_optimizer(testfunc, TIER2_THRESHOLD)
+        # self.assertEqual(res, TIER2_THRESHOLD)
+        self.assertIsNotNone(ex)
+        uops = get_opnames(ex)
+        print("-------")
+        for uop in uops:
+            print(uop)
+
+
 
 def global_identity(x):
     return x

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -155,6 +155,10 @@ dummy_func(void) {
         sym_set_type(nos, &PyFloat_Type);
     }
 
+    op(_BINARY_SLICE, (container, end, start -- res)) {
+        res = sym_new_type(ctx, sym_get_type(container));
+    }
+
     op(_BINARY_OP, (left, right -- res)) {
         bool lhs_int = sym_matches_type(left, &PyLong_Type);
         bool rhs_int = sym_matches_type(right, &PyLong_Type);

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -568,8 +568,10 @@
         }
 
         case _BINARY_SLICE: {
+            JitOptSymbol *container;
             JitOptSymbol *res;
-            res = sym_new_not_null(ctx);
+            container = stack_pointer[-3];
+            res = sym_new_type(ctx, sym_get_type(container));
             stack_pointer[-3] = res;
             stack_pointer += -2;
             assert(WITHIN_STACK_BOUNDS());


### PR DESCRIPTION
I'm not sure this patch will take some effect.

In my original thought, I think if we can setup the return type to the original container type(tuple, list etc.), the optimizer will specialize some code in the test. 

but the test is not work on my thought. I guess I miss something important here. cc @brandtbucher @Fidget-Spinner 