### PR TITLE
gh-134150: Clarify distinction between JSON and Python objects

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -284,7 +284,7 @@ Basic Usage
 
    :param object_hook:
       If set, a function that is called with the result of
-      any object literal decoded (a :class:`dict`).
+      any JSON object literal decoded (a :class:`dict`).
       The return value of this function will be used
       instead of the :class:`dict`.
       This feature can be used to implement custom decoders,
@@ -294,7 +294,7 @@ Basic Usage
 
    :param object_pairs_hook:
       If set, a function that is called with the result of
-      any object literal decoded with an ordered list of pairs.
+      any JSON object literal decoded with an ordered list of pairs.
       The return value of this function will be used
       instead of the :class:`dict`.
       This feature can be used to implement custom decoders.

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -14,16 +14,21 @@
 `JSON (JavaScript Object Notation) <https://json.org>`_, specified by
 :rfc:`7159` (which obsoletes :rfc:`4627`) and by
 `ECMA-404 <https://ecma-international.org/publications-and-standards/standards/ecma-404/>`_,
-is a lightweight data interchange format inspired by
-`JavaScript <https://en.wikipedia.org/wiki/JavaScript>`_ object literal syntax
+is a lightweight data interchange format inspired by the object literal syntax
+of `JavaScript <https://en.wikipedia.org/wiki/JavaScript>`_
 (although it is not a strict subset of JavaScript [#rfc-errata]_ ).
+
+.. note::
+   The term "object" in the context of JSON processing in Python can be
+   ambiguous. All values in Python are objects. In JSON, an object refers to
+   any data wrapped in curly braces, similar to a Python dictionary.
 
 .. warning::
    Be cautious when parsing JSON data from untrusted sources. A malicious
    JSON string may cause the decoder to consume considerable CPU and memory
    resources. Limiting the size of data to be parsed is recommended.
 
-:mod:`json` exposes an API familiar to users of the standard library
+This module exposes an API familiar to users of the standard library
 :mod:`marshal` and :mod:`pickle` modules.
 
 Encoding basic Python object hierarchies::
@@ -60,7 +65,7 @@ Pretty printing::
         "6": 7
     }
 
-Specializing JSON object encoding::
+Customizing JSON object encoding::
 
    >>> import json
    >>> def custom_json(obj):
@@ -83,7 +88,7 @@ Decoding JSON::
     >>> json.load(io)
     ['streaming API']
 
-Specializing JSON object decoding::
+Customizing JSON object decoding::
 
     >>> import json
     >>> def as_complex(dct):

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -14,8 +14,8 @@
 `JSON (JavaScript Object Notation) <https://json.org>`_, specified by
 :rfc:`7159` (which obsoletes :rfc:`4627`) and by
 `ECMA-404 <https://ecma-international.org/publications-and-standards/standards/ecma-404/>`_,
-is a lightweight data interchange format inspired by the object literal syntax
-of `JavaScript <https://en.wikipedia.org/wiki/JavaScript>`_
+is a lightweight data interchange format inspired by
+`JavaScript <https://en.wikipedia.org/wiki/JavaScript>`_ object literal syntax
 (although it is not a strict subset of JavaScript [#rfc-errata]_ ).
 
 .. note::


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
This PR clears up the ambiguity between JSON objects and Python objects in the `json` module docs by adding a note to inform the reader of the distinction. I also changed two occurrences of the word "specializing" with the word "customizing", since the latter seems to be a better fit for describing what's happening. Let me know if I need to make any changes!

Micha

<!-- gh-issue-number: gh-134150 -->
* Issue: gh-134150
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134154.org.readthedocs.build/en/134154/library/json.html

<!-- readthedocs-preview cpython-previews end -->