### PR TITLE
gh-111178: fix UBSan failures for `RemoteUnwinderObject`

### DIFF
--- a/Modules/_remote_debugging_module.c
+++ b/Modules/_remote_debugging_module.c
@@ -212,6 +212,8 @@ typedef struct {
 #endif
 } RemoteUnwinderObject;
 
+#define RemoteUnwinder_CAST(op) ((RemoteUnwinderObject *)(op))
+
 typedef struct
 {
     int lineno;
@@ -2899,8 +2901,9 @@ static PyMethodDef RemoteUnwinder_methods[] = {
 };
 
 static void
-RemoteUnwinder_dealloc(RemoteUnwinderObject *self)
+RemoteUnwinder_dealloc(PyObject *op)
 {
+    RemoteUnwinderObject *self = RemoteUnwinder_CAST(op);
     PyTypeObject *tp = Py_TYPE(self);
     if (self->code_object_cache) {
         _Py_hashtable_destroy(self->code_object_cache);


### PR DESCRIPTION
This fixes the following

```
./python -m test test_external_inspection
...
Objects/object.c:3195:5: runtime error: call to function RemoteUnwinder_dealloc through pointer to incorrect function type 'void (*)(struct _object *)'
/home/picnix/lib/python/cpython/./Modules/_remote_debugging_module.c:2903: note: RemoteUnwinder_dealloc defined here
```

<!-- gh-issue-number: gh-111178 -->
* Issue: gh-111178
<!-- /gh-issue-number -->
