### PR TITLE
gh-103092: Support subinterpreters in _zstd

### DIFF
--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -826,7 +826,7 @@ static int _zstd_exec(PyObject *module) {
     // ZstdDecompressor
     if (add_type_to_module(module,
                            "ZstdDecompressor",
-                           &ZstdDecompressor_type_spec,
+                           &zstddecompressor_type_spec,
                            &mod_state->ZstdDecompressor_type) < 0) {
         return -1;
     }
@@ -890,9 +890,9 @@ _zstd_free(void *module)
 
 static struct PyModuleDef_Slot _zstd_slots[] = {
     {Py_mod_exec, _zstd_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
-
-    {0}
+    {0, NULL},
 };
 
 struct PyModuleDef _zstdmodule = {

--- a/Modules/_zstd/_zstdmodule.h
+++ b/Modules/_zstd/_zstdmodule.h
@@ -32,7 +32,7 @@ get_zstd_state_from_type(PyTypeObject *type) {
 
 extern PyType_Spec zstddict_type_spec;
 extern PyType_Spec zstdcompressor_type_spec;
-extern PyType_Spec ZstdDecompressor_type_spec;
+extern PyType_Spec zstddecompressor_type_spec;
 
 struct _zstd_state {
     PyObject *empty_bytes;

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -883,7 +883,7 @@ static PyType_Slot ZstdDecompressor_slots[] = {
     {0}
 };
 
-PyType_Spec ZstdDecompressor_type_spec = {
+PyType_Spec zstddecompressor_type_spec = {
     .name = "_zstd.ZstdDecompressor",
     .basicsize = sizeof(ZstdDecompressor),
     .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,


### PR DESCRIPTION


<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->


<!-- gh-issue-number: gh-103092 -->
* Issue: gh-103092
<!-- /gh-issue-number -->
