### PR TITLE
gh-71253: Match _io exception in _pyio

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1563,7 +1563,8 @@ class FileIO(RawIOBase):
                     if not isinstance(fd, int):
                         raise TypeError('expected integer from opener')
                     if fd < 0:
-                        raise OSError('Negative file descriptor')
+                        # bpo-27066: Raise a ValueError for bad value.
+                        raise ValueError(f'opener returned {fd}')
                 owned_fd = fd
                 if not noinherit_flag:
                     os.set_inheritable(fd, False)

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -918,7 +918,7 @@ class IOTest(unittest.TestCase):
         def badopener(fname, flags):
             return -1
         with self.assertRaises(ValueError) as cm:
-            open('non-existent', 'r', opener=badopener)
+            self.open('non-existent', 'r', opener=badopener)
         self.assertEqual(str(cm.exception), 'opener returned -1')
 
     def test_bad_opener_other_negative(self):
@@ -926,7 +926,7 @@ class IOTest(unittest.TestCase):
         def badopener(fname, flags):
             return -2
         with self.assertRaises(ValueError) as cm:
-            open('non-existent', 'r', opener=badopener)
+            self.open('non-existent', 'r', opener=badopener)
         self.assertEqual(str(cm.exception), 'opener returned -2')
 
     def test_opener_invalid_fd(self):

--- a/Misc/NEWS.d/next/Library/2025-05-13-18-21-59.gh-issue-71253.-3Sf_K.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-13-18-21-59.gh-issue-71253.-3Sf_K.rst
@@ -1,0 +1,2 @@
+Raise ValueError if an opener returns a negative fd in ``_pyio``
+:func:`open` to match ``_io``

--- a/Misc/NEWS.d/next/Library/2025-05-13-18-21-59.gh-issue-71253.-3Sf_K.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-13-18-21-59.gh-issue-71253.-3Sf_K.rst
@@ -1,2 +1,2 @@
-Raise ValueError if an opener returns a negative fd in ``_pyio``
+Raise :exc:`ValueError` if an opener returns a negative file-descriptor in ``_pyio``
 :func:`open` to match ``_io``

--- a/Misc/NEWS.d/next/Library/2025-05-13-18-21-59.gh-issue-71253.-3Sf_K.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-13-18-21-59.gh-issue-71253.-3Sf_K.rst
@@ -1,2 +1,3 @@
-Raise :exc:`ValueError` if an opener returns a negative file-descriptor in ``_pyio``
-:func:`open` to match ``_io``
+Raise :exc:`ValueError` in :func:`open` if *opener* returns a negative
+file-descriptor in the Python implementation of :mod:`io` to match the
+C implementation.


### PR DESCRIPTION
Raise `ValueError` if an opener returns a negative fd in `_pyio.open()` to match behavior `_io`, update test to use `self.open` so behavior is tested in `_pyio` (gh-133982)

<!-- gh-issue-number: gh-71253 -->
* Issue: gh-71253
<!-- /gh-issue-number -->
