### PR TITLE
GH-134394: Add native support for t-strings in the stdlib logging library

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-05-20-17-23-45.gh-issue-134394.CWQvIP.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-20-17-23-45.gh-issue-134394.CWQvIP.rst
@@ -1,0 +1,1 @@
+Add support for t-strings to the logging module. Patch by Carey Metcalfe.


### PR DESCRIPTION
This PR adds support for using t-strings in the stdlib logging library. For more context, see the linked issue.

Note that this change is currently mostly a proof of concept and does not add any new tests or documentation to cover the feature. If the linked feature request is accepted, I'm willing to add them.

<!-- gh-issue-number: gh-134394 -->
* Issue: gh-134394
<!-- /gh-issue-number -->
