### PR TITLE
gh-135698: Fix _interpqueues.create(): max_size >= 0

### DIFF
--- a/Lib/test/test_interpreters/test_queues.py
+++ b/Lib/test/test_interpreters/test_queues.py
@@ -50,6 +50,10 @@ class LowLevelTests(TestBase):
         with self.assertRaises(queues.QueueNotFoundError):
             _queues.destroy(qid)
 
+        with self.assertRaises(ValueError):
+            # gh-135698: max_size must be greater than or equal to 0
+            _queues.create(-1, 1, 1)
+
     def test_not_destroyed(self):
         # It should have cleaned up any remaining queues.
         stdout, stderr = self.assert_python_ok(
@@ -114,8 +118,8 @@ class QueueTests(TestBase):
             self.assertEqual(queue.maxsize, 0)
 
         with self.subTest('negative maxsize'):
-            queue = queues.create(-10)
-            self.assertEqual(queue.maxsize, -10)
+            with self.assertRaises(ValueError):
+                queues.create(-10)
 
         with self.subTest('bad maxsize'):
             with self.assertRaises(TypeError):

--- a/Modules/_interpqueuesmodule.c
+++ b/Modules/_interpqueuesmodule.c
@@ -1488,6 +1488,11 @@ queuesmod_create(PyObject *self, PyObject *args, PyObject *kwds)
     {
         return NULL;
     }
+    if (maxsize < 0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "max_size must be greater than or equal to 0");
+        return NULL;
+    }
     struct _queuedefaults defaults = {0};
     if (resolve_unboundop(unboundarg, UNBOUND_REPLACE,
                           &defaults.unboundop) < 0)


### PR DESCRIPTION
Make sure that the queue maximum size is greater than or equal to 0.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135698 -->
* Issue: gh-135698
<!-- /gh-issue-number -->
