### PR TITLE
gh-100163: allow re-assuming root privileges on subprocess invocations

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-05-21-12-50-28.gh-issue-100163.jL-J9r.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-21-12-50-28.gh-issue-100163.jL-J9r.rst
@@ -1,0 +1,3 @@
+Allow :class:`subprocess.Popen` to run subprocesses as root after dropping
+root privileges but saving the original user/group identity so it can be
+re-assumed.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -627,20 +627,26 @@ reset_signal_handlers(const sigset_t *child_sigmask)
 
 static int set_user_identity(uid_t uid)
 {
-#ifdef HAVE_SETREUID
-    if (uid != (uid_t)-1)
-        return setreuid(uid, uid);
-#endif /* HAVE_SETREUID */
+    if (uid == (uid_t)-1)
+        return 0;
+#if defined(HAVE_SETRESUID)
+    return setresuid(uid, uid, uid);
+#elif defined(HAVE_SETREUID)
+    return setreuid(uid, uid);
+#endif
     return 0;
 }
 
 
 static int set_group_identity(gid_t gid)
 {
-#ifdef HAVE_SETREGID
-    if (gid != (gid_t)-1)
-        return setregid(gid, gid);
-#endif /* HAVE_SETREGID */
+    if (gid == (gid_t)-1)
+        return 0;
+#if defined(HAVE_SETRESGID)
+    return setresgid(gid, gid, gid);
+#elif defined(HAVE_SETREGID)
+    return setregid(gid, gid);
+#endif
     return 0;
 }
 

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -664,12 +664,34 @@ static int set_groups(Py_ssize_t extra_group_size, const gid_t *extra_groups)
 
 
 static int
-set_identity(uid_t uid, gid_t gid,
-             Py_ssize_t extra_group_size, const gid_t *extra_groups)
+set_identity_priv(uid_t uid, gid_t gid,
+                  Py_ssize_t extra_group_size, const gid_t *extra_groups)
+{
+    return (set_user_identity(uid)
+            || set_group_identity(gid)
+            || set_groups(extra_group_size, extra_groups)) ? -1 : 0;
+}
+
+
+static int
+set_identity_unpriv(uid_t uid, gid_t gid,
+                    Py_ssize_t extra_group_size, const gid_t *extra_groups)
 {
     return (set_groups(extra_group_size, extra_groups)
             || set_group_identity(gid)
             || set_user_identity(uid)) ? -1 : 0;
+}
+
+
+static int
+set_identity(uid_t uid, gid_t gid,
+             Py_ssize_t extra_group_size, const gid_t *extra_groups)
+{
+    if (uid == 0) {
+        return set_identity_priv(uid, gid, extra_group_size, extra_groups);
+    } else {
+        return set_identity_unpriv(uid, gid, extra_group_size, extra_groups);
+    }
 }
 
 

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -625,6 +625,48 @@ reset_signal_handlers(const sigset_t *child_sigmask)
 #endif /* VFORK_USABLE */
 
 
+static int set_user_identity(uid_t uid)
+{
+#ifdef HAVE_SETREUID
+    if (uid != (uid_t)-1)
+        return setreuid(uid, uid);
+#endif /* HAVE_SETREUID */
+    return 0;
+}
+
+
+static int set_group_identity(gid_t gid)
+{
+#ifdef HAVE_SETREGID
+    if (gid != (gid_t)-1)
+        return setregid(gid, gid);
+#endif /* HAVE_SETREGID */
+    return 0;
+}
+
+
+static int set_groups(Py_ssize_t extra_group_size, const gid_t *extra_groups)
+{
+#ifdef HAVE_SETGROUPS
+    if (extra_group_size >= 0) {
+        assert((extra_group_size == 0) == (extra_groups == NULL));
+        return setgroups(extra_group_size, extra_groups);
+    }
+#endif /* HAVE_SETGROUPS */
+    return 0;
+}
+
+
+static int
+set_identity(uid_t uid, gid_t gid,
+             Py_ssize_t extra_group_size, const gid_t *extra_groups)
+{
+    return (set_groups(extra_group_size, extra_groups)
+            || set_group_identity(gid)
+            || set_user_identity(uid)) ? -1 : 0;
+}
+
+
 /*
  * This function is code executed in the child process immediately after
  * (v)fork to set things up and call exec().
@@ -773,23 +815,7 @@ child_exec(char *const exec_array[],
     }
 #endif
 
-#ifdef HAVE_SETGROUPS
-    if (extra_group_size >= 0) {
-        assert((extra_group_size == 0) == (extra_groups == NULL));
-        POSIX_CALL(setgroups(extra_group_size, extra_groups));
-    }
-#endif /* HAVE_SETGROUPS */
-
-#ifdef HAVE_SETREGID
-    if (gid != (gid_t)-1)
-        POSIX_CALL(setregid(gid, gid));
-#endif /* HAVE_SETREGID */
-
-#ifdef HAVE_SETREUID
-    if (uid != (uid_t)-1)
-        POSIX_CALL(setreuid(uid, uid));
-#endif /* HAVE_SETREUID */
-
+    POSIX_CALL(set_identity(uid, gid, extra_group_size, extra_groups));
 
     err_msg = "";
     if (preexec_fn != Py_None && preexec_fn_args_tuple) {


### PR DESCRIPTION
The `subprocess.Popen` class takes user/group/extra groups parameters which allow invocations to run as a different user. When dropping privileges (i.e. the main program is running as root but wants to run a subprocess as an unprivileged user) this works fine. However, it fails if a program wants to drop privileges and re-assume them to run a subprocess.

To allow this there are a couple of changes required:
- Use `setresuid`/`setresgid` instead of `setreuid`/`setregid` so the saved user/group identity can be re-assumed after it has been dropped.
- Setting the user identity first so the group identity and extra groups calls can be made with root privilege.

Naturally we need to continue to set the user identity last when going from root to an unprivileged user, so the order of calls needs to be determined dynamically based on whether we are switching to or from root.

<!-- gh-issue-number: gh-100163 -->
* Issue: gh-100163
<!-- /gh-issue-number -->
