### PR TITLE
gh-133400: Fixed Ctrl+D (^D) behavior in :mod:`_pyrepl` module

### DIFF
--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -428,6 +428,9 @@ class delete(EditCommand):
             r.update_screen()
             r.console.finish()
             raise EOFError
+        elif "\n" in b and self.event[-1] == "\004":
+            self.finish = True
+
         for i in range(r.get_arg()):
             if r.pos != len(b):
                 del b[r.pos]

--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -420,16 +420,16 @@ class delete(EditCommand):
     def do(self) -> None:
         r = self.reader
         b = r.buffer
-        if (
-            r.pos == 0
-            and len(b) == 0  # this is something of a hack
-            and self.event[-1] == "\004"
-        ):
-            r.update_screen()
-            r.console.finish()
-            raise EOFError
-        elif b and b[-1].endswith('\n') and self.event[-1] == "\004":
-            self.finish = True
+        if self.event[-1] == "\004":
+            if b and b[-1].endswith("\n"):
+                self.finish = True
+            elif (
+                r.pos == 0
+                and len(b) == 0  # this is something of a hack
+            ):
+                r.update_screen()
+                r.console.finish()
+                raise EOFError
 
         for i in range(r.get_arg()):
             if r.pos != len(b):

--- a/Lib/_pyrepl/commands.py
+++ b/Lib/_pyrepl/commands.py
@@ -428,7 +428,7 @@ class delete(EditCommand):
             r.update_screen()
             r.console.finish()
             raise EOFError
-        elif "\n" in b and self.event[-1] == "\004":
+        elif b and b[-1].endswith('\n') and self.event[-1] == "\004":
             self.finish = True
 
         for i in range(r.get_arg()):

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1768,7 +1768,16 @@ class TestMain(ReplTestCase):
                     " outside of the Python REPL"
                 )
                 self.assertIn(hint, output)
+
 class TestPyReplCtrlD(TestCase):
+    """Test Ctrl+D behavior in _pyrepl to match old pre-3.13 REPL behavior.
+
+    Ctrl+D should:
+    - Exit on empty buffer
+    - Delete character when cursor is in middle of line
+    - Perform no operation when cursor is at end of line without newline
+    - Exit multiline mode when cursor is at end with trailing newline
+    """
     def prepare_reader(self, events):
         console = FakeConsole(events)
         config = ReadlineConfig(readline_completer=None)
@@ -1784,17 +1793,44 @@ class TestPyReplCtrlD(TestCase):
         with self.assertRaises(EOFError):
             multiline_input(reader)
 
-    def test_ctrl_d_multiline_mode(self):
-        """Test that pressing Ctrl+D in multiline mode exits multiline mode"""
+    def test_ctrl_d_multiline_with_new_line(self):
+        """Test that pressing Ctrl+D in multiline mode with trailing newline exits multiline mode"""
         events = itertools.chain(
-            code_to_events("def f():\n"),  # Enter multiline mode
+            code_to_events("def f():\n    pass\n"),  # Enter multiline mode with trailing newline
             [
                 Event(evt="key", data="\x04", raw=bytearray(b"\x04")),  # Ctrl+D
             ],
         )
-        reader = self.prepare_reader(events)
-        output = multiline_input(reader)
-        self.assertEqual(output, "def f():\n    ")  # Should return current input
+        reader, _ = handle_all_events(events)
+        self.assertTrue(reader.finished)
+        self.assertEqual("def f():\n    pass\n", "".join(reader.buffer))
+
+    def test_ctrl_d_multiline_middle_of_line(self):
+        """Test that pressing Ctrl+D in multiline mode with cursor in middle deletes character"""
+        events = itertools.chain(
+            code_to_events("def f():\n    hello world"),  # Enter multiline mode
+            [
+                Event(evt="key", data="left", raw=bytearray(b"\x1bOD"))
+            ] * 5,  # move cursor to 'w' in "world"
+            [
+                Event(evt="key", data="\x04", raw=bytearray(b"\x04"))
+            ], # Ctrl+D should delete 'w'
+        )
+        reader, _ = handle_all_events(events)
+        self.assertFalse(reader.finished)
+        self.assertEqual("def f():\n    hello orld", "".join(reader.buffer))
+
+    def test_ctrl_d_multiline_end_of_line_no_newline(self):
+        """Test that pressing Ctrl+D at end of line without newline performs no operation"""
+        events = itertools.chain(
+            code_to_events("def f():\n    hello"),  # Enter multiline mode, no trailing newline
+            [
+                Event(evt="key", data="\x04", raw=bytearray(b"\x04"))
+            ],  # Ctrl+D should be no-op
+        )
+        reader, _ = handle_all_events(events)
+        self.assertFalse(reader.finished)
+        self.assertEqual("def f():\n    hello", "".join(reader.buffer))
 
     def test_ctrl_d_single_line(self):
         """Test that pressing Ctrl+D in single line mode deletes current character"""

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-11-09-40-19.gh-issue-133400.zkWla8.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-11-09-40-19.gh-issue-133400.zkWla8.rst
@@ -1,0 +1,3 @@
+Fixed Ctrl+D (^D) behavior in _pyrepl module: Now properly exits multiline
+mode when pressed in multiline section. Added test cases to verify the
+behavior in both multiline and single line modes.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-11-09-40-19.gh-issue-133400.zkWla8.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-11-09-40-19.gh-issue-133400.zkWla8.rst
@@ -1,3 +1,1 @@
-Fixed Ctrl+D (^D) behavior in _pyrepl module: Now properly exits multiline
-mode when pressed in multiline section. Added test cases to verify the
-behavior in both multiline and single line modes.
+Fixed Ctrl+D (^D) behavior in _pyrepl module to match old pre-3.13 REPL behavior.


### PR DESCRIPTION

Fixed Ctrl+D (^D) behavior in :mod:`_pyrepl` module:
- Now properly exits multiline mode when pressed in multiline section
- Added test cases to verify the behavior in both multiline and single line modes

<!-- gh-issue-number: gh-133400 -->
* Issue: gh-133400
<!-- /gh-issue-number -->
