### PR TITLE
gh-81708: Support negative `datetime.datetime.timestamp` values from naive datetimes on Windows

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -2671,6 +2671,10 @@ class TestDateTime(TestDate):
         self.assertEqual(t.timestamp(),
                          18000 + 3600 + 2*60 + 3 + 4*1e-6)
 
+    def test_naive_timestamp_before_epoch(self):
+        # Before #81708 this raised OSError on Windows.
+        self.assertLess(self.theclass(1969,1,1).timestamp(), 0)
+
     @support.run_with_tz('MSK-03')  # Something east of Greenwich
     def test_microsecond_rounding(self):
         def utcfromtimestamp(*args, **kwargs):

--- a/Misc/NEWS.d/next/Windows/2025-05-22-10-33-54.gh-issue-81708.xBa0wa.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-22-10-33-54.gh-issue-81708.xBa0wa.rst
@@ -1,2 +1,3 @@
 Support negative :meth:`datetime.datetime.timestamp` values from naive
-datetimes on Windows by subtracting a naive epoch. Patch by John Keith Hohm.
+datetimes (before the UNIX epoch of 1970-01-01) on Windows by
+subtracting a naive epoch. Patch by John Keith Hohm.

--- a/Misc/NEWS.d/next/Windows/2025-05-22-10-33-54.gh-issue-81708.xBa0wa.rst
+++ b/Misc/NEWS.d/next/Windows/2025-05-22-10-33-54.gh-issue-81708.xBa0wa.rst
@@ -1,0 +1,2 @@
+Support negative :meth:`datetime.datetime.timestamp` values from naive
+datetimes on Windows by subtracting a naive epoch. Patch by John Keith Hohm.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -6869,6 +6869,20 @@ datetime_timestamp(PyObject *op, PyObject *Py_UNUSED(dummy))
         result = delta_total_seconds(delta, NULL);
         Py_DECREF(delta);
     }
+#ifdef MS_WINDOWS
+    else if (GET_YEAR(self) < 1970) {
+        PyObject *naive_epoch = new_datetime(1970, 1, 1, 0, 0, 0, 0, Py_None, 0);
+        if (naive_epoch == NULL) {
+            return NULL;
+        }
+        PyObject *delta = datetime_subtract(op, naive_epoch);
+        Py_DECREF(naive_epoch);
+        if (delta == NULL)
+            return NULL;
+        result = delta_total_seconds(delta, NULL);
+        Py_DECREF(delta);
+    }
+#endif
     else {
         long long seconds;
         seconds = local_to_seconds(GET_YEAR(self),


### PR DESCRIPTION
Support negative `datetime.datetime.timestamp` values from naive datetimes on Windows using subtraction against a naive epoch (like for non-naive datetimes) instead of the native libc function that only works for times after the UNIX epoch.

<!-- gh-issue-number: gh-81708 -->
* Issue: gh-81708
<!-- /gh-issue-number -->
