### PR TITLE
Revert "gh-135410: use a critical section around `StringIO.__next__` (#135412)"

### DIFF
--- a/Lib/test/test_memoryio.py
+++ b/Lib/test/test_memoryio.py
@@ -5,7 +5,6 @@ BytesIO -- for bytes
 
 import unittest
 from test import support
-from test.support import threading_helper
 
 import gc
 import io
@@ -13,7 +12,6 @@ import _pyio as pyio
 import pickle
 import sys
 import weakref
-import threading
 
 class IntLike:
     def __init__(self, num):
@@ -725,22 +723,6 @@ class TextIOTestMixin:
         for newline in (None, "", "\n", "\r", "\r\n"):
             self.ioclass(newline=newline)
 
-    @unittest.skipUnless(support.Py_GIL_DISABLED, "only meaningful under free-threading")
-    @threading_helper.requires_working_threading()
-    def test_concurrent_use(self):
-        memio = self.ioclass("")
-
-        def use():
-            memio.write("x" * 10)
-            memio.readlines()
-
-        threads = [threading.Thread(target=use) for _ in range(8)]
-        with threading_helper.catch_threading_exception() as cm:
-            with threading_helper.start_threads(threads):
-                pass
-
-            self.assertIsNone(cm.exc_value)
-
 
 class PyStringIOTest(MemoryTestMixin, MemorySeekTestMixin,
                      TextIOTestMixin, unittest.TestCase):
@@ -906,7 +888,6 @@ class CStringIOTest(PyStringIOTest):
         self.assertRaises(TypeError, memio.__setstate__, 0)
         memio.close()
         self.assertRaises(ValueError, memio.__setstate__, ("closed", "", 0, None))
-
 
 
 class CStringIOPickleTest(PyStringIOPickleTest):

--- a/Misc/NEWS.d/next/Library/2025-06-11-19-05-49.gh-issue-135410.E89Boi.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-11-19-05-49.gh-issue-135410.E89Boi.rst
@@ -1,2 +1,0 @@
-Fix a crash when iterating over :class:`io.StringIO` on the :term:`free
-threaded <free threading>` build.

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -404,7 +404,7 @@ _io_StringIO_readline_impl(stringio *self, Py_ssize_t size)
 }
 
 static PyObject *
-stringio_iternext_lock_held(PyObject *op)
+stringio_iternext(PyObject *op)
 {
     PyObject *line;
     stringio *self = stringio_CAST(op);
@@ -439,16 +439,6 @@ stringio_iternext_lock_held(PyObject *op)
     }
 
     return line;
-}
-
-static PyObject *
-stringio_iternext(PyObject *op)
-{
-    PyObject *res;
-    Py_BEGIN_CRITICAL_SECTION(op);
-    res = stringio_iternext_lock_held(op);
-    Py_END_CRITICAL_SECTION();
-    return res;
 }
 
 /*[clinic input]


### PR DESCRIPTION
This reverts commit e6c3039cb39e68ae9af9ddcaca341c5af8f9cf23.

cc @vstinner @kumaraditya303 @corona10

<!-- gh-issue-number: gh-135410 -->
* Issue: gh-135410
<!-- /gh-issue-number -->
