### PR TITLE
gh-134041: Avoid usage of unavailable windows path apis

### DIFF
--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1573,6 +1573,7 @@ static PyObject *
 _winapi_GetLongPathName_impl(PyObject *module, LPCWSTR path)
 /*[clinic end generated code: output=c4774b080275a2d0 input=9872e211e3a4a88f]*/
 {
+#if defined(MS_WINDOWS_APP) || defined(MS_WINDOWS_SYSTEM)
     DWORD cchBuffer;
     PyObject *result = NULL;
 
@@ -1596,6 +1597,9 @@ _winapi_GetLongPathName_impl(PyObject *module, LPCWSTR path)
         PyErr_SetFromWindowsErr(0);
     }
     return result;
+#else
+    return PyUnicode_FromWideChar(path, wcslen(path));
+#endif
 }
 
 /*[clinic input]
@@ -1649,6 +1653,7 @@ static PyObject *
 _winapi_GetShortPathName_impl(PyObject *module, LPCWSTR path)
 /*[clinic end generated code: output=dab6ae494c621e81 input=43fa349aaf2ac718]*/
 {
+#if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)
     DWORD cchBuffer;
     PyObject *result = NULL;
 
@@ -1672,6 +1677,10 @@ _winapi_GetShortPathName_impl(PyObject *module, LPCWSTR path)
         PyErr_SetFromWindowsErr(0);
     }
     return result;
+#else
+    PyErr_SetString(PyExc_OSError, "GetShortPathName unavailable on this platform");
+    return NULL;
+#endif
 }
 
 /*[clinic input]
@@ -2883,6 +2892,7 @@ _winapi_NeedCurrentDirectoryForExePath_impl(PyObject *module,
                                             LPCWSTR exe_name)
 /*[clinic end generated code: output=a65ec879502b58fc input=972aac88a1ec2f00]*/
 {
+#if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)
     BOOL result;
 
     Py_BEGIN_ALLOW_THREADS
@@ -2890,6 +2900,9 @@ _winapi_NeedCurrentDirectoryForExePath_impl(PyObject *module,
     Py_END_ALLOW_THREADS
 
     return result;
+#else
+    return TRUE;
+#endif
 }
 
 

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1598,7 +1598,7 @@ _winapi_GetLongPathName_impl(PyObject *module, LPCWSTR path)
     }
     return result;
 #else
-    return PyUnicode_FromWideChar(path, wcslen(path));
+    return PyUnicode_FromWideChar(path, -1);
 #endif
 }
 
@@ -1636,6 +1636,8 @@ _winapi_GetModuleFileName_impl(PyObject *module, HMODULE module_handle)
     return PyUnicode_FromWideChar(filename, wcslen(filename));
 }
 
+#if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)
+
 /*[clinic input]
 _winapi.GetShortPathName
 
@@ -1653,7 +1655,6 @@ static PyObject *
 _winapi_GetShortPathName_impl(PyObject *module, LPCWSTR path)
 /*[clinic end generated code: output=dab6ae494c621e81 input=43fa349aaf2ac718]*/
 {
-#if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)
     DWORD cchBuffer;
     PyObject *result = NULL;
 
@@ -1680,8 +1681,10 @@ _winapi_GetShortPathName_impl(PyObject *module, LPCWSTR path)
 #else
     PyErr_SetString(PyExc_OSError, "GetShortPathName unavailable on this platform");
     return NULL;
-#endif
+
 }
+
+#endif /* MS_WINDOWS_DESKTOP || MS_WINDOWS_SYSTEM */
 
 /*[clinic input]
 _winapi.GetStdHandle -> HANDLE

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1678,10 +1678,6 @@ _winapi_GetShortPathName_impl(PyObject *module, LPCWSTR path)
         PyErr_SetFromWindowsErr(0);
     }
     return result;
-#else
-    PyErr_SetString(PyExc_OSError, "GetShortPathName unavailable on this platform");
-    return NULL;
-
 }
 
 #endif /* MS_WINDOWS_DESKTOP || MS_WINDOWS_SYSTEM */

--- a/Modules/clinic/_winapi.c.h
+++ b/Modules/clinic/_winapi.c.h
@@ -857,6 +857,8 @@ exit:
     return return_value;
 }
 
+#if (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM))
+
 PyDoc_STRVAR(_winapi_GetShortPathName__doc__,
 "GetShortPathName($module, /, path)\n"
 "--\n"
@@ -929,6 +931,8 @@ exit:
 
     return return_value;
 }
+
+#endif /* (defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM)) */
 
 PyDoc_STRVAR(_winapi_GetStdHandle__doc__,
 "GetStdHandle($module, std_handle, /)\n"
@@ -2161,4 +2165,8 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=6cd07628af447d0a input=a9049054013a1b77]*/
+
+#ifndef _WINAPI_GETSHORTPATHNAME_METHODDEF
+    #define _WINAPI_GETSHORTPATHNAME_METHODDEF
+#endif /* !defined(_WINAPI_GETSHORTPATHNAME_METHODDEF) */
+/*[clinic end generated code: output=ede63eaaf63aa7e6 input=a9049054013a1b77]*/


### PR DESCRIPTION
This doesn't contain a doc entry yet, since I wasn't sure about some of the changes yet:
Right now I have the following changes:
- `_winapi.GetLongPathName`: I believe in the gaming partition you simply don't have short name support and so returning the path should be fine
- `_winapi.GetShortPathName`: throws an exception as unsupported
- `_winapi.NeedCurrentDirectoryForExePath`: I have absolutely no clue whether this should be True or False. Really I don't usually start different executables on these targets. Even if I do, I would always use a full path or have the exe placed next to my main executable. So really no clue whether this should: return True, False, throw an exception or be unavailable

<!-- gh-issue-number: gh-134041 -->
* Issue: gh-134041
<!-- /gh-issue-number -->
