### PR TITLE
gh-135241: Changed the  opcode of _pickle module to look for 00 and 01 specifically

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1012,6 +1012,16 @@ class AbstractUnpickleTests:
         self.assertIs(self.loads(b'I01\n.'), True)
         self.assertIs(self.loads(b'I00\n.'), False)
 
+    def test_issue135241(self):
+        # C implementation should check for hardcoded values 00 and 01
+        # when getting booleans from the INT opcode. Doing a str comparison
+        # to bypass truthy/falsy comparisons. These payloads should return
+        # 0, not False.
+        out1 = self.loads(b'I+0\n.')
+        self.assertTrue(str(out1) == str(0))
+        out2 = self.loads(b'I 0\n.')
+        self.assertTrue(str(out2) == str(0))
+
     def test_zero_padded_integers(self):
         self.assertEqual(self.loads(b'I010\n.'), 10)
         self.assertEqual(self.loads(b'I-010\n.'), -10)

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1018,7 +1018,7 @@ class AbstractUnpickleTests:
         # to bypass truthy/falsy comparisons. These payloads should return
         # 0, not False.
         out1 = self.loads(b'I+0\n.')
-        self.assertTrue(str(out1) == str(0))
+        self.assertEqual(str(out1), '0')
         out2 = self.loads(b'I 0\n.')
         self.assertTrue(str(out2) == str(0))
 

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1020,7 +1020,7 @@ class AbstractUnpickleTests:
         out1 = self.loads(b'I+0\n.')
         self.assertEqual(str(out1), '0')
         out2 = self.loads(b'I 0\n.')
-        self.assertTrue(str(out2) == str(0))
+        self.assertEqual(str(out2), '0')
 
     def test_zero_padded_integers(self):
         self.assertEqual(self.loads(b'I010\n.'), 10)

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -376,16 +376,6 @@ if has_c_implementation:
         bad_stack_errors = (pickle.UnpicklingError,)
         truncated_errors = (pickle.UnpicklingError,)
 
-        def test_issue135241(self):
-            # C implementation should check for hardcoded values 00 and 01
-            # when getting booleans from the INT opcode. Doing a str comparison
-            # to bypass truthy/falsy comparisons. These payloads should return
-            # 0, not False.
-            out1 = self.loads(b'I+0\n.')
-            self.assertTrue(str(out1) == str(0))
-            out2 = self.loads(b'I 0\n.')
-            self.assertTrue(str(out2) == str(0))
-
     class CPicklingErrorTests(PyPicklingErrorTests):
         pickler = _pickle.Pickler
 

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -376,6 +376,16 @@ if has_c_implementation:
         bad_stack_errors = (pickle.UnpicklingError,)
         truncated_errors = (pickle.UnpicklingError,)
 
+        def test_issue135241(self):
+            # C implementation should check for hardcoded values 00 and 01
+            # when getting booleans from the INT opcode. Doing a str comparison
+            # to bypass truthy/falsy comparisons. These payloads should return
+            # 0, not False.
+            out1 = self.loads(b'I+0\n.')
+            self.assertTrue(str(out1) == str(0))
+            out2 = self.loads(b'I 0\n.')
+            self.assertTrue(str(out2) == str(0))
+
     class CPicklingErrorTests(PyPicklingErrorTests):
         pickler = _pickle.Pickler
 

--- a/Misc/NEWS.d/next/Library/2025-06-08-01-10-34.gh-issue-135241.5j18IW.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-08-01-10-34.gh-issue-135241.5j18IW.rst
@@ -1,1 +1,3 @@
-The :code:`INT` opcode of the C accelerator ``_pickle`` module was updated to look only for "00" and "01" to push booleans onto the stack, aligning with the Python :mod:`pickle` module.
+The :code:`INT` opcode of the C accelerator :mod:`!_pickle` module was updated
+to look only for "00" and "01" to push booleans onto the stack, aligning with
+the Python :mod:`pickle` module.

--- a/Misc/NEWS.d/next/Library/2025-06-08-01-10-34.gh-issue-135241.5j18IW.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-08-01-10-34.gh-issue-135241.5j18IW.rst
@@ -1,1 +1,1 @@
-The :code:`INT` opcode of the C accelerator :mod:`_pickle` module was updated to look only for "00" and "01" to push booleans onto the stack, aligning with the Python :mod:`pickle` module.
+The :code:`INT` opcode of the C accelerator `_pickle` module was updated to look only for "00" and "01" to push booleans onto the stack, aligning with the Python :mod:`pickle` module.

--- a/Misc/NEWS.d/next/Library/2025-06-08-01-10-34.gh-issue-135241.5j18IW.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-08-01-10-34.gh-issue-135241.5j18IW.rst
@@ -1,0 +1,1 @@
+The :code:`INT` opcode of the C accelerator :mod:`_pickle` module was updated to look only for "00" and "01" to push booleans onto the stack, aligning with the Python :mod:`pickle` module.

--- a/Misc/NEWS.d/next/Library/2025-06-08-01-10-34.gh-issue-135241.5j18IW.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-08-01-10-34.gh-issue-135241.5j18IW.rst
@@ -1,1 +1,1 @@
-The :code:`INT` opcode of the C accelerator `_pickle` module was updated to look only for "00" and "01" to push booleans onto the stack, aligning with the Python :mod:`pickle` module.
+The :code:`INT` opcode of the C accelerator ``_pickle`` module was updated to look only for "00" and "01" to push booleans onto the stack, aligning with the Python :mod:`pickle` module.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -5255,7 +5255,7 @@ load_int(PickleState *state, UnpicklerObject *self)
         }
     }
     else {
-        if (len == 3 && (x == 0 || x == 1)) {
+        if (len == 3 && s[0] == '0' && (s[1] == '0' || s[1] == '1')) {
             if ((value = PyBool_FromLong(x)) == NULL)
                 return -1;
         }


### PR DESCRIPTION
The python pickle module looks for "00" and "01" but _pickle only looked for 2 characters that parsed to 0 or 1, meaning some payloads like "+0" or " 0" would lead to different results in different implementations. See more details in the linked issue.

This solution simply checks for the hard-coded chars ensuring no edge cases go by.

<!-- gh-issue-number: gh-135241 -->
* Issue: gh-135241
<!-- /gh-issue-number -->
