### PR TITLE
gh-134639: Clarify what "canonical" means in os.path.realpath

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -403,10 +403,18 @@ the :mod:`glob` module.)
 
 .. function:: realpath(path, *, strict=False)
 
-   Return the canonical path of the specified filename, eliminating any symbolic
-   links encountered in the path (if they are supported by the operating
-   system). On Windows, this function will also resolve MS-DOS (also called 8.3)
-   style names such as ``C:\\PROGRA~1`` to ``C:\\Program Files``.
+   Return the canonical path of the specified filename. A canonical path:
+
+   * Is an absolute path (always starts from the root of the filesystem)
+   * Has all symbolic links resolved (if supported by the operating system)
+   * Is normalized (redundant separators, ``.`` and ``..`` components are removed)
+
+   On Windows, this function will also resolve MS-DOS (also called 8.3)
+   style names such as ``C:\\PROGRA~1`` to ``C:\\Program Files`` and
+   will resolve junction points.
+
+   On POSIX systems, this function is roughly equivalent to the system's
+   ``realpath()`` function.
 
    If a path doesn't exist or a symlink loop is encountered, and *strict* is
    ``True``, :exc:`OSError` is raised. If *strict* is ``False`` these errors


### PR DESCRIPTION
## Summary

This PR improves the documentation for `os.path.realpath` by clearly defining what a "canonical path" means. The current documentation only mentions symlink resolution but doesn't explain other aspects of canonicalization.

## Details

The updated documentation now explicitly states that a canonical path:
- Is an absolute path (always starts from the root of the filesystem)
- Has all symbolic links resolved (if supported by the operating system)
- Is normalized (redundant separators, '.' and '..' components removed)

It also clarifies platform-specific behavior:
- On Windows: resolves MS-DOS (8.3) style names and junction points
- On POSIX: roughly equivalent to the system's realpath() function

## Related Issues

Closes #134639
Related to #134639

<!-- gh-issue-number: gh-134639 -->
* Issue: gh-134639
<!-- /gh-issue-number -->



<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134755.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->