### PR TITLE
gh-135573: Add a check for 0 items to `APPENDS` and `ADDITEMS` opcodes

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -1785,6 +1785,8 @@ class _Unpickler:
     def load_appends(self):
         items = self.pop_mark()
         list_obj = self.stack[-1]
+        if len(items) == 0: # nothing to do
+            return
         try:
             extend = list_obj.extend
         except AttributeError:
@@ -1818,6 +1820,8 @@ class _Unpickler:
     def load_additems(self):
         items = self.pop_mark()
         set_obj = self.stack[-1]
+        if len(items) == 0: # nothing to do
+            return
         if isinstance(set_obj, set):
             set_obj.update(items)
         else:

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1105,6 +1105,10 @@ class AbstractUnpickleTests:
         with self.assertRaisesRegex(pickle.UnpicklingError, errmsg):
             self.loads(b'T\0\0\0\x80')
 
+    def test_appends_additems_no_items(self):
+        self.assertEqual(self.loads(b'K\x01(e.'), 1)
+        self.assertEqual(self.loads(b'K\x01(\x90.'), 1)
+
     def test_get(self):
         pickled = b'((lp100000\ng100000\nt.'
         unpickled = self.loads(pickled)

--- a/Misc/NEWS.d/next/Library/2025-06-16-16-02-05.gh-issue-135573.waQmoA.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-16-16-02-05.gh-issue-135573.waQmoA.rst
@@ -1,0 +1,1 @@
+Adds a check in the ``ADDITEMS`` and ``APPENDS`` opcodes of the Python implementation of :mod:`pickle` to return early if there's no items to add.


### PR DESCRIPTION
To align the C and Python implementations of pickle, a check for 0 items is added to the `pickle` module for `APPENDS` and `ADDITEMS` opcodes.

<!-- gh-issue-number: gh-135573 -->
* Issue: gh-135573
<!-- /gh-issue-number -->
