### PR TITLE
gh-135034: Normalize link targets in tarfile, add `os.path.realpath(strict='allow_missing')`

### DIFF
--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -424,7 +424,7 @@ the :mod:`glob` module.)
    In particular, :exc:`FileNotFoundError` is raised if *path* does not exist,
    or another :exc:`OSError` if it is otherwise inaccessible.
 
-   If *strict* is the string `'allow_missing'`, errors other than
+   If *strict* is the string ``'allow_missing'``, errors other than
    :exc:`FileNotFoundError` are re-raised (as with ``strict=True``).
    Thus, the returned path will not contain any symbolic links, but the named
    file and some of its parent directories may be missing.

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -447,7 +447,8 @@ the :mod:`glob` module.)
       The *strict* parameter was added.
 
    .. versionchanged:: next
-      The :py:data:`~ntpath.ALLOW_MISSING` value for *strict* parameter was added.
+      The :py:data:`~os.path.ALLOW_MISSING` value for the *strict* parameter
+      was added.
 
 .. data:: ALLOW_MISSING
 

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -424,7 +424,7 @@ the :mod:`glob` module.)
    In particular, :exc:`FileNotFoundError` is raised if *path* does not exist,
    or another :exc:`OSError` if it is otherwise inaccessible.
 
-   If *strict* is the string ``'allow_missing'``, errors other than
+   If *strict* is :py:data:`os.path.ALLOW_MISSING`, errors other than
    :exc:`FileNotFoundError` are re-raised (as with ``strict=True``).
    Thus, the returned path will not contain any symbolic links, but the named
    file and some of its parent directories may be missing.
@@ -447,7 +447,13 @@ the :mod:`glob` module.)
       The *strict* parameter was added.
 
    .. versionchanged:: next
-      The ``'allow_missing'`` value for *strict* parameter was added.
+      The :py:data:`~ntpath.ALLOW_MISSING` value for *strict* parameter was added.
+
+.. data:: ALLOW_MISSING
+
+   Special value used for the *strict* argument in :func:`realpath`.
+
+   .. versionadded:: next
 
 .. function:: relpath(path, start=os.curdir)
 

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -408,9 +408,26 @@ the :mod:`glob` module.)
    system). On Windows, this function will also resolve MS-DOS (also called 8.3)
    style names such as ``C:\\PROGRA~1`` to ``C:\\Program Files``.
 
-   If a path doesn't exist or a symlink loop is encountered, and *strict* is
-   ``True``, :exc:`OSError` is raised. If *strict* is ``False`` these errors
-   are ignored, and so the result might be missing or otherwise inaccessible.
+   By default, the path is evaluated up to the first component that does not
+   exist, is a symlink loop, or whose evaluation raises :exc:`OSError`.
+   All such components are appended unchanged to the existing part of the path.
+
+   Some errors that are handled this way include "access denied", "not a
+   directory", or "bad argument to internal function". Thus, the
+   resulting path may be missing or inaccessible, may still contain
+   links or loops, and may traverse non-directories.
+
+   This behavior can be modified by keyword arguments:
+
+   If *strict* is ``True``, the first error encountered when evaluating the path is
+   re-raised.
+   In particular, :exc:`FileNotFoundError` is raised if *path* does not exist,
+   or another :exc:`OSError` if it is otherwise inaccessible.
+
+   If *strict* is the string `'allow_missing'`, errors other than
+   :exc:`FileNotFoundError` are re-raised (as with ``strict=True``).
+   Thus, the returned path will not contain any symbolic links, but the named
+   file and some of its parent directories may be missing.
 
    .. note::
       This function emulates the operating system's procedure for making a path
@@ -429,6 +446,8 @@ the :mod:`glob` module.)
    .. versionchanged:: 3.10
       The *strict* parameter was added.
 
+   .. versionchanged:: next
+      The ``'allow_missing'`` value for *strict* parameter was added.
 
 .. function:: relpath(path, start=os.curdir)
 

--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -1079,7 +1079,7 @@ reused in custom filters:
 
   - Normalize link targets (:attr:`TarInfo.linkname`) using
     :func:`os.path.normpath`.
-    Note that this removes internal `..` components, which may change the
+    Note that this removes internal ``..`` components, which may change the
     meaning of the link if the path in :attr:`!TarInfo.linkname` traverses
     symbolic links.
 

--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -255,6 +255,15 @@ The :mod:`tarfile` module defines the following exceptions:
    Raised to refuse extracting a symbolic link pointing outside the destination
    directory.
 
+.. exception:: LinkFallbackError
+
+   Raised to refuse emulating a link (hard or symbolic) by extracting another
+   archive member, when that member would be rejected by the filter location.
+   The exception that was raised to reject the replacement member is available
+   as :attr:`!BaseException.__context__`.
+
+   .. versionadded:: next
+
 
 The following constants are available at the module level:
 
@@ -1068,6 +1077,12 @@ reused in custom filters:
   Implements the ``'data'`` filter.
   In addition to what ``tar_filter`` does:
 
+  - Normalize link targets (:attr:`TarInfo.linkname`) using
+    :func:`os.path.normpath`.
+    Note that this removes internal `..` components, which may change the
+    meaning of the link if the path in :attr:`!TarInfo.linkname` traverses
+    symbolic links.
+
   - :ref:`Refuse <tarfile-extraction-refuse>` to extract links (hard or soft)
     that link to absolute paths, or ones that link outside the destination.
 
@@ -1099,6 +1114,10 @@ reused in custom filters:
   Note that this filter does not block *all* dangerous archive features.
   See :ref:`tarfile-further-verification`  for details.
 
+  .. versionchanged:: next
+
+     Link targets are now normalized.
+
 
 .. _tarfile-extraction-refuse:
 
@@ -1127,6 +1146,7 @@ Here is an incomplete list of things to consider:
 * Extract to a :func:`new temporary directory <tempfile.mkdtemp>`
   to prevent e.g. exploiting pre-existing links, and to make it easier to
   clean up after a failed extraction.
+* Disallow symbolic links if you do not need the functionality.
 * When working with untrusted data, use external (e.g. OS-level) limits on
   disk, memory and CPU usage.
 * Check filenames against an allow-list of characters

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -116,7 +116,7 @@ os.path
 -------
 
 * The *strict* parameter to :func:`os.path.realpath` accepts a new value,
-  `'allow_missing'`.
+  ``'allow_missing'``.
   If used, errors other than :exc:`FileNotFoundError` will be re-raised;
   the resulting path can be missing but it will be free of symlinks.
   (Contributed by Petr Viktorin for :cve:`2025-4517`.)

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -116,7 +116,7 @@ os.path
 -------
 
 * The *strict* parameter to :func:`os.path.realpath` accepts a new value,
-  ``'allow_missing'``.
+  :data:`os.path.ALLOW_MISSING`.
   If used, errors other than :exc:`FileNotFoundError` will be re-raised;
   the resulting path can be missing but it will be free of symlinks.
   (Contributed by Petr Viktorin for :cve:`2025-4517`.)

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -112,6 +112,16 @@ math
   (Contributed by Sergey B Kirpichev in :gh:`132908`.)
 
 
+os.path
+-------
+
+* The *strict* parameter to :func:`os.path.realpath` accepts a new value,
+  `'allow_missing'`.
+  If used, errors other than :exc:`FileNotFoundError` will be re-raised;
+  the resulting path can be missing but it will be free of symlinks.
+  (Contributed by Petr Viktorin for :cve:`2025-4517`.)
+
+
 shelve
 ------
 
@@ -126,6 +136,28 @@ ssl
 * Indicate through :data:`ssl.HAS_PSK_TLS13` whether the :mod:`ssl` module
   supports "External PSKs" in TLSv1.3, as described in RFC 9258.
   (Contributed by Will Childs-Klein in :gh:`133624`.)
+
+
+tarfile
+-------
+
+* :func:`~tarfile.data_filter` now normalizes symbolic link targets in order to
+  avoid path traversal attacks.
+  (Contributed by Petr Viktorin in :gh:`127987` and :cve:`2025-4138`.)
+* :func:`~tarfile.TarFile.extractall` now skips fixing up directory attributes
+  when a directory was removed or replaced by another kind of file.
+  (Contributed by Petr Viktorin in :gh:`127987` and :cve:`2024-12718`.)
+* :func:`~tarfile.TarFile.extract` and :func:`~tarfile.TarFile.extractall`
+  now (re-)apply the extraction filter when substituting a link (hard or
+  symbolic) with a copy of another archive member, and when fixing up
+  directory attributes.
+  The former raises a new exception, :exc:`~tarfile.LinkFallbackError`.
+  (Contributed by Petr Viktorin for :cve:`2025-4330` and :cve:`2024-12718`.)
+* :func:`~tarfile.TarFile.extract` and :func:`~tarfile.TarFile.extractall`
+  no longer extract rejected members when
+  :func:`~tarfile.TarFile.errorlevel` is zero.
+  (Contributed by Matt Prodani and Petr Viktorin in :gh:`112887`
+  and :cve:`2025-4435`.)
 
 
 zlib

--- a/Lib/genericpath.py
+++ b/Lib/genericpath.py
@@ -8,7 +8,7 @@ import stat
 
 __all__ = ['commonprefix', 'exists', 'getatime', 'getctime', 'getmtime',
            'getsize', 'isdevdrive', 'isdir', 'isfile', 'isjunction', 'islink',
-           'lexists', 'samefile', 'sameopenfile', 'samestat']
+           'lexists', 'samefile', 'sameopenfile', 'samestat', 'ALLOW_MISSING']
 
 
 # Does a path exist?
@@ -189,3 +189,12 @@ def _check_arg_types(funcname, *args):
                             f'os.PathLike object, not {s.__class__.__name__!r}') from None
     if hasstr and hasbytes:
         raise TypeError("Can't mix strings and bytes in path components") from None
+
+# A singleton with a true boolean value.
+@object.__new__
+class ALLOW_MISSING:
+    """Special value for use in realpath()."""
+    def __repr__(self):
+        return 'os.path.ALLOW_MISSING'
+    def __reduce__(self):
+        return self.__class__.__name__

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -601,9 +601,10 @@ try:
     from nt import _findfirstfile, _getfinalpathname, readlink as _nt_readlink
 except ImportError:
     # realpath is a no-op on systems without _getfinalpathname support.
-    realpath = abspath
+    def realpath(path, *, strict=False):
+        return abspath(path)
 else:
-    def _readlink_deep(path):
+    def _readlink_deep(path, ignored_error=OSError):
         # These error codes indicate that we should stop reading links and
         # return the path we currently have.
         # 1: ERROR_INVALID_FUNCTION
@@ -636,7 +637,7 @@ else:
                         path = old_path
                         break
                     path = normpath(join(dirname(old_path), path))
-            except OSError as ex:
+            except ignored_error as ex:
                 if ex.winerror in allowed_winerror:
                     break
                 raise
@@ -645,7 +646,7 @@ else:
                 break
         return path
 
-    def _getfinalpathname_nonstrict(path):
+    def _getfinalpathname_nonstrict(path, ignored_error=OSError):
         # These error codes indicate that we should stop resolving the path
         # and return the value we currently have.
         # 1: ERROR_INVALID_FUNCTION
@@ -673,17 +674,18 @@ else:
             try:
                 path = _getfinalpathname(path)
                 return join(path, tail) if tail else path
-            except OSError as ex:
+            except ignored_error as ex:
                 if ex.winerror not in allowed_winerror:
                     raise
                 try:
                     # The OS could not resolve this path fully, so we attempt
                     # to follow the link ourselves. If we succeed, join the tail
                     # and return.
-                    new_path = _readlink_deep(path)
+                    new_path = _readlink_deep(path,
+                                              ignored_error=ignored_error)
                     if new_path != path:
                         return join(new_path, tail) if tail else new_path
-                except OSError:
+                except ignored_error:
                     # If we fail to readlink(), let's keep traversing
                     pass
                 # If we get these errors, try to get the real name of the file without accessing it.
@@ -691,7 +693,7 @@ else:
                     try:
                         name = _findfirstfile(path)
                         path, _ = split(path)
-                    except OSError:
+                    except ignored_error:
                         path, name = split(path)
                 else:
                     path, name = split(path)
@@ -721,6 +723,15 @@ else:
             if normcase(path) == devnull:
                 return '\\\\.\\NUL'
         had_prefix = path.startswith(prefix)
+
+        if strict == 'allow_missing':
+            ignored_error = FileNotFoundError
+            strict = True
+        elif strict:
+            ignored_error = ()
+        else:
+            ignored_error = OSError
+
         if not had_prefix and not isabs(path):
             path = join(cwd, path)
         try:
@@ -728,17 +739,16 @@ else:
             initial_winerror = 0
         except ValueError as ex:
             # gh-106242: Raised for embedded null characters
-            # In strict mode, we convert into an OSError.
+            # In strict modes, we convert into an OSError.
             # Non-strict mode returns the path as-is, since we've already
             # made it absolute.
             if strict:
                 raise OSError(str(ex)) from None
             path = normpath(path)
-        except OSError as ex:
-            if strict:
-                raise
+        except ignored_error as ex:
             initial_winerror = ex.winerror
