### PR TITLE
gh-134160: Block multiple module initialization

### DIFF
--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -214,10 +214,10 @@ and initialize it by calling :c:func:`PyErr_NewException` in the module's
 
    SpamError = PyErr_NewException("spam.error", NULL, NULL);
 
-Since :c:data:`!SpamError` is a global variable, each call to the
-:c:data:`Py_mod_exec` function would overwrite it.
-For now, let's avoid the issue:
-we will block repeated initialization by raising an
+Since :c:data:`!SpamError` is a global variable, it will be overwitten every time
+the module is reinitialized, when the :c:data:`Py_mod_exec` function is called.
+
+For now, let's avoid the issue: we will block repeated initialization by raising an
 :py:exc:`ImportError`::
 
    static PyObject *SpamError = NULL;
@@ -269,8 +269,8 @@ become a dangling pointer. Should it become a dangling pointer, C code which
 raises the exception could cause a core dump or other unintended side effects.
 
 For now, the :c:func:`Py_DECREF` call to remove this reference is missing.
-Even when the Python interpreter shuts down, :c:data:`!SpamError` will not be
-garbage-collected. It will "leak".
+Even when the Python interpreter shuts down, the global :c:data:`!SpamError`
+variable will not be garbage-collected. It will "leak".
 We did, however, ensure that this will happen at most once per process.
 
 We discuss the use of :c:macro:`PyMODINIT_FUNC` as a function return type later in this

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -216,7 +216,7 @@ and initialize it by calling :c:func:`PyErr_NewException` in the module's
 
 Since :c:data:`!SpamError` is a global variable, each call to the
 :c:data:`Py_mod_exec` function would overwrite it.
-It is not very common to load multiple copies of a module, so for now,
+For now, let's avoid the issue:
 we will block repeated initialization by raising an
 :py:exc:`ImportError`::
 

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -268,7 +268,7 @@ needed to ensure that it will not be discarded, causing :c:data:`!SpamError` to
 become a dangling pointer. Should it become a dangling pointer, C code which
 raises the exception could cause a core dump or other unintended side effects.
 
-Also note that there is no :c:func:`Py_DECREF` call to remove this reference.
+For now, the :c:func:`Py_DECREF` call to remove this reference is missing.
 Even when the Python interpreter shuts down, :c:data:`!SpamError` will not be
 garbage-collected. It will "leak".
 We did, however, ensure that this will happen at most once per process.

--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -204,17 +204,32 @@ value must be in a particular range or must satisfy other conditions,
 :c:data:`PyExc_ValueError` is appropriate.
 
 You can also define a new exception that is unique to your module.
-For this, you can declare a static global object variable at the beginning
-of the file::
+The simplest way to do this is to declare a static global object variable at
+the beginning of the file::
 
-   static PyObject *SpamError;
+   static PyObject *SpamError = NULL;
 
-and initialize it with an exception object in the module's
+and initialize it by calling :c:func:`PyErr_NewException` in the module's
 :c:data:`Py_mod_exec` function (:c:func:`!spam_module_exec`)::
+
+   SpamError = PyErr_NewException("spam.error", NULL, NULL);
+
+Since :c:data:`!SpamError` is a global variable, each call to the
+:c:data:`Py_mod_exec` function would overwrite it.
+It is not very common to load multiple copies of a module, so for now,
+we will block repeated initialization by raising an
+:py:exc:`ImportError`::
+
+   static PyObject *SpamError = NULL;
 
    static int
    spam_module_exec(PyObject *m)
    {
+       if (SpamError != NULL) {
+           PyErr_SetString(PyExc_ImportError,
+                           "cannot initialize spam module more than once");
+           return -1;
+       }
        SpamError = PyErr_NewException("spam.error", NULL, NULL);
        if (PyModule_AddObjectRef(m, "SpamError", SpamError) < 0) {
            return -1;
@@ -252,6 +267,11 @@ removed from the module by external code, an owned reference to the class is
 needed to ensure that it will not be discarded, causing :c:data:`!SpamError` to
 become a dangling pointer. Should it become a dangling pointer, C code which
 raises the exception could cause a core dump or other unintended side effects.
+
+Also note that there is no :c:func:`Py_DECREF` call to remove this reference.
+Even when the Python interpreter shuts down, :c:data:`!SpamError` will not be
+garbage-collected. It will "leak".
+We did, however, ensure that this will happen at most once per process.
 
 We discuss the use of :c:macro:`PyMODINIT_FUNC` as a function return type later in this
 sample.


### PR DESCRIPTION
Change the tutorial to block multiple module initialization, and note the reference leak.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134160 -->
* Issue: gh-134160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134773.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->