### PR TITLE
gh-134262: Add retries to generate_sbom.py

### DIFF
--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -163,7 +163,9 @@ def get_externals() -> list[str]:
     return externals
 
 
-def download_with_retries(download_location: str, retries: int = 5):
+def download_with_retries(
+    download_location: str,
+    retries: int = 5) -> typing.Any:
     """Download a file with exponential backoff retry."""
     attempt = 0
     while attempt < retries:

--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -7,6 +7,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import typing
 import urllib.request
 import urllib.error
@@ -162,7 +163,7 @@ def get_externals() -> list[str]:
     return externals
 
 
-def download_with_retries(download_location, retries=5):
+def download_with_retries(download_location: str, retries: int = 5):
     """Download a file with exponential backoff retry."""
     attempt = 0
     while attempt < retries:

--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -9,8 +9,8 @@ import subprocess
 import sys
 import time
 import typing
-import urllib.request
 import urllib.error
+import urllib.request
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 CPYTHON_ROOT_DIR = Path(__file__).parent.parent.parent

--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -163,9 +163,8 @@ def get_externals() -> list[str]:
     return externals
 
 
-def download_with_retries(
-    download_location: str,
-    retries: int = 5) -> typing.Any:
+def download_with_retries(download_location: str,
+                          retries: int = 5) -> typing.Any:
     """Download a file with exponential backoff retry."""
     attempt = 0
     while attempt < retries:

--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -164,17 +164,16 @@ def get_externals() -> list[str]:
 
 
 def download_with_retries(download_location: str,
-                          retries: int = 5) -> typing.Any:
+                          max_retries: int = 5,
+                          base_delay: float = 2.0) -> typing.Any:
     """Download a file with exponential backoff retry."""
-    attempt = 0
-    while attempt < retries:
-        attempt += 1
+    for attempt in range(max_retries):
         try:
             resp = urllib.request.urlopen(download_location)
         except urllib.error.URLError as ex:
-            if attempt == retries:
+            if attempt == max_retries:
                 raise ex
-            time.sleep(2**attempt)
+            time.sleep(base_delay**attempt)
         else:
             return resp
 


### PR DESCRIPTION
`Tools/build/generate_sbom.py` downloads artifacts, which can flake. This commit adds simple exponential back-off retries to the download to avoid failures due to network flakes.

<!-- gh-issue-number: gh-134262 -->
* Issue: gh-134262
<!-- /gh-issue-number -->
