### PR TITLE
gh-127146: Emscripten: Skip test_url2pathname_resolve_host

### DIFF
--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1569,6 +1569,7 @@ class Pathname_Tests(unittest.TestCase):
                     urllib.request.url2pathname,
                     url, require_scheme=True)
 
+    @unittest.skipIf(support.is_emscripten, "Fixed by https://github.com/emscripten-core/emscripten/pull/24593")
     def test_url2pathname_resolve_host(self):
         fn = urllib.request.url2pathname
         sep = os.path.sep


### PR DESCRIPTION
It's failing because `gethostbyname_r()` is returning an incorrect ip address for `localhost`. Will be resolved by upstream PR: https://github.com/emscripten-core/emscripten/pull/24593


<!-- gh-issue-number: gh-127146 -->
* Issue: gh-127146
<!-- /gh-issue-number -->
