### PR TITLE
gh-132983: Fix refleak in zstd dictionary functions

### DIFF
--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -251,7 +251,7 @@ _zstd_train_dict_impl(PyObject *module, PyBytesObject *samples_bytes,
                                             &chunk_sizes);
     if (chunks_number < 0)
     {
-        return NULL;
+        goto error;
     }
 
     /* Allocate dict buffer */
@@ -333,7 +333,7 @@ _zstd_finalize_dict_impl(PyObject *module, PyBytesObject *custom_dict_bytes,
                                             &chunk_sizes);
     if (chunks_number < 0)
     {
-        return NULL;
+        goto error;
     }
 
     /* Allocate dict buffer */


### PR DESCRIPTION
Missed deallocating the array of samples sizes if an invalid array of samples are provided. h/t to @ericsnowcurrently for spotting the buildbot failure.

<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->
