### PR TITLE
gh-134632: Fix `build-details.json` to use `INCLUDEPY` path

### DIFF
--- a/Lib/test/test_build_details.py
+++ b/Lib/test/test_build_details.py
@@ -127,9 +127,8 @@ class CPythonBuildDetailsTests(unittest.TestCase, FormatTestsBase):
     def test_c_api(self):
         value = self.key('c_api')
         self.assertTrue(os.path.exists(os.path.join(value['headers'], 'Python.h')))
-        if 'pkgconfig_path' in value:
-            version = sysconfig.get_config_var('VERSION')
-            self.assertTrue(os.path.exists(os.path.join(value['pkgconfig_path'], f'python-{version}.pc')))
+        version = sysconfig.get_config_var('VERSION')
+        self.assertTrue(os.path.exists(os.path.join(value['pkgconfig_path'], f'python-{version}.pc')))
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_build_details.py
+++ b/Lib/test/test_build_details.py
@@ -123,6 +123,14 @@ class CPythonBuildDetailsTests(unittest.TestCase, FormatTestsBase):
 
         self.assertEqual(os.path.realpath(value), os.path.realpath(sys.executable))
 
+    @needs_installed_python
+    def test_c_api(self):
+        value = self.key('c_api')
+        self.assertTrue(os.path.exists(os.path.join(value['headers'], 'Python.h')))
+        if 'pkgconfig_path' in value:
+            version = sysconfig.get_config_var('VERSION')
+            self.assertTrue(os.path.exists(os.path.join(value['pkgconfig_path'], f'python-{version}.pc')))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Build/2025-05-24-16-59-20.gh-issue-134632.i0W2hc.rst
+++ b/Misc/NEWS.d/next/Build/2025-05-24-16-59-20.gh-issue-134632.i0W2hc.rst
@@ -1,0 +1,3 @@
+Fixed ``build-details.json`` generation to use ``INCLUDEPY``, in order to
+reference the ``pythonX.Y`` subdirectory of the include directory, as
+required in :pep:`739`, instead of the top-level include directory.

--- a/Tools/build/generate-build-details.py
+++ b/Tools/build/generate-build-details.py
@@ -75,7 +75,7 @@ def generate_data(schema_version: str) -> collections.defaultdict[str, Any]:
     PY3LIBRARY = sysconfig.get_config_var('PY3LIBRARY')
     LIBPYTHON = sysconfig.get_config_var('LIBPYTHON')
     LIBPC = sysconfig.get_config_var('LIBPC')
-    INCLUDEDIR = sysconfig.get_config_var('INCLUDEDIR')
+    INCLUDEPY = sysconfig.get_config_var('INCLUDEPY')
 
     if os.name == 'posix':
         # On POSIX, LIBRARY is always the static library, while LDLIBRARY is the
@@ -123,7 +123,7 @@ def generate_data(schema_version: str) -> collections.defaultdict[str, Any]:
     if has_static_library:
         data['libpython']['static'] = os.path.join(LIBDIR, LIBRARY)
 
-    data['c_api']['headers'] = INCLUDEDIR
+    data['c_api']['headers'] = INCLUDEPY
     if LIBPC:
         data['c_api']['pkgconfig_path'] = LIBPC
 


### PR DESCRIPTION
Fix ``build-details.json`` generation to use ``INCLUDEPY``, in order to reference the ``pythonX.Y`` subdirectory of the include directory, as required in PEP-0739, instead of the top-level include directory.

<!-- gh-issue-number: gh-134632 -->
* Issue: gh-134632
<!-- /gh-issue-number -->
