### PR TITLE
ast docs: Fix description of ast.Constant

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -268,9 +268,9 @@ Literals
 .. class:: Constant(value)
 
    A constant value. The ``value`` attribute of the ``Constant`` literal contains the
-   Python object it represents. The values represented can be simple types
-   such as a number, string or ``None``, but also immutable container types
-   (tuples and frozensets) if all of their elements are constant.
+   Python object it represents. The values represented can be instances of :class:`str`,
+   :class:`bytes`, :class:`int`, :class:`float`, :class:`complex`, and :class:`bool`,
+   and the constants :data:`None` and :data:`Ellipsis`.
 
    .. doctest::
 


### PR DESCRIPTION
Contrary to the current docs, ast.Constant will never hold containers
such as frozenset or tuple; the Python parser only emits it for simple
literals.

For precision, add the exact list of types that may be contained in an
ast.Constant.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134741.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->