### PR TITLE
gh-133926: pass commands via remote_pdb.set_trace instead of remote_pdb.rcLines.extend

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -3383,8 +3383,7 @@ def _connect(
             f"\nLocal pdb module's protocol version: {attach_ver}"
         )
     else:
-        remote_pdb.rcLines.extend(commands.splitlines())
-        remote_pdb.set_trace(frame=frame)
+        remote_pdb.set_trace(frame=frame, commands=commands.splitlines())
 
 
 def attach(pid, commands=()):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133926 -->
* Issue: gh-133926
<!-- /gh-issue-number -->
