### PR TITLE
[3.14] GH-135171: Revert async generator expressions behavior

### DIFF
--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -1836,11 +1836,18 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         self.assertEqual(res, [i * 2 for i in range(1, 10)])
 
     def test_async_gen_expression_incorrect(self):
+        async def ag():
+            yield 42
+
+        async def run(arg):
+            (x async for x in arg)
+
         err_msg_async = "'async for' requires an object with " \
             "__aiter__ method, got .*"
 
+        self.loop.run_until_complete(run(ag()))
         with self.assertRaisesRegex(TypeError, err_msg_async):
-            (x async for x in None)
+            self.loop.run_until_complete(run(None))
 
     def test_asyncgen_nonstarted_hooks_are_cancellable(self):
         # See https://bugs.python.org/issue38013

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -1835,6 +1835,13 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         res = self.loop.run_until_complete(run())
         self.assertEqual(res, [i * 2 for i in range(1, 10)])
 
+    def test_async_gen_expression_incorrect(self):
+        err_msg_async = "'async for' requires an object with " \
+            "__aiter__ method, got .*"
+
+        with self.assertRaisesRegex(TypeError, err_msg_async):
+            (x async for x in None)
+
     def test_asyncgen_nonstarted_hooks_are_cancellable(self):
         # See https://bugs.python.org/issue38013
         messages = []

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2267,7 +2267,7 @@ class CoroutineTest(unittest.TestCase):
 
     def test_call_aiter_once_in_comprehension(self):
 
-        class Iterator:
+        class AsyncIterator:
 
             def __init__(self):
                 self.val = 0
@@ -2283,12 +2283,17 @@ class CoroutineTest(unittest.TestCase):
         class C:
 
             def __aiter__(self):
-                return Iterator()
+                return AsyncIterator()
 
-        async def run():
+        async def run_listcomp():
             return [i async for i in C()]
 
-        self.assertEqual(run_async(run()), ([], [1,2]))
+        async def run_asyncgen():
+            ag = (i async for i in C())
+            return [i async for i in ag]
+
+        self.assertEqual(run_async(run_listcomp()), ([], [1, 2]))
+        self.assertEqual(run_async(run_asyncgen()), ([], [1, 2]))
 
 
 @unittest.skipIf(

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -288,7 +288,7 @@ class GeneratorTest(unittest.TestCase):
             def __iter__(self):
                 return Iterator()
 
-        self.assertEqual([1,2], list(i for i in C()))
+        self.assertEqual([1, 2], list(i for i in C()))
 
 
 class ModifyUnderlyingIterableTest(unittest.TestCase):

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -770,7 +770,7 @@ class ListComprehensionTest(unittest.TestCase):
             def __iter__(self):
                 return Iterator()
 
-        self.assertEqual([1,2], [i for i in C()])
+        self.assertEqual([1, 2], [i for i in C()])
 
 __test__ = {'doctests' : doctests}
 

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-10-17-37-11.gh-issue-135171.P9UDfS.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-10-17-37-11.gh-issue-135171.P9UDfS.rst
@@ -1,0 +1,2 @@
+Reverts the behavior of async generator expressions when created with object
+w/o __aiter__ method to the pre-3.13 behavior of raising a TypeError.

--- a/Python/codegen.c
+++ b/Python/codegen.c
@@ -4411,7 +4411,6 @@ codegen_sync_comprehension_generator(compiler *c, location loc,
 
     comprehension_ty gen = (comprehension_ty)asdl_seq_GET(generators,
                                                           gen_index);
-    int is_outer_genexpr = gen_index == 0 && type == COMP_GENEXP;
     if (!iter_on_stack) {
         if (gen_index == 0) {
             assert(METADATA(c)->u_argcount == 1);
@@ -4442,15 +4441,13 @@ codegen_sync_comprehension_generator(compiler *c, location loc,
             }
             if (IS_JUMP_TARGET_LABEL(start)) {
                 VISIT(c, expr, gen->iter);
+                ADDOP(c, LOC(gen->iter), GET_ITER);
             }
         }
     }
 
     if (IS_JUMP_TARGET_LABEL(start)) {
         depth++;
-        if (!is_outer_genexpr) {
-            ADDOP(c, LOC(gen->iter), GET_ITER);
-        }
         USE_LABEL(c, start);
         ADDOP_JUMP(c, LOC(gen->iter), FOR_ITER, anchor);
     }


### PR DESCRIPTION
This PR could be a part of https://github.com/python/cpython/pull/135225.
Changes in behavior of async generator expressions are also reverted.

@serhiy-storchaka @markshannon @Yhg1s 

<!-- gh-issue-number: gh-135171 -->
* Issue: gh-135171
<!-- /gh-issue-number -->
