### PR TITLE
Add compile_commands.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ Tools/unicode/data/
 /autom4te.cache
 /build/
 /builddir/
+/compile_commands.json
 /config.cache
 /config.log
 /config.status


### PR DESCRIPTION
Add `compile_commands.json` (clang's compilation database file) to `.gitignore`. This file is used by clang tools such as `clang-tidy`, `clangd`, and other clang LibTooling-based tools.