### PR TITLE
Update README.rst informations from 3.14 to 3.15

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ libraries for additional performance gains.
 What's New
 ----------
 
-We have a comprehensive overview of the changes in the `What's New in Python
+We have a comprehensive overview of the changes in the `What's new in Python
 3.15 <https://docs.python.org/3.15/whatsnew/3.15.html>`_ document.  For a more
 detailed change log, read `Misc/NEWS
 <https://github.com/python/cpython/tree/main/Misc/NEWS.d>`_, but a full

--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ What's New
 ----------
 
 We have a comprehensive overview of the changes in the `What's New in Python
-3.14 <https://docs.python.org/3.14/whatsnew/3.14.html>`_ document.  For a more
+3.15 <https://docs.python.org/3.15/whatsnew/3.15.html>`_ document.  For a more
 detailed change log, read `Misc/NEWS
 <https://github.com/python/cpython/tree/main/Misc/NEWS.d>`_, but a full
 accounting of changes can only be gleaned from the `commit history
@@ -149,7 +149,7 @@ entitled "Installing multiple versions".
 Documentation
 -------------
 
-`Documentation for Python 3.14 <https://docs.python.org/3.14/>`_ is online,
+`Documentation for Python 3.15 <https://docs.python.org/3.15/>`_ is online,
 updated daily.
 
 It can also be downloaded in many formats for faster access.  The documentation
@@ -208,7 +208,7 @@ and ``make altinstall`` in the others.
 Release Schedule
 ----------------
 
-See `PEP 745 <https://peps.python.org/pep-0745/>`__ for Python 3.14 release details.
+See `PEP 790 <https://peps.python.org/pep-0790/>`__ for Python 3.15 release details.
 
 
 Copyright and License Information

--- a/README.rst
+++ b/README.rst
@@ -200,8 +200,8 @@ intend to install multiple versions using the same prefix you must decide which
 version (if any) is your "primary" version.  Install that version using
 ``make install``.  Install all other versions using ``make altinstall``.
 
-For example, if you want to install Python 2.7, 3.6, and 3.14 with 3.14 being the
-primary version, you would execute ``make install`` in your 3.14 build directory
+For example, if you want to install Python 2.7, 3.6, and 3.15 with 3.15 being the
+primary version, you would execute ``make install`` in your 3.15 build directory
 and ``make altinstall`` in the others.
 
 


### PR DESCRIPTION
Please add skip news and skip issue labels~

I also made a similar PR at 3.14alpha0 a year ago https://github.com/python/cpython/pull/119539 . It seems that this part was overlooked in 3.15 as well. I'm not a member of the triage team yet, so I still can't add labels. I'd love to be one of them!
