### PR TITLE
gh-133551: Skip annotationlib for now in ast roundtrip tests

### DIFF
--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -942,6 +942,7 @@ class DirectoryTestCase(ASTTestCase):
             for directory in cls.test_directories
             for item in directory.glob("*.py")
             if not item.name.startswith("bad")
+            and item.name != "annotationlib.py"  # gh-133581: t"" does not roundtrip
         ]
 
         # Test limited subset of files unless the 'cpu' resource is specified.


### PR DESCRIPTION
Currently `t""` doesn't roundtrip. I'll put up a PR to fix that but in the meantime this fixes the buildbots.

<!-- gh-issue-number: gh-133551 -->
* Issue: gh-133551
<!-- /gh-issue-number -->
