### PR TITLE
Skip test as cpython_only that checks whether setattr interns the attribute or not

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -652,6 +652,7 @@ class ClassTests(unittest.TestCase):
         a = A(hash(A.f)^(-1))
         hash(a.f)
 
+    @cpython_only
     def testSetattrWrapperNameIntern(self):
         # Issue #25794: __setattr__ should intern the attribute name
         class A:


### PR DESCRIPTION
The details of when a string is being interned or not is implementation dependent.
