### PR TITLE
gh-127146: Emscripten: Fix pathlib glob_dotdot test

### DIFF
--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -2956,6 +2956,7 @@ class PathTest(PurePathTest):
             self.assertEqual(set(p.glob("xyzzy/..")), { P(self.base, "xyzzy", "..") })
         if sys.platform == "emscripten":
             # Emscripten will return ELOOP if there are 49 or more ..'s.
+            # Can remove when https://github.com/emscripten-core/emscripten/pull/24591 is merged.
             NDOTDOTS = 48
         else:
             NDOTDOTS = 50

--- a/Lib/test/test_pathlib/test_pathlib.py
+++ b/Lib/test/test_pathlib/test_pathlib.py
@@ -2954,7 +2954,12 @@ class PathTest(PurePathTest):
         else:
             # ".." segments are normalized first on Windows, so this path is stat()able.
             self.assertEqual(set(p.glob("xyzzy/..")), { P(self.base, "xyzzy", "..") })
-        self.assertEqual(set(p.glob("/".join([".."] * 50))), { P(self.base, *[".."] * 50)})
+        if sys.platform == "emscripten":
+            # Emscripten will return ELOOP if there are 49 or more ..'s.
+            NDOTDOTS = 48
+        else:
+            NDOTDOTS = 50
+        self.assertEqual(set(p.glob("/".join([".."] * NDOTDOTS))), { P(self.base, *[".."] * NDOTDOTS)})
 
     def test_glob_inaccessible(self):
         P = self.cls


### PR DESCRIPTION
The Emscripten path resolver uses the same mechanism for resolving .. at a file system root as for resolving symlinks. This is because roots don't store their mountpoints. If the parent of a node is itself, it is a root but it might be a mountpoint in some other file system.

Anyways, if a path has enough ..'s at the root, it will return ELOOP. Enough turns out to be 49.

Upstream fix:
https://github.com/emscripten-core/emscripten/pull/24591

<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