-            path = _getfinalpathname_nonstrict(path)
+            path = _getfinalpathname_nonstrict(path,
+                                               ignored_error=ignored_error)
         # The path returned by _getfinalpathname will always start with \\?\ -
         # strip off that prefix unless it was already provided on the original
         # path.

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -29,7 +29,7 @@ __all__ = ["normcase","isabs","join","splitdrive","splitroot","split","splitext"
            "abspath","curdir","pardir","sep","pathsep","defpath","altsep",
            "extsep","devnull","realpath","supports_unicode_filenames","relpath",
            "samefile", "sameopenfile", "samestat", "commonpath", "isjunction",
-           "isdevdrive"]
+           "isdevdrive", "ALLOW_MISSING"]
 
 def _get_bothseps(path):
     if isinstance(path, bytes):
@@ -724,7 +724,7 @@ else:
                 return '\\\\.\\NUL'
         had_prefix = path.startswith(prefix)
 
-        if strict == 'allow_missing':
+        if strict is ALLOW_MISSING:
             ignored_error = FileNotFoundError
             strict = True
         elif strict:

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -36,7 +36,7 @@ __all__ = ["normcase","isabs","join","splitdrive","splitroot","split","splitext"
            "samefile","sameopenfile","samestat",
            "curdir","pardir","sep","pathsep","defpath","altsep","extsep",
            "devnull","realpath","supports_unicode_filenames","relpath",
-           "commonpath", "isjunction","isdevdrive"]
+           "commonpath", "isjunction","isdevdrive","ALLOW_MISSING"]
 
 
 def _get_sep(path):
@@ -402,7 +402,7 @@ symbolic links encountered in the path."""
         curdir = '.'
         pardir = '..'
         getcwd = os.getcwd
-    if strict == 'allow_missing':
+    if strict is ALLOW_MISSING:
         ignored_error = FileNotFoundError
         strict = True
     elif strict:

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -402,10 +402,18 @@ symbolic links encountered in the path."""
         curdir = '.'
         pardir = '..'
         getcwd = os.getcwd
-    return _realpath(filename, strict, sep, curdir, pardir, getcwd)
+    if strict == 'allow_missing':
+        ignored_error = FileNotFoundError
+        strict = True
+    elif strict:
+        ignored_error = ()
+    else:
+        ignored_error = OSError
 
-def _realpath(filename, strict=False, sep=sep, curdir=curdir, pardir=pardir,
-              getcwd=os.getcwd, lstat=os.lstat, readlink=os.readlink, maxlinks=None):
+    lstat = os.lstat
+    readlink = os.readlink
+    maxlinks = None
+
     # The stack of unresolved path parts. When popped, a special value of None
     # indicates that a symlink target has been resolved, and that the original
     # symlink path can be retrieved by popping again. The [::-1] slice is a
@@ -477,27 +485,28 @@ def _realpath(filename, strict=False, sep=sep, curdir=curdir, pardir=pardir,
                 path = newpath
                 continue
             target = readlink(newpath)
-        except OSError:
-            if strict:
-                raise
-            path = newpath
+        except ignored_error:
+            pass
+        else:
+            # Resolve the symbolic link
+            if target.startswith(sep):
+                # Symlink target is absolute; reset resolved path.
+                path = sep
+            if maxlinks is None:
+                # Mark this symlink as seen but not fully resolved.
+                seen[newpath] = None
+                # Push the symlink path onto the stack, and signal its specialness
+                # by also pushing None. When these entries are popped, we'll
+                # record the fully-resolved symlink target in the 'seen' mapping.
+                rest.append(newpath)
+                rest.append(None)
+            # Push the unresolved symlink target parts onto the stack.
+            target_parts = target.split(sep)[::-1]
+            rest.extend(target_parts)
+            part_count += len(target_parts)
             continue
-        # Resolve the symbolic link
-        if target.startswith(sep):
-            # Symlink target is absolute; reset resolved path.
-            path = sep
-        if maxlinks is None:
-            # Mark this symlink as seen but not fully resolved.
-            seen[newpath] = None
-            # Push the symlink path onto the stack, and signal its specialness
-            # by also pushing None. When these entries are popped, we'll
-            # record the fully-resolved symlink target in the 'seen' mapping.
-            rest.append(newpath)
-            rest.append(None)
-        # Push the unresolved symlink target parts onto the stack.
-        target_parts = target.split(sep)[::-1]
-        rest.extend(target_parts)
-        part_count += len(target_parts)
+        # An error occurred and was ignored.
+        path = newpath
 
     return path
 

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -67,7 +67,7 @@ __all__ = ["TarFile", "TarInfo", "is_tarfile", "TarError", "ReadError",
            "DEFAULT_FORMAT", "open","fully_trusted_filter", "data_filter",
            "tar_filter", "FilterError", "AbsoluteLinkError",
            "OutsideDestinationError", "SpecialFileError", "AbsolutePathError",
-           "LinkOutsideDestinationError"]
+           "LinkOutsideDestinationError", "LinkFallbackError"]
 
 
 #---------------------------------------------------------
@@ -766,10 +766,22 @@ class LinkOutsideDestinationError(FilterError):
         super().__init__(f'{tarinfo.name!r} would link to {path!r}, '
                          + 'which is outside the destination')
 
+class LinkFallbackError(FilterError):
+    def __init__(self, tarinfo, path):
+        self.tarinfo = tarinfo
+        self._path = path
+        super().__init__(f'link {tarinfo.name!r} would be extracted as a '
+                         + f'copy of {path!r}, which was rejected')
+
+# Errors caused by filters -- both "fatal" and "non-fatal" -- that
+# we consider to be issues with the argument, rather than a bug in the
+# filter function
+_FILTER_ERRORS = (FilterError, OSError, ExtractError)
+
 def _get_filtered_attrs(member, dest_path, for_data=True):
     new_attrs = {}
     name = member.name
-    dest_path = os.path.realpath(dest_path)
+    dest_path = os.path.realpath(dest_path, strict='allow_missing')
     # Strip leading / (tar's directory separator) from filenames.
     # Include os.sep (target OS directory separator) as well.
     if name.startswith(('/', os.sep)):
@@ -779,7 +791,8 @@ def _get_filtered_attrs(member, dest_path, for_data=True):
         # For example, 'C:/foo' on Windows.
         raise AbsolutePathError(member)
     # Ensure we stay in the destination
-    target_path = os.path.realpath(os.path.join(dest_path, name))
+    target_path = os.path.realpath(os.path.join(dest_path, name),
+                                   strict='allow_missing')
     if os.path.commonpath([target_path, dest_path]) != dest_path:
         raise OutsideDestinationError(member, target_path)
     # Limit permissions (no high bits, and go-w)
@@ -817,6 +830,9 @@ def _get_filtered_attrs(member, dest_path, for_data=True):
         if member.islnk() or member.issym():
             if os.path.isabs(member.linkname):
                 raise AbsoluteLinkError(member)
+            normalized = os.path.normpath(member.linkname)
+            if normalized != member.linkname:
+                new_attrs['linkname'] = normalized
             if member.issym():
                 target_path = os.path.join(dest_path,
                                            os.path.dirname(name),
@@ -824,7 +840,7 @@ def _get_filtered_attrs(member, dest_path, for_data=True):
             else:
                 target_path = os.path.join(dest_path,
                                            member.linkname)
-            target_path = os.path.realpath(target_path)
+            target_path = os.path.realpath(target_path, strict='allow_missing')
             if os.path.commonpath([target_path, dest_path]) != dest_path:
                 raise LinkOutsideDestinationError(member, target_path)
     return new_attrs
@@ -2386,29 +2402,57 @@ class TarFile(object):
             members = self
 
         for member in members:
-            tarinfo = self._get_extract_tarinfo(member, filter_function, path)
+            tarinfo, unfiltered = self._get_extract_tarinfo(
+                member, filter_function, path)
             if tarinfo is None:
                 continue
             if tarinfo.isdir():
                 # For directories, delay setting attributes until later,
                 # since permissions can interfere with extraction and
                 # extracting contents can reset mtime.
-                directories.append(tarinfo)
+                directories.append(unfiltered)
             self._extract_one(tarinfo, path, set_attrs=not tarinfo.isdir(),
-                              numeric_owner=numeric_owner)
+                              numeric_owner=numeric_owner,
+                              filter_function=filter_function)
 
         # Reverse sort directories.
         directories.sort(key=lambda a: a.name, reverse=True)
 
+
         # Set correct owner, mtime and filemode on directories.
-        for tarinfo in directories:
-            dirpath = os.path.join(path, tarinfo.name)
+        for unfiltered in directories:
             try:
+                # Need to re-apply any filter, to take the *current* filesystem
+                # state into account.
+                try:
+                    tarinfo = filter_function(unfiltered, path)
+                except _FILTER_ERRORS as exc:
+                    self._log_no_directory_fixup(unfiltered, repr(exc))
+                    continue
+                if tarinfo is None:
+                    self._log_no_directory_fixup(unfiltered,
+                                                 'excluded by filter')
+                    continue
+                dirpath = os.path.join(path, tarinfo.name)
+                try:
+                    lstat = os.lstat(dirpath)
+                except FileNotFoundError:
+                    self._log_no_directory_fixup(tarinfo, 'missing')
+                    continue
+                if not stat.S_ISDIR(lstat.st_mode):
+                    # This is no longer a directory; presumably a later
+                    # member overwrote the entry.
+                    self._log_no_directory_fixup(tarinfo, 'not a directory')
+                    continue
                 self.chown(tarinfo, dirpath, numeric_owner=numeric_owner)
                 self.utime(tarinfo, dirpath)
                 self.chmod(tarinfo, dirpath)
             except ExtractError as e:
                 self._handle_nonfatal_error(e)
+
+    def _log_no_directory_fixup(self, member, reason):
+        self._dbg(2, "tarfile: Not fixing up directory %r (%s)" %
+                  (member.name, reason))
 
     def extract(self, member, path="", set_attrs=True, *, numeric_owner=False,
                 filter=None):
@@ -2425,41 +2469,56 @@ class TarFile(object):
            String names of common filters are accepted.
         """
         filter_function = self._get_filter_function(filter)
-        tarinfo = self._get_extract_tarinfo(member, filter_function, path)
+        tarinfo, unfiltered = self._get_extract_tarinfo(
+            member, filter_function, path)
         if tarinfo is not None:
             self._extract_one(tarinfo, path, set_attrs, numeric_owner)
 
     def _get_extract_tarinfo(self, member, filter_function, path):
-        """Get filtered TarInfo (or None) from member, which might be a str"""
-        if isinstance(member, str):
-            tarinfo = self.getmember(member)
-        else:
-            tarinfo = member
+        """Get (filtered, unfiltered) TarInfos from *member*
 
-        unfiltered = tarinfo
+        *member* might be a string.
+
+        Return (None, None) if not found.
+        """
+
+        if isinstance(member, str):
+            unfiltered = self.getmember(member)
+        else:
+            unfiltered = member
+
+        filtered = None
         try:
-            tarinfo = filter_function(tarinfo, path)
+            filtered = filter_function(unfiltered, path)
         except (OSError, UnicodeEncodeError, FilterError) as e:
             self._handle_fatal_error(e)
         except ExtractError as e:
             self._handle_nonfatal_error(e)
-        if tarinfo is None:
+        if filtered is None:
             self._dbg(2, "tarfile: Excluded %r" % unfiltered.name)
-            return None
-        # Prepare the link target for makelink().
-        if tarinfo.islnk():
-            tarinfo = copy.copy(tarinfo)
-            tarinfo._link_target = os.path.join(path, tarinfo.linkname)
-        return tarinfo
+            return None, None
 
-    def _extract_one(self, tarinfo, path, set_attrs, numeric_owner):
-        """Extract from filtered tarinfo to disk"""
+        # Prepare the link target for makelink().
+        if filtered.islnk():
+            filtered = copy.copy(filtered)
+            filtered._link_target = os.path.join(path, filtered.linkname)
+        return filtered, unfiltered
+
+    def _extract_one(self, tarinfo, path, set_attrs, numeric_owner,
+                     filter_function=None):
+        """Extract from filtered tarinfo to disk.
+
+           filter_function is only used when extracting a *different*
+           member (e.g. as fallback to creating a symlink)
+        """
         self._check("r")
 
         try:
             self._extract_member(tarinfo, os.path.join(path, tarinfo.name),
                                  set_attrs=set_attrs,
-                                 numeric_owner=numeric_owner)
+                                 numeric_owner=numeric_owner,
+                                 filter_function=filter_function,
+                                 extraction_root=path)
         except (OSError, UnicodeEncodeError) as e:
             self._handle_fatal_error(e)
         except ExtractError as e:
@@ -2517,9 +2576,13 @@ class TarFile(object):
             return None
 
     def _extract_member(self, tarinfo, targetpath, set_attrs=True,
-                        numeric_owner=False):
-        """Extract the TarInfo object tarinfo to a physical
+                        numeric_owner=False, *, filter_function=None,
+                        extraction_root=None):
+        """Extract the filtered TarInfo object tarinfo to a physical
            file called targetpath.
+
+           filter_function is only used when extracting a *different*
+           member (e.g. as fallback to creating a symlink)
         """
         # Fetch the TarInfo object for the given name
         # and build the destination pathname, replacing
@@ -2548,7 +2611,10 @@ class TarFile(object):
         elif tarinfo.ischr() or tarinfo.isblk():
             self.makedev(tarinfo, targetpath)
         elif tarinfo.islnk() or tarinfo.issym():
