### PR TITLE
gh-134938: Add `set_pledged_input_size` to ZstdCompressor 

### DIFF
--- a/Doc/library/compression.zstd.rst
+++ b/Doc/library/compression.zstd.rst
@@ -253,18 +253,18 @@ Compressing and decompressing data in memory
       the next frame. *size* will be written into the frame header of the next
       frame unless :attr:`CompressionParameter.content_size_flag` is ``False``
       or ``0``. A size of ``0`` means that the frame is empty. If *size* is
-      ``None``, the frame header will record the size as unknown.
+      ``None``, the frame header will omit the frame size.
 
-      If :attr:`~.last_mode` is not :attr:`~.FLUSH_FRAME`, a
+      If :attr:`last_mode` is not :attr:`FLUSH_FRAME`, a
       :exc:`RuntimeError` is raised as the compressor is not at the start of
       a frame. If the pledged size does not match the actual size of data
       provided to :meth:`~.compress`, future calls to :meth:`~.compress` or
-      :meth:`~.flush` may raise :exc:`ZstdError` and the last chunk of data may
+      :meth:`flush` may raise :exc:`ZstdError` and the last chunk of data may
       be lost.
 
-      After :meth:`~.flush` or :meth:`~.compress` are called with mode
-      :attr:`~.FLUSH_FRAME`, the next frame will default to have an unknown
-      size unless :meth:`!set_pledged_input_size` is called again.
+      After :meth:`flush` or :meth:`~.compress` are called with mode
+      :attr:`FLUSH_FRAME`, the next frame will not include the frame size into
+      the header unless :meth:`!set_pledged_input_size` is called again.
 
    .. attribute:: CONTINUE
 

--- a/Doc/library/compression.zstd.rst
+++ b/Doc/library/compression.zstd.rst
@@ -253,7 +253,9 @@ Compressing and decompressing data in memory
       the next frame. *size* will be written into the frame header of the next
       frame unless :attr:`CompressionParameter.content_size_flag` is ``False``
       or ``0``. A size of ``0`` means that the frame is empty. If *size* is
-      ``None``, the frame header will omit the frame size.
+      ``None``, the frame header will omit the frame size. Frames that include
+      the uncompressed data size require less memory to decompress, especially
+      at higher compression levels.
 
       If :attr:`last_mode` is not :attr:`FLUSH_FRAME`, a
       :exc:`RuntimeError` is raised as the compressor is not at the start of

--- a/Doc/library/compression.zstd.rst
+++ b/Doc/library/compression.zstd.rst
@@ -646,7 +646,7 @@ Advanced parameter control
       Write the size of the data to be compressed into the Zstandard frame
       header when known prior to compressing.
 
-      This flag only takes effect under the following three scenarios:
+      This flag only takes effect under the following scenarios:
 
       * Calling :func:`compress` for one-shot compression
       * Providing all of the data to be compressed in the frame in a single

--- a/Doc/library/compression.zstd.rst
+++ b/Doc/library/compression.zstd.rst
@@ -258,7 +258,7 @@ Compressing and decompressing data in memory
       at higher compression levels.
 
       If :attr:`last_mode` is not :attr:`FLUSH_FRAME`, a
-      :exc:`RuntimeError` is raised as the compressor is not at the start of
+      :exc:`ValueError` is raised as the compressor is not at the start of
       a frame. If the pledged size does not match the actual size of data
       provided to :meth:`~.compress`, future calls to :meth:`~.compress` or
       :meth:`flush` may raise :exc:`ZstdError` and the last chunk of data may

--- a/Doc/library/compression.zstd.rst
+++ b/Doc/library/compression.zstd.rst
@@ -285,6 +285,13 @@ Compressing and decompressing data in memory
       :meth:`~.compress` will be written into a new frame and
       *cannot* reference past data.
 
+   .. attribute:: last_mode
+
+      The last mode passed to either :meth:`~.compress` or :meth:`~.flush`.
+      The value can be one of :attr:`~.CONTINUE`, :attr:`~.FLUSH_BLOCK`, or
+      :attr:`~.FLUSH_FRAME`. The initial value is :attr:`~.FLUSH_FRAME`,
+      signifying that the compressor is at the start of a new frame.
+
 
 .. class:: ZstdDecompressor(zstd_dict=None, options=None)
 

