### PR TITLE
gh-134693: Fix `[-Wmaybe-uninitialized]` warning in `_remote_debugging_module.c`

### DIFF
--- a/Modules/_remote_debugging_module.c
+++ b/Modules/_remote_debugging_module.c
@@ -1875,6 +1875,14 @@ parse_async_frame_object(
 
     *previous_frame = GET_MEMBER(uintptr_t, frame, unwinder->debug_offsets.interpreter_frame.previous);
 
+    *code_object = GET_MEMBER(uintptr_t, frame, unwinder->debug_offsets.interpreter_frame.executable);
+    // Strip tag bits for consistent comparison
+    *code_object &= ~Py_TAG_BITS;
+    assert(code_object != NULL);
+    if ((void*)*code_object == NULL) {
+        return 0;
+    }
+
     if (GET_MEMBER(char, frame, unwinder->debug_offsets.interpreter_frame.owner) == FRAME_OWNED_BY_CSTACK ||
         GET_MEMBER(char, frame, unwinder->debug_offsets.interpreter_frame.owner) == FRAME_OWNED_BY_INTERPRETER) {
         return 0;  // C frame
@@ -1885,15 +1893,6 @@ parse_async_frame_object(
         PyErr_Format(PyExc_RuntimeError, "Unhandled frame owner %d.\n",
                     GET_MEMBER(char, frame, unwinder->debug_offsets.interpreter_frame.owner));
         return -1;
-    }
-
-    *code_object = GET_MEMBER(uintptr_t, frame, unwinder->debug_offsets.interpreter_frame.executable);
-    // Strip tag bits for consistent comparison
-    *code_object &= ~Py_TAG_BITS;
-
-    assert(code_object != NULL);
-    if ((void*)*code_object == NULL) {
-        return 0;
     }
 
     uintptr_t instruction_pointer = GET_MEMBER(uintptr_t, frame, unwinder->debug_offsets.interpreter_frame.instr_ptr);


### PR DESCRIPTION
I just moved the code up, so it will always be executed, and `code_object` will always be initialized.

<!-- gh-issue-number: gh-134693 -->
* Issue: gh-134693
<!-- /gh-issue-number -->
