### PR TITLE
gh-133885: skip `test_compress_locking` in `test_zstd`

### DIFF
--- a/Lib/test/test_zstd.py
+++ b/Lib/test/test_zstd.py
@@ -2430,9 +2430,9 @@ class OpenTestCase(unittest.TestCase):
             self.assertEqual(f.write(arr), LENGTH)
             self.assertEqual(f.tell(), LENGTH)
 
+@unittest.skip("it fails for now, see gh-133885")
 class FreeThreadingMethodTests(unittest.TestCase):
 
-    @unittest.skip("it fails for now, see gh-133885")
     @unittest.skipUnless(Py_GIL_DISABLED, 'this test can only possibly fail with GIL disabled')
     @threading_helper.reap_threads
     @threading_helper.requires_working_threading()

--- a/Lib/test/test_zstd.py
+++ b/Lib/test/test_zstd.py
@@ -2432,6 +2432,7 @@ class OpenTestCase(unittest.TestCase):
 
 class FreeThreadingMethodTests(unittest.TestCase):
 
+    @unittest.skip("it fails for now, see gh-133885")
     @unittest.skipUnless(Py_GIL_DISABLED, 'this test can only possibly fail with GIL disabled')
     @threading_helper.reap_threads
     @threading_helper.requires_working_threading()


### PR DESCRIPTION


<!-- gh-issue-number: gh-133885 -->
* Issue: gh-133885
<!-- /gh-issue-number -->