--- a/Doc/library/compression.zstd.rst
+++ b/Doc/library/compression.zstd.rst
@@ -258,11 +258,11 @@ Compressing and decompressing data in memory
       If :attr:`last_mode` is not :attr:`FLUSH_FRAME`, a
       :exc:`RuntimeError` is raised as the compressor is not at the start of
       a frame. If the pledged size does not match the actual size of data
-      provided to :meth:`~.compress`, future calls to :meth:`~.compress` or
+      provided to :meth:`.compress`, future calls to :meth:`!compress` or
       :meth:`flush` may raise :exc:`ZstdError` and the last chunk of data may
       be lost.
 
-      After :meth:`flush` or :meth:`~.compress` are called with mode
+      After :meth:`flush` or :meth:`.compress` are called with mode
       :attr:`FLUSH_FRAME`, the next frame will not include the frame size into
       the header unless :meth:`!set_pledged_input_size` is called again.
 

--- a/Lib/test/test_zstd.py
+++ b/Lib/test/test_zstd.py
@@ -434,7 +434,7 @@ class CompressorTestCase(unittest.TestCase):
         c = ZstdCompressor(level=1)
         c.compress(b'123456')
         self.assertEqual(c.last_mode, c.CONTINUE)
-        with self.assertRaisesRegex(RuntimeError,
+        with self.assertRaisesRegex(ValueError,
                                     r'last_mode == FLUSH_FRAME'):
             c.set_pledged_input_size(300)
 

--- a/Lib/test/test_zstd.py
+++ b/Lib/test/test_zstd.py
@@ -395,6 +395,90 @@ class CompressorTestCase(unittest.TestCase):
         c = ZstdCompressor()
         self.assertNotEqual(c.compress(b'', c.FLUSH_FRAME), b'')
 
+    def test_set_pledged_input_size(self):
+        DAT = DECOMPRESSED_100_PLUS_32KB
+        CHUNK_SIZE = len(DAT) // 3
+
+        # wrong value
+        c = ZstdCompressor()
+        with self.assertRaisesRegex(ValueError,
+                                    r'should be a positive int less than \d+'):
+            c.set_pledged_input_size(-300)
+
+        # wrong mode
+        c = ZstdCompressor(level=1)
+        c.compress(b'123456')
+        self.assertEqual(c.last_mode, c.CONTINUE)
+        with self.assertRaisesRegex(RuntimeError,
+                                    r'\.last_mode == \.FLUSH_FRAME'):
+            c.set_pledged_input_size(300)
+
+        # None value
+        c = ZstdCompressor(level=1)
+        c.set_pledged_input_size(None)
+        dat = c.compress(DAT) + c.flush()
+
+        ret = get_frame_info(dat)
+        self.assertEqual(ret.decompressed_size, None)
+
+        # correct value
+        c = ZstdCompressor(level=1)
+        c.set_pledged_input_size(len(DAT))
+
+        chunks = []
+        posi = 0
+        while posi < len(DAT):
+            dat = c.compress(DAT[posi:posi+CHUNK_SIZE])
+            posi += CHUNK_SIZE
+            chunks.append(dat)
+
+        dat = c.flush()
+        chunks.append(dat)
+        chunks = b''.join(chunks)
+
+        ret = get_frame_info(chunks)
+        self.assertEqual(ret.decompressed_size, len(DAT))
+        self.assertEqual(decompress(chunks), DAT)
+
+        c.set_pledged_input_size(len(DAT)) # the second frame
+        dat = c.compress(DAT) + c.flush()
+
+        ret = get_frame_info(dat)
+        self.assertEqual(ret.decompressed_size, len(DAT))
+        self.assertEqual(decompress(dat), DAT)
+
+        # not enough data
+        c = ZstdCompressor(level=1)
+        c.set_pledged_input_size(len(DAT)+1)
+
+        for start in range(0, len(DAT), CHUNK_SIZE):
+            end = min(start+CHUNK_SIZE, len(DAT))
+            _dat = c.compress(DAT[start:end])
+
+        with self.assertRaises(ZstdError):
+            c.flush()
+
+        # too much data
+        c = ZstdCompressor(level=1)
+        c.set_pledged_input_size(len(DAT))
+
+        for start in range(0, len(DAT), CHUNK_SIZE):
+            end = min(start+CHUNK_SIZE, len(DAT))
+            _dat = c.compress(DAT[start:end])
+
+        with self.assertRaises(ZstdError):
+            c.compress(b'extra', ZstdCompressor.FLUSH_FRAME)
+
+        # content size not set if content_size_flag == 0
+        c = ZstdCompressor(options={CompressionParameter.content_size_flag: 0})
+        c.set_pledged_input_size(10)
+        dat1 = c.compress(b"hello")
+        dat2 = c.compress(b"world")
+        dat3 = c.flush()
+        frame_data = get_frame_info(dat1 + dat2 + dat3)
+        self.assertIsNone(frame_data.decompressed_size)
+
+
 class DecompressorTestCase(unittest.TestCase):
 
     def test_simple_decompress_bad_args(self):

--- a/Lib/test/test_zstd.py
+++ b/Lib/test/test_zstd.py
@@ -410,7 +410,7 @@ class CompressorTestCase(unittest.TestCase):
         c.compress(b'123456')
         self.assertEqual(c.last_mode, c.CONTINUE)
         with self.assertRaisesRegex(RuntimeError,
-                                    r'\.last_mode == \.FLUSH_FRAME'):
+                                    r'last_mode == FLUSH_FRAME'):
             c.set_pledged_input_size(300)
 
         # None value

