### PR TITLE
gh-134632: Add iOS/Android test skip for C API check for headers.

### DIFF
--- a/Lib/test/test_build_details.py
+++ b/Lib/test/test_build_details.py
@@ -117,13 +117,20 @@ class CPythonBuildDetailsTests(unittest.TestCase, FormatTestsBase):
     # Override generic format tests with tests for our specific implemenation.
 
     @needs_installed_python
-    @unittest.skipIf(is_android or is_apple_mobile, 'Android and iOS run tests via a custom testbed method that changes sys.executable')
+    @unittest.skipIf(
+        is_android or is_apple_mobile,
+        'Android and iOS run tests via a custom testbed method that changes sys.executable'
+    )
     def test_base_interpreter(self):
         value = self.key('base_interpreter')
 
         self.assertEqual(os.path.realpath(value), os.path.realpath(sys.executable))
 
     @needs_installed_python
+    @unittest.skipIf(
+        is_android or is_apple_mobile,
+        "Android and iOS run tests via a custom testbed method that doesn't ship headers"
+    )
     def test_c_api(self):
         value = self.key('c_api')
         self.assertTrue(os.path.exists(os.path.join(value['headers'], 'Python.h')))


### PR DESCRIPTION
iOS and Android tests run in an environment where the build headers aren't visible, so testing for their existence won't work.

<!-- gh-issue-number: gh-134632 -->
* Issue: gh-134632
<!-- /gh-issue-number -->
