### PR TITLE
gh-86273: On macOS >= 10.12, use `clock_gettime(CLOCK_MONOTONIC_RAW)` for `time.monotonic`

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -295,7 +295,7 @@ Functions
 
    * On Windows, call ``QueryPerformanceCounter()`` and
      ``QueryPerformanceFrequency()``.
-   * On macOS, call ``mach_absolute_time()`` and ``mach_timebase_info()``.
+   * On macOS, call ``clock_gettime(CLOCK_MONOTONIC_RAW)`` if available, otherwise call ``mach_absolute_time()`` and ``mach_timebase_info()``.
    * On HP-UX, call ``gethrtime()``.
    * Call ``clock_gettime(CLOCK_HIGHRES)`` if available.
    * Otherwise, call ``clock_gettime(CLOCK_MONOTONIC)``.

--- a/Misc/NEWS.d/next/macOS/2025-05-22-11-48-08.gh-issue-86273.n95ARS.rst
+++ b/Misc/NEWS.d/next/macOS/2025-05-22-11-48-08.gh-issue-86273.n95ARS.rst
@@ -1,0 +1,3 @@
+On macOS >= 10.12, use :func:`clock_gettime` with
+:data:`CLOCK_MONOTONIC_RAW` for :func:`time.monotonic`. Patch by John Keith
+Hohm.

--- a/Misc/NEWS.d/next/macOS/2025-05-22-11-48-08.gh-issue-86273.n95ARS.rst
+++ b/Misc/NEWS.d/next/macOS/2025-05-22-11-48-08.gh-issue-86273.n95ARS.rst
@@ -1,3 +1,2 @@
-On macOS >= 10.12, use :func:`clock_gettime` with
-:data:`CLOCK_MONOTONIC_RAW` for :func:`time.monotonic`. Patch by John Keith
-Hohm.
+On macOS >= 10.12, use ``clock_gettime(CLOCK_MONOTONIC_RAW)`` for
+:func:`time.monotonic`. Patch by John Keith Hohm.


### PR DESCRIPTION
On macOS >= 10.12, use `clock_gettime(CLOCK_MONOTONIC_RAW)` for `time.monotonic`.

Resolves #86273.

<!-- gh-issue-number: gh-86273 -->
* Issue: gh-86273
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134521.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->