### PR TITLE
GH-134863: Add reversible keys, values, items views to collections.abc builtin library

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -857,6 +857,11 @@ class KeysView(MappingView, Set):
     def __iter__(self):
         yield from self._mapping
 
+    def __reversed__(self):
+        if not hasattr(self._mapping, '__reversed__'):
+            raise TypeError(f"'{self._mapping.__class__.__name__}' is not reversible")
+        yield from reversed(self._mapping)
+
 
 KeysView.register(dict_keys)
 
@@ -882,6 +887,12 @@ class ItemsView(MappingView, Set):
         for key in self._mapping:
             yield (key, self._mapping[key])
 
+    def __reversed__(self):
+        if not hasattr(self._mapping, '__reversed__'):
+            raise TypeError(f"'{self._mapping.__class__.__name__}' is not reversible")
+        for key in reversed(self._mapping):
+            yield (key, self._mapping[key])
+
 
 ItemsView.register(dict_items)
 
@@ -899,6 +910,12 @@ class ValuesView(MappingView, Collection):
 
     def __iter__(self):
         for key in self._mapping:
+            yield self._mapping[key]
+
+    def __reversed__(self):
+        if not hasattr(self._mapping, '__reversed__'):
+            raise TypeError(f"'{self._mapping.__class__.__name__}' is not reversible")
+        for key in reversed(self._mapping):
             yield self._mapping[key]
 
 

--- a/Misc/NEWS.d/next/Library/2025-05-29-10-04-00.gh-issue-134863.iQl1kn.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-29-10-04-00.gh-issue-134863.iQl1kn.rst
@@ -1,1 +1,1 @@
-Made ``collections.abc.Mapping``'s keys, values, items views reversible by adding ``__reversed__`` method.
+Made :class:`collections.abc.Mapping`'s keys, values, items views reversible by adding the ``__reversed__`` method.

--- a/Misc/NEWS.d/next/Library/2025-05-29-10-04-00.gh-issue-134863.iQl1kn.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-29-10-04-00.gh-issue-134863.iQl1kn.rst
@@ -1,0 +1,1 @@
+Made ``collections.abc.Mapping``'s keys, values, items views reversible by adding ``__reversed__`` method.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

[GH-134863](https://github.com/python/cpython/issues/134863)

Made `collections.abc.Mapping`'s keys, values, items views reversible by adding `__reversed__` method