### PR TITLE
gh-85045: clarified that the underlying buffer of a TextIOBase can be a RawIOBase

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -894,9 +894,10 @@ Text I/O
 
    .. attribute:: buffer
 
-      The underlying binary buffer (a :class:`BufferedIOBase` instance) that
-      :class:`TextIOBase` deals with.  This is not part of the
-      :class:`TextIOBase` API and may not exist in some implementations.
+      The underlying binary buffer (a :class:`BufferedIOBase` 
+      or :class:`RawIOBase` instance) that :class:`TextIOBase` deals with.  
+      This is not part of the :class:`TextIOBase` API and may not exist 
+      in some implementations.
 
    .. method:: detach()
 

--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -894,9 +894,9 @@ Text I/O
 
    .. attribute:: buffer
 
-      The underlying binary buffer (a :class:`BufferedIOBase` 
-      or :class:`RawIOBase` instance) that :class:`TextIOBase` deals with.  
-      This is not part of the :class:`TextIOBase` API and may not exist 
+      The underlying binary buffer (a :class:`BufferedIOBase`
+      or :class:`RawIOBase` instance) that :class:`TextIOBase` deals with.
+      This is not part of the :class:`TextIOBase` API and may not exist
       in some implementations.
 
    .. method:: detach()


### PR DESCRIPTION
Added a clarification that the underlying binary buffer of a TextIOBase
can be a BufferedIOBase OR a RawIOBase.

RawIOBase was previously not specified because it is a edge case (was recently added along with non-buffered mode).


<!-- gh-issue-number: gh-85045 -->
* Issue: gh-85045
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134372.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->