### PR TITLE
gh-133244: TPen.pensize raises TurtleGraphicsError if called with a negative number

### DIFF
--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -279,4 +279,3 @@ Examples::
 
    `NumPy <https://numpy.org/>`_
       The NumPy package defines another array type.
-

--- a/Doc/library/array.rst
+++ b/Doc/library/array.rst
@@ -279,3 +279,4 @@ Examples::
 
    `NumPy <https://numpy.org/>`_
       The NumPy package defines another array type.
+

--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -1079,6 +1079,8 @@ Drawing state
 
    :param width: a positive number
 
+   :raises TurtleGraphicsError: If *width* is less than zero.
+
    Set the line thickness to *width* or return it.  If resizemode is set to
    "auto" and turtleshape is a polygon, that polygon is drawn with the same line
    thickness.  If no argument is given, the current pensize is returned.
@@ -1089,6 +1091,9 @@ Drawing state
       >>> turtle.pensize()
       1
       >>> turtle.pensize(10)   # from here on lines of width 10 are drawn
+
+   .. versionchanged:: next
+      Raise :exc:`TurtleGraphicsError` if *width* is less than zero.
 
 
 .. function:: pen(pen=None, **pendict)

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -492,8 +492,12 @@ class TestTPen(unittest.TestCase):
         tpen.pensize(0)
         self.assertEqual(0, tpen.pensize())
 
-        tpen.pensize(-1)
-        self.assertEqual(-1, tpen.pensize())
+        width = -1
+        msg = f"width argument must be a positive number. It was {width}."
+        with self.assertRaisesRegex(turtle.TurtleGraphicsError, re.escape(msg)):
+            tpen.pensize(width)
+
+        self.assertEqual(0, tpen.pensize())
 
 
 class TestTurtleScreen(unittest.TestCase):

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -493,7 +493,7 @@ class TestTPen(unittest.TestCase):
         self.assertEqual(0, tpen.pensize())
 
         width = -1
-        msg = f"width argument must be a positive number. It was {width}."
+        msg = f"width argument must be a positive number, but got {width}."
         with self.assertRaisesRegex(turtle.TurtleGraphicsError, re.escape(msg)):
             tpen.pensize(width)
 

--- a/Lib/test/test_turtle.py
+++ b/Lib/test/test_turtle.py
@@ -480,6 +480,21 @@ class TestTPen(unittest.TestCase):
             tpen.teleport(-100, -100, fill_gap=fill_gap_value)
             self.assertTrue(tpen.isdown())
 
+    def test_pensize_with_positive_numbers(self):
+        tpen = turtle.TPen()
+
+        tpen.pensize(42)
+        self.assertEqual(42, tpen.pensize())
+
+    def test_pensize_with_nonpositive_numbers(self):
+        tpen = turtle.TPen()
+
+        tpen.pensize(0)
+        self.assertEqual(0, tpen.pensize())
+
+        tpen.pensize(-1)
+        self.assertEqual(-1, tpen.pensize())
+
 
 class TestTurtleScreen(unittest.TestCase):
     def test_save_raises_if_wrong_extension(self) -> None:

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -2141,7 +2141,10 @@ class TPen(object):
         """
         if width is None:
             return self._pensize
-        self.pen(pensize=width)
+        elif width < 0:
+            raise TurtleGraphicsError(f"width argument must be a positive number. It was {width}.")
+        else:
+            self.pen(pensize=width)
 
 
     def penup(self):

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -2142,7 +2142,8 @@ class TPen(object):
         if width is None:
             return self._pensize
         elif width < 0:
-            raise TurtleGraphicsError(f"width argument must be a positive number. It was {width}.")
+            msg = f"width argument must be a positive number, but got {width}."
+            raise TurtleGraphicsError(msg)
         else:
             self.pen(pensize=width)
 

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -2142,8 +2142,9 @@ class TPen(object):
         if width is None:
             return self._pensize
         elif width < 0:
-            msg = f"width argument must be a positive number, but got {width}."
-            raise TurtleGraphicsError(msg)
+            raise TurtleGraphicsError(
+                f"width argument must be a non-negative number, but got {width!r}."
+            )
         else:
             self.pen(pensize=width)
 

--- a/Misc/NEWS.d/next/Library/2025-06-09-08-11-47.gh-issue-133244.GINMl-.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-09-08-11-47.gh-issue-133244.GINMl-.rst
@@ -1,0 +1,1 @@
+TPen.pensize raises TurtleGraphicsError if called with a negative number

--- a/Misc/NEWS.d/next/Library/2025-06-09-08-11-47.gh-issue-133244.GINMl-.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-09-08-11-47.gh-issue-133244.GINMl-.rst
@@ -1,1 +1,1 @@
-TPen.pensize raises TurtleGraphicsError if called with a negative number
+:meth:`!turtle.TPen.pensize` raises an exception if called with a negative *width* argument.


### PR DESCRIPTION
Fix #133244.

Before
```python
>>> import turtle
>>> turtle.pensize(-1)
>>> turtle.forward(100)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 8, in forward
  File "/home/adorilson/anaconda3/lib/python3.12/turtle.py", line 1636, in forward
    self._go(distance)
  File "/home/adorilson/anaconda3/lib/python3.12/turtle.py", line 1597, in _go
    self._goto(ende)
  File "/home/adorilson/anaconda3/lib/python3.12/turtle.py", line 3248, in _goto
    screen._drawline(self.drawingLineItem,
  File "/home/adorilson/anaconda3/lib/python3.12/turtle.py", line 543, in _drawline
    self.cv.itemconfigure(lineitem, width=width)
  File "<string>", line 1, in itemconfigure
  File "/home/adorilson/anaconda3/lib/python3.12/tkinter/__init__.py", line 2988, in itemconfigure
    return self._configure(('itemconfigure', tagOrId), cnf, kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/adorilson/anaconda3/lib/python3.12/tkinter/__init__.py", line 1712, in _configure
    self.tk.call(_flatten((self._w, cmd)) + self._options(cnf))
_tkinter.TclError: bad screen distance "-1"

```

Now
```python
>>> import turtle
>>> turtle.pensize(-1)
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    turtle.pensize(-1)
    ~~~~~~~~~~~~~~^^^^
  File "<string>", line 8, in pensize
  File "/home/adorilson/workspace/cpython/Lib/turtle.py", line 2145, in pensize
    raise TurtleGraphicsError(f"width argument must be a positive number. It was {width}.")
turtle.TurtleGraphicsError: width argument must be a positive number. It was -1.
```

For now, the `0` behaviour wasn't changed, but I think it would. 

If we call `turtle.pensize(0)` it changes the width to `0`, but when the turtle draws, the real line's width is `1`. It seems to be a misconception. However, change could be a backwards compatibility concern. Perhaps we can schedule a change for now with a `DeprecationWarning`.


 

<!-- gh-issue-number: gh-133244 -->
* Issue: gh-133244
<!-- /gh-issue-number -->
