### PR TITLE
gh-135161: Remove redundant NULL check for 'exc' after dereference in ceval.c

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3190,7 +3190,7 @@ _PyEval_FormatKwargsError(PyThreadState *tstate, PyObject *func, PyObject *kwarg
     else if (_PyErr_ExceptionMatches(tstate, PyExc_KeyError)) {
         PyObject *exc = _PyErr_GetRaisedException(tstate);
         PyObject *args = PyException_GetArgs(exc);
-        if (exc && PyTuple_Check(args) && PyTuple_GET_SIZE(args) == 1) {
+        if (PyTuple_Check(args) && PyTuple_GET_SIZE(args) == 1) {
             _PyErr_Clear(tstate);
             PyObject *funcstr = _PyObject_FunctionStr(func);
             if (funcstr != NULL) {


### PR DESCRIPTION
Remove a redundant NULL check for the variable 'exc' after it has already been dereferenced.

<!-- gh-issue-number: gh-135161 -->
* Issue: gh-135161
<!-- /gh-issue-number -->
