### PR TITLE
gh-133986: Document string split algorithm when sep is None and maxsplit is 0

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -6052,4 +6052,3 @@ If you need to disable it entirely, set it to ``0``.
 
 .. [5] To format only a tuple you should therefore provide a singleton tuple whose only
    element is the tuple to be formatted.
-

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2269,6 +2269,18 @@ expression support in the :mod:`re` module).
       >>> '   1   2   3   '.split()
       ['1', '2', '3']
 
+   If *sep* is not specified or is ``None`` and  *maxsplit* is ``0``, only
+   leading runs of consecutive whitespace are considered.
+
+   For example::
+
+      >>> "".split(None, 0)
+      []
+      >>> "   ".split(None, 0)
+      []
+      >>> "   foo   ".split(maxsplit=0)
+      ['foo   ']
+
 
 .. index::
    single: universal newlines; str.splitlines method
@@ -6040,3 +6052,4 @@ If you need to disable it entirely, set it to ``0``.
 
 .. [5] To format only a tuple you should therefore provide a singleton tuple whose only
    element is the tuple to be formatted.
+


### PR DESCRIPTION
If sep is not specified or is None and maxsplit is 0, only leading runs of consecutive whitespace are considered. This is contrary to (or, at least, underspecified in) the current documentation.

I have documented the observed behaviour, and added some example code.

<!-- gh-issue-number: gh-133986 -->
* Issue: gh-133986
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--133987.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->