### PR TITLE
gh-134953: Expand theming for `True`/`False`/`None`

### DIFF
--- a/Lib/_colorize.py
+++ b/Lib/_colorize.py
@@ -176,6 +176,7 @@ class Argparse(ThemeSection):
 class Syntax(ThemeSection):
     prompt: str = ANSIColors.BOLD_MAGENTA
     keyword: str = ANSIColors.BOLD_BLUE
+    keyword_constant: str = ANSIColors.BOLD_BLUE
     builtin: str = ANSIColors.CYAN
     comment: str = ANSIColors.RED
     string: str = ANSIColors.GREEN

--- a/Lib/_pyrepl/utils.py
+++ b/Lib/_pyrepl/utils.py
@@ -196,6 +196,9 @@ def gen_colors_from_token_stream(
                     is_def_name = False
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "definition")
+                elif token.string in ("True", "False", "None"):
+                    span = Span.from_token(token, line_lengths)
+                    yield ColorSpan(span, "keyword_constant")
                 elif keyword.iskeyword(token.string):
                     span = Span.from_token(token, line_lengths)
                     yield ColorSpan(span, "keyword")

--- a/Misc/NEWS.d/next/Library/2025-06-01-11-14-00.gh-issue-134953.ashdfs.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-01-11-14-00.gh-issue-134953.ashdfs.rst
@@ -1,0 +1,2 @@
+Expand ``_colorize`` theme with ``keyword_colorize`` and implement in
+:term:`repl`.

--- a/Misc/NEWS.d/next/Library/2025-06-01-11-14-00.gh-issue-134953.ashdfs.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-01-11-14-00.gh-issue-134953.ashdfs.rst
@@ -1,2 +1,2 @@
-Expand ``_colorize`` theme with ``keyword_colorize`` and implement in
+Expand ``_colorize`` theme with ``keyword_constant`` and implement in
 :term:`repl`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

I am not a fan of `constant`, but it seems to be what Pypygments and Magicpython uses so I guess it is best?

As for the other parts of the proposal in the issue I am not as big a fan, but I think this one is fine, and something I myself am used to in editors.

<!-- gh-issue-number: gh-134953 -->
* Issue: gh-134953
<!-- /gh-issue-number -->
