### PR TITLE
gh-135177: Raise OverflowError in _Py_call_instrumentation_jump to handle potential integer overflow

### DIFF
--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1236,7 +1236,7 @@ _Py_call_instrumentation_jump(
            event == PY_MONITORING_EVENT_BRANCH_RIGHT ||
            event == PY_MONITORING_EVENT_BRANCH_LEFT);
     Py_ssize_t to = (dest - _PyFrame_GetBytecode(frame));
-    assert(to <= PY_SSIZE_T_MAX / sizeof(_Py_CODEUNIT));
+    assert(to <= PY_SSIZE_T_MAX / (Py_ssize_t)sizeof(_Py_CODEUNIT));
     PyObject *to_obj = PyLong_FromSsize_t(to * sizeof(_Py_CODEUNIT));
     if (to_obj == NULL) {
         return NULL;

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1237,7 +1237,7 @@ _Py_call_instrumentation_jump(
            event == PY_MONITORING_EVENT_BRANCH_LEFT);
     int to = (int)(dest - _PyFrame_GetBytecode(frame));
     if (to <= INT_MAX / (int)sizeof(_Py_CODEUNIT)) {
-        PyErr_SetString(PyExc_OverflowError, "instruction offset cannot be converted to an integer");
+        PyErr_SetString(PyExc_OverflowError, "instruction offset cannot be converted to a C int");
         return NULL;
     }
     PyObject *to_obj = PyLong_FromLong(to * (int)sizeof(_Py_CODEUNIT));

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1236,6 +1236,10 @@ _Py_call_instrumentation_jump(
            event == PY_MONITORING_EVENT_BRANCH_RIGHT ||
            event == PY_MONITORING_EVENT_BRANCH_LEFT);
     int to = (int)(dest - _PyFrame_GetBytecode(frame));
+    if (to <= INT_MAX / (int)sizeof(_Py_CODEUNIT)) {
+        PyErr_SetString(PyExc_OverflowError, "instruction offset is too large for int");
+        return NULL;
+    }
     PyObject *to_obj = PyLong_FromLong(to * (int)sizeof(_Py_CODEUNIT));
     if (to_obj == NULL) {
         return NULL;

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1237,7 +1237,7 @@ _Py_call_instrumentation_jump(
            event == PY_MONITORING_EVENT_BRANCH_LEFT);
     int to = (int)(dest - _PyFrame_GetBytecode(frame));
     if (to <= INT_MAX / (int)sizeof(_Py_CODEUNIT)) {
-        PyErr_SetString(PyExc_OverflowError, "instruction offset is too large for int");
+        PyErr_SetString(PyExc_OverflowError, "instruction offset cannot be converted to an integer");
         return NULL;
     }
     PyObject *to_obj = PyLong_FromLong(to * (int)sizeof(_Py_CODEUNIT));

--- a/Python/instrumentation.c
+++ b/Python/instrumentation.c
@@ -1235,12 +1235,9 @@ _Py_call_instrumentation_jump(
     assert(event == PY_MONITORING_EVENT_JUMP ||
            event == PY_MONITORING_EVENT_BRANCH_RIGHT ||
            event == PY_MONITORING_EVENT_BRANCH_LEFT);
-    int to = (int)(dest - _PyFrame_GetBytecode(frame));
-    if (to <= INT_MAX / (int)sizeof(_Py_CODEUNIT)) {
-        PyErr_SetString(PyExc_OverflowError, "instruction offset cannot be converted to a C int");
-        return NULL;
-    }
-    PyObject *to_obj = PyLong_FromLong(to * (int)sizeof(_Py_CODEUNIT));
+    Py_ssize_t to = (dest - _PyFrame_GetBytecode(frame));
+    assert(to <= PY_SSIZE_T_MAX / sizeof(_Py_CODEUNIT));
+    PyObject *to_obj = PyLong_FromSsize_t(to * sizeof(_Py_CODEUNIT));
     if (to_obj == NULL) {
         return NULL;
     }


### PR DESCRIPTION
This pull request adds a runtime check to handle potential integer overflow in the _Py_call_instrumentation_jump function.

<!-- gh-issue-number: gh-135177 -->
* Issue: gh-135177
<!-- /gh-issue-number -->
