### PR TITLE
gh-134160: Split extension module init from PyModule docs; emphasize multi-phase init

### DIFF
--- a/Doc/c-api/extension-modules.rst
+++ b/Doc/c-api/extension-modules.rst
@@ -198,11 +198,12 @@ in the following ways:
 
 * Single-phase modules are, or rather *contain*, “singletons”.
 
-  When the module is initialized, Python saves the contents of the module's
-  ``__dict__`` (that is, typically, the module's functions and types).
+  When the module is first initialized, Python saves the contents of
+  the module's ``__dict__`` (that is, typically, the module's functions and
+  types).
 
-  For subsequent initializations in the same interpreter, Python does not call
-  the initialization function again.
+  For subsequent imports, Python does not call the initialization function
+  again.
   Instead, it creates a new module object with a new ``__dict__``, and copies
   the saved contents to it.
   For example, given a single-phase module ``_testsinglephase``

--- a/Doc/c-api/extension-modules.rst
+++ b/Doc/c-api/extension-modules.rst
@@ -2,7 +2,7 @@
 
 .. _extension-modules:
 
-Defining Extension Modules
+Defining extension modules
 --------------------------
 
 A C extension for CPython is a shared library (for example, a ``.so`` file
@@ -20,7 +20,7 @@ and must be named after the module name plus an extension listed in
 
    Building, packaging and distributing extension modules is best done with
    third-party tools, and is out of scope of this document.
-   One suitable tool is ``setuptools``, whose documentation can be found at
+   One suitable tool is Setuptools, whose documentation can be found at
    https://setuptools.pypa.io/en/latest/setuptools.html.
 
 Normally, the initialization function returns a module definition initialized
@@ -141,7 +141,8 @@ It is possible to export multiple modules from a single shared library by
 defining multiple initialization functions. However, importing them requires
 using symbolic links or a custom importer, because by default only the
 function corresponding to the filename is found.
-See the *"Multiple modules in one library"* section in :pep:`489` for details.
+See the `Multiple modules in one library <https://peps.python.org/pep-0489/#multiple-modules-in-one-library>`__
+section in :pep:`489` for details.
 
 The initialization function is typically the only non-\ ``static``
 item defined in the module's C source.

--- a/Doc/c-api/extension-modules.rst
+++ b/Doc/c-api/extension-modules.rst
@@ -21,7 +21,7 @@ and must be named after the module name plus an extension listed in
    Building, packaging and distributing extension modules is best done with
    third-party tools, and is out of scope of this document.
    One suitable tool is ``setuptools``, whose documentation can be found at
-   https://setuptools.readthedocs.io/en/latest/setuptools.html.
+   https://setuptools.pypa.io/en/latest/setuptools.html.
 
 Normally, the initialization function returns a module definition initialized
 using :c:func:`PyModuleDef_Init`.
@@ -60,7 +60,7 @@ This mirrors the behavior of pure-Python modules.
 
 Additional module instances may be created in
 :ref:`sub-interpreters <sub-interpreter-support>`
-or after after Python runtime reinitialization
+or after Python runtime reinitialization
 (:c:func:`Py_Finalize` and :c:func:`Py_Initialize`).
 In these cases, sharing Python objects between module instances would likely
 cause crashes or undefined behavior.
@@ -88,7 +88,7 @@ the :c:data:`Py_mod_multiple_interpreters` slot.
 Initialization function
 .......................
 
-The initialization function defined by an extension module have the
+The initialization function defined by an extension module has the
 following signature:
 
 .. c:function:: PyObject* PyInit_modulename(void)
@@ -167,7 +167,7 @@ using the following function:
    Return *def* cast to ``PyObject*``, or ``NULL`` if an error occurred.
 
    Calling this function is required for :ref:`multi-phase-initialization`.
-   It should not be used other contexts.
+   It should not be used in other contexts.
 
    Note that Python assumes that ``PyModuleDef`` structures are statically
    allocated.

--- a/Doc/c-api/extension-modules.rst
+++ b/Doc/c-api/extension-modules.rst
@@ -1,0 +1,245 @@
+.. highlight:: c
+
+.. _extension-modules:
+
+Defining Extension Modules
+--------------------------
+
+A C extension for CPython is a shared library (for example, a ``.so`` file
+on Linux, ``.pyd`` DLL on Windows), which is loadable into the Python process
+(for example, it is compiled with compatible compiler settings), and which
+exports an :ref:`initialization function <extension-export-hook>`.
+
+To be importable by default (that is, by
+:py:class:`importlib.machinery.ExtensionFileLoader`),
+the shared library must be available on :py:attr:`sys.path`,
+and must be named after the module name plus an extension listed in
+:py:attr:`importlib.machinery.EXTENSION_SUFFIXES`.
+
+.. note::
+
+   Building, packaging and distributing extension modules is best done with
+   third-party tools, and is out of scope of this document.
+   One suitable tool is ``setuptools``, whose documentation can be found at
+   https://setuptools.readthedocs.io/en/latest/setuptools.html.
+
+Normally, the initialization function returns a module definition initialized
+using :c:func:`PyModuleDef_Init`.
+This allows splitting the creation process into several phases:
+
+- Before any substantial code is executed, Python can determine which
+  capabilities the module supports, and it can adjust the environment or
+  refuse loading an incompatible extension.
+- By default, Python itself creates the module object -- that is, it does
+  the equivalent of :py:meth:`object.__new__` for classes.
+  It also sets initial attributes like :attr:`~module.__package__` and
+  :attr:`~module.__loader__`.
+- Afterwards, the module object is initialized using extension-specific
+  code -- the equivalent of :py:meth:`~object.__init__` on classes.
+
+This is called *multi-phase initialization* to distinguish it from the legacy
+(but still supported) *single-phase initialization* scheme,
+where the initialization function returns a fully constructed module.
+See the :ref:`single-phase-initialization section below <single-phase-initialization>`
+for details.
+
+.. versionchanged:: 3.5
+
+   Added support for multi-phase initialization (:pep:`489`).
+
+
+Multiple module instances
+.........................
+
+By default, extension modules are not singletons.
+For example, if the :py:attr:`sys.modules` entry is removed and the module
+is re-imported, a new module object is created, and typically populated with
+fresh method and type objects.
+The old module is subject to normal garbage collection.
+This mirrors the behavior of pure-Python modules.
+
+Additional module instances may be created in
+:ref:`sub-interpreters <sub-interpreter-support>`
+or after after Python runtime reinitialization
+(:c:func:`Py_Finalize` and :c:func:`Py_Initialize`).
+In these cases, sharing Python objects between module instances would likely
+cause crashes or undefined behavior.
+
+To avoid such issues, each instance of an extension module should
+be *isolated*: changes to one instance should not implicitly affect the others,
+and all state owned by the module, including references to Python objects,
+should be specific to a particular module instance.
+See :ref:`isolating-extensions-howto` for more details and a practical guide.
+
+A simpler way to avoid these issues is
+:ref:`raising an error on repeated initialization <isolating-extensions-optout>`.
+
+All modules are expected to support
+:ref:`sub-interpreters <sub-interpreter-support>`, or otherwise explicitly
+signal a lack of support.
+This is usually achieved by isolation or blocking repeated initialization,
+as above.
+A module may also be limited to the main interpreter using
+the :c:data:`Py_mod_multiple_interpreters` slot.
+
+
+.. _extension-export-hook:
+
+Initialization function
+.......................
+
+The initialization function defined by an extension module have the
+following signature:
+
+.. c:function:: PyObject* PyInit_modulename(void)
+
+Its name should be :samp:`PyInit_{<name>}`, with ``<name>`` replaced by the
+name of the module.
+
+For modules with ASCII-only names, the function must instead be named
+:samp:`PyInit_{<name>}`, with ``<name>`` replaced by the name of the module.
+When using :ref:`multi-phase-initialization`, non-ASCII module names
+are allowed. In this case, the initialization function name is
+:samp:`PyInitU_{<name>}`, with ``<name>`` encoded using Python's
+*punycode* encoding with hyphens replaced by underscores. In Python:
+
+.. code-block:: python
+
+    def initfunc_name(name):
+        try:
+            suffix = b'_' + name.encode('ascii')
+        except UnicodeEncodeError:
+            suffix = b'U_' + name.encode('punycode').replace(b'-', b'_')
+        return b'PyInit' + suffix
+
+It is recommended to define the initialization function using a helper macro:
+
+.. c:macro:: PyMODINIT_FUNC
+
+   Declare an extension module initialization function.
+   This macro:
+
+   * specifies the :c:expr:`PyObject*` return type,
+   * adds any special linkage declarations required by the platform, and
+   * for C++, declares the function as ``extern "C"``.
+
+For example, a module called ``spam`` would be defined like this::
+
+   static struct PyModuleDef spam_module = {
+       .m_base = PyModuleDef_HEAD_INIT,
+       .m_name = "spam",
+       ...
+   };
+
+   PyMODINIT_FUNC
+   PyInit_spam(void)
+   {
+       return PyModuleDef_Init(&spam_module);
+   }
+
+It is possible to export multiple modules from a single shared library by
+defining multiple initialization functions. However, importing them requires
+using symbolic links or a custom importer, because by default only the
+function corresponding to the filename is found.
+See the *"Multiple modules in one library"* section in :pep:`489` for details.
+
+The initialization function is typically the only non-\ ``static``
+item defined in the module's C source.
+
+
+.. _multi-phase-initialization:
+
+Multi-phase initialization
+..........................
+
+Normally, the :ref:`initialization function <extension-export-hook>`
+(``PyInit_modulename``) returns a :c:type:`PyModuleDef` instance with
+non-``NULL`` :c:member:`~PyModuleDef.m_slots`.
+Before it is returned, the ``PyModuleDef`` instance must be initialized
+using the following function:
+
+
+.. c:function:: PyObject* PyModuleDef_Init(PyModuleDef *def)
+
+   Ensure a module definition is a properly initialized Python object that
+   correctly reports its type and a reference count.
+
+   Return *def* cast to ``PyObject*``, or ``NULL`` if an error occurred.
+
+   Calling this function is required for :ref:`multi-phase-initialization`.
+   It should not be used other contexts.
+
+   Note that Python assumes that ``PyModuleDef`` structures are statically
+   allocated.
+   This function may return either a new reference or a borrowed one;
+   this reference must not be released.
+
+   .. versionadded:: 3.5
+
+
+.. _single-phase-initialization:
+
+Legacy single-phase initialization
+..................................
+
+.. attention::
+   Single-phase initialization is a legacy mechanism to initialize extension
+   modules, with known drawbacks and design flaws. Extension module authors
+   are encouraged to use multi-phase initialization instead.
+
+In single-phase initialization, the
+:ref:`initialization function <extension-export-hook>` (``PyInit_modulename``)
+should create, populate and return a module object.
+This is typically done using :c:func:`PyModule_Create` and functions like
+:c:func:`PyModule_AddObjectRef`.
+
+Single-phase initialization differs from the :ref:`default <multi-phase-initialization>`
+in the following ways:
+
+* Single-phase modules are, or rather *contain*, “singletons”.
+
+  When the module is initialized, Python saves the contents of the module's
+  ``__dict__`` (that is, typically, the module's functions and types).
+
+  For subsequent initializations in the same interpreter, Python does not call
+  the initialization function again.
+  Instead, it creates a new module object with a new ``__dict__``, and copies
+  the saved contents to it.
+  For example, given a single-phase module ``_testsinglephase``
+  [#testsinglephase]_ that defines a function ``sum`` and an exception class
+  ``error``:
+
+  .. code-block:: python
+
+     >>> import sys
+     >>> import _testsinglephase as one
+     >>> del sys.modules['_testsinglephase']
+     >>> import _testsinglephase as two
+     >>> one is two
+     False
+     >>> one.__dict__ is two.__dict__
+     False
+     >>> one.sum is two.sum
+     True
+     >>> one.error is two.error
+     True
+
+  The exact behavior should be considered a CPython implementation detail.
+
+* To work around the fact that ``PyInit_modulename`` does not take a *spec*
+  argument, some state of the import machinery is saved and applied to the
+  first suitable module created during the ``PyInit_modulename`` call.
+  Specifically, when a sub-module is imported, this mechanism prepends the
+  parent package name to the name of the module.
+
+  A single-phase ``PyInit_modulename`` function should create “its” module
+  object as soon as possible, before any other module objects can be created.
+
+* Non-ASCII module names (``PyInitU_modulename``) are not supported.
+
+* Single-phase modules support module lookup functions like
+  :c:func:`PyState_FindModule`.
+
+.. [#testsinglephase] ``_testsinglephase`` is an internal module used \
+   in CPython's self-test suite; your installation may or may not \
+   include it.

--- a/Doc/c-api/index.rst
+++ b/Doc/c-api/index.rst
@@ -17,6 +17,7 @@ document the API functions in detail.
    veryhigh.rst
    refcounting.rst
    exceptions.rst
+   extension-modules.rst
    utilities.rst
    abstract.rst
    concrete.rst

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -111,32 +111,10 @@ Useful macros
 =============
 
 Several useful macros are defined in the Python header files.  Many are
-defined closer to where they are useful (e.g. :c:macro:`Py_RETURN_NONE`).
+defined closer to where they are useful (e.g. :c:macro:`Py_RETURN_NONE`,
+:c:macro:`PyMODINIT_FUNC`).
 Others of a more general utility are defined here.  This is not necessarily a
 complete listing.
-
-.. c:macro:: PyMODINIT_FUNC
-
-   Declare an extension module ``PyInit`` initialization function. The function
-   return type is :c:expr:`PyObject*`. The macro declares any special linkage
-   declarations required by the platform, and for C++ declares the function as
-   ``extern "C"``.
-
-   The initialization function must be named :samp:`PyInit_{name}`, where
-   *name* is the name of the module, and should be the only non-\ ``static``
-   item defined in the module file. Example::
-
-       static struct PyModuleDef spam_module = {
-           .m_base = PyModuleDef_HEAD_INIT,
-           .m_name = "spam",
-           ...
-       };
-
-       PyMODINIT_FUNC
-       PyInit_spam(void)
-       {
-           return PyModuleDef_Init(&spam_module);
-       }
 
 
 .. c:macro:: Py_ABS(x)

--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -111,7 +111,7 @@ Useful macros
 =============
 
 Several useful macros are defined in the Python header files.  Many are
-defined closer to where they are useful (e.g. :c:macro:`Py_RETURN_NONE`,
+defined closer to where they are useful (for example, :c:macro:`Py_RETURN_NONE`,
 :c:macro:`PyMODINIT_FUNC`).
 Others of a more general utility are defined here.  This is not necessarily a
 complete listing.

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -1489,9 +1489,6 @@ PyModule_SetDocString:int:::
 PyModule_SetDocString:PyObject*:module:0:
 PyModule_SetDocString:const char*:docstring::
 
-PyModuleDef_Init:PyObject*::0:
-PyModuleDef_Init:PyModuleDef*:def::
-
 PyNumber_Absolute:PyObject*::+1:
 PyNumber_Absolute:PyObject*:o:0:
 

--- a/Doc/extending/building.rst
+++ b/Doc/extending/building.rst
@@ -6,41 +6,10 @@
 Building C and C++ Extensions
 *****************************
 
-A C extension for CPython is a shared library (e.g. a ``.so`` file on Linux,
-``.pyd`` on Windows), which exports an *initialization function*.
+A C extension for CPython is a shared library (for example, a ``.so`` file on
+Linux, ``.pyd`` on Windows), which exports an *initialization function*.
 
-To be importable, the shared library must be available on :envvar:`PYTHONPATH`,
-and must be named after the module name, with an appropriate extension.
-When using setuptools, the correct filename is generated automatically.
-
-The initialization function has the signature:
-
-.. c:function:: PyObject* PyInit_modulename(void)
-
-It returns either a fully initialized module, or a :c:type:`PyModuleDef`
-instance. See :ref:`initializing-modules` for details.
-
-.. highlight:: python
-
-For modules with ASCII-only names, the function must be named
-:samp:`PyInit_{<name>}`, with ``<name>`` replaced by the name of the module.
-When using :ref:`multi-phase-initialization`, non-ASCII module names
-are allowed. In this case, the initialization function name is
-:samp:`PyInitU_{<name>}`, with ``<name>`` encoded using Python's
-*punycode* encoding with hyphens replaced by underscores. In Python::
-
-    def initfunc_name(name):
-        try:
-            suffix = b'_' + name.encode('ascii')
-        except UnicodeEncodeError:
-            suffix = b'U_' + name.encode('punycode').replace(b'-', b'_')
-        return b'PyInit' + suffix
-
-It is possible to export multiple modules from a single shared library by
-defining multiple initialization functions. However, importing them requires
-using symbolic links or a custom importer, because by default only the
-function corresponding to the filename is found.
-See the *"Multiple modules in one library"* section in :pep:`489` for details.
+See :ref:`extension-modules` for details.
 
 
 .. highlight:: c
@@ -51,7 +20,11 @@ See the *"Multiple modules in one library"* section in :pep:`489` for details.
 Building C and C++ Extensions with setuptools
 =============================================
 
-Python 3.12 and newer no longer come with distutils. Please refer to the
-``setuptools`` documentation at
-https://setuptools.readthedocs.io/en/latest/setuptools.html
-to learn more about how build and distribute C/C++ extensions with setuptools.
+
+Building, packaging and distributing extension modules is best done with
+third-party tools, and is out of scope of this document.
+One suitable tool is ``setuptools``, whose documentation can be found at
+https://setuptools.readthedocs.io/en/latest/setuptools.html.
+
+The :mod:`distutils` module, which was included in the standard library
+until Python 3.12, is now maintained as part of ``setuptools``.

--- a/Doc/extending/building.rst
+++ b/Doc/extending/building.rst
@@ -24,7 +24,7 @@ Building C and C++ Extensions with setuptools
 Building, packaging and distributing extension modules is best done with
 third-party tools, and is out of scope of this document.
 One suitable tool is Setuptools, whose documentation can be found at
-https://setuptools.readthedocs.io/en/latest/setuptools.html.
+https://setuptools.pypa.io/en/latest/setuptools.html.
 
 The :mod:`distutils` module, which was included in the standard library
 until Python 3.12, is now maintained as part of Setuptools.

--- a/Doc/extending/building.rst
+++ b/Doc/extending/building.rst
@@ -23,8 +23,8 @@ Building C and C++ Extensions with setuptools
 
 Building, packaging and distributing extension modules is best done with
 third-party tools, and is out of scope of this document.
-One suitable tool is ``setuptools``, whose documentation can be found at
+One suitable tool is Setuptools, whose documentation can be found at
 https://setuptools.readthedocs.io/en/latest/setuptools.html.
 
 The :mod:`distutils` module, which was included in the standard library
-until Python 3.12, is now maintained as part of ``setuptools``.
+until Python 3.12, is now maintained as part of Setuptools.


### PR DESCRIPTION
#134764 moved a section around; I don't think that's enough.

---

* Split extension module init from `PyModule` docs; emphasize multi-phase init

  There's a difference between working with module objects in general
  (which just needs garden-variety API docs), and defining the init
  function (which covers things like correctly exporting a function
  defined by the user, and lots of behaviour that's unrelated to generic
  module objects).

* Document behaviour of single-phase init. Call it "legacy". 
* Reorganize `PyModule` docs.
* Move PyInit_modulename docs from the tutorial, and PyMODINIT_FUNC docs
  from the generic macros section, to the new page.
* Add docs
* Add doc stubs for `PYTHON_API_VERSION` & `PYTHON_ABI_VERSION`
* Remove incorrect `refcounts.dat` entry for `PyModuleDef_Init`;
  instead note that the function sometimes returns a borrowed reference,
  sometimes as strong one.
  (IMO, it's best to pretend `PyModuleDef` isn't a `PyObject` at all,
  but, reference docs should be correct.)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134160 -->
* Issue: gh-134160
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135126.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->