### PR TITLE
gh-134604: Fix tracemalloc crash with subinterpreters

### DIFF
--- a/Include/internal/pycore_tracemalloc.h
+++ b/Include/internal/pycore_tracemalloc.h
@@ -43,7 +43,7 @@ __attribute__((packed))
 tracemalloc_frame {
     /* filename cannot be NULL: "<unknown>" is used if the Python frame
        filename is NULL */
-    PyObject *filename;
+    char *filename;
     unsigned int lineno;
 };
 #ifdef _MSC_VER

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-25-11-09-35.gh-issue-134604.AGZhQe.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-25-11-09-35.gh-issue-134604.AGZhQe.rst
@@ -1,0 +1,1 @@
+Fix crash when using :mod:`tracemalloc` with sub-interpreters.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2124,6 +2124,9 @@ _Py_Finalize(_PyRuntimeState *runtime)
     _PyImport_FiniExternal(tstate->interp);
     finalize_modules(tstate);
 
+    /* Clean up any lingering subinterpreters. */
+    finalize_subinterpreters();
+
     /* Print debug stats if any */
     _PyEval_Fini();
 
@@ -2154,11 +2157,6 @@ _Py_Finalize(_PyRuntimeState *runtime)
     /* Disable tracemalloc after all Python objects have been destroyed,
        so it is possible to use tracemalloc in objects destructor. */
     _PyTraceMalloc_Fini();
-
-    /* Clean up any lingering subinterpreters. It is important this happens
-       AFTER tracemalloc finalizes, as tracemalloc may hold references to
-       frame data in other interpreters. */
-    finalize_subinterpreters();
 
     /* Finalize any remaining import state */
     // XXX Move these up to where finalize_modules() is currently.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2124,9 +2124,6 @@ _Py_Finalize(_PyRuntimeState *runtime)
     _PyImport_FiniExternal(tstate->interp);
     finalize_modules(tstate);
 
-    /* Clean up any lingering subinterpreters. */
-    finalize_subinterpreters();
-
     /* Print debug stats if any */
     _PyEval_Fini();
 
@@ -2157,6 +2154,11 @@ _Py_Finalize(_PyRuntimeState *runtime)
     /* Disable tracemalloc after all Python objects have been destroyed,
        so it is possible to use tracemalloc in objects destructor. */
     _PyTraceMalloc_Fini();
+
+    /* Clean up any lingering subinterpreters. It is important this happens
+       AFTER tracemalloc finalizes, as tracemalloc may hold references to
+       frame data in other interpreters. */
+    finalize_subinterpreters();
 
     /* Finalize any remaining import state */
     // XXX Move these up to where finalize_modules() is currently.


### PR DESCRIPTION
This is an attempt at resolving a crash when mixing tracemalloc and sub-interpreters I came across recently. My investigation is recorded in the issue https://github.com/python/cpython/issues/134604#issuecomment-2907537969

This PR makes a few changes:
- modifies tracemalloc to copy the filename of a frame instead of referencing it
- delays sub-interpreter finalization until after tracemalloc finalizes (optional, but probably a good idea)
- fixes a typo/duplicated assignment on a line in the tracemalloc_get_frame function
- adds tests to `test__interpreters` to ensure that this functions correctly.

Should this be backported to 3.13? I suppose subinterpreters can be used there through C APIs, so it might be good to fix this there too.

<!-- gh-issue-number: gh-134604 -->
* Issue: gh-134604
<!-- /gh-issue-number -->
