### PR TITLE
gh-134360 Add processName attribute to `logging.Formatter` docstring

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -591,6 +591,7 @@ class Formatter(object):
     %(threadName)s      Thread name (if available)
     %(taskName)s        Task name (if available)
     %(process)d         Process ID (if available)
+    %(processName)s     Process name (if available)
     %(message)s         The result of record.getMessage(), computed just as
                         the record is emitted
     """


### PR DESCRIPTION
As the issue #134360 suggests, the `Formatter` class was missing the `processName` attribute inside its docstring.

I've added the attribute to the docstring and made sure that it actually is in the `LogRecord` class. Now it is just as in the [LogRecord attributes section](https://docs.python.org/3/library/logging.html#logrecord-attributes) of the Python documentation.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134360 -->
* Issue: gh-134360
<!-- /gh-issue-number -->
