### PR TITLE
gh-131178: Add CLI tests for cProfile

### DIFF
--- a/Lib/test/test_cprofile.py
+++ b/Lib/test/test_cprofile.py
@@ -156,20 +156,20 @@ class TestCommandLine(unittest.TestCase):
         self.test_script.write(textwrap.dedent("""
             def simple_function():
                 sum(range(1000))
-                
+
             if __name__ == "__main__":
                 simple_function()
         """))
         self.test_script.close()
-        
+
     def tearDown(self):
         os.unlink(self.test_script.name)
-    
+
     def test_sort(self):
         rc, out, err = assert_python_failure('-m', 'cProfile', '-s', 'demo')
         self.assertGreater(rc, 0)
         self.assertIn(b"option -s: invalid choice: 'demo'", err)
-    
+
     def test_valid_sort_options(self):
         for sort_opt in ['calls', 'cumulative', 'cumtime', 'filename',
                          'ncalls', 'pcalls', 'line', 'name', 'nfl',
@@ -177,11 +177,10 @@ class TestCommandLine(unittest.TestCase):
             rc, out, err = assert_python_ok('-m', 'cProfile', '-s', sort_opt, self.test_script.name)
             self.assertEqual(rc, 0)
             self.assertIn(b"function calls", out)
-    
+
     def test_outfile(self):
         with tempfile.NamedTemporaryFile(suffix='.prof', delete=False) as outfile:
             outfile_name = outfile.name
-        
         try:
             rc, out, err = assert_python_ok('-m', 'cProfile', '-o', outfile_name, self.test_script.name)
             self.assertEqual(rc, 0)
@@ -190,34 +189,34 @@ class TestCommandLine(unittest.TestCase):
         finally:
             if os.path.exists(outfile_name):
                 os.unlink(outfile_name)
-    
+
     def test_no_arguments(self):
         rc, out, err = assert_python_failure('-m', 'cProfile')
         self.assertGreater(rc, 0)
-    
+
     def test_help_option(self):
         rc, out, err = assert_python_ok('-m', 'cProfile', '--help')
         self.assertEqual(rc, 0)
         self.assertIn(b"Usage:", out)
-    
+
     def test_version_output(self):
         rc, out, err = assert_python_ok('-m', 'cProfile', self.test_script.name)
         self.assertEqual(rc, 0)
         import os
         self.assertIn(os.path.basename(self.test_script.name).encode(), out)
-    
+
     def test_run_command_line_module(self):
         rc, out, err = assert_python_ok('-m', 'cProfile', '-m', 'timeit', '-n', '1', 'pass')
         self.assertEqual(rc, 0)
         self.assertIn(b"function calls", out)
-    
+
     def test_profile_script_importing_main(self):
         with tempfile.NamedTemporaryFile("w+", suffix='.py', delete=False) as f:
             f.write(textwrap.dedent("""\
                 def test_func():
                     x = 1 + 1
                     return x
-                
+
                 if __name__ == "__main__":
                     test_func()
                 """))
@@ -229,31 +228,31 @@ class TestCommandLine(unittest.TestCase):
                 self.assertIn(b"test_func", out)
             finally:
                 os.unlink(f.name)
-    
+
     def test_output_format(self):
         rc, out, err = assert_python_ok('-m', 'cProfile', self.test_script.name)
         self.assertEqual(rc, 0)
-        
+
         output = out.decode('utf-8')
-        
+
         self.assertRegex(output, r'\d+ function calls in \d+\.\d+ seconds')
-        
+
         self.assertIn('Ordered by:', output)
-        
+
         self.assertIn('ncalls', output)
         self.assertIn('tottime', output)
         self.assertIn('percall', output)
         self.assertIn('cumtime', output)
         self.assertIn('filename:lineno(function)', output)
-        
+
         self.assertIn('simple_function', output)
-        
+
     def test_different_sort_outputs(self):
         rc1, out1, _ = assert_python_ok('-m', 'cProfile', '-s', 'time', self.test_script.name)
         rc2, out2, _ = assert_python_ok('-m', 'cProfile', '-s', 'cumulative', self.test_script.name)
-        
+
         self.assertNotEqual(out1, out2)
-        
+
         self.assertIn(b'simple_function', out1)
         self.assertIn(b'simple_function', out2)
 

--- a/Lib/test/test_cprofile.py
+++ b/Lib/test/test_cprofile.py
@@ -2,7 +2,7 @@
 
 import sys
 import unittest
-
+import os
 # rip off all interesting stuff from test_profile
 import cProfile
 import tempfile
@@ -151,23 +151,111 @@ class CProfileTest(ProfileTest):
 
 
 class TestCommandLine(unittest.TestCase):
+    def setUp(self):
+        self.test_script = tempfile.NamedTemporaryFile("w+", suffix=".py", delete=False)
+        self.test_script.write(textwrap.dedent("""
+            def simple_function():
+                sum(range(1000))
+                
+            if __name__ == "__main__":
+                simple_function()
+        """))
+        self.test_script.close()
+        
+    def tearDown(self):
+        os.unlink(self.test_script.name)
+    
     def test_sort(self):
         rc, out, err = assert_python_failure('-m', 'cProfile', '-s', 'demo')
         self.assertGreater(rc, 0)
         self.assertIn(b"option -s: invalid choice: 'demo'", err)
-
+    
+    def test_valid_sort_options(self):
+        for sort_opt in ['calls', 'cumulative', 'cumtime', 'filename',
+                         'ncalls', 'pcalls', 'line', 'name', 'nfl',
+                         'stdname', 'time', 'tottime']:
+            rc, out, err = assert_python_ok('-m', 'cProfile', '-s', sort_opt, self.test_script.name)
+            self.assertEqual(rc, 0)
+            self.assertIn(b"function calls", out)
+    
+    def test_outfile(self):
+        with tempfile.NamedTemporaryFile(suffix='.prof', delete=False) as outfile:
+            outfile_name = outfile.name
+        
+        try:
+            rc, out, err = assert_python_ok('-m', 'cProfile', '-o', outfile_name, self.test_script.name)
+            self.assertEqual(rc, 0)
+            self.assertTrue(os.path.exists(outfile_name))
+            self.assertGreater(os.path.getsize(outfile_name), 0)
+        finally:
+            if os.path.exists(outfile_name):
+                os.unlink(outfile_name)
+    
+    def test_no_arguments(self):
+        rc, out, err = assert_python_failure('-m', 'cProfile')
+        self.assertGreater(rc, 0)
+    
+    def test_help_option(self):
+        rc, out, err = assert_python_ok('-m', 'cProfile', '--help')
+        self.assertEqual(rc, 0)
+        self.assertIn(b"Usage:", out)
+    
+    def test_version_output(self):
+        rc, out, err = assert_python_ok('-m', 'cProfile', self.test_script.name)
+        self.assertEqual(rc, 0)
+        import os
+        self.assertIn(os.path.basename(self.test_script.name).encode(), out)
+    
+    def test_run_command_line_module(self):
+        rc, out, err = assert_python_ok('-m', 'cProfile', '-m', 'timeit', '-n', '1', 'pass')
+        self.assertEqual(rc, 0)
+        self.assertIn(b"function calls", out)
+    
     def test_profile_script_importing_main(self):
-        """Check that scripts that reference __main__ see their own namespace
-        when being profiled."""
-        with tempfile.NamedTemporaryFile("w+", delete_on_close=False) as f:
+        with tempfile.NamedTemporaryFile("w+", suffix='.py', delete=False) as f:
             f.write(textwrap.dedent("""\
-                class Foo:
-                    pass
-                import __main__
-                assert Foo == __main__.Foo
+                def test_func():
+                    x = 1 + 1
+                    return x
+                
+                if __name__ == "__main__":
+                    test_func()
                 """))
             f.close()
-            assert_python_ok('-m', "cProfile", f.name)
+            try:
+                rc, out, err = assert_python_ok('-m', "cProfile", f.name)
+                self.assertEqual(rc, 0)
+                self.assertIn(b"function calls", out)
+                self.assertIn(b"test_func", out)
+            finally:
+                os.unlink(f.name)
+    
+    def test_output_format(self):
+        rc, out, err = assert_python_ok('-m', 'cProfile', self.test_script.name)
+        self.assertEqual(rc, 0)
+        
+        output = out.decode('utf-8')
+        
+        self.assertRegex(output, r'\d+ function calls in \d+\.\d+ seconds')
+        
+        self.assertIn('Ordered by:', output)
+        
+        self.assertIn('ncalls', output)
+        self.assertIn('tottime', output)
+        self.assertIn('percall', output)
+        self.assertIn('cumtime', output)
+        self.assertIn('filename:lineno(function)', output)
+        
+        self.assertIn('simple_function', output)
+        
+    def test_different_sort_outputs(self):
+        rc1, out1, _ = assert_python_ok('-m', 'cProfile', '-s', 'time', self.test_script.name)
+        rc2, out2, _ = assert_python_ok('-m', 'cProfile', '-s', 'cumulative', self.test_script.name)
+        
+        self.assertNotEqual(out1, out2)
+        
+        self.assertIn(b'simple_function', out1)
+        self.assertIn(b'simple_function', out2)
 
 
 def main():


### PR DESCRIPTION
### gh-131178: Add tests for cProfile command-line interface

This pull request adds tests for the cProfile CLI. 
It includes:
- Help message output
- Valid and invalid sort options (though one already in main)
- Profiling scripts and modules
- Output file creation and check
- No-arg and version flag behavior
- Different formats and sort modes
