### PR TITLE
gh-135768: fix allowed/blocked IPv6 domains in `http.cookiejar`

### DIFF
--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -535,8 +535,8 @@ def parse_ns_headers(ns_headers):
 # only kept for backwards compatibilty.
 IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 
-def is_ip(text: str):
-    """Return True if text is a valid IP address."""
+def is_ip_like(text: str):
+    """Return True if text is a valid hostname in the form of IP address."""
     from ipaddress import IPv4Address, IPv6Address
     # check for IPv4 address
     try:

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -556,7 +556,7 @@ def is_HDN(text):
     # XXX
     # This may well be wrong.  Which RFC is HDN defined in, if any (for
     #  the purposes of RFC 2965)?
-    if is_ip(text):
+    if is_ip_like(text):
         return False
     if text == "":
         return False
@@ -609,7 +609,7 @@ def liberal_is_HDN(text):
     For accepting/blocking domains.
 
     """
-    return not is_ip(text)
+    return not is_ip_like(text)
 
 def user_domain_match(A, B):
     """For blocking/accepting domains.
@@ -659,12 +659,12 @@ def eff_request_host(request):
         from ipaddress import IPv6Address
         try:
             IPv6Address(req_host.removeprefix('[').removesuffix(']'))
-            is_IPV6 = True
+            is_ipV6 = True
         except ValueError:
-            is_IPV6 = False
+            is_ipV6 = False
     else:
-        is_IPV6 = False
-    if "." not in req_host and not is_IPV6:
+        is_ipV6 = False
+    if "." not in req_host and not is_ipV6:
         # avoid adding .local at the end of a IPV6 address
         erhn = req_host + ".local"
     return req_host, erhn

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -658,7 +658,7 @@ def eff_request_host(request):
     if req_host.startswith('[') and req_host.endswith(']'):
         from ipaddress import IPv6Address
         try:
-            IPv6Address(req_host.removeprefix('[').removesuffix(']'))
+            IPv6Address(req_host[1:-1])
         except ValueError:
             is_ipV6 = False
         else:

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -536,7 +536,15 @@ def parse_ns_headers(ns_headers):
 IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 
 def is_ip_like_hostname(text):
-    """Return True if text is a valid hostname in the form of IP address."""
+    """Return True if text is a valid hostname in the form of IP address.
+    
+    If text is a valid IPv4 address, retrun True;
+
+    If text is a valid IPv6 address wrapped in [], return True;
+
+    Else, return False
+    
+    """
     from ipaddress import IPv4Address, IPv6Address
     # check for IPv4 address
     try:
@@ -667,6 +675,8 @@ def eff_request_host(request):
         is_ipV6 = False
     if "." not in req_host and not is_ipV6:
         # avoid adding .local at the end of a IPV6 address
+        # for the additional ".local", see RFC 2965 section 1
+        # https://www.rfc-editor.org/rfc/rfc2965
         erhn = req_host + ".local"
     return req_host, erhn
 

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -536,11 +536,8 @@ IPV4_RE = re.compile(r"\.\d+$", re.ASCII) # kept for backwards compatibility
 def is_ip(text: str):
     """Return True if text is a valid IP address."""
     from ipaddress import ip_address
+    text = text.removeprefix('[').removesuffix(']')
     try:
-        if text.startswith('['):
-            text = text[1:]
-        if text.endswith(']'):
-            text = text[:-1]
         ip_address(text)
     except ValueError:
         return False

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -542,7 +542,7 @@ def is_ip_like_hostname(text):
 
     If text is a valid IPv6 address wrapped in [], return True;
 
-    Else, return False
+    Else, return False.
 
     """
     from ipaddress import IPv4Address, IPv6Address

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -536,7 +536,6 @@ def parse_ns_headers(ns_headers):
 IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 def is_ip(text):
     """Return True if text is a valid IP address."""
-    # This function is a replacement of regex `IPV4_RE` in previous versions.
     try:
         ip_address(text)
         return True

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -547,7 +547,6 @@ def is_HDN(text):
     # XXX
     # This may well be wrong.  Which RFC is HDN defined in, if any (for
     #  the purposes of RFC 2965)?
-    # Both IPv4 and IPv6 are supported.
     if is_ip(text):
         return False
     if text == "":

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -562,6 +562,7 @@ def is_ip_like_hostname(text):
     if _is_ipv4_hostname(text) or _is_ipv6_hostname(text):
         return True
     return False
+
 def is_HDN(text):
     """Return True if text is a host domain name."""
     # XXX

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -29,15 +29,14 @@ __all__ = ['Cookie', 'CookieJar', 'CookiePolicy', 'DefaultCookiePolicy',
            'FileCookieJar', 'LWPCookieJar', 'LoadError', 'MozillaCookieJar']
 
 import os
-import re
 import copy
-import time
 import datetime
+import re
+import time
 import urllib.parse, urllib.request
 import threading as _threading
 import http.client  # only for the default HTTP port
 from calendar import timegm
-from ipaddress import ip_address
 
 debug = False   # set to True to enable debugging via the logging module
 logger = None
@@ -536,6 +535,7 @@ def parse_ns_headers(ns_headers):
 IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 def is_ip(text):
     """Return True if text is a valid IP address."""
+    from ipaddress import ip_address
     try:
         ip_address(text)
     except ValueError:
@@ -611,10 +611,8 @@ def user_domain_match(A, B):
     B = B.lower()
     if not (liberal_is_HDN(A) and liberal_is_HDN(B)):
         if A == B:
-            # equal IPv4 addresses
             return True
         return False
-    # A and B may be HDNs or a IPv6 addresses now
     initial_dot = B.startswith(".")
     if initial_dot and A.endswith(B):
         return True

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -559,9 +559,7 @@ def is_ip_like_hostname(text):
     A valid IP-like hostname is either an IPv4 address or
     an IPv6 enclosed in brackets (for instance, "[::1]").
     """
