### PR TITLE
gh-135101: When choosing the default simulator device, don't use `simctl --set testing`

### DIFF
--- a/iOS/testbed/__main__.py
+++ b/iOS/testbed/__main__.py
@@ -127,7 +127,7 @@ async def async_check_output(*args, **kwargs):
 async def select_simulator_device():
     # List the testing simulators, in JSON format
     raw_json = await async_check_output(
-        "xcrun", "simctl", "--set", "testing", "list", "-j"
+        "xcrun", "simctl", "list", "-j"
     )
     json_data = json.loads(raw_json)
 


### PR DESCRIPTION
This is a fix for the error seen in https://github.com/pypa/cibuildwheel/pull/2443 .

I don't know what `--set testing` is doing, but the previous default device `iPhone SE (3rd edition)` was not listed there either, and omitting the flag seems to list all the devices that the SDK knows about, rather than ones previously used for testing.

cc @freakboy3742 

<!-- gh-issue-number: gh-135101 -->
* Issue: gh-135101
<!-- /gh-issue-number -->
