### PR TITLE
gh-134160: Use PyModuleDef.m_free in the example module xxlimited

### DIFF
--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -424,6 +424,12 @@ xx_clear(PyObject *module)
     return 0;
 }
 
+static void
+xx_free(void *module)
+{
+    (void)xx_clear((PyObject *)module);
+}
+
 static struct PyModuleDef xxmodule = {
     PyModuleDef_HEAD_INIT,
     .m_name = "xxlimited",
@@ -433,9 +439,7 @@ static struct PyModuleDef xxmodule = {
     .m_slots = xx_slots,
     .m_traverse = xx_traverse,
     .m_clear = xx_clear,
-    /* m_free is not necessary here: xx_clear clears all references,
-     * and the module state is deallocated along with the module.
-     */
+    .m_free = xx_free,
 };
 
 

--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -427,6 +427,7 @@ xx_clear(PyObject *module)
 static void
 xx_free(void *module)
 {
+    // allow xx_modexec to omit calling xx_clear on error
     (void)xx_clear((PyObject *)module);
 }
 


### PR DESCRIPTION
The comment about `free` not being necessary is wrong. Like classes, modules need both `clear` and `free`.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-134160 -->
* Issue: gh-134160
<!-- /gh-issue-number -->
