### PR TITLE
gh-132983: Remove pyzstd in identifiers

### DIFF
--- a/Modules/_zstd/_zstdmodule.h
+++ b/Modules/_zstd/_zstdmodule.h
@@ -172,19 +172,6 @@ set_parameter_error(const _zstd_state* const state, int is_compress,
 
 static const char init_twice_msg[] = "__init__ method is called twice.";
 
-extern int
-_PyZstd_load_c_dict(ZstdCompressor *self, PyObject *dict);
-
-extern int
-_PyZstd_load_d_dict(ZstdDecompressor *self, PyObject *dict);
-
-extern int
-_PyZstd_set_c_parameters(ZstdCompressor *self, PyObject *level_or_options,
-                         const char *arg_name, const char *arg_type);
-
-extern int
-_PyZstd_set_d_parameters(ZstdDecompressor *self, PyObject *options);
-
 extern PyObject *
 decompress_impl(ZstdDecompressor *self, ZSTD_inBuffer *in,
                 Py_ssize_t max_length,

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -26,8 +26,8 @@ class _zstd.ZstdCompressor "ZstdCompressor *" "clinic_state()->ZstdCompressor_ty
 #define ZstdCompressor_CAST(op) ((ZstdCompressor *)op)
 
 int
-_PyZstd_set_c_parameters(ZstdCompressor *self, PyObject *level_or_options,
-                         const char *arg_name, const char* arg_type)
+_zstd_set_c_parameters(ZstdCompressor *self, PyObject *level_or_options,
+                       const char *arg_name, const char* arg_type)
 {
     size_t zstd_ret;
     _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
@@ -198,7 +198,7 @@ success:
 }
 
 int
-_PyZstd_load_c_dict(ZstdCompressor *self, PyObject *dict) {
+_zstd_load_c_dict(ZstdCompressor *self, PyObject *dict) {
 
     size_t zstd_ret;
     _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
@@ -385,20 +385,20 @@ _zstd_ZstdCompressor___init___impl(ZstdCompressor *self, PyObject *level,
 
     /* Set compressLevel/options to compression context */
     if (level != Py_None) {
-        if (_PyZstd_set_c_parameters(self, level, "level", "int") < 0) {
+        if (_zstd_set_c_parameters(self, level, "level", "int") < 0) {
             return -1;
         }
     }
 
     if (options != Py_None) {
-        if (_PyZstd_set_c_parameters(self, options, "options", "dict") < 0) {
+        if (_zstd_set_c_parameters(self, options, "options", "dict") < 0) {
             return -1;
         }
     }
 
     /* Load dictionary to compression context */
     if (zstd_dict != Py_None) {
-        if (_PyZstd_load_c_dict(self, zstd_dict) < 0) {
+        if (_zstd_load_c_dict(self, zstd_dict) < 0) {
             return -1;
         }
 

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -25,7 +25,7 @@ class _zstd.ZstdCompressor "ZstdCompressor *" "clinic_state()->ZstdCompressor_ty
 
 #define ZstdCompressor_CAST(op) ((ZstdCompressor *)op)
 
-int
+static int
 _zstd_set_c_parameters(ZstdCompressor *self, PyObject *level_or_options,
                        const char *arg_name, const char* arg_type)
 {
@@ -197,7 +197,7 @@ success:
     return cdict;
 }
 
-int
+static int
 _zstd_load_c_dict(ZstdCompressor *self, PyObject *dict) {
 
     size_t zstd_ret;

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -61,7 +61,7 @@ _get_DDict(ZstdDict *self)
 }
 
 /* Set decompression parameters to decompression context */
-int
+static int
 _zstd_set_d_parameters(ZstdDecompressor *self, PyObject *options)
 {
     size_t zstd_ret;
@@ -120,7 +120,7 @@ _zstd_set_d_parameters(ZstdDecompressor *self, PyObject *options)
 }
 
 /* Load dictionary or prefix to decompression context */
-int
+static int
 _zstd_load_d_dict(ZstdDecompressor *self, PyObject *dict)
 {
     size_t zstd_ret;

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -62,7 +62,7 @@ _get_DDict(ZstdDict *self)
 
 /* Set decompression parameters to decompression context */
 int
-_PyZstd_set_d_parameters(ZstdDecompressor *self, PyObject *options)
+_zstd_set_d_parameters(ZstdDecompressor *self, PyObject *options)
 {
     size_t zstd_ret;
     PyObject *key, *value;
@@ -121,7 +121,7 @@ _PyZstd_set_d_parameters(ZstdDecompressor *self, PyObject *options)
 
 /* Load dictionary or prefix to decompression context */
 int
-_PyZstd_load_d_dict(ZstdDecompressor *self, PyObject *dict)
+_zstd_load_d_dict(ZstdDecompressor *self, PyObject *dict)
 {
     size_t zstd_ret;
     _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
@@ -709,7 +709,7 @@ _zstd_ZstdDecompressor___init___impl(ZstdDecompressor *self,
 
     /* Load dictionary to decompression context */
     if (zstd_dict != Py_None) {
-        if (_PyZstd_load_d_dict(self, zstd_dict) < 0) {
+        if (_zstd_load_d_dict(self, zstd_dict) < 0) {
             return -1;
         }
 
@@ -720,7 +720,7 @@ _zstd_ZstdDecompressor___init___impl(ZstdDecompressor *self,
 
     /* Set option to decompression context */
     if (options != Py_None) {
-        if (_PyZstd_set_d_parameters(self, options) < 0) {
+        if (_zstd_set_d_parameters(self, options) < 0) {
             return -1;
         }
     }


### PR DESCRIPTION
The `_PyZstd_xxx` extern functions were leftover artifacts of the move from pyzstd to cpython.

I have renamed them to the `_zstd_xxx` convention used for private functions.

<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->
