### PR TITLE
gh-135615: Rephrase HTTP status codes overview

### DIFF
--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -52,7 +52,11 @@ The :mod:`http` module also defines the following enums that help you work with 
 HTTP status codes
 -----------------
 
-:class:`http.HTTPStatus` supports some `IANA-registered status codes <https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml>`_, as well as 418 (the requested entity is a teapot incapable of brewing coffee)
+The supported `IANA-registered status codes`__ available in
+:class:`http.HTTPStatus` are enumerated in the table below,
+including some codes marked by IANA as 'unused'.
+
+__ https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 
 ======= =================================== ==================================================================
 Code    Enum Name                           Details

--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -52,8 +52,7 @@ The :mod:`http` module also defines the following enums that help you work with 
 HTTP status codes
 -----------------
 
-Supported,
-`IANA-registered status codes <https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml>`_
+Supported HTTP status codes
 available in :class:`http.HTTPStatus` are:
 
 ======= =================================== ==================================================================

--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -52,7 +52,7 @@ The :mod:`http` module also defines the following enums that help you work with 
 HTTP status codes
 -----------------
 
-:class:`http.HTTPStatus supports some `IANA-registered status codes <https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml>`_, as well as 418 (the requested entity is a teapot incapable of brewing coffee)
+:class:`http.HTTPStatus` supports some `IANA-registered status codes <https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml>`_, as well as 418 (the requested entity is a teapot incapable of brewing coffee)
 
 ======= =================================== ==================================================================
 Code    Enum Name                           Details

--- a/Doc/library/http.rst
+++ b/Doc/library/http.rst
@@ -52,8 +52,7 @@ The :mod:`http` module also defines the following enums that help you work with 
 HTTP status codes
 -----------------
 
-Supported HTTP status codes
-available in :class:`http.HTTPStatus` are:
+:class:`http.HTTPStatus supports some `IANA-registered status codes <https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml>`_, as well as 418 (the requested entity is a teapot incapable of brewing coffee)
 
 ======= =================================== ==================================================================
 Code    Enum Name                           Details


### PR DESCRIPTION
The HTTP module supports status codes that are unregistered/unofficial. Take http status code ``418: I'm a teapot`` Due to the save418  movement (https://save418.com/), python decided to preserve http code 418 in its codebase, but the documentation contradicts itself.

In the documentation, right above the table of status codes supported by the http library we have this:

> Supported, [IANA-registered status codes](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml) available in [http.HTTPStatus](https://docs.python.org/3/library/http.html#http.HTTPStatus) are:

This is factually incorrect, because code 418, (among others) is **not official**, and this PR lists 418 as an exception

Fix #135615

<!-- gh-issue-number: gh-135615 -->
* Issue: gh-135615
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135625.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->