### PR TITLE
gh-133886: Fix sys.remote_exec() for non-UTF-8 paths

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1976,7 +1976,9 @@ class TestRemoteExec(unittest.TestCase):
     def tearDown(self):
         test.support.reap_children()
 
-    def _run_remote_exec_test(self, script_code, python_args=None, env=None, prologue='', script_path=os_helper.TESTFN + '_remote.py'):
+    def _run_remote_exec_test(self, script_code, python_args=None, env=None,
+                              prologue='',
+                              script_path=os_helper.TESTFN + '_remote.py'):
         # Create the script that will be remotely executed
         self.addCleanup(os_helper.unlink, script_path)
 
@@ -2072,18 +2074,14 @@ sock.close()
 
     def test_remote_exec(self):
         """Test basic remote exec functionality"""
-        script = '''
-print("Remote script executed successfully!")
-'''
+        script = 'print("Remote script executed successfully!")'
         returncode, stdout, stderr = self._run_remote_exec_test(script)
         # self.assertEqual(returncode, 0)
         self.assertIn(b"Remote script executed successfully!", stdout)
         self.assertEqual(stderr, b"")
 
     def test_remote_exec_bytes(self):
-        script = '''
-print("Remote script executed successfully!")
-'''
+        script = 'print("Remote script executed successfully!")'
         script_path = os.fsencode(os_helper.TESTFN) + b'_bytes_remote.py'
         returncode, stdout, stderr = self._run_remote_exec_test(script,
                                                     script_path=script_path)

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -2091,6 +2091,8 @@ print("Remote script executed successfully!")
         self.assertEqual(stderr, b"")
 
     @unittest.skipUnless(os_helper.TESTFN_UNDECODABLE, 'requires undecodable path')
