### PR TITLE
gh-134664: Document cleanup_socket parameter in asyncio.start_unix_server()

### DIFF
--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -203,7 +203,7 @@ and work with streams:
       Added the *ssl_shutdown_timeout* parameter.
 
    .. versionchanged:: 3.13
-      Added the *cleanup_socket* parameter with a default value of ``True``.
+      Added the *cleanup_socket* parameter.
 
 
 StreamReader

--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -171,12 +171,16 @@ and work with streams:
 .. function:: start_unix_server(client_connected_cb, path=None, \
                  *, limit=None, sock=None, backlog=100, ssl=None, \
                  ssl_handshake_timeout=None, \
-                 ssl_shutdown_timeout=None, start_serving=True)
+                 ssl_shutdown_timeout=None, start_serving=True, cleanup_socket=True)
    :async:
 
    Start a Unix socket server.
 
    Similar to :func:`start_server` but works with Unix sockets.
+
+   If *cleanup_socket* is true then the Unix socket will automatically
+   be removed from the filesystem when the server is closed, unless the
+   socket has been replaced after the server has been created.
 
    See also the documentation of :meth:`loop.create_unix_server`.
 
@@ -197,6 +201,9 @@ and work with streams:
 
    .. versionchanged:: 3.11
       Added the *ssl_shutdown_timeout* parameter.
+
+   .. versionchanged:: 3.13
+      Added the *cleanup_socket* parameter with a default value of ``True``.
 
 
 StreamReader


### PR DESCRIPTION
## Summary

This PR adds documentation for the `cleanup_socket` parameter in `asyncio.start_unix_server()` function, which was added in Python 3.13 with a default value of `True`. This parameter controls whether the Unix socket is automatically removed from the filesystem when the server is closed.

## Details

In Python 3.13, a feature was added where Unix sockets are automatically cleaned up by default when using `asyncio.start_unix_server()`. This was considered a breaking change, but it wasn't properly documented at the time of implementation.

This PR:
- Adds the `cleanup_socket` parameter to the function signature in the documentation
- Adds a description of what the parameter does
- Adds a version note indicating this was added in Python 3.13

## Related Issues

Closes #134664
Related to #133354

<!-- gh-issue-number: gh-134664 -->
* Issue: gh-134664
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134750.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->