### PR TITLE
gh-133157: remove use of `_Py_NO_SANITIZE_UNDEFINED` in faulthandler

### DIFF
--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -166,29 +166,6 @@ class FaultHandlerTests(unittest.TestCase):
         fatal_error = 'Windows fatal exception: %s' % name_regex
         self.check_error(code, line_number, fatal_error, **kw)
 
-    @unittest.skipIf(sys.platform.startswith('aix'),
-                     "the first page of memory is a mapped read-only on AIX")
-    def test_read_null(self):
-        if not MS_WINDOWS:
-            self.check_fatal_error("""
-                import faulthandler
-                faulthandler.enable()
-                faulthandler._read_null()
-                """,
-                3,
-                # Issue #12700: Read NULL raises SIGILL on Mac OS X Lion
-                '(?:Segmentation fault'
-                    '|Bus error'
-                    '|Illegal instruction)')
-        else:
-            self.check_windows_exception("""
-                import faulthandler
-                faulthandler.enable()
-                faulthandler._read_null()
-                """,
-                3,
-                'access violation')
-
     @skip_segfault_on_android
     def test_sigsegv(self):
         self.check_fatal_error("""

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1069,17 +1069,6 @@ faulthandler_suppress_crash_report(void)
 #endif
 }
 
-static PyObject*
-faulthandler_read_null(PyObject *self, PyObject *Py_UNUSED(args))
-{
-    volatile int *x;
-    volatile int y;
-
-    faulthandler_suppress_crash_report();
-    x = NULL;
-    y = *x;
-    return PyLong_FromLong(y);
-}
 
 static void
 faulthandler_raise_sigsegv(void)
@@ -1304,10 +1293,6 @@ static PyMethodDef module_methods[] = {
                "Unregister the handler of the signal "
                "'signum' registered by register().")},
 #endif
-    {"_read_null", faulthandler_read_null, METH_NOARGS,
-     PyDoc_STR("_read_null($module, /)\n--\n\n"
-               "Read from NULL, raise "
-               "a SIGSEGV or SIGBUS signal depending on the platform.")},
     {"_sigsegv", faulthandler_sigsegv, METH_VARARGS,
      PyDoc_STR("_sigsegv($module, release_gil=False, /)\n--\n\n"
                "Raise a SIGSEGV signal.")},

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1069,8 +1069,8 @@ faulthandler_suppress_crash_report(void)
 #endif
 }
 
-static PyObject* _Py_NO_SANITIZE_UNDEFINED
-faulthandler_read_null(PyObject *self, PyObject *args)
+static PyObject*
+faulthandler_read_null(PyObject *self, PyObject *Py_UNUSED(args))
 {
     volatile int *x;
     volatile int y;
@@ -1079,7 +1079,6 @@ faulthandler_read_null(PyObject *self, PyObject *args)
     x = NULL;
     y = *x;
     return PyLong_FromLong(y);
-
 }
 
 static void
@@ -1158,23 +1157,13 @@ faulthandler_fatal_error_c_thread(PyObject *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
-static PyObject* _Py_NO_SANITIZE_UNDEFINED
+static PyObject*
 faulthandler_sigfpe(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     faulthandler_suppress_crash_report();
-
-    /* Do an integer division by zero: raise a SIGFPE on Intel CPU, but not on
-       PowerPC. Use volatile to disable compile-time optimizations. */
-    volatile int x = 1, y = 0, z;
-    z = x / y;
-
-    /* If the division by zero didn't raise a SIGFPE (e.g. on PowerPC),
-       raise it manually. */
+    /* raise SIGFPE manually to prevent crafted undefined behaviors */
     raise(SIGFPE);
-
-    /* This line is never reached, but we pretend to make something with z
-       to silence a compiler warning. */
-    return PyLong_FromLong(z);
+    Py_UNREACHABLE();
 }
 
 static PyObject *

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1161,7 +1161,6 @@ static PyObject*
 faulthandler_sigfpe(PyObject *self, PyObject *Py_UNUSED(dummy))
 {
     faulthandler_suppress_crash_report();
-    /* raise SIGFPE manually to prevent crafted undefined behaviors */
     raise(SIGFPE);
     Py_UNREACHABLE();
 }


### PR DESCRIPTION
- remove `_read_null()` as it's a tricky one (and the compiler didn't seem to complain)
- instead of using 1/0 arithmetic, we explicitly raise SIGFPE

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133157 -->
* Issue: gh-133157
<!-- /gh-issue-number -->
