### PR TITLE
gh-135561: ensure that the GIL is held when handling an HACL* error in `_hmac`

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-06-16-15-03-03.gh-issue-135561.mJCN8D.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-16-15-03-03.gh-issue-135561.mJCN8D.rst
@@ -1,0 +1,2 @@
+Fix a crash on DEBUG builds when an HACL* HMAC routine fails. Patch by
+Bénédikt Tran.

--- a/Modules/hmacmodule.c
+++ b/Modules/hmacmodule.c
@@ -498,28 +498,38 @@ _hacl_convert_errno(hacl_errno_t code, PyObject *algorithm)
             return 0;
         }
         case Hacl_Streaming_Types_InvalidAlgorithm: {
+            PyGILState_STATE gstate = PyGILState_Ensure();
             // only makes sense if an algorithm is known at call time
             assert(algorithm != NULL);
             assert(PyUnicode_CheckExact(algorithm));
             PyErr_Format(PyExc_ValueError, "invalid algorithm: %U", algorithm);
+            PyGILState_Release(gstate);
             return -1;
         }
         case Hacl_Streaming_Types_InvalidLength: {
+            PyGILState_STATE gstate = PyGILState_Ensure();
             PyErr_SetString(PyExc_ValueError, "invalid length");
+            PyGILState_Release(gstate);
             return -1;
         }
         case Hacl_Streaming_Types_MaximumLengthExceeded: {
+            PyGILState_STATE gstate = PyGILState_Ensure();
             PyErr_SetString(PyExc_OverflowError, "maximum length exceeded");
+            PyGILState_Release(gstate);
             return -1;
         }
         case Hacl_Streaming_Types_OutOfMemory: {
+            PyGILState_STATE gstate = PyGILState_Ensure();
             PyErr_NoMemory();
+            PyGILState_Release(gstate);
             return -1;
         }
         default: {
+            PyGILState_STATE gstate = PyGILState_Ensure();
             PyErr_Format(PyExc_RuntimeError,
                          "HACL* internal routine failed with error code: %d",
                          code);
+            PyGILState_Release(gstate);
             return -1;
         }
     }

--- a/Modules/hmacmodule.c
+++ b/Modules/hmacmodule.c
@@ -497,6 +497,7 @@ _hacl_convert_errno(hacl_errno_t code, PyObject *algorithm)
     if (code == Hacl_Streaming_Types_Success) {
         return 0;
     }
+
     PyGILState_STATE gstate = PyGILState_Ensure();
     switch (code) {
         case Hacl_Streaming_Types_InvalidAlgorithm: {


### PR DESCRIPTION
It's a bug that I discovered in https://github.com/python/cpython/pull/135267 but I'll first patch 3.14 and main.

cc @ZeroIntensity 

<!-- gh-issue-number: gh-135561 -->
* Issue: gh-135561
<!-- /gh-issue-number -->
