### PR TITLE
gh-135004: rewrite and cleanup `blake2module.c`

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-06-01-14-18-48.gh-issue-135004.cq3-fp.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-01-14-18-48.gh-issue-135004.cq3-fp.rst
@@ -1,0 +1,3 @@
+Rewrite and cleanup the internal :mod:`!_blake2` module. Some exception
+messages were changed but their types were left untouched. Patch by Bénédikt
+Tran.

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -351,10 +351,10 @@ typedef struct {
     union {
         Hacl_Hash_Blake2s_state_t *blake2s_state;
         Hacl_Hash_Blake2b_state_t *blake2b_state;
-#ifdef HACL_CAN_COMPILE_SIMD128
+#if HACL_CAN_COMPILE_SIMD128
         Hacl_Hash_Blake2s_Simd128_state_t *blake2s_128_state;
 #endif
-#ifdef HACL_CAN_COMPILE_SIMD256
+#if HACL_CAN_COMPILE_SIMD256
         Hacl_Hash_Blake2b_Simd256_state_t *blake2b_256_state;
 #endif
     };
@@ -420,14 +420,14 @@ static void
 update(Blake2Object *self, uint8_t *buf, Py_ssize_t len)
 {
     switch (self->impl) {
-      // These need to be ifdef'd out otherwise it's an unresolved symbol at
-      // link-time.
-#ifdef HACL_CAN_COMPILE_SIMD256
+        // blake2b_256_state and blake2s_128_state must be if'd since
+        // otherwise this results in an unresolved symbol at link-time.
+#if HACL_CAN_COMPILE_SIMD256
         case Blake2b_256:
             HACL_UPDATE(Hacl_Hash_Blake2b_Simd256_update,self->blake2b_256_state, buf, len);
             return;
 #endif
-#ifdef HACL_CAN_COMPILE_SIMD128
+#if HACL_CAN_COMPILE_SIMD128
         case Blake2s_128:
             HACL_UPDATE(Hacl_Hash_Blake2s_Simd128_update,self->blake2s_128_state, buf, len);
             return;

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -960,38 +960,35 @@ py_blake2_clear(PyObject *op)
     // initializes the HACL* internal state to NULL before allocating
     // it. If an error occurs in the constructor, we should only free
     // states that were allocated (i.e. that are not NULL).
+#define BLAKE2_FREE(TYPE, STATE)                \
+    do {                                        \
+        if (STATE != NULL) {                    \
+            Hacl_Hash_ ## TYPE ## _free(STATE); \
+            STATE = NULL;                       \
+        }                                       \
+    } while (0)
+
     switch (self->impl) {
 #if HACL_CAN_COMPILE_SIMD256
         case Blake2b_256:
-            if (self->blake2b_256_state != NULL) {
-                Hacl_Hash_Blake2b_Simd256_free(self->blake2b_256_state);
-                self->blake2b_256_state = NULL;
-            }
+            BLAKE2_FREE(Blake2b_Simd256, self->blake2b_256_state);
             break;
 #endif
 #if HACL_CAN_COMPILE_SIMD128
         case Blake2s_128:
-            if (self->blake2s_128_state != NULL) {
-                Hacl_Hash_Blake2s_Simd128_free(self->blake2s_128_state);
-                self->blake2s_128_state = NULL;
-            }
+            BLAKE2_FREE(Blake2s_Simd128, self->blake2s_128_state);
             break;
 #endif
         case Blake2b:
-            if (self->blake2b_state != NULL) {
-                Hacl_Hash_Blake2b_free(self->blake2b_state);
-                self->blake2b_state = NULL;
-            }
+            BLAKE2_FREE(Blake2b, self->blake2b_state);
             break;
         case Blake2s:
-            if (self->blake2s_state != NULL) {
-                Hacl_Hash_Blake2s_free(self->blake2s_state);
-                self->blake2s_state = NULL;
-            }
+            BLAKE2_FREE(Blake2s, self->blake2s_state);
             break;
         default:
             Py_UNREACHABLE();
     }
+#undef BLAKE2_FREE
     return 0;
 }
 

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -527,12 +527,11 @@ error:
 
 
 static PyObject *
-py_blake2b_or_s_new(PyTypeObject *type, PyObject *data, int digest_size,
-                    Py_buffer *key, Py_buffer *salt, Py_buffer *person,
-                    int fanout, int depth, unsigned long leaf_size,
-                    unsigned long long node_offset, int node_depth,
-                    int inner_size, int last_node, int usedforsecurity)
-
+py_blake2_new(PyTypeObject *type, PyObject *data, int digest_size,
+              Py_buffer *key, Py_buffer *salt, Py_buffer *person,
+              int fanout, int depth, unsigned long leaf_size,
+              unsigned long long node_offset, int node_depth,
+              int inner_size, int last_node, int usedforsecurity)
 {
     Blake2Object *self = NULL;
 
@@ -690,7 +689,9 @@ py_blake2b_new_impl(PyTypeObject *type, PyObject *data_obj, int digest_size,
     if (_Py_hashlib_data_argument(&data, data_obj, string) < 0) {
         return NULL;
     }
-    return py_blake2b_or_s_new(type, data, digest_size, key, salt, person, fanout, depth, leaf_size, node_offset, node_depth, inner_size, last_node, usedforsecurity);
+    return py_blake2_new(type, data, digest_size, key, salt, person,
+                         fanout, depth, leaf_size, node_offset, node_depth,
+                         inner_size, last_node, usedforsecurity);
 }
 
 /*[clinic input]
@@ -728,7 +729,9 @@ py_blake2s_new_impl(PyTypeObject *type, PyObject *data_obj, int digest_size,
     if (_Py_hashlib_data_argument(&data, data_obj, string) < 0) {
         return NULL;
     }
-    return py_blake2b_or_s_new(type, data, digest_size, key, salt, person, fanout, depth, leaf_size, node_offset, node_depth, inner_size, last_node, usedforsecurity);
+    return py_blake2_new(type, data, digest_size, key, salt, person,
+                         fanout, depth, leaf_size, node_offset, node_depth,
+                         inner_size, last_node, usedforsecurity);
 }
 
 static int

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -836,6 +836,29 @@ _blake2_blake2b_update_impl(Blake2Object *self, PyObject *data)
     Py_RETURN_NONE;
 }
 
+static uint8_t
+blake2_blake2b_compute_digest(Blake2Object *self, uint8_t *digest)
+{
+    switch (self->impl) {
+#if HACL_CAN_COMPILE_SIMD256
+        case Blake2b_256:
+            return Hacl_Hash_Blake2b_Simd256_digest(
+                self->blake2b_256_state, digest);
+#endif
+#if HACL_CAN_COMPILE_SIMD128
+        case Blake2s_128:
+            return Hacl_Hash_Blake2s_Simd128_digest(
+                self->blake2s_128_state, digest);
+#endif
+        case Blake2b:
+            return Hacl_Hash_Blake2b_digest(self->blake2b_state, digest);
+        case Blake2s:
+            return Hacl_Hash_Blake2s_digest(self->blake2s_state, digest);
+        default:
+            Py_UNREACHABLE();
+    }
+}
+
 /*[clinic input]
 _blake2.blake2b.digest
 
@@ -846,30 +869,9 @@ static PyObject *
 _blake2_blake2b_digest_impl(Blake2Object *self)
 /*[clinic end generated code: output=31ab8ad477f4a2f7 input=7d21659e9c5fff02]*/
 {
-    uint8_t digest[HACL_HASH_BLAKE2B_OUT_BYTES];
-
+    uint8_t digest_length = 0, digest[HACL_HASH_BLAKE2B_OUT_BYTES];
     ENTER_HASHLIB(self);
-    uint8_t digest_length = 0;
-    switch (self->impl) {
-#if HACL_CAN_COMPILE_SIMD256
-        case Blake2b_256:
-            digest_length = Hacl_Hash_Blake2b_Simd256_digest(self->blake2b_256_state, digest);
-            break;
-#endif
-#if HACL_CAN_COMPILE_SIMD128
-        case Blake2s_128:
-            digest_length = Hacl_Hash_Blake2s_Simd128_digest(self->blake2s_128_state, digest);
-            break;
-#endif
-        case Blake2b:
-            digest_length = Hacl_Hash_Blake2b_digest(self->blake2b_state, digest);
-            break;
-        case Blake2s:
-            digest_length = Hacl_Hash_Blake2s_digest(self->blake2s_state, digest);
-            break;
-        default:
-            Py_UNREACHABLE();
-    }
+    digest_length = blake2_blake2b_compute_digest(self, digest);
     LEAVE_HASHLIB(self);
     return PyBytes_FromStringAndSize((const char *)digest, digest_length);
 }
@@ -884,30 +886,9 @@ static PyObject *
 _blake2_blake2b_hexdigest_impl(Blake2Object *self)
 /*[clinic end generated code: output=5ef54b138db6610a input=76930f6946351f56]*/
 {
-    uint8_t digest[HACL_HASH_BLAKE2B_OUT_BYTES];
-
+    uint8_t digest_length = 0, digest[HACL_HASH_BLAKE2B_OUT_BYTES];
     ENTER_HASHLIB(self);
-    uint8_t digest_length = 0;
-    switch (self->impl) {
-#if HACL_CAN_COMPILE_SIMD256
-        case Blake2b_256:
-            digest_length = Hacl_Hash_Blake2b_Simd256_digest(self->blake2b_256_state, digest);
-            break;
-#endif
-#if HACL_CAN_COMPILE_SIMD128
-        case Blake2s_128:
-            digest_length = Hacl_Hash_Blake2s_Simd128_digest(self->blake2s_128_state, digest);
-            break;
-#endif
-        case Blake2b:
-            digest_length = Hacl_Hash_Blake2b_digest(self->blake2b_state, digest);
-            break;
-        case Blake2s:
-            digest_length = Hacl_Hash_Blake2s_digest(self->blake2s_state, digest);
-            break;
-        default:
-            Py_UNREACHABLE();
-    }
+    digest_length = blake2_blake2b_compute_digest(self, digest);
     LEAVE_HASHLIB(self);
     return _Py_strhex((const char *)digest, digest_length);
 }

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -754,6 +754,7 @@ blake2_blake2b_copy_locked(Blake2Object *self, Blake2Object *cpy)
             goto error;                                                     \
         }                                                                   \
     } while (0)
+
     switch (self->impl) {
 #if HACL_CAN_COMPILE_SIMD256
         case Blake2b_256:

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -738,42 +738,34 @@ static int
 blake2_blake2b_copy_locked(Blake2Object *self, Blake2Object *cpy)
 {
     assert(cpy != NULL);
+#define BLAKE2_COPY(TYPE, STATE_ATTR)                                       \
+    do {                                                                    \
+        cpy->STATE_ATTR = Hacl_Hash_ ## TYPE ## _copy(self->STATE_ATTR);    \
+        if (cpy->STATE_ATTR == NULL) {                                      \
+            goto error;                                                     \
+        }                                                                   \
+    } while (0)
     switch (self->impl) {
 #if HACL_CAN_COMPILE_SIMD256
-        case Blake2b_256: {
-            cpy->blake2b_256_state = Hacl_Hash_Blake2b_Simd256_copy(self->blake2b_256_state);
-            if (cpy->blake2b_256_state == NULL) {
-                goto error;
-            }
+        case Blake2b_256:
+            BLAKE2_COPY(Blake2b_Simd256, blake2b_256_state);
             break;
-        }
 #endif
 #if HACL_CAN_COMPILE_SIMD128
-        case Blake2s_128: {
-            cpy->blake2s_128_state = Hacl_Hash_Blake2s_Simd128_copy(self->blake2s_128_state);
-            if (cpy->blake2s_128_state == NULL) {
-                goto error;
-            }
+        case Blake2s_128:
+            BLAKE2_COPY(Blake2s_Simd128, blake2s_128_state);
             break;
-        }
 #endif
-        case Blake2b: {
-            cpy->blake2b_state = Hacl_Hash_Blake2b_copy(self->blake2b_state);
-            if (cpy->blake2b_state == NULL) {
-                goto error;
-            }
+        case Blake2b:
+            BLAKE2_COPY(Blake2b, blake2b_state);
             break;
-        }
-        case Blake2s: {
-            cpy->blake2s_state = Hacl_Hash_Blake2s_copy(self->blake2s_state);
-            if (cpy->blake2s_state == NULL) {
-                goto error;
-            }
+        case Blake2s:
+            BLAKE2_COPY(Blake2s, blake2s_state);
             break;
-        }
         default:
             Py_UNREACHABLE();
     }
+#undef BLAKE2_COPY
     cpy->impl = self->impl;
     return 0;
 

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -907,18 +907,16 @@ static PyObject *
 py_blake2b_get_name(PyObject *op, void *Py_UNUSED(closure))
 {
     Blake2Object *self = _Blake2Object_CAST(op);
-    return PyUnicode_FromString(is_blake2b(self->impl) ? "blake2b" : "blake2s");
+    return PyUnicode_FromString(BLAKE2_IMPLNAME(self));
 }
-
 
 
 static PyObject *
 py_blake2b_get_block_size(PyObject *op, void *Py_UNUSED(closure))
 {
     Blake2Object *self = _Blake2Object_CAST(op);
-    return PyLong_FromLong(is_blake2b(self->impl) ? HACL_HASH_BLAKE2B_BLOCK_BYTES : HACL_HASH_BLAKE2S_BLOCK_BYTES);
+    return PyLong_FromLong(GET_BLAKE2_CONST(self, BLOCK_BYTES));
 }
-
 
 
 static PyObject *

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -13,7 +13,6 @@
 #  define Py_BUILD_CORE_MODULE 1
 #endif
 
-#include "pyconfig.h"
 #include "Python.h"
 #include "hashlib.h"
 #include "pycore_strhex.h"       // _Py_strhex()
@@ -133,13 +132,13 @@ static inline bool has_simd256(cpu_flags *flags) {
 #define HACL_CAN_COMPILE_VEC128 HACL_CAN_COMPILE_SIMD128
 #define HACL_CAN_COMPILE_VEC256 HACL_CAN_COMPILE_SIMD256
 
-#include "_hacl/Hacl_Hash_Blake2b.h"
 #include "_hacl/Hacl_Hash_Blake2s.h"
-#if HACL_CAN_COMPILE_SIMD256
-#include "_hacl/Hacl_Hash_Blake2b_Simd256.h"
-#endif
+#include "_hacl/Hacl_Hash_Blake2b.h"
 #if HACL_CAN_COMPILE_SIMD128
 #include "_hacl/Hacl_Hash_Blake2s_Simd128.h"
+#endif
+#if HACL_CAN_COMPILE_SIMD256
+#include "_hacl/Hacl_Hash_Blake2b_Simd256.h"
 #endif
 
 // MODULE TYPE SLOTS

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -919,26 +919,34 @@ py_blake2b_get_block_size(PyObject *op, void *Py_UNUSED(closure))
 }
 
 
+static Hacl_Hash_Blake2b_index
+hacl_get_blake2_info(Blake2Object *self)
+{
+    switch (self->impl) {
+#if HACL_CAN_COMPILE_SIMD256
+        case Blake2b_256:
+            return Hacl_Hash_Blake2b_Simd256_info(self->blake2b_256_state);
+#endif
+#if HACL_CAN_COMPILE_SIMD128
+        case Blake2s_128:
+            return Hacl_Hash_Blake2s_Simd128_info(self->blake2s_128_state);
+#endif
+        case Blake2b:
+            return Hacl_Hash_Blake2b_info(self->blake2b_state);
+        case Blake2s:
+            return Hacl_Hash_Blake2s_info(self->blake2s_state);
+        default:
+            Py_UNREACHABLE();
+    }
+}
+
+
 static PyObject *
 py_blake2b_get_digest_size(PyObject *op, void *Py_UNUSED(closure))
 {
     Blake2Object *self = _Blake2Object_CAST(op);
-    switch (self->impl) {
-#if HACL_CAN_COMPILE_SIMD256
-        case Blake2b_256:
-            return PyLong_FromLong(Hacl_Hash_Blake2b_Simd256_info(self->blake2b_256_state).digest_length);
-#endif
-#if HACL_CAN_COMPILE_SIMD128
-        case Blake2s_128:
-            return PyLong_FromLong(Hacl_Hash_Blake2s_Simd128_info(self->blake2s_128_state).digest_length);
-#endif
-        case Blake2b:
-            return PyLong_FromLong(Hacl_Hash_Blake2b_info(self->blake2b_state).digest_length);
-        case Blake2s:
-            return PyLong_FromLong(Hacl_Hash_Blake2s_info(self->blake2s_state).digest_length);
-        default:
-            Py_UNREACHABLE();
-    }
+    Hacl_Hash_Blake2b_index info = hacl_get_blake2_info(self);
+    return PyLong_FromLong(info.digest_length);
 }
 
 

--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -70,8 +70,7 @@ static PyType_Spec blake2b_type_spec;
 static PyType_Spec blake2s_type_spec;
 
 PyDoc_STRVAR(blake2mod__doc__,
-"_blake2b provides BLAKE2b for hashlib\n"
-);
+             "_blake2 provides BLAKE2b and BLAKE2s for hashlib\n");
 
 typedef struct {
     PyTypeObject *blake2b_type;

--- a/Modules/hmacmodule.c
+++ b/Modules/hmacmodule.c
@@ -1715,11 +1715,11 @@ hmacmodule_init_cpu_features(hmacmodule_state *state)
     __cpuid_count(1, 0, eax1, ebx1, ecx1, edx1);
     __cpuid_count(7, 0, eax7, ebx7, ecx7, edx7);
 #elif defined(_M_X64)
-    int info1[4] = { 0 };
+    int info1[4] = {0};
     __cpuidex(info1, 1, 0);
     eax1 = info1[0], ebx1 = info1[1], ecx1 = info1[2], edx1 = info1[3];
 
-    int info7[4] = { 0 };
+    int info7[4] = {0};
     __cpuidex(info7, 7, 0);
     eax7 = info7[0], ebx7 = info7[1], ecx7 = info7[2], edx7 = info7[3];
 #endif


### PR DESCRIPTION
Strictly speaking, we're gaining a bit as well:

```
Modules/blake2module.c | 723
1 file changed, 357 insertions(+), 366 deletions(-)
```

I've updated `hmacmodule.c` as well so that my two functions for detecting SIMD features have the same body. I could have a separate header, but it's easier that way (ideally, I'd like to rely on #125022 for SIMD detection in the future).

<!-- gh-issue-number: gh-135004 -->
* Issue: gh-135004
<!-- /gh-issue-number -->
