### PR TITLE
gh-128627: Emscripten: Add missing semicolon in ios detection code

### DIFF
--- a/Python/emscripten_trampoline.c
+++ b/Python/emscripten_trampoline.c
@@ -80,7 +80,7 @@ function getPyEMCountArgsPtr() {
         // To differentiate, we check if the platform is 'MacIntel' (common for Macs and newer iPads)
         // AND if the device has multi-touch capabilities (navigator.maxTouchPoints > 1)
         (navigator.platform === 'MacIntel' && typeof navigator.maxTouchPoints !== 'undefined' && navigator.maxTouchPoints > 1)
-    )
+    );
     if (isIOS) {
         return 0;
     }


### PR DESCRIPTION
This causes a build failure with Emscripten 4.0.8

<!-- gh-issue-number: gh-128627 -->
* Issue: gh-128627
<!-- /gh-issue-number -->
