### PR TITLE
gh-135335: flush stdout/stderr in forkserver after preloading modules

### DIFF
--- a/Lib/multiprocessing/forkserver.py
+++ b/Lib/multiprocessing/forkserver.py
@@ -222,6 +222,10 @@ def main(listener_fd, alive_r, preload, main_path=None, sys_path=None,
             except ImportError:
                 pass
 
+        # gh-135335: flush stdout/stderr in case any of the preloaded modules
+        # wrote to them, otherwise children might inherit buffered data
+        util._flush_std_streams()
+
     util._close_stdin()
 
     sig_r, sig_w = os.pipe()

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6818,9 +6818,12 @@ class _TestSpawnedSysPath(BaseTestCase):
                     print('stderr', file=sys.stderr)''')
 
         name = os.path.join(os.path.dirname(__file__), 'mp_preload_flush.py')
-        env = {'PYTHONPATH': ":".join(sys.path)}
+        env = {'PYTHONPATH': self._temp_dir}
         rc, out, err = test.support.script_helper.assert_python_ok(name, **env)
         self.assertEqual(rc, 0)
+
+        # We want to see all the output if it isn't as expected
+        self.maxDiff = None
         self.assertEqual(out.decode().rstrip(), 'stdout')
         self.assertEqual(err.decode().rstrip(), 'stderr')
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6824,8 +6824,8 @@ class _TestSpawnedSysPath(BaseTestCase):
 
         # We want to see all the output if it isn't as expected
         self.maxDiff = None
-        self.assertEqual(out.decode().rstrip(), 'stdout')
         self.assertEqual(err.decode().rstrip(), 'stderr')
+        self.assertEqual(out.decode().rstrip(), 'stdout')
 
 
 class MiscTestCase(unittest.TestCase):

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6801,6 +6801,29 @@ class _TestSpawnedSysPath(BaseTestCase):
         self.assertEqual(child_sys_path[1:], sys.path[1:])
         self.assertIsNone(import_error, msg=f"child could not import {self._mod_name}")
 
+    def test_std_streams_flushed_after_preload(self):
+        # gh-135335: Check fork server flushes standard streams after
+        # preloading modules
+        if multiprocessing.get_start_method() != "forkserver":
+            self.skipTest("forkserver specific test")
+
+        # Create a test module in the temporary directory on the child's path
+        # TODO: This can all be simplified once gh-126631 is fixed and we can
+        #       use __main__ instead of a module.
+        os.mkdir(os.path.join(self._temp_dir, 'a'))
+        with open(os.path.join(self._temp_dir, 'a', '__init__.py'), "w") as f:
+            f.write('''if 1:
+                    import sys
+                    print('stdout', file=sys.stdout)
+                    print('stderr', file=sys.stderr)''')
+
+        name = os.path.join(os.path.dirname(__file__), 'mp_preload_flush.py')
+        env = {'PYTHONPATH': ":".join(sys.path)}
+        rc, out, err = test.support.script_helper.assert_python_ok(name, **env)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.decode().rstrip(), 'stdout')
+        self.assertEqual(err.decode().rstrip(), 'stderr')
+
 
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6829,10 +6829,8 @@ class _TestSpawnedSysPath(BaseTestCase):
             support.print_warning(err.decode())
         self.assertEqual(rc, 0)
 
-        # We want to see all the output if it isn't as expected.
         # Check stderr first, as it is more likely to be useful to see in the
         # event of a failure.
-        self.maxDiff = None
         self.assertEqual(err.decode().rstrip(), 'stderr')
         self.assertEqual(out.decode().rstrip(), 'stdout')
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6820,6 +6820,9 @@ class _TestSpawnedSysPath(BaseTestCase):
         name = os.path.join(os.path.dirname(__file__), 'mp_preload_flush.py')
         env = {'PYTHONPATH': self._temp_dir}
         rc, out, err = test.support.script_helper.assert_python_ok(name, **env)
+        if rc:
+            support.print_warning("preload flush test failed with stderr:")
+            support.print_warning(err.decode())
         self.assertEqual(rc, 0)
 
         # We want to see all the output if it isn't as expected

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6823,11 +6823,7 @@ class _TestSpawnedSysPath(BaseTestCase):
 
         name = os.path.join(os.path.dirname(__file__), 'mp_preload_flush.py')
         env = {'PYTHONPATH': self._temp_dir}
-        rc, out, err = test.support.script_helper.assert_python_ok(name, **env)
-        if rc:
-            support.print_warning("preload flush test failed with stderr:")
-            support.print_warning(err.decode())
-        self.assertEqual(rc, 0)
+        _, out, err = test.support.script_helper.assert_python_ok(name, **env)
 
         # Check stderr first, as it is more likely to be useful to see in the
         # event of a failure.

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6816,8 +6816,8 @@ class _TestSpawnedSysPath(BaseTestCase):
         with open(init_name, "w") as f:
             cmd = '''if 1:
                 import sys
-                print('stderr', file=sys.stderr)
-                print('stdout', file=sys.stdout)
+                print('stderr', end='', file=sys.stderr)
+                print('stdout', end='', file=sys.stdout)
             '''
             f.write(cmd)
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6816,8 +6816,8 @@ class _TestSpawnedSysPath(BaseTestCase):
         with open(os.path.join(init_name), "w") as f:
             cmd = '''if 1:
                 import sys
-                print('stdout', file=sys.stdout)
                 print('stderr', file=sys.stderr)
+                print('stdout', file=sys.stdout)
             '''
             f.write(cmd)
 
@@ -6829,7 +6829,9 @@ class _TestSpawnedSysPath(BaseTestCase):
             support.print_warning(err.decode())
         self.assertEqual(rc, 0)
 
-        # We want to see all the output if it isn't as expected
+        # We want to see all the output if it isn't as expected.
+        # Check stderr first, as it is more likely to be useful to see in the
+        # event of a failure.
         self.maxDiff = None
         self.assertEqual(err.decode().rstrip(), 'stderr')
         self.assertEqual(out.decode().rstrip(), 'stdout')

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6815,7 +6815,7 @@ class _TestSpawnedSysPath(BaseTestCase):
             f.write('''if 1:
                     import sys
                     print('stdout', file=sys.stdout)
-                    print('stderr', file=sys.stderr)''')
+                    print('stderr', file=sys.stderr)\n''')
 
         name = os.path.join(os.path.dirname(__file__), 'mp_preload_flush.py')
         env = {'PYTHONPATH': self._temp_dir}

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6810,12 +6810,15 @@ class _TestSpawnedSysPath(BaseTestCase):
         # Create a test module in the temporary directory on the child's path
         # TODO: This can all be simplified once gh-126631 is fixed and we can
         #       use __main__ instead of a module.
