### PR TITLE
[3.12] gh-135034: Remove test_realpath_permission

### DIFF
--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -836,51 +836,6 @@ class TestNtpath(NtpathTestCase):
                         test_file_long,
                         ntpath.realpath("file.txt", **kwargs))
 
-    @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
-    def test_realpath_permission(self):
-        # Test whether python can resolve the real filename of a
-        # shortened file name even if it does not have permission to access it.
-        ABSTFN = ntpath.realpath(os_helper.TESTFN)
-
-        os_helper.unlink(ABSTFN)
-        os_helper.rmtree(ABSTFN)
-        os.mkdir(ABSTFN)
-        self.addCleanup(os_helper.rmtree, ABSTFN)
-
-        test_file = ntpath.join(ABSTFN, "LongFileName123.txt")
-        test_file_short = ntpath.join(ABSTFN, "LONGFI~1.TXT")
-
-        with open(test_file, "wb") as f:
-            f.write(b"content")
-        # Automatic generation of short names may be disabled on
-        # NTFS volumes for the sake of performance.
-        # They're not supported at all on ReFS and exFAT.
-        p = subprocess.run(
-            # Try to set the short name manually.
-            ['fsutil.exe', 'file', 'setShortName', test_file, 'LONGFI~1.TXT'],
-            creationflags=subprocess.DETACHED_PROCESS
-        )
-
-        if p.returncode:
-            raise unittest.SkipTest('failed to set short name')
-
-        try:
-            self.assertPathEqual(test_file, ntpath.realpath(test_file_short))
-        except AssertionError:
-            raise unittest.SkipTest('the filesystem seems to lack support for short filenames')
-
-        # Deny the right to [S]YNCHRONIZE on the file to
-        # force nt._getfinalpathname to fail with ERROR_ACCESS_DENIED.
-        p = subprocess.run(
-            ['icacls.exe', test_file, '/deny', '*S-1-5-32-545:(S)'],
-            creationflags=subprocess.DETACHED_PROCESS
-        )
-
-        if p.returncode:
-            raise unittest.SkipTest('failed to deny access to the test file')
-
-        self.assertPathEqual(test_file, ntpath.realpath(test_file_short))
-
     def test_expandvars(self):
         with os_helper.EnvironmentVarGuard() as env:
             env.clear()


### PR DESCRIPTION
The test was added to 3.13 in gh-110298 with a fix that was never backported to 3.12 and below.

Now the test was backported too eagerly along with other new `ntpath` tests that passed.
This one was most likely skipped in GHA, it does not pass locally for me.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135034 -->
* Issue: gh-135034
<!-- /gh-issue-number -->
