### PR TITLE
gh-134873: Fix a DOS issue in `posixpath`

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -302,6 +302,7 @@ def expandvars(path):
         start = b'{'
         end = b'}'
         environ = getattr(os, 'environb', None)
+        join = b''.join
     else:
         if '$' not in path:
             return path
@@ -312,12 +313,16 @@ def expandvars(path):
         start = '{'
         end = '}'
         environ = os.environ
-    i = 0
+        join = ''.join
+
+    result = []
+    last = 0
     while True:
-        m = search(path, i)
+        m = search(path, last)
         if not m:
             break
         i, j = m.span(0)
+        result.append(path[last:i])
         name = m.group(1)
         if name.startswith(start) and name.endswith(end):
             name = name[1:-1]
@@ -327,13 +332,12 @@ def expandvars(path):
             else:
                 value = environ[name]
         except KeyError:
-            i = j
+            result.append(path[i:j])
         else:
-            tail = path[j:]
-            path = path[:i] + value
-            i = len(path)
-            path += tail
-    return path
+            result.append(value)
+        last = j
+    result.append(path[last:])
+    return join(result)
 
 
 # Normalize a path, e.g. A//B, A/./B and A/foo/../B all become A/B.

--- a/Misc/NEWS.d/next/Library/2025-05-30-19-15-35.gh-issue-134873.bSyFkT.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-30-19-15-35.gh-issue-134873.bSyFkT.rst
@@ -1,0 +1,1 @@
+Fix a DOS vulnerability in :mod:`posixpath` regarding string slicing.


### PR DESCRIPTION
```python
import time
import os
import posixpath
import Lib.posixpath as posixpath_fixed

os.environ['A'] = 'x'
payload = "$A" * 100000

print("Payload size:", len(payload))

start = time.time()
posixpath.expandvars(payload)
print("Original time:", time.time() - start, "seconds")

start = time.time()
posixpath_fixed.expandvars(payload)
print("Fixed time:", time.time() - start, "seconds")
```

Above is a code that reproduces the problem, and the speed difference becomes more and more noticeable with the number of times. The above 200,000 times is 15x faster

print:
```
Payload size: 200000
Original time: 1.7329566478729248 seconds
Fixed time: 0.11450839042663574 seconds
```

<!-- gh-issue-number: gh-134873 -->
* Issue: gh-134873
<!-- /gh-issue-number -->