-    if _is_ipv4_hostname(text) or _is_ipv6_hostname(text):
-        return True
-    return False
+    return _is_ipv4_hostname(text) or _is_ipv6_hostname(text)
 
 def is_HDN(text):
     """Return True if text is a host domain name."""

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -612,7 +612,7 @@ def user_domain_match(A, B):
     B = B.lower()
     if not (liberal_is_HDN(A) and liberal_is_HDN(B)):
         if A == B:
-            # equal IPV4 addresses
+            # equal IP addresses
             return True
         return False
     initial_dot = B.startswith(".")

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -545,7 +545,7 @@ def is_ip_like_hostname(text):
         # check for IPv6 address in []
         if text.startswith('[') and text.endswith(']'):
             try:
-                IPv6Address(text.removeprefix('[').removesuffix(']'))
+                IPv6Address(text[1:-1])
             except ValueError:
                 return False
         else:

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -674,9 +674,9 @@ def eff_request_host(request):
     else:
         is_ipV6 = False
     if "." not in req_host and not is_ipV6:
-        # avoid adding .local at the end of a IPV6 address
-        # for the additional ".local", see RFC 2965 section 1
-        # https://www.rfc-editor.org/rfc/rfc2965
+        # Avoid adding .local at the end of an IPv6 address.
+        # See RFC 2965 [1] for the rationale of ".local".
+        # [1]: https://www.rfc-editor.org/rfc/rfc2965
         erhn = req_host + ".local"
     return req_host, erhn
 

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -537,7 +537,7 @@ IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 
 def is_ip_like_hostname(text):
     """Return True if text is a valid hostname in the form of IP address.
-    
+\
     If text is a valid IPv4 address, retrun True;
 
     If text is a valid IPv6 address wrapped in [], return True;

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -554,7 +554,7 @@ def _is_ipv6_hostname(text):
     return False
 
 def is_ip_like_hostname(text):
-    """Return True if text is a valid hostname in the form of IP address.
+    """Check if *text* is a valid IP-like hostname.
 
     A valid IP-like hostname is either an IPv4 address or
     an IPv6 enclosed in brackets (for instance, "[::1]").

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -535,7 +535,7 @@ def parse_ns_headers(ns_headers):
 # only kept for backwards compatibilty.
 IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 
-def is_ip_like_hostname(text: str):
+def is_ip_like_hostname(text):
     """Return True if text is a valid hostname in the form of IP address."""
     from ipaddress import IPv4Address, IPv6Address
     # check for IPv4 address

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -532,7 +532,9 @@ def parse_ns_headers(ns_headers):
     return result
 
 
-IPV4_RE = re.compile(r"\.\d+$", re.ASCII) # kept for backwards compatibility
+# only kept for backwards compatibilty.
+IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
+
 def is_ip(text: str):
     """Return True if text is a valid IP address."""
     from ipaddress import ip_address

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -537,12 +537,19 @@ IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 
 def is_ip(text: str):
     """Return True if text is a valid IP address."""
-    from ipaddress import ip_address
-    text = text.removeprefix('[').removesuffix(']')
+    from ipaddress import IPv4Address, IPv6Address
+    # check for IPv4 address
     try:
-        ip_address(text)
+        IPv4Address(text)
     except ValueError:
-        return False
+        # check for IPv6 address in []
+        if text.startswith('[') and text.endswith(']'):
+            try:
+                IPv6Address(text.removeprefix('[').removesuffix(']'))
+            except ValueError:
+                return False
+        else:
+            return False # not a IPv6 address in []
     return True
 def is_HDN(text):
     """Return True if text is a host domain name."""

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -614,8 +614,8 @@ def user_domain_match(A, B):
     A = A.lower()
     B = B.lower()
     if not (liberal_is_HDN(A) and liberal_is_HDN(B)):
-        # equal IPV4 addresses
         if A == B:
+            # equal IPV4 addresses
             return True
         return False
     # A and B may be HDNs or a IPv6 addresses now

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -644,8 +644,8 @@ def eff_request_host(request):
 
     """
     erhn = req_host = request_host(request)
