### PR TITLE
[3.13] gh-133439: Fix dot commands with trailing spaces are mistaken for multi-line sqlite statements in the sqlite3 command-line interface (GH-133440)

### DIFF
--- a/Lib/sqlite3/__main__.py
+++ b/Lib/sqlite3/__main__.py
@@ -48,17 +48,25 @@ class SqliteInteractiveConsole(InteractiveConsole):
         Return True if more input is needed; buffering is done automatically.
         Return False is input is a complete statement ready for execution.
         """
-        match source:
-            case ".version":
-                print(f"{sqlite3.sqlite_version}")
-            case ".help":
-                print("Enter SQL code and press enter.")
-            case ".quit":
-                sys.exit(0)
-            case _:
-                if not sqlite3.complete_statement(source):
-                    return True
-                execute(self._cur, source)
+        if not source or source.isspace():
+            return False
+        if source[0] == ".":
+            match source[1:].strip():
+                case "version":
+                    print(f"{sqlite3.sqlite_version}")
+                case "help":
+                    print("Enter SQL code and press enter.")
+                case "quit":
+                    sys.exit(0)
+                case "":
+                    pass
+                case _ as unknown:
+                    self.write("Error: unknown command or invalid arguments:"
+                               f'  "{unknown}".\n')
+        else:
+            if not sqlite3.complete_statement(source):
+                return True
+            execute(self._cur, source)
         return False
 
 

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -111,14 +111,14 @@ class InteractiveSession(unittest.TestCase):
     def test_interact_empty_source(self):
         out, err = self.run_cli(commands=("", " "))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertEndsWith(out, self.PS1)
+        self.assertTrue(out.endswith(self.PS1))
         self.assertEqual(out.count(self.PS1), 3)
         self.assertEqual(out.count(self.PS2), 0)
 
     def test_interact_dot_commands_unknown(self):
         out, err = self.run_cli(commands=(".unknown_command", ))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertEndsWith(out, self.PS1)
+        self.assertTrue(out.endswith(self.PS1))
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
         self.assertIn("Error", err)
@@ -128,7 +128,7 @@ class InteractiveSession(unittest.TestCase):
     def test_interact_dot_commands_empty(self):
         out, err = self.run_cli(commands=("."))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertEndsWith(out, self.PS1)
+        self.assertTrue(out.endswith(self.PS1))
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
 
@@ -136,7 +136,7 @@ class InteractiveSession(unittest.TestCase):
         out, err = self.run_cli(commands=(".version ", ". version"))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertEqual(out.count(sqlite3.sqlite_version + "\n"), 2)
-        self.assertEndsWith(out, self.PS1)
+        self.assertTrue(out.endswith(self.PS1))
         self.assertEqual(out.count(self.PS1), 3)
         self.assertEqual(out.count(self.PS2), 0)
 

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -4,10 +4,11 @@ import unittest
 
 from sqlite3.__main__ import main as cli
 from test.support.os_helper import TESTFN, unlink
+from test.support.testcase import ExtraAssertions
 from test.support import captured_stdout, captured_stderr, captured_stdin
 
 
-class CommandLineInterface(unittest.TestCase):
+class CommandLineInterface(unittest.TestCase, ExtraAssertions):
 
     def _do_test(self, *args, expect_success=True):
         with (
@@ -88,14 +89,14 @@ class InteractiveSession(unittest.TestCase):
         out, err = self.run_cli()
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertTrue(out.endswith(self.PS1))
+        self.assertEndsWith(out, self.PS1)
         self.assertEqual(out.count(self.PS1), 1)
         self.assertEqual(out.count(self.PS2), 0)
 
     def test_interact_quit(self):
         out, err = self.run_cli(commands=(".quit",))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertTrue(out.endswith(self.PS1))
+        self.assertEndsWith(out, self.PS1)
         self.assertEqual(out.count(self.PS1), 1)
         self.assertEqual(out.count(self.PS2), 0)
 
@@ -103,7 +104,7 @@ class InteractiveSession(unittest.TestCase):
         out, err = self.run_cli(commands=(".version",))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertIn(sqlite3.sqlite_version + "\n", out)
-        self.assertTrue(out.endswith(self.PS1))
+        self.assertEndsWith(out, self.PS1)
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
         self.assertIn(sqlite3.sqlite_version, out)
@@ -144,14 +145,14 @@ class InteractiveSession(unittest.TestCase):
         out, err = self.run_cli(commands=("SELECT 1;",))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertIn("(1,)\n", out)
-        self.assertTrue(out.endswith(self.PS1))
+        self.assertEndsWith(out, self.PS1)
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
 
     def test_interact_incomplete_multiline_sql(self):
         out, err = self.run_cli(commands=("SELECT 1",))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertTrue(out.endswith(self.PS2))
+        self.assertEndsWith(out, self.PS2)
         self.assertEqual(out.count(self.PS1), 1)
         self.assertEqual(out.count(self.PS2), 1)
 
@@ -160,7 +161,7 @@ class InteractiveSession(unittest.TestCase):
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertIn(self.PS2, out)
         self.assertIn("(1,)\n", out)
-        self.assertTrue(out.endswith(self.PS1))
+        self.assertEndsWith(out, self.PS1)
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 1)
 
@@ -168,7 +169,7 @@ class InteractiveSession(unittest.TestCase):
         out, err = self.run_cli(commands=("sel;",))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertIn("OperationalError (SQLITE_ERROR)", err)
-        self.assertTrue(out.endswith(self.PS1))
+        self.assertEndsWith(out, self.PS1)
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
 
@@ -177,7 +178,7 @@ class InteractiveSession(unittest.TestCase):
 
         out, err = self.run_cli(TESTFN, commands=("CREATE TABLE t(t);",))
         self.assertIn(TESTFN, err)
-        self.assertTrue(out.endswith(self.PS1))
+        self.assertEndsWith(out, self.PS1)
 
         out, _ = self.run_cli(TESTFN, commands=("SELECT count(t) FROM t;",))
         self.assertIn("(0,)\n", out)

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -111,14 +111,14 @@ class InteractiveSession(unittest.TestCase):
     def test_interact_empty_source(self):
         out, err = self.run_cli(commands=("", " "))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertTrue(out.endswith(self.PS1))
+        self.assertEndsWith(out, self.PS1)
         self.assertEqual(out.count(self.PS1), 3)
         self.assertEqual(out.count(self.PS2), 0)
 
     def test_interact_dot_commands_unknown(self):
         out, err = self.run_cli(commands=(".unknown_command", ))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertTrue(out.endswith(self.PS1))
+        self.assertEndsWith(out, self.PS1)
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
         self.assertIn("Error", err)
@@ -128,7 +128,7 @@ class InteractiveSession(unittest.TestCase):
     def test_interact_dot_commands_empty(self):
         out, err = self.run_cli(commands=("."))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertTrue(out.endswith(self.PS1))
+        self.assertEndsWith(out, self.PS1)
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
 
@@ -136,7 +136,7 @@ class InteractiveSession(unittest.TestCase):
         out, err = self.run_cli(commands=(".version ", ". version"))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertEqual(out.count(sqlite3.sqlite_version + "\n"), 2)
-        self.assertTrue(out.endswith(self.PS1))
+        self.assertEndsWith(out, self.PS1)
         self.assertEqual(out.count(self.PS1), 3)
         self.assertEqual(out.count(self.PS2), 0)
 

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -62,7 +62,7 @@ class CommandLineInterface(unittest.TestCase, ExtraAssertions):
         self.assertIn("(0,)", out)
 
 
-class InteractiveSession(unittest.TestCase):
+class InteractiveSession(unittest.TestCase, ExtraAssertions):
     MEMORY_DB_MSG = "Connected to a transient in-memory database"
     PS1 = "sqlite> "
     PS2 = "... "

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -89,14 +89,14 @@ class InteractiveSession(unittest.TestCase, ExtraAssertions):
         out, err = self.run_cli()
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertEndsWith(out, self.PS1)
+        self.assertTrue(out.endswith(self.PS1))
         self.assertEqual(out.count(self.PS1), 1)
         self.assertEqual(out.count(self.PS2), 0)
 
     def test_interact_quit(self):
         out, err = self.run_cli(commands=(".quit",))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertEndsWith(out, self.PS1)
+        self.assertTrue(out.endswith(self.PS1))
         self.assertEqual(out.count(self.PS1), 1)
         self.assertEqual(out.count(self.PS2), 0)
 
@@ -104,7 +104,7 @@ class InteractiveSession(unittest.TestCase, ExtraAssertions):
         out, err = self.run_cli(commands=(".version",))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertIn(sqlite3.sqlite_version + "\n", out)
-        self.assertEndsWith(out, self.PS1)
+        self.assertTrue(out.endswith(self.PS1))
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
         self.assertIn(sqlite3.sqlite_version, out)
@@ -145,14 +145,14 @@ class InteractiveSession(unittest.TestCase, ExtraAssertions):
         out, err = self.run_cli(commands=("SELECT 1;",))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertIn("(1,)\n", out)
-        self.assertEndsWith(out, self.PS1)
+        self.assertTrue(out.endswith(self.PS1))
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
 
     def test_interact_incomplete_multiline_sql(self):
         out, err = self.run_cli(commands=("SELECT 1",))
         self.assertIn(self.MEMORY_DB_MSG, err)
-        self.assertEndsWith(out, self.PS2)
+        self.assertTrue(out.endswith(self.PS2))
         self.assertEqual(out.count(self.PS1), 1)
         self.assertEqual(out.count(self.PS2), 1)
 
@@ -161,7 +161,7 @@ class InteractiveSession(unittest.TestCase, ExtraAssertions):
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertIn(self.PS2, out)
         self.assertIn("(1,)\n", out)
-        self.assertEndsWith(out, self.PS1)
+        self.assertTrue(out.endswith(self.PS1))
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 1)
 
@@ -169,7 +169,7 @@ class InteractiveSession(unittest.TestCase, ExtraAssertions):
         out, err = self.run_cli(commands=("sel;",))
         self.assertIn(self.MEMORY_DB_MSG, err)
         self.assertIn("OperationalError (SQLITE_ERROR)", err)
-        self.assertEndsWith(out, self.PS1)
+        self.assertTrue(out.endswith(self.PS1))
         self.assertEqual(out.count(self.PS1), 2)
         self.assertEqual(out.count(self.PS2), 0)
 
@@ -178,7 +178,7 @@ class InteractiveSession(unittest.TestCase, ExtraAssertions):
 
         out, err = self.run_cli(TESTFN, commands=("CREATE TABLE t(t);",))
         self.assertIn(TESTFN, err)
-        self.assertEndsWith(out, self.PS1)
+        self.assertTrue(out.endswith(self.PS1))
 
         out, _ = self.run_cli(TESTFN, commands=("SELECT count(t) FROM t;",))
         self.assertIn("(0,)\n", out)

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -8,7 +8,7 @@ from test.support.testcase import ExtraAssertions
 from test.support import captured_stdout, captured_stderr, captured_stdin
 
 
-class CommandLineInterface(unittest.TestCase, ExtraAssertions):
+class CommandLineInterface(unittest.TestCase):
 
     def _do_test(self, *args, expect_success=True):
         with (

--- a/Lib/test/test_sqlite3/test_cli.py
+++ b/Lib/test/test_sqlite3/test_cli.py
@@ -108,6 +108,38 @@ class InteractiveSession(unittest.TestCase):
         self.assertEqual(out.count(self.PS2), 0)
         self.assertIn(sqlite3.sqlite_version, out)
 
+    def test_interact_empty_source(self):
+        out, err = self.run_cli(commands=("", " "))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 3)
+        self.assertEqual(out.count(self.PS2), 0)
+
+    def test_interact_dot_commands_unknown(self):
+        out, err = self.run_cli(commands=(".unknown_command", ))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 2)
+        self.assertEqual(out.count(self.PS2), 0)
+        self.assertIn("Error", err)
+        # test "unknown_command" is pointed out in the error message
+        self.assertIn("unknown_command", err)
+
+    def test_interact_dot_commands_empty(self):
+        out, err = self.run_cli(commands=("."))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 2)
+        self.assertEqual(out.count(self.PS2), 0)
+
+    def test_interact_dot_commands_with_whitespaces(self):
+        out, err = self.run_cli(commands=(".version ", ". version"))
+        self.assertIn(self.MEMORY_DB_MSG, err)
+        self.assertEqual(out.count(sqlite3.sqlite_version + "\n"), 2)
+        self.assertEndsWith(out, self.PS1)
+        self.assertEqual(out.count(self.PS1), 3)
+        self.assertEqual(out.count(self.PS2), 0)
+
     def test_interact_valid_sql(self):
         out, err = self.run_cli(commands=("SELECT 1;",))
         self.assertIn(self.MEMORY_DB_MSG, err)

--- a/Misc/NEWS.d/next/Library/2025-05-05-22-11-24.gh-issue-133439.LpmyFz.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-05-22-11-24.gh-issue-133439.LpmyFz.rst
@@ -1,0 +1,2 @@
+Fix dot commands with trailing spaces are mistaken for multi-line SQL
+statements in the sqlite3 command-line interface.


### PR DESCRIPTION
(cherry picked from commit https://github.com/python/cpython/commit/ebd4881db2e8448b238d8ca2f6fcf331826132dd)

<!-- gh-issue-number: gh-133439 -->
* Issue: gh-133439
<!-- /gh-issue-number -->
