### PR TITLE
gh-134768: Fix definition of `mt_continue_should_break()`

### DIFF
--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -489,7 +489,7 @@ error:
     return NULL;
 }
 
-#ifdef Py_DEBUG
+#ifndef NDEBUG
 static inline int
 mt_continue_should_break(ZSTD_inBuffer *in, ZSTD_outBuffer *out)
 {


### PR DESCRIPTION
In 121ed71f4e395948d313249b2ad33e1e21581f8a, mt_continue_should_break was changed to be guarded by `Py_DEBUG`, but it's used in `compress_mt_continue_lock_held` with just `assert`, so it needs to be available when `NDEBUG` is undefined too.

`Py_DEBUG` implies `NDEBUG` is undefined, so we can check just that.

Fixes: 121ed71f4e395948d313249b2ad33e1e21581f8a


<!-- gh-issue-number: gh-134768 -->
* Issue: gh-134768
<!-- /gh-issue-number -->
