### PR TITLE
[3.14] gh-134168: fix `http.server` CLI support for IPv6 and `--directory` when serving over HTTPS (#134169)

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-05-18-13-23-29.gh-issue-134168.hgx3Xg.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-18-13-23-29.gh-issue-134168.hgx3Xg.rst
@@ -1,0 +1,2 @@
+:mod:`http.server`: Fix IPv6 address binding and
+:option:`--directory <http.server --directory>` handling when using HTTPS.


### PR DESCRIPTION
---------
(cherry picked from commit 2fd09b011031f3c00c342b44e02e2817010e507c)

Co-authored-by: ggqlq <124190229+ggqlq@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134168 -->
* Issue: gh-134168
<!-- /gh-issue-number -->
