### PR TITLE
Remove Cirrus macOS runners from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,23 +196,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Cirrus and macos-14 are M1, macos-13 is default GHA Intel.
+        # macos-14 is M1, macos-13 is default GHA Intel.
         # macOS 13 only runs tests against the GIL-enabled CPython.
-        # Cirrus used for upstream, macos-14 for forks.
         os:
-        - ghcr.io/cirruslabs/macos-runner:sonoma
         - macos-14
         - macos-13
-        is-fork:  # only used for the exclusion trick
-        - ${{ github.repository_owner != 'python' }}
         free-threading:
         - false
         - true
         exclude:
-        - os: ghcr.io/cirruslabs/macos-runner:sonoma
-          is-fork: true
-        - os: macos-14
-          is-fork: false
         - os: macos-13
           free-threading: true
     uses: ./.github/workflows/reusable-macos.yml


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
Here's a draft PR in case we need it during sprints. We can always revert after the sprints if necessary.

---

The Cirrus workers are much faster than GitHub ones. Here's the free-threaded job (from April), with config cache available.

Left is [Cirrus, 4m 16s total](https://github.com/python/cpython/actions/runs/14380002326/job/40321343554)
Right [GHA, 7m 54s total](https://github.com/hugovk/cpython/actions/runs/14381413312/job/4032740773)

The regular build is similar: Cirrus 4m 21s, GHA 6m 47s.

![image](https://github.com/user-attachments/assets/78e78227-0ec3-41ec-ae29-8331ce6d0054)

The Cirrus workers have 4 CPUs compared to GH's 3.

---

However, when things are very busy, like during the sprints, we're limited by the number of Cirrus workers available. I don't have a number but some runs today looked like this:

![image](https://github.com/user-attachments/assets/18c69d48-1c39-4880-9429-f530be7d88a2)

The blue lines are the normal limiting factor: Windows/FT takes about 30 minutes, and everything else normally finished before this.

But here it took about 43 and 46 minutes for the two Cirrus jobs to run. There's also a GH macos-13 in this picture, but it started almost immediately and finished after 10 mins.

And we have lots of capacity now with [GH Enterprise](https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits): 50 max concurrent macOS runners:

![image](https://github.com/user-attachments/assets/715660a2-484e-4369-bad7-e0c4863fb9e5)

So the speed of Cirrus doesn't matter here when we're waiting 45 mins for them to even start.
