### PR TITLE
gh-135106: [crash repro] Randomly deposit objects in `_Py_Dealloc`

### DIFF
--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -210,6 +210,7 @@ struct _ts {
     _PyRemoteDebuggerSupport remote_debugger_support;
 
     uint64_t prng;
+    Py_ssize_t ob_dealloc_depth;
 };
 
 /* other API */

--- a/Include/cpython/pystate.h
+++ b/Include/cpython/pystate.h
@@ -208,6 +208,8 @@ struct _ts {
     */
     PyObject *threading_local_sentinel;
     _PyRemoteDebuggerSupport remote_debugger_support;
+
+    uint64_t prng;
 };
 
 /* other API */

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -325,16 +325,6 @@ _Py_RecursionLimit_GetMargin(PyThreadState *tstate)
     _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate;
     assert(_tstate->c_stack_hard_limit != 0);
     intptr_t here_addr = _Py_get_machine_stack_pointer();
-
-    // splitmix64 from https://prng.di.unimi.it/splitmix64.c
-    uint64_t z = (tstate->prng += 0x9e3779b97f4a7c15);
-    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
-    z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
-    uint64_t r = z ^ (z >> 31);
-    if ((r & 0xFF) < 2) { // 2/256 chance = ~ 0.8% chance
-        return 1;
-    }
-
     return Py_ARITHMETIC_RIGHT_SHIFT(intptr_t, here_addr - (intptr_t)_tstate->c_stack_soft_limit, PYOS_STACK_MARGIN_SHIFT);
 }
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -325,6 +325,16 @@ _Py_RecursionLimit_GetMargin(PyThreadState *tstate)
     _PyThreadStateImpl *_tstate = (_PyThreadStateImpl *)tstate;
     assert(_tstate->c_stack_hard_limit != 0);
     intptr_t here_addr = _Py_get_machine_stack_pointer();
+
+    // splitmix64 from https://prng.di.unimi.it/splitmix64.c
+    uint64_t z = (tstate->prng += 0x9e3779b97f4a7c15);
+	z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+	z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+	uint64_t r = z ^ (z >> 31);
+    if ((r & 0xFF) < 2) { // 2/256 chance = ~ 0.8% chance
+        return 1;
+    }
+
     return Py_ARITHMETIC_RIGHT_SHIFT(intptr_t, here_addr - (intptr_t)_tstate->c_stack_soft_limit, PYOS_STACK_MARGIN_SHIFT);
 }
 

--- a/Include/internal/pycore_pystate.h
+++ b/Include/internal/pycore_pystate.h
@@ -328,9 +328,9 @@ _Py_RecursionLimit_GetMargin(PyThreadState *tstate)
 
     // splitmix64 from https://prng.di.unimi.it/splitmix64.c
     uint64_t z = (tstate->prng += 0x9e3779b97f4a7c15);
-	z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
-	z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
-	uint64_t r = z ^ (z >> 31);
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+    z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+    uint64_t r = z ^ (z >> 31);
     if ((r & 0xFF) < 2) { // 2/256 chance = ~ 0.8% chance
         return 1;
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1486,6 +1486,10 @@ init_threadstate(_PyThreadStateImpl *_tstate,
         tstate->state = _Py_THREAD_SUSPENDED;
     }
 
+    PyTime_t now;
+    PyTime_MonotonicRaw(&now);
+    tstate->prng = (uint64_t)now;
+
     tstate->_status.initialized = 1;
 }
 


### PR DESCRIPTION
Returns `1` a little less than 1% of the time in
_Py_RecursionLimit_GetMargin() to force the use of the trashcan mechanism.

This isn't intended to be merged. It's just to:

1) Demonstrate the crash
2) Test on a variety of platforms and configs from the CI


<!-- gh-issue-number: gh-135106 -->
* Issue: gh-135106
<!-- /gh-issue-number -->
