### PR TITLE
gh-134036: Improve error messages for invalid `raise` statements

### DIFF
--- a/Grammar/python.gram
+++ b/Grammar/python.gram
@@ -184,6 +184,7 @@ return_stmt[stmt_ty]:
     | 'return' a=[star_expressions] { _PyAST_Return(a, EXTRA) }
 
 raise_stmt[stmt_ty]:
+    | invalid_raise_stmt
     | 'raise' a=expression b=['from' z=expression { z }] { _PyAST_Raise(a, b, EXTRA) }
     | 'raise' { _PyAST_Raise(NULL, NULL, EXTRA) }
 
@@ -1287,6 +1288,11 @@ invalid_ann_assign_target[expr_ty]:
     | list
     | tuple
     | '(' a=invalid_ann_assign_target ')' { a }
+invalid_raise_stmt:
+    | a='raise' b='from' {
+        RAISE_SYNTAX_ERROR_KNOWN_RANGE(a, b, "did you forget an expression between 'raise' and 'from'?") }
+    | 'raise' expression a='from' {
+        RAISE_SYNTAX_ERROR_KNOWN_LOCATION(a, "did you forget an expression after 'from'?") }
 invalid_del_stmt:
     | 'del' a=star_expressions {
         RAISE_SYNTAX_ERROR_INVALID_TARGET(DEL_TARGETS, a) }

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1678,6 +1678,28 @@ Make sure that the old "raise X, Y[, Z]" form is gone:
      ...
    SyntaxError: invalid syntax
 
+Better errors for `raise` statement:
+
+    >>> raise ValueError from
+    Traceback (most recent call last):
+    SyntaxError: did you forget an expression after 'from'?
+
+    >>> raise mod.ValueError() from
+    Traceback (most recent call last):
+    SyntaxError: did you forget an expression after 'from'?
+
+    >>> raise from exc
+    Traceback (most recent call last):
+    SyntaxError: did you forget an expression between 'raise' and 'from'?
+
+    >>> raise from None
+    Traceback (most recent call last):
+    SyntaxError: did you forget an expression between 'raise' and 'from'?
+
+    >>> raise from
+    Traceback (most recent call last):
+    SyntaxError: did you forget an expression between 'raise' and 'from'?
+
 Check that an multiple exception types with missing parentheses
 raise a custom exception only when using 'as'
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-09-06-38.gh-issue-134036.st2e-B.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-09-06-38.gh-issue-134036.st2e-B.rst
@@ -1,0 +1,2 @@
+Improve :exc:`SyntaxError` message when using invalid :keyword:`raise`
+statements.

--- a/Parser/parser.c
+++ b/Parser/parser.c
@@ -21,54 +21,54 @@ static KeywordToken *reserved_keywords[] = {
     (KeywordToken[]) {{NULL, -1}},
     (KeywordToken[]) {{NULL, -1}},
     (KeywordToken[]) {
-        {"if", 682},
-        {"as", 680},
-        {"in", 695},
+        {"if", 686},
+        {"as", 684},
+        {"in", 699},
         {"or", 588},
         {"is", 596},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"del", 625},
-        {"def", 699},
-        {"for", 694},
-        {"try", 656},
+        {"del", 629},
+        {"def", 703},
+        {"for", 698},
+        {"try", 660},
         {"and", 589},
-        {"not", 703},
+        {"not", 707},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"from", 633},
+        {"from", 637},
         {"pass", 526},
-        {"with", 647},
-        {"elif", 687},
-        {"else", 686},
+        {"with", 651},
+        {"elif", 691},
+        {"else", 690},
         {"None", 623},
         {"True", 622},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"raise", 525},
+        {"raise", 627},
         {"yield", 587},
         {"break", 527},
