### PR TITLE
gh-134728: Don't deopt due to eval breaker in `_TIER2_RESUME_CHECK`

### DIFF
--- a/Include/internal/pycore_uop_metadata.h
+++ b/Include/internal/pycore_uop_metadata.h
@@ -319,7 +319,7 @@ const uint16_t _PyUop_Flags[MAX_UOP_ID+1] = {
     [_FATAL_ERROR] = 0,
     [_DEOPT] = 0,
     [_ERROR_POP_N] = HAS_ARG_FLAG,
-    [_TIER2_RESUME_CHECK] = HAS_DEOPT_FLAG,
+    [_TIER2_RESUME_CHECK] = HAS_DEOPT_FLAG | HAS_ERROR_FLAG | HAS_ESCAPES_FLAG,
 };
 
 const uint8_t _PyUop_Replication[MAX_UOP_ID+1] = {

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-26-15-17-29.gh-issue-134728.YUJYfF.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-26-15-17-29.gh-issue-134728.YUJYfF.rst
@@ -1,0 +1,1 @@
+Handle ``_TIER2_RESUME_CHECK`` in the JIT.

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5392,8 +5392,6 @@ dummy_func(
             GOTO_TIER_ONE(NULL);
         }
 
-        /* Progress is guaranteed if we DEOPT on the eval breaker, because
-         * ENTER_EXECUTOR will not re-enter tier 2 with the eval breaker set. */
         tier2 op(_TIER2_RESUME_CHECK, (--)) {
 #if defined(__EMSCRIPTEN__)
             DEOPT_IF(_Py_emscripten_signal_clock == 0);

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -5400,7 +5400,10 @@ dummy_func(
             _Py_emscripten_signal_clock -= Py_EMSCRIPTEN_SIGNAL_HANDLING;
 #endif
             uintptr_t eval_breaker = _Py_atomic_load_uintptr_relaxed(&tstate->eval_breaker);
-            DEOPT_IF(eval_breaker & _PY_EVAL_EVENTS_MASK);
+            if (eval_breaker & _PY_EVAL_EVENTS_MASK) {
+                int err = _Py_HandlePending(tstate);
+                ERROR_IF(err != 0);
+            }
             assert(tstate->tracing || eval_breaker == FT_ATOMIC_LOAD_UINTPTR_ACQUIRE(_PyFrame_GetCode(frame)->_co_instrumentation_version));
         }
 

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -7303,8 +7303,12 @@
             #endif
             uintptr_t eval_breaker = _Py_atomic_load_uintptr_relaxed(&tstate->eval_breaker);
             if (eval_breaker & _PY_EVAL_EVENTS_MASK) {
-                UOP_STAT_INC(uopcode, miss);
-                JUMP_TO_JUMP_TARGET();
+                _PyFrame_SetStackPointer(frame, stack_pointer);
+                int err = _Py_HandlePending(tstate);
+                stack_pointer = _PyFrame_GetStackPointer(frame);
+                if (err != 0) {
+                    JUMP_TO_ERROR();
+                }
             }
             assert(tstate->tracing || eval_breaker == FT_ATOMIC_LOAD_UINTPTR_ACQUIRE(_PyFrame_GetCode(frame)->_co_instrumentation_version));
             break;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
On this benchmark (unscientific, noisy) https://gricad-gitlab.univ-grenoble-alpes.fr/augierpi/augierpi.gricad-pages.univ-grenoble-alpes.fr/-/blob/branch/default/content/docs/2025/about-py-jit/bench_loops_sum.py, I get the following results:

```
Before:
Number of long_calcul per second: 76.45 ± 1.19

After:
Number of long_calcul per second: 83.88 ± 10.10
```

So nearly a 10% improvement!

<!-- gh-issue-number: gh-134728 -->
* Issue: gh-134728
<!-- /gh-issue-number -->
