### PR TITLE
gh-135557: Use atomic writes on heapq operations

### DIFF
--- a/Lib/test/test_free_threading/test_heapq.py
+++ b/Lib/test/test_free_threading/test_heapq.py
@@ -180,7 +180,7 @@ class TestHeapq(unittest.TestCase):
 
     @unittest.skipUnless(Py_GIL_DISABLED, 'only used to test under free-threaded build')
     def test_lock_free_list_read(self):
-        n, n_threads = 1_000_000, 10
+        n, n_threads = 1_000, 10
         l = []
         barrier = Barrier(n_threads * 2)
 

--- a/Lib/test/test_free_threading/test_heapq.py
+++ b/Lib/test/test_free_threading/test_heapq.py
@@ -3,10 +3,10 @@ import unittest
 import heapq
 
 from enum import Enum
-from threading import Thread, Barrier
+from threading import Thread, Barrier, Lock
 from random import shuffle, randint
 
-from test.support import threading_helper, Py_GIL_DISABLED
+from test.support import threading_helper
 from test import test_heapq
 
 
@@ -178,39 +178,32 @@ class TestHeapq(unittest.TestCase):
         self.assertEqual(len(max_heap), OBJECT_COUNT)
         self.test_heapq.check_max_invariant(max_heap)
 
-    @unittest.skipUnless(Py_GIL_DISABLED, 'only used to test under free-threaded build')
     def test_lock_free_list_read(self):
         n, n_threads = 1_000, 10
         l = []
         barrier = Barrier(n_threads * 2)
 
-        def writer():
+        count = 0
+        lock = Lock()
+
+        def worker():
+            with lock:
+                nonlocal count
+                x = count
+                count += 1
+
             barrier.wait()
             for i in range(n):
-                heapq.heappush(l, 1)
-                heapq.heappop(l)
+                if x % 2:
+                    heapq.heappush(l, 1)
+                    heapq.heappop(l)
+                else:
+                    try:
+                        l[0]
+                    except IndexError:
+                        pass
 
-        def reader():
-            barrier.wait()
-            for i in range(n):
-                try:
-                    l[0]
-                except IndexError:
-                    pass
-
-        import threading
-        threads = []
-        with threading_helper.catch_threading_exception() as cm:
-            for _ in range(n_threads):
-                t1 = threading.Thread(target=writer)
-                t2 = threading.Thread(target=reader)
-                threads.append(t1)
-                threads.append(t2)
-                t1.start()
-                t2.start()
-
-            for t in threads:
-                t.join()
+        self.run_concurrently(worker, (), n_threads * 2)
 
     @staticmethod
     def is_sorted_ascending(lst):

--- a/Lib/test/test_heapq.py
+++ b/Lib/test/test_heapq.py
@@ -5,9 +5,8 @@ import unittest
 import doctest
 
 from test.support import import_helper
-from unittest import TestCase, skipUnless, skipIf
+from unittest import TestCase, skipUnless
 from operator import itemgetter
-
 
 py_heapq = import_helper.import_fresh_module('heapq', blocked=['_heapq'])
 c_heapq = import_helper.import_fresh_module('heapq', fresh=['_heapq'])
@@ -402,36 +401,6 @@ class TestHeap:
         target = sorted(data, reverse=True)
         self.assertEqual(hsort(data, LT), target)
         self.assertRaises(TypeError, data, LE)
-
-    @skipIf(py_heapq, 'only used to test c_heapq')
-    def test_lock_free_list_read(self):
-        n = 1_000_000
-        l = []
-        def writer():
-            for i in range(n):
-                self.module.heappush(l, 1)
-                self.module.heappop(l)
-
-        def reader():
-            for i in range(n):
-                try:
-                    l[0]
-                except IndexError:
-                    pass
-
-        import threading
-        threads = []
-        for _ in range(10):
-            t1 = threading.Thread(target=writer)
-            t2 = threading.Thread(target=reader)
-            threads.append(t1)
-            threads.append(t2)
-            t1.start()
-            t2.start()
-
-        for t in threads:
-            t.join()
-
 
 
 class TestHeapPython(TestHeap, TestCase):

--- a/Misc/NEWS.d/next/Library/2025-06-17-23-13-56.gh-issue-135557.Bfcy4v.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-17-23-13-56.gh-issue-135557.Bfcy4v.rst
@@ -1,0 +1,2 @@
+Fix races on ``heapq`` updates and lock-free list reads in free-threaded
+build.

