### PR TITLE
gh-133711: Fix test_regrtest for PYTHONUTF8=1

### DIFF
--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -874,7 +874,10 @@ class ProgramsTestCase(BaseTestCase):
         self.run_tests(args)
 
     def run_batch(self, *args):
-        proc = self.run_command(args)
+        proc = self.run_command(args,
+                                # gh-133711: cmd.exe uses the OEM code page
+                                # to display the non-ASCII current directory
+                                errors="backslashreplace")
         self.check_output(proc.stdout)
 
     @unittest.skipUnless(sysconfig.is_python_build(),


### PR DESCRIPTION
Use "backslashreplace" error handler to decode stdout and stderr. Example:

    vstinner@WIN C:\victor\python\main\build\test_python_worker_8360\x91>
    "C:\victor\python\main\PCbuild\amd64\python_d.exe"  -m test
    --fast-ci --slow-ci --testdir
    C:\Users\vstinner\AppData\Local\Temp\tmp0t59e8da
    test_regrtest_noop1 test_regrtest_noop2 test_regrtest_noop3
    test_regrtest_noop4

Notice the "\x91" byte at the end of the first line: it's the non-ASCII U+00E6 character encoded to the OEM cp437 code page.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133711 -->
* Issue: gh-133711
<!-- /gh-issue-number -->
