### PR TITLE
gh-134835: Remove outdated list from `howto/urllib2.rst`

### DIFF
--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -246,6 +246,27 @@ codes in the 400--599 range.
 
 :attr:`http.server.BaseHTTPRequestHandler.responses` is a useful dictionary of
 response codes that shows all the response codes used by :rfc:`2616`.
+An excerpt from the dictionary is shown below ::
+
+    responses = {
+        ...
+        <HTTPStatus.OK: 200>: ('OK', 'Request fulfilled, document follows'),
+        ...
+        <HTTPStatus.FORBIDDEN: 403>: ('Forbidden',
+                                      'Request forbidden -- authorization will '
+                                      'not help'),
+        <HTTPStatus.NOT_FOUND: 404>: ('Not Found',
+                                      'Nothing matches the given URI'),
+        ...
+        <HTTPStatus.IM_A_TEAPOT: 418>: ("I'm a Teapot",
+                                        'Server refuses to brew coffee because '
+                                        'it is a teapot'),
+        ...
+        <HTTPStatus.SERVICE_UNAVAILABLE: 503>: ('Service Unavailable',
+                                                'The server cannot process the '
+                                                'request due to a high load'),
+        ...
+        }
 
 When an error is raised the server responds by returning an HTTP error code
 *and* an error page. You can use the :exc:`~urllib.error.HTTPError` instance as a response on the

--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -245,76 +245,7 @@ codes in the 100--299 range indicate success, you will usually only see error
 codes in the 400--599 range.
 
 :attr:`http.server.BaseHTTPRequestHandler.responses` is a useful dictionary of
-response codes in that shows all the response codes used by :rfc:`2616`. The
-dictionary is reproduced here for convenience ::
-
-    # Table mapping response codes to messages; entries have the
-    # form {code: (shortmessage, longmessage)}.
-    responses = {
-        100: ('Continue', 'Request received, please continue'),
-        101: ('Switching Protocols',
-              'Switching to new protocol; obey Upgrade header'),
-
-        200: ('OK', 'Request fulfilled, document follows'),
-        201: ('Created', 'Document created, URL follows'),
-        202: ('Accepted',
-              'Request accepted, processing continues off-line'),
-        203: ('Non-Authoritative Information', 'Request fulfilled from cache'),
-        204: ('No Content', 'Request fulfilled, nothing follows'),
-        205: ('Reset Content', 'Clear input form for further input.'),
-        206: ('Partial Content', 'Partial content follows.'),
-
-        300: ('Multiple Choices',
-              'Object has several resources -- see URI list'),
-        301: ('Moved Permanently', 'Object moved permanently -- see URI list'),
-        302: ('Found', 'Object moved temporarily -- see URI list'),
-        303: ('See Other', 'Object moved -- see Method and URL list'),
-        304: ('Not Modified',
-              'Document has not changed since given time'),
-        305: ('Use Proxy',
-              'You must use proxy specified in Location to access this '
-              'resource.'),
-        307: ('Temporary Redirect',
-              'Object moved temporarily -- see URI list'),
-
-        400: ('Bad Request',
-              'Bad request syntax or unsupported method'),
-        401: ('Unauthorized',
-              'No permission -- see authorization schemes'),
-        402: ('Payment Required',
-              'No payment -- see charging schemes'),
-        403: ('Forbidden',
-              'Request forbidden -- authorization will not help'),
-        404: ('Not Found', 'Nothing matches the given URI'),
-        405: ('Method Not Allowed',
-              'Specified method is invalid for this server.'),
-        406: ('Not Acceptable', 'URI not available in preferred format.'),
-        407: ('Proxy Authentication Required', 'You must authenticate with '
-              'this proxy before proceeding.'),
-        408: ('Request Timeout', 'Request timed out; try again later.'),
-        409: ('Conflict', 'Request conflict.'),
-        410: ('Gone',
-              'URI no longer exists and has been permanently removed.'),
-        411: ('Length Required', 'Client must specify Content-Length.'),
-        412: ('Precondition Failed', 'Precondition in headers is false.'),
-        413: ('Request Entity Too Large', 'Entity is too large.'),
-        414: ('Request-URI Too Long', 'URI is too long.'),
-        415: ('Unsupported Media Type', 'Entity body in unsupported format.'),
-        416: ('Requested Range Not Satisfiable',
-              'Cannot satisfy request range.'),
-        417: ('Expectation Failed',
-              'Expect condition could not be satisfied.'),
-
-        500: ('Internal Server Error', 'Server got itself in trouble'),
-        501: ('Not Implemented',
-              'Server does not support this operation'),
-        502: ('Bad Gateway', 'Invalid responses from another server/proxy.'),
-        503: ('Service Unavailable',
-              'The server cannot process the request due to a high load'),
-        504: ('Gateway Timeout',
-              'The gateway server did not receive a timely response'),
-        505: ('HTTP Version Not Supported', 'Cannot fulfill request.'),
-        }
+response codes that shows all the response codes used by :rfc:`2616`.
 
 When an error is raised the server responds by returning an HTTP error code
 *and* an error page. You can use the :exc:`~urllib.error.HTTPError` instance as a response on the


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
The table is very different from what is returned now, and there is little point in updating it. Current return value for reference: 

