### PR TITLE
Fix warnings `set but not used [-Wunused-but-set-variable]` in remote_debug.h

### DIFF
--- a/Python/remote_debug.h
+++ b/Python/remote_debug.h
@@ -674,8 +674,6 @@ search_linux_map_for_section(proc_handle_t *handle, const char* secname, const c
     }
 
     uintptr_t retval = 0;
-    int lines_processed = 0;
-    int matches_found = 0;
 
     while (fgets(line + linelen, linesz - linelen, maps_file) != NULL) {
         linelen = strlen(line);
@@ -700,7 +698,6 @@ search_linux_map_for_section(proc_handle_t *handle, const char* secname, const c
         line[linelen - 1] = '\0';
         // and prepare to read the next line into the start of the buffer.
         linelen = 0;
-        lines_processed++;
 
         unsigned long start = 0;
         unsigned long path_pos = 0;
@@ -721,7 +718,6 @@ search_linux_map_for_section(proc_handle_t *handle, const char* secname, const c
         }
 
         if (strstr(filename, substr)) {
-            matches_found++;
             retval = search_elf_file_for_section(handle, secname, start, path);
             if (retval) {
                 break;
@@ -840,15 +836,10 @@ search_windows_map_for_section(proc_handle_t* handle, const char* secname, const
     MODULEENTRY32W moduleEntry;
     moduleEntry.dwSize = sizeof(moduleEntry);
     void* runtime_addr = NULL;
-    int modules_examined = 0;
-    int matches_found = 0;
 
     for (BOOL hasModule = Module32FirstW(hProcSnap, &moduleEntry); hasModule; hasModule = Module32NextW(hProcSnap, &moduleEntry)) {
-        modules_examined++;
-
         // Look for either python executable or DLL
         if (wcsstr(moduleEntry.szModule, substr)) {
-            matches_found++;
             runtime_addr = analyze_pe(moduleEntry.szExePath, moduleEntry.modBaseAddr, secname);
             if (runtime_addr != NULL) {
                 break;


### PR DESCRIPTION
Since https://github.com/python/cpython/pull/134682 these warnings
```
Python/remote_debug.h:677:9: warning: variable 'lines_processed' set but not used [-Wunused-but-set-variable]
Python/remote_debug.h:678:9: warning: variable 'matches_found' set but not used [-Wunused-but-set-variable]
```
show up on build bots, e.g. https://buildbot.python.org/#/builders/441/builds/8081.

Likewise, I see similar warnings in clang-cl based builds on Windows (https://github.com/python/cpython/issues/131296):
```
..\Python\remote_debug.h(843,9): warning : variable 'modules_examined' set but not used [-Wunused-but-set-variable] [e:\cpython_clang\PCbuild\pythoncore.vcxproj]
..\Python\remote_debug.h(844,9): warning : variable 'matches_found' set but not used [-Wunused-but-set-variable] [e:\cpython_clang\PCbuild\pythoncore.vcxproj]
```

@pablogsal  I think this is a skip news and a skip issue (even though it should be backported to 3.14)?
Or shall/can I link it to https://github.com/python/cpython/issues/91048?