### PR TITLE
gh-100926: use explicit stginfo lock for pointer cache 

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -578,14 +578,13 @@ _ctypes_CType_Type___sizeof___impl(PyObject *self, PyTypeObject *cls)
 
 /*[clinic input]
 @getter
-@critical_section
 _ctypes.CType_Type.__pointer_type__
 
 [clinic start generated code]*/
 
 static PyObject *
 _ctypes_CType_Type___pointer_type___get_impl(PyObject *self)
-/*[clinic end generated code: output=718c9ff10b2b0012 input=ff7498aa6edf487c]*/
+/*[clinic end generated code: output=718c9ff10b2b0012 input=ad12dc835943ceb8]*/
 {
     ctypes_state *st = get_module_state_by_def(Py_TYPE(self));
     StgInfo *info;
@@ -596,9 +595,12 @@ _ctypes_CType_Type___pointer_type___get_impl(PyObject *self)
         PyErr_Format(PyExc_TypeError, "%R must have storage info", self);
         return NULL;
     }
-
-    if (info->pointer_type) {
-        return Py_NewRef(info->pointer_type);
+    PyObject *pointer_type;
+    STGINFO_LOCK(info);
+    pointer_type = Py_XNewRef(info->pointer_type);
+    STGINFO_UNLOCK();
+    if (pointer_type) {
+        return pointer_type;
     }
 
     PyErr_Format(PyExc_AttributeError,
@@ -609,14 +611,13 @@ _ctypes_CType_Type___pointer_type___get_impl(PyObject *self)
 
 /*[clinic input]
 @setter
-@critical_section
 _ctypes.CType_Type.__pointer_type__
 
 [clinic start generated code]*/
 
 static int
 _ctypes_CType_Type___pointer_type___set_impl(PyObject *self, PyObject *value)
-/*[clinic end generated code: output=6259be8ea21693fa input=9b2dc2400c388982]*/
+/*[clinic end generated code: output=6259be8ea21693fa input=a05055fc7f4714b6]*/
 {
     ctypes_state *st = get_module_state_by_def(Py_TYPE(self));
     StgInfo *info;
@@ -627,8 +628,9 @@ _ctypes_CType_Type___pointer_type___set_impl(PyObject *self, PyObject *value)
         PyErr_Format(PyExc_TypeError, "%R must have storage info", self);
         return -1;
     }
-
+    STGINFO_LOCK(info);
     Py_XSETREF(info->pointer_type, Py_XNewRef(value));
+    STGINFO_UNLOCK();
     return 0;
 }
 

--- a/Modules/_ctypes/clinic/_ctypes.c.h
+++ b/Modules/_ctypes/clinic/_ctypes.c.h
@@ -47,13 +47,7 @@ _ctypes_CType_Type___pointer_type___get_impl(PyObject *self);
 static PyObject *
 _ctypes_CType_Type___pointer_type___get(PyObject *self, void *Py_UNUSED(context))
 {
-    PyObject *return_value = NULL;
-
-    Py_BEGIN_CRITICAL_SECTION(self);
-    return_value = _ctypes_CType_Type___pointer_type___get_impl(self);
-    Py_END_CRITICAL_SECTION();
-
-    return return_value;
+    return _ctypes_CType_Type___pointer_type___get_impl(self);
 }
 
 #if !defined(_ctypes_CType_Type___pointer_type___DOCSTR)
@@ -74,9 +68,7 @@ _ctypes_CType_Type___pointer_type___set(PyObject *self, PyObject *value, void *P
 {
     int return_value;
 
-    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ctypes_CType_Type___pointer_type___set_impl(self, value);
-    Py_END_CRITICAL_SECTION();
 
     return return_value;
 }
@@ -1050,4 +1042,4 @@ Simple_from_outparm(PyObject *self, PyTypeObject *cls, PyObject *const *args, Py
     }
     return Simple_from_outparm_impl(self, cls);
 }
-/*[clinic end generated code: output=f4bc2a77ec073b8a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=536c9bcf4e05913e input=a9049054013a1b77]*/


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This is a minor improvement to use explicit stginfo lock as the instance is not modified so holding critical section of object is not needed.

<!-- gh-issue-number: gh-100926 -->
* Issue: gh-100926
<!-- /gh-issue-number -->
