### PR TITLE
gh-87720 Fix additional header refolding-quoting edge case

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -162,6 +162,14 @@ class TokenList(list):
             comments.extend(token.comments)
         return comments
 
+    def has_token_type(self, *token_types):
+        if self.token_type in token_types:
+            return True
+        for t in self:
+            if t.has_token_type(*token_types):
+                return True
+        return False
+
     def fold(self, *, policy):
         return _refold_parse_tree(self, policy=policy)
 
@@ -921,6 +929,9 @@ class Terminal(str):
     @property
     def comments(self):
         return []
+
+    def has_token_type(self, *token_types):
+        return self.token_type in token_types
 
     def __getnewargs__(self):
         return(str(self), self.token_type)
@@ -2813,7 +2824,7 @@ def _refold_parse_tree(parse_tree, *, policy):
             continue
         tstr = str(part)
         if not want_encoding:
-            if part.token_type in ('ptext', 'vtext'):
+            if part.token_type == 'ptext' or part.has_token_type('vtext'):
                 # Encode if tstr contains special characters.
                 want_encoding = not SPECIALSNL.isdisjoint(tstr)
             else:

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -3096,6 +3096,11 @@ class TestFolding(TestEmailBase):
              'A =?utf-8?q?v=C3=A9ry?= long name\n'
              ' containing =?utf-8?q?a=2C?= comma\n'
              ' <to@example.com>\n'),
+            ('=?utf-8?Q?a=2C=20123456789012345678901234567890123456?='
+                ' <abc@example.com>',
+             '=?utf-8?q?a=2C?=\n'
+             ' 123456789012345678901234567890123456\n'
+             ' <abc@example.com>\n'),
         ]
         for (to, folded) in cases:
             with self.subTest(to=to):


### PR DESCRIPTION
In this case, the higher level syntactic unit fit on the remainder of the line in un-encoded format, so the encoding check never happened.  To fix this, we look inside the current unit to see if has anything that was originally encoded.

I'm not really happy with the method name 'has_token_type', but I haven't thought of anything I like better.  Ideas welcome.

<!-- gh-issue-number: gh-87720 -->
* Issue: gh-87720
<!-- /gh-issue-number -->