-    IPV6_RE = re.compile(r"^\[.*\]$")
-    if "." not in req_host and not IPV6_RE.search(req_host):
+    is_IPV6 = req_host.startswith('[') and req_host.endswith(']')
+    if "." not in req_host and not is_IPV6:
         # avoid adding .local at the end of a IPV6 address
         erhn = req_host + ".local"
     return req_host, erhn

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -537,7 +537,7 @@ IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 
 def is_ip_like_hostname(text):
     """Return True if text is a valid hostname in the form of IP address.
-\
+
     If text is a valid IPv4 address, retrun True;
 
     If text is a valid IPv6 address wrapped in [], return True;

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -656,7 +656,7 @@ def eff_request_host(request):
         except ValueError:
             is_IPV6 = False
     else:
-        is_IPV6 = False  
+        is_IPV6 = False
     if "." not in req_host and not is_IPV6:
         # avoid adding .local at the end of a IPV6 address
         erhn = req_host + ".local"

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -659,9 +659,10 @@ def eff_request_host(request):
         from ipaddress import IPv6Address
         try:
             IPv6Address(req_host.removeprefix('[').removesuffix(']'))
-            is_ipV6 = True
         except ValueError:
             is_ipV6 = False
+        else:
+            is_ipV6 = True
     else:
         is_ipV6 = False
     if "." not in req_host and not is_ipV6:

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -538,12 +538,8 @@ IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 def is_ip_like_hostname(text):
     """Return True if text is a valid hostname in the form of IP address.
 
-    If text is a valid IPv4 address, retrun True;
-
-    If text is a valid IPv6 address wrapped in [], return True;
-
-    Else, return False.
-
+    A valid IP-like hostname is either an IPv4 address or
+    an IPv6 enclosed in brackets (for instance, "[::1]").
     """
     from ipaddress import IPv4Address, IPv6Address
     # check for IPv4 address

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -543,7 +543,7 @@ def is_ip_like_hostname(text):
     If text is a valid IPv6 address wrapped in [], return True;
 
     Else, return False
-    
+
     """
     from ipaddress import IPv4Address, IPv6Address
     # check for IPv4 address

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -535,7 +535,7 @@ def parse_ns_headers(ns_headers):
 # only kept for backwards compatibilty.
 IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
 
-def is_ip_like(text: str):
+def is_ip_like_hostname(text: str):
     """Return True if text is a valid hostname in the form of IP address."""
     from ipaddress import IPv4Address, IPv6Address
     # check for IPv4 address
@@ -556,7 +556,7 @@ def is_HDN(text):
     # XXX
     # This may well be wrong.  Which RFC is HDN defined in, if any (for
     #  the purposes of RFC 2965)?
-    if is_ip_like(text):
+    if is_ip_like_hostname(text):
         return False
     if text == "":
         return False
@@ -609,7 +609,7 @@ def liberal_is_HDN(text):
     For accepting/blocking domains.
 
     """
-    return not is_ip_like(text)
+    return not is_ip_like_hostname(text)
 
 def user_domain_match(A, B):
     """For blocking/accepting domains.

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -648,7 +648,15 @@ def eff_request_host(request):
 
     """
     erhn = req_host = request_host(request)
-    is_IPV6 = req_host.startswith('[') and req_host.endswith(']')
+    if req_host.startswith('[') and req_host.endswith(']'):
+        from ipaddress import IPv6Address
+        try:
+            IPv6Address(req_host.removeprefix('[').removesuffix(']'))
+            is_IPV6 = True
+        except ValueError:
+            is_IPV6 = False
+    else:
+        is_IPV6 = False  
     if "." not in req_host and not is_IPV6:
         # avoid adding .local at the end of a IPV6 address
         erhn = req_host + ".local"

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -615,7 +615,6 @@ def user_domain_match(A, B):
             # equal IPV4 addresses
             return True
         return False
-    # A and B may be HDNs or a IPv6 addresses now
     initial_dot = B.startswith(".")
     if initial_dot and A.endswith(B):
         return True

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -532,11 +532,15 @@ def parse_ns_headers(ns_headers):
     return result
 
 
-IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
-def is_ip(text):
+IPV4_RE = re.compile(r"\.\d+$", re.ASCII) # kept for backwards compatibility
+def is_ip(text: str):
     """Return True if text is a valid IP address."""
     from ipaddress import ip_address
     try:
+        if text.startswith('['):
+            text = text[1:]
+        if text.endswith(']'):
+            text = text[:-1]
         ip_address(text)
     except ValueError:
         return False
@@ -610,9 +614,11 @@ def user_domain_match(A, B):
     A = A.lower()
     B = B.lower()
     if not (liberal_is_HDN(A) and liberal_is_HDN(B)):
+        # equal IPV4 addresses
         if A == B:
             return True
         return False
+    # A and B may be HDNs or a IPv6 addresses now
     initial_dot = B.startswith(".")
     if initial_dot and A.endswith(B):
         return True

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -644,8 +644,9 @@ def eff_request_host(request):
 
     """
     erhn = req_host = request_host(request)
-    if "." not in req_host and '[' not in req_host:
-        # detect '[' mainly for IPv6 addr like [::1]
+    IPV6_RE = re.compile(r"^\[.*\]$")
+    if "." not in req_host and not IPV6_RE.search(req_host):
+        # avoid adding .local at the end of a IPV6 address
         erhn = req_host + ".local"
     return req_host, erhn
 

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -599,9 +599,7 @@ def liberal_is_HDN(text):
     For accepting/blocking domains.
 
     """
-    if is_ip(text):
-        return False
-    return True
+    return not is_ip(text)
 
 def user_domain_match(A, B):
     """For blocking/accepting domains.

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -538,9 +538,9 @@ def is_ip(text):
     """Return True if text is a valid IP address."""
     try:
         ip_address(text)
