### PR TITLE
gh-133580: add missing exception in _sys_getwindowsversion_from_kernel32

### DIFF
--- a/Misc/NEWS.d/next/Windows/2025-05-07-13-04-22.gh-issue-133580.jBMujJ.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-07-13-04-22.gh-issue-133580.jBMujJ.rst
@@ -1,1 +1,1 @@
-Fix :func:`sys.getwindowsversion` failing without setting an exception when called on some WinAPI partitions
+Fix :func:`sys.getwindowsversion` failing without setting an exception when called on some WinAPI partitions.

--- a/Misc/NEWS.d/next/Windows/2025-05-07-13-04-22.gh-issue-133580.jBMujJ.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-07-13-04-22.gh-issue-133580.jBMujJ.rst
@@ -1,0 +1,1 @@
+Fix :func:`sys.getwindowsversion` failing without setting an exception when called on some WinAPI partitions

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1643,6 +1643,7 @@ static PyObject *
 _sys_getwindowsversion_from_kernel32(void)
 {
 #ifndef MS_WINDOWS_DESKTOP
+    PyErr_SetFromWindowsErr(0);
     return NULL;
 #else
     HANDLE hKernel32;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1643,7 +1643,7 @@ static PyObject *
 _sys_getwindowsversion_from_kernel32(void)
 {
 #ifndef MS_WINDOWS_DESKTOP
-    PyErr_SetFromWindowsErr(0);
+    PyErr_SetString(PyExc_OSError, "cannot read version info on this platform");
     return NULL;
 #else
     HANDLE hKernel32;


### PR DESCRIPTION
This fixes a regression from https://github.com/python/cpython/pull/102256 where I didn't properly set the exception. This didn't cause issues for me since I wrote this when I was still using Python 3.11 where this was structured differently.

<!-- gh-issue-number: gh-133580 -->
* Issue: gh-133580
<!-- /gh-issue-number -->
