### PR TITLE
gh-135755: Docs: C API: Document missing `PyFunction_GET*` macros

### DIFF
--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -142,8 +142,8 @@ There are a few functions specific to Python functions.
                 PyObject *PyFunction_GET_CLOSURE(PyObject *op)
                 PyObject *PyFunction_GET_ANNOTATIONS(PyObject *op)
 
-   Similar to their ``PyFunction_Get*`` counterparts, but do not do type
-   checking. Passing anything other than an instance of
+   These functions are similar to their ``PyFunction_Get*`` counterparts, but
+   do not do type checking. Passing anything other than an instance of
    :c:data:`PyFunction_Type` is undefined behavior.
 
 

--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -144,7 +144,7 @@ There are a few functions specific to Python functions.
 
    Similar to their ``PyFunction_Get*`` counterparts, but do not do type
    checking. Passing anything other than an instance of
-   :c:type:`PyFunction_type` is undefined behavior.
+   :c:data:`PyFunction_Type` is undefined behavior.
 
 
 .. c:function:: int PyFunction_AddWatcher(PyFunction_WatchCallback callback)

--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -121,8 +121,6 @@ There are a few functions specific to Python functions.
    Return the annotations of the function object *op*. This can be a
    mutable dictionary or ``NULL``.
 
-   .. versionadded:: 3.0
-
 
 .. c:function:: int PyFunction_SetAnnotations(PyObject *op, PyObject *annotations)
 
@@ -130,8 +128,6 @@ There are a few functions specific to Python functions.
    must be a dictionary or ``Py_None``.
 
    Raises :exc:`SystemError` and returns ``-1`` on failure.
-
-   .. versionadded:: 3.0
 
 
 .. c:function:: PyObject *PyFunction_GET_CODE(PyObject *op)

--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -245,4 +245,3 @@ There are a few functions specific to Python functions.
    it before returning.
 
    .. versionadded:: 3.12
-

--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -59,7 +59,7 @@ There are a few functions specific to Python functions.
 
 .. c:function:: PyObject *PyFunction_GET_CODE(PyObject *op)
 
-   Equivalent to :c:func:`PyFunction_GetCode`, but without error checking.
+   Similar to :c:func:`PyFunction_GetCode`, but without error checking.
 
 
 .. c:function:: PyObject* PyFunction_GetGlobals(PyObject *op)
@@ -69,7 +69,7 @@ There are a few functions specific to Python functions.
 
 .. c:function:: PyObject *PyFunction_GET_GLOBALS(PyObject *op)
 
-   Equivalent to :c:func:`PyFunction_GetGlobals`, but without error checking.
+   Similar to :c:func:`PyFunction_GetGlobals`, but without error checking.
 
 
 .. c:function:: PyObject* PyFunction_GetModule(PyObject *op)
@@ -84,7 +84,7 @@ There are a few functions specific to Python functions.
 
 .. c:function:: PyObject *PyFunction_GET_MODULE(PyObject *op)
 
-   Equivalent to :c:func:`PyFunction_GetModule`, but without error checking.
+   Similar to :c:func:`PyFunction_GetModule`, but without error checking.
 
 
 .. c:function:: PyObject* PyFunction_GetDefaults(PyObject *op)
@@ -95,7 +95,7 @@ There are a few functions specific to Python functions.
 
 .. c:function:: PyObject *PyFunction_GET_DEFAULTS(PyObject *op)
 
-   Equivalent to :c:func:`PyFunction_GetDefaults`, but without error checking.
+   Similar to :c:func:`PyFunction_GetDefaults`, but without error checking.
 
 
 .. c:function:: int PyFunction_SetDefaults(PyObject *op, PyObject *defaults)
@@ -126,7 +126,7 @@ There are a few functions specific to Python functions.
 
 .. c:function:: PyObject *PyFunction_GET_KW_DEFAULTS(PyObject *op)
 
-   Equivalent to :c:func:`PyFunction_GetKwDefaults`, but without error checking.
+   Similar to :c:func:`PyFunction_GetKwDefaults`, but without error checking.
 
    .. versionadded:: 3.0
 
@@ -139,7 +139,7 @@ There are a few functions specific to Python functions.
 
 .. c:function:: PyObject *PyFunction_GET_CLOSURE(PyObject *op)
 
