### PR TITLE
gh-131798: JIT: Assign type to sliced string/list/tuple

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -2233,6 +2233,18 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertIn("_TO_BOOL_LIST", uops)
         self.assertNotIn("_GUARD_TOS_LIST", uops)
 
+    def test_remove_guard_for_slice_tuple(self):
+        def f(n):
+            for i in range(n):
+                false = i == TIER2_THRESHOLD
+                a, b = (1, 2, 3)[: false + 2]
+
+        _, ex = self._run_with_optimizer(f, TIER2_THRESHOLD)
+        self.assertIsNotNone(ex)
+        uops = get_opnames(ex)
+        self.assertIn("_UNPACK_SEQUENCE_TWO_TUPLE", uops)
+        self.assertNotIn("_GUARD_TOS_TUPLE", uops)
+
 
 def global_identity(x):
     return x

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -2217,6 +2217,22 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertNotIn("_LOAD_ATTR_METHOD_NO_DICT", uops)
         self.assertNotIn("_LOAD_ATTR_METHOD_LAZY_DICT", uops)
 
+    def test_remove_guard_for_slice_list(self):
+        def f(n):
+            for i in range(n):
+                false = i == TIER2_THRESHOLD
+                sliced = [1, 2, 3][:false]
+                if sliced:
+                    return 1
+            return 0
+
+        res, ex = self._run_with_optimizer(f, TIER2_THRESHOLD)
+        self.assertEqual(res, 0)
+        self.assertIsNotNone(ex)
+        uops = get_opnames(ex)
+        self.assertIn("_TO_BOOL_LIST", uops)
+        self.assertNotIn("_GUARD_TOS_LIST", uops)
+
 
 def global_identity(x):
     return x

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -458,6 +458,7 @@ class TestUopsOptimization(unittest.TestCase):
         ex = get_first_executor(testfunc)
         return res, ex
 
+
     def test_int_type_propagation(self):
         def testfunc(loops):
             num = 0

--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -458,7 +458,6 @@ class TestUopsOptimization(unittest.TestCase):
         ex = get_first_executor(testfunc)
         return res, ex
 
-
     def test_int_type_propagation(self):
         def testfunc(loops):
             num = 0
@@ -1655,13 +1654,11 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertIn("_CONTAINS_OP_DICT", uops)
         self.assertNotIn("_TO_BOOL_BOOL", uops)
 
-
     def test_remove_guard_for_known_type_str(self):
         def f(n):
             for i in range(n):
                 false = i == TIER2_THRESHOLD
                 empty = "X"[:false]
-                empty += ""  # Make JIT realize this is a string.
                 if empty:
                     return 1
             return 0

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-25-19-32-15.gh-issue-131798.f5h8aI.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-25-19-32-15.gh-issue-131798.f5h8aI.rst
@@ -1,0 +1,1 @@
+Make the JIT optimizer understand that slicing a string/list/tuple returns the same type.

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1217,11 +1217,10 @@ dummy_func(void) {
     }
 
     op(_BINARY_SLICE, (container, start, stop -- res)) {
-        // Slicing a string always returns a string.
-        // TODO: We can apply this to lists and tuples as well.
-        //       We'll start with string to simplify the process.
+        // Slicing a string/list always returns the same type.
         PyTypeObject *type = sym_get_type(container);
-        if (type == &PyUnicode_Type) {
+        if (type == &PyUnicode_Type ||
+            type == &PyList_Type) {
             res = sym_new_type(ctx, type);
         } else {
             res = sym_new_not_null(ctx);

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1221,9 +1221,11 @@ dummy_func(void) {
         PyTypeObject *type = sym_get_type(container);
         if (type == &PyUnicode_Type ||
             type == &PyList_Type ||
-            type == &PyTuple_Type) {
+            type == &PyTuple_Type)
+        {
             res = sym_new_type(ctx, type);
-        } else {
+        }
+        else {
             res = sym_new_not_null(ctx);
         }
     }

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1217,10 +1217,11 @@ dummy_func(void) {
     }
 
     op(_BINARY_SLICE, (container, start, stop -- res)) {
-        // Slicing a string/list always returns the same type.
+        // Slicing a string/list/tuple always returns the same type.
         PyTypeObject *type = sym_get_type(container);
         if (type == &PyUnicode_Type ||
-            type == &PyList_Type) {
+            type == &PyList_Type ||
+            type == &PyTuple_Type) {
             res = sym_new_type(ctx, type);
         } else {
             res = sym_new_not_null(ctx);

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -1216,6 +1216,18 @@ dummy_func(void) {
         sym_set_const(callable, list_append);
     }
 
+    op(_BINARY_SLICE, (container, start, stop -- res)) {
+        // Slicing a string always returns a string.
+        // TODO: We can apply this to lists and tuples as well.
+        //       We'll start with string to simplify the process.
+        PyTypeObject *type = sym_get_type(container);
+        if (type == &PyUnicode_Type) {
+            res = sym_new_type(ctx, type);
+        } else {
+            res = sym_new_not_null(ctx);
+        }
+    }
+
 // END BYTECODES //
 
 }

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -568,9 +568,11 @@
             PyTypeObject *type = sym_get_type(container);
             if (type == &PyUnicode_Type ||
                 type == &PyList_Type ||
-                type == &PyTuple_Type) {
+                type == &PyTuple_Type)
+            {
                 res = sym_new_type(ctx, type);
-            } else {
+            }
+            else {
                 res = sym_new_not_null(ctx);
             }
             stack_pointer[-3] = res;

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -566,7 +566,8 @@
             JitOptSymbol *res;
             container = stack_pointer[-3];
             PyTypeObject *type = sym_get_type(container);
-            if (type == &PyUnicode_Type) {
+            if (type == &PyUnicode_Type ||
+                type == &PyList_Type) {
                 res = sym_new_type(ctx, type);
             } else {
                 res = sym_new_not_null(ctx);

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -562,8 +562,15 @@
         }
 
         case _BINARY_SLICE: {
+            JitOptSymbol *container;
             JitOptSymbol *res;
-            res = sym_new_not_null(ctx);
+            container = stack_pointer[-3];
+            PyTypeObject *type = sym_get_type(container);
+            if (type == &PyUnicode_Type) {
+                res = sym_new_type(ctx, type);
+            } else {
+                res = sym_new_not_null(ctx);
+            }
             stack_pointer[-3] = res;
             stack_pointer += -2;
             assert(WITHIN_STACK_BOUNDS());

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -567,7 +567,8 @@
             container = stack_pointer[-3];
             PyTypeObject *type = sym_get_type(container);
             if (type == &PyUnicode_Type ||
-                type == &PyList_Type) {
+                type == &PyList_Type ||
+                type == &PyTuple_Type) {
                 res = sym_new_type(ctx, type);
             } else {
                 res = sym_new_not_null(ctx);


### PR DESCRIPTION
Slicing a string/list/tuple always returns the same type.
Make the optimizer assign a string/list/tuple type to the result of slicing a string/list/tuple.

@brandtbucher

<!-- gh-issue-number: gh-131798 -->
* Issue: gh-131798
<!-- /gh-issue-number -->
