### PR TITLE
gh-134885: zstd: Use Py_XSETREF

### DIFF
--- a/Lib/test/test_ctypes/test_incomplete.py
+++ b/Lib/test/test_ctypes/test_incomplete.py
@@ -1,6 +1,5 @@
 import ctypes
 import unittest
-import warnings
 from ctypes import Structure, POINTER, pointer, c_char_p
 
 # String-based "incomplete pointers" were implemented in ctypes 0.6.3 (2003, when

--- a/Misc/NEWS.d/next/Library/2025-05-29-06-53-40.gh-issue-134885.-_L22o.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-29-06-53-40.gh-issue-134885.-_L22o.rst
@@ -1,0 +1,2 @@
+Fix possible crash in the :mod:`compression.zstd` module related to setting
+parameter types. Patch by Jelle Zijlstra.

--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -514,13 +514,10 @@ _zstd_set_parameter_types_impl(PyObject *module, PyObject *c_parameter_type,
         return NULL;
     }
 
-    Py_XDECREF(mod_state->CParameter_type);
-    Py_INCREF(c_parameter_type);
-    mod_state->CParameter_type = (PyTypeObject*)c_parameter_type;
-
-    Py_XDECREF(mod_state->DParameter_type);
-    Py_INCREF(d_parameter_type);
-    mod_state->DParameter_type = (PyTypeObject*)d_parameter_type;
+    Py_XSETREF(
+        mod_state->CParameter_type, Py_NewRef((PyTypeObject*)c_parameter_type));
+    Py_XSETREF(
+        mod_state->DParameter_type, Py_NewRef((PyTypeObject*)d_parameter_type));
 
     Py_RETURN_NONE;
 }

--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -515,9 +515,9 @@ _zstd_set_parameter_types_impl(PyObject *module, PyObject *c_parameter_type,
     }
 
     Py_XSETREF(
-        mod_state->CParameter_type, Py_NewRef((PyTypeObject*)c_parameter_type));
+        mod_state->CParameter_type, (PyTypeObject*)Py_NewRef(c_parameter_type));
     Py_XSETREF(
-        mod_state->DParameter_type, Py_NewRef((PyTypeObject*)d_parameter_type));
+        mod_state->DParameter_type, (PyTypeObject*)Py_NewRef(d_parameter_type));
 
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
As the Py_SETREF macro explains, the previous code is theoretically vulnerable to a bug where if the destructor for the previous value of `mod_state->CParameter_type` accesses this module, it may see a garbage value there.

<!-- gh-issue-number: gh-134885 -->
* Issue: gh-134885
<!-- /gh-issue-number -->
