### PR TITLE
gh-135103: Remove an unused local variable in Lib/code.py

### DIFF
--- a/Lib/code.py
+++ b/Lib/code.py
@@ -224,7 +224,7 @@ class InteractiveConsole(InteractiveInterpreter):
             sys.ps1 = ">>> "
             delete_ps1_after = True
         try:
-            _ps2 = sys.ps2
+            sys.ps2
             delete_ps2_after = False
         except AttributeError:
             sys.ps2 = "... "


### PR DESCRIPTION
In order to enhance the code quality, this PR removes an unused local variable (`_ps2`) in file `Lib/code.py`.


<!-- gh-issue-number: gh-135103 -->
* Issue: gh-135103
<!-- /gh-issue-number -->
