### PR TITLE
gh-135429: Fix the argument mismatch in lsprof throw event

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-06-12-18-15-31.gh-issue-135429.mch75_.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-12-18-15-31.gh-issue-135429.mch75_.rst
@@ -1,0 +1,1 @@
+Fixed the argument mismatch in ``_lsprof`` for ``PY_THROW`` event.

--- a/Misc/NEWS.d/next/Library/2025-06-12-18-15-31.gh-issue-135429.mch75_.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-12-18-15-31.gh-issue-135429.mch75_.rst
@@ -1,1 +1,1 @@
-Fixed the argument mismatch in ``_lsprof`` for ``PY_THROW`` event.
+Fix the argument mismatch in ``_lsprof`` for ``PY_THROW`` event.

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -632,6 +632,27 @@ _lsprof_Profiler__pystart_callback_impl(ProfilerObject *self, PyObject *code,
 }
 
 /*[clinic input]
+_lsprof.Profiler._pythrow_callback
+
+    code: object
+    instruction_offset: object
+    exception: object
+    /
+
+[clinic start generated code]*/
+
+static PyObject *
+_lsprof_Profiler__pythrow_callback_impl(ProfilerObject *self, PyObject *code,
+                                        PyObject *instruction_offset,
+                                        PyObject *exception)
+/*[clinic end generated code: output=0a32988919dfb94c input=fd728fc2c074f5e6]*/
+{
+    ptrace_enter_call((PyObject*)self, (void *)code, code);
+
+    Py_RETURN_NONE;
+}
+
+/*[clinic input]
 _lsprof.Profiler._pyreturn_callback
 
     code: object
@@ -747,7 +768,7 @@ static const struct {
 } callback_table[] = {
     {PY_MONITORING_EVENT_PY_START, "_pystart_callback"},
     {PY_MONITORING_EVENT_PY_RESUME, "_pystart_callback"},
-    {PY_MONITORING_EVENT_PY_THROW, "_pystart_callback"},
+    {PY_MONITORING_EVENT_PY_THROW, "_pythrow_callback"},
     {PY_MONITORING_EVENT_PY_RETURN, "_pyreturn_callback"},
     {PY_MONITORING_EVENT_PY_YIELD, "_pyreturn_callback"},
     {PY_MONITORING_EVENT_PY_UNWIND, "_pyreturn_callback"},
@@ -1002,6 +1023,7 @@ static PyMethodDef profiler_methods[] = {
     _LSPROF_PROFILER_DISABLE_METHODDEF
     _LSPROF_PROFILER_CLEAR_METHODDEF
     _LSPROF_PROFILER__PYSTART_CALLBACK_METHODDEF
+    _LSPROF_PROFILER__PYTHROW_CALLBACK_METHODDEF
     _LSPROF_PROFILER__PYRETURN_CALLBACK_METHODDEF
     _LSPROF_PROFILER__CCALL_CALLBACK_METHODDEF
     _LSPROF_PROFILER__CRETURN_CALLBACK_METHODDEF

--- a/Modules/clinic/_lsprof.c.h
+++ b/Modules/clinic/_lsprof.c.h
@@ -82,6 +82,39 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(_lsprof_Profiler__pythrow_callback__doc__,
+"_pythrow_callback($self, code, instruction_offset, exception, /)\n"
+"--\n"
+"\n");
+
+#define _LSPROF_PROFILER__PYTHROW_CALLBACK_METHODDEF    \
+    {"_pythrow_callback", _PyCFunction_CAST(_lsprof_Profiler__pythrow_callback), METH_FASTCALL, _lsprof_Profiler__pythrow_callback__doc__},
+
+static PyObject *
+_lsprof_Profiler__pythrow_callback_impl(ProfilerObject *self, PyObject *code,
+                                        PyObject *instruction_offset,
+                                        PyObject *exception);
+
+static PyObject *
+_lsprof_Profiler__pythrow_callback(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *code;
+    PyObject *instruction_offset;
+    PyObject *exception;
+
+    if (!_PyArg_CheckPositional("_pythrow_callback", nargs, 3, 3)) {
+        goto exit;
+    }
+    code = args[0];
+    instruction_offset = args[1];
+    exception = args[2];
+    return_value = _lsprof_Profiler__pythrow_callback_impl((ProfilerObject *)self, code, instruction_offset, exception);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_lsprof_Profiler__pyreturn_callback__doc__,
 "_pyreturn_callback($self, code, instruction_offset, retval, /)\n"
 "--\n"
@@ -411,4 +444,4 @@ skip_optional_pos:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=fe231309776df7a7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9e46985561166c37 input=a9049054013a1b77]*/


### PR DESCRIPTION
`PY_THROW` event has a different signature than `PY_START`. We changed the interface to argument clinic and ignored the difference. It would've been caught but the test case was changed from another PR.

This PR fixes the issue and refreshes the testcase.

<!-- gh-issue-number: gh-135429 -->
* Issue: gh-135429
<!-- /gh-issue-number -->
