### PR TITLE
gh-133653: Fix subclassing `HelpFormatter`

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2723,13 +2723,23 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         return formatter.format_help()
 
     def _get_formatter(self):
-        try:
+        import inspect
+        if len(
+            [v.kind for (k, v) in
+             inspect.signature(self.formatter_class).parameters.items()
+             if k in ('prefix_chars', 'color')
+                and v.kind in (
+                        inspect._ParameterKind.POSITIONAL_OR_KEYWORD,
+                        inspect._ParameterKind.KEYWORD_ONLY,
+                )
+             ]
+        ) == 2:
             return self.formatter_class(
                 prog=self.prog,
                 prefix_chars=self.prefix_chars,
                 color=self.color,
             )
-        except TypeError:
+        else:
             return self.formatter_class(prog=self.prog)
 
     # =====================

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2723,15 +2723,13 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
         return formatter.format_help()
 
     def _get_formatter(self):
-        if isinstance(self.formatter_class, type) and issubclass(
-            self.formatter_class, HelpFormatter
-        ):
+        try:
             return self.formatter_class(
                 prog=self.prog,
                 prefix_chars=self.prefix_chars,
                 color=self.color,
             )
-        else:
+        except TypeError:
             return self.formatter_class(prog=self.prog)
 
     # =====================

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5176,6 +5176,30 @@ class TestHelpTupleMetavarPositional(HelpTestCase):
     version = ''
 
 
+class TestHelpFormatter(HelpTestCase):
+    """Test the HelpFormatter"""
+
+    # Test subclassing the help formatter
+    class MyFormatter(argparse.HelpFormatter):
+        def __init__(self, prog) -> None:
+            super().__init__(prog)
+
+    parser_signature = Sig(
+        prog="PROG",
+        formatter_class=MyFormatter,
+        description="Test with subclassing the help formatter",
+    )
+    usage = '''\
+        usage: PROG [-h]
+        '''
+    help = usage + '''\
+
+        Test with subclassing the help formatter
+
+        options:
+          -h, --help  show this help message and exit
+        '''
+
 class TestHelpRawText(HelpTestCase):
     """Test the RawTextHelpFormatter"""
 

--- a/Misc/NEWS.d/next/Library/2025-05-08-16-28-05.gh-issue-133653.7cxHXN.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-08-16-28-05.gh-issue-133653.7cxHXN.rst
@@ -1,1 +1,1 @@
-Fix subclassing :meth:`argparse.HelpFormatter`. Patch by Hugo van Kemenade.
+Fix subclassing :meth:`!argparse.HelpFormatter`. Patch by Hugo van Kemenade.

--- a/Misc/NEWS.d/next/Library/2025-05-08-16-28-05.gh-issue-133653.7cxHXN.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-08-16-28-05.gh-issue-133653.7cxHXN.rst
@@ -1,0 +1,1 @@
+Fix subclassing :meth:`argparse.HelpFormatter`. Patch by Hugo van Kemenade.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

The problem was with this code:

```python
        if isinstance(self.formatter_class, type) and issubclass(
            self.formatter_class, HelpFormatter
        ):
            return self.formatter_class(
                prog=self.prog,
                prefix_chars=self.prefix_chars,
                color=self.color,
            )
        else:
            return self.formatter_class(prog=self.prog)
```

We want to set the extra arguments for `HelpFormatter` and `argparse`'s own subclasses, which don't have their own `__init__`s.

But many third-party subclasses do have an `__init__` and don't pass on `kwargs`. So we can't just check for a subclass of `HelpFormatter`, so let's `try`/`except` instead.

<!-- gh-issue-number: gh-133653 -->
* Issue: gh-133653
<!-- /gh-issue-number -->
