### PR TITLE
gh-85255: Teach `plistlib` to load and dump `NSDate.distantPast` represented as year 0

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -140,7 +140,15 @@ def _decode_base64(s):
 _dateParser = re.compile(r"(?P<year>\d\d\d\d)(?:-(?P<month>\d\d)(?:-(?P<day>\d\d)(?:T(?P<hour>\d\d)(?::(?P<minute>\d\d)(?::(?P<second>\d\d))?)?)?)?)?Z", re.ASCII)
 
 
+# NSDate.distantPast is represented in an unparseable format, see #85255.
+_distantPast = '0000-12-30T00:00:00Z'
+
+
 def _date_from_string(s, aware_datetime):
+    if s == _distantPast:
+        if aware_datetime:
+            return datetime.datetime.min.astimezone(datetime.UTC)
+        return datetime.datetime.min
     order = ('year', 'month', 'day', 'hour', 'minute', 'second')
     gd = _dateParser.match(s).groupdict()
     lst = []
@@ -155,6 +163,8 @@ def _date_from_string(s, aware_datetime):
 
 
 def _date_to_string(d, aware_datetime):
+    if d.year == datetime.datetime.min.year:
+        return _distantPast
     if aware_datetime:
         d = d.astimezone(datetime.UTC)
     return '%04d-%02d-%02dT%02d:%02d:%02dZ' % (

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -900,6 +900,20 @@ class TestPlistlib(unittest.TestCase):
             expected = dt.astimezone(datetime.UTC).replace(tzinfo=None)
             self.assertEqual(parsed, expected)
 
+    def test_round_trip_distant_past(self):
+        # Issue #85255: NSDate.distantPast is represented as year 0.
+        before = b"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>applicationDate</key>
+	<date>0000-12-30T00:00:00Z</date>
+</dict>
+</plist>
+"""
+        after = plistlib.dumps(plistlib.loads(before, fmt=plistlib.FMT_XML))
+        self.assertEqual(before, after)
+
 
 class TestBinaryPlistlib(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/macOS/2025-05-22-13-25-49.gh-issue-85255.sfbm1K.rst
+++ b/Misc/NEWS.d/next/macOS/2025-05-22-13-25-49.gh-issue-85255.sfbm1K.rst
@@ -1,0 +1,2 @@
+Teach :mod:`plistlib` to load and dump ``NSDate.distantPast`` represented as
+year 0. Patch by John Keith Hohm


### PR DESCRIPTION
Teach `plistlib` to load and dump `NSDate.distantPast` represented as year 0.

Resolves #85255.

<!-- gh-issue-number: gh-85255 -->
* Issue: gh-85255
<!-- /gh-issue-number -->