-        os.mkdir(os.path.join(self._temp_dir, 'a'))
-        with open(os.path.join(self._temp_dir, 'a', '__init__.py'), "w") as f:
-            f.write('''if 1:
-                    import sys
-                    print('stdout', file=sys.stdout)
-                    print('stderr', file=sys.stderr)\n''')
+        dirname = os.path.join(self._temp_dir, 'preloaded_module')
+        init_name = os.path.join(dirname, '__init__.py')
+        os.mkdir(dirname)
+        with open(os.path.join(init_name), "w") as f:
+            cmd = '''if 1:
+                import sys
+                print('stdout', file=sys.stdout)
+                print('stderr', file=sys.stderr)\n'''
+            f.write(cmd)
 
         name = os.path.join(os.path.dirname(__file__), 'mp_preload_flush.py')
         env = {'PYTHONPATH': self._temp_dir}

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6817,7 +6817,8 @@ class _TestSpawnedSysPath(BaseTestCase):
             cmd = '''if 1:
                 import sys
                 print('stdout', file=sys.stdout)
-                print('stderr', file=sys.stderr)\n'''
+                print('stderr', file=sys.stderr)
+            '''
             f.write(cmd)
 
         name = os.path.join(os.path.dirname(__file__), 'mp_preload_flush.py')

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -6813,7 +6813,7 @@ class _TestSpawnedSysPath(BaseTestCase):
         dirname = os.path.join(self._temp_dir, 'preloaded_module')
         init_name = os.path.join(dirname, '__init__.py')
         os.mkdir(dirname)
-        with open(os.path.join(init_name), "w") as f:
+        with open(init_name, "w") as f:
             cmd = '''if 1:
                 import sys
                 print('stderr', file=sys.stderr)

