### PR TITLE
feat(docs): type fix - apply pep8 by using docstring instead of comment in the doc.

### DIFF
--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -27,14 +27,16 @@ called :file:`fibo.py` in the current directory with the following contents::
 
    # Fibonacci numbers module
 
-   def fib(n):    # write Fibonacci series up to n
+   def fib(n):
+       """write Fibonacci series up to n"""
        a, b = 0, 1
        while a < n:
            print(a, end=' ')
            a, b = b, a+b
        print()
 
-   def fib2(n):   # return Fibonacci series up to n
+   def fib2(n):
+       """return Fibonacci series up to n"""
        result = []
        a, b = 0, 1
        while a < n:

--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -28,7 +28,7 @@ called :file:`fibo.py` in the current directory with the following contents::
    # Fibonacci numbers module
 
    def fib(n):
-       """write Fibonacci series up to n"""
+       """Write Fibonacci series up to n."""
        a, b = 0, 1
        while a < n:
            print(a, end=' ')

--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -36,7 +36,7 @@ called :file:`fibo.py` in the current directory with the following contents::
        print()
 
    def fib2(n):
-       """return Fibonacci series up to n"""
+       """Return Fibonacci series up to n."""
        result = []
        a, b = 0, 1
        while a < n:


### PR DESCRIPTION
replace comments by pep8 docstring for function definition.





<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135181.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->