### PR TITLE
Improve format of `InternalDocs/exception_handling.md`

### DIFF
--- a/InternalDocs/exception_handling.md
+++ b/InternalDocs/exception_handling.md
@@ -8,7 +8,7 @@ The cost of raising an exception is increased, but not by much.
 
 The following code:
 
-```
+```python
 try:
     g(0)
 except:
@@ -18,7 +18,7 @@ except:
 
 compiles into intermediate code like the following:
 
-```
+```python
                   RESUME                   0
 
      1            SETUP_FINALLY            8 (to L1)
@@ -118,13 +118,13 @@ All offsets and lengths are in code units, not bytes.
 
 We want the format to be compact, but quickly searchable.
 For it to be compact, it needs to have variable sized entries so that we can store common (small) offsets compactly, but handle large offsets if needed.
-For it to be searchable quickly, we need to support binary search giving us log(n) performance in all cases.
+For it to be searchable quickly, we need to support binary search giving us `log(n)` performance in all cases.
 Binary search typically assumes fixed size entries, but that is not necessary, as long as we can identify the start of an entry.
 
 It is worth noting that the size (end-start) is always smaller than the end, so we encode the entries as:
 `start, size, target, depth, push-lasti`.
 
-Also, sizes are limited to 2**30 as the code length cannot exceed 2**31 and each code unit takes 2 bytes.
+Also, sizes are limited to `2**30` as the code length cannot exceed `2**31` and each code unit takes 2 bytes.
 It also happens that depth is generally quite small.
 
 So, we need to encode:
@@ -140,7 +140,7 @@ lasti   (1 bit)
 We need a marker for the start of the entry, so the first byte of entry will have the most significant bit set.
 Since the most significant bit is reserved for marking the start of an entry, we have 7 bits per byte to encode offsets.
 Encoding uses a standard varint encoding, but with only 7 bits instead of the usual 8.
-The 8 bits of a byte are (msb left) SXdddddd where S is the start bit. X is the extend bit meaning that the next byte is required to extend the offset.
+The 8 bits of a byte are (msb left) `SXdddddd` where `S` is the start bit. `X` is the extend bit meaning that the next byte is required to extend the offset.
 
 In addition, we combine `depth` and `lasti` into a single value, `((depth<<1)+lasti)`, before encoding.
 


### PR DESCRIPTION
Before:
<img width="492" alt="Снимок экрана 2025-05-31 в 12 36 45" src="https://github.com/user-attachments/assets/ef79e9bd-3676-42e4-b702-d5a6d5447372" /> (wrong bold format)

After:
<img width="512" alt="Снимок экрана 2025-05-31 в 12 37 23" src="https://github.com/user-attachments/assets/ae1eb128-af04-47cd-bb65-95833b1f6871" />

Before:
<img width="225" alt="Снимок экрана 2025-05-31 в 12 38 15" src="https://github.com/user-attachments/assets/0fa9a682-9547-4991-8194-719179b98756" />

After:
<img width="194" alt="Снимок экрана 2025-05-31 в 12 38 09" src="https://github.com/user-attachments/assets/421d7aee-bb00-47fe-a919-db1b00878927" />

Before:
<img width="561" alt="Снимок экрана 2025-05-31 в 12 38 23" src="https://github.com/user-attachments/assets/ac9209f1-014b-41d3-9c5a-4c76ca8c4ca8" />

After:
<img width="583" alt="Снимок экрана 2025-05-31 в 12 40 33" src="https://github.com/user-attachments/assets/0f91496f-1e08-42cc-95c8-e89d0e75be3a" />
