### PR TITLE
`runpy:` use docstrings for all helpers

### DIFF
--- a/Lib/runpy.py
+++ b/Lib/runpy.py
@@ -101,8 +101,8 @@ def _run_module_code(code, init_globals=None,
     # may be cleared when the temporary module goes away
     return mod_globals.copy()
 
-# Helper to get the full name, spec and code for a module
 def _get_module_details(mod_name, error=ImportError):
+    """Helper to get the full name, spec and code for a module"""
     if mod_name.startswith("."):
         raise error("Relative module names not supported")
     pkg_name, _, _ = mod_name.rpartition(".")
@@ -229,10 +229,12 @@ def run_module(mod_name, init_globals=None,
         return _run_code(code, {}, init_globals, run_name, mod_spec)
 
 def _get_main_module_details(error=ImportError):
-    # Helper that gives a nicer error message when attempting to
-    # execute a zipfile or directory by invoking __main__.py
-    # Also moves the standard __main__ out of the way so that the
-    # preexisting __loader__ entry doesn't cause issues
+    """Helper that gives a nicer error message when attempting to
+       execute a zipfile or directory by invoking __main__.py
+
+       Also moves the standard __main__ out of the way so that the
+       preexisting __loader__ entry doesn't cause issues.
+    """
     main_name = "__main__"
     saved_main = sys.modules[main_name]
     del sys.modules[main_name]


### PR DESCRIPTION
Hello maintainers,

Thanks for keeping Python alive; I have been using it for years, and this is my first ever contribution.

`runpy.py` defines four helpers, and two are not documented using docstrings.

With this change, docstrings are used on all helpers:

```shell
# sed -ne '/def /h; /Helper/{x;G;p}' Lib/runpy.py 

def _run_code(code, run_globals, init_globals=None,
    """Helper to run code in nominated namespace"""
def _run_module_code(code, init_globals=None,
    """Helper to run code in new namespace with sys modified"""
def _get_module_details(mod_name, error=ImportError):
    """Helper to get the full name, spec and code for a module"""
def _get_main_module_details(error=ImportError):
    """Helper that gives a nicer error message when attempting to
```

Your feedback is much appreciated,

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->
