### PR TITLE
gh-89730: EncryptedClientHello support in ssl module

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1082,6 +1082,7 @@ Michael Layzell
 Michael Lazar
 Peter Lazorchak
 Brian Leair
+Iain Learmonth
 Mathieu Leduc-Hamel
 Amandine Lee
 Antony Lee

--- a/Misc/NEWS.d/next/Library/2025-06-12-15-39-48.gh-issue-89730.Lu35Fu.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-12-15-39-48.gh-issue-89730.Lu35Fu.rst
@@ -1,0 +1,8 @@
+Adds support for Encrypted Client Hello (ECH) to the ssl module. Clients may
+use the options exposed to establish TLS connections using ECH. Third-party
+libraries like ``dnspython`` can be used to query for HTTPS and SVCB records
+that contain the public keys required to use ECH with specific servers. If
+no public key is available, an option is available to "GREASE" the
+connection, and it is possible to retrieve the public key from the retry
+configuration sent by servers that support ECH as they terminate the initial
+connection.

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -149,6 +149,91 @@ _ssl__SSLSocket_get_unverified_chain(PyObject *self, PyObject *Py_UNUSED(ignored
     return return_value;
 }
 
+PyDoc_STRVAR(_ssl__SSLSocket_get_ech_status__doc__,
+"get_ech_status($self, /)\n"
+"--\n"
+"\n");
+
+#define _SSL__SSLSOCKET_GET_ECH_STATUS_METHODDEF    \
+    {"get_ech_status", (PyCFunction)_ssl__SSLSocket_get_ech_status, METH_NOARGS, _ssl__SSLSocket_get_ech_status__doc__},
+
+static PyObject *
+_ssl__SSLSocket_get_ech_status_impl(PySSLSocket *self);
+
+static PyObject *
+_ssl__SSLSocket_get_ech_status(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_get_ech_status_impl((PySSLSocket *)self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+PyDoc_STRVAR(_ssl__SSLSocket_get_ech_retry_config__doc__,
+"get_ech_retry_config($self, /)\n"
+"--\n"
+"\n");
+
+#define _SSL__SSLSOCKET_GET_ECH_RETRY_CONFIG_METHODDEF    \
+    {"get_ech_retry_config", (PyCFunction)_ssl__SSLSocket_get_ech_retry_config, METH_NOARGS, _ssl__SSLSocket_get_ech_retry_config__doc__},
+
+static PyObject *
+_ssl__SSLSocket_get_ech_retry_config_impl(PySSLSocket *self);
+
+static PyObject *
+_ssl__SSLSocket_get_ech_retry_config(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_get_ech_retry_config_impl((PySSLSocket *)self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+PyDoc_STRVAR(_ssl__SSLSocket_set_outer_server_name__doc__,
+"set_outer_server_name($self, outer_server_name, /)\n"
+"--\n"
+"\n");
+
+#define _SSL__SSLSOCKET_SET_OUTER_SERVER_NAME_METHODDEF    \
+    {"set_outer_server_name", (PyCFunction)_ssl__SSLSocket_set_outer_server_name, METH_O, _ssl__SSLSocket_set_outer_server_name__doc__},
+
+static PyObject *
+_ssl__SSLSocket_set_outer_server_name_impl(PySSLSocket *self,
+                                           const char *outer_server_name);
+
+static PyObject *
+_ssl__SSLSocket_set_outer_server_name(PyObject *self, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    const char *outer_server_name;
+
+    if (!PyUnicode_Check(arg)) {
+        _PyArg_BadArgument("set_outer_server_name", "argument", "str", arg);
+        goto exit;
+    }
+    Py_ssize_t outer_server_name_length;
+    outer_server_name = PyUnicode_AsUTF8AndSize(arg, &outer_server_name_length);
+    if (outer_server_name == NULL) {
+        goto exit;
+    }
+    if (strlen(outer_server_name) != (size_t)outer_server_name_length) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        goto exit;
+    }
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLSocket_set_outer_server_name_impl((PySSLSocket *)self, outer_server_name);
+    Py_END_CRITICAL_SECTION();
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_ssl__SSLSocket_shared_ciphers__doc__,
 "shared_ciphers($self, /)\n"
 "--\n"
@@ -882,6 +967,40 @@ _ssl__SSLContext__set_alpn_protocols(PyObject *self, PyObject *arg)
     }
     Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLContext__set_alpn_protocols_impl((PySSLContext *)self, &protos);
+    Py_END_CRITICAL_SECTION();
+
+exit:
+    /* Cleanup for protos */
+    if (protos.obj) {
+       PyBuffer_Release(&protos);
+    }
+
+    return return_value;
+}
+
+PyDoc_STRVAR(_ssl__SSLContext__set_outer_alpn_protocols__doc__,
+"_set_outer_alpn_protocols($self, protos, /)\n"
+"--\n"
+"\n");
+
+#define _SSL__SSLCONTEXT__SET_OUTER_ALPN_PROTOCOLS_METHODDEF    \
+    {"_set_outer_alpn_protocols", (PyCFunction)_ssl__SSLContext__set_outer_alpn_protocols, METH_O, _ssl__SSLContext__set_outer_alpn_protocols__doc__},
+
+static PyObject *
+_ssl__SSLContext__set_outer_alpn_protocols_impl(PySSLContext *self,
+                                                Py_buffer *protos);
+
+static PyObject *
+_ssl__SSLContext__set_outer_alpn_protocols(PyObject *self, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    Py_buffer protos = {NULL, NULL};
+
+    if (PyObject_GetBuffer(arg, &protos, PyBUF_SIMPLE) != 0) {
+        goto exit;
+    }
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext__set_outer_alpn_protocols_impl((PySSLContext *)self, &protos);
     Py_END_CRITICAL_SECTION();
 
 exit:
@@ -1778,6 +1897,43 @@ _ssl__SSLContext_set_default_verify_paths(PyObject *self, PyObject *Py_UNUSED(ig
     Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _ssl__SSLContext_set_default_verify_paths_impl((PySSLContext *)self);
     Py_END_CRITICAL_SECTION();
+
+    return return_value;
+}
+
+PyDoc_STRVAR(_ssl__SSLContext_set_ech_config__doc__,
+"set_ech_config($self, ech_config, /)\n"
+"--\n"
+"\n"
+"Set the ECH configuration on the SSL context.\n"
+"\n"
+"The echconfig parameter should be a bytes-like object containing the raw ECH configuration.");
+
+#define _SSL__SSLCONTEXT_SET_ECH_CONFIG_METHODDEF    \
+    {"set_ech_config", (PyCFunction)_ssl__SSLContext_set_ech_config, METH_O, _ssl__SSLContext_set_ech_config__doc__},
+
+static PyObject *
+_ssl__SSLContext_set_ech_config_impl(PySSLContext *self,
+                                     Py_buffer *ech_config);
+
+static PyObject *
+_ssl__SSLContext_set_ech_config(PyObject *self, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    Py_buffer ech_config = {NULL, NULL};
+
+    if (PyObject_GetBuffer(arg, &ech_config, PyBUF_SIMPLE) != 0) {
+        goto exit;
+    }
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _ssl__SSLContext_set_ech_config_impl((PySSLContext *)self, &ech_config);
+    Py_END_CRITICAL_SECTION();
+
+exit:
+    /* Cleanup for ech_config */
+    if (ech_config.obj) {
+       PyBuffer_Release(&ech_config);
+    }
 
     return return_value;
 }
@@ -2900,4 +3056,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=748650909fec8906 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3406ceb5919424f6 input=a9049054013a1b77]*/

--- a/configure
+++ b/configure
@@ -30892,6 +30892,63 @@ LIBS=$save_LIBS
 
 
 
+save_CFLAGS=$CFLAGS
+save_CPPFLAGS=$CPPFLAGS
+save_LDFLAGS=$LDFLAGS
+save_LIBS=$LIBS
+
+
+  CFLAGS="$CFLAGS $OPENSSL_INCLUDES"
+
+
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for SSL_ech_get1_status" >&5
+printf %s "checking for SSL_ech_get1_status... " >&6; }
+if test ${ac_cv_func_SSL_ech_get1_status+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <openssl/ech.h>
+int
+main (void)
+{
+void *x=SSL_ech_get1_status
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ac_cv_func_SSL_ech_get1_status=yes
+else case e in #(
+  e) ac_cv_func_SSL_ech_get1_status=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+   ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_SSL_ech_get1_status" >&5
+printf "%s\n" "$ac_cv_func_SSL_ech_get1_status" >&6; }
+  if test "x$ac_cv_func_SSL_ech_get1_status" = xyes
+then :
+
+printf "%s\n" "#define HAVE_OPENSSL_ECH 1" >>confdefs.h
+
+fi
+
+
+
+
+CFLAGS=$save_CFLAGS
+CPPFLAGS=$save_CPPFLAGS
+LDFLAGS=$save_LDFLAGS
+LIBS=$save_LIBS
+
+
+
 # ssl module default cipher suite string
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -7545,6 +7545,12 @@ WITH_SAVE_ENV([
   ])
 ])
 
+WITH_SAVE_ENV([
+  CFLAGS="$CFLAGS $OPENSSL_INCLUDES"
+
+  PY_CHECK_FUNC([SSL_ech_get1_status], [@%:@include <openssl/ech.h>], [HAVE_OPENSSL_ECH])
+])
+
 # ssl module default cipher suite string
 AH_TEMPLATE([PY_SSL_DEFAULT_CIPHERS],
   [Default cipher suites list for ssl module.

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -926,6 +926,9 @@
 /* Define to 1 if you have the 'openpty' function. */
 #undef HAVE_OPENPTY
 
+/* Define if you have the 'SSL_ech_get1_status' function. */
+#undef HAVE_OPENSSL_ECH
+
 /* Define if you have the 'panel' library */
 #undef HAVE_PANEL
 


### PR DESCRIPTION
Exposes options for clients to use Encrypted Client Hello (ECH) when establishing TLS connections. It is up to the user to source the ECH public keys before making use of these options.

To use these options requires a version of openssl that includes these options, which currently are on a feature branch:

https://github.com/openssl/openssl/tree/feature/ech

We do not expect that the API here will have any substaintial changes when it is merged.

For testing, clone the above repository, checkout the `feature/ech` branch, and build. Then use this openssl installation when building cPython:

```
git clone https://github.com/openssl/openssl.git
pushd openssl
git checkout feature/ech
./configure --prefix=$HOME/opt/openssl
make -j8
make install_sw
popd
git clone https://github.com/irl/cpython.git
git checkout issue-89730
./configure --with-pydebug --with-openssl=$HOME/opt/openssl
make -j8
```

Additionally I have added to the documentation an example of the use of these options, which is built at: https://irl.github.io/cpython/library/ssl.html#encrypted-client-hello

<!-- gh-issue-number: gh-89730 -->
* Issue: gh-89730
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135435.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->