### PR TITLE
patchlevel CLI: convert between string and hex versions

### DIFF
--- a/Doc/tools/extensions/patchlevel.py
+++ b/Doc/tools/extensions/patchlevel.py
@@ -73,9 +73,89 @@ def get_version_info():
         return version, release
 
 
-if __name__ == "__main__":
-    short_ver, full_ver = format_version_info(get_header_version_info())
-    if sys.argv[1:2] == ["--short"]:
+def get_version_hex(info: version_info) -> int:
+    """Convert a version_info object to a hex version number."""
+    levels = {"alpha": 0xA, "beta": 0xB, "candidate": 0xC, "final": 0xF}
+    return (
+        (info.major << 24)
+        | (info.minor << 16)
+        | (info.micro << 8)
+        | (levels[info.releaselevel] << 4)
+        | (info.serial << 0)
+    )
+
+
+def parse_str_version(version: str) -> version_info:
+    """Convert a version string to a version_info object."""
+    tag_cre = re.compile(r"(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:([ab]|rc)(\d+))?$")
+    result = tag_cre.match(version)
+    if not result:
+        raise ValueError(f"Invalid version string: {version}")
+
+    parts = list(result.groups())
+    levels = {"a": "alpha", "b": "beta", "rc": "candidate"}
+    return version_info(
+        major=int(parts[0]),
+        minor=int(parts[1]),
+        micro=int(parts[2] or 0),
+        releaselevel=levels.get(parts[3], "final"),
+        serial=int(parts[4]) if parts[4] else 0,
+    )
+
+
+def parse_hex_version(version: int) -> version_info:
+    """Convert a hex version number to a version_info object."""
+    if not isinstance(version, int):
+        raise ValueError(f"Invalid hex version: {version}")
+
+    levels = {0xA: "alpha", 0xB: "beta", 0xC: "candidate", 0xF: "final"}
+    return version_info(
+        major=(version >> 24) & 0xFF,
+        minor=(version >> 16) & 0xFF,
+        micro=(version >> 8) & 0xFF,
+        releaselevel=levels.get((version >> 4) & 0xF, "final"),
+        serial=version & 0xF,
+    )
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(color=True)
+    parser.add_argument(
+        "version",
+        nargs="?",
+        help="version to convert (default: repo version)",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--short",
+        action="store_true",
+        help="print version as x.y",
+    )
+    group.add_argument(
+        "--hex",
+        action="store_true",
+        help="print version as a 4-byte hex number",
+    )
+    args = parser.parse_args()
+
+    if args.version:
+        try:
+            info = parse_str_version(args.version)
+        except ValueError:
+            info = parse_hex_version(int(args.version, 16))
+    else:
+        info = get_header_version_info()
+
+    short_ver, full_ver = format_version_info(info)
+    if args.short:
         print(short_ver)
+    elif args.hex:
+        print(hex(get_version_hex(info)))
     else:
         print(full_ver)
+
+
+if __name__ == "__main__":
+    main()

--- a/Doc/tools/extensions/patchlevel.py
+++ b/Doc/tools/extensions/patchlevel.py
@@ -73,89 +73,9 @@ def get_version_info():
         return version, release
 
 
-def get_version_hex(info: version_info) -> int:
-    """Convert a version_info object to a hex version number."""
-    levels = {"alpha": 0xA, "beta": 0xB, "candidate": 0xC, "final": 0xF}
-    return (
-        (info.major << 24)
-        | (info.minor << 16)
-        | (info.micro << 8)
-        | (levels[info.releaselevel] << 4)
-        | (info.serial << 0)
-    )
-
-
-def parse_str_version(version: str) -> version_info:
-    """Convert a version string to a version_info object."""
-    tag_cre = re.compile(r"(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:([ab]|rc)(\d+))?$")
-    result = tag_cre.match(version)
-    if not result:
-        raise ValueError(f"Invalid version string: {version}")
-
-    parts = list(result.groups())
-    levels = {"a": "alpha", "b": "beta", "rc": "candidate"}
-    return version_info(
-        major=int(parts[0]),
-        minor=int(parts[1]),
-        micro=int(parts[2] or 0),
-        releaselevel=levels.get(parts[3], "final"),
-        serial=int(parts[4]) if parts[4] else 0,
-    )
-
-
-def parse_hex_version(version: int) -> version_info:
-    """Convert a hex version number to a version_info object."""
-    if not isinstance(version, int):
-        raise ValueError(f"Invalid hex version: {version}")
-
-    levels = {0xA: "alpha", 0xB: "beta", 0xC: "candidate", 0xF: "final"}
-    return version_info(
-        major=(version >> 24) & 0xFF,
-        minor=(version >> 16) & 0xFF,
-        micro=(version >> 8) & 0xFF,
-        releaselevel=levels.get((version >> 4) & 0xF, "final"),
-        serial=version & 0xF,
-    )
-
-
-def main() -> None:
-    import argparse
-
-    parser = argparse.ArgumentParser(color=True)
-    parser.add_argument(
-        "version",
-        nargs="?",
-        help="version to convert (default: repo version)",
-    )
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
-        "--short",
-        action="store_true",
-        help="print version as x.y",
-    )
-    group.add_argument(
-        "--hex",
-        action="store_true",
-        help="print version as a 4-byte hex number",
-    )
-    args = parser.parse_args()
-
-    if args.version:
-        try:
-            info = parse_str_version(args.version)
-        except ValueError:
-            info = parse_hex_version(int(args.version, 16))
-    else:
-        info = get_header_version_info()
-
-    short_ver, full_ver = format_version_info(info)
-    if args.short:
+if __name__ == "__main__":
+    short_ver, full_ver = format_version_info(get_header_version_info())
+    if sys.argv[1:2] == ["--short"]:
         print(short_ver)
