### PR TITLE
gh-134100: Fix UAF in PyImport_ImportModuleLevelObject

### DIFF
--- a/Lib/test/test_importlib/import_/test_relative_imports.py
+++ b/Lib/test/test_importlib/import_/test_relative_imports.py
@@ -227,9 +227,12 @@ class RelativeImports:
         # testing for gh-134100
         import sys
         loooong = "".ljust(0x23000, "b")
-        sys.modules.update({f"a.{loooong}.c": {}})
-        with self.assertRaisesRegex(KeyError, r"'a\.b+' not in sys\.modules as expected"):
-            __import__(f"{loooong}.c", {"__package__": "a"}, level=1)
+        name = f"a.{loooong}.c"
+
+        with util.uncache(name):
+            sys.modules[name] = {}
+            with self.assertRaisesRegex(KeyError, r"'a\.b+' not in sys\.modules as expected"):
+                __import__(f"{loooong}.c", {"__package__": "a"}, level=1)
 
 
 (Frozen_RelativeImports,

--- a/Lib/test/test_importlib/import_/test_relative_imports.py
+++ b/Lib/test/test_importlib/import_/test_relative_imports.py
@@ -224,14 +224,18 @@ class RelativeImports:
                             level=1)
 
     def test_malicious_relative_import(self):
-        # testing for gh-134100
+        # https://github.com/python/cpython/issues/134100
+        # Test to make sure UAF bug with error msg doesn't come back to life
         import sys
         loooong = "".ljust(0x23000, "b")
         name = f"a.{loooong}.c"
 
         with util.uncache(name):
             sys.modules[name] = {}
-            with self.assertRaisesRegex(KeyError, r"'a\.b+' not in sys\.modules as expected"):
+            with self.assertRaisesRegex(
+                KeyError,
+                r"'a\.b+' not in sys\.modules as expected"
+            ):
                 __import__(f"{loooong}.c", {"__package__": "a"}, level=1)
 
 

--- a/Lib/test/test_importlib/import_/test_relative_imports.py
+++ b/Lib/test/test_importlib/import_/test_relative_imports.py
@@ -223,6 +223,14 @@ class RelativeImports:
             self.__import__('sys', {'__package__': '', '__spec__': None},
                             level=1)
 
+    def test_malicious_relative_import(self):
+        # testing for gh-134100
+        import sys
+        loooong = "".ljust(0x23000, "b")
+        sys.modules.update({f"a.{loooong}.c": {}})
+        with self.assertRaisesRegex(KeyError, r"'a\.b+' not in sys\.modules as expected"):
+            __import__(f"{loooong}.c", {"__package__": "a"}, level=1)
+
 
 (Frozen_RelativeImports,
  Source_RelativeImports

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-17-25-52.gh-issue-134100.5-FbLK.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-17-25-52.gh-issue-134100.5-FbLK.rst
@@ -1,0 +1,2 @@
+Fixed a use-after-free bug that would occur when an imported module wasn't
+in sys.modules after the initial import. Patch by Nico-Posada.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-17-25-52.gh-issue-134100.5-FbLK.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-17-25-52.gh-issue-134100.5-FbLK.rst
@@ -1,2 +1,2 @@
 Fixed a use-after-free bug that would occur when an imported module wasn't
-in sys.modules after the initial import. Patch by Nico-Posada.
+in :data:`sys.modules` after the initial import. Patch by Nico-Posada.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-17-25-52.gh-issue-134100.5-FbLK.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-17-25-52.gh-issue-134100.5-FbLK.rst
@@ -1,2 +1,2 @@
-Fixed a use-after-free bug that would occur when an imported module wasn't
-in :data:`sys.modules` after the initial import. Patch by Nico-Posada.
+Fix a use-after-free bug that occurs when an imported module isn't
+in :data:`sys.modules` after its initial import. Patch by Nico-Posada.

--- a/Python/import.c
+++ b/Python/import.c
@@ -3854,15 +3854,17 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
                 }
 
                 final_mod = import_get_module(tstate, to_return);
-                Py_DECREF(to_return);
                 if (final_mod == NULL) {
                     if (!_PyErr_Occurred(tstate)) {
                         _PyErr_Format(tstate, PyExc_KeyError,
                                       "%R not in sys.modules as expected",
                                       to_return);
                     }
+                    Py_DECREF(to_return);
                     goto error;
                 }
+
+                Py_DECREF(to_return);
             }
         }
         else {


### PR DESCRIPTION
Decref after using `to_return` instead of before.

<!-- gh-issue-number: gh-134100 -->
* Issue: gh-134100
<!-- /gh-issue-number -->
