### PR TITLE
Fix typo in get_stack_trace docstring

### DIFF
--- a/Modules/_remote_debugging_module.c
+++ b/Modules/_remote_debugging_module.c
@@ -1765,7 +1765,7 @@ result_err:
 
 static PyMethodDef methods[] = {
     {"get_stack_trace", get_stack_trace, METH_VARARGS,
-        "Get the Python stack from a given pod"},
+        "Get the Python stack from a given pid"},
     {"get_async_stack_trace", get_async_stack_trace, METH_VARARGS,
         "Get the asyncio stack from a given pid"},
     {"get_all_awaited_by", get_all_awaited_by, METH_VARARGS,


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
