### PR TITLE
[3.14] gh-134060: Don't create a certain symlink in `venv` if platform does not support it

### DIFF
--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -315,7 +315,7 @@ class EnvBuilder:
                 os.chmod(path, 0o755)
 
             suffixes = ['python', 'python3', f'python3.{sys.version_info[1]}']
-            if sys.version_info[:2] == (3, 14):
+            if sys.version_info[:2] == (3, 14) and sys.getfilesystemencoding() == 'utf-8':
                 suffixes.append('𝜋thon')
             for suffix in suffixes:
                 path = os.path.join(binpath, suffix)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Should this get a NEWS since it is a *sensitive* topic?

I think just checking for utf8 is simplest and will cover most platforms, rather than complicated methods for an easter egg symlink (It's not worth it IMO).

Request @hugovk @hauntsaninja 


<!-- gh-issue-number: gh-134060 -->
* Issue: gh-134060
<!-- /gh-issue-number -->
