### PR TITLE
gh-134557: Suppress immortalization in _PyCode_GetScriptXIData under free-threading

### DIFF
--- a/Python/crossinterp.c
+++ b/Python/crossinterp.c
@@ -908,8 +908,15 @@ get_script_xidata(PyThreadState *tstate, PyObject *obj, int pure,
             }
             goto error;
         }
+#ifdef Py_GIL_DISABLED
+        // Don't immortalize code constants to avoid memory leaks.
+        ((_PyThreadStateImpl *)tstate)->suppress_co_const_immortalization++;
+#endif
         code = Py_CompileStringExFlags(
                     script, filename, Py_file_input, &cf, optimize);
+#ifdef Py_GIL_DISABLED
+        ((_PyThreadStateImpl *)tstate)->suppress_co_const_immortalization--;
+#endif
         Py_XDECREF(ref);
         if (code == NULL) {
             goto error;


### PR DESCRIPTION
The same approach as 332356b880576a1a00b5dc34f03d7d3995dd4512 that fixed the refleaks in `compile()` and `eval()`.

cc @colesbury @ericsnowcurrently @emmatyping  I'm not so confident.

E: 09e72cf091d03479eddcb3c4526f5c6af56d31a0 can pass `test_capi`, `test_sys` and `test__interpchannels` with this patch for me.

<!-- gh-issue-number: gh-134557 -->
* Issue: gh-134557
<!-- /gh-issue-number -->
