### PR TITLE
gh-135571: Guard _hashlib usage in test_hashlib.py

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -331,7 +331,8 @@ class HashLibTestCase(unittest.TestCase):
                 with self.subTest(digest_name, args=args, kwds=kwds):
                     with self.assertRaisesRegex(TypeError, errmsg):
                         hashlib.new(digest_name, *args, **kwds)
-                    if self._hashlib:
+                    if (self._hashlib and
+                            digest_name in self._hashlib._constructors):
                         with self.assertRaisesRegex(TypeError, errmsg):
                             self._hashlib.new(digest_name, *args, **kwds)
 

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -274,7 +274,10 @@ class HashLibTestCase(unittest.TestCase):
                 with self.assertWarnsRegex(DeprecationWarning,
                                            DEPRECATED_STRING_PARAMETER):
                     hashlib.new(digest_name, string=b'')
-                if self._hashlib:
+                # when using a combination of libcrypto and interned hash
+                # implementations, we need to make sure that _hashlib contains
+                # the constructor we're testing
+                if self._hashlib and digest_name in self._hashlib._constructors:
                     self._hashlib.new(digest_name, b'')
                     self._hashlib.new(digest_name, data=b'')
                     with self.assertWarnsRegex(DeprecationWarning,

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -274,9 +274,9 @@ class HashLibTestCase(unittest.TestCase):
                 with self.assertWarnsRegex(DeprecationWarning,
                                            DEPRECATED_STRING_PARAMETER):
                     hashlib.new(digest_name, string=b'')
-                # when using a combination of libcrypto and interned hash
-                # implementations, we need to make sure that _hashlib contains
-                # the constructor we're testing
+                # Make sure that _hashlib contains the constructor
+                # to test when using a combination of libcrypto and
+                # interned hash implementations.
                 if self._hashlib and digest_name in self._hashlib._constructors:
                     self._hashlib.new(digest_name, b'')
                     self._hashlib.new(digest_name, data=b'')


### PR DESCRIPTION
# Notes

See [here](https://github.com/python/cpython/pull/135402#issuecomment-2970965387).

# Testing

See [here](https://github.com/python/cpython/pull/135402#issue-3137499203).

<!-- gh-issue-number: gh-135571 -->
* Issue: gh-135571
<!-- /gh-issue-number -->
