### PR TITLE
gh-135773: have pyvenv.cfg without home key anchor a venv and deduce home

### DIFF
--- a/Lib/test/test_getpath.py
+++ b/Lib/test/test_getpath.py
@@ -354,6 +354,27 @@ class MockGetPathTests(unittest.TestCase):
         actual = getpath(ns, expected)
         self.assertEqual(expected, actual)
 
+    def test_venv_posix_without_home_key(self):
+        ns = MockPosixNamespace(
+            argv0="/venv/bin/python3",
+            PREFIX="/usr",
+            ENV_PATH="/usr/bin",
+        )
+        # Setup the bare minimum venv
+        ns.add_known_xfile("/usr/bin/python3")
+        ns.add_known_xfile("/venv/bin/python3")
+        ns.add_known_link("/venv/bin/python3", "/usr/bin/python3")
+        ns.add_known_file("/venv/pyvenv.cfg", [
+            # home = key intentionally omitted
+        ])
+        expected = dict(
+            executable="/venv/bin/python3",
+            prefix="/venv",
+            base_prefix="/usr",
+        )
+        actual = getpath(ns, expected)
+        self.assertEqual(expected, actual)
+
     def test_venv_changed_name_posix(self):
         "Test a venv layout on *nix."
         ns = MockPosixNamespace(

--- a/Modules/getpath.py
+++ b/Modules/getpath.py
@@ -364,10 +364,9 @@ if not py_setpath:
         venv_prefix = None
         pyvenvcfg = []
 
-    # Search for the 'home' key in pyvenv.cfg. Currently, we don't consider the
-    # presence of a pyvenv.cfg file without a 'home' key to signify the
-    # existence of a virtual environment — we quietly ignore them.
-    # XXX: If we don't find a 'home' key, we don't look for another pyvenv.cfg!
+    # Search for the 'home' key in pyvenv.cfg. If a home key isn't found,
+    # then it means a venv is active and home is based on the venv's
+    # executable (if its a symlink, home is where the symlink points).
     for line in pyvenvcfg:
         key, had_equ, value = line.partition('=')
         if had_equ and key.strip().lower() == 'home':
@@ -412,10 +411,8 @@ if not py_setpath:
                             if isfile(candidate):
                                 base_executable = candidate
                                 break
+            # home key found; stop iterating over lines
             break
-    else:
-        # We didn't find a 'home' key in pyvenv.cfg (no break), reset venv_prefix.
-        venv_prefix = None
 
 
 # ******************************************************************************


### PR DESCRIPTION
This restores the 3.13 behavior where pyvenv.cfg without a home key still activates
a virtual environment. In such cases, home is typically found by reading the symlink
that venv's interpreter executable points to.

<!-- gh-issue-number: gh-135773 -->
* Issue: gh-135773
<!-- /gh-issue-number -->
