### PR TITLE
gh-46927: Prevent readline from overriding environment

### DIFF
--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -431,6 +431,16 @@ readline.write_history_file(history_file)
         readline.set_pre_input_hook(my_hook)
         self.assertIs(readline.get_pre_input_hook(), my_hook)
 
+    def test_environment_is_not_modified(self):
+        # os.environ contains enviroment at the time "os" module was loaded, so
+        # before the "readline" module is loaded.
+        original_env = dict(os.environ)
+
+        # Force refresh of os.environ and make sure it is the same as before the
+        # refresh.
+        os.reload_environ()
+        self.assertEqual(dict(os.environ), original_env)
+
 
 @unittest.skipUnless(support.Py_GIL_DISABLED, 'these tests can only possibly fail with GIL disabled')
 class FreeThreadingTest(unittest.TestCase):

--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -405,6 +405,15 @@ readline.write_history_file(history_file)
         # So, we've only tested that the read did not fail.
         # See TestHistoryManipulation for the full test.
 
+    def test_environment_is_not_modified(self):
+        # os.environ contains enviroment at the time "os" module was loaded, so
+        # before the "readline" module is loaded.
+        original_env = dict(os.environ)
+
+        # Force refresh of os.environ and make sure it is the same as before the
+        # refresh.
+        os.reload_environ()
+        self.assertEqual(dict(os.environ), original_env)
 
 @unittest.skipUnless(support.Py_GIL_DISABLED, 'these tests can only possibly fail with GIL disabled')
 class FreeThreadingTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-07-18-31-31.gh-issue-46927.sF02gj.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-07-18-31-31.gh-issue-46927.sF02gj.rst
@@ -1,0 +1,2 @@
+Prevent :mod:`readline` from overriding the ``COLUMNS`` and ``LINES``
+environment variables, as values are not updated on terminal resize.

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1323,7 +1323,7 @@ setup_readline(readlinestate *mod_state)
     /* The name must be defined before initialization */
     rl_readline_name = "python";
 
-#ifndef WITH_EDITLINE
+#if !defined(__APPLE__)
     /* Prevent readline from changing environment variables such as LINES and
      * COLUMNS.
      */

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1323,6 +1323,13 @@ setup_readline(readlinestate *mod_state)
     /* The name must be defined before initialization */
     rl_readline_name = "python";
 
+#ifndef WITH_EDITLINE
+    /* Prevent readline from changing environment variables such as LINES and
+     * COLUMNS.
+     */
+    rl_change_environment = 0;
+#endif
+
     /* the libedit readline emulation resets key bindings etc
      * when calling rl_initialize.  So call it upfront
      */

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1349,6 +1349,13 @@ setup_readline(readlinestate *mod_state)
     /* The name must be defined before initialization */
     rl_readline_name = "python";
 
+#ifndef WITH_EDITLINE
+    /* Prevent readline from changing environment variables such as LINES and
+     * COLUMNS.
+     */
+    rl_change_environment = 0;
+#endif
+
     /* the libedit readline emulation resets key bindings etc
      * when calling rl_initialize.  So call it upfront
      */

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1349,7 +1349,7 @@ setup_readline(readlinestate *mod_state)
     /* The name must be defined before initialization */
     rl_readline_name = "python";
 
-#ifndef WITH_EDITLINE
+#if !defined(__APPLE__)
     /* Prevent readline from changing environment variables such as LINES and
      * COLUMNS.
      */

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1323,10 +1323,10 @@ setup_readline(readlinestate *mod_state)
     /* The name must be defined before initialization */
     rl_readline_name = "python";
 
-#if !defined(__APPLE__)
-    /* Prevent readline from changing environment variables such as LINES and
-     * COLUMNS.
-     */
+#ifdef HAVE_RL_CHANGE_ENVIRONMENT
+    /* Prevent readline from setting the LINES and COLUMNS environment
+     * variables: ncurses prefers them over an ioctl() query, so a stale value
+     * left after a resize breaks SIGWINCH / KEY_RESIZE handling (gh-46927). */
     rl_change_environment = 0;
 #endif
 

--- a/configure
+++ b/configure
@@ -27186,6 +27186,57 @@ printf "%s\n" "#define HAVE_RL_RESIZE_TERMINAL 1" >>confdefs.h
 
 fi
 
+    # rl_change_environment is in readline 6.3, but not in editline
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for rl_change_environment in -l$LIBREADLINE" >&5
+printf %s "checking for rl_change_environment in -l$LIBREADLINE... " >&6; }
+if test ${ac_cv_readline_rl_change_environment+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+      #include <stdio.h> /* Must be first for Gnu Readline */
+      #ifdef WITH_EDITLINE
+      # include <editline/readline.h>
+      #else
+      # include <readline/readline.h>
+      # include <readline/history.h>
+      #endif
+
+int
+main (void)
+{
+int x = rl_change_environment
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_readline_rl_change_environment=yes
+else case e in #(
+  e) ac_cv_readline_rl_change_environment=no
+       ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+     ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_readline_rl_change_environment" >&5
+printf "%s\n" "$ac_cv_readline_rl_change_environment" >&6; }
+    if test "x$ac_cv_readline_rl_change_environment" = xyes
+then :
+
+
+printf "%s\n" "#define HAVE_RL_CHANGE_ENVIRONMENT 1" >>confdefs.h
+
+
+fi
+
     # check for readline 4.2
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for rl_completion_matches in -l$LIBREADLINE" >&5
 printf %s "checking for rl_completion_matches in -l$LIBREADLINE... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -6472,6 +6472,17 @@ AS_VAR_IF([with_readline], [no], [
       AC_DEFINE([HAVE_RL_RESIZE_TERMINAL], [1], [Define if you have readline 4.0])
     ])
 
+    # rl_change_environment is in readline 6.3, but not in editline
+    AC_CACHE_CHECK([for rl_change_environment in -l$LIBREADLINE], [ac_cv_readline_rl_change_environment], [
+      AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([readline_includes], [int x = rl_change_environment])],
+        [ac_cv_readline_rl_change_environment=yes], [ac_cv_readline_rl_change_environment=no]
+      )
+    ])
+    AS_VAR_IF([ac_cv_readline_rl_change_environment], [yes], [
+      AC_DEFINE([HAVE_RL_CHANGE_ENVIRONMENT], [1], [Define if you have readline 6.3])
+    ])
+
     # check for readline 4.2
     AC_CACHE_CHECK([for rl_completion_matches in -l$LIBREADLINE], [ac_cv_readline_rl_completion_matches], [
       AC_LINK_IFELSE(

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1074,6 +1074,9 @@
 /* Define if you can turn off readline's signal handling. */
 #undef HAVE_RL_CATCH_SIGNAL
 
+/* Define if you have readline 6.3 */
+#undef HAVE_RL_CHANGE_ENVIRONMENT
+
 /* Define to 1 if the system has the type 'rl_compdisp_func_t'. */
 #undef HAVE_RL_COMPDISP_FUNC_T
 


### PR DESCRIPTION
Readline library will set the LINES and COLUMNS environment variables during initialization. One might expect these variables to be updated later on SIGWINCH, but this is not the case with cpython.

As a consequence, when the readline module is imported, any process launched from cpython with the default environment will have LINES and COLUMNS variables set, potentially to a wrong value.

Use the rl_change_environment global variable to disable this initial setup of the environment variables.

<!-- gh-issue-number: gh-46927 -->
* Issue: gh-46927
<!-- /gh-issue-number -->
