### PR TITLE
gh-135552: Clear weakrefs to types in GC after garbage finalization not before

### DIFF
--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1517,6 +1517,23 @@ class PythonFinalizationTests(unittest.TestCase):
         """)
         assert_python_ok("-c", code)
 
+    def test_reset_type_cache_after_finalization(self):
+        # https://github.com/python/cpython/issues/135552
+        code = textwrap.dedent("""
+            class BaseNode:
+                def __del__(self):
+                    BaseNode.next = BaseNode.next.next
+            
+            
+            class Node(BaseNode):
+                pass
+            
+            
+            BaseNode.next = Node()
+            BaseNode.next.next = Node()
+        """)
+        assert_python_ok("-c", code)
+
 
 def setUpModule():
     global enabled, debug

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1127,30 +1127,23 @@ class GCTests(unittest.TestCase):
 
     def test_do_not_cleanup_type_subclasses_before_finalization(self):
         # https://github.com/python/cpython/issues/135552
-        code = textwrap.dedent("""
+        code = """
             class BaseNode:
                 def __del__(self):
                     BaseNode.next = BaseNode.next.next
+                    BaseNode.next.next
 
             class Node(BaseNode):
                 pass
 
             BaseNode.next = Node()
             BaseNode.next.next = Node()
-        """)
-        assert_python_ok("-c", code)
+        """
+        assert_python_ok("-c", textwrap.dedent(code))
 
-        code_inside_function = textwrap.dedent("""
+        code_inside_function = textwrap.dedent(F"""
             def test():
-                class BaseNode:
-                    def __del__(self):
-                        BaseNode.next = BaseNode.next.next
-
-                class Node(BaseNode):
-                    pass
-
-                BaseNode.next = Node()
-                BaseNode.next.next = Node()
+                {textwrap.indent(code, '    ')}
 
             test()
         """)

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-23-01-07-09.gh-issue-135552.eG9vzP.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-23-01-07-09.gh-issue-135552.eG9vzP.rst
@@ -1,0 +1,4 @@
+Split the handling of weak references in the GC if both types and instances
+within a generation are unreachable. This prevent  the clearing  of the
+type's subclasses list too early. This fix a segfault that occurs when
+__del__ modifies the base's attributes and tries to access them from self.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-23-01-07-09.gh-issue-135552.eG9vzP.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-23-01-07-09.gh-issue-135552.eG9vzP.rst
@@ -1,4 +1,4 @@
 Split the handling of weak references in the GC if both types and instances
 within a generation are unreachable. This prevent  the clearing  of the
-type's subclasses list too early. This fix a segfault that occurs when
+type's subclasses list too early. This fix a crash that occurs when
 :meth:`~object.__del__` modifies the base's attributes and tries to access them from self.

--- a/Misc/NEWS.d/next/Core_and_Builtins/2025-06-23-01-07-09.gh-issue-135552.eG9vzP.rst
+++ b/Misc/NEWS.d/next/Core_and_Builtins/2025-06-23-01-07-09.gh-issue-135552.eG9vzP.rst
@@ -1,4 +1,4 @@
 Split the handling of weak references in the GC if both types and instances
 within a generation are unreachable. This prevent  the clearing  of the
 type's subclasses list too early. This fix a segfault that occurs when
-__del__ modifies the base's attributes and tries to access them from self.
+:meth:`~object.__del__` modifies the base's attributes and tries to access them from self.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -10767,8 +10767,6 @@ slot_tp_finalize(PyObject *self)
         }
     }
 
-    PyType_Modified(Py_TYPE(self));
-
     _PyThreadState_PopCStackRef(tstate, &cref);
 
     /* Restore the saved exception. */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -10767,6 +10767,8 @@ slot_tp_finalize(PyObject *self)
         }
     }
 
+    PyType_Modified(Py_TYPE(self));
+
     _PyThreadState_PopCStackRef(tstate, &cref);
 
     /* Restore the saved exception. */


### PR DESCRIPTION
While trying to find the root cause of the linked issue, I observed that the type cache was holding an obsolete reference. Because the type cache holds borrowed references, this leads to a use-after-free error. 

I'm resetting the cache in this PR. But I suspect that this may affect overall performance. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135552 -->
* Issue: gh-135552
<!-- /gh-issue-number -->
