### PR TITLE
gh-135500: Use ipaddress.ip_address instead of regex to detect IPv4 string in http.cookiejar

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -38,6 +38,7 @@ import threading as _threading
 import http.client  # only for the default HTTP port
 from calendar import timegm
 from ipaddress import ip_address
+
 debug = False   # set to True to enable debugging via the logging module
 logger = None
 

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -585,8 +585,6 @@ def domain_match(A, B):
     if not is_HDN(A):
         return False
     i = A.rfind(B)
-    # B = .baidu.com
-    # A = lamentxu.top@www.baidu.com
     if i == -1 or i == 0:
         # A does not have form NB, or N is the empty string
         return False

--- a/Misc/NEWS.d/next/Library/2025-06-14-07-59-32.gh-issue-135500.Bp6zIB.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-14-07-59-32.gh-issue-135500.Bp6zIB.rst
@@ -1,1 +1,1 @@
-:mod:`http.cookiejar`: use `ipaddress.ip_address()` instead of regex to check if a string is a HDN or a ipaddress.
+:mod:`http.cookiejar`: use :func:`~ipaddress.ip_address` instead of regex to check if a string is a HDN or a ipaddress.

--- a/Misc/NEWS.d/next/Library/2025-06-14-07-59-32.gh-issue-135500.Bp6zIB.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-14-07-59-32.gh-issue-135500.Bp6zIB.rst
@@ -1,0 +1,1 @@
+:mod:`http.cookiejar`: use `ipaddress.ip_address()` instead of regex to check if a string is a HDN or a ipaddress.


### PR DESCRIPTION
PR for #135500 

discuss post on Disclosure: https://discuss.python.org/t/support-ipv6-in-http-cookiejar-when-deciding-whether-a-string-is-a-hdn-or-a-ip-addr/95439 

Changing the regex detection into `is
_ip()`which use`ipaddress.ip_address()`.

<!-- gh-issue-number: gh-135500 -->
* Issue: gh-135500
<!-- /gh-issue-number -->
