### PR TITLE
gh-134733: Fix documentation for the show_empty option of ast.dump()

### DIFF
--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2445,8 +2445,9 @@ and classes for traversing abstract syntax trees:
    indents that many spaces per level.  If *indent* is a string (such as ``"\t"``),
    that string is used to indent each level.
 
-   If *show_empty* is ``False`` (the default), empty lists and fields that are ``None``
-   will be omitted from the output.
+   Unless *show_empty* is true, optional empty lists will be
+   omitted from the output.
+   Optional ``None`` values are always omitted.
 
    .. versionchanged:: 3.9
       Added the *indent* option.

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -2445,7 +2445,7 @@ and classes for traversing abstract syntax trees:
    indents that many spaces per level.  If *indent* is a string (such as ``"\t"``),
    that string is used to indent each level.
 
-   Unless *show_empty* is true, optional empty lists will be
+   If *show_empty* is false (the default), optional empty lists will be
    omitted from the output.
    Optional ``None`` values are always omitted.
 


### PR DESCRIPTION
Optional None values are always omitted.


<!-- gh-issue-number: gh-134733 -->
* Issue: gh-134733
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134925.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->