-    elif args.hex:
-        print(hex(get_version_hex(info)))
     else:
         print(full_ver)
-
-
-if __name__ == "__main__":
-    main()

--- a/Tools/build/patchlevel.py
+++ b/Tools/build/patchlevel.py
@@ -1,0 +1,160 @@
+"""Extract version information from Include/patchlevel.h."""
+
+import re
+import sys
+from pathlib import Path
+from typing import Literal, NamedTuple
+
+CPYTHON_ROOT = Path(
+    __file__,  # cpython/Tools/build/patchlevel.py
+    "..",  # cpython/Tools/build
+    "..",  # cpython/Tools
+    "..",  # cpython
+).resolve()
+PATCHLEVEL_H = CPYTHON_ROOT / "Include" / "patchlevel.h"
+
+RELEASE_LEVELS = {
+    "PY_RELEASE_LEVEL_ALPHA": "alpha",
+    "PY_RELEASE_LEVEL_BETA": "beta",
+    "PY_RELEASE_LEVEL_GAMMA": "candidate",
+    "PY_RELEASE_LEVEL_FINAL": "final",
+}
+
+
+class version_info(NamedTuple):
+    major: int  #: Major release number
+    minor: int  #: Minor release number
+    micro: int  #: Patch release number
+    releaselevel: Literal["alpha", "beta", "candidate", "final"]
+    serial: int  #: Serial release number
+
+
+def get_header_version_info() -> version_info:
+    # Capture PY_ prefixed #defines.
+    pat = re.compile(r"\s*#define\s+(PY_\w*)\s+(\w+)", re.ASCII)
+
+    defines = {}
+    patchlevel_h = PATCHLEVEL_H.read_text(encoding="utf-8")
+    for line in patchlevel_h.splitlines():
+        if (m := pat.match(line)) is not None:
+            name, value = m.groups()
+            defines[name] = value
+
+    return version_info(
+        major=int(defines["PY_MAJOR_VERSION"]),
+        minor=int(defines["PY_MINOR_VERSION"]),
+        micro=int(defines["PY_MICRO_VERSION"]),
+        releaselevel=RELEASE_LEVELS[defines["PY_RELEASE_LEVEL"]],
+        serial=int(defines["PY_RELEASE_SERIAL"]),
+    )
+
+
+def format_version_info(info: version_info) -> tuple[str, str]:
+    version = f"{info.major}.{info.minor}"
+    release = f"{info.major}.{info.minor}.{info.micro}"
+    if info.releaselevel != "final":
+        suffix = {"alpha": "a", "beta": "b", "candidate": "rc"}
+        release += f"{suffix[info.releaselevel]}{info.serial}"
+    return version, release
+
+
+def get_version_info():
+    try:
+        info = get_header_version_info()
+        return format_version_info(info)
+    except OSError:
+        version, release = format_version_info(sys.version_info)
+        print(
+            f"Failed to get version info from Include/patchlevel.h, "
+            f"using version of this interpreter ({release}).",
+            file=sys.stderr,
+        )
+        return version, release
+
+
+def get_version_hex(info: version_info) -> int:
+    """Convert a version_info object to a hex version number."""
+    levels = {"alpha": 0xA, "beta": 0xB, "candidate": 0xC, "final": 0xF}
+    return (
+        (info.major << 24)
+        | (info.minor << 16)
+        | (info.micro << 8)
+        | (levels[info.releaselevel] << 4)
+        | (info.serial << 0)
+    )
+
+
+def parse_str_version(version: str) -> version_info:
+    """Convert a version string to a version_info object."""
+    tag_cre = re.compile(r"(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:([ab]|rc)(\d+))?$")
+    result = tag_cre.match(version)
+    if not result:
+        raise ValueError(f"Invalid version string: {version}")
+
+    parts = list(result.groups())
+    levels = {"a": "alpha", "b": "beta", "rc": "candidate"}
+    return version_info(
+        major=int(parts[0]),
+        minor=int(parts[1]),
+        micro=int(parts[2] or 0),
+        releaselevel=levels.get(parts[3], "final"),
+        serial=int(parts[4]) if parts[4] else 0,
+    )
+
+
+def parse_hex_version(version: int) -> version_info:
+    """Convert a hex version number to a version_info object."""
+    if not isinstance(version, int):
+        raise ValueError(f"Invalid hex version: {version}")
+
+    levels = {0xA: "alpha", 0xB: "beta", 0xC: "candidate", 0xF: "final"}
+    return version_info(
+        major=(version >> 24) & 0xFF,
+        minor=(version >> 16) & 0xFF,
+        micro=(version >> 8) & 0xFF,
+        releaselevel=levels.get((version >> 4) & 0xF, "final"),
+        serial=version & 0xF,
+    )
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(color=True)
+    parser.add_argument(
+        "version",
+        nargs="?",
+        help="version to convert (default: repo version)",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--short",
+        action="store_true",
+        help="print version as x.y",
+    )
+    group.add_argument(
+        "--hex",
+        action="store_true",
+        help="print version as a 4-byte hex number",
+    )
+    args = parser.parse_args()
+
+    if args.version:
+        try:
+            info = parse_str_version(args.version)
+        except ValueError:
+            info = parse_hex_version(int(args.version, 16))
+    else:
+        info = get_header_version_info()
+
+    short_ver, full_ver = format_version_info(info)
+    if args.short:
+        print(short_ver)
+    elif args.hex:
+        print(hex(get_version_hex(info)))
+    else:
+        print(full_ver)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Existing behaviour, shows the version number of the repo:

