### PR TITLE
gh-134771: Fix time_clockid_converter() on Cygwin.

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-05-26-22-18-32.gh-issue-134771.RKXpLT.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-26-22-18-32.gh-issue-134771.RKXpLT.rst
@@ -1,0 +1,2 @@
+The ``time_clockid_converter()`` function now selects correct type for
+``clockid_t`` on Cygwin which fixes a build error.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -187,7 +187,7 @@ time_clockid_converter(PyObject *obj, clockid_t *p)
 {
 #ifdef _AIX
     long long clk_id = PyLong_AsLongLong(obj);
-#elif defined(__DragonFly__)
+#elif defined(__DragonFly__) || defined(__CYGWIN__)
     long clk_id = PyLong_AsLong(obj);
 #else
     int clk_id = PyLong_AsInt(obj);


### PR DESCRIPTION
Use long for clockid_t instead of int.


<!-- gh-issue-number: gh-134771 -->
* Issue: gh-134771
<!-- /gh-issue-number -->
