### PR TITLE
gh-121782: Remove deprecated `%Z` directive in strftime-related tests

### DIFF
--- a/Lib/test/test_strptime.py
+++ b/Lib/test/test_strptime.py
@@ -658,7 +658,7 @@ class CalculationTests(unittest.TestCase):
     @skip_if_buggy_ucrt_strfptime
     def test_julian_calculation(self):
         # Make sure that when Julian is missing that it is calculated
-        format_string = "%Y %m %d %H %M %S %w %Z"
+        format_string = "%Y %m %d %H %M %S %w"
         result = _strptime._strptime_time(time.strftime(format_string, self.time_tuple),
                                     format_string)
         self.assertTrue(result.tm_yday == self.time_tuple.tm_yday,
@@ -668,7 +668,7 @@ class CalculationTests(unittest.TestCase):
     @skip_if_buggy_ucrt_strfptime
     def test_gregorian_calculation(self):
         # Test that Gregorian date can be calculated from Julian day
-        format_string = "%Y %H %M %S %w %j %Z"
+        format_string = "%Y %H %M %S %w %j"
         result = _strptime._strptime_time(time.strftime(format_string, self.time_tuple),
                                     format_string)
         self.assertTrue(result.tm_year == self.time_tuple.tm_year and
@@ -683,7 +683,7 @@ class CalculationTests(unittest.TestCase):
     @skip_if_buggy_ucrt_strfptime
     def test_day_of_week_calculation(self):
         # Test that the day of the week is calculated as needed
-        format_string = "%Y %m %d %H %S %j %Z"
+        format_string = "%Y %m %d %H %S %j"
         result = _strptime._strptime_time(time.strftime(format_string, self.time_tuple),
                                     format_string)
         self.assertTrue(result.tm_wday == self.time_tuple.tm_wday,

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -325,7 +325,7 @@ class TimeTestCase(unittest.TestCase):
         tt = time.gmtime(self.t)
         for directive in ('a', 'A', 'b', 'B', 'c', 'd', 'H', 'I',
                           'j', 'm', 'M', 'p', 'S',
-                          'U', 'w', 'W', 'x', 'X', 'y', 'Y', 'Z', '%'):
+                          'U', 'w', 'W', 'x', 'X', 'y', 'Y', '%'):
             format = '%' + directive
             if directive == 'd':
                 format += ',%Y'  # Avoid GH-70647.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
The `%Z` in `time.strftime` is a platform-specific directive. It causes `strftime` to return no characters on some platforms, which makes tests unstable.

But fortunately the `%Z` in `time.strftime` is deprecated, so we can remove it from those tests safely.

> [%Z](https://docs.python.org/3/library/time.html#time.strftime): Time zone name (no characters if no time zone exists). Deprecated.


<!-- gh-issue-number: gh-121782 -->
* Issue: gh-121782
<!-- /gh-issue-number -->
