### PR TITLE
gh-133818: remove `typing.no_type_check_decorator`

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.15.rst
+++ b/Doc/deprecations/pending-removal-in-3.15.rst
@@ -85,7 +85,7 @@ Pending removal in Python 3.15
     has been deprecated since Python 3.13.
     Use the class-based syntax or the functional syntax instead.
 
-  * The :func:`typing.no_type_check_decorator` decorator function
+  * The :func:`!typing.no_type_check_decorator` decorator function
     has been deprecated since Python 3.13.
     After eight years in the :mod:`typing` module,
     it has yet to be supported by any major type checker.

--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -3257,16 +3257,6 @@ Functions and decorators
 
    ``@no_type_check`` mutates the decorated object in place.
 
-.. decorator:: no_type_check_decorator
-
-   Decorator to give another decorator the :func:`no_type_check` effect.
-
-   This wraps the decorator with something that wraps the decorated
-   function in :func:`no_type_check`.
-
-   .. deprecated-removed:: 3.13 3.15
-      No type checker ever added support for ``@no_type_check_decorator``. It
-      is therefore deprecated, and will be removed in Python 3.15.
 
 .. decorator:: override
 
@@ -4081,7 +4071,7 @@ convenience. This is subject to change, and not all deprecations are listed.
      - 3.12
      - Undecided
      - :pep:`695`
-   * - :func:`@typing.no_type_check_decorator <no_type_check_decorator>`
+   * - :func:`!@typing.no_type_check_decorator <no_type_check_decorator>`
      - 3.13
      - 3.15
      - :gh:`106309`

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1979,7 +1979,7 @@ New Deprecations
     use ``class TD(TypedDict): pass`` or ``TD = TypedDict("TD", {})``.
     (Contributed by Alex Waygood in :gh:`105566` and :gh:`105570`.)
 
-  * Deprecate the :func:`typing.no_type_check_decorator` decorator function,
+  * Deprecate the :func:`!typing.no_type_check_decorator` decorator function,
     to be removed in in Python 3.15.
     After eight years in the :mod:`typing` module,
     it has yet to be supported by any major type checker.

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -118,10 +118,12 @@ Deprecated
 Removed
 =======
 
-module_name
------------
+typing
+------
 
-* TODO
+* Remove deprecated decorator :func:`!typing.no_type_check_decorator`
+  as it has yet to be supported by any major type checker.
+  (Contributed by Bénédikt Tran in :gh:`133818`.)
 
 
 Porting to Python 3.15

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -32,7 +32,7 @@ from typing import override
 from typing import is_typeddict, is_protocol
 from typing import reveal_type
 from typing import dataclass_transform
-from typing import no_type_check, no_type_check_decorator
+from typing import no_type_check
 from typing import Type
 from typing import NamedTuple, NotRequired, Required, ReadOnly, TypedDict
 from typing import IO, TextIO, BinaryIO
@@ -6272,35 +6272,6 @@ class NoTypeCheckTests(BaseTestCase):
         expected_result = {'foo': typing.ClassVar[int]}
         for clazz in [C, D, E, F]:
             self.assertEqual(get_type_hints(clazz), expected_result)
-
-    def test_meta_no_type_check(self):
-        depr_msg = (
-            "'typing.no_type_check_decorator' is deprecated "
-            "and slated for removal in Python 3.15"
-        )
-        with self.assertWarnsRegex(DeprecationWarning, depr_msg):
-            @no_type_check_decorator
-            def magic_decorator(func):
-                return func
-
-        self.assertEqual(magic_decorator.__name__, 'magic_decorator')
-
-        @magic_decorator
-        def foo(a: 'whatevers') -> {}:
-            pass
-
-        @magic_decorator
-        class C:
-            def foo(a: 'whatevers') -> {}:
-                pass
-
-        self.assertEqual(foo.__name__, 'foo')
-        th = get_type_hints(foo)
-        self.assertEqual(th, {})
-        cth = get_type_hints(C.foo)
-        self.assertEqual(cth, {})
-        ith = get_type_hints(C().foo)
-        self.assertEqual(ith, {})
 
 
 class InternalsTests(BaseTestCase):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -139,7 +139,6 @@ __all__ = [
     'Never',
     'NewType',
     'no_type_check',
-    'no_type_check_decorator',
     'NoDefault',
     'NoReturn',
     'NotRequired',
@@ -2549,23 +2548,6 @@ def no_type_check(arg):
     except TypeError:  # built-in classes
         pass
     return arg
-
-
-def no_type_check_decorator(decorator):
-    """Decorator to give another decorator the @no_type_check effect.
-
-    This wraps the decorator with something that wraps the decorated
-    function in @no_type_check.
-    """
-    import warnings
-    warnings._deprecated("typing.no_type_check_decorator", remove=(3, 15))
-    @functools.wraps(decorator)
-    def wrapped_decorator(*args, **kwds):
-        func = decorator(*args, **kwds)
-        func = no_type_check(func)
-        return func
-
-    return wrapped_decorator
 
 
 def _overload_dummy(*args, **kwds):

--- a/Misc/NEWS.d/3.13.0a1.rst
+++ b/Misc/NEWS.d/3.13.0a1.rst
@@ -3426,7 +3426,7 @@ This bug was introduced in Python 3.12.0 beta 1.
 .. nonce: hSlB17
 .. section: Library
 
-Deprecate :func:`typing.no_type_check_decorator`. No major type checker ever
+Deprecate :func:`!typing.no_type_check_decorator`. No major type checker ever
 added support for this decorator. Patch by Alex Waygood.
 
 ..

--- a/Misc/NEWS.d/next/Library/2025-05-10-11-49-12.gh-issue-133818.7mjPBT.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-10-11-49-12.gh-issue-133818.7mjPBT.rst
@@ -1,0 +1,2 @@
+Remove deprecated decorator :func:`!typing.no_type_check_decorator`. Patch
+by Bénédikt Tran.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133818 -->
* Issue: gh-133818
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133820.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->