### PR TITLE
gh-134657: Remove newly added private names from asyncio.__all__

### DIFF
--- a/Lib/asyncio/__init__.py
+++ b/Lib/asyncio/__init__.py
@@ -51,15 +51,24 @@ else:
 def __getattr__(name: str):
     import warnings
 
-    deprecated = {
-        "AbstractEventLoopPolicy",
-        "DefaultEventLoopPolicy",
-        "WindowsSelectorEventLoopPolicy",
-        "WindowsProactorEventLoopPolicy",
-    }
-    if name in deprecated:
-        warnings._deprecated(f"asyncio.{name}", remove=(3, 16))
-        # deprecated things have underscores in front of them
-        return globals()["_" + name]
+    match name:
+        case "AbstractEventLoopPolicy":
+            warnings._deprecated(f"asyncio.{name}", remove=(3, 16))
+            return events._AbstractEventLoopPolicy
+        case "DefaultEventLoopPolicy":
+            warnings._deprecated(f"asyncio.{name}", remove=(3, 16))
+            if sys.platform == 'win32':
+                return windows_events._DefaultEventLoopPolicy
+            return unix_events._DefaultEventLoopPolicy
+        case "WindowsSelectorEventLoopPolicy":
+            if sys.platform == 'win32':
+                warnings._deprecated(f"asyncio.{name}", remove=(3, 16))
+                return windows_events._WindowsSelectorEventLoopPolicy
+            # Else fall through to the AttributeError below.
+        case "WindowsProactorEventLoopPolicy":
+            if sys.platform == 'win32':
+                warnings._deprecated(f"asyncio.{name}", remove=(3, 16))
+                return windows_events._WindowsProactorEventLoopPolicy
+            # Else fall through to the AttributeError below.
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -788,7 +788,10 @@ def _init_event_loop_policy():
     global _event_loop_policy
     with _lock:
         if _event_loop_policy is None:  # pragma: no branch
