### PR TITLE
gh-134908: protect ``textiowrapper_iternext`` with critical section

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -1064,7 +1064,6 @@ class IOTest(unittest.TestCase):
 
     @threading_helper.requires_working_threading()
     def test_write_readline_races(self):
-
         # gh-134908: Concurrent iteration over a file caused races
         thread_count = 2
         write_count = 100

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -1067,29 +1067,27 @@ class IOTest(unittest.TestCase):
         # gh-134908: Concurrent iteration over a file caused races
         thread_count = 2
         write_count = 100
+        read_count = 100
 
         def writer(file, barrier):
             barrier.wait()
             for _ in range(write_count):
                 file.write("x")
 
-        def reader(file, stopping):
-            while not stopping.is_set():
+        def reader(file, barrier):
+            barrier.wait()
+            for _ in range(read_count):
                 for line in file:
                     self.assertEqual(line, "")
 
-        stopping = threading.Event()
         with self.open(os_helper.TESTFN, "w+") as f:
-            barrier = threading.Barrier(thread_count)
-            reader = threading.Thread(target=reader, args=(f, stopping))
+            barrier = threading.Barrier(thread_count + 1)
+            reader = threading.Thread(target=reader, args=(f, barrier))
             writers = [threading.Thread(target=writer, args=(f, barrier))
                        for _ in range(thread_count)]
             with threading_helper.catch_threading_exception() as cm:
-                reader.start()
-                with threading_helper.start_threads(writers):
+                with threading_helper.start_threads(writers + [reader]):
                     pass
-                stopping.set()
-                reader.join()
                 self.assertIsNone(cm.exc_type)
 
         self.assertEqual(os.stat(os_helper.TESTFN).st_size,

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-30-15-56-19.gh-issue-134908.3a7PxM.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-30-15-56-19.gh-issue-134908.3a7PxM.rst
@@ -1,0 +1,1 @@
+Protect ``textiowrapper_iternext`` with a critical section.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-30-15-56-19.gh-issue-134908.3a7PxM.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-30-15-56-19.gh-issue-134908.3a7PxM.rst
@@ -1,1 +1,1 @@
-Fix crash when iterating over lines in a text file thread safe on the :term:`free threaded <free threading>` build.
+Fix crash when iterating over lines in a text file on the :term:`free threaded <free threading>` build.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-30-15-56-19.gh-issue-134908.3a7PxM.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-30-15-56-19.gh-issue-134908.3a7PxM.rst
@@ -1,1 +1,1 @@
-Protect ``textiowrapper_iternext`` with a critical section.
+Make iterating over lines in a text file thread safe in free threading.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-05-30-15-56-19.gh-issue-134908.3a7PxM.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-05-30-15-56-19.gh-issue-134908.3a7PxM.rst
@@ -1,1 +1,1 @@
-Make iterating over lines in a text file thread safe in free threading.
+Fix crash when iterating over lines in a text file thread safe on the :term:`free threaded <free threading>` build.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -3217,7 +3217,7 @@ textiowrapper_iternext(PyObject *op)
 {
     PyObject *result;
     Py_BEGIN_CRITICAL_SECTION(op);
-    result = textiowrapper_iternext_locked(op);
+    result = textiowrapper_iternext_lock_held(op);
     Py_END_CRITICAL_SECTION();
     return result;
 }

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -3175,8 +3175,9 @@ _io_TextIOWrapper_close_impl(textio *self)
 }
 
 static PyObject *
-textiowrapper_iternext_locked(PyObject *op)
+textiowrapper_iternext_lock_held(PyObject *op)
 {
+    _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(op);
     PyObject *line;
     textio *self = textio_CAST(op);
 

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1578,6 +1578,8 @@ _io_TextIOWrapper_detach_impl(textio *self)
 static int
 _textiowrapper_writeflush(textio *self)
 {
+    _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(self);
+
     if (self->pending_bytes == NULL)
         return 0;
 
@@ -3173,7 +3175,7 @@ _io_TextIOWrapper_close_impl(textio *self)
 }
 
 static PyObject *
-textiowrapper_iternext(PyObject *op)
+textiowrapper_iternext_locked(PyObject *op)
 {
     PyObject *line;
     textio *self = textio_CAST(op);
@@ -3208,6 +3210,16 @@ textiowrapper_iternext(PyObject *op)
     }
 
     return line;
+}
+
+static PyObject *
+textiowrapper_iternext(PyObject *op)
+{
+    PyObject *result;
+    Py_BEGIN_CRITICAL_SECTION(op);
+    result = textiowrapper_iternext_locked(op);
+    Py_END_CRITICAL_SECTION();
+    return result;
 }
 
 /*[clinic input]


### PR DESCRIPTION
``textiowrapper_iternext`` calls ``_textiowrapper_writeflush`` but does not take the critical section, making it racy in free-threaded builds.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134908 -->
* Issue: gh-134908
<!-- /gh-issue-number -->
