### PR TITLE
gh-75229: make ensurepip honour value of --prefix option

### DIFF
--- a/Doc/library/ensurepip.rst
+++ b/Doc/library/ensurepip.rst
@@ -65,7 +65,11 @@ is at least as recent as the one available in ``ensurepip``, pass the
 By default, ``pip`` is installed into the current virtual environment
 (if one is active) or into the system site packages (if there is no
 active virtual environment). The installation location can be controlled
-through two additional command line options:
+through some additional command line options:
+
+.. option:: --prefix <dir>
+
+   Installs ``pip`` using the given directory prefix.
 
 .. option:: --root <dir>
 
@@ -108,7 +112,7 @@ Module API
 
 .. function:: bootstrap(root=None, upgrade=False, user=False, \
                         altinstall=False, default_pip=False, \
-                        verbosity=0)
+                        verbosity=0, prefix=None)
 
    Bootstraps ``pip`` into the current or designated environment.
 
@@ -135,6 +139,12 @@ Module API
 
    *verbosity* controls the level of output to :data:`sys.stdout` from the
    bootstrapping operation.
+
+   *prefix* specifies the directory prefix to use when installing.
+
+   .. versionadded:: 3.14
+
+      The *prefix* parameter.
 
    .. audit-event:: ensurepip.bootstrap root ensurepip.bootstrap
 

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -140,8 +140,6 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
             "to install pip."
         ) from None
 
-    if root is not None and prefix is not None:
-        raise ValueError("Cannot use 'root' and 'prefix' together")
     if altinstall and default_pip:
         raise ValueError("Cannot use altinstall and default_pip together")
 
@@ -172,18 +170,39 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
 
         # Construct the arguments to be passed to the pip command
         args = ["install", "--no-cache-dir", "--no-index", "--find-links", tmpdir]
-        if root:
-            args += ["--root", root]
-        if prefix:
-            args += ["--prefix", prefix]
         if upgrade:
             args += ["--upgrade"]
-        if user:
-            args += ["--user"]
         if verbosity:
             args += ["-" + "v" * verbosity]
         if sys.implementation.cache_tag is None:
             args += ["--no-compile"]
+
+        if user:
+            # --user is mutually exclusive with --root/--prefix,
+            # pip will enforce this.
+            args += ["--user"]
+        else:
+            # Handle installation paths.
+            # If --root is given but not --prefix, we default to a prefix of "/"
+            # so that the install happens at the root of the --root directory.
+            # Otherwise, pip would use the configured sys.prefix, e.g.
+            # /usr/local, and install into ${root}/usr/local/.
+            effective_prefix = prefix
+            if root and not prefix:
+                effective_prefix = "/"
+
+            if root:
+                args += ["--root", root]
+
+            if effective_prefix:
+                args += ["--prefix", effective_prefix]
+
+                # Force the script shebang to point to the correct, final
+                # executable path. This is necessary when --root is used.
+                executable_path = (
+                    Path(effective_prefix) / "bin" / Path(sys.executable).name
+                )
+                args += ["--executable", os.fsdecode(executable_path)]
 
         return _run_pip([*args, "pip"], [os.fsdecode(tmp_wheel_path)])
 

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -109,25 +109,25 @@ def _disable_pip_configuration_settings():
 
 def bootstrap(*, root=None, upgrade=False, user=False,
               altinstall=False, default_pip=False,
-              verbosity=0):
+              verbosity=0, prefix=None):
     """
     Bootstrap pip into the current Python installation (or the given root
-    directory).
+    and directory prefix).
 
     Note that calling this function will alter both sys.path and os.environ.
     """
     # Discard the return value
     _bootstrap(root=root, upgrade=upgrade, user=user,
                altinstall=altinstall, default_pip=default_pip,
-               verbosity=verbosity)
+               verbosity=verbosity, prefix=prefix)
 
 
 def _bootstrap(*, root=None, upgrade=False, user=False,
               altinstall=False, default_pip=False,
-              verbosity=0):
+              verbosity=0, prefix=None):
     """
     Bootstrap pip into the current Python installation (or the given root
-    directory). Returns pip command status code.
+    and directory prefix). Returns pip command status code.
 
     Note that calling this function will alter both sys.path and os.environ.
     """
