### PR TITLE
GH-133779: Fix Windows JIT builds

### DIFF
--- a/PCbuild/regen.targets
+++ b/PCbuild/regen.targets
@@ -125,8 +125,7 @@
       <JITArgs Condition="$(Platform) == 'x64'">x86_64-pc-windows-msvc</JITArgs>
       <JITArgs Condition="$(Configuration) == 'Debug'">$(JITArgs) --debug</JITArgs>
     </PropertyGroup>
-    <Exec Command='$(PythonForBuild) "$(PySourcePath)Tools\jit\build.py" $(JITArgs)'
-          WorkingDirectory="$(GeneratedJitStencilsDir)"/>
+    <Exec Command='$(PythonForBuild) "$(PySourcePath)Tools\jit\build.py" $(JITArgs) --output-dir "$(GeneratedJitStencilsDir)" --pyconfig-dir "$(PySourcePath)PC"'/>
   </Target>
   <Target Name="_CleanJIT" AfterTargets="Clean">
     <Delete Files="@(_JITOutputs)"/>

--- a/Tools/jit/_targets.py
+++ b/Tools/jit/_targets.py
@@ -47,6 +47,7 @@ class _Target(typing.Generic[_S, _R]):
     debug: bool = False
     verbose: bool = False
     known_symbols: dict[str, int] = dataclasses.field(default_factory=dict)
+    pyconfig: pathlib.Path | None = None
 
     def _get_nop(self) -> bytes:
         if re.fullmatch(r"aarch64-.*", self.triple):
@@ -57,13 +58,14 @@ class _Target(typing.Generic[_S, _R]):
             raise ValueError(f"NOP not defined for {self.triple}")
         return nop
 
-    def _compute_digest(self, out: pathlib.Path) -> str:
+    def _compute_digest(self) -> str:
         hasher = hashlib.sha256()
         hasher.update(self.triple.encode())
         hasher.update(self.debug.to_bytes())
         # These dependencies are also reflected in _JITSources in regen.targets:
         hasher.update(PYTHON_EXECUTOR_CASES_C_H.read_bytes())
-        hasher.update((out / "pyconfig.h").read_bytes())
+        assert self.pyconfig is not None
+        hasher.update(self.pyconfig.read_bytes())
         for dirpath, _, filenames in sorted(os.walk(TOOLS_JIT)):
             for filename in filenames:
                 hasher.update(pathlib.Path(dirpath, filename).read_bytes())
@@ -118,6 +120,7 @@ class _Target(typing.Generic[_S, _R]):
         self, opname: str, c: pathlib.Path, tempdir: pathlib.Path
     ) -> _stencils.StencilGroup:
         o = tempdir / f"{opname}.o"
