### PR TITLE
gh-134565: Use ExceptionGroup to handle multiple errors in unittest.doModuleCleanups()

### DIFF
--- a/Lib/test/test_unittest/test_result.py
+++ b/Lib/test/test_unittest/test_result.py
@@ -1282,12 +1282,20 @@ class TestOutputBuffering(unittest.TestCase):
         suite(result)
         expected_out = '\nStdout:\ndo cleanup2\ndo cleanup1\n'
         self.assertEqual(stdout.getvalue(), expected_out)
-        self.assertEqual(len(result.errors), 1)
+        self.assertEqual(len(result.errors), 2)
         description = 'tearDownModule (Module)'
         test_case, formatted_exc = result.errors[0]
         self.assertEqual(test_case.description, description)
         self.assertIn('ValueError: bad cleanup2', formatted_exc)
+        self.assertNotIn('ExceptionGroup', formatted_exc)
         self.assertNotIn('TypeError', formatted_exc)
+        self.assertIn(expected_out, formatted_exc)
+
+        test_case, formatted_exc = result.errors[1]
+        self.assertEqual(test_case.description, description)
+        self.assertIn('TypeError: bad cleanup1', formatted_exc)
+        self.assertNotIn('ExceptionGroup', formatted_exc)
+        self.assertNotIn('ValueError', formatted_exc)
         self.assertIn(expected_out, formatted_exc)
 
     def testBufferSetUpModule_DoModuleCleanups(self):
@@ -1313,20 +1321,32 @@ class TestOutputBuffering(unittest.TestCase):
         suite(result)
         expected_out = '\nStdout:\nset up module\ndo cleanup2\ndo cleanup1\n'
         self.assertEqual(stdout.getvalue(), expected_out)
-        self.assertEqual(len(result.errors), 2)
+        self.assertEqual(len(result.errors), 3)
         description = 'setUpModule (Module)'
         test_case, formatted_exc = result.errors[0]
         self.assertEqual(test_case.description, description)
         self.assertIn('ZeroDivisionError: division by zero', formatted_exc)
+        self.assertNotIn('ExceptionGroup', formatted_exc)
         self.assertNotIn('ValueError', formatted_exc)
         self.assertNotIn('TypeError', formatted_exc)
         self.assertIn('\nStdout:\nset up module\n', formatted_exc)
+
         test_case, formatted_exc = result.errors[1]
         self.assertIn(expected_out, formatted_exc)
         self.assertEqual(test_case.description, description)
         self.assertIn('ValueError: bad cleanup2', formatted_exc)
+        self.assertNotIn('ExceptionGroup', formatted_exc)
         self.assertNotIn('ZeroDivisionError', formatted_exc)
         self.assertNotIn('TypeError', formatted_exc)
+        self.assertIn(expected_out, formatted_exc)
+
+        test_case, formatted_exc = result.errors[2]
+        self.assertIn(expected_out, formatted_exc)
+        self.assertEqual(test_case.description, description)
+        self.assertIn('TypeError: bad cleanup1', formatted_exc)
+        self.assertNotIn('ExceptionGroup', formatted_exc)
+        self.assertNotIn('ZeroDivisionError', formatted_exc)
+        self.assertNotIn('ValueError', formatted_exc)
         self.assertIn(expected_out, formatted_exc)
 
     def testBufferTearDownModule_DoModuleCleanups(self):
@@ -1355,19 +1375,30 @@ class TestOutputBuffering(unittest.TestCase):
         suite(result)
         expected_out = '\nStdout:\ntear down module\ndo cleanup2\ndo cleanup1\n'
         self.assertEqual(stdout.getvalue(), expected_out)
-        self.assertEqual(len(result.errors), 2)
+        self.assertEqual(len(result.errors), 3)
         description = 'tearDownModule (Module)'
         test_case, formatted_exc = result.errors[0]
         self.assertEqual(test_case.description, description)
         self.assertIn('ZeroDivisionError: division by zero', formatted_exc)
+        self.assertNotIn('ExceptionGroup', formatted_exc)
         self.assertNotIn('ValueError', formatted_exc)
         self.assertNotIn('TypeError', formatted_exc)
         self.assertIn('\nStdout:\ntear down module\n', formatted_exc)
+
         test_case, formatted_exc = result.errors[1]
         self.assertEqual(test_case.description, description)
         self.assertIn('ValueError: bad cleanup2', formatted_exc)
+        self.assertNotIn('ExceptionGroup', formatted_exc)
         self.assertNotIn('ZeroDivisionError', formatted_exc)
         self.assertNotIn('TypeError', formatted_exc)
+        self.assertIn(expected_out, formatted_exc)
+
+        test_case, formatted_exc = result.errors[2]
+        self.assertEqual(test_case.description, description)
+        self.assertIn('TypeError: bad cleanup1', formatted_exc)
+        self.assertNotIn('ExceptionGroup', formatted_exc)
+        self.assertNotIn('ZeroDivisionError', formatted_exc)
+        self.assertNotIn('ValueError', formatted_exc)
         self.assertIn(expected_out, formatted_exc)
 
 

--- a/Lib/test/test_unittest/test_runner.py
+++ b/Lib/test/test_unittest/test_runner.py
@@ -646,9 +646,11 @@ class TestModuleCleanUp(unittest.TestCase):
                          [(module_cleanup_good, (1, 2, 3),
                            dict(four='hello', five='goodbye')),
                           (module_cleanup_bad, (), {})])
-        with self.assertRaises(CustomError) as e:
+        with self.assertRaises(Exception) as e:
             unittest.case.doModuleCleanups()
