### PR TITLE
[3.13] Docs: C API: Fix the incorrect `PyThreadState_Swap` documentation

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1190,9 +1190,10 @@ code, or when embedding the Python interpreter:
 .. c:function:: PyThreadState* PyThreadState_Swap(PyThreadState *tstate)
 
    Swap the current thread state with the thread state given by the argument
-   *tstate*, which may be ``NULL``.  The global interpreter lock must be held
-   and is not released.
+   *tstate*, which may be ``NULL``.
 
+   The :term:`GIL` does not need to be held, but will be held upon returning
+   if *tstate* is non-``NULL``.
 
 The following functions use thread-local storage, and are not compatible
 with sub-interpreters:


### PR DESCRIPTION
I've already fixed this for main and 3.14 in gh-127990, but that wasn't backported to 3.13. I'm not planning on fixing any other 3.13 docs, but `PyThreadState_Swap` is especially bad, because the documentation says you need to hold the GIL to call it, which is wrong and would defeat the whole point of the function if it were true. I've seen people get confused by that on several different occasions.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133900.org.readthedocs.build/en/133900/c-api/init.html#c.PyThreadState_Swap

<!-- readthedocs-preview cpython-previews end -->