--- a/Modules/_zstd/_zstdmodule.c
+++ b/Modules/_zstd/_zstdmodule.c
@@ -35,6 +35,9 @@ set_zstd_error(const _zstd_state* const state,
         case ERR_COMPRESS:
             msg = "Unable to compress Zstandard data: %s";
             break;
+        case ERR_SET_PLEDGED_INPUT_SIZE:
+            msg = "Unable to set pledged uncompressed content size: %s";
+            break;
 
         case ERR_LOAD_D_DICT:
             msg = "Unable to load Zstandard dictionary or prefix for "

--- a/Modules/_zstd/_zstdmodule.h
+++ b/Modules/_zstd/_zstdmodule.h
@@ -25,6 +25,7 @@ typedef struct {
 typedef enum {
     ERR_DECOMPRESS,
     ERR_COMPRESS,
+    ERR_SET_PLEDGED_INPUT_SIZE,
 
     ERR_LOAD_D_DICT,
     ERR_LOAD_C_DICT,

--- a/Modules/_zstd/clinic/compressor.c.h
+++ b/Modules/_zstd/clinic/compressor.c.h
@@ -264,7 +264,7 @@ PyDoc_STRVAR(_zstd_ZstdCompressor_set_pledged_input_size__doc__,
 "\n"
 "This method can be used to ensure the header of the frame about to be written\n"
 "includes the size of the data, unless CompressionParameter.content_size_flag is\n"
-"set to False. If .last_mode != .FLUSH_FRAME, then a RuntimeError is raised.\n"
+"set to False. If last_mode != FLUSH_FRAME, then a RuntimeError is raised.\n"
 "\n"
 "It is important to ensure that the pledged data size matches the actual data\n"
 "size. If they do not match the compressed output data may be corrupted and the\n"
@@ -275,15 +275,20 @@ PyDoc_STRVAR(_zstd_ZstdCompressor_set_pledged_input_size__doc__,
 
 static PyObject *
 _zstd_ZstdCompressor_set_pledged_input_size_impl(ZstdCompressor *self,
-                                                 PyObject *size);
+                                                 unsigned long long size);
 
 static PyObject *
-_zstd_ZstdCompressor_set_pledged_input_size(PyObject *self, PyObject *size)
+_zstd_ZstdCompressor_set_pledged_input_size(PyObject *self, PyObject *arg)
 {
     PyObject *return_value = NULL;
+    unsigned long long size;
 
+    if (!zstd_contentsize_converter(arg, &size)) {
+        goto exit;
+    }
     return_value = _zstd_ZstdCompressor_set_pledged_input_size_impl((ZstdCompressor *)self, size);
 
+exit:
     return return_value;
 }
-/*[clinic end generated code: output=6ffee5a8c9b54742 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=128a94ce706328e0 input=a9049054013a1b77]*/

--- a/Modules/_zstd/clinic/compressor.c.h
+++ b/Modules/_zstd/clinic/compressor.c.h
@@ -263,8 +263,8 @@ PyDoc_STRVAR(_zstd_ZstdCompressor_set_pledged_input_size__doc__,
 "    The size of the uncompressed data to be provided to the compressor.\n"
 "\n"
 "This method can be used to ensure the header of the frame about to be written\n"
-"includes the size of the data, unless CompressionParameter.content_size_flag is\n"
-"set to False. If last_mode != FLUSH_FRAME, then a RuntimeError is raised.\n"
+"includes the size of the data, unless the CompressionParameter.content_size_flag\n"
+"is set to False. If last_mode != FLUSH_FRAME, then a RuntimeError is raised.\n"
 "\n"
 "It is important to ensure that the pledged data size matches the actual data\n"
 "size. If they do not match the compressed output data may be corrupted and the\n"
@@ -291,4 +291,4 @@ _zstd_ZstdCompressor_set_pledged_input_size(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=128a94ce706328e0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c1d5c2cf06a8becd input=a9049054013a1b77]*/

--- a/Modules/_zstd/clinic/compressor.c.h
+++ b/Modules/_zstd/clinic/compressor.c.h
@@ -252,4 +252,38 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ee2d1dc298de790c input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(_zstd_ZstdCompressor_set_pledged_input_size__doc__,
+"set_pledged_input_size($self, size, /)\n"
+"--\n"
+"\n"
+"Set the uncompressed content size to be written into the frame header.\n"
+"\n"
+"  size\n"
+"    The size of the uncompressed data to be provided to the compressor.\n"
+"\n"
+"This method can be used to ensure the header of the frame about to be written\n"
+"includes the size of the data, unless CompressionParameter.content_size_flag is\n"
+"set to False. If .last_mode != .FLUSH_FRAME, then a RuntimeError is raised.\n"
+"\n"
+"It is important to ensure that the pledged data size matches the actual data\n"
+"size. If they do not match the compressed output data may be corrupted and the\n"
+"final chunk written may be lost.");
+
+#define _ZSTD_ZSTDCOMPRESSOR_SET_PLEDGED_INPUT_SIZE_METHODDEF    \
+    {"set_pledged_input_size", (PyCFunction)_zstd_ZstdCompressor_set_pledged_input_size, METH_O, _zstd_ZstdCompressor_set_pledged_input_size__doc__},
+
+static PyObject *
+_zstd_ZstdCompressor_set_pledged_input_size_impl(ZstdCompressor *self,
+                                                 PyObject *size);
+
+static PyObject *
+_zstd_ZstdCompressor_set_pledged_input_size(PyObject *self, PyObject *size)
+{
+    PyObject *return_value = NULL;
+
+    return_value = _zstd_ZstdCompressor_set_pledged_input_size_impl((ZstdCompressor *)self, size);
+
+    return return_value;
+}
+/*[clinic end generated code: output=6ffee5a8c9b54742 input=a9049054013a1b77]*/

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -749,8 +749,8 @@ _zstd.ZstdCompressor.set_pledged_input_size
 Set the uncompressed content size to be written into the frame header.
 
 This method can be used to ensure the header of the frame about to be written
-includes the size of the data, unless CompressionParameter.content_size_flag is
-set to False. If last_mode != FLUSH_FRAME, then a RuntimeError is raised.
+includes the size of the data, unless the CompressionParameter.content_size_flag
+is set to False. If last_mode != FLUSH_FRAME, then a RuntimeError is raised.
 
 It is important to ensure that the pledged data size matches the actual data
 size. If they do not match the compressed output data may be corrupted and the
@@ -762,8 +762,6 @@ _zstd_ZstdCompressor_set_pledged_input_size_impl(ZstdCompressor *self,
                                                  unsigned long long size)
 /*[clinic end generated code: output=3a09e55cc0e3b4f9 input=563b9a1ddd4facc3]*/
 {
-    size_t zstd_ret;
-
     // Error occured while converting argument, should be unreachable
     assert(size != ZSTD_CONTENTSIZE_ERROR);
 
@@ -780,7 +778,7 @@ _zstd_ZstdCompressor_set_pledged_input_size_impl(ZstdCompressor *self,
     }
 
     /* Set pledged content size */
-    zstd_ret = ZSTD_CCtx_setPledgedSrcSize(self->cctx, size);
+    size_t zstd_ret = ZSTD_CCtx_setPledgedSrcSize(self->cctx, size);
     PyMutex_Unlock(&self->lock);
     if (ZSTD_isError(zstd_ret)) {
         _zstd_state* mod_state = PyType_GetModuleState(Py_TYPE(self));

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -55,14 +55,6 @@ class zstd_contentsize_converter(CConverter):
 [python start generated code]*/
 /*[python end generated code: output=da39a3ee5e6b4b0d input=0932c350d633c7de]*/
 
-static inline int
-raise_wrong_contentsize(void)
-{
-    PyErr_Format(PyExc_ValueError,
-                 "size argument should be a positive int less "
-                 "than %ull", ZSTD_CONTENTSIZE_ERROR);
-    return 0;
-}
 
 static int
 zstd_contentsize_converter(PyObject *size, unsigned long long *p)
@@ -81,13 +73,19 @@ zstd_contentsize_converter(PyObject *size, unsigned long long *p)
         if (pledged_size == (unsigned long long)-1 && PyErr_Occurred()) {
             *p = ZSTD_CONTENTSIZE_ERROR;
             if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
-                return raise_wrong_contentsize();
+                PyErr_Format(PyExc_ValueError,
+                             "size argument should be a positive int less "
+                             "than %ull", ZSTD_CONTENTSIZE_ERROR);
+                return 0;
             }
             return 0;
         }
         if (pledged_size >= ZSTD_CONTENTSIZE_ERROR) {
             *p = ZSTD_CONTENTSIZE_ERROR;
-            return raise_wrong_contentsize();
+            PyErr_Format(PyExc_ValueError,
+                         "size argument should be a positive int less "
+                         "than %ull", ZSTD_CONTENTSIZE_ERROR);
+            return 0;
         }
         *p = pledged_size;
     }

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -764,7 +764,7 @@ _zstd_ZstdCompressor_set_pledged_input_size_impl(ZstdCompressor *self,
     if (self->last_mode != ZSTD_e_end) {
         PyErr_SetString(PyExc_RuntimeError,
                         "set_pledged_input_size() method must be called "
-                        "when (last_mode == FLUSH_FRAME)");
+                        "when last_mode == FLUSH_FRAME");
         goto error;
     }
 

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -770,7 +770,7 @@ _zstd_ZstdCompressor_set_pledged_input_size_impl(ZstdCompressor *self,
 
     /* Check the current mode */
     if (self->last_mode != ZSTD_e_end) {
-        PyErr_SetString(PyExc_RuntimeError,
+        PyErr_SetString(PyExc_ValueError,
                         "set_pledged_input_size() method must be called "
                         "when last_mode == FLUSH_FRAME");
         PyMutex_Unlock(&self->lock);

--- a/Modules/_zstd/compressor.c
+++ b/Modules/_zstd/compressor.c
@@ -758,7 +758,7 @@ final chunk written may be lost.
 static PyObject *
 _zstd_ZstdCompressor_set_pledged_input_size_impl(ZstdCompressor *self,
                                                  unsigned long long size)
-/*[clinic end generated code: output=3a09e55cc0e3b4f9 input=563b9a1ddd4facc3]*/
+/*[clinic end generated code: output=3a09e55cc0e3b4f9 input=afd8a7d78cff2eb5]*/
 {
     // Error occured while converting argument, should be unreachable
     assert(size != ZSTD_CONTENTSIZE_ERROR);


### PR DESCRIPTION
This PR adds a new method `set_pledged_input_size()`, which allows users to declare up front how much data will be written to the compressor for a given frame. This combined with `CompressionParameter.content_size_flag` allows users to ensure that even for streaming compression scenarios the content size is written into the zstd frame header, which is beneficial for reducing decompression memory usage.

<!-- gh-issue-number: gh-134938 -->
* Issue: gh-134938
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135010.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->