### PR TITLE
Docs: Clarify generator.close() behavior regarding GeneratorExit

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -956,6 +956,12 @@ methods.
 More information about generators can be found in :ref:`the documentation for
 the yield expression <yieldexpr>`.
 
+.. note::
+
+   Calling ``close()`` on a generator raises a ``GeneratorExit`` exception inside the generator 
+   at the point where it is paused. If this exception is not caught or handled inside the 
+   generator (for example, using ``try``/``except`` or ``finally``), then the call to 
+   ``close()`` will simply return ``None`` without raising any error to the caller.
 
 .. _typesseq:
 


### PR DESCRIPTION
gh-135110: Clarify that generator.close() does not externally raise GeneratorExit

Where: gh-135110 refers to the GitHub issue number being fixed.

This change addresses a documentation inconsistency where it was previously implied that `generator.close()` raises a `GeneratorExit` externally. However, this exception is raised *inside* the generator at the suspension point, and if not handled, it fails silently without propagating.

This change helps new users clearly understand how `close()` behaves when called on a generator.

Closes: gh-135110
-->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135819.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->