### PR TITLE
gh-135497: fix MAXLOGNAME detection in configure

### DIFF
--- a/Misc/NEWS.d/next/Build/2025-06-14-10-32-11.gh-issue-135497.ajlV4F.rst
+++ b/Misc/NEWS.d/next/Build/2025-06-14-10-32-11.gh-issue-135497.ajlV4F.rst
@@ -1,1 +1,1 @@
-Fix the detection of ``MAXLOGNAME`` in the configure script.
+Fix the detection of ``MAXLOGNAME`` in the ``configure.ac`` script.

--- a/Misc/NEWS.d/next/Build/2025-06-14-10-32-11.gh-issue-135497.ajlV4F.rst
+++ b/Misc/NEWS.d/next/Build/2025-06-14-10-32-11.gh-issue-135497.ajlV4F.rst
@@ -1,0 +1,1 @@
+Fix the detection of ``MAXLOGNAME`` in the configure script.

--- a/Misc/NEWS.d/next/Library/2025-06-14-14-19-13.gh-issue-135497.1pzwdA.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-14-14-19-13.gh-issue-135497.1pzwdA.rst
@@ -1,0 +1,1 @@
+Fix :func:`os.getlogin` failing for longer usernames on BSD-based platforms.

--- a/configure
+++ b/configure
@@ -23849,7 +23849,7 @@ fi
 
 
 
-ac_fn_check_decl "$LINENO" "MAXLOGNAME" "ac_cv_have_decl_MAXLOGNAME" "#include <sys/params.h>
+ac_fn_check_decl "$LINENO" "MAXLOGNAME" "ac_cv_have_decl_MAXLOGNAME" "#include <sys/param.h>
 " "$ac_c_undeclared_builtin_options" "CFLAGS"
 if test "x$ac_cv_have_decl_MAXLOGNAME" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -5542,7 +5542,7 @@ AC_CHECK_DECL([MAXLOGNAME],
               [AC_DEFINE([HAVE_MAXLOGNAME], [1],
                          [Define if you have the 'MAXLOGNAME' constant.])],
               [],
-              [@%:@include <sys/params.h>])
+              [@%:@include <sys/param.h>])
 
 AC_CHECK_DECLS([UT_NAMESIZE],
               [AC_DEFINE([HAVE_UT_NAMESIZE], [1],


### PR DESCRIPTION


<!-- gh-issue-number: gh-135497 -->
* Issue: gh-135497
<!-- /gh-issue-number -->