-            self.makelink(tarinfo, targetpath)
+            self.makelink_with_filter(
+                tarinfo, targetpath,
+                filter_function=filter_function,
+                extraction_root=extraction_root)
         elif tarinfo.type not in SUPPORTED_TYPES:
             self.makeunknown(tarinfo, targetpath)
         else:
@@ -2631,10 +2697,18 @@ class TarFile(object):
                  os.makedev(tarinfo.devmajor, tarinfo.devminor))
 
     def makelink(self, tarinfo, targetpath):
+        return self.makelink_with_filter(tarinfo, targetpath, None, None)
+
+    def makelink_with_filter(self, tarinfo, targetpath,
+                             filter_function, extraction_root):
         """Make a (symbolic) link called targetpath. If it cannot be created
           (platform limitation), we try to make a copy of the referenced file
           instead of a link.
+
+          filter_function is only used when extracting a *different*
+          member (e.g. as fallback to creating a link).
         """
+        keyerror_to_extracterror = False
         try:
             # For systems that support symbolic and hard links.
             if tarinfo.issym():
@@ -2642,18 +2716,38 @@ class TarFile(object):
                     # Avoid FileExistsError on following os.symlink.
                     os.unlink(targetpath)
                 os.symlink(tarinfo.linkname, targetpath)
+                return
             else:
                 if os.path.exists(tarinfo._link_target):
                     os.link(tarinfo._link_target, targetpath)
-                else:
-                    self._extract_member(self._find_link_target(tarinfo),
-                                         targetpath)
+                    return
         except symlink_exception:
+            keyerror_to_extracterror = True
+
+        try:
+            unfiltered = self._find_link_target(tarinfo)
+        except KeyError:
+            if keyerror_to_extracterror:
+                raise ExtractError(
+                    "unable to resolve link inside archive") from None
+            else:
+                raise
+
+        if filter_function is None:
+            filtered = unfiltered
+        else:
+            if extraction_root is None:
+                raise ExtractError(
+                    "makelink_with_filter: if filter_function is not None, "
+                    + "extraction_root must also not be None")
             try:
