### PR TITLE
gh-133740: Fix locale.nl_langinfo(ALT_DIGITS)

### DIFF
--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -692,7 +692,8 @@ _locale_nl_langinfo_impl(PyObject *module, int item)
             result = result != NULL ? result : "";
             char *oldloc = NULL;
             if (langinfo_constants[i].category != LC_CTYPE
-                && !is_all_ascii(result)
+                // gh-133740: Always change the locale for ALT_DIGITS
+                && (item == ALT_DIGITS || !is_all_ascii(result))
                 && change_locale(langinfo_constants[i].category, &oldloc) < 0)
             {
                 return NULL;

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -692,8 +692,17 @@ _locale_nl_langinfo_impl(PyObject *module, int item)
             result = result != NULL ? result : "";
             char *oldloc = NULL;
             if (langinfo_constants[i].category != LC_CTYPE
-                // gh-133740: Always change the locale for ALT_DIGITS
-                && (item == ALT_DIGITS || !is_all_ascii(result))
+                // gh-133740: Always change the locale for ALT_DIGITS and ERA
+                && (
+#ifdef __GLIBC__
+#  ifdef ALT_DIGITS
+                    item == ALT_DIGITS ||
+#  endif
+#  ifdef ERA
+                    item == ERA ||
+#  endif
+#endif
+                    !is_all_ascii(result))
                 && change_locale(langinfo_constants[i].category, &oldloc) < 0)
             {
                 return NULL;

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -692,9 +692,9 @@ _locale_nl_langinfo_impl(PyObject *module, int item)
             result = result != NULL ? result : "";
             char *oldloc = NULL;
             if (langinfo_constants[i].category != LC_CTYPE
-                // gh-133740: Always change the locale for ALT_DIGITS and ERA
                 && (
 #ifdef __GLIBC__
+                    // gh-133740: Always change the locale for ALT_DIGITS and ERA
 #  ifdef ALT_DIGITS
                     item == ALT_DIGITS ||
 #  endif


### PR DESCRIPTION
Set the LC_CTYPE locale to the LC_TIME locale even if nl_langinfo(ALT_DIGITS) result is ASCII. The result is a list separated by NUL characters and the code only checks the first list item which can be ASCII whereas following items are non-ASCII.

Fix test__locale for the uk_UA locale on RHEL 7.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133740 -->
* Issue: gh-133740
<!-- /gh-issue-number -->
