### PR TITLE
gh-134821: Automatically enable deferred reference counting on shared objects

### DIFF
--- a/Python/gc_free_threading.c
+++ b/Python/gc_free_threading.c
@@ -1218,8 +1218,8 @@ scan_heap_visitor(const mi_heap_t *heap, const mi_heap_area_t *area,
             worklist_push(&state->unreachable, op);
         }
         return true;
-    } else if (_Py_REF_SHARED(Py_REFCNT(op), 0) >= 3) {
-        // Objects with 3 or more shared references are candidates
+    } else if (_Py_REF_SHARED(op->ob_ref_shared, 0) >= 3) {
+        // Objects with 10 or more shared references are candidates
         // for deferred reference counting.
         // This probably needs tuning.
         maybe_enable_deferred_refcount(op);


### PR DESCRIPTION
This is a very rough POC. I think it's important that we don't cause performance regressions here, so I've implemented this alongside the garbage collector.

Does this approach make sense to everyone?

<!-- gh-issue-number: gh-134821 -->
* Issue: gh-134821
<!-- /gh-issue-number -->
