### PR TITLE
gh-133503: Update `compileall.rst`'s documentation of `-s` and `-p` for clarity, 

### DIFF
--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -56,18 +56,18 @@ compile Python sources.
    executed.
 
 .. option:: -s strip_prefix
+
+.. warning::
+   Removing the prefix makes paths relative to it.
+
 .. option:: -p prepend_prefix
 
    Remove (``-s``) or append (``-p``) the given prefix of paths
    recorded in the ``.pyc`` files.
    Cannot be combined with ``-d``.
 
-.. warning::
-   Removing the prefix makes paths relative to it.
-
-.. note::
-   - ``-s`` and ``-p`` can be used simultaneously.
-   - ``-p /`` can be used to make the path absolute.
+   ``-s`` and ``-p`` can be used simultaneously.
+   ``-p /`` can be used to make the path absolute.
 
 .. option:: -x regex
 

--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -57,16 +57,17 @@ compile Python sources.
 
 .. option:: -s strip_prefix
 
-   Removing the prefix makes paths relative to it.
-   You can remove (``s``) the given prefix of paths recorded in the ``.pyc`` files.
-   Can be used with ``p``
+   Remove the given prefix from paths recorded in the ``.pyc`` files.
+   Paths are made relative to the prefix.
+
+   This option can be used with ``-p`` but not with ``-d``.
 
 .. option:: -p prepend_prefix
 
-   You can append (``-p``) the given prefix of paths recorded in the ``.pyc`` files.
-   Cannot be combined with ``-d``.
-   Can be used with ``s``
-   ``-p /`` can be used to make the path absolute.
+   Append the given prefix to paths recorded in the ``.pyc`` files.
+   Use ``-p /`` to make the paths absolute.
+
+   This option can be used with ``-s`` but not with ``-d``.
 
 .. option:: -x regex
 

--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -58,12 +58,12 @@ compile Python sources.
 .. option:: -s strip_prefix
 
    Removing the prefix makes paths relative to it.
+   You can remove (``s``) the given prefix of paths recorded in the ``.pyc`` files.
    Can be used with ``p``
 
 .. option:: -p prepend_prefix
 
-   Remove (``-s``) or append (``-p``) the given prefix of paths
-   recorded in the ``.pyc`` files.
+   You can append (``-p``) the given prefix of paths recorded in the ``.pyc`` files.
    Cannot be combined with ``-d``.
    Can be used with ``s``
    ``-p /`` can be used to make the path absolute.

--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -57,16 +57,15 @@ compile Python sources.
 
 .. option:: -s strip_prefix
 
-.. warning::
    Removing the prefix makes paths relative to it.
+   Can be used with ``p``
 
 .. option:: -p prepend_prefix
 
    Remove (``-s``) or append (``-p``) the given prefix of paths
    recorded in the ``.pyc`` files.
    Cannot be combined with ``-d``.
-
-   ``-s`` and ``-p`` can be used simultaneously.
+   Can be used with ``s``
    ``-p /`` can be used to make the path absolute.
 
 .. option:: -x regex

--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -64,7 +64,7 @@ compile Python sources.
 
 .. option:: -p prepend_prefix
 
-   Append the given prefix to paths recorded in the ``.pyc`` files.
+   Prepend the given prefix to paths recorded in the ``.pyc`` files.
    Use ``-p /`` to make the paths absolute.
 
    This option can be used with ``-s`` but not with ``-d``.

--- a/Doc/library/compileall.rst
+++ b/Doc/library/compileall.rst
@@ -62,6 +62,13 @@ compile Python sources.
    recorded in the ``.pyc`` files.
    Cannot be combined with ``-d``.
 
+.. warning::
+   Removing the prefix makes paths relative to it.
+
+.. note::
+   - ``-s`` and ``-p`` can be used simultaneously.
+   - ``-p /`` can be used to make the path absolute.
+
 .. option:: -x regex
 
    regex is used to search the full path to each file considered for


### PR DESCRIPTION
This will close #133503 

This PR simple updates ``compileall.rst`` to alert users to these following risks as stated by @mgorny 

Removing the prefix makes paths relative to it.
-s and -p can be used simultaneously.
-p / can be used to make the path absolute.

<!-- gh-issue-number: gh-133503 -->
* Issue: gh-133503
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134756.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->