### PR TITLE
gh-128840: Fix parsing long IPv6 addresses with embedded IPv4 address

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1660,10 +1660,12 @@ class _BaseV6:
         """
         if not ip_str:
             raise AddressValueError('Address cannot be empty')
-        if len(ip_str) > 39:
-            msg = ("At most 39 characters expected in "
-                   f"{ip_str[:14]!r}({len(ip_str)-28} chars elided){ip_str[-14:]!r}")
-            raise AddressValueError(msg)
+        if len(ip_str) > 45:
+            shorten = ip_str
+            if len(shorten) > 100:
+                shorten = f'{ip_str[:45]}({len(ip_str)-90} chars elided){ip_str[-45:]}'
+            raise AddressValueError(f"At most 45 characters expected in "
+                                    f"{shorten!r}")
 
         # We want to allow more parts than the max to be 'split'
         # to preserve the correct error message when there are

--- a/Misc/NEWS.d/next/Library/2025-05-28-15-53-27.gh-issue-128840.Nur2pB.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-28-15-53-27.gh-issue-128840.Nur2pB.rst
@@ -1,0 +1,1 @@
+Fix parsing long IPv6 addresses with embedded IPv4 address.


### PR DESCRIPTION


<!-- gh-issue-number: gh-128840 -->
* Issue: gh-128840
<!-- /gh-issue-number -->
