### PR TITLE
gh-135379: fix MSVC warning: conversion from 'stwodigits' to 'digit'

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -337,7 +337,7 @@ medium_from_stwodigits(stwodigits x)
         }
         _PyObject_Init((PyObject*)v, &PyLong_Type);
     }
-    digit abs_x = x < 0 ? -x : x;
+    digit abs_x = x < 0 ? (digit)(-x) : (digit)x;
     _PyLong_SetSignAndDigitCount(v, x<0?-1:1, 1);
     v->long_value.ob_digit[0] = abs_x;
     return PyStackRef_FromPyObjectStealMortal((PyObject *)v);


### PR DESCRIPTION
Fixes MSVC `warning C4244: 'initializing': conversion from 'stwodigits' to 'digit', possible loss of data`.

<!-- gh-issue-number: gh-135379 -->
* Issue: gh-135379
<!-- /gh-issue-number -->
