### PR TITLE
GH-122089: Cache LogRecord.getMessage() the first time the message is formatted

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -303,6 +303,7 @@ class LogRecord(object):
         ct = time.time_ns()
         self.name = name
         self.msg = msg
+        self.message = None
         #
         # The following statement allows passing of a dictionary as a sole
         # argument, so that you can do something like
@@ -395,10 +396,13 @@ class LogRecord(object):
         Return the message for this LogRecord after merging any user-supplied
         arguments with the message.
         """
-        msg = str(self.msg)
-        if self.args:
-            msg = msg % self.args
-        return msg
+        if self.message is None:
+            msg = str(self.msg)
+            if self.args:
+                msg = msg % self.args
+            self.message = msg
+
+        return self.message
 
 #
 #   Determine which class to use when instantiating log records.
@@ -708,6 +712,8 @@ class Formatter(object):
         called to format the event time. If there is exception information,
         it is formatted using formatException() and appended to the message.
         """
+        # note: LogRecord.getMessage() will set record.message already but
+        #       custom LogRecord objects may not so it's assigned here anyway
         record.message = record.getMessage()
         if self.usesTime():
             record.asctime = self.formatTime(record, self.datefmt)

--- a/Misc/NEWS.d/next/Library/2025-05-20-13-18-23.gh-issue-122089.SkjbnT.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-20-13-18-23.gh-issue-122089.SkjbnT.rst
@@ -1,0 +1,2 @@
+Cache LogRecord.getMessage() the first time the message is formatted. Patch
+by Carey Metcalfe.


### PR DESCRIPTION
This improves performance in cases where multiple `logging.Formatter`s are used when logging objects with expensive `__str__`/`__repr__` functions.

<!-- gh-issue-number: gh-122089 -->
* Issue: gh-122089
<!-- /gh-issue-number -->
