### PR TITLE
GH-132983: PEP 7 and Argument Clinic changes for zstd

### DIFF
--- a/Lib/compression/zstd/__init__.py
+++ b/Lib/compression/zstd/__init__.py
@@ -71,7 +71,7 @@ def get_frame_info(frame_buffer):
     the frame may or may not need a dictionary to be decoded,
     and the ID of such a dictionary is not specified.
     """
-    return FrameInfo(*_zstd._get_frame_info(frame_buffer))
+    return FrameInfo(*_zstd.get_frame_info(frame_buffer))
 
 
 def train_dict(samples, dict_size):
@@ -91,7 +91,7 @@ def train_dict(samples, dict_size):
     chunk_sizes = tuple(_nbytes(sample) for sample in samples)
     if not chunks:
         raise ValueError("samples contained no data; can't train dictionary.")
-    dict_content = _zstd._train_dict(chunks, chunk_sizes, dict_size)
+    dict_content = _zstd.train_dict(chunks, chunk_sizes, dict_size)
     return ZstdDict(dict_content)
 
 
@@ -127,7 +127,7 @@ def finalize_dict(zstd_dict, /, samples, dict_size, level):
     if not chunks:
         raise ValueError("The samples are empty content, can't finalize the"
                          "dictionary.")
-    dict_content = _zstd._finalize_dict(zstd_dict.dict_content,
+    dict_content = _zstd.finalize_dict(zstd_dict.dict_content,
                                         chunks, chunk_sizes,
                                         dict_size, level)
     return ZstdDict(dict_content)
@@ -201,7 +201,7 @@ class CompressionParameter(enum.IntEnum):
 
         Both the lower and upper bounds are inclusive.
         """
-        return _zstd._get_param_bounds(self.value, is_compress=True)
+        return _zstd.get_param_bounds(self.value, is_compress=True)
 
 
 class DecompressionParameter(enum.IntEnum):
