### PR TITLE
gh-133953: Add `attach` command to pdb

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -702,7 +702,8 @@ can be overridden by the local file.
 .. pdbcommand:: attach process
 
    Attach to a running process.  The *process* argument could be either a
-   :class:`subprocess.Popen`, :class:`multiprocessing.Process` or a process ID.
+   process ID, or any object that has a ``pid`` attribute like
+   :class:`subprocess.Popen` or :class:`multiprocessing.Process`.
 
    .. versionadded:: 3.15
 

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -700,7 +700,7 @@ can be overridden by the local file.
       output channel rather than :data:`sys.stderr`.
 
 .. pdbcommand:: attach process
-   
+
    Attach to a running process.  The *process* argument could be either a
    :class:`subprocess.Popen`, :class:`multiprocessing.Process` or a process ID.
 

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -699,6 +699,13 @@ can be overridden by the local file.
       :pdbcmd:`interact` directs its output to the debugger's
       output channel rather than :data:`sys.stderr`.
 
+.. pdbcommand:: attach process
+   
+   Attach to a running process.  The *process* argument could be either a
+   :class:`subprocess.Popen`, :class:`multiprocessing.Process` or a process ID.
+
+   .. versionadded:: 3.15
+
 .. _debugger-aliases:
 
 .. pdbcommand:: alias [name [command]]

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -89,6 +89,12 @@ New modules
 Improved modules
 ================
 
+pdb
+---
+
+* :pdbcommand:`attach` command has been added to attach to a running process.
+  (Contributed by Tian Gao in :gh:`133954`.)
+
 ssl
 ---
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -92,7 +92,8 @@ Improved modules
 pdb
 ---
 
-* :pdbcommand:`attach` command has been added to attach to a running process.
+* :pdbcommand:`attach` command is added to attach to a running process
+  from :mod:`pdb`.
   (Contributed by Tian Gao in :gh:`133954`.)
 
 ssl

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -92,8 +92,7 @@ Improved modules
 pdb
 ---
 
-* :pdbcommand:`attach` command is added to attach to a running process
-  from :mod:`pdb`.
+* ``attach`` command is added to attach to a running process from :mod:`pdb`.
   (Contributed by Tian Gao in :gh:`133954`.)
 
 ssl

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -725,7 +725,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             self.error(f"Invalid process {process!r}")
             return None
 
-        return pid 
+        return pid
 
     def interaction(self, frame, tb_or_exc):
         # Restore the previous signal handler at the Pdb prompt.

--- a/Lib/test/test_remote_pdb.py
+++ b/Lib/test/test_remote_pdb.py
@@ -1600,6 +1600,17 @@ class PdbAttachTestCase(unittest.TestCase):
         self.assertNotIn("while x == 1", output["client"]["stdout"])
         self.assertIn("while x == 1", re.sub("\x1b[^m]*m", "", output["client"]["stdout"]))
 
+    def test_attach_from_worker_thread(self):
+        # Test attaching from a worker thread
+        def worker():
+            with self.assertRaises(RuntimeError):
+                # We are not allowed to attach from a thread that's not main
+                pdb.attach(1234)
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+
 
 @unittest.skipIf(not sys.is_remote_debug_enabled(), "Remote debugging is not enabled")
 @unittest.skipIf(sys.platform != "darwin" and sys.platform != "linux" and sys.platform != "win32",

--- a/Lib/test/test_remote_pdb.py
+++ b/Lib/test/test_remote_pdb.py
@@ -819,6 +819,18 @@ class PdbClientTestCase(unittest.TestCase):
             expected_state={"state": "interact"},
         )
 
+    def test_client_attach(self):
+        with unittest.mock.patch("pdb.attach") as mock_attach:
+            incoming = [
+                ("server", {"attach": 1234}),
+            ]
+            self.do_test(
+                incoming=incoming,
+                expected_outgoing=[],
+                expected_stdout_substring="Attaching to process 1234",
+            )
+            mock_attach.assert_called_once_with(1234)
+
 
 class RemotePdbTestCase(unittest.TestCase):
     """Tests for the _PdbServer class."""
@@ -956,6 +968,15 @@ class RemotePdbTestCase(unittest.TestCase):
                 self.pdb.commands[1],
                 ["_pdbcmd_silence_frame_status", "print('hi')"],
             )
+
+    def test_server_attach(self):
+        self.sockfile.add_input({"reply": "attach 1234"})
+        self.sockfile.add_input({"signal": "EOF"})
+
+        self.pdb.cmdloop()
+
+        outputs = self.sockfile.get_output()
+        self.assertEqual(outputs[2], {"attach": 1234})
 
     def test_detach(self):
         """Test the detach method."""
