### PR TITLE
Fix signature of `_curses.assume_default_colors` in the docs

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -68,7 +68,7 @@ The module :mod:`curses` defines the following exception:
 The module :mod:`curses` defines the following functions:
 
 
-.. function:: assume_default_colors(fg, bg)
+.. function:: assume_default_colors(fg, bg, /)
 
    Allow use of default values for colors on terminals supporting this feature.
    Use this to support transparency in your application.


### PR DESCRIPTION
I think that we should properly document that this function does not accept any keyword args.

```python
>>> import _curses
>>> _curses.assume_default_colors
<built-in function assume_default_colors>
>>> _curses.assume_default_colors(fg=1, bg=2)
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    _curses.assume_default_colors(fg=1, bg=2)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
TypeError: _curses.assume_default_colors() takes no keyword arguments
```

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134409.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->