### PR TITLE
gh-62824: Adjust test_alias_modules_exist test to allow .pyc codec files

### DIFF
--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3114,7 +3114,7 @@ class TransformCodecTest(unittest.TestCase):
         for value in encodings.aliases.aliases.values():
             codec_mod = f"encodings.{value}"
             self.assertIsNotNone(importlib.util.find_spec(codec_mod),
-                                 "Codec module not found: " + codec_mod)
+                                 f"Codec module not found: {codec_mod}")
 
     def test_quopri_stateless(self):
         # Should encode with quotetabs=True

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -3112,7 +3112,9 @@ class TransformCodecTest(unittest.TestCase):
         encodings_dir = os.path.dirname(encodings.__file__)
         for value in encodings.aliases.aliases.values():
             codec_file = os.path.join(encodings_dir, value + ".py")
-            self.assertTrue(os.path.isfile(codec_file),
+            pyc_file = codec_file + "c"
+            self.assertTrue(os.path.isfile(codec_file)
+                            or os.path.isfile(pyc_file),
                             "Codec file not found: " + codec_file)
 
     def test_quopri_stateless(self):

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1,6 +1,7 @@
 import codecs
 import contextlib
 import copy
+import importlib
 import io
 import pickle
 import os
@@ -3111,11 +3112,9 @@ class TransformCodecTest(unittest.TestCase):
     def test_alias_modules_exist(self):
         encodings_dir = os.path.dirname(encodings.__file__)
         for value in encodings.aliases.aliases.values():
-            codec_file = os.path.join(encodings_dir, value + ".py")
-            pyc_file = codec_file + "c"
-            self.assertTrue(os.path.isfile(codec_file)
-                            or os.path.isfile(pyc_file),
-                            "Codec file not found: " + codec_file)
+            codec_mod = f"encodings.{value}"
+            self.assertIsNotNone(importlib.util.find_spec(codec_mod),
+                                 "Codec module not found: " + codec_mod)
 
     def test_quopri_stateless(self):
         # Should encode with quotetabs=True


### PR DESCRIPTION
In Fedora, we install many codecs as .pyc files to save space.

This test was failing when running from installed Python:

    ======================================================================
    FAIL: test_alias_modules_exist (test.test_codecs.TransformCodecTest.test_alias_modules_exist)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/usr/lib64/python3.14/test/test_codecs.py", line 3115, in test_alias_modules_exist
        self.assertTrue(os.path.isfile(codec_file),
        ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                        "Codec file not found: " + codec_file)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AssertionError: False is not true : Codec file not found: /usr/lib64/python3.14/encodings/cp037.py

    ----------------------------------------------------------------------

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-62824 -->
* Issue: gh-62824
<!-- /gh-issue-number -->
