### PR TITLE
gh-127502: Update XML vulnerability table

### DIFF
--- a/Doc/library/pyexpat.rst
+++ b/Doc/library/pyexpat.rst
@@ -16,11 +16,10 @@
    references to these attributes should be marked using the :member: role.
 
 
-.. warning::
+.. note::
 
-   The :mod:`pyexpat` module is not secure against maliciously
-   constructed data.  If you need to parse untrusted or unauthenticated data see
-   :ref:`xml-vulnerabilities`.
+   If you need to parse untrusted or unauthenticated data, see
+   :ref:`xml-security`.
 
 
 .. index:: single: Expat

--- a/Doc/library/security_warnings.rst
+++ b/Doc/library/security_warnings.rst
@@ -28,7 +28,7 @@ The following modules have specific security considerations:
   <subprocess-security>`
 * :mod:`tempfile`: :ref:`mktemp is deprecated due to vulnerability to race
   conditions <tempfile-mktemp-deprecated>`
-* :mod:`xml`: :ref:`XML vulnerabilities <xml-vulnerabilities>`
+* :mod:`xml`: :ref:`XML security <xml-security>`
 * :mod:`zipfile`: :ref:`maliciously prepared .zip files can cause disk volume
   exhaustion <zipfile-resources-limitations>`
 

--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -19,11 +19,10 @@ not already proficient with the DOM should consider using the
 :mod:`xml.etree.ElementTree` module for their XML processing instead.
 
 
-.. warning::
+.. note::
 
-   The :mod:`xml.dom.minidom` module is not secure against
-   maliciously constructed data.  If you need to parse untrusted or
-   unauthenticated data see :ref:`xml-vulnerabilities`.
+   If you need to parse untrusted or unauthenticated data, see
+   :ref:`xml-security`.
 
 
 DOM applications typically start by parsing some XML into a DOM.  With

--- a/Doc/library/xml.dom.pulldom.rst
+++ b/Doc/library/xml.dom.pulldom.rst
@@ -19,11 +19,10 @@ responsible for explicitly pulling events from the stream, looping over those
 events until either processing is finished or an error condition occurs.
 
 
-.. warning::
+.. note::
 
-   The :mod:`xml.dom.pulldom` module is not secure against
-   maliciously constructed data.  If you need to parse untrusted or
-   unauthenticated data see :ref:`xml-vulnerabilities`.
+   If you need to parse untrusted or unauthenticated data, see
+   :ref:`xml-security`.
 
 .. versionchanged:: 3.7.1
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -20,11 +20,10 @@ for parsing and creating XML data.
    The :mod:`!xml.etree.cElementTree` module is deprecated.
 
 
-.. warning::
+.. note::
 
-   The :mod:`xml.etree.ElementTree` module is not secure against
-   maliciously constructed data.  If you need to parse untrusted or
-   unauthenticated data see :ref:`xml-vulnerabilities`.
+   If you need to parse untrusted or unauthenticated data, see
+   :ref:`xml-security`.
 
 Tutorial
 --------

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -57,13 +57,11 @@ circumvent firewalls.
 
 Expat versions lower that 2.6.0 may be vulnerable to "billion laughs",
 "quadratic blowup" and "large tokens". Python may be vulnerable if it uses such
-older versions of Expat as a system-provided library, it may be vulnerable.
+older versions of Expat as a system-provided library.
 Check :const:`!pyexpat.EXPAT_VERSION`.
 
-xmlrpc is **vulnerable** to "decompression bomb".
+:mod:`xmlrpc` is **vulnerable** to the "decompression bomb" attack.
 
-Since Python 3.7.1, external general entities are no longer processed by
-default.
 
 billion laughs / exponential entity expansion
   The `Billion Laughs`_ attack -- also known as exponential entity expansion --

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -54,37 +54,15 @@ An attacker can abuse XML features to carry out denial of service attacks,
 access local files, generate network connections to other machines, or
 circumvent firewalls.
 
-The following table gives an overview of the known attacks and whether
-the various modules are vulnerable to them.
+Expat versions lower that 2.6.0 may be vulnerable to "billion laughs",
+"quadratic blowup" and "large tokens". Python may be vulnerable if it uses such
+older versions of Expat as a system-provided library, it may be vulnerable.
+Check :const:`!pyexpat.EXPAT_VERSION`.
 
-=========================  ==================  ==================  ==================  ==================  ==================
-kind                       sax                 etree               minidom             pulldom             xmlrpc
-=========================  ==================  ==================  ==================  ==================  ==================
-billion laughs             Safe (1)            Safe (1)            Safe (1)            Safe (1)            Safe (1)
-quadratic blowup           Safe (1)            Safe (1)            Safe (1)            Safe (1)            Safe (1)
-external entity expansion  Safe (5)            Safe (2)            Safe (3)            Safe (5)            Safe (4)
-`DTD`_ retrieval           Safe (5)            Safe                Safe                Safe (5)            Safe
-decompression bomb         Safe                Safe                Safe                Safe                **Vulnerable**
-large tokens               Safe (6)            Safe (6)            Safe (6)            Safe (6)            Safe (6)
-=========================  ==================  ==================  ==================  ==================  ==================
+xmlrpc is **vulnerable** to "decompression bomb".
 
-1. Expat 2.4.1 and newer is not vulnerable to the "billion laughs" and
-   "quadratic blowup" vulnerabilities. Items still listed as vulnerable due to
-   potential reliance on system-provided libraries. Check
-   :const:`!pyexpat.EXPAT_VERSION`.
-2. :mod:`xml.etree.ElementTree` doesn't expand external entities and raises a
-   :exc:`~xml.etree.ElementTree.ParseError` when an entity occurs.
-3. :mod:`xml.dom.minidom` doesn't expand external entities and simply returns
-   the unexpanded entity verbatim.
-4. :mod:`xmlrpc.client` doesn't expand external entities and omits them.
-5. Since Python 3.7.1, external general entities are no longer processed by
-   default.
-6. Expat 2.6.0 and newer is not vulnerable to denial of service
-   through quadratic runtime caused by parsing large tokens.
-   Items still listed as vulnerable due to
-   potential reliance on system-provided libraries. Check
-   :const:`!pyexpat.EXPAT_VERSION`.
-
+Since Python 3.7.1, external general entities are no longer processed by
+default.
 
 billion laughs / exponential entity expansion
   The `Billion Laughs`_ attack -- also known as exponential entity expansion --
@@ -99,16 +77,6 @@ quadratic blowup entity expansion
   with a couple of thousand chars over and over again. The attack isn't as
   efficient as the exponential case but it avoids triggering parser countermeasures
   that forbid deeply nested entities.
-
-external entity expansion
-  Entity declarations can contain more than just text for replacement. They can
-  also point to external resources or local files. The XML
-  parser accesses the resource and embeds the content into the XML document.
-
-`DTD`_ retrieval
-  Some XML libraries like Python's :mod:`xml.dom.pulldom` retrieve document type
-  definitions from remote or local locations. The feature has similar
-  implications as the external entity expansion issue.
 
 decompression bomb
   Decompression bombs (aka `ZIP bomb`_) apply to all XML libraries
@@ -125,4 +93,3 @@ large tokens
 
 .. _Billion Laughs: https://en.wikipedia.org/wiki/Billion_laughs
 .. _ZIP bomb: https://en.wikipedia.org/wiki/Zip_bomb
-.. _DTD: https://en.wikipedia.org/wiki/Document_type_definition

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -46,6 +46,7 @@ The XML handling submodules are:
 
 
 .. _xml-security:
+.. _xml-vulnerabilities:
 
 XML security
 ------------

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -63,12 +63,12 @@ the various modules are vulnerable to them.
 =========================  ==================  ==================  ==================  ==================  ==================
 kind                       sax                 etree               minidom             pulldom             xmlrpc
 =========================  ==================  ==================  ==================  ==================  ==================
-billion laughs             **Vulnerable** (1)  **Vulnerable** (1)  **Vulnerable** (1)  **Vulnerable** (1)  **Vulnerable** (1)
-quadratic blowup           **Vulnerable** (1)  **Vulnerable** (1)  **Vulnerable** (1)  **Vulnerable** (1)  **Vulnerable** (1)
+billion laughs             Safe (1)            Safe (1)            Safe (1)            Safe (1)            Safe (1)
+quadratic blowup           Safe (1)            Safe (1)            Safe (1)            Safe (1)            Safe (1)
 external entity expansion  Safe (5)            Safe (2)            Safe (3)            Safe (5)            Safe (4)
 `DTD`_ retrieval           Safe (5)            Safe                Safe                Safe (5)            Safe
 decompression bomb         Safe                Safe                Safe                Safe                **Vulnerable**
-large tokens               **Vulnerable** (6)  **Vulnerable** (6)  **Vulnerable** (6)  **Vulnerable** (6)  **Vulnerable** (6)
+large tokens               Safe (6)            Safe (6)            Safe (6)            Safe (6)            Safe (6)
 =========================  ==================  ==================  ==================  ==================  ==================
 
 1. Expat 2.4.1 and newer is not vulnerable to the "billion laughs" and

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -15,6 +15,11 @@ XML Processing Modules
 
 Python's interfaces for processing XML are grouped in the ``xml`` package.
 
+.. note::
+
+   If you need to parse untrusted or unauthenticated data, see
+   :ref:`xml-security`.
+
 It is important to note that modules in the :mod:`xml` package require that
 there be at least one SAX-compliant XML parser available. The Expat parser is
 included with Python, so the :mod:`xml.parsers.expat` module will always be

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -40,12 +40,11 @@ The XML handling submodules are:
 * :mod:`xml.parsers.expat`: the Expat parser binding
 
 
-.. _xml-vulnerabilities:
+.. _xml-security:
 
-XML vulnerabilities
--------------------
+XML security
+------------
 
-The XML processing modules are not secure against maliciously constructed data.
 An attacker can abuse XML features to carry out denial of service attacks,
 access local files, generate network connections to other machines, or
 circumvent firewalls.

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -15,13 +15,6 @@ XML Processing Modules
 
 Python's interfaces for processing XML are grouped in the ``xml`` package.
 
-.. warning::
-
-   The XML modules are not secure against erroneous or maliciously
-   constructed data.  If you need to parse untrusted or
-   unauthenticated data see the :ref:`xml-vulnerabilities` and
-   :ref:`defusedxml-package` sections.
-
 It is important to note that modules in the :mod:`xml` package require that
 there be at least one SAX-compliant XML parser available. The Expat parser is
 included with Python, so the :mod:`xml.parsers.expat` module will always be
@@ -125,21 +118,6 @@ large tokens
   introduced in Expat 2.6.0, this can lead to quadratic runtime that can
   be used to cause denial of service in the application parsing XML.
   The issue is known as :cve:`2023-52425`.
-
-The documentation for :pypi:`defusedxml` on PyPI has further information about
-all known attack vectors with examples and references.
-
-.. _defusedxml-package:
-
-The :mod:`!defusedxml` Package
-------------------------------
-
-:pypi:`defusedxml` is a pure Python package with modified subclasses of all stdlib
-XML parsers that prevent any potentially malicious operation. Use of this
-package is recommended for any server code that parses untrusted XML data. The
-package also ships with example exploits and extended documentation on more
-XML exploits such as XPath injection.
-
 
 .. _Billion Laughs: https://en.wikipedia.org/wiki/Billion_laughs
 .. _ZIP bomb: https://en.wikipedia.org/wiki/Zip_bomb

--- a/Doc/library/xml.sax.rst
+++ b/Doc/library/xml.sax.rst
@@ -18,11 +18,10 @@ SAX exceptions and the convenience functions which will be most used by users of
 the SAX API.
 
 
-.. warning::
+.. note::
 
-   The :mod:`xml.sax` module is not secure against maliciously
-   constructed data.  If you need to parse untrusted or unauthenticated data see
-   :ref:`xml-vulnerabilities`.
+   If you need to parse untrusted or unauthenticated data, see
+   :ref:`xml-security`.
 
 .. versionchanged:: 3.7.1
 

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -24,8 +24,8 @@ between conformable Python objects and XML on the wire.
 .. warning::
 
    The :mod:`xmlrpc.client` module is not secure against maliciously
-   constructed data.  If you need to parse untrusted or unauthenticated data see
-   :ref:`xml-vulnerabilities`.
+   constructed data.  If you need to parse untrusted or unauthenticated data,
+   see :ref:`xml-security`.
 
 .. versionchanged:: 3.5
 

--- a/Doc/library/xmlrpc.server.rst
+++ b/Doc/library/xmlrpc.server.rst
@@ -20,8 +20,8 @@ servers written in Python.  Servers can either be free standing, using
 .. warning::
 
    The :mod:`xmlrpc.server` module is not secure against maliciously
-   constructed data.  If you need to parse untrusted or unauthenticated data see
-   :ref:`xml-vulnerabilities`.
+   constructed data.  If you need to parse untrusted or unauthenticated data,
+   see :ref:`xml-security`.
 
 .. include:: ../includes/wasm-notavail.rst
 


### PR DESCRIPTION
Python 3.11-3.15 include expat 2.7.1 which is not vulnerable.

expat 2.6.0 was released in February 2024.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127502 -->
* Issue: gh-127502
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135294.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->