### PR TITLE
gh-135543: emit ``sys.remote_exec`` audit event when ``sys.remote_exec`` has been called

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1933,6 +1933,11 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    interpreter is pre-release (alpha, beta, or release candidate) then the
    local and remote interpreters must be the same exact version.
 
+   .. audit-event:: remove_exec pid script_path
+
+      When the code is executed in the remote process, an :ref:`auditing event <auditing>`
+      ``remove_exec`` is raised with the *pid* and the path to the script file.
+
    .. availability:: Unix, Windows.
    .. versionadded:: 3.14
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1933,7 +1933,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    interpreter is pre-release (alpha, beta, or release candidate) then the
    local and remote interpreters must be the same exact version.
 
-   .. audit-event:: remove_exec pid script_path
+   .. audit-event:: remote_exec pid script_path
 
       When the code is executed in the remote process, an :ref:`auditing event <auditing>`
       ``remote_exec`` is raised with the *pid* and the path to the script file.

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1935,8 +1935,10 @@ always available. Unless explicitly noted otherwise, all variables are read-only
 
    .. audit-event:: sys.remote_exec pid script_path
 
-      When the code is executed in the remote process, an :ref:`auditing event <auditing>`
-      ``sys.remote_exec`` is raised with the *pid* and the path to the script file.
+      When the code is executed in the remote process, an
+      :ref:`auditing event <auditing>` ``sys.remote_exec`` is raised with
+      the *pid* and the path to the script file.
+      This event is raised in the process that called :func:`sys.remote_exec`.
 
    .. audit-event:: cpython.remote_debugger_script script_path
 
@@ -1944,6 +1946,8 @@ always available. Unless explicitly noted otherwise, all variables are read-only
       :ref:`auditing event <auditing>`
       ``cpython.remote_debugger_script`` is raised
       with the path in the remote process.
+      This event is raised in the remote process, not the one
+      that called :func:`sys.remote_exec`.
 
    .. availability:: Unix, Windows.
    .. versionadded:: 3.14

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1933,16 +1933,16 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    interpreter is pre-release (alpha, beta, or release candidate) then the
    local and remote interpreters must be the same exact version.
 
-   .. audit-event:: remote_exec pid script_path
+   .. audit-event:: sys.remote_exec pid script_path
 
       When the code is executed in the remote process, an :ref:`auditing event <auditing>`
-      ``remote_exec`` is raised with the *pid* and the path to the script file.
+      ``sys.remote_exec`` is raised with the *pid* and the path to the script file.
 
-   .. audit-event:: remote_debugger_script script_path
+   .. audit-event:: cpython.remote_debugger_script script_path
 
       When the script is executed in the remote process, an
       :ref:`auditing event <auditing>`
-      ``sys.remote_debugger_script`` is raised
+      ``cpython.remote_debugger_script`` is raised
       with the path in the remote process.
 
    .. availability:: Unix, Windows.

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1936,7 +1936,7 @@ always available. Unless explicitly noted otherwise, all variables are read-only
    .. audit-event:: remove_exec pid script_path
 
       When the code is executed in the remote process, an :ref:`auditing event <auditing>`
-      ``remove_exec`` is raised with the *pid* and the path to the script file.
+      ``remote_exec`` is raised with the *pid* and the path to the script file.
 
    .. audit-event:: remote_debugger_script script_path
 

--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -650,7 +650,7 @@ def test_sys_remote_exec():
     event_pid = -1
     event_script_path = ""
     def hook(event, args):
-        if event != "remote_exec": return
+        if event != "sys.remote_exec": return
         nonlocal event_pid
         event_pid = args[0]
         nonlocal event_script_path

--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -661,8 +661,8 @@ def test_sys_remote_exec():
         tmp_file.write("print('Hello from remote_exec!')\n")
         tmp_file.flush()
         sys.remote_exec(pid, tmp_file.name)
