### PR TITLE
gh-131357: Add some extra tests for empty bytes and bytearray

### DIFF
--- a/Lib/test/test_capi/test_bytearray.py
+++ b/Lib/test/test_capi/test_bytearray.py
@@ -152,7 +152,9 @@ class CAPITest(unittest.TestCase):
         self.assertEqual(resize(ba, 0), 0)
         self.assertEqual(ba, bytearray())
 
-        self.assertEqual(resize(bytearray(b''), 0), 0)
+        ba = bytearray(b'')
+        self.assertEqual(resize(ba, 0), 0)
+        self.assertEqual(ba, bytearray())
 
         ba = ByteArraySubclass(b'abcdef')
         self.assertEqual(resize(ba, 3), 0)

--- a/Lib/test/test_capi/test_bytearray.py
+++ b/Lib/test/test_capi/test_bytearray.py
@@ -66,6 +66,7 @@ class CAPITest(unittest.TestCase):
         # Test PyByteArray_FromObject()
         fromobject = _testlimitedcapi.bytearray_fromobject
 
+        self.assertEqual(fromobject(b''), bytearray(b''))
         self.assertEqual(fromobject(b'abc'), bytearray(b'abc'))
         self.assertEqual(fromobject(bytearray(b'abc')), bytearray(b'abc'))
         self.assertEqual(fromobject(ByteArraySubclass(b'abc')), bytearray(b'abc'))
@@ -115,6 +116,7 @@ class CAPITest(unittest.TestCase):
         self.assertEqual(concat(b'abc', bytearray(b'def')), bytearray(b'abcdef'))
         self.assertEqual(concat(bytearray(b'abc'), b''), bytearray(b'abc'))
         self.assertEqual(concat(b'', bytearray(b'def')), bytearray(b'def'))
+        self.assertEqual(concat(bytearray(b''), bytearray(b'')), bytearray(b''))
         self.assertEqual(concat(memoryview(b'xabcy')[1:4], b'def'),
                          bytearray(b'abcdef'))
         self.assertEqual(concat(b'abc', memoryview(b'xdefy')[1:4]),
@@ -149,6 +151,8 @@ class CAPITest(unittest.TestCase):
         self.assertEqual(ba[:3], bytearray(b'abc'))
         self.assertEqual(resize(ba, 0), 0)
         self.assertEqual(ba, bytearray())
+
+        self.assertEqual(resize(bytearray(b''), 0), 0)
 
         ba = ByteArraySubclass(b'abcdef')
         self.assertEqual(resize(ba, 3), 0)

--- a/Lib/test/test_capi/test_bytes.py
+++ b/Lib/test/test_capi/test_bytes.py
@@ -139,7 +139,7 @@ class CAPITest(unittest.TestCase):
         # Test PyBytes_Repr()
         bytes_repr = _testlimitedcapi.bytes_repr
 
-        self.assertEqual(bytes_repr(b'''''', 0), r"""b''""")
+        self.assertEqual(bytes_repr(b'', 0), r"""b''""")
         self.assertEqual(bytes_repr(b'''abc''', 0), r"""b'abc'""")
         self.assertEqual(bytes_repr(b'''abc''', 1), r"""b'abc'""")
         self.assertEqual(bytes_repr(b'''a'b"c"d''', 0), r"""b'a\'b"c"d'""")

--- a/Lib/test/test_capi/test_bytes.py
+++ b/Lib/test/test_capi/test_bytes.py
@@ -81,6 +81,7 @@ class CAPITest(unittest.TestCase):
         # Test PyBytes_FromObject()
         fromobject = _testlimitedcapi.bytes_fromobject
 
+        self.assertEqual(fromobject(b''), b'')
         self.assertEqual(fromobject(b'abc'), b'abc')
         self.assertEqual(fromobject(bytearray(b'abc')), b'abc')
         self.assertEqual(fromobject(BytesSubclass(b'abc')), b'abc')
@@ -138,6 +139,7 @@ class CAPITest(unittest.TestCase):
         # Test PyBytes_Repr()
         bytes_repr = _testlimitedcapi.bytes_repr
 
+        self.assertEqual(bytes_repr(b'''''', 0), r"""b''""")
         self.assertEqual(bytes_repr(b'''abc''', 0), r"""b'abc'""")
         self.assertEqual(bytes_repr(b'''abc''', 1), r"""b'abc'""")
         self.assertEqual(bytes_repr(b'''a'b"c"d''', 0), r"""b'a\'b"c"d'""")
@@ -197,6 +199,7 @@ class CAPITest(unittest.TestCase):
         """Test PyBytes_DecodeEscape()"""
         decodeescape = _testlimitedcapi.bytes_decodeescape
 
+        self.assertEqual(decodeescape(b''), b'')
         self.assertEqual(decodeescape(b'abc'), b'abc')
         self.assertEqual(decodeescape(br'\t\n\r\x0b\x0c\x00\\\'\"'),
                          b'''\t\n\r\v\f\0\\'"''')


### PR DESCRIPTION
Tests for `PyBytes_FromObject`, `PyBytes_Repr` and `PyBytes_DecodeEscape`

<!-- gh-issue-number: gh-131357 -->
* Issue: gh-131357
<!-- /gh-issue-number -->
