### PR TITLE
[3.14] Mention that HTMLParser.handle_starttag value can be None (GH-134312)

### DIFF
--- a/Doc/library/html.parser.rst
+++ b/Doc/library/html.parser.rst
@@ -134,7 +134,8 @@ implementations do nothing (except for :meth:`~HTMLParser.handle_startendtag`):
    argument is a list of ``(name, value)`` pairs containing the attributes found
    inside the tag's ``<>`` brackets.  The *name* will be translated to lower case,
    and quotes in the *value* have been removed, and character and entity references
-   have been replaced.
+   have been replaced. If a boolean attribute is encountered, the *value* for the
+   ``(name, value)`` attribute pair will be ``None``.
 
    For instance, for the tag ``<A HREF="https://www.cwi.nl/">``, this method
    would be called as ``handle_starttag('a', [('href', 'https://www.cwi.nl/')])``.
@@ -308,6 +309,16 @@ further parsing:
    Start tag: script
         attr: ('type', 'text/javascript')
    Data     : alert("<strong>hello!</strong>");
+   End tag  : script
+
+Boolean attributes have a *value* of ``None``:
+
+.. doctest::
+
+   >>> parser.feed("<script src='/script.js' defer></script>")
+   Start tag: script
+        attr: ('src', '/script.js')
+        attr: ('defer', None)
    End tag  : script
 
 Parsing comments:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This change adds documentation that specifies the behavior of HTMLParser.handle_starttag when a boolean attribute is parsed.

Since there is no value for the standard "key - value" format, "None" is placed into the tuple as the corresponding value for the boolean attribute.

I will submit PR's for each version specified on the issue.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134333.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->