-        {"async", 698},
-        {"class", 701},
-        {"while", 689},
+        {"async", 702},
+        {"class", 705},
+        {"while", 693},
         {"False", 624},
         {"await", 597},
         {NULL, -1},
     },
     (KeywordToken[]) {
         {"return", 522},
-        {"import", 634},
+        {"import", 638},
         {"assert", 532},
         {"global", 529},
-        {"except", 677},
+        {"except", 681},
         {"lambda", 621},
         {NULL, -1},
     },
     (KeywordToken[]) {
-        {"finally", 673},
+        {"finally", 677},
         {NULL, -1},
     },
     (KeywordToken[]) {
@@ -298,235 +298,236 @@ static char *soft_keywords[] = {
 #define invalid_named_expression_type 1211
 #define invalid_assignment_type 1212
 #define invalid_ann_assign_target_type 1213
-#define invalid_del_stmt_type 1214
-#define invalid_block_type 1215
-#define invalid_comprehension_type 1216
-#define invalid_dict_comprehension_type 1217
-#define invalid_parameters_type 1218
-#define invalid_default_type 1219
-#define invalid_star_etc_type 1220
-#define invalid_kwds_type 1221
-#define invalid_parameters_helper_type 1222
-#define invalid_lambda_parameters_type 1223
-#define invalid_lambda_parameters_helper_type 1224
-#define invalid_lambda_star_etc_type 1225
-#define invalid_lambda_kwds_type 1226
-#define invalid_double_type_comments_type 1227
-#define invalid_with_item_type 1228
-#define invalid_for_if_clause_type 1229
-#define invalid_for_target_type 1230
-#define invalid_group_type 1231
-#define invalid_import_type 1232
-#define invalid_dotted_as_name_type 1233
-#define invalid_import_from_as_name_type 1234
-#define invalid_import_from_targets_type 1235
-#define invalid_with_stmt_type 1236
-#define invalid_with_stmt_indent_type 1237
-#define invalid_try_stmt_type 1238
-#define invalid_except_stmt_type 1239
-#define invalid_except_star_stmt_type 1240
-#define invalid_finally_stmt_type 1241
-#define invalid_except_stmt_indent_type 1242
-#define invalid_except_star_stmt_indent_type 1243
-#define invalid_match_stmt_type 1244
-#define invalid_case_block_type 1245
-#define invalid_as_pattern_type 1246
-#define invalid_class_pattern_type 1247
-#define invalid_class_argument_pattern_type 1248
-#define invalid_if_stmt_type 1249
-#define invalid_elif_stmt_type 1250
-#define invalid_else_stmt_type 1251
-#define invalid_while_stmt_type 1252
-#define invalid_for_stmt_type 1253
-#define invalid_def_raw_type 1254
-#define invalid_class_def_raw_type 1255
-#define invalid_double_starred_kvpairs_type 1256
-#define invalid_kvpair_type 1257
-#define invalid_starred_expression_unpacking_type 1258
-#define invalid_starred_expression_type 1259
-#define invalid_fstring_replacement_field_type 1260
-#define invalid_fstring_conversion_character_type 1261
-#define invalid_tstring_replacement_field_type 1262
-#define invalid_tstring_conversion_character_type 1263
-#define invalid_arithmetic_type 1264
-#define invalid_factor_type 1265
-#define invalid_type_params_type 1266
-#define _loop0_1_type 1267
-#define _loop1_2_type 1268
-#define _loop0_3_type 1269
-#define _gather_4_type 1270
-#define _tmp_5_type 1271
-#define _tmp_6_type 1272
-#define _tmp_7_type 1273
-#define _tmp_8_type 1274
-#define _tmp_9_type 1275
-#define _tmp_10_type 1276
-#define _tmp_11_type 1277
-#define _loop1_12_type 1278
-#define _tmp_13_type 1279
-#define _loop0_14_type 1280
-#define _gather_15_type 1281
-#define _tmp_16_type 1282
-#define _tmp_17_type 1283
-#define _loop0_18_type 1284
-#define _loop1_19_type 1285
-#define _loop0_20_type 1286
-#define _gather_21_type 1287
-#define _tmp_22_type 1288
-#define _loop0_23_type 1289
-#define _gather_24_type 1290
-#define _loop1_25_type 1291
-#define _tmp_26_type 1292
-#define _tmp_27_type 1293
-#define _loop0_28_type 1294
-#define _loop0_29_type 1295
-#define _loop1_30_type 1296
-#define _loop1_31_type 1297
-#define _loop0_32_type 1298
-#define _loop1_33_type 1299
-#define _loop0_34_type 1300
-#define _gather_35_type 1301
-#define _tmp_36_type 1302
-#define _loop1_37_type 1303
-#define _loop1_38_type 1304
-#define _loop1_39_type 1305
-#define _loop0_40_type 1306
-#define _gather_41_type 1307
-#define _tmp_42_type 1308
-#define _tmp_43_type 1309
-#define _tmp_44_type 1310
-#define _loop0_45_type 1311
-#define _gather_46_type 1312
-#define _loop0_47_type 1313
-#define _gather_48_type 1314
-#define _tmp_49_type 1315
-#define _loop0_50_type 1316
-#define _gather_51_type 1317
-#define _loop0_52_type 1318
-#define _gather_53_type 1319
-#define _loop0_54_type 1320
-#define _gather_55_type 1321
-#define _loop1_56_type 1322
-#define _loop1_57_type 1323
-#define _loop0_58_type 1324
-#define _gather_59_type 1325
-#define _loop1_60_type 1326
-#define _loop1_61_type 1327
-#define _loop1_62_type 1328
-#define _tmp_63_type 1329
-#define _loop0_64_type 1330
-#define _gather_65_type 1331
-#define _tmp_66_type 1332
-#define _tmp_67_type 1333
-#define _tmp_68_type 1334
-#define _tmp_69_type 1335
-#define _tmp_70_type 1336
-#define _loop0_71_type 1337
-#define _loop0_72_type 1338
-#define _loop1_73_type 1339
-#define _loop1_74_type 1340
-#define _loop0_75_type 1341
-#define _loop1_76_type 1342
-#define _loop0_77_type 1343
-#define _loop0_78_type 1344
-#define _loop0_79_type 1345
-#define _loop0_80_type 1346
-#define _loop1_81_type 1347
-#define _tmp_82_type 1348
-#define _loop0_83_type 1349
-#define _gather_84_type 1350
-#define _loop1_85_type 1351
-#define _loop0_86_type 1352
-#define _tmp_87_type 1353
-#define _loop0_88_type 1354
-#define _gather_89_type 1355
-#define _tmp_90_type 1356
-#define _loop0_91_type 1357
-#define _gather_92_type 1358
-#define _loop0_93_type 1359
-#define _gather_94_type 1360
-#define _loop0_95_type 1361
-#define _loop0_96_type 1362
-#define _gather_97_type 1363
-#define _loop1_98_type 1364
-#define _tmp_99_type 1365
-#define _loop0_100_type 1366
-#define _gather_101_type 1367
-#define _loop0_102_type 1368
-#define _gather_103_type 1369
-#define _tmp_104_type 1370
-#define _tmp_105_type 1371
-#define _loop0_106_type 1372
-#define _gather_107_type 1373
-#define _tmp_108_type 1374
-#define _tmp_109_type 1375
-#define _tmp_110_type 1376
-#define _tmp_111_type 1377
-#define _tmp_112_type 1378
-#define _loop1_113_type 1379
-#define _tmp_114_type 1380
-#define _tmp_115_type 1381
-#define _tmp_116_type 1382
-#define _tmp_117_type 1383
-#define _tmp_118_type 1384
-#define _loop0_119_type 1385
-#define _loop0_120_type 1386
-#define _tmp_121_type 1387
-#define _tmp_122_type 1388
-#define _tmp_123_type 1389
-#define _tmp_124_type 1390
-#define _tmp_125_type 1391
-#define _tmp_126_type 1392
-#define _tmp_127_type 1393
-#define _tmp_128_type 1394
-#define _tmp_129_type 1395
-#define _loop0_130_type 1396
-#define _gather_131_type 1397
-#define _tmp_132_type 1398
-#define _tmp_133_type 1399
-#define _tmp_134_type 1400
-#define _tmp_135_type 1401
-#define _loop0_136_type 1402
-#define _gather_137_type 1403
-#define _tmp_138_type 1404
-#define _loop0_139_type 1405
-#define _gather_140_type 1406
-#define _loop0_141_type 1407
-#define _gather_142_type 1408
-#define _tmp_143_type 1409
-#define _loop0_144_type 1410
-#define _tmp_145_type 1411
-#define _tmp_146_type 1412
-#define _tmp_147_type 1413
-#define _tmp_148_type 1414
-#define _tmp_149_type 1415
-#define _tmp_150_type 1416
-#define _tmp_151_type 1417
-#define _tmp_152_type 1418
-#define _tmp_153_type 1419
-#define _tmp_154_type 1420
-#define _tmp_155_type 1421
-#define _tmp_156_type 1422
-#define _tmp_157_type 1423
-#define _tmp_158_type 1424
-#define _tmp_159_type 1425
-#define _tmp_160_type 1426
-#define _tmp_161_type 1427
-#define _tmp_162_type 1428
-#define _tmp_163_type 1429
-#define _tmp_164_type 1430
-#define _tmp_165_type 1431
-#define _tmp_166_type 1432
-#define _tmp_167_type 1433
-#define _tmp_168_type 1434
-#define _tmp_169_type 1435
-#define _tmp_170_type 1436
-#define _loop0_171_type 1437
-#define _tmp_172_type 1438
-#define _tmp_173_type 1439
-#define _tmp_174_type 1440
-#define _tmp_175_type 1441
-#define _tmp_176_type 1442
+#define invalid_raise_stmt_type 1214
+#define invalid_del_stmt_type 1215
+#define invalid_block_type 1216
+#define invalid_comprehension_type 1217
+#define invalid_dict_comprehension_type 1218
+#define invalid_parameters_type 1219
+#define invalid_default_type 1220
+#define invalid_star_etc_type 1221
+#define invalid_kwds_type 1222
+#define invalid_parameters_helper_type 1223
+#define invalid_lambda_parameters_type 1224
+#define invalid_lambda_parameters_helper_type 1225
+#define invalid_lambda_star_etc_type 1226
+#define invalid_lambda_kwds_type 1227
+#define invalid_double_type_comments_type 1228
+#define invalid_with_item_type 1229
+#define invalid_for_if_clause_type 1230
+#define invalid_for_target_type 1231
+#define invalid_group_type 1232
+#define invalid_import_type 1233
+#define invalid_dotted_as_name_type 1234
+#define invalid_import_from_as_name_type 1235
+#define invalid_import_from_targets_type 1236
+#define invalid_with_stmt_type 1237
+#define invalid_with_stmt_indent_type 1238
+#define invalid_try_stmt_type 1239
+#define invalid_except_stmt_type 1240
+#define invalid_except_star_stmt_type 1241
+#define invalid_finally_stmt_type 1242
+#define invalid_except_stmt_indent_type 1243
+#define invalid_except_star_stmt_indent_type 1244
+#define invalid_match_stmt_type 1245
+#define invalid_case_block_type 1246
+#define invalid_as_pattern_type 1247
+#define invalid_class_pattern_type 1248
+#define invalid_class_argument_pattern_type 1249
+#define invalid_if_stmt_type 1250
+#define invalid_elif_stmt_type 1251
+#define invalid_else_stmt_type 1252
+#define invalid_while_stmt_type 1253
+#define invalid_for_stmt_type 1254
+#define invalid_def_raw_type 1255
+#define invalid_class_def_raw_type 1256
+#define invalid_double_starred_kvpairs_type 1257
+#define invalid_kvpair_type 1258
+#define invalid_starred_expression_unpacking_type 1259
+#define invalid_starred_expression_type 1260
+#define invalid_fstring_replacement_field_type 1261
+#define invalid_fstring_conversion_character_type 1262
+#define invalid_tstring_replacement_field_type 1263
+#define invalid_tstring_conversion_character_type 1264
+#define invalid_arithmetic_type 1265
+#define invalid_factor_type 1266
+#define invalid_type_params_type 1267
+#define _loop0_1_type 1268
+#define _loop1_2_type 1269
+#define _loop0_3_type 1270
+#define _gather_4_type 1271
+#define _tmp_5_type 1272
+#define _tmp_6_type 1273
+#define _tmp_7_type 1274
+#define _tmp_8_type 1275
+#define _tmp_9_type 1276
+#define _tmp_10_type 1277
+#define _tmp_11_type 1278
+#define _loop1_12_type 1279
+#define _tmp_13_type 1280
+#define _loop0_14_type 1281
+#define _gather_15_type 1282
+#define _tmp_16_type 1283
+#define _tmp_17_type 1284
+#define _loop0_18_type 1285
+#define _loop1_19_type 1286
+#define _loop0_20_type 1287
+#define _gather_21_type 1288
+#define _tmp_22_type 1289
+#define _loop0_23_type 1290
+#define _gather_24_type 1291
+#define _loop1_25_type 1292
+#define _tmp_26_type 1293
+#define _tmp_27_type 1294
+#define _loop0_28_type 1295
+#define _loop0_29_type 1296
+#define _loop1_30_type 1297
+#define _loop1_31_type 1298
+#define _loop0_32_type 1299
+#define _loop1_33_type 1300
+#define _loop0_34_type 1301
+#define _gather_35_type 1302
+#define _tmp_36_type 1303
+#define _loop1_37_type 1304
+#define _loop1_38_type 1305
+#define _loop1_39_type 1306
+#define _loop0_40_type 1307
+#define _gather_41_type 1308
+#define _tmp_42_type 1309
+#define _tmp_43_type 1310
+#define _tmp_44_type 1311
+#define _loop0_45_type 1312
+#define _gather_46_type 1313
+#define _loop0_47_type 1314
+#define _gather_48_type 1315
+#define _tmp_49_type 1316
+#define _loop0_50_type 1317
+#define _gather_51_type 1318
+#define _loop0_52_type 1319
+#define _gather_53_type 1320
+#define _loop0_54_type 1321
+#define _gather_55_type 1322
+#define _loop1_56_type 1323
+#define _loop1_57_type 1324
+#define _loop0_58_type 1325
+#define _gather_59_type 1326
+#define _loop1_60_type 1327
+#define _loop1_61_type 1328
+#define _loop1_62_type 1329
+#define _tmp_63_type 1330
+#define _loop0_64_type 1331
+#define _gather_65_type 1332
+#define _tmp_66_type 1333
+#define _tmp_67_type 1334
+#define _tmp_68_type 1335
+#define _tmp_69_type 1336
+#define _tmp_70_type 1337
+#define _loop0_71_type 1338
+#define _loop0_72_type 1339
+#define _loop1_73_type 1340
+#define _loop1_74_type 1341
+#define _loop0_75_type 1342
+#define _loop1_76_type 1343
+#define _loop0_77_type 1344
+#define _loop0_78_type 1345
+#define _loop0_79_type 1346
+#define _loop0_80_type 1347
+#define _loop1_81_type 1348
+#define _tmp_82_type 1349
+#define _loop0_83_type 1350
+#define _gather_84_type 1351
+#define _loop1_85_type 1352
+#define _loop0_86_type 1353
+#define _tmp_87_type 1354
+#define _loop0_88_type 1355
+#define _gather_89_type 1356
+#define _tmp_90_type 1357
+#define _loop0_91_type 1358
+#define _gather_92_type 1359
+#define _loop0_93_type 1360
+#define _gather_94_type 1361
+#define _loop0_95_type 1362
+#define _loop0_96_type 1363
+#define _gather_97_type 1364
+#define _loop1_98_type 1365
+#define _tmp_99_type 1366
+#define _loop0_100_type 1367
+#define _gather_101_type 1368
+#define _loop0_102_type 1369
+#define _gather_103_type 1370
+#define _tmp_104_type 1371
+#define _tmp_105_type 1372
+#define _loop0_106_type 1373
+#define _gather_107_type 1374
+#define _tmp_108_type 1375
+#define _tmp_109_type 1376
+#define _tmp_110_type 1377
+#define _tmp_111_type 1378
+#define _tmp_112_type 1379
+#define _loop1_113_type 1380
+#define _tmp_114_type 1381
+#define _tmp_115_type 1382
+#define _tmp_116_type 1383
+#define _tmp_117_type 1384
+#define _tmp_118_type 1385
+#define _loop0_119_type 1386
+#define _loop0_120_type 1387
+#define _tmp_121_type 1388
+#define _tmp_122_type 1389
+#define _tmp_123_type 1390
+#define _tmp_124_type 1391
+#define _tmp_125_type 1392
+#define _tmp_126_type 1393
+#define _tmp_127_type 1394
+#define _tmp_128_type 1395
+#define _tmp_129_type 1396
+#define _loop0_130_type 1397
+#define _gather_131_type 1398
+#define _tmp_132_type 1399
+#define _tmp_133_type 1400
+#define _tmp_134_type 1401
+#define _tmp_135_type 1402
+#define _loop0_136_type 1403
+#define _gather_137_type 1404
+#define _tmp_138_type 1405
+#define _loop0_139_type 1406
+#define _gather_140_type 1407
+#define _loop0_141_type 1408
+#define _gather_142_type 1409
+#define _tmp_143_type 1410
+#define _loop0_144_type 1411
+#define _tmp_145_type 1412
+#define _tmp_146_type 1413
+#define _tmp_147_type 1414
+#define _tmp_148_type 1415
+#define _tmp_149_type 1416
+#define _tmp_150_type 1417
+#define _tmp_151_type 1418
+#define _tmp_152_type 1419
+#define _tmp_153_type 1420
+#define _tmp_154_type 1421
+#define _tmp_155_type 1422
+#define _tmp_156_type 1423
+#define _tmp_157_type 1424
+#define _tmp_158_type 1425
+#define _tmp_159_type 1426
+#define _tmp_160_type 1427
+#define _tmp_161_type 1428
+#define _tmp_162_type 1429
+#define _tmp_163_type 1430
+#define _tmp_164_type 1431
+#define _tmp_165_type 1432
+#define _tmp_166_type 1433
+#define _tmp_167_type 1434
+#define _tmp_168_type 1435
+#define _tmp_169_type 1436
+#define _tmp_170_type 1437
+#define _loop0_171_type 1438
+#define _tmp_172_type 1439
+#define _tmp_173_type 1440
+#define _tmp_174_type 1441
+#define _tmp_175_type 1442
+#define _tmp_176_type 1443
 
 static mod_ty file_rule(Parser *p);
 static mod_ty interactive_rule(Parser *p);
@@ -742,6 +743,7 @@ static void *invalid_expression_rule(Parser *p);
 static void *invalid_named_expression_rule(Parser *p);
 static void *invalid_assignment_rule(Parser *p);
 static expr_ty invalid_ann_assign_target_rule(Parser *p);
+static void *invalid_raise_stmt_rule(Parser *p);
 static void *invalid_del_stmt_rule(Parser *p);
 static void *invalid_block_rule(Parser *p);
 static void *invalid_comprehension_rule(Parser *p);
@@ -1698,7 +1700,7 @@ simple_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'raise' raise_stmt"));
         stmt_ty raise_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 525)  // token='raise'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 627)  // token='raise'
             &&
             (raise_stmt_var = raise_stmt_rule(p))  // raise_stmt
         )
