### PR TITLE
[3.13] GH-135171: Roll back all fixes for GH-127682 as they are not suitable for 3.13

### DIFF
--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2252,31 +2252,6 @@ class CoroutineTest(unittest.TestCase):
         # before fixing, visible stack from throw would be shorter than from send.
         self.assertEqual(len_send, len_throw)
 
-    def test_call_aiter_once_in_comprehension(self):
-
-        class Iterator:
-
-            def __init__(self):
-                self.val = 0
-
-            async def __anext__(self):
-                if self.val == 2:
-                    raise StopAsyncIteration
-                self.val += 1
-                return self.val
-
-            # No __aiter__ method
-
-        class C:
-
-            def __aiter__(self):
-                return Iterator()
-
-        async def run():
-            return [i async for i in C()]
-
-        self.assertEqual(run_async(run()), ([], [1,2]))
-
 
 @unittest.skipIf(
     support.is_emscripten or support.is_wasi,

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -184,6 +184,7 @@ dis_bug1333982 = """\
               LOAD_CONST               1 (<code object <genexpr> at 0x..., file "%s", line %d>)
               MAKE_FUNCTION
               LOAD_FAST                0 (x)
+              GET_ITER
               CALL                     0
 
 %3d           LOAD_CONST               2 (1)
@@ -764,6 +765,7 @@ Disassembly of <code object foo at 0x..., file "%s", line %d>:
                MAKE_FUNCTION
                SET_FUNCTION_ATTRIBUTE   8 (closure)
                LOAD_DEREF               1 (y)
+               GET_ITER
                CALL                     0
                CALL                     1
                RETURN_VALUE

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -246,28 +246,6 @@ class GeneratorTest(unittest.TestCase):
         #This should not raise
         loop()
 
-    def test_genexpr_only_calls_dunder_iter_once(self):
-
-        class Iterator:
-
-            def __init__(self):
-                self.val = 0
-
-            def __next__(self):
-                if self.val == 2:
-                    raise StopIteration
-                self.val += 1
-                return self.val
-
-            # No __iter__ method
-
-        class C:
-
-            def __iter__(self):
-                return Iterator()
-
-        self.assertEqual([1,2], list(i for i in C()))
-
 
 class ModifyUnderlyingIterableTest(unittest.TestCase):
     iterables = [

--- a/Lib/test/test_genexps.py
+++ b/Lib/test/test_genexps.py
@@ -123,6 +123,15 @@ Verify early binding for the outermost for-expression
     >>> list(g)
     [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
 
+Verify that the outermost for-expression makes an immediate check
+for iterability
+
+    >>> (i for i in 6)
+    Traceback (most recent call last):
+      File "<pyshell#4>", line 1, in -toplevel-
+        (i for i in 6)
+    TypeError: 'int' object is not iterable
+
 Verify late binding for the outermost if-expression
 
     >>> include = (2,4,6,8)

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -750,28 +750,6 @@ class ListComprehensionTest(unittest.TestCase):
                 self.assertEqual(f.line[f.colno - indent : f.end_colno - indent],
                                  expected)
 
-    def test_only_calls_dunder_iter_once(self):
-
-        class Iterator:
-
-            def __init__(self):
-                self.val = 0
-
-            def __next__(self):
-                if self.val == 2:
-                    raise StopIteration
-                self.val += 1
-                return self.val
-
-            # No __iter__ method
-
-        class C:
-
-            def __iter__(self):
-                return Iterator()
-
-        self.assertEqual([1,2], [i for i in C()])
-
 __test__ = {'doctests' : doctests}
 
 def load_tests(loader, tests, pattern):

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-11-14-09-12.gh-issue-135171.VUdivl.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-11-14-09-12.gh-issue-135171.VUdivl.rst
@@ -1,0 +1,1 @@
+Roll back changes to generator and list comprehensions that went into 3.13.4 to fix GH-127682, but which involved semantic and bytecode changes not appropriate for a bugfix release.


### PR DESCRIPTION
Roll back commits c6af7f4bf7edc9924efbaa7352c4eb636258d072 (GH-134799), 814ac0d58789fd544855a6c1afb9d89a690a0c3b (GH-134788) and 132bdf6990003df61d30c379a12c041010d00245 (GH-132384), which changed bytecode (not allowed in patch releases) and semantics (also problematic in patch releases). This reopens GH-127682 as an issue.

<!-- gh-issue-number: gh-135171 -->
* Issue: gh-135171
<!-- /gh-issue-number -->