-   Equivalent to :c:func:`PyFunction_GetClosure`, but without error checking.
+   Similar to :c:func:`PyFunction_GetClosure`, but without error checking.
 
 
 .. c:function:: int PyFunction_SetClosure(PyObject *op, PyObject *closure)
@@ -160,7 +160,7 @@ There are a few functions specific to Python functions.
 
 .. c:function:: PyObject *PyFunction_GET_ANNOTATIONS(PyObject *op)
 
-   Equivalent to :c:func:`PyFunction_GetAnnotations`, but without error checking.
+   Similar to :c:func:`PyFunction_GetAnnotations`, but without error checking.
 
    .. versionadded:: 3.0
 

--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -57,19 +57,9 @@ There are a few functions specific to Python functions.
    Return the code object associated with the function object *op*.
 
 
-.. c:function:: PyObject *PyFunction_GET_CODE(PyObject *op)
-
-   Similar to :c:func:`PyFunction_GetCode`, but without error checking.
-
-
 .. c:function:: PyObject* PyFunction_GetGlobals(PyObject *op)
 
    Return the globals dictionary associated with the function object *op*.
-
-
-.. c:function:: PyObject *PyFunction_GET_GLOBALS(PyObject *op)
-
-   Similar to :c:func:`PyFunction_GetGlobals`, but without error checking.
 
 
 .. c:function:: PyObject* PyFunction_GetModule(PyObject *op)
@@ -82,20 +72,10 @@ There are a few functions specific to Python functions.
    but can be set to any other object by Python code.
 
 
-.. c:function:: PyObject *PyFunction_GET_MODULE(PyObject *op)
-
-   Similar to :c:func:`PyFunction_GetModule`, but without error checking.
-
-
 .. c:function:: PyObject* PyFunction_GetDefaults(PyObject *op)
 
    Return the argument default values of the function object *op*. This can be a
    tuple of arguments or ``NULL``.
-
-
-.. c:function:: PyObject *PyFunction_GET_DEFAULTS(PyObject *op)
-
-   Similar to :c:func:`PyFunction_GetDefaults`, but without error checking.
 
 
 .. c:function:: int PyFunction_SetDefaults(PyObject *op, PyObject *defaults)
@@ -121,25 +101,11 @@ There are a few functions specific to Python functions.
    Return the keyword-only argument default values of the function object *op*. This can be a
    dictionary of arguments or ``NULL``.
 
-   .. versionadded:: 3.0
-
-
-.. c:function:: PyObject *PyFunction_GET_KW_DEFAULTS(PyObject *op)
-
-   Similar to :c:func:`PyFunction_GetKwDefaults`, but without error checking.
-
-   .. versionadded:: 3.0
-
 
 .. c:function:: PyObject* PyFunction_GetClosure(PyObject *op)
 
    Return the closure associated with the function object *op*. This can be ``NULL``
    or a tuple of cell objects.
-
-
-.. c:function:: PyObject *PyFunction_GET_CLOSURE(PyObject *op)
-
-   Similar to :c:func:`PyFunction_GetClosure`, but without error checking.
 
 
 .. c:function:: int PyFunction_SetClosure(PyObject *op, PyObject *closure)
@@ -158,13 +124,6 @@ There are a few functions specific to Python functions.
    .. versionadded:: 3.0
 
 
-.. c:function:: PyObject *PyFunction_GET_ANNOTATIONS(PyObject *op)
-
-   Similar to :c:func:`PyFunction_GetAnnotations`, but without error checking.
-
-   .. versionadded:: 3.0
-
-
 .. c:function:: int PyFunction_SetAnnotations(PyObject *op, PyObject *annotations)
 
    Set the annotations for the function object *op*. *annotations*
@@ -173,6 +132,19 @@ There are a few functions specific to Python functions.
    Raises :exc:`SystemError` and returns ``-1`` on failure.
 
    .. versionadded:: 3.0
+
+
+.. c:function:: PyObject *PyFunction_GET_CODE(PyObject *op)
+                PyObject *PyFunction_GET_GLOBALS(PyObject *op)
+                PyObject *PyFunction_GET_MODULE(PyObject *op)
+                PyObject *PyFunction_GET_DEFAULTS(PyObject *op)
+                PyObject *PyFunction_GET_KW_DEFAULTS(PyObject *op)
+                PyObject *PyFunction_GET_CLOSURE(PyObject *op)
+                PyObject *PyFunction_GET_ANNOTATIONS(PyObject *op)
+
+   Similar to their ``PyFunction_Get*`` counterparts, but do not do type
+   checking. Passing anything other than an instance of
+   :c:type:`PyFunction_type` is undefined behavior.
 
 
 .. c:function:: int PyFunction_AddWatcher(PyFunction_WatchCallback callback)

