### PR TITLE
gh-134986: Catch PermissionError when trying to call perf in tests

### DIFF
--- a/Lib/test/test_perf_profiler.py
+++ b/Lib/test/test_perf_profiler.py
@@ -508,7 +508,7 @@ def _is_perf_version_at_least(major, minor):
     # a commit hash in the version string, like "6.12.9.g242e6068fd5c"
     try:
         output = subprocess.check_output(["perf", "--version"], text=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except (subprocess.CalledProcessError, FileNotFoundError, PermissionError):
         return False
     version = output.split()[2]
     version = version.split("-")[0]

--- a/Lib/test/test_perf_profiler.py
+++ b/Lib/test/test_perf_profiler.py
@@ -506,6 +506,9 @@ def _is_perf_version_at_least(major, minor):
     # The output of perf --version looks like "perf version 6.7-3" but
     # it can also be perf version "perf version 5.15.143", or even include
     # a commit hash in the version string, like "6.12.9.g242e6068fd5c"
+    #
+    # PermissionError is raised if perf does not exist on the Windows Subsystem
+    # for Linux, see #134987
     try:
         output = subprocess.check_output(["perf", "--version"], text=True)
     except (subprocess.CalledProcessError, FileNotFoundError, PermissionError):


### PR DESCRIPTION
Using Ubuntu 24.04 on the Windows Subsystem for Linux, `perf` will raise a `PermissionError` instead of `FileNotFoundError` when it is missing. This PR modifies the tests to catch that.

<!-- gh-issue-number: gh-134986 -->
* Issue: gh-134986
<!-- /gh-issue-number -->
