### PR TITLE
Improved error message for metaclass incompatibility

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -878,7 +878,7 @@ static inline int _PyType_SUPPORTS_WEAKREFS(PyTypeObject *type) {
 extern PyObject* _PyType_AllocNoTrack(PyTypeObject *type, Py_ssize_t nitems);
 PyAPI_FUNC(PyObject *) _PyType_NewManagedObject(PyTypeObject *type);
 
-extern PyTypeObject* _PyType_CalculateMetaclass(PyTypeObject *, PyObject *);
+extern PyTypeObject* _PyType_CalculateMetaclass(PyTypeObject *, PyObject *, PyObject *);
 extern PyObject* _PyType_GetDocFromInternalDoc(const char *, const char *);
 extern PyObject* _PyType_GetTextSignatureFromInternalDoc(const char *, const char *, int);
 extern int _PyObject_SetAttributeErrorContext(PyObject *v, PyObject* name);

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -2562,5 +2562,19 @@ class SubinterpreterTests(unittest.TestCase):
         self.assertEqual(interp_results, {})
 
 
+class TestMetaclassConflict(unittest.TestCase):
+    def test_metaclass_conflict_message(self):
+        class MetaFoo(type): pass
+        class MetaBar(type): pass
+        class Bar(metaclass=MetaBar): pass
+        with self.assertRaises(TypeError) as cm:
+            class Foo(Bar, metaclass=MetaFoo): pass
+        msg = str(cm.exception)
+        self.assertIn("Metaclass conflict", msg)
+        self.assertIn("MetaFoo", msg)
+        self.assertIn("MetaBar", msg)
+        self.assertIn("Bar", msg)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-28-20-47-06.gh-issue-skip.CO_d25.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-28-20-47-06.gh-issue-skip.CO_d25.rst
@@ -1,0 +1,1 @@
+Metaclass incompatibility error message now more clearly explains the issue including the name of the offending baseclass and the conflicting metaclasses.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-28-metaclass-error.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-28-metaclass-error.rst
@@ -1,0 +1,2 @@
+Metaclass incompatibility error message now more clearly explains the issue
+including the name of the offending baseclass and the conflicting metaclasses.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -169,7 +169,7 @@ builtin___build_class__(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
         /* meta is really a class, so check for a more derived
            metaclass, or possible metaclass conflicts: */
         winner = (PyObject *)_PyType_CalculateMetaclass((PyTypeObject *)meta,
-                                                        bases);
+                                                        bases,name);
         if (winner == NULL) {
             goto error;
         }


### PR DESCRIPTION
### Summary
This PR adds context to the metaclass conflict error message along with clear terminology.

### Motivation
Class inheritance in OOP has well-established terminology conventions across languages, none of which should be used to describe the custom metaclass introduced by Python. This PR proposes to distinguish between them by the following convention:

- A class *is derived from* its **metaclass**
- A class *is based on* its **base classes**

This convention is then reflected in the proposed error message raised by metaclass conflicts.

### Example
In the example below, `MetaFoo` and `MetaBar` are both subclasses of `type` and neither is a (non-strict) subclass of the other. `Foo` is a class derived from `MetaFoo`, and `Bar` attempts to be derived from `MetaBar` while also based on `Foo`, revealing the incompatibility between `MetaFoo` and `MetaBar`:

```python
class MetaFoo(type):  pass

class MetaBar(type): pass

class Foo(metaclass=MetaFoo):  pass

class Bar(Foo, metaclass=MetaBar):  pass  # raises
```
### Behaviour Before
Previously, the resulting TypeError would show:
```terminal
TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
```

### Behaviour After
This pull request attempts to improve with:
```terminal
Metaclass conflict while defining class: 'Foo'
- Declared metaclass: 'MetaFoo'
- Incompatible base class: 'Bar'
- That base is derived from metaclass: 'MetaBar'
All base classes must be based on classes derived from the same metaclass or a subclass thereof.
```
### Conclusion
This PR hopes to contribute to the ongoing effort towards better error messages, whilst reinforcing clear and consistent terminology. 