### PR TITLE
gh-135709: Fix two compile warnings on WASM buildbot

### DIFF
--- a/Modules/_testcapi/long.c
+++ b/Modules/_testcapi/long.c
@@ -228,7 +228,7 @@ pylongwriter_create(PyObject *module, PyObject *args)
             goto error;
         }
 
-        if (num < 0 || num >= PyLong_BASE) {
+        if (num < 0 || num >= (long)PyLong_BASE) {
             PyErr_SetString(PyExc_ValueError, "digit doesn't fit into digit");
             goto error;
         }

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2424,7 +2424,7 @@ test_critical_sections(PyObject *module, PyObject *Py_UNUSED(args))
 
 
 // Used by `finalize_thread_hang`.
-#ifdef _POSIX_THREADS
+#if defined(_POSIX_THREADS) && !defined(__wasi__)
 static void finalize_thread_hang_cleanup_callback(void *Py_UNUSED(arg)) {
     // Should not reach here.
     Py_FatalError("pthread thread termination was triggered unexpectedly");


### PR DESCRIPTION


<!-- gh-issue-number: gh-135709 -->
* Issue: gh-135709
<!-- /gh-issue-number -->
