### PR TITLE
Fix a typo in Misc/NEWS.d/3.140a1.rst

### DIFF
--- a/Misc/NEWS.d/3.14.0a1.rst
+++ b/Misc/NEWS.d/3.14.0a1.rst
@@ -1033,7 +1033,7 @@ retrieve the spec information.
 .. nonce: s3vKql
 .. section: Library
 
-:mod:`argparse` vim supports abbreviated single-dash long options separated
+:mod:`argparse` supports abbreviated single-dash long options separated
 by ``=`` from its value.
 
 ..


### PR DESCRIPTION
Removed the extra "vim" which is irrelevant to that news item. (The developer guide says typo fixes don't require an issue to be created, so I make this PR directly.)