### PR TITLE
gh-127987: Ensure that directories are not renamed during `tar.TarFile.extractall()`

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2410,7 +2410,9 @@ class TarFile(object):
         for tarinfo, dirpath, original_ino, original_dev in directories:
             dirstat = os.stat(dirpath, follow_symlinks=False)
             if (dirstat.st_ino != original_ino or
-                dirstat.st_dev != original_dev):
+                dirstat.st_dev != original_dev or
+                not stat.S_ISDIR(dirstat.st_mode) # just in case the inode was reused
+            ):
                 self._dbg(1, "tarfile: Directory renamed before its " \
                      "attributes could be extracted %r" % dirpath)
                 continue

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2516,16 +2516,18 @@ class TarFile(object):
             # blkdev, etc.), return None instead of a file object.
             return None
 
+    def _transform_destination_path(self, targetpath):
+        # Build the destination pathname, replacing
+        # forward slashes to platform specific separators.
+        targetpath = targetpath.rstrip("/")
+        return targetpath.replace("/", os.sep)
+
     def _extract_member(self, tarinfo, targetpath, set_attrs=True,
                         numeric_owner=False):
         """Extract the TarInfo object tarinfo to a physical
            file called targetpath.
         """
-        # Fetch the TarInfo object for the given name
-        # and build the destination pathname, replacing
-        # forward slashes to platform specific separators.
-        targetpath = targetpath.rstrip("/")
-        targetpath = targetpath.replace("/", os.sep)
+        targetpath = self._transform_destination_path(targetpath)
 
         # Create all upper directories.
         upperdirs = os.path.dirname(targetpath)

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2399,7 +2399,7 @@ class TarFile(object):
                 # if it was changed during extraction.
                 dirpath = os.path.join(path, tarinfo.name)
                 dirpath = self._transform_destination_path(dirpath)
-                targetstat = os.stat(dirpath)
+                targetstat = os.stat(dirpath, follow_symlinks=False)
                 directories.append((tarinfo, dirpath, targetstat.st_ino,
                                     targetstat.st_dev))
 
@@ -2408,7 +2408,7 @@ class TarFile(object):
 
         # Set correct owner, mtime and filemode on directories.
         for tarinfo, dirpath, original_ino, original_dev in directories:
-            dirstat = os.stat(dirpath)
+            dirstat = os.stat(dirpath, follow_symlinks=False)
             if (dirstat.st_ino != original_ino or
                 dirstat.st_dev != original_dev):
                 self._dbg(1, "tarfile: Directory renamed before its " \

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2389,20 +2389,32 @@ class TarFile(object):
             tarinfo = self._get_extract_tarinfo(member, filter_function, path)
             if tarinfo is None:
                 continue
+            self._extract_one(tarinfo, path, set_attrs=not tarinfo.isdir(),
+                              numeric_owner=numeric_owner)
             if tarinfo.isdir():
                 # For directories, delay setting attributes until later,
                 # since permissions can interfere with extraction and
                 # extracting contents can reset mtime.
-                directories.append(tarinfo)
-            self._extract_one(tarinfo, path, set_attrs=not tarinfo.isdir(),
-                              numeric_owner=numeric_owner)
+                # We also the keep the original inode and device, to detect
+                # if it was changed during extraction.
+                dirpath = os.path.join(path, tarinfo.name)
+                dirpath = self._transform_destination_path(dirpath)
+                targetstat = os.stat(dirpath)
+                directories.append((tarinfo, dirpath, targetstat.st_ino,
+                                    targetstat.st_dev))
 
         # Reverse sort directories.
-        directories.sort(key=lambda a: a.name, reverse=True)
+        directories.sort(key=lambda a: a[0].name, reverse=True)
 
         # Set correct owner, mtime and filemode on directories.
-        for tarinfo in directories:
-            dirpath = os.path.join(path, tarinfo.name)
+        for tarinfo, dirpath, original_ino, original_dev in directories:
+            dirstat = os.stat(dirpath)
+            if (dirstat.st_ino != original_ino or
+                dirstat.st_dev != original_dev):
+                self._dbg(1, "tarfile: Directory renamed before its " \
+                     "attributes could be extracted %r" % dirpath)
+                continue
+
             try:
                 self.chown(tarinfo, dirpath, numeric_owner=numeric_owner)
                 self.utime(tarinfo, dirpath)

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -2731,8 +2731,7 @@ class MiscTest(unittest.TestCase):
         with ArchiveMaker() as arc:
             arc.add('x', symlink_to='.')
             arc.add('x', type=tarfile.DIRTYPE, mode='?rwsrwsrwt')
-            arc.add('x', symlink_to=('y/' + '../' + outside_tree_dir))
-            arc.add('y/', symlink_to=('../' * len(tempdir.split(os.path.sep))))
+            arc.add('x', symlink_to=outside_tree_dir)
 
         os.makedirs(outside_tree_dir)
         try:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1680,6 +1680,7 @@ class WriteTest(WriteTestBase, unittest.TestCase):
                 tar.addfile(tarinfo)
 
     @unittest.skipUnless(os_helper.can_symlink(), 'requires symlink support')
+    @unittest.skipUnless(hasattr(os, 'chmod'), "missing os.chmod")
     @unittest.mock.patch('os.chmod')
     def test_deferred_directory_attributes_update(self, mock_chmod):
         # Regression test for gh-127987: setting attributes on arbitrary files

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1695,8 +1695,8 @@ class WriteTest(WriteTestBase, unittest.TestCase):
         with ArchiveMaker() as arc:
             arc.add('x', symlink_to='.')
             arc.add('x', type=tarfile.DIRTYPE, mode='?rwsrwsrwt')
-            arc.add('x', symlink_to=('y/' * 99 + '../' * 99 + outside_tree_dir))
-            arc.add('y/' * 99, symlink_to=('../' * 98))
+            arc.add('x', symlink_to=('y/' + '../' + outside_tree_dir))
+            arc.add('y/', symlink_to=('../' * len(tempdir.split(os.path.sep))))
 
         os.makedirs(outside_tree_dir)
         try:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1679,32 +1679,6 @@ class WriteTest(WriteTestBase, unittest.TestCase):
             with self.assertRaises(ValueError):
                 tar.addfile(tarinfo)
 
-    @unittest.skipUnless(os_helper.can_symlink(), 'requires symlink support')
-    @unittest.skipUnless(hasattr(os, 'chmod'), "missing os.chmod")
-    @unittest.mock.patch('os.chmod')
-    def test_deferred_directory_attributes_update(self, mock_chmod):
-        # Regression test for gh-127987: setting attributes on arbitrary files
-        tempdir = os.path.join(TEMPDIR, 'test127987')
-        def mock_chmod_side_effect(path, mode, **kwargs):
-            target_path = os.path.realpath(path)
-            if os.path.commonpath([target_path, tempdir]) != tempdir:
-                raise Exception("should not try to chmod anything outside the destination", target_path)
-        mock_chmod.side_effect = mock_chmod_side_effect
-
-        outside_tree_dir = os.path.join(TEMPDIR, 'outside_tree_dir')
-        with ArchiveMaker() as arc:
-            arc.add('x', symlink_to='.')
-            arc.add('x', type=tarfile.DIRTYPE, mode='?rwsrwsrwt')
-            arc.add('x', symlink_to=('y/' + '../' + outside_tree_dir))
-            arc.add('y/', symlink_to=('../' * len(tempdir.split(os.path.sep))))
-
-        os.makedirs(outside_tree_dir)
-        try:
-            arc.open().extractall(path=tempdir, filter='tar')
-        finally:
-            os_helper.rmtree(outside_tree_dir)
-            os_helper.rmtree(tempdir)
-
 
 class GzipWriteTest(GzipTest, WriteTest):
     pass
@@ -2740,6 +2714,32 @@ class MiscTest(unittest.TestCase):
             "\n- method xz: CompressionError('lzma module is not available')\n",
             str(excinfo.exception),
         )
