### PR TITLE
gh-135237: fix `setUp/tearDown` of `_colorize.can_colorize` in `test_argparse`

### DIFF
--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -7107,8 +7107,12 @@ class TestColorized(TestCase):
     def setUp(self):
         super().setUp()
         # Ensure color even if ran with NO_COLOR=1
+        self.original_can_colorize = _colorize.can_colorize
         _colorize.can_colorize = lambda *args, **kwargs: True
         self.theme = _colorize.get_theme(force_color=True).argparse
+
+    def tearDown(self):
+        _colorize.can_colorize = self.original_can_colorize
 
     def test_argparse_color(self):
         # Arrange: create a parser with a bit of everything


### PR DESCRIPTION

See `test_regrtest` `TestColorized` and `test_pdb` `PdbTestColorize` for similar tests with safe setups.

https://github.com/python/cpython/blob/24069fbca861a5904ee7718469919e84828f22e7/Lib/test/test_regrtest.py#L2577-L2580

https://github.com/python/cpython/blob/24069fbca861a5904ee7718469919e84828f22e7/Lib/test/test_pdb.py#L4694-L4701

<!-- gh-issue-number: gh-135237 -->
* Issue: gh-135237
<!-- /gh-issue-number -->
