### PR TITLE
GH-135304: Reported resolution of `time.process_time` and `time.thread_time` is wrong on Windows

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-06-09-17-33-49.gh-issue-135304.GN747s.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-09-17-33-49.gh-issue-135304.GN747s.rst
@@ -1,0 +1,2 @@
+Fix reported resolution of :func:`time.process_time` and
+:func:`time.thread_time` on Windows. Patch by Chris Eibl.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1307,7 +1307,7 @@ py_process_time(time_module_state *state, PyTime_t *tp,
 
     if (info) {
         info->implementation = "GetProcessTimes()";
-        info->resolution = 1e-7;
+        info->resolution = 15.625e-3;
         info->monotonic = 1;
         info->adjustable = 0;
     }
@@ -1468,7 +1468,7 @@ _PyTime_GetThreadTimeWithInfo(PyTime_t *tp, _Py_clock_info_t *info)
 
     if (info) {
         info->implementation = "GetThreadTimes()";
-        info->resolution = 1e-7;
+        info->resolution = 15.625e-3;
         info->monotonic = 1;
         info->adjustable = 0;
     }


### PR DESCRIPTION
```python
>>> import time
>>> time.get_clock_info("process_time")
namespace(implementation='GetProcessTimes()', monotonic=True, adjustable=False, resolution=1e-07)
>>> time.get_clock_info("thread_time")
namespace(implementation='GetThreadTimes()', monotonic=True, adjustable=False, resolution=1e-07)
```
I suggest to report `15.625 ms`, since this is the upper limit.

<!-- gh-issue-number: gh-135304 -->
* Issue: gh-135304
<!-- /gh-issue-number -->
