### PR TITLE
gh-135504: Document `LIBZSTD_CFLAGS` and `LIBZSTD_LIBS` config options

### DIFF
--- a/Doc/using/configure.rst
+++ b/Doc/using/configure.rst
@@ -445,6 +445,14 @@ Options for third-party dependencies
    C compiler and linker flags for ``libuuid``, used by :mod:`uuid` module,
    overriding ``pkg-config``.
 
+.. option:: LIBZSTD_CFLAGS
+.. option:: LIBZSTD_LIBS
+
+   C compiler and linker flags for ``libzstd``, used by :mod:`compression.zstd` module,
+   overriding ``pkg-config``.
+
+   .. versionadded:: 3.14
+
 .. option:: PANEL_CFLAGS
 .. option:: PANEL_LIBS
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-135504 -->
* Issue: gh-135504
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135505.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->