### PR TITLE
gh-131093: Enforce -std=c11 for gcc at configure time rather than make time

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -2032,6 +2032,7 @@ Cliff Wells
 Rickard Westman
 Joseph Weston
 Jeff Wheeler
+Chris White
 Christopher White
 David White
 Mats Wichmann

--- a/Misc/NEWS.d/next/Build/2025-03-13-13-43-51.gh-issue-131093.q2jF6K.rst
+++ b/Misc/NEWS.d/next/Build/2025-03-13-13-43-51.gh-issue-131093.q2jF6K.rst
@@ -1,0 +1,3 @@
+On GCC-compatible compilers, check at configure time that ``-std=c11``
+works. This way you don't hit an "invalid option" error at make time on old
+compilers.

--- a/configure
+++ b/configure
@@ -10059,7 +10059,51 @@ fi
 if test "x$ac_cv_gcc_compat" = xyes
 then :
 
-    CFLAGS_NODIST="$CFLAGS_NODIST -std=c11"
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -std=c11" >&5
+printf %s "checking whether C compiler accepts -std=c11... " >&6; }
+if test ${ax_cv_check_cflags__Werror__std_c11+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e)
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS -Werror -std=c11"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ax_cv_check_cflags__Werror__std_c11=yes
+else case e in #(
+  e) ax_cv_check_cflags__Werror__std_c11=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags__Werror__std_c11" >&5
+printf "%s\n" "$ax_cv_check_cflags__Werror__std_c11" >&6; }
+if test "x$ax_cv_check_cflags__Werror__std_c11" = xyes
+then :
+
+      as_fn_append CFLAGS_NODIST " -std=c11"
+
+else case e in #(
+  e)
+      as_fn_error $? "Python requires -std=c11 on gcc" "$LINENO" 5
+     ;;
+esac
+fi
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -2456,7 +2456,11 @@ then
 fi
 
 AS_VAR_IF([ac_cv_gcc_compat], [yes], [
-    CFLAGS_NODIST="$CFLAGS_NODIST -std=c11"
+    AX_CHECK_COMPILE_FLAG([-std=c11],[
+      AS_VAR_APPEND([CFLAGS_NODIST], [" -std=c11"])
+    ], [
+      AC_MSG_ERROR([Python requires -std=c11 on gcc])
+    ], [-Werror])
 
     PY_CHECK_CC_WARNING([enable], [extra], [if we can add -Wextra])
     AS_VAR_IF([ac_cv_enable_extra_warning], [yes],


### PR DESCRIPTION
When compiling under gcc, configure.ac currently assumes `-std=c11` rather than checking it.  This causes configure to succeed but make to fail on old compilers.  Fix this by adding a check for `-std=c11` in configure.ac.

The changes to `configure` are the result of running `Tools/build/regen-configure.sh`.

### Manual test on gcc 4.4.7:

Before:
```
$ ./configure
... (after it builds for a while)
gcc -std=gnu99 -pthread -c -fno-strict-overflow -Wsign-compare ...  -DPy_BUILD_CORE -o Parser/lexer/buffer.o Parser/lexer/buffer.c
cc1: error: unrecognized command line option "-std=c11"cc1: error: unrecognized command line option "-std=c11"
```

After:
```
$ ./configure
...
checking whether C compiler accepts -std=c11... no
configure: error: Python requires -std=c11 on gcc
```

Fixes #131093.


<!-- gh-issue-number: gh-131093 -->
* Issue: gh-131093
<!-- /gh-issue-number -->
