### PR TITLE
gh-69605: Disable PyREPL module autocomplete fallback on regular completion

### DIFF
--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -43,10 +43,7 @@ class ModuleCompleter:
         self._curr_sys_path: list[str] = sys.path[:]
 
     def get_completions(self, line: str) -> list[str] | None:
-        """Return the next possible import completions for 'line'.
-
-        If 'line' is not an import statement, return None.
-        """
+        """Return the next possible import completions for 'line'."""
         result = ImportParser(line).parse()
         if not result:
             return None

--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -42,11 +42,14 @@ class ModuleCompleter:
         self._global_cache: list[pkgutil.ModuleInfo] = []
         self._curr_sys_path: list[str] = sys.path[:]
 
-    def get_completions(self, line: str) -> list[str]:
-        """Return the next possible import completions for 'line'."""
+    def get_completions(self, line: str) -> list[str] | None:
+        """Return the next possible import completions for 'line'.
+
+        If 'line' is not an import statement, return None.
+        """
         result = ImportParser(line).parse()
         if not result:
-            return []
+            return None
         try:
             return self.complete(*result)
         except Exception:

--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -134,7 +134,7 @@ class ReadlineAlikeReader(historical_reader.HistoricalReader, CompletingReader):
         return "".join(b[p + 1 : self.pos])
 
     def get_completions(self, stem: str) -> list[str]:
-        if module_completions := self.get_module_completions():
+        if (module_completions := self.get_module_completions()) is not None:
             return module_completions
         if len(stem) == 0 and self.more_lines is not None:
             b = self.buffer
@@ -165,7 +165,7 @@ class ReadlineAlikeReader(historical_reader.HistoricalReader, CompletingReader):
             result.sort()
         return result
 
-    def get_module_completions(self) -> list[str]:
+    def get_module_completions(self) -> list[str] | None:
         line = self.get_line()
         return self.config.module_completer.get_completions(line)
 

--- a/Lib/_pyrepl/readline.py
+++ b/Lib/_pyrepl/readline.py
@@ -134,7 +134,8 @@ class ReadlineAlikeReader(historical_reader.HistoricalReader, CompletingReader):
         return "".join(b[p + 1 : self.pos])
 
     def get_completions(self, stem: str) -> list[str]:
-        if (module_completions := self.get_module_completions()) is not None:
+        module_completions = self.get_module_completions()
+        if module_completions is not None:
             return module_completions
         if len(stem) == 0 and self.more_lines is not None:
             b = self.buffer

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -944,13 +944,16 @@ class TestPyReplModuleCompleter(TestCase):
             ("import importlib.resources.\t\ta\t\n", "import importlib.resources.abc"),
             ("import foo, impo\t\n", "import foo, importlib"),
             ("import foo as bar, impo\t\n", "import foo as bar, importlib"),
+            ("import pri\t\n", "import pri"),  # do not complete with "print("
             ("from impo\t\n", "from importlib"),
+            ("from pri\t\n", "from pri"),
             ("from importlib.res\t\n", "from importlib.resources"),
             ("from importlib.\t\tres\t\n", "from importlib.resources"),
             ("from importlib.resources.ab\t\n", "from importlib.resources.abc"),
             ("from importlib import mac\t\n", "from importlib import machinery"),
             ("from importlib import res\t\n", "from importlib import resources"),
             ("from importlib.res\t import a\t\n", "from importlib.resources import abc"),
+            ("from typing import Na\t\n", "from typing import Na"),  # do not complete with "NameError("
         )
         for code, expected in cases:
             with self.subTest(code=code):

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -917,7 +917,14 @@ class TestPyReplCompleter(TestCase):
 
 class TestPyReplModuleCompleter(TestCase):
     def setUp(self):
+        import importlib
+        # Make iter_modules() search only the standard library.
+        # This makes the test more reliable in case there are
+        # other user packages/scripts on PYTHONPATH which can
+        # interfere with the completions.
+        lib_path = os.path.dirname(importlib.__path__[0])
         self._saved_sys_path = sys.path
+        sys.path = [lib_path]
 
     def tearDown(self):
         sys.path = self._saved_sys_path
@@ -929,17 +936,7 @@ class TestPyReplModuleCompleter(TestCase):
         reader = ReadlineAlikeReader(console=console, config=config)
         return reader
 
-    def _only_stdlib_imports(self):
-        import importlib
-        # Make iter_modules() search only the standard library.
-        # This makes the test more reliable in case there are
-        # other user packages/scripts on PYTHONPATH which can
-        # intefere with the completions.
-        lib_path = os.path.dirname(importlib.__path__[0])
-        sys.path = [lib_path]
-
     def test_import_completions(self):
-        self._only_stdlib_imports()
         cases = (
             ("import path\t\n", "import pathlib"),
             ("import importlib.\t\tres\t\n", "import importlib.resources"),
@@ -991,7 +988,6 @@ class TestPyReplModuleCompleter(TestCase):
                 self.assertEqual(output, expected)
 
     def test_no_fallback_on_regular_completion(self):
-        self._only_stdlib_imports()
         cases = (
             ("import pri\t\n", "import pri"),
             ("from pri\t\n", "from pri"),

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-18-14-33-23.gh-issue-69605.ZMO49F.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-18-14-33-23.gh-issue-69605.ZMO49F.rst
@@ -1,1 +1,2 @@
-Stop import names completion fallback on regular names completion in the :term:`REPL`.
+When auto-completing an import in the :term:`REPL`, finding no candidates
+now issues no suggestion, rather than suggestions from the current namespace.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-18-14-33-23.gh-issue-69605.ZMO49F.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-18-14-33-23.gh-issue-69605.ZMO49F.rst
@@ -1,0 +1,1 @@
+Stop import names completion fallback on regular names completion in the :term:`REPL`.


### PR DESCRIPTION
When no module completions are available, do not fallback on completions from current namespace, as there are not relevant.

Before:

```pycon 
>>> import pri<TAB>
>>> import print(
>>>
>>> from typing import Na<TAB>
>>> from typing import NameError(
```

After:

```pycon 
>>> import pri<TAB>
>>> import pri
>>>
>>> from typing import Na<TAB>
>>> from typing import Na
```

cc @tomasr8

<!-- gh-issue-number: gh-69605 -->
* Issue: gh-69605
<!-- /gh-issue-number -->
