### PR TITLE
gh-132617: Fix `dict.update()` mutation check

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -290,6 +290,38 @@ class DictTest(unittest.TestCase):
             ['Cannot convert dictionary update sequence element #0 to a sequence'],
         )
 
+    def test_update_shared_keys(self):
+        class MyClass: pass
+
+        # Subclass str to enable us to create an object during the
+        # dict.update() call.
+        class MyStr(str):
+            def __hash__(self):
+                return super().__hash__()
+
+            def __eq__(self, other):
+                # Create an object that shares the same PyDictKeysObject as
+                # the dict
+                obj2 = MyClass()
+                obj2.a = "a"
+                obj2.b = "b"
+                obj2.c = "c"
+                return super().__eq__(other)
+
+        obj = MyClass()
+        obj.a = "a"
+        obj.b = "b"
+
+        x = {}
+        x[MyStr("a")] = MyStr("a")
+
+        # gh-132617: this previously raised "dict mutated during update" error
+        x.update(obj.__dict__)
+
+        self.assertEqual(x, {
+            MyStr("a"): "a",
+            "b": "b",
+        })
 
     def test_fromkeys(self):
         self.assertEqual(dict.fromkeys('abc'), {'a':None, 'b':None, 'c':None})

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -301,7 +301,7 @@ class DictTest(unittest.TestCase):
 
             def __eq__(self, other):
                 # Create an object that shares the same PyDictKeysObject as
-                # the dict
+                # the obj.__dict__.
                 obj2 = MyClass()
                 obj2.a = "a"
                 obj2.b = "b"

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -301,7 +301,7 @@ class DictTest(unittest.TestCase):
 
             def __eq__(self, other):
                 # Create an object that shares the same PyDictKeysObject as
-                # the obj.__dict__.
+                # obj.__dict__.
                 obj2 = MyClass()
                 obj2.a = "a"
                 obj2.b = "b"

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-27-20-29-00.gh-issue-132617.EmUfQQ.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-27-20-29-00.gh-issue-132617.EmUfQQ.rst
@@ -1,0 +1,3 @@
+Fix :meth:`dict.update` modification check that could incorrectly raise a
+"dict mutated during update" error when a different dictionary was modified
+that happens to share the same underlying keys object.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3858,7 +3858,7 @@ dict_dict_merge(PyInterpreterState *interp, PyDictObject *mp, PyDictObject *othe
         }
     }
 
-    Py_ssize_t orig_size = other->ma_keys->dk_nentries;
+    Py_ssize_t orig_size = other->ma_used;
     Py_ssize_t pos = 0;
     Py_hash_t hash;
     PyObject *key, *value;
@@ -3892,7 +3892,7 @@ dict_dict_merge(PyInterpreterState *interp, PyDictObject *mp, PyDictObject *othe
         if (err != 0)
             return -1;
 
-        if (orig_size != other->ma_keys->dk_nentries) {
+        if (orig_size != other->ma_used) {
             PyErr_SetString(PyExc_RuntimeError,
                     "dict mutated during update");
             return -1;


### PR DESCRIPTION
Use `ma_used` instead of `ma_keys->dk_nentries` for modification check so that we only check if the dictionary is modified, not if new keys are added to a different dictionary that shared the same keys object.


<!-- gh-issue-number: gh-132617 -->
* Issue: gh-132617
<!-- /gh-issue-number -->
