### PR TITLE
GH-132983: Remove subclassing support from zstd types

### DIFF
--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -702,6 +702,6 @@ static PyType_Slot zstdcompressor_slots[] = {
 PyType_Spec zstdcompressor_type_spec = {
     .name = "_zstd.ZstdCompressor",
     .basicsize = sizeof(ZstdCompressor),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .slots = zstdcompressor_slots,
 };

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -886,6 +886,6 @@ static PyType_Slot ZstdDecompressor_slots[] = {
 PyType_Spec ZstdDecompressor_type_spec = {
     .name = "_zstd.ZstdDecompressor",
     .basicsize = sizeof(ZstdDecompressor),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .slots = ZstdDecompressor_slots,
 };

--- a/Modules/_zstd/zstddict.c
+++ b/Modules/_zstd/zstddict.c
@@ -281,6 +281,6 @@ static PyType_Slot zstddict_slots[] = {
 PyType_Spec zstddict_type_spec = {
     .name = "_zstd.ZstdDict",
     .basicsize = sizeof(ZstdDict),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .slots = zstddict_slots,
 };


### PR DESCRIPTION
cc @Rogdham

> For what it's worth, `bz2` and `lzma`'s decompressor subclassing fail on creation:
> 
> ```pycon
> >>> import bz2
> >>> class D(bz2.BZ2Decompressor): pass
> ... 
> Traceback (most recent call last):
>   File "<python-input-18>", line 1, in <module>
>     class D(bz2.BZ2Decompressor): pass
> TypeError: type '_bz2.BZ2Decompressor' is not an acceptable base type
> 
> >>> import lzma
> >>> class D(lzma.LZMADecompressor): pass
> ... 
> Traceback (most recent call last):
>   File "<python-input-19>", line 1, in <module>
>     class D(lzma.LZMADecompressor): pass
> TypeError: type '_lzma.LZMADecompressor' is not an acceptable base type
> ```


<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->