@@ -1740,7 +1742,7 @@ simple_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> simple_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'del' del_stmt"));
         stmt_ty del_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 625)  // token='del'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 629)  // token='del'
             &&
             (del_stmt_var = del_stmt_rule(p))  // del_stmt
         )
@@ -1936,7 +1938,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'if' if_stmt"));
         stmt_ty if_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 682)  // token='if'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 686)  // token='if'
             &&
             (if_stmt_var = if_stmt_rule(p))  // if_stmt
         )
@@ -2020,7 +2022,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'try' try_stmt"));
         stmt_ty try_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 656)  // token='try'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 660)  // token='try'
             &&
             (try_stmt_var = try_stmt_rule(p))  // try_stmt
         )
@@ -2041,7 +2043,7 @@ compound_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> compound_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "&'while' while_stmt"));
         stmt_ty while_stmt_var;
         if (
-            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 689)  // token='while'
+            _PyPegen_lookahead_with_int(1, _PyPegen_expect_token, p, 693)  // token='while'
             &&
             (while_stmt_var = while_stmt_rule(p))  // while_stmt
         )
@@ -2767,7 +2769,7 @@ return_stmt_rule(Parser *p)
     return _res;
 }
 
-// raise_stmt: 'raise' expression ['from' expression] | 'raise'
+// raise_stmt: invalid_raise_stmt | 'raise' expression ['from' expression] | 'raise'
 static stmt_ty
 raise_stmt_rule(Parser *p)
 {
@@ -2789,6 +2791,25 @@ raise_stmt_rule(Parser *p)
     UNUSED(_start_lineno); // Only used by EXTRA macro
     int _start_col_offset = p->tokens[_mark]->col_offset;
     UNUSED(_start_col_offset); // Only used by EXTRA macro
+    if (p->call_invalid_rules) { // invalid_raise_stmt
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> raise_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "invalid_raise_stmt"));
+        void *invalid_raise_stmt_var;
+        if (
+            (invalid_raise_stmt_var = invalid_raise_stmt_rule(p))  // invalid_raise_stmt
+        )
+        {
+            D(fprintf(stderr, "%*c+ raise_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "invalid_raise_stmt"));
+            _res = invalid_raise_stmt_var;
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s raise_stmt[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "invalid_raise_stmt"));
+    }
     { // 'raise' expression ['from' expression]
         if (p->error_indicator) {
             p->level--;
@@ -2799,7 +2820,7 @@ raise_stmt_rule(Parser *p)
         expr_ty a;
         void *b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 525))  // token='raise'
+            (_keyword = _PyPegen_expect_token(p, 627))  // token='raise'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -2836,7 +2857,7 @@ raise_stmt_rule(Parser *p)
         D(fprintf(stderr, "%*c> raise_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'raise'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 525))  // token='raise'
+            (_keyword = _PyPegen_expect_token(p, 627))  // token='raise'
         )
         {
             D(fprintf(stderr, "%*c+ raise_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'raise'"));
@@ -3209,7 +3230,7 @@ del_stmt_rule(Parser *p)
         Token * _keyword;
         asdl_expr_seq* a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 625))  // token='del'
+            (_keyword = _PyPegen_expect_token(p, 629))  // token='del'
             &&
             (a = del_targets_rule(p))  // del_targets
             &&
@@ -3498,7 +3519,7 @@ import_name_rule(Parser *p)
         Token * _keyword;
         asdl_alias_seq* a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 634))  // token='import'
