### PR TITLE
gh-117852: eagerly check arguments to asyncgen.athrow()

### DIFF
--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -2021,6 +2021,15 @@ class TestUnawaitedWarnings(unittest.TestCase):
             g.athrow(RuntimeError)
             gc_collect()
 
+    def test_athrow_throws_immediately(self):
+        async def gen():
+            yield 1
+
+        g = gen()
+        msg = "athrow expected at least 1 argument, got 0"
+        with self.assertRaisesRegex(TypeError, msg):
+            g.athrow()
+
     def test_aclose(self):
         async def gen():
             yield 1

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-28-23-58-50.gh-issue-117852.BO9g7z.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-28-23-58-50.gh-issue-117852.BO9g7z.rst
@@ -1,1 +1,1 @@
-Check ``async_generator_athrow.athrow`` arguments immediately on instantiation.
+Fix argument checking of :meth:`~agen.athrow`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-28-23-58-50.gh-issue-117852.BO9g7z.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-28-23-58-50.gh-issue-117852.BO9g7z.rst
@@ -1,1 +1,1 @@
-Check :meth:`asyncgen.athrow` arguments immediately on instantiation.
+Check ``async_generator_athrow.athrow`` arguments immediately on instantiation.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-28-23-58-50.gh-issue-117852.BO9g7z.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-28-23-58-50.gh-issue-117852.BO9g7z.rst
@@ -1,0 +1,1 @@
+Check :meth:`asyncgen.athrow` arguments immediately on instantiation.


### PR DESCRIPTION
At present the arguments to asyncgen.athrow() are not checked until the coroutine is awaited. Unpack them on coroutine creation instead, so they are checked immediately.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117852 -->
* Issue: gh-117852
<!-- /gh-issue-number -->
