### PR TITLE
gh-133713: Compare the `f->stackpointer` to the result of `_PyFrame_Stackbase(f)`

### DIFF
--- a/Include/internal/pycore_interpframe.h
+++ b/Include/internal/pycore_interpframe.h
@@ -48,13 +48,13 @@ static inline _PyStackRef *_PyFrame_Stackbase(_PyInterpreterFrame *f) {
 }
 
 static inline _PyStackRef _PyFrame_StackPeek(_PyInterpreterFrame *f) {
-    assert(f->stackpointer >  f->localsplus + _PyFrame_GetCode(f)->co_nlocalsplus);
+    assert(f->stackpointer > _PyFrame_Stackbase(f));
     assert(!PyStackRef_IsNull(f->stackpointer[-1]));
     return f->stackpointer[-1];
 }
 
 static inline _PyStackRef _PyFrame_StackPop(_PyInterpreterFrame *f) {
-    assert(f->stackpointer >  f->localsplus + _PyFrame_GetCode(f)->co_nlocalsplus);
+    assert(f->stackpointer > _PyFrame_Stackbase(f));
     f->stackpointer--;
     return *f->stackpointer;
 }


### PR DESCRIPTION
Compare the `f->stackpointer` to the result of the `_PyFrame_Stackbase(f)` in the `_PyFrame_StackPeek` and in the `_PyFrame_StackPop`

<!-- gh-issue-number: gh-133713 -->
* Issue: gh-133713
<!-- /gh-issue-number -->