```
{
<HTTPStatus.CONTINUE: 100>: ('Continue', 'Request received, please continue'), 
<HTTPStatus.SWITCHING_PROTOCOLS: 101>: ('Switching Protocols', 'Switching to new protocol; obey Upgrade header'), 
<HTTPStatus.PROCESSING: 102>: ('Processing', 'Server is processing the request'), 
<HTTPStatus.EARLY_HINTS: 103>: ('Early Hints', 'Headers sent to prepare for the response'), 

<HTTPStatus.OK: 200>: ('OK', 'Request fulfilled, document follows'), 
<HTTPStatus.CREATED: 201>: ('Created', 'Document created, URL follows'), 
<HTTPStatus.ACCEPTED: 202>: ('Accepted', 'Request accepted, processing continues off-line'), 
<HTTPStatus.NON_AUTHORITATIVE_INFORMATION: 203>: ('Non-Authoritative Information', 'Request fulfilled from cache'), 
<HTTPStatus.NO_CONTENT: 204>: ('No Content', 'Request fulfilled, nothing follows'), 
<HTTPStatus.RESET_CONTENT: 205>: ('Reset Content', 'Clear input form for further input'), 
<HTTPStatus.PARTIAL_CONTENT: 206>: ('Partial Content', 'Partial content follows'), 
<HTTPStatus.MULTI_STATUS: 207>: ('Multi-Status', 'Response contains multiple statuses in the body'), 
<HTTPStatus.ALREADY_REPORTED: 208>: ('Already Reported', 'Operation has already been reported'), 
<HTTPStatus.IM_USED: 226>: ('IM Used', 'Request completed using instance manipulations'), 

<HTTPStatus.MULTIPLE_CHOICES: 300>: ('Multiple Choices', 'Object has several resources -- see URI list'), 
<HTTPStatus.MOVED_PERMANENTLY: 301>: ('Moved Permanently', 'Object moved permanently -- see URI list'), 
<HTTPStatus.FOUND: 302>: ('Found', 'Object moved temporarily -- see URI list'), 
<HTTPStatus.SEE_OTHER: 303>: ('See Other', 'Object moved -- see Method and URL list'), 
<HTTPStatus.NOT_MODIFIED: 304>: ('Not Modified', 'Document has not changed since given time'), 
<HTTPStatus.USE_PROXY: 305>: ('Use Proxy', 'You must use proxy specified in Location to access this resource'), 
<HTTPStatus.TEMPORARY_REDIRECT: 307>: ('Temporary Redirect', 'Object moved temporarily -- see URI list'), 
<HTTPStatus.PERMANENT_REDIRECT: 308>: ('Permanent Redirect', 'Object moved permanently -- see URI list'), 

<HTTPStatus.BAD_REQUEST: 400>: ('Bad Request', 'Bad request syntax or unsupported method'), 
<HTTPStatus.UNAUTHORIZED: 401>: ('Unauthorized', 'No permission -- see authorization schemes'), 
<HTTPStatus.PAYMENT_REQUIRED: 402>: ('Payment Required', 'No payment -- see charging schemes'), 
<HTTPStatus.FORBIDDEN: 403>: ('Forbidden', 'Request forbidden -- authorization will not help'), 
<HTTPStatus.NOT_FOUND: 404>: ('Not Found', 'Nothing matches the given URI'), 
<HTTPStatus.METHOD_NOT_ALLOWED: 405>: ('Method Not Allowed', 'Specified method is invalid for this resource'), 
<HTTPStatus.NOT_ACCEPTABLE: 406>: ('Not Acceptable', 'URI not available in preferred format'), 
<HTTPStatus.PROXY_AUTHENTICATION_REQUIRED: 407>: ('Proxy Authentication Required', 'You must authenticate with this proxy before proceeding'), 
<HTTPStatus.REQUEST_TIMEOUT: 408>: ('Request Timeout', 'Request timed out; try again later'), 
<HTTPStatus.CONFLICT: 409>: ('Conflict', 'Request conflict'), 
<HTTPStatus.GONE: 410>: ('Gone', 'URI no longer exists and has been permanently removed'), 
<HTTPStatus.LENGTH_REQUIRED: 411>: ('Length Required', 'Client must specify Content-Length'), 
<HTTPStatus.PRECONDITION_FAILED: 412>: ('Precondition Failed', 'Precondition in headers is false'), 
<HTTPStatus.CONTENT_TOO_LARGE: 413>: ('Content Too Large', 'Content is too large'), 
<HTTPStatus.URI_TOO_LONG: 414>: ('URI Too Long', 'URI is too long'), 
<HTTPStatus.UNSUPPORTED_MEDIA_TYPE: 415>: ('Unsupported Media Type', 'Entity body in unsupported format'), 
<HTTPStatus.RANGE_NOT_SATISFIABLE: 416>: ('Range Not Satisfiable', 'Cannot satisfy request range'), 
<HTTPStatus.EXPECTATION_FAILED: 417>: ('Expectation Failed', 'Expect condition could not be satisfied'), 
<HTTPStatus.IM_A_TEAPOT: 418>: ("I'm a Teapot", 'Server refuses to brew coffee because it is a teapot'), 
<HTTPStatus.MISDIRECTED_REQUEST: 421>: ('Misdirected Request', 'Server is not able to produce a response'), 
<HTTPStatus.UNPROCESSABLE_CONTENT: 422>: ('Unprocessable Content', 'Server is not able to process the contained instructions'), 
<HTTPStatus.LOCKED: 423>: ('Locked', 'Resource of a method is locked'), 
<HTTPStatus.FAILED_DEPENDENCY: 424>: ('Failed Dependency', 'Dependent action of the request failed'), 
<HTTPStatus.TOO_EARLY: 425>: ('Too Early', 'Server refuses to process a request that might be replayed'), 
<HTTPStatus.UPGRADE_REQUIRED: 426>: ('Upgrade Required', 'Server refuses to perform the request using the current protocol'), 
<HTTPStatus.PRECONDITION_REQUIRED: 428>: ('Precondition Required', 'The origin server requires the request to be conditional'), 
<HTTPStatus.TOO_MANY_REQUESTS: 429>: ('Too Many Requests', 'The user has sent too many requests in a given amount of time ("rate limiting")'), 
<HTTPStatus.REQUEST_HEADER_FIELDS_TOO_LARGE: 431>: ('Request Header Fields Too Large', 'The server is unwilling to process the request because its header fields are too large'), 
<HTTPStatus.UNAVAILABLE_FOR_LEGAL_REASONS: 451>: ('Unavailable For Legal Reasons', 'The server is denying access to the resource as a consequence of a legal demand'), 

<HTTPStatus.INTERNAL_SERVER_ERROR: 500>: ('Internal Server Error', 'Server got itself in trouble'), 
<HTTPStatus.NOT_IMPLEMENTED: 501>: ('Not Implemented', 'Server does not support this operation'), 
<HTTPStatus.BAD_GATEWAY: 502>: ('Bad Gateway', 'Invalid responses from another server/proxy'), 
<HTTPStatus.SERVICE_UNAVAILABLE: 503>: ('Service Unavailable', 'The server cannot process the request due to a high load'), 
<HTTPStatus.GATEWAY_TIMEOUT: 504>: ('Gateway Timeout', 'The gateway server did not receive a timely response'), 
<HTTPStatus.HTTP_VERSION_NOT_SUPPORTED: 505>: ('HTTP Version Not Supported', 'Cannot fulfill request'), 
<HTTPStatus.VARIANT_ALSO_NEGOTIATES: 506>: ('Variant Also Negotiates', 'Server has an internal configuration error'), 
<HTTPStatus.INSUFFICIENT_STORAGE: 507>: ('Insufficient Storage', 'Server is not able to store the representation'), 
<HTTPStatus.LOOP_DETECTED: 508>: ('Loop Detected', 'Server encountered an infinite loop while processing a request'), 
<HTTPStatus.NOT_EXTENDED: 510>: ('Not Extended', 'Request does not meet the resource access policy'), 
<HTTPStatus.NETWORK_AUTHENTICATION_REQUIRED: 511>: ('Network Authentication Required', 'The client needs to authenticate to gain network access')
}
```
Also corrected typo in existing line.

<!-- gh-issue-number: gh-134835 -->
* Issue: gh-134835
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134844.org.readthedocs.build/en/134844/howto/urllib2.html#urllib-howto

<!-- readthedocs-preview cpython-previews end -->