### PR TITLE
[3.13] GH-135171: Roll back fix for GH-125038 as it's not suitable for 3.13

### DIFF
--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -786,7 +786,6 @@ Disassembly of <code object <genexpr> at 0x..., file "%s", line %d>:
                POP_TOP
        L1:     RESUME                   0
                LOAD_FAST                0 (.0)
-               GET_ITER
        L2:     FOR_ITER                10 (to L3)
                STORE_FAST               1 (z)
                LOAD_DEREF               2 (x)

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -274,21 +274,26 @@ class ModifyUnderlyingIterableTest(unittest.TestCase):
                 yield x
         return gen(range(10))
 
-    def process_tests(self, get_generator):
+    def process_tests(self, get_generator, is_expr):
+        err_iterator = "'.*' object is not an iterator"
+        err_iterable = "'.*' object is not iterable"
         for obj in self.iterables:
             g_obj = get_generator(obj)
             with self.subTest(g_obj=g_obj, obj=obj):
-                self.assertListEqual(list(g_obj), list(obj))
+                if is_expr:
+                    self.assertRaisesRegex(TypeError, err_iterator, list, g_obj)
+                else:
+                    self.assertListEqual(list(g_obj), list(obj))
 
             g_iter = get_generator(iter(obj))
             with self.subTest(g_iter=g_iter, obj=obj):
                 self.assertListEqual(list(g_iter), list(obj))
 
-        err_regex = "'.*' object is not iterable"
         for obj in self.non_iterables:
             g_obj = get_generator(obj)
             with self.subTest(g_obj=g_obj):
-                self.assertRaisesRegex(TypeError, err_regex, list, g_obj)
+                err = err_iterator if is_expr else err_iterable
+                self.assertRaisesRegex(TypeError, err, list, g_obj)
 
     def test_modify_f_locals(self):
         def modify_f_locals(g, local, obj):
@@ -301,8 +306,8 @@ class ModifyUnderlyingIterableTest(unittest.TestCase):
         def get_generator_genfunc(obj):
             return modify_f_locals(self.genfunc(), 'it', obj)
 
-        self.process_tests(get_generator_genexpr)
-        self.process_tests(get_generator_genfunc)
+        self.process_tests(get_generator_genexpr, True)
+        self.process_tests(get_generator_genfunc, False)
 
     def test_new_gen_from_gi_code(self):
         def new_gen_from_gi_code(g, obj):
@@ -315,8 +320,8 @@ class ModifyUnderlyingIterableTest(unittest.TestCase):
         def get_generator_genfunc(obj):
             return new_gen_from_gi_code(self.genfunc(), obj)
 
