### PR TITLE
gh-134674: remove ast.MatchStar.name class-level default value

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -1570,7 +1570,7 @@ Pattern matching
                         match_case(
                             pattern=MatchSequence(
                                 patterns=[
-                                    MatchStar()]),
+                                    MatchStar(None)]),
                             body=[
                                 Expr(
                                     value=Constant(value=Ellipsis))])])])

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -151,7 +151,7 @@ def dump(
                     not show_empty
                     and (value is None or value == [])
                     # Special cases:
-                    # `Constant(value=None)` and `MatchSingleton(value=None) and `MatchStar(name=None)`
+                    # `Constant(value=None)` and `MatchSingleton(value=None)` and `MatchStar(name=None)`
                     and not isinstance(node, (Constant, MatchSingleton, MatchStar))
                 ):
                     args_buffer.append(repr(value))

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -151,8 +151,8 @@ def dump(
                     not show_empty
                     and (value is None or value == [])
                     # Special cases:
-                    # `Constant(value=None)` and `MatchSingleton(value=None)`
-                    and not isinstance(node, (Constant, MatchSingleton))
+                    # `Constant(value=None)` and `MatchSingleton(value=None) and `MatchStar(name=None)`
+                    and not isinstance(node, (Constant, MatchSingleton, MatchStar))
                 ):
                     args_buffer.append(repr(value))
                     continue

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -2398,7 +2398,7 @@ class ASTValidatorTests(unittest.TestCase):
         ),
         ast.MatchClass(
             name_carter,
-            patterns=[ast.MatchStar()],
+            patterns=[ast.MatchStar(None)],
             kwd_attrs=[],
             kwd_patterns=[]
         ),
@@ -2406,7 +2406,7 @@ class ASTValidatorTests(unittest.TestCase):
             name_carter,
             patterns=[],
             kwd_attrs=[],
-            kwd_patterns=[ast.MatchStar()]
+            kwd_patterns=[ast.MatchStar(None)]
         ),
         ast.MatchClass(
             constant_true,  # invalid name

--- a/Misc/NEWS.d/next/Library/2025-05-25-20-30-00.gh-issue-134674.MatchS.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-25-20-30-00.gh-issue-134674.MatchS.rst
@@ -1,0 +1,4 @@
+Fixed :class:`ast.MatchStar` to remove incorrect class-level default value
+for the ``name`` field.
+Fixed :func:`ast.dump` to show the ``name`` field of
+:class:`ast.MatchStar` when the value is ``None``.

--- a/Parser/Python.asdl
+++ b/Parser/Python.asdl
@@ -137,7 +137,7 @@ module Python
             | MatchMapping(expr* keys, pattern* patterns, identifier? rest)
             | MatchClass(expr cls, pattern* patterns, identifier* kwd_attrs, pattern* kwd_patterns)
 
-            | MatchStar(identifier? name)
+            | MatchStar(identifier name)
             -- The optional "rest" MatchMapping parameter handles capturing extra mapping keys
 
             | MatchAs(pattern? pattern, identifier? name)

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -4839,12 +4839,7 @@ add_ast_annotations(struct ast_state *state)
     if (!MatchStar_annotations) return 0;
     {
         PyObject *type = (PyObject *)&PyUnicode_Type;
-        type = _Py_union_type_or(type, Py_None);
-        cond = type != NULL;
-        if (!cond) {
-            Py_DECREF(MatchStar_annotations);
-            return 0;
-        }
+        Py_INCREF(type);
         cond = PyDict_SetItemString(MatchStar_annotations, "name", type) == 0;
         Py_DECREF(type);
         if (!cond) {
@@ -6880,7 +6875,7 @@ init_types(void *arg)
         "        | MatchSequence(pattern* patterns)\n"
         "        | MatchMapping(expr* keys, pattern* patterns, identifier? rest)\n"
         "        | MatchClass(expr cls, pattern* patterns, identifier* kwd_attrs, pattern* kwd_patterns)\n"
-        "        | MatchStar(identifier? name)\n"
+        "        | MatchStar(identifier name)\n"
         "        | MatchAs(pattern? pattern, identifier? name)\n"
         "        | MatchOr(pattern* patterns)");
     if (!state->pattern_type) return -1;
@@ -6915,10 +6910,8 @@ init_types(void *arg)
     if (!state->MatchClass_type) return -1;
     state->MatchStar_type = make_type(state, "MatchStar", state->pattern_type,
                                       MatchStar_fields, 1,
-        "MatchStar(identifier? name)");
+        "MatchStar(identifier name)");
     if (!state->MatchStar_type) return -1;
-    if (PyObject_SetAttr(state->MatchStar_type, state->name, Py_None) == -1)
-        return -1;
     state->MatchAs_type = make_type(state, "MatchAs", state->pattern_type,
                                     MatchAs_fields, 2,
         "MatchAs(pattern? pattern, identifier? name)");
@@ -8746,6 +8739,11 @@ _PyAST_MatchStar(identifier name, int lineno, int col_offset, int end_lineno,
                  int end_col_offset, PyArena *arena)
 {
     pattern_ty p;
+    if (!name) {
+        PyErr_SetString(PyExc_ValueError,
+                        "field 'name' is required for MatchStar");
+        return NULL;
+    }
     p = (pattern_ty)_PyArena_Malloc(arena, sizeof(*p));
     if (!p)
         return NULL;
@@ -17530,9 +17528,9 @@ obj2ast_pattern(struct ast_state *state, PyObject* obj, pattern_ty* out,
         if (PyObject_GetOptionalAttr(obj, state->name, &tmp) < 0) {
             return -1;
         }
-        if (tmp == NULL || tmp == Py_None) {
-            Py_CLEAR(tmp);
-            name = NULL;
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"name\" missing from MatchStar");
+            return -1;
         }
         else {
             int res;


### PR DESCRIPTION
## Note prior pull requests

* In pull request #134676, I attempted to merge a branch based on 3.13 into main.
* I misunderstood the instructions from #134676, and attempted to backport merge to branch 3.13 in pull request #134681.

## Changes to and compiled from branch main

Fixes gh-134674

### Problem

ast.MatchStar.name incorrectly appears to have a class-level default value when using ast.dump(). The issue causes ast.MatchStar(name=None) to display as MatchStar() instead of the expected MatchStar(name=None).

### Solution

Change the ASDL definition of MatchStar, and add MatchStar to the special cases list in ast.dump() alongside Constant and MatchSingleton.