### PR TITLE
gh-80184: Set getattr(socket, "SOMAXCONN", 5) as the default queue size for TCPServer

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -23,7 +23,9 @@ There are four basic concrete server classes:
    invoke :meth:`~BaseServer.server_bind` and
    :meth:`~BaseServer.server_activate`.  The other parameters are passed to
    the :class:`BaseServer` base class.
-
+   
+   .. versionchanged:: next
+      Set getattr(socket, "SOMAXCONN", 5) as the default queue size for TCPServer.
 
 .. class:: UDPServer(server_address, RequestHandlerClass, bind_and_activate=True)
 

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -23,7 +23,7 @@ There are four basic concrete server classes:
    invoke :meth:`~BaseServer.server_bind` and
    :meth:`~BaseServer.server_activate`.  The other parameters are passed to
    the :class:`BaseServer` base class.
-   
+
    .. versionchanged:: next
       Set getattr(socket, "SOMAXCONN", 5) as the default queue size for TCPServer.
 

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -25,7 +25,7 @@ There are four basic concrete server classes:
    the :class:`BaseServer` base class.
 
    .. versionchanged:: next
-      Set getattr(socket, "SOMAXCONN", 5) as the default queue size for TCPServer.
+      The default queue size is now ``socket.SOMAXCONN`` for :class:`socketserver.TCPServer`.
 
 .. class:: UDPServer(server_address, RequestHandlerClass, bind_and_activate=True)
 

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -441,7 +441,7 @@ class TCPServer(BaseServer):
 
     socket_type = socket.SOCK_STREAM
 
-    request_queue_size = 5
+    request_queue_size = 0
 
     allow_reuse_address = False
 

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -441,7 +441,7 @@ class TCPServer(BaseServer):
 
     socket_type = socket.SOCK_STREAM
 
-    request_queue_size = 0
+    request_queue_size = getattr(socket, "SOMAXCONN", 5)
 
     allow_reuse_address = False
 

--- a/Misc/NEWS.d/next/Library/2025-05-19-17-27-21.gh-issue-80184.LOkbaw.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-19-17-27-21.gh-issue-80184.LOkbaw.rst
@@ -1,0 +1,1 @@
+Set 0 as the default queue size for TCPServer

--- a/Misc/NEWS.d/next/Library/2025-05-19-17-27-21.gh-issue-80184.LOkbaw.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-19-17-27-21.gh-issue-80184.LOkbaw.rst
@@ -1,1 +1,1 @@
-Set ``getattr(socket, "SOMAXCONN", 5)`` as the default queue size for :class:`socketserver.TCPServer`.
+The default queue size is now ``socket.SOMAXCONN`` for :class:`socketserver.TCPServer`.

--- a/Misc/NEWS.d/next/Library/2025-05-19-17-27-21.gh-issue-80184.LOkbaw.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-19-17-27-21.gh-issue-80184.LOkbaw.rst
@@ -1,1 +1,1 @@
-Set 0 as the default queue size for TCPServer
+Set getattr(socket, "SOMAXCONN", 5) as the default queue size for TCPServer

--- a/Misc/NEWS.d/next/Library/2025-05-19-17-27-21.gh-issue-80184.LOkbaw.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-19-17-27-21.gh-issue-80184.LOkbaw.rst
@@ -1,1 +1,1 @@
-Set getattr(socket, "SOMAXCONN", 5) as the default queue size for TCPServer
+Set ``getattr(socket, "SOMAXCONN", 5)`` as the default queue size for :class:`socketserver.TCPServer`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-80184 -->
* Issue: gh-80184
<!-- /gh-issue-number -->
