### PR TITLE
gh-131798: JIT: Optimize `_CALL_TYPE_1` when the result is known

### DIFF
--- a/Lib/test/test_capi/test_opt.py
+++ b/Lib/test/test_capi/test_opt.py
@@ -1778,7 +1778,23 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertNotIn("_GUARD_TOS_UNICODE", uops)
         self.assertIn("_BINARY_OP_ADD_UNICODE", uops)
 
-    def test_call_type_1(self):
+    def test_call_type_1_guards_removed(self):
+        def testfunc(n):
+            x = 0
+            for _ in range(n):
+                foo = eval('42')
+                x += type(foo) is int
+            return x
+
+        res, ex = self._run_with_optimizer(testfunc, TIER2_THRESHOLD)
+        self.assertEqual(res, TIER2_THRESHOLD)
+        self.assertIsNotNone(ex)
+        uops = get_opnames(ex)
+        self.assertIn("_CALL_TYPE_1", uops)
+        self.assertNotIn("_GUARD_NOS_NULL", uops)
+        self.assertNotIn("_GUARD_CALLABLE_TYPE_1", uops)
+
+    def test_call_type_1_known_type(self):
         def testfunc(n):
             x = 0
             for _ in range(n):
@@ -1789,9 +1805,13 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertEqual(res, TIER2_THRESHOLD)
         self.assertIsNotNone(ex)
         uops = get_opnames(ex)
-        self.assertIn("_CALL_TYPE_1", uops)
-        self.assertNotIn("_GUARD_NOS_NULL", uops)
-        self.assertNotIn("_GUARD_CALLABLE_TYPE_1", uops)
+        # When the result of type(...) is known, _CALL_TYPE_1 is replaced with
+        # _POP_CALL_ONE_LOAD_CONST_INLINE_BORROW which is optimized away in
+        # remove_unneeded_uops.
+        self.assertNotIn("_CALL_TYPE_1", uops)
+        self.assertNotIn("_POP_CALL_ONE_LOAD_CONST_INLINE_BORROW", uops)
+        self.assertNotIn("_POP_CALL_LOAD_CONST_INLINE_BORROW", uops)
+        self.assertNotIn("_POP_TOP_LOAD_CONST_INLINE_BORROW", uops)
 
     def test_call_type_1_result_is_const(self):
         def testfunc(n):
@@ -1806,7 +1826,6 @@ class TestUopsOptimization(unittest.TestCase):
         self.assertEqual(res, TIER2_THRESHOLD)
         self.assertIsNotNone(ex)
         uops = get_opnames(ex)
-        self.assertIn("_CALL_TYPE_1", uops)
         self.assertNotIn("_GUARD_IS_NOT_NONE_POP", uops)
 
     def test_call_str_1(self):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-05-21-58-30.gh-issue-131798.nt5Ab7.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-05-21-58-30.gh-issue-131798.nt5Ab7.rst
@@ -1,0 +1,2 @@
+Optimize away ``_CALL_TYPE_1`` in the JIT when the return type is known.
+Patch by Tomas Roun

--- a/Python/optimizer_bytecodes.c
+++ b/Python/optimizer_bytecodes.c
@@ -937,8 +937,11 @@ dummy_func(void) {
     }
 
     op(_CALL_TYPE_1, (unused, unused, arg -- res)) {
-        if (sym_has_type(arg)) {
-            res = sym_new_const(ctx, (PyObject *)sym_get_type(arg));
+        PyObject* type = (PyObject *)sym_get_type(arg);
+        if (type) {
+            res = sym_new_const(ctx, type);
+            REPLACE_OP(this_instr, _POP_CALL_ONE_LOAD_CONST_INLINE_BORROW, 0,
+                       (uintptr_t)type);
         }
         else {
             res = sym_new_not_null(ctx);

--- a/Python/optimizer_cases.c.h
+++ b/Python/optimizer_cases.c.h
@@ -2056,8 +2056,11 @@
             JitOptSymbol *arg;
             JitOptSymbol *res;
             arg = stack_pointer[-1];
-            if (sym_has_type(arg)) {
-                res = sym_new_const(ctx, (PyObject *)sym_get_type(arg));
+            PyObject* type = (PyObject *)sym_get_type(arg);
+            if (type) {
+                res = sym_new_const(ctx, type);
+                REPLACE_OP(this_instr, _POP_CALL_ONE_LOAD_CONST_INLINE_BORROW, 0,
+                       (uintptr_t)type);
             }
             else {
                 res = sym_new_not_null(ctx);


### PR DESCRIPTION
Followup to https://github.com/python/cpython/pull/134369#issuecomment-2902118149

This completely removes `_CALL_TYPE_1` when the abstract interpreter is able to deduce the result (by knowing the type of the argument).

For example, for something like `type(42)`, we currently do
```
_LOAD_CONST_INLINE_BORROW (callable: type)
_PUSH_NULL
_LOAD_CONST_INLINE_BORROW (arg: 42)
_CALL_TYPE_1
```

Note that we still do the call even when we know the result.

In this PR, when the result is known,  `_CALL_TYPE_1` is replaced with `_POP_CALL_ONE_LOAD_CONST_INLINE_BORROW`:
```diff
_LOAD_CONST_INLINE_BORROW (callable: type)
_PUSH_NULL
_LOAD_CONST_INLINE_BORROW (arg: 42)
- _CALL_TYPE_1
+ _POP_CALL_ONE_LOAD_CONST_INLINE_BORROW (arg: int)
```

Thanks to some previous work on optimizing `remove_unneeded_uops` this becomes just:

```
_LOAD_CONST_INLINE_BORROW (arg: int)
```

that is, the entire call is replaced with a load.


<!-- gh-issue-number: gh-131798 -->
* Issue: gh-131798
<!-- /gh-issue-number -->
