### PR TITLE
gh-132983: Don't allow trailer data in ZstdFile

### DIFF
--- a/Lib/compression/zstd/_zstdfile.py
+++ b/Lib/compression/zstd/_zstdfile.py
@@ -91,7 +91,6 @@ class ZstdFile(_streams.BaseStream):
             raw = _streams.DecompressReader(
                 self._fp,
                 ZstdDecompressor,
-                trailing_error=ZstdError,
                 zstd_dict=zstd_dict,
                 options=options,
             )

--- a/Lib/test/test_zstd.py
+++ b/Lib/test/test_zstd.py
@@ -1682,10 +1682,10 @@ class FileTestCase(unittest.TestCase):
 
         # Trailing data isn't a valid compressed stream
         with ZstdFile(io.BytesIO(self.FRAME_42 + b'12345')) as f:
-            self.assertEqual(f.read(), self.DECOMPRESSED_42)
+            self.assertRaises(ZstdError, f.read)
 
         with ZstdFile(io.BytesIO(SKIPPABLE_FRAME + b'12345')) as f:
-            self.assertEqual(f.read(), b'')
+            self.assertRaises(ZstdError, f.read)
 
     def test_read_truncated(self):
         # Drop stream epilogue: 4 bytes checksum


### PR DESCRIPTION
We previously made sure that an exception is raised when decompressing trailer data with `decompress`:
```py
>>> from compression.zstd import compress, decompress
>>> invalid = compress(b'xxx') + b'yyy'
>>> decompress(invalid)
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    decompress(invalid)
    ~~~~~~~~~~^^^^^^^^^
  File "/redacted/Lib/compression/zstd/__init__.py", line 157, in decompress
    results.append(decomp.decompress(data))
                   ~~~~~~~~~~~~~~~~~^^^^^^
_zstd.ZstdError: Unable to decompress zstd data: Unknown frame descriptor
```

_Indeed, [the Zstandard specification](https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frames) says “Zstandard compressed data is made of one or more frames”, and it does not say that random data can be added at the end._

However, this is not the case in `ZstdFile` / `zstd.open`:
```py
>>> from compression.zstd import ZstdFile
>>> from io import BytesIO
>>> ZstdFile(BytesIO(invalid)).read()
b'xxx'
```

After this PR, the last call becomes:
```py
>>> ZstdFile(BytesIO(invalid)).read()
Traceback (most recent call last):
  File "<python-input-5>", line 1, in <module>
    ZstdFile(BytesIO(invalid)).read()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/redacted/Lib/compression/zstd/_zstdfile.py", line 176, in read
    return self._buffer.read(size)
           ~~~~~~~~~~~~~~~~~^^^^^^
  File "/redacted/Lib/compression/_common/_streams.py", line 118, in readall
    while data := self.read(sys.maxsize):
                  ~~~~~~~~~^^^^^^^^^^^^^
  File "/redacted/Lib/compression/_common/_streams.py", line 91, in read
    data = self._decompressor.decompress(rawblock, size)
_zstd.ZstdError: Unable to decompress zstd data: Unknown frame descriptor
```

---

<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->