-                self._extract_member(self._find_link_target(tarinfo),
-                                     targetpath)
-            except KeyError:
-                raise ExtractError("unable to resolve link inside archive") from None
+                filtered = filter_function(unfiltered, extraction_root)
+            except _FILTER_ERRORS as cause:
+                raise LinkFallbackError(tarinfo, unfiltered.name) from cause
+        if filtered is not None:
+            self._extract_member(filtered, targetpath,
+                                 filter_function=filter_function,
+                                 extraction_root=extraction_root)
 
     def chown(self, tarinfo, targetpath, numeric_owner):
         """Set owner of targetpath according to tarinfo. If numeric_owner

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -781,7 +781,7 @@ _FILTER_ERRORS = (FilterError, OSError, ExtractError)
 def _get_filtered_attrs(member, dest_path, for_data=True):
     new_attrs = {}
     name = member.name
-    dest_path = os.path.realpath(dest_path, strict='allow_missing')
+    dest_path = os.path.realpath(dest_path, strict=os.path.ALLOW_MISSING)
     # Strip leading / (tar's directory separator) from filenames.
     # Include os.sep (target OS directory separator) as well.
     if name.startswith(('/', os.sep)):
@@ -792,7 +792,7 @@ def _get_filtered_attrs(member, dest_path, for_data=True):
         raise AbsolutePathError(member)
     # Ensure we stay in the destination
     target_path = os.path.realpath(os.path.join(dest_path, name),
-                                   strict='allow_missing')
+                                   strict=os.path.ALLOW_MISSING)
     if os.path.commonpath([target_path, dest_path]) != dest_path:
         raise OutsideDestinationError(member, target_path)
     # Limit permissions (no high bits, and go-w)
@@ -840,7 +840,8 @@ def _get_filtered_attrs(member, dest_path, for_data=True):
             else:
                 target_path = os.path.join(dest_path,
                                            member.linkname)
-            target_path = os.path.realpath(target_path, strict='allow_missing')
+            target_path = os.path.realpath(target_path,
+                                           strict=os.path.ALLOW_MISSING)
             if os.path.commonpath([target_path, dest_path]) != dest_path:
                 raise LinkOutsideDestinationError(member, target_path)
     return new_attrs

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -989,10 +989,6 @@ class TestNtpath(NtpathTestCase):
             raise unittest.SkipTest('failed to deny access to the test file')
 
         self.assertPathEqual(test_file, ntpath.realpath(test_file_short))
-        with self.assertRaises(OSError):
-            ntpath.realpath(test_file_short, strict=True)
-        with self.assertRaises(OSError):
-            ntpath.realpath(test_file_short, strict='allow_missing')
 
     def test_expandvars(self):
         with os_helper.EnvironmentVarGuard() as env:

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import unittest
 import warnings
+from ntpath import ALLOW_MISSING
 from test.support import TestFailed, cpython_only, os_helper
 from test.support.os_helper import FakePath
 from test import test_genericpath
@@ -505,15 +506,15 @@ class TestNtpath(NtpathTestCase):
 
     def test_realpath_curdir_missing_ok(self):
         expected = ntpath.normpath(os.getcwd())
-        tester("ntpath.realpath('.', strict='allow_missing')",
+        tester("ntpath.realpath('.', strict=ALLOW_MISSING)",
                expected)
-        tester("ntpath.realpath('./.', strict='allow_missing')",
+        tester("ntpath.realpath('./.', strict=ALLOW_MISSING)",
                expected)
-        tester("ntpath.realpath('/'.join(['.'] * 100), strict='allow_missing')",
+        tester("ntpath.realpath('/'.join(['.'] * 100), strict=ALLOW_MISSING)",
                expected)
-        tester("ntpath.realpath('.\\.', strict='allow_missing')",
+        tester("ntpath.realpath('.\\.', strict=ALLOW_MISSING)",
                expected)
-        tester("ntpath.realpath('\\'.join(['.'] * 100), strict='allow_missing')",
+        tester("ntpath.realpath('\\'.join(['.'] * 100), strict=ALLOW_MISSING)",
                expected)
 
     def test_realpath_pardir(self):
@@ -542,20 +543,20 @@ class TestNtpath(NtpathTestCase):
 
     def test_realpath_pardir_missing_ok(self):
         expected = ntpath.normpath(os.getcwd())
-        tester("ntpath.realpath('..', strict='allow_missing')",
+        tester("ntpath.realpath('..', strict=ALLOW_MISSING)",
                ntpath.dirname(expected))
-        tester("ntpath.realpath('../..', strict='allow_missing')",
+        tester("ntpath.realpath('../..', strict=ALLOW_MISSING)",
                ntpath.dirname(ntpath.dirname(expected)))
-        tester("ntpath.realpath('/'.join(['..'] * 50), strict='allow_missing')",
+        tester("ntpath.realpath('/'.join(['..'] * 50), strict=ALLOW_MISSING)",
                ntpath.splitdrive(expected)[0] + '\\')
-        tester("ntpath.realpath('..\\..', strict='allow_missing')",
+        tester("ntpath.realpath('..\\..', strict=ALLOW_MISSING)",
                ntpath.dirname(ntpath.dirname(expected)))
-        tester("ntpath.realpath('\\'.join(['..'] * 50), strict='allow_missing')",
+        tester("ntpath.realpath('\\'.join(['..'] * 50), strict=ALLOW_MISSING)",
                ntpath.splitdrive(expected)[0] + '\\')
 
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
-    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_basic(self, kwargs):
         ABSTFN = ntpath.abspath(os_helper.TESTFN)
         open(ABSTFN, "wb").close()
@@ -603,38 +604,38 @@ class TestNtpath(NtpathTestCase):
         self.assertEqual(realpath(path, strict=False), path)
         # gh-106242: Embedded nulls should raise OSError (not ValueError)
         self.assertRaises(OSError, realpath, path, strict=True)
-        self.assertRaises(OSError, realpath, path, strict='allow_missing')
+        self.assertRaises(OSError, realpath, path, strict=ALLOW_MISSING)
         path = ABSTFNb + b'\x00'
         self.assertEqual(realpath(path, strict=False), path)
         self.assertRaises(OSError, realpath, path, strict=True)
-        self.assertRaises(OSError, realpath, path, strict='allow_missing')
+        self.assertRaises(OSError, realpath, path, strict=ALLOW_MISSING)
         path = ABSTFN + '\\nonexistent\\x\x00'
         self.assertEqual(realpath(path, strict=False), path)
         self.assertRaises(OSError, realpath, path, strict=True)
-        self.assertRaises(OSError, realpath, path, strict='allow_missing')
+        self.assertRaises(OSError, realpath, path, strict=ALLOW_MISSING)
         path = ABSTFNb + b'\\nonexistent\\x\x00'
         self.assertEqual(realpath(path, strict=False), path)
         self.assertRaises(OSError, realpath, path, strict=True)
-        self.assertRaises(OSError, realpath, path, strict='allow_missing')
+        self.assertRaises(OSError, realpath, path, strict=ALLOW_MISSING)
         path = ABSTFN + '\x00\\..'
         self.assertEqual(realpath(path, strict=False), os.getcwd())
         self.assertEqual(realpath(path, strict=True), os.getcwd())
-        self.assertEqual(realpath(path, strict='allow_missing'), os.getcwd())
+        self.assertEqual(realpath(path, strict=ALLOW_MISSING), os.getcwd())
         path = ABSTFNb + b'\x00\\..'
         self.assertEqual(realpath(path, strict=False), os.getcwdb())
         self.assertEqual(realpath(path, strict=True), os.getcwdb())
-        self.assertEqual(realpath(path, strict='allow_missing'), os.getcwdb())
+        self.assertEqual(realpath(path, strict=ALLOW_MISSING), os.getcwdb())
         path = ABSTFN + '\\nonexistent\\x\x00\\..'
         self.assertEqual(realpath(path, strict=False), ABSTFN + '\\nonexistent')
         self.assertRaises(OSError, realpath, path, strict=True)
-        self.assertEqual(realpath(path, strict='allow_missing'), ABSTFN + '\\nonexistent')
+        self.assertEqual(realpath(path, strict=ALLOW_MISSING), ABSTFN + '\\nonexistent')
         path = ABSTFNb + b'\\nonexistent\\x\x00\\..'
         self.assertEqual(realpath(path, strict=False), ABSTFNb + b'\\nonexistent')
         self.assertRaises(OSError, realpath, path, strict=True)
-        self.assertEqual(realpath(path, strict='allow_missing'), ABSTFNb + b'\\nonexistent')
+        self.assertEqual(realpath(path, strict=ALLOW_MISSING), ABSTFNb + b'\\nonexistent')
 
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
-    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_invalid_unicode_paths(self, kwargs):
         realpath = ntpath.realpath
         ABSTFN = ntpath.abspath(os_helper.TESTFN)
@@ -654,7 +655,7 @@ class TestNtpath(NtpathTestCase):
 
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
-    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_relative(self, kwargs):
         ABSTFN = ntpath.abspath(os_helper.TESTFN)
         open(ABSTFN, "wb").close()
@@ -815,7 +816,7 @@ class TestNtpath(NtpathTestCase):
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_symlink_loops_raise(self):
-        # Symlink loops raise OSError in 'allow_missing' mode
+        # Symlink loops raise OSError in ALLOW_MISSING mode
         ABSTFN = ntpath.abspath(os_helper.TESTFN)
         self.addCleanup(os_helper.unlink, ABSTFN)
         self.addCleanup(os_helper.unlink, ABSTFN + "1")
@@ -826,16 +827,16 @@ class TestNtpath(NtpathTestCase):
         self.addCleanup(os_helper.unlink, ABSTFN + "x")
 
         os.symlink(ABSTFN, ABSTFN)
-        self.assertRaises(OSError, ntpath.realpath, ABSTFN, strict='allow_missing')
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN, strict=ALLOW_MISSING)
 
         os.symlink(ABSTFN + "1", ABSTFN + "2")
         os.symlink(ABSTFN + "2", ABSTFN + "1")
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1",
-                            strict='allow_missing')
+                            strict=ALLOW_MISSING)
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "2",
-                            strict='allow_missing')
+                            strict=ALLOW_MISSING)
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1\\x",
-                            strict='allow_missing')
+                            strict=ALLOW_MISSING)
 
         # Windows eliminates '..' components before resolving links;
         # realpath is not expected to raise if this removes the loop.
@@ -851,24 +852,24 @@ class TestNtpath(NtpathTestCase):
         self.assertRaises(
             OSError, ntpath.realpath,
             ABSTFN + "1\\..\\" + ntpath.basename(ABSTFN) + "1",
-            strict='allow_missing')
+            strict=ALLOW_MISSING)
 
         os.symlink(ntpath.basename(ABSTFN) + "a\\b", ABSTFN + "a")
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "a",
-                            strict='allow_missing')
+                            strict=ALLOW_MISSING)
 
         os.symlink("..\\" + ntpath.basename(ntpath.dirname(ABSTFN))
                 + "\\" + ntpath.basename(ABSTFN) + "c", ABSTFN + "c")
         self.assertRaises(OSError, ntpath.realpath, ABSTFN + "c",
-                            strict='allow_missing')
+                            strict=ALLOW_MISSING)
 
         # Test using relative path as well.
         self.assertRaises(OSError, ntpath.realpath, ntpath.basename(ABSTFN),
-                            strict='allow_missing')
+                            strict=ALLOW_MISSING)
 
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
-    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_symlink_prefix(self, kwargs):
         ABSTFN = ntpath.abspath(os_helper.TESTFN)
         self.addCleanup(os_helper.unlink, ABSTFN + "3")
@@ -906,7 +907,7 @@ class TestNtpath(NtpathTestCase):
         tester("ntpath.realpath('NUL')", r'\\.\NUL')
         tester("ntpath.realpath('NUL', strict=False)", r'\\.\NUL')
         tester("ntpath.realpath('NUL', strict=True)", r'\\.\NUL')
-        tester("ntpath.realpath('NUL', strict='allow_missing')", r'\\.\NUL')
+        tester("ntpath.realpath('NUL', strict=ALLOW_MISSING)", r'\\.\NUL')
 
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     @unittest.skipUnless(HAVE_GETSHORTPATHNAME, 'need _getshortpathname')
@@ -930,7 +931,7 @@ class TestNtpath(NtpathTestCase):
 
         self.assertPathEqual(test_file_long, ntpath.realpath(test_file_short))
 
-        for kwargs in {}, {'strict': True}, {'strict': 'allow_missing'}:
+        for kwargs in {}, {'strict': True}, {'strict': ALLOW_MISSING}:
             with self.subTest(**kwargs):
                 with os_helper.change_cwd(test_dir_long):
                     self.assertPathEqual(

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -979,17 +979,40 @@ class TestNtpath(NtpathTestCase):
         except AssertionError:
             raise unittest.SkipTest('the filesystem seems to lack support for short filenames')
 
-        # Deny the right to [S]YNCHRONIZE on the file to
-        # force nt._getfinalpathname to fail with ERROR_ACCESS_DENIED.
         p = subprocess.run(
-            ['icacls.exe', test_file, '/deny', '*S-1-5-32-545:(S)'],
-            creationflags=subprocess.DETACHED_PROCESS
+            ['whoami.exe', '/GROUPS'],
+            creationflags=subprocess.DETACHED_PROCESS,
+            capture_output=True,
+        )
+        if p.returncode:
+            raise unittest.SkipTest('cannot check group membership')
+
+        groups_output = p.stdout
+        groups = (
+            'S-1-5-32-544',  # Administrators
+            'S-1-5-32-545',  # Users
         )
 
-        if p.returncode:
+        for group in groups:
+            if group.encode() not in groups_output:
+                continue
+
+            # Deny the right to [S]YNCHRONIZE on the file to
+            # force nt._getfinalpathname to fail with ERROR_ACCESS_DENIED.
+            p = subprocess.run(
+                ['icacls.exe', test_file, '/deny', f'*{group}:(S)'],
+                creationflags=subprocess.DETACHED_PROCESS
+            )
+            if p.returncode == 0:
+                break
+        else:
             raise unittest.SkipTest('failed to deny access to the test file')
 
         self.assertPathEqual(test_file, ntpath.realpath(test_file_short))
+        with self.assertRaises(OSError):
+            ntpath.realpath(test_file_short, strict=True)
+        with self.assertRaises(OSError):
+            ntpath.realpath(test_file_short, strict=ALLOW_MISSING)
 
     def test_expandvars(self):
         with os_helper.EnvironmentVarGuard() as env:

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -964,11 +964,14 @@ class TestNtpath(NtpathTestCase):
         # Automatic generation of short names may be disabled on
         # NTFS volumes for the sake of performance.
         # They're not supported at all on ReFS and exFAT.
-        subprocess.run(
+        p = subprocess.run(
             # Try to set the short name manually.
             ['fsutil.exe', 'file', 'setShortName', test_file, 'LONGFI~1.TXT'],
             creationflags=subprocess.DETACHED_PROCESS
         )
+
+        if p.returncode:
+            raise unittest.SkipTest('failed to set short name')
 
         try:
             self.assertPathEqual(test_file, ntpath.realpath(test_file_short))
@@ -988,6 +991,7 @@ class TestNtpath(NtpathTestCase):
         self.assertPathEqual(test_file, ntpath.realpath(test_file_short))
         with self.assertRaises(OSError):
             ntpath.realpath(test_file_short, strict=True)
+        with self.assertRaises(OSError):
             ntpath.realpath(test_file_short, strict='allow_missing')
 
     def test_expandvars(self):

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -5,7 +5,7 @@ import random
 import sys
 import unittest
 from functools import partial
-from posixpath import realpath, abspath, dirname, basename
+from posixpath import realpath, abspath, dirname, basename, ALLOW_MISSING
 from test import support
 from test import test_genericpath
 from test.support import import_helper
@@ -464,7 +464,7 @@ class PosixPathTest(unittest.TestCase):
                 self.assertEqual(result, expected)
 
     @skip_if_ABSTFN_contains_backslash
-    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_curdir(self, kwargs):
         self.assertEqual(realpath('.', **kwargs), os.getcwd())
         self.assertEqual(realpath('./.', **kwargs), os.getcwd())
@@ -475,7 +475,7 @@ class PosixPathTest(unittest.TestCase):
         self.assertEqual(realpath(b'/'.join([b'.'] * 100), **kwargs), os.getcwdb())
 
     @skip_if_ABSTFN_contains_backslash
-    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_pardir(self, kwargs):
         self.assertEqual(realpath('..', **kwargs), dirname(os.getcwd()))
         self.assertEqual(realpath('../..', **kwargs), dirname(dirname(os.getcwd())))
@@ -487,7 +487,7 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    @_parameterize({}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': ALLOW_MISSING})
     def test_realpath_basic(self, kwargs):
         # Basic operation.
         try:
@@ -512,100 +512,100 @@ class PosixPathTest(unittest.TestCase):
         path = '/\x00'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(ValueError, realpath, path, strict=True)
-        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
+        self.assertRaises(ValueError, realpath, path, strict=ALLOW_MISSING)
         path = b'/\x00'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(ValueError, realpath, path, strict=True)
-        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
+        self.assertRaises(ValueError, realpath, path, strict=ALLOW_MISSING)
         path = '/nonexistent/x\x00'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
-        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
+        self.assertRaises(ValueError, realpath, path, strict=ALLOW_MISSING)
         path = b'/nonexistent/x\x00'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
-        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
+        self.assertRaises(ValueError, realpath, path, strict=ALLOW_MISSING)
         path = '/\x00/..'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(ValueError, realpath, path, strict=True)
-        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
+        self.assertRaises(ValueError, realpath, path, strict=ALLOW_MISSING)
         path = b'/\x00/..'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(ValueError, realpath, path, strict=True)
-        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
+        self.assertRaises(ValueError, realpath, path, strict=ALLOW_MISSING)
 
         path = '/nonexistent/x\x00/..'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
-        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
+        self.assertRaises(ValueError, realpath, path, strict=ALLOW_MISSING)
         path = b'/nonexistent/x\x00/..'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
-        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
+        self.assertRaises(ValueError, realpath, path, strict=ALLOW_MISSING)
 
         path = '/\udfff'
         if sys.platform == 'win32':
             self.assertEqual(realpath(path, strict=False), path)
             self.assertRaises(FileNotFoundError, realpath, path, strict=True)
-            self.assertEqual(realpath(path, strict='allow_missing'), path)
+            self.assertEqual(realpath(path, strict=ALLOW_MISSING), path)
         else:
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=False)
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=True)
-            self.assertRaises(UnicodeEncodeError, realpath, path, strict='allow_missing')
+            self.assertRaises(UnicodeEncodeError, realpath, path, strict=ALLOW_MISSING)
         path = '/nonexistent/\udfff'
         if sys.platform == 'win32':
             self.assertEqual(realpath(path, strict=False), path)
-            self.assertEqual(realpath(path, strict='allow_missing'), path)
+            self.assertEqual(realpath(path, strict=ALLOW_MISSING), path)
         else:
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=False)
-            self.assertRaises(UnicodeEncodeError, realpath, path, strict='allow_missing')
+            self.assertRaises(UnicodeEncodeError, realpath, path, strict=ALLOW_MISSING)
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
         path = '/\udfff/..'
         if sys.platform == 'win32':
             self.assertEqual(realpath(path, strict=False), '/')
             self.assertRaises(FileNotFoundError, realpath, path, strict=True)
-            self.assertEqual(realpath(path, strict='allow_missing'), '/')
+            self.assertEqual(realpath(path, strict=ALLOW_MISSING), '/')
         else:
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=False)
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=True)
-            self.assertRaises(UnicodeEncodeError, realpath, path, strict='allow_missing')
+            self.assertRaises(UnicodeEncodeError, realpath, path, strict=ALLOW_MISSING)
         path = '/nonexistent/\udfff/..'
         if sys.platform == 'win32':
             self.assertEqual(realpath(path, strict=False), '/nonexistent')
-            self.assertEqual(realpath(path, strict='allow_missing'), '/nonexistent')
+            self.assertEqual(realpath(path, strict=ALLOW_MISSING), '/nonexistent')
         else:
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=False)
-            self.assertRaises(UnicodeEncodeError, realpath, path, strict='allow_missing')
+            self.assertRaises(UnicodeEncodeError, realpath, path, strict=ALLOW_MISSING)
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
 
         path = b'/\xff'
         if sys.platform == 'win32':
             self.assertRaises(UnicodeDecodeError, realpath, path, strict=False)
             self.assertRaises(UnicodeDecodeError, realpath, path, strict=True)
-            self.assertRaises(UnicodeDecodeError, realpath, path, strict='allow_missing')
+            self.assertRaises(UnicodeDecodeError, realpath, path, strict=ALLOW_MISSING)
         else:
             self.assertEqual(realpath(path, strict=False), path)
             if support.is_wasi:
                 self.assertRaises(OSError, realpath, path, strict=True)
-                self.assertRaises(OSError, realpath, path, strict='allow_missing')
+                self.assertRaises(OSError, realpath, path, strict=ALLOW_MISSING)
             else:
                 self.assertRaises(FileNotFoundError, realpath, path, strict=True)
-                self.assertEqual(realpath(path, strict='allow_missing'), path)
+                self.assertEqual(realpath(path, strict=ALLOW_MISSING), path)
         path = b'/nonexistent/\xff'
         if sys.platform == 'win32':
             self.assertRaises(UnicodeDecodeError, realpath, path, strict=False)
-            self.assertRaises(UnicodeDecodeError, realpath, path, strict='allow_missing')
+            self.assertRaises(UnicodeDecodeError, realpath, path, strict=ALLOW_MISSING)
         else:
             self.assertEqual(realpath(path, strict=False), path)
         if support.is_wasi:
             self.assertRaises(OSError, realpath, path, strict=True)
-            self.assertRaises(OSError, realpath, path, strict='allow_missing')
+            self.assertRaises(OSError, realpath, path, strict=ALLOW_MISSING)
         else:
             self.assertRaises(FileNotFoundError, realpath, path, strict=True)
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    @_parameterize({}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': ALLOW_MISSING})
     def test_realpath_relative(self, kwargs):
         try:
             os.symlink(posixpath.relpath(ABSTFN+"1"), ABSTFN)
@@ -615,7 +615,7 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    @_parameterize({}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': ALLOW_MISSING})
     def test_realpath_missing_pardir(self, kwargs):
         try:
             os.symlink(TESTFN + "1", TESTFN)
@@ -667,7 +667,7 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    @_parameterize({'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_symlink_loops_strict(self, kwargs):
         # Bug #43757, raise OSError if we get into an infinite symlink loop in
         # the strict modes.
@@ -709,7 +709,7 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_repeated_indirect_symlinks(self, kwargs):
         # Issue #6975.
         try:
@@ -724,7 +724,7 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_deep_recursion(self, kwargs):
         depth = 10
         try:
@@ -744,7 +744,7 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    @_parameterize({}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': ALLOW_MISSING})
     def test_realpath_resolve_parents(self, kwargs):
         # We also need to resolve any symlinks in the parents of a relative
         # path passed to realpath. E.g.: current working directory is
@@ -765,7 +765,7 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_resolve_before_normalizing(self, kwargs):
         # Bug #990669: Symbolic links should be resolved before we
         # normalize the path. E.g.: if we have directories 'a', 'k' and 'y'
@@ -794,7 +794,7 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_resolve_first(self, kwargs):
         # Bug #1213894: The first component of the path, if not absolute,
         # must be resolved too.
@@ -832,7 +832,7 @@ class PosixPathTest(unittest.TestCase):
     @skip_if_ABSTFN_contains_backslash
     @unittest.skipIf(os.chmod not in os.supports_follow_symlinks, "Can't set symlink permissions")
     @unittest.skipIf(sys.platform != "darwin", "only macOS requires read permission to readlink()")
-    @_parameterize({'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({'strict': True}, {'strict': ALLOW_MISSING})
     def test_realpath_unreadable_symlink_strict(self, kwargs):
         try:
             os.symlink(ABSTFN+"1", ABSTFN)
@@ -858,21 +858,21 @@ class PosixPathTest(unittest.TestCase):
             os.chmod(ABSTFN, 0o000)
             self.assertEqual(realpath(ABSTFN, strict=False), ABSTFN)
             self.assertEqual(realpath(ABSTFN, strict=True), ABSTFN)
-            self.assertEqual(realpath(ABSTFN, strict='allow_missing'), ABSTFN)
+            self.assertEqual(realpath(ABSTFN, strict=ALLOW_MISSING), ABSTFN)
 
             self.assertEqual(realpath(ABSTFN + '/k', strict=False),
                              ABSTFN + '/k')
             self.assertRaises(PermissionError, realpath, ABSTFN + '/k',
                               strict=True)
             self.assertRaises(PermissionError, realpath, ABSTFN + '/k',
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
 
             self.assertEqual(realpath(ABSTFN + '/missing', strict=False),
                              ABSTFN + '/missing')
             self.assertRaises(PermissionError, realpath, ABSTFN + '/missing',
                               strict=True)
             self.assertRaises(PermissionError, realpath, ABSTFN + '/missing',
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
         finally:
             os.chmod(ABSTFN, 0o755)
             os_helper.rmdir(ABSTFN + '/k')
@@ -885,27 +885,27 @@ class PosixPathTest(unittest.TestCase):
                 f.write('test_posixpath wuz ere')
             self.assertEqual(realpath(ABSTFN, strict=False), ABSTFN)
             self.assertEqual(realpath(ABSTFN, strict=True), ABSTFN)
-            self.assertEqual(realpath(ABSTFN, strict='allow_missing'), ABSTFN)
+            self.assertEqual(realpath(ABSTFN, strict=ALLOW_MISSING), ABSTFN)
 
             self.assertEqual(realpath(ABSTFN + "/", strict=False), ABSTFN)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
 
             self.assertEqual(realpath(ABSTFN + "/.", strict=False), ABSTFN)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
 
             self.assertEqual(realpath(ABSTFN + "/..", strict=False), dirname(ABSTFN))
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
 
             self.assertEqual(realpath(ABSTFN + "/subdir", strict=False), ABSTFN + "/subdir")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
         finally:
             os_helper.unlink(ABSTFN)
 
@@ -918,27 +918,27 @@ class PosixPathTest(unittest.TestCase):
             os.symlink(ABSTFN + "1", ABSTFN)
             self.assertEqual(realpath(ABSTFN, strict=False), ABSTFN + "1")
             self.assertEqual(realpath(ABSTFN, strict=True), ABSTFN + "1")
-            self.assertEqual(realpath(ABSTFN, strict='allow_missing'), ABSTFN + "1")
+            self.assertEqual(realpath(ABSTFN, strict=ALLOW_MISSING), ABSTFN + "1")
 
             self.assertEqual(realpath(ABSTFN + "/", strict=False), ABSTFN + "1")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
 
             self.assertEqual(realpath(ABSTFN + "/.", strict=False), ABSTFN + "1")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
 
             self.assertEqual(realpath(ABSTFN + "/..", strict=False), dirname(ABSTFN))
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
 
             self.assertEqual(realpath(ABSTFN + "/subdir", strict=False), ABSTFN + "1/subdir")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
         finally:
             os_helper.unlink(ABSTFN)
             os_helper.unlink(ABSTFN + "1")
@@ -958,22 +958,22 @@ class PosixPathTest(unittest.TestCase):
             self.assertEqual(realpath(ABSTFN + "/", strict=False), ABSTFN + "2")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
 
             self.assertEqual(realpath(ABSTFN + "/.", strict=False), ABSTFN + "2")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
 
             self.assertEqual(realpath(ABSTFN + "/..", strict=False), dirname(ABSTFN))
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
 
             self.assertEqual(realpath(ABSTFN + "/subdir", strict=False), ABSTFN + "2/subdir")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir", strict=True)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir",
-                              strict='allow_missing')
+                              strict=ALLOW_MISSING)
         finally:
             os_helper.unlink(ABSTFN)
             os_helper.unlink(ABSTFN + "1")
@@ -1161,7 +1161,7 @@ class PathLikeTests(unittest.TestCase):
     def test_path_abspath(self):
         self.assertPathEqual(self.path.abspath)
 
-    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    @_parameterize({}, {'strict': True}, {'strict': ALLOW_MISSING})
     def test_path_realpath(self, kwargs):
         self.assertPathEqual(self.path.realpath)
 

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -860,6 +860,13 @@ class PosixPathTest(unittest.TestCase):
             self.assertEqual(realpath(ABSTFN, strict=True), ABSTFN)
             self.assertEqual(realpath(ABSTFN, strict=ALLOW_MISSING), ABSTFN)
 
+            try:
+                os.stat(ABSTFN)
+            except PermissionError:
+                pass
+            else:
+                self.skipTest('Cannot block permissions')
+
             self.assertEqual(realpath(ABSTFN + '/k', strict=False),
                              ABSTFN + '/k')
             self.assertRaises(PermissionError, realpath, ABSTFN + '/k',

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -4,6 +4,7 @@ import posixpath
 import random
 import sys
 import unittest
+from functools import partial
 from posixpath import realpath, abspath, dirname, basename
 from test import support
 from test import test_genericpath
@@ -32,6 +33,27 @@ def skip_if_ABSTFN_contains_backslash(test):
     found_backslash = '\\' in ABSTFN
     msg = "ABSTFN is not a posix path - tests fail"
     return [test, unittest.skip(msg)(test)][found_backslash]
+
+
+def _parameterize(*parameters):
+    """Simplistic decorator to parametrize a test
+
+    Runs the decorated test multiple times in subTest, with a value from
+    'parameters' passed as an extra positional argument.
+    Does *not* call doCleanups() after each run.
+
+    Not for general use. Intended to avoid indenting for easier backports.
+
+    See https://discuss.python.org/t/91827 for discussing generalizations.
+    """
+    def _parametrize_decorator(func):
+        def _parameterized(self, *args, **kwargs):
+            for parameter in parameters:
+                with self.subTest(parameter):
+                    func(self, *args, parameter, **kwargs)
+        return _parameterized
+    return _parametrize_decorator
+
 
 class PosixPathTest(unittest.TestCase):
 
@@ -442,32 +464,35 @@ class PosixPathTest(unittest.TestCase):
                 self.assertEqual(result, expected)
 
     @skip_if_ABSTFN_contains_backslash
-    def test_realpath_curdir(self):
-        self.assertEqual(realpath('.'), os.getcwd())
-        self.assertEqual(realpath('./.'), os.getcwd())
-        self.assertEqual(realpath('/'.join(['.'] * 100)), os.getcwd())
+    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    def test_realpath_curdir(self, kwargs):
+        self.assertEqual(realpath('.', **kwargs), os.getcwd())
+        self.assertEqual(realpath('./.', **kwargs), os.getcwd())
+        self.assertEqual(realpath('/'.join(['.'] * 100), **kwargs), os.getcwd())
 
-        self.assertEqual(realpath(b'.'), os.getcwdb())
-        self.assertEqual(realpath(b'./.'), os.getcwdb())
-        self.assertEqual(realpath(b'/'.join([b'.'] * 100)), os.getcwdb())
+        self.assertEqual(realpath(b'.', **kwargs), os.getcwdb())
+        self.assertEqual(realpath(b'./.', **kwargs), os.getcwdb())
+        self.assertEqual(realpath(b'/'.join([b'.'] * 100), **kwargs), os.getcwdb())
 
     @skip_if_ABSTFN_contains_backslash
-    def test_realpath_pardir(self):
-        self.assertEqual(realpath('..'), dirname(os.getcwd()))
-        self.assertEqual(realpath('../..'), dirname(dirname(os.getcwd())))
-        self.assertEqual(realpath('/'.join(['..'] * 100)), '/')
+    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    def test_realpath_pardir(self, kwargs):
+        self.assertEqual(realpath('..', **kwargs), dirname(os.getcwd()))
+        self.assertEqual(realpath('../..', **kwargs), dirname(dirname(os.getcwd())))
+        self.assertEqual(realpath('/'.join(['..'] * 100), **kwargs), '/')
 
-        self.assertEqual(realpath(b'..'), dirname(os.getcwdb()))
-        self.assertEqual(realpath(b'../..'), dirname(dirname(os.getcwdb())))
-        self.assertEqual(realpath(b'/'.join([b'..'] * 100)), b'/')
+        self.assertEqual(realpath(b'..', **kwargs), dirname(os.getcwdb()))
+        self.assertEqual(realpath(b'../..', **kwargs), dirname(dirname(os.getcwdb())))
+        self.assertEqual(realpath(b'/'.join([b'..'] * 100), **kwargs), b'/')
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    def test_realpath_basic(self):
+    @_parameterize({}, {'strict': 'allow_missing'})
+    def test_realpath_basic(self, kwargs):
         # Basic operation.
         try:
             os.symlink(ABSTFN+"1", ABSTFN)
-            self.assertEqual(realpath(ABSTFN), ABSTFN+"1")
+            self.assertEqual(realpath(ABSTFN, **kwargs), ABSTFN+"1")
         finally:
             os_helper.unlink(ABSTFN)
 
@@ -487,90 +512,115 @@ class PosixPathTest(unittest.TestCase):
         path = '/\x00'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(ValueError, realpath, path, strict=True)
+        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
         path = b'/\x00'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(ValueError, realpath, path, strict=True)
+        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
         path = '/nonexistent/x\x00'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
+        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
         path = b'/nonexistent/x\x00'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
+        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
         path = '/\x00/..'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(ValueError, realpath, path, strict=True)
+        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
         path = b'/\x00/..'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(ValueError, realpath, path, strict=True)
+        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
+
         path = '/nonexistent/x\x00/..'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
+        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
         path = b'/nonexistent/x\x00/..'
         self.assertRaises(ValueError, realpath, path, strict=False)
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
+        self.assertRaises(ValueError, realpath, path, strict='allow_missing')
 
         path = '/\udfff'
         if sys.platform == 'win32':
             self.assertEqual(realpath(path, strict=False), path)
             self.assertRaises(FileNotFoundError, realpath, path, strict=True)
+            self.assertEqual(realpath(path, strict='allow_missing'), path)
         else:
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=False)
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=True)
+            self.assertRaises(UnicodeEncodeError, realpath, path, strict='allow_missing')
         path = '/nonexistent/\udfff'
         if sys.platform == 'win32':
             self.assertEqual(realpath(path, strict=False), path)
+            self.assertEqual(realpath(path, strict='allow_missing'), path)
         else:
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=False)
+            self.assertRaises(UnicodeEncodeError, realpath, path, strict='allow_missing')
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
         path = '/\udfff/..'
         if sys.platform == 'win32':
             self.assertEqual(realpath(path, strict=False), '/')
             self.assertRaises(FileNotFoundError, realpath, path, strict=True)
+            self.assertEqual(realpath(path, strict='allow_missing'), '/')
         else:
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=False)
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=True)
+            self.assertRaises(UnicodeEncodeError, realpath, path, strict='allow_missing')
         path = '/nonexistent/\udfff/..'
         if sys.platform == 'win32':
             self.assertEqual(realpath(path, strict=False), '/nonexistent')
+            self.assertEqual(realpath(path, strict='allow_missing'), '/nonexistent')
         else:
             self.assertRaises(UnicodeEncodeError, realpath, path, strict=False)
+            self.assertRaises(UnicodeEncodeError, realpath, path, strict='allow_missing')
         self.assertRaises(FileNotFoundError, realpath, path, strict=True)
 
         path = b'/\xff'
         if sys.platform == 'win32':
             self.assertRaises(UnicodeDecodeError, realpath, path, strict=False)
             self.assertRaises(UnicodeDecodeError, realpath, path, strict=True)
+            self.assertRaises(UnicodeDecodeError, realpath, path, strict='allow_missing')
         else:
             self.assertEqual(realpath(path, strict=False), path)
             if support.is_wasi:
                 self.assertRaises(OSError, realpath, path, strict=True)
+                self.assertRaises(OSError, realpath, path, strict='allow_missing')
             else:
                 self.assertRaises(FileNotFoundError, realpath, path, strict=True)
+                self.assertEqual(realpath(path, strict='allow_missing'), path)
         path = b'/nonexistent/\xff'
         if sys.platform == 'win32':
             self.assertRaises(UnicodeDecodeError, realpath, path, strict=False)
+            self.assertRaises(UnicodeDecodeError, realpath, path, strict='allow_missing')
         else:
             self.assertEqual(realpath(path, strict=False), path)
         if support.is_wasi:
             self.assertRaises(OSError, realpath, path, strict=True)
+            self.assertRaises(OSError, realpath, path, strict='allow_missing')
         else:
             self.assertRaises(FileNotFoundError, realpath, path, strict=True)
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    def test_realpath_relative(self):
+    @_parameterize({}, {'strict': 'allow_missing'})
+    def test_realpath_relative(self, kwargs):
         try:
             os.symlink(posixpath.relpath(ABSTFN+"1"), ABSTFN)
-            self.assertEqual(realpath(ABSTFN), ABSTFN+"1")
+            self.assertEqual(realpath(ABSTFN, **kwargs), ABSTFN+"1")
         finally:
             os_helper.unlink(ABSTFN)
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    def test_realpath_missing_pardir(self):
+    @_parameterize({}, {'strict': 'allow_missing'})
+    def test_realpath_missing_pardir(self, kwargs):
         try:
             os.symlink(TESTFN + "1", TESTFN)
-            self.assertEqual(realpath("nonexistent/../" + TESTFN), ABSTFN + "1")
+            self.assertEqual(
+                realpath("nonexistent/../" + TESTFN, **kwargs), ABSTFN + "1")
         finally:
             os_helper.unlink(TESTFN)
 
@@ -617,37 +667,38 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    def test_realpath_symlink_loops_strict(self):
+    @_parameterize({'strict': True}, {'strict': 'allow_missing'})
+    def test_realpath_symlink_loops_strict(self, kwargs):
         # Bug #43757, raise OSError if we get into an infinite symlink loop in
-        # strict mode.
+        # the strict modes.
         try:
             os.symlink(ABSTFN, ABSTFN)
-            self.assertRaises(OSError, realpath, ABSTFN, strict=True)
+            self.assertRaises(OSError, realpath, ABSTFN, **kwargs)
 
             os.symlink(ABSTFN+"1", ABSTFN+"2")
             os.symlink(ABSTFN+"2", ABSTFN+"1")
-            self.assertRaises(OSError, realpath, ABSTFN+"1", strict=True)
-            self.assertRaises(OSError, realpath, ABSTFN+"2", strict=True)
+            self.assertRaises(OSError, realpath, ABSTFN+"1", **kwargs)
+            self.assertRaises(OSError, realpath, ABSTFN+"2", **kwargs)
 
-            self.assertRaises(OSError, realpath, ABSTFN+"1/x", strict=True)
-            self.assertRaises(OSError, realpath, ABSTFN+"1/..", strict=True)
-            self.assertRaises(OSError, realpath, ABSTFN+"1/../x", strict=True)
+            self.assertRaises(OSError, realpath, ABSTFN+"1/x", **kwargs)
+            self.assertRaises(OSError, realpath, ABSTFN+"1/..", **kwargs)
+            self.assertRaises(OSError, realpath, ABSTFN+"1/../x", **kwargs)
             os.symlink(ABSTFN+"x", ABSTFN+"y")
             self.assertRaises(OSError, realpath,
-                              ABSTFN+"1/../" + basename(ABSTFN) + "y", strict=True)
+                              ABSTFN+"1/../" + basename(ABSTFN) + "y", **kwargs)
             self.assertRaises(OSError, realpath,
-                              ABSTFN+"1/../" + basename(ABSTFN) + "1", strict=True)
+                              ABSTFN+"1/../" + basename(ABSTFN) + "1", **kwargs)
 
             os.symlink(basename(ABSTFN) + "a/b", ABSTFN+"a")
-            self.assertRaises(OSError, realpath, ABSTFN+"a", strict=True)
+            self.assertRaises(OSError, realpath, ABSTFN+"a", **kwargs)
 
             os.symlink("../" + basename(dirname(ABSTFN)) + "/" +
                        basename(ABSTFN) + "c", ABSTFN+"c")
-            self.assertRaises(OSError, realpath, ABSTFN+"c", strict=True)
+            self.assertRaises(OSError, realpath, ABSTFN+"c", **kwargs)
 
             # Test using relative path as well.
             with os_helper.change_cwd(dirname(ABSTFN)):
-                self.assertRaises(OSError, realpath, basename(ABSTFN), strict=True)
+                self.assertRaises(OSError, realpath, basename(ABSTFN), **kwargs)
         finally:
             os_helper.unlink(ABSTFN)
             os_helper.unlink(ABSTFN+"1")
@@ -658,13 +709,14 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    def test_realpath_repeated_indirect_symlinks(self):
+    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    def test_realpath_repeated_indirect_symlinks(self, kwargs):
         # Issue #6975.
         try:
             os.mkdir(ABSTFN)
             os.symlink('../' + basename(ABSTFN), ABSTFN + '/self')
             os.symlink('self/self/self', ABSTFN + '/link')
-            self.assertEqual(realpath(ABSTFN + '/link'), ABSTFN)
+            self.assertEqual(realpath(ABSTFN + '/link', **kwargs), ABSTFN)
         finally:
             os_helper.unlink(ABSTFN + '/self')
             os_helper.unlink(ABSTFN + '/link')
@@ -672,14 +724,15 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    def test_realpath_deep_recursion(self):
+    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    def test_realpath_deep_recursion(self, kwargs):
         depth = 10
         try:
             os.mkdir(ABSTFN)
             for i in range(depth):
                 os.symlink('/'.join(['%d' % i] * 10), ABSTFN + '/%d' % (i + 1))
             os.symlink('.', ABSTFN + '/0')
-            self.assertEqual(realpath(ABSTFN + '/%d' % depth), ABSTFN)
+            self.assertEqual(realpath(ABSTFN + '/%d' % depth, **kwargs), ABSTFN)
 
             # Test using relative path as well.
             with os_helper.change_cwd(ABSTFN):
@@ -691,7 +744,8 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    def test_realpath_resolve_parents(self):
+    @_parameterize({}, {'strict': 'allow_missing'})
+    def test_realpath_resolve_parents(self, kwargs):
         # We also need to resolve any symlinks in the parents of a relative
         # path passed to realpath. E.g.: current working directory is
         # /usr/doc with 'doc' being a symlink to /usr/share/doc. We call
@@ -702,7 +756,8 @@ class PosixPathTest(unittest.TestCase):
             os.symlink(ABSTFN + "/y", ABSTFN + "/k")
 
             with os_helper.change_cwd(ABSTFN + "/k"):
-                self.assertEqual(realpath("a"), ABSTFN + "/y/a")
+                self.assertEqual(realpath("a", **kwargs),
+                                    ABSTFN + "/y/a")
         finally:
             os_helper.unlink(ABSTFN + "/k")
             os_helper.rmdir(ABSTFN + "/y")
@@ -710,7 +765,8 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    def test_realpath_resolve_before_normalizing(self):
+    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    def test_realpath_resolve_before_normalizing(self, kwargs):
         # Bug #990669: Symbolic links should be resolved before we
         # normalize the path. E.g.: if we have directories 'a', 'k' and 'y'
         # in the following hierarchy:
@@ -725,10 +781,10 @@ class PosixPathTest(unittest.TestCase):
             os.symlink(ABSTFN + "/k/y", ABSTFN + "/link-y")
 
             # Absolute path.
-            self.assertEqual(realpath(ABSTFN + "/link-y/.."), ABSTFN + "/k")
+            self.assertEqual(realpath(ABSTFN + "/link-y/..", **kwargs), ABSTFN + "/k")
             # Relative path.
             with os_helper.change_cwd(dirname(ABSTFN)):
-                self.assertEqual(realpath(basename(ABSTFN) + "/link-y/.."),
+                self.assertEqual(realpath(basename(ABSTFN) + "/link-y/..", **kwargs),
                                  ABSTFN + "/k")
         finally:
             os_helper.unlink(ABSTFN + "/link-y")
@@ -738,7 +794,8 @@ class PosixPathTest(unittest.TestCase):
 
     @os_helper.skip_unless_symlink
     @skip_if_ABSTFN_contains_backslash
-    def test_realpath_resolve_first(self):
+    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    def test_realpath_resolve_first(self, kwargs):
         # Bug #1213894: The first component of the path, if not absolute,
         # must be resolved too.
 
@@ -748,8 +805,8 @@ class PosixPathTest(unittest.TestCase):
             os.symlink(ABSTFN, ABSTFN + "link")
             with os_helper.change_cwd(dirname(ABSTFN)):
                 base = basename(ABSTFN)
-                self.assertEqual(realpath(base + "link"), ABSTFN)
-                self.assertEqual(realpath(base + "link/k"), ABSTFN + "/k")
+                self.assertEqual(realpath(base + "link", **kwargs), ABSTFN)
+                self.assertEqual(realpath(base + "link/k", **kwargs), ABSTFN + "/k")
         finally:
             os_helper.unlink(ABSTFN + "link")
             os_helper.rmdir(ABSTFN + "/k")
@@ -767,11 +824,59 @@ class PosixPathTest(unittest.TestCase):
             self.assertEqual(realpath(ABSTFN + '/foo'), ABSTFN + '/foo')
             self.assertEqual(realpath(ABSTFN + '/../foo'), dirname(ABSTFN) + '/foo')
             self.assertEqual(realpath(ABSTFN + '/foo/..'), ABSTFN)
-            with self.assertRaises(PermissionError):
-                realpath(ABSTFN, strict=True)
         finally:
             os.chmod(ABSTFN, 0o755, follow_symlinks=False)
             os_helper.unlink(ABSTFN)
+
+    @os_helper.skip_unless_symlink
+    @skip_if_ABSTFN_contains_backslash
+    @unittest.skipIf(os.chmod not in os.supports_follow_symlinks, "Can't set symlink permissions")
+    @unittest.skipIf(sys.platform != "darwin", "only macOS requires read permission to readlink()")
+    @_parameterize({'strict': True}, {'strict': 'allow_missing'})
+    def test_realpath_unreadable_symlink_strict(self, kwargs):
+        try:
+            os.symlink(ABSTFN+"1", ABSTFN)
+            os.chmod(ABSTFN, 0o000, follow_symlinks=False)
+            with self.assertRaises(PermissionError):
+                realpath(ABSTFN, **kwargs)
+            with self.assertRaises(PermissionError):
+                realpath(ABSTFN + '/foo', **kwargs),
+            with self.assertRaises(PermissionError):
+                realpath(ABSTFN + '/../foo', **kwargs)
+            with self.assertRaises(PermissionError):
+                realpath(ABSTFN + '/foo/..', **kwargs)
+        finally:
+            os.chmod(ABSTFN, 0o755, follow_symlinks=False)
+            os.unlink(ABSTFN)
+
+    @skip_if_ABSTFN_contains_backslash
+    @os_helper.skip_unless_symlink
+    def test_realpath_unreadable_directory(self):
+        try:
+            os.mkdir(ABSTFN)
+            os.mkdir(ABSTFN + '/k')
+            os.chmod(ABSTFN, 0o000)
+            self.assertEqual(realpath(ABSTFN, strict=False), ABSTFN)
+            self.assertEqual(realpath(ABSTFN, strict=True), ABSTFN)
+            self.assertEqual(realpath(ABSTFN, strict='allow_missing'), ABSTFN)
+
+            self.assertEqual(realpath(ABSTFN + '/k', strict=False),
+                             ABSTFN + '/k')
+            self.assertRaises(PermissionError, realpath, ABSTFN + '/k',
+                              strict=True)
+            self.assertRaises(PermissionError, realpath, ABSTFN + '/k',
+                              strict='allow_missing')
+
+            self.assertEqual(realpath(ABSTFN + '/missing', strict=False),
+                             ABSTFN + '/missing')
+            self.assertRaises(PermissionError, realpath, ABSTFN + '/missing',
+                              strict=True)
+            self.assertRaises(PermissionError, realpath, ABSTFN + '/missing',
+                              strict='allow_missing')
+        finally:
+            os.chmod(ABSTFN, 0o755)
+            os_helper.rmdir(ABSTFN + '/k')
+            os_helper.rmdir(ABSTFN)
 
     @skip_if_ABSTFN_contains_backslash
     def test_realpath_nonterminal_file(self):
@@ -780,14 +885,27 @@ class PosixPathTest(unittest.TestCase):
                 f.write('test_posixpath wuz ere')
             self.assertEqual(realpath(ABSTFN, strict=False), ABSTFN)
             self.assertEqual(realpath(ABSTFN, strict=True), ABSTFN)
+            self.assertEqual(realpath(ABSTFN, strict='allow_missing'), ABSTFN)
+
             self.assertEqual(realpath(ABSTFN + "/", strict=False), ABSTFN)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/",
+                              strict='allow_missing')
+
             self.assertEqual(realpath(ABSTFN + "/.", strict=False), ABSTFN)
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.",
+                              strict='allow_missing')
+
             self.assertEqual(realpath(ABSTFN + "/..", strict=False), dirname(ABSTFN))
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..",
+                              strict='allow_missing')
+
             self.assertEqual(realpath(ABSTFN + "/subdir", strict=False), ABSTFN + "/subdir")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir",
+                              strict='allow_missing')
         finally:
             os_helper.unlink(ABSTFN)
 
@@ -800,14 +918,27 @@ class PosixPathTest(unittest.TestCase):
             os.symlink(ABSTFN + "1", ABSTFN)
             self.assertEqual(realpath(ABSTFN, strict=False), ABSTFN + "1")
             self.assertEqual(realpath(ABSTFN, strict=True), ABSTFN + "1")
+            self.assertEqual(realpath(ABSTFN, strict='allow_missing'), ABSTFN + "1")
+
             self.assertEqual(realpath(ABSTFN + "/", strict=False), ABSTFN + "1")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/",
+                              strict='allow_missing')
+
             self.assertEqual(realpath(ABSTFN + "/.", strict=False), ABSTFN + "1")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.",
+                              strict='allow_missing')
+
             self.assertEqual(realpath(ABSTFN + "/..", strict=False), dirname(ABSTFN))
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..",
+                              strict='allow_missing')
+
             self.assertEqual(realpath(ABSTFN + "/subdir", strict=False), ABSTFN + "1/subdir")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir",
+                              strict='allow_missing')
         finally:
             os_helper.unlink(ABSTFN)
             os_helper.unlink(ABSTFN + "1")
@@ -822,14 +953,27 @@ class PosixPathTest(unittest.TestCase):
             os.symlink(ABSTFN + "1", ABSTFN)
             self.assertEqual(realpath(ABSTFN, strict=False), ABSTFN + "2")
             self.assertEqual(realpath(ABSTFN, strict=True), ABSTFN + "2")
+            self.assertEqual(realpath(ABSTFN, strict=True), ABSTFN + "2")
+
             self.assertEqual(realpath(ABSTFN + "/", strict=False), ABSTFN + "2")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/",
+                              strict='allow_missing')
+
             self.assertEqual(realpath(ABSTFN + "/.", strict=False), ABSTFN + "2")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/.",
+                              strict='allow_missing')
+
             self.assertEqual(realpath(ABSTFN + "/..", strict=False), dirname(ABSTFN))
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/..",
+                              strict='allow_missing')
+
             self.assertEqual(realpath(ABSTFN + "/subdir", strict=False), ABSTFN + "2/subdir")
             self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir", strict=True)
+            self.assertRaises(NotADirectoryError, realpath, ABSTFN + "/subdir",
+                              strict='allow_missing')
         finally:
             os_helper.unlink(ABSTFN)
             os_helper.unlink(ABSTFN + "1")
@@ -1017,8 +1161,11 @@ class PathLikeTests(unittest.TestCase):
     def test_path_abspath(self):
         self.assertPathEqual(self.path.abspath)
 
-    def test_path_realpath(self):
+    @_parameterize({}, {'strict': True}, {'strict': 'allow_missing'})
+    def test_path_realpath(self, kwargs):
         self.assertPathEqual(self.path.realpath)
+
+        self.assertPathEqual(partial(self.path.realpath, **kwargs))
 
     def test_path_relpath(self):
         self.assertPathEqual(self.path.relpath)

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3827,13 +3827,19 @@ class TestExtractionFilters(unittest.TestCase):
             # we can also create new files as well!
             arc.add("escape/newfile", content='new')
 
-        with self.check_context(arc.open(), filter='fully_trusted',
-                                check_flag=False):
+        with (self.subTest('fully_trusted'),
+              self.check_context(arc.open(), filter='fully_trusted',
+                                 check_flag=False)):
             if sys.platform == 'win32':
                 self.expect_exception((FileNotFoundError, FileExistsError))
             elif self.raised_exception:
                 # Most likely, guess for number of components was wrong?
-                self.expect_exception(KeyError)
+                try:
+                    raise self.raised_exception
+                except KeyError:
+                    pass
+                except OSError as exc:
+                    self.assertEqual(exc.errno, errno.ENAMETOOLONG)
             elif os_helper.can_symlink() and os_helper.can_hardlink():
                 self.expect_any_tree(component)
                 self.expect_file('flaglink', content='overwrite')

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3786,11 +3786,9 @@ class TestExtractionFilters(unittest.TestCase):
                 self.expect_file('parent/evil')
 
     @symlink_test
+    @os_helper.skip_unless_symlink
     def test_realpath_limit_attack(self):
         # (CVE-2025-4517)
-
-        if not os_helper.can_symlink():
-            raise SkipTest('requires symlinking ability')
 
         with ArchiveMaker() as arc:
             # populate the symlinks and dirs that expand in os.path.realpath()

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3813,7 +3813,8 @@ class TestExtractionFilters(unittest.TestCase):
             # this link will never be expanded by
             # os.path.realpath(strict=False), nor anything after it.
             linkpath = os.path.join(*steps, "l"*254)
-            arc.add(linkpath, symlink_to=os.path.join(*".." * len(steps)))
+            parent_segments = [".."] * len(steps)
+            arc.add(linkpath, symlink_to=os.path.join(*parent_segments))
             # make a symlink outside to keep the tar command happy
             arc.add("escape", symlink_to=os.path.join(linkpath, ".."))
             # use the symlinks above, that are not checked, to create a hardlink

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -4337,7 +4337,7 @@ class TestExtractionFilters(unittest.TestCase):
         # The 'tar' filter returns TarInfo objects with the same name/type.
         # (It can also fail for particularly "evil" input, but we don't have
         # that in the test archive.)
-        with tarfile.TarFile.open(tarname) as tar:
+        with tarfile.TarFile.open(tarname, encoding="iso8859-1") as tar:
             for tarinfo in tar.getmembers():
                 try:
                     filtered = tarfile.tar_filter(tarinfo, '')
@@ -4349,7 +4349,7 @@ class TestExtractionFilters(unittest.TestCase):
     def test_data_filter(self):
         # The 'data' filter either raises, or returns TarInfo with the same
         # name/type.
-        with tarfile.TarFile.open(tarname) as tar:
+        with tarfile.TarFile.open(tarname, encoding="iso8859-1") as tar:
             for tarinfo in tar.getmembers():
                 try:
                     filtered = tarfile.data_filter(tarinfo, '')

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3800,6 +3800,8 @@ class TestExtractionFilters(unittest.TestCase):
                 component = 'd' * 55
             elif sys.platform == 'win32':
                 component = 'd' * 25
+            elif sys.platform == 'android':
+                component = 'd' * 25
             else:
                 component = 'd' * 247
             steps = "abcdefghijklmnop"

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3830,7 +3830,7 @@ class TestExtractionFilters(unittest.TestCase):
         with self.check_context(arc.open(), filter='fully_trusted',
                                 check_flag=False):
             if sys.platform == 'win32':
-                self.expect_exception(FileNotFoundError)
+                self.expect_exception((FileNotFoundError, FileExistsError))
             elif self.raised_exception:
                 # Most likely, guess for number of components was wrong?
                 self.expect_exception(KeyError)

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3847,8 +3847,9 @@ class TestExtractionFilters(unittest.TestCase):
                     exc = self.expect_exception(OSError)
                     if sys.platform == 'win32':
                         # 3: ERROR_PATH_NOT_FOUND
+                        # 5: ERROR_ACCESS_DENIED
                         # 206: ERROR_FILENAME_EXCED_RANGE
-                        self.assertIn(exc.winerror, (3, 206))
+                        self.assertIn(exc.winerror, (3, 5, 206))
                     else:
                         self.assertEqual(exc.errno, errno.ENAMETOOLONG)
                 else:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3302,7 +3302,8 @@ class NoneInfoExtractTests(ReadTest):
             for p in pathlib.Path(directory).glob('**/*'))
         if self.extraction_filter in (None, 'data'):
             # The 'data' filter is expected to reject special files
-            got_paths.discard(pathlib.Path('ustar/fifotype'))
+            for path in 'ustar/fifotype', 'ustar/blktype', 'ustar/chrtype':
+                got_paths.discard(pathlib.Path(path))
         self.assertEqual(self.control_paths, got_paths)
 
     @contextmanager

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -3788,6 +3788,10 @@ class TestExtractionFilters(unittest.TestCase):
     @symlink_test
     def test_realpath_limit_attack(self):
         # (CVE-2025-4517)
+
+        if not os_helper.can_symlink():
+            raise SkipTest('requires symlinking ability')
+
         with ArchiveMaker() as arc:
             # populate the symlinks and dirs that expand in os.path.realpath()
             # The number is chosen so that in common cases, the unexpanded

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -2715,6 +2715,31 @@ class MiscTest(unittest.TestCase):
             str(excinfo.exception),
         )
 
+    @unittest.skipUnless(os_helper.can_symlink(), 'requires symlink support')
+    @unittest.skipUnless(hasattr(os, 'chmod'), "missing os.chmod")
+    @unittest.mock.patch('os.chmod')
+    def test_deferred_directory_attributes_update(self, mock_chmod):
+        # Regression test for gh-127987: setting attributes on arbitrary files
+        tempdir = os.path.join(TEMPDIR, 'test127987')
+        def mock_chmod_side_effect(path, mode, **kwargs):
+            target_path = os.path.realpath(path)
+            if os.path.commonpath([target_path, tempdir]) != tempdir:
+                raise Exception("should not try to chmod anything outside the destination", target_path)
+        mock_chmod.side_effect = mock_chmod_side_effect
+
+        outside_tree_dir = os.path.join(TEMPDIR, 'outside_tree_dir')
+        with ArchiveMaker() as arc:
+            arc.add('x', symlink_to='.')
+            arc.add('x', type=tarfile.DIRTYPE, mode='?rwsrwsrwt')
+            arc.add('x', symlink_to=outside_tree_dir)
+
+        os.makedirs(outside_tree_dir)
+        try:
+            arc.open().extractall(path=tempdir, filter='tar')
+        finally:
+            os_helper.rmtree(outside_tree_dir)
+            os_helper.rmtree(tempdir)
+
 
 class CommandLineTest(unittest.TestCase):
 
@@ -3275,6 +3300,9 @@ class NoneInfoExtractTests(ReadTest):
         got_paths = set(
             p.relative_to(directory)
             for p in pathlib.Path(directory).glob('**/*'))
+        if self.extraction_filter in (None, 'data'):
+            # The 'data' filter is expected to reject special files
+            got_paths.discard(pathlib.Path('ustar/fifotype'))
         self.assertEqual(self.control_paths, got_paths)
 
     @contextmanager
@@ -3504,12 +3532,28 @@ class ArchiveMaker:
         self.bio = None
 
     def add(self, name, *, type=None, symlink_to=None, hardlink_to=None,
-            mode=None, size=None, **kwargs):
-        """Add a member to the test archive. Call within `with`."""
+            mode=None, size=None, content=None, **kwargs):
+        """Add a member to the test archive. Call within `with`.
+
+        Provides many shortcuts:
+        - default `type` is based on symlink_to, hardlink_to, and trailing `/`
+          in name (which is stripped)
+        - size & content defaults are based on each other
+        - content can be str or bytes
+        - mode should be textual ('-rwxrwxrwx')
+
+        (add more! this is unstable internal test-only API)
+        """
         name = str(name)
         tarinfo = tarfile.TarInfo(name).replace(**kwargs)
+        if content is not None:
+            if isinstance(content, str):
+                content = content.encode()
+            size = len(content)
         if size is not None:
             tarinfo.size = size
+            if content is None:
+                content = bytes(tarinfo.size)
         if mode:
             tarinfo.mode = _filemode_to_int(mode)
         if symlink_to is not None:
@@ -3523,7 +3567,7 @@ class ArchiveMaker:
         if type is not None:
             tarinfo.type = type
         if tarinfo.isreg():
-            fileobj = io.BytesIO(bytes(tarinfo.size))
+            fileobj = io.BytesIO(content)
         else:
             fileobj = None
         self.tar_w.addfile(tarinfo, fileobj)
@@ -3557,7 +3601,7 @@ class TestExtractionFilters(unittest.TestCase):
     destdir = outerdir / 'dest'
 
     @contextmanager
-    def check_context(self, tar, filter):
+    def check_context(self, tar, filter, *, check_flag=True):
         """Extracts `tar` to `self.destdir` and allows checking the result
 
         If an error occurs, it must be checked using `expect_exception`
