### PR TITLE
gh-132983: Make _zstd C code PEP 7 compliant

### DIFF
--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -28,41 +28,40 @@ set_zstd_error(const _zstd_state* const state,
     char *msg;
     assert(ZSTD_isError(zstd_ret));
 
-    switch (type)
-    {
-    case ERR_DECOMPRESS:
-        msg = "Unable to decompress Zstandard data: %s";
-        break;
-    case ERR_COMPRESS:
-        msg = "Unable to compress Zstandard data: %s";
-        break;
+    switch (type) {
+        case ERR_DECOMPRESS:
+            msg = "Unable to decompress Zstandard data: %s";
+            break;
+        case ERR_COMPRESS:
+            msg = "Unable to compress Zstandard data: %s";
+            break;
 
-    case ERR_LOAD_D_DICT:
-        msg = "Unable to load Zstandard dictionary or prefix for decompression: %s";
-        break;
-    case ERR_LOAD_C_DICT:
-        msg = "Unable to load Zstandard dictionary or prefix for compression: %s";
-        break;
+        case ERR_LOAD_D_DICT:
+            msg = "Unable to load Zstandard dictionary or prefix for decompression: %s";
+            break;
+        case ERR_LOAD_C_DICT:
+            msg = "Unable to load Zstandard dictionary or prefix for compression: %s";
+            break;
 
-    case ERR_GET_C_BOUNDS:
-        msg = "Unable to get zstd compression parameter bounds: %s";
-        break;
-    case ERR_GET_D_BOUNDS:
-        msg = "Unable to get zstd decompression parameter bounds: %s";
-        break;
-    case ERR_SET_C_LEVEL:
-        msg = "Unable to set zstd compression level: %s";
-        break;
+        case ERR_GET_C_BOUNDS:
+            msg = "Unable to get zstd compression parameter bounds: %s";
+            break;
+        case ERR_GET_D_BOUNDS:
+            msg = "Unable to get zstd decompression parameter bounds: %s";
+            break;
+        case ERR_SET_C_LEVEL:
+            msg = "Unable to set zstd compression level: %s";
+            break;
 
-    case ERR_TRAIN_DICT:
-        msg = "Unable to train the Zstandard dictionary: %s";
-        break;
-    case ERR_FINALIZE_DICT:
-        msg = "Unable to finalize the Zstandard dictionary: %s";
-        break;
+        case ERR_TRAIN_DICT:
+            msg = "Unable to train the Zstandard dictionary: %s";
+            break;
+        case ERR_FINALIZE_DICT:
+            msg = "Unable to finalize the Zstandard dictionary: %s";
+            break;
 
-    default:
-        Py_UNREACHABLE();
+        default:
+            Py_UNREACHABLE();
     }
     PyErr_Format(state->ZstdError, msg, ZSTD_getErrorName(zstd_ret));
 }
@@ -183,7 +182,7 @@ calculate_samples_stats(PyBytesObject *samples_bytes, PyObject *samples_sizes,
     chunks_number = Py_SIZE(samples_sizes);
     if ((size_t) chunks_number > UINT32_MAX) {
         PyErr_Format(PyExc_ValueError,
-                        "The number of samples should be <= %u.", UINT32_MAX);
+                     "The number of samples should be <= %u.", UINT32_MAX);
         return -1;
     }
 
@@ -200,8 +199,8 @@ calculate_samples_stats(PyBytesObject *samples_bytes, PyObject *samples_sizes,
         (*chunk_sizes)[i] = PyLong_AsSize_t(size);
         if ((*chunk_sizes)[i] == (size_t)-1 && PyErr_Occurred()) {
             PyErr_Format(PyExc_ValueError,
-                            "Items in samples_sizes should be an int "
-                            "object, with a value between 0 and %u.", SIZE_MAX);
+                         "Items in samples_sizes should be an int "
+                         "object, with a value between 0 and %u.", SIZE_MAX);
             return -1;
         }
         sizes_sum += (*chunk_sizes)[i];
@@ -209,7 +208,8 @@ calculate_samples_stats(PyBytesObject *samples_bytes, PyObject *samples_sizes,
 
     if (sizes_sum != Py_SIZE(samples_bytes)) {
         PyErr_SetString(PyExc_ValueError,
-                        "The samples size tuple doesn't match the concatenation's size.");
+                        "The samples size tuple doesn't match the "
+                        "concatenation's size.");
         return -1;
     }
     return chunks_number;
@@ -242,15 +242,15 @@ _zstd_train_dict_impl(PyObject *module, PyBytesObject *samples_bytes,
 
     /* Check arguments */
     if (dict_size <= 0) {
-        PyErr_SetString(PyExc_ValueError, "dict_size argument should be positive number.");
+        PyErr_SetString(PyExc_ValueError,
+                        "dict_size argument should be positive number.");
         return NULL;
     }
 
     /* Check that the samples are valid and get their sizes */
     chunks_number = calculate_samples_stats(samples_bytes, samples_sizes,
                                             &chunk_sizes);
-    if (chunks_number < 0)
-    {
+    if (chunks_number < 0) {
         goto error;
     }
 
@@ -271,7 +271,7 @@ _zstd_train_dict_impl(PyObject *module, PyBytesObject *samples_bytes,
 
     /* Check Zstandard dict error */
     if (ZDICT_isError(zstd_ret)) {
-        _zstd_state* const mod_state = get_zstd_state(module);
+        _zstd_state* mod_state = get_zstd_state(module);
         set_zstd_error(mod_state, ERR_TRAIN_DICT, zstd_ret);
         goto error;
     }
@@ -324,15 +324,15 @@ _zstd_finalize_dict_impl(PyObject *module, PyBytesObject *custom_dict_bytes,
 
     /* Check arguments */
     if (dict_size <= 0) {
-        PyErr_SetString(PyExc_ValueError, "dict_size argument should be positive number.");
+        PyErr_SetString(PyExc_ValueError,
+                        "dict_size argument should be positive number.");
         return NULL;
     }
 
     /* Check that the samples are valid and get their sizes */
     chunks_number = calculate_samples_stats(samples_bytes, samples_sizes,
                                             &chunk_sizes);
-    if (chunks_number < 0)
-    {
+    if (chunks_number < 0) {
         goto error;
     }
 
@@ -355,14 +355,15 @@ _zstd_finalize_dict_impl(PyObject *module, PyBytesObject *custom_dict_bytes,
     Py_BEGIN_ALLOW_THREADS
     zstd_ret = ZDICT_finalizeDictionary(
                         PyBytes_AS_STRING(dst_dict_bytes), dict_size,
-                        PyBytes_AS_STRING(custom_dict_bytes), Py_SIZE(custom_dict_bytes),
+                        PyBytes_AS_STRING(custom_dict_bytes),
+                        Py_SIZE(custom_dict_bytes),
                         PyBytes_AS_STRING(samples_bytes), chunk_sizes,
                         (uint32_t)chunks_number, params);
     Py_END_ALLOW_THREADS
 
     /* Check Zstandard dict error */
     if (ZDICT_isError(zstd_ret)) {
-        _zstd_state* const mod_state = get_zstd_state(module);
+        _zstd_state* mod_state = get_zstd_state(module);
         set_zstd_error(mod_state, ERR_FINALIZE_DICT, zstd_ret);
         goto error;
     }
@@ -402,7 +403,7 @@ _zstd_get_param_bounds_impl(PyObject *module, int parameter, int is_compress)
     if (is_compress) {
         bound = ZSTD_cParam_getBounds(parameter);
         if (ZSTD_isError(bound.error)) {
-            _zstd_state* const mod_state = get_zstd_state(module);
+            _zstd_state* mod_state = get_zstd_state(module);
             set_zstd_error(mod_state, ERR_GET_C_BOUNDS, bound.error);
             return NULL;
         }
@@ -410,7 +411,7 @@ _zstd_get_param_bounds_impl(PyObject *module, int parameter, int is_compress)
     else {
         bound = ZSTD_dParam_getBounds(parameter);
         if (ZSTD_isError(bound.error)) {
-            _zstd_state* const mod_state = get_zstd_state(module);
+            _zstd_state* mod_state = get_zstd_state(module);
             set_zstd_error(mod_state, ERR_GET_D_BOUNDS, bound.error);
             return NULL;
         }
@@ -435,9 +436,10 @@ _zstd_get_frame_size_impl(PyObject *module, Py_buffer *frame_buffer)
 {
     size_t frame_size;
 
-    frame_size = ZSTD_findFrameCompressedSize(frame_buffer->buf, frame_buffer->len);
+    frame_size = ZSTD_findFrameCompressedSize(frame_buffer->buf,
+                                              frame_buffer->len);
     if (ZSTD_isError(frame_size)) {
-        _zstd_state* const mod_state = get_zstd_state(module);
+        _zstd_state* mod_state = get_zstd_state(module);
         PyErr_Format(mod_state->ZstdError,
             "Error when finding the compressed size of a Zstandard frame. "
             "Ensure the frame_buffer argument starts from the "
@@ -473,7 +475,7 @@ _zstd_get_frame_info_impl(PyObject *module, Py_buffer *frame_buffer)
     /* #define ZSTD_CONTENTSIZE_UNKNOWN (0ULL - 1)
        #define ZSTD_CONTENTSIZE_ERROR   (0ULL - 2) */
     if (decompressed_size == ZSTD_CONTENTSIZE_ERROR) {
-        _zstd_state* const mod_state = get_zstd_state(module);
+        _zstd_state* mod_state = get_zstd_state(module);
         PyErr_SetString(mod_state->ZstdError,
             "Error when getting information from the header of "
             "a Zstandard frame. Ensure the frame_buffer argument "
@@ -508,7 +510,7 @@ _zstd_set_parameter_types_impl(PyObject *module, PyObject *c_parameter_type,
                                PyObject *d_parameter_type)
 /*[clinic end generated code: output=f3313b1294f19502 input=75d7a953580fae5f]*/
 {
-    _zstd_state* const mod_state = get_zstd_state(module);
+    _zstd_state* mod_state = get_zstd_state(module);
 
     if (!PyType_Check(c_parameter_type) || !PyType_Check(d_parameter_type)) {
         PyErr_SetString(PyExc_ValueError,
@@ -568,7 +570,7 @@ do {                                                                         \
     Py_DECREF(v);                                                            \
 } while (0)
 
-    _zstd_state* const mod_state = get_zstd_state(m);
+    _zstd_state* mod_state = get_zstd_state(m);
 
     /* Reusable objects & variables */
     mod_state->CParameter_type = NULL;
@@ -674,7 +676,7 @@ do {                                                                         \
 static int
 _zstd_traverse(PyObject *module, visitproc visit, void *arg)
 {
-    _zstd_state* const mod_state = get_zstd_state(module);
+    _zstd_state* mod_state = get_zstd_state(module);
 
     Py_VISIT(mod_state->ZstdDict_type);
     Py_VISIT(mod_state->ZstdCompressor_type);
@@ -691,7 +693,7 @@ _zstd_traverse(PyObject *module, visitproc visit, void *arg)
 static int
 _zstd_clear(PyObject *module)
 {
-    _zstd_state* const mod_state = get_zstd_state(module);
+    _zstd_state* mod_state = get_zstd_state(module);
 
     Py_CLEAR(mod_state->ZstdDict_type);
     Py_CLEAR(mod_state->ZstdCompressor_type);

--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -37,10 +37,12 @@ set_zstd_error(const _zstd_state* const state,
             break;
 
         case ERR_LOAD_D_DICT:
-            msg = "Unable to load Zstandard dictionary or prefix for decompression: %s";
+            msg = "Unable to load Zstandard dictionary or prefix for "
+                  "decompression: %s";
             break;
         case ERR_LOAD_C_DICT:
-            msg = "Unable to load Zstandard dictionary or prefix for compression: %s";
+            msg = "Unable to load Zstandard dictionary or prefix for "
+                  "compression: %s";
             break;
 
         case ERR_GET_C_BOUNDS:

--- a/Modules/_zstd/buffer.h
+++ b/Modules/_zstd/buffer.h
@@ -19,7 +19,8 @@ _OutputBuffer_InitAndGrow(_BlocksOutputBuffer *buffer, ZSTD_outBuffer *ob,
     /* Ensure .list was set to NULL */
     assert(buffer->list == NULL);
 
-    Py_ssize_t res = _BlocksOutputBuffer_InitAndGrow(buffer, max_length, &ob->dst);
+    Py_ssize_t res = _BlocksOutputBuffer_InitAndGrow(buffer, max_length,
+                                                     &ob->dst);
     if (res < 0) {
         return -1;
     }
@@ -34,8 +35,7 @@ _OutputBuffer_InitAndGrow(_BlocksOutputBuffer *buffer, ZSTD_outBuffer *ob,
     Return -1 on failure */
 static inline int
 _OutputBuffer_InitWithSize(_BlocksOutputBuffer *buffer, ZSTD_outBuffer *ob,
-                            Py_ssize_t max_length,
-                            Py_ssize_t init_size)
+                            Py_ssize_t max_length, Py_ssize_t init_size)
 {
     Py_ssize_t block_size;
 
@@ -50,7 +50,8 @@ _OutputBuffer_InitWithSize(_BlocksOutputBuffer *buffer, ZSTD_outBuffer *ob,
         block_size = init_size;
     }
 
-    Py_ssize_t res = _BlocksOutputBuffer_InitWithSize(buffer, block_size, &ob->dst);
+    Py_ssize_t res = _BlocksOutputBuffer_InitWithSize(buffer, block_size,
+                                                      &ob->dst);
     if (res < 0) {
         return -1;
     }

--- a/Modules/_zstd/clinic/zstddict.c.h
+++ b/Modules/_zstd/clinic/zstddict.c.h
@@ -89,7 +89,9 @@ exit:
 PyDoc_STRVAR(_zstd_ZstdDict_as_digested_dict__doc__,
 "Load as a digested dictionary to compressor.\n"
 "\n"
-"Pass this attribute as zstd_dict argument: compress(dat, zstd_dict=zd.as_digested_dict)\n"
+"Pass this attribute as zstd_dict argument:\n"
+"compress(dat, zstd_dict=zd.as_digested_dict)\n"
+"\n"
 "1. Some advanced compression parameters of compressor may be overridden\n"
 "   by parameters of digested dictionary.\n"
 "2. ZstdDict has a digested dictionaries cache for each compression level.\n"
@@ -123,7 +125,9 @@ _zstd_ZstdDict_as_digested_dict_get(PyObject *self, void *Py_UNUSED(context))
 PyDoc_STRVAR(_zstd_ZstdDict_as_undigested_dict__doc__,
 "Load as an undigested dictionary to compressor.\n"
 "\n"
-"Pass this attribute as zstd_dict argument: compress(dat, zstd_dict=zd.as_undigested_dict)\n"
+"Pass this attribute as zstd_dict argument:\n"
+"compress(dat, zstd_dict=zd.as_undigested_dict)\n"
+"\n"
 "1. The advanced compression parameters of compressor will not be overridden.\n"
 "2. Loading an undigested dictionary is costly. If load an undigested dictionary\n"
 "   multiple times, consider reusing a compressor object.\n"
@@ -155,7 +159,9 @@ _zstd_ZstdDict_as_undigested_dict_get(PyObject *self, void *Py_UNUSED(context))
 PyDoc_STRVAR(_zstd_ZstdDict_as_prefix__doc__,
 "Load as a prefix to compressor/decompressor.\n"
 "\n"
-"Pass this attribute as zstd_dict argument: compress(dat, zstd_dict=zd.as_prefix)\n"
+"Pass this attribute as zstd_dict argument:\n"
+"compress(dat, zstd_dict=zd.as_prefix)\n"
+"\n"
 "1. Prefix is compatible with long distance matching, while dictionary is not.\n"
 "2. It only works for the first frame, then the compressor/decompressor will\n"
 "   return to no prefix state.\n"
@@ -183,4 +189,4 @@ _zstd_ZstdDict_as_prefix_get(PyObject *self, void *Py_UNUSED(context))
 {
     return _zstd_ZstdDict_as_prefix_get_impl((ZstdDict *)self);
 }
-/*[clinic end generated code: output=8692eabee4e0d1fe input=a9049054013a1b77]*/
+/*[clinic end generated code: output=47b12b5848b53ed8 input=a9049054013a1b77]*/

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -138,7 +138,7 @@ _zstd_set_c_parameters(ZstdCompressor *self, PyObject *level_or_options,
         }
         return 0;
     }
-    PyErr_Format(PyExc_TypeError, 
+    PyErr_Format(PyExc_TypeError,
                  "Invalid type for %s. Expected %s", arg_name, arg_type);
     return -1;
 }

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -53,7 +53,7 @@ _zstd_set_c_parameters(ZstdCompressor *self, PyObject *level_or_options,
                        const char *arg_name, const char* arg_type)
 {
     size_t zstd_ret;
-    _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
+    _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));
     if (mod_state == NULL) {
         return -1;
     }
@@ -63,8 +63,8 @@ _zstd_set_c_parameters(ZstdCompressor *self, PyObject *level_or_options,
         int level = PyLong_AsInt(level_or_options);
         if (level == -1 && PyErr_Occurred()) {
             PyErr_Format(PyExc_ValueError,
-                            "Compression level should be an int value between %d and %d.",
-                            ZSTD_minCLevel(), ZSTD_maxCLevel());
+                         "Compression level should be an int value between "
+                         "%d and %d.", ZSTD_minCLevel(), ZSTD_maxCLevel());
             return -1;
         }
 
@@ -138,7 +138,8 @@ _zstd_set_c_parameters(ZstdCompressor *self, PyObject *level_or_options,
         }
         return 0;
     }
-    PyErr_Format(PyExc_TypeError, "Invalid type for %s. Expected %s", arg_name, arg_type);
+    PyErr_Format(PyExc_TypeError, 
+                 "Invalid type for %s. Expected %s", arg_name, arg_type);
     return -1;
 }
 
@@ -181,7 +182,7 @@ _get_CDict(ZstdDict *self, int compressionLevel)
         Py_END_ALLOW_THREADS
 
         if (cdict == NULL) {
-            _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
+            _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));
             if (mod_state != NULL) {
                 PyErr_SetString(mod_state->ZstdError,
                     "Failed to create a ZSTD_CDict instance from "
@@ -262,7 +263,7 @@ _zstd_load_impl(ZstdCompressor *self, ZstdDict *zd,
 static int
 _zstd_load_c_dict(ZstdCompressor *self, PyObject *dict)
 {
-    _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
+    _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));
     if (mod_state == NULL) {
         return -1;
     }
@@ -295,9 +296,9 @@ _zstd_load_c_dict(ZstdCompressor *self, PyObject *dict)
         else if (ret > 0) {
             /* type == -1 may indicate an error. */
             type = PyLong_AsInt(PyTuple_GET_ITEM(dict, 1));
-            if (type == DICT_TYPE_DIGESTED ||
-                type == DICT_TYPE_UNDIGESTED ||
-                type == DICT_TYPE_PREFIX)
+            if (type == DICT_TYPE_DIGESTED
+                || type == DICT_TYPE_UNDIGESTED
+                || type == DICT_TYPE_PREFIX)
             {
                 assert(type >= 0);
                 zd = (ZstdDict*)PyTuple_GET_ITEM(dict, 0);
@@ -348,7 +349,7 @@ _zstd_ZstdCompressor_new_impl(PyTypeObject *type, PyObject *level,
     /* Compression context */
     self->cctx = ZSTD_createCCtx();
     if (self->cctx == NULL) {
-        _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
+        _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));
         if (mod_state != NULL) {
             PyErr_SetString(mod_state->ZstdError,
                             "Unable to create ZSTD_CCtx instance.");
@@ -360,7 +361,8 @@ _zstd_ZstdCompressor_new_impl(PyTypeObject *type, PyObject *level,
     self->last_mode = ZSTD_e_end;
 
     if (level != Py_None && options != Py_None) {
-        PyErr_SetString(PyExc_RuntimeError, "Only one of level or options should be used.");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Only one of level or options should be used.");
         goto error;
     }
 
@@ -449,7 +451,7 @@ compress_lock_held(ZstdCompressor *self, Py_buffer *data,
     }
 
     if (_OutputBuffer_InitWithSize(&buffer, &out, -1,
-                                    (Py_ssize_t) output_buffer_size) < 0) {
+                                   (Py_ssize_t) output_buffer_size) < 0) {
         goto error;
     }
 
@@ -462,7 +464,7 @@ compress_lock_held(ZstdCompressor *self, Py_buffer *data,
 
         /* Check error */
         if (ZSTD_isError(zstd_ret)) {
-            _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
+            _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));
             if (mod_state != NULL) {
                 set_zstd_error(mod_state, ERR_COMPRESS, zstd_ret);
             }
@@ -525,13 +527,16 @@ compress_mt_continue_lock_held(ZstdCompressor *self, Py_buffer *data)
     while (1) {
         Py_BEGIN_ALLOW_THREADS
         do {
-            zstd_ret = ZSTD_compressStream2(self->cctx, &out, &in, ZSTD_e_continue);
-        } while (out.pos != out.size && in.pos != in.size && !ZSTD_isError(zstd_ret));
+            zstd_ret = ZSTD_compressStream2(self->cctx, &out, &in,
+                                            ZSTD_e_continue);
+        } while (out.pos != out.size
+                 && in.pos != in.size
+                 && !ZSTD_isError(zstd_ret));
         Py_END_ALLOW_THREADS
 
         /* Check error */
         if (ZSTD_isError(zstd_ret)) {
-            _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
+            _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));
             if (mod_state != NULL) {
                 set_zstd_error(mod_state, ERR_COMPRESS, zstd_ret);
             }
@@ -678,12 +683,12 @@ static PyMethodDef ZstdCompressor_methods[] = {
 PyDoc_STRVAR(ZstdCompressor_last_mode_doc,
 "The last mode used to this compressor object, its value can be .CONTINUE,\n"
 ".FLUSH_BLOCK, .FLUSH_FRAME. Initialized to .FLUSH_FRAME.\n\n"
-"It can be used to get the current state of a compressor, such as, data flushed,\n"
-"a frame ended.");
+"It can be used to get the current state of a compressor, such as, data\n"
+"flushed, or a frame ended.");
 
 static PyMemberDef ZstdCompressor_members[] = {
     {"last_mode", Py_T_INT, offsetof(ZstdCompressor, last_mode),
-        Py_READONLY, ZstdCompressor_last_mode_doc},
+     Py_READONLY, ZstdCompressor_last_mode_doc},
     {NULL}
 };
 

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -718,9 +718,10 @@ PyDoc_STRVAR(ZstdDecompressor_eof_doc,
 "after that, an EOFError exception will be raised.");
 
 PyDoc_STRVAR(ZstdDecompressor_needs_input_doc,
-"If the max_length output limit in .decompress() method has been reached, and\n"
-"the decompressor has (or may has) unconsumed input data, it will be set to\n"
-"False. In this case, pass b'' to .decompress() method may output further data.");
+"If the max_length output limit in .decompress() method has been reached,\n"
+"and the decompressor has (or may has) unconsumed input data, it will be set\n"
+"to False. In this case, passing b'' to the .decompress() method may output\n"
+"further data.");
 
 static PyMemberDef ZstdDecompressor_members[] = {
     {"eof", Py_T_BOOL, offsetof(ZstdDecompressor, eof),

--- a/Modules/_zstd/decompressor.c
+++ b/Modules/_zstd/decompressor.c
@@ -76,7 +76,7 @@ _get_DDict(ZstdDict *self)
         self->d_dict = ret;
 
         if (self->d_dict == NULL) {
-            _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
+            _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));
             if (mod_state != NULL) {
                 PyErr_SetString(mod_state->ZstdError,
                                 "Failed to create a ZSTD_DDict instance from "
@@ -95,7 +95,7 @@ _zstd_set_d_parameters(ZstdDecompressor *self, PyObject *options)
     size_t zstd_ret;
     PyObject *key, *value;
     Py_ssize_t pos;
-    _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
+    _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));
     if (mod_state == NULL) {
         return -1;
     }
@@ -191,7 +191,7 @@ _zstd_load_impl(ZstdDecompressor *self, ZstdDict *zd,
 static int
 _zstd_load_d_dict(ZstdDecompressor *self, PyObject *dict)
 {
-    _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
+    _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));
     if (mod_state == NULL) {
         return -1;
     }
@@ -224,9 +224,9 @@ _zstd_load_d_dict(ZstdDecompressor *self, PyObject *dict)
         else if (ret > 0) {
             /* type == -1 may indicate an error. */
             type = PyLong_AsInt(PyTuple_GET_ITEM(dict, 1));
-            if (type == DICT_TYPE_DIGESTED ||
-                type == DICT_TYPE_UNDIGESTED ||
-                type == DICT_TYPE_PREFIX)
+            if (type == DICT_TYPE_DIGESTED
+                || type == DICT_TYPE_UNDIGESTED
+                || type == DICT_TYPE_PREFIX)
             {
                 assert(type >= 0);
                 zd = (ZstdDict*)PyTuple_GET_ITEM(dict, 0);
@@ -291,7 +291,7 @@ decompress_lock_held(ZstdDecompressor *self, ZSTD_inBuffer *in,
 
         /* Check error */
         if (ZSTD_isError(zstd_ret)) {
-            _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
+            _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));
             if (mod_state != NULL) {
                 set_zstd_error(mod_state, ERR_DECOMPRESS, zstd_ret);
             }
@@ -369,7 +369,8 @@ stream_decompress_lock_held(ZstdDecompressor *self, Py_buffer *data,
 
     /* Check .eof flag */
     if (self->eof) {
-        PyErr_SetString(PyExc_EOFError, "Already at the end of a Zstandard frame.");
+        PyErr_SetString(PyExc_EOFError,
+                        "Already at the end of a Zstandard frame.");
         assert(ret == NULL);
         return NULL;
     }
@@ -486,8 +487,8 @@ stream_decompress_lock_held(ZstdDecompressor *self, Py_buffer *data,
         if (!use_input_buffer) {
             /* Discard buffer if it's too small
                (resizing it may needlessly copy the current contents) */
-            if (self->input_buffer != NULL &&
-                self->input_buffer_size < data_size)
+            if (self->input_buffer != NULL
+                && self->input_buffer_size < data_size)
             {
                 PyMem_Free(self->input_buffer);
                 self->input_buffer = NULL;
@@ -565,7 +566,7 @@ _zstd_ZstdDecompressor_new_impl(PyTypeObject *type, PyObject *zstd_dict,
     /* Decompression context */
     self->dctx = ZSTD_createDCtx();
     if (self->dctx == NULL) {
-        _zstd_state* const mod_state = PyType_GetModuleState(Py_TYPE(self));
+        _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));
         if (mod_state != NULL) {
             PyErr_SetString(mod_state->ZstdError,
                             "Unable to create ZSTD_DCtx instance.");

--- a/Modules/_zstd/zstddict.c
+++ b/Modules/_zstd/zstddict.c
@@ -74,13 +74,15 @@ _zstd_ZstdDict_new_impl(PyTypeObject *type, PyObject *dict_content,
        at least 8 bytes */
     if (Py_SIZE(self->dict_content) < 8) {
         PyErr_SetString(PyExc_ValueError,
-                        "Zstandard dictionary content should at least 8 bytes.");
+                        "Zstandard dictionary content should at least "
+                        "8 bytes.");
         goto error;
     }
 
     /* Get dict_id, 0 means "raw content" dictionary. */
-    self->dict_id = ZSTD_getDictID_fromDict(PyBytes_AS_STRING(self->dict_content),
-                                            Py_SIZE(self->dict_content));
+    self->dict_id = ZSTD_getDictID_fromDict(
+                                    PyBytes_AS_STRING(self->dict_content),
+                                    Py_SIZE(self->dict_content));
 
     /* Check validity for ordinary dictionary */
     if (!is_raw && self->dict_id == 0) {
@@ -141,8 +143,10 @@ ZstdDict_str(PyObject *ob)
 }
 
 static PyMemberDef ZstdDict_members[] = {
-    {"dict_id", Py_T_UINT, offsetof(ZstdDict, dict_id), Py_READONLY, ZstdDict_dictid_doc},
-    {"dict_content", Py_T_OBJECT_EX, offsetof(ZstdDict, dict_content), Py_READONLY, ZstdDict_dictcontent_doc},
+    {"dict_id", Py_T_UINT, offsetof(ZstdDict, dict_id), Py_READONLY,
+     ZstdDict_dictid_doc},
+    {"dict_content", Py_T_OBJECT_EX, offsetof(ZstdDict, dict_content),
+     Py_READONLY, ZstdDict_dictcontent_doc},
     {NULL}
 };
 
@@ -152,7 +156,9 @@ _zstd.ZstdDict.as_digested_dict
 
 Load as a digested dictionary to compressor.
 
-Pass this attribute as zstd_dict argument: compress(dat, zstd_dict=zd.as_digested_dict)
+Pass this attribute as zstd_dict argument:
+compress(dat, zstd_dict=zd.as_digested_dict)
+
 1. Some advanced compression parameters of compressor may be overridden
    by parameters of digested dictionary.
 2. ZstdDict has a digested dictionaries cache for each compression level.
@@ -163,7 +169,7 @@ Pass this attribute as zstd_dict argument: compress(dat, zstd_dict=zd.as_digeste
 
 static PyObject *
 _zstd_ZstdDict_as_digested_dict_get_impl(ZstdDict *self)
-/*[clinic end generated code: output=09b086e7a7320dbb input=10cd2b6165931b77]*/
+/*[clinic end generated code: output=09b086e7a7320dbb input=ee45e1b4a48f6f2c]*/
 {
     return Py_BuildValue("Oi", self, DICT_TYPE_DIGESTED);
 }
@@ -174,7 +180,9 @@ _zstd.ZstdDict.as_undigested_dict
 
 Load as an undigested dictionary to compressor.
 
-Pass this attribute as zstd_dict argument: compress(dat, zstd_dict=zd.as_undigested_dict)
+Pass this attribute as zstd_dict argument:
+compress(dat, zstd_dict=zd.as_undigested_dict)
+
 1. The advanced compression parameters of compressor will not be overridden.
 2. Loading an undigested dictionary is costly. If load an undigested dictionary
    multiple times, consider reusing a compressor object.
@@ -183,7 +191,7 @@ Pass this attribute as zstd_dict argument: compress(dat, zstd_dict=zd.as_undiges
 
 static PyObject *
 _zstd_ZstdDict_as_undigested_dict_get_impl(ZstdDict *self)
-/*[clinic end generated code: output=43c7a989e6d4253a input=11e5f5df690a85b4]*/
+/*[clinic end generated code: output=43c7a989e6d4253a input=d39210eedec76fed]*/
 {
     return Py_BuildValue("Oi", self, DICT_TYPE_UNDIGESTED);
 }
@@ -194,7 +202,9 @@ _zstd.ZstdDict.as_prefix
 
 Load as a prefix to compressor/decompressor.
 
-Pass this attribute as zstd_dict argument: compress(dat, zstd_dict=zd.as_prefix)
+Pass this attribute as zstd_dict argument:
+compress(dat, zstd_dict=zd.as_prefix)
+
 1. Prefix is compatible with long distance matching, while dictionary is not.
 2. It only works for the first frame, then the compressor/decompressor will
    return to no prefix state.
@@ -203,7 +213,7 @@ Pass this attribute as zstd_dict argument: compress(dat, zstd_dict=zd.as_prefix)
 
 static PyObject *
 _zstd_ZstdDict_as_prefix_get_impl(ZstdDict *self)
-/*[clinic end generated code: output=6f7130c356595a16 input=b028e0ae6ec4292b]*/
+/*[clinic end generated code: output=6f7130c356595a16 input=d59757b0b5a9551a]*/
 {
     return Py_BuildValue("Oi", self, DICT_TYPE_PREFIX);
 }


### PR DESCRIPTION
Mostly just making sure things are under 80 characters and fixing a few incorrectly placed left braces. I also removed `const` from instances of `_zstd_state* const mod_state` since a) it was making some lines go over 80 characters b) it is unnecessary and c) it better matches the CPython style.

This is the final todo left in https://github.com/python/cpython/issues/132983 🎉 



<!-- gh-issue-number: gh-132983 -->
* Issue: gh-132983
<!-- /gh-issue-number -->
