### PR TITLE
gh-135410: Use a critical section around `StringIO.__next__`

### DIFF
--- a/Lib/test/test_memoryio.py
+++ b/Lib/test/test_memoryio.py
@@ -5,6 +5,7 @@ BytesIO -- for bytes
 
 import unittest
 from test import support
+from test.support import threading_helper
 
 import gc
 import io
@@ -12,6 +13,7 @@ import _pyio as pyio
 import pickle
 import sys
 import weakref
+import threading
 
 class IntLike:
     def __init__(self, num):
@@ -723,6 +725,22 @@ class TextIOTestMixin:
         for newline in (None, "", "\n", "\r", "\r\n"):
             self.ioclass(newline=newline)
 
+    @unittest.skipUnless(support.Py_GIL_DISABLED, "only meaningful under free-threading")
+    @threading_helper.requires_working_threading()
+    def test_concurrent_use(self):
+        memio = self.ioclass("")
+
+        def use():
+            memio.write("x" * 10)
+            memio.readlines()
+
+        threads = [threading.Thread(target=use) for _ in range(8)]
+        with threading_helper.catch_threading_exception() as cm:
+            with threading_helper.start_threads(threads):
+                pass
+
+            self.assertIsNone(cm.exc_value)
+
 
 class PyStringIOTest(MemoryTestMixin, MemorySeekTestMixin,
                      TextIOTestMixin, unittest.TestCase):
@@ -888,6 +906,7 @@ class CStringIOTest(PyStringIOTest):
         self.assertRaises(TypeError, memio.__setstate__, 0)
         memio.close()
         self.assertRaises(ValueError, memio.__setstate__, ("closed", "", 0, None))
+
 
 
 class CStringIOPickleTest(PyStringIOPickleTest):

--- a/Misc/NEWS.d/next/Library/2025-06-11-19-05-49.gh-issue-135410.E89Boi.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-11-19-05-49.gh-issue-135410.E89Boi.rst
@@ -1,0 +1,2 @@
+Fix a crash when iterating over :class:`io.StringIO` on the :term:`free
+threaded <free threading>` build.

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -79,7 +79,6 @@ static int _io_StringIO___init__(PyObject *self, PyObject *args, PyObject *kwarg
 static int
 resize_buffer(stringio *self, size_t size)
 {
-    _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(self);
     /* Here, unsigned types are used to avoid dealing with signed integer
        overflow, which is undefined in C. */
     size_t alloc = self->buf_size;
@@ -132,7 +131,6 @@ resize_buffer(stringio *self, size_t size)
 static PyObject *
 make_intermediate(stringio *self)
 {
-    _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(self);
     PyObject *intermediate = PyUnicodeWriter_Finish(self->writer);
     self->writer = NULL;
     self->state = STATE_REALIZED;
@@ -155,7 +153,6 @@ make_intermediate(stringio *self)
 static int
 realize(stringio *self)
 {
-    _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(self);
     Py_ssize_t len;
     PyObject *intermediate;
 
@@ -191,7 +188,6 @@ realize(stringio *self)
 static Py_ssize_t
 write_str(stringio *self, PyObject *obj)
 {
-    _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(self);
     Py_ssize_t len;
     PyObject *decoded = NULL;
 
@@ -359,7 +355,6 @@ _io_StringIO_read_impl(stringio *self, Py_ssize_t size)
 static PyObject *
 _stringio_readline(stringio *self, Py_ssize_t limit)
 {
-    _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(self);
     Py_UCS4 *start, *end, old_char;
     Py_ssize_t len, consumed;
 
@@ -411,7 +406,6 @@ _io_StringIO_readline_impl(stringio *self, Py_ssize_t size)
 static PyObject *
 stringio_iternext_lock_held(PyObject *op)
 {
-    _Py_CRITICAL_SECTION_ASSERT_OBJECT_LOCKED(op);
     PyObject *line;
     stringio *self = stringio_CAST(op);
 


### PR DESCRIPTION
I'm generally not a fan of adding locks around `__next__`, because concurrent iteration isn't generally a real use case, but `readlines` calls into `__next__`. 

<!-- gh-issue-number: gh-135410 -->
* Issue: gh-135410
<!-- /gh-issue-number -->
