### PR TITLE
gh-134895: Add sphinx-codeautolink to doc build

### DIFF
--- a/Doc/_static/sphinx-codeautolink.css
+++ b/Doc/_static/sphinx-codeautolink.css
@@ -1,0 +1,12 @@
+/*
+Style autolinks from Python example code to reference documentation
+(https://sphinx-codeautolink.readthedocs.io/en/latest/examples.html#custom-link-styles)
+*/
+
+.sphinx-codeautolink-a {
+    text-decoration-style: solid !important;
+    text-decoration-color: #aaa;
+}
+.sphinx-codeautolink-a:hover {
+    text-decoration-color: black;
+}

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -419,14 +419,15 @@ gettext_compact = False
 
 # Options for automatic links from code examples to reference documentation.
 # (https://sphinx-codeautolink.readthedocs.io/)
-codeautolink_warn_on_missing_inventory = False
-codeautolink_warn_on_failed_resolve = False
+# codeautolink_warn_on_missing_inventory = False
+# codeautolink_warn_on_failed_resolve = False
 codeautolink_custom_blocks = {
-    # https://sphinx-codeautolink.readthedocs.io/en/latest/examples.html#doctest-code-blocks
-    "pycon3": "sphinx_codeautolink.clean_pycon",
+    # https://sphinx-codeautolink.readthedocs.io/en/latest/reference.html#cleanup-functions
+    "pycon": "sphinx_codeautolink.clean_pycon",
 }
 
 suppress_warnings = [
+    # https://sphinx-codeautolink.readthedocs.io/en/latest/reference.html#warning-types
     # "codeautolink",
     "codeautolink.import_star",
     "codeautolink.match_block",

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',
+    'sphinx_codeautolink',
 ]
 
 # Skip if downstream redistributors haven't installed them
@@ -404,6 +405,9 @@ html_use_opensearch = 'https://docs.python.org/' + version
 # Additional static files.
 html_static_path = ['_static', 'tools/static']
 
+# Additional CSS files.
+html_css_files = ["sphinx-codeautolink.css"]
+
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'python' + release.replace('.', '')
 
@@ -412,6 +416,25 @@ html_split_index = True
 
 # Split pot files one per reST file
 gettext_compact = False
+
+# Options for automatic links from code examples to reference documentation.
+# (https://sphinx-codeautolink.readthedocs.io/)
+codeautolink_warn_on_missing_inventory = False
+codeautolink_warn_on_failed_resolve = False
+codeautolink_custom_blocks = {
+    # https://sphinx-codeautolink.readthedocs.io/en/latest/examples.html#doctest-code-blocks
+    "pycon3": "sphinx_codeautolink.clean_pycon",
+}
+
+suppress_warnings = [
+    # "codeautolink",
+    "codeautolink.import_star",
+    "codeautolink.match_block",
+    "codeautolink.match_name",
+    "codeautolink.parse_block",
+    "config.cache",
+]
+
 
 # Options for LaTeX output
 # ------------------------

--- a/Doc/constraints.txt
+++ b/Doc/constraints.txt
@@ -22,3 +22,6 @@ sphinxcontrib-serializinghtml<3
 
 # Direct dependencies of Jinja2 (Jinja is a dependency of Sphinx, see above)
 MarkupSafe<3
+
+# Direct dependencies of the sphinx-codeautolink extension
+beautifulsoup4<4.13.4

--- a/Doc/requirements.txt
+++ b/Doc/requirements.txt
@@ -13,6 +13,7 @@ blurb
 
 sphinxext-opengraph~=0.9.0
 sphinx-notfound-page~=1.0.0
+sphinx-codeautolink~=0.17.4
 
 # The theme used by the documentation is stored separately, so we need
 # to install that as well.

--- a/Misc/NEWS.d/next/Documentation/2025-05-29-17-35-28.gh-issue-134895.z7WboA.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-05-29-17-35-28.gh-issue-134895.z7WboA.rst
@@ -1,0 +1,2 @@
+Add sphinx-codeautolink extension for reference links in code examples.
+Patch by Colin Marquardt.


### PR DESCRIPTION
This PR adds the https://sphinx-codeautolink.readthedocs.io/ Sphinx extension to the documentation build process. In their own words, it

> makes code examples clickable by inserting links from individual code elements to the corresponding reference documentation

In my opinion, it is quite helpful for documentation readers to be able to immediately jump from e.g. tutorial code using [`logging.getLogger`](https://cpython-previews--134896.org.readthedocs.build/en/134896/howto/logging-cookbook.html) (**<-- points to the PR doc build that shows the linking**) to its reference description.

A bit of discussion has happened in https://discuss.python.org/t/add-the-sphinx-codeautolink-extension-to-doc-build-process/80814, back when the extension was not as robust and featureful as nowadays.
As said there, the styling of these extra links can be as unobtrusive as we want them.

Code examples that are parseable and self-contained (i.e. have all their imports) will have clickable objects.

Examples that are made up of parts that build on each other can also be supported with some extra markup (not part of this PR).
Missing imports can be annotated "invisibly" (not part of this PR).

Also, in the current state of the documentation, not all code examples that *could* be parseable actually *are*.
#133906 would fix a number of these.

Other examples would benefit from using `.. code-block::` with an explicit language set instead of `::` so that special handling for `pycon` (`clean_pycon`) could kick in. Right now, these places are producing a warning that is handled via  `suppress_warnings`.

Speaking of `suppress_warnings`, it contains `config.cache` because of 
`WARNING: cannot cache unpickleable configuration value: 'codeautolink_custom_blocks' (because it contains a function, class, or module object) [config.cache]`, which is indeed set to the function `clean_pycon`.

<!-- gh-issue-number: gh-134895 -->
* Issue: gh-134895
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134896.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->