### PR TITLE
gh-127146: Emscripten: Fix test failure due to missing os.link

### DIFF
--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -5877,8 +5877,8 @@ class TestSignatureDefinitions(unittest.TestCase):
     def test_os_module_has_signatures(self):
         unsupported_signature = {'chmod', 'utime'}
         unsupported_signature |= {name for name in
-            ['get_terminal_size', 'posix_spawn', 'posix_spawnp',
-             'register_at_fork', 'startfile', 'link']
+            ['get_terminal_size', 'link', 'posix_spawn', 'posix_spawnp',
+             'register_at_fork', 'startfile']
             if hasattr(os, name)}
         self._test_module_has_signatures(os, unsupported_signature=unsupported_signature)
 

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -5875,10 +5875,10 @@ class TestSignatureDefinitions(unittest.TestCase):
         self._test_module_has_signatures(operator)
 
     def test_os_module_has_signatures(self):
-        unsupported_signature = {'chmod', 'link', 'utime'}
+        unsupported_signature = {'chmod', 'utime'}
         unsupported_signature |= {name for name in
             ['get_terminal_size', 'posix_spawn', 'posix_spawnp',
-             'register_at_fork', 'startfile']
+             'register_at_fork', 'startfile', 'link']
             if hasattr(os, name)}
         self._test_module_has_signatures(os, unsupported_signature=unsupported_signature)
 


### PR DESCRIPTION


<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
