### PR TITLE
gh-135788: Support NETRC environment variable in `netrc`

### DIFF
--- a/Doc/library/netrc.rst
+++ b/Doc/library/netrc.rst
@@ -19,7 +19,7 @@ the Unix :program:`ftp` program and other FTP clients.
 
    A :class:`~netrc.netrc` instance or subclass instance encapsulates data from  a netrc
    file. The initialization argument, if present, specifies the file to parse. If no
-   argument is given, it will look for the file path in the :envvar:`NETRC` environment variable.
+   argument is given, it will look for the file path in the :envvar:`!NETRC` environment variable.
    If that is not set, it defaults to reading the file :file:`.netrc` in the user's home
    directory -- as determined by :func:`os.path.expanduser`. If the file cannot be found,
    a :exc:`FileNotFoundError` exception will be raised.

--- a/Doc/library/netrc.rst
+++ b/Doc/library/netrc.rst
@@ -18,9 +18,10 @@ the Unix :program:`ftp` program and other FTP clients.
 .. class:: netrc([file])
 
    A :class:`~netrc.netrc` instance or subclass instance encapsulates data from  a netrc
-   file.  The initialization argument, if present, specifies the file to parse.  If
-   no argument is given, the file :file:`.netrc` in the user's home directory --
-   as determined by :func:`os.path.expanduser` -- will be read.  Otherwise,
+   file. The initialization argument, if present, specifies the file to parse. If no
+   argument is given, it will look for the file path in the `NETRC` environment variable.
+   If that is not set, it defaults to reading the file :file:`.netrc` in the user's home
+   directory -- as determined by :func:`os.path.expanduser`. If the file cannot be found,
    a :exc:`FileNotFoundError` exception will be raised.
    Parse errors will raise :exc:`NetrcParseError` with diagnostic
    information including the file name, line number, and terminating token.

--- a/Doc/library/netrc.rst
+++ b/Doc/library/netrc.rst
@@ -46,6 +46,11 @@ the Unix :program:`ftp` program and other FTP clients.
       can contain arbitrary characters, like whitespace and non-ASCII characters.
       If the login name is anonymous, it won't trigger the security check.
 
+   .. versionadded:: next
+      :class:`netrc` try to use the value of the :envvar:`NETRC` environment variable
+      if when *file* is not passed as argument, before falling back to the user's
+      :file:`.netrc` file in the home directory.
+
 
 .. exception:: NetrcParseError
 

--- a/Doc/library/netrc.rst
+++ b/Doc/library/netrc.rst
@@ -19,7 +19,7 @@ the Unix :program:`ftp` program and other FTP clients.
 
    A :class:`~netrc.netrc` instance or subclass instance encapsulates data from  a netrc
    file. The initialization argument, if present, specifies the file to parse. If no
-   argument is given, it will look for the file path in the `NETRC` environment variable.
+   argument is given, it will look for the file path in the :envvar:`NETRC` environment variable.
    If that is not set, it defaults to reading the file :file:`.netrc` in the user's home
    directory -- as determined by :func:`os.path.expanduser`. If the file cannot be found,
    a :exc:`FileNotFoundError` exception will be raised.

--- a/Doc/library/netrc.rst
+++ b/Doc/library/netrc.rst
@@ -19,8 +19,8 @@ the Unix :program:`ftp` program and other FTP clients.
 
    A :class:`~netrc.netrc` instance or subclass instance encapsulates data from  a netrc
    file. The initialization argument, if present, specifies the file to parse. If no
-   argument is given, it will look for the file path in the :envvar:`!NETRC` environment variable.
-   If that is not set, it defaults to reading the file :file:`.netrc` in the user's home
+   argument is given, it will look for the file path in the :envvar:`!NETRC` environment variable,
+   before defaulting to reading the file :file:`.netrc` in the user's home
    directory -- as determined by :func:`os.path.expanduser`. If the file cannot be found,
    a :exc:`FileNotFoundError` exception will be raised.
    Parse errors will raise :exc:`NetrcParseError` with diagnostic
@@ -47,9 +47,7 @@ the Unix :program:`ftp` program and other FTP clients.
       If the login name is anonymous, it won't trigger the security check.
 
    .. versionadded:: next
