### PR TITLE
[3.13] gh-135151: Fix incorrect packaging of pyconfig.h in Windows installer

### DIFF
--- a/Doc/howto/free-threading-extensions.rst
+++ b/Doc/howto/free-threading-extensions.rst
@@ -23,6 +23,14 @@ You can use it to enable code that only runs under the free-threaded build::
     /* code that only runs in the free-threaded build */
     #endif
 
+.. note::
+
+   On Windows, this macro is not defined automatically, but must be specified
+   to the compiler when building. The :func:`sysconfig.get_config_var` function
+   can be used to determine whether the current running interpreter had the
+   macro defined.
+
+
 Module Initialization
 =====================
 

--- a/Misc/NEWS.d/next/Windows/2025-06-05-13-52-36.gh-issue-135151.4PfNZQ.rst
+++ b/Misc/NEWS.d/next/Windows/2025-06-05-13-52-36.gh-issue-135151.4PfNZQ.rst
@@ -1,0 +1,3 @@
+Avoid distributing modified :file:`pyconfig.h` in the traditional installer.
+Extension module builds must always specify ``Py_GIL_DISABLED`` when
+targeting the free-threaded runtime.

--- a/Tools/msi/dev/dev_files.wxs
+++ b/Tools/msi/dev/dev_files.wxs
@@ -3,7 +3,8 @@
     <Fragment>
         <ComponentGroup Id="dev_pyconfig">
             <Component Id="include_pyconfig.h" Directory="include" Guid="*">
-                <File Id="include_pyconfig.h" Name="pyconfig.h" Source="pyconfig.h" KeyPath="yes" />
+                <!-- gh-135151 Always use the unmodified header for the installer. -->
+                <File Id="include_pyconfig.h" Name="pyconfig.h" Source="!(bindpath.src)PC\pyconfig.h.in" KeyPath="yes" />
             </Component>
         </ComponentGroup>
     </Fragment>


### PR DESCRIPTION


<!-- gh-issue-number: gh-135151 -->
* Issue: gh-135151
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135180.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->