### PR TITLE
gh-133342: Remove `sym_is_const` and `sym_has_type`

### DIFF
--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -266,7 +266,6 @@ extern JitOptSymbol *_Py_uop_sym_new_type(
     JitOptContext *ctx, PyTypeObject *typ);
 extern JitOptSymbol *_Py_uop_sym_new_const(JitOptContext *ctx, PyObject *const_val);
 extern JitOptSymbol *_Py_uop_sym_new_null(JitOptContext *ctx);
-extern bool _Py_uop_sym_has_type(JitOptSymbol *sym);
 extern bool _Py_uop_sym_matches_type(JitOptSymbol *sym, PyTypeObject *typ);
 extern bool _Py_uop_sym_matches_type_version(JitOptSymbol *sym, unsigned int version);
 extern void _Py_uop_sym_set_null(JitOptContext *ctx, JitOptSymbol *sym);

--- a/Include/internal/pycore_optimizer.h
+++ b/Include/internal/pycore_optimizer.h
@@ -258,7 +258,6 @@ typedef struct _JitOptContext {
 
 extern bool _Py_uop_sym_is_null(JitOptSymbol *sym);
 extern bool _Py_uop_sym_is_not_null(JitOptSymbol *sym);
-extern bool _Py_uop_sym_is_const(JitOptContext *ctx, JitOptSymbol *sym);
 extern PyObject *_Py_uop_sym_get_const(JitOptContext *ctx, JitOptSymbol *sym);
 extern JitOptSymbol *_Py_uop_sym_new_unknown(JitOptContext *ctx);
 extern JitOptSymbol *_Py_uop_sym_new_not_null(JitOptContext *ctx);

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -316,7 +316,6 @@ remove_globals(_PyInterpreterFrame *frame, _PyUOpInstruction *buffer,
 
 /* Shortened forms for convenience, used in optimizer_bytecodes.c */
 #define sym_is_not_null _Py_uop_sym_is_not_null
-#define sym_is_const _Py_uop_sym_is_const
 #define sym_get_const _Py_uop_sym_get_const
 #define sym_new_unknown _Py_uop_sym_new_unknown
 #define sym_new_not_null _Py_uop_sym_new_not_null

--- a/Python/optimizer_analysis.c
+++ b/Python/optimizer_analysis.c
@@ -324,7 +324,6 @@ remove_globals(_PyInterpreterFrame *frame, _PyUOpInstruction *buffer,
 #define sym_is_null _Py_uop_sym_is_null
 #define sym_new_const _Py_uop_sym_new_const
 #define sym_new_null _Py_uop_sym_new_null
-#define sym_has_type _Py_uop_sym_has_type
 #define sym_get_type _Py_uop_sym_get_type
 #define sym_matches_type _Py_uop_sym_matches_type
 #define sym_matches_type_version _Py_uop_sym_matches_type_version

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -21,7 +21,6 @@ typedef struct _Py_UOpsAbstractFrame _Py_UOpsAbstractFrame;
 #define sym_matches_type _Py_uop_sym_matches_type
 #define sym_matches_type_version _Py_uop_sym_matches_type_version
 #define sym_get_type _Py_uop_sym_get_type
-#define sym_has_type _Py_uop_sym_has_type
 #define sym_set_null(SYM) _Py_uop_sym_set_null(ctx, SYM)
 #define sym_set_non_null(SYM) _Py_uop_sym_set_non_null(ctx, SYM)
 #define sym_set_type(SYM, TYPE) _Py_uop_sym_set_type(ctx, SYM, TYPE)
@@ -872,8 +871,9 @@ dummy_func(void) {
     }
 
     op(_CALL_TYPE_1, (unused, unused, arg -- res)) {
-        if (sym_has_type(arg)) {
-            res = sym_new_const(ctx, (PyObject *)sym_get_type(arg));
+        PyObject *type = (PyObject *)sym_get_type(arg);
+        if (type) {
+            res = sym_new_const(ctx, type);
         }
         else {
             res = sym_new_not_null(ctx);
@@ -914,7 +914,7 @@ dummy_func(void) {
             assert(value != NULL);
             eliminate_pop_guard(this_instr, !Py_IsNone(value));
         }
-        else if (sym_has_type(val)) {
+        else if (sym_get_type(val)) {
             assert(!sym_matches_type(val, &_PyNone_Type));
             eliminate_pop_guard(this_instr, true);
         }
@@ -927,7 +927,7 @@ dummy_func(void) {
             assert(value != NULL);
             eliminate_pop_guard(this_instr, Py_IsNone(value));
         }
-        else if (sym_has_type(val)) {
+        else if (sym_get_type(val)) {
             assert(!sym_matches_type(val, &_PyNone_Type));
             eliminate_pop_guard(this_instr, false);
         }

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -10,7 +10,6 @@ typedef struct _Py_UOpsAbstractFrame _Py_UOpsAbstractFrame;
 
 /* Shortened forms for convenience */
 #define sym_is_not_null _Py_uop_sym_is_not_null
-#define sym_is_const _Py_uop_sym_is_const
 #define sym_get_const _Py_uop_sym_get_const
 #define sym_new_unknown _Py_uop_sym_new_unknown
 #define sym_new_not_null _Py_uop_sym_new_not_null
@@ -184,7 +183,7 @@ dummy_func(void) {
                 // Case C:
                 res = sym_new_type(ctx, &PyFloat_Type);
             }
-            else if (!sym_is_const(ctx, rhs)) {
+            else if (!sym_get_const(ctx, rhs)) {
                 // Case A or B... can't know without the sign of the RHS:
                 res = sym_new_unknown(ctx);
             }
@@ -209,11 +208,12 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_ADD_INT, (left, right -- res)) {
-        if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-            assert(PyLong_CheckExact(sym_get_const(ctx, left)));
-            assert(PyLong_CheckExact(sym_get_const(ctx, right)));
-            PyObject *temp = _PyLong_Add((PyLongObject *)sym_get_const(ctx, left),
-                                         (PyLongObject *)sym_get_const(ctx, right));
+        PyLongObject *lhs = (PyLongObject *)sym_get_const(ctx, left);
+        PyLongObject *rhs = (PyLongObject *)sym_get_const(ctx, right);
+        if (lhs && rhs) {
+            assert(PyLong_CheckExact(lhs));
+            assert(PyLong_CheckExact(rhs));
+            PyObject *temp = _PyLong_Add(lhs, rhs);
             if (temp == NULL) {
                 goto error;
             }
@@ -228,11 +228,12 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_SUBTRACT_INT, (left, right -- res)) {
-        if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-            assert(PyLong_CheckExact(sym_get_const(ctx, left)));
-            assert(PyLong_CheckExact(sym_get_const(ctx, right)));
-            PyObject *temp = _PyLong_Subtract((PyLongObject *)sym_get_const(ctx, left),
-                                              (PyLongObject *)sym_get_const(ctx, right));
+        PyLongObject *lhs = (PyLongObject *)sym_get_const(ctx, left);
+        PyLongObject *rhs = (PyLongObject *)sym_get_const(ctx, right);
+        if (lhs && rhs) {
+            assert(PyLong_CheckExact(lhs));
+            assert(PyLong_CheckExact(rhs));
+            PyObject *temp = _PyLong_Subtract(lhs, rhs);
             if (temp == NULL) {
                 goto error;
             }
@@ -247,11 +248,12 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_MULTIPLY_INT, (left, right -- res)) {
-        if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-            assert(PyLong_CheckExact(sym_get_const(ctx, left)));
-            assert(PyLong_CheckExact(sym_get_const(ctx, right)));
-            PyObject *temp = _PyLong_Multiply((PyLongObject *)sym_get_const(ctx, left),
-                                              (PyLongObject *)sym_get_const(ctx, right));
+        PyLongObject *lhs = (PyLongObject *)sym_get_const(ctx, left);
+        PyLongObject *rhs = (PyLongObject *)sym_get_const(ctx, right);
+        if (lhs && rhs) {
+            assert(PyLong_CheckExact(lhs));
+            assert(PyLong_CheckExact(rhs));
+            PyObject *temp = _PyLong_Multiply(lhs, rhs);
             if (temp == NULL) {
                 goto error;
             }
@@ -266,12 +268,14 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_ADD_FLOAT, (left, right -- res)) {
-        if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-            assert(PyFloat_CheckExact(sym_get_const(ctx, left)));
-            assert(PyFloat_CheckExact(sym_get_const(ctx, right)));
+        PyObject *lhs = sym_get_const(ctx, left);
+        PyObject *rhs = sym_get_const(ctx, right);
+        if (lhs && rhs) {
+            assert(PyFloat_CheckExact(lhs));
+            assert(PyFloat_CheckExact(rhs));
             PyObject *temp = PyFloat_FromDouble(
-                PyFloat_AS_DOUBLE(sym_get_const(ctx, left)) +
-                PyFloat_AS_DOUBLE(sym_get_const(ctx, right)));
+                PyFloat_AS_DOUBLE(lhs) +
+                PyFloat_AS_DOUBLE(rhs));
             if (temp == NULL) {
                 goto error;
             }
@@ -286,12 +290,14 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_SUBTRACT_FLOAT, (left, right -- res)) {
-        if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-            assert(PyFloat_CheckExact(sym_get_const(ctx, left)));
-            assert(PyFloat_CheckExact(sym_get_const(ctx, right)));
+        PyObject *lhs = sym_get_const(ctx, left);
+        PyObject *rhs = sym_get_const(ctx, right);
+        if (lhs && rhs) {
+            assert(PyFloat_CheckExact(lhs));
+            assert(PyFloat_CheckExact(rhs));
             PyObject *temp = PyFloat_FromDouble(
-                PyFloat_AS_DOUBLE(sym_get_const(ctx, left)) -
-                PyFloat_AS_DOUBLE(sym_get_const(ctx, right)));
+                PyFloat_AS_DOUBLE(lhs) -
+                PyFloat_AS_DOUBLE(rhs));
             if (temp == NULL) {
                 goto error;
             }
@@ -306,12 +312,14 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_MULTIPLY_FLOAT, (left, right -- res)) {
-        if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-            assert(PyFloat_CheckExact(sym_get_const(ctx, left)));
-            assert(PyFloat_CheckExact(sym_get_const(ctx, right)));
+        PyObject *lhs = sym_get_const(ctx, left);
+        PyObject *rhs = sym_get_const(ctx, right);
+        if (lhs && rhs) {
+            assert(PyFloat_CheckExact(lhs));
+            assert(PyFloat_CheckExact(rhs));
             PyObject *temp = PyFloat_FromDouble(
-                PyFloat_AS_DOUBLE(sym_get_const(ctx, left)) *
-                PyFloat_AS_DOUBLE(sym_get_const(ctx, right)));
+                PyFloat_AS_DOUBLE(lhs) *
+                PyFloat_AS_DOUBLE(rhs));
             if (temp == NULL) {
                 goto error;
             }
@@ -326,10 +334,12 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_ADD_UNICODE, (left, right -- res)) {
-        if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-            assert(PyUnicode_CheckExact(sym_get_const(ctx, left)));
-            assert(PyUnicode_CheckExact(sym_get_const(ctx, right)));
-            PyObject *temp = PyUnicode_Concat(sym_get_const(ctx, left), sym_get_const(ctx, right));
+        PyObject *lhs = sym_get_const(ctx, left);
+        PyObject *rhs = sym_get_const(ctx, right);
+        if (lhs && rhs) {
+            assert(PyUnicode_CheckExact(lhs));
+            assert(PyUnicode_CheckExact(rhs));
+            PyObject *temp = PyUnicode_Concat(lhs, rhs);
             if (temp == NULL) {
                 goto error;
             }
@@ -343,10 +353,12 @@ dummy_func(void) {
 
     op(_BINARY_OP_INPLACE_ADD_UNICODE, (left, right -- )) {
         JitOptSymbol *res;
-        if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-            assert(PyUnicode_CheckExact(sym_get_const(ctx, left)));
-            assert(PyUnicode_CheckExact(sym_get_const(ctx, right)));
-            PyObject *temp = PyUnicode_Concat(sym_get_const(ctx, left), sym_get_const(ctx, right));
+        PyObject *lhs = sym_get_const(ctx, left);
+        PyObject *rhs = sym_get_const(ctx, right);
+        if (lhs && rhs) {
+            assert(PyUnicode_CheckExact(lhs));
+            assert(PyUnicode_CheckExact(rhs));
+            PyObject *temp = PyUnicode_Concat(lhs, rhs);
             if (temp == NULL) {
                 goto error;
             }
@@ -370,10 +382,11 @@ dummy_func(void) {
     }
 
     op(_BINARY_OP_SUBSCR_TUPLE_INT, (tuple_st, sub_st -- res)) {
+        PyObject *sub_st_o = sym_get_const(ctx, sub_st);
         assert(sym_matches_type(tuple_st, &PyTuple_Type));
-        if (sym_is_const(ctx, sub_st)) {
-            assert(PyLong_CheckExact(sym_get_const(ctx, sub_st)));
-            long index = PyLong_AsLong(sym_get_const(ctx, sub_st));
+        if (sub_st_o) {
+            assert(PyLong_CheckExact(sub_st_o));
+            long index = PyLong_AsLong(sub_st_o);
             assert(index >= 0);
             int tuple_length = sym_tuple_length(tuple_st);
             if (tuple_length == -1) {
@@ -464,12 +477,12 @@ dummy_func(void) {
     }
 
     op(_COMPARE_OP_INT, (left, right -- res)) {
-        if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-            assert(PyLong_CheckExact(sym_get_const(ctx, left)));
-            assert(PyLong_CheckExact(sym_get_const(ctx, right)));
-            PyObject *tmp = PyObject_RichCompare(sym_get_const(ctx, left),
-                                                 sym_get_const(ctx, right),
-                                                 oparg >> 5);
+        PyObject *lhs = sym_get_const(ctx, left);
+        PyObject *rhs = sym_get_const(ctx, right);
+        if (lhs && rhs) {
+            assert(PyLong_CheckExact(lhs));
+            assert(PyLong_CheckExact(rhs));
+            PyObject *tmp = PyObject_RichCompare(lhs, rhs, oparg >> 5);
             if (tmp == NULL) {
                 goto error;
             }
@@ -570,8 +583,8 @@ dummy_func(void) {
         (void)dict_version;
         (void)index;
         attr = NULL;
-        if (sym_is_const(ctx, owner)) {
-            PyModuleObject *mod = (PyModuleObject *)sym_get_const(ctx, owner);
+        PyModuleObject *mod = (PyModuleObject *)sym_get_const(ctx, owner);
+        if (mod) {
             if (PyModule_CheckExact(mod)) {
                 PyObject *dict = mod->md_dict;
                 uint64_t watched_mutations = get_mutations(dict);
@@ -652,19 +665,21 @@ dummy_func(void) {
     }
 
     op(_CHECK_FUNCTION_VERSION, (func_version/2, callable, self_or_null, unused[oparg] -- callable, self_or_null, unused[oparg])) {
-        if (sym_is_const(ctx, callable) && sym_matches_type(callable, &PyFunction_Type)) {
-            assert(PyFunction_Check(sym_get_const(ctx, callable)));
+        PyObject *callable_o = sym_get_const(ctx, callable);
+        if (callable_o && sym_matches_type(callable, &PyFunction_Type)) {
+            assert(PyFunction_Check(callable_o));
             REPLACE_OP(this_instr, _CHECK_FUNCTION_VERSION_INLINE, 0, func_version);
-            this_instr->operand1 = (uintptr_t)sym_get_const(ctx, callable);
+            this_instr->operand1 = (uintptr_t)callable_o;
         }
         sym_set_type(callable, &PyFunction_Type);
     }
 
     op(_CHECK_FUNCTION_EXACT_ARGS, (callable, self_or_null, unused[oparg] -- callable, self_or_null, unused[oparg])) {
         assert(sym_matches_type(callable, &PyFunction_Type));
-        if (sym_is_const(ctx, callable)) {
+        PyObject *callable_o = sym_get_const(ctx, callable);
+        if (callable_o) {
             if (sym_is_null(self_or_null) || sym_is_not_null(self_or_null)) {
-                PyFunctionObject *func = (PyFunctionObject *)sym_get_const(ctx, callable);
+                PyFunctionObject *func = (PyFunctionObject *)callable_o;
                 PyCodeObject *co = (PyCodeObject *)func->func_code;
                 if (co->co_argcount == oparg + !sym_is_null(self_or_null)) {
                     REPLACE_OP(this_instr, _NOP, 0 ,0);
@@ -891,8 +906,8 @@ dummy_func(void) {
     }
 
     op(_GUARD_IS_TRUE_POP, (flag -- )) {
-        if (sym_is_const(ctx, flag)) {
-            PyObject *value = sym_get_const(ctx, flag);
+        PyObject *value = sym_get_const(ctx, flag);
+        if (value) {
             assert(value != NULL);
             eliminate_pop_guard(this_instr, value != Py_True);
         }
@@ -900,8 +915,8 @@ dummy_func(void) {
     }
 
     op(_GUARD_IS_FALSE_POP, (flag -- )) {
-        if (sym_is_const(ctx, flag)) {
-            PyObject *value = sym_get_const(ctx, flag);
+        PyObject *value = sym_get_const(ctx, flag);
+        if (value) {
             assert(value != NULL);
             eliminate_pop_guard(this_instr, value != Py_False);
         }
@@ -909,8 +924,8 @@ dummy_func(void) {
     }
 
     op(_GUARD_IS_NONE_POP, (val -- )) {
-        if (sym_is_const(ctx, val)) {
-            PyObject *value = sym_get_const(ctx, val);
+        PyObject *value = sym_get_const(ctx, val);
+        if (value) {
             assert(value != NULL);
             eliminate_pop_guard(this_instr, !Py_IsNone(value));
         }
@@ -922,8 +937,8 @@ dummy_func(void) {
     }
 
     op(_GUARD_IS_NOT_NONE_POP, (val -- )) {
-        if (sym_is_const(ctx, val)) {
-            PyObject *value = sym_get_const(ctx, val);
+        PyObject *value = sym_get_const(ctx, val);
+        if (value) {
             assert(value != NULL);
             eliminate_pop_guard(this_instr, Py_IsNone(value));
         }

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -1959,8 +1959,9 @@
             JitOptSymbol *arg;
             JitOptSymbol *res;
             arg = stack_pointer[-1];
-            if (sym_has_type(arg)) {
-                res = sym_new_const(ctx, (PyObject *)sym_get_type(arg));
+            PyObject *type = (PyObject *)sym_get_type(arg);
+            if (type) {
+                res = sym_new_const(ctx, type);
             }
             else {
                 res = sym_new_not_null(ctx);
@@ -2418,8 +2419,8 @@
                 assert(value != NULL);
                 eliminate_pop_guard(this_instr, !Py_IsNone(value));
             }
-            else if (sym_has_type(val)) {
-                assert(!sym_matches_type(val, &_PyNone_Type));
+            else if (sym_get_type(flag)) {
+                assert(!sym_matches_type(flag, &_PyNone_Type));
                 eliminate_pop_guard(this_instr, true);
             }
             sym_set_const(val, Py_None);
@@ -2436,8 +2437,8 @@
                 assert(value != NULL);
                 eliminate_pop_guard(this_instr, Py_IsNone(value));
             }
-            else if (sym_has_type(val)) {
-                assert(!sym_matches_type(val, &_PyNone_Type));
+            else if (sym_get_type(flag)) {
+                assert(!sym_matches_type(flag, &_PyNone_Type));
                 eliminate_pop_guard(this_instr, false);
             }
             stack_pointer += -1;

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -316,11 +316,12 @@
             JitOptSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-                assert(PyLong_CheckExact(sym_get_const(ctx, left)));
-                assert(PyLong_CheckExact(sym_get_const(ctx, right)));
-                PyObject *temp = _PyLong_Multiply((PyLongObject *)sym_get_const(ctx, left),
-                    (PyLongObject *)sym_get_const(ctx, right));
+            PyLongObject *lhs = (PyLongObject *)sym_get_const(ctx, left);
+            PyLongObject *rhs = (PyLongObject *)sym_get_const(ctx, right);
+            if (lhs && rhs) {
+                assert(PyLong_CheckExact(lhs));
+                assert(PyLong_CheckExact(rhs));
+                PyObject *temp = _PyLong_Multiply(lhs, rhs);
                 if (temp == NULL) {
                     goto error;
                 }
@@ -344,11 +345,12 @@
             JitOptSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-                assert(PyLong_CheckExact(sym_get_const(ctx, left)));
-                assert(PyLong_CheckExact(sym_get_const(ctx, right)));
-                PyObject *temp = _PyLong_Add((PyLongObject *)sym_get_const(ctx, left),
-                    (PyLongObject *)sym_get_const(ctx, right));
+            PyLongObject *lhs = (PyLongObject *)sym_get_const(ctx, left);
+            PyLongObject *rhs = (PyLongObject *)sym_get_const(ctx, right);
+            if (lhs && rhs) {
+                assert(PyLong_CheckExact(lhs));
+                assert(PyLong_CheckExact(rhs));
+                PyObject *temp = _PyLong_Add(lhs, rhs);
                 if (temp == NULL) {
                     goto error;
                 }
@@ -372,11 +374,12 @@
             JitOptSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-                assert(PyLong_CheckExact(sym_get_const(ctx, left)));
-                assert(PyLong_CheckExact(sym_get_const(ctx, right)));
-                PyObject *temp = _PyLong_Subtract((PyLongObject *)sym_get_const(ctx, left),
-                    (PyLongObject *)sym_get_const(ctx, right));
+            PyLongObject *lhs = (PyLongObject *)sym_get_const(ctx, left);
+            PyLongObject *rhs = (PyLongObject *)sym_get_const(ctx, right);
+            if (lhs && rhs) {
+                assert(PyLong_CheckExact(lhs));
+                assert(PyLong_CheckExact(rhs));
+                PyObject *temp = _PyLong_Subtract(lhs, rhs);
                 if (temp == NULL) {
                     goto error;
                 }
@@ -420,12 +423,14 @@
             JitOptSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-                assert(PyFloat_CheckExact(sym_get_const(ctx, left)));
-                assert(PyFloat_CheckExact(sym_get_const(ctx, right)));
+            PyObject *lhs = sym_get_const(ctx, left);
+            PyObject *rhs = sym_get_const(ctx, right);
+            if (lhs && rhs) {
+                assert(PyFloat_CheckExact(lhs));
+                assert(PyFloat_CheckExact(rhs));
                 PyObject *temp = PyFloat_FromDouble(
-                    PyFloat_AS_DOUBLE(sym_get_const(ctx, left)) *
-                    PyFloat_AS_DOUBLE(sym_get_const(ctx, right)));
+                    PyFloat_AS_DOUBLE(lhs) *
+                    PyFloat_AS_DOUBLE(rhs));
                 if (temp == NULL) {
                     goto error;
                 }
@@ -449,12 +454,14 @@
             JitOptSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-                assert(PyFloat_CheckExact(sym_get_const(ctx, left)));
-                assert(PyFloat_CheckExact(sym_get_const(ctx, right)));
+            PyObject *lhs = sym_get_const(ctx, left);
+            PyObject *rhs = sym_get_const(ctx, right);
+            if (lhs && rhs) {
+                assert(PyFloat_CheckExact(lhs));
+                assert(PyFloat_CheckExact(rhs));
                 PyObject *temp = PyFloat_FromDouble(
-                    PyFloat_AS_DOUBLE(sym_get_const(ctx, left)) +
-                    PyFloat_AS_DOUBLE(sym_get_const(ctx, right)));
+                    PyFloat_AS_DOUBLE(lhs) +
+                    PyFloat_AS_DOUBLE(rhs));
                 if (temp == NULL) {
                     goto error;
                 }
@@ -478,12 +485,14 @@
             JitOptSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-                assert(PyFloat_CheckExact(sym_get_const(ctx, left)));
-                assert(PyFloat_CheckExact(sym_get_const(ctx, right)));
+            PyObject *lhs = sym_get_const(ctx, left);
+            PyObject *rhs = sym_get_const(ctx, right);
+            if (lhs && rhs) {
+                assert(PyFloat_CheckExact(lhs));
+                assert(PyFloat_CheckExact(rhs));
                 PyObject *temp = PyFloat_FromDouble(
-                    PyFloat_AS_DOUBLE(sym_get_const(ctx, left)) -
-                    PyFloat_AS_DOUBLE(sym_get_const(ctx, right)));
+                    PyFloat_AS_DOUBLE(lhs) -
+                    PyFloat_AS_DOUBLE(rhs));
                 if (temp == NULL) {
                     goto error;
                 }
@@ -507,10 +516,12 @@
             JitOptSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-                assert(PyUnicode_CheckExact(sym_get_const(ctx, left)));
-                assert(PyUnicode_CheckExact(sym_get_const(ctx, right)));
-                PyObject *temp = PyUnicode_Concat(sym_get_const(ctx, left), sym_get_const(ctx, right));
+            PyObject *lhs = sym_get_const(ctx, left);
+            PyObject *rhs = sym_get_const(ctx, right);
+            if (lhs && rhs) {
+                assert(PyUnicode_CheckExact(lhs));
+                assert(PyUnicode_CheckExact(rhs));
+                PyObject *temp = PyUnicode_Concat(lhs, rhs);
                 if (temp == NULL) {
                     goto error;
                 }
@@ -534,10 +545,12 @@
             right = stack_pointer[-1];
             left = stack_pointer[-2];
             JitOptSymbol *res;
-            if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-                assert(PyUnicode_CheckExact(sym_get_const(ctx, left)));
-                assert(PyUnicode_CheckExact(sym_get_const(ctx, right)));
-                PyObject *temp = PyUnicode_Concat(sym_get_const(ctx, left), sym_get_const(ctx, right));
+            PyObject *lhs = sym_get_const(ctx, left);
+            PyObject *rhs = sym_get_const(ctx, right);
+            if (lhs && rhs) {
+                assert(PyUnicode_CheckExact(lhs));
+                assert(PyUnicode_CheckExact(rhs));
+                PyObject *temp = PyUnicode_Concat(lhs, rhs);
                 if (temp == NULL) {
                     goto error;
                 }
@@ -634,10 +647,11 @@
             JitOptSymbol *res;
             sub_st = stack_pointer[-1];
             tuple_st = stack_pointer[-2];
+            PyObject *sub_st_o = sym_get_const(ctx, sub_st);
             assert(sym_matches_type(tuple_st, &PyTuple_Type));
-            if (sym_is_const(ctx, sub_st)) {
-                assert(PyLong_CheckExact(sym_get_const(ctx, sub_st)));
-                long index = PyLong_AsLong(sym_get_const(ctx, sub_st));
+            if (sub_st_o) {
+                assert(PyLong_CheckExact(sub_st_o));
+                long index = PyLong_AsLong(sub_st_o);
                 assert(index >= 0);
                 int tuple_length = sym_tuple_length(tuple_st);
                 if (tuple_length == -1) {
@@ -1233,8 +1247,8 @@
             (void)dict_version;
             (void)index;
             attr = NULL;
-            if (sym_is_const(ctx, owner)) {
-                PyModuleObject *mod = (PyModuleObject *)sym_get_const(ctx, owner);
+            PyModuleObject *mod = (PyModuleObject *)sym_get_const(ctx, owner);
+            if (mod) {
                 if (PyModule_CheckExact(mod)) {
                     PyObject *dict = mod->md_dict;
                     stack_pointer[-1] = attr;
@@ -1348,12 +1362,12 @@
             JitOptSymbol *res;
             right = stack_pointer[-1];
             left = stack_pointer[-2];
-            if (sym_is_const(ctx, left) && sym_is_const(ctx, right)) {
-                assert(PyLong_CheckExact(sym_get_const(ctx, left)));
-                assert(PyLong_CheckExact(sym_get_const(ctx, right)));
-                PyObject *tmp = PyObject_RichCompare(sym_get_const(ctx, left),
-                    sym_get_const(ctx, right),
-                    oparg >> 5);
+            PyObject *lhs = sym_get_const(ctx, left);
+            PyObject *rhs = sym_get_const(ctx, right);
+            if (lhs && rhs) {
+                assert(PyLong_CheckExact(lhs));
+                assert(PyLong_CheckExact(rhs));
+                PyObject *tmp = PyObject_RichCompare(lhs, rhs, oparg >> 5);
                 if (tmp == NULL) {
                     goto error;
                 }
@@ -1771,10 +1785,11 @@
             JitOptSymbol *callable;
             callable = stack_pointer[-2 - oparg];
             uint32_t func_version = (uint32_t)this_instr->operand0;
-            if (sym_is_const(ctx, callable) && sym_matches_type(callable, &PyFunction_Type)) {
-                assert(PyFunction_Check(sym_get_const(ctx, callable)));
+            PyObject *callable_o = sym_get_const(ctx, callable);
+            if (callable_o && sym_matches_type(callable, &PyFunction_Type)) {
+                assert(PyFunction_Check(callable_o));
                 REPLACE_OP(this_instr, _CHECK_FUNCTION_VERSION_INLINE, 0, func_version);
-                this_instr->operand1 = (uintptr_t)sym_get_const(ctx, callable);
+                this_instr->operand1 = (uintptr_t)callable_o;
             }
             sym_set_type(callable, &PyFunction_Type);
             break;
@@ -1840,9 +1855,10 @@
             self_or_null = stack_pointer[-1 - oparg];
             callable = stack_pointer[-2 - oparg];
             assert(sym_matches_type(callable, &PyFunction_Type));
-            if (sym_is_const(ctx, callable)) {
+            PyObject *callable_o = sym_get_const(ctx, callable);
+            if (callable_o) {
                 if (sym_is_null(self_or_null) || sym_is_not_null(self_or_null)) {
-                    PyFunctionObject *func = (PyFunctionObject *)sym_get_const(ctx, callable);
+                    PyFunctionObject *func = (PyFunctionObject *)callable_o;
                     PyCodeObject *co = (PyCodeObject *)func->func_code;
                     if (co->co_argcount == oparg + !sym_is_null(self_or_null)) {
                         REPLACE_OP(this_instr, _NOP, 0 ,0);
@@ -2326,7 +2342,7 @@
                 else if (lhs_float) {
                     res = sym_new_type(ctx, &PyFloat_Type);
                 }
-                else if (!sym_is_const(ctx, rhs)) {
+                else if (!sym_get_const(ctx, rhs)) {
                     res = sym_new_unknown(ctx);
                 }
                 else if (_PyLong_IsNegative((PyLongObject *)sym_get_const(ctx, rhs))) {
@@ -2386,8 +2402,8 @@
         case _GUARD_IS_TRUE_POP: {
             JitOptSymbol *flag;
             flag = stack_pointer[-1];
-            if (sym_is_const(ctx, flag)) {
-                PyObject *value = sym_get_const(ctx, flag);
+            PyObject *value = sym_get_const(ctx, flag);
+            if (value) {
                 assert(value != NULL);
                 eliminate_pop_guard(this_instr, value != Py_True);
             }
@@ -2400,8 +2416,8 @@
         case _GUARD_IS_FALSE_POP: {
             JitOptSymbol *flag;
             flag = stack_pointer[-1];
-            if (sym_is_const(ctx, flag)) {
-                PyObject *value = sym_get_const(ctx, flag);
+            PyObject *value = sym_get_const(ctx, flag);
+            if (value) {
                 assert(value != NULL);
                 eliminate_pop_guard(this_instr, value != Py_False);
             }
@@ -2414,13 +2430,13 @@
         case _GUARD_IS_NONE_POP: {
             JitOptSymbol *val;
             val = stack_pointer[-1];
-            if (sym_is_const(ctx, val)) {
-                PyObject *value = sym_get_const(ctx, val);
+            PyObject *value = sym_get_const(ctx, val);
+            if (value) {
                 assert(value != NULL);
                 eliminate_pop_guard(this_instr, !Py_IsNone(value));
             }
-            else if (sym_get_type(flag)) {
-                assert(!sym_matches_type(flag, &_PyNone_Type));
+            else if (sym_get_type(val)) {
+                assert(!sym_matches_type(val, &_PyNone_Type));
                 eliminate_pop_guard(this_instr, true);
             }
             sym_set_const(val, Py_None);
@@ -2432,13 +2448,13 @@
         case _GUARD_IS_NOT_NONE_POP: {
             JitOptSymbol *val;
             val = stack_pointer[-1];
-            if (sym_is_const(ctx, val)) {
-                PyObject *value = sym_get_const(ctx, val);
+            PyObject *value = sym_get_const(ctx, val);
+            if (value) {
                 assert(value != NULL);
                 eliminate_pop_guard(this_instr, Py_IsNone(value));
             }
-            else if (sym_get_type(flag)) {
-                assert(!sym_matches_type(flag, &_PyNone_Type));
+            else if (sym_get_type(val)) {
+                assert(!sym_matches_type(val, &_PyNone_Type));
                 eliminate_pop_guard(this_instr, false);
             }
             stack_pointer += -1;

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -104,24 +104,6 @@ _Py_uop_sym_is_not_null(JitOptSymbol *sym) {
 }
 
 bool
-_Py_uop_sym_is_const(JitOptContext *ctx, JitOptSymbol *sym)
-{
-    if (sym->tag == JIT_SYM_KNOWN_VALUE_TAG) {
-        return true;
-    }
-    if (sym->tag == JIT_SYM_TRUTHINESS_TAG) {
-        JitOptSymbol *value = allocation_base(ctx) + sym->truthiness.value;
-        int truthiness = _Py_uop_sym_truthiness(ctx, value);
-        if (truthiness < 0) {
-            return false;
-        }
-        make_const(sym, (truthiness ^ sym->truthiness.invert) ? Py_True : Py_False);
-        return true;
-    }
-    return false;
-}
-
-bool
 _Py_uop_sym_is_null(JitOptSymbol *sym)
 {
     return sym->tag == JIT_SYM_NULL_TAG;
@@ -283,7 +265,7 @@ _Py_uop_sym_set_const(JitOptContext *ctx, JitOptSymbol *sym, PyObject *const_val
             return;
         case JIT_SYM_TRUTHINESS_TAG:
             if (!PyBool_Check(const_val) ||
-                (_Py_uop_sym_is_const(ctx, sym) &&
+                (_Py_uop_sym_get_const(ctx, sym) != NULL &&
                  _Py_uop_sym_get_const(ctx, sym) != const_val))
             {
                 sym_set_bottom(ctx, sym);
@@ -721,7 +703,6 @@ _Py_uop_symbols_test(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
     TEST_PREDICATE(!_Py_uop_sym_is_null(sym), "top is NULL");
     TEST_PREDICATE(!_Py_uop_sym_is_not_null(sym), "top is not NULL");
     TEST_PREDICATE(!_Py_uop_sym_matches_type(sym, &PyLong_Type), "top matches a type");
-    TEST_PREDICATE(!_Py_uop_sym_is_const(ctx, sym), "top is a constant");
     TEST_PREDICATE(_Py_uop_sym_get_const(ctx, sym) == NULL, "top as constant is not NULL");
     TEST_PREDICATE(!_Py_uop_sym_is_bottom(sym), "top is bottom");
 
@@ -732,7 +713,6 @@ _Py_uop_symbols_test(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
     TEST_PREDICATE(!_Py_uop_sym_is_null(sym), "bottom is NULL is not false");
     TEST_PREDICATE(!_Py_uop_sym_is_not_null(sym), "bottom is not NULL is not false");
     TEST_PREDICATE(!_Py_uop_sym_matches_type(sym, &PyLong_Type), "bottom matches a type");
-    TEST_PREDICATE(!_Py_uop_sym_is_const(ctx, sym), "bottom is a constant is not false");
     TEST_PREDICATE(_Py_uop_sym_get_const(ctx, sym) == NULL, "bottom as constant is not NULL");
     TEST_PREDICATE(_Py_uop_sym_is_bottom(sym), "bottom isn't bottom");
 
@@ -744,7 +724,6 @@ _Py_uop_symbols_test(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
     TEST_PREDICATE(_Py_uop_sym_is_not_null(sym), "int isn't not NULL");
     TEST_PREDICATE(_Py_uop_sym_matches_type(sym, &PyLong_Type), "int isn't int");
     TEST_PREDICATE(!_Py_uop_sym_matches_type(sym, &PyFloat_Type), "int matches float");
-    TEST_PREDICATE(!_Py_uop_sym_is_const(ctx, sym), "int is a constant");
     TEST_PREDICATE(_Py_uop_sym_get_const(ctx, sym) == NULL, "int as constant is not NULL");
 
     _Py_uop_sym_set_type(ctx, sym, &PyLong_Type);  // Should be a no-op
@@ -771,7 +750,6 @@ _Py_uop_symbols_test(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
     TEST_PREDICATE(_Py_uop_sym_is_not_null(sym), "42 isn't not NULL");
     TEST_PREDICATE(_Py_uop_sym_matches_type(sym, &PyLong_Type), "42 isn't an int");
     TEST_PREDICATE(!_Py_uop_sym_matches_type(sym, &PyFloat_Type), "42 matches float");
-    TEST_PREDICATE(_Py_uop_sym_is_const(ctx, sym), "42 is not a constant");
     TEST_PREDICATE(_Py_uop_sym_get_const(ctx, sym) != NULL, "42 as constant is NULL");
     TEST_PREDICATE(_Py_uop_sym_get_const(ctx, sym) == val_42, "42 as constant isn't 42");
     TEST_PREDICATE(_Py_uop_sym_is_immortal(sym), "42 is not immortal");
@@ -825,16 +803,12 @@ _Py_uop_symbols_test(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(ignored))
     sym = _Py_uop_sym_new_truthiness(ctx, value, false);
     TEST_PREDICATE(_Py_uop_sym_matches_type(sym, &PyBool_Type), "truthiness is not boolean");
     TEST_PREDICATE(_Py_uop_sym_truthiness(ctx, sym) == -1, "truthiness is not unknown");
-    TEST_PREDICATE(_Py_uop_sym_is_const(ctx, sym) == false, "truthiness is constant");
     TEST_PREDICATE(_Py_uop_sym_get_const(ctx, sym) == NULL, "truthiness is not NULL");
-    TEST_PREDICATE(_Py_uop_sym_is_const(ctx, value) == false, "value is constant");
     TEST_PREDICATE(_Py_uop_sym_get_const(ctx, value) == NULL, "value is not NULL");
     _Py_uop_sym_set_const(ctx, sym, Py_False);
     TEST_PREDICATE(_Py_uop_sym_matches_type(sym, &PyBool_Type), "truthiness is not boolean");
     TEST_PREDICATE(_Py_uop_sym_truthiness(ctx, sym) == 0, "truthiness is not True");
-    TEST_PREDICATE(_Py_uop_sym_is_const(ctx, sym) == true, "truthiness is not constant");
     TEST_PREDICATE(_Py_uop_sym_get_const(ctx, sym) == Py_False, "truthiness is not False");
-    TEST_PREDICATE(_Py_uop_sym_is_const(ctx, value) == true, "value is not constant");
     TEST_PREDICATE(_Py_uop_sym_get_const(ctx, value) == Py_True, "value is not True");
     _Py_uop_abstractcontext_fini(ctx);
     Py_DECREF(val_42);

--- a/Python/optimizer_symbols.c
+++ b/Python/optimizer_symbols.c
@@ -440,26 +440,6 @@ _Py_uop_sym_get_type_version(JitOptSymbol *sym)
 }
 
 bool
-_Py_uop_sym_has_type(JitOptSymbol *sym)
-{
-    JitSymType tag = sym->tag;
-    switch(tag) {
-        case JIT_SYM_NULL_TAG:
-        case JIT_SYM_TYPE_VERSION_TAG:
-        case JIT_SYM_BOTTOM_TAG:
-        case JIT_SYM_NON_NULL_TAG:
-        case JIT_SYM_UNKNOWN_TAG:
-            return false;
-        case JIT_SYM_KNOWN_CLASS_TAG:
-        case JIT_SYM_KNOWN_VALUE_TAG:
-        case JIT_SYM_TUPLE_TAG:
-        case JIT_SYM_TRUTHINESS_TAG:
-            return true;
-    }
-    Py_UNREACHABLE();
-}
-
-bool
 _Py_uop_sym_matches_type(JitOptSymbol *sym, PyTypeObject *typ)
 {
     assert(typ != NULL && PyType_Check(typ));


### PR DESCRIPTION
- Simplify patterns such as
```c
if (sym_is_const(ctx, flag)) {
  PyObject *value = sym_get_const(ctx, flag);
  // use value
}
```
into
```c
PyObject *value = sym_get_const(ctx, flag);
if (value) {
  // use value
}
```
- Remove `sym_is_const` and `sym_has_type`. They can be replaced by `sym_get_const` and `sym_get_type` respectively. This part is more of an exploration, these functions might still be useful in some situations. If we do decide to keep them, we can still simplify them quite a bit.

Check out the issue for more context!

<!-- gh-issue-number: gh-133342 -->
* Issue: gh-133342
<!-- /gh-issue-number -->
