### PR TITLE
[3.13] GH-133231: Backport `PYTHON_JIT` documentation to 3.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,7 @@ Tools/unicode/data/
 # hendrikmuhs/ccache-action@v1
 /.ccache
 /cross-build/
-/jit_stencils.h
+/jit_stencils*.h
 /platform
 /profile-clean-stamp
 /profile-run-stamp

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -1229,6 +1229,14 @@ conflict.
 
    .. versionadded:: 3.13
 
+.. envvar:: PYTHON_JIT
+
+   On builds where experimental just-in-time compilation is available, this
+   variable can force the JIT to be disabled (``0``) or enabled (``1``) at
+   interpreter startup.
+
+   .. versionadded:: 3.13
+
 Debug-mode variables
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -390,11 +390,11 @@ without the optional value.
 
 * ``no``: Disable the entire Tier 2 and JIT pipeline.
 * ``yes``: Enable the JIT.
-  To disable the JIT at runtime, pass the environment variable ``PYTHON_JIT=0``.
+  To disable the JIT at runtime, pass the environment variable :envvar:`PYTHON_JIT=0 <PYTHON_JIT>`.
 * ``yes-off``: Build the JIT but disable it by default.
-  To enable the JIT at runtime, pass the environment variable ``PYTHON_JIT=1``.
+  To enable the JIT at runtime, pass the environment variable :envvar:`PYTHON_JIT=1 <PYTHON_JIT>`.
 * ``interpreter``: Enable the Tier 2 interpreter but disable the JIT.
-  The interpreter can be disabled by running with ``PYTHON_JIT=0``.
+  The interpreter can be disabled by running with :envvar:`PYTHON_JIT=0 <PYTHON_JIT>`.
 
 The internal architecture is roughly as follows:
 


### PR DESCRIPTION
Also backport a `.gitignore` change I found while working on this, to keep files from showing up when branches are switched.

<!-- gh-issue-number: gh-133231 -->
* Issue: gh-133231
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133539.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->