### PR TITLE
[3.13] fix: remove `ast.MatchStar.name` class-level default value (gh-134674)

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -155,8 +155,8 @@ def dump(
                     not show_empty
                     and (value is None or value == [])
                     # Special cases:
-                    # `Constant(value=None)` and `MatchSingleton(value=None)`
-                    and not isinstance(node, (Constant, MatchSingleton))
+                    # `Constant(value=None)` and `MatchSingleton(value=None)` and `MatchStar(name=None)`
+                    and not isinstance(node, (Constant, MatchSingleton, MatchStar))
                 ):
                     args_buffer.append(repr(value))
                     continue

--- a/Misc/NEWS.d/next/Library/2025-05-25-20-30-00.gh-issue-134674.MatchS.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-25-20-30-00.gh-issue-134674.MatchS.rst
@@ -1,0 +1,4 @@
+Fixed :class:`ast.MatchStar` to remove incorrect class-level default value
+for the ``name`` field.
+Fixed :func:`ast.dump` to show the ``name`` field of
+:class:`ast.MatchStar` when the value is ``None``.

--- a/Parser/Python.asdl
+++ b/Parser/Python.asdl
@@ -135,7 +135,7 @@ module Python
             | MatchMapping(expr* keys, pattern* patterns, identifier? rest)
             | MatchClass(expr cls, pattern* patterns, identifier* kwd_attrs, pattern* kwd_patterns)
 
-            | MatchStar(identifier? name)
+            | MatchStar(identifier name)
             -- The optional "rest" MatchMapping parameter handles capturing extra mapping keys
 
             | MatchAs(pattern? pattern, identifier? name)


### PR DESCRIPTION
I inappropriately submitted this to the main branch in pull request #134676, which is now closed.

Fixes gh-134674

## Problem
`ast.MatchStar.name` incorrectly appears to have a class-level default value when using `ast.dump()`. The issue causes `ast.MatchStar(name=None)` to display as `MatchStar()` instead of the expected `MatchStar(name=None)`.

## Solution
Change the ASDL definition of `MatchStar`, and add `MatchStar` to the special cases list in `ast.dump()` alongside `Constant` and `MatchSingleton`. 