@@ -140,6 +140,8 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
             "to install pip."
         ) from None
 
+    if root is not None and prefix is not None:
+        raise ValueError("Cannot use 'root' and 'prefix' together")
     if altinstall and default_pip:
         raise ValueError("Cannot use altinstall and default_pip together")
 
@@ -172,6 +174,8 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
         args = ["install", "--no-cache-dir", "--no-index", "--find-links", tmpdir]
         if root:
             args += ["--root", root]
+        if prefix:
+            args += ["--prefix", prefix]
         if upgrade:
             args += ["--upgrade"]
         if user:
@@ -250,6 +254,11 @@ def _main(argv=None):
         help="Install everything relative to this alternate root directory.",
     )
     parser.add_argument(
+        "--prefix",
+        default=None,
+        help="Install everything using this prefix.",
+    )
+    parser.add_argument(
         "--altinstall",
         action="store_true",
         default=False,
@@ -268,6 +277,7 @@ def _main(argv=None):
 
     return _bootstrap(
         root=args.root,
+        prefix=args.prefix,
         upgrade=args.upgrade,
         user=args.user,
         verbosity=args.verbosity,

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -177,32 +177,32 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
         if sys.implementation.cache_tag is None:
             args += ["--no-compile"]
 
-        if user:
-            # --user is mutually exclusive with --root/--prefix,
-            # pip will enforce this.
-            args += ["--user"]
-        else:
-            # Handle installation paths.
-            # If --root is given but not --prefix, we default to a prefix of "/"
-            # so that the install happens at the root of the --root directory.
-            # Otherwise, pip would use the configured sys.prefix, e.g.
-            # /usr/local, and install into ${root}/usr/local/.
-            effective_prefix = prefix
-            if root and not prefix:
-                effective_prefix = "/"
+        if user:
+            # --user is mutually exclusive with --root/--prefix,
+            # pip will enforce this.
+            args += ["--user"]
+        else:
+            # Handle installation paths.
+            # If --root is given but not --prefix, we default to a prefix of "/"
+            # so that the install happens at the root of the --root directory.
+            # Otherwise, pip would use the configured sys.prefix, e.g.
+            # /usr/local, and install into ${root}/usr/local/.
+            effective_prefix = prefix
+            if root and not prefix:
+                effective_prefix = "/"
 
-            if root:
-                args += ["--root", root]
+            if root:
+                args += ["--root", root]
 
-            if effective_prefix:
-                args += ["--prefix", effective_prefix]
+            if effective_prefix:
+                args += ["--prefix", effective_prefix]
 
-                # Force the script shebang to point to the correct, final
-                # executable path. This is necessary when --root is used.
-                executable_path = (
-                    Path(effective_prefix) / "bin" / Path(sys.executable).name
-                )
-                args += ["--executable", os.fsdecode(executable_path)]
+                # Force the script shebang to point to the correct, final
+                # executable path. This is necessary when --root is used.
+                executable_path = (
+                    Path(effective_prefix) / "bin" / Path(sys.executable).name
+                )
+                args += ["--executable", os.fsdecode(executable_path)]
 
         return _run_pip([*args, "pip"], [os.fsdecode(tmp_wheel_path)])
 

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -177,32 +177,20 @@ def _bootstrap(*, root=None, upgrade=False, user=False,
         if sys.implementation.cache_tag is None:
             args += ["--no-compile"]
 
+        if root:
+            args += ["--root", root]
+
         if user:
             # --user is mutually exclusive with --root/--prefix,
             # pip will enforce this.
             args += ["--user"]
-        else:
-            # Handle installation paths.
-            # If --root is given but not --prefix, we default to a prefix of "/"
-            # so that the install happens at the root of the --root directory.
-            # Otherwise, pip would use the configured sys.prefix, e.g.
-            # /usr/local, and install into ${root}/usr/local/.
-            effective_prefix = prefix
-            if root and not prefix:
-                effective_prefix = "/"
+        elif prefix:
+            args += ["--prefix", prefix]
 
-            if root:
-                args += ["--root", root]
-
-            if effective_prefix:
-                args += ["--prefix", effective_prefix]
-
-                # Force the script shebang to point to the correct, final
-                # executable path. This is necessary when --root is used.
-                executable_path = (
-                    Path(effective_prefix) / "bin" / Path(sys.executable).name
-                )
-                args += ["--executable", os.fsdecode(executable_path)]
+            # Force the script shebang to point to the correct, final
+            # executable path. This is necessary when --root is used.
+            executable_path = Path(prefix) / "bin" / Path(sys.executable).name
+            args += ["--executable", os.fsdecode(executable_path)]
 
         return _run_pip([*args, "pip"], [os.fsdecode(tmp_wheel_path)])
 

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -70,8 +70,53 @@ def _run_pip(args, additional_paths=None):
     code = f"""
 import runpy
 import sys
+import os
+
+# Extract --executable from args if present to avoid "unknown option" error from pip
+# while still honoring the requested shebang.
+pip_args = {args}
+executable_path = None
+if "--executable" in pip_args:
+    try:
+        idx = pip_args.index("--executable")
+        executable_path = pip_args[idx + 1]
+        del pip_args[idx:idx + 2]
+    except (ValueError, IndexError):
+        pass
+
 sys.path = {additional_paths or []} + sys.path
-sys.argv[1:] = {args}
+
+if executable_path:
+    try:
+        import pip._internal.operations.install.wheel as w
+        from pip._vendor.distlib.scripts import ScriptMaker
+
+        def patched_fix_script(path):
+            with open(path, "rb") as script:
+                firstline = script.readline()
+                if not firstline.startswith(b"#!python"):
+                    return False
+                exename = executable_path.encode(sys.getfilesystemencoding())
+                firstline = b"#!" + exename + os.linesep.encode("ascii")
+                rest = script.read()
+            with open(path, "wb") as script:
+                script.write(firstline)
+                script.write(rest)
+            return True
+
+        w.fix_script = patched_fix_script
+
+        orig_init = ScriptMaker.__init__
+        def patched_init(self, *a, **kw):
+            orig_init(self, *a, **kw)
+            self.executable = executable_path
+        ScriptMaker.__init__ = patched_init
+    except ImportError:
+        # If pip internals changed, we might not be able to patch.
+        # But we still want to run pip.
+        pass
+
+sys.argv[1:] = pip_args
 runpy.run_module("pip", run_name="__main__", alter_sys=True)
 """
 

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -131,11 +131,6 @@ class TestBootstrap(EnsurepipMixin, unittest.TestCase):
             unittest.mock.ANY,
         )
 
-    def test_root_and_prefix_mutual_exclusive(self):
-        with self.assertRaises(ValueError):
-            ensurepip.bootstrap(root="", prefix="")
-        self.assertFalse(self.run_pip.called)
-
     def test_bootstrapping_with_user(self):
         ensurepip.bootstrap(user=True)
 

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -115,7 +115,8 @@ class TestBootstrap(EnsurepipMixin, unittest.TestCase):
         self.run_pip.assert_called_once_with(
             [
                 "install", "--no-cache-dir", "--no-index", "--find-links",
-                unittest.mock.ANY, "--root", "/foo/bar/", *COMPILE_OPT,
+                unittest.mock.ANY, "--root", "/foo/bar/", "--prefix", "/",
+                "--executable", unittest.mock.ANY, *COMPILE_OPT,
                 "pip",
             ],
             unittest.mock.ANY,
@@ -126,7 +127,8 @@ class TestBootstrap(EnsurepipMixin, unittest.TestCase):
         self.run_pip.assert_called_once_with(
             [
                 "install", "--no-cache-dir", "--no-index", "--find-links",
-                unittest.mock.ANY, "--prefix", "/foo/bar/", "pip",
+                unittest.mock.ANY, "--prefix", "/foo/bar/",
+                "--executable", unittest.mock.ANY, "pip",
             ],
             unittest.mock.ANY,
         )

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -115,9 +115,7 @@ class TestBootstrap(EnsurepipMixin, unittest.TestCase):
         self.run_pip.assert_called_once_with(
             [
                 "install", "--no-cache-dir", "--no-index", "--find-links",
-                unittest.mock.ANY, "--root", "/foo/bar/", "--prefix", "/",
-                "--executable", unittest.mock.ANY, *COMPILE_OPT,
-                "pip",
+                unittest.mock.ANY, "--root", "/foo/bar/", "pip", *COMPILE_OPT,
             ],
             unittest.mock.ANY,
         )
@@ -129,6 +127,18 @@ class TestBootstrap(EnsurepipMixin, unittest.TestCase):
                 "install", "--no-cache-dir", "--no-index", "--find-links",
                 unittest.mock.ANY, "--prefix", "/foo/bar/",
                 "--executable", unittest.mock.ANY, "pip",
+            ],
+            unittest.mock.ANY,
+        )
+
+    def test_bootstrapping_with_root_and_prefix(self):
+        ensurepip.bootstrap(root="/foo/root/", prefix="/foo/prefix/")
+        self.run_pip.assert_called_once_with(
+            [
+                "install", "--no-cache-dir", "--no-index", "--find-links",
+                unittest.mock.ANY, "--root", "/foo/root/",
+                "--prefix", "/foo/prefix/", "--executable",
+                unittest.mock.ANY, "pip",
             ],
             unittest.mock.ANY,
         )

--- a/Lib/test/test_ensurepip.py
+++ b/Lib/test/test_ensurepip.py
@@ -121,6 +121,21 @@ class TestBootstrap(EnsurepipMixin, unittest.TestCase):
             unittest.mock.ANY,
         )
 
