### PR TITLE
gh-134119: Fix crash from calling next() on exhausted template iterator

### DIFF
--- a/Lib/test/test_string/test_templatelib.py
+++ b/Lib/test/test_string/test_templatelib.py
@@ -148,6 +148,15 @@ class TemplateIterTests(unittest.TestCase):
         self.assertEqual(res[1].format_spec, '')
         self.assertEqual(res[2], ' yz')
 
+    def test_exhausted(self):
+        # gh-134119
+        template_iter = iter(t"{1}")
+        self.assertIsInstance(next(template_iter), Interpolation)
+        with self.assertRaises(StopIteration):
+            next(template_iter)
+        with self.assertRaises(StopIteration):
+            next(template_iter)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_string/test_templatelib.py
+++ b/Lib/test/test_string/test_templatelib.py
@@ -149,13 +149,11 @@ class TemplateIterTests(unittest.TestCase):
         self.assertEqual(res[2], ' yz')
 
     def test_exhausted(self):
-        # gh-134119
+        # See https://github.com/python/cpython/issues/134119.
         template_iter = iter(t"{1}")
         self.assertIsInstance(next(template_iter), Interpolation)
-        with self.assertRaises(StopIteration):
-            next(template_iter)
-        with self.assertRaises(StopIteration):
-            next(template_iter)
+        self.assertRaises(StopIteration, next, template_iter)
+        self.assertRaises(StopIteration, next, template_iter)
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-20-59-12.gh-issue-134119.w8expI.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-20-59-12.gh-issue-134119.w8expI.rst
@@ -1,0 +1,2 @@
+Fix crash when calling ``next()`` on an exhausted template string iterator.
+Patch by Jelle Zijlstra.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-20-59-12.gh-issue-134119.w8expI.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-16-20-59-12.gh-issue-134119.w8expI.rst
@@ -1,2 +1,2 @@
-Fix crash when calling ``next()`` on an exhausted template string iterator.
+Fix crash when calling :func:`next` on an exhausted template string iterator.
 Patch by Jelle Zijlstra.

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -23,6 +23,9 @@ templateiter_next(PyObject *op)
     if (self->from_strings) {
         item = PyIter_Next(self->stringsiter);
         self->from_strings = 0;
+        if (item == NULL) {
+            return NULL;
+        }
         if (PyUnicode_GET_LENGTH(item) == 0) {
             Py_SETREF(item, PyIter_Next(self->interpolationsiter));
             self->from_strings = 1;


### PR DESCRIPTION


<!-- gh-issue-number: gh-134119 -->
* Issue: gh-134119
<!-- /gh-issue-number -->
