### PR TITLE
gh-135263: Fix typo in token.NAME documentation

### DIFF
--- a/Doc/library/token.rst
+++ b/Doc/library/token.rst
@@ -51,7 +51,7 @@ The token constants are:
 .. data:: NAME
 
    Token value that indicates an :ref:`identifier <identifiers>`.
-   Note that keywords are also initially tokenized an ``NAME`` tokens.
+   Note that keywords are also initially tokenized as ``NAME`` tokens.
 
 .. data:: NUMBER
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-135263 -->
* Issue: gh-135263
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135275.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->