### PR TITLE
gh-109070: multiprocessing.get_context will not set the start method globally

### DIFF
--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -236,9 +236,7 @@ class DefaultContext(BaseContext):
 
     def get_context(self, method=None):
         if method is None:
-            if self._actual_context is None:
-                self._actual_context = self._default_context
-            return self._actual_context
+            return self._actual_context or self._default_context
         else:
             return super().get_context(method)
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5811,6 +5811,12 @@ class TestStartMethod(unittest.TestCase):
         p.join()
         self.assertEqual(child_method, ctx.get_start_method())
 
+    def test_default_context(self):
+        # Get_context should not have side effect, see gh-109070.
+        multiprocessing.set_start_method(None, force=True)
+        multiprocessing.get_context()
+        self.assertIsNone(multiprocessing.context._default_context._actual_context)
+
     def test_context(self):
         for method in ('fork', 'spawn', 'forkserver'):
             try:

--- a/Misc/NEWS.d/next/Library/2025-06-18-23-59-40.gh-issue-109070.2XNJ7X.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-18-23-59-40.gh-issue-109070.2XNJ7X.rst
@@ -1,0 +1,1 @@
+:func:`multiprocessing.get_context` will not set the start method globally.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-109070 -->
* Issue: gh-109070
<!-- /gh-issue-number -->
