### PR TITLE
gh-72902: improve Fraction constructor speed for typical inputs

### DIFF
--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -238,11 +238,6 @@ class Fraction(numbers.Rational):
                 self._denominator = 1
                 return self
 
-            elif isinstance(numerator, numbers.Rational):
-                self._numerator = numerator.numerator
-                self._denominator = numerator.denominator
-                return self
-
             elif (isinstance(numerator, float) or
                   (not isinstance(numerator, type) and
                    hasattr(numerator, 'as_integer_ratio'))):
@@ -277,6 +272,11 @@ class Fraction(numbers.Rational):
                             denominator *= 10**-exp
                 if m.group('sign') == '-':
                     numerator = -numerator
+
+            elif isinstance(numerator, numbers.Rational):
+                self._numerator = numerator.numerator
+                self._denominator = numerator.denominator
+                return self
 
             else:
                 raise TypeError("argument should be a string or a Rational "

--- a/Misc/NEWS.d/next/Library/2025-05-20-11-35-08.gh-issue-72902.jzEI-E.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-20-11-35-08.gh-issue-72902.jzEI-E.rst
@@ -1,0 +1,2 @@
+Improve speed (x1.1-1.8) of the :class:`~fractions.Fraction` constructor for
+typical inputs (:class:`float`'s, :class:`~decimal.Decimal`'s or strings).


### PR DESCRIPTION
This moves abc check for numbers.Rational - down.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-72902 -->
* Issue: gh-72902
<!-- /gh-issue-number -->

------------------------------

| Benchmark                     | ref     | patch                 |
|-------------------------------|:-------:|:---------------------:|
| Fraction(myint)               | 5.62 us | 7.03 us: 1.25x slower |
| Fraction(Fraction(1, 2))      | 5.89 us | 4.88 us: 1.21x faster |
| Fraction(Decimal('0.25'))     | 11.1 us | 7.98 us: 1.39x faster |
| Fraction(IntSubclass(123))    | 5.93 us | 5.05 us: 1.17x faster |
| Fraction(FloatSubclass(0.25)) | 7.69 us | 4.26 us: 1.81x faster |
| Fraction('123')               | 19.2 us | 16.1 us: 1.19x faster |
| Fraction('1/3')               | 19.6 us | 16.4 us: 1.20x faster |
| Fraction('1.2e-3')            | 26.1 us | 23.0 us: 1.14x faster |
| Fraction('-.2')               | 23.4 us | 20.2 us: 1.16x faster |
| Geometric mean                | (ref)   | 1.21x faster          |

<details>

```py
# bench.py
import pyperf
from fractions import Fraction as F
from decimal import Decimal as D
from numbers import Integral

runner = pyperf.Runner()
s = 'Fraction'
class MyInt:
    numerator = 123
    denominator = 1
    def __int__(self):
        return 123
    def __repr__(self):
        return "myint"
class IntSubclass(int):
    def __repr__(self):
        return 'IntSubclass('+super().__repr__()+')'
class FloatSubclass(float):
    def __repr__(self):
        return 'FloatSubclass('+super().__repr__()+')'

Integral.register(MyInt)
for v in [MyInt(), F(1, 2), D("0.25"),
          IntSubclass(123), FloatSubclass(0.25),
          "123", "1/3", "1.2e-3", "-.2"]:
    r = s + '(' + repr(v) + ')'
    runner.bench_func(r, F, v)
```

</details>