### PR TITLE
gh-135074: Fix exception messages in test.support module

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1084,7 +1084,7 @@ def set_memlimit(limit: str) -> None:
     global real_max_memuse
     memlimit = _parse_memlimit(limit)
     if memlimit < _2G - 1:
-        raise ValueError('Memory limit {limit!r} too low to be useful')
+        raise ValueError(f'Memory limit {limit!r} too low to be useful')
 
     real_max_memuse = memlimit
     memlimit = min(memlimit, MAX_Py_ssize_t)
@@ -2358,7 +2358,7 @@ def infinite_recursion(max_depth=None):
         # very deep recursion.
         max_depth = 20_000
     elif max_depth < 3:
-        raise ValueError("max_depth must be at least 3, got {max_depth}")
+        raise ValueError(f"max_depth must be at least 3, got {max_depth}")
     depth = get_recursion_depth()
     depth = max(depth - 1, 1)  # Ignore infinite_recursion() frame.
     limit = depth + max_depth

--- a/Misc/NEWS.d/next/Library/2025-06-03-13-27-23.gh-issue-135074.JMdFEi.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-03-13-27-23.gh-issue-135074.JMdFEi.rst
@@ -1,0 +1,2 @@
+Fix exception messages in the :mod:`test.support` module that were missing
+the 'f' prefix.

--- a/Misc/NEWS.d/next/Library/2025-06-03-13-27-23.gh-issue-135074.JMdFEi.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-03-13-27-23.gh-issue-135074.JMdFEi.rst
@@ -1,2 +1,0 @@
-Fix exception messages in the :mod:`test.support` module that were missing
-the 'f' prefix.


### PR DESCRIPTION
Fixes #135074. 

The issue also exists on 3.13 and 3.14 branches, not sure if changes to `test.support` are backported? (also not sure if blurb is needed here).

<!-- gh-issue-number: gh-135074 -->
* Issue: gh-135074
<!-- /gh-issue-number -->
