### PR TITLE
GH-130727: test_wmi_query_error test is flaky 

### DIFF
--- a/Misc/NEWS.d/next/Windows/2025-05-20-21-43-20.gh-issue-130727.-69t4D.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-20-21-43-20.gh-issue-130727.-69t4D.rst
@@ -1,0 +1,2 @@
+Fix a race  in :mod:`_wmimodule` that can result in an "invalid handle"
+exception under high load. Fix by Chris Eibl.

--- a/Misc/NEWS.d/next/Windows/2025-05-20-21-43-20.gh-issue-130727.-69t4D.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-20-21-43-20.gh-issue-130727.-69t4D.rst
@@ -1,2 +1,2 @@
-Fix a race  in :mod:`_wmimodule` that can result in an "invalid handle"
-exception under high load. Fix by Chris Eibl.
+Fix a race in :mod:`_wmi` that can result in an "invalid handle"
+exception under high load. Patch by Chris Eibl.

--- a/Misc/NEWS.d/next/Windows/2025-05-20-21-43-20.gh-issue-130727.-69t4D.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-20-21-43-20.gh-issue-130727.-69t4D.rst
@@ -1,2 +1,2 @@
-Fix a race in :mod:`_wmi` that can result in an "invalid handle"
+Fix a race in internal calls into WMI that can result in an "invalid handle"
 exception under high load. Patch by Chris Eibl.

--- a/PC/_wmimodule.cpp
+++ b/PC/_wmimodule.cpp
@@ -57,11 +57,11 @@ _query_thread(LPVOID param)
     IEnumWbemClassObject* enumerator = NULL;
     HRESULT hr = S_OK;
     BSTR bstrQuery = NULL;
-    struct _query_data *data = (struct _query_data*)param;
+    _query_data data = *(struct _query_data*)param;
 
     // gh-125315: Copy the query string first, so that if the main thread gives
     // up on waiting we aren't left with a dangling pointer (and a likely crash)
-    bstrQuery = SysAllocString(data->query);
+    bstrQuery = SysAllocString(data.query);
     if (!bstrQuery) {
         hr = HRESULT_FROM_WIN32(ERROR_NOT_ENOUGH_MEMORY);
     }
@@ -71,7 +71,7 @@ _query_thread(LPVOID param)
     }
 
     if (FAILED(hr)) {
-        CloseHandle(data->writePipe);
+        CloseHandle(data.writePipe);
         if (bstrQuery) {
             SysFreeString(bstrQuery);
         }
@@ -96,7 +96,7 @@ _query_thread(LPVOID param)
             IID_IWbemLocator, (LPVOID *)&locator
         );
     }
-    if (SUCCEEDED(hr) && !SetEvent(data->initEvent)) {
+    if (SUCCEEDED(hr) && !SetEvent(data.initEvent)) {
         hr = HRESULT_FROM_WIN32(GetLastError());
     }
     if (SUCCEEDED(hr)) {
@@ -105,7 +105,7 @@ _query_thread(LPVOID param)
             NULL, NULL, 0, NULL, 0, 0, &services
         );
     }
-    if (SUCCEEDED(hr) && !SetEvent(data->connectEvent)) {
+    if (SUCCEEDED(hr) && !SetEvent(data.connectEvent)) {
         hr = HRESULT_FROM_WIN32(GetLastError());
     }
     if (SUCCEEDED(hr)) {
@@ -143,7 +143,7 @@ _query_thread(LPVOID param)
         if (FAILED(hr) || got != 1 || !value) {
             continue;
         }
-        if (!startOfEnum && !WriteFile(data->writePipe, (LPVOID)L"\0", 2, &written, NULL)) {
+        if (!startOfEnum && !WriteFile(data.writePipe, (LPVOID)L"\0", 2, &written, NULL)) {
             hr = HRESULT_FROM_WIN32(GetLastError());
             break;
         }
@@ -171,10 +171,10 @@ _query_thread(LPVOID param)
                     DWORD cbStr1, cbStr2;
                     cbStr1 = (DWORD)(wcslen(propName) * sizeof(propName[0]));
                     cbStr2 = (DWORD)(wcslen(propStr) * sizeof(propStr[0]));
-                    if (!WriteFile(data->writePipe, propName, cbStr1, &written, NULL) ||
-                        !WriteFile(data->writePipe, (LPVOID)L"=", 2, &written, NULL) ||
-                        !WriteFile(data->writePipe, propStr, cbStr2, &written, NULL) ||
-                        !WriteFile(data->writePipe, (LPVOID)L"\0", 2, &written, NULL)
+                    if (!WriteFile(data.writePipe, propName, cbStr1, &written, NULL) ||
+                        !WriteFile(data.writePipe, (LPVOID)L"=", 2, &written, NULL) ||
+                        !WriteFile(data.writePipe, propStr, cbStr2, &written, NULL) ||
+                        !WriteFile(data.writePipe, (LPVOID)L"\0", 2, &written, NULL)
                     ) {
                         hr = HRESULT_FROM_WIN32(GetLastError());
                     }
@@ -200,7 +200,7 @@ _query_thread(LPVOID param)
         locator->Release();
     }
     CoUninitialize();
-    CloseHandle(data->writePipe);
+    CloseHandle(data.writePipe);
     return (DWORD)hr;
 }
 


### PR DESCRIPTION
I can reproduce the  the "invalid handle" errors which @vstinner has also seen https://github.com/python/cpython/issues/130727#issuecomment-2697599470 under high load (using "Stress CPU" of CPU-Z) running
```
python -m test test_wmi -m test.test_wmi.WmiTests.test_wmi_query_repeated -F
```

The reason is, that the main thread calls `CloseHandle` on the still running thread in case of a `WAIT_TIMEOUT`, and then the thread dies with 
```
Exception thrown at 0x00007FFE1A35144A (ntdll.dll) in python_d.exe: 0xC0000008: An invalid handle was specified.
```

and call stack
```
 	ntdll.dll!00007ffe1a35144a()	Unknown
 	KernelBase.dll!00007ffe17cd0905()	Unknown
>	_wmi_d.pyd!_query_thread(void * param) Line 204	C++
```

where
```
    CloseHandle(data->writePipe); //Line 204
    return (DWORD)hr;
```
when I debug it in Visual Studio.

This has already been anticipated by @runn in https://github.com/python/cpython/issues/125315#issuecomment-2422821177.

Another manifestation of this race results in

```
======================================================================
FAIL: test_wmi_query_repeated (test.test_wmi.WmiTests.test_wmi_query_repeated)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "R:\buildarea\3.14.ambv-bb-win11.bigmem\build\Lib\test\test_wmi.py", line 41, in test_wmi_query_repeated
    self.test_wmi_query_os_version()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "R:\buildarea\3.14.ambv-bb-win11.bigmem\build\Lib\test\test_wmi.py", line 30, in test_wmi_query_os_version
    self.assertEqual(1, len(r))
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^
AssertionError: 1 != 2
```
which sometimes occur on the build bots, e.g. https://buildbot.python.org/#/builders/1799/builds/20.

Copying the `_query_data` struct in the wmi thread fixes both issues.

<!-- gh-issue-number: gh-130727 -->
* Issue: gh-130727
<!-- /gh-issue-number -->
