### PR TITLE
gh-134976: document the exception type that can be raised by `s[i]`

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1018,7 +1018,7 @@ operations have the same priority as the corresponding numeric operations. [3]_
 | ``s * n`` or             | equivalent to adding *s* to    | (2)(7)   |
 | ``n * s``                | itself *n* times               |          |
 +--------------------------+--------------------------------+----------+
-| ``s[i]``                 | *i*\ th item of *s*, origin 0  | \(3)     |
+| ``s[i]``                 | *i*\ th item of *s*, origin 0  | (3)(9)   |
 +--------------------------+--------------------------------+----------+
 | ``s[i:j]``               | slice of *s* from *i* to *j*   | (3)(4)   |
 +--------------------------+--------------------------------+----------+
@@ -1149,6 +1149,10 @@ Notes:
    the extra arguments is roughly equivalent to using ``s[i:j].index(x)``, only
    without copying any data and with the returned index being relative to
    the start of the sequence rather than the start of the slice.
+
+(9)
+   If the sequence is empty or *i* is outside the sequence range, :exc:`IndexError`
+   will be raised.
 
 
 .. _typesseq-immutable:

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1151,8 +1151,7 @@ Notes:
    the start of the sequence rather than the start of the slice.
 
 (9)
-   If the sequence is empty or *i* is outside the sequence range, :exc:`IndexError`
-   will be raised.
+   An :exc:`IndexError` is raised if *i* is outside the sequence range.
 
 
 .. _typesseq-immutable:


### PR DESCRIPTION

<!-- gh-issue-number: gh-134976 -->
* Issue: gh-134976
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--134977.org.readthedocs.build/en/134977/library/stdtypes.html#common-sequence-operations

<!-- readthedocs-preview cpython-previews end -->