### PR TITLE
gh-134235: Import Autocomplete for Builtin Modules

### DIFF
--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -81,9 +81,9 @@ class ModuleCompleter:
     def _find_modules(self, path: str, prefix: str) -> list[str]:
         if not path:
             # Top-level import (e.g. `import foo<tab>`` or `from foo<tab>`)`
-            builtins = [name for name in sys.builtin_module_names if name.startswith(prefix)]
-            modules = [name for _, name, _ in self.global_cache if name.startswith(prefix)]
-            return sorted(builtins + modules)
+            builtin_modules = [name for name in sys.builtin_module_names if name.startswith(prefix)]
+            third_party_modules = [name for _, name, _ in self.global_cache if name.startswith(prefix)]
+            return sorted(builtin_modules + third_party_modules)
 
         if path.startswith('.'):
             # Convert relative path to absolute path

--- a/Lib/_pyrepl/_module_completer.py
+++ b/Lib/_pyrepl/_module_completer.py
@@ -81,8 +81,9 @@ class ModuleCompleter:
     def _find_modules(self, path: str, prefix: str) -> list[str]:
         if not path:
             # Top-level import (e.g. `import foo<tab>`` or `from foo<tab>`)`
-            return [name for _, name, _ in self.global_cache
-                    if name.startswith(prefix)]
+            builtins = [name for name in sys.builtin_module_names if name.startswith(prefix)]
+            modules = [name for _, name, _ in self.global_cache if name.startswith(prefix)]
+            return sorted(builtins + modules)
 
         if path.startswith('.'):
             # Convert relative path to absolute path

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1004,7 +1004,6 @@ class TestPyReplModuleCompleter(TestCase):
             ('foo.bar', ('foo', 'bar')),
             ('foo.bar.', ('foo.bar', '')),
             ('foo.bar.baz', ('foo.bar', 'baz')),
-            ('sys', ('', 'sys')),
         )
         completer = ModuleCompleter()
         for name, expected in cases:

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -959,7 +959,7 @@ class TestPyReplModuleCompleter(TestCase):
                 output = reader.readline()
                 self.assertEqual(output, expected)
 
-    def test_builtin_completion(self):
+    def test_builtin_completion_top_level(self):
         import importlib
         # Make iter_modules() search only the standard library.
         # This makes the test more reliable in case there are
@@ -980,28 +980,17 @@ class TestPyReplModuleCompleter(TestCase):
             ("import foo, sys\t\n", "import foo, sys"),
 
             # Import with alias
-            ("import time as t\t\n", "import time as t"),
+            ("import tim\t as t\n", "import time as t"),
             ("import math as m, sys\t\n", "import math as m, sys"),
 
-            # From-import for functions or attributes
-            ("from math import si\t\n", "from math import sin"),
-            ("from math import co\t\n", "from math import cos"),
-            ("from sys import pat\t\n", "from sys import path"),
+            # From-import with top level
+            ("from mat\t", "from math"),
+            ("from ma\t\tt\t\n", "from math"),
             ("from builtins import str\t\n", "from builtins import str"),
 
             # From-import for modules
             ("from bui\t\n", "from builtins"),
-            ("from math impo\t\n", "from math import"),
-            ("from sys impo\t\n", "from sys import"),
 
-            # Nested completion with tab navigation
-            ("import builti\t\t\n", "import builtins"),
-            ("from builti\t\t\n", "from builtins"),
-
-            # tab twice
-            ("import ma\t\t\n", "import math"),
-            ("from ma\t\t\n", "from math"),
-            
             # not matching anything
             ("import ll\t\t\n", "import ll")
         )

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -969,29 +969,15 @@ class TestPyReplModuleCompleter(TestCase):
         sys.path = [lib_path]
 
         cases = (
-            # Basic import completion
             ("import tim\t\n", "import time"),
-            ("import sys\t\t\n", "import sys"),  # should pass?
+            ("import sys\t\t\n", "import sys"),
             ("import mat\t\n", "import math"),
             ("import bui\t\n", "import builtins"),
-
-            # Multiple imports
-            ("import foo, ti\t\n", "import foo, time"),
-            ("import foo, sys\t\n", "import foo, sys"),
-
-            # Import with alias
-            ("import tim\t as t\n", "import time as t"),
-            ("import math as m, sys\t\n", "import math as m, sys"),
-
-            # From-import with top level
             ("from mat\t\n", "from math"),
             ("from ma\t\tt\t\n", "from math"),
-
-            # From-import for modules
             ("from bui\t\n", "from builtins"),
-
-            # not matching anything
-            ("import ll\t\t\n", "import ll")
+            ("import foo, ti\t\n", "import foo, time"),
+            ("import foo, sys\t\n", "import foo, sys"),
         )
         for code, expected in cases:
             with self.subTest(code=code):

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -969,15 +969,8 @@ class TestPyReplModuleCompleter(TestCase):
         sys.path = [lib_path]
 
         cases = (
-            ("import tim\t\n", "import time"),
-            ("import sys\t\t\n", "import sys"),
-            ("import mat\t\n", "import math"),
             ("import bui\t\n", "import builtins"),
-            ("from mat\t\n", "from math"),
-            ("from ma\t\tt\t\n", "from math"),
             ("from bui\t\n", "from builtins"),
-            ("import foo, ti\t\n", "import foo, time"),
-            ("import foo, sys\t\n", "import foo, sys"),
         )
         for code, expected in cases:
             with self.subTest(code=code):

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -986,7 +986,6 @@ class TestPyReplModuleCompleter(TestCase):
             # From-import with top level
             ("from mat\t", "from math"),
             ("from ma\t\tt\t\n", "from math"),
-            ("from builtins import str\t\n", "from builtins import str"),
 
             # From-import for modules
             ("from bui\t\n", "from builtins"),

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -984,7 +984,7 @@ class TestPyReplModuleCompleter(TestCase):
             ("import math as m, sys\t\n", "import math as m, sys"),
 
             # From-import with top level
-            ("from mat\t", "from math"),
+            ("from mat\t\n", "from math"),
             ("from ma\t\tt\t\n", "from math"),
 
             # From-import for modules

--- a/Lib/test/test_pyrepl/test_pyrepl.py
+++ b/Lib/test/test_pyrepl/test_pyrepl.py
@@ -1004,6 +1004,7 @@ class TestPyReplModuleCompleter(TestCase):
             ('foo.bar', ('foo', 'bar')),
             ('foo.bar.', ('foo.bar', '')),
             ('foo.bar.baz', ('foo.bar', 'baz')),
+            ('sys', ('', 'sys')),
         )
         completer = ModuleCompleter()
         for name, expected in cases:

--- a/Misc/NEWS.d/next/Library/2025-05-19-15-05-24.gh-issue-134235.pz9PwV.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-19-15-05-24.gh-issue-134235.pz9PwV.rst
@@ -1,0 +1,2 @@
+Updated tab completion on REPL to include builtin modules. Contributed by
+Tom Wang, Hunter Young


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Added autocompletion in REPL for importing builtin modules.
#134235


<!-- gh-issue-number: gh-134235 -->
* Issue: gh-134235
<!-- /gh-issue-number -->
