### PR TITLE
gh-133465: Efficient signal checks with detached thread state.

### DIFF
--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -235,6 +235,8 @@ PyAPI_FUNC(void) PyErr_WriteUnraisable(PyObject *);
 
 /* In signalmodule.c */
 PyAPI_FUNC(int) PyErr_CheckSignals(void);
+PyAPI_FUNC(int) PyErr_CheckSignalsDetached(PyThreadState *state);
+PyAPI_FUNC(int) PyErr_AreSignalsPending(PyThreadState *state);
 PyAPI_FUNC(void) PyErr_SetInterrupt(void);
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x030A0000
 PyAPI_FUNC(int) PyErr_SetInterruptEx(int signum);

--- a/Misc/NEWS.d/next/C_API/2025-06-10-13-10-23.gh-issue-133465.PzxlaV.rst
+++ b/Misc/NEWS.d/next/C_API/2025-06-10-13-10-23.gh-issue-133465.PzxlaV.rst
@@ -1,0 +1,4 @@
+New functions :c:func:`PyErr_CheckSignalsDetached` and
+:c:func:`PyErr_AreSignalsPending` for responding to signals
+from within C extension modules that detach the thread state.
+Patch by Zack Weinberg.


### PR DESCRIPTION
Add new C-API functions `PyErr_CheckSignalsDetached` and `PyErr_AreSignalsPending`.

`PyErr_CheckSignalsDetached` can *only* be called by threads that *don’t* have an attached thread state.  It does the same thing as `PyErr_CheckSignals`, except that it guarantees it will only reattach the supplied thread state if necessary in order to run signal handlers.  (Also, it never runs the cycle collector.)

`PyErr_AreSignalsPending` can be called with or without an attached thread state.  It reports to its caller whether signals are pending, but never runs any handlers itself.

Rationale: Compiled-code modules that implement time-consuming operations that don’t require manipulating Python objects, are supposed to call PyErr_CheckSignals frequently throughout each such operation, so that if the user interrupts the operation with control-C, it is canceled promptly.

In the normal case where no signals are pending, PyErr_CheckSignals is cheap (two atomic memory operations); however, callers must have an attached thread state, and compiled-code modules that implement time-consuming operations are also supposed to detach their thread state during each such operation.  The overhead of re-attaching a thread state in order to call PyErr_CheckSignals, and then releasing it again, sufficiently often for reasonable user responsiveness, can be substantial, particularly in traditional (non-free-threaded) builds. These new functions permit compiled-code modules to avoid that extra overhead.

<!-- gh-issue-number: gh-133465 -->
* Issue: gh-133465
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135358.org.readthedocs.build/en/135358/c-api/exceptions.html#c.PyErr_CheckSignalsDetached

<!-- readthedocs-preview cpython-previews end -->