```console
❯ python3 Tools/build/patchlevel.py
3.15.0a0

❯ python3 Tools/build/patchlevel.py --short
3.15
```

New:

Use `argparse` to add (colour) help:

```console
❯ python3 Tools/build/patchlevel.py --help
usage: patchlevel.py [-h] [--short | --hex] [version]

positional arguments:
  version               version to convert (default: repo version)

options:
  -h, --help            show this help message and exit
  --short               print version as x.y
  --hex                 print version as a 4-byte hex number
```

Pass an x.y version number on the command line:

```console
❯ python3 Tools/build/patchlevel.py 3.15
3.15.0

❯ python3 Tools/build/patchlevel.py 3.15 --short
3.15
```

Add `--hex` option to get the patch level as 4-byte hex number:

```console
❯ python3 Tools/build/patchlevel.py 3.15 --hex
0x30f00f0
```

Pass an x.y.z version:

```console
❯ python3 Tools/build/patchlevel.py 3.15.0
3.15.0

❯ python3 Tools/build/patchlevel.py 3.14.0
3.14.0

❯ python3 Tools/build/patchlevel.py 3.14.0 --short
3.14

❯ python3 Tools/build/patchlevel.py 3.14.0 --hex
0x30e00f0
```

Pass an x.y.z[release-level]serial version:

```console
❯ python3 Tools/build/patchlevel.py 3.13.0b1
3.13.0b1

❯ python3 Tools/build/patchlevel.py 3.13.0b1 --short
3.13

❯ python3 Tools/build/patchlevel.py 3.13.0b1 --hex
0x30d00b1
```

Pass a hex patch level:

```console
❯ python3 Tools/build/patchlevel.py 0x030502A1
3.5.2a1

❯ python3 Tools/build/patchlevel.py 0x030502A1 --short
3.5

❯ python3 Tools/build/patchlevel.py 0x030502A1 --hex
0x30502a1
```


Tested by temporarily adding these asserts:
```python
assert get_version_hex(version_info(1, 5, 2, "alpha", 2)) == 0x010502A2
assert get_version_hex(version_info(3, 5, 2, "alpha", 1)) == 0x030502A1
assert get_version_hex(version_info(1, 5, 2, "beta", 2)) == 0x010502B2
assert get_version_hex(version_info(3, 9, 0, "final", 0)) == 0x030900F0
assert get_version_hex(version_info(3, 10, 0, "final", 0)) == 0x030A00F0
assert get_version_hex(version_info(3, 11, 0, "final", 0)) == 0x030B00F0
assert get_version_hex(version_info(3, 12, 0, "final", 0)) == 0x030C00F0
assert get_version_hex(version_info(3, 13, 0, "final", 0)) == 0x030D00F0
assert get_version_hex(version_info(3, 14, 0, "final", 0)) == 0x030E00F0

assert parse_str_version("3.8") == version_info(3, 8, 0, "final", 0)
assert parse_str_version("3.9.0") == version_info(3, 9, 0, "final", 0)
assert parse_str_version("3.10.1") == version_info(3, 10, 1, "final", 0)
assert parse_str_version("3.11.1a2") == version_info(3, 11, 1, "alpha", 2)
assert parse_str_version("3.12.13b3") == version_info(3, 12, 13, "beta", 3)
assert parse_str_version("3.13.3rc2") == version_info(3, 13, 3, "candidate", 2)

assert parse_hex_version(0x30A00A0) == version_info(3, 10, 0, "alpha", 0)
```


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134000.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->