### PR TITLE
gh-134262: increase retries in `Tools/build/generate_sbom.py`

### DIFF
--- a/Tools/build/generate_sbom.py
+++ b/Tools/build/generate_sbom.py
@@ -4,6 +4,7 @@ import glob
 import hashlib
 import json
 import os
+import random
 import re
 import subprocess
 import sys
@@ -164,16 +165,18 @@ def get_externals() -> list[str]:
 
 
 def download_with_retries(download_location: str,
-                          max_retries: int = 5,
-                          base_delay: float = 2.0) -> typing.Any:
+                          max_retries: int = 7,
+                          base_delay: float = 2.25,
+                          max_jitter: float = 1.0) -> typing.Any:
     """Download a file with exponential backoff retry."""
     for attempt in range(max_retries):
         try:
             resp = urllib.request.urlopen(download_location)
         except urllib.error.URLError as ex:
             if attempt == max_retries:
-                raise ex
-            time.sleep(base_delay**attempt)
+                msg = f"Download from {download_location} failed."
+                raise OSError(msg) from ex
+            time.sleep(base_delay**attempt + random.uniform(0, max_jitter))
         else:
             return resp
 


### PR DESCRIPTION
- Increase max retry count to 7
- Increase base of exponential backoff to 2.25
- Add jitter in case there is some issue with sending requests at the same time
- Also print the location that fails

The retry backoff now ranges from 1 second to 130 seconds.

<!-- gh-issue-number: gh-134262 -->
* Issue: gh-134262
<!-- /gh-issue-number -->
