### PR TITLE
gh-133438: Fix the use of the terms "argument" and "parameter" in error messages for invalid function calls

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1391,7 +1391,7 @@ def _missing_arguments(f_name, argnames, pos, values):
         s = ", ".join(names) + tail
     raise TypeError("%s() missing %i required %s argument%s: %s" %
                     (f_name, missing,
-                      "positional" if pos else "keyword-only",
+                      "positional" if pos else "keyword",
                       "" if missing == 1 else "s", s))
 
 def _too_many(f_name, args, kwonly, varargs, defcount, given, values):
@@ -1408,7 +1408,7 @@ def _too_many(f_name, args, kwonly, varargs, defcount, given, values):
         sig = str(len(args))
     kwonly_sig = ""
     if kwonly_given:
-        msg = " positional argument%s (and %d keyword-only argument%s)"
+        msg = " positional argument%s (and %d keyword argument%s)"
         kwonly_sig = (msg % ("s" if given != 1 else "", kwonly_given,
                              "s" if kwonly_given != 1 else ""))
     raise TypeError("%s() takes %s positional argument%s but %d%s %s given" %
@@ -3107,7 +3107,7 @@ class Signature:
                     elif param.name in kwargs:
                         if param.kind == _POSITIONAL_ONLY:
                             if param.default is _empty:
-                                msg = f'missing a required positional-only argument: {param.name!r}'
+                                msg = f'missing a required positional argument: {param.name!r}'
                                 raise TypeError(msg)
                             # Raise a TypeError once we are sure there is no
                             # **kwargs param later.
@@ -3130,7 +3130,7 @@ class Signature:
                             break
                         else:
                             if param.kind == _KEYWORD_ONLY:
-                                argtype = ' keyword-only'
+                                argtype = ' keyword'
                             else:
                                 argtype = ''
                             msg = 'missing a required{argtype} argument: {arg!r}'

--- a/Lib/test/test_extcall.py
+++ b/Lib/test/test_extcall.py
@@ -401,7 +401,7 @@ Call with dict subtype:
     >>> s3(**md)
     Traceback (most recent call last):
       ...
-    TypeError: s3() missing 1 required keyword-only argument: 'n'
+    TypeError: s3() missing 1 required keyword argument: 'n'
 
 Another helper function
 
@@ -487,17 +487,17 @@ Too many arguments:
     >>> f(1, kw=3)
     Traceback (most recent call last):
       ...
-    TypeError: f() takes 0 positional arguments but 1 positional argument (and 1 keyword-only argument) were given
+    TypeError: f() takes 0 positional arguments but 1 positional argument (and 1 keyword argument) were given
     >>> def f(*, kw, b): pass
     >>> f(1, 2, 3, b=3, kw=3)
     Traceback (most recent call last):
       ...
-    TypeError: f() takes 0 positional arguments but 3 positional arguments (and 2 keyword-only arguments) were given
+    TypeError: f() takes 0 positional arguments but 3 positional arguments (and 2 keyword arguments) were given
     >>> def f(a, b=2, *, kw): pass
     >>> f(2, 3, 4, kw=4)
     Traceback (most recent call last):
       ...
-    TypeError: f() takes from 1 to 2 positional arguments but 3 positional arguments (and 1 keyword-only argument) were given
+    TypeError: f() takes from 1 to 2 positional arguments but 3 positional arguments (and 1 keyword argument) were given
 
 Too few and missing arguments:
 
@@ -533,12 +533,12 @@ Same with keyword only args:
     >>> f()
     Traceback (most recent call last):
       ...
-    TypeError: f() missing 1 required keyword-only argument: 'w'
+    TypeError: f() missing 1 required keyword argument: 'w'
     >>> def f(*, a, b, c, d, e): pass
     >>> f()
     Traceback (most recent call last):
       ...
-    TypeError: f() missing 5 required keyword-only arguments: 'a', 'b', 'c', 'd', and 'e'
+    TypeError: f() missing 5 required keyword arguments: 'a', 'b', 'c', 'd', and 'e'
 
 """
 

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -2243,7 +2243,7 @@ class TestGetcallargsFunctions(unittest.TestCase):
         # kwonlydefaults and raises a wrong TypeError
         def f5(*, a): pass
         with self.assertRaisesRegex(TypeError,
-                                    'missing 1 required keyword-only'):
+                                    'missing 1 required keyword argument'):
             inspect.getcallargs(f5)
 
 
@@ -5405,7 +5405,7 @@ class TestSignatureBind(unittest.TestCase):
             self.call(test, 1, bar=2, spam='ham')
 
         with self.assertRaisesRegex(TypeError,
-                                     "missing a required keyword-only "
+                                     "missing a required keyword "
                                      "argument: 'bar'"):
             self.call(test, 1)
 
@@ -5462,7 +5462,7 @@ class TestSignatureBind(unittest.TestCase):
         self.assertEqual(self.call(test, 1, 2, c_po=4),
                          (1, 2, 3, 42, 50, {'c_po': 4}))
 
-        with self.assertRaisesRegex(TypeError, "missing a required positional-only argument: 'a_po'"):
+        with self.assertRaisesRegex(TypeError, "missing a required positional argument: 'a_po'"):
             self.call(test, a_po=1, b_po=2)
 
         def without_var_kwargs(c_po=3, d_po=4, /):

--- a/Lib/test/test_positional_only_arg.py
+++ b/Lib/test/test_positional_only_arg.py
@@ -166,9 +166,9 @@ class PositionalOnlyTestCase(unittest.TestCase):
         def f(a, b, /, c, *, d, e):
             pass
         f(1, 2, 3, d=1, e=2)  # does not raise
-        with self.assertRaisesRegex(TypeError, r"missing 1 required keyword-only argument: 'd'"):
+        with self.assertRaisesRegex(TypeError, r"missing 1 required keyword argument: 'd'"):
             f(1, 2, 3, e=2)
-        with self.assertRaisesRegex(TypeError, r"missing 2 required keyword-only arguments: 'd' and 'e'"):
+        with self.assertRaisesRegex(TypeError, r"missing 2 required keyword arguments: 'd' and 'e'"):
             f(1, 2, 3)
         with self.assertRaisesRegex(TypeError, r"f\(\) missing 1 required positional argument: 'c'"):
             f(1, 2)
@@ -177,7 +177,7 @@ class PositionalOnlyTestCase(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, r" missing 3 required positional arguments: 'a', 'b', and 'c'"):
             f()
         with self.assertRaisesRegex(TypeError, r"f\(\) takes 3 positional arguments but 6 positional arguments "
-                                               r"\(and 2 keyword-only arguments\) were given"):
+                                               r"\(and 2 keyword arguments\) were given"):
             f(1, 2, 3, 4, 5, 6, d=7, e=8)
         with self.assertRaisesRegex(TypeError, r"f\(\) got an unexpected keyword argument 'f'"):
             f(1, 2, 3, d=1, e=4, f=56)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-05-12-51-52.gh-issue-133438.-3S9y4.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-05-12-51-52.gh-issue-133438.-3S9y4.rst
@@ -1,0 +1,2 @@
+Fix the use of the terms "argument" and "parameter" in error messages for
+invalid function calls.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1318,7 +1318,7 @@ missing_arguments(PyThreadState *tstate, PyCodeObject *co,
     Py_ssize_t i, j = 0;
     Py_ssize_t start, end;
     int positional = (defcount != -1);
-    const char *kind = positional ? "positional" : "keyword-only";
+    const char *kind = positional ? "positional" : "keyword";
     PyObject *missing_names;
 
     /* Compute the names of the arguments that are missing. */
@@ -1380,7 +1380,7 @@ too_many_positional(PyThreadState *tstate, PyCodeObject *co,
     if (sig == NULL)
         return;
     if (kwonly_given) {
-        const char *format = " positional argument%s (and %zd keyword-only argument%s)";
+        const char *format = " positional argument%s (and %zd keyword argument%s)";
         kwonly_sig = PyUnicode_FromFormat(format,
                                           given != 1 ? "s" : "",
                                           kwonly_given,


### PR DESCRIPTION


<!-- gh-issue-number: gh-133438 -->
* Issue: gh-133438
<!-- /gh-issue-number -->
