### PR TITLE
Docs: remove link elements in builders other than HTML

### DIFF
--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -29,7 +29,7 @@
     {% if builder == "html" and enable_analytics %}
       <script defer data-domain="docs.python.org" src="https://analytics.python.org/js/script.outbound-links.js"></script>
     {% endif %}
-    <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html">
+    {% if builder == "html" %}<link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html">{% endif %}
     {% if builder != "htmlhelp" %}
       {% if pagename == 'whatsnew/changelog' and not embedded %}
       <script type="text/javascript" src="{{ pathto('_static/changelog_search.js', 1) }}"></script>{% endif %}

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -26,11 +26,11 @@
 {% endblock %}
 
 {% block extrahead %}
-    {% if builder == "html" and enable_analytics %}
+    {% if builder == "html" %}
+      {% if enable_analytics %}
       <script defer data-domain="docs.python.org" src="https://analytics.python.org/js/script.outbound-links.js"></script>
-    {% endif %}
-    {% if builder == "html" %}<link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html">{% endif %}
-    {% if builder != "htmlhelp" %}
+      {% endif %}
+      <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html">
       {% if pagename == 'whatsnew/changelog' and not embedded %}
       <script type="text/javascript" src="{{ pathto('_static/changelog_search.js', 1) }}"></script>{% endif %}
     {% endif %}


### PR DESCRIPTION
Follow-up for https://github.com/python/cpython/pull/132220 (https://github.com/python/cpython/pull/132220#issuecomment-2862578140). This change fixes EPUB builds. `epubcheck` after this change results in 25 fewer errors. Could we please backport it for supported versions?

Before:
```shell
% uvx epubcheck 2>&1 >/dev/null | grep 'FATAL'
FATAL - RSC-016 - Python.epub/about.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/bugs.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/abstract.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/allocation.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/apiabiversion.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/arg.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/bool.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/buffer.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/bytearray.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/bytes.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/call.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/capsule.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/cell.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/code.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/codec.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/complex.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/concrete.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/c-api/contextvars.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/contents.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/copyright.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/download.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/glossary.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/index.xhtml:26:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/license.xhtml:27:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
FATAL - RSC-016 - Python.epub/py-modindex.xhtml:29:5 - Fatal Error while parsing file: The element type "link" must be terminated by the matching end-tag "</link>".
```

<img width="1136" alt="Zrzut ekranu 2025-05-9 o 01 11 57" src="https://github.com/user-attachments/assets/9a26047b-06d5-4b30-92dd-3dccf54b0819" />

After:

<img width="1136" alt="Zrzut ekranu 2025-05-9 o 03 34 10" src="https://github.com/user-attachments/assets/f817a5ed-eada-40fd-9139-7333511c5bac" />

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133720.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->