### PR TITLE
gh-135444: fix DatagramTransport buffer_size accounting

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -460,6 +460,8 @@ class _ProactorWritePipeTransport(_ProactorBaseWritePipeTransport):
 class _ProactorDatagramTransport(_ProactorBasePipeTransport,
                                  transports.DatagramTransport):
     max_size = 256 * 1024
+    _header_size = 8
+
     def __init__(self, loop, sock, protocol, address=None,
                  waiter=None, extra=None):
         self._address = address
@@ -499,7 +501,7 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport,
 
         # Ensure that what we buffer is immutable.
         self._buffer.append((bytes(data), addr))
-        self._buffer_size += len(data) + 8  # include header bytes
+        self._buffer_size += len(data) + self._header_size
 
         if self._write_fut is None:
             # No current write operations are active, kick one off
@@ -526,7 +528,7 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport,
                 return
 
             data, addr = self._buffer.popleft()
-            self._buffer_size -= len(data)
+            self._buffer_size -= len(data) + self._header_size
             if self._address is not None:
                 self._write_fut = self._loop._proactor.send(self._sock,
                                                             data)

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -566,6 +566,8 @@ class ProactorDatagramTransportTests(test_utils.TestCase):
         self.assertTrue(self.proactor.sendto.called)
         self.proactor.sendto.assert_called_with(
             self.sock, data, addr=('0.0.0.0', 1234))
+        self.assertFalse(transport._buffer)
+        self.assertEqual(0, transport._buffer_size)
 
     def test_sendto_bytearray(self):
         data = bytearray(b'data')

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -1497,6 +1497,47 @@ class SelectorDatagramTransportTests(test_utils.TestCase):
         transport.sendto(b'data', (1,))
         self.assertEqual(transport._conn_lost, 2)
 
+    def test_sendto_sendto_ready(self):
+        data = b'data'
+
+        # First queue up a buffer by having the socket block
+        self.sock.sendto.side_effect = BlockingIOError
+        transport = self.datagram_transport()
+        transport.sendto(data, ('0.0.0.0', 12345))
+        self.loop.assert_writer(7, transport._sendto_ready)
+        self.assertEqual(1, len(transport._buffer))
+        self.assertEqual(transport._buffer_size, len(data) + transport._header_size)
+
+        # Now let the socket send the buffer
+        self.sock.sendto.side_effect = None
+        transport._sendto_ready()
+        self.assertTrue(self.sock.sendto.called)
+        self.assertEqual(
+            self.sock.sendto.call_args[0], (data, ('0.0.0.0', 12345)))
+        self.assertFalse(self.loop.writers)
+        self.assertFalse(transport._buffer)
+        self.assertEqual(transport._buffer_size, 0)
+
+    def test_sendto_sendto_ready_blocked(self):
+        data = b'data'
+
+        # First queue up a buffer by having the socket block
+        self.sock.sendto.side_effect = BlockingIOError
+        transport = self.datagram_transport()
+        transport.sendto(data, ('0.0.0.0', 12345))
+        self.loop.assert_writer(7, transport._sendto_ready)
+        self.assertEqual(1, len(transport._buffer))
+        self.assertEqual(transport._buffer_size, len(data) + transport._header_size)
+
+        # Now try to send the buffer, it will be added to buffer again if it fails
+        transport._sendto_ready()
+        self.assertTrue(self.sock.sendto.called)
+        self.assertEqual(
+            self.sock.sendto.call_args[0], (data, ('0.0.0.0', 12345)))
+        self.assertTrue(self.loop.writers)
+        self.assertEqual(1, len(transport._buffer))
+        self.assertEqual(transport._buffer_size, len(data) + transport._header_size)
+
     def test_sendto_ready(self):
         data = b'data'
         self.sock.sendto.return_value = len(data)

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -1500,7 +1500,7 @@ class SelectorDatagramTransportTests(test_utils.TestCase):
     def test_sendto_sendto_ready(self):
         data = b'data'
 
-        # First queue up a buffer by having the socket block
+        # First queue up the buffer by having the socket blocked
         self.sock.sendto.side_effect = BlockingIOError
         transport = self.datagram_transport()
         transport.sendto(data, ('0.0.0.0', 12345))

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -1521,7 +1521,7 @@ class SelectorDatagramTransportTests(test_utils.TestCase):
     def test_sendto_sendto_ready_blocked(self):
         data = b'data'
 
-        # First queue up a buffer by having the socket block
+        # First queue up the buffer by having the socket blocked
         self.sock.sendto.side_effect = BlockingIOError
         transport = self.datagram_transport()
         transport.sendto(data, ('0.0.0.0', 12345))

--- a/Misc/NEWS.d/next/Library/2025-06-16-12-37-02.gh-issue-135444.An2eeA.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-16-12-37-02.gh-issue-135444.An2eeA.rst
@@ -1,0 +1,2 @@
+Fix :meth:`asyncio.DatagramTransport.sendto` to account for datagram header size when
+data cannot be sent.


### PR DESCRIPTION
Commit 73e8637002639e565938d3f205bf46e7f1dbd6a8 added 8 to the buffer_size when send could not be called right away.  However, it did not complete this accounting by removing 8 from the buffer size when sending did finally complete.


<!-- gh-issue-number: gh-135444 -->
* Issue: gh-135444
<!-- /gh-issue-number -->
