### PR TITLE
gh-133357: Add anti-regression test for caret location in error message

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -3271,6 +3271,21 @@ while 1:
         ]:
             self._check_error(f"x = {lhs_stmt} if 1 else {rhs_stmt}", msg)
 
+    def test_caret_location_invalid_star_expr(self):
+        # regression test for caret location, see #133357
+        with self.assertRaises(SyntaxError) as cm:
+            compile("A[*]", "<string>", "exec")
+        with self.assertRaises(SyntaxError) as cm2:
+            compile("A[*(1:2)] = 1", "<string>", "exec")
+        e = cm.exception
+        e2 = cm2.exception
+        self.assertEqual(e.msg, "Invalid star expression")
+        self.assertEqual(e.text.strip(), "A[*]")
+        self.assertEqual(e.offset, 4)
+        self.assertEqual(e2.msg, "Invalid star expression")
+        self.assertEqual(e2.text.strip(), "A[*(1:2)] = 1")
+        self.assertEqual(e2.offset, 6)
+
 def load_tests(loader, tests, pattern):
     tests.addTest(doctest.DocTestSuite())
     return tests


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
It was concluded that it will be kept as it is in https://github.com/python/cpython/pull/133455#issuecomment-2865931184.

To ensure it does not change again, let's actually test it.

<!-- gh-issue-number: gh-133357 -->
* Issue: gh-133357
<!-- /gh-issue-number -->