--- a/Misc/NEWS.d/next/Library/2025-06-17-23-13-56.gh-issue-135557.Bfcy4v.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-17-23-13-56.gh-issue-135557.Bfcy4v.rst
@@ -1,2 +1,2 @@
-Fix races on ``heapq`` updates and lock-free list reads in free-threaded
+Fix races on :mod:`heapq` updates and :class:`list` reads on the :term:`free threaded <free threading>`
 build.

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -625,7 +625,7 @@ _heapq_heappushpop_max_impl(PyObject *module, PyObject *heap, PyObject *item)
     }
 
     returnitem = PyList_GET_ITEM(heap, 0);
-    PyListObject * list = _PyList_CAST(heap);
+    PyListObject *list = _PyList_CAST(heap);
     FT_ATOMIC_STORE_PTR_RELAXED(list->ob_item[0], Py_NewRef(item));
     if (siftup_max(list, 0) < 0) {
         Py_DECREF(returnitem);

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -441,8 +441,8 @@ siftdown_max(PyListObject *heap, Py_ssize_t startpos, Py_ssize_t pos)
         arr = _PyList_ITEMS(heap);
         parent = arr[parentpos];
         newitem = arr[pos];
-        arr[parentpos] = newitem;
-        arr[pos] = parent;
+        FT_ATOMIC_STORE_PTR_RELAXED(arr[parentpos], newitem);
+        FT_ATOMIC_STORE_PTR_RELAXED(arr[pos], parent);
         pos = parentpos;
     }
     return 0;
@@ -490,8 +490,8 @@ siftup_max(PyListObject *heap, Py_ssize_t pos)
         /* Move the smaller child up. */
         tmp1 = arr[childpos];
         tmp2 = arr[pos];
-        arr[childpos] = tmp2;
-        arr[pos] = tmp1;
+        FT_ATOMIC_STORE_PTR_RELAXED(arr[childpos], tmp2);
+        FT_ATOMIC_STORE_PTR_RELAXED(arr[pos], tmp1);
         pos = childpos;
     }
     /* Bubble it up to its final resting place (by sifting its parents down). */
@@ -625,8 +625,9 @@ _heapq_heappushpop_max_impl(PyObject *module, PyObject *heap, PyObject *item)
     }
 
     returnitem = PyList_GET_ITEM(heap, 0);
-    PyList_SET_ITEM(heap, 0, Py_NewRef(item));
-    if (siftup_max((PyListObject *)heap, 0) < 0) {
+    PyListObject * list = _PyList_CAST(heap);
+    FT_ATOMIC_STORE_PTR_RELAXED(list->ob_item[0], Py_NewRef(item));
+    if (siftup_max(list, 0) < 0) {
         Py_DECREF(returnitem);
         return NULL;
     }

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -60,8 +60,8 @@ siftdown(PyListObject *heap, Py_ssize_t startpos, Py_ssize_t pos)
         arr = _PyList_ITEMS(heap);
         parent = arr[parentpos];
         newitem = arr[pos];
-        FT_ATOMIC_STORE_PTR_RELEASE(arr[parentpos], newitem);
-        FT_ATOMIC_STORE_PTR_RELEASE(arr[pos], parent);
+        FT_ATOMIC_STORE_PTR_RELAXED(arr[parentpos], newitem);
+        FT_ATOMIC_STORE_PTR_RELAXED(arr[pos], parent);
         pos = parentpos;
     }
     return 0;
@@ -109,8 +109,8 @@ siftup(PyListObject *heap, Py_ssize_t pos)
         /* Move the smaller child up. */
         tmp1 = arr[childpos];
         tmp2 = arr[pos];
-        FT_ATOMIC_STORE_PTR_RELEASE(arr[childpos], tmp2);
-        FT_ATOMIC_STORE_PTR_RELEASE(arr[pos], tmp1);
+        FT_ATOMIC_STORE_PTR_RELAXED(arr[childpos], tmp2);
+        FT_ATOMIC_STORE_PTR_RELAXED(arr[pos], tmp1);
         pos = childpos;
     }
     /* Bubble it up to its final resting place (by sifting its parents down). */
@@ -175,7 +175,7 @@ heappop_internal(PyObject *heap, int siftup_func(PyListObject *, Py_ssize_t))
     returnitem = PyList_GET_ITEM(heap, 0);
     // We're in the critical section now
     PyListObject *list = _PyList_CAST(heap);