--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -118,13 +118,17 @@ There are a few functions specific to Python functions.
 
 .. c:function:: PyObject* PyFunction_GetKwDefaults(PyObject *op)
 
-   Return the keyword-argument default values of the function object *op*. This can be a
-   tuple of arguments or ``NULL``.
+   Return the keyword-only argument default values of the function object *op*. This can be a
+   dictionary of arguments or ``NULL``.
+
+   .. versionadded:: 3.0
 
 
 .. c:function:: PyObject *PyFunction_GET_KW_DEFAULTS(PyObject *op)
 
    Equivalent to :c:func:`PyFunction_GetKwDefaults`, but without error checking.
+
+   .. versionadded:: 3.0
 
 
 .. c:function:: PyObject* PyFunction_GetClosure(PyObject *op)

--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -57,9 +57,19 @@ There are a few functions specific to Python functions.
    Return the code object associated with the function object *op*.
 
 
+.. c:function:: PyObject *PyFunction_GET_CODE(PyObject *op)
+
+   Equivalent to :c:func:`PyFunction_GetCode`, but without error checking.
+
+
 .. c:function:: PyObject* PyFunction_GetGlobals(PyObject *op)
 
    Return the globals dictionary associated with the function object *op*.
+
+
+.. c:function:: PyObject *PyFunction_GET_GLOBALS(PyObject *op)
+
+   Equivalent to :c:func:`PyFunction_GetGlobals`, but without error checking.
 
 
 .. c:function:: PyObject* PyFunction_GetModule(PyObject *op)
@@ -72,10 +82,20 @@ There are a few functions specific to Python functions.
    but can be set to any other object by Python code.
 
 
+.. c:function:: PyObject *PyFunction_GET_MODULE(PyObject *op)
+
+   Equivalent to :c:func:`PyFunction_GetModule`, but without error checking.
+
+
 .. c:function:: PyObject* PyFunction_GetDefaults(PyObject *op)
 
    Return the argument default values of the function object *op*. This can be a
    tuple of arguments or ``NULL``.
+
+
+.. c:function:: PyObject *PyFunction_GET_DEFAULTS(PyObject *op)
+
+   Equivalent to :c:func:`PyFunction_GetDefaults`, but without error checking.
 
 
 .. c:function:: int PyFunction_SetDefaults(PyObject *op, PyObject *defaults)
@@ -95,10 +115,27 @@ There are a few functions specific to Python functions.
 
    .. versionadded:: 3.12
 
+
+.. c:function:: PyObject* PyFunction_GetKwDefaults(PyObject *op)
+
+   Return the keyword-argument default values of the function object *op*. This can be a
+   tuple of arguments or ``NULL``.
+
+
+.. c:function:: PyObject *PyFunction_GET_KW_DEFAULTS(PyObject *op)
+
+   Equivalent to :c:func:`PyFunction_GetKwDefaults`, but without error checking.
+
+
 .. c:function:: PyObject* PyFunction_GetClosure(PyObject *op)
 
    Return the closure associated with the function object *op*. This can be ``NULL``
    or a tuple of cell objects.
+
+
+.. c:function:: PyObject *PyFunction_GET_CLOSURE(PyObject *op)
+
+   Equivalent to :c:func:`PyFunction_GetClosure`, but without error checking.
 
 
 .. c:function:: int PyFunction_SetClosure(PyObject *op, PyObject *closure)
@@ -113,6 +150,11 @@ There are a few functions specific to Python functions.
 
    Return the annotations of the function object *op*. This can be a
    mutable dictionary or ``NULL``.
+
+
+.. c:function:: PyObject *PyFunction_GET_ANNOTATIONS(PyObject *op)
+
+   Equivalent to :c:func:`PyFunction_GetAnnotations`, but without error checking.
 
 
 .. c:function:: int PyFunction_SetAnnotations(PyObject *op, PyObject *annotations)
