### PR TITLE
gh-134158: Fix PyREPL coloring of double braces in f/t-strings

### DIFF
--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -41,17 +41,15 @@ class Span(NamedTuple):
 
     @classmethod
     def from_token(cls, token: TI, line_len: list[int]) -> Self:
-        end_offset = 0
-        if ((token.type is T.FSTRING_MIDDLE or token.type is T.TSTRING_MIDDLE)
+        end_offset = -1
+        if (token.type in {T.FSTRING_MIDDLE, T.TSTRING_MIDDLE}
             and token.string.endswith(("{", "}"))):
-            # Double braces in f-string / t-string are translated into a single
-            # brace by the tokenizer, and are always at the end of the token:
-            # we must add 1 to the token end position to color the two braces.
-            end_offset = 1
+            # gh-134158: a visible trailing brace comes from a double brace in input
+            end_offset += 1
 
         return cls(
             line_len[token.start[0] - 1] + token.start[1],
-            line_len[token.end[0] - 1] + token.end[1] - 1 + end_offset,
+            line_len[token.end[0] - 1] + token.end[1] + end_offset,
         )
 
 

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -41,9 +41,17 @@ class Span(NamedTuple):
 
     @classmethod
     def from_token(cls, token: TI, line_len: list[int]) -> Self:
+        end_offset = 0
+        if ((token.type is T.FSTRING_MIDDLE or token.type is T.TSTRING_MIDDLE)
+            and token.string.endswith(("{", "}"))):
+            # Double braces in f-string / t-string are translated into a single
+            # brace by the tokenizer, and are always at the end of the token:
+            # we must add 1 to the token end position to color the two braces.
+            end_offset = 1
+
         return cls(
             line_len[token.start[0] - 1] + token.start[1],
-            line_len[token.end[0] - 1] + token.end[1] - 1,
+            line_len[token.end[0] - 1] + token.end[1] - 1 + end_offset,
         )
 
 

--- a/Lib/test/test_pyrepl/test_reader.py
+++ b/Lib/test/test_pyrepl/test_reader.py
@@ -517,6 +517,37 @@ class TestReaderInColor(ScreenEqualMixin, TestCase):
         self.assert_screen_equal(reader, code, clean=True)
         self.assert_screen_equal(reader, expected)
 
+    def test_syntax_highlighting_literal_brace_in_fstring_or_tstring(self):
+        code = dedent(
+            """\
+            f"{{"
+            f"}}"
+            f"a{{b"
+            f"a}}b"
+            f"a{{b}}c"
+            t"a{{b}}c"
+            f"{{{0}}}"
+            f"{ {0} }"
+            """
+        )
+        expected = dedent(
+            """\
+            {s}f"{z}{s}<<{z}{s}"{z}
+            {s}f"{z}{s}>>{z}{s}"{z}
+            {s}f"{z}{s}a<<{z}{s}b{z}{s}"{z}
+            {s}f"{z}{s}a>>{z}{s}b{z}{s}"{z}
+            {s}f"{z}{s}a<<{z}{s}b>>{z}{s}c{z}{s}"{z}
+            {s}t"{z}{s}a<<{z}{s}b>>{z}{s}c{z}{s}"{z}
+            {s}f"{z}{s}<<{z}{o}<{z}{n}0{z}{o}>{z}{s}>>{z}{s}"{z}
+            {s}f"{z}{o}<{z} {o}<{z}{n}0{z}{o}>{z} {o}>{z}{s}"{z}
+            """
+        ).format(**colors).replace("<", "{").replace(">", "}")
+        events = code_to_events(code)
+        reader, _ = handle_all_events(events)
+        self.assert_screen_equal(reader, code, clean=True)
+        self.maxDiff=None
+        self.assert_screen_equal(reader, expected)
+
     def test_control_characters(self):
         code = 'flag = "🏳️‍🌈"'
         events = code_to_events(code)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-17-20-44-51.gh-issue-134158.ewLNLp.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-17-20-44-51.gh-issue-134158.ewLNLp.rst
@@ -1,1 +1,1 @@
-Fix PyREPL coloring of double braces in f-strings and t-strings
+Fix coloring of double braces in f-strings and t-strings in the :term:`REPL`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-17-20-44-51.gh-issue-134158.ewLNLp.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-17-20-44-51.gh-issue-134158.ewLNLp.rst
@@ -1,0 +1,1 @@
+Fix PyREPL coloring of double braces in f-strings and t-strings


### PR DESCRIPTION
This PR add a special-case in `_pyrepl.utils.Span.from_token` to correctly color double braces in f-strings or t-strings.

Before:

![image](https://github.com/user-attachments/assets/dcbc6e33-6be7-4e14-badb-858b9bf74f26)

After:

![image](https://github.com/user-attachments/assets/7173bfab-4a00-41be-835c-4a17fa3620a1)


<!-- gh-issue-number: gh-134158 -->
* Issue: gh-134158
<!-- /gh-issue-number -->
