### PR TITLE
gh-118234: Avoid socket failure with missing SYSTEMROOT env var on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2025-05-20-12-35-33.gh-issue-118234.HjbkIh.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-20-12-35-33.gh-issue-118234.HjbkIh.rst
@@ -1,0 +1,2 @@
+Avoid socket failure with missing SYSTEMROOT env var on Windows. Patch by
+John Keith Hohm.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -405,17 +405,17 @@ remove_unusable_flags(PyObject *m)
 
 /* issue #118234, avoid WinError 10106 with empty environment */
 static void ensure_system_root() {
-  LPCWSTR name = L"SystemRoot";
-  DWORD size = GetEnvironmentVariableW(name, NULL, 0);
-  if (size) {
-    return;
-  }
-  wchar_t root[4096];
-  UINT len = GetWindowsDirectoryW(root, 4096);
-  if (len == 0 || len >= 4096) {
-    return;
-  }
-  SetEnvironmentVariableW(name, root);
+    LPCWSTR name = L"SystemRoot";
+    DWORD size = GetEnvironmentVariableW(name, NULL, 0);
+    if (size) {
+        return;
+    }
+    wchar_t root[4096];
+    UINT len = GetWindowsDirectoryW(root, 4096);
+    if (len == 0 || len >= 4096) {
+        return;
+    }
+    SetEnvironmentVariableW(name, root);
 }
 
 #endif


### PR DESCRIPTION
Resolves #118234 by checking for the SystemRoot environment variable and, if it is missing, setting it based on `GetWindowsDirectoryW`.

As described in the issue, the default path of the provider DLL is stored in the registry as "%SystemRoot%\System32\mswsock.dll" which does not resolve without SystemRoot set (typically to "C:\Windows").


<!-- gh-issue-number: gh-118234 -->
* Issue: gh-118234
<!-- /gh-issue-number -->
