### PR TITLE
GH-90117: Check for `list` and `tuple` before `MappingView` in `pprint`

### DIFF
--- a/Misc/NEWS.d/next/Library/2025-06-20-17-06-59.gh-issue-90117.GYWVrn.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-20-17-06-59.gh-issue-90117.GYWVrn.rst
@@ -1,0 +1,1 @@
+Speed up :mod:`pprint` for :class:`list` and :class:`tuple`.


### PR DESCRIPTION
GH-30135 added an expensive ABC subclass check for an uncommon case (`MappingView`) before fast subclass checks for 2 common cases (`list` and `tuple`), resulting in a [~10% performance regression](https://github.com/faster-cpython/benchmarking-public/blob/main/results/bm-20250520-3.15.0a0-c7f8e70/bm-20250520-linux-x86_64-python-c7f8e706e116d7986da4-3.15.0a0-c7f8e70-vs-base.svg) for our `pprint` benchmarks. There's also *some* evidence that this *may* have also made our PGO profile worse on some builds, since `test_pprint` is part of the profiling task (so we're spending a good chunk of that time hitting the newly-added ABC subclass-checking machinery).

This just switches the order of the branches so the cheap, common case is checked before the expensive, uncommon one.

<!-- gh-issue-number: gh-90117 -->
* Issue: gh-90117
<!-- /gh-issue-number -->