-            from . import _DefaultEventLoopPolicy
+            if sys.platform == 'win32':
+                from .windows_events import _DefaultEventLoopPolicy
+            else:
+                from .unix_events import _DefaultEventLoopPolicy
             _event_loop_policy = _DefaultEventLoopPolicy()
 
 

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -5,14 +5,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2015-2021 MagicStack Inc.  http://magic.io
 
 __all__ = (
-    "_AbstractEventLoopPolicy",
     "AbstractEventLoop",
     "AbstractServer",
     "Handle",
     "TimerHandle",
-    "_get_event_loop_policy",
     "get_event_loop_policy",
-    "_set_event_loop_policy",
     "set_event_loop_policy",
     "get_event_loop",
     "set_event_loop",

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -28,7 +28,6 @@ from .log import logger
 
 __all__ = (
     'SelectorEventLoop',
-    '_DefaultEventLoopPolicy',
     'EventLoop',
 )
 

--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -97,7 +97,7 @@ class saved_test_environment:
         return support.maybe_get_event_loop_policy()
     def restore_asyncio_events__event_loop_policy(self, policy):
         asyncio = self.get_module('asyncio')
-        asyncio._set_event_loop_policy(policy)
+        asyncio.events._set_event_loop_policy(policy)
 
     def get_sys_argv(self):
         return id(sys.argv), sys.argv, sys.argv[:]

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -629,7 +629,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
     def tearDown(self):
         self.loop.close()
         self.loop = None
-        asyncio._set_event_loop_policy(None)
+        asyncio.events._set_event_loop_policy(None)
 
     def check_async_iterator_anext(self, ait_class):
         with self.subTest(anext="pure-Python"):

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -25,7 +25,7 @@ MOCK_ANY = mock.ANY
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 def mock_socket_module():

--- a/Lib/test/test_asyncio/test_buffered_proto.py
+++ b/Lib/test/test_asyncio/test_buffered_proto.py
@@ -5,7 +5,7 @@ from test.test_asyncio import functional as func_tests
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class ReceiveStuffProto(asyncio.BufferedProtocol):

--- a/Lib/test/test_asyncio/test_context.py
+++ b/Lib/test/test_asyncio/test_context.py
@@ -4,7 +4,7 @@ import unittest
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 @unittest.skipUnless(decimal.HAVE_CONTEXTVAR, "decimal is built with a thread-local context")

--- a/Lib/test/test_asyncio/test_eager_task_factory.py
+++ b/Lib/test/test_asyncio/test_eager_task_factory.py
@@ -13,7 +13,7 @@ MOCK_ANY = mock.ANY
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class EagerTaskFactoryLoopTests:

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -38,7 +38,7 @@ from test.support import threading_helper
 from test.support import ALWAYS_EQ, LARGEST, SMALLEST
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 def broken_unix_getsockname():
@@ -2843,13 +2843,13 @@ class PolicyTests(unittest.TestCase):
             self.assertIsInstance(policy, asyncio.DefaultEventLoopPolicy)
 
     def test_event_loop_policy(self):
-        policy = asyncio._AbstractEventLoopPolicy()
+        policy = asyncio.events._AbstractEventLoopPolicy()
         self.assertRaises(NotImplementedError, policy.get_event_loop)
         self.assertRaises(NotImplementedError, policy.set_event_loop, object())
         self.assertRaises(NotImplementedError, policy.new_event_loop)
 
     def test_get_event_loop(self):
-        policy = asyncio._DefaultEventLoopPolicy()
+        policy = test_utils.DefaultEventLoopPolicy()
         self.assertIsNone(policy._local._loop)
 
         with self.assertRaises(RuntimeError):
@@ -2857,7 +2857,7 @@ class PolicyTests(unittest.TestCase):
         self.assertIsNone(policy._local._loop)
 
     def test_get_event_loop_does_not_call_set_event_loop(self):
-        policy = asyncio._DefaultEventLoopPolicy()
+        policy = test_utils.DefaultEventLoopPolicy()
 
         with mock.patch.object(
                 policy, "set_event_loop",
@@ -2869,7 +2869,7 @@ class PolicyTests(unittest.TestCase):
             m_set_event_loop.assert_not_called()
 
     def test_get_event_loop_after_set_none(self):
-        policy = asyncio._DefaultEventLoopPolicy()
+        policy = test_utils.DefaultEventLoopPolicy()
         policy.set_event_loop(None)
         self.assertRaises(RuntimeError, policy.get_event_loop)
 
@@ -2877,7 +2877,7 @@ class PolicyTests(unittest.TestCase):
     def test_get_event_loop_thread(self, m_current_thread):
 
         def f():
-            policy = asyncio._DefaultEventLoopPolicy()
+            policy = test_utils.DefaultEventLoopPolicy()
             self.assertRaises(RuntimeError, policy.get_event_loop)
 
         th = threading.Thread(target=f)
@@ -2885,14 +2885,14 @@ class PolicyTests(unittest.TestCase):
         th.join()
 
     def test_new_event_loop(self):
-        policy = asyncio._DefaultEventLoopPolicy()
+        policy = test_utils.DefaultEventLoopPolicy()
 
         loop = policy.new_event_loop()
         self.assertIsInstance(loop, asyncio.AbstractEventLoop)
         loop.close()
 
     def test_set_event_loop(self):
-        policy = asyncio._DefaultEventLoopPolicy()
+        policy = test_utils.DefaultEventLoopPolicy()
         old_loop = policy.new_event_loop()
         policy.set_event_loop(old_loop)
 
@@ -2909,7 +2909,7 @@ class PolicyTests(unittest.TestCase):
         with self.assertWarnsRegex(
                 DeprecationWarning, "'asyncio.get_event_loop_policy' is deprecated"):
             policy = asyncio.get_event_loop_policy()
-            self.assertIsInstance(policy, asyncio._AbstractEventLoopPolicy)
+            self.assertIsInstance(policy, asyncio.events._AbstractEventLoopPolicy)
             self.assertIs(policy, asyncio.get_event_loop_policy())
 
     def test_set_event_loop_policy(self):
@@ -2922,7 +2922,7 @@ class PolicyTests(unittest.TestCase):
                 DeprecationWarning, "'asyncio.get_event_loop_policy' is deprecated"):
             old_policy = asyncio.get_event_loop_policy()
 
-        policy = asyncio._DefaultEventLoopPolicy()
+        policy = test_utils.DefaultEventLoopPolicy()
         with self.assertWarnsRegex(
                 DeprecationWarning, "'asyncio.set_event_loop_policy' is deprecated"):
             asyncio.set_event_loop_policy(policy)
@@ -3034,13 +3034,13 @@ class GetEventLoopTestsMixin:
         class TestError(Exception):
             pass
 
-        class Policy(asyncio._DefaultEventLoopPolicy):
+        class Policy(test_utils.DefaultEventLoopPolicy):
             def get_event_loop(self):
                 raise TestError
 
-        old_policy = asyncio._get_event_loop_policy()
+        old_policy = asyncio.events._get_event_loop_policy()
         try:
-            asyncio._set_event_loop_policy(Policy())
+            asyncio.events._set_event_loop_policy(Policy())
             loop = asyncio.new_event_loop()
 
             with self.assertRaises(TestError):
@@ -3068,7 +3068,7 @@ class GetEventLoopTestsMixin:
                 asyncio.get_event_loop()
 
         finally:
-            asyncio._set_event_loop_policy(old_policy)
+            asyncio.events._set_event_loop_policy(old_policy)
             if loop is not None:
                 loop.close()
 
@@ -3078,9 +3078,9 @@ class GetEventLoopTestsMixin:
         self.assertIs(asyncio._get_running_loop(), None)
 
     def test_get_event_loop_returns_running_loop2(self):
-        old_policy = asyncio._get_event_loop_policy()
+        old_policy = asyncio.events._get_event_loop_policy()
         try:
-            asyncio._set_event_loop_policy(asyncio._DefaultEventLoopPolicy())
+            asyncio.events._set_event_loop_policy(test_utils.DefaultEventLoopPolicy())
             loop = asyncio.new_event_loop()
             self.addCleanup(loop.close)
 
@@ -3106,7 +3106,7 @@ class GetEventLoopTestsMixin:
                 asyncio.get_event_loop()
 
         finally:
-            asyncio._set_event_loop_policy(old_policy)
+            asyncio.events._set_event_loop_policy(old_policy)
             if loop is not None:
                 loop.close()
 

--- a/Lib/test/test_asyncio/test_free_threading.py
+++ b/Lib/test/test_asyncio/test_free_threading.py
@@ -15,7 +15,7 @@ class MyException(Exception):
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class TestFreeThreading:

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -17,7 +17,7 @@ from test import support
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 def _fakefunc(f):

--- a/Lib/test/test_asyncio/test_futures2.py
+++ b/Lib/test/test_asyncio/test_futures2.py
@@ -7,7 +7,7 @@ from asyncio import tasks
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class FutureTests:

--- a/Lib/test/test_asyncio/test_graph.py
+++ b/Lib/test/test_asyncio/test_graph.py
@@ -5,7 +5,7 @@ import unittest
 
 # To prevent a warning "test altered the execution environment"
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 def capture_test_stack(*, fut=None, depth=1):

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -20,7 +20,7 @@ RGX_REPR = re.compile(STR_RGX_REPR)
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class LockTests(unittest.IsolatedAsyncioTestCase):

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -11,7 +11,7 @@ from test.test_asyncio import utils as test_utils
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 # Test that asyncio.iscoroutine() uses collections.abc.Coroutine

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -18,7 +18,7 @@ from test.test_asyncio import utils as test_utils
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 def close_transport(transport):

--- a/Lib/test/test_asyncio/test_protocols.py
+++ b/Lib/test/test_asyncio/test_protocols.py
@@ -7,7 +7,7 @@ import asyncio
 def tearDownModule():
     # not needed for the test file but added for uniformness with all other
     # asyncio test files for the sake of unified cleanup
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class ProtocolsAbsTests(unittest.TestCase):

--- a/Lib/test/test_asyncio/test_queues.py
+++ b/Lib/test/test_asyncio/test_queues.py
@@ -6,7 +6,7 @@ from types import GenericAlias
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class QueueBasicTests(unittest.IsolatedAsyncioTestCase):

--- a/Lib/test/test_asyncio/test_runners.py
+++ b/Lib/test/test_asyncio/test_runners.py
@@ -12,14 +12,14 @@ from unittest.mock import patch
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 def interrupt_self():
     _thread.interrupt_main()
 
 
-class TestPolicy(asyncio._AbstractEventLoopPolicy):
+class TestPolicy(asyncio.events._AbstractEventLoopPolicy):
 
     def __init__(self, loop_factory):
         self.loop_factory = loop_factory
@@ -61,15 +61,15 @@ class BaseTest(unittest.TestCase):
         super().setUp()
 
         policy = TestPolicy(self.new_loop)
-        asyncio._set_event_loop_policy(policy)
+        asyncio.events._set_event_loop_policy(policy)
 
     def tearDown(self):
-        policy = asyncio._get_event_loop_policy()
+        policy = asyncio.events._get_event_loop_policy()
         if policy.loop is not None:
             self.assertTrue(policy.loop.is_closed())
             self.assertTrue(policy.loop.shutdown_ag_run)
 
-        asyncio._set_event_loop_policy(None)
+        asyncio.events._set_event_loop_policy(None)
         super().tearDown()
 
 
@@ -208,7 +208,7 @@ class RunTests(BaseTest):
             await asyncio.sleep(0)
             return 42
 
-        policy = asyncio._get_event_loop_policy()
+        policy = asyncio.events._get_event_loop_policy()
         policy.set_event_loop = mock.Mock()
         asyncio.run(main())
         self.assertTrue(policy.set_event_loop.called)
@@ -259,7 +259,7 @@ class RunTests(BaseTest):
             loop.set_task_factory(Task)
             return loop
 
-        asyncio._set_event_loop_policy(TestPolicy(new_event_loop))
+        asyncio.events._set_event_loop_policy(TestPolicy(new_event_loop))
         with self.assertRaises(asyncio.CancelledError):
             asyncio.run(main())
 
@@ -495,7 +495,7 @@ class RunnerTests(BaseTest):
         async def coro():
             pass
 
-        policy = asyncio._get_event_loop_policy()
+        policy = asyncio.events._get_event_loop_policy()
         policy.set_event_loop = mock.Mock()
         runner = asyncio.Runner()
         runner.run(coro())

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -24,7 +24,7 @@ MOCK_ANY = mock.ANY
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class TestBaseSelectorEventLoop(BaseSelectorEventLoop):

--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -22,7 +22,7 @@ except ImportError:
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class MySendfileProto(asyncio.Protocol):

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -11,7 +11,7 @@ from test.test_asyncio import functional as func_tests
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class BaseStartServer(func_tests.FunctionalTestCaseMixin):

--- a/Lib/test/test_asyncio/test_sock_lowlevel.py
+++ b/Lib/test/test_asyncio/test_sock_lowlevel.py
@@ -15,7 +15,7 @@ if socket_helper.tcp_blackhole():
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class MyProto(asyncio.Protocol):

--- a/Lib/test/test_asyncio/test_ssl.py
+++ b/Lib/test/test_asyncio/test_ssl.py
@@ -30,7 +30,7 @@ BUF_MULTIPLIER = 1024 if not MACOS else 64
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class MyBaseProto(asyncio.Protocol):

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -21,7 +21,7 @@ from test.test_asyncio import functional as func_tests
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 @unittest.skipIf(ssl is None, 'No ssl module')

--- a/Lib/test/test_asyncio/test_staggered.py
+++ b/Lib/test/test_asyncio/test_staggered.py
@@ -8,7 +8,7 @@ support.requires_working_socket(module=True)
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class StaggeredTests(unittest.IsolatedAsyncioTestCase):

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -18,7 +18,7 @@ from test.support import socket_helper
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class StreamTests(test_utils.TestCase):

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -37,7 +37,7 @@ PROGRAM_CAT = [
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class TestSubprocessTransport(base_subprocess.BaseSubprocessTransport):

--- a/Lib/test/test_asyncio/test_taskgroups.py
+++ b/Lib/test/test_asyncio/test_taskgroups.py
@@ -15,7 +15,7 @@ from test.test_asyncio.utils import await_without_task
 
 # To prevent a warning "test altered the execution environment"
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class MyExc(Exception):

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -24,7 +24,7 @@ from test.support.warnings_helper import ignore_warnings
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 async def coroutine_function():

--- a/Lib/test/test_asyncio/test_threads.py
+++ b/Lib/test/test_asyncio/test_threads.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class ToThreadTests(unittest.IsolatedAsyncioTestCase):

--- a/Lib/test/test_asyncio/test_timeouts.py
+++ b/Lib/test/test_asyncio/test_timeouts.py
@@ -9,7 +9,7 @@ from test.test_asyncio.utils import await_without_task
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 class TimeoutTests(unittest.IsolatedAsyncioTestCase):
 

--- a/Lib/test/test_asyncio/test_transports.py
+++ b/Lib/test/test_asyncio/test_transports.py
@@ -10,7 +10,7 @@ from asyncio import transports
 def tearDownModule():
     # not needed for the test file but added for uniformness with all other
     # asyncio test files for the sake of unified cleanup
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class TransportTests(unittest.TestCase):

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -30,7 +30,7 @@ from test.test_asyncio import utils as test_utils
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 MOCK_ANY = mock.ANY

--- a/Lib/test/test_asyncio/test_waitfor.py
+++ b/Lib/test/test_asyncio/test_waitfor.py
@@ -5,7 +5,7 @@ from test import support
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 # The following value can be used as a very small timeout:

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -19,7 +19,7 @@ from test.test_asyncio import utils as test_utils
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class UpperProto(asyncio.Protocol):
@@ -330,16 +330,16 @@ class WinPolicyTests(WindowsEventsTestCase):
         async def main():
             self.assertIsInstance(asyncio.get_running_loop(), asyncio.SelectorEventLoop)
 
-        old_policy = asyncio._get_event_loop_policy()
+        old_policy = asyncio.events._get_event_loop_policy()
         try:
             with self.assertWarnsRegex(
                 DeprecationWarning,
                 "'asyncio.WindowsSelectorEventLoopPolicy' is deprecated",
             ):
-                asyncio._set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+                asyncio.events._set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
             asyncio.run(main())
         finally:
-            asyncio._set_event_loop_policy(old_policy)
+            asyncio.events._set_event_loop_policy(old_policy)
 
     def test_proactor_win_policy(self):
         async def main():
@@ -347,16 +347,16 @@ class WinPolicyTests(WindowsEventsTestCase):
                 asyncio.get_running_loop(),
                 asyncio.ProactorEventLoop)
 
-        old_policy = asyncio._get_event_loop_policy()
+        old_policy = asyncio.events._get_event_loop_policy()
         try:
             with self.assertWarnsRegex(
                 DeprecationWarning,
                 "'asyncio.WindowsProactorEventLoopPolicy' is deprecated",
             ):
-                asyncio._set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+                asyncio.events._set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
             asyncio.run(main())
         finally:
-            asyncio._set_event_loop_policy(old_policy)
+            asyncio.events._set_event_loop_policy(old_policy)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_asyncio/test_windows_utils.py
+++ b/Lib/test/test_asyncio/test_windows_utils.py
@@ -16,7 +16,7 @@ from test import support
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class PipeTests(unittest.TestCase):

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -601,3 +601,9 @@ async def await_without_task(coro):
     await asyncio.sleep(0)
     if exc is not None:
         raise exc
+
+
+if sys.platform == 'win32':
+    DefaultEventLoopPolicy = asyncio.windows_events._DefaultEventLoopPolicy
+else:
+    DefaultEventLoopPolicy = asyncio.unix_events._DefaultEventLoopPolicy

--- a/Lib/test/test_concurrent_futures/test_interpreter_pool.py
+++ b/Lib/test/test_concurrent_futures/test_interpreter_pool.py
@@ -310,7 +310,7 @@ class AsyncioTest(InterpretersMixin, testasyncio_utils.TestCase):
         # tests left a policy in place, just in case.
         policy = support.maybe_get_event_loop_policy()
         assert policy is None, policy
-        cls.addClassCleanup(lambda: asyncio._set_event_loop_policy(None))
+        cls.addClassCleanup(lambda: asyncio.events._set_event_loop_policy(None))
 
     def setUp(self):
         super().setUp()

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2307,7 +2307,7 @@ class CoroAsyncIOCompatTest(unittest.TestCase):
             pass
         finally:
             loop.close()
-            asyncio._set_event_loop_policy(None)
+            asyncio.events._set_event_loop_policy(None)
 
         self.assertEqual(buffer, [1, 2, 'MyException'])
 

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -2820,7 +2820,7 @@ class TestGetAsyncGenState(unittest.IsolatedAsyncioTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        asyncio._set_event_loop_policy(None)
+        asyncio.events._set_event_loop_policy(None)
 
     def _asyncgenstate(self):
         return inspect.getasyncgenstate(self.asyncgen)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5504,7 +5504,7 @@ class LogRecordTest(BaseTest):
                 logging.logAsyncioTasks = False
                 runner.run(make_record(self.assertIsNone))
         finally:
-            asyncio._set_event_loop_policy(None)
+            asyncio.events._set_event_loop_policy(None)
 
     @support.requires_working_socket()
     def test_taskName_without_asyncio_imported(self):
@@ -5516,7 +5516,7 @@ class LogRecordTest(BaseTest):
                 logging.logAsyncioTasks = False
                 runner.run(make_record(self.assertIsNone))
         finally:
-            asyncio._set_event_loop_policy(None)
+            asyncio.events._set_event_loop_policy(None)
 
 
 class BasicConfigTest(unittest.TestCase):
@@ -5841,7 +5841,7 @@ class BasicConfigTest(unittest.TestCase):
                 data = f.read().strip()
             self.assertRegex(data, r'Task-\d+ - hello world')
         finally:
-            asyncio._set_event_loop_policy(None)
+            asyncio.events._set_event_loop_policy(None)
             if handler:
                 handler.close()
 

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -105,7 +105,7 @@ requires_splice_pipe = unittest.skipIf(sys.platform.startswith("aix"),
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class MiscTests(unittest.TestCase):

--- a/Lib/test/test_unittest/test_async_case.py
+++ b/Lib/test/test_unittest/test_async_case.py
@@ -12,7 +12,7 @@ class MyException(Exception):
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class TestCM:
@@ -480,7 +480,7 @@ class TestAsyncCase(unittest.TestCase):
 
         class TestCase1(unittest.IsolatedAsyncioTestCase):
             def setUp(self):
-                asyncio._get_event_loop_policy().get_event_loop()
+                asyncio.events._get_event_loop_policy().get_event_loop()
 
             async def test_demo1(self):
                 pass
@@ -490,7 +490,7 @@ class TestAsyncCase(unittest.TestCase):
         self.assertTrue(result.wasSuccessful())
 
     def test_loop_factory(self):
-        asyncio._set_event_loop_policy(None)
+        asyncio.events._set_event_loop_policy(None)
 
         class TestCase1(unittest.IsolatedAsyncioTestCase):
             loop_factory = asyncio.EventLoop

--- a/Lib/test/test_unittest/testmock/testasync.py
+++ b/Lib/test/test_unittest/testmock/testasync.py
@@ -15,7 +15,7 @@ from unittest.mock import (ANY, call, AsyncMock, patch, MagicMock, Mock,
 
 
 def tearDownModule():
-    asyncio._set_event_loop_policy(None)
+    asyncio.events._set_event_loop_policy(None)
 
 
 class AsyncClass:

--- a/Misc/NEWS.d/next/Library/2025-05-25-11-02-05.gh-issue-134657.3YFhR9.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-25-11-02-05.gh-issue-134657.3YFhR9.rst
@@ -1,1 +1,1 @@
-Remove some private names from ``asyncio.__all__``.
+:mod:`asyncio`: Remove some private names from ``asyncio.__all__``.

--- a/Misc/NEWS.d/next/Library/2025-05-25-11-02-05.gh-issue-134657.3YFhR9.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-25-11-02-05.gh-issue-134657.3YFhR9.rst
@@ -1,0 +1,1 @@
+Remove some private names from ``asyncio.__all__``.


### PR DESCRIPTION
This removes the names that were added in 3.14, so we can backport to the 3.14 branch.
We can remove the remaining private names for 3.15 only in the main branch.


<!-- gh-issue-number: gh-134657 -->
* Issue: gh-134657
<!-- /gh-issue-number -->
