### PR TITLE
Ensure that `zipfile._Extra.split` is polymorphic

### DIFF
--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -219,7 +219,7 @@ class _Extra(bytes):
         # use memoryview for zero-copy slices
         rest = memoryview(data)
         while rest:
-            extra, rest = _Extra.read_one(rest)
+            extra, rest = cls.read_one(rest)
             yield extra
 
     @classmethod


### PR DESCRIPTION
As a class method, it should call from `cls` instead of `_Extra`.
