### PR TITLE
[3.13] gh-131531: android.py enhancements to support cibuildwheel (GH-132870)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -244,8 +244,8 @@ Modules/_interp*module.c      @ericsnowcurrently
 Lib/test/test_interpreters/   @ericsnowcurrently
 
 # Android
-**/*Android*                  @mhsmith
-**/*android*                  @mhsmith
+**/*Android*                  @mhsmith @freakboy3742
+**/*android*                  @mhsmith @freakboy3742
 
 # iOS (but not termios)
 **/iOS*                       @freakboy3742

--- a/Android/README.md
+++ b/Android/README.md
@@ -156,6 +156,10 @@ repository's `Lib` directory will be picked up immediately. Changes in C files,
 and architecture-specific files such as sysconfigdata, will not take effect
 until you re-run `android.py make-host` or `build`.
 
+The testbed app can also be used to test third-party packages. For more details,
+run `android.py test --help`, paying attention to the options `--site-packages`,
+`--cwd`, `-c` and `-m`.
+
 
 ## Using in your own app
 

--- a/Android/android-env.sh
+++ b/Android/android-env.sh
@@ -3,7 +3,7 @@
 : "${HOST:?}"  # GNU target triplet
 
 # You may also override the following:
-: "${api_level:=21}"  # Minimum Android API level the build will run on
+: "${ANDROID_API_LEVEL:=21}"  # Minimum Android API level the build will run on
 : "${PREFIX:-}"  # Path in which to find required libraries
 
 
@@ -24,7 +24,7 @@ fail() {
 # * https://android.googlesource.com/platform/ndk/+/ndk-rXX-release/docs/BuildSystemMaintainers.md
 #   where XX is the NDK version. Do a diff against the version you're upgrading from, e.g.:
 #   https://android.googlesource.com/platform/ndk/+/ndk-r25-release..ndk-r26-release/docs/BuildSystemMaintainers.md
-ndk_version=27.1.12297006
+ndk_version=27.2.12479018
 
 ndk=$ANDROID_HOME/ndk/$ndk_version
 if ! [ -e "$ndk" ]; then
@@ -43,7 +43,7 @@ fi
 toolchain=$(echo "$ndk"/toolchains/llvm/prebuilt/*)
 export AR="$toolchain/bin/llvm-ar"
 export AS="$toolchain/bin/llvm-as"
-export CC="$toolchain/bin/${clang_triplet}${api_level}-clang"
+export CC="$toolchain/bin/${clang_triplet}${ANDROID_API_LEVEL}-clang"
 export CXX="${CC}++"
 export LD="$toolchain/bin/ld"
 export NM="$toolchain/bin/llvm-nm"

--- a/Android/testbed/app/build.gradle.kts
+++ b/Android/testbed/app/build.gradle.kts
@@ -85,7 +85,7 @@ android {
 
         minSdk = androidEnvFile.useLines {
             for (line in it) {
-                """api_level:=(\d+)""".toRegex().find(line)?.let {
+                """ANDROID_API_LEVEL:=(\d+)""".toRegex().find(line)?.let {
                     return@useLines it.groupValues[1].toInt()
                 }
             }
@@ -205,10 +205,28 @@ androidComponents.onVariants { variant ->
 
                 into("site-packages") {
                     from("$projectDir/src/main/python")
+
+                    val sitePackages = findProperty("python.sitePackages") as String?
+                    if (!sitePackages.isNullOrEmpty()) {
+                        if (!file(sitePackages).exists()) {
+                            throw GradleException("$sitePackages does not exist")
+                        }
+                        from(sitePackages)
+                    }
                 }
 
                 duplicatesStrategy = DuplicatesStrategy.EXCLUDE
                 exclude("**/__pycache__")
+            }
+
+            into("cwd") {
+                val cwd = findProperty("python.cwd") as String?
+                if (!cwd.isNullOrEmpty()) {
+                    if (!file(cwd).exists()) {
+                        throw GradleException("$cwd does not exist")
+                    }
+                    from(cwd)
+                }
             }
         }
     }

--- a/Android/testbed/app/src/androidTest/java/org/python/testbed/PythonSuite.kt
+++ b/Android/testbed/app/src/androidTest/java/org/python/testbed/PythonSuite.kt
@@ -17,11 +17,11 @@ class PythonSuite {
     fun testPython() {
         val start = System.currentTimeMillis()
         try {
-            val context =
+            val status = PythonTestRunner(
                 InstrumentationRegistry.getInstrumentation().targetContext
-            val args =
-                InstrumentationRegistry.getArguments().getString("pythonArgs", "")
-            val status = PythonTestRunner(context).run(args)
+            ).run(
+                InstrumentationRegistry.getArguments()
+            )
             assertEquals(0, status)
         } finally {
             // Make sure the process lives long enough for the test script to

--- a/Android/testbed/app/src/main/python/android_testbed_main.py
+++ b/Android/testbed/app/src/main/python/android_testbed_main.py
@@ -26,7 +26,23 @@ import sys
 #     test_signals in test_threadsignals.py.
 signal.pthread_sigmask(signal.SIG_UNBLOCK, [signal.SIGUSR1])
 
+mode = os.environ["PYTHON_MODE"]
+module = os.environ["PYTHON_MODULE"]
 sys.argv[1:] = shlex.split(os.environ["PYTHON_ARGS"])
 
-# The test module will call sys.exit to indicate whether the tests passed.
-runpy.run_module("test")
+cwd = f"{sys.prefix}/cwd"
+if not os.path.exists(cwd):
+    # Empty directories are lost in the asset packing/unpacking process.
+    os.mkdir(cwd)
+os.chdir(cwd)
+
+if mode == "-c":
+    # In -c mode, sys.path starts with an empty string, which means whatever the current
+    # working directory is at the moment of each import.
+    sys.path.insert(0, "")
+    exec(module, {})
+elif mode == "-m":
+    sys.path.insert(0, os.getcwd())
+    runpy.run_module(module, run_name="__main__", alter_sys=True)
+else:
+    raise ValueError(f"unknown mode: {mode}")

--- a/Android/testbed/build.gradle.kts
+++ b/Android/testbed/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.6.1" apply false
+    id("com.android.application") version "8.10.0" apply false
     id("org.jetbrains.kotlin.android") version "1.9.22" apply false
 }

--- a/Android/testbed/gradle/wrapper/gradle-wrapper.properties
+++ b/Android/testbed/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Feb 19 20:29:06 GMT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Doc/using/android.rst
+++ b/Doc/using/android.rst
@@ -63,3 +63,12 @@ link to the relevant file.
 * Add code to your app to :source:`start Python in embedded mode
   <Android/testbed/app/src/main/c/main_activity.c>`. This will need to be C code
   called via JNI.
+
+Building a Python package for Android
+-------------------------------------
+
+Python packages can be built for Android as wheels and released on PyPI. The
+recommended tool for doing this is `cibuildwheel
+<https://cibuildwheel.pypa.io/en/stable/platforms/#android>`__, which automates
+all the details of setting up a cross-compilation environment, building the
+wheel, and testing it on an emulator.


### PR DESCRIPTION
Modifies the environment handling and execution arguments of the Android management script to support the compilation of third-party binaries, and the use of the testbed to invoke third-party test code.
(cherry picked from commit 2e1544fd2b0cd46ba93fc51e3cdd47f4781d7499)


<!-- gh-issue-number: gh-131531 -->
* Closes #131531
<!-- /gh-issue-number -->