-      :class:`netrc` try to use the value of the :envvar:`NETRC` environment variable
-      if when *file* is not passed as argument, before falling back to the user's
-      :file:`.netrc` file in the home directory.
+      Added support for the :envvar:`!NETRC` environment variable.
 
 
 .. exception:: NetrcParseError

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -116,6 +116,13 @@ math
   (Contributed by Sergey B Kirpichev in :gh:`132908`.)
 
 
+netrc
+-----
+
+* Support :envvar:`!NETRC` environment variable in :func:`netrc.netrc`.
+  (Contributed by Berthin Torres in :gh:`135788`.)
+
+
 os.path
 -------
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -119,7 +119,7 @@ math
 netrc
 -----
 
-* Added support for the :envvar:`NETRC` environment variable in :func:`netrc.netrc`.
+* Added support for the :envvar:`!NETRC` environment variable in :func:`netrc.netrc`.
   (Contributed by Berthin Torres in :gh:`135788`.)
 
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -119,7 +119,7 @@ math
 netrc
 -----
 
-* Support :envvar:`!NETRC` environment variable in :func:`netrc.netrc`.
+* Added support for the :envvar:`NETRC` environment variable in :func:`netrc.netrc`.
   (Contributed by Berthin Torres in :gh:`135788`.)
 
 

--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -67,7 +67,7 @@ class netrc:
     def __init__(self, file=None):
         default_netrc = file is None
         if file is None:
-            file = os.path.join(os.path.expanduser("~"), ".netrc")
+            file = os.environ.get("NETRC", "") or os.path.join(os.path.expanduser("~"), ".netrc")
         self.hosts = {}
         self.macros = {}
         try:

--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -65,10 +65,10 @@ class _netrclex:
 
 class netrc:
     def __init__(self, file=None):
-        netrc_envvar = os.environ.get("NETRC", "")
-        default_netrc = file is None and not bool(netrc_envvar)
-        if file is None:
-            file = netrc_envvar or os.path.join(os.path.expanduser("~"), ".netrc")
+        envvar_netrc = os.environ.get("NETRC", "")
+        home_netrc = os.path.join(os.path.expanduser("~"), ".netrc")
+        file = file or envvar_netrc or home_netrc
+        default_netrc = (file == home_netrc)
         self.hosts = {}
         self.macros = {}
         try:

--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -65,9 +65,10 @@ class _netrclex:
 
 class netrc:
     def __init__(self, file=None):
-        default_netrc = file is None
+        netrc_envvar = os.environ.get("NETRC", "")
+        default_netrc = file is None and not bool(netrc_envvar)
         if file is None:
-            file = os.environ.get("NETRC", "") or os.path.join(os.path.expanduser("~"), ".netrc")
+            file = netrc_envvar or os.path.join(os.path.expanduser("~"), ".netrc")
         self.hosts = {}
         self.macros = {}
         try:

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -10,9 +10,8 @@ except ImportError:
 
 
 class NetrcEnvironment:
-    """
-    Context manager for setting up an isolated environment to test `.netrc` file
-    handling.
+    """Context manager for setting up an isolated environment to test
+    `.netrc` file handling.
 
     This class configures a temporary directory for the `.netrc` file and
     environment variables, providing a controlled setup to simulate different
@@ -20,9 +19,7 @@ class NetrcEnvironment:
     """
 
     def __enter__(self):
-        """
-        Enter the managed environment.
-        """
+        """Enter the managed environment."""
         self.stack = ExitStack()
         self.environ = self.stack.enter_context(
             support.os_helper.EnvironmentVarGuard(),
@@ -31,10 +28,10 @@ class NetrcEnvironment:
         return self
 
     def __exit__(self, *ignore_exc):
-        """
-        Exit the managed environment and performs cleanup. This method closes
-        the `ExitStack`, which automatically cleans up the temporary directory
-        and environment.
+        """Exit the managed environment and performs cleanup.
+
+        This method closes the `ExitStack`, which automatically cleans up the
+        temporary directory and environment.
         """
         self.stack.close()
 

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -22,9 +22,9 @@ class NetrcEnvironment:
         """Enter the managed environment."""
         self.stack = ExitStack()
         self.environ = self.stack.enter_context(
-            support.os_helper.EnvironmentVarGuard(),
+            os_helper.EnvironmentVarGuard(),
         )
