### PR TITLE
gh-135648: Document that `shutil.copyfileobj` doesn't flush

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -47,6 +47,13 @@ Directory and files operations
    0, only the contents from the current file position to the end of the file will
    be copied.
 
+   :func:`copyfileobj` will *not* guarantee that the destination stream has
+   been flushed on completion of the copy. If you want to read from the
+   destination at the completion of the copy operation (for example, reading
+   the contents of a temporary file that has been copied from a HTTP stream),
+   you must ensure that you have called :func:`~io.IOBase.flush` or
+   :func:`~io.IOBase.close` on the file-like object before attempting to read
+   the destination file.
 
 .. function:: copyfile(src, dst, *, follow_symlinks=True)
 

--- a/Misc/NEWS.d/next/Documentation/2025-06-20-10-27-11.gh-issue-135648.xCC_zC.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-06-20-10-27-11.gh-issue-135648.xCC_zC.rst
@@ -1,2 +1,0 @@
-The documentation for :func:`shutil.copyfileobj` now warns the user of the
-need to close or flush the destination stream on completion.

--- a/Misc/NEWS.d/next/Documentation/2025-06-20-10-27-11.gh-issue-135648.xCC_zC.rst
+++ b/Misc/NEWS.d/next/Documentation/2025-06-20-10-27-11.gh-issue-135648.xCC_zC.rst
@@ -1,0 +1,2 @@
+The documentation for :func:`shutil.copyfileobj` now warns the user of the
+need to close or flush the destination stream on completion.

--- a/Tools/wasm/emscripten/__main__.py
+++ b/Tools/wasm/emscripten/__main__.py
@@ -167,11 +167,12 @@ def make_build_python(context, working_dir):
 @subdir(HOST_BUILD_DIR, clean_ok=True)
 def make_emscripten_libffi(context, working_dir):
     shutil.rmtree(working_dir / "libffi-3.4.6", ignore_errors=True)
-    with tempfile.NamedTemporaryFile(suffix=".tar.gz") as tmp_file:
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete_on_close=False) as tmp_file:
         with urlopen(
             "https://github.com/libffi/libffi/releases/download/v3.4.6/libffi-3.4.6.tar.gz"
         ) as response:
             shutil.copyfileobj(response, tmp_file)
+        tmp_file.close()
         shutil.unpack_archive(tmp_file.name, working_dir)
     call(
         [EMSCRIPTEN_DIR / "make_libffi.sh"],


### PR DESCRIPTION
Document that `shutil.copyfileobj()` doesn't flush the destination stream on completion, so file content may not be reliably available.

Modifies the Emscripten build script to avoid the problem that the documentation is warning about.

<!-- gh-issue-number: gh-135648 -->
* Issue: gh-135648
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135737.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->