### PR TITLE
gh-135853: add `math.signbit`

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -59,6 +59,7 @@ noted otherwise, all return values are floats.
 :func:`isnan(x) <isnan>`                              Check if *x* is a NaN  (not a number)
 :func:`ldexp(x, i) <ldexp>`                           ``x * (2**i)``, inverse of function :func:`frexp`
 :func:`nextafter(x, y, steps) <nextafter>`            Floating-point value *steps* steps after *x* towards *y*
+:func:`signbit(x) <signbit>`                          Check if *x* is a negative number
 :func:`ulp(x) <ulp>`                                  Value of the least significant bit of *x*
 
 **Power, exponential and logarithmic functions**
@@ -429,6 +430,15 @@ Floating point manipulation functions
 
    .. versionchanged:: 3.12
       Added the *steps* argument.
+
+
+.. function:: signbit(x)
+
+   Return :const:`True` if *x* is negative and :const:`False` otherwise.
+
+   This is useful to detect the sign bit of zeroes, infinities and NaNs.
+
+   .. versionadded:: next
 
 
 .. function:: ulp(x)

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -434,7 +434,7 @@ Floating point manipulation functions
 
 .. function:: signbit(x)
 
-   Return :const:`True` if *x* is negative and :const:`False` otherwise.
+   Return ``True`` if the sign of *x* is negative and ``False`` otherwise.
 
    This is useful to detect the sign bit of zeroes, infinities and NaNs.
 

--- a/Doc/whatsnew/3.15.rst
+++ b/Doc/whatsnew/3.15.rst
@@ -115,6 +115,9 @@ math
 * Add :func:`math.isnormal` and :func:`math.issubnormal` functions.
   (Contributed by Sergey B Kirpichev in :gh:`132908`.)
 
+* Add :func:`math.signbit` function.
+  (Contributed by Bénédikt Tran in :gh:`135853`.)
+
 
 os.path
 -------

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -18,12 +18,8 @@ import sys
 eps = 1E-05
 NAN = float('nan')
 NNAN = float('-nan')
-DNAN = decimal.Decimal("nan")
-DNNAN = decimal.Decimal("-nan")
 INF = float('inf')
 NINF = float('-inf')
-DINF = decimal.Decimal("inf")
-DNINF = decimal.Decimal("-inf")
 FLOAT_MAX = sys.float_info.max
 FLOAT_MIN = sys.float_info.min
 
@@ -481,10 +477,13 @@ class MathTests(unittest.TestCase):
         self.assertEqual(abs(math.copysign(2., NAN)), 2.)
 
     def test_signbit(self):
-        for arg in [0, 0., 1, 1., INF, NAN, DINF, DNAN]:
+        self.assertRaises(TypeError, math.signbit)
+        self.assertRaises(TypeError, math.signbit, '1.0')
+
+        for arg in [0, 0., 1, 1., INF, NAN]:
             with self.subTest('positive', arg=arg):
                 self.assertFalse(math.signbit(arg))
-        for arg in [-0., -1, -1., NINF, NNAN, DNINF, DNNAN]:
+        for arg in [-0., -1, -1., NINF, NNAN]:
             with self.subTest('negative', arg=arg):
                 self.assertTrue(math.signbit(arg))
 

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -17,8 +17,13 @@ import sys
 
 eps = 1E-05
 NAN = float('nan')
+NNAN = float('-nan')
+DNAN = decimal.Decimal("nan")
+DNNAN = decimal.Decimal("-nan")
 INF = float('inf')
 NINF = float('-inf')
+DINF = decimal.Decimal("inf")
+DNINF = decimal.Decimal("-inf")
 FLOAT_MAX = sys.float_info.max
 FLOAT_MIN = sys.float_info.min
 
@@ -474,6 +479,14 @@ class MathTests(unittest.TestCase):
         self.assertTrue(math.isinf(math.copysign(INF, NAN)))
         # similarly, copysign(2., NAN) could be 2. or -2.
         self.assertEqual(abs(math.copysign(2., NAN)), 2.)
