### PR TITLE
annotationlib docs: note that ForwardRef.evaluate eventually defaults to empty globals

### DIFF
--- a/Doc/library/annotationlib.rst
+++ b/Doc/library/annotationlib.rst
@@ -211,6 +211,10 @@ Classes
       means may not have any information about their scope, so passing
       arguments to this method may be necessary to evaluate them successfully.
 
+      If no *owner*, *globals*, *locals*, or *type_params* are provided and the
+      :class:`~ForwardRef` does not contain information about its origin,
+      empty globals and locals dictionaries are used.
+
    .. versionadded:: 3.14
 
 


### PR DESCRIPTION


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134661.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->