### PR TITLE
gh-127264: Update document behavior of Path.resolve()

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -982,6 +982,24 @@ Expanding and resolving paths
       strict mode, and no exception is raised in non-strict mode. In previous
       versions, :exc:`RuntimeError` is raised no matter the value of *strict*.
 
+   .. note::
+
+      Even with ``strict=False``, ``Path.resolve()`` internally calls
+      :func:`os.getcwd` to obtain the current working directory (cwd).
+      If the cwd has been removed (for example, by unlinking it externally),
+      :func:`os.getcwd` will raise :exc:`FileNotFoundError`, causing
+      ``resolve()`` to fail.
+
+      Therefore:
+
+      - Do **not** rely solely on ``Path.exists()`` as a pre-check for
+        ``resolve()``: ``exists()`` only reflects the existence of the
+        *target* path in the filesystem, and does not detect whether the cwd
+        has been deleted.
+      - In multi-threaded or multi-process environments, a successful
+        ``exists()`` check may still race with filesystem changes that occur
+        before calling ``resolve()``.
+
 
 .. method:: Path.readlink()
 


### PR DESCRIPTION
Closes https://github.com/python/cpython/issues/127264

# What
Issue [#127264](https://github.com/python/cpython/issues/127264) pointed out that users relying on `exists()` as a safe pre-check for `resolve()` may still encounter an unexpected `FileNotFoundError` when the cwd is gone. This note:

- Explains the underlying cause (the `getcwd()` call).  
- Warns that non-strict mode isn’t immune to failing when the cwd is deleted.  
- Reminds users that a pre-check with `exists()` can race with filesystem changes.

# How
- Added a “.. note::” under the “Expanding and resolving paths” section of `Doc/library/pathlib.rst` to document that `Path.resolve(strict=False)` will call `os.getcwd()` internally and thus can raise `FileNotFoundError` if the current working directory has been deleted.


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-127264 -->
* Issue: gh-127264
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135531.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->