### PR TITLE
gh-126845: Some edge cases in email.utils.parsedate_to_datetime seem to differ from RFC2822 spec #126845

### DIFF
--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -149,7 +149,7 @@ def _parsedate_tz(data):
     # calls for a two-digit yy, but RFC 2822 (which obsoletes RFC 822)
     # mandates a 4-digit yy. For more information, see the documentation for
     # the time module.
-    if yy < 100:
+    if len(str(yy)) >= 2 and yy < 100:
         # The year is between 1969 and 1999 (inclusive).
         if yy > 68:
             yy += 1900

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3227,7 +3227,7 @@ class TestMiscellaneous(TestEmailBase):
 
         """
         self.assertEqual(utils.parsedate_tz('25 Feb 03 13:47:26 -0800'),
-                         utils.parsedate_tz('25 Feb 2003 13:47:26 -0800'))
+                         utils.parsedate_tz('25 Feb 3 13:47:26 -0800'))
         self.assertEqual(utils.parsedate_tz('25 Feb 71 13:47:26 -0800'),
                          utils.parsedate_tz('25 Feb 1971 13:47:26 -0800'))
 

--- a/Lib/test/test_email/test_parsedate_to_datetime.py
+++ b/Lib/test/test_email/test_parsedate_to_datetime.py
@@ -1,0 +1,17 @@
+# Test to see if parsedate_to_datetime returns the correct year for different digit numbers, adhering to the RFC2822 spec
+
+import unittest
+from email.utils import parsedate_to_datetime
+
+class ParsedateToDatetimeTest(unittest.TestCase):
+    def test(self):
+        expectations = {
+            "Sat, 15 Aug 0001 23:12:09 +0500": "0001",
+            "Thu, 1 Sep 1 23:12:09 +0800": "0001",
+            "Thu, 7 Oct 123 23:12:09 +0500": "0123",
+        }
+        for input_string, output_string in expectations.items():
+            self.assertEqual(str(parsedate_to_datetime(input_string))[:4], output_string)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-20-15-41-51.gh-issue-133315.QhEGg6.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-20-15-41-51.gh-issue-133315.QhEGg6.rst
@@ -1,0 +1,2 @@
+Fixed _parsedate_tz to not evaluate 1 digit years as as 4-digit years, adhering to RFC 2855 4.3
+Contributed by Gustaf Gyllensporre.


### PR DESCRIPTION
Regarding no.1 from #126845 

Also added tests for different digit years and updated a test in test_email.py to correctly assert 1 digit years (03 is evaluated to 3)

<!-- gh-issue-number: gh-126845 -->
* Issue: gh-126845
<!-- /gh-issue-number -->
