### PR TITLE
gh-129958: New syntax error in format spec applies to both f-strings and t-strings

### DIFF
--- a/Lib/test/test_tstring.py
+++ b/Lib/test/test_tstring.py
@@ -219,6 +219,7 @@ class TestTString(unittest.TestCase, TStringBaseCase):
             ("t'{lambda:1}'", "t-string: lambda expressions are not allowed "
                               "without parentheses"),
             ("t'{x:{;}}'", "t-string: expecting a valid expression after '{'"),
+            ("""t'{1:d\n}'""","t-string: newlines are not allowed in format specifiers")
         ):
             with self.subTest(case), self.assertRaisesRegex(SyntaxError, err):
                 eval(case)

--- a/Lib/test/test_tstring.py
+++ b/Lib/test/test_tstring.py
@@ -219,7 +219,7 @@ class TestTString(unittest.TestCase, TStringBaseCase):
             ("t'{lambda:1}'", "t-string: lambda expressions are not allowed "
                               "without parentheses"),
             ("t'{x:{;}}'", "t-string: expecting a valid expression after '{'"),
-            ("""t'{1:d\n}'""","t-string: newlines are not allowed in format specifiers")
+            ("t'{1:d\n}'", "t-string: newlines are not allowed in format specifiers")
         ):
             with self.subTest(case), self.assertRaisesRegex(SyntaxError, err):
                 eval(case)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-24-06-41-47.gh-issue-129958.EaJuS0.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-24-06-41-47.gh-issue-129958.EaJuS0.rst
@@ -1,0 +1,2 @@
+Differentiate between t-strings and f-strings in syntax error for newlines
+in format specifiers of single-quoted interpolated strings.

--- a/Parser/lexer/lexer.c
+++ b/Parser/lexer/lexer.c
@@ -1422,7 +1422,7 @@ f_string_middle:
                         _PyTokenizer_syntaxerror(
                             tok,
                             "%c-string: newlines are not allowed in format specifiers for single quoted %c-strings",
-                            TOK_GET_STRING_PREFIX(tok),TOK_GET_STRING_PREFIX(tok)
+                            TOK_GET_STRING_PREFIX(tok), TOK_GET_STRING_PREFIX(tok)
                         )
                     );
                 }

--- a/Parser/lexer/lexer.c
+++ b/Parser/lexer/lexer.c
@@ -1421,7 +1421,8 @@ f_string_middle:
                     return MAKE_TOKEN(
                         _PyTokenizer_syntaxerror(
                             tok,
-                            "f-string: newlines are not allowed in format specifiers for single quoted f-strings"
+                            "%c-string: newlines are not allowed in format specifiers for single quoted %c-strings",
+                            TOK_GET_STRING_PREFIX(tok),TOK_GET_STRING_PREFIX(tok)
                         )
                     );
                 }


### PR DESCRIPTION
Closes #129958 
(again)

And I think requires backport to 3.14.

Let me know if this warrants a test in `test_tstring.py` and/or a blurb!


<!-- gh-issue-number: gh-129958 -->
* Issue: gh-129958
<!-- /gh-issue-number -->
