### PR TITLE
 gh-135069: Fix exception message in encodings.idna module

### DIFF
--- a/Lib/encodings/idna.py
+++ b/Lib/encodings/idna.py
@@ -316,7 +316,7 @@ class IncrementalEncoder(codecs.BufferedIncrementalEncoder):
 class IncrementalDecoder(codecs.BufferedIncrementalDecoder):
     def _buffer_decode(self, input, errors, final):
         if errors != 'strict':
-            raise UnicodeError("Unsupported error handling: {errors}")
+            raise UnicodeError(f"Unsupported error handling: {errors}")
 
         if not input:
             return ("", 0)

--- a/Misc/NEWS.d/next/Library/2025-06-03-12-59-17.gh-issue-135069.xop30V.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-03-12-59-17.gh-issue-135069.xop30V.rst
@@ -1,0 +1,3 @@
+Fix the "Invalid error handling" exception in
+:meth:`encodings.idna.IncrementalDecoder.decode` to correctly replace the
+'errors' parameter.

--- a/Misc/NEWS.d/next/Library/2025-06-03-12-59-17.gh-issue-135069.xop30V.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-03-12-59-17.gh-issue-135069.xop30V.rst
@@ -1,3 +1,3 @@
 Fix the "Invalid error handling" exception in
-:class:`encodings.idna.IncrementalDecoder` to correctly replace the
+:class:`!encodings.idna.IncrementalDecoder` to correctly replace the
 'errors' parameter.

--- a/Misc/NEWS.d/next/Library/2025-06-03-12-59-17.gh-issue-135069.xop30V.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-03-12-59-17.gh-issue-135069.xop30V.rst
@@ -1,3 +1,3 @@
 Fix the "Invalid error handling" exception in
-:meth:`encodings.idna.IncrementalDecoder.decode` to correctly replace the
+:class:`encodings.idna.IncrementalDecoder` to correctly replace the
 'errors' parameter.


### PR DESCRIPTION
Fixes #135069.

 Requires backport to 3.13 and 3.14 branches. 

<!-- gh-issue-number: gh-135069 -->
* Issue: gh-135069
<!-- /gh-issue-number -->
