### PR TITLE
gh-135490: Add warning about arguments that conflict with pdb

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -88,6 +88,15 @@ after normal exit of the program), pdb will restart the program.  Automatic
 restarting preserves pdb's state (such as breakpoints) and in most cases is more
 useful than quitting the debugger upon program's exit.
 
+.. warning::
+
+   If the target program has arguments that overlap with those given below,
+   they will be parsed incorrectly. To avoid this problem, separate target
+   program arguments from ``pdb`` arguments using ``--``, for example::
+
+      pdb target.py -- -m "Target program argument"
+      pdb -m target -- -m "Target program argument"
+
 .. option:: -c, --command <command>
 
    To execute commands as if given in a :file:`.pdbrc` file; see


### PR DESCRIPTION
Closes #135490.

This changeset adds a warning to the `pdb` docs explaining that target program arguments that overlap with `pdb` arguments must be separated from the rest of the command line by `--` to prevent confusion on the part of `argparse`.

Should only be merged if a fix for that issue does not materialize, although the `pdb target.py -- -m XYZ` case is likely to apply even if there is a fix for the the repeated `-m` case.


### Screenshot
![Screenshot of proposed Python documentation](https://github.com/user-attachments/assets/d1b5200f-8e02-44d6-8357-0c8056ae4a3e)


<!-- gh-issue-number: gh-135490 -->
* Issue: gh-135490
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135520.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->