-        self.tmpdir = self.stack.enter_context(support.os_helper.temp_dir())
+        self.tmpdir = self.stack.enter_context(os_helper.temp_dir())
         return self
 
     def __exit__(self, *ignore_exc):
@@ -43,7 +43,7 @@ class NetrcEnvironment:
         write_mode = "w" if sys.platform != "cygwin" else "wt"
         with open(netrc_file, mode=write_mode, encoding=encoding) as fp:
             fp.write(textwrap.dedent(content))
-        if support.os_helper.can_chmod():
+        if os_helper.can_chmod():
             os.chmod(netrc_file, mode=mode)
         return netrc_file
 
@@ -372,20 +372,20 @@ class NetrcTestCase(unittest.TestCase):
 
     @unittest.skipUnless(os.name == 'posix', 'POSIX only test')
     @unittest.skipIf(pwd is None, 'security check requires pwd module')
-    @support.os_helper.skip_unless_working_chmod
+    @os_helper.skip_unless_working_chmod
     def test_security(self):
         # This test is incomplete since we are normally not run as root and
         # therefore can't test the file ownership being wrong.
-        d = support.os_helper.TESTFN
+        d = os_helper.TESTFN
         os.mkdir(d)
-        self.addCleanup(support.os_helper.rmtree, d)
+        self.addCleanup(os_helper.rmtree, d)
         fn = os.path.join(d, '.netrc')
         with open(fn, 'wt') as f:
             f.write("""\
                 machine foo.domain.com login bar password pass
                 default login foo password pass
                 """)
-        with support.os_helper.EnvironmentVarGuard() as environ:
+        with os_helper.EnvironmentVarGuard() as environ:
             environ.set('HOME', d)
             os.chmod(fn, 0o600)
             nrc = netrc.netrc()
@@ -398,7 +398,7 @@ class NetrcTestCase(unittest.TestCase):
                 machine foo.domain.com login anonymous password pass
                 default login foo password pass
                 """)
-        with support.os_helper.EnvironmentVarGuard() as environ:
+        with os_helper.EnvironmentVarGuard() as environ:
             environ.set('HOME', d)
             os.chmod(fn, 0o600)
             nrc = netrc.netrc()

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -24,7 +24,7 @@ class NetrcEnvironment:
         write_mode = "w"
         if sys.platform != "cygwin":
             write_mode += "t"
-        
+
         netrc_file = os.path.join(self.tmpdir, filename)
         with open(netrc_file, mode=write_mode, encoding=encoding) as fp:
             fp.write(textwrap.dedent(content))
@@ -40,7 +40,7 @@ class NetrcBuilder:
         with NetrcEnvironment() as helper:
             helper.environ.unset("NETRC")
             helper.environ.unset("HOME")
-            
+
             helper.generate_netrc(*args, **kwargs)
 
             with mock.patch("os.path.expanduser"):
@@ -54,7 +54,7 @@ class NetrcBuilder:
 
             helper.environ.set("NETRC", netrc_file)
             return netrc.netrc()
-        
+
     @staticmethod
     def use_file_argument(*args, **kwargs):
         with NetrcEnvironment() as helper:
@@ -157,7 +157,7 @@ class NetrcTestCase(unittest.TestCase):
             self.assertEqual(nrc.hosts['host.domain.com'], ('log', value, 'pass'))
         elif token == 'password':
             self.assertEqual(nrc.hosts['host.domain.com'], ('log', 'acct', value))
-    
+
     @support.subTests('make_nrc', ALL_STRATEGIES)
     def test_token_value_quotes(self, make_nrc):
         self._test_token_x(make_nrc, """\

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -1,4 +1,4 @@
-import netrc, os, unittest, sys, tempfile, textwrap
+import netrc, os, unittest, sys, textwrap
 from contextlib import ExitStack
 from test.support import os_helper, subTests
 from unittest import mock
@@ -24,7 +24,7 @@ class NetrcEnvironment:
         self.environ = self.stack.enter_context(
             os_helper.EnvironmentVarGuard(),
         )
-        self.tmpdir = self.stack.enter_context(tempfile.TemporaryDirectory())
+        self.tmpdir = self.stack.enter_context(os_helper.temp_dir())
         return self
 
     def __exit__(self, *ignore_exc):