+            (_keyword = _PyPegen_expect_token(p, 638))  // token='import'
             &&
             (a = dotted_as_names_rule(p))  // dotted_as_names
         )
@@ -3567,13 +3588,13 @@ import_from_rule(Parser *p)
         expr_ty b;
         asdl_alias_seq* c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 633))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 637))  // token='from'
             &&
             (a = _loop0_18_rule(p))  // (('.' | '...'))*
             &&
             (b = dotted_name_rule(p))  // dotted_name
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 634))  // token='import'
+            (_keyword_1 = _PyPegen_expect_token(p, 638))  // token='import'
             &&
             (c = import_from_targets_rule(p))  // import_from_targets
         )
@@ -3611,11 +3632,11 @@ import_from_rule(Parser *p)
         asdl_seq * a;
         asdl_alias_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 633))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 637))  // token='from'
             &&
             (a = _loop1_19_rule(p))  // (('.' | '...'))+
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 634))  // token='import'
+            (_keyword_1 = _PyPegen_expect_token(p, 638))  // token='import'
             &&
             (b = import_from_targets_rule(p))  // import_from_targets
         )
@@ -4402,7 +4423,7 @@ class_def_raw_rule(Parser *p)
         asdl_stmt_seq* c;
         void *t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 701))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 705))  // token='class'
             &&
             (a = _PyPegen_name_token(p))  // NAME
             &&
