### PR TITLE
gh-134082: Modernize docstrings in `string.Formatter`

### DIFF
--- a/Lib/string/__init__.py
+++ b/Lib/string/__init__.py
@@ -294,6 +294,7 @@ class Formatter:
         (literal_text, field_name, format_spec, conversion).
 
         *literal_text* can be zero length.
+
         *field_name* can be None, in which case there's no object
         to format and output; otherwise, it is looked up and
         formatted with *format_spec* and *conversion*.

--- a/Lib/string/__init__.py
+++ b/Lib/string/__init__.py
@@ -264,21 +264,17 @@ class Formatter:
 
         return ''.join(result), auto_arg_index
 
-
     def get_value(self, key, args, kwargs):
         if isinstance(key, int):
             return args[key]
         else:
             return kwargs[key]
 
-
     def check_unused_args(self, used_args, args, kwargs):
         pass
 
-
     def format_field(self, value, format_spec):
         return format(value, format_spec)
-
 
     def convert_field(self, value, conversion):
         # do any conversion on the resulting object
@@ -292,28 +288,28 @@ class Formatter:
             return ascii(value)
         raise ValueError("Unknown conversion specifier {0!s}".format(conversion))
 
-
-    # returns an iterable that contains tuples of the form:
-    # (literal_text, field_name, format_spec, conversion)
-    # literal_text can be zero length
-    # field_name can be None, in which case there's no
-    #  object to format and output
-    # if field_name is not None, it is looked up, formatted
-    #  with format_spec and conversion and then used
     def parse(self, format_string):
+        """
+        Return an iterable that contains tuples of the form
+        (literal_text, field_name, format_spec, conversion).
+
+        *literal_text* can be zero length and *field_name*
+        can be None, in which case nothing is formatted.
+
+        If *field_name* is not None, it is looked up and
+        formatted with *format_spec* and *conversion*.
+        """
         return _string.formatter_parser(format_string)
 
-
-    # given a field_name, find the object it references.
-    #  field_name:   the field being looked up, e.g. "0.name"
-    #                 or "lookup[3]"
-    #  used_args:    a set of which args have been used
-    #  args, kwargs: as passed in to vformat
     def get_field(self, field_name, args, kwargs):
+        """Find the object referenced by a given field name.
+
+        The field name *field_name* can be for instance "0.name"
+        or "lookup[3]". The *args* and *kwargs* arguments are
+        passed to get_value().
+        """
         first, rest = _string.formatter_field_name_split(field_name)
-
         obj = self.get_value(first, args, kwargs)
-
         # loop through the rest of the field_name, doing
         #  getattr or getitem as needed
         for is_attr, i in rest:
@@ -321,5 +317,4 @@ class Formatter:
                 obj = getattr(obj, i)
             else:
                 obj = obj[i]
-
         return obj, first

--- a/Lib/string/__init__.py
+++ b/Lib/string/__init__.py
@@ -293,7 +293,6 @@ class Formatter:
         Return an iterable that contains tuples of the form
         (literal_text, field_name, format_spec, conversion).
 
-        *literal_text* can be zero length.
 
         *field_name* can be None, in which case there's no object
         to format and output; otherwise, it is looked up and

--- a/Lib/string/__init__.py
+++ b/Lib/string/__init__.py
@@ -293,7 +293,7 @@ class Formatter:
         Return an iterable that contains tuples of the form
         (literal_text, field_name, format_spec, conversion).
 
-        *literal_text* can be zero length;
+        *literal_text* can be zero length.
         
         *field_name* can be None, in which case there's no object
         to format and output; otherwise, it is looked up and

--- a/Lib/string/__init__.py
+++ b/Lib/string/__init__.py
@@ -294,7 +294,6 @@ class Formatter:
         (literal_text, field_name, format_spec, conversion).
 
         *literal_text* can be zero length.
-        
         *field_name* can be None, in which case there's no object
         to format and output; otherwise, it is looked up and
         formatted with *format_spec* and *conversion*.

--- a/Lib/string/__init__.py
+++ b/Lib/string/__init__.py
@@ -293,10 +293,10 @@ class Formatter:
         Return an iterable that contains tuples of the form
         (literal_text, field_name, format_spec, conversion).
 
-        *literal_text* can be zero length and *field_name*
-        can be None, in which case nothing is formatted.
-
-        If *field_name* is not None, it is looked up and
+        *literal_text* can be zero length;
+        
+        *field_name* can be None, in which case there's no object
+        to format and output; otherwise, it is looked up and
         formatted with *format_spec* and *conversion*.
         """
         return _string.formatter_parser(format_string)


### PR DESCRIPTION
`string.Formatter` is using legacy docstrings that are picked up by pydoc but are not by modern IDEs. I suggest changing them to regular docstrings.

<!-- gh-issue-number: gh-134082 -->
* Issue: gh-134082
<!-- /gh-issue-number -->