@@ -110,8 +110,7 @@ class NetrcTestCase(unittest.TestCase):
             machine host.domain.com password pass1 login log1 account acct1
             default login log2 password pass2 account acct2
             """)
-        self.assertEqual(nrc.hosts['host.domain.com'],
-                         ('log1', 'acct1', 'pass1'))
+        self.assertEqual(nrc.hosts['host.domain.com'], ('log1', 'acct1', 'pass1'))
         self.assertEqual(nrc.hosts['default'], ('log2', 'acct2', 'pass2'))
 
     @subTests('make_nrc', ALL_NETRC_FILE_SCENARIOS)
@@ -120,8 +119,7 @@ class NetrcTestCase(unittest.TestCase):
             machine host.domain.com login log1 password pass1 account acct1
             default login log2 password pass2 account acct2
             """)
-        self.assertEqual(nrc.hosts['host.domain.com'],
-                         ('log1', 'acct1', 'pass1'))
+        self.assertEqual(nrc.hosts['host.domain.com'], ('log1', 'acct1', 'pass1'))
         self.assertEqual(nrc.hosts['default'], ('log2', 'acct2', 'pass2'))
 
     @subTests('make_nrc', ALL_NETRC_FILE_SCENARIOS)

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -2,6 +2,7 @@ import netrc, os, unittest, sys, textwrap, tempfile
 
 from test import support
 from unittest import mock
+from contextlib import ExitStack
 
 try:
     import pwd
@@ -9,84 +10,89 @@ except ImportError:
     pwd = None
 
 
-def generate_netrc(directory, filename, data):
-    data = textwrap.dedent(data)
-    mode = 'w'
-    mode = 'w'
-    if sys.platform != 'cygwin':
-        mode += 't'
-    with open(os.path.join(directory, filename), mode, encoding="utf-8") as fp:
-        fp.write(data)
+class NetrcEnvironment:
+    def __enter__(self):
+        self.stack = ExitStack()
+        self.environ = self.stack.enter_context(support.os_helper.EnvironmentVarGuard())
+        self.tmpdir = self.stack.enter_context(tempfile.TemporaryDirectory())
+        return self
+
+    def __exit__(self, *ignore_exc):
+        self.stack.close()
+
+    def generate_netrc(self, content, filename=".netrc", mode=0o600, encoding="utf-8"):
+        write_mode = "w"
+        if sys.platform != "cygwin":
+            write_mode += "t"
+        
+        netrc_file = os.path.join(self.tmpdir, filename)
+        with open(netrc_file, mode=write_mode, encoding=encoding) as fp:
+            fp.write(textwrap.dedent(content))
+
+        os.chmod(netrc_file, mode=mode)
+
+        return netrc_file
+
+
+class NetrcBuilder:
+    @staticmethod
+    def use_default_netrc_in_home(*args, **kwargs):
+        with NetrcEnvironment() as helper:
+            helper.environ.unset("NETRC")
+            helper.environ.unset("HOME")
+            
+            helper.generate_netrc(*args, **kwargs)
+
+            with mock.patch("os.path.expanduser"):
+                os.path.expanduser.return_value = helper.tmpdir
+                return netrc.netrc()
+
+    @staticmethod
+    def use_netrc_envvar(*args, **kwargs):
+        with NetrcEnvironment() as helper:
+            netrc_file = helper.generate_netrc(*args, **kwargs)
+
+            helper.environ.set("NETRC", netrc_file)
+            return netrc.netrc()
+        
+    @staticmethod
+    def use_file_argument(*args, **kwargs):
+        with NetrcEnvironment() as helper:
+            helper.environ.set("NETRC", "not-a-file.netrc")
+
+            netrc_file = helper.generate_netrc(*args, **kwargs)
+            return netrc.netrc(netrc_file)
+
+    @staticmethod
+    def use_all_strategies():
+        return (NetrcBuilder.use_default_netrc_in_home,
+                NetrcBuilder.use_netrc_envvar,
+                NetrcBuilder.use_file_argument)
 
 
 class NetrcTestCase(unittest.TestCase):
+    ALL_STRATEGIES = NetrcBuilder.use_all_strategies()
 