@@ -4569,7 +4590,7 @@ function_def_raw_rule(Parser *p)
         void *t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 699))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 703))  // token='def'
             &&
             (n = _PyPegen_name_token(p))  // NAME
             &&
@@ -4630,9 +4651,9 @@ function_def_raw_rule(Parser *p)
         void *t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 702))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='def'
+            (_keyword_1 = _PyPegen_expect_token(p, 703))  // token='def'
             &&
             (n = _PyPegen_name_token(p))  // NAME
             &&
@@ -5970,7 +5991,7 @@ if_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         stmt_ty c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='if'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6015,7 +6036,7 @@ if_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='if'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6110,7 +6131,7 @@ elif_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         stmt_ty c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 687))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 691))  // token='elif'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6155,7 +6176,7 @@ elif_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 687))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 691))  // token='elif'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6236,7 +6257,7 @@ else_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 686))  // token='else'
+            (_keyword = _PyPegen_expect_token(p, 690))  // token='else'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -6315,7 +6336,7 @@ while_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 689))  // token='while'
+            (_keyword = _PyPegen_expect_token(p, 693))  // token='while'
             &&
             (a = named_expression_rule(p))  // named_expression
             &&
@@ -6415,11 +6436,11 @@ for_stmt_rule(Parser *p)
         expr_ty t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='for'
             &&
             (t = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 695))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -6477,13 +6498,13 @@ for_stmt_rule(Parser *p)
         expr_ty t;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 702))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 694))  // token='for'
+            (_keyword_1 = _PyPegen_expect_token(p, 698))  // token='for'
             &&
             (t = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_2 = _PyPegen_expect_token(p, 695))  // token='in'
+            (_keyword_2 = _PyPegen_expect_token(p, 699))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -6612,7 +6633,7 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 647))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -6663,7 +6684,7 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 647))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='with'
             &&
             (a = (asdl_withitem_seq*)_gather_35_rule(p))  // ','.with_item+
             &&
@@ -6712,9 +6733,9 @@ with_stmt_rule(Parser *p)
         asdl_withitem_seq* a;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 702))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 647))  // token='with'
+            (_keyword_1 = _PyPegen_expect_token(p, 651))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -6764,9 +6785,9 @@ with_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         void *tc;
         if (
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 702))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 647))  // token='with'
+            (_keyword_1 = _PyPegen_expect_token(p, 651))  // token='with'
             &&
             (a = (asdl_withitem_seq*)_gather_35_rule(p))  // ','.with_item+
             &&
@@ -6852,7 +6873,7 @@ with_item_rule(Parser *p)
         if (
             (e = expression_rule(p))  // expression
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (t = star_target_rule(p))  // star_target
             &&
@@ -6977,7 +6998,7 @@ try_stmt_rule(Parser *p)
         asdl_stmt_seq* b;
         asdl_stmt_seq* f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7021,7 +7042,7 @@ try_stmt_rule(Parser *p)
         asdl_excepthandler_seq* ex;
         void *f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7069,7 +7090,7 @@ try_stmt_rule(Parser *p)
         asdl_excepthandler_seq* ex;
         void *f;
         if (
-            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='try'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7168,7 +7189,7 @@ except_block_rule(Parser *p)
         asdl_stmt_seq* b;
         expr_ty e;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (e = expression_rule(p))  // expression
             &&
@@ -7212,11 +7233,11 @@ except_block_rule(Parser *p)
         expr_ty e;
         expr_ty t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (e = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (t = _PyPegen_name_token(p))  // NAME
             &&
@@ -7258,7 +7279,7 @@ except_block_rule(Parser *p)
         asdl_stmt_seq* b;
         expr_ty e;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (e = expressions_rule(p))  // expressions
             &&
@@ -7299,7 +7320,7 @@ except_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* b;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -7411,7 +7432,7 @@ except_star_block_rule(Parser *p)
         asdl_stmt_seq* b;
         expr_ty e;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -7458,13 +7479,13 @@ except_star_block_rule(Parser *p)
         expr_ty e;
         expr_ty t;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
             (e = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (t = _PyPegen_name_token(p))  // NAME
             &&
@@ -7507,7 +7528,7 @@ except_star_block_rule(Parser *p)
         asdl_stmt_seq* b;
         expr_ty e;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -7607,7 +7628,7 @@ finally_block_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 673))  // token='finally'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='finally'
             &&
             (_literal = _PyPegen_expect_forced_token(p, 11, ":"))  // forced_token=':'
             &&
@@ -7915,7 +7936,7 @@ guard_rule(Parser *p)
         Token * _keyword;
         expr_ty guard;
         if (
-            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='if'
             &&
             (guard = named_expression_rule(p))  // named_expression
         )
@@ -8110,7 +8131,7 @@ as_pattern_rule(Parser *p)
         if (
             (pattern = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (target = pattern_capture_target_rule(p))  // pattern_capture_target
         )
@@ -11407,11 +11428,11 @@ expression_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 686))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 690))  // token='else'
             &&
             (c = expression_rule(p))  // expression
         )
@@ -11517,7 +11538,7 @@ yield_expr_rule(Parser *p)
         if (
             (_keyword = _PyPegen_expect_token(p, 587))  // token='yield'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 633))  // token='from'
+            (_keyword_1 = _PyPegen_expect_token(p, 637))  // token='from'
             &&
             (a = expression_rule(p))  // expression
         )
@@ -12293,7 +12314,7 @@ inversion_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 703))  // token='not'
+            (_keyword = _PyPegen_expect_token(p, 707))  // token='not'
             &&
             (a = inversion_rule(p))  // inversion
         )
@@ -12947,9 +12968,9 @@ notin_bitwise_or_rule(Parser *p)
         Token * _keyword_1;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 703))  // token='not'
+            (_keyword = _PyPegen_expect_token(p, 707))  // token='not'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 695))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='in'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -12995,7 +13016,7 @@ in_bitwise_or_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='in'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='in'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -13044,7 +13065,7 @@ isnot_bitwise_or_rule(Parser *p)
         if (
             (_keyword = _PyPegen_expect_token(p, 596))  // token='is'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 703))  // token='not'
+            (_keyword_1 = _PyPegen_expect_token(p, 707))  // token='not'
             &&
             (a = bitwise_or_rule(p))  // bitwise_or
         )
@@ -17651,13 +17672,13 @@ for_if_clause_rule(Parser *p)
         expr_ty b;
         asdl_expr_seq* c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 702))  // token='async'
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 694))  // token='for'
+            (_keyword_1 = _PyPegen_expect_token(p, 698))  // token='for'
             &&
             (a = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_2 = _PyPegen_expect_token(p, 695))  // token='in'
