### PR TITLE
gh-135410: Fix `test_memoryio` refleak buildbots

### DIFF
--- a/Lib/test/test_memoryio.py
+++ b/Lib/test/test_memoryio.py
@@ -909,8 +909,6 @@ class CStringIOTest(PyStringIOTest):
                 raise cm.exc_value
 
 
-
-
 class CStringIOPickleTest(PyStringIOPickleTest):
     UnsupportedOperation = io.UnsupportedOperation
 


### PR DESCRIPTION
The problem is that we were testing both `_pyio.StringIO` and `_io.StringIO`. The former, in `_pyio`, isn't really thread-safe (but it doesn't *crash*, and that's what we care about). I'm not sure why it only revealed itself on the refleak buildbots, but it's probably something about the threads being slower.

Anyways, I'm fixing this by only testing the C implementation of `StringIO`. Making the Python version thread-safe is a separate project that we shouldn't deal with here. I also changed the `assertIsNone` to an `if` that actually raises the exception, so we get a better traceback when dealing with failures.

<!-- gh-issue-number: gh-135410 -->
* Issue: gh-135410
<!-- /gh-issue-number -->
