### PR TITLE
Docs EPUB: fix meta tags connected with Open Graph

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -630,13 +630,10 @@ ogp_social_cards = {  # Used when matplotlib is installed
     'image': '_static/og-image.png',
     'line_color': '#3776ab',
 }
-ogp_custom_meta_tags = [
-    '<meta name="theme-color" content="#3776ab">',
-]
 if 'create-social-cards' not in tags:  # noqa: F821
     # Define a static preview image when not creating social cards
     ogp_image = '_static/og-image.png'
-    ogp_custom_meta_tags += [
+    ogp_custom_meta_tags = [
         '<meta property="og:image:width" content="200">',
         '<meta property="og:image:height" content="200">',
     ]

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -634,6 +634,7 @@ if 'create-social-cards' not in tags:  # noqa: F821
     # Define a static preview image when not creating social cards
     ogp_image = '_static/og-image.png'
     ogp_custom_meta_tags = [
-        '<meta property="og:image:width" content="200">',
-        '<meta property="og:image:height" content="200">',
+        # Self-closing for EPUB validity
+        '<meta property="og:image:width" content="200" />',
+        '<meta property="og:image:height" content="200" />',
     ]

--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -31,6 +31,7 @@
       <script defer data-domain="docs.python.org" src="https://analytics.python.org/js/script.outbound-links.js"></script>
       {% endif %}
       <link rel="canonical" href="https://docs.python.org/3/{{pagename}}.html">
+      <meta name="theme-color" content="#3776ab">
       {% if pagename == 'whatsnew/changelog' and not embedded %}
       <script type="text/javascript" src="{{ pathto('_static/changelog_search.js', 1) }}"></script>{% endif %}
     {% endif %}


### PR DESCRIPTION
* Move meta `theme-color` tag from `sphinxext-opengraph` custom tags config directly to `layout.html`. Previously it would be added for all HTML-related Sphinx builders, after it's only added when builder == HTML.
* Partially revert https://github.com/python/cpython/pull/132220, bring back self-closing tags in custom meta tags in `sphinxext-opengraph` config. (I've opened https://github.com/sphinx-doc/sphinxext-opengraph/issues/136 to discuss alternative fixes.)

It's a follow-up to https://github.com/python/cpython/pull/132220 and https://github.com/python/cpython/pull/133720. This change should fix EPUB builds. When testing locally for #133720 I didn't have `sphinxext-opengraph` installed in the environment, that's why I didn't catch it earlier, I'm sorry.

Could we please backport it for supported versions and 3.12?

Before:

<img width="1136" alt="Zrzut ekranu 2025-05-16 o 00 59 52" src="https://github.com/user-attachments/assets/300ecf54-83dc-4a58-9068-4ccbc826049a" />

After:

<img width="1136" alt="Zrzut ekranu 2025-05-16 o 01 01 58" src="https://github.com/user-attachments/assets/79e78da9-97f2-45c6-bc53-8929ea532744" />


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134071.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->