### PR TITLE
gh-135171: Update documentation for the generator expression

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -406,7 +406,8 @@ brackets or curly braces.
 Variables used in the generator expression are evaluated lazily when the
 :meth:`~generator.__next__` method is called for the generator object (in the same
 fashion as normal generators).  However, the iterable expression in the
-leftmost :keyword:`!for` clause is immediately evaluated, so that an error
+leftmost :keyword:`!for` clause is immediately evaluated, and the
+:term:`iterator` is immediately created for that iterable, so that an error
 produced by it will be emitted at the point where the generator expression
 is defined, rather than at the point where the first value is retrieved.
 Subsequent :keyword:`!for` clauses and any filter condition in the leftmost

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -408,7 +408,7 @@ Variables used in the generator expression are evaluated lazily when the
 fashion as normal generators).  However, the iterable expression in the
 leftmost :keyword:`!for` clause is immediately evaluated, and the
 :term:`iterator` is immediately created for that iterable, so that an error
-produced by it will be emitted at the point where the generator expression
+produced while creating the iterator will be emitted at the point where the generator expression
 is defined, rather than at the point where the first value is retrieved.
 Subsequent :keyword:`!for` clauses and any filter condition in the leftmost
 :keyword:`!for` clause cannot be evaluated in the enclosing scope as they may

--- a/Misc/NEWS.d/next/Documentation/2025-06-10-17-02-06.gh-issue-135171.quHvts.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-06-10-17-02-06.gh-issue-135171.quHvts.rst
@@ -1,0 +1,2 @@
+Document that the :term:`iterator` for the leftmost :keyword:`!for` clause
+in the generator expression is created immediately.


### PR DESCRIPTION
Document that the iterator for the leftmost "for" clause is created immediately.


<!-- gh-issue-number: gh-135171 -->
* Issue: gh-135171
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135351.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->