@@ -214,7 +214,7 @@ class DecompressionParameter(enum.IntEnum):
 
         Both the lower and upper bounds are inclusive.
         """
-        return _zstd._get_param_bounds(self.value, is_compress=False)
+        return _zstd.get_param_bounds(self.value, is_compress=False)
 
 
 class Strategy(enum.IntEnum):
@@ -237,4 +237,4 @@ class Strategy(enum.IntEnum):
 
 
 # Check validity of the CompressionParameter & DecompressionParameter types
-_zstd._set_parameter_types(CompressionParameter, DecompressionParameter)
+_zstd.set_parameter_types(CompressionParameter, DecompressionParameter)

--- a/Lib/test/test_zstd.py
+++ b/Lib/test/test_zstd.py
@@ -1174,43 +1174,43 @@ class ZstdDictTestCase(unittest.TestCase):
     def test_train_dict_c(self):
         # argument wrong type
         with self.assertRaises(TypeError):
-            _zstd._train_dict({}, (), 100)
+            _zstd.train_dict({}, (), 100)
         with self.assertRaises(TypeError):
-            _zstd._train_dict(b'', 99, 100)
+            _zstd.train_dict(b'', 99, 100)
         with self.assertRaises(TypeError):
-            _zstd._train_dict(b'', (), 100.1)
+            _zstd.train_dict(b'', (), 100.1)
 
         # size > size_t
         with self.assertRaises(ValueError):
-            _zstd._train_dict(b'', (2**64+1,), 100)
+            _zstd.train_dict(b'', (2**64+1,), 100)
 
         # dict_size <= 0
         with self.assertRaises(ValueError):
-            _zstd._train_dict(b'', (), 0)
+            _zstd.train_dict(b'', (), 0)
 
     def test_finalize_dict_c(self):
         with self.assertRaises(TypeError):
-            _zstd._finalize_dict(1, 2, 3, 4, 5)
+            _zstd.finalize_dict(1, 2, 3, 4, 5)
 
         # argument wrong type
         with self.assertRaises(TypeError):
-            _zstd._finalize_dict({}, b'', (), 100, 5)
+            _zstd.finalize_dict({}, b'', (), 100, 5)
         with self.assertRaises(TypeError):
-            _zstd._finalize_dict(TRAINED_DICT.dict_content, {}, (), 100, 5)
+            _zstd.finalize_dict(TRAINED_DICT.dict_content, {}, (), 100, 5)
         with self.assertRaises(TypeError):
-            _zstd._finalize_dict(TRAINED_DICT.dict_content, b'', 99, 100, 5)
+            _zstd.finalize_dict(TRAINED_DICT.dict_content, b'', 99, 100, 5)
         with self.assertRaises(TypeError):
-            _zstd._finalize_dict(TRAINED_DICT.dict_content, b'', (), 100.1, 5)
+            _zstd.finalize_dict(TRAINED_DICT.dict_content, b'', (), 100.1, 5)
         with self.assertRaises(TypeError):
-            _zstd._finalize_dict(TRAINED_DICT.dict_content, b'', (), 100, 5.1)
+            _zstd.finalize_dict(TRAINED_DICT.dict_content, b'', (), 100, 5.1)
 
         # size > size_t
         with self.assertRaises(ValueError):
-            _zstd._finalize_dict(TRAINED_DICT.dict_content, b'', (2**64+1,), 100, 5)
+            _zstd.finalize_dict(TRAINED_DICT.dict_content, b'', (2**64+1,), 100, 5)
 
         # dict_size <= 0
         with self.assertRaises(ValueError):
-            _zstd._finalize_dict(TRAINED_DICT.dict_content, b'', (), 0, 5)
+            _zstd.finalize_dict(TRAINED_DICT.dict_content, b'', (), 0, 5)
 
     def test_train_buffer_protocol_samples(self):
         def _nbytes(dat):
@@ -1232,19 +1232,19 @@ class ZstdDictTestCase(unittest.TestCase):
         # wrong size list
         with self.assertRaisesRegex(ValueError,
                 "The samples size tuple doesn't match the concatenation's size"):
-            _zstd._train_dict(concatenation, tuple(wrong_size_lst), 100*_1K)
+            _zstd.train_dict(concatenation, tuple(wrong_size_lst), 100*_1K)
 
         # correct size list
-        _zstd._train_dict(concatenation, tuple(correct_size_lst), 3*_1K)
+        _zstd.train_dict(concatenation, tuple(correct_size_lst), 3*_1K)
 
         # wrong size list
         with self.assertRaisesRegex(ValueError,
                 "The samples size tuple doesn't match the concatenation's size"):
-            _zstd._finalize_dict(TRAINED_DICT.dict_content,
+            _zstd.finalize_dict(TRAINED_DICT.dict_content,
                                   concatenation, tuple(wrong_size_lst), 300*_1K, 5)
 
         # correct size list
-        _zstd._finalize_dict(TRAINED_DICT.dict_content,
+        _zstd.finalize_dict(TRAINED_DICT.dict_content,
                               concatenation, tuple(correct_size_lst), 300*_1K, 5)
 
     def test_as_prefix(self):

--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -173,7 +173,7 @@ get_zstd_state(PyObject *module)
 
 
 /*[clinic input]
-_zstd._train_dict
+_zstd.train_dict
 
     samples_bytes: PyBytesObject
         Concatenation of samples.
@@ -187,9 +187,9 @@ Internal function, train a zstd dictionary on sample data.
 [clinic start generated code]*/
 
 static PyObject *
-_zstd__train_dict_impl(PyObject *module, PyBytesObject *samples_bytes,
-                       PyObject *samples_sizes, Py_ssize_t dict_size)
-/*[clinic end generated code: output=b5b4f36347c0addd input=2dce5b57d63923e2]*/
+_zstd_train_dict_impl(PyObject *module, PyBytesObject *samples_bytes,
+                      PyObject *samples_sizes, Py_ssize_t dict_size)
+/*[clinic end generated code: output=8e87fe43935e8f77 input=70fcd8937f2528b6]*/
 {
     // TODO(emmatyping): The preamble and suffix to this function and _finalize_dict
     // are pretty similar. We should see if we can refactor them to share that code.
@@ -277,7 +277,7 @@ success:
 }
 
 /*[clinic input]
-_zstd._finalize_dict
+_zstd.finalize_dict
 
     custom_dict_bytes: PyBytesObject
         Custom dictionary content.
@@ -295,11 +295,11 @@ Internal function, finalize a zstd dictionary.
 [clinic start generated code]*/
 
 static PyObject *
-_zstd__finalize_dict_impl(PyObject *module, PyBytesObject *custom_dict_bytes,
-                          PyBytesObject *samples_bytes,
-                          PyObject *samples_sizes, Py_ssize_t dict_size,
-                          int compression_level)
-/*[clinic end generated code: output=5dc5b520fddba37f input=8afd42a249078460]*/
+_zstd_finalize_dict_impl(PyObject *module, PyBytesObject *custom_dict_bytes,
+                         PyBytesObject *samples_bytes,
+                         PyObject *samples_sizes, Py_ssize_t dict_size,
+                         int compression_level)
+/*[clinic end generated code: output=f91821ba5ae85bda input=130d1508adb55ba1]*/
 {
     Py_ssize_t chunks_number;
     size_t *chunk_sizes = NULL;
@@ -396,7 +396,7 @@ success:
 
 
 /*[clinic input]
-_zstd._get_param_bounds
+_zstd.get_param_bounds
 
     parameter: int
         The parameter to get bounds.
@@ -407,9 +407,8 @@ Internal function, get CompressionParameter/DecompressionParameter bounds.
 [clinic start generated code]*/
 
 static PyObject *
-_zstd__get_param_bounds_impl(PyObject *module, int parameter,
-                             int is_compress)
-/*[clinic end generated code: output=9892cd822f937e79 input=884cd1a01125267d]*/
+_zstd_get_param_bounds_impl(PyObject *module, int parameter, int is_compress)
+/*[clinic end generated code: output=4acf5a876f0620ca input=84e669591e487008]*/
 {
     ZSTD_bounds bound;
     if (is_compress) {
@@ -466,7 +465,7 @@ _zstd_get_frame_size_impl(PyObject *module, Py_buffer *frame_buffer)
 }
 
 /*[clinic input]
-_zstd._get_frame_info
+_zstd.get_frame_info
 
     frame_buffer: Py_buffer
         A bytes-like object, containing the header of a zstd frame.
@@ -475,8 +474,8 @@ Internal function, get zstd frame infomation from a frame header.
 [clinic start generated code]*/
 
 static PyObject *
-_zstd__get_frame_info_impl(PyObject *module, Py_buffer *frame_buffer)
-/*[clinic end generated code: output=5462855464ecdf81 input=67f1f8e4b7b89c4d]*/
+_zstd_get_frame_info_impl(PyObject *module, Py_buffer *frame_buffer)
+/*[clinic end generated code: output=56e033cf48001929 input=1816f14656b6aa22]*/
 {
     uint64_t decompressed_size;
     uint32_t dict_id;
@@ -508,7 +507,7 @@ _zstd__get_frame_info_impl(PyObject *module, Py_buffer *frame_buffer)
 }
 
 /*[clinic input]
-_zstd._set_parameter_types
+_zstd.set_parameter_types
 
     c_parameter_type: object(subclass_of='&PyType_Type')
         CompressionParameter IntEnum type object
@@ -519,9 +518,9 @@ Internal function, set CompressionParameter/DecompressionParameter types for val
 [clinic start generated code]*/
 
 static PyObject *
-_zstd__set_parameter_types_impl(PyObject *module, PyObject *c_parameter_type,
-                                PyObject *d_parameter_type)
-/*[clinic end generated code: output=a13d4890ccbd2873 input=4535545d903853d3]*/
+_zstd_set_parameter_types_impl(PyObject *module, PyObject *c_parameter_type,
+                               PyObject *d_parameter_type)
+/*[clinic end generated code: output=f3313b1294f19502 input=30402523871b8280]*/
 {
     _zstd_state* const mod_state = get_zstd_state(module);
 
@@ -544,14 +543,13 @@ _zstd__set_parameter_types_impl(PyObject *module, PyObject *c_parameter_type,
 }
 
 static PyMethodDef _zstd_methods[] = {
-    _ZSTD__TRAIN_DICT_METHODDEF
-    _ZSTD__FINALIZE_DICT_METHODDEF
-    _ZSTD__GET_PARAM_BOUNDS_METHODDEF
+    _ZSTD_TRAIN_DICT_METHODDEF
+    _ZSTD_FINALIZE_DICT_METHODDEF
+    _ZSTD_GET_PARAM_BOUNDS_METHODDEF
     _ZSTD_GET_FRAME_SIZE_METHODDEF
-    _ZSTD__GET_FRAME_INFO_METHODDEF
-    _ZSTD__SET_PARAMETER_TYPES_METHODDEF
-
-    {0}
+    _ZSTD_GET_FRAME_INFO_METHODDEF
+    _ZSTD_SET_PARAMETER_TYPES_METHODDEF
+    {NULL, NULL}
 };
 
 static int

--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -593,7 +593,7 @@ do {                                                                         \
     ADD_TYPE(mod_state->ZstdCompressor_type, zstd_compressor_type_spec);
     ADD_TYPE(mod_state->ZstdDecompressor_type, zstd_decompressor_type_spec);
     mod_state->ZstdError = PyErr_NewExceptionWithDoc(
-        "_zstd.ZstdError",
+        "compression.zstd.ZstdError",
         "An error occurred in the zstd library.",
         NULL, NULL);
     if (mod_state->ZstdError == NULL) {

--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -69,8 +69,7 @@ typedef struct {
     char parameter_name[32];
 } ParameterInfo;
 
-static const ParameterInfo cp_list[] =
-{
+static const ParameterInfo cp_list[] = {
     {ZSTD_c_compressionLevel, "compression_level"},
     {ZSTD_c_windowLog,        "window_log"},
     {ZSTD_c_hashLog,          "hash_log"},
@@ -95,8 +94,7 @@ static const ParameterInfo cp_list[] =
     {ZSTD_c_overlapLog,       "overlap_log"}
 };
 
-static const ParameterInfo dp_list[] =
-{
+static const ParameterInfo dp_list[] = {
     {ZSTD_d_windowLogMax, "window_log_max"}
 };
 
@@ -730,14 +728,14 @@ static struct PyModuleDef_Slot _zstd_slots[] = {
 };
 
 struct PyModuleDef _zstdmodule = {
-    PyModuleDef_HEAD_INIT,
+    .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "_zstd",
     .m_size = sizeof(_zstd_state),
     .m_slots = _zstd_slots,
     .m_methods = _zstd_methods,
     .m_traverse = _zstd_traverse,
     .m_clear = _zstd_clear,
-    .m_free = _zstd_free
+    .m_free = _zstd_free,
 };
 
 PyMODINIT_FUNC

--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -730,6 +730,7 @@ static struct PyModuleDef_Slot _zstd_slots[] = {
 struct PyModuleDef _zstdmodule = {
     .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "_zstd",
+    .m_doc = "Implementation module for Zstandard compression.",
     .m_size = sizeof(_zstd_state),
     .m_slots = _zstd_slots,
     .m_methods = _zstd_methods,

--- a/Modules/_zstd/_zstdmodule.h
+++ b/Modules/_zstd/_zstdmodule.h
@@ -20,7 +20,8 @@ extern PyModuleDef _zstdmodule;
 
 /* For clinic type calculations */
 static inline _zstd_state *
-get_zstd_state_from_type(PyTypeObject *type) {
+get_zstd_state_from_type(PyTypeObject *type)
+{
     PyObject *module = PyType_GetModuleByDef(type, &_zstdmodule);
     if (module == NULL) {
         return NULL;
@@ -149,7 +150,8 @@ typedef enum {
 } dictionary_type;
 
 static inline int
-mt_continue_should_break(ZSTD_inBuffer *in, ZSTD_outBuffer *out) {
+mt_continue_should_break(ZSTD_inBuffer *in, ZSTD_outBuffer *out)
+{
     return in->size == in->pos && out->size != out->pos;
 }
 
@@ -163,13 +165,3 @@ set_parameter_error(const _zstd_state* const state, int is_compress,
                     int key_v, int value_v);
 
 static const char init_twice_msg[] = "__init__ method is called twice.";
-
-extern PyObject *
-decompress_impl(ZstdDecompressor *self, ZSTD_inBuffer *in,
-                Py_ssize_t max_length,
-                Py_ssize_t initial_size,
-                decompress_type type);
-
-extern PyObject *
-compress_impl(ZstdCompressor *self, Py_buffer *data,
-              ZSTD_EndDirective end_directive);

--- a/Modules/_zstd/clinic/_zstdmodule.c.h
+++ b/Modules/_zstd/clinic/_zstdmodule.c.h
@@ -9,8 +9,8 @@ preserve
 #include "pycore_abstract.h"      // _PyNumber_Index()
 #include "pycore_modsupport.h"    // _PyArg_CheckPositional()
 
-PyDoc_STRVAR(_zstd__train_dict__doc__,
-"_train_dict($module, samples_bytes, samples_sizes, dict_size, /)\n"
+PyDoc_STRVAR(_zstd_train_dict__doc__,
+"train_dict($module, samples_bytes, samples_sizes, dict_size, /)\n"
 "--\n"
 "\n"
 "Internal function, train a zstd dictionary on sample data.\n"
@@ -22,31 +22,31 @@ PyDoc_STRVAR(_zstd__train_dict__doc__,
 "  dict_size\n"
 "    The size of the dictionary.");
 
-#define _ZSTD__TRAIN_DICT_METHODDEF    \
-    {"_train_dict", _PyCFunction_CAST(_zstd__train_dict), METH_FASTCALL, _zstd__train_dict__doc__},
+#define _ZSTD_TRAIN_DICT_METHODDEF    \
+    {"train_dict", _PyCFunction_CAST(_zstd_train_dict), METH_FASTCALL, _zstd_train_dict__doc__},
 
 static PyObject *
-_zstd__train_dict_impl(PyObject *module, PyBytesObject *samples_bytes,
-                       PyObject *samples_sizes, Py_ssize_t dict_size);
+_zstd_train_dict_impl(PyObject *module, PyBytesObject *samples_bytes,
+                      PyObject *samples_sizes, Py_ssize_t dict_size);
 
 static PyObject *
-_zstd__train_dict(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+_zstd_train_dict(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyBytesObject *samples_bytes;
     PyObject *samples_sizes;
     Py_ssize_t dict_size;
 
-    if (!_PyArg_CheckPositional("_train_dict", nargs, 3, 3)) {
+    if (!_PyArg_CheckPositional("train_dict", nargs, 3, 3)) {
         goto exit;
     }
     if (!PyBytes_Check(args[0])) {
-        _PyArg_BadArgument("_train_dict", "argument 1", "bytes", args[0]);
+        _PyArg_BadArgument("train_dict", "argument 1", "bytes", args[0]);
         goto exit;
     }
     samples_bytes = (PyBytesObject *)args[0];
     if (!PyTuple_Check(args[1])) {
-        _PyArg_BadArgument("_train_dict", "argument 2", "tuple", args[1]);
+        _PyArg_BadArgument("train_dict", "argument 2", "tuple", args[1]);
         goto exit;
     }
     samples_sizes = args[1];
@@ -62,15 +62,15 @@ _zstd__train_dict(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
         }
         dict_size = ival;
     }
-    return_value = _zstd__train_dict_impl(module, samples_bytes, samples_sizes, dict_size);
+    return_value = _zstd_train_dict_impl(module, samples_bytes, samples_sizes, dict_size);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(_zstd__finalize_dict__doc__,
-"_finalize_dict($module, custom_dict_bytes, samples_bytes,\n"
-"               samples_sizes, dict_size, compression_level, /)\n"
+PyDoc_STRVAR(_zstd_finalize_dict__doc__,
+"finalize_dict($module, custom_dict_bytes, samples_bytes, samples_sizes,\n"
+"              dict_size, compression_level, /)\n"
 "--\n"
 "\n"
 "Internal function, finalize a zstd dictionary.\n"
@@ -86,17 +86,17 @@ PyDoc_STRVAR(_zstd__finalize_dict__doc__,
 "  compression_level\n"
 "    Optimize for a specific zstd compression level, 0 means default.");
 
-#define _ZSTD__FINALIZE_DICT_METHODDEF    \
-    {"_finalize_dict", _PyCFunction_CAST(_zstd__finalize_dict), METH_FASTCALL, _zstd__finalize_dict__doc__},
+#define _ZSTD_FINALIZE_DICT_METHODDEF    \
+    {"finalize_dict", _PyCFunction_CAST(_zstd_finalize_dict), METH_FASTCALL, _zstd_finalize_dict__doc__},
 
 static PyObject *
-_zstd__finalize_dict_impl(PyObject *module, PyBytesObject *custom_dict_bytes,
-                          PyBytesObject *samples_bytes,
-                          PyObject *samples_sizes, Py_ssize_t dict_size,
-                          int compression_level);
+_zstd_finalize_dict_impl(PyObject *module, PyBytesObject *custom_dict_bytes,
+                         PyBytesObject *samples_bytes,
+                         PyObject *samples_sizes, Py_ssize_t dict_size,
+                         int compression_level);
 
 static PyObject *
-_zstd__finalize_dict(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+_zstd_finalize_dict(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyBytesObject *custom_dict_bytes;
@@ -105,21 +105,21 @@ _zstd__finalize_dict(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     Py_ssize_t dict_size;
     int compression_level;
 
-    if (!_PyArg_CheckPositional("_finalize_dict", nargs, 5, 5)) {
+    if (!_PyArg_CheckPositional("finalize_dict", nargs, 5, 5)) {
         goto exit;
     }
     if (!PyBytes_Check(args[0])) {
-        _PyArg_BadArgument("_finalize_dict", "argument 1", "bytes", args[0]);
+        _PyArg_BadArgument("finalize_dict", "argument 1", "bytes", args[0]);
         goto exit;
     }
     custom_dict_bytes = (PyBytesObject *)args[0];
     if (!PyBytes_Check(args[1])) {
-        _PyArg_BadArgument("_finalize_dict", "argument 2", "bytes", args[1]);
+        _PyArg_BadArgument("finalize_dict", "argument 2", "bytes", args[1]);
         goto exit;
     }
     samples_bytes = (PyBytesObject *)args[1];
     if (!PyTuple_Check(args[2])) {
-        _PyArg_BadArgument("_finalize_dict", "argument 3", "tuple", args[2]);
+        _PyArg_BadArgument("finalize_dict", "argument 3", "tuple", args[2]);
         goto exit;
     }
     samples_sizes = args[2];
@@ -139,14 +139,14 @@ _zstd__finalize_dict(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     if (compression_level == -1 && PyErr_Occurred()) {
         goto exit;
     }
-    return_value = _zstd__finalize_dict_impl(module, custom_dict_bytes, samples_bytes, samples_sizes, dict_size, compression_level);
+    return_value = _zstd_finalize_dict_impl(module, custom_dict_bytes, samples_bytes, samples_sizes, dict_size, compression_level);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(_zstd__get_param_bounds__doc__,
-"_get_param_bounds($module, /, parameter, is_compress)\n"
+PyDoc_STRVAR(_zstd_get_param_bounds__doc__,
+"get_param_bounds($module, /, parameter, is_compress)\n"
 "--\n"
 "\n"
 "Internal function, get CompressionParameter/DecompressionParameter bounds.\n"
@@ -156,15 +156,14 @@ PyDoc_STRVAR(_zstd__get_param_bounds__doc__,
 "  is_compress\n"
 "    True for CompressionParameter, False for DecompressionParameter.");
 
-#define _ZSTD__GET_PARAM_BOUNDS_METHODDEF    \
-    {"_get_param_bounds", _PyCFunction_CAST(_zstd__get_param_bounds), METH_FASTCALL|METH_KEYWORDS, _zstd__get_param_bounds__doc__},
+#define _ZSTD_GET_PARAM_BOUNDS_METHODDEF    \
+    {"get_param_bounds", _PyCFunction_CAST(_zstd_get_param_bounds), METH_FASTCALL|METH_KEYWORDS, _zstd_get_param_bounds__doc__},
 
 static PyObject *
-_zstd__get_param_bounds_impl(PyObject *module, int parameter,
-                             int is_compress);
+_zstd_get_param_bounds_impl(PyObject *module, int parameter, int is_compress);
 
 static PyObject *
-_zstd__get_param_bounds(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+_zstd_get_param_bounds(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
@@ -190,7 +189,7 @@ _zstd__get_param_bounds(PyObject *module, PyObject *const *args, Py_ssize_t narg
     static const char * const _keywords[] = {"parameter", "is_compress", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
-        .fname = "_get_param_bounds",
+        .fname = "get_param_bounds",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
@@ -211,7 +210,7 @@ _zstd__get_param_bounds(PyObject *module, PyObject *const *args, Py_ssize_t narg
     if (is_compress < 0) {
         goto exit;
     }
-    return_value = _zstd__get_param_bounds_impl(module, parameter, is_compress);
+    return_value = _zstd_get_param_bounds_impl(module, parameter, is_compress);
 
 exit:
     return return_value;
@@ -288,8 +287,8 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(_zstd__get_frame_info__doc__,
-"_get_frame_info($module, /, frame_buffer)\n"
+PyDoc_STRVAR(_zstd_get_frame_info__doc__,
+"get_frame_info($module, /, frame_buffer)\n"
 "--\n"
 "\n"
 "Internal function, get zstd frame infomation from a frame header.\n"
@@ -297,14 +296,14 @@ PyDoc_STRVAR(_zstd__get_frame_info__doc__,
 "  frame_buffer\n"
 "    A bytes-like object, containing the header of a zstd frame.");
 
-#define _ZSTD__GET_FRAME_INFO_METHODDEF    \
-    {"_get_frame_info", _PyCFunction_CAST(_zstd__get_frame_info), METH_FASTCALL|METH_KEYWORDS, _zstd__get_frame_info__doc__},
+#define _ZSTD_GET_FRAME_INFO_METHODDEF    \
+    {"get_frame_info", _PyCFunction_CAST(_zstd_get_frame_info), METH_FASTCALL|METH_KEYWORDS, _zstd_get_frame_info__doc__},
 
 static PyObject *
-_zstd__get_frame_info_impl(PyObject *module, Py_buffer *frame_buffer);
+_zstd_get_frame_info_impl(PyObject *module, Py_buffer *frame_buffer);
 
 static PyObject *
-_zstd__get_frame_info(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+_zstd_get_frame_info(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
@@ -330,7 +329,7 @@ _zstd__get_frame_info(PyObject *module, PyObject *const *args, Py_ssize_t nargs,
     static const char * const _keywords[] = {"frame_buffer", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
-        .fname = "_get_frame_info",
+        .fname = "get_frame_info",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
@@ -345,7 +344,7 @@ _zstd__get_frame_info(PyObject *module, PyObject *const *args, Py_ssize_t nargs,
     if (PyObject_GetBuffer(args[0], &frame_buffer, PyBUF_SIMPLE) != 0) {
         goto exit;
     }
-    return_value = _zstd__get_frame_info_impl(module, &frame_buffer);
+    return_value = _zstd_get_frame_info_impl(module, &frame_buffer);
 
 exit:
     /* Cleanup for frame_buffer */
@@ -356,8 +355,8 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(_zstd__set_parameter_types__doc__,
-"_set_parameter_types($module, /, c_parameter_type, d_parameter_type)\n"
+PyDoc_STRVAR(_zstd_set_parameter_types__doc__,
+"set_parameter_types($module, /, c_parameter_type, d_parameter_type)\n"
 "--\n"
 "\n"
 "Internal function, set CompressionParameter/DecompressionParameter types for validity check.\n"
@@ -367,15 +366,15 @@ PyDoc_STRVAR(_zstd__set_parameter_types__doc__,
 "  d_parameter_type\n"
 "    DecompressionParameter IntEnum type object");
 
-#define _ZSTD__SET_PARAMETER_TYPES_METHODDEF    \
-    {"_set_parameter_types", _PyCFunction_CAST(_zstd__set_parameter_types), METH_FASTCALL|METH_KEYWORDS, _zstd__set_parameter_types__doc__},
+#define _ZSTD_SET_PARAMETER_TYPES_METHODDEF    \
+    {"set_parameter_types", _PyCFunction_CAST(_zstd_set_parameter_types), METH_FASTCALL|METH_KEYWORDS, _zstd_set_parameter_types__doc__},
 
 static PyObject *
-_zstd__set_parameter_types_impl(PyObject *module, PyObject *c_parameter_type,
-                                PyObject *d_parameter_type);
+_zstd_set_parameter_types_impl(PyObject *module, PyObject *c_parameter_type,
+                               PyObject *d_parameter_type);
 
 static PyObject *
-_zstd__set_parameter_types(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+_zstd_set_parameter_types(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
     #if defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_MODULE)
@@ -401,7 +400,7 @@ _zstd__set_parameter_types(PyObject *module, PyObject *const *args, Py_ssize_t n
     static const char * const _keywords[] = {"c_parameter_type", "d_parameter_type", NULL};
     static _PyArg_Parser _parser = {
         .keywords = _keywords,
-        .fname = "_set_parameter_types",
+        .fname = "set_parameter_types",
         .kwtuple = KWTUPLE,
     };
     #undef KWTUPLE
@@ -415,18 +414,18 @@ _zstd__set_parameter_types(PyObject *module, PyObject *const *args, Py_ssize_t n
         goto exit;
     }
     if (!PyObject_TypeCheck(args[0], &PyType_Type)) {
-        _PyArg_BadArgument("_set_parameter_types", "argument 'c_parameter_type'", (&PyType_Type)->tp_name, args[0]);
+        _PyArg_BadArgument("set_parameter_types", "argument 'c_parameter_type'", (&PyType_Type)->tp_name, args[0]);
         goto exit;
     }
     c_parameter_type = args[0];
     if (!PyObject_TypeCheck(args[1], &PyType_Type)) {
-        _PyArg_BadArgument("_set_parameter_types", "argument 'd_parameter_type'", (&PyType_Type)->tp_name, args[1]);
+        _PyArg_BadArgument("set_parameter_types", "argument 'd_parameter_type'", (&PyType_Type)->tp_name, args[1]);
         goto exit;
     }
     d_parameter_type = args[1];
-    return_value = _zstd__set_parameter_types_impl(module, c_parameter_type, d_parameter_type);
+    return_value = _zstd_set_parameter_types_impl(module, c_parameter_type, d_parameter_type);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=189c462236a7096c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8445b658dcdcbb9c input=a9049054013a1b77]*/

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -198,7 +198,8 @@ success:
 }
 
 static int
-_zstd_load_c_dict(ZstdCompressor *self, PyObject *dict) {
+_zstd_load_c_dict(ZstdCompressor *self, PyObject *dict)
+{
 
     size_t zstd_ret;
     _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
@@ -412,7 +413,7 @@ _zstd_ZstdCompressor___init___impl(ZstdCompressor *self, PyObject *level,
     return 0;
 }
 
-PyObject *
+static PyObject *
 compress_impl(ZstdCompressor *self, Py_buffer *data,
               ZSTD_EndDirective end_directive)
 {
@@ -667,7 +668,7 @@ PyDoc_STRVAR(ZstdCompressor_last_mode_doc,
 static PyMemberDef ZstdCompressor_members[] = {
     {"last_mode", Py_T_INT, offsetof(ZstdCompressor, last_mode),
         Py_READONLY, ZstdCompressor_last_mode_doc},
-    {0}
+    {NULL}
 };
 
 static int
@@ -695,7 +696,7 @@ static PyType_Slot zstdcompressor_slots[] = {
     {Py_tp_doc, (char*)_zstd_ZstdCompressor___init____doc__},
     {Py_tp_traverse,  ZstdCompressor_traverse},
     {Py_tp_clear, ZstdCompressor_clear},
-    {0}
+    {0, 0}
 };
 
 PyType_Spec zstd_compressor_type_spec = {

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -699,7 +699,7 @@ static PyType_Slot zstdcompressor_slots[] = {
 };
 
 PyType_Spec zstd_compressor_type_spec = {
-    .name = "_zstd.ZstdCompressor",
+    .name = "compression.zstd.ZstdCompressor",
     .basicsize = sizeof(ZstdCompressor),
     .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .slots = zstdcompressor_slots,

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -655,8 +655,7 @@ _zstd_ZstdCompressor_flush_impl(ZstdCompressor *self, int mode)
 static PyMethodDef ZstdCompressor_methods[] = {
     _ZSTD_ZSTDCOMPRESSOR_COMPRESS_METHODDEF
     _ZSTD_ZSTDCOMPRESSOR_FLUSH_METHODDEF
-
-    {0}
+    {NULL, NULL}
 };
 
 PyDoc_STRVAR(ZstdCompressor_last_mode_doc,

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -276,7 +276,7 @@ load:
     output stream: ====================|
                                        ^
 */
-PyObject *
+static PyObject *
 decompress_impl(ZstdDecompressor *self, ZSTD_inBuffer *in,
                 Py_ssize_t max_length,
                 Py_ssize_t initial_size,
@@ -374,7 +374,7 @@ error:
     return NULL;
 }
 
-void
+static void
 decompressor_reset_session(ZstdDecompressor *self,
                            decompress_type type)
 {
@@ -399,7 +399,7 @@ decompressor_reset_session(ZstdDecompressor *self,
     ZSTD_DCtx_reset(self->dctx, ZSTD_reset_session_only);
 }
 
-PyObject *
+static PyObject *
 stream_decompress(ZstdDecompressor *self, Py_buffer *data, Py_ssize_t max_length,
                   decompress_type type)
 {
@@ -823,17 +823,14 @@ PyDoc_STRVAR(ZstdDecompressor_needs_input_doc,
 static PyMemberDef ZstdDecompressor_members[] = {
     {"eof", Py_T_BOOL, offsetof(ZstdDecompressor, eof),
     Py_READONLY, ZstdDecompressor_eof_doc},
-
     {"needs_input", Py_T_BOOL, offsetof(ZstdDecompressor, needs_input),
     Py_READONLY, ZstdDecompressor_needs_input_doc},
-
-    {0}
+    {NULL}
 };
 
 static PyGetSetDef ZstdDecompressor_getset[] = {
     _ZSTD_ZSTDDECOMPRESSOR_UNUSED_DATA_GETSETDEF
-
-    {0}
+    {NULL}
 };
 
 static int
@@ -863,7 +860,7 @@ static PyType_Slot ZstdDecompressor_slots[] = {
     {Py_tp_doc, (char*)_zstd_ZstdDecompressor___init____doc__},
     {Py_tp_traverse, ZstdDecompressor_traverse},
     {Py_tp_clear, ZstdDecompressor_clear},
-    {0}
+    {0, 0}
 };
 
 PyType_Spec zstd_decompressor_type_spec = {

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -808,8 +808,7 @@ _zstd_ZstdDecompressor_decompress_impl(ZstdDecompressor *self,
 
 static PyMethodDef ZstdDecompressor_methods[] = {
     _ZSTD_ZSTDDECOMPRESSOR_DECOMPRESS_METHODDEF
-
-    {0}
+    {NULL, NULL}
 };
 
 PyDoc_STRVAR(ZstdDecompressor_eof_doc,

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -867,7 +867,7 @@ static PyType_Slot ZstdDecompressor_slots[] = {
 };
 
 PyType_Spec zstd_decompressor_type_spec = {
-    .name = "_zstd.ZstdDecompressor",
+    .name = "compression.zstd.ZstdDecompressor",
     .basicsize = sizeof(ZstdDecompressor),
     .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .slots = ZstdDecompressor_slots,

--- a/Modules/_zstd/zstddict.c
+++ b/Modules/_zstd/zstddict.c
@@ -279,7 +279,7 @@ static PyType_Slot zstddict_slots[] = {
 };
 
 PyType_Spec zstd_dict_type_spec = {
-    .name = "_zstd.ZstdDict",
+    .name = "compression.zstd.ZstdDict",
     .basicsize = sizeof(ZstdDict),
     .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .slots = zstddict_slots,

--- a/Modules/_zstd/zstddict.c
+++ b/Modules/_zstd/zstddict.c
@@ -161,7 +161,7 @@ ZstdDict_str(PyObject *ob)
 static PyMemberDef ZstdDict_members[] = {
     {"dict_id", Py_T_UINT, offsetof(ZstdDict, dict_id), Py_READONLY, ZstdDict_dictid_doc},
     {"dict_content", Py_T_OBJECT_EX, offsetof(ZstdDict, dict_content), Py_READONLY, ZstdDict_dictcontent_doc},
-    {0}
+    {NULL}
 };
 
 /*[clinic input]
@@ -231,12 +231,9 @@ _zstd_ZstdDict_as_prefix_get_impl(ZstdDict *self)
 
 static PyGetSetDef ZstdDict_getset[] = {
     _ZSTD_ZSTDDICT_AS_DIGESTED_DICT_GETSETDEF
-
     _ZSTD_ZSTDDICT_AS_UNDIGESTED_DICT_GETSETDEF
-
     _ZSTD_ZSTDDICT_AS_PREFIX_GETSETDEF
-
-    {0}
+    {NULL}
 };
 
 static Py_ssize_t
@@ -275,7 +272,7 @@ static PyType_Slot zstddict_slots[] = {
     {Py_sq_length, ZstdDict_length},
     {Py_tp_traverse, ZstdDict_traverse},
     {Py_tp_clear, ZstdDict_clear},
-    {0}
+    {0, 0}
 };
 
 PyType_Spec zstd_dict_type_spec = {


### PR DESCRIPTION
* Remove leading underscore from module-level functions
* Fix ``__module__`` for zstd types implemented in C
* PEP 7 style conformance
* Make more things static


<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->
