### PR TITLE
[3.12] gh-128605: Add branch protections for x86_64 in asm_trampolineS (#128606)

### DIFF
--- a/Python/asm_trampoline.S
+++ b/Python/asm_trampoline.S
@@ -9,6 +9,9 @@
 # }
 _Py_trampoline_func_start:
 #ifdef __x86_64__
+#if defined(__CET__) && (__CET__ & 1)
+    endbr64
+#endif
     sub    $8, %rsp
     call    *%rcx
     add    $8, %rsp
@@ -26,3 +29,22 @@ _Py_trampoline_func_start:
     .globl	_Py_trampoline_func_end
 _Py_trampoline_func_end:
     .section        .note.GNU-stack,"",@progbits
+# Note for indicating the assembly code supports CET
+#if defined(__x86_64__) && defined(__CET__) && (__CET__ & 1)
+    .section    .note.gnu.property,"a"
+    .align 8
+    .long    1f - 0f
+    .long    4f - 1f
+    .long    5
+0:
+    .string  "GNU"
+1:
+    .align 8
+    .long    0xc0000002
+    .long    3f - 2f
+2:
+    .long    0x3
+3:
+    .align 8
+4:
+#endif // __x86_64__


### PR DESCRIPTION
Apply Intel Control-flow Technology for x86-64 on asm_trampoline.S.

Required for mitigation against return-oriented programming (ROP) and Call or Jump Oriented Programming (COP/JOP) attacks.

Manual application is required for the assembly files.

See also: https://sourceware.org/annobin/annobin.html/Test-cf-protection.html

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128605 -->
* Issue: gh-128605
<!-- /gh-issue-number -->