-        return True
     except ValueError:
         return False
+    return True
 def is_HDN(text):
     """Return True if text is a host domain name."""
     # XXX

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -533,15 +533,41 @@ def parse_ns_headers(ns_headers):
     return result
 
 
+# only kept for backwards compatibilty.
 IPV4_RE = re.compile(r"\.\d+$", re.ASCII)
+
+def _is_ipv4_hostname(text):
+    from ipaddress import IPv4Address
+    try:
+        IPv4Address(text)
+    except ValueError:
+        return False
+    return True
+
+def _is_ipv6_hostname(text):
+    if text.startswith('[') and text.endswith(']'):
+        from ipaddress import IPv6Address
+        try:
+            IPv6Address(text[1:-1])
+        except ValueError:
+            return False
+        return True
+    return False
+
+def _is_ip_like_hostname(text):
+    """Check if *text* is a valid IP-like hostname.
+
+    A valid IP-like hostname is either an IPv4 address or
+    an IPv6 enclosed in brackets (for instance, "[::1]").
+    """
+    return _is_ipv4_hostname(text) or _is_ipv6_hostname(text)
+
 def is_HDN(text):
     """Return True if text is a host domain name."""
     # XXX
     # This may well be wrong.  Which RFC is HDN defined in, if any (for
     #  the purposes of RFC 2965)?
-    # For the current implementation, what about IPv6?  Remember to look
-    #  at other uses of IPV4_RE also, if change this.
-    if IPV4_RE.search(text):
+    if _is_ip_like_hostname(text):
         return False
     if text == "":
         return False
@@ -594,9 +620,7 @@ def liberal_is_HDN(text):
     For accepting/blocking domains.
 
     """
-    if IPV4_RE.search(text):
-        return False
-    return True
+    return not _is_ip_like_hostname(text)
 
 def user_domain_match(A, B):
     """For blocking/accepting domains.
