### PR TITLE
gh-133410: Fix PR detection in build workflow

### DIFF
--- a/.github/workflows/reusable-context.yml
+++ b/.github/workflows/reusable-context.yml
@@ -97,6 +97,7 @@ jobs:
       run: python Tools/build/compute-changes.py
       env:
         GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
         CCF_TARGET_REF: ${{ github.base_ref || github.event.repository.default_branch }}
         CCF_HEAD_REF: ${{ github.event.pull_request.head.sha || github.sha }}
 

--- a/Tools/build/compute-changes.py
+++ b/Tools/build/compute-changes.py
@@ -57,7 +57,7 @@ class Outputs:
 
 def compute_changes() -> None:
     target_branch, head_ref = git_refs()
-    if target_branch and head_ref:
+    if os.environ.get("GITHUB_EVENT_NAME", "") == "pull_request":
         # Getting changed files only makes sense on a pull request
         files = get_changed_files(target_branch, head_ref)
         outputs = process_changed_files(files)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

It's running on my fork: https://github.com/hugovk/cpython/actions/runs/14908903403/job/41878001194#step:6:16

And on this PR: https://github.com/python/cpython/actions/runs/14909052522/job/41878505661?pr=133671#step:6:19

<!-- gh-issue-number: gh-133410 -->
* Issue: gh-133410
<!-- /gh-issue-number -->
