### PR TITLE
gh-134679: Fix assertion failure in QSBR

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-27-18-59-54.gh-issue-134679.FWPBu6.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-27-18-59-54.gh-issue-134679.FWPBu6.rst
@@ -1,0 +1,2 @@
+Fix crash in the :term:`free threading` build's QSBR code that could occur
+when changing an object's ``__dict__`` attribute.


### PR DESCRIPTION
This is the same underlying bug as gh-130519. The destructor may call arbitrary code, changing the `tstate->qsbr` pointer and invalidating the old `_qsbr_thread_state`.


<!-- gh-issue-number: gh-134679 -->
* Issue: gh-134679
<!-- /gh-issue-number -->
