### PR TITLE
gh-117888: print failing command when platform triplet detection errors

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-05-30-11-19-19.gh-issue-117888.-4okIx.rst
+++ b/Misc/NEWS.d/next/Build/2025-05-30-11-19-19.gh-issue-117888.-4okIx.rst
@@ -1,0 +1,1 @@
+Report error if platform triplet detection fails.

--- a/configure
+++ b/configure
@@ -7161,14 +7161,14 @@ fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
 printf %s "checking for the platform triplet based on compiler characteristics... " >&6; }
-if $CPP $CPPFLAGS $srcdir/Misc/platform_triplet.c >conftest.out 2>/dev/null; then
+if $CPP $CPPFLAGS $srcdir/Misc/platform_triplet.c >conftest.out 2>conftest.err; then
   PLATFORM_TRIPLET=`grep '^PLATFORM_TRIPLET=' conftest.out | tr -d ' 	'`
   PLATFORM_TRIPLET="${PLATFORM_TRIPLET#PLATFORM_TRIPLET=}"
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PLATFORM_TRIPLET" >&5
 printf "%s\n" "$PLATFORM_TRIPLET" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none" >&5
-printf "%s\n" "none" >&6; }
+  cat conftest.err >&2
+  as_fn_error $? "platform triplet detection failed, see error output above" "$LINENO" 5
 fi
 rm -f conftest.out
 

--- a/configure.ac
+++ b/configure.ac
@@ -1151,12 +1151,13 @@ fi
 
 
 AC_MSG_CHECKING([for the platform triplet based on compiler characteristics])
-if $CPP $CPPFLAGS $srcdir/Misc/platform_triplet.c >conftest.out 2>/dev/null; then
+if $CPP $CPPFLAGS $srcdir/Misc/platform_triplet.c >conftest.out 2>conftest.err; then
   PLATFORM_TRIPLET=`grep '^PLATFORM_TRIPLET=' conftest.out | tr -d ' 	'`
   PLATFORM_TRIPLET="${PLATFORM_TRIPLET@%:@PLATFORM_TRIPLET=}"
   AC_MSG_RESULT([$PLATFORM_TRIPLET])
 else
-  AC_MSG_RESULT([none])
+  cat conftest.err >&2
+  AC_MSG_ERROR([platform triplet detection failed, see error output above])
 fi
 rm -f conftest.out
 


### PR DESCRIPTION
The build system determines the platform triplet using the C preprocessor. If that fails for whatever reason we presently just report "none" for the triplet and continue until the invalid triplet causes a messy failure down the line.

Instead, store any error output, and in the event of a failure send it to stderr and fail immediately with a clear error message.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-117888 -->
* Issue: gh-117888
<!-- /gh-issue-number -->
