### PR TITLE
gh-128307: Update what's new in 3.13 and 3.14 with create_task changes

### DIFF
--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -736,9 +736,11 @@ asyncio
   and broke the API contract for custom task factories.
   Several third-party task factories implemented workarounds for this.
   In 3.13.4 and later releases the old factory contract is honored
-  once again (until 3.14), but the extra ``**kwargs`` argument still
+  once again (until 3.14).
+  To keep the workarounds working, the extra ``**kwargs`` argument still
   allows passing additional keyword arguments to :class:`~asyncio.Task`
-  and to custom task factories, to keep the workarounds working.
+  and to custom task factories.
+
   This affects the following function and methods:
   :meth:`asyncio.create_task`,
   :meth:`asyncio.loop.create_task`,

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -730,6 +730,20 @@ asyncio
   never awaited).
   (Contributed by Arthur Tacca and Jason Zhang in :gh:`115957`.)
 
+* The function and methods named ``create_task`` have received a new
+  ``**kwargs`` argument that is passed through to the task constructor.
+  This changed was accidentally added in 3.13.3,
+  and broke the API contract for custom task factories.
+  Several third-party task factories implemented workarounds for this.
+  In 3.13.4 and later releases the old factory contract is honored
+  once again (until 3.14), but the extra ``**kwargs`` argument still
+  allows passing additional keyword arguments to :class:`~asyncio.Task`
+  and to custom task factories, to keep the workarounds working.
+  This affects the following function and methods:
+  :meth:`asyncio.create_task`,
+  :meth:`asyncio.loop.create_task`,
+  :meth:`asyncio.TaskGroup.create_task`.
+  (Contributed by Thomas Grainger in :gh:`128307`.)
 
 base64
 ------

--- a/Doc/whatsnew/3.13.rst
+++ b/Doc/whatsnew/3.13.rst
@@ -732,7 +732,7 @@ asyncio
 
 * The function and methods named ``create_task`` have received a new
   ``**kwargs`` argument that is passed through to the task constructor.
-  This changed was accidentally added in 3.13.3,
+  This change was accidentally added in 3.13.3,
   and broke the API contract for custom task factories.
   Several third-party task factories implemented workarounds for this.
   In 3.13.4 and later releases the old factory contract is honored

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1067,13 +1067,14 @@ ast
 asyncio
 -------
 
-* The function and methods named ``create_task`` now take an arbitrary
+* The function and methods named :func:`!create_task` now take an arbitrary
   list of keyword arguments. All keyword arguments are passed to the
   :class:`~asyncio.Task` constructor or the custom task factory.
   (See :meth:`~asyncio.loop.set_task_factory` for details.)
-  Keywords ``name`` and ``context`` are no longer special; the name
-  should now be set using the ``name`` keyword argument of the factory,
+  The ``name`` and ``context`` keyword arguments are no longer special;
+  the name should now be set using the ``name`` keyword argument of the factory,
   and ``context`` may be ``None``.
+
   This affects the following function and methods:
   :meth:`asyncio.create_task`,
   :meth:`asyncio.loop.create_task`,

--- a/Doc/whatsnew/3.14.rst
+++ b/Doc/whatsnew/3.14.rst
@@ -1064,6 +1064,23 @@ ast
   (Contributed by Semyon Moroz in :gh:`133367`.)
 
 
+asyncio
+-------
+
+* The function and methods named ``create_task`` now take an arbitrary
+  list of keyword arguments. All keyword arguments are passed to the
+  :class:`~asyncio.Task` constructor or the custom task factory.
+  (See :meth:`~asyncio.loop.set_task_factory` for details.)
+  Keywords ``name`` and ``context`` are no longer special; the name
+  should now be set using the ``name`` keyword argument of the factory,
+  and ``context`` may be ``None``.
+  This affects the following function and methods:
+  :meth:`asyncio.create_task`,
+  :meth:`asyncio.loop.create_task`,
+  :meth:`asyncio.TaskGroup.create_task`.
+  (Contributed by Thomas Grainger in :gh:`128307`.)
+
+
 bdb
 ---
 


### PR DESCRIPTION
Note: there are more updates to the docs of the individual create_task function/methods, see gh-134202.

<!-- gh-issue-number: gh-128307 -->
* Issue: gh-128307
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134304.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->