+        assert self.pyconfig is not None
         args = [
             f"--target={self.triple}",
             "-DPy_BUILD_CORE_MODULE",
@@ -125,7 +128,7 @@ class _Target(typing.Generic[_S, _R]):
             f"-D_JIT_OPCODE={opname}",
             "-D_PyJIT_ACTIVE",
             "-D_Py_JIT",
-            "-I.",
+            f"-I{self.pyconfig.parent}",
             f"-I{CPYTHON / 'Include'}",
             f"-I{CPYTHON / 'Include' / 'internal'}",
             f"-I{CPYTHON / 'Include' / 'internal' / 'mimalloc'}",
@@ -193,20 +196,19 @@ class _Target(typing.Generic[_S, _R]):
 
     def build(
         self,
-        out: pathlib.Path,
         *,
         comment: str = "",
         force: bool = False,
-        stencils_h: str = "jit_stencils.h",
+        jit_stencils: pathlib.Path,
     ) -> None:
         """Build jit_stencils.h in the given directory."""
+        jit_stencils.parent.mkdir(parents=True, exist_ok=True)
         if not self.stable:
             warning = f"JIT support for {self.triple} is still experimental!"
             request = "Please report any issues you encounter.".center(len(warning))
             outline = "=" * len(warning)
             print("\n".join(["", outline, warning, request, outline, ""]))
-        digest = f"// {self._compute_digest(out)}\n"
-        jit_stencils = out / stencils_h
+        digest = f"// {self._compute_digest()}\n"
         if (
             not force
             and jit_stencils.exists()
@@ -214,7 +216,7 @@ class _Target(typing.Generic[_S, _R]):
         ):
             return
         stencil_groups = ASYNCIO_RUNNER.run(self._build_stencils())
-        jit_stencils_new = out / "jit_stencils.h.new"
+        jit_stencils_new = jit_stencils.parent / "jit_stencils.h.new"
         try:
             with jit_stencils_new.open("w") as file:
                 file.write(digest)

--- a/Tools/jit/build.py
+++ b/Tools/jit/build.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         target.debug = args.debug
         target.force = args.force
         target.verbose = args.verbose
-        target.pyconfig = args.pyconfig_dir / "pyconfig.h"
+        target.pyconfig_dir = args.pyconfig_dir
         target.build(
             comment=comment,
             force=args.force,

--- a/Tools/jit/build.py
+++ b/Tools/jit/build.py
@@ -8,7 +8,6 @@ import sys
 import _targets
 
 if __name__ == "__main__":
-    out = pathlib.Path.cwd().resolve()
     comment = f"$ {shlex.join([pathlib.Path(sys.executable).name] + sys.argv)}"
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -24,6 +23,12 @@ if __name__ == "__main__":
         "-f", "--force", action="store_true", help="force the entire JIT to be rebuilt"
     )
     parser.add_argument(
+        "-o", "--output-dir", help="where to output generated files", required=True, type=lambda p: pathlib.Path(p).resolve()
+    )
+    parser.add_argument(
+        "-p", "--pyconfig-dir", help="where to find pyconfig.h", required=True, type=lambda p: pathlib.Path(p).resolve()
+    )
+    parser.add_argument(
         "-v", "--verbose", action="store_true", help="echo commands as they are run"
     )
     args = parser.parse_args()
@@ -31,13 +36,13 @@ if __name__ == "__main__":
         target.debug = args.debug
         target.force = args.force
         target.verbose = args.verbose
+        target.pyconfig=args.pyconfig_dir / "pyconfig.h"
         target.build(
-            out,
             comment=comment,
-            stencils_h=f"jit_stencils-{target.triple}.h",
             force=args.force,
+            jit_stencils=args.output_dir / f"jit_stencils-{target.triple}.h",
         )
-    jit_stencils_h = out / "jit_stencils.h"
+    jit_stencils_h = args.output_dir / "jit_stencils.h"
     lines = [f"// {comment}\n"]
     guard = "#if"
     for target in args.target:

--- a/Tools/jit/build.py
+++ b/Tools/jit/build.py
@@ -23,10 +23,18 @@ if __name__ == "__main__":
         "-f", "--force", action="store_true", help="force the entire JIT to be rebuilt"
     )
     parser.add_argument(
-        "-o", "--output-dir", help="where to output generated files", required=True, type=lambda p: pathlib.Path(p).resolve()
+        "-o",
+        "--output-dir",
+        help="where to output generated files",
+        required=True,
+        type=lambda p: pathlib.Path(p).resolve(),
     )
     parser.add_argument(
-        "-p", "--pyconfig-dir", help="where to find pyconfig.h", required=True, type=lambda p: pathlib.Path(p).resolve()
+        "-p",
+        "--pyconfig-dir",
+        help="where to find pyconfig.h",
+        required=True,
+        type=lambda p: pathlib.Path(p).resolve(),
     )
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="echo commands as they are run"
@@ -36,7 +44,7 @@ if __name__ == "__main__":
         target.debug = args.debug
         target.force = args.force
         target.verbose = args.verbose
-        target.pyconfig=args.pyconfig_dir / "pyconfig.h"
+        target.pyconfig = args.pyconfig_dir / "pyconfig.h"
         target.build(
             comment=comment,
             force=args.force,

--- a/configure
+++ b/configure
@@ -10863,7 +10863,7 @@ then :
 
 else case e in #(
   e) as_fn_append CFLAGS_NODIST " $jit_flags"
-           REGEN_JIT_COMMAND="\$(PYTHON_FOR_REGEN) \$(srcdir)/Tools/jit/build.py ${ARCH_TRIPLES:-$host}"
+           REGEN_JIT_COMMAND="\$(PYTHON_FOR_REGEN) \$(srcdir)/Tools/jit/build.py ${ARCH_TRIPLES:-$host} --output-dir . --pyconfig-dir ."
            JIT_STENCILS_H="jit_stencils.h"
            if test "x$Py_DEBUG" = xtrue
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -2776,7 +2776,7 @@ AS_VAR_IF([jit_flags],
           [],
           [AS_VAR_APPEND([CFLAGS_NODIST], [" $jit_flags"])
            AS_VAR_SET([REGEN_JIT_COMMAND],
-                      ["\$(PYTHON_FOR_REGEN) \$(srcdir)/Tools/jit/build.py ${ARCH_TRIPLES:-$host}"])
+                      ["\$(PYTHON_FOR_REGEN) \$(srcdir)/Tools/jit/build.py ${ARCH_TRIPLES:-$host} --output-dir . --pyconfig-dir ."])
            AS_VAR_SET([JIT_STENCILS_H], ["jit_stencils.h"])
            AS_VAR_IF([Py_DEBUG],
                      [true],


### PR DESCRIPTION
This updates the JIT build scripts to handle arbitrary `pyconfig.h` locations and build directories.

It's not super pretty, but it unblocks CI for the sprint until I have time go through and clean some of this stuff up.

<!-- gh-issue-number: gh-133779 -->
* Issue: gh-133779
<!-- /gh-issue-number -->
