### PR TITLE
gh-134970: Fix exception message in `argparse` module

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1534,7 +1534,7 @@ class _ActionsContainer(object):
         action_name = kwargs.get('action')
         action_class = self._pop_action_class(kwargs)
         if not callable(action_class):
-            raise ValueError('unknown action {action_class!r}')
+            raise ValueError(f'unknown action {action_class!r}')
         action = action_class(**kwargs)
 
         # raise an error if action for positional argument does not

--- a/Misc/NEWS.d/next/Library/2025-05-31-12-08-12.gh-issue-134970.lgSaxq.rst
+++ b/Misc/NEWS.d/next/Library/2025-05-31-12-08-12.gh-issue-134970.lgSaxq.rst
@@ -1,0 +1,3 @@
+Fix the "unknown action" exception in
+:meth:`argparse.ArgumentParser.add_argument_group` to correctly replace the
+action class.


### PR DESCRIPTION
Fix the "unknown action" exception in `argparse.ArgumentParser.add_argument_group()` to correctly replace the action class.

<!-- gh-issue-number: gh-134970 -->
* Issue: gh-134970
<!-- /gh-issue-number -->