+    def test_bootstrapping_with_prefix(self):
+        ensurepip.bootstrap(prefix="/foo/bar/")
+        self.run_pip.assert_called_once_with(
+            [
+                "install", "--no-cache-dir", "--no-index", "--find-links",
+                unittest.mock.ANY, "--prefix", "/foo/bar/", "pip",
+            ],
+            unittest.mock.ANY,
+        )
+
+    def test_root_and_prefix_mutual_exclusive(self):
+        with self.assertRaises(ValueError):
+            ensurepip.bootstrap(root="", prefix="")
+        self.assertFalse(self.run_pip.called)
+
     def test_bootstrapping_with_user(self):
         ensurepip.bootstrap(user=True)
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2443,7 +2443,7 @@ install: @FRAMEWORKINSTALLFIRST@ @INSTALLTARGETS@ @FRAMEWORKINSTALLLAST@
 			install|*) ensurepip="" ;; \
 		esac; \
 		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-			$$ensurepip --prefix=$(prefix) ; \
+			$$ensurepip --root=$(DESTDIR)/ --prefix=$(prefix) ; \
 	fi
 
 .PHONY: altinstall
@@ -2454,7 +2454,7 @@ altinstall: commoninstall
 			install|*) ensurepip="--altinstall" ;; \
 		esac; \
 		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-			$$ensurepip --prefix=$(prefix) ; \