+
+    @unittest.skipUnless(os_helper.can_symlink(), 'requires symlink support')
+    @unittest.skipUnless(hasattr(os, 'chmod'), "missing os.chmod")
+    @unittest.mock.patch('os.chmod')
+    def test_deferred_directory_attributes_update(self, mock_chmod):
+        # Regression test for gh-127987: setting attributes on arbitrary files
+        tempdir = os.path.join(TEMPDIR, 'test127987')
+        def mock_chmod_side_effect(path, mode, **kwargs):
+            target_path = os.path.realpath(path)
+            if os.path.commonpath([target_path, tempdir]) != tempdir:
+                raise Exception("should not try to chmod anything outside the destination", target_path)
+        mock_chmod.side_effect = mock_chmod_side_effect
+
+        outside_tree_dir = os.path.join(TEMPDIR, 'outside_tree_dir')
+        with ArchiveMaker() as arc:
+            arc.add('x', symlink_to='.')
+            arc.add('x', type=tarfile.DIRTYPE, mode='?rwsrwsrwt')
+            arc.add('x', symlink_to=('y/' + '../' + outside_tree_dir))
+            arc.add('y/', symlink_to=('../' * len(tempdir.split(os.path.sep))))
+
+        os.makedirs(outside_tree_dir)
+        try:
+            arc.open().extractall(path=tempdir, filter='tar')
+        finally:
+            os_helper.rmtree(outside_tree_dir)
+            os_helper.rmtree(tempdir)
 
 
 class CommandLineTest(unittest.TestCase):

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1680,10 +1680,8 @@ class WriteTest(WriteTestBase, unittest.TestCase):
                 tar.addfile(tarinfo)
 
     @unittest.skipUnless(os_helper.can_symlink(), 'requires symlink support')
-    @unittest.mock.patch('os.chown')
-    @unittest.mock.patch('os.utime')
     @unittest.mock.patch('os.chmod')
-    def test_deferred_directory_attributes_update(self, mock_chmod, mock_utime, mock_chown):
+    def test_deferred_directory_attributes_update(self, mock_chmod):
         # Regression test for gh-127987: setting attributes on arbitrary files
         tempdir = os.path.join(TEMPDIR, 'test127987')
         def mock_chmod_side_effect(path, mode, **kwargs):


### PR DESCRIPTION
The most straightforward approach to solving this issue is to re-consult the `filter_function` just before updating the attributes in the directory within `extract_all()`. However, this would result in [stateful extraction filters](https://docs.python.org/3/library/tarfile.html#stateful-extraction-filter-example) receiving a redundant call for a file that has already passed the filter.

Inspired by [GNU Tar](https://git.savannah.gnu.org/cgit/tar.git/tree/src/extract.c?h=v1.35#n964), I decided to save the exact inode number of the created directory to ensure it hasn't changed.
The only downside I can see is that `stat()` is called shortly after the directory is created, which introduces a race condition. Since the entire module is already susceptible to these kinds of races (the path is resolved in the `filter_function` and then re-resolved in the actual file creation methods), I believe this is acceptable.

<!-- gh-issue-number: gh-127987 -->
* Issue: gh-127987
<!-- /gh-issue-number -->
