### PR TITLE
gh-133889: Only show the path of the URL in the SimpleHTTPRequestHandler page

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -840,11 +840,14 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             return None
         list.sort(key=lambda a: a.lower())
         r = []
+        displaypath = self.path
+        displaypath = displaypath.split('#', 1)[0]
+        displaypath = displaypath.split('?', 1)[0]
         try:
-            displaypath = urllib.parse.unquote(self.path,
+            displaypath = urllib.parse.unquote(displaypath,
                                                errors='surrogatepass')
         except UnicodeDecodeError:
-            displaypath = urllib.parse.unquote(self.path)
+            displaypath = urllib.parse.unquote(displaypath)
         displaypath = html.escape(displaypath, quote=False)
         enc = sys.getfilesystemencoding()
         title = f'Directory listing for {displaypath}'

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -628,13 +628,14 @@ class SimpleHTTPServerTestCase(BaseTestCase):
                 self.check_list_dir_filename(filename)
                 os_helper.unlink(os.path.join(self.tempdir, filename))
 
-    def test_undecodable_parameter(self):
-        # sanity check using a valid parameter
+    def test_list_dir_with_query_and_fragment(self):
+        prefix = f'listing for {self.base_url}/</'.encode('latin1')
+        response = self.request(self.base_url + '/#123').read()
+        self.assertIn(prefix + b'title>', response)
+        self.assertIn(prefix + b'h1>', response)
         response = self.request(self.base_url + '/?x=123').read()
-        self.assertRegex(response, rf'listing for {self.base_url}/\?x=123'.encode('latin1'))
-        # now the bogus encoding
-        response = self.request(self.base_url + '/?x=%bb').read()
-        self.assertRegex(response, rf'listing for {self.base_url}/\?x=\xef\xbf\xbd'.encode('latin1'))
+        self.assertIn(prefix + b'title>', response)
+        self.assertIn(prefix + b'h1>', response)
 
     def test_get_dir_redirect_location_domain_injection_bug(self):
         """Ensure //evil.co/..%2f../../X does not put //evil.co/ in Location.

--- a/Misc/NEWS.d/next/Library/2025-05-17-12-40-12.gh-issue-133889.Eh-zO4.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-17-12-40-12.gh-issue-133889.Eh-zO4.rst
@@ -1,0 +1,3 @@
+The generated directory listing page in
+:class:`http.servers.SimpleHTTPRequestHandler` now only shows the decoded
+path component of the requested URL, not the query and the fragment.

--- a/Misc/NEWS.d/next/Library/2025-05-17-12-40-12.gh-issue-133889.Eh-zO4.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-17-12-40-12.gh-issue-133889.Eh-zO4.rst
@@ -1,3 +1,3 @@
 The generated directory listing page in
 :class:`http.server.SimpleHTTPRequestHandler` now only shows the decoded
-path component of the requested URL, not the query and the fragment.
+path component of the requested URL, and not the query and fragment.

--- a/Misc/NEWS.d/next/Library/2025-05-17-12-40-12.gh-issue-133889.Eh-zO4.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-17-12-40-12.gh-issue-133889.Eh-zO4.rst
@@ -1,3 +1,3 @@
 The generated directory listing page in
-:class:`http.servers.SimpleHTTPRequestHandler` now only shows the decoded
+:class:`http.server.SimpleHTTPRequestHandler` now only shows the decoded
 path component of the requested URL, not the query and the fragment.


### PR DESCRIPTION
The query and the fragment are ambiguous and not used.


<!-- gh-issue-number: gh-133889 -->
* Issue: gh-133889
<!-- /gh-issue-number -->
