### PR TITLE
gh-135032: Disable the SIMD128/SIMD256 for Linux arm64 explictly

### DIFF
--- a/Modules/blake2module.c
+++ b/Modules/blake2module.c
@@ -41,12 +41,12 @@
 
 #include <stdbool.h>
 
-// SIMD256 can't be compiled on macOS ARM64, and performance of SIMD128 isn't
+// SIMD256 can't be compiled on macOS and Linux ARM64, and performance of SIMD128 isn't
 // great; but when compiling a universal2 binary, autoconf will set
 // HACL_CAN_COMPILE_SIMD128 and HACL_CAN_COMPILE_SIMD256 because they *can* be
-// compiled on x86_64. If we're on macOS ARM64, disable these preprocessor
+// compiled on x86_64. If we're on macOS and Linux ARM6, disable these preprocessor
 // symbols.
-#if defined(__APPLE__) && defined(__arm64__)
+#if (defined(__APPLE__) || defined(__linux__)) && defined(__arm64__)
 #  undef HACL_CAN_COMPILE_SIMD128
 #  undef HACL_CAN_COMPILE_SIMD256
 #endif

--- a/Modules/hmacmodule.c
+++ b/Modules/hmacmodule.c
@@ -30,7 +30,7 @@
 #  include <intrin.h>
 #endif
 
-#if defined(__APPLE__) && defined(__arm64__)
+#if (defined(__APPLE__) || defined(__linux__)) && defined(__arm64__)
 #  undef HACL_CAN_COMPILE_SIMD128
 #  undef HACL_CAN_COMPILE_SIMD256
 #endif


### PR DESCRIPTION
Fix #135032