### PR TITLE
GH-134160: Prefer multi-phase initialisation in docs

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -296,7 +296,12 @@ instance must be initialized with the following function:
    .. versionadded:: 3.5
 
 The *m_slots* member of the module definition must point to an array of
-``PyModuleDef_Slot`` structures:
+:c:type:`PyModuleDef_Slot` structures, terminated by a slot with id 0.
+
+See :PEP:`489` for more details on multi-phase initialization.
+
+Module slots
+............
 
 .. c:type:: PyModuleDef_Slot
 
@@ -309,8 +314,6 @@ The *m_slots* member of the module definition must point to an array of
       Value of the slot, whose meaning depends on the slot ID.
 
    .. versionadded:: 3.5
-
-The *m_slots* array must be terminated by a slot with id 0.
 
 The available slot types are:
 
@@ -421,8 +424,6 @@ The available slot types are:
    ``Py_MOD_GIL_USED``.
 
    .. versionadded:: 3.13
-
-See :PEP:`489` for more details on multi-phase initialization.
 
 .. _single-phase-initialization:
 

--- a/Doc/howto/free-threading-extensions.rst
+++ b/Doc/howto/free-threading-extensions.rst
@@ -50,7 +50,7 @@ Extensions that use multi-phase initialization (i.e.,
 module definition.  If your extension supports older versions of CPython,
 you should guard the slot with a :c:data:`PY_VERSION_HEX` check.
 
-::
+.. code-block:: c
 
     static struct PyModuleDef_Slot module_slots[] = {
         ...
@@ -70,13 +70,17 @@ you should guard the slot with a :c:data:`PY_VERSION_HEX` check.
 Single-Phase Initialization
 ...........................
 
-Extensions that use single-phase initialization (i.e.,
+Extensions that use legacy single-phase initialization (i.e.,
 :c:func:`PyModule_Create`) should call :c:func:`PyUnstable_Module_SetGIL` to
 indicate that they support running with the GIL disabled.  The function is
 only defined in the free-threaded build, so you should guard the call with
 ``#ifdef Py_GIL_DISABLED`` to avoid compilation errors in the regular build.
 
-::
+Note that this function is part of the :pep:`unstable C API <689>`, meaning
+that it may change without warning between minor releases. Where possible,
+prefer using multi-phase initialization with the ``Py_mod_gil`` slot.
+
+.. code-block:: c
 
     static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,


### PR DESCRIPTION
Follows from #134296.

A

<!-- gh-issue-number: gh-134160 -->
* Issue: gh-134160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134764.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->