### PR TITLE
gh-135805: Document the X option and env var for controlling thread-local bytecode

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -671,7 +671,7 @@ Miscellaneous options
 
    * :samp:`-X tlbc={0,1}` enables (1, the default) or disables (0) thread-local
      bytecode in builds configured with :option:`--disable-gil`.  When disabled,
-     this also disables specialization in the tier 1 interpreter.  See also
+     this also disables the specializing interpreter.  See also
      :envvar:`PYTHON_TLBC`.
 
      .. versionadded:: 3.14
@@ -1312,10 +1312,10 @@ conflict.
 .. envvar:: PYTHON_TLBC
 
    If set to ``1`` enables thread-local bytecode. If set to ``0`` thread-local
-   bytecode (and specialization in the tier 1 interpreter) is disabled. Only
-   applies to builds configured with :option:`--disable-gil`.
+   bytecode and the specializing interpreter are disabled.  Only applies to
+   builds configured with :option:`--disable-gil`.
 
-   See also the :option:`-X tlbc <-X>` command-line option
+   See also the :option:`-X tlbc <-X>` command-line option.
 
    .. versionadded:: 3.14
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -669,6 +669,13 @@ Miscellaneous options
 
      .. versionadded:: 3.14
 
+   * :samp:`-X tlbc={0,1}` enables (1, the default) or disables (0) thread-local
+     bytecode in builds configured with :option:`--disable-gil`.  When disabled,
+     this also disables specialization in the tier 1 interpreter.  See also
+     :envvar:`PYTHON_TLBC`.
+
+     .. versionadded:: 3.14
+
    It also allows passing arbitrary values and retrieving them through the
    :data:`sys._xoptions` dictionary.
 
@@ -1301,6 +1308,16 @@ conflict.
    interpreter startup.
 
    .. versionadded:: 3.13
+
+.. envvar:: PYTHON_TLBC
+
+   If set to ``1`` enables thread-local bytecode. If set to ``0`` thread-local
+   bytecode (and specialization in the tier 1 interpreter) is disabled. Only
+   applies to builds configured with :option:`--disable-gil`.
+
+   See also the :option:`-X tlbc <-X>` command-line option
+
+   .. versionadded:: 3.14
 
 Debug-mode variables
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Add documentation for `-X tlbc` and `PYTHON_TLBC`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNNN: Summary of the changes made
```

Where: gh-NNNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNNNN)
```

Where: [X.Y] is the branch name, for example: [3.13].

GH-NNNNNN refers to the PR number from `main`.

-->


<!-- gh-issue-number: gh-135805 -->
* Issue: gh-135805
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135868.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->