-        self.assertEqual(str(e.exception), 'CleanUpExc')
+        e = e.exception
+        self.assertEqual(str(e), 'module cleanup failed (1 sub-exception)')
+        self.assertEqual(str(e.exceptions[0]), 'CleanUpExc')
         self.assertEqual(unittest.case._module_cleanups, [])
 
     def test_doModuleCleanup_with_multiple_errors_in_addModuleCleanup(self):
@@ -658,7 +660,7 @@ class TestModuleCleanUp(unittest.TestCase):
         def module_cleanup_bad2():
             raise ValueError('CleanUpExc2')
 
-        class Module(object):
+        class Module:
             unittest.addModuleCleanup(module_cleanup_bad1)
             unittest.addModuleCleanup(module_cleanup_bad2)
         with self.assertRaises(ExceptionGroup) as e:
@@ -673,7 +675,7 @@ class TestModuleCleanUp(unittest.TestCase):
             raise ExceptionGroup('CleanUpExc', [TypeError('CleanUpExc1'),
                                                 ValueError('CleanUpExc2')])
 
-        class Module(object):
+        class Module:
             unittest.addModuleCleanup(module_cleanup_bad)
         with self.assertRaises(ExceptionGroup) as e:
             unittest.case.doModuleCleanups()
@@ -904,9 +906,11 @@ class TestModuleCleanUp(unittest.TestCase):
         ordering = []
         blowUp = True
         suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestableTest)
-        with self.assertRaises(CustomError) as cm:
+        with self.assertRaises(Exception) as cm:
             suite.debug()
-        self.assertEqual(str(cm.exception), 'CleanUpExc')
+        e = cm.exception
+        self.assertEqual(str(e), 'module cleanup failed (1 sub-exception)')
+        self.assertEqual(str(e.exceptions[0]), 'CleanUpExc')
         self.assertEqual(ordering, ['setUpModule', 'setUpClass', 'test',
                                     'tearDownClass', 'tearDownModule', 'cleanup_exc'])
         self.assertEqual(unittest.case._module_cleanups, [])

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -149,9 +149,9 @@ def doModuleCleanups():
         except Exception as exc:
             exceptions.append(exc)
     if exceptions:
-        # Swallows all but first exception. If a multi-exception handler
-        # gets written we should use that here instead.
-        raise exceptions[0]
+        if len(exceptions) == 1 and not isinstance(exceptions[0], ExceptionGroup):
+            raise exceptions[0]
+        raise ExceptionGroup('module cleanup failed', exceptions)
 
 
 def skip(reason):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -149,8 +149,6 @@ def doModuleCleanups():
         except Exception as exc:
             exceptions.append(exc)
     if exceptions:
-        if len(exceptions) == 1 and not isinstance(exceptions[0], ExceptionGroup):
-            raise exceptions[0]
         raise ExceptionGroup('module cleanup failed', exceptions)
 
 

--- a/Lib/unittest/suite.py
+++ b/Lib/unittest/suite.py
@@ -223,6 +223,11 @@ class TestSuite(BaseTestSuite):
                 if result._moduleSetUpFailed:
                     try:
                         case.doModuleCleanups()
+                    except ExceptionGroup as eg:
+                        for e in eg.exceptions:
+                            self._createClassOrModuleLevelException(result, e,
+                                                                    'setUpModule',
+                                                                    currentModule)
                     except Exception as e:
                         self._createClassOrModuleLevelException(result, e,
                                                                 'setUpModule',
@@ -235,15 +240,15 @@ class TestSuite(BaseTestSuite):
         errorName = f'{method_name} ({parent})'
         self._addClassOrModuleLevelException(result, exc, errorName, info)
 
-    def _addClassOrModuleLevelException(self, result, exception, errorName,
+    def _addClassOrModuleLevelException(self, result, exc, errorName,
                                         info=None):
         error = _ErrorHolder(errorName)
         addSkip = getattr(result, 'addSkip', None)
-        if addSkip is not None and isinstance(exception, case.SkipTest):
-            addSkip(error, str(exception))
+        if addSkip is not None and isinstance(exc, case.SkipTest):
+            addSkip(error, str(exc))
         else:
             if not info:
-                result.addError(error, sys.exc_info())
+                result.addError(error, (type(exc), exc, exc.__traceback__))
             else:
                 result.addError(error, info)
 
@@ -273,6 +278,13 @@ class TestSuite(BaseTestSuite):
                                                             previousModule)
             try:
                 case.doModuleCleanups()
+            except ExceptionGroup as eg:
+                if isinstance(result, _DebugResult):
+                    raise
+                for e in eg.exceptions:
+                    self._createClassOrModuleLevelException(result, e,
+                                                            'tearDownModule',
+                                                            previousModule)
             except Exception as e:
                 if isinstance(result, _DebugResult):
                     raise

--- a/Misc/NEWS.d/next/Library/2025-05-23-10-15-36.gh-issue-134565.zmb66C.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-23-10-15-36.gh-issue-134565.zmb66C.rst
@@ -1,3 +1,3 @@
-:func:`unittest.doModuleCleanup` no longer swallows all but first exception
+:func:`unittest.doModuleCleanups` no longer swallows all but first exception
 raised in the cleanup code, but raises a :exc:`ExceptionGroup` if multiple
 errors occurred.

--- a/Misc/NEWS.d/next/Library/2025-05-23-10-15-36.gh-issue-134565.zmb66C.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-23-10-15-36.gh-issue-134565.zmb66C.rst
@@ -1,0 +1,3 @@
+:func:`unittest.doModuleCleanup` no longer swallows all but first exception
+raised in the cleanup code, but raises a :exc:`ExceptionGroup` if multiple
+errors occurred.


### PR DESCRIPTION


<!-- gh-issue-number: gh-134565 -->
* Issue: gh-134565
<!-- /gh-issue-number -->
