### PR TITLE
[3.13] gh-127081: use `getlogin_r` if available (gh-132751)

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-04-21-01-03-15.gh-issue-127081.WXRliX.rst
+++ b/Misc/NEWS.d/next/Library/2025-04-21-01-03-15.gh-issue-127081.WXRliX.rst
@@ -1,0 +1,2 @@
+Fix libc thread safety issues with :mod:`os` by replacing ``getlogin`` with
+``getlogin_r`` re-entrant version.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -9464,6 +9464,24 @@ os_getlogin_impl(PyObject *module)
     }
     else
         result = PyErr_SetFromWindowsErr(GetLastError());
+#elif defined (HAVE_GETLOGIN_R)
+# if defined (HAVE_MAXLOGNAME)
+    char name[MAXLOGNAME + 1];
+# elif defined (HAVE_UT_NAMESIZE)
+    char name[UT_NAMESIZE + 1];
+# else
+    char name[256];
+# endif
+    int err = getlogin_r(name, sizeof(name));
+    if (err) {
+        int old_errno = errno;
+        errno = -err;
+        posix_error();
+        errno = old_errno;
+    }
+    else {
+        result = PyUnicode_DecodeFSDefault(name);
+    }
 #else
     char *name;
     int old_errno = errno;

--- a/configure
+++ b/configure
@@ -21907,9 +21907,8 @@ ac_fn_check_decl "$LINENO" "UT_NAMESIZE" "ac_cv_have_decl_UT_NAMESIZE" "#include
 if test "x$ac_cv_have_decl_UT_NAMESIZE" = xyes
 then :
   ac_have_decl=1
-else case e in #(
-  e) ac_have_decl=0 ;;
-esac
+else $as_nop
+  ac_have_decl=0
 fi
 printf "%s\n" "#define HAVE_DECL_UT_NAMESIZE $ac_have_decl" >>confdefs.h
 if test $ac_have_decl = 1

--- a/configure
+++ b/configure
@@ -18181,6 +18181,12 @@ then :
   printf "%s\n" "#define HAVE_GETLOGIN 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "getlogin_r" "ac_cv_func_getlogin_r"
+if test "x$ac_cv_func_getlogin_r" = xyes
+then :
+  printf "%s\n" "#define HAVE_GETLOGIN_R 1" >>confdefs.h
+
+fi
 ac_fn_c_check_func "$LINENO" "getpeername" "ac_cv_func_getpeername"
 if test "x$ac_cv_func_getpeername" = xyes
 then :
@@ -21885,6 +21891,33 @@ printf "%s\n" "#define HAVE_SETGROUPS 1" >>confdefs.h
 fi
 
 
+
+
+ac_fn_check_decl "$LINENO" "MAXLOGNAME" "ac_cv_have_decl_MAXLOGNAME" "#include <sys/params.h>
+" "$ac_c_undeclared_builtin_options" "CFLAGS"
+if test "x$ac_cv_have_decl_MAXLOGNAME" = xyes
+then :
+
+printf "%s\n" "#define HAVE_MAXLOGNAME 1" >>confdefs.h
+
+fi
+
+ac_fn_check_decl "$LINENO" "UT_NAMESIZE" "ac_cv_have_decl_UT_NAMESIZE" "#include <utmp.h>
+" "$ac_c_undeclared_builtin_options" "CFLAGS"
+if test "x$ac_cv_have_decl_UT_NAMESIZE" = xyes
+then :
+  ac_have_decl=1
+else case e in #(
+  e) ac_have_decl=0 ;;
+esac
+fi
+printf "%s\n" "#define HAVE_DECL_UT_NAMESIZE $ac_have_decl" >>confdefs.h
+if test $ac_have_decl = 1
+then :
+
+printf "%s\n" "#define HAVE_UT_NAMESIZE 1" >>confdefs.h
+
+fi
 
 
 # check for openpty, login_tty, and forkpty

