### PR TITLE
gh-135487: fix `reprlib.Repr.repr_int` when given very large integers

### DIFF
--- a/Doc/library/reprlib.rst
+++ b/Doc/library/reprlib.rst
@@ -219,6 +219,7 @@ which format specific object types.
 
 
 .. method:: Repr.repr_TYPE(obj, level)
+   :noindex:
 
    Formatting methods for specific types are implemented as methods with a name
    based on the type name.  In the method name, **TYPE** is replaced by

--- a/Doc/library/reprlib.rst
+++ b/Doc/library/reprlib.rst
@@ -219,7 +219,6 @@ which format specific object types.
 
 
 .. method:: Repr.repr_TYPE(obj, level)
-   :noindex:
 
    Formatting methods for specific types are implemented as methods with a name
    based on the type name.  In the method name, **TYPE** is replaced by

--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -181,7 +181,23 @@ class Repr:
         return s
 
     def repr_int(self, x, level):
-        s = builtins.repr(x) # XXX Hope this isn't too slow...
+        try:
+            s = builtins.repr(x)
+        except ValueError as exc:
+            assert 'sys.set_int_max_str_digits()' in str(exc)
+            # Those imports must be deferred due to Python's build system
+            # where the reprlib module is imported before the math module.
+            import math, sys
+            # Integers with more than sys.get_int_max_str_digits() digits
+            # are rendered differently as their repr() raises a ValueError.
+            # See https://github.com/python/cpython/issues/135487.
+            k = 1 + int(math.log10(abs(x)))
+            # When math.log10(abs(x)) is overestimated or underestimated,
+            # the number of digits should be k - 1 or k + 1 respectively.
+            # For simplicity, we do not compute the exact number of digits.
+            max_digits = sys.get_int_max_str_digits()
+            return (f'<{x.__class__.__name__} instance with roughly {k} '
+                    f'digits (limit at {max_digits}) at 0x{id(x):x}>')
         if len(s) > self.maxlong:
             i = max(0, (self.maxlong-3)//2)
             j = max(0, self.maxlong-3-i)

--- a/Lib/reprlib.py
+++ b/Lib/reprlib.py
@@ -192,9 +192,8 @@ class Repr:
             # are rendered differently as their repr() raises a ValueError.
             # See https://github.com/python/cpython/issues/135487.
             k = 1 + int(math.log10(abs(x)))
-            # When math.log10(abs(x)) is overestimated or underestimated,
-            # the number of digits should be k - 1 or k + 1 respectively.
-            # For simplicity, we do not compute the exact number of digits.
+            # Note: math.log10(abs(x)) may be overestimated or underestimated,
+            # but for simplicity, we do not compute the exact number of digits.
             max_digits = sys.get_int_max_str_digits()
             return (f'<{x.__class__.__name__} instance with roughly {k} '
                     f'digits (limit at {max_digits}) at 0x{id(x):x}>')

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -151,14 +151,38 @@ class ReprTests(unittest.TestCase):
         eq(r(frozenset({1, 2, 3, 4, 5, 6, 7})), "frozenset({1, 2, 3, 4, 5, 6, ...})")
 
     def test_numbers(self):
-        eq = self.assertEqual
-        eq(r(123), repr(123))
-        eq(r(123), repr(123))
-        eq(r(1.0/3), repr(1.0/3))
+        for x in [123, 1.0 / 3]:
+            self.assertEqual(r(x), repr(x))
 
-        n = 10**100
-        expected = repr(n)[:18] + "..." + repr(n)[-19:]
-        eq(r(n), expected)
+        max_digits = sys.get_int_max_str_digits()
+        for k in [100, max_digits - 1]:
+            with self.subTest(f'10 ** {k}', k=k):
+                n = 10 ** k
+                expected = repr(n)[:18] + "..." + repr(n)[-19:]
+                self.assertEqual(r(n), expected)
+
+        def re_msg(n, d):
+            return (rf'<{n.__class__.__name__} instance with roughly {d} '
+                    rf'digits \(limit at {max_digits}\) at 0x[a-f0-9]+>')
+
+        k = max_digits
+        with self.subTest(f'10 ** {k}', k=k):
+            n = 10 ** k
+            self.assertRaises(ValueError, repr, n)
+            self.assertRegex(r(n), re_msg(n, k + 1))
+
+        for k in [max_digits + 1, 2 * max_digits]:
+            self.assertGreater(k, 100)
+            with self.subTest(f'10 ** {k}', k=k):
+                n = 10 ** k
+                self.assertRaises(ValueError, repr, n)
+                self.assertRegex(r(n), re_msg(n, k + 1))
+            with self.subTest(f'10 ** {k} - 1', k=k):
+                n = 10 ** k - 1
+                # For k >> 1, since math.log10(n) == math.log10(n-1),
+                # the number of digits of n - 1 is overestimated.
+                self.assertRaises(ValueError, repr, n)
+                self.assertRegex(r(n), re_msg(n, k + 1))
 
     def test_instance(self):
         eq = self.assertEqual

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -179,7 +179,7 @@ class ReprTests(unittest.TestCase):
                 self.assertRegex(r(n), re_msg(n, k + 1))
             with self.subTest(f'10 ** {k} - 1', k=k):
                 n = 10 ** k - 1
-                # For k >> 1, since math.log10(n) == math.log10(n-1),
+                # Here, since math.log10(n) == math.log10(n-1),
                 # the number of digits of n - 1 is overestimated.
                 self.assertRaises(ValueError, repr, n)
                 self.assertRegex(r(n), re_msg(n, k + 1))

--- a/Misc/NEWS.d/next/Library/2025-06-14-12-06-55.gh-issue-135487.KdVFff.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-14-12-06-55.gh-issue-135487.KdVFff.rst
@@ -1,3 +1,2 @@
-Fix :meth:`reprlib.Repr.repr_int <reprlib.Repr.repr_TYPE>` when given
-integers with more than :func:`sys.get_int_max_str_digits` digits. Patch by
-Bénédikt Tran.
+Fix :meth:`!reprlib.Repr.repr_int` when given integers with more than
+:func:`sys.get_int_max_str_digits` digits. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-06-14-12-06-55.gh-issue-135487.KdVFff.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-14-12-06-55.gh-issue-135487.KdVFff.rst
@@ -1,0 +1,3 @@
+Fix :meth:`reprlib.Repr.repr_int <reprlib.Repr.repr_TYPE>` when given
+integers with more than :func:`sys.get_int_max_str_digits` digits. Patch by
+Bénédikt Tran.


### PR DESCRIPTION
Getting the number of digits may be wrong due to some round-off errors but I don't want to overcomplicate the code.

<!-- gh-issue-number: gh-135487 -->
* Issue: gh-135487
<!-- /gh-issue-number -->