-        assertEqual(pid, event_pid)
-        assertEqual(tmp_file.name, event_script_path)
+        assertEqual(event_pid, pid)
+        assertEqual(event_script_path, tmp_file.name)
 
 if __name__ == "__main__":
     from test.support import suppress_msvcrt_asserts

--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -649,20 +649,28 @@ def test_sys_remote_exec():
     pid = os.getpid()
     event_pid = -1
     event_script_path = ""
+    remote_event_script_path = ""
     def hook(event, args):
-        if event != "sys.remote_exec": return
-        nonlocal event_pid
-        event_pid = args[0]
-        nonlocal event_script_path
-        event_script_path = args[1]
+        if event not in ["sys.remote_exec", "cpython.remote_debugger_script"]:
+            return
+        print(event, args)
+        match event:
+            case "sys.remote_exec":
+                nonlocal event_pid, event_script_path
+                event_pid = args[0]
+                event_script_path = args[1]
+            case "cpython.remote_debugger_script":
+                nonlocal remote_event_script_path
+                remote_event_script_path = args[0]
 
     sys.addaudithook(hook)
     with tempfile.NamedTemporaryFile(mode='w+', delete=True) as tmp_file:
-        tmp_file.write("print('Hello from remote_exec!')\n")
+        tmp_file.write("a = 1+1\n")
         tmp_file.flush()
         sys.remote_exec(pid, tmp_file.name)
         assertEqual(event_pid, pid)
         assertEqual(event_script_path, tmp_file.name)
+        assertEqual(remote_event_script_path, tmp_file.name)
 
 if __name__ == "__main__":
     from test.support import suppress_msvcrt_asserts

--- a/Lib/test/audit-tests.py
+++ b/Lib/test/audit-tests.py
@@ -648,6 +648,7 @@ def test_sys_remote_exec():
     import sys
     pid = os.getpid()
     event_pid = -1
+    event_script_path = ""
     remote_exec_trigger = False
     def hook(event, args):
         if event == "remote_exec":
@@ -655,13 +656,17 @@ def test_sys_remote_exec():
             remote_exec_trigger = True
             nonlocal event_pid
             event_pid = args[0]
+            nonlocal event_script_path
+            event_script_path = args[1]
+
     sys.addaudithook(hook)
     with tempfile.NamedTemporaryFile(mode='w+', delete=True) as tmp_file:
         tmp_file.write("print('Hello from remote_exec!')\n")
         tmp_file.flush()
         sys.remote_exec(pid, tmp_file.name)
-    assert remote_exec_trigger
-    assert event_pid == pid
+        assert remote_exec_trigger
+        assert event_pid == pid
+        assert event_script_path == tmp_file.name
 
 if __name__ == "__main__":
     from test.support import suppress_msvcrt_asserts

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3090,7 +3090,7 @@ def _support_remote_exec_only_impl(test):
     return _id
 
 def support_remote_exec_only(test):
