### PR TITLE
gh-135321: Changing data type of `size` variable for `BINSTRING` in `_pickle`

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1101,7 +1101,7 @@ class AbstractUnpickleTests:
                                     dumped)
 
     def test_large_binstring(self):
-        errmsg = 'UnpicklingError: BINSTRING pickle has negative byte count'
+        errmsg = 'BINSTRING pickle has negative byte count'
         with self.assertRaisesRegex(pickle.UnpicklingError, errmsg):
             self.loads(b'T\0\0\0\x80')
 

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1100,6 +1100,11 @@ class AbstractUnpickleTests:
         self.check_unpickling_error((pickle.UnpicklingError, OverflowError),
                                     dumped)
 
+    def test_large_binstring(self):
+        errmsg = 'UnpicklingError: BINSTRING pickle has negative byte count'
+        with self.assertRaisesRegex(pickle.UnpicklingError, errmsg):
+            self.loads(b'T\0\0\0\x80')
+
     def test_get(self):
         pickled = b'((lp100000\ng100000\nt.'
         unpickled = self.loads(pickled)

--- a/Misc/NEWS.d/next/Library/2025-06-10-00-42-30.gh-issue-135321.UHh9jT.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-10-00-42-30.gh-issue-135321.UHh9jT.rst
@@ -1,0 +1,1 @@
+The ``BINSTRING`` opcode of the C accelerator implementation of :mod:`pickle` was modified to have a signed 32-bit data type instead of 64-bit, keeping in line with the Python implementation of :mod:`pickle` and :mod:`pickletools`.

--- a/Misc/NEWS.d/next/Library/2025-06-10-00-42-30.gh-issue-135321.UHh9jT.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-10-00-42-30.gh-issue-135321.UHh9jT.rst
@@ -1,1 +1,1 @@
-The ``BINSTRING`` opcode of the C accelerator implementation of :mod:`pickle` was modified to have a signed 32-bit data type instead of 64-bit, keeping in line with the Python implementation of :mod:`pickle` and :mod:`pickletools`.
+Raise a correct exception for values greater than 0x7fffffff for the ``BINSTRING`` opcode in the C implementation of :mod:`pickle`.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -5543,7 +5543,7 @@ static int
 load_counted_binstring(PickleState *st, UnpicklerObject *self, int nbytes)
 {
     PyObject *obj;
-    Py_ssize_t size;
+    int size;
     char *s;
 
     if (_Unpickler_Read(self, st, &s, nbytes) < 0)
@@ -5551,9 +5551,8 @@ load_counted_binstring(PickleState *st, UnpicklerObject *self, int nbytes)
 
     size = calc_binsize(s, nbytes);
     if (size < 0) {
-        PyErr_Format(st->UnpicklingError,
-                     "BINSTRING exceeds system's maximum size of %zd bytes",
-                     PY_SSIZE_T_MAX);
+        PyErr_SetString(st->UnpicklingError,
+                     "BINSTRING pickle has negative byte count");
         return -1;
     }
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -5549,7 +5549,7 @@ load_counted_binstring(PickleState *st, UnpicklerObject *self, int nbytes)
     if (_Unpickler_Read(self, st, &s, nbytes) < 0)
         return -1;
 
-    size = calc_binsize(s, nbytes);
+    size = calc_binint(s, nbytes);
     if (size < 0) {
         PyErr_SetString(st->UnpicklingError,
                      "BINSTRING pickle has negative byte count");

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -5543,7 +5543,7 @@ static int
 load_counted_binstring(PickleState *st, UnpicklerObject *self, int nbytes)
 {
     PyObject *obj;
-    int size;
+    long size;
     char *s;
 
     if (_Unpickler_Read(self, st, &s, nbytes) < 0)


### PR DESCRIPTION
I changed the data type to `int` from `Py_ssize_t` for the `size` variable. This variable is also used as an argument to 3 other functions but should be auto-casted (similar to [`load_counted_long`](https://github.com/python/cpython/blob/a58026a5e3da9ca2d09ef51aa90fe217f9a975ec/Modules/_pickle.c#L5422)). I also changed the error message to [match the error message in the Python `load_binstring()` function](https://github.com/python/cpython/blob/754e7c9b5187fcad22acf7555479603f173a4a09/Lib/pickle.py#L1458C36-L1458C76).

I would like to add tests for this specific case, but the payload that would show whether or not it works as intended requires a 2GB large pickle, and I'm not sure if you'd like that to be in the tests. Let me know what you think.

<!-- gh-issue-number: gh-135321 -->
* Issue: gh-135321
<!-- /gh-issue-number -->
