### PR TITLE
gh-134761: Use deferred reference counting for `threading` concurrency primitives

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -290,26 +290,6 @@ always available. Unless explicitly noted otherwise, all variables are read-only
       This function is specific to CPython.  The exact output format is not
       defined here, and may change.
 
-.. function:: _defer_refcount(op)
-
-   Enable deferred reference counting on *op*, mitigating reference count
-   contention on :term:`free threaded <free threading>` builds of Python.
-
-   Return :const:`True` if deferred reference counting was enabled on *op*,
-   and :const:`False` otherwise.
-
-   .. versionadded:: next
-
-   .. impl-detail::
-
-      This function should be used for specialized purposes only.
-      It is not guaranteed to exist in all implementations of Python.
-
-   .. seealso::
-
-      :c:func:`PyUnstable_Object_EnableDeferredRefcount`
-
-
 .. data:: dllhandle
 
    Integer specifying the handle of the Python DLL.

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -290,6 +290,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
       This function is specific to CPython.  The exact output format is not
       defined here, and may change.
 
+
 .. data:: dllhandle
 
    Integer specifying the handle of the Python DLL.

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -290,6 +290,25 @@ always available. Unless explicitly noted otherwise, all variables are read-only
       This function is specific to CPython.  The exact output format is not
       defined here, and may change.
 
+.. function:: _defer_refcount(op)
+
+   Enable deferred reference counting on *op*, mitigating reference count
+   contention on :term:`free threaded <free threading>` builds of Python.
+
+   Return :const:`True` if deferred reference counting was enabled on *op*,
+   and :const:`False` otherwise.
+
+   .. versionadded:: next
+
+   .. impl-detail::
+
+      This function should be used for specialized purposes only.
+      It is not guaranteed to exist in all implementations of Python.
+
+   .. seealso::
+
+      :c:func:`PyUnstable_Object_EnableDeferredRefcount`
+
 
 .. data:: dllhandle
 

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1343,6 +1343,25 @@ class SysModuleTest(unittest.TestCase):
     def test_disable_gil_abi(self):
         self.assertEqual('t' in sys.abiflags, support.Py_GIL_DISABLED)
 
+    @test.support.cpython_only
+    @unittest.skipUnless(hasattr(sys, '_defer_refcount'), "requires _defer_refcount()")
+    def test_defer_refcount(self):
+        _testinternalcapi = import_helper.import_module('_testinternalcapi')
+
+        class Test:
+            pass
+
+        ref = Test()
+        if support.Py_GIL_DISABLED:
+            self.assertTrue(sys._defer_refcount(ref))
+            self.assertTrue(_testinternalcapi.has_deferred_refcount(ref))
+            self.assertFalse(sys._defer_refcount(ref))
+            self.assertFalse(sys._defer_refcount(42))
+        else:
+            self.assertFalse(sys._defer_refcount(ref))
+            self.assertFalse(_testinternalcapi.has_deferred_refcount(ref))
+            self.assertFalse(sys._defer_refcount(42))
+
 
 @test.support.cpython_only
 class UnraisableHookTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2025-05-26-19-49-16.gh-issue-134761.LeMefI.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-26-19-49-16.gh-issue-134761.LeMefI.rst
@@ -1,0 +1,2 @@
+Improve performance when using :mod:`threading` primitives across multiple
+threads.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -950,6 +950,7 @@ lock_new_impl(PyTypeObject *type)
     if (self == NULL) {
         return NULL;
     }
+    _PyObject_SetDeferredRefcount((PyObject *)self);
     self->lock = (PyMutex){0};
     return (PyObject *)self;
 }
@@ -1221,6 +1222,7 @@ rlock_new_impl(PyTypeObject *type)
     if (self == NULL) {
         return NULL;
     }
+    _PyObject_SetDeferredRefcount((PyObject *)self);
     self->lock = (_PyRecursiveMutex){0};
     return (PyObject *) self;
 }

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -950,8 +950,8 @@ lock_new_impl(PyTypeObject *type)
     if (self == NULL) {
         return NULL;
     }
-    _PyObject_SetDeferredRefcount((PyObject *)self);
     self->lock = (PyMutex){0};
+    _PyObject_SetDeferredRefcount((PyObject *)self);
     return (PyObject *)self;
 }
 
