### PR TITLE
gh-106318: Add example for `str.encode()`

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1817,13 +1817,15 @@ expression support in the :mod:`re` module).
    See :ref:`error-handlers` for details.
 
    For performance reasons, the value of *errors* is not checked for validity
-   unless an encoding error actually occurs, :ref:`devmode` is enabled or a :ref:`debug build <debug-build>` is used.
+   unless an encoding error actually occurs,
+   :ref:`devmode` is enabled
+   or a :ref:`debug build <debug-build>` is used.
    For example::
 
-      >>> encoded_str_to_byte = 'Python'.encode()
-      >>> type(encoded_str_to_byte)
+      >>> encoded_str_to_bytes = 'Python'.encode()
+      >>> type(encoded_str_to_bytes)
       <class 'bytes'>
-      >>> encoded_str_to_byte
+      >>> encoded_str_to_bytes
       b'Python'
 
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1817,9 +1817,15 @@ expression support in the :mod:`re` module).
    See :ref:`error-handlers` for details.
 
    For performance reasons, the value of *errors* is not checked for validity
-   unless an encoding error actually occurs,
-   :ref:`devmode` is enabled
-   or a :ref:`debug build <debug-build>` is used.
+   unless an encoding error actually occurs, :ref:`devmode` is enabled or a :ref:`debug build <debug-build>` is used.
+   For example::
+
+      >>> encoded_str_to_byte = 'Python'.encode()
+      >>> type(encoded_str_to_byte)
+      <class 'bytes'>
+      >>> encoded_str_to_byte
+      b'Python'
+
 
    .. versionchanged:: 3.1
       Added support for keyword arguments.


### PR DESCRIPTION
WIP for #106318 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134520.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-106318 -->
* Issue: gh-106318
<!-- /gh-issue-number -->
