### PR TITLE
gh-135756: Fix nonexistent parameter in tkinter docs

### DIFF
--- a/Doc/library/dialog.rst
+++ b/Doc/library/dialog.rst
@@ -220,7 +220,7 @@ is the base class for dialogs defined in other supporting modules.
 
 .. class:: Dialog(master=None, **options)
 
-   .. method:: show(color=None, **options)
+   .. method:: show(**options)
 
       Render the Dialog window.
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->

Remove nonexistent `color` parameter from `tkinter.commondialog.Dialog.show()` method documentation.


<!-- gh-issue-number: gh-135756 -->
* Issue: gh-135756
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135770.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->