### PR TITLE
gh-124825: Adding PurePath.erase_parents() to pathlib

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -383,6 +383,27 @@ class PurePath(object):
         are created from methods like `iterdir()`.
         """
         return type(self)(*pathsegments)
+        
+    def erase_parents(self):
+        r"""
+        Remove path components referring to parent directories ('..'),
+        without any attempt to verify the existence or structure of any
+        path components.
+    
+        If this is a relative path, there may be leftover '..' segments
+        after erasing parent segments. For example:
+    
+        - Path('spam/../../eggs').erase_parents() == Path('../eggs')
+    
+        If this is an absolute path, and it reaches the root filesystem
+        (or the root of a drive or UNC share for Windows paths),
+        further '..' components will be ignored. For example:
+    
+        - Path('/spam/../../../eggs').erase_parents() == Path('/eggs')
+        - PureWindowsPath(r'c:\spam\..\..\eggs').erase_parents() == PureWindowsPath(r'c:\eggs')
+        - PureWindowsPath(r'\\server\share\foo\..\..\eggs').erase_parents() == PureWindowsPath(r'\\server\share\eggs')
+        """
+        return type(self)(self._flavour.normpath(self))
 
     @classmethod
     def _parse_path(cls, path):
@@ -479,7 +500,7 @@ class PurePath(object):
             # It's a posix path => 'file:///etc/hosts'
             prefix = 'file://'
             path = str(self)
-        return prefix + urlquote_from_bytes(os.fsencode(path))
+        return prefix + urlquote_from_bytes(os.fsencode(path)) 
 
     @property
     def _str_normcase(self):

--- a/Misc/NEWS.d/next/Library/2025-06-11-19-35-18.gh-issue-124825.ta9HSE.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-11-19-35-18.gh-issue-124825.ta9HSE.rst
@@ -1,0 +1,1 @@
+Added :func:`pathlib.PurePath.erase_parents`, which will remove path components referring to parent directories ('..') without any attempt to verify the existence or structure of any path components.


### PR DESCRIPTION
The `PurePath.erase_parents()` method remove path components referring to parent directories ('..').

Unlike `Pure.resolve()`, this occurs without an attempt to verify the existence or structure of any path components.

See discussion in gh-124825 for use cases, involving lexical normalization and simplification of paths without reference to any particular underlying filesystem.

Issue:

- gh-124825

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
