### PR TITLE
gh-134830: Fix reference in `Doc/extending/windows.rst`

### DIFF
--- a/Doc/c-api/stable.rst
+++ b/Doc/c-api/stable.rst
@@ -51,6 +51,7 @@ It is generally intended for specialized, low-level tools like debuggers.
 Projects that use this API are expected to follow
 CPython development and spend extra effort adjusting to changes.
 
+.. _stable-application-binary-interface:
 
 Stable Application Binary Interface
 ===================================

--- a/Doc/extending/windows.rst
+++ b/Doc/extending/windows.rst
@@ -121,7 +121,7 @@ When creating DLLs in Windows, you can use the CPython library in two ways:
    :file:`Python.h` triggers an implicit, configure-aware link with the
    library.  The header file chooses :file:`pythonXY_d.lib` for Debug,
    :file:`pythonXY.lib` for Release, and :file:`pythonX.lib` for Release with
-   the `Limited API <stable-application-binary-interface>`_ enabled.
+   the `Limited API <stable-abi>`_ enabled.
 
    To build two DLLs, spam and ni (which uses C functions found in spam), you
    could use these commands::

--- a/Doc/extending/windows.rst
+++ b/Doc/extending/windows.rst
@@ -121,7 +121,7 @@ When creating DLLs in Windows, you can use the CPython library in two ways:
    :file:`Python.h` triggers an implicit, configure-aware link with the
    library.  The header file chooses :file:`pythonXY_d.lib` for Debug,
    :file:`pythonXY.lib` for Release, and :file:`pythonX.lib` for Release with
-   the `Limited API <stable-abi>`_ enabled.
+   the :ref:`Limited API <stable-abi>`_ enabled.
 
    To build two DLLs, spam and ni (which uses C functions found in spam), you
    could use these commands::

--- a/Doc/extending/windows.rst
+++ b/Doc/extending/windows.rst
@@ -121,7 +121,7 @@ When creating DLLs in Windows, you can use the CPython library in two ways:
    :file:`Python.h` triggers an implicit, configure-aware link with the
    library.  The header file chooses :file:`pythonXY_d.lib` for Debug,
    :file:`pythonXY.lib` for Release, and :file:`pythonX.lib` for Release with
-   the :ref:`Limited API <stable-abi>` enabled.
+   the :ref:`Limited API <stable-application-binary-interface>` enabled.
 
    To build two DLLs, spam and ni (which uses C functions found in spam), you
    could use these commands::

--- a/Doc/extending/windows.rst
+++ b/Doc/extending/windows.rst
@@ -121,7 +121,7 @@ When creating DLLs in Windows, you can use the CPython library in two ways:
    :file:`Python.h` triggers an implicit, configure-aware link with the
    library.  The header file chooses :file:`pythonXY_d.lib` for Debug,
    :file:`pythonXY.lib` for Release, and :file:`pythonX.lib` for Release with
-   the :ref:`Limited API <stable-abi>`_ enabled.
+   the :ref:`Limited API <stable-abi>` enabled.
 
    To build two DLLs, spam and ni (which uses C functions found in spam), you
    could use these commands::


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
No other instances of this error in the docs.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134831.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-134830 -->
* Issue: gh-134830
<!-- /gh-issue-number -->