-        self.process_tests(get_generator_genexpr)
-        self.process_tests(get_generator_genfunc)
+        self.process_tests(get_generator_genexpr, True)
+        self.process_tests(get_generator_genfunc, False)
 
 
 class ExceptionTest(unittest.TestCase):

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -2599,7 +2599,14 @@ dummy_func(
 
         replaced op(_FOR_ITER, (iter -- iter, next)) {
             /* before: [iter]; after: [iter, iter()] *or* [] (and jump over END_FOR.) */
-            next = (*Py_TYPE(iter)->tp_iternext)(iter);
+            iternextfunc func = Py_TYPE(iter)->tp_iternext;
+            if (func == NULL) {
+                _PyErr_Format(tstate, PyExc_TypeError,
+                              "'%.100s' object is not an iterator",
+                              Py_TYPE(iter)->tp_name);
+                ERROR_NO_POP();
+            }
+            next = func(iter);
             if (next == NULL) {
                 if (_PyErr_Occurred(tstate)) {
                     if (!_PyErr_ExceptionMatches(tstate, PyExc_StopIteration)) {
@@ -2622,7 +2629,14 @@ dummy_func(
 
         op(_FOR_ITER_TIER_TWO, (iter -- iter, next)) {
             /* before: [iter]; after: [iter, iter()] *or* [] (and jump over END_FOR.) */
-            next = (*Py_TYPE(iter)->tp_iternext)(iter);
+            iternextfunc func = Py_TYPE(iter)->tp_iternext;
+            if (func == NULL) {
+                _PyErr_Format(tstate, PyExc_TypeError,
+                              "'%.100s' object is not an iterator",
+                              Py_TYPE(iter)->tp_name);
+                ERROR_NO_POP();
+            }
+            next = func(iter);
             if (next == NULL) {
                 if (_PyErr_Occurred(tstate)) {
                     if (!_PyErr_ExceptionMatches(tstate, PyExc_StopIteration)) {
@@ -2643,7 +2657,14 @@ dummy_func(
         inst(INSTRUMENTED_FOR_ITER, (unused/1 -- )) {
             _Py_CODEUNIT *target;
             PyObject *iter = TOP();
-            PyObject *next = (*Py_TYPE(iter)->tp_iternext)(iter);
+            iternextfunc func = Py_TYPE(iter)->tp_iternext;
+            if (func == NULL) {
+                _PyErr_Format(tstate, PyExc_TypeError,
+                              "'%.100s' object is not an iterator",
+                              Py_TYPE(iter)->tp_name);
+                ERROR_NO_POP();
+            }
+            PyObject *next = func(iter);
             if (next != NULL) {
                 PUSH(next);
                 target = next_instr;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5407,7 +5407,6 @@ compiler_sync_comprehension_generator(struct compiler *c, location loc,
 
     if (IS_LABEL(start)) {
         depth++;
-        ADDOP(c, LOC(gen->iter), GET_ITER);
         USE_LABEL(c, start);
         ADDOP_JUMP(c, LOC(gen->iter), FOR_ITER, anchor);
     }

--- a/Python/executor_cases.c.h
+++ b/Python/executor_cases.c.h
@@ -2629,7 +2629,14 @@
             PyObject *next;
             iter = stack_pointer[-1];
             /* before: [iter]; after: [iter, iter()] *or* [] (and jump over END_FOR.) */
-            next = (*Py_TYPE(iter)->tp_iternext)(iter);
+            iternextfunc func = Py_TYPE(iter)->tp_iternext;
+            if (func == NULL) {
+                _PyErr_Format(tstate, PyExc_TypeError,
+                              "'%.100s' object is not an iterator",
+                              Py_TYPE(iter)->tp_name);
+                JUMP_TO_ERROR();
+            }
+            next = func(iter);
             if (next == NULL) {
                 if (_PyErr_Occurred(tstate)) {
                     if (!_PyErr_ExceptionMatches(tstate, PyExc_StopIteration)) {

--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -2787,7 +2787,14 @@
             // _FOR_ITER
             {
                 /* before: [iter]; after: [iter, iter()] *or* [] (and jump over END_FOR.) */
-                next = (*Py_TYPE(iter)->tp_iternext)(iter);
+                iternextfunc func = Py_TYPE(iter)->tp_iternext;
+                if (func == NULL) {
+                    _PyErr_Format(tstate, PyExc_TypeError,
+                              "'%.100s' object is not an iterator",
+                              Py_TYPE(iter)->tp_name);
+                    goto error;
+                }
+                next = func(iter);
                 if (next == NULL) {
                     if (_PyErr_Occurred(tstate)) {
                         if (!_PyErr_ExceptionMatches(tstate, PyExc_StopIteration)) {
@@ -3303,7 +3310,14 @@
             /* Skip 1 cache entry */
             _Py_CODEUNIT *target;
             PyObject *iter = TOP();
-            PyObject *next = (*Py_TYPE(iter)->tp_iternext)(iter);
+            iternextfunc func = Py_TYPE(iter)->tp_iternext;
+            if (func == NULL) {
+                _PyErr_Format(tstate, PyExc_TypeError,
+                              "'%.100s' object is not an iterator",
+                              Py_TYPE(iter)->tp_name);
+                goto error;
+            }
+            PyObject *next = func(iter);
             if (next != NULL) {
                 PUSH(next);
                 target = next_instr;


### PR DESCRIPTION
Roll back PR https://github.com/python/cpython/pull/125846 and add additional null check for FOR_ITER from https://github.com/python/cpython/pull/135225.

IMO, after this PR being merged all generator expression related bytecode will be reverted for 3.13.0 version.

cc @Yhg1s @serhiy-storchaka @markshannon 

<!-- gh-issue-number: gh-135171 -->
* Issue: gh-135171
<!-- /gh-issue-number -->
