### PR TITLE
gh-133537: only use console when available

### DIFF
--- a/Misc/NEWS.d/next/Windows/2025-05-07-08-19-15.gh-issue-133537.yzf963.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-07-08-19-15.gh-issue-133537.yzf963.rst
@@ -1,0 +1,1 @@
+Avoid using console I/O in WinAPI partitions that don’t support it

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -16865,12 +16865,16 @@ static PyObject *
 os__supports_virtual_terminal_impl(PyObject *module)
 /*[clinic end generated code: output=bd0556a6d9d99fe6 input=0752c98e5d321542]*/
 {
+#ifdef HAVE_WINDOWS_CONSOLE_IO
     DWORD mode = 0;
     HANDLE handle = GetStdHandle(STD_ERROR_HANDLE);
     if (!GetConsoleMode(handle, &mode)) {
         Py_RETURN_FALSE;
     }
     return PyBool_FromLong(mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+#else
+    Py_RETURN_FALSE;
+#endif /* HAVE_WINDOWS_CONSOLE_IO */
 }
 #endif
 


### PR DESCRIPTION
Alternatively to always returning false the function could only be available when the partition supports console io. Similar to the functions in winconsoleio which are only available when the partition supports console io.

<!-- gh-issue-number: gh-133537 -->
* Issue: gh-133537
<!-- /gh-issue-number -->
