### PR TITLE
Update outdated statement from `math` about C standard

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -10,9 +10,6 @@
 
 --------------
 
-This module provides access to the mathematical functions defined by the C
-standard.
-
 These functions cannot be used with complex numbers; use the functions of the
 same name from the :mod:`cmath` module if you require support for complex
 numbers.  The distinction between functions which support complex numbers and

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -10,6 +10,9 @@
 
 --------------
 
+This module provides access to common mathematical functions and constants,
+including those defined by the C standard.
+
 These functions cannot be used with complex numbers; use the functions of the
 same name from the :mod:`cmath` module if you require support for complex
 numbers.  The distinction between functions which support complex numbers and


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
The [PEP 791 draft](https://peps.python.org/pep-0791/) says:

> The [math](https://docs.python.org/3.14/library/math.html#module-math) documentation says: “This module provides access to the mathematical functions defined by the C standard.” But, over time the module was populated with functions that aren’t related to the C standard or floating-point arithmetics.

Let's start by removing this outdated sentence from the docs.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134621.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->