### PR TITLE
Remove unnecessary trailing backslashes

### DIFF
--- a/Doc/c-api/extension-modules.rst
+++ b/Doc/c-api/extension-modules.rst
@@ -242,6 +242,6 @@ in the following ways:
 * Single-phase modules support module lookup functions like
   :c:func:`PyState_FindModule`.
 
-.. [#testsinglephase] ``_testsinglephase`` is an internal module used \
-   in CPython's self-test suite; your installation may or may not \
+.. [#testsinglephase] ``_testsinglephase`` is an internal module used
+   in CPython's self-test suite; your installation may or may not
    include it.


### PR DESCRIPTION
The trailing backlash doesn't seem to be needed. Besides, they are extracted by Sphinx `gettext` builder as part of the translation string, which can lead to wrong translation.

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135781.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->