### PR TITLE
gh-89083: Attaching RFC links in UUID docs

### DIFF
--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -193,11 +193,11 @@ The :mod:`uuid` module defines the following functions:
 
 .. function:: uuid1(node=None, clock_seq=None)
 
-   Generate a UUID from a host ID, sequence number, and the current time 
+   Generate a UUID from a host ID, sequence number, and the current time
    according to :rfc:`RFC 9562, §5.1 <9562#section-5.1>`.
 
    If *node* is not given, :func:`getnode` is used to obtain the hardware address.
-   
+
    If *clock_seq* is given, it is used as the sequence number; otherwise a random
    14-bit sequence number is chosen.
 

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -193,9 +193,12 @@ The :mod:`uuid` module defines the following functions:
 
 .. function:: uuid1(node=None, clock_seq=None)
 
-   Generate a UUID from a host ID, sequence number, and the current time. If *node*
-   is not given, :func:`getnode` is used to obtain the hardware address. If
-   *clock_seq* is given, it is used as the sequence number; otherwise a random
+   Generate a UUID from a host ID, sequence number, and the current time 
+   according to :rfc:`RFC 9562, §5.1 <9562#section-5.1>`.
+
+   If *node* is not given, :func:`getnode` is used to obtain the hardware address.
+   
+   If *clock_seq* is given, it is used as the sequence number; otherwise a random
    14-bit sequence number is chosen.
 
 
@@ -203,25 +206,29 @@ The :mod:`uuid` module defines the following functions:
 
    Generate a UUID based on the MD5 hash of a namespace identifier (which is a
    UUID) and a name (which is a :class:`bytes` object or a string
-   that will be encoded using UTF-8).
+   that will be encoded using UTF-8)
+   according to :rfc:`RFC 9562, §5.3 <9562#section-5.3>`.
 
 
 .. function:: uuid4()
 
-   Generate a random UUID.
+   Generate a random UUID in a cryptographically-secure method
+   according to :rfc:`RFC 9562, §5.4 <9562#section-5.4>`.
 
 
 .. function:: uuid5(namespace, name)
 
    Generate a UUID based on the SHA-1 hash of a namespace identifier (which is a
    UUID) and a name (which is a :class:`bytes` object or a string
-   that will be encoded using UTF-8).
+   that will be encoded using UTF-8)
+   according to :rfc:`RFC 9562, §5.5 <9562#section-5.5>`.
 
 
 .. function:: uuid6(node=None, clock_seq=None)
 
    Generate a UUID from a sequence number and the current time according to
-   :rfc:`9562`.
+   :rfc:`RFC 9562, §5.6 <9562#section-5.6>`.
+
    This is an alternative to :func:`uuid1` to improve database locality.
 
    When *node* is not specified, :func:`getnode` is used to obtain the hardware

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -199,7 +199,6 @@ The :mod:`uuid` module defines the following functions:
    When *node* is not specified, :func:`getnode` is used to obtain the hardware
    address as a 48-bit positive integer. When a sequence number *clock_seq* is
    not specified, a pseudo-random 14-bit positive integer is generated.
-   14-bit sequence number is chosen.
 
 
 .. function:: uuid3(namespace, name)

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -200,6 +200,9 @@ The :mod:`uuid` module defines the following functions:
    address as a 48-bit positive integer. When a sequence number *clock_seq* is
    not specified, a pseudo-random 14-bit positive integer is generated.
 
+   If *node* or *clock_seq* exceed their expected bit count,
+   only their least significant bits are kept.
+
 
 .. function:: uuid3(namespace, name)
 
@@ -234,8 +237,8 @@ The :mod:`uuid` module defines the following functions:
    address as a 48-bit positive integer. When a sequence number *clock_seq* is
    not specified, a pseudo-random 14-bit positive integer is generated.
 
-   If *node* or *clock_seq* exceed their expected bit count, only their least
-   significant bits are kept.
+   If *node* or *clock_seq* exceed their expected bit count,
+   only their least significant bits are kept.
 
    .. versionadded:: 3.14
 

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -196,9 +196,9 @@ The :mod:`uuid` module defines the following functions:
    Generate a UUID from a host ID, sequence number, and the current time
    according to :rfc:`RFC 9562, §5.1 <9562#section-5.1>`.
 
-   If *node* is not given, :func:`getnode` is used to obtain the hardware address.
-
-   If *clock_seq* is given, it is used as the sequence number; otherwise a random
+   When *node* is not specified, :func:`getnode` is used to obtain the hardware
+   address as a 48-bit positive integer. When a sequence number *clock_seq* is
+   not specified, a pseudo-random 14-bit positive integer is generated.
    14-bit sequence number is chosen.
 
 


### PR DESCRIPTION
Add RFC links to the former UUID version and standardize the docs since UUIDv7-8 and nil, max has its RFC links

Skipping news and issues caz this is a doc change :)

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135684.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-89083 -->
* Issue: gh-89083
<!-- /gh-issue-number -->