-    @staticmethod
-    def home_netrc(data):
-        with support.os_helper.EnvironmentVarGuard() as environ, \
-            tempfile.TemporaryDirectory() as tmpdir:
-                environ.unset('NETRC')
-                environ.unset('HOME')
-
-                generate_netrc(tmpdir, ".netrc", data)
-                os.chmod(os.path.join(tmpdir, ".netrc"), 0o600)
-
-                with mock.patch("os.path.expanduser"):
-                    os.path.expanduser.return_value = tmpdir
-                    nrc = netrc.netrc()
-
-        return nrc
-
-    @staticmethod
-    def envvar_netrc(data):
-        with support.os_helper.EnvironmentVarGuard() as environ:
-            with tempfile.TemporaryDirectory() as tmpdir:
-                environ.set('NETRC', os.path.join(tmpdir, ".netrc"))
-                environ.unset('HOME')
-
-                generate_netrc(tmpdir, ".netrc", data)
-                os.chmod(os.path.join(tmpdir, ".netrc"), 0o600)
-
-                nrc = netrc.netrc()
-
-        return nrc
-        
-    @staticmethod
-    def file_argument(data):
-        with support.os_helper.EnvironmentVarGuard() as environ:
-            with tempfile.TemporaryDirectory() as tmpdir:
-                environ.set('NETRC', 'not-a-file.random')
-
-                generate_netrc(tmpdir, ".netrc", data)
-                os.chmod(os.path.join(tmpdir, ".netrc"), 0o600)
-
-                nrc = netrc.netrc(os.path.join(tmpdir, ".netrc"))
-
-        return nrc
-
-    def make_nrc(self, test_data):
-        return self.file_argument(test_data)
-    
-    @support.subTests('nrc_builder', (home_netrc, envvar_netrc, file_argument))
-    def test_toplevel_non_ordered_tokens(self, nrc_builder):
-        nrc = nrc_builder("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_toplevel_non_ordered_tokens(self, make_nrc):
+        nrc = make_nrc("""\
             machine host.domain.com password pass1 login log1 account acct1
             default login log2 password pass2 account acct2
             """)
         self.assertEqual(nrc.hosts['host.domain.com'], ('log1', 'acct1', 'pass1'))
         self.assertEqual(nrc.hosts['default'], ('log2', 'acct2', 'pass2'))
 
-    @support.subTests('nrc_builder', (home_netrc, envvar_netrc, file_argument))
-    def test_toplevel_tokens(self, nrc_builder):
-        nrc = nrc_builder("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_toplevel_tokens(self, make_nrc):
+        nrc = make_nrc("""\
             machine host.domain.com login log1 password pass1 account acct1
             default login log2 password pass2 account acct2
             """)
         self.assertEqual(nrc.hosts['host.domain.com'], ('log1', 'acct1', 'pass1'))
         self.assertEqual(nrc.hosts['default'], ('log2', 'acct2', 'pass2'))
 
-    @support.subTests('nrc_builder', (home_netrc, envvar_netrc, file_argument))
-    def test_macros(self, nrc_builder):
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_macros(self, make_nrc):
         data = """\
             macdef macro1
             line1
@@ -97,15 +103,15 @@ class NetrcTestCase(unittest.TestCase):
             line4
 
         """
-        nrc = nrc_builder(data)
+        nrc = make_nrc(data)
         self.assertEqual(nrc.macros, {'macro1': ['line1\n', 'line2\n'],
                                       'macro2': ['line3\n', 'line4\n']})
         # strip the last \n
-        self.assertRaises(netrc.NetrcParseError, self.make_nrc,
+        self.assertRaises(netrc.NetrcParseError, make_nrc,
                           data.rstrip(' ')[:-1])
 
-    @support.subTests('nrc_builder', (home_netrc, envvar_netrc, file_argument))
-    def test_optional_tokens(self, nrc_builder):
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_optional_tokens(self, make_nrc):
         data = (
             "machine host.domain.com",
             "machine host.domain.com login",
@@ -116,7 +122,7 @@ class NetrcTestCase(unittest.TestCase):
             "machine host.domain.com account \"\" password"
         )
         for item in data:
-            nrc = nrc_builder(item)
+            nrc = make_nrc(item)
             self.assertEqual(nrc.hosts['host.domain.com'], ('', '', ''))
         data = (
             "default",
@@ -128,11 +134,11 @@ class NetrcTestCase(unittest.TestCase):
             "default account \"\" password"
         )
         for item in data:
-            nrc = self.make_nrc(item)
+            nrc = make_nrc(item)
             self.assertEqual(nrc.hosts['default'], ('', '', ''))
 
-    @support.subTests('nrc_builder', (home_netrc, envvar_netrc, file_argument))
-    def test_invalid_tokens(self, nrc_builder):
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_invalid_tokens(self, make_nrc):
         data = (
             "invalid host.domain.com",
             "machine host.domain.com invalid",
@@ -141,10 +147,10 @@ class NetrcTestCase(unittest.TestCase):
             "default host.domain.com login log password pass account acct invalid"
         )
         for item in data:
-            self.assertRaises(netrc.NetrcParseError, nrc_builder, item)
+            self.assertRaises(netrc.NetrcParseError, make_nrc, item)
 
-    def _test_token_x(self, nrc, token, value):
-        nrc = self.make_nrc(nrc)
+    def _test_token_x(self, make_nrc, content, token, value):
+        nrc = make_nrc(content)
         if token == 'login':
             self.assertEqual(nrc.hosts['host.domain.com'], (value, 'acct', 'pass'))
         elif token == 'account':
@@ -152,210 +158,247 @@ class NetrcTestCase(unittest.TestCase):
         elif token == 'password':
             self.assertEqual(nrc.hosts['host.domain.com'], ('log', 'acct', value))
     
-    def test_token_value_quotes(self):
-        self._test_token_x("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_token_value_quotes(self, make_nrc):
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login "log" password pass account acct
             """, 'login', 'log')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password pass account "acct"
             """, 'account', 'acct')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password "pass" account acct
             """, 'password', 'pass')
 
-    def test_token_value_escape(self):
-        self._test_token_x("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_token_value_escape(self, make_nrc):
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login \\"log password pass account acct
             """, 'login', '"log')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login "\\"log" password pass account acct
             """, 'login', '"log')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password pass account \\"acct
             """, 'account', '"acct')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password pass account "\\"acct"
             """, 'account', '"acct')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password \\"pass account acct
             """, 'password', '"pass')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password "\\"pass" account acct
             """, 'password', '"pass')
 
-    def test_token_value_whitespace(self):
-        self._test_token_x("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_token_value_whitespace(self, make_nrc):
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login "lo g" password pass account acct
             """, 'login', 'lo g')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password "pas s" account acct
             """, 'password', 'pas s')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password pass account "acc t"
             """, 'account', 'acc t')
 
