### PR TITLE
gh-88994: Change `datetime.now` to half-even rounding for consistency with `datetime.fromtimestamp`.

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -795,6 +795,7 @@ Albert Hofkamp
 Chris Hogan
 Tomas Hoger
 Jonathan Hogg
+John Keith Hohm
 Vladyslav Hoi
 Kamilla Holanda
 Steve Holden

--- a/Misc/NEWS.d/next/Library/2025-05-19-18-12-42.gh-issue-88994.7avvVu.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-19-18-12-42.gh-issue-88994.7avvVu.rst
@@ -1,2 +1,3 @@
 Change :func:`datetime.datetime.now` to half-even rounding for
-consistency with :func:`datetime.datetime.fromtimestamp`.
+consistency with :func:`datetime.datetime.fromtimestamp`.  Patch by
+John Keith Hohm.

--- a/Misc/NEWS.d/next/Library/2025-05-19-18-12-42.gh-issue-88994.7avvVu.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-19-18-12-42.gh-issue-88994.7avvVu.rst
@@ -1,1 +1,2 @@
-Change :func:`datetime.now` to half-even rounding for consistency with :func:`datetime.fromtimestamp`.
+Change :func:`datetime.datetime.now` to half-even rounding for
+consistency with :func:`datetime.datetime.fromtimestamp`.

--- a/Misc/NEWS.d/next/Library/2025-05-19-18-12-42.gh-issue-88994.7avvVu.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-19-18-12-42.gh-issue-88994.7avvVu.rst
@@ -1,0 +1,1 @@
+Change :func:`datetime.now` to half-even rounding for consistency with :func:`datetime.fromtimestamp`.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5539,7 +5539,7 @@ datetime_best_possible(PyObject *cls, TM_FUNC f, PyObject *tzinfo)
     time_t secs;
     int us;
 
-    if (_PyTime_AsTimevalTime_t(ts, &secs, &us, _PyTime_ROUND_FLOOR) < 0)
+    if (_PyTime_AsTimevalTime_t(ts, &secs, &us, _PyTime_ROUND_HALF_EVEN) < 0)
         return NULL;
     assert(0 <= us && us <= 999999);
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -5539,8 +5539,9 @@ datetime_best_possible(PyObject *cls, TM_FUNC f, PyObject *tzinfo)
     time_t secs;
     int us;
 
-    if (_PyTime_AsTimevalTime_t(ts, &secs, &us, _PyTime_ROUND_HALF_EVEN) < 0)
+    if (_PyTime_AsTimevalTime_t(ts, &secs, &us, _PyTime_ROUND_HALF_EVEN) < 0) {
         return NULL;
+    }
     assert(0 <= us && us <= 999999);
 
     return datetime_from_timet_and_us(cls, f, secs, us, tzinfo);


### PR DESCRIPTION
Resolves #88994 where, on platforms with nanosecond resolution system clocks (such as Windows), the truncation within `datetime.now` could cause time to appear to go backwards by 1 microsecond between `datetime.datetime.fromtimestamp(time.time(), None)` and `datetime.datetime.now()`.

As suggested by @pganssle, not adding a test that would probably be flaky since it would involve comparing the results of multiple reads of the system clock. Verified manually that the following quickly fails the assert on Windows but passes with this commit:

```python
import datetime
import time

def test():
    start = time.time()
    end = datetime.datetime.now()
    start = datetime.datetime.fromtimestamp(start, None)
    assert end >= start, f'{end=} < {start=}'

for i in range(10000000):
    test()
```

<!-- gh-issue-number: gh-88994 -->
* Issue: gh-88994
<!-- /gh-issue-number -->