+            (_keyword_2 = _PyPegen_expect_token(p, 699))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -17696,11 +17717,11 @@ for_if_clause_rule(Parser *p)
         expr_ty b;
         asdl_expr_seq* c;
         if (
-            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='for'
             &&
             (a = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 695))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='in'
             &&
             (_cut_var = 1)
             &&
@@ -21001,11 +21022,11 @@ expression_without_invalid_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 686))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 690))  // token='else'
             &&
             (c = expression_rule(p))  // expression
         )
@@ -21305,7 +21326,7 @@ invalid_expression_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
@@ -21338,11 +21359,11 @@ invalid_expression_rule(Parser *p)
         if (
             (a = disjunction_rule(p))  // disjunction
             &&
-            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 686))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 690))  // token='else'
             &&
             _PyPegen_lookahead(0, (void *(*)(Parser *)) expression_rule, p)
         )
@@ -21374,11 +21395,11 @@ invalid_expression_rule(Parser *p)
         if (
             (a = (stmt_ty)_tmp_116_rule(p))  // pass_stmt | break_stmt | continue_stmt
             &&
-            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='if'
             &&
             (b = disjunction_rule(p))  // disjunction
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 686))  // token='else'
+            (_keyword_1 = _PyPegen_expect_token(p, 690))  // token='else'
             &&
             (c = simple_stmt_rule(p))  // simple_stmt
         )
@@ -21889,6 +21910,82 @@ invalid_ann_assign_target_rule(Parser *p)
     return _res;
 }
 
+// invalid_raise_stmt: 'raise' 'from' | 'raise' expression 'from'
+static void *
+invalid_raise_stmt_rule(Parser *p)
+{
+    if (p->level++ == MAXSTACK || _Py_ReachedRecursionLimitWithMargin(PyThreadState_Get(), 1)) {
+        _Pypegen_stack_overflow(p);
+    }
+    if (p->error_indicator) {
+        p->level--;
+        return NULL;
+    }
+    void * _res = NULL;
+    int _mark = p->mark;
+    { // 'raise' 'from'
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_raise_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'raise' 'from'"));
+        Token * a;
+        Token * b;
+        if (
+            (a = _PyPegen_expect_token(p, 627))  // token='raise'
+            &&
+            (b = _PyPegen_expect_token(p, 637))  // token='from'
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_raise_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'raise' 'from'"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_RANGE ( a , b , "did you forget an expression between 'raise' and 'from'?" );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_raise_stmt[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'raise' 'from'"));
+    }
+    { // 'raise' expression 'from'
+        if (p->error_indicator) {
+            p->level--;
+            return NULL;
+        }
+        D(fprintf(stderr, "%*c> invalid_raise_stmt[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'raise' expression 'from'"));
+        Token * _keyword;
+        Token * a;
+        expr_ty expression_var;
+        if (
+            (_keyword = _PyPegen_expect_token(p, 627))  // token='raise'
+            &&
+            (expression_var = expression_rule(p))  // expression
+            &&
+            (a = _PyPegen_expect_token(p, 637))  // token='from'
+        )
+        {
+            D(fprintf(stderr, "%*c+ invalid_raise_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'raise' expression 'from'"));
+            _res = RAISE_SYNTAX_ERROR_KNOWN_LOCATION ( a , "did you forget an expression after 'from'?" );
+            if (_res == NULL && PyErr_Occurred()) {
+                p->error_indicator = 1;
+                p->level--;
+                return NULL;
+            }
+            goto done;
+        }
+        p->mark = _mark;
+        D(fprintf(stderr, "%*c%s invalid_raise_stmt[%d-%d]: %s failed!\n", p->level, ' ',
+                  p->error_indicator ? "ERROR!" : "-", _mark, p->mark, "'raise' expression 'from'"));
+    }
+    _res = NULL;
+  done:
+    p->level--;
+    return _res;
+}
+
 // invalid_del_stmt: 'del' star_expressions
 static void *
 invalid_del_stmt_rule(Parser *p)
@@ -21911,7 +22008,7 @@ invalid_del_stmt_rule(Parser *p)
         Token * _keyword;
         expr_ty a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 625))  // token='del'
+            (_keyword = _PyPegen_expect_token(p, 629))  // token='del'
             &&
             (a = star_expressions_rule(p))  // star_expressions
         )
@@ -23347,7 +23444,7 @@ invalid_with_item_rule(Parser *p)
         if (
             (expression_var = expression_rule(p))  // expression
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -23397,13 +23494,13 @@ invalid_for_if_clause_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         void *_tmp_135_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 702), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='for'
             &&
             (_tmp_135_var = _tmp_135_rule(p))  // bitwise_or ((',' bitwise_or))* ','?
             &&
-            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 695)  // token='in'
+            _PyPegen_lookahead_with_int(0, _PyPegen_expect_token, p, 699)  // token='in'
         )
         {
             D(fprintf(stderr, "%*c+ invalid_for_if_clause[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'? 'for' (bitwise_or ((',' bitwise_or))* ','?) !'in'"));
@@ -23449,9 +23546,9 @@ invalid_for_target_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         expr_ty a;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 702), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='for'
             &&
             (a = star_expressions_rule(p))  // star_expressions
         )
@@ -23581,11 +23678,11 @@ invalid_import_rule(Parser *p)
         Token * a;
         expr_ty dotted_name_var;
         if (
-            (a = _PyPegen_expect_token(p, 634))  // token='import'
+            (a = _PyPegen_expect_token(p, 638))  // token='import'
             &&
             (_gather_137_var = _gather_137_rule(p))  // ','.dotted_name+
             &&
-            (_keyword = _PyPegen_expect_token(p, 633))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 637))  // token='from'
             &&
             (dotted_name_var = dotted_name_rule(p))  // dotted_name
         )
@@ -23612,7 +23709,7 @@ invalid_import_rule(Parser *p)
         Token * _keyword;
         Token * token;
         if (
-            (_keyword = _PyPegen_expect_token(p, 634))  // token='import'
+            (_keyword = _PyPegen_expect_token(p, 638))  // token='import'
             &&
             (token = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
@@ -23661,7 +23758,7 @@ invalid_dotted_as_name_rule(Parser *p)
         if (
             (dotted_name_var = dotted_name_rule(p))  // dotted_name
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             _PyPegen_lookahead(0, (void *(*)(Parser *)) _tmp_138_rule, p)
             &&
@@ -23712,7 +23809,7 @@ invalid_import_from_as_name_rule(Parser *p)
         if (
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             _PyPegen_lookahead(0, (void *(*)(Parser *)) _tmp_138_rule, p)
             &&
@@ -23838,9 +23935,9 @@ invalid_with_stmt_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 702), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 647))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='with'
             &&
             (_gather_140_var = _gather_140_rule(p))  // ','.(expression ['as' star_target])+
             &&
@@ -23876,9 +23973,9 @@ invalid_with_stmt_rule(Parser *p)
         UNUSED(_opt_var_1); // Silence compiler warnings
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 702), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 647))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -23938,9 +24035,9 @@ invalid_with_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 702), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 647))  // token='with'
+            (a = _PyPegen_expect_token(p, 651))  // token='with'
             &&
             (_gather_140_var = _gather_140_rule(p))  // ','.(expression ['as' star_target])+
             &&
