### PR TITLE
[3.13] gh-135496: Fix f string exclamation mark error typo (GH-135495)

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1370,7 +1370,7 @@ x = (
         for conv in ' s', ' s ':
             self.assertAllRaise(SyntaxError,
                                 "f-string: conversion type must come right after the"
-                                " exclamanation mark",
+                                " exclamation mark",
                                 ["f'{3!" + conv + "}'"])
 
         self.assertAllRaise(SyntaxError,

--- a/Misc/NEWS.d/next/Core and Builtins/2025-06-14-01-01-14.gh-issue-135496.ER0Me3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2025-06-14-01-01-14.gh-issue-135496.ER0Me3.rst
@@ -1,0 +1,1 @@
+Fix typo in the f-string conversion type error ("exclamanation" -> "exclamation").

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -955,7 +955,7 @@ _PyPegen_check_fstring_conversion(Parser *p, Token* conv_token, expr_ty conv)
     if (conv_token->lineno != conv->lineno || conv_token->end_col_offset != conv->col_offset) {
         return RAISE_SYNTAX_ERROR_KNOWN_RANGE(
             conv_token, conv,
-            "f-string: conversion type must come right after the exclamanation mark"
+            "f-string: conversion type must come right after the exclamation mark"
         );
     }
     return result_token_with_metadata(p, conv, conv_token->metadata);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Typo fix, the error has "exclamanation" instead of "exclamation"
Backport to 3.13 manually because of conflict in bot
@terryjreedy


<!-- gh-issue-number: gh-135496 -->
* Issue: gh-135496
<!-- /gh-issue-number -->
