### PR TITLE
gh-133572: Disable error reporting for invalid memory access on unsupported WinAPI partitions

### DIFF
--- a/Misc/NEWS.d/next/Windows/2025-05-07-11-45-30.gh-issue-133572.Xc2zxH.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-07-11-45-30.gh-issue-133572.Xc2zxH.rst
@@ -1,0 +1,1 @@
+Disable error reporting for invalid memory access on unsupported WinAPI partitions.

--- a/Misc/NEWS.d/next/Windows/2025-05-07-11-45-30.gh-issue-133572.Xc2zxH.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-07-11-45-30.gh-issue-133572.Xc2zxH.rst
@@ -1,1 +1,1 @@
-Disable error reporting for invalid memory access on unsupported WinAPI partitions.
+Avoid LsaNtStatus to WinError conversion on unsupported WinAPI partitions.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -60,12 +60,6 @@ my_getallocationgranularity (void)
 
 #endif
 
-#if !defined(DONT_USE_SEH) && !(defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM))
-// Only the WINDOWS_DESKTOP and WINDOWS_SYSTEM API partitions support lsa handling we want to
-// perform in there
-#define DONT_USE_SEH
-#endif
-
 #ifdef UNIX
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -296,6 +290,24 @@ filter_page_exception_method(mmap_object *self, EXCEPTION_POINTERS *ptrs,
     }
     return EXCEPTION_CONTINUE_SEARCH;
 }
+
+static void
+_PyErr_SetFromNTSTATUS(ULONG status)
+{
+#if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)
+    PyErr_SetFromWindowsErr(LsaNtStatusToWinError((NTSTATUS)status));
+#else
+    if (status & 0x80000000) {
+        // HRESULT-shaped codes are supported by PyErr_SetFromWindowsErr
+        PyErr_SetFromWindowsErr((int)status);
+    }
+    else {
+        // No mapping for NTSTATUS values, so just return it for diagnostic purposes
+        // If we provide it as winerror it could incorrectly change the type of the exception.
+        PyErr_Format(PyExc_OSError, "Operating system error NTSTATUS=0x%08lX", status);
+    }
+#endif
+}
 #endif
 
 #if defined(MS_WINDOWS) && !defined(DONT_USE_SEH)
@@ -309,9 +321,7 @@ do {                                                                       \
         assert(record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR ||          \
                record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION);        \
         if (record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR) {             \
-            NTSTATUS status = (NTSTATUS) record.ExceptionInformation[2];   \
-            ULONG code = LsaNtStatusToWinError(status);                    \
-            PyErr_SetFromWindowsErr(code);                                 \
+            _PyErr_SetFromNTSTATUS((ULONG)record.ExceptionInformation[2]); \
         }                                                                  \
         else if (record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {     \
             PyErr_SetFromWindowsErr(ERROR_NOACCESS);                       \
@@ -338,9 +348,7 @@ do {                                                                          \
         assert(record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR ||             \
                record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION);           \
         if (record.ExceptionCode == EXCEPTION_IN_PAGE_ERROR) {                \
-            NTSTATUS status = (NTSTATUS) record.ExceptionInformation[2];      \
-            ULONG code = LsaNtStatusToWinError(status);                       \
-            PyErr_SetFromWindowsErr(code);                                    \
+            _PyErr_SetFromNTSTATUS((ULONG)record.ExceptionInformation[2]);    \
         }                                                                     \
         else if (record.ExceptionCode == EXCEPTION_ACCESS_VIOLATION) {        \
             PyErr_SetFromWindowsErr(ERROR_NOACCESS);                          \

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -292,7 +292,7 @@ filter_page_exception_method(mmap_object *self, EXCEPTION_POINTERS *ptrs,
 }
 #endif
 
-#if defined(MS_WINDOWS) && !defined(DONT_USE_SEH)
+#if (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)) && !defined(DONT_USE_SEH)
 #define HANDLE_INVALID_MEM(sourcecode)                                     \
 do {                                                                       \
     EXCEPTION_RECORD record;                                               \
@@ -320,7 +320,7 @@ do {                                                                       \
 } while (0)
 #endif
 
-#if defined(MS_WINDOWS) && !defined(DONT_USE_SEH)
+#if (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)) && !defined(DONT_USE_SEH)
 #define HANDLE_INVALID_MEM_METHOD(self, sourcecode)                           \
 do {                                                                          \
     EXCEPTION_RECORD record;                                                  \

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -60,6 +60,12 @@ my_getallocationgranularity (void)
 
 #endif
 
+#if !defined(DONT_USE_SEH) && !(defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM))
+// Only the WINDOWS_DESKTOP and WINDOWS_SYSTEM API partitions support lsa handling we want to
+// perform in there
+#define DONT_USE_SEH
+#endif
+
 #ifdef UNIX
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -292,7 +298,7 @@ filter_page_exception_method(mmap_object *self, EXCEPTION_POINTERS *ptrs,
 }
 #endif
 
-#if (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)) && !defined(DONT_USE_SEH)
+#if defined(MS_WINDOWS) && !defined(DONT_USE_SEH)
 #define HANDLE_INVALID_MEM(sourcecode)                                     \
 do {                                                                       \
     EXCEPTION_RECORD record;                                               \
@@ -320,7 +326,7 @@ do {                                                                       \
 } while (0)
 #endif
 
-#if (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)) && !defined(DONT_USE_SEH)
+#if defined(MS_WINDOWS) && !defined(DONT_USE_SEH)
 #define HANDLE_INVALID_MEM_METHOD(self, sourcecode)                           \
 do {                                                                          \
     EXCEPTION_RECORD record;                                                  \


### PR DESCRIPTION
aside from the mimalloc fix that has to be downstreamed later on this is the last change required to get cpython to compile on the xbox again

<!-- gh-issue-number: gh-133572 -->
* Issue: gh-133572
<!-- /gh-issue-number -->