@@ -1578,6 +1599,126 @@ class PdbAttachTestCase(unittest.TestCase):
         self.assertIn("\x1b", output["client"]["stdout"])
         self.assertNotIn("while x == 1", output["client"]["stdout"])
         self.assertIn("while x == 1", re.sub("\x1b[^m]*m", "", output["client"]["stdout"]))
+
+
+@unittest.skipIf(not sys.is_remote_debug_enabled(), "Remote debugging is not enabled")
+@unittest.skipIf(sys.platform != "darwin" and sys.platform != "linux" and sys.platform != "win32",
+                    "Test only runs on Linux, Windows and MacOS")
+@cpython_only
+@requires_subprocess()
+class PdbAttachCommand(unittest.TestCase):
+    def do_test(self, target, commands):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = textwrap.dedent(target)
+            target_path = os.path.join(tmpdir, "target.py")
+            with open(target_path, "wt") as f:
+                f.write(target)
+
+            script = textwrap.dedent(
+                f"""
+                import subprocess
+                import sys
+                process = subprocess.Popen([sys.executable, {target_path!r}],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True
+                )
+                breakpoint()
+                """)
+            script_path = os.path.join(tmpdir, "script.py")
+
+            with open(script_path, "wt") as f:
+                f.write(script)
+
+            process = subprocess.Popen(
+                [sys.executable, script_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                text=True
+            )
+
+            self.addCleanup(process.terminate)
+
+            self.addCleanup(process.stdout.close)
+            self.addCleanup(process.stderr.close)
+
+            stdout, stderr = process.communicate(textwrap.dedent(commands),
+                                                 timeout=SHORT_TIMEOUT)
+
+            return stdout, stderr
+
+    def test_attach_simple(self):
+        """Test basic attach command"""
+        target = """
+            block = True
+            import time
+            while block:
+                time.sleep(0.2)
+            def test_function():
+                x = 42
+                return x
+            test_function()
+        """
+
+        commands = """
+            attach process
+            block = False
+            b test_function
+            c
+            n
+            p x + 42
+            quit
+            continue
+        """
+        stdout, _ = self.do_test(target, commands)
+        self.assertIn("84", stdout)
+
+    def test_attach_multiprocessing(self):
+        """Spawn a process with multiprocessing and attach to it."""
+        target = """
+            block = True
+            import time
+            import multiprocessing
+
+            def worker(queue):
+                block = True
+                queue.put(42)
+                while block:
+                    time.sleep(0.2)
+
+            def test_function(queue):
+                data = queue.get()
+                return data
+
+            if __name__ == '__main__':
+                while block:
+                    time.sleep(0.2)
+
+                queue = multiprocessing.Queue()
+                p = multiprocessing.Process(target=worker, args=(queue,))
+                p.start()
+                test_function(queue)
+                p.join()
+        """
+
+        commands = """
+            attach process
+            block = False
+            b test_function
+            c
+            attach p
+            block = False
+            q
+            n
+            p data + 42
+            quit
+            continue
+        """
+        stdout, _ = self.do_test(target, commands)
+        self.assertIn("84", stdout)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_remote_pdb.py
+++ b/Lib/test/test_remote_pdb.py
@@ -1683,9 +1683,10 @@ class PdbAttachCommand(unittest.TestCase):
 
             def worker(queue):
                 block = True
-                queue.put(42)
+                queue.put(0)
                 while block:
                     time.sleep(0.2)
+                queue.put(42)
 
             def test_function(queue):
                 data = queue.get()
@@ -1698,6 +1699,7 @@ class PdbAttachCommand(unittest.TestCase):
                 queue = multiprocessing.Queue()
                 p = multiprocessing.Process(target=worker, args=(queue,))
                 p.start()
+                queue.get()
                 test_function(queue)
                 p.join()
         """

--- a/Misc/NEWS.d/next/Library/2025-05-12-20-58-11.gh-issue-133953.1dswu9.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-12-20-58-11.gh-issue-133953.1dswu9.rst
@@ -1,0 +1,1 @@
+``attach`` command is added to :mod:`pdb` to attach to a running process.


### PR DESCRIPTION
This PR added a protocol from server to client: `{"attach": int(pid)}`, which tells the client to attach to another process. This is the best way I can think of to avoid multiple hops between processes, while keeping the synchronization. We use the natural stack on the pdb client to simulate the process hop.

`attach` command is added to `pdb`, which is not exactly the same thing - we don't need the protocol change if we don't need multiple hop. A single attach from the client to the server would just work.

<!-- gh-issue-number: gh-133953 -->
* Issue: gh-133953
<!-- /gh-issue-number -->