+			$$ensurepip --root=$(DESTDIR)/ --prefix=$(prefix) ; \
 	fi
 
 .PHONY: commoninstall

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2443,7 +2443,7 @@ install: @FRAMEWORKINSTALLFIRST@ @INSTALLTARGETS@ @FRAMEWORKINSTALLLAST@
 			install|*) ensurepip="" ;; \
 		esac; \
 		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-			$$ensurepip --root=$(DESTDIR)/ ; \
+			$$ensurepip --prefix=$(prefix) ; \
 	fi
 
 .PHONY: altinstall
@@ -2454,7 +2454,7 @@ altinstall: commoninstall
 			install|*) ensurepip="--altinstall" ;; \
 		esac; \
 		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-			$$ensurepip --root=$(DESTDIR)/ ; \
+			$$ensurepip --prefix=$(prefix) ; \
 	fi
 
 .PHONY: commoninstall

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2354,7 +2354,7 @@ install: @FRAMEWORKINSTALLFIRST@ @INSTALLTARGETS@ @FRAMEWORKINSTALLLAST@
 			install|*) ensurepip="" ;; \
 		esac; \
 		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-			$$ensurepip --prefix=$(prefix) ; \
+			$$ensurepip --root=$(DESTDIR)/ --prefix=$(prefix) ; \
 	fi
 
 .PHONY: altinstall
