### PR TITLE
[3.13] gh-133256: Add _Py_NONSTRING macro (#133257)

### DIFF
--- a/Include/internal/pycore_runtime.h
+++ b/Include/internal/pycore_runtime.h
@@ -60,7 +60,7 @@ typedef struct _Py_AuditHookEntry {
 } _Py_AuditHookEntry;
 
 typedef struct _Py_DebugOffsets {
-    char cookie[8];
+    char cookie[8] _Py_NONSTRING;
     uint64_t version;
     uint64_t free_threaded;
     // Runtime state offset;

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -541,6 +541,14 @@ extern "C" {
 #  define _Py__has_builtin(x) 0
 #endif
 
+// Preprocessor check for a compiler __attribute__. Always return 0
+// if __has_attribute() macro is not defined.
+#ifdef __has_attribute
+#  define _Py__has_attribute(x) __has_attribute(x)
+#else
+#  define _Py__has_attribute(x) 0
+#endif
+
 // _Py_TYPEOF(expr) gets the type of an expression.
 //
 // Example: _Py_TYPEOF(x) x_copy = (x);
@@ -605,5 +613,21 @@ extern "C" {
 #if defined(__sgi) && !defined(_SGI_MP_SOURCE)
 #  define _SGI_MP_SOURCE
 #endif
+
+
+// _Py_NONSTRING: The nonstring variable attribute specifies that an object or
+// member declaration with type array of char, signed char, or unsigned char,
+// or pointer to such a type is intended to store character arrays that do not
+// necessarily contain a terminating NUL.
+//
+// Usage:
+//
+//   char name [8] _Py_NONSTRING;
+#if _Py__has_attribute(nonstring)
+#  define _Py_NONSTRING __attribute__((nonstring))
+#else
+#  define _Py_NONSTRING
+#endif
+
 
 #endif /* Py_PYPORT_H */


### PR DESCRIPTION
Fix GCC 15 compiler warnings such as:

    In file included from Python/pylifecycle.c:26:
    Include/internal/pycore_runtime.h:47:26: warning:
    initializer-string for array of 'char' truncates NUL terminator
    but destination lacks 'nonstring' attribute (9 chars into 8
    available) [-Wunterminated-string-initialization]
       47 | #define _Py_Debug_Cookie "xdebugpy"
          |                          ^~~~~~~~~~

(cherry picked from commit e26bafd107aa86a4bdd6051848640f36a56d0efb)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-133256 -->
* Issue: gh-133256
<!-- /gh-issue-number -->
