### PR TITLE
GH-80334: make multiprocessing freeze_support() usable on all spawn default platforms, not just windows

### DIFF
--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -145,7 +145,7 @@ class BaseContext(object):
         '''Check whether this is a fake forked process in a frozen executable.
         If so then run code specified by commandline and exit.
         '''
-        if sys.platform == 'win32' and getattr(sys, 'frozen', False):
+        if self.get_start_method() == 'spawn' and getattr(sys, 'frozen', False):
             from .spawn import freeze_support
             freeze_support()
 

--- a/Misc/NEWS.d/next/Library/2025-05-24-03-10-36.gh-issue-80334.z21cMa.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-24-03-10-36.gh-issue-80334.z21cMa.rst
@@ -1,0 +1,2 @@
+:func:`multiprocessing.freeze_support` now checks for work on any "spawn"
+start method platform rather than only on Windows.


### PR DESCRIPTION
`multiprocessing.freeze_support()` now checks for work on any "spawn"
start method platform rather than only on Windows.

This may be a behavior change that some might count as not being a bugfix?  unclear to me.  we'll start with 3.14 betas.

Related documentation in https://github.com/python/cpython/pull/134462.

<!-- gh-issue-number: gh-80334 -->
* Issue: gh-80334
<!-- /gh-issue-number -->
