### PR TITLE
[3.13] gh-133703: dict: fix calculate_log2_keysize() (GH-133809)

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1120,10 +1120,8 @@ class DictTest(unittest.TestCase):
         a = C()
         a.x = 1
         d = a.__dict__
-        before_resize = sys.getsizeof(d)
         d[2] = 2 # split table is resized to a generic combined table
 
-        self.assertGreater(sys.getsizeof(d), before_resize)
         self.assertEqual(list(d), ['x', 2])
 
     def test_iterator_pickling(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2025-05-10-17-12-27.gh-issue-133703.bVM-re.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-05-10-17-12-27.gh-issue-133703.bVM-re.rst
@@ -1,0 +1,1 @@
+Fix hashtable in dict can be bigger than intended in some situations.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -580,13 +580,13 @@ static inline uint8_t
 calculate_log2_keysize(Py_ssize_t minsize)
 {
 #if SIZEOF_LONG == SIZEOF_SIZE_T
-    minsize = (minsize | PyDict_MINSIZE) - 1;
-    return _Py_bit_length(minsize | (PyDict_MINSIZE-1));
+    minsize = Py_MAX(minsize, PyDict_MINSIZE);
+    return _Py_bit_length(minsize - 1);
 #elif defined(_MSC_VER)
-    // On 64bit Windows, sizeof(long) == 4.
-    minsize = (minsize | PyDict_MINSIZE) - 1;
+    // On 64bit Windows, sizeof(long) == 4. We cannot use _Py_bit_length.
+    minsize = Py_MAX(minsize, PyDict_MINSIZE);
     unsigned long msb;
-    _BitScanReverse64(&msb, (uint64_t)minsize);
+    _BitScanReverse64(&msb, (uint64_t)minsize - 1);
     return (uint8_t)(msb + 1);
 #else
     uint8_t log2_size;


### PR DESCRIPTION
(cherry picked from commit 92337f666e8a076a68305a8d6dc8bc9c095000e9)


<!-- gh-issue-number: gh-133703 -->
* Issue: gh-133703
<!-- /gh-issue-number -->
