### PR TITLE
gh-135368: Fix mocks on dataclass specs with `instance=True`

### DIFF
--- a/Lib/test/test_unittest/testmock/testhelpers.py
+++ b/Lib/test/test_unittest/testmock/testhelpers.py
@@ -1125,6 +1125,8 @@ class SpecSignatureTest(unittest.TestCase):
                 self.assertIs(mock.__class__, Description)
                 self.assertIsInstance(mock.__dataclass_fields__, MagicMock)
                 self.assertIsInstance(mock.__dataclass_params__, MagicMock)
+                self.assertIsInstance(mock.__match_args__, MagicMock)
+                self.assertIsInstance(mock.__hash__, MagicMock)
 
 class TestCallList(unittest.TestCase):
 

--- a/Lib/test/test_unittest/testmock/testhelpers.py
+++ b/Lib/test/test_unittest/testmock/testhelpers.py
@@ -1050,6 +1050,7 @@ class SpecSignatureTest(unittest.TestCase):
             create_autospec(WithPostInit()),
         ]:
             with self.subTest(mock=mock):
+                self.assertIsInstance(mock, WithPostInit)
                 self.assertIsInstance(mock.a, int)
                 self.assertIsInstance(mock.b, int)
 
@@ -1072,6 +1073,7 @@ class SpecSignatureTest(unittest.TestCase):
             create_autospec(WithDefault(1)),
         ]:
             with self.subTest(mock=mock):
+                self.assertIsInstance(mock, WithDefault)
                 self.assertIsInstance(mock.a, int)
                 self.assertIsInstance(mock.b, int)
 
@@ -1087,6 +1089,7 @@ class SpecSignatureTest(unittest.TestCase):
             create_autospec(WithMethod(1)),
         ]:
             with self.subTest(mock=mock):
+                self.assertIsInstance(mock, WithMethod)
                 self.assertIsInstance(mock.a, int)
                 mock.b.assert_not_called()
 
@@ -1102,10 +1105,26 @@ class SpecSignatureTest(unittest.TestCase):
             create_autospec(WithNonFields(1)),
         ]:
             with self.subTest(mock=mock):
+                self.assertIsInstance(mock, WithNonFields)
                 with self.assertRaisesRegex(AttributeError, msg):
                     mock.a
                 with self.assertRaisesRegex(AttributeError, msg):
                     mock.b
+
+    def test_dataclass_special_attrs(self):
+        @dataclass
+        class Description:
+            name: str
+
+        for mock in [
+            create_autospec(Description, instance=True),
+            create_autospec(Description(1)),
+        ]:
+            with self.subTest(mock=mock):
+                self.assertIsInstance(mock, Description)
+                self.assertIs(mock.__class__, Description)
+                self.assertIsInstance(mock.__dataclass_fields__, MagicMock)
+                self.assertIsInstance(mock.__dataclass_params__, MagicMock)
 
 class TestCallList(unittest.TestCase):
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -569,6 +569,11 @@ class NonCallableMock(Base):
         __dict__['_mock_methods'] = spec
         __dict__['_spec_asyncs'] = _spec_asyncs
 
+    def _mock_extend_spec_methods(self, spec_methods):
+        methods = self.__dict__.get('_mock_methods') or []
+        methods.extend(spec_methods)
+        self.__dict__['_mock_methods'] = methods
+
     def __get_return_value(self):
         ret = self._mock_return_value
         if self._mock_delegate is not None:
@@ -2766,17 +2771,15 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
         raise InvalidSpecError(f'Cannot autospec a Mock object. '
                                f'[object={spec!r}]')
     is_async_func = _is_async_func(spec)
+    _kwargs = {'spec': spec}
 
     entries = [(entry, _missing) for entry in dir(spec)]
     if is_type and instance and is_dataclass(spec):
+        is_dataclass_spec = True
         dataclass_fields = fields(spec)
         entries.extend((f.name, f.type) for f in dataclass_fields)
-        spec_list = [f.name for f in dataclass_fields]
-        spec_list.extend(['__dataclass_fields__', '__dataclass_params__'])
-        _kwargs = {'spec': spec_list}  # we set `__class__` further
-        is_dataclass_spec = True
+        dataclass_spec_list = [f.name for f in dataclass_fields]
     else:
-        _kwargs = {'spec': spec}
         is_dataclass_spec = False
 
     if spec_set:
@@ -2815,7 +2818,7 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
     mock = Klass(parent=_parent, _new_parent=_parent, _new_name=_new_name,
                  name=_name, **_kwargs)
     if is_dataclass_spec:
-        mock.__class__ = spec  # we need this for `isinstance` to work
+        mock._mock_extend_spec_methods(dataclass_spec_list)
 
     if isinstance(spec, FunctionTypes):
         # should only happen at the top level because we don't

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2771,9 +2771,13 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
     if is_type and instance and is_dataclass(spec):
         dataclass_fields = fields(spec)
         entries.extend((f.name, f.type) for f in dataclass_fields)
-        _kwargs = {'spec': [f.name for f in dataclass_fields]}
+        spec_list = [f.name for f in dataclass_fields]
+        spec_list.extend(['__dataclass_fields__', '__dataclass_params__'])
+        _kwargs = {'spec': spec_list}  # we set `__class__` further
+        is_dataclass_spec = True
     else:
         _kwargs = {'spec': spec}
+        is_dataclass_spec = False
 
     if spec_set:
         _kwargs = {'spec_set': spec}
@@ -2810,6 +2814,8 @@ def create_autospec(spec, spec_set=False, instance=False, _parent=None,
 
     mock = Klass(parent=_parent, _new_parent=_parent, _new_name=_new_name,
                  name=_name, **_kwargs)
+    if is_dataclass_spec:
+        mock.__class__ = spec  # we need this for `isinstance` to work
 
     if isinstance(spec, FunctionTypes):
         # should only happen at the top level because we don't

--- a/Misc/NEWS.d/next/Library/2025-06-12-10-45-02.gh-issue-135368.OjWVHL.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-12-10-45-02.gh-issue-135368.OjWVHL.rst
@@ -1,0 +1,2 @@
+Fix :class:`unittest.mock.Mock` generation on :func:`dataclasses.dataclass`
+objects. Now all special attributes are set as it was before :gh:`124429`.


### PR DESCRIPTION
cc @ncoghlan, @cdce8p 

This brings back two features mentioned in https://github.com/python/cpython/issues/135368
- `__class__`
- `__dataclass_*__` features

Basically, the fix is rather obvious: we just set the proper fields.

`__annotations__` has changed due to `__annotate__` function, this is not our fault :)

I also have a revert PR ready, if this one is not good enough.

Refs https://github.com/python/cpython/pull/124429

<!-- gh-issue-number: gh-135368 -->
* Issue: gh-135368
<!-- /gh-issue-number -->