+
+    def test_signbit(self):
+        for arg in [0, 0., 1, 1., INF, NAN, DINF, DNAN]:
+            with self.subTest('positive', arg=arg):
+                self.assertFalse(math.signbit(arg))
+        for arg in [-0., -1, -1., NINF, NNAN, DNINF, DNNAN]:
+            with self.subTest('negative', arg=arg):
+                self.assertTrue(math.signbit(arg))
 
     def testCos(self):
         self.assertRaises(TypeError, math.cos)
@@ -1386,7 +1399,6 @@ class MathTests(unittest.TestCase):
         # Error cases that arose during development
         args = ((-5, -5, 10), (1.5, 4611686018427387904, 2305843009213693952))
         self.assertEqual(sumprod(*args), 0.0)
-
 
     @requires_IEEE_754
     @unittest.skipIf(HAVE_DOUBLE_ROUNDING,
@@ -2485,7 +2497,6 @@ class MathTests(unittest.TestCase):
         self.assertEqual(1.0, math.nextafter(1.0, INF, steps=0))
         with self.assertRaises(ValueError):
             math.nextafter(1.0, INF, steps=-1)
-
 
     @requires_IEEE_754
     def test_ulp(self):

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -17,7 +17,6 @@ import sys
 
 eps = 1E-05
 NAN = float('nan')
-NNAN = float('-nan')
 INF = float('inf')
 NINF = float('-inf')
 FLOAT_MAX = sys.float_info.max
@@ -480,12 +479,14 @@ class MathTests(unittest.TestCase):
         self.assertRaises(TypeError, math.signbit)
         self.assertRaises(TypeError, math.signbit, '1.0')
 
-        for arg in [0, 0., 1, 1., INF, NAN]:
-            with self.subTest('positive', arg=arg):
-                self.assertFalse(math.signbit(arg))
-        for arg in [-0., -1, -1., NINF, NNAN]:
-            with self.subTest('negative', arg=arg):
-                self.assertTrue(math.signbit(arg))
+        # C11, §7.12.3.6 requires signbit() to return a nonzero value
+        # if and only if the sign of its argument value is negative,
+        # but in practice, we are only interested in a boolean value.
+        self.assertIsInstance(math.signbit(1.0), bool)
+
+        for arg in [0., 1., INF, NAN]:
+            self.assertFalse(math.signbit(arg))
+            self.assertTrue(math.signbit(-arg))
 
     def testCos(self):
         self.assertRaises(TypeError, math.cos)

--- a/Misc/NEWS.d/next/Library/2025-06-24-10-23-37.gh-issue-135853.6xDNOG.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-24-10-23-37.gh-issue-135853.6xDNOG.rst
@@ -1,2 +1,2 @@
 :mod:`math`: expose C99 :func:`~math.signbit` function to determine whether
-a floating-point value is negative. Patch by Bénédikt Tran.
+the sign bit of a floating-point value is set. Patch by Bénédikt Tran.

--- a/Misc/NEWS.d/next/Library/2025-06-24-10-23-37.gh-issue-135853.6xDNOG.rst
+++ b/Misc/NEWS.d/next/Library/2025-06-24-10-23-37.gh-issue-135853.6xDNOG.rst
@@ -1,0 +1,2 @@
+:mod:`math`: expose C99 :func:`~math.signbit` function to determine whether
+a floating-point value is negative. Patch by Bénédikt Tran.

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -84,6 +84,42 @@ PyDoc_STRVAR(math_floor__doc__,
 #define MATH_FLOOR_METHODDEF    \
     {"floor", (PyCFunction)math_floor, METH_O, math_floor__doc__},
 
+PyDoc_STRVAR(math_signbit__doc__,
+"signbit($module, x, /)\n"
+"--\n"
+"\n"
+"Return True if \'x\' is negative and False otherwise.\n"
+"\n"
+"This is useful to detect the sign bit of zeroes, infinities and NaNs.");
+
+#define MATH_SIGNBIT_METHODDEF    \
+    {"signbit", (PyCFunction)math_signbit, METH_O, math_signbit__doc__},
+
+static PyObject *
+math_signbit_impl(PyObject *module, double x);
+
+static PyObject *
+math_signbit(PyObject *module, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    double x;
+
+    if (PyFloat_CheckExact(arg)) {
+        x = PyFloat_AS_DOUBLE(arg);
+    }
+    else
+    {
+        x = PyFloat_AsDouble(arg);
+        if (x == -1.0 && PyErr_Occurred()) {
+            goto exit;
+        }
+    }
+    return_value = math_signbit_impl(module, x);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(math_fsum__doc__,
 "fsum($module, seq, /)\n"
 "--\n"
@@ -1178,4 +1214,4 @@ math_ulp(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=44bba3a0a052a364 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ae85f0ca1de2c864 input=a9049054013a1b77]*/

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -88,9 +88,7 @@ PyDoc_STRVAR(math_signbit__doc__,
 "signbit($module, x, /)\n"
 "--\n"
 "\n"
-"Return True if \'x\' is negative and False otherwise.\n"
-"\n"
-"This is useful to detect the sign bit of zeroes, infinities and NaNs.");
+"Return True if the sign of x is negative and False otherwise.");
 
 #define MATH_SIGNBIT_METHODDEF    \
     {"signbit", (PyCFunction)math_signbit, METH_O, math_signbit__doc__},
@@ -1214,4 +1212,4 @@ math_ulp(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ae85f0ca1de2c864 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4e3fa94d026f027b input=a9049054013a1b77]*/

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1240,7 +1240,7 @@ math.signbit
     x: double
     /
 
-Return True if 'x' is negative and False otherwise.
+Return True if the sign of 'x' is negative and False otherwise.
 
 This is useful to detect the sign bit of zeroes, infinities and NaNs.
 [clinic start generated code]*/

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1233,6 +1233,25 @@ FUNC2(remainder, m_remainder,
       "Return x - n*y where n*y is the closest integer multiple of y.\n"
       "In the case where x is exactly halfway between two multiples of\n"
       "y, the nearest even value of n is used. The result is always exact.")
+
+/*[clinic input]
+math.signbit
+
+    x: double
+    /
+
+Return True if 'x' is negative and False otherwise.
+
+This is useful to detect the sign bit of zeroes, infinities and NaNs.
+[clinic start generated code]*/
+
+static PyObject *
+math_signbit_impl(PyObject *module, double x)
+/*[clinic end generated code: output=20c5f20156a9b871 input=1765b06afd3c4bd0]*/
+{
+    return PyBool_FromLong(signbit(x));
+}
+
 FUNC1D(sin, sin, 0,
       "sin($module, x, /)\n--\n\n"
       "Return the sine of x (measured in radians).",
@@ -4199,6 +4218,7 @@ static PyMethodDef math_methods[] = {
     MATH_POW_METHODDEF
     MATH_RADIANS_METHODDEF
     {"remainder",       _PyCFunction_CAST(math_remainder), METH_FASTCALL,  math_remainder_doc},
+    MATH_SIGNBIT_METHODDEF
     {"sin",             math_sin,       METH_O,         math_sin_doc},
     {"sinh",            math_sinh,      METH_O,         math_sinh_doc},
     {"sqrt",            math_sqrt,      METH_O,         math_sqrt_doc},

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1240,14 +1240,12 @@ math.signbit
     x: double
     /
 
-Return True if the sign of 'x' is negative and False otherwise.
-
-This is useful to detect the sign bit of zeroes, infinities and NaNs.
+Return True if the sign of x is negative and False otherwise.
 [clinic start generated code]*/
 
 static PyObject *
 math_signbit_impl(PyObject *module, double x)
-/*[clinic end generated code: output=20c5f20156a9b871 input=1765b06afd3c4bd0]*/
+/*[clinic end generated code: output=20c5f20156a9b871 input=3d3493fbcb5bdb3e]*/
 {
     return PyBool_FromLong(signbit(x));
 }


### PR DESCRIPTION
cc @mdickinson @skirpichev @rhettinger 

I made the choice of returning True/False like numpy rather than the nonzero value itself as in C. If you want me to have another function that returns a boolean and keep signbit as in C, please tell me.

<!-- gh-issue-number: gh-135853 -->
* Issue: gh-135853
<!-- /gh-issue-number -->


<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135877.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->