--- a/configure.ac
+++ b/configure.ac
@@ -5116,7 +5116,7 @@ AC_CHECK_FUNCS([ \
   faccessat fchmod fchmodat fchown fchownat fdopendir fdwalk fexecve \
   fork fork1 fpathconf fstatat ftime ftruncate futimens futimes futimesat \
   gai_strerror getegid geteuid getgid getgrent getgrgid getgrgid_r \
-  getgrnam_r getgrouplist gethostname getitimer getloadavg getlogin \
+  getgrnam_r getgrouplist gethostname getitimer getloadavg getlogin getlogin_r \
   getpeername getpgid getpid getppid getpriority _getpty \
   getpwent getpwnam_r getpwuid getpwuid_r getresgid getresuid getrusage getsid getspent \
   getspnam getuid getwd grantpt if_nameindex initgroups kill killpg lchown linkat \
@@ -5399,6 +5399,18 @@ PY_CHECK_FUNC([setgroups], [
 #include <grp.h>
 #endif
 ])
+
+AC_CHECK_DECL([MAXLOGNAME],
+              [AC_DEFINE([HAVE_MAXLOGNAME], [1],
+                         [Define if you have the 'MAXLOGNAME' constant.])],
+              [],
+              [@%:@include <sys/params.h>])
+
+AC_CHECK_DECLS([UT_NAMESIZE],
+              [AC_DEFINE([HAVE_UT_NAMESIZE], [1],
+                         [Define if you have the 'HAVE_UT_NAMESIZE' constant.])],
+              [],
+              [@%:@include <utmp.h>])
 
 # check for openpty, login_tty, and forkpty
 

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -258,7 +258,7 @@
    */
 #undef HAVE_DECL_TZNAME
 
-/* Define to 1 if you have the declaration of 'UT_NAMESIZE', and to 0 if you
+/* Define to 1 if you have the declaration of `UT_NAMESIZE', and to 0 if you
    don't. */
 #undef HAVE_DECL_UT_NAMESIZE
 
@@ -525,7 +525,7 @@
 /* Define to 1 if you have the `getlogin' function. */
 #undef HAVE_GETLOGIN
 
-/* Define to 1 if you have the 'getlogin_r' function. */
+/* Define to 1 if you have the `getlogin_r' function. */
 #undef HAVE_GETLOGIN_R
 
 /* Define to 1 if you have the `getnameinfo' function. */

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -258,6 +258,10 @@
    */
 #undef HAVE_DECL_TZNAME
 
+/* Define to 1 if you have the declaration of 'UT_NAMESIZE', and to 0 if you
+   don't. */
+#undef HAVE_DECL_UT_NAMESIZE
+
 /* Define to 1 if you have the device macros. */
 #undef HAVE_DEVICE_MACROS
 
@@ -520,6 +524,9 @@
 
 /* Define to 1 if you have the `getlogin' function. */
 #undef HAVE_GETLOGIN
+
+/* Define to 1 if you have the 'getlogin_r' function. */
+#undef HAVE_GETLOGIN_R
 
 /* Define to 1 if you have the `getnameinfo' function. */
 #undef HAVE_GETNAMEINFO
@@ -785,6 +792,9 @@
 
 /* Define this if you have the makedev macro. */
 #undef HAVE_MAKEDEV
+
+/* Define if you have the 'MAXLOGNAME' constant. */
+#undef HAVE_MAXLOGNAME
 
 /* Define to 1 if you have the `mbrtowc' function. */
 #undef HAVE_MBRTOWC
@@ -1538,6 +1548,9 @@
 
 /* Define to 1 if you have the <utmp.h> header file. */
 #undef HAVE_UTMP_H
+
+/* Define if you have the 'HAVE_UT_NAMESIZE' constant. */
+#undef HAVE_UT_NAMESIZE
 
 /* Define to 1 if you have the `uuid_create' function. */
 #undef HAVE_UUID_CREATE


### PR DESCRIPTION
The `getlogin` function is not thread-safe: replace with `getlogin_r` where available.
(cherry picked from commit 1ffe913c2017b44804aca18befd45689df06c069)


<!-- gh-issue-number: gh-127081 -->
* Issue: gh-127081
<!-- /gh-issue-number -->
