### PR TITLE
gh-135885: Fix undocumented method `CookieJar.clear_expired_cookies` in lib `http.cookiejar`

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -255,11 +255,14 @@ contained :class:`Cookie` objects.
    Discards all contained cookies that have a true :attr:`expires` attribute
    (usually because their expiration time have passed)
 
-   This is a low-level function which probably don't need to be called because
-   expired cookies are never sent back to the server (provided using
-   :class:`DefaultCookiePolicy`). This method is called by :class:`CookieJar`
-   itself every so often. It *could* only be useful when customizing a
-   :class:`CookiePolicy` with an expiring logic.
+   This is a low-level function which usually does not need to be called
+   since expired cookies are never sent back to the server when using
+   :class:`DefaultCookiePolicy` nor are they saved by :meth:`save` unless
+   the latter is called with a truthy *ignore_expires*.
+
+   Since :class:`CookieJar` also calls this method every so often,
+   it *could* only be useful when customizing a :class:`CookiePolicy`
+   with an expiring logic.
 
    Note that the :meth:`save` method won't save expired cookies anyway (unless you
    ask otherwise by passing a true *ignore_expires* argument).

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -252,8 +252,7 @@ contained :class:`Cookie` objects.
 
    Discard all expired cookies.
 
-   Discards all contained cookies that have a true :attr:`expires` attribute
-   (usually because their expiration time have passed)
+   Discards all contained cookies that have a true :attr:`expires` attribute.
 
    This is a low-level function which usually does not need to be called
    since expired cookies are never sent back to the server when using

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -258,7 +258,7 @@ contained :class:`Cookie` objects.
    You probably don't need to call this method because expired cookies are never
    sent back to the server (provided you're using :class:`DefaultCookiePolicy`).
    This method is called by :class:`CookieJar` itself every so often. It *could*
-   only be useful when you are customizing a `CookiePolicy` with your own 
+   only be useful when you are customizing a `CookiePolicy` with your own
    expiring logic.
 
    Note that the :meth:`save` method won't save expired cookies anyway (unless you ask

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -261,8 +261,8 @@ contained :class:`Cookie` objects.
    itself every so often. It *could* only be useful when customizing a
    :class:`CookiePolicy` with an expiring logic.
 
-   Note that the :meth:`save` method won't save expired cookies anyway (unless you ask
-   otherwise by passing a true *ignore_expires* argument).
+   Note that the :meth:`save` method won't save expired cookies anyway (unless you
+   ask otherwise by passing a true *ignore_expires* argument).
 
 :class:`FileCookieJar` implements the following additional methods:
 

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -264,8 +264,6 @@ contained :class:`Cookie` objects.
    it *could* only be useful when customizing a :class:`CookiePolicy`
    with an expiring logic.
 
-   Note that the :meth:`save` method won't save expired cookies anyway (unless you
-   ask otherwise by passing a true *ignore_expires* argument).
 
 :class:`FileCookieJar` implements the following additional methods:
 

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -255,11 +255,11 @@ contained :class:`Cookie` objects.
    Discards all contained cookies that have a true :attr:`expires` attribute
    (usually because their expiration time have passed)
 
-   You probably don't need to call this method because expired cookies are never
-   sent back to the server (provided you're using :class:`DefaultCookiePolicy`).
-   This method is called by :class:`CookieJar` itself every so often. It *could*
-   only be useful when you are customizing a :class:`CookiePolicy` with your own
-   expiring logic.
+   This is a low-level function which probably don't need to be called because
+   expired cookies are never sent back to the server (provided using
+   :class:`DefaultCookiePolicy`). This method is called by :class:`CookieJar`
+   itself every so often. It *could* only be useful when customizing a
+   :class:`CookiePolicy` with an expiring logic.
 
    Note that the :meth:`save` method won't save expired cookies anyway (unless you ask
    otherwise by passing a true *ignore_expires* argument).

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -258,7 +258,7 @@ contained :class:`Cookie` objects.
    You probably don't need to call this method because expired cookies are never
    sent back to the server (provided you're using :class:`DefaultCookiePolicy`).
    This method is called by :class:`CookieJar` itself every so often. It *could*
-   only be useful when you are customizing a `CookiePolicy` with your own
+   only be useful when you are customizing a :class:`CookiePolicy` with your own
    expiring logic.
 
    Note that the :meth:`save` method won't save expired cookies anyway (unless you ask

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -247,6 +247,20 @@ contained :class:`Cookie` objects.
    Note that the :meth:`save` method won't save session cookies anyway, unless you
    ask otherwise by passing a true *ignore_discard* argument.
 
+
+.. method:: CookieJar.clear_expired_cookies()
+
+   Discard all expired cookies.
+
+   Discards all contained cookies that have a true :attr:`is_expired` attribute
+   (usually because their expiration time have passed)
+
+   You probably don't need to call this method because expired cookies are never
+   sent back to the server (provided you're using :class:`DefaultCookiePolicy`),
+   this method is called by :class:`CookieJar` itself every so often, and the
+   :meth:`save` method won't save expired cookies anyway (unless you ask
+   otherwise by passing a true *ignore_expires* argument).
+
 :class:`FileCookieJar` implements the following additional methods:
 
 

--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -252,13 +252,16 @@ contained :class:`Cookie` objects.
 
    Discard all expired cookies.
 
-   Discards all contained cookies that have a true :attr:`is_expired` attribute
+   Discards all contained cookies that have a true :attr:`expires` attribute
    (usually because their expiration time have passed)
 
    You probably don't need to call this method because expired cookies are never
-   sent back to the server (provided you're using :class:`DefaultCookiePolicy`),
-   this method is called by :class:`CookieJar` itself every so often, and the
-   :meth:`save` method won't save expired cookies anyway (unless you ask
+   sent back to the server (provided you're using :class:`DefaultCookiePolicy`).
+   This method is called by :class:`CookieJar` itself every so often. It *could*
+   only be useful when you are customizing a `CookiePolicy` with your own 
+   expiring logic.
+
+   Note that the :meth:`save` method won't save expired cookies anyway (unless you ask
    otherwise by passing a true *ignore_expires* argument).
 
 :class:`FileCookieJar` implements the following additional methods:


### PR DESCRIPTION
Although there is low possibility to call this method if you are using `DefaultCookiePolicy`, but as a method of `CookieJar` that could be used(do not start with `_`, and would be used when users are customizing their own policies), the method is supposed to be documented. 

<!-- readthedocs-preview cpython-previews start -->
----
📚 Documentation preview 📚: https://cpython-previews--135882.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->

<!-- gh-issue-number: gh-135885 -->
* Issue: gh-135885
<!-- /gh-issue-number -->
