### PR TITLE
gh-134637: make PyCFuncPtr_call lock free in ctypes

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-05-26-17-06-40.gh-issue-134637.9-3zRL.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-26-17-06-40.gh-issue-134637.9-3zRL.rst
@@ -1,1 +1,1 @@
-Fix performance regression in calling ``ctypes._CFuncPtr`` in free-threading.
+Fix performance regression in calling a :mod:`ctypes` function pointer in :term:`free threading`.

--- a/Misc/NEWS.d/next/Library/2025-05-26-17-06-40.gh-issue-134637.9-3zRL.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-26-17-06-40.gh-issue-134637.9-3zRL.rst
@@ -1,0 +1,1 @@
+Fix performance regression in calling ``ctypes._CFuncPtr`` in free-threading.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3623,8 +3623,9 @@ atomic_xsetref(PyObject **field, PyObject *value)
 }
 /*
     This function atomically loads the reference from *field, and
-    tries to get a new reference to it. If the increment fails,
+    tries to get a new reference to it. If the incref fails,
     it acquires critical section of obj and returns a new reference to the *field.
+    In the general case, this avoids contention on acquiring the critical section.
 */
 static inline PyObject *
 atomic_xgetref(PyObject *obj, PyObject **field)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

This fixes the performance regression mentioned on the issue, it avoids acquiring the critical section in the general case of no contention.



<!-- gh-issue-number: gh-134637 -->
* Issue: gh-134637
<!-- /gh-issue-number -->
