### PR TITLE
gh-133873: remove mark interface for `wave.Wave_{read,write}` objects

### DIFF
--- a/Doc/deprecations/pending-removal-in-3.15.rst
+++ b/Doc/deprecations/pending-removal-in-3.15.rst
@@ -99,8 +99,7 @@ Pending removal in Python 3.15
 
 * :mod:`wave`:
 
-  * The :meth:`~wave.Wave_read.getmark`, :meth:`!setmark`,
-    and :meth:`~wave.Wave_read.getmarkers` methods of
+  * The ``getmark()``, ``setmark()`` and ``getmarkers()`` methods of
     the :class:`~wave.Wave_read` and :class:`~wave.Wave_write` classes
     have been deprecated since Python 3.13.
 

--- a/Doc/library/wave.rst
+++ b/Doc/library/wave.rst
@@ -123,26 +123,6 @@ Wave_read Objects
 
       Rewind the file pointer to the beginning of the audio stream.
 
-   The following two methods are defined for compatibility with the old :mod:`!aifc`
-   module, and don't do anything interesting.
-
-
-   .. method:: getmarkers()
-
-      Returns ``None``.
-
-      .. deprecated-removed:: 3.13 3.15
-         The method only existed for compatibility with the :mod:`!aifc` module
-         which has been removed in Python 3.13.
-
-
-   .. method:: getmark(id)
-
-      Raise an error.
-
-      .. deprecated-removed:: 3.13 3.15
-         The method only existed for compatibility with the :mod:`!aifc` module
-         which has been removed in Python 3.13.
 
    The following two methods define a term "position" which is compatible between
    them, and is otherwise implementation dependent.

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -1995,8 +1995,7 @@ New Deprecations
 
 * :mod:`wave`:
 
-  * Deprecate the :meth:`~wave.Wave_read.getmark`, :meth:`!setmark`,
-    and :meth:`~wave.Wave_read.getmarkers` methods of
+  * Deprecate the ``getmark()``, ``setmark()`` and ``getmarkers()`` methods of
     the :class:`~wave.Wave_read` and :class:`~wave.Wave_write` classes,
     to be removed in Python 3.15.
     (Contributed by Victor Stinner in :gh:`105096`.)

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -147,7 +147,7 @@ typing
 wave
 ----
 
-* The ``getmark()``, ``setmark()`` and ``getmarkers()`` methods of
+* Removed the ``getmark()``, ``setmark()`` and ``getmarkers()`` methods of
   the :class:`~wave.Wave_read` and :class:`~wave.Wave_write` classes.
   (Contributed by Bénédikt Tran in :gh:`133873`.)
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -147,8 +147,8 @@ typing
 wave
 ----
 
-* Removed the ``getmark()``, ``setmark()`` and ``getmarkers()`` methods of
-  the :class:`~wave.Wave_read` and :class:`~wave.Wave_write` classes.
+* Removed the ``getmark()``, ``setmark()`` and ``getmarkers()`` methods
+  of the :class:`~wave.Wave_read` and :class:`~wave.Wave_write` classes.
   (Contributed by Bénédikt Tran in :gh:`133873`.)
 
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -148,7 +148,8 @@ wave
 ----
 
 * Removed the ``getmark()``, ``setmark()`` and ``getmarkers()`` methods
-  of the :class:`~wave.Wave_read` and :class:`~wave.Wave_write` classes.
+  of the :class:`~wave.Wave_read` and :class:`~wave.Wave_write` classes,
+  which were deprecated since Python 3.13.
   (Contributed by Bénédikt Tran in :gh:`133873`.)
 
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -144,6 +144,14 @@ typing
   (Contributed by Bénédikt Tran in :gh:`133823`.)
 
 
+wave
+----
+
+* The ``getmark()``, ``setmark()`` and ``getmarkers()`` methods of
+  the :class:`~wave.Wave_read` and :class:`~wave.Wave_write` classes.
+  (Contributed by Bénédikt Tran in :gh:`133873`.)
+
+
 Porting to Python 3.15
 ======================
 

--- a/Lib/test/test_wave.py
+++ b/Lib/test/test_wave.py
@@ -136,32 +136,6 @@ class MiscTestCase(unittest.TestCase):
         not_exported = {'WAVE_FORMAT_PCM', 'WAVE_FORMAT_EXTENSIBLE', 'KSDATAFORMAT_SUBTYPE_PCM'}
         support.check__all__(self, wave, not_exported=not_exported)
 
