### PR TITLE
gh-134906: Document CompressionParameter.content_size_flag

### DIFF
--- a/Doc/library/compression.zstd.rst
+++ b/Doc/library/compression.zstd.rst
@@ -621,7 +621,7 @@ Advanced parameter control
       header when known prior to compressing.
 
       This flag only takes effect under the following two scenarios:
-      
+
       * Calling :func:`compress` for one-shot compression
       * Providing all of the data to be compressed in the frame in a single
         :meth:`ZstdCompressor.compress` call, with the

--- a/Doc/library/compression.zstd.rst
+++ b/Doc/library/compression.zstd.rst
@@ -615,6 +615,24 @@ Advanced parameter control
 
       A value of zero causes the value to be selected automatically.
 
+   .. attribute:: content_size_flag
+
+      Write the size of the data to be compressed into the Zstandard frame
+      header when known prior to compressing.
+
+      This flag only takes effect under the following two scenarios:
+      
+      * Calling :func:`compress` for one-shot compression
+      * Providing all of the data to be compressed in the frame in a single
+        :meth:`ZstdCompressor.compress` call, with the
+        :attr:`ZstdCompressor.FLUSH_FRAME` mode.
+
+      All other compression calls may not write the size information into the
+      frame header.
+
+      ``True`` or ``1`` enable the content size flag while ``False`` or ``0``
+      disable it.
+
    .. attribute:: checksum_flag
 
       A four-byte checksum using XXHash64 of the uncompressed content is


### PR DESCRIPTION
This was elided from the original PR to add docs for compression.zstd because I wanted to audit the cases where it would take effect. I've done that now and so wanted to document the behavior.

<!-- gh-issue-number: gh-134906 -->
* Issue: gh-134906
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134907.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->