### PR TITLE
gh-85393: Handle partial and blocking .write in TextIOWrapper

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-05-21-13-28-43.gh-issue-85383.NCmYBp.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-21-13-28-43.gh-issue-85383.NCmYBp.rst
@@ -1,0 +1,3 @@
+Improve behavior of :meth:`TextIOWrapper.write` when there is a partial write
+caused by underlying buffer being :class:`RawIOBase` (:gh:`91606` :gh:`85393`)
+or if there is a :exc:`BlockingIOError` :gh:`97531`

--- a/Misc/NEWS.d/next/Library/2025-05-21-13-28-43.gh-issue-85383.NCmYBp.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-21-13-28-43.gh-issue-85383.NCmYBp.rst
@@ -1,3 +1,3 @@
-Improve behavior of :meth:`TextIOWrapper.write` when there is a partial write
-caused by underlying buffer being :class:`RawIOBase` (:gh:`91606` :gh:`85393`)
+Improve behavior of :meth:`io.TextIOWrapper.write` when there is a partial write
+caused by underlying buffer being :class:`io.RawIOBase` (:gh:`91606` :gh:`85393`)
 or if there is a :exc:`BlockingIOError` :gh:`97531`

--- a/Misc/NEWS.d/next/Library/2025-05-21-13-28-43.gh-issue-85383.NCmYBp.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-21-13-28-43.gh-issue-85383.NCmYBp.rst
@@ -1,3 +1,3 @@
-Improve behavior of :meth:`io.TextIOWrapper.write` when there is a partial write
-caused by underlying buffer being :class:`io.RawIOBase` (:gh:`91606` :gh:`85393`)
-or if there is a :exc:`BlockingIOError` :gh:`97531`
+Improve behavior of :meth:`!io.TextIOWrapper.write` when there is a partial
+write caused by underlying buffer being :class:`io.RawIOBase` or if there is a
+:exc:`BlockingIOError`

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1622,8 +1622,8 @@ _textiowrapper_writeflush(textio *self)
        NOTE: this code relies on GIL / @critical_section. It needs to ensure
        state is "safe" before/after calls to other Python code.
 
-       In particular _textiowrapper_writeflush() calls buffer.write(). That will
-       modify self->pending_bytes.
+       In particular during calls to `buffer.write` self->pending_bytes may be
+       modified by other threads.
 
        At the end of this function either pending_bytes needs to be NULL _or_
        there needs to be an exception.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1587,7 +1587,7 @@ _textiowrapper_prepend(textio *self, PyObject *unwritten)
 
     if (self->pending_bytes == NULL) {
         self->pending_bytes = unwritten;
-        assert(self->pending_bytes == 0);
+        assert(self->pending_bytes_count == 0);
         self->pending_bytes_count += PyBytes_GET_SIZE(unwritten);
     }
     else if (!PyList_CheckExact(self->pending_bytes)) {
@@ -1901,12 +1901,11 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
     // Flush the buffer before adding b to the buffer if b is not small.
     // https://github.com/python/cpython/issues/87426
     if (bytes_len >= self->chunk_size) {
-        /* writeflush works to ensure all data written.
+        /* writeflush ensures one pending_bytes is written.
 
            Additional data may be written to the TextIO when the lock is
-           released while calling buffer.write (and show up in
-           pending_bytes). When that happens, flush again to avoid copying
-           the current bytes. */
+           released while calling buffer.write (and show up in pending_bytes).
+           When that happens, flush again to avoid copying the current bytes. */
         while (self->pending_bytes != NULL) {
             if (_textiowrapper_writeflush(self) < 0) {
                 Py_DECREF(b);

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1715,7 +1715,7 @@ _textiowrapper_writeflush(textio *self)
                 if (bytes_to_write) {
                     pending = PyBytes_FromStringAndSize(
                         PyBytes_AS_STRING(b) + err->written,
-                        self->pending_bytes_count);
+                        bytes_to_write);
                     if (pending) {
                         /* _textiowrapper can raise an exception if it fails to
                             allocate a list, that just adds to active error
@@ -1803,7 +1803,7 @@ _textiowrapper_writeflush(textio *self)
         /* Make a new PyBytes to keep type for next call to write. */
         pending = PyBytes_FromStringAndSize(
             PyBytes_AS_STRING(b) + size,
-            self->pending_bytes_count);
+            bytes_to_write);
         Py_DECREF(b);
         b = pending;
         pending = NULL;
@@ -1811,7 +1811,6 @@ _textiowrapper_writeflush(textio *self)
 
     /* All data owned by this function is written. Other bytes could have shown
        up while running. */
-    assert(self->pending_bytes_count >= 0);
     Py_DECREF(b);
     return 0;
 }


### PR DESCRIPTION
Also improves non-blocking support (gh-57531) and unbuffered support (gh-61606)

While behavior doesn't (generally) change it adds a _lot_ of new warnings so I feel this is more of a feature (support non-blocking and unbuffered!) than a bugfix.

## TODO before non-Draft
 - [ ] Review what type each warning should be
 - [ ] Validate if should warn on None (if so, fix CPython test cases)
 - [ ] Implement a blocking I/O write test like the one for BufferedIO (test_nonblock_pipe_write_bigbuf)
 - [ ] Add a partial write test

<!-- gh-issue-number: gh-85393 -->
* Issue: gh-85393
<!-- /gh-issue-number -->
