### PR TITLE
gh-133510: Added Resources section

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -451,9 +451,13 @@ Several other key features of this statement:
               print("Grass is green")
           case Color.BLUE:
               print("I'm feeling the blues :(")
-
-For a more detailed explanation and additional examples, you can look into
-:pep:`636` which is written in a tutorial format.
+Resources
+---------
+For more detailed explanation and additional examples, you can look into the
+following resources, which are written in tutorial format:
+- :pep:`636`
+- `W3Schools <https://www.w3schools.com/python/python_match.asp>`_
+- `Real Python <https://realpython.com/structural-pattern-matching/>`_
 
 .. _tut-functions:
 


### PR DESCRIPTION
Issue #133511 :
points out the lack of detailed examples and use cases for the match statement in Python

I added a resources section, and listed 2 sites(hyperlinks) for beginners seeking examples/tutorials to find, in addition to the previously linked PEP 636 tutorial.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133559.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-133510 -->
* Issue: gh-133510
<!-- /gh-issue-number -->
