### PR TITLE
gh-116909: fix data race with versions in typeobject

### DIFF
--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1413,6 +1413,7 @@ class TestPendingCalls(unittest.TestCase):
                 self.assertNotIn(task.requester_tid, runner_tids)
 
     @requires_subinterpreters
+    @support.skip_if_sanitizer("gh-129824: race on assign_version_tag", thread=True)
     def test_isolated_subinterpreter(self):
         # We exercise the most important permutations.
 

--- a/Lib/test/test_capi/test_misc.py
+++ b/Lib/test/test_capi/test_misc.py
@@ -1413,7 +1413,6 @@ class TestPendingCalls(unittest.TestCase):
                 self.assertNotIn(task.requester_tid, runner_tids)
 
     @requires_subinterpreters
-    @support.skip_if_sanitizer("gh-129824: race on assign_version_tag", thread=True)
     def test_isolated_subinterpreter(self):
         # We exercise the most important permutations.
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-25-23-55-43.gh-issue-116909.FGbNKx.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-25-23-55-43.gh-issue-116909.FGbNKx.rst
@@ -1,0 +1,2 @@
+Access and update ``_PyRuntime.types.next_version_tag`` in a thread-safe
+manner.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-25-23-55-43.gh-issue-116909.FGbNKx.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-25-23-55-43.gh-issue-116909.FGbNKx.rst
@@ -1,2 +1,1 @@
-Access and update ``_PyRuntime.types.next_version_tag`` in a thread-safe
-manner.
+Fix crash upon importing a static type in a subinterpreter.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -54,7 +54,6 @@ class object "PyObject *" "&PyBaseObject_Type"
         PyUnicode_CheckExact(name) &&                           \
         (PyUnicode_GET_LENGTH(name) <= MCACHE_MAX_ATTR_SIZE)
 
-#define NEXT_GLOBAL_VERSION_TAG _PyRuntime.types.next_version_tag
 #define NEXT_VERSION_TAG(interp) \
     (interp)->types.next_version_tag
 
@@ -1259,6 +1258,25 @@ _PyType_GetVersionForCurrentState(PyTypeObject *tp)
 #endif
 
 static int
+get_next_global_version(unsigned int *dest)
+{
+    unsigned int v;
+    while (1) {
+        v = _Py_atomic_load_uint_relaxed(&_PyRuntime.types.next_version_tag);
+
+        /* Stop if passed the maximum or we successfully updated the field */
+        if (v > _Py_MAX_GLOBAL_TYPE_VERSION_TAG ||
+            _Py_atomic_compare_exchange_uint(&_PyRuntime.types.next_version_tag,
+                                             &v, v + 1)) {
+            break;
+        }
+    }
+
+    *dest = v;
+    return v <= _Py_MAX_GLOBAL_TYPE_VERSION_TAG;
+}
+
+static int
 assign_version_tag(PyInterpreterState *interp, PyTypeObject *type)
 {
     ASSERT_TYPE_LOCK_HELD();
@@ -1288,11 +1306,12 @@ assign_version_tag(PyInterpreterState *interp, PyTypeObject *type)
     }
     if (type->tp_flags & Py_TPFLAGS_IMMUTABLETYPE) {
         /* static types */
-        if (NEXT_GLOBAL_VERSION_TAG > _Py_MAX_GLOBAL_TYPE_VERSION_TAG) {
+        unsigned int version;
+        if (!get_next_global_version(&version)) {
             /* We have run out of version numbers */
             return 0;
         }
-        set_version_unlocked(type, NEXT_GLOBAL_VERSION_TAG++);
+        set_version_unlocked(type, version);
         assert (type->tp_version_tag <= _Py_MAX_GLOBAL_TYPE_VERSION_TAG);
     }
     else {
@@ -8877,9 +8896,12 @@ init_static_type(PyInterpreterState *interp, PyTypeObject *self,
         type_add_flags(self, _Py_TPFLAGS_STATIC_BUILTIN);
         type_add_flags(self, Py_TPFLAGS_IMMUTABLETYPE);
 
-        assert(NEXT_GLOBAL_VERSION_TAG <= _Py_MAX_GLOBAL_TYPE_VERSION_TAG);
+        unsigned int version;
+        if (!get_next_global_version(&version)) {
+            assert("we have run out of version numbers");
+        }
         if (self->tp_version_tag == 0) {
-            _PyType_SetVersion(self, NEXT_GLOBAL_VERSION_TAG++);
+            _PyType_SetVersion(self, version);
         }
     }
     else {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8898,7 +8898,7 @@ init_static_type(PyInterpreterState *interp, PyTypeObject *self,
 
         unsigned int version;
         if (!get_next_global_version(&version)) {
-            assert("we have run out of version numbers");
+            assert(0 && "we have run out of version numbers");
         }
         if (self->tp_version_tag == 0) {
             _PyType_SetVersion(self, version);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -8896,11 +8896,11 @@ init_static_type(PyInterpreterState *interp, PyTypeObject *self,
         type_add_flags(self, _Py_TPFLAGS_STATIC_BUILTIN);
         type_add_flags(self, Py_TPFLAGS_IMMUTABLETYPE);
 
-        unsigned int version;
-        if (!get_next_global_version(&version)) {
-            assert(0 && "we have run out of version numbers");
-        }
         if (self->tp_version_tag == 0) {
+            unsigned int version;
+            if (!get_next_global_version(&version)) {
+                assert(0 && "we have run out of version numbers");
+            }
             _PyType_SetVersion(self, version);
         }
     }


### PR DESCRIPTION
Global state `_PyRuntime.types.next_version_tag` is being accessed without synchronization or atomics. This could potentially result in the same version being used in two different type objects, incrementing past the maximum limit, and the usual non-atomic memory access issues.

Fix this by using atomics to ensure the version is accessed and updated in a race-free manner, while also ensuring it is never incremented past the expected (maximum + 1).

Note there is a theoretical change in behaviour with the second use, for static builtin types, if their versions exceed the maximum, with assertions disabled: previously they would have continued incrementing past the maximum and using the increasing version number; now they will all use the maximum. It might be better to replace the `assert` with an `abort()`: I assume we would be crashing shortly if we continue after this, both before and after this change.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-116909 -->
* Issue: gh-116909
<!-- /gh-issue-number -->