+    @unittest.skipIf(sys.platform == 'darwin',
+                     'undecodable paths are not supported on macOS')
     def test_remote_exec_undecodable(self):
         script = '''
 print("Remote script executed successfully!")

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -2094,14 +2094,13 @@ print("Remote script executed successfully!")
     @unittest.skipIf(sys.platform == 'darwin',
                      'undecodable paths are not supported on macOS')
     def test_remote_exec_undecodable(self):
-        script = '''
-print("Remote script executed successfully!")
-'''
+        script = 'print("Remote script executed successfully!")'
         script_path = os_helper.TESTFN_UNDECODABLE + b'_undecodable_remote.py'
-        returncode, stdout, stderr = self._run_remote_exec_test(script,
-                                                    script_path=script_path)
-        self.assertIn(b"Remote script executed successfully!", stdout)
-        self.assertEqual(stderr, b"")
+        for script_path in [script_path, os.fsdecode(script_path)]:
+            returncode, stdout, stderr = self._run_remote_exec_test(script,
+                                                        script_path=script_path)
+            self.assertIn(b"Remote script executed successfully!", stdout)
+            self.assertEqual(stderr, b"")
 
     def test_remote_exec_with_self_process(self):
         """Test remote exec with the target process being the same as the test process"""

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-11-13-40-42.gh-issue-133886.ryBAyo.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-11-13-40-42.gh-issue-133886.ryBAyo.rst
@@ -1,0 +1,2 @@
+Fix :func:`sys.remote_exec` for non-ASCII paths in non-UTF-8 locales and
+non-UTF-8 paths in UTF-8 locales.

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -1220,7 +1220,7 @@ static inline int run_remote_debugger_source(PyObject *source)
 // that would be an easy target for a ROP gadget.
 static inline void run_remote_debugger_script(PyObject *path)
 {
-    if (0 != PySys_Audit("remote_debugger_script", "U", path)) {
+    if (0 != PySys_Audit("remote_debugger_script", "O", path)) {
         PyErr_FormatUnraisable(
             "Audit hook failed for remote debugger script %U", path);
         return;

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -1218,30 +1218,30 @@ static inline int run_remote_debugger_source(PyObject *source)
 
 // Note that this function is inline to avoid creating a PLT entry
 // that would be an easy target for a ROP gadget.
-static inline void run_remote_debugger_script(const char *path)
+static inline void run_remote_debugger_script(PyObject *path)
 {
-    if (0 != PySys_Audit("remote_debugger_script", "s", path)) {
+    if (0 != PySys_Audit("remote_debugger_script", "U", path)) {
         PyErr_FormatUnraisable(
-            "Audit hook failed for remote debugger script %s", path);
+            "Audit hook failed for remote debugger script %U", path);
         return;
     }
 
     // Open the debugger script with the open code hook, and reopen the
     // resulting file object to get a C FILE* object.
-    PyObject* fileobj = PyFile_OpenCode(path);
+    PyObject* fileobj = PyFile_OpenCodeObject(path);
     if (!fileobj) {
-        PyErr_FormatUnraisable("Can't open debugger script %s", path);
+        PyErr_FormatUnraisable("Can't open debugger script %U", path);
         return;
     }
 
     PyObject* source = PyObject_CallMethodNoArgs(fileobj, &_Py_ID(read));
     if (!source) {
-        PyErr_FormatUnraisable("Error reading debugger script %s", path);
+        PyErr_FormatUnraisable("Error reading debugger script %U", path);
     }
 
     PyObject* res = PyObject_CallMethodNoArgs(fileobj, &_Py_ID(close));
     if (!res) {
-        PyErr_FormatUnraisable("Error closing debugger script %s", path);
+        PyErr_FormatUnraisable("Error closing debugger script %U", path);
     } else {
         Py_DECREF(res);
     }
@@ -1249,7 +1249,7 @@ static inline void run_remote_debugger_script(const char *path)
 
     if (source) {
         if (0 != run_remote_debugger_source(source)) {
-            PyErr_FormatUnraisable("Error executing debugger script %s", path);
+            PyErr_FormatUnraisable("Error executing debugger script %U", path);
         }
         Py_DECREF(source);
     }
@@ -1278,7 +1278,14 @@ int _PyRunRemoteDebugger(PyThreadState *tstate)
                 pathsz);
             path[pathsz - 1] = '\0';
             if (*path) {
-                run_remote_debugger_script(path);
+                PyObject *path_obj = PyUnicode_DecodeFSDefault(path);
+                if (path_obj == NULL) {
+                    PyErr_FormatUnraisable("Can't decode debugger script");
+                }
+                else {
+                    run_remote_debugger_script(path_obj);
+                    Py_DECREF(path_obj);
+                }
             }
             PyMem_Free(path);
         }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2451,60 +2451,6 @@ sys_is_remote_debug_enabled_impl(PyObject *module)
 #endif
 }
 
-static PyObject *
-sys_remote_exec_unicode_path(PyObject *module, int pid, PyObject *script)
-{
-    const char *debugger_script_path = PyUnicode_AsUTF8(script);
-    if (debugger_script_path == NULL) {
-        return NULL;
-    }
-
-#ifdef MS_WINDOWS
-    // Use UTF-16 (wide char) version of the path for permission checks
-    wchar_t *debugger_script_path_w = PyUnicode_AsWideCharString(script, NULL);
-    if (debugger_script_path_w == NULL) {
-        return NULL;
-    }
-
-    // Check file attributes using wide character version (W) instead of ANSI (A)
-    DWORD attr = GetFileAttributesW(debugger_script_path_w);
-    PyMem_Free(debugger_script_path_w);
-    if (attr == INVALID_FILE_ATTRIBUTES) {
-        DWORD err = GetLastError();
-        if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND) {
-            PyErr_SetString(PyExc_FileNotFoundError, "Script file does not exist");
-        }
-        else if (err == ERROR_ACCESS_DENIED) {
-            PyErr_SetString(PyExc_PermissionError, "Script file cannot be read");
-        }
-        else {
-            PyErr_SetFromWindowsErr(0);
-        }
-        return NULL;
-    }
-#else
-    if (access(debugger_script_path, F_OK | R_OK) != 0) {
-        switch (errno) {
-            case ENOENT:
-                PyErr_SetString(PyExc_FileNotFoundError, "Script file does not exist");
-                break;
-            case EACCES:
-                PyErr_SetString(PyExc_PermissionError, "Script file cannot be read");
-                break;
-            default:
-                PyErr_SetFromErrno(PyExc_OSError);
-        }
-        return NULL;
-    }
-#endif
-
-    if (_PySysRemoteDebug_SendExec(pid, 0, debugger_script_path) < 0) {
-        return NULL;
-    }
-
-    Py_RETURN_NONE;
-}
-
 /*[clinic input]
 sys.remote_exec
 
@@ -2535,13 +2481,69 @@ static PyObject *
 sys_remote_exec_impl(PyObject *module, int pid, PyObject *script)
 /*[clinic end generated code: output=7d94c56afe4a52c0 input=39908ca2c5fe1eb0]*/
 {
-    PyObject *ret = NULL;
     PyObject *path;
-    if (PyUnicode_FSDecoder(script, &path)) {
-        ret = sys_remote_exec_unicode_path(module, pid, path);
-        Py_DECREF(path);
+    const char *debugger_script_path;
+#ifdef MS_WINDOWS
+    if (PyUnicode_FSDecoder(script, &path) < 0) {
+        return NULL;
     }
-    return ret;
+    debugger_script_path = PyUnicode_AsUTF8(path);
+    if (debugger_script_path == NULL) {
+        Py_DECREF(path);
+        return NULL;
+    }
+    // Use UTF-16 (wide char) version of the path for permission checks
+    wchar_t *debugger_script_path_w = PyUnicode_AsWideCharString(path, NULL);
+    if (debugger_script_path_w == NULL) {
+        Py_DECREF(path);
+        return NULL;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    DWORD attr = GetFileAttributesW(debugger_script_path_w);
+    Py_END_ALLOW_THREADS
+    PyMem_Free(debugger_script_path_w);
+    if (attr == INVALID_FILE_ATTRIBUTES) {
+        DWORD err = GetLastError();
+        if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND) {
+            PyErr_SetString(PyExc_FileNotFoundError, "Script file does not exist");
+        }
+        else if (err == ERROR_ACCESS_DENIED) {
+            PyErr_SetString(PyExc_PermissionError, "Script file cannot be read");
+        }
+        else {
+            PyErr_SetFromWindowsErr(err);
+        }
+        Py_DECREF(path);
+        return NULL;
+    }
+#else // MS_WINDOWS
+    if (PyUnicode_FSConverter(script, &path) < 0) {
+        return NULL;
+    }
+    debugger_script_path = PyBytes_AS_STRING(path);
+
+    if (access(debugger_script_path, F_OK | R_OK) != 0) {
+        switch (errno) {
+            case ENOENT:
+                PyErr_SetString(PyExc_FileNotFoundError, "Script file does not exist");
+                break;
+            case EACCES:
+                PyErr_SetString(PyExc_PermissionError, "Script file cannot be read");
+                break;
+            default:
+                PyErr_SetFromErrno(PyExc_OSError);
+        }
+        Py_DECREF(path);
+        return NULL;
+    }
+#endif // MS_WINDOWS
+    if (_PySysRemoteDebug_SendExec(pid, 0, debugger_script_path) < 0) {
+        Py_DECREF(path);
+        return NULL;
+    }
+
+    Py_DECREF(path);
+    Py_RETURN_NONE;
 }
 
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2498,9 +2498,7 @@ sys_remote_exec_impl(PyObject *module, int pid, PyObject *script)
         Py_DECREF(path);
         return NULL;
     }
-    Py_BEGIN_ALLOW_THREADS
     DWORD attr = GetFileAttributesW(debugger_script_path_w);
-    Py_END_ALLOW_THREADS
     PyMem_Free(debugger_script_path_w);
     if (attr == INVALID_FILE_ATTRIBUTES) {
         DWORD err = GetLastError();


### PR DESCRIPTION
It now supports non-ASCII paths in non-UTF-8 locales and non-UTF-8 paths in UTF-8 locales.


<!-- gh-issue-number: gh-133886 -->
* Issue: gh-133886
<!-- /gh-issue-number -->
