### PR TITLE
gh-133893: asyncio.graph: Replace TextIO annotation with io.Writer

### DIFF
--- a/Lib/asyncio/graph.py
+++ b/Lib/asyncio/graph.py
@@ -17,7 +17,7 @@ __all__ = (
 )
 
 if False:  # for type checkers
-    from typing import TextIO
+    from io import Writer
 
 # Sadly, we can't re-use the traceback module's datastructures as those
 # are tailored for error reporting, whereas we need to represent an
@@ -270,7 +270,7 @@ def print_call_graph(
     future: futures.Future | None = None,
     /,
     *,
-    file: TextIO | None = None,
+    file: Writer[str] | None = None,
     depth: int = 1,
     limit: int | None = None,
 ) -> None:

--- a/Lib/asyncio/graph.py
+++ b/Lib/asyncio/graph.py
@@ -1,6 +1,7 @@
 """Introspection utils for tasks call graphs."""
 
 import dataclasses
+import io
 import sys
 import types
 
@@ -15,9 +16,6 @@ __all__ = (
     'FrameCallGraphEntry',
     'FutureCallGraph',
 )
-
-if False:  # for type checkers
-    from io import Writer
 
 # Sadly, we can't re-use the traceback module's datastructures as those
 # are tailored for error reporting, whereas we need to represent an
@@ -270,7 +268,7 @@ def print_call_graph(
     future: futures.Future | None = None,
     /,
     *,
-    file: Writer[str] | None = None,
+    file: io.Writer[str] | None = None,
     depth: int = 1,
     limit: int | None = None,
 ) -> None:

--- a/Misc/NEWS.d/next/Library/2025-05-11-13-50-44.gh-issue-133893.Cv9Yxs.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-11-13-50-44.gh-issue-133893.Cv9Yxs.rst
@@ -1,3 +1,0 @@
-Use protocol :class:`io.Writer` as annotation for
-:func:`asyncio.format_call_graph`'s ``file`` parameter instead of
-:class:`typing.TextIO`.

--- a/Misc/NEWS.d/next/Library/2025-05-11-13-50-44.gh-issue-133893.Cv9Yxs.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-11-13-50-44.gh-issue-133893.Cv9Yxs.rst
@@ -1,3 +1,3 @@
 Use protocol :class:`io.Writer` as annotation for
-:func:`asyncio.graph.format_call_graph()`'s ``file`` argument instead of
+:func:`asyncio.graph.format_call_graph`'s ``file`` parameter instead of
 :class:`typing.TextIO`.

--- a/Misc/NEWS.d/next/Library/2025-05-11-13-50-44.gh-issue-133893.Cv9Yxs.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-11-13-50-44.gh-issue-133893.Cv9Yxs.rst
@@ -1,0 +1,3 @@
+Use protocol :class:`io.Writer` as annotation for
+:func:`asyncio.graph.format_call_graph()`'s ``file`` argument instead of
+:class:`typing.TextIO`.

--- a/Misc/NEWS.d/next/Library/2025-05-11-13-50-44.gh-issue-133893.Cv9Yxs.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-11-13-50-44.gh-issue-133893.Cv9Yxs.rst
@@ -1,3 +1,3 @@
 Use protocol :class:`io.Writer` as annotation for
-:func:`asyncio.graph.format_call_graph`'s ``file`` parameter instead of
+:func:`asyncio.format_call_graph`'s ``file`` parameter instead of
 :class:`typing.TextIO`.


### PR DESCRIPTION
Considering that this is a new module in 3.14, I think this should be backported.


<!-- gh-issue-number: gh-133893 -->
* Issue: gh-133893
<!-- /gh-issue-number -->