@@ -193,3 +235,4 @@ There are a few functions specific to Python functions.
    it before returning.
 
    .. versionadded:: 3.12
+

--- a/Doc/c-api/function.rst
+++ b/Doc/c-api/function.rst
@@ -155,10 +155,14 @@ There are a few functions specific to Python functions.
    Return the annotations of the function object *op*. This can be a
    mutable dictionary or ``NULL``.
 
+   .. versionadded:: 3.0
+
 
 .. c:function:: PyObject *PyFunction_GET_ANNOTATIONS(PyObject *op)
 
    Equivalent to :c:func:`PyFunction_GetAnnotations`, but without error checking.
+
+   .. versionadded:: 3.0
 
 
 .. c:function:: int PyFunction_SetAnnotations(PyObject *op, PyObject *annotations)
@@ -167,6 +171,8 @@ There are a few functions specific to Python functions.
    must be a dictionary or ``Py_None``.
 
    Raises :exc:`SystemError` and returns ``-1`` on failure.
+
+   .. versionadded:: 3.0
 
 
 .. c:function:: int PyFunction_AddWatcher(PyFunction_WatchCallback callback)

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -963,23 +963,44 @@ PyFunction_Check:PyObject*:o:0:
 PyFunction_GetAnnotations:PyObject*::0:
 PyFunction_GetAnnotations:PyObject*:op:0:
 
+PyFunction_GET_ANNOTATIONS:PyObject*::0:
+PyFunction_GET_ANNOTATIONS:PyObject*:op:0:
+
 PyFunction_GetClosure:PyObject*::0:
 PyFunction_GetClosure:PyObject*:op:0:
+
+PyFunction_GET_CLOSURE:PyObject*::0:
+PyFunction_GET_CLOSURE:PyObject*:op:0:
 
 PyFunction_GetCode:PyObject*::0:
 PyFunction_GetCode:PyObject*:op:0:
 
+PyFunction_GET_CODE:PyObject*::0:
+PyFunction_GET_CODE:PyObject*:op:0:
+
 PyFunction_GetDefaults:PyObject*::0:
 PyFunction_GetDefaults:PyObject*:op:0:
+
+PyFunction_GET_DEFAULTS:PyObject*::0:
+PyFunction_GET_DEFAULTS:PyObject*:op:0:
 
 PyFunction_GetKwDefaults:PyObject*::0:
 PyFunction_GetKwDefaults:PyObject*:op:0:
 
+PyFunction_GET_KW_DEFAULTS:PyObject*::0:
+PyFunction_GET_KW_DEFAULTS:PyObject*:op:0:
+
 PyFunction_GetGlobals:PyObject*::0:
 PyFunction_GetGlobals:PyObject*:op:0:
 
+PyFunction_GET_GLOBALS:PyObject*::0:
+PyFunction_GET_GLOBALS:PyObject*:op:0:
+
 PyFunction_GetModule:PyObject*::0:
 PyFunction_GetModule:PyObject*:op:0:
+
+PyFunction_GET_MODULE:PyObject*::0:
+PyFunction_GET_MODULE:PyObject*:op:0:
 
 PyFunction_New:PyObject*::+1:
 PyFunction_New:PyObject*:code:+1:

--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -972,6 +972,9 @@ PyFunction_GetCode:PyObject*:op:0:
 PyFunction_GetDefaults:PyObject*::0:
 PyFunction_GetDefaults:PyObject*:op:0:
 
+PyFunction_GetKwDefaults:PyObject*::0:
+PyFunction_GetKwDefaults:PyObject*:op:0:
+
 PyFunction_GetGlobals:PyObject*::0:
 PyFunction_GetGlobals:PyObject*:op:0:
 


### PR DESCRIPTION
I'm documenting all of these before getting to `PyFunction_GET_BUILTINS`, because this needs to be backported to 3.13. I'll document `PyFunction_GET_BUILTINS` in a follow-up that goes only to 3.14. 

~~I've included `versionadded` directives for a few APIs that were added in 3.0 (PEP-3102 and PEP-3107), but I don't know if those are particularly useful these days. AFAIK, it's a controversial topic.~~

<!-- gh-issue-number: gh-135755 -->
* Issue: gh-135755
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135762.org.readthedocs.build/en/135762/c-api/function.html#function-objects

<!-- readthedocs-preview cpython-previews end -->