-    return _support_remote_exec_only_impl(test)
+    return _support_remote_exec_only_impl()(test)
 
 class EqualToForwardRef:
     """Helper to ease use of annotationlib.ForwardRef in tests.

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3083,7 +3083,7 @@ def _supports_remote_attaching():
 def support_remote_exec_only(test):
     if not sys.is_remote_debug_enabled():
         return unittest.skip("Remote debugging is not enabled")(test)
-    if sys.platform != "darwin" and sys.platform != "linux" and sys.platform != "win32":
+    if sys.platform not in ("darwin", "linux", "win32"):
         return unittest.skip("Test only runs on Linux, Windows and macOS")(test)
     if sys.platform == "linux" and not _supports_remote_attaching():
         return unittest.skip("Test only runs on Linux with process_vm_readv support")(test)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3080,7 +3080,7 @@ def _supports_remote_attaching():
 
     return PROCESS_VM_READV_SUPPORTED
 
-def _support_remote_exec_only_impl(test):
+def _support_remote_exec_only_impl():
     if not sys.is_remote_debug_enabled():
         return unittest.skip("Remote debugging is not enabled")
     if sys.platform not in ("darwin", "linux", "win32"):

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3080,14 +3080,17 @@ def _supports_remote_attaching():
 
     return PROCESS_VM_READV_SUPPORTED
 
-def support_remote_exec_only(test):
+def _support_remote_exec_only_impl(test):
     if not sys.is_remote_debug_enabled():
-        return unittest.skip("Remote debugging is not enabled")(test)
+        return unittest.skip("Remote debugging is not enabled")
     if sys.platform not in ("darwin", "linux", "win32"):
-        return unittest.skip("Test only runs on Linux, Windows and macOS")(test)
+        return unittest.skip("Test only runs on Linux, Windows and macOS")
     if sys.platform == "linux" and not _supports_remote_attaching():
-        return unittest.skip("Test only runs on Linux with process_vm_readv support")(test)
-    return _id(test)
+        return unittest.skip("Test only runs on Linux with process_vm_readv support")
+    return _id
+
+def support_remote_exec_only(test):
+    return _support_remote_exec_only_impl(test)
 
 class EqualToForwardRef:
     """Helper to ease use of annotationlib.ForwardRef in tests.

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3084,7 +3084,7 @@ def support_remote_exec_only(test):
     if not sys.is_remote_debug_enabled():
         return unittest.skip("Remote debugging is not enabled")(test)
     if sys.platform != "darwin" and sys.platform != "linux" and sys.platform != "win32":
-        return unittest.skip("Test only runs on Linux, Windows and MacOS")(test)
+        return unittest.skip("Test only runs on Linux, Windows and macOS")(test)
     if sys.platform == "linux" and not _supports_remote_attaching():
         return unittest.skip("Test only runs on Linux with process_vm_readv support")(test)
     return _id(test)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3082,11 +3082,11 @@ def _supports_remote_attaching():
 
 def support_remote_exec_only(test):
     if not sys.is_remote_debug_enabled():
-        return unittest.skip("Remote debugging is not enabled")
+        return unittest.skip("Remote debugging is not enabled")(test)
     if sys.platform != "darwin" and sys.platform != "linux" and sys.platform != "win32":
-        return unittest.skip("Test only runs on Linux, Windows and MacOS")
+        return unittest.skip("Test only runs on Linux, Windows and MacOS")(test)
     if sys.platform == "linux" and not _supports_remote_attaching():
-        return unittest.skip("Test only runs on Linux with process_vm_readv support")
+        return unittest.skip("Test only runs on Linux with process_vm_readv support")(test)
     return _id(test)
 
 class EqualToForwardRef:

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -331,11 +331,7 @@ class AuditTest(unittest.TestCase):
         if returncode:
             self.fail(stderr)
 
-    @unittest.skipIf(not sys.is_remote_debug_enabled(), "Remote debugging is not enabled")
-    @unittest.skipIf(sys.platform != "darwin" and sys.platform != "linux" and sys.platform != "win32",
-                        "Test only runs on Linux, Windows and MacOS")
-    @unittest.skipIf(sys.platform == "linux" and not _supports_remote_attaching(),
-                        "Test only runs on Linux with process_vm_readv support")
+    @support.support_remote_exec_only
     @support.cpython_only
     def test_sys_remote_exec(self):
         returncode, stdout, stderr = self.run_python("test_sys_remote_exec")

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -14,16 +14,6 @@ if not hasattr(sys, "addaudithook") or not hasattr(sys, "audit"):
 
 AUDIT_TESTS_PY = support.findfile("audit-tests.py")
 
