### PR TITLE
gh-135075: Deprecate PyObject_SetAttr(obj, name, NULL) with exc

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -197,6 +197,10 @@ Object Protocol
    in favour of using :c:func:`PyObject_DelAttr`, but there are currently no
    plans to remove it.
 
+   .. deprecated:: next
+      Calling this function with ``NULL`` *v* and an exception set is now
+      deprecated.
+
 
 .. c:function:: int PyObject_SetAttrString(PyObject *o, const char *attr_name, PyObject *v)
 
@@ -214,6 +218,11 @@ Object Protocol
    :c:func:`PyUnicode_FromString` and :c:func:`PyObject_SetAttr` directly.
    For more details, see :c:func:`PyUnicode_InternFromString`, which may be
    used internally to create a key object.
+
+   .. deprecated:: next
+      Calling this function with ``NULL`` *v* and an exception set is now
+      deprecated.
+
 
 .. c:function:: int PyObject_GenericSetAttr(PyObject *o, PyObject *name, PyObject *value)
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -322,7 +322,9 @@ Porting to Python 3.15
 Deprecated C APIs
 -----------------
 
-* TODO
+* Calling :c:func:`PyObject_SetAttr` and :c:func:`PyObject_SetAttrString` with
+  ``NULL`` value and an exception set is now deprecated.
+  (Contributed by Victor Stinner in :gh:`135075`.)
 
 .. Add C API deprecations above alphabetically, not here at the end.
 

--- a/Lib/test/test_capi/test_object.py
+++ b/Lib/test/test_capi/test_object.py
@@ -247,5 +247,23 @@ class CAPITest(unittest.TestCase):
 
         func(object())
 
+    def test_object_setattr_null_exc(self):
+        class Obj:
+            pass
+        obj = Obj()
+
+        obj.attr = 123
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(ValueError):
+                _testcapi.object_setattr_null_exc(obj, 'attr')
+        self.assertFalse(hasattr(obj, 'attr'))
+
+        obj.attr = 456
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(ValueError):
+                _testcapi.object_setattrstring_null_exc(obj, 'attr')
+        self.assertFalse(hasattr(obj, 'attr'))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/C_API/2025-06-03-14-55-43.gh-issue-135075.fq1iqH.rst
+++ b/Misc/NEWS.d/next/C_API/2025-06-03-14-55-43.gh-issue-135075.fq1iqH.rst
@@ -1,0 +1,3 @@
+Deprecate calling :c:func:`PyObject_SetAttr` and
+:c:func:`PyObject_SetAttrString` with ``NULL`` value and an exception set is
+now deprecated. Patch by Victor Stinner.

--- a/Modules/_testcapi/object.c
+++ b/Modules/_testcapi/object.c
@@ -485,6 +485,41 @@ is_uniquely_referenced(PyObject *self, PyObject *op)
 }
 
 
+static PyObject *
+object_setattr_null_exc(PyObject *self, PyObject *args)
+{
+    PyObject *obj, *name;
+    if (!PyArg_ParseTuple(args, "OO", &obj, &name)) {
+        return NULL;
+    }
+
+    PyErr_SetString(PyExc_ValueError, "error");
+    if (PyObject_SetAttr(obj, name, NULL) < 0) {
+        return NULL;
+    }
+    assert(PyErr_Occurred());
+    return NULL;
+}
+
+
+static PyObject *
+object_setattrstring_null_exc(PyObject *self, PyObject *args)
+{
+    PyObject *obj;
+    const char *name;
+    if (!PyArg_ParseTuple(args, "Os", &obj, &name)) {
+        return NULL;
+    }
+
+    PyErr_SetString(PyExc_ValueError, "error");
+    if (PyObject_SetAttrString(obj, name, NULL) < 0) {
+        return NULL;
+    }
+    assert(PyErr_Occurred());
+    return NULL;
+}
+
+
 static PyMethodDef test_methods[] = {
     {"call_pyobject_print", call_pyobject_print, METH_VARARGS},
     {"pyobject_print_null", pyobject_print_null, METH_VARARGS},
@@ -511,6 +546,8 @@ static PyMethodDef test_methods[] = {
     {"test_py_is_funcs", test_py_is_funcs, METH_NOARGS},
     {"clear_managed_dict", clear_managed_dict, METH_O, NULL},
     {"is_uniquely_referenced", is_uniquely_referenced, METH_O},
+    {"object_setattr_null_exc", object_setattr_null_exc, METH_VARARGS},
+    {"object_setattrstring_null_exc", object_setattrstring_null_exc, METH_VARARGS},
     {NULL},
 };
 


### PR DESCRIPTION
Deprecate calling PyObject_SetAttr() and PyObject_SetAttrString() with NULL value and an exception set.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135075 -->
* Issue: gh-135075
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135082.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->