@@ -2365,7 +2365,7 @@ altinstall: commoninstall
 			install|*) ensurepip="--altinstall" ;; \
 		esac; \
 		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-			$$ensurepip --prefix=$(prefix) ; \
+			$$ensurepip --root=$(DESTDIR)/ --prefix=$(prefix) ; \
 	fi
 
 .PHONY: commoninstall

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2354,7 +2354,7 @@ install: @FRAMEWORKINSTALLFIRST@ @INSTALLTARGETS@ @FRAMEWORKINSTALLLAST@
 			install|*) ensurepip="" ;; \
 		esac; \
 		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-			$$ensurepip --root=$(DESTDIR)/ ; \
+			$$ensurepip --prefix=$(prefix) ; \
 	fi
 
 .PHONY: altinstall
@@ -2365,7 +2365,7 @@ altinstall: commoninstall
 			install|*) ensurepip="--altinstall" ;; \
 		esac; \
 		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m ensurepip \
-			$$ensurepip --root=$(DESTDIR)/ ; \
+			$$ensurepip --prefix=$(prefix) ; \
 	fi
 
 .PHONY: commoninstall

--- a/Misc/NEWS.d/next/Library/2019-12-16-17-50-42.bpo-31046.XA-Qfr.rst
+++ b/Misc/NEWS.d/next/Library/2019-12-16-17-50-42.bpo-31046.XA-Qfr.rst
@@ -1,0 +1,1 @@
+A directory prefix can now be specified when using :mod:`ensurepip`.


### PR DESCRIPTION
When cross-compiling, the local Python interpreter that is used to run `ensurepip` may not have the same value of `sys.prefix` as the value of the 'prefix' variable that is set in the Makefile.

With the following values used to install Python locally for a later copy to the files hierarchy owned by the 'termux' application on an Android device:

```
    DESTDIR=/tmp/android
    prefix=/data/data/com.termux/files/usr/local
```

'make install' causes ensurepip to install pip in `$(DESTDIR)/usr/local` instead of the expected `$(DESTDIR)/$(prefix)` where is installed the standard library.

The attached patch fixes the problem. The patch was implemented assuming that pip uses `distutils` for the installation (note that setup.py also uses the --prefix option in the Makefile), but I know nothing about pip so forgive me if the patch is wrong and please just assume it is just a way to demonstrate the problem.

Fixes: https://github.com/python/cpython/issues/75229
Co-authored-by: Pradyun Gedam <pradyunsg@gmail.com>
Co-authored-by: Erlend E. Aasland <erlend.aasland@protonmail.com>
Co-authored-by: Zackery Spytz <zspytz@gmail.com>
References: https://github.com/python/cpython/pull/17634
Signed-off-by: Matěj Cepl <mcepl@cepl.eu>

<!-- gh-issue-number: gh-75229 -->
* Issue: gh-75229
<!-- /gh-issue-number -->