@@ -23981,9 +24078,9 @@ invalid_with_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 702), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 647))  // token='with'
+            (a = _PyPegen_expect_token(p, 651))  // token='with'
             &&
             (_literal = _PyPegen_expect_token(p, 7))  // token='('
             &&
@@ -24046,7 +24143,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 656))  // token='try'
+            (a = _PyPegen_expect_token(p, 660))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24078,7 +24175,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* block_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24117,7 +24214,7 @@ invalid_try_stmt_rule(Parser *p)
         Token * b;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24125,7 +24222,7 @@ invalid_try_stmt_rule(Parser *p)
             &&
             (_loop1_37_var = _loop1_37_rule(p))  // except_block+
             &&
-            (a = _PyPegen_expect_token(p, 677))  // token='except'
+            (a = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (b = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -24164,7 +24261,7 @@ invalid_try_stmt_rule(Parser *p)
         UNUSED(_opt_var); // Silence compiler warnings
         Token * a;
         if (
-            (_keyword = _PyPegen_expect_token(p, 656))  // token='try'
+            (_keyword = _PyPegen_expect_token(p, 660))  // token='try'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24172,7 +24269,7 @@ invalid_try_stmt_rule(Parser *p)
             &&
             (_loop1_38_var = _loop1_38_rule(p))  // except_star_block+
             &&
-            (a = _PyPegen_expect_token(p, 677))  // token='except'
+            (a = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (_opt_var = _tmp_145_rule(p), !p->error_indicator)  // [expression ['as' NAME]]
             &&
@@ -24229,7 +24326,7 @@ invalid_except_stmt_rule(Parser *p)
         expr_ty expressions_var;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (a = expression_rule(p))  // expression
             &&
@@ -24237,7 +24334,7 @@ invalid_except_stmt_rule(Parser *p)
             &&
             (expressions_var = expressions_rule(p))  // expressions
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -24269,7 +24366,7 @@ invalid_except_stmt_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 677))  // token='except'
+            (a = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
@@ -24300,7 +24397,7 @@ invalid_except_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 677))  // token='except'
+            (a = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (newline_var = _PyPegen_expect_token(p, NEWLINE))  // token='NEWLINE'
         )
@@ -24329,11 +24426,11 @@ invalid_except_stmt_rule(Parser *p)
         expr_ty a;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (a = expression_rule(p))  // expression
         )
@@ -24389,7 +24486,7 @@ invalid_except_star_stmt_rule(Parser *p)
         expr_ty expressions_var;
         expr_ty name_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -24399,7 +24496,7 @@ invalid_except_star_stmt_rule(Parser *p)
             &&
             (expressions_var = expressions_rule(p))  // expressions
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -24432,7 +24529,7 @@ invalid_except_star_stmt_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 677))  // token='except'
+            (a = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -24466,7 +24563,7 @@ invalid_except_star_stmt_rule(Parser *p)
         void *_tmp_146_var;
         Token * a;
         if (
-            (a = _PyPegen_expect_token(p, 677))  // token='except'
+            (a = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -24498,13 +24595,13 @@ invalid_except_star_stmt_rule(Parser *p)
         expr_ty a;
         expr_ty expression_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword_1 = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (a = expression_rule(p))  // expression
         )
@@ -24551,7 +24648,7 @@ invalid_finally_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 673))  // token='finally'
+            (a = _PyPegen_expect_token(p, 677))  // token='finally'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24607,7 +24704,7 @@ invalid_except_stmt_indent_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 677))  // token='except'
+            (a = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (expression_var = expression_rule(p))  // expression
             &&
@@ -24643,7 +24740,7 @@ invalid_except_stmt_indent_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 677))  // token='except'
+            (a = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -24699,7 +24796,7 @@ invalid_except_star_stmt_indent_rule(Parser *p)
         expr_ty expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 677))  // token='except'
+            (a = _PyPegen_expect_token(p, 681))  // token='except'
             &&
             (_literal = _PyPegen_expect_token(p, 16))  // token='*'
             &&
@@ -24938,7 +25035,7 @@ invalid_as_pattern_rule(Parser *p)
         if (
             (or_pattern_var = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (a = _PyPegen_expect_soft_keyword(p, "_"))  // soft_keyword='"_"'
         )
@@ -24968,7 +25065,7 @@ invalid_as_pattern_rule(Parser *p)
         if (
             (or_pattern_var = or_pattern_rule(p))  // or_pattern
             &&
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (a = expression_rule(p))  // expression
         )
@@ -25120,7 +25217,7 @@ invalid_if_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='if'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -25151,7 +25248,7 @@ invalid_if_stmt_rule(Parser *p)
         expr_ty a_1;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 682))  // token='if'
+            (a = _PyPegen_expect_token(p, 686))  // token='if'
             &&
             (a_1 = named_expression_rule(p))  // named_expression
             &&
@@ -25206,7 +25303,7 @@ invalid_elif_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 687))  // token='elif'
+            (_keyword = _PyPegen_expect_token(p, 691))  // token='elif'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -25237,7 +25334,7 @@ invalid_elif_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 687))  // token='elif'
+            (a = _PyPegen_expect_token(p, 691))  // token='elif'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -25290,7 +25387,7 @@ invalid_else_stmt_rule(Parser *p)
         Token * a;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 686))  // token='else'
+            (a = _PyPegen_expect_token(p, 690))  // token='else'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
@@ -25323,13 +25420,13 @@ invalid_else_stmt_rule(Parser *p)
         Token * _literal;
         asdl_stmt_seq* block_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 686))  // token='else'
+            (_keyword = _PyPegen_expect_token(p, 690))  // token='else'
             &&
             (_literal = _PyPegen_expect_token(p, 11))  // token=':'
             &&
             (block_var = block_rule(p))  // block
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 687))  // token='elif'
+            (_keyword_1 = _PyPegen_expect_token(p, 691))  // token='elif'
         )
         {
             D(fprintf(stderr, "%*c+ invalid_else_stmt[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'else' ':' block 'elif'"));
@@ -25376,7 +25473,7 @@ invalid_while_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 689))  // token='while'
+            (_keyword = _PyPegen_expect_token(p, 693))  // token='while'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -25407,7 +25504,7 @@ invalid_while_stmt_rule(Parser *p)
         expr_ty named_expression_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 689))  // token='while'
+            (a = _PyPegen_expect_token(p, 693))  // token='while'
             &&
             (named_expression_var = named_expression_rule(p))  // named_expression
             &&
@@ -25466,13 +25563,13 @@ invalid_for_stmt_rule(Parser *p)
         expr_ty star_expressions_var;
         expr_ty star_targets_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 702), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='for'
             &&
             (star_targets_var = star_targets_rule(p))  // star_targets
             &&
