### PR TITLE
gh-134717: Allow overriding serialization of NaN and Infinity in json.encoder

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -202,6 +202,28 @@ class JSONEncoder(object):
             chunks = list(chunks)
         return ''.join(chunks)
 
+    def floatstr(o, allow_nan=self.allow_nan,
+            _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
+        # Check for specials.  Note that this type of test is processor
+        # and/or platform-specific, so do tests which don't depend on the
+        # internals.
+
+        if o != o:
+            text = 'NaN'
+        elif o == _inf:
+            text = 'Infinity'
+        elif o == _neginf:
+            text = '-Infinity'
+        else:
+            return _repr(o)
+
+        if not allow_nan:
+            raise ValueError(
+                "Out of range float values are not JSON compliant: " +
+                repr(o))
+
+        return text
+
     def iterencode(self, o, _one_shot=False):
         """Encode the given object and yield each string
         representation as available.
@@ -221,29 +243,6 @@ class JSONEncoder(object):
         else:
             _encoder = encode_basestring
 
-        def floatstr(o, allow_nan=self.allow_nan,
-                _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
-            # Check for specials.  Note that this type of test is processor
-            # and/or platform-specific, so do tests which don't depend on the
-            # internals.
-
-            if o != o:
-                text = 'NaN'
-            elif o == _inf:
-                text = 'Infinity'
-            elif o == _neginf:
-                text = '-Infinity'
-            else:
-                return _repr(o)
-
-            if not allow_nan:
-                raise ValueError(
-                    "Out of range float values are not JSON compliant: " +
-                    repr(o))
-
-            return text
-
-
         if self.indent is None or isinstance(self.indent, str):
             indent = self.indent
         else:
@@ -255,7 +254,7 @@ class JSONEncoder(object):
                 self.skipkeys, self.allow_nan)
         else:
             _iterencode = _make_iterencode(
-                markers, self.default, _encoder, indent, floatstr,
+                markers, self.default, _encoder, indent, self.floatstr,
                 self.key_separator, self.item_separator, self.sort_keys,
                 self.skipkeys, _one_shot)
         return _iterencode(o, 0)

--- a/Misc/NEWS.d/next/feature-112517.bpo
+++ b/Misc/NEWS.d/next/feature-112517.bpo
@@ -1,0 +1,1 @@
+The `json.encoder` module now supports overriding how NaN and Infinity values are serialized by allowing a custom `floatstr` function.


### PR DESCRIPTION
This change modifies the `json.encoder` module to permit customization of how special floating-point values (`NaN`, `Infinity`, `-Infinity`) are serialized. By introducing a `floatstr` function, developers can now define alternative representations for these values, such as `null`, `0`, or custom strings, enhancing flexibility in JSON output.

<!-- gh-issue-number: gh-134717 -->
* Issue: gh-134717
<!-- /gh-issue-number -->
