### PR TITLE
gh-133677: Skip test in test_asyncio if not UTF-8

### DIFF
--- a/Lib/test/test_asyncio/test_tools.py
+++ b/Lib/test/test_asyncio/test_tools.py
@@ -771,6 +771,7 @@ class TestAsyncioToolsBasic(unittest.TestCase):
         cycles = ctx.exception.cycles
         self.assertTrue(any(set(c) == {1, 2, 3} for c in cycles))
 
+    @unittest.skipIf(locale.getpreferredencoding().lower() != 'utf-8', 'test requires utf-8')
     def test_table_output_format(self):
         input_ = [(1, [(1, "Task-A", [[["foo"], 2]]), (2, "Task-B", [])])]
         table = tools.build_task_table(input_)

--- a/Lib/test/test_asyncio/test_tools.py
+++ b/Lib/test/test_asyncio/test_tools.py
@@ -1,7 +1,7 @@
 import unittest
 
 from asyncio import tools
-
+import locale
 
 # mock output of get_all_awaited_by function.
 TEST_INPUTS_TREE = [


### PR DESCRIPTION
gh-133677

#133677 Fixes the ``test_asyncio`` fail but not running it if the encoding is not UTF-8

similar to #133706 but for ``test_asyncio``