-    def test_token_value_non_ascii(self):
-        self._test_token_x("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_token_value_non_ascii(self, make_nrc):
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login \xa1\xa2 password pass account acct
             """, 'login', '\xa1\xa2')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password pass account \xa1\xa2
             """, 'account', '\xa1\xa2')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password \xa1\xa2 account acct
             """, 'password', '\xa1\xa2')
 
-    def test_token_value_leading_hash(self):
-        self._test_token_x("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_token_value_leading_hash(self, make_nrc):
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login #log password pass account acct
             """, 'login', '#log')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password pass account #acct
             """, 'account', '#acct')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password #pass account acct
             """, 'password', '#pass')
 
-    def test_token_value_trailing_hash(self):
-        self._test_token_x("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_token_value_trailing_hash(self, make_nrc):
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log# password pass account acct
             """, 'login', 'log#')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password pass account acct#
             """, 'account', 'acct#')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password pass# account acct
             """, 'password', 'pass#')
 
-    def test_token_value_internal_hash(self):
-        self._test_token_x("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_token_value_internal_hash(self, make_nrc):
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login lo#g password pass account acct
             """, 'login', 'lo#g')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password pass account ac#ct
             """, 'account', 'ac#ct')
-        self._test_token_x("""\
+        self._test_token_x(make_nrc, """\
             machine host.domain.com login log password pa#ss account acct
             """, 'password', 'pa#ss')
 
