### PR TITLE
Remove newline in `Doc/c-api/lifecycle.rst` for `gettext` builder

### DIFF
--- a/Doc/c-api/lifecycle.rst
+++ b/Doc/c-api/lifecycle.rst
@@ -55,16 +55,14 @@ that must be true for *B* to occur after *A*.
    .. image:: lifecycle.dot.svg
       :align: center
       :class: invert-in-dark-mode
-      :alt: Diagram showing events in an object's life.  Explained in detail
-            below.
+      :alt: Diagram showing events in an object's life.  Explained in detail below.
 
 .. only:: latex
 
    .. image:: lifecycle.dot.pdf
       :align: center
       :class: invert-in-dark-mode
-      :alt: Diagram showing events in an object's life.  Explained in detail
-            below.
+      :alt: Diagram showing events in an object's life.  Explained in detail below.
 
 .. container::
    :name: life-events-graph-description


### PR DESCRIPTION
This newline is causing Sphinx's gettext builder to extract the message including the `\n` character instead of keeping all in a single string.

For instance, see how that string looks in the [translation file for Brazilian Portuguese](https://github.com/python/python-docs-pt-br/blob/cbde60a4c95e2bea6465aba0f45476fd0d256f8c/c-api/lifecycle.po#L51-L55):

```gettext
#: ../../c-api/lifecycle.rst:55 ../../c-api/lifecycle.rst:63
msgid ""
"Diagram showing events in an object's life.  Explained in detail\n"
"below."
msgstr ""
```

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135013.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->