### PR TITLE
gh-135385: Fix memory regression for classes with both __slots__ and __dict__

### DIFF
--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-11-21-40-21.gh-issue-135385.e2TFON.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-11-21-40-21.gh-issue-135385.e2TFON.rst
@@ -1,2 +1,2 @@
-Fixed a memory regression for classes that have both ``__slots__`` and
-``__dict__``.
+Fix a memory regression for classes that have both :attr:`~object.__slots__` and
+:attr:`~object.__dict__`.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-11-21-40-21.gh-issue-135385.e2TFON.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-11-21-40-21.gh-issue-135385.e2TFON.rst
@@ -1,0 +1,2 @@
+Fixed a memory regression for classes that have both ``__slots__`` and
+``__dict__``.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4621,7 +4621,19 @@ type_new_descriptors(const type_new_ctx *ctx, PyTypeObject *type)
     }
 
     type->tp_basicsize = slotoffset;
-    type->tp_itemsize = ctx->base->tp_itemsize;
+
+    // Only inherit tp_itemsize if this type defines its own __slots__
+    // Classes that don't define __slots__ but inherit from __slots__ classes
+    // should not inherit tp_itemsize as they don't use variable-size items
+    if (et->ht_slots != NULL && PyTuple_GET_SIZE(et->ht_slots) > 0) {
+        // This type defines its own __slots__, inherit tp_itemsize
+        type->tp_itemsize = ctx->base->tp_itemsize;
+    }
+    else {
+        // This type doesn't define __slots__, don't inherit tp_itemsize
+        type->tp_itemsize = 0;
+    }
+
     type->tp_members = _PyHeapType_GET_MEMBERS(et);
     return 0;
 }


### PR DESCRIPTION
**EDIT:** Apologies, I commited my pr before seeing Eclips4's comment. I have since confirmed locally by compiling and testing the `main` branch that this issue is indeed fixed there.
This PR should NOT be merged or backported. It would fail to fix the bug on 3.13 and could potentially mask the real issue or introduce other instabilities.

---

This patch fixes a significant memory regression in Python 3.13 where classes that inherit \_\_slots\_\_ but also have a \_\_dict\_\_ consume ~4x more memory than necessary.

The root cause was that such subclasses incorrectly inherited a non-zero tp_itemsize from their base. This prevented the Py_TPFLAGS_INLINE_VALUES flag from being set, disabling the key-sharing dictionary optimization.

The fix, located in Objects/typeobject.c, adjusts the logic to ensure a subclass only inherits a non-zero tp_itemsize if it defines its own _\_slots_\_. Otherwise, tp_itemsize is correctly set to 0, re-enabling the memory optimization.

test: 
```bash
PS F:\github\cpython001> .\python.bat -m test -j3 test_class test_types test_dict
Running Debug|x64 interpreter...
Using random seed: 1566459836
0:00:00 Run 3 tests in parallel using 3 worker processes
0:00:01 [1/3] test_class passed
0:00:02 [2/3] test_dict passed
0:00:03 [3/3] test_types passed

== Tests result: SUCCESS ==

All 3 tests OK.

Total duration: 3.5 sec
Total tests: run=273
Total test files: run=3/3
Result: SUCCESS
```

benchmark:
```bash
PS F:\github\cpython001> .\python.bat .\build\o-test.py  
Running Debug|x64 interpreter...
1M Point3D (only __slots__) instances:         64_448_944 bytes
1M Point3D (only __dict__) instances:          104_452_144 bytes
1M Point3D (__dict__ and __slots__) instances: 120_452_144 bytes
```

```python
# o-test.py
import tracemalloc
import gc


class _Point2D:
    __slots__ = ("x", "y")


class Point3D_OnlySlots(_Point2D):
    __slots__ = ("z",)

    def __init__(self, x, y, z):
        self.x, self.y, self.z = x, y, z


class Point3D_DictAndSlots(_Point2D):
    def __init__(self, x, y, z):
        self.x, self.y, self.z = x, y, z


class Point3D_OnlyDict:
    def __init__(self, x, y, z):
        self.x, self.y, self.z = x, y, z


gc.collect()  # clear freelists
tracemalloc.start()
_ = [Point3D_OnlySlots(1, 2, 3) for _ in range(1_000_000)]
print(
    f"1M Point3D (only __slots__) instances:         {tracemalloc.get_traced_memory()[0]:_} bytes"
)

gc.collect()  # clear freelists
tracemalloc.start()
_ = [Point3D_OnlyDict(1, 2, 3) for _ in range(1_000_000)]
print(
    f"1M Point3D (only __dict__) instances:          {tracemalloc.get_traced_memory()[0]:_} bytes"
)

gc.collect()  # clear freelists
tracemalloc.start()
_ = [Point3D_DictAndSlots(1, 2, 3) for _ in range(1_000_000)]
print(
    f"1M Point3D (__dict__ and __slots__) instances: {tracemalloc.get_traced_memory()[0]:_} bytes"
)
```

<!-- gh-issue-number: gh-135385 -->
* Issue: gh-135385
<!-- /gh-issue-number -->
