### PR TITLE
gh-133885: Disallow sharing zstd (de)compressor contexts

### DIFF
--- a/Modules/_zstd/_zstdmodule.h
+++ b/Modules/_zstd/_zstdmodule.h
@@ -52,4 +52,21 @@ extern void
 set_parameter_error(const _zstd_state* const state, int is_compress,
                     int key_v, int value_v);
 
+static inline int
+check_object_shared(PyObject *ob, char *type)
+{
+#if defined(Py_GIL_DISABLED)
+    if (!_Py_IsOwnedByCurrentThread(ob))
+    {
+        PyErr_Format(PyExc_RuntimeError,
+                     "%s cannot be shared across multiple threads.",
+                     type);
+        return 1;
+    }
+    return 0;
+#else
+    return 0;
+#endif
+}
+
 #endif  // !ZSTD_MODULE_H

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -639,6 +639,12 @@ _zstd_ZstdDecompressor_unused_data_get_impl(ZstdDecompressor *self)
 {
     PyObject *ret;
 
+    /* Check we are on the same thread as the decompressor was created */
+    if (check_object_shared((PyObject *)self, "ZstdDecompressor") > 0)
+    {
+        return NULL;
+    }
+
     if (!self->eof) {
         return Py_GetConstant(Py_CONSTANT_EMPTY_BYTES);
     }
@@ -692,11 +698,12 @@ _zstd_ZstdDecompressor_decompress_impl(ZstdDecompressor *self,
 /*[clinic end generated code: output=a4302b3c940dbec6 input=6463dfdf98091caa]*/
 {
     PyObject *ret;
-    /* Thread-safe code */
-    Py_BEGIN_CRITICAL_SECTION(self);
-
+    /* Check we are on the same thread as the decompressor was created */
+    if (check_object_shared((PyObject *)self, "ZstdDecompressor") > 0)
+    {
+        return NULL;
+    }
     ret = stream_decompress(self, data, max_length);
-    Py_END_CRITICAL_SECTION();
     return ret;
 }
 


### PR DESCRIPTION
It is not possible to share Zstandard objects across thread boundaries. To resolve this, we check if the object was created on the current thread and raise a `RuntimeError` if it is not. Wasn't totally sure what exception to raise to communicate the issue, so if `RuntimeError` isn't correct, please suggestion another option.

The tests are updated to ensure that the error is raised if a (de)compression context is shared across threads.

(as requested, cc @ngoldbaum )



<!-- gh-issue-number: gh-133885 -->
* Issue: gh-133885
<!-- /gh-issue-number -->
