### PR TITLE
Add CI job to run tests sequentially

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,6 +316,14 @@ jobs:
     - name: SSL tests
       run: ./python Lib/test/ssltests.py
 
+  build-sequential:
+    name: 'Sequential'
+    needs: build-context
+    if: needs.build-context.outputs.run-tests == 'true'
+    uses: ./.github/workflows/reusable-sequential.yml
+    with:
+      config_hash: ${{ needs.build-context.outputs.config-hash }}
+
   build-wasi:
     name: 'WASI'
     needs: build-context

--- a/.github/workflows/reusable-sequential.yml
+++ b/.github/workflows/reusable-sequential.yml
@@ -43,14 +43,14 @@ jobs:
     - name: Configure CPython
       run: >-
         ./configure
-          --config-cache
-          --with-pydebug
-          --enable-slower-safety
-          --enable-safety
-          --prefix=/opt/python-dev
+        --config-cache
+        --prefix=/opt/python-dev
     - name: Build CPython
-      run: make all --jobs 4
+      run: make --jobs 4
+    - name: Install
+      run: make install --jobs 4
     - name: Display build info
       run: make pythoninfo
     - name: Tests
-      run: ./python -m test --single-process --timeout 4500 --verbose2 --verbose3
+      run: ./bin/python3 -m test -uall
+      working-directory: /opt/python-dev

--- a/.github/workflows/reusable-sequential.yml
+++ b/.github/workflows/reusable-sequential.yml
@@ -1,0 +1,56 @@
+name: Reusable sequential
+
+on:
+  workflow_call:
+    inputs:
+      config_hash:
+        required: true
+        type: string
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  build-sequential:
+    name: test sequential (ubuntu-24.04)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      OPENSSL_VER: 3.0.15
+      PYTHONSTRICTEXTENSIONBUILD: 1
+      TERM: linux
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Runner image version
+      run: echo "IMAGE_OS_VERSION=${ImageOS}-${ImageVersion}" >> "$GITHUB_ENV"
+    - name: Restore config.cache
+      uses: actions/cache@v4
+      with:
+        path: config.cache
+        key: ${{ github.job }}-${{ env.IMAGE_OS_VERSION }}-${{ inputs.config_hash }}
+    - name: Install dependencies
+      run: sudo ./.github/workflows/posix-deps-apt.sh
+    - name: Add ccache to PATH
+      run: |
+        echo "PATH=/usr/lib/ccache:$PATH" >> "$GITHUB_ENV"
+    - name: Configure ccache action
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        save: ${{ github.event_name == 'push' }}
+        max-size: "200M"
+    - name: Configure CPython
+      run: >-
+        ./configure
+          --config-cache
+          --with-pydebug
+          --enable-slower-safety
+          --enable-safety
+          --prefix=/opt/python-dev
+    - name: Build CPython
+      run: make all --jobs 4
+    - name: Display build info
+      run: make pythoninfo
+    - name: Tests
+      run: ./python -m test --single-process --timeout 4500 --verbose2 --verbose3

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1161,14 +1161,6 @@ class IncrementalGCTests(unittest.TestCase):
             return head
 
         head = make_ll(1000)
-        count = 1000
-
-        # There will be some objects we aren't counting,
-        # e.g. the gc stats dicts. This test checks
-        # that the counts don't grow, so we try to
-        # correct for the uncounted objects
-        # This is just an estimate.
-        CORRECTION = 20
 
         enabled = gc.isenabled()
         gc.enable()
@@ -1176,12 +1168,11 @@ class IncrementalGCTests(unittest.TestCase):
         initial_heap_size = _testinternalcapi.get_tracked_heap_size()
         for i in range(20_000):
             newhead = make_ll(20)
-            count += 20
             newhead.surprise = head
             olds.append(newhead)
             if len(olds) == 20:
                 new_objects = _testinternalcapi.get_tracked_heap_size() - initial_heap_size
-                self.assertLess(new_objects, 27_000, f"Heap growing. Reached limit after {i} iterations")
+                self.assertLess(new_objects, 27_500, f"Heap growing. Reached limit after {i} iterations")
                 del olds[:]
         if not enabled:
             gc.disable()


### PR DESCRIPTION
Add a CI job to run all tests sequentially. This takes ~30m, so might be better as a buildbot worker?

Open questions:

* How close to the `release-tools` check should we make this? Currently I've mirrored it quite closely, but we probably ought to be closer to the other common test configurations.
* Should the job be required, if on CI? Currently I don't think it should be.
* Should we add a `make` target for sequential testing?

A