### PR TITLE
gh-135489: Allow verbose output for PGO runs in _runtest function

### DIFF
--- a/Lib/test/libregrtest/single.py
+++ b/Lib/test/libregrtest/single.py
@@ -283,7 +283,7 @@ def _runtest(result: TestResult, runtests: RunTests) -> None:
     try:
         setup_tests(runtests)
 
-        if output_on_failure:
+        if output_on_failure or runtests.pgo:
             support.verbose = True
 
             stream = io.StringIO()

--- a/Misc/NEWS.d/next/Tests/2025-06-14-13-20-17.gh-issue-135489.Uh0yVO.rst
+++ b/Misc/NEWS.d/next/Tests/2025-06-14-13-20-17.gh-issue-135489.Uh0yVO.rst
@@ -1,0 +1,1 @@
+Allow verbose output for PGO runs in _runtest function

--- a/Misc/NEWS.d/next/Tests/2025-06-14-13-20-17.gh-issue-135489.Uh0yVO.rst
+++ b/Misc/NEWS.d/next/Tests/2025-06-14-13-20-17.gh-issue-135489.Uh0yVO.rst
@@ -1,1 +1,1 @@
-Allow verbose output for PGO runs in _runtest function
+Show verbose output for failing tests during PGO profiling step with --enable-optimizations.


### PR DESCRIPTION
<!-- gh-issue-number: gh-135489 -->
* Issue: gh-135489
<!-- /gh-issue-number -->


Before:

<img width="613" alt="image" src="https://github.com/user-attachments/assets/98d1a220-ad17-4c18-8424-181d6ab7849e" />

After:

<img width="1047" alt="image" src="https://github.com/user-attachments/assets/83e51b1f-2888-4a6d-940b-ffd1a8e31bc8" />
