### PR TITLE
Use f-strings in csv docs example

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -609,7 +609,7 @@ A slightly more advanced use of the reader --- catching and reporting errors::
            for row in reader:
                print(row)
        except csv.Error as e:
-           sys.exit('file {}, line {}: {}'.format(filename, reader.line_num, e))
+           sys.exit(f'file {filename}, line {reader.line_num}: {e}')
 
 And while the module doesn't directly support parsing strings, it can easily be
 done::


### PR DESCRIPTION
Just a minor tweak to the `csv` module docs to use f-strings instead of `.format()`.


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135245.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->