@@ -642,7 +666,10 @@ def eff_request_host(request):
 
     """
     erhn = req_host = request_host(request)
-    if "." not in req_host:
+    if "." not in req_host and not _is_ipv6_hostname(req_host):
+        # Avoid adding .local at the end of an IPv6 address.
+        # See RFC 2965 [1] for the rationale of ".local".
+        # [1]: https://www.rfc-editor.org/rfc/rfc2965
         erhn = req_host + ".local"
     return req_host, erhn
 

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -1215,6 +1215,14 @@ class CookieTests(unittest.TestCase):
         c.extract_cookies(res, req)
         self.assertEqual(len(c), 1)
 
+        c.clear()
+
+        pol.set_blocked_domains(["::1"])
+        req = urllib.request.Request("http://[::1]:8080")
+        res = FakeResponse(headers, "http://[::1]:8080")
+        c.extract_cookies(res, req)
+        self.assertEqual(len(c), 1)
+
     def test_secure(self):
         for ns in True, False:
             for whitespace in " ", "":

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -1198,10 +1198,6 @@ class CookieTests(unittest.TestCase):
         c.extract_cookies(res, req)
         self.assertEqual(len(c), 1)
 
-        c.clear()
-        
-
-
     def test_secure(self):
         for ns in True, False:
             for whitespace in " ", "":

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -912,11 +912,11 @@ class CookieTests(unittest.TestCase):
         self.assertFalse(user_domain_match("x.y.com", ".m"))
         self.assertFalse(user_domain_match("x.y.com", ""))
         self.assertFalse(user_domain_match("x.y.com", "."))
+        # not both HDNs, so must string-compare equal to match
         self.assertTrue(user_domain_match("192.168.1.1", "192.168.1.1"))
         self.assertTrue(user_domain_match("[::1]", "[::1]"))
-        self.assertFalse(user_domain_match("[::1]", "::1"))
         self.assertTrue(domain_match("[2001:db8:85a3::8a2e:370:7334]", "[2001:db8:85a3::8a2e:370:7334]"))
-        # not both HDNs, so must string-compare equal to match
+        self.assertFalse(user_domain_match("[::1]", "::1"))
         self.assertFalse(user_domain_match("192.168.1.1", ".168.1.1"))
         self.assertFalse(user_domain_match("192.168.1.1", "."))
         # empty string is a special case

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -16,7 +16,7 @@ from http.cookiejar import (time2isoz, http2time, iso2time, time2netscape,
      CookieJar, DefaultCookiePolicy, LWPCookieJar, MozillaCookieJar,
      LoadError, lwp_cookie_str, DEFAULT_HTTP_PORT, escape_path,
      reach, is_HDN, domain_match, user_domain_match, request_path,
-     request_port, request_host)
+     request_port, request_host, is_ip)
 
 mswindows = (sys.platform == "win32")
 
@@ -867,6 +867,18 @@ class CookieTests(unittest.TestCase):
         self.assertFalse(is_HDN(".foo.bar.com"))
         self.assertFalse(is_HDN("..foo"))
         self.assertFalse(is_HDN("foo."))
+    
+    def test_is_ip(self):
+        self.assertTrue(is_ip('[::1]'))
+        self.assertTrue(is_ip('::1'))
+        self.assertTrue(is_ip('[2001:db8:85a3::8a2e:370:7334]'))
+        self.assertTrue(is_ip('2001:db8:85a3::8a2e:370:7334'))
+        self.assertTrue(is_ip('192.168.0.1'))
+        self.assertFalse(is_ip('256.256.256.256'))
+        self.assertFalse(is_ip('[::2001:db8:85a3::]'))
+        self.assertFalse(is_ip('acme.com'))
+        self.assertFalse(is_ip(''))
+
 
     def test_reach(self):
         self.assertEqual(reach("www.acme.com"), ".acme.com")
@@ -915,7 +927,7 @@ class CookieTests(unittest.TestCase):
         # not both HDNs, so must string-compare equal to match
         self.assertTrue(user_domain_match("192.168.1.1", "192.168.1.1"))
         self.assertTrue(user_domain_match("[::1]", "[::1]"))
-        self.assertTrue(domain_match("[2001:db8:85a3::8a2e:370:7334]", "[2001:db8:85a3::8a2e:370:7334]"))
+        self.assertTrue(domain_match("2001:db8::", "2001:db8::"))
         self.assertFalse(user_domain_match("[::1]", "::1"))
         self.assertFalse(user_domain_match("192.168.1.1", ".168.1.1"))
         self.assertFalse(user_domain_match("192.168.1.1", "."))

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -16,7 +16,7 @@ from http.cookiejar import (time2isoz, http2time, iso2time, time2netscape,
      CookieJar, DefaultCookiePolicy, LWPCookieJar, MozillaCookieJar,
      LoadError, lwp_cookie_str, DEFAULT_HTTP_PORT, escape_path,
      reach, is_HDN, domain_match, user_domain_match, request_path,
-     request_port, request_host, is_ip_like)
+     request_port, request_host, is_ip_like_hostname)
 
 mswindows = (sys.platform == "win32")
 
@@ -868,15 +868,15 @@ class CookieTests(unittest.TestCase):
         self.assertFalse(is_HDN("..foo"))
         self.assertFalse(is_HDN("foo."))
 
-    def test_is_ip_like(self):
-        self.assertTrue(is_ip_like('[::1]'))
-        self.assertTrue(is_ip_like('[2001:db8:85a3::8a2e:370:7334]'))
-        self.assertTrue(is_ip_like('192.168.0.1'))
+    def test_is_ip_like_hostname(self):
+        self.assertTrue(is_ip_like_hostname('[::1]'))
+        self.assertTrue(is_ip_like_hostname('[2001:db8:85a3::8a2e:370:7334]'))
+        self.assertTrue(is_ip_like_hostname('192.168.0.1'))
 
-        self.assertFalse(is_ip_like('256.256.256.256'))
-        self.assertFalse(is_ip_like('[::2001:db8:85a3::]'))
-        self.assertFalse(is_ip_like('acme.com'))
-        self.assertFalse(is_ip_like(''))
+        self.assertFalse(is_ip_like_hostname('256.256.256.256'))
+        self.assertFalse(is_ip_like_hostname('[::2001:db8:85a3::]'))
+        self.assertFalse(is_ip_like_hostname('acme.com'))
+        self.assertFalse(is_ip_like_hostname(''))
 
     def test_reach(self):
         self.assertEqual(reach("www.acme.com"), ".acme.com")

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -873,6 +873,7 @@ class CookieTests(unittest.TestCase):
         self.assertTrue(is_ip('[2001:db8:85a3::8a2e:370:7334]'))
         self.assertTrue(is_ip('2001:db8:85a3::8a2e:370:7334'))
         self.assertTrue(is_ip('192.168.0.1'))
+
         self.assertFalse(is_ip('256.256.256.256'))
         self.assertFalse(is_ip('[::2001:db8:85a3::]'))
         self.assertFalse(is_ip('acme.com'))

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -879,9 +879,8 @@ class CookieTests(unittest.TestCase):
         self.assertFalse(is_ip('acme.com'))
         self.assertFalse(is_ip(''))
 
-
     def test_reach(self):
-        self.assertEqual(reach("www.acme.com"), ".acme.com")
+        self.assertEqual(reach("www.acme.com"), ".acme.coEm")
         self.assertEqual(reach("acme.com"), "acme.com")
         self.assertEqual(reach("acme.local"), ".local")
         self.assertEqual(reach(".local"), ".local")

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -880,7 +880,7 @@ class CookieTests(unittest.TestCase):
         self.assertFalse(is_ip(''))
 
     def test_reach(self):
-        self.assertEqual(reach("www.acme.com"), ".acme.coEm")
+        self.assertEqual(reach("www.acme.com"), ".acme.com")
         self.assertEqual(reach("acme.com"), "acme.com")
         self.assertEqual(reach("acme.local"), ".local")
         self.assertEqual(reach(".local"), ".local")

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -867,7 +867,7 @@ class CookieTests(unittest.TestCase):
         self.assertFalse(is_HDN(".foo.bar.com"))
         self.assertFalse(is_HDN("..foo"))
         self.assertFalse(is_HDN("foo."))
-    
+
     def test_is_ip(self):
         self.assertTrue(is_ip('[::1]'))
         self.assertTrue(is_ip('::1'))

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -873,6 +873,7 @@ class CookieTests(unittest.TestCase):
         self.assertTrue(is_ip_like_hostname('[2001:db8:85a3::8a2e:370:7334]'))
         self.assertTrue(is_ip_like_hostname('192.168.0.1'))
 
+        self.assertFalse(is_ip_like_hostname('::1'))
         self.assertFalse(is_ip_like_hostname('256.256.256.256'))
         self.assertFalse(is_ip_like_hostname('[::2001:db8:85a3::]'))
         self.assertFalse(is_ip_like_hostname('acme.com'))

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -874,7 +874,6 @@ class CookieTests(unittest.TestCase):
         self.assertTrue(is_ip('[2001:db8:85a3::8a2e:370:7334]'))
         self.assertTrue(is_ip('2001:db8:85a3::8a2e:370:7334'))
         self.assertTrue(is_ip('192.168.0.1'))
-
         self.assertFalse(is_ip('256.256.256.256'))
         self.assertFalse(is_ip('[::2001:db8:85a3::]'))
         self.assertFalse(is_ip('acme.com'))
@@ -890,13 +889,15 @@ class CookieTests(unittest.TestCase):
         self.assertEqual(reach(""), "")
         self.assertEqual(reach("192.168.0.1"), "192.168.0.1")
         self.assertEqual(reach("[::1]"), "[::1]")
-        self.assertEqual(reach("[2001:db8:85a3::8a2e:370:7334]"), "[2001:db8:85a3::8a2e:370:7334]")
+        self.assertEqual(reach("[2001:db8:85a3::8a2e:370:7334]"),
+                          "[2001:db8:85a3::8a2e:370:7334]")
 
     def test_domain_match(self):
         self.assertTrue(domain_match("192.168.1.1", "192.168.1.1"))
         self.assertTrue(domain_match("[::1]", "[::1]"))
         self.assertFalse(domain_match("[::1]", "::1"))
-        self.assertTrue(domain_match("[2001:db8:85a3::8a2e:370:7334]", "[2001:db8:85a3::8a2e:370:7334]"))
+        self.assertTrue(domain_match("[2001:db8:85a3::8a2e:370:7334]",
+                                      "[2001:db8:85a3::8a2e:370:7334]"))
         self.assertFalse(domain_match("192.168.1.1", ".168.1.1"))
         self.assertTrue(domain_match("x.y.com", "x.Y.com"))
         self.assertTrue(domain_match("x.y.com", ".Y.com"))
@@ -1190,7 +1191,11 @@ class CookieTests(unittest.TestCase):
         c.add_cookie_header(req)
         self.assertFalse(req.has_header("Cookie"))
 
-        c.clear()
+    def test_block_ip_domains(self):
+        pol = DefaultCookiePolicy(
+            rfc2965=True, blocked_domains=[])
+        c = CookieJar(policy=pol)
+        headers = ["Set-Cookie: CUSTOMER=WILE_E_COYOTE; path=/"]
 
         pol.set_blocked_domains(["[::1]"])
         req = urllib.request.Request("http://[::1]:8080")

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -16,7 +16,7 @@ from http.cookiejar import (time2isoz, http2time, iso2time, time2netscape,
      CookieJar, DefaultCookiePolicy, LWPCookieJar, MozillaCookieJar,
      LoadError, lwp_cookie_str, DEFAULT_HTTP_PORT, escape_path,
      reach, is_HDN, domain_match, user_domain_match, request_path,
-     request_port, request_host, is_ip)
+     request_port, request_host, is_ip_like)
 
 mswindows = (sys.platform == "win32")
 
@@ -868,15 +868,15 @@ class CookieTests(unittest.TestCase):
         self.assertFalse(is_HDN("..foo"))
         self.assertFalse(is_HDN("foo."))
 
-    def test_is_ip(self):
-        self.assertTrue(is_ip('[::1]'))
-        self.assertTrue(is_ip('[2001:db8:85a3::8a2e:370:7334]'))
-        self.assertTrue(is_ip('192.168.0.1'))
+    def test_is_ip_like(self):
+        self.assertTrue(is_ip_like('[::1]'))
+        self.assertTrue(is_ip_like('[2001:db8:85a3::8a2e:370:7334]'))
+        self.assertTrue(is_ip_like('192.168.0.1'))
 
-        self.assertFalse(is_ip('256.256.256.256'))
-        self.assertFalse(is_ip('[::2001:db8:85a3::]'))
-        self.assertFalse(is_ip('acme.com'))
-        self.assertFalse(is_ip(''))
+        self.assertFalse(is_ip_like('256.256.256.256'))
+        self.assertFalse(is_ip_like('[::2001:db8:85a3::]'))
+        self.assertFalse(is_ip_like('acme.com'))
+        self.assertFalse(is_ip_like(''))
 
     def test_reach(self):
         self.assertEqual(reach("www.acme.com"), ".acme.com")

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -870,7 +870,6 @@ class CookieTests(unittest.TestCase):
 
     def test_is_ip(self):
         self.assertTrue(is_ip('[::1]'))
-        self.assertTrue(is_ip('::1'))
         self.assertTrue(is_ip('[2001:db8:85a3::8a2e:370:7334]'))
         self.assertTrue(is_ip('2001:db8:85a3::8a2e:370:7334'))
         self.assertTrue(is_ip('192.168.0.1'))

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -1168,6 +1168,12 @@ class CookieTests(unittest.TestCase):
         c.add_cookie_header(req)
         self.assertFalse(req.has_header("Cookie"))
 
+        pol.set_blocked_domains(["[::1]"])
+        req = urllib.request.Request("http://[::1]:8080")
+        res = FakeResponse(headers, "http://[::1]:8080")
+        c.extract_cookies(res, req)
+        self.assertEqual(len(c), 0)
+
     def test_secure(self):
         for ns in True, False:
             for whitespace in " ", "":

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -874,6 +874,7 @@ class CookieTests(unittest.TestCase):
         self.assertTrue(is_ip('[2001:db8:85a3::8a2e:370:7334]'))
         self.assertTrue(is_ip('2001:db8:85a3::8a2e:370:7334'))
         self.assertTrue(is_ip('192.168.0.1'))
+
         self.assertFalse(is_ip('256.256.256.256'))
         self.assertFalse(is_ip('[::2001:db8:85a3::]'))
         self.assertFalse(is_ip('acme.com'))

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -871,7 +871,6 @@ class CookieTests(unittest.TestCase):
     def test_is_ip(self):
         self.assertTrue(is_ip('[::1]'))
         self.assertTrue(is_ip('[2001:db8:85a3::8a2e:370:7334]'))
-        self.assertTrue(is_ip('2001:db8:85a3::8a2e:370:7334'))
         self.assertTrue(is_ip('192.168.0.1'))
 
         self.assertFalse(is_ip('256.256.256.256'))

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -16,7 +16,7 @@ from http.cookiejar import (time2isoz, http2time, iso2time, time2netscape,
      CookieJar, DefaultCookiePolicy, LWPCookieJar, MozillaCookieJar,
      LoadError, lwp_cookie_str, DEFAULT_HTTP_PORT, escape_path,
      reach, is_HDN, domain_match, user_domain_match, request_path,
-     request_port, request_host, NETSCAPE_HEADER_TEXT)
+     request_port, request_host, _is_ip_like_hostname, NETSCAPE_HEADER_TEXT)
 
 mswindows = (sys.platform == "win32")
 
@@ -885,11 +885,27 @@ class CookieTests(unittest.TestCase):
         self.assertTrue(is_HDN("foo.bar.com"))
         self.assertTrue(is_HDN("1foo2.3bar4.5com"))
         self.assertFalse(is_HDN("192.168.1.1"))
+        self.assertFalse(is_HDN("[::1]"))
+        self.assertFalse(is_HDN("[2001:db8:85a3::8a2e:370:7334]"))
         self.assertFalse(is_HDN(""))
         self.assertFalse(is_HDN("."))
         self.assertFalse(is_HDN(".foo.bar.com"))
         self.assertFalse(is_HDN("..foo"))
         self.assertFalse(is_HDN("foo."))
+
+    def test_is_ip_like_hostname(self):
+        self.assertTrue(_is_ip_like_hostname('[::1]'))
+        self.assertTrue(_is_ip_like_hostname('[2001:db8:85a3::8a2e:370:7334]'))
+        self.assertTrue(_is_ip_like_hostname('192.168.0.1'))
+
+        self.assertFalse(_is_ip_like_hostname('::1'))
+        self.assertFalse(_is_ip_like_hostname('foo.123'))
+        self.assertFalse(_is_ip_like_hostname('256.256.256.256'))
+        self.assertFalse(_is_ip_like_hostname('999.1.1.1'))
+        self.assertFalse(_is_ip_like_hostname('192.168.01.1'))
+        self.assertFalse(_is_ip_like_hostname('[::2001:db8:85a3::]'))
+        self.assertFalse(_is_ip_like_hostname('acme.com'))
+        self.assertFalse(_is_ip_like_hostname(''))
 
     def test_reach(self):
         self.assertEqual(reach("www.acme.com"), ".acme.com")
@@ -900,9 +916,16 @@ class CookieTests(unittest.TestCase):
         self.assertEqual(reach("."), ".")
         self.assertEqual(reach(""), "")
         self.assertEqual(reach("192.168.0.1"), "192.168.0.1")
+        self.assertEqual(reach("[::1]"), "[::1]")
+        self.assertEqual(reach("[2001:db8:85a3::8a2e:370:7334]"),
+                          "[2001:db8:85a3::8a2e:370:7334]")
 
     def test_domain_match(self):
         self.assertTrue(domain_match("192.168.1.1", "192.168.1.1"))
+        self.assertTrue(domain_match("[::1]", "[::1]"))
+        self.assertFalse(domain_match("[::1]", "::1"))
+        self.assertTrue(domain_match("[2001:db8:85a3::8a2e:370:7334]",
+                                      "[2001:db8:85a3::8a2e:370:7334]"))
         self.assertFalse(domain_match("192.168.1.1", ".168.1.1"))
         self.assertTrue(domain_match("x.y.com", "x.Y.com"))
         self.assertTrue(domain_match("x.y.com", ".Y.com"))
@@ -930,8 +953,11 @@ class CookieTests(unittest.TestCase):
         self.assertFalse(user_domain_match("x.y.com", ".m"))
         self.assertFalse(user_domain_match("x.y.com", ""))
         self.assertFalse(user_domain_match("x.y.com", "."))
-        self.assertTrue(user_domain_match("192.168.1.1", "192.168.1.1"))
         # not both HDNs, so must string-compare equal to match
+        self.assertTrue(user_domain_match("192.168.1.1", "192.168.1.1"))
+        self.assertTrue(user_domain_match("[::1]", "[::1]"))
+        self.assertTrue(user_domain_match("[2001:db8::]", "[2001:db8::]"))
+        self.assertFalse(user_domain_match("[::1]", "::1"))
         self.assertFalse(user_domain_match("192.168.1.1", ".168.1.1"))
         self.assertFalse(user_domain_match("192.168.1.1", "."))
         # empty string is a special case
@@ -1192,6 +1218,38 @@ class CookieTests(unittest.TestCase):
         req = urllib.request.Request("http://badacme.com/")
         c.add_cookie_header(req)
         self.assertFalse(req.has_header("Cookie"))
+
+    def test_block_ip_domains(self):
+        pol = DefaultCookiePolicy(
+            rfc2965=True, blocked_domains=[])
+        c = CookieJar(policy=pol)
+        headers = ["Set-Cookie: CUSTOMER=WILE_E_COYOTE; path=/"]
+
+        pol.set_blocked_domains(["[::1]"])
+        req = urllib.request.Request("http://[::1]:8080")
+        res = FakeResponse(headers, "http://[::1]:8080")
+        c.extract_cookies(res, req)
+        self.assertEqual(len(c), 0)
+
+        pol.set_blocked_domains(["[2001:db8:85a3::8a2e:370:7334]"])
+        req = urllib.request.Request("http://[2001:db8:85a3::8a2e:370:7334]:8080")
+        res = FakeResponse(headers, "http://[2001:db8:85a3::8a2e:370:7334]:8080")
+        c.extract_cookies(res, req)
+        self.assertEqual(len(c), 0)
+
+        pol.set_blocked_domains([""])
+        req = urllib.request.Request("http://[::1]:8080")
+        res = FakeResponse(headers, "http://[::1]:8080")
+        c.extract_cookies(res, req)
+        self.assertEqual(len(c), 1)
+
+        c.clear()
+
+        pol.set_blocked_domains(["::1"])
+        req = urllib.request.Request("http://[::1]:8080")
+        res = FakeResponse(headers, "http://[::1]:8080")
+        c.extract_cookies(res, req)
+        self.assertEqual(len(c), 1)
 
     def test_secure(self):
         for ns in True, False:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -478,6 +478,7 @@ Dean Draayer
 Fred L. Drake, Jr.
 Mehdi Drissi
 Derk Drukker
+Weilin Du
 John DuBois
 Paul Dubois
 Jacques Ducasse

--- a/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
@@ -1,0 +1,2 @@
+:mod:`http.cookiejar`: fix allowed and blocked IPv6 domains
+in :class:`~http.cookiejar.DefaultCookiePolicy`.

--- a/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
@@ -1,1 +1,1 @@
-:mod: `http.cookiejar` now supports IPv6 address in :attr:`blocked_domains` and :attr:`allowed_domains` of ``DefaultCookiePolicy``
+:mod: `http.cookiejar` now supports IPv6 address in `blocked_domains` and `allowed_domains` of class `DefaultCookiePolicy`

--- a/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
@@ -1,1 +1,2 @@
-:mod:`http.cookiejar` now supports IPv6 address in blocked_domains and allowed_domains of class DefaultCookiePolicy
+:mod:`http.cookiejar`: fix allowed and blocked IPv6 domains
+in :class:`~http.cookiejar.DefaultCookiePolicy`.

--- a/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
@@ -1,0 +1,1 @@
+:mod: `http.cookiejar` now supports IPv6 address in :attr:`blocked_domains` and :attr:`allowed_domains` of ``DefaultCookiePolicy``

--- a/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
@@ -1,1 +1,1 @@
-:mod: `http.cookiejar` now supports IPv6 address in `blocked_domains` and `allowed_domains` of class `DefaultCookiePolicy`
+:mod:`http.cookiejar` now supports IPv6 address in `blocked_domains` and `allowed_domains` of class `DefaultCookiePolicy`

--- a/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-20-17-03-51.gh-issue-135768.DhUJWf.rst
@@ -1,1 +1,1 @@
-:mod:`http.cookiejar` now supports IPv6 address in `blocked_domains` and `allowed_domains` of class `DefaultCookiePolicy`
+:mod:`http.cookiejar` now supports IPv6 address in blocked_domains and allowed_domains of class DefaultCookiePolicy


### PR DESCRIPTION
PR for #135768, Thanks!

<!-- gh-issue-number: gh-135768 -->
* Issue: gh-135768
<!-- /gh-issue-number -->
