### PR TITLE
Docs: Fix the `_PyGenObject_HEAD` reference in the `InternalDocs/generators.md`

### DIFF
--- a/InternalDocs/generators.md
+++ b/InternalDocs/generators.md
@@ -30,7 +30,7 @@ The `frame` of a generator is embedded in the generator object struct as a
 [`_PyInterpreterFrame`](frames.md) (see `_PyGenObject_HEAD` in
 [`pycore_interpframe_structs.h`](../Include/internal/pycore_interpframe_structs.h)).
 This means that we can get the frame from the generator or the generator
-from the frame (see `_PyGen_GetGeneratorFromFrame` in the same file).
+from the frame (see `_PyGen_GetGeneratorFromFrame` in [`pycore_genobject.h`](../Include/internal/pycore_genobject.h)).
 Other fields of the generator struct include metadata (such as the name of
 the generator function) and runtime state information (such as whether its
 frame is executing, suspended, cleared, etc.).

--- a/InternalDocs/generators.md
+++ b/InternalDocs/generators.md
@@ -28,7 +28,7 @@ interpreter state.
 
 The `frame` of a generator is embedded in the generator object struct as a
 [`_PyInterpreterFrame`](frames.md) (see `_PyGenObject_HEAD` in
-[`pycore_genobject.h`](../Include/internal/pycore_genobject.h)).
+[`pycore_interpframe_structs.h`](../Include/internal/pycore_interpframe_structs.h)).
 This means that we can get the frame from the generator or the generator
 from the frame (see `_PyGen_GetGeneratorFromFrame` in the same file).
 Other fields of the generator struct include metadata (such as the name of


### PR DESCRIPTION
Fix the `_PyGenObject_HEAD` reference in the `generators.md` file.