### PR TITLE
[3.13] gh-134718: Fix ast.dump() for empty non-default values (GH-134926)

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -151,18 +151,16 @@ def dump(
                 if value is None and getattr(cls, name, ...) is None:
                     keywords = True
                     continue
-                if (
-                    not show_empty
-                    and (value is None or value == [])
-                    # Special cases:
-                    # `Constant(value=None)` and `MatchSingleton(value=None)`
-                    and not isinstance(node, (Constant, MatchSingleton))
-                ):
-                    args_buffer.append(repr(value))
-                    continue
-                elif not keywords:
-                    args.extend(args_buffer)
-                    args_buffer = []
+                if not show_empty:
+                    if value == []:
+                        field_type = cls._field_types.get(name, object)
+                        if getattr(field_type, '__origin__', ...) is list:
+                            if not keywords:
+                                args_buffer.append(repr(value))
+                            continue
+                    if not keywords:
+                        args.extend(args_buffer)
+                        args_buffer = []
                 value, simple = _format(value, level)
                 allsimple = allsimple and simple
                 if keywords:

--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -1347,9 +1347,21 @@ Module(
         )
 
         check_node(
+            ast.MatchSingleton(value=[]),
+            empty="MatchSingleton(value=[])",
+            full="MatchSingleton(value=[])",
+        )
+
+        check_node(
             ast.Constant(value=None),
             empty="Constant(value=None)",
             full="Constant(value=None)",
+        )
+
+        check_node(
+            ast.Constant(value=[]),
+            empty="Constant(value=[])",
+            full="Constant(value=[])",
         )
 
         check_node(

--- a/Misc/NEWS.d/next/Library/2025-05-30-13-07-29.gh-issue-134718.9Qvhxn.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-30-13-07-29.gh-issue-134718.9Qvhxn.rst
@@ -1,0 +1,2 @@
+:func:`ast.dump` now only omits ``None`` and ``[]`` values if they are
+default values.


### PR DESCRIPTION
(cherry picked from commit cc344e8dd0a6fdc83a032c229f9b3cf53f76a887)


<!-- gh-issue-number: gh-134718 -->
* Issue: gh-134718
<!-- /gh-issue-number -->
