### PR TITLE
Fix versionadded directive rendering in c-api/arg.rst

### DIFF
--- a/Doc/c-api/arg.rst
+++ b/Doc/c-api/arg.rst
@@ -685,6 +685,7 @@ Building values
 
    ``p`` (:class:`bool`) [int]
       Convert a C :c:expr:`int` to a Python :class:`bool` object.
+
       .. versionadded:: 3.14
 
    ``c`` (:class:`bytes` of length 1) [char]


### PR DESCRIPTION
The lack of a blank line causes `.. versionadded:: 3.14`  to be considered part of the paragraph instead of a directive.

Before:
![image](https://github.com/user-attachments/assets/94bddded-e126-4d48-b2b4-70d6985b6574)

After:
![image](https://github.com/user-attachments/assets/1bf748b5-1558-4bc8-9768-e444aca7bdb8)


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135199.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->