### PR TITLE
[3.14] GH-128161: Remove redundant GET_ITER from list comprehension code

### DIFF
--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2290,6 +2290,7 @@ class CoroutineTest(unittest.TestCase):
 
         self.assertEqual(run_async(run()), ([], [1,2]))
 
+
 @unittest.skipIf(
     support.is_emscripten or support.is_wasi,
     "asyncio does not work under Emscripten/WASI yet."

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2265,6 +2265,30 @@ class CoroutineTest(unittest.TestCase):
         # before fixing, visible stack from throw would be shorter than from send.
         self.assertEqual(len_send, len_throw)
 
+    def test_call_aiter_once_in_comprehension(self):
+
+        class Iterator:
+
+            def __init__(self):
+                self.val = 0
+
+            async def __anext__(self):
+                if self.val == 2:
+                    raise StopAsyncIteration
+                self.val += 1
+                return self.val
+
+            # No __aiter__ method
+
+        class C:
+
+            def __aiter__(self):
+                return Iterator()
+
+        async def run():
+            return [i async for i in C()]
+
+        self.assertEqual(run_async(run()), ([], [1,2]))
 
 @unittest.skipIf(
     support.is_emscripten or support.is_wasi,

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -750,6 +750,28 @@ class ListComprehensionTest(unittest.TestCase):
                 self.assertEqual(f.line[f.colno - indent : f.end_colno - indent],
                                  expected)
 
+    def test_only_calls_dunder_iter_once(self):
+
+        class Iterator:
+
+            def __init__(self):
+                self.val = 0
+
+            def __next__(self):
+                if self.val == 2:
+                    raise StopIteration
+                self.val += 1
+                return self.val
+
+            # No __iter__ method
+
+        class C:
+
+            def __iter__(self):
+                return Iterator()
+
+        self.assertEqual([1,2], [i for i in C()])
+
 __test__ = {'doctests' : doctests}
 
 def load_tests(loader, tests, pattern):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-27-09-19-21.gh-issue-127682.9WwFrM.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-27-09-19-21.gh-issue-127682.9WwFrM.rst
@@ -1,0 +1,2 @@
+No longer call ``__iter__`` twice in list comprehensions. This brings the
+behavior of list comprehensions in line with other forms of iteration

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -4543,9 +4543,9 @@ codegen_async_comprehension_generator(compiler *c, location loc,
         else {
             /* Sub-iter - calculate on the fly */
             VISIT(c, expr, gen->iter);
-            ADDOP(c, LOC(gen->iter), GET_AITER);
         }
     }
+    ADDOP(c, LOC(gen->iter), GET_AITER);
 
     USE_LABEL(c, start);
     /* Runtime will push a block here, so we need to account for that */
@@ -4757,19 +4757,6 @@ pop_inlined_comprehension_state(compiler *c, location loc,
     return SUCCESS;
 }
 
-static inline int
-codegen_comprehension_iter(compiler *c, comprehension_ty comp)
-{
-    VISIT(c, expr, comp->iter);
-    if (comp->is_async) {
-        ADDOP(c, LOC(comp->iter), GET_AITER);
-    }
-    else {
-        ADDOP(c, LOC(comp->iter), GET_ITER);
-    }
-    return SUCCESS;
-}
-
 static int
 codegen_comprehension(compiler *c, expr_ty e, int type,
                       identifier name, asdl_comprehension_seq *generators, expr_ty elt,
@@ -4789,9 +4776,7 @@ codegen_comprehension(compiler *c, expr_ty e, int type,
 
     outermost = (comprehension_ty) asdl_seq_GET(generators, 0);
     if (is_inlined) {
-        if (codegen_comprehension_iter(c, outermost)) {
-            goto error;
-        }
+        VISIT(c, expr, outermost->iter);
         if (push_inlined_comprehension_state(c, loc, entry, &inline_state)) {
             goto error;
         }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128161 -->
* Issue: gh-128161
<!-- /gh-issue-number -->
