### PR TITLE
gh-134449: fix grammar for `precision_with_grouping` in format description

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -328,7 +328,7 @@ The general form of a *standard format specifier* is:
    sign: "+" | "-" | " "
    width_and_precision: [`width_with_grouping`][`precision_with_grouping`]
    width_with_grouping: [`width`][`grouping`]
-   precision_with_grouping: "." [`precision`][`grouping`]
+   precision_with_grouping: "." [`precision`][`grouping`] | "." `grouping`
    width: `~python-grammar:digit`+
    precision: `~python-grammar:digit`+
    grouping: "," | "_"


### PR DESCRIPTION
This amends f39a07b.  Thanks to Jonathan Poelen.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134449 -->
* Issue: gh-134449
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134608.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->