### PR TITLE
Add classmethod to setUpClass in test_pdb

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -4749,7 +4749,9 @@ class TestREPLSession(unittest.TestCase):
 @support.force_not_colorized_test_class
 @support.requires_subprocess()
 class PdbTestReadline(unittest.TestCase):
-    def setUpClass():
+
+    @classmethod
+    def setUpClass(cls):
         # Ensure that the readline module is loaded
         # If this fails, the test is skipped because SkipTest will be raised
         readline = import_module('readline')


### PR DESCRIPTION
There was a mistake in `PdbTestReadline` where `setUpClass` was not decorated with `classmethod` and it did not have any argument - which made it magically work in the wrong way. We'll just fix this. This is a test-only fix and it's trivial so I'll skip everything. Backporting is safe - maybe not necessary, but again it's test only and it's obviously more correct.