### PR TITLE
gh-134789: Document del s[i] operation for mutable sequences

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1214,6 +1214,8 @@ accepts integers that meet the value restriction ``0 <= x <= 255``).
 | ``s[i] = x``                 | item *i* of *s* is replaced by |                     |
 |                              | *x*                            |                     |
 +------------------------------+--------------------------------+---------------------+
+| ``del s[i]``                 | removes item *i* of *s*        |                     |
++------------------------------+--------------------------------+---------------------+
 | ``s[i:j] = t``               | slice of *s* from *i* to *j*   |                     |
 |                              | is replaced by the contents of |                     |
 |                              | the iterable *t*               |                     |


### PR DESCRIPTION
- Added explicit mention of `del s[i]` (item deletion by index) to the Mutable Sequence Types section.
- Clarified that this operation removes the item at the specified index from the sequence.


<!-- gh-issue-number: gh-134789 -->
* Issue: gh-134789
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134804.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->