### PR TITLE
Docs: Fix and improve the `PyUnstable_Object_EnableDeferredRefcount` documentation

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -596,12 +596,13 @@ Object Protocol
    if supported by the runtime.  In the :term:`free-threaded <free threading>` build,
    this allows the interpreter to avoid reference count adjustments to *obj*,
    which may improve multi-threaded performance.  The tradeoff is
-   that *obj* will only be deallocated by the tracing garbage collector.
+   that *obj* will only be deallocated by the tracing garbage collector, and
+   not when the object's :term:`reference count` reaches zero.
 
-   This function returns ``1`` if deferred reference counting is enabled on *obj*
-   (including when it was enabled before the call),
+   This function returns ``1`` if deferred reference counting is enabled on *obj*,
    and ``0`` if deferred reference counting is not supported or if the hint was
-   ignored by the runtime. This function is thread-safe, and cannot fail.
+   ignored by the interpreter, such as when deferred reference counting is already
+   enabled on *obj*. This function is thread-safe, and cannot fail.
 
    This function does nothing on builds with the :term:`GIL` enabled, which do
    not support deferred reference counting. This also does nothing if *obj* is not
@@ -609,7 +610,8 @@ Object Protocol
    :c:func:`PyObject_GC_IsTracked`).
 
    This function is intended to be used soon after *obj* is created,
-   by the code that creates it.
+   by the code that creates it, such as in the object's :c:member:`~PyTypeObject.tp_new`
+   slot.
 
    .. versionadded:: 3.14
 

--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -597,7 +597,7 @@ Object Protocol
    this allows the interpreter to avoid reference count adjustments to *obj*,
    which may improve multi-threaded performance.  The tradeoff is
    that *obj* will only be deallocated by the tracing garbage collector, and
-   not when the object's :term:`reference count` reaches zero.
+   not when the interpreter no longer has any references to it.
 
    This function returns ``1`` if deferred reference counting is enabled on *obj*,
    and ``0`` if deferred reference counting is not supported or if the hint was


### PR DESCRIPTION
1. Clarify that the object isn't immediately deallocated when the interpreter is done with it.
2. Fix the documented return value; it's documented as returning `1` when DRC is already enabled, but it actually returns `0`.
3. Mention the `tp_new` slot, where it should generally be used.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135323.org.readthedocs.build/en/135323/c-api/object.html#c.PyUnstable_Object_EnableDeferredRefcount

<!-- readthedocs-preview cpython-previews end -->