@@ -1222,8 +1222,8 @@ rlock_new_impl(PyTypeObject *type)
     if (self == NULL) {
         return NULL;
     }
-    _PyObject_SetDeferredRefcount((PyObject *)self);
     self->lock = (_PyRecursiveMutex){0};
+    _PyObject_SetDeferredRefcount((PyObject *)self);
     return (PyObject *) self;
 }
 

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -1821,6 +1821,36 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(sys__defer_refcount__doc__,
+"_defer_refcount($module, op, /)\n"
+"--\n"
+"\n"
+"Defer reference counting for the object, allowing for better scaling across multiple threads.\n"
+"\n"
+"This function should be used for specialized purposes only.");
+
+#define SYS__DEFER_REFCOUNT_METHODDEF    \
+    {"_defer_refcount", (PyCFunction)sys__defer_refcount, METH_O, sys__defer_refcount__doc__},
+
+static int
+sys__defer_refcount_impl(PyObject *module, PyObject *op);
+
+static PyObject *
+sys__defer_refcount(PyObject *module, PyObject *op)
+{
+    PyObject *return_value = NULL;
+    int _return_value;
+
+    _return_value = sys__defer_refcount_impl(module, op);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyBool_FromLong((long)_return_value);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_jit_is_available__doc__,
 "is_available($module, /)\n"
 "--\n"
@@ -1948,4 +1978,4 @@ exit:
 #ifndef SYS_GETANDROIDAPILEVEL_METHODDEF
     #define SYS_GETANDROIDAPILEVEL_METHODDEF
 #endif /* !defined(SYS_GETANDROIDAPILEVEL_METHODDEF) */
-/*[clinic end generated code: output=449d16326e69dcf6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e84ea46c0ecf9fa3 input=a9049054013a1b77]*/

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -15,6 +15,7 @@ Data members:
 */
 
 #include "Python.h"
+#include "object.h"
 #include "pycore_audit.h"         // _Py_AuditHookEntry
 #include "pycore_call.h"          // _PyObject_CallNoArgs()
 #include "pycore_ceval.h"         // _PyEval_SetAsyncGenFinalizer()
@@ -2653,6 +2654,23 @@ sys__is_gil_enabled_impl(PyObject *module)
 #endif
 }
 
+/*[clinic input]
+sys._defer_refcount -> bool
+
+  op: object
+  /
+
+Defer reference counting for the object, allowing for better scaling across multiple threads.
+
+This function should be used for specialized purposes only.
+[clinic start generated code]*/
+
+static int
+sys__defer_refcount_impl(PyObject *module, PyObject *op)
+/*[clinic end generated code: output=3b965122056085f5 input=a081971a76c49e64]*/
+{
+    return PyUnstable_Object_EnableDeferredRefcount(op);
+}
 
 #ifndef MS_WINDOWS
 static PerfMapState perf_map_state;
@@ -2834,6 +2852,7 @@ static PyMethodDef sys_methods[] = {
     SYS__GET_CPU_COUNT_CONFIG_METHODDEF
     SYS__IS_GIL_ENABLED_METHODDEF
     SYS__DUMP_TRACELETS_METHODDEF
+    SYS__DEFER_REFCOUNT_METHODDEF
     {NULL, NULL}  // sentinel
 };
 


### PR DESCRIPTION
This scales much better. Using this script:

```py
import threading
import time

lock = threading.Lock()

def scale():
    a = time.perf_counter()
    for _ in range(10000000):
        lock.locked()
    b = time.perf_counter()
    print(b - a, "s")

threads = [threading.Thread(target=scale) for _ in range(8)]
for thread in threads:
    thread.start()
```

With this applied, I see similar performance to if `lock` was a local variable:

```
0.3701289139999062 s
0.40727080300075613 s
0.41241479399923264 s
0.4155945310003517 s
0.44201267799962807 s
0.4484649369996987 s
0.4601175060006426 s
0.46210344200062536 s
```

Prior to this change, I see:

```
3.425866439999936 s
3.5953266010001244 s
3.6094701500001065 s
3.667731437000157 s
4.458146230000011 s
4.466017671000145 s
4.499206339000011 s
4.50090869099995 s
```

<!-- gh-issue-number: gh-134761 -->
* Issue: gh-134761
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134762.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->