### PR TITLE
gh-135450: Remove assertion in `_PyCode_CheckNoExternalState`

### DIFF
--- a/Lib/test/test_interpreters/test_api.py
+++ b/Lib/test/test_interpreters/test_api.py
@@ -944,6 +944,22 @@ class TestInterpreterExec(TestBase):
             with self.assertRaisesRegex(InterpreterError, 'unrecognized'):
                 interp.exec('raise Exception("it worked!")')
 
+    def test_list_comprehension(self):
+        # gh-135450: List comprehensions caused an assertion failure
+        # in _PyCode_CheckNoExternalState()
+        import string
+        r_interp, w_interp = self.pipe()
+
+        interp = interpreters.create()
+        interp.exec(f"""if True:
+            import os
+            comp = [str(i) for i in range(10)]
+            os.write({w_interp}, ''.join(comp).encode())
+        """)
+        self.assertEqual(os.read(r_interp, 10).decode(), string.digits)
+        interp.close()
+
+
     # test__interpreters covers the remaining
     # Interpreter.exec() behavior.
 

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -1979,7 +1979,6 @@ _PyCode_CheckNoExternalState(PyCodeObject *co, _PyCode_var_counts_t *counts,
                              const char **p_errmsg)
 {
     const char *errmsg = NULL;
-    assert(counts->locals.hidden.total == 0);
     if (counts->numfree > 0) {  // It's a closure.
         errmsg = "closures not supported";
     }


### PR DESCRIPTION
`skip news` because `_interpreters` isn't public.

<!-- gh-issue-number: gh-135450 -->
* Issue: gh-135450
<!-- /gh-issue-number -->
