### PR TITLE
gh-133644: update `Py_InteractiveFlag` deprecation notice

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -197,7 +197,7 @@ to 1 and ``-bb`` sets :c:data:`Py_BytesWarningFlag` to 2.
 
    Set by the :option:`-i` option.
 
-   .. deprecated:: 3.12
+   .. deprecated-removed:: 3.12 3.15
 
 .. c:var:: int Py_IsolatedFlag
 


### PR DESCRIPTION
Note that `Py_UTF8Mode` is not documented at all but it's mentioned sometimes.

See https://github.com/python/cpython/pull/133654#issuecomment-2866474956.

<!-- gh-issue-number: gh-133644 -->
* Issue: gh-133644
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133749.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->