### PR TITLE
Avoid `__file__` in `hashlib` example

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -284,7 +284,7 @@ a file or file-like object.
    Example:
 
       >>> import io, hashlib, hmac
-      >>> with open("Doc/library/hashlib.rst", "rb") as f:
+      >>> with open("library/hashlib.rst", "rb") as f:
       ...     digest = hashlib.file_digest(f, "sha256")
       ...
       >>> digest.hexdigest()  # doctest: +ELLIPSIS

--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -284,7 +284,7 @@ a file or file-like object.
    Example:
 
       >>> import io, hashlib, hmac
-      >>> with open("path/to/file", "rb") as f:
+      >>> with open("Doc/library/hashlib.rst", "rb") as f:
       ...     digest = hashlib.file_digest(f, "sha256")
       ...
       >>> digest.hexdigest()  # doctest: +ELLIPSIS

--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -284,7 +284,7 @@ a file or file-like object.
    Example:
 
       >>> import io, hashlib, hmac
-      >>> with open(hashlib.__file__, "rb") as f:
+      >>> with open("path/to/file", "rb") as f:
       ...     digest = hashlib.file_digest(f, "sha256")
       ...
       >>> digest.hexdigest()  # doctest: +ELLIPSIS


### PR DESCRIPTION
I love the cleverness and quirkiness of the `hashlib` documentation choosing to hash the `hashlib` module itself, _however_ it is exactly that: "clever" and "quirky". Unfortunately, I've seen Python newbies and intermediates struggling to understand this example when trying to hash files themselves (not the least because the example does `hashlib.__file__` and not `__file__` or `some_other_module.__file__`).

So, let's move to something more "obvious" 👍  at the cost of being a slightly less silly place 👎 

Open question to the room on whether this should be backported.



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134540.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->