### PR TITLE
gh-133454: Mark test_queue tests with many threads as bigmem

### DIFF
--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -6,7 +6,7 @@ import threading
 import time
 import unittest
 import weakref
-from test.support import gc_collect
+from test.support import gc_collect, bigmemtest
 from test.support import import_helper
 from test.support import threading_helper
 
@@ -963,33 +963,33 @@ class BaseSimpleQueueTest:
         # One producer, one consumer => results appended in well-defined order
         self.assertEqual(results, inputs)
 
-    def test_many_threads(self):
+    @bigmemtest(size=50, memuse=100*2**20, dry_run=False)
+    def test_many_threads(self, size):
         # Test multiple concurrent put() and get()
-        N = 50
         q = self.q
         inputs = list(range(10000))
-        results = self.run_threads(N, q, inputs, self.feed, self.consume)
+        results = self.run_threads(size, q, inputs, self.feed, self.consume)
 
         # Multiple consumers without synchronization append the
         # results in random order
         self.assertEqual(sorted(results), inputs)
 
-    def test_many_threads_nonblock(self):
+    @bigmemtest(size=50, memuse=100*2**20, dry_run=False)
+    def test_many_threads_nonblock(self, size):
         # Test multiple concurrent put() and get(block=False)
-        N = 50
         q = self.q
         inputs = list(range(10000))
-        results = self.run_threads(N, q, inputs,
+        results = self.run_threads(size, q, inputs,
                                    self.feed, self.consume_nonblock)
 
         self.assertEqual(sorted(results), inputs)
 
-    def test_many_threads_timeout(self):
+    @bigmemtest(size=50, memuse=100*2**20, dry_run=False)
+    def test_many_threads_timeout(self, size):
         # Test multiple concurrent put() and get(timeout=...)
-        N = 50
         q = self.q
         inputs = list(range(1000))
-        results = self.run_threads(N, q, inputs,
+        results = self.run_threads(size, q, inputs,
                                    self.feed, self.consume_timeout)
 
         self.assertEqual(sorted(results), inputs)


### PR DESCRIPTION
50 producer and 50 consumer threads need more than 5GB of memory.


<!-- gh-issue-number: gh-133454 -->
* Issue: gh-133454
<!-- /gh-issue-number -->
