### PR TITLE
gh-135627: Remove documentation for LOAD_CONST_IMMORTAL opcode

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1094,14 +1094,6 @@ iterations of the loop.
    .. versionadded:: 3.14
 
 
-.. opcode:: LOAD_CONST_IMMORTAL (consti)
-
-   Pushes ``co_consts[consti]`` onto the stack.
-   Can be used when the constant value is known to be immortal.
-
-   .. versionadded:: 3.14
-
-
 .. opcode:: LOAD_NAME (namei)
 
    Pushes the value associated with ``co_names[namei]`` onto the stack.


### PR DESCRIPTION


<!-- gh-issue-number: gh-135627 -->
* Issue: gh-135627
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135632.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->