-def _supports_remote_attaching():
-    PROCESS_VM_READV_SUPPORTED = False
-
-    try:
-        from _remote_debugging import PROCESS_VM_READV_SUPPORTED
-    except ImportError:
-        pass
-
-    return PROCESS_VM_READV_SUPPORTED
-
 class AuditTest(unittest.TestCase):
     maxDiff = None
 

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -325,7 +325,9 @@ class AuditTest(unittest.TestCase):
     @support.support_remote_exec_only
     @support.cpython_only
     def test_sys_remote_exec(self):
-        returncode, stdout, stderr = self.run_python("test_sys_remote_exec")
+        returncode, events, stderr = self.run_python("test_sys_remote_exec")
+        self.assertTrue(any(["sys.remote_exec" in event for event in events]))
+        self.assertTrue(any(["cpython.remote_debugger_script" in event for event in events]))
         if returncode:
             self.fail(stderr)
 

--- a/Lib/test/test_audit.py
+++ b/Lib/test/test_audit.py
@@ -14,6 +14,7 @@ if not hasattr(sys, "addaudithook") or not hasattr(sys, "audit"):
 
 AUDIT_TESTS_PY = support.findfile("audit-tests.py")
 
+
 class AuditTest(unittest.TestCase):
     maxDiff = None
 

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1943,22 +1943,7 @@ class SizeofTest(unittest.TestCase):
         self.assertEqual(out, b"")
         self.assertEqual(err, b"")
 
-
-def _supports_remote_attaching():
-    PROCESS_VM_READV_SUPPORTED = False
-
-    try:
-        from _remote_debugging import PROCESS_VM_READV_SUPPORTED
-    except ImportError:
-        pass
-
-    return PROCESS_VM_READV_SUPPORTED
-
-@unittest.skipIf(not sys.is_remote_debug_enabled(), "Remote debugging is not enabled")
-@unittest.skipIf(sys.platform != "darwin" and sys.platform != "linux" and sys.platform != "win32",
-                    "Test only runs on Linux, Windows and MacOS")
-@unittest.skipIf(sys.platform == "linux" and not _supports_remote_attaching(),
-                    "Test only runs on Linux with process_vm_readv support")
+@test.support.support_remote_exec_only
 @test.support.cpython_only
 class TestRemoteExec(unittest.TestCase):
     def tearDown(self):

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -2114,12 +2114,18 @@ sys.addaudithook(audit_hook)
         script = '''
 print("Remote script executed successfully!")
 '''
+        remote_exec_event_triggered = False
+        def audit_hook(event, arg):
+            if event == "remote_exec":
+                nonlocal remote_exec_event_triggered
+                remote_exec_event_triggered = True
+        sys.addaudithook(audit_hook)
         returncode, stdout, stderr = self._run_remote_exec_test(script, prologue=prologue)
         self.assertEqual(returncode, 0)
         self.assertIn(b"Remote script executed successfully!", stdout)
         self.assertIn(b"Audit event: remote_debugger_script, arg: ", stdout)
-        self.assertIn(b"Audit event: remote_exec, arg: ", stdout)
         self.assertEqual(stderr, b"")
