### PR TITLE
gh-128627: Fix iPad detection in wasm-gc

### DIFF
--- a/Python/emscripten_trampoline.c
+++ b/Python/emscripten_trampoline.c
@@ -71,7 +71,13 @@ EM_JS(CountArgsFunc, _PyEM_GetCountArgsPtr, (), {
 // )
 
 function getPyEMCountArgsPtr() {
-    let isIOS = globalThis.navigator && /iPad|iPhone|iPod/.test(navigator.platform);
+    let isIOS = globalThis.navigator && (
+        /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+        // Starting with iPadOS 13, iPads might send a platform string that looks like a desktop Mac.
+        // To differentiate, we check if the platform is 'MacIntel' (common for Macs and newer iPads)
+        // AND if the device has multi-touch capabilities (navigator.maxTouchPoints > 1)
+        (navigator.platform === 'MacIntel' && typeof navigator.maxTouchPoints !== 'undefined' && navigator.maxTouchPoints > 1)
+    )
     if (isIOS) {
         return 0;
     }

--- a/Python/emscripten_trampoline.c
+++ b/Python/emscripten_trampoline.c
@@ -71,6 +71,9 @@ EM_JS(CountArgsFunc, _PyEM_GetCountArgsPtr, (), {
 // )
 
 function getPyEMCountArgsPtr() {
+    // Starting with iOS 18.3.1, WebKit on iOS has an issue with the garbage
+    // collector that breaks the call trampoline. See #130418 and
+    // https://bugs.webkit.org/show_bug.cgi?id=293113 for details.
     let isIOS = globalThis.navigator && (
         /iPad|iPhone|iPod/.test(navigator.userAgent) ||
         // Starting with iPadOS 13, iPads might send a platform string that looks like a desktop Mac.


### PR DESCRIPTION
As of iOS / iPadOS 18.3.1, enabling wasm-gc is making the interpreter fail to load. 

This issue was handled by @ambv in #130418, but that fix had an issue with not detecting the iPad correctly.
In iPad + Safari, iPad behaves like a Mac and checking `iPad` string in `navigator.platform` fails to detect iPad.

Confirmed on device + downstream PR (https://github.com/pyodide/pyodide/pull/5695)

cc: @hoodmane @WebReflection



<!-- gh-issue-number: gh-128627 -->
* Issue: gh-128627
<!-- /gh-issue-number -->
