### PR TITLE
gh-132983: Fix zstd compiler warning about unused function mt_continue_should_break()

### DIFF
--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -486,11 +486,13 @@ error:
     return NULL;
 }
 
+#ifdef Py_DEBUG
 static inline int
 mt_continue_should_break(ZSTD_inBuffer *in, ZSTD_outBuffer *out)
 {
     return in->size == in->pos && out->size != out->pos;
 }
+#endif
 
 static PyObject *
 compress_mt_continue_impl(ZstdCompressor *self, Py_buffer *data)


### PR DESCRIPTION
Fixes the following compiler warning:

```
./Modules/_zstd/compressor.c:490:1: warning: unused function 'mt_continue_should_break' [-Wunused-function]
  490 | mt_continue_should_break(ZSTD_inBuffer *in, ZSTD_outBuffer *out)
      | ^~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->
