### PR TITLE
gh-132775: Always Set __builtins__ In _PyFunction_FromXIData()

### DIFF
--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -705,6 +705,7 @@ _PyFunction_FromXIData(_PyXIData_t *xidata)
     if (PyDict_SetItemString(globals, "__builtins__",
                              tstate->interp->builtins) < 0)
     {
+        Py_DECREF(code);
         Py_DECREF(globals);
         return NULL;
     }

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -701,6 +701,13 @@ _PyFunction_FromXIData(_PyXIData_t *xidata)
         Py_DECREF(code);
         return NULL;
     }
+    PyThreadState *tstate = _PyThreadState_GET();
+    if (PyDict_SetItemString(globals, "__builtins__",
+                             tstate->interp->builtins) < 0)
+    {
+        Py_DECREF(globals);
+        return NULL;
+    }
     PyObject *func = PyFunction_New(code, globals);
     Py_DECREF(code);
     Py_DECREF(globals);

--- a/Python/crossinterp_data_lookup.h
+++ b/Python/crossinterp_data_lookup.h
@@ -702,8 +702,8 @@ _PyFunction_FromXIData(_PyXIData_t *xidata)
         return NULL;
     }
     PyThreadState *tstate = _PyThreadState_GET();
-    if (PyDict_SetItemString(globals, "__builtins__",
-                             tstate->interp->builtins) < 0)
+    if (PyDict_SetItem(globals, &_Py_ID(__builtins__),
+                       tstate->interp->builtins) < 0)
     {
         Py_DECREF(code);
         Py_DECREF(globals);


### PR DESCRIPTION
This is a small follow-up to gh-133481.  There's a corner case in the behavior of `PyImport_ImportModuleAttrString()` where it expects `__builtins__` to be set if `__globals__` is set.

<!-- gh-issue-number: gh-132775 -->
* Issue: gh-132775
<!-- /gh-issue-number -->
