### PR TITLE
GH-135287: clangcl PGO builds on Windows fail with `could not open '/GENPROFILE'`

### DIFF
--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -100,8 +100,8 @@
       <AdditionalDependencies>advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions Condition="$(Configuration) != 'Debug'">/OPT:REF,NOICF %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="$(MSVCHasBrokenARM64Clamping) == 'true' and $(Platform) == 'ARM64'">-d2:-pattern-opt-disable:-932189325 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="$(SupportPGO) and $(Configuration) == 'PGInstrument'">/GENPROFILE %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="$(SupportPGO) and $(Configuration) == 'PGUpdate'">/USEPROFILE %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="$(SupportPGO) and $(Configuration) == 'PGInstrument' and $(PlatformToolset) != 'ClangCL'">/GENPROFILE %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="$(SupportPGO) and $(Configuration) == 'PGUpdate' and $(PlatformToolset) != 'ClangCL'">/USEPROFILE %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Lib>
       <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>


### PR DESCRIPTION
Since https://github.com/python/cpython/issues/134923 / PR https://github.com/python/cpython/pull/134924 clangcl PGO builds on Windows fail with
```
lld-link : error : could not open '/GENPROFILE': no such file or directory [e:\cpython_clang\PCbuild\pythoncore.vcxproj]
```

I thought about skipping news, but since this also affects 3.14, I should blurb it?

@zooba WDYT? Can you suggest something that's not too verbose?

<!-- gh-issue-number: gh-135287 -->
* Issue: gh-135287
<!-- /gh-issue-number -->
