### PR TITLE
gh-134644: handle exceptions set in `PyOS_Readline`

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-26-15-44-40.gh-issue-134644.GmBYO6.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-26-15-44-40.gh-issue-134644.GmBYO6.rst
@@ -1,0 +1,1 @@
+Fix assertion failure when ``input`` is interrupted by another thread.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -1773,6 +1773,7 @@ _PySignal_Fini(void)
 int
 PyErr_CheckSignals(void)
 {
+    assert(!PyErr_Occurred());
     PyThreadState *tstate = _PyThreadState_GET();
 
     /* Opportunistically check if the GC is scheduled to run and run it

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2426,7 +2426,8 @@ builtin_input_impl(PyObject *module, PyObject *prompt)
         }
         s = PyOS_Readline(stdin, stdout, promptstr);
         if (s == NULL) {
-            PyErr_CheckSignals();
+            if (!PyErr_Occurred())
+                PyErr_CheckSignals();
             if (!PyErr_Occurred())
                 PyErr_SetNone(PyExc_KeyboardInterrupt);
             goto _readline_errors;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2605,7 +2605,8 @@ builtin_input_impl(PyObject *module, PyObject *prompt)
         }
         s = PyOS_Readline(stdin, stdout, promptstr);
         if (s == NULL) {
-            PyErr_CheckSignals();
+            if (!PyErr_Occurred())
+                PyErr_CheckSignals();
             if (!PyErr_Occurred())
                 PyErr_SetNone(PyExc_KeyboardInterrupt);
             goto _readline_errors;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2605,10 +2605,12 @@ builtin_input_impl(PyObject *module, PyObject *prompt)
         }
         s = PyOS_Readline(stdin, stdout, promptstr);
         if (s == NULL) {
-            if (!PyErr_Occurred())
+            if (!PyErr_Occurred()) {
                 PyErr_CheckSignals();
-            if (!PyErr_Occurred())
+            }
+            if (!PyErr_Occurred()) {
                 PyErr_SetNone(PyExc_KeyboardInterrupt);
+            }
             goto _readline_errors;
         }
 


### PR DESCRIPTION
The builtin input calls `PyOS_Readline` but seems to assume it does not set exceptions: if the call fails it checks signals and runs handlers if any are pending, which will cause an assertion failure if an exception has already been set.

Fix this by only checking signals if an exception has not already been set.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134644 -->
* Issue: gh-134644
<!-- /gh-issue-number -->