-    def _test_comment(self, nrc, passwd='pass'):
-        nrc = self.make_nrc(nrc)
+    def _test_comment(self, make_nrc, content, passwd='pass'):
+        nrc = make_nrc(content)
         self.assertEqual(nrc.hosts['foo.domain.com'], ('bar', '', passwd))
         self.assertEqual(nrc.hosts['bar.domain.com'], ('foo', '', 'pass'))
 
-    def test_comment_before_machine_line(self):
-        self._test_comment("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_comment_before_machine_line(self, make_nrc):
+        self._test_comment(make_nrc, """\
             # comment
             machine foo.domain.com login bar password pass
             machine bar.domain.com login foo password pass
             """)
 
-    def test_comment_before_machine_line_no_space(self):
-        self._test_comment("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_comment_before_machine_line_no_space(self, make_nrc):
+        self._test_comment(make_nrc, """\
             #comment
             machine foo.domain.com login bar password pass
             machine bar.domain.com login foo password pass
             """)
 
-    def test_comment_before_machine_line_hash_only(self):
-        self._test_comment("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_comment_before_machine_line_hash_only(self, make_nrc):
+        self._test_comment(make_nrc, """\
             #
             machine foo.domain.com login bar password pass
             machine bar.domain.com login foo password pass
             """)
 
-    def test_comment_after_machine_line(self):
-        self._test_comment("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_comment_after_machine_line(self, make_nrc):
+        self._test_comment(make_nrc, """\
             machine foo.domain.com login bar password pass
             # comment
             machine bar.domain.com login foo password pass
             """)
-        self._test_comment("""\
+        self._test_comment(make_nrc, """\
             machine foo.domain.com login bar password pass
             machine bar.domain.com login foo password pass
             # comment
             """)
 
-    def test_comment_after_machine_line_no_space(self):
-        self._test_comment("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_comment_after_machine_line_no_space(self, make_nrc):
+        self._test_comment(make_nrc, """\
             machine foo.domain.com login bar password pass
             #comment
             machine bar.domain.com login foo password pass
             """)
-        self._test_comment("""\
+        self._test_comment(make_nrc, """\
             machine foo.domain.com login bar password pass
             machine bar.domain.com login foo password pass
             #comment
             """)
 
-    def test_comment_after_machine_line_hash_only(self):
-        self._test_comment("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_comment_after_machine_line_hash_only(self, make_nrc):
+        self._test_comment(make_nrc, """\
             machine foo.domain.com login bar password pass
             #
             machine bar.domain.com login foo password pass
             """)
-        self._test_comment("""\
+        self._test_comment(make_nrc, """\
             machine foo.domain.com login bar password pass
             machine bar.domain.com login foo password pass
             #
             """)
 
-    def test_comment_at_end_of_machine_line(self):
-        self._test_comment("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_comment_at_end_of_machine_line(self, make_nrc):
+        self._test_comment(make_nrc, """\
             machine foo.domain.com login bar password pass # comment
             machine bar.domain.com login foo password pass
             """)
 
-    def test_comment_at_end_of_machine_line_no_space(self):
-        self._test_comment("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_comment_at_end_of_machine_line_no_space(self, make_nrc):
+        self._test_comment(make_nrc, """\
             machine foo.domain.com login bar password pass #comment
             machine bar.domain.com login foo password pass
             """)
 
-    def test_comment_at_end_of_machine_line_pass_has_hash(self):
-        self._test_comment("""\
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_comment_at_end_of_machine_line_pass_has_hash(self, make_nrc):
+        self._test_comment(make_nrc, """\
             machine foo.domain.com login bar password #pass #comment
             machine bar.domain.com login foo password pass
             """, '#pass')
 
+    @unittest.skipUnless(os.name == 'posix', 'POSIX only test')
+    @unittest.skipIf(pwd is None, 'security check requires pwd module')
+    @support.os_helper.skip_unless_working_chmod
+    def test_non_anonymous_security(self):
+        # This test is incomplete since we are normally not run as root and
+        # therefore can't test the file ownership being wrong.
+        content = """
+            machine foo.domain.com login bar password pass
+            default login foo password pass
+        """
+        mode = 0o662
+
+        # Use ~/.netrc and login is not anon
+        with self.assertRaises(netrc.NetrcParseError):
+            NetrcBuilder.use_default_netrc_in_home(content, mode=mode)
+
+        # Don't use default file
+        nrc = NetrcBuilder.use_file_argument(content, mode=mode)
+        self.assertEqual(nrc.hosts['foo.domain.com'],
+                            ('bar', '', 'pass'))
 
     @unittest.skipUnless(os.name == 'posix', 'POSIX only test')
     @unittest.skipIf(pwd is None, 'security check requires pwd module')
     @support.os_helper.skip_unless_working_chmod
-    def test_security(self):
+    @support.subTests('make_nrc', ALL_STRATEGIES)
+    def test_anonymous_security(self, make_nrc):
         # This test is incomplete since we are normally not run as root and
         # therefore can't test the file ownership being wrong.
-        d = support.os_helper.TESTFN
-        os.mkdir(d)
-        self.addCleanup(support.os_helper.rmtree, d)
-        fn = os.path.join(d, '.netrc')
-        with open(fn, 'wt') as f:
-            f.write("""\
-                machine foo.domain.com login bar password pass
-                default login foo password pass
-                """)
-        with support.os_helper.EnvironmentVarGuard() as environ:
-            environ.set('HOME', d)
-            os.chmod(fn, 0o600)
-            nrc = netrc.netrc()
+        content = """\
+            machine foo.domain.com login anonymous password pass
+        """
+        mode = 0o662
+
+        # When it's anonymous, file permissions are not bypassed
+        nrc = make_nrc(content, mode=mode)
+        self.assertEqual(nrc.hosts['foo.domain.com'],
+                         ('anonymous', '', 'pass'))
+
+    @unittest.skipUnless(os.name == 'posix', 'POSIX only test')
+    @unittest.skipIf(pwd is None, 'security check requires pwd module')
+    @support.os_helper.skip_unless_working_chmod
+    def test_anonymous_security_with_default(self):
+        # This test is incomplete since we are normally not run as root and
+        # therefore can't test the file ownership being wrong.
+        content = """\
+            machine foo.domain.com login anonymous password pass
+            default login foo password pass
+        """
+        mode = 0o622
+
+        # "foo" is not anonymous, therefore the security check is triggered when we fallback to default netrc
+        with self.assertRaises(netrc.NetrcParseError):
+            NetrcBuilder.use_default_netrc_in_home(content, mode=mode)
+
+        # Security check isn't triggered if the file is passed as environment variable or argument
+        for make_nrc in (NetrcBuilder.use_file_argument, NetrcBuilder.use_netrc_envvar):
+            nrc = make_nrc(content, mode=mode)
             self.assertEqual(nrc.hosts['foo.domain.com'],
-                             ('bar', '', 'pass'))
-            os.chmod(fn, 0o622)
-            self.assertRaises(netrc.NetrcParseError, netrc.netrc)
-        with open(fn, 'wt') as f:
-            f.write("""\
-                machine foo.domain.com login anonymous password pass
-                default login foo password pass
-                """)
-        with support.os_helper.EnvironmentVarGuard() as environ:
-            environ.set('HOME', d)
-            os.chmod(fn, 0o600)
-            nrc = netrc.netrc()
-            self.assertEqual(nrc.hosts['foo.domain.com'],
-                             ('anonymous', '', 'pass'))
-            os.chmod(fn, 0o622)
-            self.assertEqual(nrc.hosts['foo.domain.com'],
-                             ('anonymous', '', 'pass'))
+                            ('anonymous', '', 'pass'))
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Library/2025-06-22-09-04-24.gh-issue-135788.XLT8TW.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-22-09-04-24.gh-issue-135788.XLT8TW.rst
@@ -1,0 +1,4 @@
+The :mod:`netrc` module now checks the :envvar:`!NETRC` environment
+variable when no file path is explicitly passed to :func:`netrc.netrc`.
+If :envvar:`!NETRC` is not set, it falls back to the :file:`.netrc` file in the
+user's home directory.


### PR DESCRIPTION
- This change adds support for reading the NETRC environment variable when no file is passed as argument to the constructor of netrc, which takes precedence over the user's home directory .netrc file.
- Test cases are updated to check all initialisation scenarios.
- The documentation for netrc has been updated to reflect this behavior.


<!-- gh-issue-number: gh-135788 -->
* Issue: gh-135788
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135802.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->