### PR TITLE
gh-71253: Run unclosed file test on all io implementations

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4417,7 +4417,7 @@ class MiscIOTest(unittest.TestCase):
         self._check_abc_inheritance(io)
 
     def _check_warn_on_dealloc(self, *args, **kwargs):
-        f = open(*args, **kwargs)
+        f = self.open(*args, **kwargs)
         r = repr(f)
         with self.assertWarns(ResourceWarning) as cm:
             f = None
@@ -4446,7 +4446,7 @@ class MiscIOTest(unittest.TestCase):
         r, w = os.pipe()
         fds += r, w
         with warnings_helper.check_no_resource_warning(self):
-            open(r, *args, closefd=False, **kwargs)
+            self.open(r, *args, closefd=False, **kwargs)
 
     @unittest.skipUnless(hasattr(os, "pipe"), "requires os.pipe()")
     def test_warn_on_dealloc_fd(self):

--- a/Misc/NEWS.d/next/Library/2025-05-17-19-56-43.gh-issue-71253.BJzTU7.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-17-19-56-43.gh-issue-71253.BJzTU7.rst
@@ -1,0 +1,3 @@
+Emit :exc:`RuntimeWarning` in the Python implementation of :mod:`io` when
+the :term:`file object` is not closed explicitly in the presence of multiple
+I/O layers.


### PR DESCRIPTION
Update `test_io` `_check_warn_on_dealloc` to use `self.` to dispatch to different I/O implementations.

Update the `_pyio` implementation to match expected behavior, using the same `_dealloc_warn` design as the C implementation uses to report the topmost `__del__` object.


<!-- gh-issue-number: gh-71253 -->
* Issue: gh-71253
<!-- /gh-issue-number -->
