### PR TITLE
gh-134012: Simplify IPv*Interface.__hash__()

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1456,7 +1456,7 @@ class IPv4Interface(IPv4Address):
             return False
 
     def __hash__(self):
-        return hash((self._ip, self._prefixlen, int(self.network.network_address)))
+        return hash((self._ip, self._prefixlen))
 
     __reduce__ = _IPAddressBase.__reduce__
 
@@ -2233,7 +2233,7 @@ class IPv6Interface(IPv6Address):
             return False
 
     def __hash__(self):
-        return hash((self._ip, self._prefixlen, int(self.network.network_address)))
+        return hash((self._ip, self._prefixlen))
 
     __reduce__ = _IPAddressBase.__reduce__
 


### PR DESCRIPTION
The value of `self._ip` and `int(self.network.network_address)` will always be the identical. Therefore, it's unnecessary to include `int(self.network.network_address)` in the tuple used to compute the hash.

Fixes #134012.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134012 -->
* Issue: gh-134012
<!-- /gh-issue-number -->
