### PR TITLE
gh-126845: Some edge cases in email.utils.parsedate_to_datetime seem to differ from RFC2822 spec

### DIFF
--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -149,7 +149,7 @@ def _parsedate_tz(data):
     # calls for a two-digit yy, but RFC 2822 (which obsoletes RFC 822)
     # mandates a 4-digit yy. For more information, see the documentation for
     # the time module.
-    if yy < 100:
+    if len(str(yy)) > 2 and yy < 100:
         # The year is between 1969 and 1999 (inclusive).
         if yy > 68:
             yy += 1900

--- a/Lib/test/test_parsedate_to_datetime.py
+++ b/Lib/test/test_parsedate_to_datetime.py
@@ -1,0 +1,18 @@
+# Test to see if parsedate_to_datetime returns the correct year for different digit numbers, adhering to the RFC2822 spec
+
+import unittest
+from email.utils import parsedate_to_datetime
+
+class ParsedateToDatetimeTest(unittest.TestCase):
+    def test(self):
+        expectations = {
+            "Sat, 15 Aug 0001 23:12:09 +0500": "0001",
+            "Thu, 1 Sep 1 23:12:09 +0800": "0001",
+            "Thu, 7 Oct 123 23:12:09 +0500": "0123",
+        }
+        for input_string, output_string in expectations.items():
+            self.assertEqual(str(parsedate_to_datetime(input_string))[:4], output_string)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/Lib/test/test_strftime.py
+++ b/Lib/test/test_strftime.py
@@ -39,7 +39,21 @@ class StrftimeTest(unittest.TestCase):
         if now[3] < 12: self.ampm='(AM|am)'
         else: self.ampm='(PM|pm)'
 
-        self.jan1 = time.localtime(time.mktime((now[0], 1, 1, 0, 0, 0, 0, 1, 0)))
+        jan1 = time.struct_time(
+            (
+                now.tm_year,  # Year
+                1,  # Month (January)
+                1,  # Day (1st)
+                0,  # Hour (0)
+                0,  # Minute (0)
+                0,  # Second (0)
+                -1,  # tm_wday (will be determined)
+                1,  # tm_yday (day 1 of the year)
+                -1,  # tm_isdst (let the system determine)
+            )
+        )
+        # use mktime to get the correct tm_wday and tm_isdst values
+        self.jan1 = time.localtime(time.mktime(jan1))
 
         try:
             if now[8]: self.tz = time.tzname[1]

--- a/issues.py
+++ b/issues.py
@@ -1,0 +1,4 @@
+import datetime
+from email.utils import parsedate_to_datetime
+
+print(parsedate_to_datetime("Sat, 15 Aug 5000 23:12:09 +0500"))


### PR DESCRIPTION
Addressing no.1 from #126845 and included tests.

<!-- gh-issue-number: gh-126845 -->
* Issue: gh-126845
<!-- /gh-issue-number -->
