### PR TITLE
gh-133829: Update zipimport example to not mention Python 2.3

### DIFF
--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -192,7 +192,7 @@ Here is an example that imports a module from a ZIP archive - note that the
    Archive:  example_archive.zip
      Length     Date   Time    Name
     --------    ----   ----    ----
-        8467  05-11-25 12:29   example.py
+        8467  01-01-00 12:30   example.py
     --------                   -------
         8467                   1 file
 

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -199,7 +199,8 @@ Here is an example that imports a module from a ZIP archive - note that the
 .. code-block:: pycon
 
    >>> import sys
-   >>> sys.path.insert(0, 'example_archive.zip')  # Add .zip file to front of path
+   >>> # Add the archive to the front of the module search path
+   >>> sys.path.insert(0, 'example_archive.zip')
    >>> import example
    >>> example.__file__
    'example_archive.zip/example.py'

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -188,6 +188,7 @@ Here is an example that imports a module from a ZIP archive - note that the
 
 .. code-block:: shell-session
 
+
    $ unzip -l example_archive.zip
    Archive:  example_archive.zip
      Length     Date   Time    Name

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -187,6 +187,7 @@ Here is an example that imports a module from a ZIP archive - note that the
 :mod:`zipimport` module is not explicitly used.
 
 .. code-block:: shell-session
+
    $ unzip -l example_archive.zip
    Archive:  example_archive.zip
      Length     Date   Time    Name

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -189,8 +189,8 @@ Here is an example that imports a module from a ZIP archive - note that the
 .. code-block:: python
 
    >>> import sys
-   >>> sys.path.insert(0, 'pip.pyz')  # Add .pyz file to front of path
-   >>> import pip
-   >>> pip.__file__
-   'pip.pyz/pip/__main__.py'
+   >>> sys.path.insert(0, 'example.zip')  # Add .zip file to front of path
+   >>> import example
+   >>> example.__file__
+   'example.zip/example/__main__.py'
 

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -186,18 +186,6 @@ Examples
 Here is an example that imports a module from a ZIP archive - note that the
 :mod:`zipimport` module is not explicitly used.
 
-.. code-block:: shell-session
-
-   $ unzip -l pip.pyz
-   Archive:  pip.pyz
-     Length     Date   Time    Name
-    --------    ----   ----    ----
-       32145  05-10-25 10:00   pip/__main__.py
-    --------                   -------
-       32145                   1 file
-
-Now for the Python:
-
 .. code-block:: python
 
    >>> import sys

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -197,7 +197,7 @@ Here is an example that imports a module from a ZIP archive - note that the
     --------                   -------
         8467                   1 file
 
-.. code-block:: python
+.. code-block:: pycon
 
    >>> import sys
    >>> sys.path.insert(0, 'example_archive.zip')  # Add .zip file to front of path

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -195,8 +195,12 @@ Here is an example that imports a module from a ZIP archive - note that the
        32145  05-10-25 10:00   pip/__main__.py
     --------                   -------
        32145                   1 file
+
+Now for the Python:
+
+.. code-block:: python
+
    $ ./python
-   Python 3.x
    >>> import sys
    >>> sys.path.insert(0, 'pip.pyz')  # Add .pyz file to front of path
    >>> import pip

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -188,7 +188,6 @@ Here is an example that imports a module from a ZIP archive - note that the
 
 .. code-block:: shell-session
 
-
    $ unzip -l example_archive.zip
    Archive:  example_archive.zip
      Length     Date   Time    Name

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -186,11 +186,20 @@ Examples
 Here is an example that imports a module from a ZIP archive - note that the
 :mod:`zipimport` module is not explicitly used.
 
+.. code-block:: shell-session
+   $ unzip -l example_archive.zip
+   Archive:  example.zip
+     Length     Date   Time    Name
+    --------    ----   ----    ----
+        8467  05-11-25 12:29   example.py
+    --------                   -------
+        8467                   1 file
+
 .. code-block:: python
 
    >>> import sys
-   >>> sys.path.insert(0, 'example.zip')  # Add .zip file to front of path
+   >>> sys.path.insert(0, 'example_archive.zip')  # Add .zip file to front of path
    >>> import example
    >>> example.__file__
-   'example.zip/example/__main__.py'
+   'example.zip/example.py'
 

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -200,7 +200,6 @@ Now for the Python:
 
 .. code-block:: python
 
-   $ ./python
    >>> import sys
    >>> sys.path.insert(0, 'pip.pyz')  # Add .pyz file to front of path
    >>> import pip

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -188,7 +188,7 @@ Here is an example that imports a module from a ZIP archive - note that the
 
 .. code-block:: shell-session
    $ unzip -l example_archive.zip
-   Archive:  example.zip
+   Archive:  example_archive.zip
      Length     Date   Time    Name
     --------    ----   ----    ----
         8467  05-11-25 12:29   example.py
@@ -201,5 +201,5 @@ Here is an example that imports a module from a ZIP archive - note that the
    >>> sys.path.insert(0, 'example_archive.zip')  # Add .zip file to front of path
    >>> import example
    >>> example.__file__
-   'example.zip/example.py'
+   'example_archive.zip/example.py'
 

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -188,17 +188,18 @@ Here is an example that imports a module from a ZIP archive - note that the
 
 .. code-block:: shell-session
 
-   $ unzip -l example.zip
-   Archive:  example.zip
+   $ unzip -l pip.pyz
+   Archive:  pip.pyz
      Length     Date   Time    Name
     --------    ----   ----    ----
-        8467  11-26-02 22:30   jwzthreading.py
+       32145  05-10-25 10:00   pip/__main__.py
     --------                   -------
-        8467                   1 file
+       32145                   1 file
    $ ./python
-   Python 2.3 (#1, Aug 1 2003, 19:54:32)
+   Python 3.x
    >>> import sys
-   >>> sys.path.insert(0, 'example.zip')  # Add .zip file to front of path
-   >>> import jwzthreading
-   >>> jwzthreading.__file__
-   'example.zip/jwzthreading.py'
+   >>> sys.path.insert(0, 'pip.pyz')  # Add .pyz file to front of path
+   >>> import pip
+   >>> pip.__file__
+   'pip.pyz/pip/__main__.py'
+


### PR DESCRIPTION
#133829 

Updates this zipimport example: https://docs.python.org/3.14/library/zipimport.html#examples which uses Python 2.3 to use 3.x and pip.pyz as the new example

This will close #133829 

Ready for review


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133835.org.readthedocs.build/en/133835/library/zipimport.html#examples

<!-- readthedocs-preview cpython-previews end -->