### PR TITLE
gh-113878: Fix versionadded in `dataclasses.field()` documentation

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -304,9 +304,9 @@ Module contents
 
     .. versionadded:: 3.10
 
-   - ``doc``: optional docstring for this field.
+   - *doc*: optional docstring for this field.
 
-    .. versionadded:: 3.13
+    .. versionadded:: 3.14
 
    If the default value of a field is specified by a call to
    :func:`!field`, then the class attribute for this field will be


### PR DESCRIPTION
cc @sobolevn 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134065.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-113878 -->
* Issue: gh-113878
<!-- /gh-issue-number -->