-    FT_ATOMIC_STORE_PTR_RELEASE(list->ob_item[0], lastelt);
+    FT_ATOMIC_STORE_PTR_RELAXED(list->ob_item[0], lastelt);
     if (siftup_func(list, 0)) {
         Py_DECREF(returnitem);
         return NULL;

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -210,8 +210,9 @@ heapreplace_internal(PyObject *heap, PyObject *item, int siftup_func(PyListObjec
     }
 
     returnitem = PyList_GET_ITEM(heap, 0);
-    PyList_SET_ITEM(heap, 0, Py_NewRef(item));
-    if (siftup_func((PyListObject *)heap, 0)) {
+    PyListObject *list = _PyList_CAST(heap);
+    FT_ATOMIC_STORE_PTR_RELAXED(list->ob_item[0], Py_NewRef(item));
+    if (siftup_func(list, 0)) {
         Py_DECREF(returnitem);
         return NULL;
     }
@@ -286,8 +287,9 @@ _heapq_heappushpop_impl(PyObject *module, PyObject *heap, PyObject *item)
     }
 
     returnitem = PyList_GET_ITEM(heap, 0);
-    PyList_SET_ITEM(heap, 0, Py_NewRef(item));
-    if (siftup((PyListObject *)heap, 0)) {
+    PyListObject *list = _PyList_CAST(heap);
+    FT_ATOMIC_STORE_PTR_RELAXED(list->ob_item[0], Py_NewRef(item));
+    if (siftup(list, 0)) {
         Py_DECREF(returnitem);
         return NULL;
     }

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -59,8 +59,8 @@ siftdown(PyListObject *heap, Py_ssize_t startpos, Py_ssize_t pos)
         arr = _PyList_ITEMS(heap);
         parent = arr[parentpos];
         newitem = arr[pos];
-        _Py_atomic_store_ptr(&arr[parentpos], newitem);
-        _Py_atomic_store_ptr(&arr[pos], parent);
+        FT_ATOMIC_STORE_PTR_RELEASE(arr[parentpos], newitem);
+        FT_ATOMIC_STORE_PTR_RELEASE(arr[pos], parent);
         pos = parentpos;
     }
     return 0;
@@ -108,8 +108,8 @@ siftup(PyListObject *heap, Py_ssize_t pos)
         /* Move the smaller child up. */
         tmp1 = arr[childpos];
         tmp2 = arr[pos];
-        _Py_atomic_store_ptr(&arr[childpos], tmp2);
-        _Py_atomic_store_ptr(&arr[pos], tmp1);
+        FT_ATOMIC_STORE_PTR_RELEASE(arr[childpos], tmp2);
+        FT_ATOMIC_STORE_PTR_RELEASE(arr[pos], tmp1);
         pos = childpos;
     }
     /* Bubble it up to its final resting place (by sifting its parents down). */
@@ -174,7 +174,7 @@ heappop_internal(PyObject *heap, int siftup_func(PyListObject *, Py_ssize_t))
     returnitem = PyList_GET_ITEM(heap, 0);
     // We're in the critical section now
     PyListObject *list = _PyList_CAST(heap);
-    _Py_atomic_store_ptr(&list->ob_item[0], lastelt);
+    FT_ATOMIC_STORE_PTR_RELEASE(list->ob_item[0], lastelt);
     if (siftup_func(list, 0)) {
         Py_DECREF(returnitem);
         return NULL;

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -12,6 +12,7 @@ annotated by François Pinard, and converted to C by Raymond Hettinger.
 
 #include "Python.h"
 #include "pycore_list.h"          // _PyList_ITEMS(), _PyList_AppendTakeRef()
+#include "pycore_pyatomic_ft_wrappers.h"
 
 #include "clinic/_heapqmodule.c.h"
 

--- a/Modules/_heapqmodule.c
+++ b/Modules/_heapqmodule.c
@@ -173,7 +173,6 @@ heappop_internal(PyObject *heap, int siftup_func(PyListObject *, Py_ssize_t))
     if (!n)
         return lastelt;
     returnitem = PyList_GET_ITEM(heap, 0);
-    // We're in the critical section now
     PyListObject *list = _PyList_CAST(heap);
     FT_ATOMIC_STORE_PTR_RELAXED(list->ob_item[0], lastelt);
     if (siftup_func(list, 0)) {


### PR DESCRIPTION
Use atomic writes on heapq operation.

<!-- gh-issue-number: gh-135557 -->
* Issue: gh-135557
<!-- /gh-issue-number -->
