### PR TITLE
Emphasize parameter name

### DIFF
--- a/Doc/library/pkgutil.rst
+++ b/Doc/library/pkgutil.rst
@@ -69,8 +69,8 @@ support.
 
    Yield :term:`finder` objects for the given module name.
 
-   If fullname contains a ``'.'``, the finders will be for the package
-   containing fullname, otherwise they will be all registered top level
+   If *fullname* contains a ``'.'``, the finders will be for the package
+   containing *fullname*, otherwise they will be all registered top level
    finders (i.e. those on both :data:`sys.meta_path` and :data:`sys.path_hooks`).
 
    If the named module is in a package, that package is imported as a side


### PR DESCRIPTION
This aims to emphasize the [pkgutil.iter_importers()](https://docs.python.org/3.14/library/pkgutil.html#pkgutil.iter_importers)'s parameter name `fullname`.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135597.org.readthedocs.build/en/135597/library/pkgutil.html#pkgutil.iter_importers

<!-- readthedocs-preview cpython-previews end -->