### PR TITLE
gh-133319: Use python versioning in `msgfmt` & `pygettext`

### DIFF
--- a/Lib/test/test_tools/i18n_data/ascii-escapes.pot
+++ b/Lib/test/test_tools/i18n_data/ascii-escapes.pot
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Generated-By: pygettext.py 3.15\n"
 
 
 #. Special characters that are always escaped in the POT file

--- a/Lib/test/test_tools/i18n_data/comments.pot
+++ b/Lib/test/test_tools/i18n_data/comments.pot
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Generated-By: pygettext.py 3.15\n"
 
 
 #: comments.py:4

--- a/Lib/test/test_tools/i18n_data/custom_keywords.pot
+++ b/Lib/test/test_tools/i18n_data/custom_keywords.pot
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Generated-By: pygettext.py 3.15\n"
 
 
 #: custom_keywords.py:10 custom_keywords.py:11

--- a/Lib/test/test_tools/i18n_data/docstrings.pot
+++ b/Lib/test/test_tools/i18n_data/docstrings.pot
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Generated-By: pygettext.py 3.15\n"
 
 
 #: docstrings.py:1

--- a/Lib/test/test_tools/i18n_data/escapes.pot
+++ b/Lib/test/test_tools/i18n_data/escapes.pot
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Generated-By: pygettext.py 3.15\n"
 
 
 #. Special characters that are always escaped in the POT file

--- a/Lib/test/test_tools/i18n_data/fileloc.pot
+++ b/Lib/test/test_tools/i18n_data/fileloc.pot
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Generated-By: pygettext.py 3.15\n"
 
 
 #: fileloc.py:5 fileloc.py:6

--- a/Lib/test/test_tools/i18n_data/messages.pot
+++ b/Lib/test/test_tools/i18n_data/messages.pot
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Generated-By: pygettext.py 3.15\n"
 
 
 #: messages.py:16

--- a/Lib/test/test_tools/i18n_data/multiple_keywords.pot
+++ b/Lib/test/test_tools/i18n_data/multiple_keywords.pot
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: pygettext.py 1.5\n"
+"Generated-By: pygettext.py 3.15\n"
 
 
 #: multiple_keywords.py:3

--- a/Lib/test/test_tools/test_msgfmt.py
+++ b/Lib/test/test_tools/test_msgfmt.py
@@ -253,7 +253,7 @@ class CLITest(unittest.TestCase):
         for option in ('--version', '-V'):
             res = assert_python_ok(msgfmt_py, option)
             out = res.out.decode('utf-8').strip()
-            self.assertEqual('msgfmt.py 1.2', out)
+            self.assertRegex(out, r'^msgfmt\.py \d+\.\d+$')
 
     def test_invalid_option(self):
         res = assert_python_failure(msgfmt_py, '--invalid-option')

--- a/Misc/NEWS.d/next/Tools-Demos/2025-05-19-10-41-00.gh-issue-133319.asgss.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2025-05-19-10-41-00.gh-issue-133319.asgss.rst
@@ -1,0 +1,1 @@
+Use Python versioning in :program:`msgfmt` and :program:`pygettext`.

--- a/Tools/i18n/msgfmt.py
+++ b/Tools/i18n/msgfmt.py
@@ -34,7 +34,7 @@ import array
 from email.parser import HeaderParser
 import codecs
 
-__version__ = "1.2"
+__version__ = "3.15"
 
 
 MESSAGES = {}

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -152,7 +152,7 @@ from dataclasses import dataclass, field
 from io import BytesIO
 from operator import itemgetter
 
-__version__ = '1.5'
+__version__ = '3.15'
 
 
 # The normal pot-file header. msgmerge and Emacs's po-mode work better if it's
@@ -387,7 +387,7 @@ def unparse_spec(name, spec):
             parts.append(f'{pos + 1}c')
         else:
             parts.append(str(pos + 1))
-    return f'{name}:{','.join(parts)}'
+    return f'{name}:{",".join(parts)}'
 
 
 def process_keywords(keywords, *, no_default_keywords):

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -152,6 +152,7 @@ from dataclasses import dataclass, field
 from io import BytesIO
 from operator import itemgetter
 
+# Update this to the current python version when modifying this script.
 __version__ = '3.15'
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Simplest approach maintaining full backwards compatibility. We cannot use the version of the python running the script, updating this number every few years is not overly complex, it can be picked up by any pr modifying the file.

<!-- gh-issue-number: gh-133319 -->
* Issue: gh-133319
<!-- /gh-issue-number -->
