### PR TITLE
[3.14] gh-128605: Revert "Add branch protections for x86_64 in asm_tr…ampoline.S (#128606) (#135077)"

### DIFF
--- a/Python/asm_trampoline.S
+++ b/Python/asm_trampoline.S
@@ -9,9 +9,6 @@
 # }
 _Py_trampoline_func_start:
 #ifdef __x86_64__
-#if defined(__CET__) && (__CET__ & 1)
-    endbr64
-#endif
     sub    $8, %rsp
     call    *%rcx
     add    $8, %rsp
@@ -37,22 +34,3 @@ _Py_trampoline_func_start:
     .globl	_Py_trampoline_func_end
 _Py_trampoline_func_end:
     .section        .note.GNU-stack,"",@progbits
-# Note for indicating the assembly code supports CET
-#if defined(__x86_64__) && defined(__CET__) && (__CET__ & 1)
-    .section    .note.gnu.property,"a"
-    .align 8
-    .long    1f - 0f
-    .long    4f - 1f
-    .long    5
-0:
-    .string  "GNU"
-1:
-    .align 8
-    .long    0xc0000002
-    .long    3f - 2f
-2:
-    .long    0x3
-3:
-    .align 8
-4:
-#endif // __x86_64__

--- a/Python/perf_jit_trampoline.c
+++ b/Python/perf_jit_trampoline.c
@@ -473,11 +473,6 @@ elf_init_ehframe(ELFObjectContext* ctx)
                  DWRF_U8(0); /* Augmentation data. */
     /* Registers saved in CFRAME. */
 #ifdef __x86_64__
-#  if defined(__CET__) && (__CET__ & 1)
-                 DWRF_U8(DWRF_CFA_advance_loc | 8);
-#  else
-                 DWRF_U8(DWRF_CFA_advance_loc | 4);
-#  endif
                  DWRF_U8(DWRF_CFA_advance_loc | 4);
                  DWRF_U8(DWRF_CFA_def_cfa_offset); DWRF_UV(16);
                  DWRF_U8(DWRF_CFA_advance_loc | 6);


### PR DESCRIPTION

This reverts commit 899cca6dbf76bf3e06a99f60a5f996ad6ba0761f, which appears to have broken buildbots.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-128605 -->
* Issue: gh-128605
<!-- /gh-issue-number -->
