### PR TITLE
gh-133581: Improve AST unparsing of t-strings

### DIFF
--- a/Lib/_ast_unparse.py
+++ b/Lib/_ast_unparse.py
@@ -627,6 +627,9 @@ class Unparser(NodeVisitor):
         self._ftstring_helper(fstring_parts)
 
     def _tstring_helper(self, node):
+        if not node.values:
+            self._write_ftstring([], "t")
+            return
         last_idx = 0
         for i, value in enumerate(node.values):
             # This can happen if we have an implicit concat of a t-string
@@ -679,9 +682,12 @@ class Unparser(NodeVisitor):
         unparser.set_precedence(_Precedence.TEST.next(), inner)
         return unparser.visit(inner)
 
-    def _write_interpolation(self, node):
+    def _write_interpolation(self, node, is_interpolation=False):
         with self.delimit("{", "}"):
-            expr = self._unparse_interpolation_value(node.value)
+            if is_interpolation:
+                expr = node.str
+            else:
+                expr = self._unparse_interpolation_value(node.value)
             if expr.startswith("{"):
                 # Separate pair of opening brackets as "{ {"
                 self.write(" ")
@@ -696,7 +702,7 @@ class Unparser(NodeVisitor):
         self._write_interpolation(node)
 
     def visit_Interpolation(self, node):
-        self._write_interpolation(node)
+        self._write_interpolation(node, is_interpolation=True)
 
     def visit_Name(self, node):
         self.write(node.id)

--- a/Lib/test/test_future_stmt/test_future.py
+++ b/Lib/test/test_future_stmt/test_future.py
@@ -422,6 +422,8 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         eq('(((a)))', 'a')
         eq('(((a, b)))', '(a, b)')
         eq("1 + 2 + 3")
+        eq('t""')
+        eq('t"{a    +  b}"')
 
     def test_fstring_debug_annotations(self):
         # f-strings with '=' don't round trip very well, so set the expected

--- a/Lib/test/test_future_stmt/test_future.py
+++ b/Lib/test/test_future_stmt/test_future.py
@@ -422,8 +422,11 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         eq('(((a)))', 'a')
         eq('(((a, b)))', '(a, b)')
         eq("1 + 2 + 3")
-        eq('t""')
-        eq('t"{a    +  b}"')
+        eq("t''")
+        eq("t'{a    +  b}'")
+        eq("t'{a!s}'")
+        eq("t'{a:b}'")
+        eq("t'{a:b=}'")
 
     def test_fstring_debug_annotations(self):
         # f-strings with '=' don't round trip very well, so set the expected

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -817,6 +817,15 @@ class CosmeticTestCase(ASTTestCase):
         self.check_ast_roundtrip("def f[T: int = int, **P = int, *Ts = *int]():\n    pass")
         self.check_ast_roundtrip("class C[T: int = int, **P = int, *Ts = *int]():\n    pass")
 
+    def test_tstr(self):
+        self.check_ast_roundtrip("t'{a +    b}'")
+        self.check_ast_roundtrip("t'{a +    b:x}'")
+        self.check_ast_roundtrip("t'{a +    b!s}'")
+        self.check_ast_roundtrip("t'{ {a}}'")
+        self.check_ast_roundtrip("t'{ {a}=}'")
+        self.check_ast_roundtrip("t'{{a}}'")
+        self.check_ast_roundtrip("t''")
+
 
 class ManualASTCreationTestCase(unittest.TestCase):
     """Test that AST nodes created without a type_params field unparse correctly."""

--- a/Lib/test/test_unparse.py
+++ b/Lib/test/test_unparse.py
@@ -951,7 +951,6 @@ class DirectoryTestCase(ASTTestCase):
             for directory in cls.test_directories
             for item in directory.glob("*.py")
             if not item.name.startswith("bad")
-            and item.name != "annotationlib.py"  # gh-133581: t"" does not roundtrip
         ]
 
         # Test limited subset of files unless the 'cpu' resource is specified.

--- a/Misc/NEWS.d/next/Library/2025-05-07-19-16-41.gh-issue-133581.kERUCJ.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-07-19-16-41.gh-issue-133581.kERUCJ.rst
@@ -1,0 +1,4 @@
+Improve unparsing of t-strings in :func:`ast.unparse` and ``from __future__
+import annotations``. Empty t-strings now round-trip correctly and
+formatting in interpolations is preserved.
+Patch by Jelle Zijlstra.

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -702,6 +702,13 @@ append_templatestr(PyUnicodeWriter *writer, expr_ty e)
 
     Py_ssize_t last_idx = 0;
     Py_ssize_t len = asdl_seq_LEN(e->v.TemplateStr.values);
+    if (len == 0) {
+        int result = _write_values_subarray(writer, e->v.TemplateStr.values,
+                0, len - 1, 't', arena);
+        _PyArena_Free(arena);
+        return result;
+    }
+
     for (Py_ssize_t i = 0; i < len; i++) {
         expr_ty value = asdl_seq_GET(e->v.TemplateStr.values, i);
 


### PR DESCRIPTION
Fix unparsing of empty t-strings, and use the string value in unparsing interpolations.

<!-- gh-issue-number: gh-133581 -->
* Issue: gh-133581
<!-- /gh-issue-number -->
