### PR TITLE
gh-134585: disable `_Atomic` and `__thread` keywords during CLion parsing phase

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -8,6 +8,22 @@
 #  error "Python's source code assumes C's unsigned char is an 8-bit type"
 #endif
 
+/*
+ * Disable keywords and operators that are not recognized by CLion.
+ *
+ * This is only a temporary solution until CLion correctly supports them.
+ */
+#ifdef __JETBRAINS_IDE__
+/*
+ * Prevents false positives in CLion's static analysis which incorrectly
+ * detects _Atomic(size_t) and _Atomic(uintptr_t) as duplicated declarations
+ * of size_t and uintptr_t respectively.
+ */
+#define _Atomic(x)  x
+
+/* Ignore C99 TLS extension '__thread' keyword. */
+#define __thread
+#endif
 
 // Preprocessor check for a builtin preprocessor function. Always return 0
 // if __has_builtin() macro is not defined.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134585 -->
* Issue: gh-134585
<!-- /gh-issue-number -->
