### PR TITLE
gh-133891: Add missing error check to `SET_COUNT` macro in `_testinternalcapi.c`

### DIFF
--- a/Modules/_testinternalcapi.c
+++ b/Modules/_testinternalcapi.c
@@ -1045,6 +1045,9 @@ get_code_var_counts(PyObject *self, PyObject *_args, PyObject *_kwargs)
 #define SET_COUNT(DICT, STRUCT, NAME) \
     do { \
         PyObject *count = PyLong_FromLong(STRUCT.NAME); \
+        if (count == NULL) { \
+            goto error; \
+        } \
         int res = PyDict_SetItemString(DICT, #NAME, count); \
         Py_DECREF(count); \
         if (res < 0) { \


### PR DESCRIPTION


<!-- gh-issue-number: gh-133891 -->
* Issue: gh-133891
<!-- /gh-issue-number -->
