### PR TITLE
gh-134583: Update devcontainer reference to include image with libzstd-devel

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "ghcr.io/python/devcontainer:2024.09.25.11038928730",
+    "image": "ghcr.io/python/devcontainer:2025.05.25.15232270922",
     "onCreateCommand": [
         // Install common tooling.
         "dnf",


### PR DESCRIPTION
Updates the reference to the devcontainer image to include the new release containing libzstd-devel.

* Issue: gh-134583