### PR TITLE
gh-133940: test_strftime incorrectly calculates expected week

### DIFF
--- a/Lib/test/test_strftime.py
+++ b/Lib/test/test_strftime.py
@@ -39,7 +39,21 @@ class StrftimeTest(unittest.TestCase):
         if now[3] < 12: self.ampm='(AM|am)'
         else: self.ampm='(PM|pm)'
 
-        self.jan1 = time.localtime(time.mktime((now[0], 1, 1, 0, 0, 0, 0, 1, 0)))
+        jan1 = time.struct_time(
+            (
+                now.tm_year,  # Year
+                1,  # Month (January)
+                1,  # Day (1st)
+                0,  # Hour (0)
+                0,  # Minute (0)
+                0,  # Second (0)
+                -1,  # tm_wday (will be determined)
+                1,  # tm_yday (day 1 of the year)
+                -1,  # tm_isdst (let the system determine)
+            )
+        )
+        # use mktime to get the correct tm_wday and tm_isdst values
+        self.jan1 = time.localtime(time.mktime(jan1))
 
         try:
             if now[8]: self.tz = time.tzname[1]


### PR DESCRIPTION
self.jan1 results to January 1st 2024 if set to Irish Time Zone. By letting time.mktime correct the tm_wday and tm_isdst values we can prevent this and we will always get the current year. 

<!-- gh-issue-number: gh-133940 -->
* Issue: gh-133940
<!-- /gh-issue-number -->
