### PR TITLE
[3.13] gh-133626: Ensure the traditional Windows installer doesn't accidentally pick up site-packages (GH-133693)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2025-05-08-19-07-26.gh-issue-133626.yFTKYK.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-08-19-07-26.gh-issue-133626.yFTKYK.rst
@@ -1,0 +1,2 @@
+Ensures packages are not accidentally bundled into the traditional
+installer.

--- a/Tools/msi/lib/lib.wixproj
+++ b/Tools/msi/lib/lib.wixproj
@@ -15,11 +15,10 @@
         <EmbeddedResource Include="*.wxl" />
     </ItemGroup>
     <ItemGroup>
-        <ExcludeFolders Include="Lib\test;Lib\tests;Lib\tkinter;Lib\idlelib;Lib\turtledemo" />
+        <ExcludeFolders Include="Lib\site-packages;Lib\test;Lib\tests;Lib\tkinter;Lib\idlelib;Lib\turtledemo" />
         <InstallFiles Include="$(PySourcePath)Lib\**\*"
                       Exclude="$(PySourcePath)Lib\**\*.pyc;
                                $(PySourcePath)Lib\**\*.pyo;
-                               $(PySourcePath)Lib\site-packages\README;
                                @(ExcludeFolders->'$(PySourcePath)%(Identity)\*');
                                @(ExcludeFolders->'$(PySourcePath)%(Identity)\**\*')">
             <SourceBase>$(PySourcePath)Lib</SourceBase>


### PR DESCRIPTION


<!-- gh-issue-number: gh-133626 -->
* Issue: gh-133626
<!-- /gh-issue-number -->