+        self.assertTrue(remote_exec_event_triggered)
 
     def test_remote_exec_with_exception(self):
         """Test remote exec with an exception raised in the target process

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -2102,7 +2102,7 @@ print("Remote script executed successfully!")
         returncode, stdout, stderr = self._run_remote_exec_test(script, prologue=prologue)
         self.assertEqual(returncode, 0)
         self.assertIn(b"Remote script executed successfully!", stdout)
-        self.assertIn(b"Audit event: remote_debugger_script, arg: ", stdout)
+        self.assertIn(b"Audit event: cpython.remote_debugger_script, arg: ", stdout)
         self.assertEqual(stderr, b"")
 
     def test_remote_exec_with_exception(self):

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -2118,6 +2118,7 @@ print("Remote script executed successfully!")
         self.assertEqual(returncode, 0)
         self.assertIn(b"Remote script executed successfully!", stdout)
         self.assertIn(b"Audit event: remote_debugger_script, arg: ", stdout)
+        self.assertIn(b"Audit event: remote_exec, arg: ", stdout)
         self.assertEqual(stderr, b"")
 
     def test_remote_exec_with_exception(self):

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -2114,18 +2114,11 @@ sys.addaudithook(audit_hook)
         script = '''
 print("Remote script executed successfully!")
 '''
-        remote_exec_event_triggered = False
-        def audit_hook(event, arg):
-            if event == "remote_exec":
-                nonlocal remote_exec_event_triggered
-                remote_exec_event_triggered = True
-        sys.addaudithook(audit_hook)
         returncode, stdout, stderr = self._run_remote_exec_test(script, prologue=prologue)
         self.assertEqual(returncode, 0)
         self.assertIn(b"Remote script executed successfully!", stdout)
         self.assertIn(b"Audit event: remote_debugger_script, arg: ", stdout)
         self.assertEqual(stderr, b"")
-        self.assertTrue(remote_exec_event_triggered)
 
     def test_remote_exec_with_exception(self):
         """Test remote exec with an exception raised in the target process

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-16-02-31-42.gh-issue-135543.6b0HOF.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-16-02-31-42.gh-issue-135543.6b0HOF.rst
@@ -1,0 +1,2 @@
+emit ``sys.remote_exec`` audit event when ``sys.remote_exec`` has been
+called

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-16-02-31-42.gh-issue-135543.6b0HOF.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-16-02-31-42.gh-issue-135543.6b0HOF.rst
@@ -1,1 +1,2 @@
-Emit ``remote_exec`` audit event when :func:`sys.remote_exec` is called.
+Emit ``sys.remote_exec`` audit event when :func:`sys.remote_exec` is called
+and migrate ``remote_debugger_script`` to ``cpython.remote_debugger_script``.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-16-02-31-42.gh-issue-135543.6b0HOF.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-16-02-31-42.gh-issue-135543.6b0HOF.rst
@@ -1,2 +1,1 @@
-emit ``sys.remote_exec`` audit event when ``sys.remote_exec`` has been
-called
+Emit ``remote_exec`` audit event when :func:`sys.remote_exec` is called.

--- a/Python/ceval_gil.c
+++ b/Python/ceval_gil.c
@@ -1220,7 +1220,7 @@ static inline int run_remote_debugger_source(PyObject *source)
 // that would be an easy target for a ROP gadget.
 static inline void run_remote_debugger_script(PyObject *path)
 {
-    if (0 != PySys_Audit("remote_debugger_script", "O", path)) {
+    if (0 != PySys_Audit("cpython.remote_debugger_script", "O", path)) {
         PyErr_FormatUnraisable(
             "Audit hook failed for remote debugger script %U", path);
         return;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2485,13 +2485,14 @@ sys_remote_exec_impl(PyObject *module, int pid, PyObject *script)
     PyObject *path;
     const char *debugger_script_path;
 
-    if (PySys_Audit("remote_exec", "iO", pid, script) < 0) {
-        return NULL;
-    }
-
     if (PyUnicode_FSConverter(script, &path) == 0) {
         return NULL;
     }
+
+    if (PySys_Audit("sys.remote_exec", "iO", pid, script) < 0) {
+        return NULL;
+    }
+
     debugger_script_path = PyBytes_AS_STRING(path);
 #ifdef MS_WINDOWS
     PyObject *unicode_path;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2485,6 +2485,10 @@ sys_remote_exec_impl(PyObject *module, int pid, PyObject *script)
     PyObject *path;
     const char *debugger_script_path;
 
+    if (PySys_Audit("remote_exec", "iO", pid, script) < 0) {
+        return NULL;
+    }
+
     if (PyUnicode_FSConverter(script, &path) == 0) {
         return NULL;
     }


### PR DESCRIPTION
Fix #135543

<!-- gh-issue-number: gh-135543 -->
* Issue: gh-135543
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135544.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->