-            (_keyword_1 = _PyPegen_expect_token(p, 695))  // token='in'
+            (_keyword_1 = _PyPegen_expect_token(p, 699))  // token='in'
             &&
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
             &&
@@ -25507,13 +25604,13 @@ invalid_for_stmt_rule(Parser *p)
         expr_ty star_expressions_var;
         expr_ty star_targets_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 702), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 694))  // token='for'
+            (a = _PyPegen_expect_token(p, 698))  // token='for'
             &&
             (star_targets_var = star_targets_rule(p))  // star_targets
             &&
-            (_keyword = _PyPegen_expect_token(p, 695))  // token='in'
+            (_keyword = _PyPegen_expect_token(p, 699))  // token='in'
             &&
             (star_expressions_var = star_expressions_rule(p))  // star_expressions
             &&
@@ -25579,9 +25676,9 @@ invalid_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 702), !p->error_indicator)  // 'async'?
             &&
-            (a = _PyPegen_expect_token(p, 699))  // token='def'
+            (a = _PyPegen_expect_token(p, 703))  // token='def'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -25638,9 +25735,9 @@ invalid_def_raw_rule(Parser *p)
         asdl_stmt_seq* block_var;
         expr_ty name_var;
         if (
-            (_opt_var = _PyPegen_expect_token(p, 698), !p->error_indicator)  // 'async'?
+            (_opt_var = _PyPegen_expect_token(p, 702), !p->error_indicator)  // 'async'?
             &&
-            (_keyword = _PyPegen_expect_token(p, 699))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 703))  // token='def'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -25704,7 +25801,7 @@ invalid_class_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 701))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 705))  // token='class'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -25743,7 +25840,7 @@ invalid_class_def_raw_rule(Parser *p)
         expr_ty name_var;
         Token * newline_var;
         if (
-            (a = _PyPegen_expect_token(p, 701))  // token='class'
+            (a = _PyPegen_expect_token(p, 705))  // token='class'
             &&
             (name_var = _PyPegen_name_token(p))  // NAME
             &&
@@ -27003,7 +27100,7 @@ invalid_arithmetic_rule(Parser *p)
             &&
             (_tmp_153_var = _tmp_153_rule(p))  // '+' | '-' | '*' | '/' | '%' | '//' | '@'
             &&
-            (a = _PyPegen_expect_token(p, 703))  // token='not'
+            (a = _PyPegen_expect_token(p, 707))  // token='not'
             &&
             (b = inversion_rule(p))  // inversion
         )
@@ -27052,7 +27149,7 @@ invalid_factor_rule(Parser *p)
         if (
             (_tmp_154_var = _tmp_154_rule(p))  // '+' | '-' | '~'
             &&
-            (a = _PyPegen_expect_token(p, 703))  // token='not'
+            (a = _PyPegen_expect_token(p, 707))  // token='not'
             &&
             (b = factor_rule(p))  // factor
         )
@@ -27399,7 +27496,7 @@ _tmp_5_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_5[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'import'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 634))  // token='import'
+            (_keyword = _PyPegen_expect_token(p, 638))  // token='import'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_5[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'import'"));
@@ -27418,7 +27515,7 @@ _tmp_5_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_5[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'from'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 633))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 637))  // token='from'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_5[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'from'"));
@@ -27456,7 +27553,7 @@ _tmp_6_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_6[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'def'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 699))  // token='def'
+            (_keyword = _PyPegen_expect_token(p, 703))  // token='def'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_6[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'def'"));
@@ -27494,7 +27591,7 @@ _tmp_6_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_6[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 702))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_6[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -27532,7 +27629,7 @@ _tmp_7_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_7[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'class'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 701))  // token='class'
+            (_keyword = _PyPegen_expect_token(p, 705))  // token='class'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_7[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'class'"));
@@ -27589,7 +27686,7 @@ _tmp_8_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_8[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'with'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 647))  // token='with'
+            (_keyword = _PyPegen_expect_token(p, 651))  // token='with'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_8[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'with'"));
@@ -27608,7 +27705,7 @@ _tmp_8_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_8[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 702))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_8[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -27646,7 +27743,7 @@ _tmp_9_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_9[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'for'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 694))  // token='for'
+            (_keyword = _PyPegen_expect_token(p, 698))  // token='for'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_9[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'for'"));
@@ -27665,7 +27762,7 @@ _tmp_9_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_9[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'async'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 698))  // token='async'
+            (_keyword = _PyPegen_expect_token(p, 702))  // token='async'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_9[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'async'"));
@@ -27890,7 +27987,7 @@ _tmp_13_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 633))  // token='from'
+            (_keyword = _PyPegen_expect_token(p, 637))  // token='from'
             &&
             (z = expression_rule(p))  // expression
         )
@@ -28412,7 +28509,7 @@ _tmp_22_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (z = _PyPegen_name_token(p))  // NAME
         )
@@ -34176,7 +34273,7 @@ _tmp_115_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_115[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'else'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 686))  // token='else'
+            (_keyword = _PyPegen_expect_token(p, 690))  // token='else'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_115[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'else'"));
@@ -35915,7 +36012,7 @@ _tmp_143_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_143[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'except'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 677))  // token='except'
+            (_keyword = _PyPegen_expect_token(p, 681))  // token='except'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_143[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'except'"));
@@ -35934,7 +36031,7 @@ _tmp_143_rule(Parser *p)
         D(fprintf(stderr, "%*c> _tmp_143[%d-%d]: %s\n", p->level, ' ', _mark, p->mark, "'finally'"));
         Token * _keyword;
         if (
-            (_keyword = _PyPegen_expect_token(p, 673))  // token='finally'
+            (_keyword = _PyPegen_expect_token(p, 677))  // token='finally'
         )
         {
             D(fprintf(stderr, "%*c+ _tmp_143[%d-%d]: %s succeeded!\n", p->level, ' ', _mark, p->mark, "'finally'"));
@@ -37157,7 +37254,7 @@ _tmp_163_rule(Parser *p)
         Token * _keyword;
         expr_ty z;
         if (
-            (_keyword = _PyPegen_expect_token(p, 682))  // token='if'
+            (_keyword = _PyPegen_expect_token(p, 686))  // token='if'
             &&
             (z = disjunction_rule(p))  // disjunction
         )
@@ -37815,7 +37912,7 @@ _tmp_176_rule(Parser *p)
         Token * _keyword;
         expr_ty star_target_var;
         if (
-            (_keyword = _PyPegen_expect_token(p, 680))  // token='as'
+            (_keyword = _PyPegen_expect_token(p, 684))  // token='as'
             &&
             (star_target_var = star_target_rule(p))  // star_target
         )


### PR DESCRIPTION
<img width="788" alt="Снимок экрана 2025-05-16 в 09 07 44" src="https://github.com/user-attachments/assets/ced16afa-1cbb-48b4-824c-95300b5f7062" />

Better error message wordings are welcome!

<!-- gh-issue-number: gh-134036 -->
* Issue: gh-134036
<!-- /gh-issue-number -->
