### PR TITLE
Fixes #133895

### DIFF
--- a/Lib/test/test_math_errors.py
+++ b/Lib/test/test_math_errors.py
@@ -1,0 +1,71 @@
+import unittest
+import math
+import cmath
+
+class TestMathErrors(unittest.TestCase):
+    def test_math_value_error_with_value(self):
+        # Test math.sqrt with negative number
+        try:
+            math.sqrt(-1)
+        except ValueError as e:
+            self.assertTrue(hasattr(e, 'value'))
+            self.assertTrue(math.isnan(e.value))
+
+        # Test math.log with negative number
+        try:
+            math.log(-1)
+        except ValueError as e:
+            self.assertTrue(hasattr(e, 'value'))
+            self.assertTrue(math.isnan(e.value))
+
+        # Test math.acos with value > 1
+        try:
+            math.acos(2)
+        except ValueError as e:
+            self.assertTrue(hasattr(e, 'value'))
+            self.assertTrue(math.isnan(e.value))
+
+    def test_cmath_value_error_with_value(self):
+        # Test cmath.sqrt with negative number
+        try:
+            cmath.sqrt(-1)
+        except ValueError as e:
+            self.assertTrue(hasattr(e, 'value'))
+            self.assertTrue(isinstance(e.value, complex))
+            self.assertTrue(cmath.isnan(e.value))
+
+        # Test cmath.log with negative number
+        try:
+            cmath.log(-1)
+        except ValueError as e:
+            self.assertTrue(hasattr(e, 'value'))
+            self.assertTrue(isinstance(e.value, complex))
+            self.assertTrue(cmath.isnan(e.value))
+
+        # Test cmath.acos with value > 1
+        try:
+            cmath.acos(2)
+        except ValueError as e:
+            self.assertTrue(hasattr(e, 'value'))
+            self.assertTrue(isinstance(e.value, complex))
+            self.assertTrue(cmath.isnan(e.value))
+
+    def test_math_overflow_error_with_value(self):
+        # Test math.exp with very large number
+        try:
+            math.exp(1000)
+        except OverflowError as e:
+            self.assertTrue(hasattr(e, 'value'))
+            self.assertTrue(math.isinf(e.value))
+
+    def test_cmath_overflow_error_with_value(self):
+        # Test cmath.exp with very large number
+        try:
+            cmath.exp(1000)
+        except OverflowError as e:
+            self.assertTrue(hasattr(e, 'value'))
+            self.assertTrue(isinstance(e.value, complex))
+            self.assertTrue(cmath.isinf(e.value.real) or cmath.isinf(e.value.imag))
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
     This PR modifies the error handling in math and cmath modules to include the computed result value when raising ValueError and OverflowError exceptions. This is particularly useful for applications that need to adhere to C99 Annex G recommendations.

     Changes made:
     - Modified is_error() in mathmodule.c to include computed result value
     - Modified math_error() in cmathmodule.c to include computed result value
     - Added tests to verify the changes

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
