### PR TITLE
gh-133741: Fix _can_strace(): check --trace option

### DIFF
--- a/Lib/test/support/strace_helper.py
+++ b/Lib/test/support/strace_helper.py
@@ -178,7 +178,10 @@ def get_syscalls(code, strace_flags, prelude="", cleanup="",
 # Moderately expensive (spawns a subprocess), so share results when possible.
 @cache
 def _can_strace():
-    res = strace_python("import sys; sys.exit(0)", [], check=False)
+    res = strace_python("import sys; sys.exit(0)",
+                        # --trace option needs strace 5.5 (gh-133741)
+                        ["--trace=%process"],
+                        check=False)
     if res.strace_returncode == 0 and res.python_returncode == 0:
         assert res.events(), "Should have parsed multiple calls"
         return True


### PR DESCRIPTION
The --trace option needs strace 5.5 or newer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133741 -->
* Issue: gh-133741
<!-- /gh-issue-number -->
