### PR TITLE
gh-62184: Remove _pyio import of _io.FileIO

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -645,8 +645,6 @@ class RawIOBase(IOBase):
         self._unsupported("write")
 
 io.RawIOBase.register(RawIOBase)
-from _io import FileIO
-RawIOBase.register(FileIO)
 
 
 class BufferedIOBase(IOBase):

--- a/Misc/NEWS.d/next/Library/2025-05-18-12-48-39.gh-issue-62184.y11l10.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-18-12-48-39.gh-issue-62184.y11l10.rst
@@ -1,0 +1,2 @@
+Remove import of C implementation of :class:`io.FileIO` from Python
+implementation which has its own implementation


### PR DESCRIPTION
This was added in the add of `_io`, isn't used since bpo-21859 added a Python-native `_pyio` implementation of `FileIO` further down in the file.

(Happy to add a news, but also don't think there is particularly a user visible change?)

---
This is the last direct import of `_io` in `_pyio`. `_io` is still imported indirectly (by way of `io`) for io.open_code, io.UnsupportedOperation, and registering `_pyio` base abstract classes to the general `io` ones for `isinstance`, and several constants (ex. SEEK_SET, ...).
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-62184 -->
* Issue: gh-62184
<!-- /gh-issue-number -->
