### PR TITLE
gh-134568: added handler for BrokenPipeError to logging.StreamHandler.emit

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1155,6 +1155,10 @@ class StreamHandler(Handler):
             self.flush()
         except RecursionError:  # See issue 36272
             raise
+        except BrokenPipeError:
+            devnull = os.open(os.devnull, os.O_WRONLY)
+            os.dup2(devnull, sys.stdout.fileno())
+            sys.exit(1)
         except Exception:
             self.handleError(record)
 

--- a/Misc/NEWS.d/next/Library/2025-05-23-09-09-54.gh-issue-134568.BevBCI.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-23-09-09-54.gh-issue-134568.BevBCI.rst
@@ -1,0 +1,1 @@
+:class:`logging.StreamHandler` now handles :exc:`BrokenPipeError` when the output is cut short by piping to the ``head`` utility.


### PR DESCRIPTION


<!-- gh-issue-number: gh-134568 -->
* Issue: gh-134568
<!-- /gh-issue-number -->
