### PR TITLE
Fix incorrect error type in math.factorial documentation (GH-133904)

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -144,8 +144,8 @@ Number-theoretic functions
 
 .. function:: factorial(n)
 
-   Return *n* factorial as an integer.  Raises :exc:`ValueError` if *n* is not integral or
-   is negative.
+   Return *n* factorial as an integer.  Raises :exc:`TypeError` if *n* is not an integer.
+   Raises :exc:`ValueError` if *n* is negative.
 
    .. versionchanged:: 3.10
       Floats with integral values (like ``5.0``) are no longer accepted.

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -110,7 +110,8 @@ PyDoc_STRVAR(math_factorial__doc__,
 "\n"
 "Find n!.\n"
 "\n"
-"Raise a ValueError if x is negative or non-integral.");
+"Raises TypeError if n is not an integer.\n"
+"Raises ValueError if n is negative.");
 
 #define MATH_FACTORIAL_METHODDEF    \
     {"factorial", (PyCFunction)math_factorial, METH_O, math_factorial__doc__},


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133904 -->
* Issue: gh-133904
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133913.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->