### PR TITLE
GH-130328: Fix WindowsConsoleGetEventTests after gh-133728

### DIFF
--- a/Lib/test/test_pyrepl/test_windows_console.py
+++ b/Lib/test/test_pyrepl/test_windows_console.py
@@ -386,6 +386,7 @@ class WindowsConsoleGetEventTests(TestCase):
         self.console._read_input = self.mock
         self.console._WindowsConsole__vt_support = kwargs.get("vt_support",
                                                               False)
+        self.console.wait = MagicMock(return_value=True)
         event = self.console.get_event(block=False)
         return event
 


### PR DESCRIPTION
Fixes the WindowsConsoleGetEventTests which got broken due to moving `wait` into `get_event` in `WindowsConsole` during https://github.com/python/cpython/pull/133728.

<!-- gh-issue-number: gh-130328 -->
* Issue: gh-130328
<!-- /gh-issue-number -->
