### PR TITLE
gh-135177: Add assert to catch potential overflow

### DIFF
--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1236,6 +1236,7 @@ _Py_call_instrumentation_jump(
            event == PY_MONITORING_EVENT_BRANCH_RIGHT ||
            event == PY_MONITORING_EVENT_BRANCH_LEFT);
     int to = (int)(dest - _PyFrame_GetBytecode(frame));
+    assert(to <= INT_MAX / (int)sizeof(_Py_CODEUNIT));
     PyObject *to_obj = PyLong_FromLong(to * (int)sizeof(_Py_CODEUNIT));
     if (to_obj == NULL) {
         return NULL;


### PR DESCRIPTION
This pull request adds an assertion to the _Py_call_instrumentation_jump function to catch potential integer overflow in the expression `to * (int)sizeof(_Py_CODEUNIT)`.

<!-- gh-issue-number: gh-135177 -->
* Issue: gh-135177
<!-- /gh-issue-number -->