@@ -3566,27 +3610,40 @@ class TestExtractionFilters(unittest.TestCase):
         except the destination directory itself and parent directories of
         other files.
         When checking directories, do so before their contents.
+
+        A file called 'flag' is made in outerdir (i.e. outside destdir)
+        before extraction; it should not be altered nor should its contents
+        be read/copied.
         """
         with os_helper.temp_dir(self.outerdir):
+            flag_path = self.outerdir / 'flag'
+            flag_path.write_text('capture me')
             try:
                 tar.extractall(self.destdir, filter=filter)
             except Exception as exc:
                 self.raised_exception = exc
+                self.reraise_exception = True
                 self.expected_paths = set()
             else:
                 self.raised_exception = None
+                self.reraise_exception = False
                 self.expected_paths = set(self.outerdir.glob('**/*'))
                 self.expected_paths.discard(self.destdir)
+                self.expected_paths.discard(flag_path)
             try:
-                yield
+                yield self
             finally:
                 tar.close()
-            if self.raised_exception:
+            if self.reraise_exception:
                 raise self.raised_exception
             self.assertEqual(self.expected_paths, set())
+            if check_flag:
+                self.assertEqual(flag_path.read_text(), 'capture me')
+            else:
+                assert filter == 'fully_trusted'
 
     def expect_file(self, name, type=None, symlink_to=None, mode=None,
-                    size=None):
+                    size=None, content=None):
         """Check a single file. See check_context."""
         if self.raised_exception:
             raise self.raised_exception
@@ -3605,26 +3662,45 @@ class TestExtractionFilters(unittest.TestCase):
             # The symlink might be the same (textually) as what we expect,
             # but some systems change the link to an equivalent path, so
             # we fall back to samefile().
-            if expected != got:
-                self.assertTrue(got.samefile(expected))
+            try:
+                if expected != got:
+                    self.assertTrue(got.samefile(expected))
+            except Exception as e:
+                # attach a note, so it's shown even if `samefile` fails
+                e.add_note(f'{expected=}, {got=}')
+                raise
         elif type == tarfile.REGTYPE or type is None:
             self.assertTrue(path.is_file())
         elif type == tarfile.DIRTYPE:
             self.assertTrue(path.is_dir())
         elif type == tarfile.FIFOTYPE:
             self.assertTrue(path.is_fifo())
+        elif type == tarfile.SYMTYPE:
+            self.assertTrue(path.is_symlink())
         else:
             raise NotImplementedError(type)
         if size is not None:
             self.assertEqual(path.stat().st_size, size)
+        if content is not None:
+            self.assertEqual(path.read_text(), content)
         for parent in path.parents:
             self.expected_paths.discard(parent)
+
+    def expect_any_tree(self, name):
+        """Check a directory; forget about its contents."""
+        tree_path = (self.destdir / name).resolve()
+        self.expect_file(tree_path, type=tarfile.DIRTYPE)
+        self.expected_paths = {
+            p for p in self.expected_paths
+            if tree_path not in p.parents
+        }
 
     def expect_exception(self, exc_type, message_re='.'):
         with self.assertRaisesRegex(exc_type, message_re):
             if self.raised_exception is not None:
                 raise self.raised_exception
-        self.raised_exception = None
+        self.reraise_exception = False
+        return self.raised_exception
 
     def test_benign_file(self):
         with ArchiveMaker() as arc:
@@ -3708,6 +3784,72 @@ class TestExtractionFilters(unittest.TestCase):
                 self.expect_file('parent/evil')
             with self.check_context(arc.open(), 'data'):
                 self.expect_file('parent/evil')
+
+    @symlink_test
+    def test_realpath_limit_attack(self):
+        # (CVE-2025-4517)
+        with ArchiveMaker() as arc:
+            # populate the symlinks and dirs that expand in os.path.realpath()
+            # The number is chosen so that in common cases, the unexpanded
+            # path fits in PATH_MAX, but it overflows when the final symlink
+            # is expanded
+            if sys.platform == 'darwin':
+                component = 'd' * 55
+            elif sys.platform == 'win32':
+                component = 'd' * 25
+            else:
+                component = 'd' * 247
+            steps = "abcdefghijklmnop"
+            path = ""
+            step_path = ""
+            for i in steps:
+                arc.add(os.path.join(path, component), type=tarfile.DIRTYPE,
+                        mode='drwxrwxrwx')
+                arc.add(os.path.join(path, i), symlink_to=component)
+                path = os.path.join(path, component)
+                step_path = os.path.join(step_path, i)
+            # create the final symlink that exceeds PATH_MAX and simply points
+            # to the top dir.
+            # this link will never be expanded by
+            # os.path.realpath(strict=False), nor anything after it.
+            linkpath = os.path.join(*steps, "l"*254)
+            arc.add(linkpath, symlink_to=os.path.join(*".." * len(steps)))
+            # make a symlink outside to keep the tar command happy
+            arc.add("escape", symlink_to=os.path.join(linkpath, ".."))
+            # use the symlinks above, that are not checked, to create a hardlink
+            # to a file outside of the destination path
+            arc.add("flaglink", hardlink_to=os.path.join("escape", "flag"))
+            # now that we have the hardlink we can overwrite the file
+            arc.add("flaglink", content='overwrite')
+            # we can also create new files as well!
+            arc.add("escape/newfile", content='new')
+
+        with self.check_context(arc.open(), filter='fully_trusted',
+                                check_flag=False):
+            if sys.platform == 'win32':
+                self.expect_exception(FileNotFoundError)
+            elif self.raised_exception:
+                # Most likely, guess for number of components was wrong?
+                self.expect_exception(KeyError)
+            elif os_helper.can_symlink() and os_helper.can_hardlink():
+                self.expect_any_tree(component)
+                self.expect_file('flaglink', content='overwrite')
+                self.expect_file('../newfile', content='new')
+                self.expect_file('escape', type=tarfile.SYMTYPE)
+                self.expect_file('a', symlink_to=component)
+
+        for filter in 'tar', 'data':
+            with self.subTest(filter), self.check_context(arc.open(), filter='tar'):
+                if os_helper.can_hardlink():
+                    exc = self.expect_exception(OSError)
+                    if sys.platform == 'win32':
+                        # 3: ERROR_PATH_NOT_FOUND
+                        # 206: ERROR_FILENAME_EXCED_RANGE
+                        self.assertIn(exc.winerror, (3, 206))
+                    else:
+                        self.assertEqual(exc.errno, errno.ENAMETOOLONG)
+                else:
+                    self.expect_exception(KeyError)
 
     @symlink_test
     def test_parent_symlink2(self):
@@ -3931,8 +4073,8 @@ class TestExtractionFilters(unittest.TestCase):
             arc.add('symlink2', symlink_to=os.path.join(
                 'linkdir', 'hardlink2'))
             arc.add('targetdir/target', size=3)
-            arc.add('linkdir/hardlink', hardlink_to='targetdir/target')
-            arc.add('linkdir/hardlink2', hardlink_to='linkdir/symlink')
+            arc.add('linkdir/hardlink', hardlink_to=os.path.join('targetdir', 'target'))
+            arc.add('linkdir/hardlink2', hardlink_to=os.path.join('linkdir', 'symlink'))
 
         for filter in 'tar', 'data', 'fully_trusted':
             with self.check_context(arc.open(), filter):
@@ -3947,6 +4089,129 @@ class TestExtractionFilters(unittest.TestCase):
                 else:
                     self.expect_file('linkdir/symlink', size=3)
                     self.expect_file('symlink2', size=3)
+
+    @symlink_test
+    def test_sneaky_hardlink_fallback(self):
+        # (CVE-2025-4330)
+        # Test that when hardlink extraction falls back to extracting members
+        # from the archive, the extracted member is (re-)filtered.
+        with ArchiveMaker() as arc:
+            # Create a directory structure so the c/escape symlink stays
+            # inside the path
+            arc.add("a/t/dummy")
+            # Create b/ directory
+            arc.add("b/")
+            # Point "c" to the bottom of the tree in "a"
+            arc.add("c", symlink_to=os.path.join("a", "t"))
+            # link to non-existant location under "a"
+            arc.add("c/escape", symlink_to=os.path.join("..", "..",
+                                                        "link_here"))
+            # Move "c" to point to "b" ("c/escape" no longer exists)
+            arc.add("c", symlink_to="b")
+            # Attempt to create a hard link to "c/escape". Since it doesn't
+            # exist it will attempt to extract "cescape" but at "boom".
+            arc.add("boom", hardlink_to=os.path.join("c", "escape"))
+
+        with self.check_context(arc.open(), 'data'):
+            if not os_helper.can_symlink():
+                # When 'c/escape' is extracted, 'c' is a regular
+                # directory, and 'c/escape' *would* point outside
+                # the destination if symlinks were allowed.
+                self.expect_exception(
+                    tarfile.LinkOutsideDestinationError)
+            elif sys.platform == "win32":
+                # On Windows, 'c/escape' points outside the destination
+                self.expect_exception(tarfile.LinkOutsideDestinationError)
+            else:
+                e = self.expect_exception(
+                    tarfile.LinkFallbackError,
+                    "link 'boom' would be extracted as a copy of "
+                    + "'c/escape', which was rejected")
+                self.assertIsInstance(e.__cause__,
+                                      tarfile.LinkOutsideDestinationError)
+        for filter in 'tar', 'fully_trusted':
+            with self.subTest(filter), self.check_context(arc.open(), filter):
+                if not os_helper.can_symlink():
+                    self.expect_file("a/t/dummy")
+                    self.expect_file("b/")
+                    self.expect_file("c/")
+                else:
+                    self.expect_file("a/t/dummy")
+                    self.expect_file("b/")
+                    self.expect_file("a/t/escape", symlink_to='../../link_here')
+                    self.expect_file("boom", symlink_to='../../link_here')
+                    self.expect_file("c", symlink_to='b')
+
+    @symlink_test
+    def test_exfiltration_via_symlink(self):
+        # (CVE-2025-4138)
+        # Test changing symlinks that result in a symlink pointing outside
+        # the extraction directory, unless prevented by 'data' filter's
+        # normalization.
+        with ArchiveMaker() as arc:
+            arc.add("escape", symlink_to=os.path.join('link', 'link', '..', '..', 'link-here'))
+            arc.add("link", symlink_to='./')
+
+        for filter in 'tar', 'data', 'fully_trusted':
+            with self.check_context(arc.open(), filter):
+                if os_helper.can_symlink():
+                    self.expect_file("link", symlink_to='./')
+                    if filter == 'data':
+                        self.expect_file("escape", symlink_to='link-here')
+                    else:
+                        self.expect_file("escape",
+                                         symlink_to='link/link/../../link-here')
+                else:
+                    # Nothing is extracted.
+                    pass
+
+    @symlink_test
+    def test_chmod_outside_dir(self):
+        # (CVE-2024-12718)
+        # Test that members used for delayed updates of directory metadata
+        # are (re-)filtered.
+        with ArchiveMaker() as arc:
+            # "pwn" is a veeeery innocent symlink:
+            arc.add("a/pwn", symlink_to='.')
+            # But now "pwn" is also a directory, so it's scheduled to have its
+            # metadata updated later:
+            arc.add("a/pwn/", mode='drwxrwxrwx')
+            # Oops, "pwn" is not so innocent any more:
+            arc.add("a/pwn", symlink_to='x/../')
+            # Newly created symlink points to the dest dir,
+            # so it's OK for the "data" filter.
+            arc.add('a/x', symlink_to=('../'))
+            # But now "pwn" points outside the dest dir
+
+        for filter in 'tar', 'data', 'fully_trusted':
+            with self.check_context(arc.open(), filter) as cc:
+                if not os_helper.can_symlink():
+                    self.expect_file("a/pwn/")
+                elif filter == 'data':
+                    self.expect_file("a/x", symlink_to='../')
+                    self.expect_file("a/pwn", symlink_to='.')
+                else:
+                    self.expect_file("a/x", symlink_to='../')
+                    self.expect_file("a/pwn", symlink_to='x/../')
+                if sys.platform != "win32":
+                    st_mode = cc.outerdir.stat().st_mode
+                    self.assertNotEqual(st_mode & 0o777, 0o777)
+
+    def test_link_fallback_normalizes(self):
+        # Make sure hardlink fallbacks work for non-normalized paths for all
+        # filters
+        with ArchiveMaker() as arc:
+            arc.add("dir/")
+            arc.add("dir/../afile")
+            arc.add("link1", hardlink_to='dir/../afile')
+            arc.add("link2", hardlink_to='dir/../dir/../afile')
+
+        for filter in 'tar', 'data', 'fully_trusted':
+            with self.check_context(arc.open(), filter) as cc:
+                self.expect_file("dir/")
+                self.expect_file("afile")
+                self.expect_file("link1")
+                self.expect_file("link2")
 
     def test_modes(self):
         # Test how file modes are extracted
@@ -4242,13 +4507,13 @@ class TestExtractionFilters(unittest.TestCase):
         # If errorlevel is 0, errors affected by errorlevel are ignored
 
         with self.check_context(arc.open(errorlevel=0), extracterror_filter):
-            self.expect_file('file')
+            pass
 
         with self.check_context(arc.open(errorlevel=0), filtererror_filter):
-            self.expect_file('file')
+            pass
 
         with self.check_context(arc.open(errorlevel=0), oserror_filter):
-            self.expect_file('file')
+            pass
 
         with self.check_context(arc.open(errorlevel=0), tarerror_filter):
             self.expect_exception(tarfile.TarError)
@@ -4259,7 +4524,7 @@ class TestExtractionFilters(unittest.TestCase):
         # If 1, all fatal errors are raised
 
         with self.check_context(arc.open(errorlevel=1), extracterror_filter):
-            self.expect_file('file')
+            pass
 
         with self.check_context(arc.open(errorlevel=1), filtererror_filter):
             self.expect_exception(tarfile.FilterError)

--- a/Misc/NEWS.d/next/Security/2025-06-02-11-32-23.gh-issue-135034.RLGjbp.rst
+++ b/Misc/NEWS.d/next/Security/2025-06-02-11-32-23.gh-issue-135034.RLGjbp.rst
@@ -1,0 +1,7 @@
+cat Misc/NEWS.d/next/Security/2025-06-02-11-32-23.gh-issue-135034.RLGjbp.rst
+Fixes multiple issues that allowed ``tarfile`` extraction filters
+(``filter="data"`` and ``filter="tar"``) to be bypassed using crafted
+symlinks and hard links.
+
+Addresses :cve:`2024-12718`, :cve:`2025-4138`, :cve:`2025-4330`, and :cve:`2025-4517`.
+

--- a/Misc/NEWS.d/next/Security/2025-06-02-11-32-23.gh-issue-135034.RLGjbp.rst
+++ b/Misc/NEWS.d/next/Security/2025-06-02-11-32-23.gh-issue-135034.RLGjbp.rst
@@ -1,4 +1,3 @@
-cat Misc/NEWS.d/next/Security/2025-06-02-11-32-23.gh-issue-135034.RLGjbp.rst
 Fixes multiple issues that allowed ``tarfile`` extraction filters
 (``filter="data"`` and ``filter="tar"``) to be bypassed using crafted
 symlinks and hard links.


### PR DESCRIPTION
Addresses CVEs 2024-12718, 2025-4138, 2025-4330, and 2025-4517.

[edit @encukou]: Also addresses CVE-2025-4435. Sorry for leaving that out of the commit messages.

Co-authored-by: Petr Viktorin <encukou@gmail.com>
Signed-off-by: Łukasz Langa <lukasz@langa.pl>


<!-- gh-issue-number: gh-135034 -->
* Issue: gh-135034
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135037.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->