-    def test_read_deprecations(self):
-        filename = support.findfile('pluck-pcm8.wav', subdir='audiodata')
-        with wave.open(filename) as reader:
-            with self.assertWarns(DeprecationWarning):
-                with self.assertRaises(wave.Error):
-                    reader.getmark('mark')
-            with self.assertWarns(DeprecationWarning):
-                self.assertIsNone(reader.getmarkers())
-
-    def test_write_deprecations(self):
-        with io.BytesIO(b'') as tmpfile:
-            with wave.open(tmpfile, 'wb') as writer:
-                writer.setnchannels(1)
-                writer.setsampwidth(1)
-                writer.setframerate(1)
-                writer.setcomptype('NONE', 'not compressed')
-
-                with self.assertWarns(DeprecationWarning):
-                    with self.assertRaises(wave.Error):
-                        writer.setmark(0, 0, 'mark')
-                with self.assertWarns(DeprecationWarning):
-                    with self.assertRaises(wave.Error):
-                        writer.getmark('mark')
-                with self.assertWarns(DeprecationWarning):
-                    self.assertIsNone(writer.getmarkers())
-
 
 class WaveLowLevelTest(unittest.TestCase):
 

--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -20,10 +20,6 @@ This returns an instance of a class with the following public methods:
                          compression type ('not compressed' linear samples)
       getparams()     -- returns a namedtuple consisting of all of the
                          above in the above order
-      getmarkers()    -- returns None (for compatibility with the
-                         old aifc module)
-      getmark(id)     -- raises an error since the mark does not
-                         exist (for compatibility with the old aifc module)
       readframes(n)   -- returns at most n frames of audio
       rewind()        -- rewind to the beginning of the audio stream
       setpos(pos)     -- seek to the specified position
@@ -341,16 +337,6 @@ class Wave_read:
                        self.getframerate(), self.getnframes(),
                        self.getcomptype(), self.getcompname())
 
-    def getmarkers(self):
-        import warnings
-        warnings._deprecated("Wave_read.getmarkers", remove=(3, 15))
-        return None
-
-    def getmark(self, id):
-        import warnings
-        warnings._deprecated("Wave_read.getmark", remove=(3, 15))
-        raise Error('no marks')
-
     def setpos(self, pos):
         if pos < 0 or pos > self._nframes:
             raise Error('position not in range')
@@ -550,21 +536,6 @@ class Wave_write:
             raise Error('not all parameters set')
         return _wave_params(self._nchannels, self._sampwidth, self._framerate,
               self._nframes, self._comptype, self._compname)
-
-    def setmark(self, id, pos, name):
-        import warnings
-        warnings._deprecated("Wave_write.setmark", remove=(3, 15))
-        raise Error('setmark() not supported')
-
-    def getmark(self, id):
-        import warnings
-        warnings._deprecated("Wave_write.getmark", remove=(3, 15))
-        raise Error('no marks')
-
-    def getmarkers(self):
-        import warnings
-        warnings._deprecated("Wave_write.getmarkers", remove=(3, 15))
-        return None
 
     def tell(self):
         return self._nframeswritten

--- a/Misc/NEWS.d/next/Library/2025-05-11-10-28-11.gh-issue-133873.H03nov.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-11-10-28-11.gh-issue-133873.H03nov.rst
@@ -1,0 +1,3 @@
+Remove the deprecated ``getmark()``, ``setmark()`` and ``getmarkers()``
+methods of the :class:`~wave.Wave_read` and :class:`~wave.Wave_write`
+classes. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-05-11-10-28-11.gh-issue-133873.H03nov.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-11-10-28-11.gh-issue-133873.H03nov.rst
@@ -1,3 +1,3 @@
 Remove the deprecated ``getmark()``, ``setmark()`` and ``getmarkers()``
 methods of the :class:`~wave.Wave_read` and :class:`~wave.Wave_write`
-classes. Patch by Bénédikt Tran.
+classes, which were deprecated since Python 3.13. Patch by Bénédikt Tran.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133873 -->
* Issue: gh-133873
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133874.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->