### PR TITLE
[3.13] gh-128066: Properly handle history file writes for RO fs on PyREPL (gh-134380)

### DIFF
--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -30,6 +30,11 @@ import functools
 import os
 import sys
 import code
+<<<<<<< HEAD
+=======
+import warnings
+import errno
+>>>>>>> c91ad5da9d9 (gh-128066: Properly handle history file writes for RO fs on PyREPL (gh-134380))
 
 from .readline import _get_reader, multiline_input
 

--- a/Lib/_pyrepl/simple_interact.py
+++ b/Lib/_pyrepl/simple_interact.py
@@ -30,11 +30,6 @@ import functools
 import os
 import sys
 import code
-<<<<<<< HEAD
-=======
-import warnings
-import errno
->>>>>>> c91ad5da9d9 (gh-128066: Properly handle history file writes for RO fs on PyREPL (gh-134380))
 
 from .readline import _get_reader, multiline_input
 

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -573,7 +573,7 @@ def register_readline():
         def write_history():
             try:
                 readline_module.write_history_file(history)
-            except FileNotFoundError, PermissionError:
+            except (FileNotFoundError, PermissionError):
                 # home directory does not exist or is not writable
                 # https://bugs.python.org/issue19891
                 pass

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -75,6 +75,7 @@ import builtins
 import _sitebuiltins
 import io
 import stat
+import errno
 
 # Prefixes for site-packages; add additional prefixes like /usr/local here
 PREFIXES = [sys.prefix, sys.exec_prefix]
@@ -572,10 +573,15 @@ def register_readline():
         def write_history():
             try:
                 readline_module.write_history_file(history)
-            except (FileNotFoundError, PermissionError):
+            except FileNotFoundError, PermissionError:
                 # home directory does not exist or is not writable
                 # https://bugs.python.org/issue19891
                 pass
+            except OSError:
+                if errno.EROFS:
+                    pass  # gh-128066: read-only file system
+                else:
+                    raise
 
         atexit.register(write_history)
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-20-14-41-50.gh-issue-128066.qzzGfv.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-20-14-41-50.gh-issue-128066.qzzGfv.rst
@@ -1,0 +1,3 @@
+Fixes an edge case where PyREPL improperly threw an error when Python is
+invoked on a read only filesystem while trying to write history file
+entries.


### PR DESCRIPTION
(cherry picked from commit c91ad5da9d92eac4718e4da8d53689c3cc24535e)


<!-- gh-issue-number: gh-128066 -->
* Issue: gh-128066
<!-- /gh-issue-number -->
