### PR TITLE
Fix assert Crash for certain Cython generated functions

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1015,7 +1015,7 @@ failed:
 int
 PyCode_Addr2Line(PyCodeObject *co, int addrq)
 {
-    if (addrq < 0) {
+    if (addrq < 0 || _PyCode_NBYTES(co)) {
         return co->co_firstlineno;
     }
     if (co->_co_monitoring && co->_co_monitoring->lines) {
@@ -1232,7 +1232,7 @@ PyCode_Addr2Location(PyCodeObject *co, int addrq,
                      int *start_line, int *start_column,
                      int *end_line, int *end_column)
 {
-    if (addrq < 0) {
+    if (addrq < 0 || _PyCode_NBYTES(co) == 0) {
         *start_line = *end_line = co->co_firstlineno;
         *start_column = *end_column = 0;
         return 1;

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1015,7 +1015,7 @@ failed:
 int
 PyCode_Addr2Line(PyCodeObject *co, int addrq)
 {
-    if (addrq < 0 || _PyCode_NBYTES(co)) {
+    if (addrq < 0 || addrq == _PyCode_NBYTES(co)) {
         return co->co_firstlineno;
     }
     if (co->_co_monitoring && co->_co_monitoring->lines) {
@@ -1232,7 +1232,7 @@ PyCode_Addr2Location(PyCodeObject *co, int addrq,
                      int *start_line, int *start_column,
                      int *end_line, int *end_column)
 {
-    if (addrq < 0 || _PyCode_NBYTES(co) == 0) {
+    if (addrq < 0 || addrq == _PyCode_NBYTES(co)) {
         *start_line = *end_line = co->co_firstlineno;
         *start_column = *end_column = 0;
         return 1;


### PR DESCRIPTION
I encountered a crash from the asertion line (e.g. 1240) when running a Cython generated extension module (grpc-python, which creates async def functions) under PYTHONDEBUGMODE.

It appears that the co object created by Cython in this case has nbytes == 8 and somehow the addrq is also 8. This is probably some sort of empty code object convention but I am out of my depth here. 

Without this patch the assertion below crashes the interpreter. If I simply comment out the assertion the line numbers shows up as None; but I worry some of the returning value being -1 is used as an indication of errors. In any case there is no real byte code so I think we should return something like 0 to indicate such. 