--- a/Lib/test/mp_preload_flush.py
+++ b/Lib/test/mp_preload_flush.py
@@ -1,0 +1,7 @@
+import multiprocessing
+if __name__ == '__main__':
+    multiprocessing.set_forkserver_preload(['a'])
+    for _ in range(2):
+        p = multiprocessing.Process()
+        p.start()
+        p.join()

--- a/Lib/test/mp_preload_flush.py
+++ b/Lib/test/mp_preload_flush.py
@@ -3,6 +3,7 @@ import sys
 
 if __name__ == '__main__':
     assert 'a' not in sys.modules
+    multiprocessing.set_start_method('forkserver')
     multiprocessing.set_forkserver_preload(['a'])
     for _ in range(2):
         p = multiprocessing.Process()

--- a/Lib/test/mp_preload_flush.py
+++ b/Lib/test/mp_preload_flush.py
@@ -10,5 +10,5 @@ if __name__ == '__main__':
         p = multiprocessing.Process()
         p.start()
         p.join()
-else:
-    assert modname in sys.modules
+elif modname not in sys.modules:
+    raise AssertionError(f'{modname!r} is not in sys.modules')

--- a/Lib/test/mp_preload_flush.py
+++ b/Lib/test/mp_preload_flush.py
@@ -1,13 +1,14 @@
 import multiprocessing
 import sys
 
+modname = 'preloaded_module'
 if __name__ == '__main__':
-    assert 'a' not in sys.modules
+    assert modname not in sys.modules
     multiprocessing.set_start_method('forkserver')
-    multiprocessing.set_forkserver_preload(['a'])
+    multiprocessing.set_forkserver_preload([modname])
     for _ in range(2):
         p = multiprocessing.Process()
         p.start()
         p.join()
 else:
-    assert 'a' in sys.modules
+    assert modname in sys.modules

--- a/Lib/test/mp_preload_flush.py
+++ b/Lib/test/mp_preload_flush.py
@@ -3,7 +3,8 @@ import sys
 
 modname = 'preloaded_module'
 if __name__ == '__main__':
-    assert modname not in sys.modules
+    if modname in sys.modules:
+        raise AssertionError(f'{modname!r} is not in sys.modules')
     multiprocessing.set_start_method('forkserver')
     multiprocessing.set_forkserver_preload([modname])
     for _ in range(2):

--- a/Lib/test/mp_preload_flush.py
+++ b/Lib/test/mp_preload_flush.py
@@ -1,7 +1,12 @@
 import multiprocessing
+import sys
+
 if __name__ == '__main__':
+    assert 'a' not in sys.modules
     multiprocessing.set_forkserver_preload(['a'])
     for _ in range(2):
         p = multiprocessing.Process()
         p.start()
         p.join()
+else:
+    assert 'a' in sys.modules

--- a/Misc/NEWS.d/next/Library/2025-06-10-21-42-04.gh-issue-135335.WnUqb_.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-10-21-42-04.gh-issue-135335.WnUqb_.rst
@@ -1,2 +1,2 @@
-Flush ``stdout`` and ``stderr`` after preloading modules in the
-:mod:`multiprocessing` ``forkserver``.
+:mod:`multiprocessing`: Flush ``stdout`` and ``stderr`` after preloading
+modules in the ``forkserver``.

--- a/Misc/NEWS.d/next/Library/2025-06-10-21-42-04.gh-issue-135335.WnUqb_.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-10-21-42-04.gh-issue-135335.WnUqb_.rst
@@ -1,0 +1,2 @@
+Flush ``stdout`` and ``stderr`` after preloading modules in the
+:mod:`multiprocessing` ``forkserver``.


### PR DESCRIPTION
If a preloaded module writes to stdout or stderr, and the stream is buffered, child processes will inherit the buffered data after forking. Attempt to prevent this by flushing the streams after preload.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135335 -->
* Issue: gh-135335
<!-- /gh-issue-number -->
