### PR TITLE
gh-117208: handle EAGAIN in non-blocking connect

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-05-26-01-48-09.gh-issue-117208.mmFGDb.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-26-01-48-09.gh-issue-117208.mmFGDb.rst
@@ -1,3 +1,3 @@
 Fix error handling for non-blocking ``connect`` calls which meant
-:func:`socket.connect` was sometimes raising a :exc:`BlockingIOError` instead
+:meth:`socket.connect` was sometimes raising a :exc:`BlockingIOError` instead
 of waiting when a connection could not be immediately completed.

--- a/Misc/NEWS.d/next/Library/2025-05-26-01-48-09.gh-issue-117208.mmFGDb.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-26-01-48-09.gh-issue-117208.mmFGDb.rst
@@ -1,0 +1,3 @@
+Fix error handling for non-blocking ``connect`` calls which meant
+:func:`socket.connect` was sometimes raising a :exc:`BlockingIOError` instead
+of waiting when a connection could not be immediately completed.

--- a/Misc/NEWS.d/next/Library/2025-05-26-01-48-09.gh-issue-117208.mmFGDb.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-26-01-48-09.gh-issue-117208.mmFGDb.rst
@@ -1,3 +1,3 @@
 Fix error handling for non-blocking ``connect`` calls which meant
-:meth:`socket.connect` was sometimes raising a :exc:`BlockingIOError` instead
-of waiting when a connection could not be immediately completed.
+:meth:`socket.socket.connect` was sometimes raising a :exc:`BlockingIOError`
+instead of waiting when a connection could not be immediately completed.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -3671,7 +3671,8 @@ internal_connect(PySocketSockObject *s, struct sockaddr *addr, int addrlen,
         wait_connect = (s->sock_timeout != 0 && IS_SELECTABLE(s));
     }
     else {
-        wait_connect = (s->sock_timeout > 0 && err == SOCK_INPROGRESS_ERR
+        wait_connect = (s->sock_timeout > 0
+                        && (err == EAGAIN || err == SOCK_INPROGRESS_ERR)
                         && IS_SELECTABLE(s));
     }
 


### PR DESCRIPTION
When calling ``connect`` in non-blocking mode it fails with errno set to EINPROGRESS if the connection cannot be completed immediately. Except for UNIX domain sockets, on Linux, which fail with EAGAIN instead.

Fix the conditional check in the socket connection code to account for this lovely little inconsistency.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117208 -->
* Issue: gh-117208
<!-- /gh-issue-number -->
