### PR TITLE
Exclude include in `reference/grammar.rst` in gettext builds

### DIFF
--- a/Doc/reference/grammar.rst
+++ b/Doc/reference/grammar.rst
@@ -18,7 +18,7 @@ required *not* to match).  We use the ``|`` separator to mean PEG's
 "ordered choice" (written as ``/`` in traditional PEG grammars). See
 :pep:`617` for more details on the grammar's syntax.
 
-.. only:: html or pdf or epub
+.. only:: not gettext
 
    .. literalinclude:: ../../Grammar/python.gram
      :language: peg

--- a/Doc/reference/grammar.rst
+++ b/Doc/reference/grammar.rst
@@ -18,5 +18,7 @@ required *not* to match).  We use the ``|`` separator to mean PEG's
 "ordered choice" (written as ``/`` in traditional PEG grammars). See
 :pep:`617` for more details on the grammar's syntax.
 
-.. literalinclude:: ../../Grammar/python.gram
-  :language: peg
+.. only:: html or pdf or epub
+
+   .. literalinclude:: ../../Grammar/python.gram
+     :language: peg

--- a/Doc/reference/grammar.rst
+++ b/Doc/reference/grammar.rst
@@ -18,7 +18,7 @@ required *not* to match).  We use the ``|`` separator to mean PEG's
 "ordered choice" (written as ``/`` in traditional PEG grammars). See
 :pep:`617` for more details on the grammar's syntax.
 
-.. only:: not gettext
+.. only:: html or latex or epub
 
    .. literalinclude:: ../../Grammar/python.gram
      :language: peg

--- a/Doc/reference/grammar.rst
+++ b/Doc/reference/grammar.rst
@@ -18,7 +18,7 @@ required *not* to match).  We use the ``|`` separator to mean PEG's
 "ordered choice" (written as ``/`` in traditional PEG grammars). See
 :pep:`617` for more details on the grammar's syntax.
 
-.. only:: html or latex or epub
+.. only:: html or latex or epub or text or texinfo
 
    .. literalinclude:: ../../Grammar/python.gram
      :language: peg


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
The include is too big (one string) and translations leave it untranslated.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133868.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->