### PR TITLE
gh-130999: Fix globals() poisoning in test_traceback

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -4232,8 +4232,8 @@ class SuggestionFormattingTestBase:
 
         return mod_name
 
-    def get_import_from_suggestion(self, mod_dict, name):
-        modname = self.make_module(mod_dict)
+    def get_import_from_suggestion(self, code, name):
+        modname = self.make_module(code)
 
         def callable():
             try:
@@ -4416,8 +4416,9 @@ class SuggestionFormattingTestBase:
     def test_name_error_suggestions_with_non_string_candidates(self):
         def func():
             abc = 1
-            globals()[0] = 1
-            abv
+            custom_globals = globals().copy()
+            custom_globals[0] = 1
+            print(eval("abv", custom_globals, locals()))
         actual = self.get_suggestion(func)
         self.assertIn("abc", actual)
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-130999 -->
* Issue: gh-130999
<!-- /gh-issue-number -->
