### PR TITLE
gh-134893: Fix zstd module build failed when people setup the argument without debug mode

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-05-29-22-58-04.gh-issue-134893.75BRS0.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-29-22-58-04.gh-issue-134893.75BRS0.rst
@@ -1,0 +1,2 @@
+Fix zstd module build failed when people setup the argument without debug
+mode

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -518,6 +518,12 @@ mt_continue_should_break(ZSTD_inBuffer *in, ZSTD_outBuffer *out)
 {
     return in->size == in->pos && out->size != out->pos;
 }
+#else
+static inline int
+mt_continue_should_break(ZSTD_inBuffer *in, ZSTD_outBuffer *out)
+{
+    return 1;
+}
 #endif
 
 static PyObject *


### PR DESCRIPTION
Fix #134893 

<!-- gh-issue-number: gh-134893 -->
* Issue: gh-134893
<!-- /gh-issue-number -->
